### PR TITLE
Update excludes

### DIFF
--- a/ci/axis/docker.yml
+++ b/ci/axis/docker.yml
@@ -36,6 +36,14 @@ CXX_VER:
   - latest
 
 exclude:
+  - SDK_TYPE: nvidia/cuda
+    SDK_VER: 20.7-devel
+  - SDK_TYPE: nvcr.io/nvidia/nvhpc
+    SDK_VER: 11.0-devel
+  - OS_TYPE: ubuntu
+    OS_VER: 7
+  - OS_TYPE: centos
+    OS_VER: 18.04
   - CXX_TYPE: clang
     SDK_TYPE: nvcr.io/nvidia/nvhpc
   - CXX_TYPE: gcc
@@ -81,5 +89,5 @@ exclude:
   - CXX_TYPE: nvc++
     CXX_VER: 10
   - CXX_TYPE: nvc++
-    CXX_VER: 20.7
+    CXX_VER: latest
 


### PR DESCRIPTION
Update excludes for `SDK_TYPE/SDK_VER` and `OS_TYPE/OS_VER`.

Additionally, I think `nvc++` uses only version `20.7`, not `latest`.