### PR TITLE
[BUG] Rework how we handle feature test macros

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/atomics/atomics.lockfree/isalwayslockfree.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/atomics/atomics.lockfree/isalwayslockfree.pass.cpp
@@ -21,9 +21,9 @@
 TEST_NV_DIAG_SUPPRESS(cuda_demote_unsupported_floating_point)
 
 // NVRTC doesn't include host atomic making this feature test invalid
-// TODO: Should we define __cpp_lib_atomic_is_always_lock_free for NVRTC?
-#if !defined(__CUDACC_RTC__)
-#if !defined(__cpp_lib_atomic_is_always_lock_free)
+// TODO: Should we define __cccl_lib_atomic_is_always_lock_free for NVRTC?
+#if !defined(_LIBCUDACXX_COMPILER_NVRTC)
+#if !defined(__cccl_lib_atomic_is_always_lock_free)
 # error Feature test macro missing.
 #endif
 #endif

--- a/libcudacxx/.upstream-tests/test/std/utilities/meta/meta.const.eval/is_constant_evaluated.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/meta/meta.const.eval/is_constant_evaluated.pass.cpp
@@ -17,14 +17,13 @@
 
 #include "test_macros.h"
 
-// libcudacxx does not have feature test macros... yet
-/*
-#ifndef __cpp_lib_is_constant_evaluated
+#if TEST_STD_VER > 17
+#ifndef __cccl_lib_is_constant_evaluated
 #if TEST_HAS_BUILTIN(__builtin_is_constant_evaluated)
-# error __cpp_lib_is_constant_evaluated should be defined
+# error __cccl_lib_is_constant_evaluated should be defined
 #endif
-#endif
-*/
+#endif // __cccl_lib_is_constant_evaluated
+#endif // TEST_STD_VER > 17
 
 template <bool> struct InTemplate {};
 

--- a/libcudacxx/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.cat/is_integral.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.cat/is_integral.pass.cpp
@@ -88,7 +88,7 @@ int main(int, char**)
     test_is_integral<signed char>();
     test_is_integral<unsigned char>();
     test_is_integral<wchar_t>();
-#if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
+#if defined(__cccl_lib_char8_t) && __cccl_lib_char8_t >= 201811L
     test_is_integral<char8_t>();
 #endif
 

--- a/libcudacxx/.upstream-tests/utils/generate_feature_test_macro_components.py
+++ b/libcudacxx/.upstream-tests/utils/generate_feature_test_macro_components.py
@@ -31,128 +31,128 @@ def add_version_header(tc):
 
 feature_test_macros = sorted([ add_version_header(x) for x in [
   # C++14 macros
-  {"name": "__cpp_lib_integer_sequence",
+  {"name": "__cccl_lib_integer_sequence",
    "values": {
       "c++14": 201304L
     },
     "headers": ["utility"],
   },
-  {"name": "__cpp_lib_exchange_function",
+  {"name": "__cccl_lib_exchange_function",
    "values": {
      "c++14": 201304L
    },
    "headers": ["utility"],
   },
-  {"name": "__cpp_lib_tuples_by_type",
+  {"name": "__cccl_lib_tuples_by_type",
    "values": {
      "c++14": 201304L
    },
    "headers": ["utility", "tuple"],
   },
-  {"name": "__cpp_lib_tuple_element_t",
+  {"name": "__cccl_lib_tuple_element_t",
    "values": {
      "c++14": 201402L
    },
    "headers": ["tuple"],
   },
-  {"name": "__cpp_lib_make_unique",
+  {"name": "__cccl_lib_make_unique",
    "values": {
      "c++14": 201304L
    },
    "headers": ["memory"],
   },
-  {"name": "__cpp_lib_transparent_operators",
+  {"name": "__cccl_lib_transparent_operators",
    "values": {
      "c++14": 201210L,
      "c++17": 201510L,
    },
    "headers": ["functional"],
   },
-  {"name": "__cpp_lib_integral_constant_callable",
+  {"name": "__cccl_lib_integral_constant_callable",
    "values": {
      "c++14": 201304L
    },
    "headers": ["type_traits"],
   },
-  {"name": "__cpp_lib_transformation_trait_aliases",
+  {"name": "__cccl_lib_transformation_trait_aliases",
    "values": {
      "c++14": 201304L,
    },
    "headers": ["type_traits"]
   },
-  {"name": "__cpp_lib_result_of_sfinae",
+  {"name": "__cccl_lib_result_of_sfinae",
    "values": {
      "c++14": 201210L,
    },
    "headers": ["functional", "type_traits"]
   },
-  {"name": "__cpp_lib_is_final",
+  {"name": "__cccl_lib_is_final",
    "values": {
      "c++14": 201402L,
    },
    "headers": ["type_traits"]
   },
-  {"name": "__cpp_lib_is_null_pointer",
+  {"name": "__cccl_lib_is_null_pointer",
    "values": {
      "c++14": 201309L,
    },
    "headers": ["type_traits"]
   },
-  {"name": "__cpp_lib_chrono_udls",
+  {"name": "__cccl_lib_chrono_udls",
    "values": {
      "c++14": 201304L,
    },
    "headers": ["chrono"]
   },
-  {"name": "__cpp_lib_string_udls",
+  {"name": "__cccl_lib_string_udls",
    "values": {
      "c++14": 201304L,
    },
    "headers": ["string"]
   },
-  {"name": "__cpp_lib_generic_associative_lookup",
+  {"name": "__cccl_lib_generic_associative_lookup",
    "values": {
      "c++14": 201304L,
    },
    "headers": ["map", "set"]
   },
-  {"name": "__cpp_lib_null_iterators",
+  {"name": "__cccl_lib_null_iterators",
    "values": {
      "c++14": 201304L,
    },
    "headers": ["iterator"]
   },
-  {"name": "__cpp_lib_make_reverse_iterator",
+  {"name": "__cccl_lib_make_reverse_iterator",
    "values": {
      "c++14": 201402L,
    },
    "headers": ["iterator"]
   },
-  {"name": "__cpp_lib_robust_nonmodifying_seq_ops",
+  {"name": "__cccl_lib_robust_nonmodifying_seq_ops",
    "values": {
      "c++14": 201304L,
    },
    "headers": ["algorithm"]
   },
-  {"name": "__cpp_lib_complex_udls",
+  {"name": "__cccl_lib_complex_udls",
    "values": {
      "c++14": 201309L,
    },
    "headers": ["complex"]
   },
-  {"name": "__cpp_lib_constexpr_complex",
+  {"name": "__cccl_lib_constexpr_complex",
    "values": {
       "c++14": 201711L
     },
     "headers": ["complex"],
   },
-  {"name": "__cpp_lib_quoted_string_io",
+  {"name": "__cccl_lib_quoted_string_io",
    "values": {
      "c++14": 201304L,
    },
    "headers": ["iomanip"]
   },
-  {"name": "__cpp_lib_shared_timed_mutex",
+  {"name": "__cccl_lib_shared_timed_mutex",
    "values": {
      "c++14": 201402L,
    },
@@ -161,7 +161,7 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
    "internal_depends": "!defined(_LIBCUDACXX_HAS_NO_THREADS)",
   },
   # C++17 macros
-  {"name": "__cpp_lib_atomic_is_always_lock_free",
+  {"name": "__cccl_lib_atomic_is_always_lock_free",
    "values": {
      "c++17": 201603L,
    },
@@ -169,91 +169,91 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
    "depends": "!defined(_LIBCUDACXX_HAS_NO_THREADS)",
    "internal_depends": "!defined(_LIBCUDACXX_HAS_NO_THREADS)",
   },
-  {"name": "__cpp_lib_filesystem",
+  {"name": "__cccl_lib_filesystem",
    "values": {
      "c++17": 201703L,
    },
    "headers": ["filesystem"]
   },
-  {"name": "__cpp_lib_invoke",
+  {"name": "__cccl_lib_invoke",
    "values": {
      "c++17": 201411L,
    },
    "headers": ["functional"]
   },
-  {"name": "__cpp_lib_void_t",
+  {"name": "__cccl_lib_void_t",
    "values": {
      "c++17": 201411L,
    },
    "headers": ["type_traits"]
   },
-  {"name": "__cpp_lib_node_extract",
+  {"name": "__cccl_lib_node_extract",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["map", "set", "unordered_map", "unordered_set"]
   },
-  {"name": "__cpp_lib_byte",
+  {"name": "__cccl_lib_byte",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["cstddef"],
    },
-  {"name": "__cpp_lib_hardware_interference_size",
+  {"name": "__cccl_lib_hardware_interference_size",
    "values": {
      "c++17": 201703L,
    },
    "headers": ["new"],
    },
-  {"name": "__cpp_lib_launder",
+  {"name": "__cccl_lib_launder",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["new"],
    },
-  {"name": "__cpp_lib_uncaught_exceptions",
+  {"name": "__cccl_lib_uncaught_exceptions",
    "values": {
      "c++17": 201411L,
    },
    "headers": ["exception"],
    },
-  {"name": "__cpp_lib_as_const",
+  {"name": "__cccl_lib_as_const",
    "values": {
      "c++17": 201510L,
    },
    "headers": ["utility"],
    },
-  {"name": "__cpp_lib_make_from_tuple",
+  {"name": "__cccl_lib_make_from_tuple",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["tuple"],
    },
-  {"name": "__cpp_lib_apply",
+  {"name": "__cccl_lib_apply",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["tuple"],
    },
-  {"name": "__cpp_lib_optional",
+  {"name": "__cccl_lib_optional",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["optional"],
    },
-  {"name": "__cpp_lib_variant",
+  {"name": "__cccl_lib_variant",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["variant"],
    },
-  {"name": "__cpp_lib_any",
+  {"name": "__cccl_lib_any",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["any"],
    },
-  {"name": "__cpp_lib_addressof_constexpr",
+  {"name": "__cccl_lib_addressof_constexpr",
    "values": {
      "c++17": 201603L,
    },
@@ -261,82 +261,82 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
    "depends": "TEST_HAS_BUILTIN(__builtin_addressof) || TEST_GCC_VER >= 700",
    "internal_depends": "defined(_LIBCUDACXX_ADDRESSOF)",
    },
-  {"name": "__cpp_lib_raw_memory_algorithms",
+  {"name": "__cccl_lib_raw_memory_algorithms",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["memory"],
    },
-  {"name": "__cpp_lib_enable_shared_from_this",
+  {"name": "__cccl_lib_enable_shared_from_this",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["memory"],
    },
-  {"name": "__cpp_lib_shared_ptr_weak_type",
+  {"name": "__cccl_lib_shared_ptr_weak_type",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["memory"],
    },
-  {"name": "__cpp_lib_shared_ptr_arrays",
+  {"name": "__cccl_lib_shared_ptr_arrays",
    "values": {
      "c++17": 201611L,
    },
    "headers": ["memory"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_memory_resource",
+  {"name": "__cccl_lib_memory_resource",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["memory_resource"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_boyer_moore_searcher",
+  {"name": "__cccl_lib_boyer_moore_searcher",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["functional"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_not_fn",
+  {"name": "__cccl_lib_not_fn",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["functional"],
    },
-  {"name": "__cpp_lib_bool_constant",
+  {"name": "__cccl_lib_bool_constant",
    "values": {
      "c++17": 201505L,
    },
    "headers": ["type_traits"],
    },
-  {"name": "__cpp_lib_type_trait_variable_templates",
+  {"name": "__cccl_lib_type_trait_variable_templates",
    "values": {
      "c++17": 201510L,
    },
    "headers": ["type_traits"],
    },
-  {"name": "__cpp_lib_logical_traits",
+  {"name": "__cccl_lib_logical_traits",
    "values": {
      "c++17": 201510L,
    },
    "headers": ["type_traits"],
    },
-  {"name": "__cpp_lib_is_swappable",
+  {"name": "__cccl_lib_is_swappable",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["type_traits"],
    },
-  {"name": "__cpp_lib_is_invocable",
+  {"name": "__cccl_lib_is_invocable",
    "values": {
      "c++17": 201703L,
    },
    "headers": ["type_traits"],
    },
-  {"name": "__cpp_lib_has_unique_object_representations",
+  {"name": "__cccl_lib_has_unique_object_representations",
    "values": {
      "c++17": 201606L,
    },
@@ -344,7 +344,7 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
    "depends": "TEST_HAS_BUILTIN_IDENTIFIER(__has_unique_object_representations) || TEST_GCC_VER >= 700",
    "internal_depends": "defined(_LIBCUDACXX_HAS_UNIQUE_OBJECT_REPRESENTATIONS)",
    },
-  {"name": "__cpp_lib_is_aggregate",
+  {"name": "__cccl_lib_is_aggregate",
    "values": {
      "c++17": 201703L,
    },
@@ -352,108 +352,108 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
    "depends": "TEST_HAS_BUILTIN_IDENTIFIER(__is_aggregate) || TEST_GCC_VER_NEW >= 7001",
    "internal_depends": "!defined(_LIBCUDACXX_HAS_NO_IS_AGGREGATE)",
    },
-  {"name": "__cpp_lib_chrono",
+  {"name": "__cccl_lib_chrono",
    "values": {
      "c++17": 201611L,
    },
    "headers": ["chrono"],
    },
-  {"name": "__cpp_lib_execution",
+  {"name": "__cccl_lib_execution",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["execution"],
    "unimplemented": True
    },
-  {"name": "__cpp_lib_parallel_algorithm",
+  {"name": "__cccl_lib_parallel_algorithm",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["algorithm", "numeric"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_to_chars",
+  {"name": "__cccl_lib_to_chars",
    "values": {
      "c++17": 201611L,
    },
    "headers": ["utility"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_string_view",
+  {"name": "__cccl_lib_string_view",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["string", "string_view"],
    },
-  {"name": "__cpp_lib_allocator_traits_is_always_equal",
+  {"name": "__cccl_lib_allocator_traits_is_always_equal",
    "values": {
      "c++17": 201411L,
    },
    "headers": ["memory", "scoped_allocator", "string", "deque", "forward_list", "list", "vector", "map", "set", "unordered_map", "unordered_set"],
    },
-  {"name": "__cpp_lib_incomplete_container_elements",
+  {"name": "__cccl_lib_incomplete_container_elements",
    "values": {
      "c++17": 201505L,
    },
    "headers": ["forward_list", "list", "vector"],
    },
-  {"name": "__cpp_lib_map_try_emplace",
+  {"name": "__cccl_lib_map_try_emplace",
    "values": {
      "c++17": 201411L,
    },
    "headers": ["map"],
    },
-  {"name": "__cpp_lib_unordered_map_try_emplace",
+  {"name": "__cccl_lib_unordered_map_try_emplace",
    "values": {
      "c++17": 201411L,
    },
    "headers": ["unordered_map"],
    },
-  {"name": "__cpp_lib_array_constexpr",
+  {"name": "__cccl_lib_array_constexpr",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["iterator", "array"],
    },
-  {"name": "__cpp_lib_nonmember_container_access",
+  {"name": "__cccl_lib_nonmember_container_access",
    "values": {
      "c++17": 201411L,
    },
    "headers": ["iterator", "array", "deque", "forward_list", "list", "map", "regex",
                "set", "string", "unordered_map", "unordered_set", "vector"],
    },
-  {"name": "__cpp_lib_sample",
+  {"name": "__cccl_lib_sample",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["algorithm"],
    },
-  {"name": "__cpp_lib_clamp",
+  {"name": "__cccl_lib_clamp",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["algorithm"],
    },
-  {"name": "__cpp_lib_gcd_lcm",
+  {"name": "__cccl_lib_gcd_lcm",
    "values": {
      "c++17": 201606L,
    },
    "headers": ["numeric"],
    },
-  {"name": "__cpp_lib_hypot",
+  {"name": "__cccl_lib_hypot",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["cmath"],
    },
-  {"name": "__cpp_lib_math_special_functions",
+  {"name": "__cccl_lib_math_special_functions",
    "values": {
      "c++17": 201603L,
    },
    "headers": ["cmath"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_shared_mutex",
+  {"name": "__cccl_lib_shared_mutex",
    "values": {
      "c++17": 201505L,
    },
@@ -461,14 +461,14 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
    "depends": "!defined(_LIBCUDACXX_HAS_NO_THREADS)",
    "internal_depends": "!defined(_LIBCUDACXX_HAS_NO_THREADS)",
    },
-  {"name": "__cpp_lib_scoped_lock",
+  {"name": "__cccl_lib_scoped_lock",
    "values": {
      "c++17": 201703L,
    },
    "headers": ["mutex"],
    },
   # C++2a
-  {"name": "__cpp_lib_char8_t",
+  {"name": "__cccl_lib_char8_t",
    "values": {
      "c++2a": 201811L,
    },
@@ -477,14 +477,14 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
    "depends": "defined(__cpp_char8_t)",
    "internal_depends": "!defined(_LIBCUDACXX_NO_HAS_CHAR8_T)",
    },
-  {"name": "__cpp_lib_erase_if",
+  {"name": "__cccl_lib_erase_if",
    "values": {
      "c++2a": 201811L,
    },
    "headers": ["string", "deque", "forward_list", "list", "vector", "map",
                "set", "unordered_map", "unordered_set"]
   },
-  {"name": "__cpp_lib_destroying_delete",
+  {"name": "__cccl_lib_destroying_delete",
    "values": {
      "c++2a": 201806L,
    },
@@ -498,40 +498,40 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
       " && defined(__cpp_impl_destroying_delete)"
       " && __cpp_impl_destroying_delete >= 201806L",
    },
-  {"name": "__cpp_lib_three_way_comparison",
+  {"name": "__cccl_lib_three_way_comparison",
    "values": {
      "c++2a": 201711L,
    },
    "headers": ["compare"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_concepts",
+  {"name": "__cccl_lib_concepts",
    "values": {
      "c++14": 202002L,
    },
    "headers": ["concepts"],
    },
-  {"name": "__cpp_lib_constexpr_swap_algorithms",
+  {"name": "__cccl_lib_constexpr_swap_algorithms",
    "values": {
      "c++2a": 201806L,
    },
    "headers": ["algorithm"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_constexpr_misc",
+  {"name": "__cccl_lib_constexpr_misc",
    "values": {
      "c++2a": 201811L,
    },
    "headers": ["array", "functional", "iterator", "string_view", "tuple", "utility"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_bind_front",
+  {"name": "__cccl_lib_bind_front",
    "values": {
      "c++17": 201907L,
    },
    "headers": ["functional"],
    },
-  {"name": "__cpp_lib_is_constant_evaluated",
+  {"name": "__cccl_lib_is_constant_evaluated",
    "values": {
      "c++2a": 201811L,
    },
@@ -539,35 +539,35 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
    "depends": "TEST_HAS_BUILTIN(__builtin_is_constant_evaluated) || TEST_GCC_VER >= 900",
    "internal_depends": "defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED)",
    },
-  {"name": "__cpp_lib_list_remove_return_type",
+  {"name": "__cccl_lib_list_remove_return_type",
    "values": {
      "c++2a": 201806L,
    },
    "headers": ["forward_list", "list"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_generic_unordered_lookup",
+  {"name": "__cccl_lib_generic_unordered_lookup",
    "values": {
      "c++2a": 201811L,
    },
    "headers": ["unordered_map", "unordered_set"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_ranges",
+  {"name": "__cccl_lib_ranges",
    "values": {
      "c++2a": 201811L,
    },
    "headers": ["algorithm", "functional", "iterator", "memory", "ranges"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_bit_cast",
+  {"name": "__cccl_lib_bit_cast",
    "values": {
      "c++2a": 201806L,
    },
    "headers": ["bit"],
    "unimplemented": True,
    },
-  {"name": "__cpp_lib_atomic_ref",
+  {"name": "__cccl_lib_atomic_ref",
    "values": {
      "c++2a": 201806L,
    },
@@ -576,7 +576,7 @@ feature_test_macros = sorted([ add_version_header(x) for x in [
    "depends": "!defined(_LIBCUDACXX_HAS_NO_THREADS)",
    "internal_depends": "!defined(_LIBCUDACXX_HAS_NO_THREADS)",
    },
-  {"name": "__cpp_lib_interpolate",
+  {"name": "__cccl_lib_interpolate",
    "values": {
      "c++2a": 201902L,
    },

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -1024,10 +1024,6 @@ typedef __char32_t char32_t;
 
 #define _LIBCUDACXX_DISABLE_EXTENSION_WARNING
 
-#ifdef __cuda_std__
-# undef __cpp_lib_transparent_operators
-#endif // __cuda_std__
-
 #elif defined(_LIBCUDACXX_COMPILER_IBM)
 
 #define _ATTRIBUTE(x) __attribute__((x))

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/version
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/version
@@ -245,7 +245,7 @@ __cpp_lib_void_t                                        201411L <type_traits>
 # define __cccl_lib_span                                 201902L
 // # define __cccl_lib_string_udls                          201304L
 # define __cccl_lib_transformation_trait_aliases         201304L
-# define __cccl_lib_transparent_operators                201510L
+# define __cccl_lib_transparent_operators                201210L
 # define __cccl_lib_tuple_element_t                      201402L
 # define __cccl_lib_tuples_by_type                       201304L
 #endif // _LIBCUDACXX_STD_VER > 11

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/version
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/version
@@ -201,234 +201,464 @@ __cpp_lib_void_t                                        201411L <type_traits>
 
 #ifndef __cuda_std__
 #include <__config>
-#include <__pragma_push>
+#endif // __cuda_std__
+
+// If we are replacing the stl we need to define our own feature test macros.
+// However, if we are in __cuda_std__ we need to define our own symbols to not
+// conflict with the host stl.
+// At the same time we want bring in all feature test macros from host
+#ifdef __cuda_std__
+#if __has_include(<version>) // <version> should be the smallest include possible
+#include <version>
+#elif !defined(_LIBCUDACXX_COMPILER_NVRTC)
+#include <ciso646> // otherwise go for the smallest possible header
+#endif
+#endif // __cuda_std__
 
 #if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
 #pragma GCC system_header
 #endif
 
+// We unconditionally define `__cccl_lib_meow` so that there is only one place to set the value
 #if _LIBCUDACXX_STD_VER > 11
-# define __cpp_lib_chrono_udls                          201304L
-# define __cpp_lib_complex_udls                         201309L
+# define __cccl_lib_chrono_udls                          201304L
+# define __cccl_lib_complex_udls                         201309L
 #ifdef _LIBCUDACXX_IS_CONSTANT_EVALUATED
-# define __cpp_lib_constexpr_complex                    201711L
+# define __cccl_lib_constexpr_complex                    201711L
 #endif
-# define __cpp_lib_concepts                             202002L
-# define __cpp_lib_exchange_function                    201304L
-# define __cpp_lib_generic_associative_lookup           201304L
-# define __cpp_lib_integer_sequence                     201304L
-# define __cpp_lib_integral_constant_callable           201304L
-# define __cpp_lib_is_final                             201402L
-# define __cpp_lib_is_null_pointer                      201309L
-# define __cpp_lib_make_reverse_iterator                201402L
-# define __cpp_lib_make_unique                          201304L
-# define __cpp_lib_null_iterators                       201304L
-# define __cpp_lib_quoted_string_io                     201304L
-# define __cpp_lib_result_of_sfinae                     201210L
-# define __cpp_lib_robust_nonmodifying_seq_ops          201304L
+# define __cccl_lib_concepts                             202002L
+# define __cccl_lib_exchange_function                    201304L
+// # define __cccl_lib_generic_associative_lookup           201304L
+# define __cccl_lib_integer_sequence                     201304L
+# define __cccl_lib_integral_constant_callable           201304L
+# define __cccl_lib_is_final                             201402L
+# define __cccl_lib_is_null_pointer                      201309L
+# define __cccl_lib_make_reverse_iterator                201402L
+// # define __cccl_lib_make_unique                          201304L
+# define __cccl_lib_null_iterators                       201304L
+// # define __cccl_lib_quoted_string_io                     201304L
+# define __cccl_lib_result_of_sfinae                     201210L
+# define __cccl_lib_robust_nonmodifying_seq_ops          201304L
 # if !defined(_LIBCUDACXX_HAS_NO_THREADS)
-#   define __cpp_lib_shared_timed_mutex                 201402L
+// #   define __cccl_lib_shared_timed_mutex                 201402L
 # endif
-# define __cpp_lib_span                                 201902L
-# define __cpp_lib_string_udls                          201304L
-# define __cpp_lib_transformation_trait_aliases         201304L
-# define __cpp_lib_transparent_operators                201210L
-# define __cpp_lib_tuple_element_t                      201402L
-# define __cpp_lib_tuples_by_type                       201304L
-#endif
+# define __cccl_lib_span                                 201902L
+// # define __cccl_lib_string_udls                          201304L
+# define __cccl_lib_transformation_trait_aliases         201304L
+# define __cccl_lib_transparent_operators                201510L
+# define __cccl_lib_tuple_element_t                      201402L
+# define __cccl_lib_tuples_by_type                       201304L
+#endif // _LIBCUDACXX_STD_VER > 11
 
 #if _LIBCUDACXX_STD_VER > 14
 # if defined(_LIBCUDACXX_ADDRESSOF)
-#   define __cpp_lib_addressof_constexpr                201603L
+#   define __cccl_lib_addressof_constexpr                201603L
+# endif
+// # define __cccl_lib_allocator_traits_is_always_equal     201411L
+// # define __cccl_lib_any                                  201606L
+# define __cccl_lib_apply                                201603L
+# define __cccl_lib_array_constexpr                      201603L
+# define __cccl_lib_as_const                             201510L
+# if !defined(_LIBCUDACXX_HAS_NO_THREADS)
+#   define __cccl_lib_atomic_is_always_lock_free         201603L
+# endif
+# define __cccl_lib_bind_front                           201907L
+# define __cccl_lib_bool_constant                        201505L
+// # define __cccl_lib_boyer_moore_searcher                 201603L
+# define __cccl_lib_byte                                 201603L
+# define __cccl_lib_chrono                               201611L
+// # define __cccl_lib_clamp                                201603L
+// # define __cccl_lib_enable_shared_from_this              201603L
+// # define __cccl_lib_execution                            201603L
+// # define __cccl_lib_filesystem                           201703L
+# define __cccl_lib_gcd_lcm                              201606L
+# define __cccl_lib_hardware_interference_size           201703L
+# if defined(_LIBCUDACXX_HAS_UNIQUE_OBJECT_REPRESENTATIONS)
+#   define __cccl_lib_has_unique_object_representations  201606L
+# endif
+# define __cccl_lib_hypot                                201603L
+// # define __cccl_lib_incomplete_container_elements        201505L
+# define __cccl_lib_invoke                               201411L
+# if !defined(_LIBCUDACXX_HAS_NO_IS_AGGREGATE)
+#   define __cccl_lib_is_aggregate                       201703L
+# endif
+# define __cccl_lib_is_invocable                         201703L
+# define __cccl_lib_is_swappable                         201603L
+# define __cccl_lib_launder                              201606L
+# define __cccl_lib_logical_traits                       201510L
+# define __cccl_lib_make_from_tuple                      201606L
+// # define __cccl_lib_map_try_emplace                      201411L
+// # define __cccl_lib_math_special_functions               201603L
+// # define __cccl_lib_memory_resource                      201603L
+// # define __cccl_lib_node_extract                         201606L
+// # define __cccl_lib_nonmember_container_access           201411L
+# define __cccl_lib_not_fn                               201603L
+# define __cccl_lib_optional                             201606L
+// # define __cccl_lib_parallel_algorithm                   201603L
+// # define __cccl_lib_raw_memory_algorithms                201606L
+// # define __cccl_lib_sample                               201603L
+// # define __cccl_lib_scoped_lock                          201703L
+# if !defined(_LIBCUDACXX_HAS_NO_THREADS)
+// #   define __cccl_lib_shared_mutex                       201505L
+# endif
+// # define __cccl_lib_shared_ptr_arrays                    201611L
+// # define __cccl_lib_shared_ptr_weak_type                 201606L
+// # define __cccl_lib_string_view                          201606L
+// # define __cccl_lib_to_chars                             201611L
+# define __cccl_lib_type_trait_variable_templates        201510L
+# define __cccl_lib_uncaught_exceptions                  201411L
+# define __cccl_lib_unordered_map_try_emplace            201411L
+# define __cccl_lib_variant                              201606L
+# define __cccl_lib_void_t                               201411L
+#endif // _LIBCUDACXX_STD_VER > 14
+
+#if _LIBCUDACXX_STD_VER > 17
+# undef  __cccl_lib_array_constexpr
+# define __cccl_lib_array_constexpr                      201811L
+// # define __cccl_lib_assume_aligned                       201811L
+# define __cccl_lib_atomic_flag_test                     201907L
+# define __cccl_lib_atomic_float                         201711L
+# define __cccl_lib_atomic_lock_free_type_aliases        201907L
+# if !defined(_LIBCUDACXX_HAS_NO_THREADS)
+#   define __cccl_lib_atomic_ref                         201806L
+#endif
+// # define __cccl_lib_atomic_shared_ptr                    201711L
+# define __cccl_lib_atomic_value_initialization          201911L
+# if !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_atomic_wait)
+#   define __cccl_lib_atomic_wait                        201907L
+# endif
+# if !defined(_LIBCUDACXX_HAS_NO_THREADS) && !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_barrier)
+#   define __cccl_lib_barrier                            201907L
+# endif
+# define __cccl_lib_bit_cast                             201806L
+# define __cccl_lib_bitops                               201907L
+# define __cccl_lib_bounded_array_traits                 201902L
+# if !defined(_LIBCUDACXX_NO_HAS_CHAR8_T)
+#   define __cccl_lib_char8_t                            201811L
+# endif
+// # define __cccl_lib_constexpr_algorithms                 201806L
+// # define __cccl_lib_constexpr_dynamic_alloc              201907L
+# define __cccl_lib_constexpr_functional                 201907L
+// # define __cccl_lib_constexpr_iterator                   201811L
+// # define __cccl_lib_constexpr_memory                     201811L
+// # define __cccl_lib_constexpr_misc                       201811L
+// # define __cccl_lib_constexpr_numeric                    201911L
+// # define __cccl_lib_constexpr_string                     201907L
+// # define __cccl_lib_constexpr_string_view                201811L
+// # define __cccl_lib_constexpr_swap_algorithms            201806L
+// # define __cccl_lib_constexpr_tuple                      201811L
+// # define __cccl_lib_constexpr_utility                    201811L
+// # define __cccl_lib_constexpr_vector                     201907L
+// # define __cccl_lib_coroutine                            201902L
+# if _LIBCUDACXX_STD_VER > 17 && defined(__cpp_impl_destroying_delete) && __cpp_impl_destroying_delete >= 201806L
+#   define __cccl_lib_destroying_delete                  201806L
+# endif
+// # define __cccl_lib_endian                               201907L
+// # define __cccl_lib_erase_if                             201811L
+// # undef  __cccl_lib_execution
+// # define __cccl_lib_execution                            201902L
+# if !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_format) && !defined(_LIBCUDACXX_HAS_NO_INCOMPLETE_FORMAT)
+// #   define __cccl_lib_format                             202106L
+# endif
+// # define __cccl_lib_generic_unordered_lookup             201811L
+// # define __cccl_lib_int_pow2                             202002L
+// # define __cccl_lib_integer_comparison_functions         202002L
+// # define __cccl_lib_interpolate                          201902L
+# if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED)
+#   define __cccl_lib_is_constant_evaluated              201811L
+# endif
+// # define __cccl_lib_is_layout_compatible                 201907L
+# define __cccl_lib_is_nothrow_convertible               201806L
+// # define __cccl_lib_is_pointer_interconvertible          201907L
+# if !defined(_LIBCUDACXX_HAS_NO_THREADS)
+// #   define __cccl_lib_jthread                            201911L
+# endif
+# if !defined(_LIBCUDACXX_HAS_NO_THREADS) && !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_latch)
+// #   define __cccl_lib_latch                              201907L
+# endif
+// # define __cccl_lib_list_remove_return_type              201806L
+// # define __cccl_lib_math_constants                       201907L
+// # define __cccl_lib_polymorphic_allocator                201902L
+// # define __cccl_lib_ranges                               201811L
+// # define __cccl_lib_remove_cvref                         201711L
+# if !defined(_LIBCUDACXX_HAS_NO_THREADS) && !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_semaphore)
+// #   define __cccl_lib_semaphore                          201907L
+# endif
+// # undef  __cccl_lib_shared_ptr_arrays
+// # define __cccl_lib_shared_ptr_arrays                    201707L
+// # define __cccl_lib_shift                                201806L
+// # define __cccl_lib_smart_ptr_for_overwrite              202002L
+// # define __cccl_lib_source_location                      201907L
+// # define __cccl_lib_ssize                                201902L
+// # define __cccl_lib_starts_ends_with                     201711L
+// # undef  __cccl_lib_string_view
+// # define __cccl_lib_string_view                          201803L
+// # define __cccl_lib_syncbuf                              201803L
+// # define __cccl_lib_three_way_comparison                 201907L
+// # define __cccl_lib_to_address                           201711L
+// # define __cccl_lib_to_array                             201907L
+// # define __cccl_lib_type_identity                        201806L
+# define __cccl_lib_unwrap_ref                           201811L
+#endif // _LIBCUDACXX_STD_VER > 17
+
+#if _LIBCUDACXX_STD_VER > 20
+// # define __cccl_lib_adaptor_iterator_pair_constructor    202106L
+// # define __cccl_lib_allocate_at_least                    202106L
+// # define __cccl_lib_associative_heterogeneous_erasure    202110L
+// # define __cccl_lib_bind_back                            202202L
+// # define __cccl_lib_byteswap                             202110L
+// # define __cccl_lib_constexpr_bitset                     202207L
+// # define __cccl_lib_constexpr_charconv                   202207L
+// # define __cccl_lib_constexpr_cmath                      202202L
+// # undef  __cccl_lib_constexpr_memory
+// # define __cccl_lib_constexpr_memory                     202202L
+// # define __cccl_lib_constexpr_typeinfo                   202106L
+# define __cccl_lib_forward_like                         202207L
+// # define __cccl_lib_invoke_r                             202106L
+# define __cccl_lib_is_scoped_enum                       202011L
+// # define __cccl_lib_move_only_function                   202110L
+# undef  __cccl_lib_optional
+# define __cccl_lib_optional                             202110L
+// # define __cccl_lib_out_ptr                              202106L
+// # define __cccl_lib_ranges_chunk                         202202L
+// # define __cccl_lib_ranges_chunk_by                      202202L
+// # define __cccl_lib_ranges_iota                          202202L
+// # define __cccl_lib_ranges_join_with                     202202L
+// # define __cccl_lib_ranges_slide                         202202L
+// # define __cccl_lib_ranges_starts_ends_with              202106L
+// # define __cccl_lib_ranges_to_container                  202202L
+// # define __cccl_lib_ranges_zip                           202110L
+// # define __cccl_lib_reference_from_temporary             202202L
+// # define __cccl_lib_spanstream                           202106L
+// # define __cccl_lib_stacktrace                           202011L
+// # define __cccl_lib_stdatomic_h                          202011L
+// # define __cccl_lib_string_contains                      202011L
+// # define __cccl_lib_string_resize_and_overwrite          202110L
+# define __cccl_lib_to_underlying                        202102L
+# define __cccl_lib_unreachable                          202202L
+
+#endif // _LIBCUDACXX_STD_VER > 20
+
+#ifndef __cuda_std__
+#if _LIBCUDACXX_STD_VER > 11
+# define __cpp_lib_chrono_udls                          __cccl_lib_chrono_udls
+# define __cpp_lib_complex_udls                         __cccl_lib_complex_udls
+#ifdef __cccl_lib_constexpr_complex
+# define __cpp_lib_constexpr_complex                    __cccl_lib_constexpr_complex
+#endif
+# define __cpp_lib_concepts                             __cccl_lib_concepts
+# define __cpp_lib_exchange_function                    __cccl_lib_exchange_function
+# define __cpp_lib_generic_associative_lookup           201304L
+# define __cpp_lib_integer_sequence                     __cccl_lib_integer_sequence
+# define __cpp_lib_integral_constant_callable           __cccl_lib_integral_constant_callable
+# define __cpp_lib_is_final                             __cccl_lib_is_final
+# define __cpp_lib_is_null_pointer                      __cccl_lib_is_null_pointer
+# define __cpp_lib_make_reverse_iterator                __cccl_lib_make_reverse_iterator
+# define __cpp_lib_make_unique                          201304L
+# define __cpp_lib_null_iterators                       __cccl_lib_null_iterators
+# define __cpp_lib_quoted_string_io                     201304L
+# define __cpp_lib_result_of_sfinae                     __cccl_lib_result_of_sfinae
+# define __cpp_lib_robust_nonmodifying_seq_ops          __cccl_lib_robust_nonmodifying_seq_ops
+# ifdef __cccl_lib_shared_timed_mutex
+#   define __cpp_lib_shared_timed_mutex                 201402L
+# endif
+# define __cpp_lib_span                                 __cccl_lib_span
+# define __cpp_lib_string_udls                          201304L
+# define __cpp_lib_transformation_trait_aliases         __cccl_lib_transformation_trait_aliases
+# define __cpp_lib_transparent_operators                __cccl_lib_transparent_operators
+# define __cpp_lib_tuple_element_t                      __cccl_lib_tuple_element_t
+# define __cpp_lib_tuples_by_type                       __cccl_lib_tuples_by_type
+#endif // _LIBCUDACXX_STD_VER > 11
+
+#if _LIBCUDACXX_STD_VER > 14
+# ifdef __cccl_lib_addressof_constexpr
+#   define __cpp_lib_addressof_constexpr                __cccl_lib_addressof_constexpr
 # endif
 # define __cpp_lib_allocator_traits_is_always_equal     201411L
 # define __cpp_lib_any                                  201606L
-# define __cpp_lib_apply                                201603L
-# define __cpp_lib_array_constexpr                      201603L
-# define __cpp_lib_as_const                             201510L
-# if !defined(_LIBCUDACXX_HAS_NO_THREADS)
-#   define __cpp_lib_atomic_is_always_lock_free         201603L
+# define __cpp_lib_apply                                __cccl_lib_apply
+# define __cpp_lib_array_constexpr                      __cccl_lib_array_constexpr
+# define __cpp_lib_as_const                             __cccl_lib_as_const
+# ifdef __cccl_lib_atomic_is_always_lock_free
+#   define __cpp_lib_atomic_is_always_lock_free         __cccl_lib_atomic_is_always_lock_free
 # endif
-# define __cpp_lib_bind_front                           201907L
-# define __cpp_lib_bool_constant                        201505L
-// # define __cpp_lib_boyer_moore_searcher                 201603L
-# define __cpp_lib_byte                                 201603L
-# define __cpp_lib_chrono                               201611L
+# define __cpp_lib_bind_front                           __cccl_lib_bind_front
+# define __cpp_lib_bool_constant                        __cccl_lib_bool_constant
+// # define __cpp_lib_boyer_moore_searcher                 __cccl_lib_boyer_moore_searcher
+# define __cpp_lib_byte                                 __cccl_lib_byte
+# define __cpp_lib_chrono                               __cccl_lib_chrono
 # define __cpp_lib_clamp                                201603L
 # define __cpp_lib_enable_shared_from_this              201603L
-// # define __cpp_lib_execution                            201603L
+// # define __cpp_lib_execution                            __cccl_lib_execution
 # define __cpp_lib_filesystem                           201703L
-# define __cpp_lib_gcd_lcm                              201606L
-# define __cpp_lib_hardware_interference_size           201703L
-# if defined(_LIBCUDACXX_HAS_UNIQUE_OBJECT_REPRESENTATIONS)
-#   define __cpp_lib_has_unique_object_representations  201606L
+# define __cpp_lib_gcd_lcm                              __cccl_lib_gcd_lcm
+# define __cpp_lib_hardware_interference_size           __cccl_lib_hardware_interference_size
+# ifdef __cccl_lib_has_unique_object_representations
+#   define __cpp_lib_has_unique_object_representations  __cccl_lib_has_unique_object_representations
 # endif
-# define __cpp_lib_hypot                                201603L
+# define __cpp_lib_hypot                                __cccl_lib_hypot
 # define __cpp_lib_incomplete_container_elements        201505L
-# define __cpp_lib_invoke                               201411L
-# if !defined(_LIBCUDACXX_HAS_NO_IS_AGGREGATE)
-#   define __cpp_lib_is_aggregate                       201703L
+# define __cpp_lib_invoke                               __cccl_lib_invoke
+# ifdef __cccl_lib_is_aggregate
+#   define __cpp_lib_is_aggregate                       __cccl_lib_is_aggregate
 # endif
-# define __cpp_lib_is_invocable                         201703L
-# define __cpp_lib_is_swappable                         201603L
-# define __cpp_lib_launder                              201606L
-# define __cpp_lib_logical_traits                       201510L
-# define __cpp_lib_make_from_tuple                      201606L
+# define __cpp_lib_is_invocable                         __cccl_lib_is_invocable
+# define __cpp_lib_is_swappable                         __cccl_lib_is_swappable
+# define __cpp_lib_launder                              __cccl_lib_launder
+# define __cpp_lib_logical_traits                       __cccl_lib_logical_traits
+# define __cpp_lib_make_from_tuple                      __cccl_lib_make_from_tuple
 # define __cpp_lib_map_try_emplace                      201411L
-// # define __cpp_lib_math_special_functions               201603L
-// # define __cpp_lib_memory_resource                      201603L
+// # define __cpp_lib_math_special_functions               __cccl_lib_math_special_functions
+// # define __cpp_lib_memory_resource                      __cccl_lib_memory_resource
 # define __cpp_lib_node_extract                         201606L
 # define __cpp_lib_nonmember_container_access           201411L
-# define __cpp_lib_not_fn                               201603L
-# define __cpp_lib_optional                             201606L
-// # define __cpp_lib_parallel_algorithm                   201603L
+# define __cpp_lib_not_fn                               __cccl_lib_not_fn
+# define __cpp_lib_optional                             __cccl_lib_optional
+// # define __cpp_lib_parallel_algorithm                   __cccl_lib_parallel_algorithm
 # define __cpp_lib_raw_memory_algorithms                201606L
 # define __cpp_lib_sample                               201603L
 # define __cpp_lib_scoped_lock                          201703L
-# if !defined(_LIBCUDACXX_HAS_NO_THREADS)
+# ifdef __cccl_lib_shared_mutex
 #   define __cpp_lib_shared_mutex                       201505L
 # endif
-// # define __cpp_lib_shared_ptr_arrays                    201611L
+// # define __cpp_lib_shared_ptr_arrays                    __cccl_lib_shared_ptr_arrays
 # define __cpp_lib_shared_ptr_weak_type                 201606L
 # define __cpp_lib_string_view                          201606L
-// # define __cpp_lib_to_chars                             201611L
-# undef  __cpp_lib_transparent_operators
-# define __cpp_lib_transparent_operators                201510L
-# define __cpp_lib_type_trait_variable_templates        201510L
-# define __cpp_lib_uncaught_exceptions                  201411L
-# define __cpp_lib_unordered_map_try_emplace            201411L
-# define __cpp_lib_variant                              201606L
-# define __cpp_lib_void_t                               201411L
-#endif
+// # define __cpp_lib_to_chars                             __cccl_lib_to_chars
+# define __cpp_lib_type_trait_variable_templates        __cccl_lib_type_trait_variable_templates
+# define __cpp_lib_uncaught_exceptions                  __cccl_lib_uncaught_exceptions
+# define __cpp_lib_unordered_map_try_emplace            __cccl_lib_unordered_map_try_emplace
+# define __cpp_lib_variant                              __cccl_lib_variant
+# define __cpp_lib_void_t                               __cccl_lib_void_t
+#endif // _LIBCUDACXX_STD_VER > 14
 
 #if _LIBCUDACXX_STD_VER > 17
 // # undef  __cpp_lib_array_constexpr
-// # define __cpp_lib_array_constexpr                      201811L
-// # define __cpp_lib_assume_aligned                       201811L
-// # define __cpp_lib_atomic_flag_test                     201907L
-// # define __cpp_lib_atomic_float                         201711L
-// # define __cpp_lib_atomic_lock_free_type_aliases        201907L
-# if !defined(_LIBCUDACXX_HAS_NO_THREADS)
-// #   define __cpp_lib_atomic_ref                         201806L
+// # define __cpp_lib_array_constexpr                      __cccl_lib_array_constexpr
+// # define __cpp_lib_assume_aligned                       __cccl_lib_assume_aligned
+// # define __cpp_lib_atomic_flag_test                     __cccl_lib_atomic_flag_test
+// # define __cpp_lib_atomic_float                         __cccl_lib_atomic_float
+// # define __cpp_lib_atomic_lock_free_type_aliases        __cccl_lib_atomic_lock_free_type_aliases
+# ifdef __cccl_lib_atomic_ref
+#   define __cpp_lib_atomic_ref                         __cccl_lib_atomic_ref
 #endif
-// # define __cpp_lib_atomic_shared_ptr                    201711L
-// # define __cpp_lib_atomic_value_initialization          201911L
-# if !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_atomic_wait)
-// #   define __cpp_lib_atomic_wait                        201907L
+// # define __cpp_lib_atomic_shared_ptr                    __cccl_lib_atomic_shared_ptr
+// # define __cpp_lib_atomic_value_initialization          __cccl_lib_atomic_value_initialization
+# ifdef __cccl_lib_atomic_wait
+// #   define __cpp_lib_atomic_wait                        __cccl_lib_atomic_wait
 # endif
 # if !defined(_LIBCUDACXX_HAS_NO_THREADS) && !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_barrier)
-// #   define __cpp_lib_barrier                            201907L
+#   define __cpp_lib_barrier                            __cccl_lib_barrier
 # endif
-// # define __cpp_lib_bit_cast                             201806L
-// # define __cpp_lib_bitops                               201907L
-// # define __cpp_lib_bounded_array_traits                 201902L
-# if !defined(_LIBCUDACXX_NO_HAS_CHAR8_T)
-#   define __cpp_lib_char8_t                            201811L
+// # define __cpp_lib_bit_cast                             __cccl_lib_bit_cast
+// # define __cpp_lib_bitops                               __cccl_lib_bitops
+// # define __cpp_lib_bounded_array_traits                 __cccl_lib_bounded_array_traits
+# ifdef __cccl_lib_char8_t
+#   define __cpp_lib_char8_t                            __cccl_lib_char8_t
 # endif
-// # define __cpp_lib_constexpr_algorithms                 201806L
-// # define __cpp_lib_constexpr_dynamic_alloc              201907L
-// # define __cpp_lib_constexpr_functional                 201907L
-// # define __cpp_lib_constexpr_iterator                   201811L
-// # define __cpp_lib_constexpr_memory                     201811L
-// # define __cpp_lib_constexpr_misc                       201811L
-// # define __cpp_lib_constexpr_numeric                    201911L
-// # define __cpp_lib_constexpr_string                     201907L
-// # define __cpp_lib_constexpr_string_view                201811L
-// # define __cpp_lib_constexpr_swap_algorithms            201806L
-// # define __cpp_lib_constexpr_tuple                      201811L
-// # define __cpp_lib_constexpr_utility                    201811L
-// # define __cpp_lib_constexpr_vector                     201907L
-// # define __cpp_lib_coroutine                            201902L
-# if _LIBCUDACXX_STD_VER > 17 && defined(__cpp_impl_destroying_delete) && __cpp_impl_destroying_delete >= 201806L
-#   define __cpp_lib_destroying_delete                  201806L
+// # define __cpp_lib_constexpr_algorithms                 __cccl_lib_constexpr_algorithms
+// # define __cpp_lib_constexpr_dynamic_alloc              __cccl_lib_constexpr_dynamic_alloc
+// # define __cpp_lib_constexpr_functional                 __cccl_lib_constexpr_functional
+// # define __cpp_lib_constexpr_iterator                   __cccl_lib_constexpr_iterator
+// # define __cpp_lib_constexpr_memory                     __cccl_lib_constexpr_memory
+// # define __cpp_lib_constexpr_misc                       __cccl_lib_constexpr_misc
+// # define __cpp_lib_constexpr_numeric                    __cccl_lib_constexpr_numeric
+// # define __cpp_lib_constexpr_string                     __cccl_lib_constexpr_string
+// # define __cpp_lib_constexpr_string_view                __cccl_lib_constexpr_string_view
+// # define __cpp_lib_constexpr_swap_algorithms            __cccl_lib_constexpr_swap_algorithms
+// # define __cpp_lib_constexpr_tuple                      __cccl_lib_constexpr_tuple
+// # define __cpp_lib_constexpr_utility                    __cccl_lib_constexpr_utility
+// # define __cpp_lib_constexpr_vector                     __cccl_lib_constexpr_vector
+// # define __cpp_lib_coroutine                            __cccl_lib_coroutine
+# ifdef __cccl_lib_destroying_delete
+#   define __cpp_lib_destroying_delete                  __cccl_lib_destroying_delete
 # endif
-// # define __cpp_lib_endian                               201907L
+// # define __cpp_lib_endian                               __cccl_lib_endian
 # define __cpp_lib_erase_if                             201811L
 // # undef  __cpp_lib_execution
-// # define __cpp_lib_execution                            201902L
-# if !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_format) && !defined(_LIBCUDACXX_HAS_NO_INCOMPLETE_FORMAT)
-// #   define __cpp_lib_format                             202106L
+// # define __cpp_lib_execution                            __cccl_lib_execution
+# ifdef __cccl_lib_format
+// #   define __cpp_lib_format                             __cccl_lib_format
 # endif
-// # define __cpp_lib_generic_unordered_lookup             201811L
+// # define __cpp_lib_generic_unordered_lookup             __cccl_lib_generic_unordered_lookup
 // # define __cpp_lib_int_pow2                             202002L
 # define __cpp_lib_integer_comparison_functions         202002L
 # define __cpp_lib_interpolate                          201902L
-# if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED)
-#   define __cpp_lib_is_constant_evaluated              201811L
+# ifdef __cccl_lib_is_constant_evaluated
+#   define __cpp_lib_is_constant_evaluated              __cccl_lib_is_constant_evaluated
 # endif
-// # define __cpp_lib_is_layout_compatible                 201907L
-# define __cpp_lib_is_nothrow_convertible               201806L
-// # define __cpp_lib_is_pointer_interconvertible          201907L
-# if !defined(_LIBCUDACXX_HAS_NO_THREADS)
-// #   define __cpp_lib_jthread                            201911L
+// # define __cpp_lib_is_layout_compatible                 __cccl_lib_is_layout_compatible
+# define __cpp_lib_is_nothrow_convertible               __cccl_lib_is_nothrow_convertible
+// # define __cpp_lib_is_pointer_interconvertible          __cccl_lib_is_pointer_interconvertible
+# ifdef __cccl_lib_jthread
+#   define __cpp_lib_jthread                            __cccl_lib_jthread
 # endif
-# if !defined(_LIBCUDACXX_HAS_NO_THREADS) && !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_latch)
-// #   define __cpp_lib_latch                              201907L
+# ifdef __cccl_lib_latch
+#   define __cpp_lib_latch                              __cccl_lib_latch
 # endif
-// # define __cpp_lib_list_remove_return_type              201806L
-// # define __cpp_lib_math_constants                       201907L
-// # define __cpp_lib_polymorphic_allocator                201902L
-// # define __cpp_lib_ranges                               201811L
-// # define __cpp_lib_remove_cvref                         201711L
-# if !defined(_LIBCUDACXX_HAS_NO_THREADS) && !defined(_LIBCUDACXX_AVAILABILITY_DISABLE_FTM___cpp_lib_semaphore)
-// #   define __cpp_lib_semaphore                          201907L
+// # define __cpp_lib_list_remove_return_type              __cccl_lib_list_remove_return_type
+// # define __cpp_lib_math_constants                       __cccl_lib_math_constants
+// # define __cpp_lib_polymorphic_allocator                __cccl_lib_polymorphic_allocator
+// # define __cpp_lib_ranges                               __cccl_lib_ranges
+// # define __cpp_lib_remove_cvref                         __cccl_lib_remove_cvref
+# ifdef __cccl_lib_semaphore
+#   define __cpp_lib_semaphore                          __cccl_lib_semaphore
 # endif
 // # undef  __cpp_lib_shared_ptr_arrays
-// # define __cpp_lib_shared_ptr_arrays                    201707L
-// # define __cpp_lib_shift                                201806L
-// # define __cpp_lib_smart_ptr_for_overwrite              202002L
-// # define __cpp_lib_source_location                      201907L
-// # define __cpp_lib_ssize                                201902L
-// # define __cpp_lib_starts_ends_with                     201711L
+// # define __cpp_lib_shared_ptr_arrays                    __cccl_lib_shared_ptr_arrays
+// # define __cpp_lib_shift                                __cccl_lib_shift
+// # define __cpp_lib_smart_ptr_for_overwrite              __cccl_lib_smart_ptr_for_overwrite
+// # define __cpp_lib_source_location                      __cccl_lib_source_location
+// # define __cpp_lib_ssize                                __cccl_lib_ssize
+// # define __cpp_lib_starts_ends_with                     __cccl_lib_starts_ends_with
 // # undef  __cpp_lib_string_view
-// # define __cpp_lib_string_view                          201803L
-// # define __cpp_lib_syncbuf                              201803L
-// # define __cpp_lib_three_way_comparison                 201907L
-// # define __cpp_lib_to_address                           201711L
-// # define __cpp_lib_to_array                             201907L
-// # define __cpp_lib_type_identity                        201806L
-# define __cpp_lib_unwrap_ref                           201811L
-#endif
+// # define __cpp_lib_string_view                          __cccl_lib_string_view
+// # define __cpp_lib_syncbuf                              __cccl_lib_syncbuf
+// # define __cpp_lib_three_way_comparison                 __cccl_lib_three_way_comparison
+// # define __cpp_lib_to_address                           __cccl_lib_to_address
+// # define __cpp_lib_to_array                             __cccl_lib_to_array
+// # define __cpp_lib_type_identity                        __cccl_lib_type_identity
+# define __cpp_lib_unwrap_ref                           __cccl_lib_unwrap_ref
+#endif // _LIBCUDACXX_STD_VER > 17
 
 #if _LIBCUDACXX_STD_VER > 20
-// # define __cpp_lib_adaptor_iterator_pair_constructor    202106L
-// # define __cpp_lib_allocate_at_least                    202106L
-// # define __cpp_lib_associative_heterogeneous_erasure    202110L
-// # define __cpp_lib_bind_back                            202202L
-// # define __cpp_lib_byteswap                             202110L
-// # define __cpp_lib_constexpr_bitset                     202207L
-// # define __cpp_lib_constexpr_charconv                   202207L
-// # define __cpp_lib_constexpr_cmath                      202202L
+// # define __cpp_lib_adaptor_iterator_pair_constructor    __cccl_lib_adaptor_iterator_pair_constructor
+// # define __cpp_lib_allocate_at_least                    __cccl_lib_allocate_at_least
+// # define __cpp_lib_associative_heterogeneous_erasure    __cccl_lib_associative_heterogeneous_erasure
+// # define __cpp_lib_bind_back                            __cccl_lib_bind_back
+// # define __cpp_lib_byteswap                             __cccl_lib_byteswap
+// # define __cpp_lib_constexpr_bitset                     __cccl_lib_constexpr_bitset
+// # define __cpp_lib_constexpr_charconv                   __cccl_lib_constexpr_charconv
+// # define __cpp_lib_constexpr_cmath                      __cccl_lib_constexpr_cmath
 // # undef  __cpp_lib_constexpr_memory
-// # define __cpp_lib_constexpr_memory                     202202L
-// # define __cpp_lib_constexpr_typeinfo                   202106L
-# define __cpp_lib_forward_like                         202207L
-// # define __cpp_lib_invoke_r                             202106L
-# define __cpp_lib_is_scoped_enum                       202011L
-// # define __cpp_lib_move_only_function                   202110L
+// # define __cpp_lib_constexpr_memory                     __cccl_lib_constexpr_memory
+// # define __cpp_lib_constexpr_typeinfo                   __cccl_lib_constexpr_typeinfo
+# define __cpp_lib_forward_like                         __cccl_lib_forward_like
+// # define __cpp_lib_invoke_r                             __cccl_lib_invoke_r
+# define __cpp_lib_is_scoped_enum                       __cccl_lib_is_scoped_enum
+// # define __cpp_lib_move_only_function                   __cccl_lib_move_only_function
 // # undef  __cpp_lib_optional
-// # define __cpp_lib_optional                             202110L
-// # define __cpp_lib_out_ptr                              202106L
-// # define __cpp_lib_ranges_chunk                         202202L
-// # define __cpp_lib_ranges_chunk_by                      202202L
-// # define __cpp_lib_ranges_iota                          202202L
-// # define __cpp_lib_ranges_join_with                     202202L
-// # define __cpp_lib_ranges_slide                         202202L
-// # define __cpp_lib_ranges_starts_ends_with              202106L
-// # define __cpp_lib_ranges_to_container                  202202L
-// # define __cpp_lib_ranges_zip                           202110L
-// # define __cpp_lib_reference_from_temporary             202202L
-// # define __cpp_lib_spanstream                           202106L
-// # define __cpp_lib_stacktrace                           202011L
-// # define __cpp_lib_stdatomic_h                          202011L
-// # define __cpp_lib_string_contains                      202011L
-// # define __cpp_lib_string_resize_and_overwrite          202110L
-# define __cpp_lib_to_underlying                        202102L
-# define __cpp_lib_unreachable                          202202L
+// # define __cpp_lib_optional                             __cccl_lib_optional
+// # define __cpp_lib_out_ptr                              __cccl_lib_out_ptr
+// # define __cpp_lib_ranges_chunk                         __cccl_lib_ranges_chunk
+// # define __cpp_lib_ranges_chunk_by                      __cccl_lib_ranges_chunk_by
+// # define __cpp_lib_ranges_iota                          __cccl_lib_ranges_iota
+// # define __cpp_lib_ranges_join_with                     __cccl_lib_ranges_join_with
+// # define __cpp_lib_ranges_slide                         __cccl_lib_ranges_slide
+// # define __cpp_lib_ranges_starts_ends_with              __cccl_lib_ranges_starts_ends_with
+// # define __cpp_lib_ranges_to_container                  __cccl_lib_ranges_to_container
+// # define __cpp_lib_ranges_zip                           __cccl_lib_ranges_zip
+// # define __cpp_lib_reference_from_temporary             __cccl_lib_reference_from_temporary
+// # define __cpp_lib_spanstream                           __cccl_lib_spanstream
+// # define __cpp_lib_stacktrace                           __cccl_lib_stacktrace
+// # define __cpp_lib_stdatomic_h                          __cccl_lib_stdatomic_h
+// # define __cpp_lib_string_contains                      __cccl_lib_string_contains
+// # define __cpp_lib_string_resize_and_overwrite          __cccl_lib_string_resize_and_overwrite
+# define __cpp_lib_to_underlying                        __cccl_lib_to_underlying
+# define __cpp_lib_unreachable                          __cccl_lib_unreachable
 
-#endif
+#endif // _LIBCUDACXX_STD_VER > 20
 
-#include <__pragma_pop>
-#endif
+#endif // !__cuda_std__
 
 #endif // _LIBCUDACXX_VERSIONH

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/version
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/version
@@ -228,6 +228,7 @@ __cpp_lib_void_t                                        201411L <type_traits>
 #endif
 # define __cccl_lib_concepts                             202002L
 # define __cccl_lib_exchange_function                    201304L
+# define __cccl_lib_expected                             202211L
 // # define __cccl_lib_generic_associative_lookup           201304L
 # define __cccl_lib_integer_sequence                     201304L
 # define __cccl_lib_integral_constant_callable           201304L
@@ -236,6 +237,7 @@ __cpp_lib_void_t                                        201411L <type_traits>
 # define __cccl_lib_make_reverse_iterator                201402L
 // # define __cccl_lib_make_unique                          201304L
 # define __cccl_lib_null_iterators                       201304L
+# define __cccl_lib_optional                             202110L
 // # define __cccl_lib_quoted_string_io                     201304L
 # define __cccl_lib_result_of_sfinae                     201210L
 # define __cccl_lib_robust_nonmodifying_seq_ops          201304L
@@ -293,7 +295,6 @@ __cpp_lib_void_t                                        201411L <type_traits>
 // # define __cccl_lib_node_extract                         201606L
 // # define __cccl_lib_nonmember_container_access           201411L
 # define __cccl_lib_not_fn                               201603L
-# define __cccl_lib_optional                             201606L
 // # define __cccl_lib_parallel_algorithm                   201603L
 // # define __cccl_lib_raw_memory_algorithms                201606L
 // # define __cccl_lib_sample                               201603L
@@ -417,8 +418,6 @@ __cpp_lib_void_t                                        201411L <type_traits>
 // # define __cccl_lib_invoke_r                             202106L
 # define __cccl_lib_is_scoped_enum                       202011L
 // # define __cccl_lib_move_only_function                   202110L
-# undef  __cccl_lib_optional
-# define __cccl_lib_optional                             202110L
 // # define __cccl_lib_out_ptr                              202106L
 // # define __cccl_lib_ranges_chunk                         202202L
 // # define __cccl_lib_ranges_chunk_by                      202202L
@@ -448,6 +447,7 @@ __cpp_lib_void_t                                        201411L <type_traits>
 #endif
 # define __cpp_lib_concepts                             __cccl_lib_concepts
 # define __cpp_lib_exchange_function                    __cccl_lib_exchange_function
+# define __cpp_lib_expected                             __cccl_lib_expected
 # define __cpp_lib_generic_associative_lookup           201304L
 # define __cpp_lib_integer_sequence                     __cccl_lib_integer_sequence
 # define __cpp_lib_integral_constant_callable           __cccl_lib_integral_constant_callable
@@ -637,8 +637,6 @@ __cpp_lib_void_t                                        201411L <type_traits>
 // # define __cpp_lib_invoke_r                             __cccl_lib_invoke_r
 # define __cpp_lib_is_scoped_enum                       __cccl_lib_is_scoped_enum
 // # define __cpp_lib_move_only_function                   __cccl_lib_move_only_function
-// # undef  __cpp_lib_optional
-// # define __cpp_lib_optional                             __cccl_lib_optional
 // # define __cpp_lib_out_ptr                              __cccl_lib_out_ptr
 // # define __cpp_lib_ranges_chunk                         __cccl_lib_ranges_chunk
 // # define __cpp_lib_ranges_chunk_by                      __cccl_lib_ranges_chunk_by


### PR DESCRIPTION
Previously, we would define `__cpp_lib_meow` which interferes with the host  standard library.

Worst case we might actually break user code, because we define some macros earlier than the host library would.

To alleviate this and also let a user check what *we* actually implement we rename our feature test macros to `__cccl_lib_meow`

We still keep the naming convention of the standard and try to define the standard macros when applicable.

In addition to renaming we also fix some macros that should not be defined and fix some values of others

Fixes #189 