### PR TITLE
Fix GCC 10 build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,8 +88,28 @@ RUN if [[ "${OS_TYPE}" == "ubuntu"* ]]; then \
       apt-get -y --no-install-recommends install vim emacs-nox; \
       if   [[ "${CXX_TYPE}" == "gcc" ]]; then \
         apt-get -y --no-install-recommends install g++-${CXX_VER} gcc-${CXX_VER}; \
-        export CC=$(which gcc-${CXX_VER}); \
-        export CXX=$(which g++-${CXX_VER}); \
+        if [[ "${CXX_VER}" == "10" ]]; then \
+          GCC_VERSION=10.2.0; \
+          apt-get -y --no-install-recommends install wget; \
+          cd /opt; \
+          wget -q ftp://gcc.gnu.org/pub/gcc/releases/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.gz; \
+          tar xf gcc-${GCC_VERSION}.tar.gz; \
+          cd gcc-${GCC_VERSION}; \
+          ./contrib/download_prerequisites; \
+          cd ..; \
+          mkdir gcc-build-${GCC_VERSION}; \
+          mkdir gcc-bin-${GCC_VERSION}; \
+          cd gcc-build-${GCC_VERSION}; \
+          ../gcc-${GCC_VERSION}/configure --prefix=$(readlink -f ../gcc-bin-${GCC_VERSION}) --enable-languages=c,c++ --disable-multilib; \
+          make -j &>/dev/null;  \
+          make install &>/dev/null; \
+          cd ..; \
+          export CC=$(readlink -f gcc-bin-${GCC_VERSION}/bin/gcc); \
+          export CXX=$(readlink -f gcc-bin-${GCC_VERSION}/bin/g++); \
+        else \
+          export CC=$(which gcc-${CXX_VER}); \
+          export CXX=$(which g++-${CXX_VER}); \
+        fi \
       elif [[ "${CXX_TYPE}" == "clang" ]]; then \
         apt-get -y --no-install-recommends install clang-${CXX_VER}; \
         export CC=$(which clang-${CXX_VER}); \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,7 +101,7 @@ RUN if [[ "${OS_TYPE}" == "ubuntu"* ]]; then \
           mkdir gcc-bin-${GCC_VERSION}; \
           cd gcc-build-${GCC_VERSION}; \
           ../gcc-${GCC_VERSION}/configure --prefix=$(readlink -f ../gcc-bin-${GCC_VERSION}) --enable-languages=c,c++ --disable-multilib; \
-          make -j &>/dev/null;  \
+          make &>/dev/null;  \
           make install &>/dev/null; \
           cd ..; \
           export CC=$(readlink -f gcc-bin-${GCC_VERSION}/bin/gcc); \


### PR DESCRIPTION
There is [an issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100102) with GCC 10.3 which we are using in `gpuCI/thrust/cpu/cuda11.3.1-devel/ubuntu-20.04/gcc10`. I've tested GCC 10.3 and GCC 10.2. The compilation failure is reproduced only in GCC 10.3, so it seems that we have to roll back to GCC 10.2.

```
:nvcc --compiler-bindir /opt/gcc/10.2.0/gcc-10.2.0-bin/bin -I/home/gevtushenko/src/senior-zero/cub -I/home/gevtushenko/src/senior-zero/cub/examples/device -I/home/gevtushenko/src/senior-zero/thrust main.cu
:nvcc --compiler-bindir /opt/gcc/10.3.0/gcc-10.3.0-bin/bin -I/home/gevtushenko/src/senior-zero/cub -I/home/gevtushenko/src/senior-zero/cub/examples/device -I/home/gevtushenko/src/senior-zero/thrust main.cu
/opt/gcc/10.3.0/gcc-10.3.0-bin/include/c++/10.3.0/chrono: In substitution of 'template<class _Rep, class _Period> template<class _Period2> using __is_harmonic = std::__bool_constant<(std::ratio<((_Period2::num / std::chrono::duration<_Rep, _Period>::_S_gcd(_Period2::num, _Period::num)) * (_Period::den / std::chrono::duration<_Rep, _Period>::_S_gcd(_Period2::den, _Period::den))), ((_Period2::den / std::chrono::duration<_Rep, _Period>::_S_gcd(_Period2::den, _Period::den)) * (_Period::num / std::chrono::duration<_Rep, _Period>::_S_gcd(_Period2::num, _Period::num)))>::den == 1)> [with _Period2 = _Period2; _Rep = _Rep; _Period = _Period]':
/opt/gcc/10.3.0/gcc-10.3.0-bin/include/c++/10.3.0/chrono:473:154:   required from here
/opt/gcc/10.3.0/gcc-10.3.0-bin/include/c++/10.3.0/chrono:428:27: internal compiler error: Segmentation fault
  428 |  _S_gcd(intmax_t __m, intmax_t __n) noexcept
      |                           ^~~~~~
0xc9e3bf crash_signal
        ../../gcc-10.3.0-src/gcc/toplev.c:328
0x7959bd tsubst(tree_node*, tree_node*, int, tree_node*)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:15310
0x7a89b6 tsubst_template_args(tree_node*, tree_node*, int, tree_node*)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:13225
0x7a13b6 tsubst_aggr_type
        ../../gcc-10.3.0-src/gcc/cp/pt.c:13428
0x7ab69f tsubst_function_decl
        ../../gcc-10.3.0-src/gcc/cp/pt.c:13816
0x7a2059 tsubst_decl
        ../../gcc-10.3.0-src/gcc/cp/pt.c:14267
0x790041 tsubst_copy
        ../../gcc-10.3.0-src/gcc/cp/pt.c:16512
0x79393a tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:20707
0x792496 tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:19274
0x792496 tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:19896
0x7918cd tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:19274
0x7918cd tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:19588
0x791896 tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:19274
0x791896 tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:19587
0x7a3e74 tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:19274
0x7a3e74 tsubst_expr(tree_node*, tree_node*, int, tree_node*, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:18886
0x7a89b6 tsubst_template_args(tree_node*, tree_node*, int, tree_node*)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:13225
0x7a13b6 tsubst_aggr_type
        ../../gcc-10.3.0-src/gcc/cp/pt.c:13428
0x7912b7 tsubst_qualified_id
        ../../gcc-10.3.0-src/gcc/cp/pt.c:16215
0x792fdd tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
        ../../gcc-10.3.0-src/gcc/cp/pt.c:19625
Please submit a full bug report,
with preprocessed source if appropriate.
Please include the complete backtrace with any bug report.
See <https://gcc.gnu.org/bugs/> for instructions.
```

There is no GCC 10.2 in the repositories, so I've built it from sources. 