### PR TITLE
Fix async scan / counting iterator tests

### DIFF
--- a/thrust/testing/async/exclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/exclusive_scan/counting_iterator.cu
@@ -41,6 +41,6 @@ struct test_counting_iterator
 // Use built-in types only, counting_iterator doesn't seem to be compatible with
 // the custom_numeric.
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator,
-                                          BuiltinNumericTypes);
+                                          UnsignedIntegralTypes);
 
 #endif // C++14

--- a/thrust/testing/async/inclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/inclusive_scan/counting_iterator.cu
@@ -40,6 +40,6 @@ struct test_counting_iterator
 // Use built-in types only, counting_iterator doesn't seem to be compatible with
 // the custom_numeric.
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator,
-                                          BuiltinNumericTypes);
+                                          UnsignedIntegralTypes);
 
 #endif // C++14


### PR DESCRIPTION
Counting iterator mixin used for async scan tests is currently converting `std::size_t num_items` to `signed char`, leading to CI issues. This PR limits the test to unsigned types. Fixes https://github.com/NVIDIA/cccl/issues/117.