### PR TITLE
Fix `tuple_cat` for `std::` qualified types

### DIFF
--- a/libcudacxx/.upstream-tests/test/cuda/tuple/forward_as_tuple_interop.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/tuple/forward_as_tuple_interop.pass.cpp
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++11
+// UNSUPPORTED: nvrtc
+#include <nv/target>
+
+#include <tuple>
+
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+constexpr bool test() {
+    // Ensure we can use std:: types inside cuda::std::make_tuple
+    {
+        using ret = cuda::std::tuple<cuda::std::integral_constant<int, 42>, std::integral_constant<int, 1337>>;
+        auto t = cuda::std::make_tuple(cuda::std::integral_constant<int, 42>(),
+                                             std::integral_constant<int, 1337>());
+        static_assert(cuda::std::is_same<decltype(t), ret>::value, "");
+        assert(cuda::std::get<0>(t) == 42);
+        assert(cuda::std::get<1>(t) == 1337);
+    }
+
+    // Ensure we can use std:: types inside cuda::std::tuple_cat
+    {
+        using ret = cuda::std::tuple<cuda::std::integral_constant<int, 42>, std::integral_constant<int, 1337>>;
+        auto t = cuda::std::tuple_cat(cuda::std::make_tuple(cuda::std::integral_constant<int, 42>()),
+                                      cuda::std::make_tuple(      std::integral_constant<int, 1337>()));
+        static_assert(cuda::std::is_same<decltype(t), ret>::value, "");
+        assert(cuda::std::get<0>(t) == 42);
+        assert(cuda::std::get<1>(t) == 1337);
+    }
+
+    return true;
+}
+
+int main(int arg, char ** argv)
+{
+NV_IF_TARGET(
+NV_IS_HOST, (
+    test();
+    static_assert(test(), "");
+));
+
+    return 0;
+}

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -1407,8 +1407,8 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
     operator()(tuple<_Types...> __t, _Tuple0&& __t0)
     {
         (void)__t;
-        return forward_as_tuple(_CUDA_VSTD::forward<_Types>(_CUDA_VSTD::get<_I0>(__t))...,
-                                      _CUDA_VSTD::get<_J0>(_CUDA_VSTD::forward<_Tuple0>(__t0))...);
+        return _CUDA_VSTD::forward_as_tuple(_CUDA_VSTD::forward<_Types>(_CUDA_VSTD::get<_I0>(__t))...,
+                                            _CUDA_VSTD::get<_J0>(_CUDA_VSTD::forward<_Tuple0>(__t0))...);
     }
 
     template <class _Tuple0, class _Tuple1, class ..._Tuples>
@@ -1423,7 +1423,7 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
            tuple<_Types..., typename __apply_cv<_Tuple0, typename tuple_element<_J0, _T0>::type>::type&&...>,
            typename __make_tuple_indices<sizeof ...(_Types) + tuple_size<_T0>::value>::type,
            typename __make_tuple_indices<tuple_size<_T1>::value>::type>()
-                           (forward_as_tuple(
+                           (_CUDA_VSTD::forward_as_tuple(
                               _CUDA_VSTD::forward<_Types>(_CUDA_VSTD::get<_I0>(__t))...,
                               _CUDA_VSTD::get<_J0>(_CUDA_VSTD::forward<_Tuple0>(__t0))...
                             ),


### PR DESCRIPTION
We werent properly qualifying `forward_as_tuple` inside tuple_cat. Together with ADL this created ambiguous overloads.