### PR TITLE
Remove submodules from CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,16 +31,6 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Echo git version
-        run: git --version
-      #TODO: We can remove this when we aren't using submodules anymore
-      - name: Update git version
-        run: |
-          sudo apt-get install software-properties-common
-          sudo add-apt-repository ppa:git-core/ppa -y
-          sudo apt-get update
-          sudo apt-get install git -y
-          git --version
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Configure credentials and environment variables for sccache
@@ -79,14 +69,6 @@ jobs:
     permissions:
       id-token: write
     steps:
-    # TODO: We can remove this when we aren't using submodules anymore
-      - name: Update git version
-        run: |
-          sudo apt-get install software-properties-common
-          sudo add-apt-repository ppa:git-core/ppa -y
-          sudo apt-get update
-          sudo apt-get install git -y
-          git --version
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Configure credentials and environment variables for sccache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,8 +43,6 @@ jobs:
           git --version
       - name: Checkout repo
         uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
       - name: Configure credentials and environment variables for sccache
         uses: ./.github/actions/configure_cccl_sccache
       - name: Run build script
@@ -91,8 +89,6 @@ jobs:
           git --version
       - name: Checkout repo
         uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
       - name: Configure credentials and environment variables for sccache
         uses: ./.github/actions/configure_cccl_sccache
       - name: Run test script


### PR DESCRIPTION
We don't need to do a recursive checkout or update the git version anymore. 