### PR TITLE
Add axis for docker builds

### DIFF
--- a/ci/axis/docker.yml
+++ b/ci/axis/docker.yml
@@ -1,0 +1,29 @@
+SDK_TYPE:
+  - nvidia/cuda
+
+SDK_VER:
+  - 11.0-devel
+
+OS_TYPE:
+  - ubuntu
+
+OS_VER:
+  - 18.04
+
+CXX_TYPE:
+  - clang
+  - gcc
+
+CXX_VER:
+  - 5
+  - 6
+  - 7
+  - 8
+  - 9
+  - 10
+
+exclude:
+  - CXX_TYPE: clang
+    CXX_VER: 5
+  - CXX_TYPE: clang
+    CXX_VER: 6

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,9 +38,9 @@ RUN if [[ "${OS_TYPE}" == "ubuntu"* ]]; then \
       apt-get -y --no-install-recommends install wget ca-certificates; \
       apt-get -y --no-install-recommends install python3-pip python3-setuptools python3-wheel; \
       apt-get -y --no-install-recommends install cmake; \
-      if   [[ "{CXX_TYPE}" == "gcc" ]]; then \
+      if   [[ "${CXX_TYPE}" == "gcc" ]]; then \
         apt-get -y --no-install-recommends install g++-${CXX_VER}; \
-      elif [[ "{CXX_TYPE}" == "clang" ]]; then \
+      elif [[ "${CXX_TYPE}" == "clang" ]]; then \
         apt-get -y --no-install-recommends install clang-${CXX_VER}; \
       fi; \
       apt-get clean; \


### PR DESCRIPTION
This PR adds an axis file for parameterizing out the docker builds.

You can checkout the resulting docker images here: https://hub.docker.com/r/gpuci/cccl/tags

Once this file is merged, I'll configure a gpuCI job to listen to this repo and rebuild images as changes are made.