### PR TITLE
Fix compilation of thrust and cub

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -629,6 +629,10 @@ extern "C++" {
 #define _LIBCUDACXX_IS_LVALUE_REFERENCE(...) __is_lvalue_reference(__VA_ARGS__)
 #endif // __check_builtin(is_lvalue_reference)
 
+#if defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1103000
+#define _LIBCUDACXX_USE_IS_LVALUE_REFERENCE_FALLBACK
+#endif // nvcc < 11.3
+
 #if __check_builtin(is_nothrow_assignable) \
  || defined(_LIBCUDACXX_COMPILER_MSVC)     \
  || defined(_LIBCUDACXX_COMPILER_NVRTC)
@@ -650,6 +654,10 @@ extern "C++" {
 #if __check_builtin(is_object)
 #define _LIBCUDACXX_IS_OBJECT(...) __is_object(__VA_ARGS__)
 #endif // __check_builtin(is_object)
+
+#if defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1103000
+#define _LIBCUDACXX_USE_IS_OBJECT_FALLBACK
+#endif // nvcc < 11.3
 
 #if __check_builtin(is_pod)                                  \
  || (defined(_LIBCUDACXX_COMPILER_GCC)  && _GNUC_VER >= 403) \
@@ -748,6 +756,10 @@ extern "C++" {
 #if __check_builtin(is_unsigned)
 #define _LIBCUDACXX_IS_UNSIGNED(...) __is_unsigned(__VA_ARGS__)
 #endif // __check_builtin(is_unsigned)
+
+#if defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1103000
+#define _LIBCUDACXX_USE_IS_UNSIGNED_FALLBACK
+#endif // nvcc < 11.3
 
 // libstdc++ defines this as a function, breaking functionality
 #if 0 // __check_builtin(is_void)


### PR DESCRIPTION
Our build was broken due to use of builtins that old nvcc allowed, but couldnt handle

To ensure we can actually build stuff, disable those builtins