### PR TITLE
Ensure all headers build individually

### DIFF
--- a/libcudacxx/.upstream-tests/maintenance/all-internal-headers
+++ b/libcudacxx/.upstream-tests/maintenance/all-internal-headers
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#this creates a set of tests, that ensures, that all itnernal headers can be build independently
+
+set -e
+
+internal_headers=$(find ../../include -path "*cuda/std/detail/libcxx/include/__*/*" -not -path "*/__cuda/*")
+
+cd ../../test/libcxx/selftest/internal_headers
+
+for f in $internal_headers
+do
+    short_path=${f##*../include/}
+    test_name=${f##*include/}
+    test_name=${test_name%.h}.pass.cpp
+
+    mkdir -p -- "${test_name%/*}"
+    cat > $test_name << EOL
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/version>
+#include <$short_path>
+
+int main(int, char**) { return 0; }
+EOL
+done

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__mdspan/layout_left.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__mdspan/layout_left.h
@@ -50,6 +50,7 @@
 
 #include "../__assert"
 #include "../__mdspan/extents.h"
+#include "../__mdspan/layout_stride.h"
 #include "../__mdspan/macros.h"
 #include "../__type_traits/is_constructible.h"
 #include "../__type_traits/is_convertible.h"

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__mdspan/type_list.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__mdspan/type_list.h
@@ -49,6 +49,7 @@
 #endif // __cuda_std__
 
 #include "../__mdspan/macros.h"
+#include "../__utility/integer_sequence.h"
 
 #if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
 #pragma GCC system_header

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_fundamental.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_fundamental.h
@@ -15,6 +15,7 @@
 #endif // __cuda_std__
 
 #include "../__type_traits/integral_constant.h"
+#include "../__type_traits/is_arithmetic.h"
 #include "../__type_traits/is_null_pointer.h"
 #include "../__type_traits/is_void.h"
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/in_place.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/in_place.h
@@ -16,6 +16,7 @@
 
 #include "../__type_traits/is_reference.h"
 #include "../__type_traits/remove_reference.h"
+#include "../__type_traits/remove_cvref.h"
 
 #if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
 #pragma GCC system_header

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/exception
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/exception
@@ -76,11 +76,14 @@ template <class E> void rethrow_if_nested(const E& e);
 
 */
 
+#ifndef __cuda_std__
 #include <__config>
-#include <cstddef>
-#include <cstdlib>
-#include <type_traits>
-#include <version>
+#endif //__cuda_std__
+
+#include "cstddef"
+#include "cstdlib"
+#include "type_traits"
+#include "version"
 
 #if defined(_LIBCUDACXX_ABI_VCRUNTIME)
 #include <vcruntime_exception.h>
@@ -90,16 +93,15 @@ template <class E> void rethrow_if_nested(const E& e);
 #pragma GCC system_header
 #endif
 
-namespace std  // purposefully not using versioning namespace
-{
+_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION  // purposefully not using versioning namespace
 
 #if !defined(_LIBCUDACXX_ABI_VCRUNTIME)
 class _LIBCUDACXX_EXCEPTION_ABI exception
 {
 public:
     _LIBCUDACXX_INLINE_VISIBILITY exception() _NOEXCEPT {}
-    virtual ~exception() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE virtual ~exception() _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE virtual const char* what() const _NOEXCEPT;
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI bad_exception
@@ -107,8 +109,8 @@ class _LIBCUDACXX_EXCEPTION_ABI bad_exception
 {
 public:
     _LIBCUDACXX_INLINE_VISIBILITY bad_exception() _NOEXCEPT {}
-    virtual ~bad_exception() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE virtual ~bad_exception() _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE virtual const char* what() const _NOEXCEPT;
 };
 #endif // !_LIBCUDACXX_ABI_VCRUNTIME
 
@@ -324,6 +326,6 @@ rethrow_if_nested(const _Ep&,
 {
 }
 
-}  // std
+_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
 
 #endif  // _LIBCUDACXX_EXCEPTION

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/stdexcept
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/stdexcept
@@ -50,6 +50,7 @@ public:
 #endif //__cuda_std__
 
 #include "__assert" // all public C++ headers provide the assertion handler
+#include "cstdlib"
 #include "iosfwd"
 
 #ifndef __cuda_std__


### PR DESCRIPTION
We want to ensure that each and every header includes what it needs. Otherwise we can get ugly bugs regarding include order.

I did not add the individual test files because that would be a lot of churn 