### PR TITLE
Properly querry `CMAKE_CUDA_COMPILER_LAUNCHER` for ccache support

### DIFF
--- a/libcudacxx/.upstream-tests/test/lit.site.cfg.in
+++ b/libcudacxx/.upstream-tests/test/lit.site.cfg.in
@@ -17,7 +17,6 @@ config.configuration_variant    = "libcudacxx"
 config.host_triple              = "@LLVM_HOST_TRIPLE@"
 config.target_triple            = "@TARGET_TRIPLE@"
 config.use_target               = bool("@LIBCUDACXX_TARGET_TRIPLE@")
-config.use_ccache               = True
 config.generate_coverage        = False
 config.target_info              = "@LIBCUDACXX_TARGET_INFO@"
 config.test_linker_flags        = "@LIBCUDACXX_TEST_LINKER_FLAGS@"

--- a/libcudacxx/.upstream-tests/utils/libcudacxx/compiler.py
+++ b/libcudacxx/.upstream-tests/utils/libcudacxx/compiler.py
@@ -153,7 +153,7 @@ class CXXCompiler(object):
         if self.use_ccache \
                 and not mode == self.CM_Link \
                 and not mode == self.CM_PreProcess:
-            cmd += ['sccache']
+            cmd += [os.environ.get('CMAKE_CUDA_COMPILER_LAUNCHER')]
         cmd += [self.path] + ([self.first_arg] if self.first_arg != '' else [])
         if out is not None:
             cmd += ['-o', out]

--- a/libcudacxx/.upstream-tests/utils/libcudacxx/test/config.py
+++ b/libcudacxx/.upstream-tests/utils/libcudacxx/test/config.py
@@ -421,7 +421,7 @@ class Configuration(object):
             self.config.available_features.add('no_execute')
 
     def configure_ccache(self):
-        use_ccache_default = os.environ.get('LIBCUDACXX_USE_CCACHE') is not None
+        use_ccache_default = os.environ.get('CMAKE_CUDA_COMPILER_LAUNCHER') is not None
         use_ccache = self.get_lit_bool('use_ccache', use_ccache_default)
         if use_ccache:
             self.cxx.use_ccache = True

--- a/libcudacxx/libcxx/test/lit.site.cfg.in
+++ b/libcudacxx/libcxx/test/lit.site.cfg.in
@@ -20,7 +20,6 @@ config.configuration_variant    = "@LIBCXX_LIT_VARIANT@"
 config.host_triple              = "@LLVM_HOST_TRIPLE@"
 config.target_triple            = "@TARGET_TRIPLE@"
 config.use_target               = bool("@LIBCXX_TARGET_TRIPLE@")
-config.use_ccache               = True
 config.sysroot                  = "@LIBCXX_SYSROOT@"
 config.gcc_toolchain            = "@LIBCXX_GCC_TOOLCHAIN@"
 config.generate_coverage        = @LIBCXX_GENERATE_COVERAGE@

--- a/libcudacxx/libcxx/utils/libcxx/compiler.py
+++ b/libcudacxx/libcxx/utils/libcxx/compiler.py
@@ -153,7 +153,7 @@ class CXXCompiler(object):
         if self.use_ccache \
                 and not mode == self.CM_Link \
                 and not mode == self.CM_PreProcess:
-            cmd += ['sccache']
+            cmd += [os.environ.get('CMAKE_CXX_COMPILER_LAUNCHER')]
         cmd += [self.path] + ([self.first_arg] if self.first_arg != '' else [])
         if out is not None:
             cmd += ['-o', out]

--- a/libcudacxx/libcxx/utils/libcxx/test/config.py
+++ b/libcudacxx/libcxx/utils/libcxx/test/config.py
@@ -417,7 +417,7 @@ class Configuration(object):
             self.config.available_features.add('no_execute')
 
     def configure_ccache(self):
-        use_ccache_default = os.environ.get('LIBCXX_USE_CCACHE') is not None
+        use_ccache_default = os.environ.get('CMAKE_CXX_COMPILER_LAUNCHER') is not None
         use_ccache = self.get_lit_bool('use_ccache', use_ccache_default)
         if use_ccache:
             self.cxx.use_ccache = True


### PR DESCRIPTION
We hardcoded it in a first attempt.

Now after sleeping over it we should simply query the environment variable