### PR TITLE
Change component section to more general "area"

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,15 +12,17 @@ body:
         - label: I confirmed there appear to be no [duplicate issues](https://github.com/NVIDIA/cccl/issues) for this request and that I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)
 
   - type: dropdown
-    id: component
+    id: area
     attributes:
-      label: Component
-      description: Which CCCL component does this apply to?
+      label: Area
+      description: What area does this request apply to?
       multiple: false
       options:
         - Thrust
         - CUB
         - libcu++
+        - General CCCL
+        - Infrastructure
         - Not sure
     validations:
       required: true


### PR DESCRIPTION
## Description

Closes: https://github.com/NVIDIA/cccl/issues/129 

Updates the feature request template "component" section to be more general.

I renamed "component" to "area" and added options for "General CCCL" and "Infrastructure".

I kept "not sure" for now just to be extra lenient to people filing issues who may not be sure if a request better belongs in Thrust/CUB/libcu++. 

## Checklist 
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.