### PR TITLE
[FEA] Implement `iter_move` CPO

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.nodiscard.verify.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.nodiscard.verify.cpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: LIBCUDACXX-has-no-incomplete-ranges
+
+// Test the [[nodiscard]] extension in libc++.
+
+// template<class I>
+// unspecified iter_move;
+
+#include <cuda/std/iterator>
+
+struct WithADL {
+  WithADL() = default;
+  __host__ __device__ constexpr decltype(auto) operator*() const noexcept;
+  __host__ __device__ constexpr WithADL& operator++() noexcept;
+  __host__ __device__ constexpr void operator++(int) noexcept;
+  __host__ __device__ constexpr bool operator==(WithADL const&) const noexcept;
+  __host__ __device__ friend constexpr auto iter_move(WithADL&) { return 0; }
+};
+
+int main(int, char**) {
+  int* noADL = nullptr;
+  cuda::std::ranges::iter_move(noADL); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  WithADL adl;
+  cuda::std::ranges::iter_move(adl); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
@@ -1,0 +1,222 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// template<class I>
+// unspecified iter_move;
+
+#include <cuda/std/iterator>
+
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+#include "../unqualified_lookup_wrapper.h"
+
+using IterMoveT = decltype(cuda::std::ranges::iter_move);
+
+// Wrapper around an iterator for testing `iter_move` when an unqualified call to `iter_move` isn't
+// possible.
+template <typename I>
+class iterator_wrapper {
+public:
+  iterator_wrapper() = default;
+
+  __host__ __device__ constexpr explicit iterator_wrapper(I i) noexcept : base_(cuda::std::move(i)) {}
+
+  // `noexcept(false)` is used to check that this operator is called.
+  __host__ __device__ constexpr decltype(auto) operator*() const& noexcept(false) { return *base_; }
+
+  // `noexcept` is used to check that this operator is called.
+  __host__ __device__ constexpr auto&& operator*() && noexcept { return cuda::std::move(*base_); }
+
+  __host__ __device__ constexpr iterator_wrapper& operator++() noexcept {
+    ++base_;
+    return *this;
+  }
+
+  __host__ __device__ constexpr void operator++(int) noexcept { ++base_; }
+
+  __host__ __device__ constexpr bool operator==(iterator_wrapper const& other) const noexcept { return base_ == other.base_; }
+#if TEST_STD_VER < 20
+  __host__ __device__ constexpr bool operator!=(iterator_wrapper const& other) const noexcept { return base_ != other.base_; }
+#endif
+
+private:
+  I base_ = I{};
+};
+
+template <typename It, typename Out>
+__host__ __device__ constexpr void unqualified_lookup_move(It first_, It last_, Out result_first_, Out result_last_) {
+  auto first = ::check_unqualified_lookup::unqualified_lookup_wrapper<It>{cuda::std::move(first_)};
+  auto last = ::check_unqualified_lookup::unqualified_lookup_wrapper<It>{cuda::std::move(last_)};
+  auto result_first = ::check_unqualified_lookup::unqualified_lookup_wrapper<It>{cuda::std::move(result_first_)};
+  auto result_last = ::check_unqualified_lookup::unqualified_lookup_wrapper<It>{cuda::std::move(result_last_)};
+
+  static_assert(!noexcept(cuda::std::ranges::iter_move(first)), "unqualified-lookup case not being chosen");
+
+  for (; first != last && result_first != result_last; (void)++first, ++result_first) {
+    *result_first = cuda::std::ranges::iter_move(first);
+  }
+}
+
+template <typename It, typename Out>
+__host__ __device__ constexpr void lvalue_move(It first_, It last_, Out result_first_, Out result_last_) {
+  auto first = iterator_wrapper<It>{cuda::std::move(first_)};
+  auto last = ::iterator_wrapper<It>{cuda::std::move(last_)};
+  auto result_first = iterator_wrapper<It>{cuda::std::move(result_first_)};
+  auto result_last = iterator_wrapper<It>{cuda::std::move(result_last_)};
+
+  static_assert(!noexcept(cuda::std::ranges::iter_move(first)), "`operator*() const&` is not noexcept, and there's no hidden "
+                                                          "friend iter_move.");
+
+  for (; first != last && result_first != result_last; (void)++first, ++result_first) {
+    *result_first = cuda::std::ranges::iter_move(first);
+  }
+}
+
+template <typename It, typename Out>
+__host__ __device__ constexpr void rvalue_move(It first_, It last_, Out result_first_, Out result_last_) {
+  auto first = iterator_wrapper<It>{cuda::std::move(first_)};
+  auto last = iterator_wrapper<It>{cuda::std::move(last_)};
+  auto result_first = iterator_wrapper<It>{cuda::std::move(result_first_)};
+  auto result_last = iterator_wrapper<It>{cuda::std::move(result_last_)};
+
+  static_assert(noexcept(cuda::std::ranges::iter_move(cuda::std::move(first))),
+                "`operator*() &&` is noexcept, and there's no hidden friend iter_move.");
+
+  for (; first != last && result_first != result_last; (void)++first, ++result_first) {
+    auto i = first;
+    *result_first = cuda::std::ranges::iter_move(cuda::std::move(i));
+  }
+}
+
+template <bool NoExcept>
+struct WithADL {
+  WithADL() = default;
+  __host__ __device__ constexpr int operator*() const { return 0; }
+  __host__ __device__ constexpr WithADL& operator++();
+  __host__ __device__ constexpr void operator++(int);
+  __host__ __device__ constexpr bool operator==(WithADL const&) const;
+  __host__ __device__ friend constexpr int iter_move(WithADL&&) noexcept(NoExcept) { return 0; }
+};
+
+template <bool NoExcept>
+struct WithoutADL {
+  WithoutADL() = default;
+  __host__ __device__ constexpr int operator*() const noexcept(NoExcept) { return 0; }
+  __host__ __device__ constexpr WithoutADL& operator++();
+  __host__ __device__ constexpr void operator++(int);
+  __host__ __device__ constexpr bool operator==(WithoutADL const&) const;
+};
+
+template <class It, class Pred>
+__host__ __device__ constexpr bool all_of(It first, It last, Pred pred) {
+    for (; first != last; ++first) {
+        if (!pred(*first)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+__host__ __device__ constexpr bool test() {
+  constexpr int full_size = 100;
+  constexpr int half_size = full_size / 2;
+  constexpr int reset = 0;
+  move_tracker v1[full_size];
+
+  struct move_counter_is {
+    __host__ __device__ constexpr move_counter_is(const int counter) : _counter(counter) {}
+
+    __host__ __device__ constexpr bool operator()(move_tracker const& x) {
+      return x.moves() == _counter;
+    }
+
+    const int _counter;
+  };
+
+  move_tracker v2[half_size];
+  unqualified_lookup_move(cuda::std::begin(v1), cuda::std::end(v1), cuda::std::begin(v2), cuda::std::end(v2));
+  assert(all_of(cuda::std::cbegin(v1), cuda::std::cend(v1), move_counter_is(reset)));
+  assert(all_of(cuda::std::cbegin(v2), cuda::std::cend(v2), move_counter_is(1)));
+
+  move_tracker v3[half_size];
+  unqualified_lookup_move(cuda::std::begin(v1) + half_size, cuda::std::end(v1), cuda::std::begin(v3), cuda::std::end(v3));
+  assert(all_of(cuda::std::cbegin(v1), cuda::std::cend(v1), move_counter_is(reset)));
+  assert(all_of(cuda::std::cbegin(v3), cuda::std::cend(v3), move_counter_is(1)));
+
+  move_tracker v4[half_size];
+  unqualified_lookup_move(cuda::std::begin(v3), cuda::std::end(v3), cuda::std::begin(v4), cuda::std::end(v4));
+  assert(all_of(cuda::std::cbegin(v3), cuda::std::cend(v3), move_counter_is(reset)));
+  assert(all_of(cuda::std::cbegin(v4), cuda::std::cend(v4), move_counter_is(2)));
+
+  lvalue_move(cuda::std::begin(v2), cuda::std::end(v2), cuda::std::begin(v1) + half_size, cuda::std::end(v1));
+  assert(all_of(cuda::std::cbegin(v2), cuda::std::cend(v2), move_counter_is(reset)));
+  assert(all_of(cuda::std::cbegin(v1) + half_size, cuda::std::cend(v1), move_counter_is(2)));
+
+  lvalue_move(cuda::std::begin(v4), cuda::std::end(v4), cuda::std::begin(v1), cuda::std::end(v1));
+  assert(all_of(cuda::std::cbegin(v4), cuda::std::cend(v4), move_counter_is(reset)));
+  assert(all_of(cuda::std::cbegin(v1), cuda::std::cbegin(v1) + half_size, move_counter_is(3)));
+
+  rvalue_move(cuda::std::begin(v1), cuda::std::end(v1), cuda::std::begin(v2), cuda::std::end(v2));
+  assert(all_of(cuda::std::cbegin(v1), cuda::std::cbegin(v1) + half_size, move_counter_is(reset)));
+  assert(all_of(cuda::std::cbegin(v2), cuda::std::cend(v2), move_counter_is(4)));
+
+  rvalue_move(cuda::std::begin(v1) + half_size, cuda::std::end(v1), cuda::std::begin(v3), cuda::std::end(v3));
+  assert(all_of(cuda::std::cbegin(v1), cuda::std::cend(v1), move_counter_is(reset)));
+  assert(all_of(cuda::std::cbegin(v3), cuda::std::cend(v3), move_counter_is(3)));
+
+  auto unscoped = check_unqualified_lookup::unscoped_enum::a;
+  assert(cuda::std::ranges::iter_move(unscoped) == check_unqualified_lookup::unscoped_enum::a);
+  assert(!noexcept(cuda::std::ranges::iter_move(unscoped)));
+
+  auto scoped = check_unqualified_lookup::scoped_enum::a;
+  assert(cuda::std::ranges::iter_move(scoped) == nullptr);
+  assert(noexcept(cuda::std::ranges::iter_move(scoped)));
+
+  auto some_union = check_unqualified_lookup::some_union{0};
+  assert(cuda::std::ranges::iter_move(some_union) == 0);
+  assert(!noexcept(cuda::std::ranges::iter_move(some_union)));
+
+  // Check noexcept-correctness
+  static_assert(noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithADL<true>>())));
+  static_assert(noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithoutADL<true>>())));
+// old GCC seems to fall over the chaining of the noexcept clauses here
+#if (!defined(TEST_COMPILER_GCC) || __GNUC__ >= 9)
+  static_assert(!noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithADL<false>>())));
+  static_assert(!noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithoutADL<false>>())));
+#endif
+
+  return true;
+}
+
+#ifndef _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3 // nvcc segfaults here
+static_assert(!cuda::std::is_invocable_v<IterMoveT, int*, int*>); // too many arguments
+static_assert(!cuda::std::is_invocable_v<IterMoveT, int>);
+#endif // _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3
+
+#if TEST_STD_VER > 17
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(cuda::std::is_invocable_v<IterMoveT, Holder<Incomplete>**>);
+static_assert(cuda::std::is_invocable_v<IterMoveT, Holder<Incomplete>**&>);
+#endif
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_rvalue_reference_t.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_rvalue_reference_t.compile.pass.cpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// template<class I>
+// using iter_rvalue_reference;
+
+#include <cuda/std/iterator>
+
+static_assert(cuda::std::same_as<cuda::std::iter_rvalue_reference_t<int*>, int&&>);
+static_assert(cuda::std::same_as<cuda::std::iter_rvalue_reference_t<const int*>, const int&&>);
+
+__host__ __device__ void test_undefined_internal() {
+  struct A {
+    __host__ __device__ int& operator*() const;
+  };
+  static_assert(cuda::std::same_as<cuda::std::iter_rvalue_reference_t<A>, int&&>);
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/unqualified_lookup_wrapper.h
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/unqualified_lookup_wrapper.h
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LIBCUDACXX_TEST_STD_ITERATOR_UNQUALIFIED_LOOKUP_WRAPPER
+#define LIBCUDACXX_TEST_STD_ITERATOR_UNQUALIFIED_LOOKUP_WRAPPER
+
+#include <cuda/std/iterator>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+namespace check_unqualified_lookup {
+// Wrapper around an iterator for testing unqualified calls to `iter_move` and `iter_swap`.
+template <typename I>
+class unqualified_lookup_wrapper {
+public:
+  unqualified_lookup_wrapper() = default;
+
+  __host__ __device__ constexpr explicit unqualified_lookup_wrapper(I i) noexcept : base_(cuda::std::move(i)) {}
+
+  __host__ __device__ constexpr decltype(auto) operator*() const noexcept { return *base_; }
+
+  __host__ __device__ constexpr unqualified_lookup_wrapper& operator++() noexcept {
+    ++base_;
+    return *this;
+  }
+
+  __host__ __device__ constexpr void operator++(int) noexcept { ++base_; }
+
+  __host__ __device__ constexpr bool operator==(unqualified_lookup_wrapper const& other) const noexcept {
+    return base_ == other.base_;
+  }
+#if TEST_STD_VER < 20
+  __host__ __device__ constexpr bool operator!=(unqualified_lookup_wrapper const& other) const noexcept {
+    return base_ != other.base_;
+  }
+#endif
+
+  // Delegates `cuda::std::ranges::iter_move` for the underlying iterator. `noexcept(false)` will be used
+  // to ensure that the unqualified-lookup overload is chosen.
+  __host__ __device__ friend constexpr decltype(auto) iter_move(unqualified_lookup_wrapper& i) noexcept(false) {
+    return cuda::std::ranges::iter_move(i.base_);
+  }
+
+private:
+  I base_ = I{};
+};
+
+enum unscoped_enum { a, b, c };
+__host__ __device__ constexpr unscoped_enum iter_move(unscoped_enum& e) noexcept(false) { return e; }
+
+enum class scoped_enum { a, b, c };
+__host__ __device__ constexpr scoped_enum* iter_move(scoped_enum&) noexcept { return nullptr; }
+
+union some_union {
+  int x;
+  double y;
+};
+__host__ __device__ constexpr int iter_move(some_union& u) noexcept(false) { return u.x; }
+
+} // namespace check_unqualified_lookup
+
+class move_tracker {
+public:
+  move_tracker() = default;
+  __host__ __device__ constexpr move_tracker(move_tracker&& other) noexcept : moves_{other.moves_ + 1} { other.moves_ = 0; }
+  __host__ __device__ constexpr move_tracker& operator=(move_tracker&& other) noexcept {
+    moves_ = other.moves_ + 1;
+    other.moves_ = 0;
+    return *this;
+  }
+
+  move_tracker(move_tracker const& other) = delete;
+  move_tracker& operator=(move_tracker const& other) = delete;
+
+  __host__ __device__ constexpr int moves() const noexcept { return moves_; }
+
+private:
+  int moves_ = 0;
+};
+
+#endif // LIBCUDACXX_TEST_STD_ITERATOR_UNQUALIFIED_LOOKUP_WRAPPER

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
@@ -93,6 +93,7 @@ set(files
   __iterator/incrementable_traits.h
   __iterator/istream_iterator.h
   __iterator/istreambuf_iterator.h
+  __iterator/iter_move.h
   __iterator/iterator.h
   __iterator/iterator_traits.h
   __iterator/move_iterator.h

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iter_move.h
@@ -1,0 +1,177 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___ITERATOR_ITER_MOVE_H
+#define _LIBCUDACXX___ITERATOR_ITER_MOVE_H
+
+#ifndef __cuda_std__
+#include <__config>
+#endif // __cuda_std__
+
+#include "../__concepts/class_or_enum.h"
+#include "../__iterator/iterator_traits.h"
+#include "../__type_traits/enable_if.h"
+#include "../__type_traits/is_reference.h"
+#include "../__type_traits/remove_cvref.h"
+#include "../__utility/declval.h"
+#include "../__utility/forward.h"
+#include "../__utility/move.h"
+
+#if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvoid-ptr-dereference"
+#endif
+
+
+#if _LIBCUDACXX_STD_VER > 14
+
+// [iterator.cust.move]
+
+_LIBCUDACXX_BEGIN_NAMESPACE_RANGES
+_LIBCUDACXX_BEGIN_NAMESPACE_CPO(__iter_move)
+
+_LIBCUDACXX_INLINE_VISIBILITY
+void iter_move();
+
+#if LIBCUDACXX_STD_VER > 17
+template <class _Tp>
+concept __unqualified_iter_move =
+  __class_or_enum<remove_cvref_t<_Tp>> &&
+  requires (_Tp&& __t) {
+    iter_move(_CUDA_VSTD::forward<_Tp>(__t));
+  };
+
+template<class _Tp>
+concept __move_deref =
+  !__unqualified_iter_move<_Tp> &&
+  requires (_Tp&& __t) {
+    *__t;
+    requires is_lvalue_reference_v<decltype(*__t)>;
+  };
+
+template<class _Tp>
+concept __just_deref =
+  !__unqualified_iter_move<_Tp> &&
+  !__move_deref<_Tp> &&
+  requires (_Tp&& __t) {
+    *__t;
+    requires (!is_lvalue_reference_v<decltype(*__t)>);
+  };
+
+#else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+
+template <class _Tp>
+_LIBCUDACXX_CONCEPT_FRAGMENT(
+  __unqualified_iter_move_,
+  requires(_Tp&& __t)(
+    requires(__class_or_enum<remove_cvref_t<_Tp>>),
+    (iter_move(_CUDA_VSTD::forward<_Tp>(__t)))
+  ));
+
+template <class _Tp>
+_LIBCUDACXX_CONCEPT __unqualified_iter_move = _LIBCUDACXX_FRAGMENT(__unqualified_iter_move_, _Tp);
+
+template <class _Tp>
+_LIBCUDACXX_CONCEPT_FRAGMENT(
+  __move_deref_,
+  requires(_Tp&& __t)(
+    requires(!__unqualified_iter_move<_Tp>),
+    requires(is_lvalue_reference_v<decltype(*__t)>)
+  ));
+
+template<class _Tp>
+_LIBCUDACXX_CONCEPT __move_deref = _LIBCUDACXX_FRAGMENT(__move_deref_, _Tp);
+
+template<class _Tp>
+_LIBCUDACXX_CONCEPT_FRAGMENT(
+  __just_deref_,
+  requires(_Tp&& __t)(
+    requires(!__unqualified_iter_move<_Tp>),
+    requires(!__move_deref<_Tp>),
+    requires(!is_lvalue_reference_v<decltype(*__t)>)
+  ));
+
+template<class _Tp>
+_LIBCUDACXX_CONCEPT __just_deref = _LIBCUDACXX_FRAGMENT(__just_deref_, _Tp);
+#endif // LIBCUDACXX_STD_VER < 20
+
+// [iterator.cust.move]
+
+struct __fn {
+  _LIBCUDACXX_TEMPLATE(class _Ip)
+    (requires __unqualified_iter_move<_Ip>)
+  _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr decltype(auto) operator()(_Ip&& __i) const
+    noexcept(noexcept(iter_move(_CUDA_VSTD::forward<_Ip>(__i))))
+  {
+    return iter_move(_CUDA_VSTD::forward<_Ip>(__i));
+  }
+
+  _LIBCUDACXX_TEMPLATE(class _Ip)
+    (requires __move_deref<_Ip>)
+  _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY constexpr auto operator()(_Ip&& __i) const
+    noexcept(noexcept(_CUDA_VSTD::move(*_CUDA_VSTD::forward<_Ip>(__i))))
+    -> decltype(      _CUDA_VSTD::move(*_CUDA_VSTD::forward<_Ip>(__i)))
+    { return          _CUDA_VSTD::move(*_CUDA_VSTD::forward<_Ip>(__i)); }
+
+  _LIBCUDACXX_TEMPLATE(class _Ip)
+    (requires __just_deref<_Ip>)
+  _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY constexpr auto operator()(_Ip&& __i) const
+    noexcept(noexcept(*_CUDA_VSTD::forward<_Ip>(__i)))
+    -> decltype(      *_CUDA_VSTD::forward<_Ip>(__i))
+    { return          *_CUDA_VSTD::forward<_Ip>(__i); }
+};
+_LIBCUDACXX_END_NAMESPACE_CPO
+inline namespace __cpo {
+  _LIBCUDACXX_CPO_ACCESSIBILITY auto iter_move = __iter_move::__fn{};
+} // namespace __cpo
+_LIBCUDACXX_END_NAMESPACE_RANGES
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+#if _LIBCUDACXX_STD_VER > 17
+template<__dereferenceable _Tp>
+  requires requires(_Tp& __t) { { _CUDA_VRANGES::iter_move(__t) } -> __can_reference; }
+using iter_rvalue_reference_t = decltype(_CUDA_VRANGES::iter_move(_CUDA_VSTD::declval<_Tp&>()));
+
+#else
+
+template<class _Tp>
+_LIBCUDACXX_CONCEPT_FRAGMENT(
+  __can_iter_rvalue_reference_t_,
+  requires(_Tp& __t)(
+    requires(__dereferenceable<_Tp>),
+    requires(__can_reference<decltype(_CUDA_VRANGES::iter_move(__t))>)
+  ));
+
+template<class _Tp>
+_LIBCUDACXX_CONCEPT __can_iter_rvalue_reference_t =  _LIBCUDACXX_FRAGMENT(__can_iter_rvalue_reference_t_, _Tp);
+
+template<class _Tp>
+using __iter_rvalue_reference_t = decltype(_CUDA_VRANGES::iter_move(_CUDA_VSTD::declval<_Tp&>()));
+
+template<class _Tp>
+using iter_rvalue_reference_t = enable_if_t<__can_iter_rvalue_reference_t<_Tp>,
+                                            __iter_rvalue_reference_t<_Tp>>;
+#endif // LIBCUDACXX_STD_VER < 20
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX_STD_VER > 14
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#endif // _LIBCUDACXX___ITERATOR_ITER_MOVE_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/iterator
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/iterator
@@ -693,6 +693,7 @@ template <class E> constexpr const E* data(initializer_list<E> il) noexcept;    
 #include "__iterator/insert_iterator.h"
 #include "__iterator/istream_iterator.h"
 #include "__iterator/istreambuf_iterator.h"
+#include "__iterator/iter_move.h"
 #include "__iterator/iterator.h"
 #include "__iterator/iterator_traits.h"
 #include "__iterator/move_iterator.h"

--- a/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.nodiscard.verify.cpp
+++ b/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.nodiscard.verify.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// Test the [[nodiscard]] extension in libc++.
+
+// template<class I>
+// unspecified iter_move;
+
+#include <iterator>
+
+struct WithADL {
+  WithADL() = default;
+  constexpr decltype(auto) operator*() const noexcept;
+  constexpr WithADL& operator++() noexcept;
+  constexpr void operator++(int) noexcept;
+  constexpr bool operator==(WithADL const&) const noexcept;
+  friend constexpr auto iter_move(WithADL&) { return 0; }
+};
+
+void f() {
+  int* noADL = nullptr;
+  std::ranges::iter_move(noADL); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  WithADL adl;
+  std::ranges::iter_move(adl); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+}

--- a/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
+++ b/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
@@ -1,0 +1,195 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// template<class I>
+// unspecified iter_move;
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+#include "../unqualified_lookup_wrapper.h"
+
+using IterMoveT = decltype(std::ranges::iter_move);
+
+// Wrapper around an iterator for testing `iter_move` when an unqualified call to `iter_move` isn't
+// possible.
+template <typename I>
+class iterator_wrapper {
+public:
+  iterator_wrapper() = default;
+
+  constexpr explicit iterator_wrapper(I i) noexcept : base_(std::move(i)) {}
+
+  // `noexcept(false)` is used to check that this operator is called.
+  constexpr decltype(auto) operator*() const& noexcept(false) { return *base_; }
+
+  // `noexcept` is used to check that this operator is called.
+  constexpr auto&& operator*() && noexcept { return std::move(*base_); }
+
+  constexpr iterator_wrapper& operator++() noexcept {
+    ++base_;
+    return *this;
+  }
+
+  constexpr void operator++(int) noexcept { ++base_; }
+
+  constexpr bool operator==(iterator_wrapper const& other) const noexcept { return base_ == other.base_; }
+
+private:
+  I base_ = I{};
+};
+
+template <class I>
+iterator_wrapper(I) -> iterator_wrapper<I>;
+
+template <typename It, typename Out>
+constexpr void unqualified_lookup_move(It first_, It last_, Out result_first_, Out result_last_) {
+  auto first = ::check_unqualified_lookup::unqualified_lookup_wrapper{std::move(first_)};
+  auto last = ::check_unqualified_lookup::unqualified_lookup_wrapper{std::move(last_)};
+  auto result_first = ::check_unqualified_lookup::unqualified_lookup_wrapper{std::move(result_first_)};
+  auto result_last = ::check_unqualified_lookup::unqualified_lookup_wrapper{std::move(result_last_)};
+
+  static_assert(!noexcept(std::ranges::iter_move(first)), "unqualified-lookup case not being chosen");
+
+  for (; first != last && result_first != result_last; (void)++first, ++result_first) {
+    *result_first = std::ranges::iter_move(first);
+  }
+}
+
+template <typename It, typename Out>
+constexpr void lvalue_move(It first_, It last_, Out result_first_, Out result_last_) {
+  auto first = iterator_wrapper{std::move(first_)};
+  auto last = ::iterator_wrapper{std::move(last_)};
+  auto result_first = iterator_wrapper{std::move(result_first_)};
+  auto result_last = iterator_wrapper{std::move(result_last_)};
+
+  static_assert(!noexcept(std::ranges::iter_move(first)), "`operator*() const&` is not noexcept, and there's no hidden "
+                                                          "friend iter_move.");
+
+  for (; first != last && result_first != result_last; (void)++first, ++result_first) {
+    *result_first = std::ranges::iter_move(first);
+  }
+}
+
+template <typename It, typename Out>
+constexpr void rvalue_move(It first_, It last_, Out result_first_, Out result_last_) {
+  auto first = iterator_wrapper{std::move(first_)};
+  auto last = iterator_wrapper{std::move(last_)};
+  auto result_first = iterator_wrapper{std::move(result_first_)};
+  auto result_last = iterator_wrapper{std::move(result_last_)};
+
+  static_assert(noexcept(std::ranges::iter_move(std::move(first))),
+                "`operator*() &&` is noexcept, and there's no hidden friend iter_move.");
+
+  for (; first != last && result_first != result_last; (void)++first, ++result_first) {
+    auto i = first;
+    *result_first = std::ranges::iter_move(std::move(i));
+  }
+}
+
+template <bool NoExcept>
+struct WithADL {
+  WithADL() = default;
+  constexpr int operator*() const { return 0; }
+  constexpr WithADL& operator++();
+  constexpr void operator++(int);
+  constexpr bool operator==(WithADL const&) const;
+  friend constexpr int iter_move(WithADL&&) noexcept(NoExcept) { return 0; }
+};
+
+template <bool NoExcept>
+struct WithoutADL {
+  WithoutADL() = default;
+  constexpr int operator*() const noexcept(NoExcept) { return 0; }
+  constexpr WithoutADL& operator++();
+  constexpr void operator++(int);
+  constexpr bool operator==(WithoutADL const&) const;
+};
+
+constexpr bool test() {
+  constexpr int full_size = 100;
+  constexpr int half_size = full_size / 2;
+  constexpr int reset = 0;
+  auto v1 = std::array<move_tracker, full_size>{};
+
+  auto move_counter_is = [](auto const n) { return [n](auto const& x) { return x.moves() == n; }; };
+
+  auto v2 = std::array<move_tracker, half_size>{};
+  unqualified_lookup_move(v1.begin(), v1.end(), v2.begin(), v2.end());
+  assert(std::all_of(v1.cbegin(), v1.cend(), move_counter_is(reset)));
+  assert(std::all_of(v2.cbegin(), v2.cend(), move_counter_is(1)));
+
+  auto v3 = std::array<move_tracker, half_size>{};
+  unqualified_lookup_move(v1.begin() + half_size, v1.end(), v3.begin(), v3.end());
+  assert(std::all_of(v1.cbegin(), v1.cend(), move_counter_is(reset)));
+  assert(std::all_of(v3.cbegin(), v3.cend(), move_counter_is(1)));
+
+  auto v4 = std::array<move_tracker, half_size>{};
+  unqualified_lookup_move(v3.begin(), v3.end(), v4.begin(), v4.end());
+  assert(std::all_of(v3.cbegin(), v3.cend(), move_counter_is(reset)));
+  assert(std::all_of(v4.cbegin(), v4.cend(), move_counter_is(2)));
+
+  lvalue_move(v2.begin(), v2.end(), v1.begin() + half_size, v1.end());
+  assert(std::all_of(v2.cbegin(), v2.cend(), move_counter_is(reset)));
+  assert(std::all_of(v1.cbegin() + half_size, v1.cend(), move_counter_is(2)));
+
+  lvalue_move(v4.begin(), v4.end(), v1.begin(), v1.end());
+  assert(std::all_of(v4.cbegin(), v4.cend(), move_counter_is(reset)));
+  assert(std::all_of(v1.cbegin(), v1.cbegin() + half_size, move_counter_is(3)));
+
+  rvalue_move(v1.begin(), v1.end(), v2.begin(), v2.end());
+  assert(std::all_of(v1.cbegin(), v1.cbegin() + half_size, move_counter_is(reset)));
+  assert(std::all_of(v2.cbegin(), v2.cend(), move_counter_is(4)));
+
+  rvalue_move(v1.begin() + half_size, v1.end(), v3.begin(), v3.end());
+  assert(std::all_of(v1.cbegin(), v1.cend(), move_counter_is(reset)));
+  assert(std::all_of(v3.cbegin(), v3.cend(), move_counter_is(3)));
+
+  auto unscoped = check_unqualified_lookup::unscoped_enum::a;
+  assert(std::ranges::iter_move(unscoped) == check_unqualified_lookup::unscoped_enum::a);
+  assert(!noexcept(std::ranges::iter_move(unscoped)));
+
+  auto scoped = check_unqualified_lookup::scoped_enum::a;
+  assert(std::ranges::iter_move(scoped) == nullptr);
+  assert(noexcept(std::ranges::iter_move(scoped)));
+
+  auto some_union = check_unqualified_lookup::some_union{0};
+  assert(std::ranges::iter_move(some_union) == 0);
+  assert(!noexcept(std::ranges::iter_move(some_union)));
+
+  // Check noexcept-correctness
+  static_assert(noexcept(std::ranges::iter_move(std::declval<WithADL<true>>())));
+  static_assert(!noexcept(std::ranges::iter_move(std::declval<WithADL<false>>())));
+  static_assert(noexcept(std::ranges::iter_move(std::declval<WithoutADL<true>>())));
+  static_assert(!noexcept(std::ranges::iter_move(std::declval<WithoutADL<false>>())));
+
+  return true;
+}
+
+static_assert(!std::is_invocable_v<IterMoveT, int*, int*>); // too many arguments
+static_assert(!std::is_invocable_v<IterMoveT, int>);
+
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(std::is_invocable_v<IterMoveT, Holder<Incomplete>**>);
+static_assert(std::is_invocable_v<IterMoveT, Holder<Incomplete>**&>);
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_rvalue_reference_t.compile.pass.cpp
+++ b/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_rvalue_reference_t.compile.pass.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// template<class I>
+// using iter_rvalue_reference;
+
+#include <iterator>
+
+static_assert(std::same_as<std::iter_rvalue_reference_t<int*>, int&&>);
+static_assert(std::same_as<std::iter_rvalue_reference_t<const int*>, const int&&>);
+
+void test_undefined_internal() {
+  struct A {
+    int& operator*() const;
+  };
+  static_assert(std::same_as<std::iter_rvalue_reference_t<A>, int&&>);
+}
+
+int main(int, char**) {
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/unqualified_lookup_wrapper.h
+++ b/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/unqualified_lookup_wrapper.h
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIBCPP_TEST_STD_ITERATOR_UNQUALIFIED_LOOKUP_WRAPPER
+#define LIBCPP_TEST_STD_ITERATOR_UNQUALIFIED_LOOKUP_WRAPPER
+
+#include <iterator>
+#include <utility>
+
+namespace check_unqualified_lookup {
+// Wrapper around an iterator for testing unqualified calls to `iter_move` and `iter_swap`.
+template <typename I>
+class unqualified_lookup_wrapper {
+public:
+  unqualified_lookup_wrapper() = default;
+
+  constexpr explicit unqualified_lookup_wrapper(I i) noexcept : base_(std::move(i)) {}
+
+  constexpr decltype(auto) operator*() const noexcept { return *base_; }
+
+  constexpr unqualified_lookup_wrapper& operator++() noexcept {
+    ++base_;
+    return *this;
+  }
+
+  constexpr void operator++(int) noexcept { ++base_; }
+
+  constexpr bool operator==(unqualified_lookup_wrapper const& other) const noexcept {
+    return base_ == other.base_;
+  }
+
+  // Delegates `std::ranges::iter_move` for the underlying iterator. `noexcept(false)` will be used
+  // to ensure that the unqualified-lookup overload is chosen.
+  friend constexpr decltype(auto) iter_move(unqualified_lookup_wrapper& i) noexcept(false) {
+    return std::ranges::iter_move(i.base_);
+  }
+
+private:
+  I base_ = I{};
+};
+
+template <class It>
+unqualified_lookup_wrapper(It) -> unqualified_lookup_wrapper<It>;
+
+enum unscoped_enum { a, b, c };
+constexpr unscoped_enum iter_move(unscoped_enum& e) noexcept(false) { return e; }
+
+enum class scoped_enum { a, b, c };
+constexpr scoped_enum* iter_move(scoped_enum&) noexcept { return nullptr; }
+
+union some_union {
+  int x;
+  double y;
+};
+constexpr int iter_move(some_union& u) noexcept(false) { return u.x; }
+
+} // namespace check_unqualified_lookup
+
+class move_tracker {
+public:
+  move_tracker() = default;
+  constexpr move_tracker(move_tracker&& other) noexcept : moves_{other.moves_ + 1} { other.moves_ = 0; }
+  constexpr move_tracker& operator=(move_tracker&& other) noexcept {
+    moves_ = other.moves_ + 1;
+    other.moves_ = 0;
+    return *this;
+  }
+
+  move_tracker(move_tracker const& other) = delete;
+  move_tracker& operator=(move_tracker const& other) = delete;
+
+  constexpr int moves() const noexcept { return moves_; }
+
+private:
+  int moves_ = 0;
+};
+
+#endif // LIBCPP_TEST_STD_ITERATOR_UNQUALIFIED_LOOKUP_WRAPPER


### PR DESCRIPTION
This implements the `iter_move` CPO that is necessary for `<ranges>`