### PR TITLE
Add a configuration to test libcu++ with nvrtc

### DIFF
--- a/.devcontainer/cuda12.1-nvrtc/devcontainer.json
+++ b/.devcontainer/cuda12.1-nvrtc/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "shutdownAction": "stopContainer",
+  "image": "rapidsai/devcontainers:23.06-cpp-gcc12-cuda12.1-ubuntu22.04",
+  "hostRequirements": {
+    "gpu": true
+  },
+  "initializeCommand": [
+    "/bin/bash",
+    "-c",
+    "mkdir -m 0755 -p ${localWorkspaceFolder}/.{aws,cache,config}"
+  ],
+  "containerEnv": {
+    "SCCACHE_REGION": "us-east-2",
+    "SCCACHE_BUCKET": "rapids-sccache-devs",
+    "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
+    "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
+    "DEVCONTAINER_NAME": "cuda12.1-nvrtc12.1",
+    "LIBCUDACXX_USE_NVRTC": "ON"
+  },
+  "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
+  "mounts": [
+    "source=${localWorkspaceFolder}/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/.config,target=/home/coder/.config,type=bind,consistency=consistent"
+  ],
+  "name": "cuda12.1-nvrtc12.1"
+}

--- a/ci/build_cub.sh
+++ b/ci/build_cub.sh
@@ -2,6 +2,11 @@
 
 source "$(dirname "$0")/build_common.sh"
 
+if [ -n ${LIBCUDACXX_USE_NVRTC+x} ]; then
+    echo "The LIBCUDACXX_USE_NVRTC configuration is only used for libcu++. Not running any tests."
+    exit 0
+fi
+
 CMAKE_OPTIONS="
     -DCCCL_ENABLE_THRUST=OFF \
     -DCCCL_ENABLE_LIBCUDACXX=OFF \

--- a/ci/build_libcudacxx.sh
+++ b/ci/build_libcudacxx.sh
@@ -2,12 +2,20 @@
 
 source "$(dirname "$0")/build_common.sh"
 
+if [ -z ${LIBCUDACXX_USE_NVRTC+x} ]; then
+    LIBCUDACXX_USE_NVRTC=OFF
+elif [ ${LIBCUDACXX_USE_NVRTC+x} != "ON" && ${LIBCUDACXX_USE_NVRTC+x} != "OFF"]; then
+    echo "The LIBCUDACXX_USE_NVRTC environment variable must be set to either \"ON\" or \"OFF\""
+    exit 1
+fi
+
 CMAKE_OPTIONS="
     -DCCCL_ENABLE_THRUST=OFF \
     -DCCCL_ENABLE_LIBCUDACXX=ON \
     -DCCCL_ENABLE_CUB=OFF \
     -DCCCL_ENABLE_TESTING=OFF \
     -DLIBCUDACXX_ENABLE_LIBCUDACXX_TESTS=ON \
+    -DLIBCUDACXX_TEST_WITH_NVRTC=${LIBCUDACXX_USE_NVRTC} \
 "
 configure "$CMAKE_OPTIONS"
 

--- a/ci/build_thrust.sh
+++ b/ci/build_thrust.sh
@@ -2,6 +2,11 @@
 
 source "$(dirname "$0")/build_common.sh"
 
+if [ -n ${LIBCUDACXX_USE_NVRTC+x} ]; then
+    echo "The LIBCUDACXX_USE_NVRTC configuration is only used for libcu++. Not running any tests."
+    exit 0
+fi
+
 CMAKE_OPTIONS="
       -DCCCL_ENABLE_THRUST=ON \
       -DCCCL_ENABLE_LIBCUDACXX=OFF \

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -40,3 +40,4 @@ pull-request:
 - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '13', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20]}
 - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '14', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20]}
 - {cuda: '12.1', os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'llvm', version: '15', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20]}
+- {cuda: '12.1', os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'nvrtc', version: '12.1', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17, 20]}

--- a/ci/test_cub.sh
+++ b/ci/test_cub.sh
@@ -2,6 +2,11 @@
 
 set -xeuo pipefail
 
+if [ -n ${LIBCUDACXX_USE_NVRTC+x} ]; then
+    echo "The LIBCUDACXX_USE_NVRTC configuration is only used for libcu++. Not running any tests."
+    exit 0
+fi
+
 # Ensure the script is being executed in its containing directory
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 

--- a/ci/test_libcudacxx.sh
+++ b/ci/test_libcudacxx.sh
@@ -2,6 +2,13 @@
 
 source "$(dirname "$0")/build_common.sh"
 
+if [ -z ${LIBCUDACXX_USE_NVRTC+x} ]; then
+    LIBCUDACXX_USE_NVRTC=OFF
+elif [ ${LIBCUDACXX_USE_NVRTC+x} != "ON" && ${LIBCUDACXX_USE_NVRTC+x} != "OFF"]; then
+    echo "The LIBCUDACXX_USE_NVRTC environment variable must be set to either \"ON\" or \"OFF\""
+    exit 1
+fi
+
 cmake -S .. -B ../build \
     -DCCCL_ENABLE_THRUST=OFF \
     -DCCCL_ENABLE_LIBCUDACXX=ON \
@@ -13,6 +20,7 @@ cmake -S .. -B ../build \
     -DCMAKE_CUDA_HOST_COMPILER=${HOST_COMPILER} \
     -DLIBCUDACXX_ENABLE_LIBCUDACXX_TESTS=ON \
     -Dlibcudacxx_ENABLE_INSTALL_RULES=ON \
+    -DLIBCUDACXX_TEST_WITH_NVRTC=${LIBCUDACXX_USE_NVRTC} \
     -DCUB_ENABLE_INSTALL_RULES=ON \
     -DTHRUST_ENABLE_INSTALL_RULES=ON \
     -G Ninja

--- a/ci/test_thrust.sh
+++ b/ci/test_thrust.sh
@@ -2,6 +2,11 @@
 
 set -xeuo pipefail
 
+if [ -n ${LIBCUDACXX_USE_NVRTC+x} ]; then
+    echo "The LIBCUDACXX_USE_NVRTC configuration is only used for libcu++. Not running any tests."
+    exit 0
+fi
+
 # Ensure the script is being executed in its containing directory
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 

--- a/libcudacxx/.upstream-tests/utils/libcudacxx/test/config.py
+++ b/libcudacxx/.upstream-tests/utils/libcudacxx/test/config.py
@@ -423,7 +423,7 @@ class Configuration(object):
     def configure_ccache(self):
         use_ccache_default = os.environ.get('CMAKE_CUDA_COMPILER_LAUNCHER') is not None
         use_ccache = self.get_lit_bool('use_ccache', use_ccache_default)
-        if use_ccache:
+        if use_ccache and not self.cxx.is_nvrtc:
             self.cxx.use_ccache = True
             self.lit_config.note('enabling ccache')
 


### PR DESCRIPTION
We want to support building and testing libcu++ with nvrtc

Therefor add a devcontainer that sets a special environment variable that we can use to detect nvrtc.

in case we want to test with nvrtc we skip both cub and thrust tests