### PR TITLE
[NFC] Modularize `<exception>`

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/utilities/memory/sanity/sanity.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/memory/sanity/sanity.pass.cpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/memory>
+
+// template <ObjectType T> T* addressof(T& r);
+
+#include <cuda/std/__memory>
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/include/cuda/std/__memory
+++ b/libcudacxx/include/cuda/std/__memory
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_MEMORY
+#define _CUDA_STD_MEMORY
+
+#include "detail/__config"
+
+#include "detail/__pragma_push"
+
+#include "detail/libcxx/include/memory"
+
+#include "detail/__pragma_pop"
+
+#endif // _CUDA_STD_MEMORY

--- a/libcudacxx/include/cuda/std/cstdlib
+++ b/libcudacxx/include/cuda/std/cstdlib
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_CSTDLIB
+#define _CUDA_STD_CSTDLIB
+
+#include "detail/__config"
+
+#include "detail/__pragma_push"
+
+#include "detail/libcxx/include/cstdlib"
+
+#include "detail/__pragma_pop"
+
+#endif // _CUDA_STD_CSTDLIB

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
@@ -46,6 +46,7 @@ set(files
   __expected/unexpect.h
   __expected/unexpected.h
   __exception/exception.h
+  __exception/operations.h
   __functional/binary_function.h
   __functional/binary_negate.h
   __functional/bind_back.h

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
@@ -45,6 +45,7 @@ set(files
   __expected/unexpected.h
   __expected/unexpect.h
   __expected/unexpected.h
+  __exception/exception_ptr.h
   __exception/exception.h
   __exception/operations.h
   __exception/terminate.h

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
@@ -47,6 +47,7 @@ set(files
   __expected/unexpected.h
   __exception/exception.h
   __exception/operations.h
+  __exception/terminate.h
   __functional/binary_function.h
   __functional/binary_negate.h
   __functional/bind_back.h

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
@@ -47,6 +47,7 @@ set(files
   __expected/unexpected.h
   __exception/exception_ptr.h
   __exception/exception.h
+  __exception/nested_exception.h
   __exception/operations.h
   __exception/terminate.h
   __functional/binary_function.h

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
@@ -45,6 +45,7 @@ set(files
   __expected/unexpected.h
   __expected/unexpect.h
   __expected/unexpected.h
+  __exception/exception.h
   __functional/binary_function.h
   __functional/binary_negate.h
   __functional/bind_back.h

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -1445,11 +1445,13 @@ typedef __char32_t char32_t;
 #  define _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION namespace cuda { namespace std {
 #  define _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION } }
 #  define _CUDA_VSTD cuda::std::_LIBCUDACXX_ABI_NAMESPACE
+#  define _CUDA_VSTD_NOVERSION cuda::std
 #  define _CUDA_VRANGES cuda::std::ranges::_LIBCUDACXX_ABI_NAMESPACE
 #else
 #  define _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION namespace std {
 #  define _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION }
 #  define _CUDA_VSTD std::_LIBCUDACXX_ABI_NAMESPACE
+#  define _CUDA_VSTD_NOVERSION std
 #  define _CUDA_VRANGES std::ranges::_LIBCUDACXX_ABI_NAMESPACE
 #endif
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/exception.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/exception.h
@@ -1,0 +1,95 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___EXCEPTION_EXCEPTION_H
+#define _LIBCUDACXX___EXCEPTION_EXCEPTION_H
+
+#ifndef __cuda_std__
+#include <__config>
+#endif //__cuda_std__
+
+// <vcruntime_exception.h> defines its own std::exception and std::bad_exception types,
+// which we use in order to be ABI-compatible with other STLs on Windows.
+#if defined(_LIBCUDACXX_ABI_VCRUNTIME)
+#  include <vcruntime_exception.h>
+#endif
+
+#if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
+
+#if defined(_LIBCUDACXX_ABI_VCRUNTIME) && (!defined(_HAS_EXCEPTIONS) || _HAS_EXCEPTIONS != 0)
+// The std::exception class was already included above, but we're explicit about this condition here for clarity.
+
+#elif defined(_LIBCUDACXX_ABI_VCRUNTIME) && _HAS_EXCEPTIONS == 0
+// However, <vcruntime_exception.h> does not define std::exception and std::bad_exception
+// when _HAS_EXCEPTIONS == 0.
+//
+// Since libc++ still wants to provide the std::exception hierarchy even when _HAS_EXCEPTIONS == 0
+// (after all those are simply types like any other), we define an ABI-compatible version
+// of the VCRuntime std::exception and std::bad_exception types in that mode.
+
+struct __std_exception_data {
+  char const* _What;
+  bool _DoFree;
+};
+
+class exception { // base of all library exceptions
+public:
+  _LIBCUDACXX_INLINE_VISIBILITY exception() noexcept : __data_() {}
+
+  _LIBCUDACXX_INLINE_VISIBILITY explicit exception(char const* __message) noexcept : __data_() {
+    __data_._What   = __message;
+    __data_._DoFree = true;
+  }
+
+  _LIBCUDACXX_INLINE_VISIBILITY exception(exception const&) noexcept {}
+
+  _LIBCUDACXX_INLINE_VISIBILITY exception& operator=(exception const&) noexcept { return *this; }
+
+  _LIBCUDACXX_INLINE_VISIBILITY virtual ~exception() noexcept {}
+
+  _LIBCUDACXX_INLINE_VISIBILITY virtual char const* what() const noexcept { return __data_._What ? __data_._What : "Unknown exception"; }
+
+private:
+  __std_exception_data __data_;
+};
+
+class bad_exception : public exception {
+public:
+  _LIBCUDACXX_INLINE_VISIBILITY bad_exception() noexcept : exception("bad exception") {}
+};
+
+#else  // !defined(_LIBCUDACXX_ABI_VCRUNTIME)
+// On all other platforms, we define our own std::exception and std::bad_exception types
+// regardless of whether exceptions are turned on as a language feature.
+
+class _LIBCUDACXX_EXCEPTION_ABI exception {
+public:
+  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY exception() noexcept {}
+  _LIBCUDACXX_HIDE_FROM_ABI exception(const exception&) noexcept = default;
+  _LIBCUDACXX_HOST_DEVICE virtual ~exception() noexcept;
+  _LIBCUDACXX_HOST_DEVICE virtual const char* what() const noexcept;
+};
+
+class _LIBCUDACXX_EXCEPTION_ABI bad_exception : public exception {
+public:
+  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY bad_exception() noexcept {}
+  _LIBCUDACXX_HOST_DEVICE virtual ~bad_exception() noexcept;
+  _LIBCUDACXX_HOST_DEVICE virtual const char* what() const noexcept;
+};
+#endif // !_LIBCUDACXX_ABI_VCRUNTIME
+
+_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
+
+#endif // _LIBCUDACXX___EXCEPTION_EXCEPTION_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/exception_ptr.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/exception_ptr.h
@@ -1,0 +1,123 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___EXCEPTION_EXCEPTION_PTR_H
+#define _LIBCUDACXX___EXCEPTION_EXCEPTION_PTR_H
+
+#ifndef __cuda_std__
+#include <__config>
+#endif //__cuda_std__
+
+#include "../__exception/operations.h"
+#include "../__memory/addressof.h"
+#include "../cstddef"
+#include "../cstdlib"
+
+#if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
+
+#ifndef _LIBCUDACXX_ABI_MICROSOFT
+
+class _LIBCUDACXX_TYPE_VIS exception_ptr {
+  void* __ptr_;
+
+public:
+  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY exception_ptr() noexcept : __ptr_() {}
+  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY exception_ptr(nullptr_t) noexcept : __ptr_() {}
+
+  _LIBCUDACXX_HOST_DEVICE exception_ptr(const exception_ptr&) noexcept;
+  _LIBCUDACXX_HOST_DEVICE exception_ptr& operator=(const exception_ptr&) noexcept;
+  _LIBCUDACXX_HOST_DEVICE ~exception_ptr() noexcept;
+
+  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY explicit operator bool() const noexcept { return __ptr_ != nullptr; }
+
+  friend _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+  bool operator==(const exception_ptr& __x, const exception_ptr& __y) noexcept {
+    return __x.__ptr_ == __y.__ptr_;
+  }
+
+  friend _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+  bool operator!=(const exception_ptr& __x, const exception_ptr& __y) noexcept {
+    return !(__x == __y);
+  }
+
+  friend _LIBCUDACXX_FUNC_VIS exception_ptr current_exception() noexcept;
+  friend _LIBCUDACXX_FUNC_VIS void rethrow_exception(exception_ptr);
+};
+
+template <class _Ep>
+inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+exception_ptr make_exception_ptr(_Ep __e) noexcept {
+#ifndef _LIBCUDACXX_NO_EXCEPTIONS
+  try {
+    throw __e;
+  } catch (...) {
+    return current_exception();
+  }
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
+  ((void)__e);
+  _LIBCUDACXX_UNREACHABLE();
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
+}
+
+#else // ^^^ !_LIBCUDACXX_ABI_MICROSOFT ^^^ / vvv _LIBCUDACXX_ABI_MICROSOFT vvv
+
+class _LIBCUDACXX_TYPE_VIS exception_ptr {
+  _LIBCUDACXX_DIAGNOSTIC_PUSH
+  _LIBCUDACXX_CLANG_DIAGNOSTIC_IGNORED("-Wunused-private-field")
+  void* __ptr1_;
+  void* __ptr2_;
+  _LIBCUDACXX_DIAGNOSTIC_POP
+
+public:
+  _LIBCUDACXX_HOST_DEVICE exception_ptr() noexcept;
+  _LIBCUDACXX_HOST_DEVICE exception_ptr(nullptr_t) noexcept;
+  _LIBCUDACXX_HOST_DEVICE exception_ptr(const exception_ptr& __other) noexcept;
+  _LIBCUDACXX_HOST_DEVICE exception_ptr& operator=(const exception_ptr& __other) noexcept;
+  _LIBCUDACXX_HOST_DEVICE exception_ptr& operator=(nullptr_t) noexcept;
+  _LIBCUDACXX_HOST_DEVICE ~exception_ptr() noexcept;
+  _LIBCUDACXX_HOST_DEVICE explicit operator bool() const noexcept;
+};
+
+_LIBCUDACXX_FUNC_VIS
+bool operator==(const exception_ptr& __x, const exception_ptr& __y) noexcept;
+
+inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+bool operator!=(const exception_ptr& __x, const exception_ptr& __y) noexcept {
+  return !(__x == __y);
+}
+
+_LIBCUDACXX_FUNC_VIS void swap(exception_ptr&, exception_ptr&) noexcept;
+
+_LIBCUDACXX_FUNC_VIS exception_ptr __copy_exception_ptr(void* __except, const void* __ptr);
+_LIBCUDACXX_FUNC_VIS exception_ptr current_exception() noexcept;
+_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void rethrow_exception(exception_ptr p);
+
+// This is a built-in template function which automagically extracts the required
+// information.
+template <class _E>
+_LIBCUDACXX_HOST_DEVICE void* __GetExceptionInfo(_E);
+
+template <class _Ep>
+_LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+exception_ptr make_exception_ptr(_Ep __e) noexcept
+{
+  return __copy_exception_ptr(_CUDA_VSTD::addressof(__e), __GetExceptionInfo(__e));
+}
+
+#endif // _LIBCUDACXX_ABI_MICROSOFT
+
+_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
+
+#endif // _LIBCUDACXX___EXCEPTION_EXCEPTION_PTR_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/nested_exception.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/nested_exception.h
@@ -1,0 +1,108 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___EXCEPTION_NESTED_EXCEPTION_H
+#define _LIBCUDACXX___EXCEPTION_NESTED_EXCEPTION_H
+
+#ifndef __cuda_std__
+#include <__config>
+#endif //__cuda_std__
+
+#include "../__exception/exception_ptr.h"
+#include "../__memory/addressof.h"
+#include "../__type_traits/decay.h"
+#include "../__type_traits/is_base_of.h"
+#include "../__type_traits/is_class.h"
+#include "../__type_traits/is_convertible.h"
+#include "../__type_traits/is_copy_constructible.h"
+#include "../__type_traits/is_final.h"
+#include "../__type_traits/is_polymorphic.h"
+#include "../__utility/forward.h"
+#include "../cstddef"
+
+#if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
+
+class _LIBCUDACXX_EXCEPTION_ABI nested_exception {
+  exception_ptr __ptr_;
+
+public:
+  _LIBCUDACXX_INLINE_VISIBILITY nested_exception() noexcept;
+  nested_exception(const nested_exception&) noexcept = default;
+  nested_exception& operator=(const nested_exception&) noexcept = default;
+  _LIBCUDACXX_HOST_DEVICE virtual ~nested_exception() noexcept;
+
+  // access functions
+  _LIBCUDACXX_NORETURN _LIBCUDACXX_HOST_DEVICE void rethrow_nested() const;
+  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY exception_ptr nested_ptr() const noexcept { return __ptr_; }
+};
+
+template <class _Tp>
+struct __nested : public _Tp, public nested_exception {
+  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY explicit __nested(const _Tp& __t) : _Tp(__t) {}
+};
+
+#ifndef _LIBCUDACXX_NO_EXCEPTIONS
+template <class _Tp, class _Up, bool>
+struct __throw_with_nested;
+
+template <class _Tp, class _Up>
+struct __throw_with_nested<_Tp, _Up, true> {
+  _LIBCUDACXX_NORETURN static inline _LIBCUDACXX_INLINE_VISIBILITY void __do_throw(_Tp&& __t) {
+    throw __nested<_Up>(std::forward<_Tp>(__t));
+  }
+};
+
+template <class _Tp, class _Up>
+struct __throw_with_nested<_Tp, _Up, false> {
+  _LIBCUDACXX_NORETURN static inline _LIBCUDACXX_INLINE_VISIBILITY void __do_throw(_Tp&& __t) { throw std::forward<_Tp>(__t); }
+};
+#endif // !_LIBCUDACXX_NO_EXCEPTIONS
+
+template <class _Tp>
+_LIBCUDACXX_NORETURN inline  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+void throw_with_nested(_Tp&& __t) {
+#ifndef _LIBCUDACXX_NO_EXCEPTIONS
+  using _Up = __decay_t<_Tp>;
+  static_assert(is_copy_constructible<_Up>::value, "type thrown must be CopyConstructible");
+  __throw_with_nested<_Tp,
+                      _Up,
+                      is_class<_Up>::value && !is_base_of<nested_exception, _Up>::value &&
+                          !__libcpp_is_final<_Up>::value>::__do_throw(std::forward<_Tp>(__t));
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
+  ((void)__t);
+  _LIBCUDACXX_UNREACHABLE();
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
+}
+
+template <class _From, class _To>
+struct __can_dynamic_cast
+    : _BoolConstant< is_polymorphic<_From>::value &&
+                     (!is_base_of<_To, _From>::value || is_convertible<const _From*, const _To*>::value)> {};
+
+template <class _Ep>
+inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+void rethrow_if_nested(const _Ep& __e, __enable_if_t< __can_dynamic_cast<_Ep, nested_exception>::value>* = 0) {
+  const nested_exception* __nep = dynamic_cast<const nested_exception*>(std::addressof(__e));
+  if (__nep)
+    __nep->rethrow_nested();
+}
+
+template <class _Ep>
+inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+void rethrow_if_nested(const _Ep&, __enable_if_t<!__can_dynamic_cast<_Ep, nested_exception>::value>* = 0) {}
+
+_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
+
+#endif // _LIBCUDACXX___EXCEPTION_NESTED_EXCEPTION_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/operations.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/operations.h
@@ -1,0 +1,52 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___EXCEPTION_OPERATIONS_H
+#define _LIBCUDACXX___EXCEPTION_OPERATIONS_H
+
+#ifndef __cuda_std__
+#include <__config>
+#endif //__cuda_std__
+
+#include "../__availability"
+#include "../cstddef"
+#include "../cstdlib"
+
+#if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
+
+#if _LIBCUDACXX_STD_VER <= 14 \
+    || defined(_LIBCUDACXX_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS) \
+    || defined(_LIBCUDACXX_BUILDING_LIBRARY)
+typedef void (*unexpected_handler)();
+_LIBCUDACXX_FUNC_VIS unexpected_handler set_unexpected(unexpected_handler) _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS unexpected_handler get_unexpected() _NOEXCEPT;
+_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void unexpected();
+#endif
+
+typedef void (*terminate_handler)();
+_LIBCUDACXX_FUNC_VIS terminate_handler set_terminate(terminate_handler) _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS terminate_handler get_terminate() _NOEXCEPT;
+
+_LIBCUDACXX_FUNC_VIS bool uncaught_exception() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS _LIBCUDACXX_AVAILABILITY_UNCAUGHT_EXCEPTIONS int uncaught_exceptions() _NOEXCEPT;
+
+class _LIBCUDACXX_TYPE_VIS exception_ptr;
+
+_LIBCUDACXX_FUNC_VIS exception_ptr current_exception() _NOEXCEPT;
+_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void rethrow_exception(exception_ptr);
+
+_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
+
+#endif // _LIBCUDACXX___EXCEPTION_OPERATIONS_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/terminate.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__exception/terminate.h
@@ -1,0 +1,29 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___EXCEPTION_TERMINATE_H
+#define _LIBCUDACXX___EXCEPTION_TERMINATE_H
+
+#ifndef __cuda_std__
+#include <__config>
+#endif //__cuda_std__
+
+#if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
+
+_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void terminate() _NOEXCEPT;
+
+_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
+
+#endif // _LIBCUDACXX___EXCEPTION_TERMINATE_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/function.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/function.h
@@ -15,7 +15,6 @@
 
 #ifndef __cuda_std__
 #include <__config>
-#include <exception>
 #include <memory>
 #include <new>
 #include <typeinfo>
@@ -42,6 +41,7 @@
 #include "../__utility/move.h"
 #include "../__utility/piecewise_construct.h"
 #include "../__utility/swap.h"
+#include "../exception"
 #include "../tuple"
 
 #if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/function.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/function.h
@@ -16,7 +16,6 @@
 #ifndef __cuda_std__
 #include <__config>
 #include <memory>
-#include <new>
 #include <typeinfo>
 #endif // __cuda_std__
 
@@ -42,6 +41,7 @@
 #include "../__utility/piecewise_construct.h"
 #include "../__utility/swap.h"
 #include "../exception"
+#include "../new"
 #include "../tuple"
 
 #if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional_base
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional_base
@@ -13,7 +13,6 @@
 #ifndef __cuda_std__
 #include <__config>
 #include <typeinfo>
-#include <exception>
 #include <new>
 #endif // __cuda_std__
 
@@ -27,6 +26,8 @@
 #include "__type_traits/is_convertible.h"
 #include "__type_traits/remove_cvref.h"
 #include "__utility/forward.h"
+
+#include "exception"
 
 #ifndef __cuda_std__
 #include <__pragma_push>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional_base
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional_base
@@ -13,7 +13,6 @@
 #ifndef __cuda_std__
 #include <__config>
 #include <typeinfo>
-#include <new>
 #endif // __cuda_std__
 
 #include "__functional/binary_function.h"
@@ -28,6 +27,7 @@
 #include "__utility/forward.h"
 
 #include "exception"
+#include "new"
 
 #ifndef __cuda_std__
 #include <__pragma_push>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/barrier
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/barrier
@@ -49,10 +49,6 @@ namespace std
 #  include <thread>
 #  include <vector>
 #endif
-#else
-#ifndef _LIBCUDACXX_COMPILER_NVRTC
-#include <new>
-#endif // _LIBCUDACXX_COMPILER_NVRTC
 #endif // __cuda_std__
 
 #include "__assert" // all public C++ headers provide the assertion handler
@@ -60,6 +56,7 @@ namespace std
 #include "atomic"
 #include "chrono"
 #include "cstddef"
+#include "new"
 
 #ifndef __cuda_std__
 #include <__pragma_push>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/exception
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/exception
@@ -81,6 +81,7 @@ template <class E> void rethrow_if_nested(const E& e);
 #endif //__cuda_std__
 
 #include "__exception/exception.h"
+#include "__exception/operations.h"
 
 #include "cstddef"
 #include "cstdlib"
@@ -97,27 +98,7 @@ template <class E> void rethrow_if_nested(const E& e);
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
 
-#if _LIBCUDACXX_STD_VER <= 14 \
-    || defined(_LIBCUDACXX_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS) \
-    || defined(_LIBCUDACXX_BUILDING_LIBRARY)
-typedef void (*unexpected_handler)();
-_LIBCUDACXX_FUNC_VIS unexpected_handler set_unexpected(unexpected_handler) _NOEXCEPT;
-_LIBCUDACXX_FUNC_VIS unexpected_handler get_unexpected() _NOEXCEPT;
-_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void unexpected();
-#endif
-
-typedef void (*terminate_handler)();
-_LIBCUDACXX_FUNC_VIS terminate_handler set_terminate(terminate_handler) _NOEXCEPT;
-_LIBCUDACXX_FUNC_VIS terminate_handler get_terminate() _NOEXCEPT;
 _LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void terminate() _NOEXCEPT;
-
-_LIBCUDACXX_FUNC_VIS bool uncaught_exception() _NOEXCEPT;
-_LIBCUDACXX_FUNC_VIS _LIBCUDACXX_AVAILABILITY_UNCAUGHT_EXCEPTIONS int uncaught_exceptions() _NOEXCEPT;
-
-class _LIBCUDACXX_TYPE_VIS exception_ptr;
-
-_LIBCUDACXX_FUNC_VIS exception_ptr current_exception() _NOEXCEPT;
-_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void rethrow_exception(exception_ptr);
 
 #ifndef _LIBCUDACXX_ABI_MICROSOFT
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/exception
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/exception
@@ -82,6 +82,7 @@ template <class E> void rethrow_if_nested(const E& e);
 
 #include "__exception/exception.h"
 #include "__exception/operations.h"
+#include "__exception/terminate.h"
 
 #include "cstddef"
 #include "cstdlib"
@@ -97,8 +98,6 @@ template <class E> void rethrow_if_nested(const E& e);
 #endif
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
-
-_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void terminate() _NOEXCEPT;
 
 #ifndef _LIBCUDACXX_ABI_MICROSOFT
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/exception
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/exception
@@ -1,9 +1,11 @@
 // -*- C++ -*-
-//===-------------------------- exception ---------------------------------===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -80,27 +82,17 @@ template <class E> void rethrow_if_nested(const E& e);
 #include <__config>
 #endif //__cuda_std__
 
+#include "__assert" // all public C++ headers provide the assertion handler
 #include "__exception/exception_ptr.h"
 #include "__exception/exception.h"
 #include "__exception/nested_exception.h"
 #include "__exception/operations.h"
 #include "__exception/terminate.h"
 
-#include "cstddef"
-#include "cstdlib"
-#include "type_traits"
 #include "version"
-
-#if defined(_LIBCUDACXX_ABI_VCRUNTIME)
-#include <vcruntime_exception.h>
-#endif
 
 #if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
 #pragma GCC system_header
 #endif
-
-_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
-
-_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
 
 #endif  // _LIBCUDACXX_EXCEPTION

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/exception
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/exception
@@ -82,6 +82,7 @@ template <class E> void rethrow_if_nested(const E& e);
 
 #include "__exception/exception_ptr.h"
 #include "__exception/exception.h"
+#include "__exception/nested_exception.h"
 #include "__exception/operations.h"
 #include "__exception/terminate.h"
 
@@ -99,101 +100,6 @@ template <class E> void rethrow_if_nested(const E& e);
 #endif
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
-
-// nested_exception
-
-class _LIBCUDACXX_EXCEPTION_ABI nested_exception
-{
-    exception_ptr __ptr_;
-public:
-    nested_exception() _NOEXCEPT;
-//     nested_exception(const nested_exception&) noexcept = default;
-//     nested_exception& operator=(const nested_exception&) noexcept = default;
-    virtual ~nested_exception() _NOEXCEPT;
-
-    // access functions
-    _LIBCUDACXX_NORETURN void rethrow_nested() const;
-    _LIBCUDACXX_INLINE_VISIBILITY exception_ptr nested_ptr() const _NOEXCEPT {return __ptr_;}
-};
-
-template <class _Tp>
-struct __nested
-    : public _Tp,
-      public nested_exception
-{
-    _LIBCUDACXX_INLINE_VISIBILITY explicit __nested(const _Tp& __t) : _Tp(__t) {}
-};
-
-#ifndef _LIBCUDACXX_NO_EXCEPTIONS
-template <class _Tp, class _Up, bool>
-struct __throw_with_nested;
-
-template <class _Tp, class _Up>
-struct __throw_with_nested<_Tp, _Up, true> {
-    _LIBCUDACXX_NORETURN static inline _LIBCUDACXX_INLINE_VISIBILITY void
-    __do_throw(_Tp&& __t)
-    {
-        throw __nested<_Up>(_CUDA_VSTD::forward<_Tp>(__t));
-    }
-};
-
-template <class _Tp, class _Up>
-struct __throw_with_nested<_Tp, _Up, false> {
-    _LIBCUDACXX_NORETURN static inline _LIBCUDACXX_INLINE_VISIBILITY void
-#ifndef _LIBCUDACXX_CXX03_LANG
-    __do_throw(_Tp&& __t)
-#else
-    __do_throw (_Tp& __t)
-#endif  // _LIBCUDACXX_CXX03_LANG
-    {
-        throw _CUDA_VSTD::forward<_Tp>(__t);
-    }
-};
-#endif
-
-template <class _Tp>
-_LIBCUDACXX_NORETURN
-void
-throw_with_nested(_Tp&& __t)
-{
-#ifndef _LIBCUDACXX_NO_EXCEPTIONS
-    typedef __decay_t<_Tp> _Up;
-    static_assert( is_copy_constructible<_Up>::value, "type thrown must be CopyConstructible");
-    __throw_with_nested<_Tp, _Up,
-        is_class<_Up>::value &&
-        !is_base_of<nested_exception, _Up>::value &&
-        !__libcpp_is_final<_Up>::value>::
-            __do_throw(_CUDA_VSTD::forward<_Tp>(__t));
-#else
-    ((void)__t);
-    // FIXME: Make this abort
-#endif
-}
-
-template <class _From, class _To>
-struct __can_dynamic_cast : public _LIBCUDACXX_BOOL_CONSTANT(
-              is_polymorphic<_From>::value &&
-                 (!is_base_of<_To, _From>::value ||
-                   is_convertible<const _From*, const _To*>::value)) {};
-
-template <class _Ep>
-inline _LIBCUDACXX_INLINE_VISIBILITY
-void
-rethrow_if_nested(const _Ep& __e,
-                  typename enable_if< __can_dynamic_cast<_Ep, nested_exception>::value>::type* = 0)
-{
-    const nested_exception* __nep = dynamic_cast<const nested_exception*>(_CUDA_VSTD::addressof(__e));
-    if (__nep)
-        __nep->rethrow_nested();
-}
-
-template <class _Ep>
-inline _LIBCUDACXX_INLINE_VISIBILITY
-void
-rethrow_if_nested(const _Ep&,
-                  typename enable_if<!__can_dynamic_cast<_Ep, nested_exception>::value>::type* = 0)
-{
-}
 
 _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/exception
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/exception
@@ -76,11 +76,16 @@ template <class E> void rethrow_if_nested(const E& e);
 
 */
 
+#ifndef __cuda_std__
 #include <__config>
-#include <cstddef>
-#include <cstdlib>
-#include <type_traits>
-#include <version>
+#endif //__cuda_std__
+
+#include "__exception/exception.h"
+
+#include "cstddef"
+#include "cstdlib"
+#include "type_traits"
+#include "version"
 
 #if defined(_LIBCUDACXX_ABI_VCRUNTIME)
 #include <vcruntime_exception.h>
@@ -90,27 +95,7 @@ template <class E> void rethrow_if_nested(const E& e);
 #pragma GCC system_header
 #endif
 
-namespace std  // purposefully not using versioning namespace
-{
-
-#if !defined(_LIBCUDACXX_ABI_VCRUNTIME)
-class _LIBCUDACXX_EXCEPTION_ABI exception
-{
-public:
-    _LIBCUDACXX_INLINE_VISIBILITY exception() _NOEXCEPT {}
-    virtual ~exception() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
-};
-
-class _LIBCUDACXX_EXCEPTION_ABI bad_exception
-    : public exception
-{
-public:
-    _LIBCUDACXX_INLINE_VISIBILITY bad_exception() _NOEXCEPT {}
-    virtual ~bad_exception() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
-};
-#endif // !_LIBCUDACXX_ABI_VCRUNTIME
+_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
 
 #if _LIBCUDACXX_STD_VER <= 14 \
     || defined(_LIBCUDACXX_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS) \
@@ -324,6 +309,6 @@ rethrow_if_nested(const _Ep&,
 {
 }
 
-}  // std
+_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
 
 #endif  // _LIBCUDACXX_EXCEPTION

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/exception
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/exception
@@ -80,6 +80,7 @@ template <class E> void rethrow_if_nested(const E& e);
 #include <__config>
 #endif //__cuda_std__
 
+#include "__exception/exception_ptr.h"
 #include "__exception/exception.h"
 #include "__exception/operations.h"
 #include "__exception/terminate.h"
@@ -99,101 +100,6 @@ template <class E> void rethrow_if_nested(const E& e);
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
 
-#ifndef _LIBCUDACXX_ABI_MICROSOFT
-
-class _LIBCUDACXX_TYPE_VIS exception_ptr
-{
-    void* __ptr_;
-public:
-    _LIBCUDACXX_INLINE_VISIBILITY exception_ptr() _NOEXCEPT : __ptr_() {}
-    _LIBCUDACXX_INLINE_VISIBILITY exception_ptr(nullptr_t) _NOEXCEPT : __ptr_() {}
-
-    exception_ptr(const exception_ptr&) _NOEXCEPT;
-    exception_ptr& operator=(const exception_ptr&) _NOEXCEPT;
-    ~exception_ptr() _NOEXCEPT;
-
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_EXPLICIT operator bool() const _NOEXCEPT
-    {return __ptr_ != nullptr;}
-
-    friend _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator==(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT
-        {return __x.__ptr_ == __y.__ptr_;}
-
-    friend _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator!=(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT
-        {return !(__x == __y);}
-
-    friend _LIBCUDACXX_FUNC_VIS exception_ptr current_exception() _NOEXCEPT;
-    friend _LIBCUDACXX_FUNC_VIS void rethrow_exception(exception_ptr);
-};
-
-template<class _Ep>
-_LIBCUDACXX_INLINE_VISIBILITY exception_ptr
-make_exception_ptr(_Ep __e) _NOEXCEPT
-{
-#ifndef _LIBCUDACXX_NO_EXCEPTIONS
-    try
-    {
-        throw __e;
-    }
-    catch (...)
-    {
-        return current_exception();
-    }
-#else
-    ((void)__e);
-    _CUDA_VSTD::abort();
-#endif
-}
-
-#else // _LIBCUDACXX_ABI_MICROSOFT
-
-class _LIBCUDACXX_TYPE_VIS exception_ptr
-{
-#if defined(_LIBCUDACXX_COMPILER_CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-    void* __ptr1_;
-    void* __ptr2_;
-#if defined(_LIBCUDACXX_COMPILER_CLANG)
-#pragma clang diagnostic pop
-#endif
-public:
-    exception_ptr() _NOEXCEPT;
-    exception_ptr(nullptr_t) _NOEXCEPT;
-    exception_ptr(const exception_ptr& __other) _NOEXCEPT;
-    exception_ptr& operator=(const exception_ptr& __other) _NOEXCEPT;
-    exception_ptr& operator=(nullptr_t) _NOEXCEPT;
-    ~exception_ptr() _NOEXCEPT;
-    _LIBCUDACXX_EXPLICIT operator bool() const _NOEXCEPT;
-};
-
-_LIBCUDACXX_FUNC_VIS
-bool operator==(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT;
-
-inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator!=(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT
-    {return !(__x == __y);}
-
-_LIBCUDACXX_FUNC_VIS void swap(exception_ptr&, exception_ptr&) _NOEXCEPT;
-
-_LIBCUDACXX_FUNC_VIS exception_ptr __copy_exception_ptr(void *__except, const void* __ptr);
-_LIBCUDACXX_FUNC_VIS exception_ptr current_exception() _NOEXCEPT;
-_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void rethrow_exception(exception_ptr p);
-
-// This is a built-in template function which automagically extracts the required
-// information.
-template <class _E> void *__GetExceptionInfo(_E);
-
-template<class _Ep>
-_LIBCUDACXX_INLINE_VISIBILITY exception_ptr
-make_exception_ptr(_Ep __e) _NOEXCEPT
-{
-  return __copy_exception_ptr(_CUDA_VSTD::addressof(__e), __GetExceptionInfo(__e));
-}
-
-#endif // _LIBCUDACXX_ABI_MICROSOFT
 // nested_exception
 
 class _LIBCUDACXX_EXCEPTION_ABI nested_exception

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/memory
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/memory
@@ -708,6 +708,8 @@ void* align(size_t alignment, size_t size, void*& ptr, size_t& space);
 #pragma GCC system_header
 #endif
 
+#ifndef __cuda_std__
+
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _ValueType>
@@ -5148,6 +5150,8 @@ struct __builtin_new_allocator {
 
 
 _LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // __cuda_std__
 
 #ifndef __cuda_std__
 #include <__pragma_pop>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/new
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/new
@@ -1,9 +1,11 @@
 // -*- C++ -*-
-//===----------------------------- new ------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -49,11 +51,11 @@ new_handler get_new_handler() noexcept;
 template <class T> constexpr T* launder(T* p) noexcept; // C++17
 }  // std
 
-void* operator new(std::size_t size);                                   // replaceable, nodiscard in C++2a
-void* operator new(std::size_t size, std::align_val_t alignment);       // replaceable, C++17, nodiscard in C++2a
-void* operator new(std::size_t size, const std::nothrow_t&) noexcept;   // replaceable, nodiscard in C++2a
+void* operator new(std::size_t size);                                   // replaceable, nodiscard in C++20
+void* operator new(std::size_t size, std::align_val_t alignment);       // replaceable, C++17, nodiscard in C++20
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept;   // replaceable, nodiscard in C++20
 void* operator new(std::size_t size, std::align_val_t alignment,
-                   const std::nothrow_t&) noexcept;                     // replaceable, C++17, nodiscard in C++2a
+                   const std::nothrow_t&) noexcept;                     // replaceable, C++17, nodiscard in C++20
 void  operator delete(void* ptr) noexcept;                              // replaceable
 void  operator delete(void* ptr, std::size_t size) noexcept;            // replaceable, C++14
 void  operator delete(void* ptr, std::align_val_t alignment) noexcept;  // replaceable, C++17
@@ -63,12 +65,12 @@ void  operator delete(void* ptr, const std::nothrow_t&) noexcept;       // repla
 void  operator delete(void* ptr, std:align_val_t alignment,
                       const std::nothrow_t&) noexcept;                  // replaceable, C++17
 
-void* operator new[](std::size_t size);                                 // replaceable, nodiscard in C++2a
+void* operator new[](std::size_t size);                                 // replaceable, nodiscard in C++20
 void* operator new[](std::size_t size,
-                     std::align_val_t alignment) noexcept;              // replaceable, C++17, nodiscard in C++2a
-void* operator new[](std::size_t size, const std::nothrow_t&) noexcept; // replaceable, nodiscard in C++2a
+                     std::align_val_t alignment) noexcept;              // replaceable, C++17, nodiscard in C++20
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept; // replaceable, nodiscard in C++20
 void* operator new[](std::size_t size, std::align_val_t alignment,
-                     const std::nothrow_t&) noexcept;                   // replaceable, C++17, nodiscard in C++2a
+                     const std::nothrow_t&) noexcept;                   // replaceable, C++17, nodiscard in C++20
 void  operator delete[](void* ptr) noexcept;                            // replaceable
 void  operator delete[](void* ptr, std::size_t size) noexcept;          // replaceable, C++14
 void  operator delete[](void* ptr,
@@ -79,8 +81,8 @@ void  operator delete[](void* ptr, const std::nothrow_t&) noexcept;     // repla
 void  operator delete[](void* ptr, std::align_val_t alignment,
                         const std::nothrow_t&) noexcept;                // replaceable, C++17
 
-void* operator new  (std::size_t size, void* ptr) noexcept;             // nodiscard in C++2a
-void* operator new[](std::size_t size, void* ptr) noexcept;             // nodiscard in C++2a
+void* operator new  (std::size_t size, void* ptr) noexcept;             // nodiscard in C++20
+void* operator new[](std::size_t size, void* ptr) noexcept;             // nodiscard in C++20
 void  operator delete  (void* ptr, void*) noexcept;
 void  operator delete[](void* ptr, void*) noexcept;
 
@@ -91,11 +93,22 @@ void  operator delete[](void* ptr, void*) noexcept;
 #endif // __cuda_std__
 
 #include "__assert" // all public C++ headers provide the assertion handler
+#include "__availability"
+#include "__exception/exception.h"
+#include "__type_traits/alignment_of.h"
+#include "__type_traits/is_function.h"
+#include "__type_traits/is_same.h"
+#include "__type_traits/remove_cv.h"
+#include "__verbose_abort"
 #include "cstddef"
 #include "cstdlib"
-#include "exception"
-#include "type_traits"
+
 #include "version"
+
+#if  defined(__cuda_std__) \
+ && !defined(_LIBCUDACXX_COMPILER_NVRTC)
+#include <new>
+#endif // __cuda_std__ && !_LIBCUDACXX_COMPILER_NVRTC
 
 #if defined(_LIBCUDACXX_ABI_VCRUNTIME)
 #include <new.h>
@@ -123,51 +136,74 @@ void  operator delete[](void* ptr, void*) noexcept;
 # define _LIBCUDACXX_HAS_NO_SIZED_DEALLOCATION
 #endif
 
-#if !__has_builtin(__builtin_operator_new) || \
-   __has_builtin(__builtin_operator_new) < 201802L
-#define _LIBCUDACXX_HAS_NO_BUILTIN_OVERLOADED_OPERATOR_NEW_DELETE
-#endif
-
-namespace std  // purposefully not using versioning namespace
-{
+_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
 
 #if !defined(_LIBCUDACXX_ABI_VCRUNTIME)
 struct _LIBCUDACXX_TYPE_VIS nothrow_t { explicit nothrow_t() = default; };
-extern _LIBCUDACXX_FUNC_VIS const nothrow_t nothrow;
+
+#ifndef __cuda_std__
+extern
+#endif // !__cuda_std__
+ _LIBCUDACXX_DEVICE const nothrow_t nothrow;
 
 class _LIBCUDACXX_EXCEPTION_ABI bad_alloc
     : public exception
 {
 public:
-    bad_alloc() _NOEXCEPT;
-    virtual ~bad_alloc() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE bad_alloc() noexcept;
+    _LIBCUDACXX_HOST_DEVICE ~bad_alloc() noexcept override;
+    _LIBCUDACXX_HOST_DEVICE const char* what() const noexcept override;
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI bad_array_new_length
     : public bad_alloc
 {
 public:
-    bad_array_new_length() _NOEXCEPT;
-    virtual ~bad_array_new_length() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE bad_array_new_length() noexcept;
+    _LIBCUDACXX_HOST_DEVICE ~bad_array_new_length() noexcept override;
+    _LIBCUDACXX_HOST_DEVICE const char* what() const noexcept override;
 };
 
 typedef void (*new_handler)();
-_LIBCUDACXX_FUNC_VIS new_handler set_new_handler(new_handler) _NOEXCEPT;
-_LIBCUDACXX_FUNC_VIS new_handler get_new_handler() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS new_handler set_new_handler(new_handler) noexcept;
+_LIBCUDACXX_FUNC_VIS new_handler get_new_handler() noexcept;
 
-#endif // !_LIBCUDACXX_ABI_VCRUNTIME
+#elif defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 0 // !_LIBCUDACXX_ABI_VCRUNTIME
 
-_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void __throw_bad_alloc();  // not in C++ spec
+// When _HAS_EXCEPTIONS == 0, these complete definitions are needed,
+// since they would normally be provided in vcruntime_exception.h
+class bad_alloc : public exception {
+public:
+  _LIBCUDACXX_HOST_DEVICE bad_alloc() noexcept : exception("bad allocation") {}
 
-#if !defined(_LIBCUDACXX_HAS_NO_LIBRARY_ALIGNED_ALLOCATION) && \
-    !defined(_LIBCUDACXX_ABI_VCRUNTIME)
-#ifndef _LIBCUDACXX_CXX03_LANG
+private:
+  friend class bad_array_new_length;
+
+  _LIBCUDACXX_HOST_DEVICE bad_alloc(char const* const __message) noexcept : exception(__message) {}
+};
+
+class bad_array_new_length : public bad_alloc {
+public:
+  _LIBCUDACXX_HOST_DEVICE bad_array_new_length() noexcept : bad_alloc("bad array new length") {}
+};
+#endif // defined(_LIBCUDACXX_ABI_VCRUNTIME) && defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 0
+
+_LIBCUDACXX_NORETURN _LIBCUDACXX_HOST_DEVICE void __throw_bad_alloc();  // not in C++ spec
+
+_LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
+void __throw_bad_array_new_length()
+{
+#ifndef _LIBCUDACXX_NO_EXCEPTIONS
+    throw bad_array_new_length();
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
+    _LIBCUDACXX_UNREACHABLE();
+    //__libcpp_verbose_abort("bad_array_new_length was thrown in -fno-exceptions mode");
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LIBRARY_ALIGNED_ALLOCATION) \
+ && !defined(_LIBCUDACXX_ABI_VCRUNTIME)
 enum class _LIBCUDACXX_ENUM_VIS align_val_t : size_t { };
-#else
-enum align_val_t { __zero = 0, __max = (size_t)-1 };
-#endif
 #endif
 
 #if _LIBCUDACXX_STD_VER > 17
@@ -179,60 +215,58 @@ struct destroying_delete_t {
 _LIBCUDACXX_INLINE_VAR constexpr destroying_delete_t destroying_delete{};
 #endif // _LIBCUDACXX_STD_VER > 17
 
-}  // std
-
-#if defined(_LIBCUDACXX_CXX03_LANG)
-#define _THROW_BAD_ALLOC throw(std::bad_alloc)
-#else
-#define _THROW_BAD_ALLOC
-#endif
+_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
 
 #if !defined(_LIBCUDACXX_ABI_VCRUNTIME)
 
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz) _THROW_BAD_ALLOC;
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, const std::nothrow_t&) _NOEXCEPT _LIBCUDACXX_NOALIAS;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p) _NOEXCEPT;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, const std::nothrow_t&) _NOEXCEPT;
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(_CUDA_VSTD::size_t __sz);
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(_CUDA_VSTD::size_t __sz, const _CUDA_VSTD_NOVERSION::nothrow_t&) noexcept _LIBCUDACXX_NOALIAS;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p) noexcept;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, const _CUDA_VSTD_NOVERSION::nothrow_t&) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz) _NOEXCEPT;
-#endif
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, _CUDA_VSTD::size_t __sz) noexcept;
+#endif // _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
 
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz) _THROW_BAD_ALLOC;
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, const std::nothrow_t&) _NOEXCEPT _LIBCUDACXX_NOALIAS;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p) _NOEXCEPT;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, const std::nothrow_t&) _NOEXCEPT;
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](_CUDA_VSTD::size_t __sz);
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](_CUDA_VSTD::size_t __sz, const _CUDA_VSTD_NOVERSION::nothrow_t&) noexcept _LIBCUDACXX_NOALIAS;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p) noexcept;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, const _CUDA_VSTD_NOVERSION::nothrow_t&) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete[](void* __p, std::size_t __sz) _NOEXCEPT;
-#endif
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete[](void* __p, _CUDA_VSTD::size_t __sz) noexcept;
+#endif // _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
 
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_ALIGNED_ALLOCATION
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCUDACXX_NOALIAS;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, std::align_val_t) _NOEXCEPT;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(_CUDA_VSTD::size_t __sz, _CUDA_VSTD_NOVERSION::align_val_t);
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(_CUDA_VSTD::size_t __sz, _CUDA_VSTD_NOVERSION::align_val_t, const _CUDA_VSTD_NOVERSION::nothrow_t&) noexcept _LIBCUDACXX_NOALIAS;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, _CUDA_VSTD_NOVERSION::align_val_t) noexcept;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, _CUDA_VSTD_NOVERSION::align_val_t, const _CUDA_VSTD_NOVERSION::nothrow_t&) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz, std::align_val_t) _NOEXCEPT;
-#endif
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, _CUDA_VSTD::size_t __sz, _CUDA_VSTD_NOVERSION::align_val_t) noexcept;
+#endif // _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
 
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCUDACXX_NOALIAS;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, std::align_val_t) _NOEXCEPT;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](_CUDA_VSTD::size_t __sz, _CUDA_VSTD_NOVERSION::align_val_t);
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](_CUDA_VSTD::size_t __sz, _CUDA_VSTD_NOVERSION::align_val_t, const _CUDA_VSTD_NOVERSION::nothrow_t&) noexcept _LIBCUDACXX_NOALIAS;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, _CUDA_VSTD_NOVERSION::align_val_t) noexcept;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, _CUDA_VSTD_NOVERSION::align_val_t, const _CUDA_VSTD_NOVERSION::nothrow_t&) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete[](void* __p, std::size_t __sz, std::align_val_t) _NOEXCEPT;
-#endif
-#endif
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete[](void* __p, _CUDA_VSTD::size_t __sz, _CUDA_VSTD_NOVERSION::align_val_t) noexcept;
+#endif // _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
+#endif // _LIBCUDACXX_HAS_NO_LIBRARY_ALIGNED_ALLOCATION
 
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_INLINE_VISIBILITY void* operator new  (std::size_t, void* __p) _NOEXCEPT {return __p;}
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_INLINE_VISIBILITY void* operator new[](std::size_t, void* __p) _NOEXCEPT {return __p;}
-inline _LIBCUDACXX_INLINE_VISIBILITY void  operator delete  (void*, void*) _NOEXCEPT {}
-inline _LIBCUDACXX_INLINE_VISIBILITY void  operator delete[](void*, void*) _NOEXCEPT {}
+#if !defined(__cuda_std__) \
+ && !defined(_LIBCUDACXX_COMPILER_NVCC) \
+ && !defined(_LIBCUDACXX_COMPILER_NVRTC)
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_INLINE_VISIBILITY void* operator new  (_CUDA_VSTD::size_t, void* __p) noexcept {return __p;}
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_INLINE_VISIBILITY void* operator new[](_CUDA_VSTD::size_t, void* __p) noexcept {return __p;}
+inline _LIBCUDACXX_INLINE_VISIBILITY void  operator delete  (void*, void*) noexcept {}
+inline _LIBCUDACXX_INLINE_VISIBILITY void  operator delete[](void*, void*) noexcept {}
+#endif // !__cuda_std__ && !_LIBCUDACXX_COMPILER_NVCC && !_LIBCUDACXX_COMPILER_NVRTC
 
 #endif // !_LIBCUDACXX_ABI_VCRUNTIME
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-_LIBCUDACXX_CONSTEXPR inline _LIBCUDACXX_INLINE_VISIBILITY bool __is_overaligned_for_new(size_t __align) _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR inline _LIBCUDACXX_INLINE_VISIBILITY bool __is_overaligned_for_new(size_t __align) noexcept {
 #ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
   return __align > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
 #else
@@ -240,119 +274,84 @@ _LIBCUDACXX_CONSTEXPR inline _LIBCUDACXX_INLINE_VISIBILITY bool __is_overaligned
 #endif
 }
 
-inline _LIBCUDACXX_INLINE_VISIBILITY void *__libcpp_allocate(size_t __size, size_t __align) {
-#ifndef _LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION
-  if (__is_overaligned_for_new(__align)) {
-    const align_val_t __align_val = static_cast<align_val_t>(__align);
-# ifdef _LIBCUDACXX_HAS_NO_BUILTIN_OVERLOADED_OPERATOR_NEW_DELETE
-    return ::operator new(__size, __align_val);
-# else
-    return __builtin_operator_new(__size, __align_val);
-# endif
-  }
+template <class ..._Args>
+_LIBCUDACXX_INLINE_VISIBILITY
+void* __libcpp_operator_new(_Args ...__args) {
+#if (__has_builtin(__builtin_operator_new) && __builtin_operator_new >= 201802L ) \
+ && __has_builtin(__builtin_operator_delete)
+  return __builtin_operator_new(__args...);
 #else
-  ((void)__align);
-#endif
-#ifdef _LIBCUDACXX_HAS_NO_BUILTIN_OPERATOR_NEW_DELETE
-  return ::operator new(__size);
-#else
-  return __builtin_operator_new(__size);
+  return ::operator new(__args...);
 #endif
 }
 
-struct _DeallocateCaller {
-  static inline _LIBCUDACXX_INLINE_VISIBILITY
-  void __do_deallocate_handle_size_align(void *__ptr, size_t __size, size_t __align) {
-#if defined(_LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION)
-    ((void)__align);
-    return __do_deallocate_handle_size(__ptr, __size);
+template <class ..._Args>
+_LIBCUDACXX_INLINE_VISIBILITY
+void __libcpp_operator_delete(_Args ...__args) {
+#if (__has_builtin(__builtin_operator_new) && __builtin_operator_new >= 201802L) \
+ && __has_builtin(__builtin_operator_delete)
+  __builtin_operator_delete(__args...);
 #else
+  ::operator delete(__args...);
+#endif
+}
+
+inline _LIBCUDACXX_INLINE_VISIBILITY
+void *__libcpp_allocate(size_t __size, size_t __align) {
+#ifndef _LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION
+  if (__is_overaligned_for_new(__align)) {
+    const align_val_t __align_val = static_cast<align_val_t>(__align);
+    return __libcpp_operator_new(__size, __align_val);
+  }
+#endif // !_LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION
+
+  (void)__align;
+  return __libcpp_operator_new(__size);
+}
+
+template <class ..._Args>
+_LIBCUDACXX_INLINE_VISIBILITY
+void __do_deallocate_handle_size(void *__ptr, size_t __size, _Args ...__args) {
+#ifdef _LIBCUDACXX_HAS_NO_SIZED_DEALLOCATION
+  (void)__size;
+  return _CUDA_VSTD::__libcpp_operator_delete(__ptr, __args...);
+#else // ^^^ _LIBCUDACXX_HAS_NO_SIZED_DEALLOCATION ^^^ / vvv !_LIBCUDACXX_HAS_NO_SIZED_DEALLOCATION vvv
+  return _CUDA_VSTD::__libcpp_operator_delete(__ptr, __size, __args...);
+#endif // !_LIBCUDACXX_HAS_NO_SIZED_DEALLOCATION
+}
+
+inline _LIBCUDACXX_INLINE_VISIBILITY
+void __libcpp_deallocate(void* __ptr, size_t __size, size_t __align) {
+#if defined(_LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION)
+    (void)__align;
+    return __do_deallocate_handle_size(__ptr, __size);
+#else // ^^^ _LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION ^^^ / vvv !_LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION vvv
     if (__is_overaligned_for_new(__align)) {
       const align_val_t __align_val = static_cast<align_val_t>(__align);
       return __do_deallocate_handle_size(__ptr, __size, __align_val);
     } else {
       return __do_deallocate_handle_size(__ptr, __size);
     }
-#endif
-  }
-
-  static inline _LIBCUDACXX_INLINE_VISIBILITY
-  void __do_deallocate_handle_align(void *__ptr, size_t __align) {
-#if defined(_LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION)
-    ((void)__align);
-    return __do_call(__ptr);
-#else
-    if (__is_overaligned_for_new(__align)) {
-      const align_val_t __align_val = static_cast<align_val_t>(__align);
-      return __do_call(__ptr, __align_val);
-    } else {
-      return __do_call(__ptr);
-    }
-#endif
-  }
-
- private:
-  static inline void __do_deallocate_handle_size(void *__ptr, size_t __size) {
-#ifdef _LIBCUDACXX_HAS_NO_SIZED_DEALLOCATION
-    ((void)__size);
-    return __do_call(__ptr);
-#else
-    return __do_call(__ptr, __size);
-#endif
-  }
-
-#ifndef _LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION
-  static inline void __do_deallocate_handle_size(void *__ptr, size_t __size, align_val_t __align) {
-#ifdef _LIBCUDACXX_HAS_NO_SIZED_DEALLOCATION
-    ((void)__size);
-    return __do_call(__ptr, __align);
-#else
-    return __do_call(__ptr, __size, __align);
-#endif
-  }
-#endif
-
-private:
-  template <class _A1, class _A2>
-  static inline void __do_call(void *__ptr, _A1 __a1, _A2 __a2) {
-#if defined(_LIBCUDACXX_HAS_NO_BUILTIN_OPERATOR_NEW_DELETE) || \
-    defined(_LIBCUDACXX_HAS_NO_BUILTIN_OVERLOADED_OPERATOR_NEW_DELETE)
-    return ::operator delete(__ptr, __a1, __a2);
-#else
-    return __builtin_operator_delete(__ptr, __a1, __a2);
-#endif
-  }
-
-  template <class _A1>
-  static inline void __do_call(void *__ptr, _A1 __a1) {
-#if defined(_LIBCUDACXX_HAS_NO_BUILTIN_OPERATOR_NEW_DELETE) || \
-    defined(_LIBCUDACXX_HAS_NO_BUILTIN_OVERLOADED_OPERATOR_NEW_DELETE)
-    return ::operator delete(__ptr, __a1);
-#else
-    return __builtin_operator_delete(__ptr, __a1);
-#endif
-  }
-
-  static inline void __do_call(void *__ptr) {
-#ifdef _LIBCUDACXX_HAS_NO_BUILTIN_OPERATOR_NEW_DELETE
-    return ::operator delete(__ptr);
-#else
-    return __builtin_operator_delete(__ptr);
-#endif
-  }
-};
-
-inline _LIBCUDACXX_INLINE_VISIBILITY void __libcpp_deallocate(void* __ptr, size_t __size, size_t __align) {
-  _DeallocateCaller::__do_deallocate_handle_size_align(__ptr, __size, __align);
+#endif // !_LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY void __libcpp_deallocate_unsized(void* __ptr, size_t __align) {
-  _DeallocateCaller::__do_deallocate_handle_align(__ptr, __align);
+#if defined(_LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION)
+    (void)__align;
+    return __libcpp_operator_delete(__ptr);
+#else // ^^^ _LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION ^^^ / vvv !_LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION vvv
+    if (__is_overaligned_for_new(__align)) {
+      const align_val_t __align_val = static_cast<align_val_t>(__align);
+      return __libcpp_operator_delete(__ptr, __align_val);
+    } else {
+      return __libcpp_operator_delete(__ptr);
+    }
+#endif // !_LIBCUDACXX_HAS_NO_ALIGNED_ALLOCATION
 }
 
 template <class _Tp>
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline
-_LIBCUDACXX_CONSTEXPR _Tp* __launder(_Tp* __p) _NOEXCEPT
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+_LIBCUDACXX_CONSTEXPR _Tp* __launder(_Tp* __p) noexcept
 {
     static_assert (!(is_function<_Tp>::value), "can't launder functions" );
     static_assert (!(is_same<void, __remove_cv_t<_Tp>>::value), "can't launder cv-void" );
@@ -363,15 +362,22 @@ _LIBCUDACXX_CONSTEXPR _Tp* __launder(_Tp* __p) _NOEXCEPT
 #endif // defined(_LIBCUDACXX_LAUNDER)
 }
 
-
 #if _LIBCUDACXX_STD_VER > 14
 template <class _Tp>
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_INLINE_VISIBILITY
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
 constexpr _Tp* launder(_Tp* __p) noexcept
 {
     return _CUDA_VSTD::__launder(__p);
 }
-#endif
+
+#if defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
+
+_LIBCUDACXX_INLINE_VAR constexpr size_t hardware_destructive_interference_size = __GCC_DESTRUCTIVE_SIZE;
+_LIBCUDACXX_INLINE_VAR constexpr size_t hardware_constructive_interference_size = __GCC_CONSTRUCTIVE_SIZE;
+
+#endif // defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
+
+#endif // _LIBCUDACXX_STD_VER > 14
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
@@ -379,4 +385,4 @@ _LIBCUDACXX_END_NAMESPACE_STD
 #include <__pragma_pop>
 #endif //__cuda_std__
 
-#endif  // _LIBCUDACXX_NEW
+#endif // _LIBCUDACXX_NEW

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/new
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/new
@@ -88,19 +88,18 @@ void  operator delete[](void* ptr, void*) noexcept;
 
 #ifndef __cuda_std__
 #include <__config>
-#include <exception>
-#ifdef _LIBCUDACXX_NO_EXCEPTIONS
-#include <cstdlib>
-#endif
-#if defined(_LIBCUDACXX_ABI_VCRUNTIME)
-#include <new.h>
-#endif
 #endif // __cuda_std__
 
 #include "__assert" // all public C++ headers provide the assertion handler
 #include "cstddef"
+#include "cstdlib"
+#include "exception"
 #include "type_traits"
 #include "version"
+
+#if defined(_LIBCUDACXX_ABI_VCRUNTIME)
+#include <new.h>
+#endif // _LIBCUDACXX_ABI_VCRUNTIME
 
 #ifndef __cuda_std__
 #include <__pragma_push>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -161,7 +161,6 @@ template<class T>
 
 #ifndef __cuda_std__
 #include <__config>
-#include <new>
 #include <stdexcept>
 #endif // __cuda_std__
 
@@ -191,6 +190,7 @@ template<class T>
 #include "__verbose_abort"
 #include "cstdlib"
 #include "initializer_list"
+#include "new"
 #include "version"
 
 // standard-mandated includes

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/stdexcept
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/stdexcept
@@ -1,9 +1,11 @@
 // -*- C++ -*-
-//===--------------------------- stdexcept --------------------------------===//
+//===----------------------------------------------------------------------===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -46,8 +48,8 @@ public:
 #endif //__cuda_std__
 
 #include "__assert" // all public C++ headers provide the assertion handler
-#include "cstdlib"
-#include "exception"
+#include "__exception/exception.h"
+#include "__verbose_abort"
 #include "iosfwd"
 
 #ifndef __cuda_std__
@@ -68,23 +70,17 @@ class _LIBCUDACXX_HIDDEN __libcpp_refstring
     _LIBCUDACXX_HOST_DEVICE bool __uses_refcount() const;
 public:
     _LIBCUDACXX_HOST_DEVICE explicit __libcpp_refstring(const char* __msg);
-    _LIBCUDACXX_HOST_DEVICE __libcpp_refstring(const __libcpp_refstring& __s) _NOEXCEPT;
-    _LIBCUDACXX_HOST_DEVICE __libcpp_refstring& operator=(const __libcpp_refstring& __s) _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE __libcpp_refstring(const __libcpp_refstring& __s) noexcept;
+    _LIBCUDACXX_HOST_DEVICE __libcpp_refstring& operator=(const __libcpp_refstring& __s) noexcept;
     _LIBCUDACXX_HOST_DEVICE ~__libcpp_refstring();
 
-    _LIBCUDACXX_HOST_DEVICE const char* c_str() const _NOEXCEPT {return __imp_;}
+    _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_HIDE_FROM_ABI const char* c_str() const noexcept {return __imp_;}
 };
 #endif // !_LIBCUDACXX_ABI_VCRUNTIME
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#ifndef __cuda_std__
-#ifdef _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
 _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
-#else
-namespace std  // purposefully not versioned
-{
-#endif //_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
 
 class _LIBCUDACXX_EXCEPTION_ABI logic_error
     : public exception
@@ -93,20 +89,20 @@ class _LIBCUDACXX_EXCEPTION_ABI logic_error
 private:
     _CUDA_VSTD::__libcpp_refstring __imp_;
 public:
-    explicit logic_error(const string&);
-    explicit logic_error(const char*);
+    _LIBCUDACXX_HOST_DEVICE explicit logic_error(const string&);
+    _LIBCUDACXX_HOST_DEVICE explicit logic_error(const char*);
 
-    logic_error(const logic_error&) _NOEXCEPT;
-    logic_error& operator=(const logic_error&) _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE logic_error(const logic_error&) noexcept;
+    _LIBCUDACXX_HOST_DEVICE logic_error& operator=(const logic_error&) noexcept;
 
-    virtual ~logic_error() _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE virtual ~logic_error() noexcept;
 
-    virtual const char* what() const _NOEXCEPT;
-#else
+    _LIBCUDACXX_HOST_DEVICE virtual const char* what() const noexcept;
+#else // ^^^ !_LIBCUDACXX_ABI_VCRUNTIME ^^^ / vvv _LIBCUDACXX_ABI_VCRUNTIME vvv
 public:
-    explicit logic_error(const _CUDA_VSTD::string&); // Symbol uses versioned std::string
+    _LIBCUDACXX_HOST_DEVICE explicit logic_error(const _CUDA_VSTD::string&); // Symbol uses versioned std::string
     _LIBCUDACXX_INLINE_VISIBILITY explicit logic_error(const char* __s) : exception(__s) {}
-#endif
+#endif // _LIBCUDACXX_ABI_VCRUNTIME
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI runtime_error
@@ -116,18 +112,18 @@ class _LIBCUDACXX_EXCEPTION_ABI runtime_error
 private:
     _CUDA_VSTD::__libcpp_refstring __imp_;
 public:
-    explicit runtime_error(const string&);
-    explicit runtime_error(const char*);
+    _LIBCUDACXX_HOST_DEVICE explicit runtime_error(const string&);
+    _LIBCUDACXX_HOST_DEVICE explicit runtime_error(const char*);
 
-    runtime_error(const runtime_error&) _NOEXCEPT;
-    runtime_error& operator=(const runtime_error&) _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE runtime_error(const runtime_error&) noexcept;
+    _LIBCUDACXX_HOST_DEVICE runtime_error& operator=(const runtime_error&) noexcept;
 
-    virtual ~runtime_error() _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE virtual ~runtime_error() noexcept;
 
-    virtual const char* what() const _NOEXCEPT;
-#else
+    _LIBCUDACXX_HOST_DEVICE virtual const char* what() const noexcept;
+#else // ^^^ !_LIBCUDACXX_ABI_VCRUNTIME ^^^ / vvv _LIBCUDACXX_ABI_VCRUNTIME vvv
 public:
-   explicit runtime_error(const _CUDA_VSTD::string&); // Symbol uses versioned std::string
+   _LIBCUDACXX_HOST_DEVICE explicit runtime_error(const _CUDA_VSTD::string&); // Symbol uses versioned std::string
    _LIBCUDACXX_INLINE_VISIBILITY explicit runtime_error(const char* __s) : exception(__s) {}
 #endif // _LIBCUDACXX_ABI_VCRUNTIME
 };
@@ -140,8 +136,9 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit domain_error(const char* __s)   : logic_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~domain_error() _NOEXCEPT;
-#endif
+    _LIBCUDACXX_HIDE_FROM_ABI domain_error(const domain_error&) noexcept = default;
+    _LIBCUDACXX_HOST_DEVICE virtual ~domain_error() noexcept;
+#endif // _LIBCUDACXX_ABI_VCRUNTIME
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI invalid_argument
@@ -152,8 +149,9 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit invalid_argument(const char* __s)   : logic_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~invalid_argument() _NOEXCEPT;
-#endif
+    _LIBCUDACXX_HIDE_FROM_ABI invalid_argument(const invalid_argument&) noexcept = default;
+    _LIBCUDACXX_HOST_DEVICE virtual ~invalid_argument() noexcept;
+#endif // _LIBCUDACXX_ABI_VCRUNTIME
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI length_error
@@ -163,8 +161,9 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit length_error(const string& __s) : logic_error(__s) {}
     _LIBCUDACXX_INLINE_VISIBILITY explicit length_error(const char* __s)   : logic_error(__s) {}
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~length_error() _NOEXCEPT;
-#endif
+    _LIBCUDACXX_HIDE_FROM_ABI length_error(const length_error&) noexcept = default;
+    _LIBCUDACXX_HOST_DEVICE virtual ~length_error() noexcept;
+#endif // _LIBCUDACXX_ABI_VCRUNTIME
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI out_of_range
@@ -175,8 +174,9 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit out_of_range(const char* __s)   : logic_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~out_of_range() _NOEXCEPT;
-#endif
+    _LIBCUDACXX_HIDE_FROM_ABI out_of_range(const out_of_range&) noexcept = default;
+    _LIBCUDACXX_HOST_DEVICE virtual ~out_of_range() noexcept;
+#endif // _LIBCUDACXX_ABI_VCRUNTIME
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI range_error
@@ -187,8 +187,9 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit range_error(const char* __s)   : runtime_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~range_error() _NOEXCEPT;
-#endif
+    _LIBCUDACXX_HIDE_FROM_ABI range_error(const range_error&) noexcept = default;
+    _LIBCUDACXX_HOST_DEVICE virtual ~range_error() noexcept;
+#endif // _LIBCUDACXX_ABI_VCRUNTIME
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI overflow_error
@@ -199,8 +200,9 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit overflow_error(const char* __s)   : runtime_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~overflow_error() _NOEXCEPT;
-#endif
+    _LIBCUDACXX_HIDE_FROM_ABI overflow_error(const overflow_error&) noexcept = default;
+    _LIBCUDACXX_HOST_DEVICE virtual ~overflow_error() noexcept;
+#endif // _LIBCUDACXX_ABI_VCRUNTIME
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI underflow_error
@@ -211,16 +213,12 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit underflow_error(const char* __s)   : runtime_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~underflow_error() _NOEXCEPT;
-#endif
+    _LIBCUDACXX_HIDE_FROM_ABI underflow_error(const underflow_error&) noexcept = default;
+    _LIBCUDACXX_HOST_DEVICE virtual ~underflow_error() noexcept;
+#endif // _LIBCUDACXX_ABI_VCRUNTIME
 };
 
-#ifdef _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
 _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
-#else
-}
-#endif //_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
-#endif //__cuda_std__
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -232,10 +230,10 @@ void __throw_logic_error(const char*__msg)
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     throw logic_error(__msg);
-#else
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
     ((void)__msg);
     _LIBCUDACXX_UNREACHABLE();
-#endif
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
 }
 
 _LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -243,10 +241,10 @@ void __throw_domain_error(const char*__msg)
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     throw domain_error(__msg);
-#else
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
     ((void)__msg);
     _LIBCUDACXX_UNREACHABLE();
-#endif
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
 }
 
 _LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -254,10 +252,10 @@ void __throw_invalid_argument(const char*__msg)
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     throw invalid_argument(__msg);
-#else
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
     ((void)__msg);
     _LIBCUDACXX_UNREACHABLE();
-#endif
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
 }
 
 _LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -265,10 +263,10 @@ void __throw_length_error(const char*__msg)
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     throw length_error(__msg);
-#else
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
     ((void)__msg);
     _LIBCUDACXX_UNREACHABLE();
-#endif
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
 }
 
 _LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -276,10 +274,10 @@ void __throw_out_of_range(const char*__msg)
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     throw out_of_range(__msg);
-#else
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
     ((void)__msg);
     _LIBCUDACXX_UNREACHABLE();
-#endif
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
 }
 
 _LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -287,10 +285,10 @@ void __throw_range_error(const char*__msg)
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     throw range_error(__msg);
-#else
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
     ((void)__msg);
     _LIBCUDACXX_UNREACHABLE();
-#endif
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
 }
 
 _LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -298,10 +296,10 @@ void __throw_overflow_error(const char*__msg)
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     throw overflow_error(__msg);
-#else
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
     ((void)__msg);
     _LIBCUDACXX_UNREACHABLE();
-#endif
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
 }
 
 _LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -309,10 +307,10 @@ void __throw_underflow_error(const char*__msg)
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     throw underflow_error(__msg);
-#else
+#else // ^^^ !_LIBCUDACXX_NO_EXCEPTIONS ^^^ / vvv _LIBCUDACXX_NO_EXCEPTIONS vvv
     ((void)__msg);
     _LIBCUDACXX_UNREACHABLE();
-#endif
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/stdexcept
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/stdexcept
@@ -43,13 +43,11 @@ public:
 
 #ifndef __cuda_std__
 #include <__config>
-#include <exception>
-#ifdef _LIBCUDACXX_NO_EXCEPTIONS
-#include <cstdlib>
-#endif
 #endif //__cuda_std__
 
 #include "__assert" // all public C++ headers provide the assertion handler
+#include "cstdlib"
+#include "exception"
 #include "iosfwd"
 
 #ifndef __cuda_std__


### PR DESCRIPTION
This modularizes the `<exception>` header and makes it usable internally.

We also rework `<stdexcept>` and `<new>`

In order to test those internal headers we add a non user accessible header `cuda/std/__memory` which acts as an entry point for our tests