### PR TITLE
Make sccache work locally

### DIFF
--- a/.github/actions/configure_cccl_sccache/action.yml
+++ b/.github/actions/configure_cccl_sccache/action.yml
@@ -11,7 +11,7 @@ runs:
         role-duration-seconds: 43200 # 12 hours)
     - name: Set environment variables
       run: |
-        echo "SCCACHE_BUCKET=rapids-sccache-east" >> $GITHUB_ENV
+        echo "SCCACHE_BUCKET=rapids-sccache-devs" >> $GITHUB_ENV
         echo "SCCACHE_REGION=us-east-2" >> $GITHUB_ENV
         echo "SCCACHE_IDLE_TIMEOUT=32768" >> $GITHUB_ENV
         echo "SCCACHE_S3_USE_SSL=true" >> $GITHUB_ENV

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,7 +64,7 @@ jobs:
             sccache -s > sccache_after.txt
       - name: Calculate sccache hit rate
         run: |
-          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
+          hit_rate=$(./cccl/ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" >> $GITHUB_STEP_SUMMARY
   test:
     needs: build
@@ -98,5 +98,5 @@ jobs:
             sccache -s > sccache_after.txt
       - name: Calculate sccache hit rate
         run: |
-          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
+          hit_rate=$(./cccl/ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,14 +36,14 @@ jobs:
         with:
           fetch-depth: 0
           path: cccl
+      - name: Configure credentials and environment variables for sccache
+        uses: ./cccl/.github/actions/configure_cccl_sccache
       # In order for sccache to be shared between CI and lcaal devcontainers, code needs to be in the same absolute path
       # This ensures the code is in the same path as it is within the devcontainer
       - name: Move files to coder user home directory
         run: |
           mv cccl /home/coder/cccl
           chown -R coder:coder /home/coder/
-      - name: Configure credentials and environment variables for sccache
-        uses: ./cccl/.github/actions/configure_cccl_sccache
       - name: Run build script
         shell: su coder {0}
         run: | 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,6 +66,8 @@ jobs:
         shell: su coder {0}
         run: |
           cd ~/cccl
+          pwd
+          set -x
           hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" 
   test:
@@ -102,5 +104,7 @@ jobs:
         shell: su coder {0}
         run: |
           cd ~/cccl
+          pwd
+          set -x
           hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,7 +70,7 @@ jobs:
           echo "::group::Details"
           cat info.log
           echo "::endgroup"
-          echo "::notice::sccache hit rate: $hit_rate" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "::notice::sccache hit rate: $hit_rate" 
   test:
     needs: build
     if:  ${{ !cancelled() && ( needs.build.result == 'success' || needs.build.result == 'skipped' ) && inputs.test_script != '' && inputs.test_image != '' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -85,12 +85,12 @@ jobs:
         with:
           fetch-depth: 0
           path: cccl
+      - name: Configure credentials and environment variables for sccache
+        uses: cccl/.github/actions/configure_cccl_sccache
       - name: Move files to coder user home directory
         run: |
           mv cccl /home/coder/cccl
           chown -R coder:coder /home/coder/
-      - name: Configure credentials and environment variables for sccache
-        uses: ./.github/actions/configure_cccl_sccache
       - name: Run test script
         shell: su coder {0}
         run: | 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: build and test
 
 defaults:
   run:
-    shell: bash -eo pipefail {0}
+    shell: bash -exo pipefail {0}
 
 on:
   workflow_call:
@@ -46,8 +46,8 @@ jobs:
       - name: Run build script
         shell: su coder {0}
         run: | 
-            sccache -s > sccache_before.txt
             cd ~/cccl
+            sccache -s > sccache_before.txt
             cmd="${{ inputs.build_script }} \"${{inputs.compiler_exe}}\" \"${{inputs.std}}\" \"${{inputs.gpu_build_archs}}\""
             eval $cmd || exit_code=$?
             if [ ! -z "$exit_code" ]; then
@@ -63,6 +63,7 @@ jobs:
             fi
             sccache -s > sccache_after.txt
       - name: Calculate sccache hit rate
+        shell: su coder {0}
         run: |
           hit_rate=$(./cccl/ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" >> $GITHUB_STEP_SUMMARY
@@ -97,6 +98,7 @@ jobs:
             time ./${{ inputs.test_script }} "${{inputs.compiler_exe}}" "${{inputs.std}}" "${{inputs.gpu_build_archs}}"
             sccache -s > sccache_after.txt
       - name: Calculate sccache hit rate
+        shell: su coder {0}
         run: |
           hit_rate=$(./cccl/ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,8 +71,8 @@ jobs:
           cat sccache_before.txt
           cat sccache_after.txt
           set -x
-          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt)
-          echo "sccache hit rate: $hit_rate" 
+          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt )
+          echo "::notice::sccache hit rate: $hit_rate" 
   test:
     needs: build
     if:  ${{ !cancelled() && ( needs.build.result == 'success' || needs.build.result == 'skipped' ) && inputs.test_script != '' && inputs.test_image != '' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
           cp -R cccl /home/coder/cccl
           chown -R coder:coder /home/coder/
       - name: Configure credentials and environment variables for sccache
-        uses: ./.github/actions/configure_cccl_sccache
+        uses: ./cccl/.github/actions/configure_cccl_sccache
       - name: Run build script
         shell: su coder {0}
         run: | 
@@ -88,7 +88,7 @@ jobs:
           cp -R cccl /home/coder/cccl
           chown -R coder:coder /home/coder/
       - name: Configure credentials and environment variables for sccache
-        uses: ./.github/actions/configure_cccl_sccache
+        uses: ./cccl/.github/actions/configure_cccl_sccache
       - name: Run test script
         shell: su coder {0}
         run: | 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,7 +71,7 @@ jobs:
           cat sccache_before.txt
           cat sccache_after.txt
           set -x
-          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
+          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt)
           echo "sccache hit rate: $hit_rate" 
   test:
     needs: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -69,7 +69,7 @@ jobs:
           hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt 2> info.log)
           echo "::group::Details"
           cat info.log
-          echo "::endgroup"
+          echo "::endgroup::"
           echo "::notice::sccache hit rate: $hit_rate" 
   test:
     needs: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,20 +31,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Echo git version
-        run: git --version
-      #TODO: We can remove this when we aren't using submodules anymore
-      - name: Update git version
-        run: |
-          sudo apt-get install software-properties-common
-          sudo add-apt-repository ppa:git-core/ppa -y
-          sudo apt-get update
-          sudo apt-get install git -y
-          git --version
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          fetch-depth: 0
+          path: cccl
       - name: Configure credentials and environment variables for sccache
         uses: ./.github/actions/configure_cccl_sccache
       - name: Run build script
@@ -81,18 +72,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-    # TODO: We can remove this when we aren't using submodules anymore
-      - name: Update git version
-        run: |
-          sudo apt-get install software-properties-common
-          sudo add-apt-repository ppa:git-core/ppa -y
-          sudo apt-get update
-          sudo apt-get install git -y
-          git --version
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          fetch-depth: 0
       - name: Configure credentials and environment variables for sccache
         uses: ./.github/actions/configure_cccl_sccache
       - name: Run test script

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
           mv cccl /home/coder/cccl
           chown -R coder:coder /home/coder/
       - name: Configure credentials and environment variables for sccache
-        uses: ./.github/actions/configure_cccl_sccache
+        uses: ./cccl/.github/actions/configure_cccl_sccache
       - name: Run build script
         shell: su coder {0}
         run: | 
@@ -86,7 +86,7 @@ jobs:
           fetch-depth: 0
           path: cccl
       - name: Configure credentials and environment variables for sccache
-        uses: cccl/.github/actions/configure_cccl_sccache
+        uses: ./cccl/.github/actions/configure_cccl_sccache
       - name: Move files to coder user home directory
         run: |
           mv cccl /home/coder/cccl

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           cd ~/cccl
           hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt )
-          echo "::notice::sccache hit rate: $hit_rate" 
+          echo "::notice::sccache hit rate: $hit_rate" | tee -a "$GITHUB_STEP_SUMMARY"
   test:
     needs: build
     if:  ${{ !cancelled() && ( needs.build.result == 'success' || needs.build.result == 'skipped' ) && inputs.test_script != '' && inputs.test_image != '' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,11 +66,6 @@ jobs:
         shell: su coder {0}
         run: |
           cd ~/cccl
-          pwd
-          ls 
-          cat sccache_before.txt
-          cat sccache_after.txt
-          set -x
           hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt )
           echo "::notice::sccache hit rate: $hit_rate" 
   test:
@@ -107,7 +102,5 @@ jobs:
         shell: su coder {0}
         run: |
           cd ~/cccl
-          pwd
-          set -x
           hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,11 +36,19 @@ jobs:
         with:
           fetch-depth: 0
           path: cccl
+      # In order for sccache to be shared between CI and lcaal devcontainers, code needs to be in the same absolute path
+      # This ensures the code is in the same path as it is within the devcontainer
+      - name: Move files to coder user home directory
+        run: |
+          mv cccl /home/coder/cccl
+          chown -R coder:coder /home/coder/
       - name: Configure credentials and environment variables for sccache
         uses: ./.github/actions/configure_cccl_sccache
       - name: Run build script
+        shell: su coder {0}
         run: | 
             sccache -s > sccache_before.txt
+            cd ~
             cmd="${{ inputs.build_script }} \"${{inputs.compiler_exe}}\" \"${{inputs.std}}\" \"${{inputs.gpu_build_archs}}\""
             eval $cmd || exit_code=$?
             if [ ! -z "$exit_code" ]; then
@@ -76,10 +84,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          path: cccl
+      - name: Move files to coder user home directory
+        run: |
+          mv cccl /home/coder/cccl
+          chown -R coder:coder /home/coder/
       - name: Configure credentials and environment variables for sccache
         uses: ./.github/actions/configure_cccl_sccache
       - name: Run test script
+        shell: su coder {0}
         run: | 
+            cd ~
             sccache -s > sccache_before.txt
             time ./${{ inputs.test_script }} "${{inputs.compiler_exe}}" "${{inputs.std}}" "${{inputs.gpu_build_archs}}"
             sccache -s > sccache_after.txt

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,10 +40,10 @@ jobs:
       # This ensures the code is in the same path as it is within the devcontainer
       - name: Move files to coder user home directory
         run: |
-          mv cccl /home/coder/cccl
+          cp -R cccl /home/coder/cccl
           chown -R coder:coder /home/coder/
       - name: Configure credentials and environment variables for sccache
-        uses: ./home/coder/cccl/.github/actions/configure_cccl_sccache
+        uses: ./.github/actions/configure_cccl_sccache
       - name: Run build script
         shell: su coder {0}
         run: | 
@@ -87,10 +87,10 @@ jobs:
           path: cccl
       - name: Move files to coder user home directory
         run: |
-          mv cccl /home/coder/cccl
+          cp -R cccl /home/coder/cccl
           chown -R coder:coder /home/coder/
       - name: Configure credentials and environment variables for sccache
-        uses: ./home/coder/cccl/.github/actions/configure_cccl_sccache
+        uses: ./.github/actions/configure_cccl_sccache
       - name: Run test script
         shell: su coder {0}
         run: | 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,10 @@ jobs:
         shell: su coder {0}
         run: |
           cd ~/cccl
-          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt )
+          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt >2 info.log)
+          echo "::group::Details"
+          cat info.log
+          echo "::endgroup"
           echo "::notice::sccache hit rate: $hit_rate" | tee -a "$GITHUB_STEP_SUMMARY"
   test:
     needs: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,19 +36,19 @@ jobs:
         with:
           fetch-depth: 0
           path: cccl
-      - name: Configure credentials and environment variables for sccache
-        uses: ./cccl/.github/actions/configure_cccl_sccache
       # In order for sccache to be shared between CI and lcaal devcontainers, code needs to be in the same absolute path
       # This ensures the code is in the same path as it is within the devcontainer
       - name: Move files to coder user home directory
         run: |
           mv cccl /home/coder/cccl
           chown -R coder:coder /home/coder/
+      - name: Configure credentials and environment variables for sccache
+        uses: ./home/coder/cccl/.github/actions/configure_cccl_sccache
       - name: Run build script
         shell: su coder {0}
         run: | 
             sccache -s > sccache_before.txt
-            cd ~
+            cd ~/cccl
             cmd="${{ inputs.build_script }} \"${{inputs.compiler_exe}}\" \"${{inputs.std}}\" \"${{inputs.gpu_build_archs}}\""
             eval $cmd || exit_code=$?
             if [ ! -z "$exit_code" ]; then
@@ -85,16 +85,16 @@ jobs:
         with:
           fetch-depth: 0
           path: cccl
-      - name: Configure credentials and environment variables for sccache
-        uses: ./cccl/.github/actions/configure_cccl_sccache
       - name: Move files to coder user home directory
         run: |
           mv cccl /home/coder/cccl
           chown -R coder:coder /home/coder/
+      - name: Configure credentials and environment variables for sccache
+        uses: ./home/coder/cccl/.github/actions/configure_cccl_sccache
       - name: Run test script
         shell: su coder {0}
         run: | 
-            cd ~
+            cd ~/cccl
             sccache -s > sccache_before.txt
             time ./${{ inputs.test_script }} "${{inputs.compiler_exe}}" "${{inputs.std}}" "${{inputs.gpu_build_archs}}"
             sccache -s > sccache_after.txt

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,7 @@ jobs:
         shell: su coder {0}
         run: |
           cd ~/cccl
-          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt >2 info.log)
+          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt 2> info.log)
           echo "::group::Details"
           cat info.log
           echo "::endgroup"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           cd ~/cccl
           pwd
+          ls 
           set -x
           hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,7 @@ jobs:
         shell: su coder {0}
         run: |
           hit_rate=$(./cccl/ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
-          echo "sccache hit rate: $hit_rate" >> $GITHUB_STEP_SUMMARY
+          echo "sccache hit rate: $hit_rate" 
   test:
     needs: build
     if:  ${{ !cancelled() && ( needs.build.result == 'success' || needs.build.result == 'skipped' ) && inputs.test_script != '' && inputs.test_image != '' }}
@@ -101,4 +101,4 @@ jobs:
         shell: su coder {0}
         run: |
           hit_rate=$(./cccl/ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
-          echo "sccache hit rate: $hit_rate" >> $GITHUB_STEP_SUMMARY
+          echo "sccache hit rate: $hit_rate" 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,8 @@ jobs:
       - name: Calculate sccache hit rate
         shell: su coder {0}
         run: |
-          hit_rate=$(./cccl/ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
+          cd ~/cccl
+          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" 
   test:
     needs: build
@@ -100,5 +101,6 @@ jobs:
       - name: Calculate sccache hit rate
         shell: su coder {0}
         run: |
-          hit_rate=$(./cccl/ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
+          cd ~/cccl
+          hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,6 +68,8 @@ jobs:
           cd ~/cccl
           pwd
           ls 
+          cat sccache_before.txt
+          cat sccache_after.txt
           set -x
           hit_rate=$(./ci/sccache_hit_rate.sh sccache_before.txt sccache_after.txt  2>&1 >/dev/null)
           echo "sccache hit rate: $hit_rate" 

--- a/ci/sccache_hit_rate.sh
+++ b/ci/sccache_hit_rate.sh
@@ -19,18 +19,21 @@ cat $2 >&2
 echo "=== End of $2 ===" >&2
 
 # Extract compile requests and cache hits from the before and after files
-requests_before=$(awk '/^Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $1)
-hits_before=$(awk '/^Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' $1)
-requests_after=$(awk '/^Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $2)
-hits_after=$(awk '/^Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' $2)
+requests_before=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $1)
+hits_before=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' $1)
+requests_after=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $2)
+hits_after=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' $2)
 
 # Calculate the differences to find out how many new requests and hits
 requests_diff=$((requests_after - requests_before))
 hits_diff=$((hits_after - hits_before))
 
+echo "New Compile Requests: $requests_diff" >&2
+echo "New Hits: $hits_diff" >&2
+
 # Calculate and print the hit rate
 if [ $requests_diff -eq 0 ]; then
-    echo "No new compile requests, hit rate is not applicable" 
+    echo "No new compile requests, hit rate is not applicable"
 else
     hit_rate=$(awk -v hits=$hits_diff -v requests=$requests_diff 'BEGIN {printf "%.2f", hits/requests * 100}')
     echo "sccache hit rate: $hit_rate%" >&2

--- a/ci/sccache_hit_rate.sh
+++ b/ci/sccache_hit_rate.sh
@@ -21,10 +21,10 @@ echo "=== End of $2 ===" >&2
 # Extract compile requests and cache hits from the before and after files
 awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $1 >&2
 awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $2 >&2
-requests_before=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $1)
-hits_before=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' $1)
-requests_after=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $2)
-hits_after=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' $2)
+requests_before=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' "$1")
+hits_before=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' "$1")
+requests_after=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' "$2")
+hits_after=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' "$2")
 
 echo $requests_before >&2
 echo $hits_before >&2

--- a/ci/sccache_hit_rate.sh
+++ b/ci/sccache_hit_rate.sh
@@ -19,17 +19,10 @@ cat $2 >&2
 echo "=== End of $2 ===" >&2
 
 # Extract compile requests and cache hits from the before and after files
-awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $1 >&2
-awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $2 >&2
-requests_before=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' "$1")
-hits_before=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' "$1")
-requests_after=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' "$2")
-hits_after=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' "$2")
-
-echo $requests_before >&2
-echo $hits_before >&2
-echo $requests_after >&2
-echo $hits_after >&2
+requests_before=$(awk '/^[ \t]*Compile requests[ \t]+[0-9]+/ {print $3}' "$1")
+hits_before=$(awk '/^[ \t]*Cache hits[ \t]+[0-9]+/ {print $3}' "$1")
+requests_after=$(awk '/^[ \t]*Compile requests[ \t]+[0-9]+/ {print $3}' "$2")
+hits_after=$(awk '/^[ \t]*Cache hits[ \t]+[0-9]+/ {print $3}' "$2")
 
 # Calculate the differences to find out how many new requests and hits
 requests_diff=$((requests_after - requests_before))

--- a/ci/sccache_hit_rate.sh
+++ b/ci/sccache_hit_rate.sh
@@ -19,10 +19,17 @@ cat $2 >&2
 echo "=== End of $2 ===" >&2
 
 # Extract compile requests and cache hits from the before and after files
+awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $1
+awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $2
 requests_before=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $1)
 hits_before=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' $1)
 requests_after=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $2)
 hits_after=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' $2)
+
+echo $requests_before >&2
+echo $hits_before >&2
+echo $requests_after >&2
+echo $hits_after >&2
 
 # Calculate the differences to find out how many new requests and hits
 requests_diff=$((requests_after - requests_before))

--- a/ci/sccache_hit_rate.sh
+++ b/ci/sccache_hit_rate.sh
@@ -4,19 +4,19 @@ set -euo pipefail
 
 # Ensure two arguments are provided
 if [ $# -ne 2 ]; then
-  echo "Usage: $0 <before-file> <after-file>"
+  echo "Usage: $0 <before-file> <after-file>" >&2
   exit 1
 fi
 
 # Print the contents of the before file
-echo "=== Contents of $1 ==="
-cat $1
-echo "=== End of $1 ==="
+echo "=== Contents of $1 ===" >&2
+cat $1 >&2
+echo "=== End of $1 ===" >&2
 
 # Print the contents of the after file
-echo "=== Contents of $2 ==="
-cat $2
-echo "=== End of $2 ==="
+echo "=== Contents of $2 ==="  >&2
+cat $2 >&2
+echo "=== End of $2 ===" >&2
 
 # Extract compile requests and cache hits from the before and after files
 requests_before=$(awk '/^Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $1)
@@ -30,10 +30,9 @@ hits_diff=$((hits_after - hits_before))
 
 # Calculate and print the hit rate
 if [ $requests_diff -eq 0 ]; then
-    echo "No new compile requests, hit rate is not applicable"
+    echo "No new compile requests, hit rate is not applicable" >&2
 else
     hit_rate=$(awk -v hits=$hits_diff -v requests=$requests_diff 'BEGIN {printf "%.2f", hits/requests * 100}')
-    echo "sccache hit rate: $hit_rate%"
-    # Write just the hit rate out to stderr to make it easier to get this value later
-    echo "$hit_rate" >&2
+    echo "sccache hit rate: $hit_rate%" >&2
+    echo "$hit_rate" 
 fi

--- a/ci/sccache_hit_rate.sh
+++ b/ci/sccache_hit_rate.sh
@@ -30,7 +30,7 @@ hits_diff=$((hits_after - hits_before))
 
 # Calculate and print the hit rate
 if [ $requests_diff -eq 0 ]; then
-    echo "No new compile requests, hit rate is not applicable" >&2
+    echo "No new compile requests, hit rate is not applicable" 
 else
     hit_rate=$(awk -v hits=$hits_diff -v requests=$requests_diff 'BEGIN {printf "%.2f", hits/requests * 100}')
     echo "sccache hit rate: $hit_rate%" >&2

--- a/ci/sccache_hit_rate.sh
+++ b/ci/sccache_hit_rate.sh
@@ -19,8 +19,8 @@ cat $2 >&2
 echo "=== End of $2 ===" >&2
 
 # Extract compile requests and cache hits from the before and after files
-awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $1
-awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $2
+awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $1 >&2
+awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/' $2 >&2
 requests_before=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $1)
 hits_before=$(awk '/^[[:space:]]*Cache hits[[:space:]]+[[:digit:]]+/ {print $3}' $1)
 requests_after=$(awk '/^[[:space:]]*Compile requests[[:space:]]+[[:digit:]]+/ {print $3}' $2)


### PR DESCRIPTION
Updates CI to use the same sccache bucket as is used within the devcontainers so that local builds within the devcontainers can hit from the cache populated by CI. 

This also required updating the workflow to move the source code to the `/home/coder/cccl` directory such that it will be in a consistent location between CI and local devcontainer development. 

While I'm at it, removed the submodules stuff as it is no longer needed. 