### PR TITLE
Update PR template to more explicitly prompt for a linked issue closed by the PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Description
 
 <!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
-closes: <!-- Link issue here -->
+closes <!-- Link issue here -->
 
 <!-- Provide a standalone description of changes in this PR. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,10 @@
 ## Description
+
+<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
+closes: <!-- Link issue here -->
+
 <!-- Provide a standalone description of changes in this PR. -->
-<!-- Reference any issues closed by this PR with "closes #1234". -->
+
 <!-- Note: The pull request title will be included in the CHANGELOG. -->
 
 ## Checklist


### PR DESCRIPTION
## Description
closes: https://github.com/NVIDIA/cccl/issues/133

Updates the PR template to always include a "closes: " line to more explicitly prompt for a linked PR. 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.