### PR TITLE
Improve implementation of `destructible`

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/destructible.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/destructible.h
@@ -15,8 +15,12 @@
 #endif //__cuda_std__
 
 #include "../__concepts/__concept_macros.h"
+#include "../__type_traits/enable_if.h"
+#include "../__type_traits/is_destructible.h"
 #include "../__type_traits/is_object.h"
 #include "../__type_traits/is_nothrow_destructible.h"
+#include "../__type_traits/void_t.h"
+#include "../__utility/declval.h"
 
 #if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
 #pragma GCC system_header
@@ -24,54 +28,37 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _LIBCUDACXX_STD_VER > 11 && _GNUC_VER < 1100
-
-template<class _Tp>
-_LIBCUDACXX_CONCEPT destructible = is_nothrow_destructible_v<_Tp>;
-
-#else
-// [concept.destructible]
-#if _LIBCUDACXX_STD_VER > 17
-
-template<class _Tp>
-constexpr bool __destructible_impl = false;
-
-template<class _Tp>
-    requires requires(_Tp& __t) { { __t.~_Tp() } noexcept; }
-constexpr bool __destructible_impl<_Tp> = true;
-
-#elif _LIBCUDACXX_STD_VER > 11
-
-template<class _Tp>
-_LIBCUDACXX_CONCEPT_FRAGMENT(
-  __destructible_impl_req_,
-  requires(_Tp& __t)(
-    requires(is_object_v<_Tp>),
-    requires(noexcept(__t.~_Tp()))
-  ));
-
-template<class _Tp>
-constexpr bool __destructible_impl = _LIBCUDACXX_FRAGMENT(__destructible_impl_req_, _Tp);
-#endif // _LIBCUDACXX_STD_VER > 11
-
 #if _LIBCUDACXX_STD_VER > 11
-template<class _Tp>
-constexpr bool __destructible = __destructible_impl<_Tp>;
+
+template<class _Tp, class = void, class = void>
+_LIBCUDACXX_INLINE_VAR constexpr bool __destructible_impl = false;
 
 template<class _Tp>
-constexpr bool __destructible<_Tp&> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __destructible_impl<_Tp,
+                                   __enable_if_t<_LIBCUDACXX_TRAIT(is_object, _Tp)>,
+#if defined(_LIBCUDACXX_COMPILER_GCC)
+                                   __enable_if_t<_LIBCUDACXX_TRAIT(is_destructible, _Tp)>>
+#else // ^^^ defined(_LIBCUDACXX_COMPILER_GCC) ^^^ / vvv !_LIBCUDACXX_COMPILER_GCC vvv
+                                   __void_t<decltype(_CUDA_VSTD::declval<_Tp>().~_Tp())>>
+#endif // !_LIBCUDACXX_COMPILER_GCC
+                                   = noexcept(_CUDA_VSTD::declval<_Tp>().~_Tp());
 
 template<class _Tp>
-constexpr bool __destructible<_Tp&&> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __destructible = __destructible_impl<_Tp>;
+
+template<class _Tp>
+_LIBCUDACXX_INLINE_VAR constexpr bool __destructible<_Tp&> = true;
+
+template<class _Tp>
+_LIBCUDACXX_INLINE_VAR constexpr bool __destructible<_Tp&&> = true;
 
 template<class _Tp, size_t _Nm>
-constexpr bool __destructible<_Tp[_Nm]> = __destructible<_Tp>;
+_LIBCUDACXX_INLINE_VAR constexpr bool __destructible<_Tp[_Nm]> = __destructible<_Tp>;
 
 template<class _Tp>
 _LIBCUDACXX_CONCEPT destructible = __destructible<_Tp>;
 
 #endif // _LIBCUDACXX_STD_VER > 11
-#endif // _GNUC_VER < 1100
 
 _LIBCUDACXX_END_NAMESPACE_STD
 


### PR DESCRIPTION
Our implementation worked around some issues with older gcc.

However, those break when used with more complex ranges concepts. We can work around this by just falling back to `is_destructible` in that case and go our merry way.

While we are at it also simplify the implementation a bit and add `_LIBCUDACXX_INLINE_VAR`