### PR TITLE
Benchmark batched memcpy

### DIFF
--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -49,8 +49,6 @@
 #include <thrust/shuffle.h>
 #include <thrust/tabulate.h>
 
-#include "thrust/device_vector.h"
-#include "thrust/scan.h"
 #include <nvbench_helper.cuh>
 
 template <class T, class OffsetT>

--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -1,0 +1,241 @@
+/******************************************************************************
+ * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <cub/device/device_copy.cuh>
+
+#include <thrust/random.h>
+#include <thrust/scan.h>
+#include <thrust/scatter.h>
+#include <thrust/sequence.h>
+#include <thrust/shuffle.h>
+#include <thrust/tabulate.h>
+
+#include "thrust/device_vector.h"
+#include "thrust/scan.h"
+#include <nvbench_helper.cuh>
+
+template <class T, class OffsetT>
+struct offset_to_ptr_t
+{
+  T *d_ptr;
+  OffsetT *d_offsets;
+
+  __device__ T *operator()(OffsetT i) const { return d_ptr + d_offsets[i]; }
+};
+
+template <class T, class OffsetT>
+struct reordered_offset_to_ptr_t
+{
+  T *d_ptr;
+  OffsetT *d_map;
+  OffsetT *d_offsets;
+
+  __device__ T *operator()(OffsetT i) const { return d_ptr + d_offsets[d_map[i]]; }
+};
+
+template <class T, class OffsetT>
+struct offset_to_bytes_t
+{
+  OffsetT *d_offsets;
+
+  __device__ OffsetT operator()(OffsetT i) const
+  {
+    return (d_offsets[i + 1] - d_offsets[i]) * sizeof(T);
+  }
+};
+
+template <class T, class OffsetT>
+struct offset_to_size_t
+{
+  OffsetT *d_offsets;
+
+  __device__ OffsetT operator()(OffsetT i) const { return d_offsets[i + 1] - d_offsets[i]; }
+};
+
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_BUFFERS_PER_THREAD bpt 1:18:1
+// %RANGE% TUNE_TLEV_BYTES_PER_THREAD tlevbpt 2:16:2
+// %RANGE% TUNE_LARGE_THREADS ltpb 128:1024:32
+// %RANGE% TUNE_LARGE_BUFFER_BYTES_PER_THREAD lbbpt 4:128:4
+// %RANGE% TUNE_PREFER_POW2_BITS ppb 0:1:1
+
+#if !TUNE_BASE
+struct policy_hub_t
+{
+  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
+  {
+    using AgentSmallBufferPolicyT =
+      cub::detail::AgentBatchMemcpyPolicy<TUNE_THREADS,
+                                          TUNE_BUFFERS_PER_THREAD,
+                                          TUNE_TLEV_BYTES_PER_THREAD,
+                                          TUNE_PREFER_POW2_BITS,
+                                          TUNE_LARGE_THREADS * TUNE_LARGE_BUFFER_BYTES_PER_THREAD>;
+
+    using AgentLargeBufferPolicyT =
+      cub::detail::AgentBatchMemcpyLargeBuffersPolicy<TUNE_LARGE_THREADS,
+                                                      TUNE_LARGE_BUFFER_BYTES_PER_THREAD>;
+  };
+
+  using MaxPolicy = policy_t;
+};
+#endif
+
+template <class T, class OffsetT>
+void copy(nvbench::state &state, nvbench::type_list<T, OffsetT>)
+{
+  using offset_t           = OffsetT;
+  using it_t               = T *;
+  using input_buffer_it_t  = it_t *;
+  using output_buffer_it_t = it_t *;
+  using buffer_size_it_t   = offset_t *;
+  using buffer_offset_t    = std::uint32_t;
+  using block_offset_t     = std::uint32_t;
+
+  const auto elements        = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  const auto max_buffer_size = static_cast<std::size_t>(state.get_int64("MaxBufferSize"));
+  const auto min_buffer_size_ratio =
+    static_cast<std::size_t>(state.get_int64("MinBufferSizeRatio"));
+  const auto min_buffer_size =
+    static_cast<std::size_t>(static_cast<double>(max_buffer_size) / 100.0) * min_buffer_size_ratio;
+
+  constexpr bool is_memcpy = true;
+
+#if !TUNE_BASE
+  using policy_t = policy_hub_t;
+#else
+  using policy_t = cub::detail::DeviceBatchMemcpyPolicy;
+#endif
+
+  using dispatch_t = cub::detail::DispatchBatchMemcpy<input_buffer_it_t,
+                                                      output_buffer_it_t,
+                                                      buffer_size_it_t,
+                                                      buffer_offset_t,
+                                                      block_offset_t,
+                                                      policy_t,
+                                                      is_memcpy>;
+
+  thrust::device_vector<T> input_buffer(elements);
+  thrust::device_vector<T> output_buffer(elements);
+  thrust::device_vector<offset_t> offsets =
+    gen_uniform_offsets<offset_t>(seed_t{}, elements, min_buffer_size, max_buffer_size);
+  gen(seed_t{}, input_buffer);
+
+  T *d_input_buffer   = thrust::raw_pointer_cast(input_buffer.data());
+  T *d_output_buffer  = thrust::raw_pointer_cast(output_buffer.data());
+  offset_t *d_offsets = thrust::raw_pointer_cast(offsets.data());
+
+  const auto buffers = offsets.size() - 1;
+
+  thrust::device_vector<offset_t> buffer_sizes(buffers);
+  thrust::tabulate(buffer_sizes.begin(),
+                   buffer_sizes.end(),
+                   offset_to_bytes_t<T, offset_t>{d_offsets});
+
+  thrust::device_vector<it_t> input_buffers(buffers);
+  thrust::tabulate(input_buffers.begin(),
+                   input_buffers.end(),
+                   offset_to_ptr_t<T, offset_t>{d_input_buffer, d_offsets});
+
+  thrust::device_vector<it_t> output_buffers(buffers);
+
+  if (state.get_int64("RandomizeOutput"))
+  {
+    thrust::default_random_engine rne;
+    thrust::device_vector<offset_t> map(buffers);
+    thrust::sequence(map.begin(), map.end());
+    thrust::shuffle(map.begin(), map.end(), rne);
+    thrust::device_vector<offset_t> sizes(buffers);
+    thrust::tabulate(sizes.begin(), sizes.end(), offset_to_size_t<T, offset_t>{d_offsets});
+    thrust::scatter(sizes.begin(), sizes.end(), map.begin(), offsets.begin());
+    thrust::exclusive_scan(offsets.begin(), offsets.end(), offsets.begin());
+    offset_t *d_map = thrust::raw_pointer_cast(map.data());
+    thrust::tabulate(output_buffers.begin(),
+                     output_buffers.end(),
+                     reordered_offset_to_ptr_t<T, offset_t>{d_output_buffer, d_map, d_offsets});
+  }
+  else
+  {
+    thrust::tabulate(output_buffers.begin(),
+                     output_buffers.end(),
+                     offset_to_ptr_t<T, offset_t>{d_output_buffer, d_offsets});
+  }
+
+  // Clear the offsets vector to free memory
+  offsets.clear();
+  offsets.shrink_to_fit();
+  d_offsets = nullptr;
+
+  input_buffer_it_t d_input_buffers   = thrust::raw_pointer_cast(input_buffers.data());
+  output_buffer_it_t d_output_buffers = thrust::raw_pointer_cast(output_buffers.data());
+  buffer_size_it_t d_buffer_sizes     = thrust::raw_pointer_cast(buffer_sizes.data());
+
+  state.add_element_count(elements);
+  state.add_global_memory_writes<T>(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_reads<it_t>(buffers);
+  state.add_global_memory_reads<it_t>(buffers);
+  state.add_global_memory_reads<offset_t>(buffers);
+
+  std::size_t temp_storage_bytes{};
+  std::uint8_t *d_temp_storage{};
+  dispatch_t::Dispatch(d_temp_storage,
+                       temp_storage_bytes,
+                       d_input_buffers,
+                       d_output_buffers,
+                       d_buffer_sizes,
+                       buffers,
+                       0);
+
+  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    dispatch_t::Dispatch(d_temp_storage,
+                         temp_storage_bytes,
+                         d_input_buffers,
+                         d_output_buffers,
+                         d_buffer_sizes,
+                         buffers,
+                         launch.get_stream());
+  });
+}
+
+using types = nvbench::type_list<nvbench::uint8_t, nvbench::uint32_t>;
+
+#ifdef TUNE_OffsetT
+using u_offset_types = nvbench::type_list<TUNE_OffsetT>;
+#else
+using u_offset_types = nvbench::type_list<uint32_t, uint64_t>;
+#endif
+
+NVBENCH_BENCH_TYPES(copy, NVBENCH_TYPE_AXES(types, u_offset_types))
+  .set_name("cub::DeviceMemcpy::Batched")
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(25, 29, 2))
+  .add_int64_axis("MinBufferSizeRatio", {1, 99})
+  .add_int64_axis("MaxBufferSize", {8, 64, 256, 1024, 64 * 1024})
+  .add_int64_axis("RandomizeOutput", {0, 1});

--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -82,6 +82,8 @@ struct offset_to_size_t
 // %RANGE% TUNE_LARGE_THREADS ltpb 128:1024:32
 // %RANGE% TUNE_LARGE_BUFFER_BYTES_PER_THREAD lbbpt 4:128:4
 // %RANGE% TUNE_PREFER_POW2_BITS ppb 0:1:1
+// %RANGE% TUNE_WARP_LEVEL_THRESHOLD wlt 32:512:32
+// %RANGE% TUNE_BLOCK_LEVEL_THRESHOLD blt 1024:16384:512
 
 #if !TUNE_BASE
 struct policy_hub_t
@@ -93,7 +95,9 @@ struct policy_hub_t
                                           TUNE_BUFFERS_PER_THREAD,
                                           TUNE_TLEV_BYTES_PER_THREAD,
                                           TUNE_PREFER_POW2_BITS,
-                                          TUNE_LARGE_THREADS * TUNE_LARGE_BUFFER_BYTES_PER_THREAD>;
+                                          TUNE_LARGE_THREADS * TUNE_LARGE_BUFFER_BYTES_PER_THREAD,
+                                          TUNE_WARP_LEVEL_THRESHOLD,
+                                          TUNE_BLOCK_LEVEL_THRESHOLD>;
 
     using AgentLargeBufferPolicyT =
       cub::detail::AgentBatchMemcpyLargeBuffersPolicy<TUNE_LARGE_THREADS,

--- a/cub/benchmarks/nvbench_helper/CMakeLists.txt
+++ b/cub/benchmarks/nvbench_helper/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Fetch nvbench
 CPMAddPackage("gh:NVIDIA/nvbench#main")
 
-add_library(nvbench_helper SHARED nvbench_helper.cuh nvbench_helper.cu)
+add_library(nvbench_helper OBJECT nvbench_helper.cuh nvbench_helper.cu)
 target_link_libraries(nvbench_helper PUBLIC CUB::CUB 
                                             Thrust::Thrust 
                                             CUB::libcudacxx 

--- a/cub/benchmarks/nvbench_helper/nvbench_helper.cuh
+++ b/cub/benchmarks/nvbench_helper/nvbench_helper.cuh
@@ -118,7 +118,7 @@ inline double entropy_to_probability(bit_entropy entropy)
   }
 }
 
-[[nodiscard]] bit_entropy str_to_entropy(std::string str) 
+[[nodiscard]] inline bit_entropy str_to_entropy(std::string str) 
 {
   if (str == "1.000") 
   {
@@ -287,7 +287,7 @@ struct less_t
 };
 
 template <>
-__device__ bool less_t::operator()(const complex &lhs, const complex &rhs) {
+__device__ inline bool less_t::operator()(const complex &lhs, const complex &rhs) {
   double magnitude_0 = cuda::std::abs(lhs);
   double magnitude_1 = cuda::std::abs(rhs);
 

--- a/cub/benchmarks/scripts/analyze.py
+++ b/cub/benchmarks/scripts/analyze.py
@@ -390,6 +390,39 @@ def coverage_plot(args):
     iterate_case_dfs(args, case_coverage_plot)
 
 
+def case_pair_plot(algname, ct_point_name, case_df):
+    import seaborn as sns
+    data_list = []
+
+    for _, row_description in case_df.iterrows():
+        variant = row_description['variant']
+        speedup = row_description['speedup']
+
+        if variant.startswith('base'):
+            continue
+
+        varname, _ = variant.split(' ')
+        params = varname.split('.')
+        data_dict = {}
+
+        for param in params:
+            print(variant)
+            name, val = param.split('_')
+            data_dict[name] = int(val)
+
+        data_dict['speedup'] = speedup
+        data_list.append(data_dict)
+    
+    df = pd.DataFrame(data_list)
+    sns.pairplot(df, hue='speedup')
+    plt.title("{} ({})".format(algname, ct_point_name))
+    plt.show()
+
+
+def pair_plot(args):
+    iterate_case_dfs(args, case_pair_plot)
+
+
 def qrde_hd(samples):
     """
     Computes quantile-respectful density estimation based on the Harrell-Davis 
@@ -672,6 +705,8 @@ def parse_arguments():
     parser.add_argument(
         '--coverage-plot', action=argparse.BooleanOptionalAction, help="Plot variant space coverage.")
     parser.add_argument(
+        '--pair-plot', action=argparse.BooleanOptionalAction, help="Pair plot.")
+    parser.add_argument(
         '--top', default=7, type=int, action='store', nargs='?', help="Show top N variants with highest score.")
     parser.add_argument(
         'files', type=file_exists, nargs='+', help='At least one file is required.')
@@ -697,6 +732,10 @@ def main():
 
     if args.coverage_plot:
         coverage_plot(args)
+        return
+
+    if args.pair_plot:
+        pair_plot(args)
         return
     
     if args.variants_pdf:

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -480,7 +480,9 @@ template <uint32_t _BLOCK_THREADS,
           uint32_t _BUFFERS_PER_THREAD,
           uint32_t _TLEV_BYTES_PER_THREAD,
           bool _PREFER_POW2_BITS,
-          uint32_t _BLOCK_LEVEL_TILE_SIZE>
+          uint32_t _BLOCK_LEVEL_TILE_SIZE,
+          uint32_t _WARP_LEVEL_THRESHOLD,
+          uint32_t _BLOCK_LEVEL_THRESHOLD>
 struct AgentBatchMemcpyPolicy
 {
   /// Threads per thread block
@@ -496,6 +498,9 @@ struct AgentBatchMemcpyPolicy
   static constexpr uint32_t PREFER_POW2_BITS = _PREFER_POW2_BITS;
   /// BLEV tile size granularity
   static constexpr uint32_t BLOCK_LEVEL_TILE_SIZE = _BLOCK_LEVEL_TILE_SIZE;
+
+  static constexpr uint32_t WARP_LEVEL_THRESHOLD  = _WARP_LEVEL_THRESHOLD;
+  static constexpr uint32_t BLOCK_LEVEL_THRESHOLD = _BLOCK_LEVEL_THRESHOLD;
 };
 
 template <typename AgentMemcpySmallBuffersPolicyT,
@@ -531,8 +536,11 @@ private:
   static constexpr uint32_t TLEV_BUFFERS_PER_THREAD = BUFFERS_PER_THREAD;
   static constexpr uint32_t BLEV_BUFFERS_PER_THREAD = BUFFERS_PER_THREAD;
 
-  static constexpr uint32_t WARP_LEVEL_THRESHOLD  = 128;
-  static constexpr uint32_t BLOCK_LEVEL_THRESHOLD = 8 * 1024;
+  static constexpr uint32_t WARP_LEVEL_THRESHOLD =
+    AgentMemcpySmallBuffersPolicyT::WARP_LEVEL_THRESHOLD;
+
+  static constexpr uint32_t BLOCK_LEVEL_THRESHOLD =
+    AgentMemcpySmallBuffersPolicyT::BLOCK_LEVEL_THRESHOLD;
 
   static constexpr uint32_t BUFFER_STABLE_PARTITION = false;
 

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -482,7 +482,9 @@ template <uint32_t _BLOCK_THREADS,
           bool _PREFER_POW2_BITS,
           uint32_t _BLOCK_LEVEL_TILE_SIZE,
           uint32_t _WARP_LEVEL_THRESHOLD,
-          uint32_t _BLOCK_LEVEL_THRESHOLD>
+          uint32_t _BLOCK_LEVEL_THRESHOLD,
+          class BuffDelayConstructor,
+          class BlockDelayConstructor>
 struct AgentBatchMemcpyPolicy
 {
   /// Threads per thread block
@@ -501,6 +503,9 @@ struct AgentBatchMemcpyPolicy
 
   static constexpr uint32_t WARP_LEVEL_THRESHOLD  = _WARP_LEVEL_THRESHOLD;
   static constexpr uint32_t BLOCK_LEVEL_THRESHOLD = _BLOCK_LEVEL_THRESHOLD;
+
+  using buff_delay_constructor = BuffDelayConstructor;
+  using block_delay_constructor = BlockDelayConstructor;
 };
 
 template <typename AgentMemcpySmallBuffersPolicyT,
@@ -640,9 +645,18 @@ private:
                                                 static_cast<int32_t>(TLEV_BYTES_PER_THREAD)>;
 
   using BLevBuffScanPrefixCallbackOpT =
-    TilePrefixCallbackOp<BufferOffsetT, Sum, BLevBufferOffsetTileState>;
+    TilePrefixCallbackOp<BufferOffsetT,
+                         Sum,
+                         BLevBufferOffsetTileState,
+                         0,
+                         typename AgentMemcpySmallBuffersPolicyT::buff_delay_constructor>;
+
   using BLevBlockScanPrefixCallbackOpT =
-    TilePrefixCallbackOp<BlockOffsetT, Sum, BLevBlockOffsetTileState>;
+    TilePrefixCallbackOp<BlockOffsetT,
+                         Sum,
+                         BLevBlockOffsetTileState,
+                         0,
+                         typename AgentMemcpySmallBuffersPolicyT::block_delay_constructor>;
 
   //-----------------------------------------------------------------------------
   // SHARED MEMORY DECLARATIONS

--- a/cub/cub/device/device_copy.cuh
+++ b/cub/cub/device/device_copy.cuh
@@ -158,7 +158,7 @@ struct DeviceCopy
                                        SizeIteratorT,
                                        RangeOffsetT,
                                        BlockOffsetT,
-                                       detail::DeviceBatchMemcpyPolicy,
+                                       detail::DeviceBatchMemcpyPolicy<RangeOffsetT, BlockOffsetT>,
                                        false>::Dispatch(d_temp_storage,
                                                         temp_storage_bytes,
                                                         input_it,

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -165,7 +165,7 @@ struct DeviceMemcpy
                                        BufferSizeIteratorT,
                                        BufferOffsetT,
                                        BlockOffsetT,
-                                       detail::DeviceBatchMemcpyPolicy,
+                                       detail::DeviceBatchMemcpyPolicy<BufferOffsetT, BlockOffsetT>,
                                        true>::Dispatch(d_temp_storage,
                                                        temp_storage_bytes,
                                                        input_buffer_it,

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -278,6 +278,9 @@ struct DeviceBatchMemcpyPolicy
   static constexpr uint32_t LARGE_BUFFER_BLOCK_THREADS    = 256U;
   static constexpr uint32_t LARGE_BUFFER_BYTES_PER_THREAD = 32U;
 
+  static constexpr uint32_t WARP_LEVEL_THRESHOLD  = 128;
+  static constexpr uint32_t BLOCK_LEVEL_THRESHOLD = 8 * 1024;
+
   /// SM35
   struct Policy350 : ChainedPolicy<350, Policy350, Policy350>
   {
@@ -287,7 +290,9 @@ struct DeviceBatchMemcpyPolicy
                              BUFFERS_PER_THREAD,
                              TLEV_BYTES_PER_THREAD,
                              PREFER_POW2_BITS,
-                             LARGE_BUFFER_BLOCK_THREADS * LARGE_BUFFER_BYTES_PER_THREAD>;
+                             LARGE_BUFFER_BLOCK_THREADS * LARGE_BUFFER_BYTES_PER_THREAD,
+                             WARP_LEVEL_THRESHOLD,
+                             BLOCK_LEVEL_THRESHOLD>;
 
     using AgentLargeBufferPolicyT =
       AgentBatchMemcpyLargeBuffersPolicy<LARGE_BUFFER_BLOCK_THREADS, LARGE_BUFFER_BYTES_PER_THREAD>;
@@ -302,7 +307,9 @@ struct DeviceBatchMemcpyPolicy
                              BUFFERS_PER_THREAD,
                              TLEV_BYTES_PER_THREAD,
                              PREFER_POW2_BITS,
-                             LARGE_BUFFER_BLOCK_THREADS * LARGE_BUFFER_BYTES_PER_THREAD>;
+                             LARGE_BUFFER_BLOCK_THREADS * LARGE_BUFFER_BYTES_PER_THREAD,
+                             WARP_LEVEL_THRESHOLD,
+                             BLOCK_LEVEL_THRESHOLD>;
 
     using AgentLargeBufferPolicyT =
       AgentBatchMemcpyLargeBuffersPolicy<LARGE_BUFFER_BLOCK_THREADS, LARGE_BUFFER_BYTES_PER_THREAD>;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Apart from fixing https://github.com/NVIDIA/cccl/issues/135, this issue addresses https://github.com/NVIDIA/cub/issues/719 related issue by making nvbench helper object library instead of shared one. Also adds a pair plot to help see correlation in tuning parameters. 

![pairplot](https://github.com/NVIDIA/cccl/assets/9890394/bc65133e-1eee-4b49-9cb5-51af4d017c61)

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
