### PR TITLE
Update `sccache` version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ ARG CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/c
 ARG TINI_VER=0.18.0
 ARG TINI_URL=https://github.com/krallin/tini/releases/download/v${TINI_VER}/tini
 
-ARG SCCACHE_VERSION=0.2.15
+ARG SCCACHE_VERSION=0.3.3
 ARG SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
 
 # `--silent --show-error` disables non-error output.


### PR DESCRIPTION
This PR updates the `sccache` version for the `gpuci/cccl` CI images.

This change is necessary because we are moving the bucket that is used by our `sccache` users to a new AWS region that is closer to the rest of our CI resources.

In order to support this switch, `sccache` users will need the changes from [this `sccache` PR](https://github.com/mozilla/sccache/pull/1403), which was published in the `v0.3.2` release.

`v0.3.3` is the latest stable version at this time.