### PR TITLE
Fix icpc / denormals

### DIFF
--- a/cub/cmake/CubBuildCompilerTargets.cmake
+++ b/cub/cmake/CubBuildCompilerTargets.cmake
@@ -72,8 +72,9 @@ function(cub_build_compiler_targets)
   endif()
 
   if ("Intel" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-    # Disable warning that inlining is inhibited by compiler thresholds.
+    # Do not flush denormal floats to zero
     append_option_if_available("-no-ftz" cxx_compile_options)
+    # Disable warning that inlining is inhibited by compiler thresholds.
     append_option_if_available("-diag-disable=11074" cxx_compile_options)
     append_option_if_available("-diag-disable=11076" cxx_compile_options)
   endif()
@@ -86,6 +87,7 @@ function(cub_build_compiler_targets)
   endif()
 
   if ("NVHPC" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
+    # Do not flush denormal floats to zero
     list(APPEND cxx_compile_options -Mnodaz)
     # TODO: Managed memory is currently not supported on windows with WSL
     list(APPEND cxx_compile_options -gpu=nomanaged)

--- a/cub/cmake/CubBuildCompilerTargets.cmake
+++ b/cub/cmake/CubBuildCompilerTargets.cmake
@@ -73,6 +73,7 @@ function(cub_build_compiler_targets)
 
   if ("Intel" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     # Disable warning that inlining is inhibited by compiler thresholds.
+    append_option_if_available("-no-ftz" cxx_compile_options)
     append_option_if_available("-diag-disable=11074" cxx_compile_options)
     append_option_if_available("-diag-disable=11076" cxx_compile_options)
   endif()


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes 4053381

<!-- Provide a standalone description of changes in this PR. -->
Intel compiler flushes denormals by default, leading to most radix sort tests failing. This PR disables flushing of denormals. 


<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
