### PR TITLE
Add a nvrtc configuration for libcu++

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  
+
   get-devcontainer-version:
     name: Get devcontainer version
     runs-on: ubuntu-latest
@@ -76,14 +76,50 @@ jobs:
           PER_CUDA_COMPILER_MATRIX=$(echo $FULL_MATRIX | jq -c ' group_by(.cuda + .compiler.name) | map({(.[0].cuda + "-" + .[0].compiler.name): .}) | add')
           echo "PER_CUDA_COMPILER_MATRIX=$PER_CUDA_COMPILER_MATRIX" | tee -a "$GITHUB_OUTPUT"
 
+  compute-nvrtc-matrix:
+    name: Compute NVRTC matrix
+    runs-on: ubuntu-latest
+    outputs:
+      NVRTC_MATRIX: ${{ steps.set-outputs.outputs.NVRTC_MATRIX }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Get full nvrtc matrix
+        id: compute-nvrtc-matrix
+        uses: ./.github/actions/compute-matrix
+        with:
+          matrix_file: './ci/matrix.yaml'
+          matrix_query: '.pull_request.nvrtc'
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          NVRTC_MATRIX='${{steps.compute-nvrtc-matrix.outputs.matrix}}'
+          echo "NVRTC_MATRIX=$NVRTC_MATRIX" | tee -a "$GITHUB_OUTPUT"
+
+  nvrtc:
+    name: NVRTC CUDA${{matrix.cuda}} C++${{matrix.std}}
+    needs: [compute-nvrtc-matrix, get-devcontainer-version]
+    uses: ./.github/workflows/run-as-coder.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.compute-nvrtc-matrix.outputs.NVRTC_MATRIX) }}
+    with:
+      name: NVRTC CUDA${{matrix.cuda}} C++${{matrix.std}}
+      runner: linux-${{matrix.cpu}}-gpu-v100-latest-1
+      image: rapidsai/devcontainers:${{needs.get-devcontainer-version.outputs.DEVCONTAINER_VERSION}}-cpp-gcc12-cuda${{matrix.cuda}}-${{matrix.os}}
+      command: |
+        ./ci/nvrtc_libcudacxx.sh g++ ${{matrix.std}} ${{matrix.gpu_build_archs}}
+
+
   thrust:
     name: Thrust CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
     needs: [compute-nvcc-matrix, get-devcontainer-version]
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
       fail-fast: false
-      matrix: 
-        cuda_version: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.CUDA_VERSIONS) }} 
+      matrix:
+        cuda_version: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.CUDA_VERSIONS) }}
         compiler: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.HOST_COMPILERS) }}
     with:
       per_cuda_compiler_matrix: ${{ toJSON(fromJSON(needs.compute-nvcc-matrix.outputs.PER_CUDA_COMPILER_MATRIX)[ format('{0}-{1}', matrix.cuda_version, matrix.compiler) ]) }}
@@ -97,36 +133,36 @@ jobs:
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
       fail-fast: false
-      matrix: 
-        cuda_version: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.CUDA_VERSIONS) }} 
+      matrix:
+        cuda_version: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.CUDA_VERSIONS) }}
         compiler: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.HOST_COMPILERS) }}
     with:
       per_cuda_compiler_matrix: ${{ toJSON(fromJSON(needs.compute-nvcc-matrix.outputs.PER_CUDA_COMPILER_MATRIX)[ format('{0}-{1}', matrix.cuda_version, matrix.compiler) ]) }}
       build_script: "./ci/build_cub.sh"
       test_script: "./ci/test_cub.sh"
       devcontainer_version: ${{ needs.get-devcontainer-version.outputs.DEVCONTAINER_VERSION }}
-  
+
   libcudacxx:
     name: libcudacxx CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
     needs: [compute-nvcc-matrix, get-devcontainer-version]
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
       fail-fast: false
-      matrix: 
-        cuda_version: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.CUDA_VERSIONS) }} 
+      matrix:
+        cuda_version: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.CUDA_VERSIONS) }}
         compiler: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.HOST_COMPILERS) }}
     with:
       per_cuda_compiler_matrix: ${{ toJSON(fromJSON(needs.compute-nvcc-matrix.outputs.PER_CUDA_COMPILER_MATRIX)[ format('{0}-{1}', matrix.cuda_version, matrix.compiler) ]) }}
       build_script: "./ci/build_libcudacxx.sh"
-      test_script: "./ci/test_libcudacxx.sh" 
+      test_script: "./ci/test_libcudacxx.sh"
       devcontainer_version: ${{ needs.get-devcontainer-version.outputs.DEVCONTAINER_VERSION }}
-  
+
   examples:
     name: CCCL Examples
     needs: [compute-nvcc-matrix, get-devcontainer-version]
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         include: ${{ fromJSON(needs.compute-nvcc-matrix.outputs.FULL_MATRIX) }}
     uses: ./.github/workflows/run-as-coder.yml
     with:
@@ -143,8 +179,9 @@ jobs:
     runs-on: ubuntu-latest
     name: CI
     needs:
-      - libcudacxx
       - cub
+      - libcudacxx
+      - nvrtc
       - thrust
       - examples
     steps:

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,7 +8,7 @@ gpus:
   - 'a100'
   - 'v100'
 
-# The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers 
+# The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers
 devcontainer_version: '23.08'
 
 # Each environment below will generate a unique build/test job
@@ -45,3 +45,5 @@ pull_request:
     - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '13', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
     - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '14', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
     - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'llvm', version: '15', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build', 'test']}
+  nvrtc:
+    - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'amd64', gpu_build_archs: '70', std: [11, 14, 17, 20]}

--- a/ci/nvrtc_libcudacxx.sh
+++ b/ci/nvrtc_libcudacxx.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source "$(dirname "$0")/build_common.sh"
+
+CMAKE_OPTIONS="
+    -DCCCL_ENABLE_THRUST=OFF \
+    -DCCCL_ENABLE_LIBCUDACXX=ON \
+    -DCCCL_ENABLE_CUB=OFF \
+    -DCCCL_ENABLE_TESTING=OFF \
+    -DLIBCUDACXX_ENABLE_LIBCUDACXX_TESTS=ON \
+    -DLIBCUDACXX_TEST_WITH_NVRTC=ON \
+"
+configure "$CMAKE_OPTIONS"
+
+readonly TEST_PARALLEL_LEVEL=8
+
+source "./sccache_stats.sh" "start"
+LIBCUDACXX_SITE_CONFIG="${BUILD_DIR}/libcudacxx/test/lit.site.cfg" lit -v -j ${TEST_PARALLEL_LEVEL} --no-progress-bar -Dcompute_archs=${GPU_ARCHS} -Dstd="c++${CXX_STANDARD}" ../libcudacxx/.upstream-tests/test
+source "./sccache_stats.sh" "end"

--- a/libcudacxx/.upstream-tests/test/std/concepts/concepts.callable/concept.invocable/invocable.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/concepts/concepts.callable/concept.invocable/invocable.compile.pass.cpp
@@ -420,7 +420,8 @@ __host__ __device__ constexpr bool is_invocable(F, Args&&...) {
   return invocable<F, Args...>;
 }
 
-#if TEST_STD_VER > 14
+// execution space annotations on lambda require --extended-lambda flag with nvrtc
+#if TEST_STD_VER > 14 && !defined(TEST_COMPILER_NVRTC)
 static_assert(is_invocable([] {}), "");
 static_assert(is_invocable([](int) {}, 0), "");
 static_assert(is_invocable([](int) {}, 0L), "");

--- a/libcudacxx/.upstream-tests/test/std/concepts/concepts.callable/concept.regularinvocable/regular_invocable.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/concepts/concepts.callable/concept.regularinvocable/regular_invocable.compile.pass.cpp
@@ -465,7 +465,8 @@ __host__ __device__ constexpr bool is_regular_invocable(F, Args&&...) {
 }
 #endif // TEST_STD_VER > 17
 
-#if TEST_STD_VER > 14
+// execution space annotations on lambda require --extended-lambda flag with nvrtc
+#if TEST_STD_VER > 14 && !defined(TEST_COMPILER_NVRTC)
 static_assert(is_regular_invocable([] {}), "");
 static_assert(is_regular_invocable([](int) {}, 0), "");
 static_assert(is_regular_invocable([](int) {}, 0L), "");

--- a/libcudacxx/.upstream-tests/utils/libcudacxx/test/config.py
+++ b/libcudacxx/.upstream-tests/utils/libcudacxx/test/config.py
@@ -423,7 +423,7 @@ class Configuration(object):
     def configure_ccache(self):
         use_ccache_default = os.environ.get('CMAKE_CUDA_COMPILER_LAUNCHER') is not None
         use_ccache = self.get_lit_bool('use_ccache', use_ccache_default)
-        if use_ccache:
+        if use_ccache and not self.cxx.is_nvrtc:
             self.cxx.use_ccache = True
             self.lit_config.note('enabling ccache')
 

--- a/libcudacxx/.upstream-tests/utils/nvidia/nvrtc/middle.cu.in
+++ b/libcudacxx/.upstream-tests/utils/nvidia/nvrtc/middle.cu.in
@@ -11,8 +11,6 @@ int main() {
         0, NULL, NULL));
 
     const char * opts[] = {
-        "-rdc=true",
-
 #if __cplusplus < 201103L
         "-std=c++98",
 #elif __cplusplus < 201402L

--- a/libcudacxx/.upstream-tests/utils/nvidia/nvrtc/tail.cu.in
+++ b/libcudacxx/.upstream-tests/utils/nvidia/nvrtc/tail.cu.in
@@ -18,10 +18,16 @@
         exit(1);
     }
 
-    size_t ptxSize;
-    NVRTC_SAFE_CALL(nvrtcGetPTXSize(prog, &ptxSize));
-    std::unique_ptr<char[]> ptx{ new char[ptxSize] };
-    NVRTC_SAFE_CALL(nvrtcGetPTX(prog, ptx.get()));
+    size_t codeSize;
+#ifdef LIBCUDACXX_NVRTC_USE_CUBIN
+    NVRTC_SAFE_CALL(nvrtcGetCUBINSize(prog, &codeSize));
+    std::unique_ptr<char[]> code{new char[codeSize]};
+    NVRTC_SAFE_CALL(nvrtcGetCUBIN(prog, code.get()));
+#else
+    NVRTC_SAFE_CALL(nvrtcGetPTXSize(prog, &codeSize));
+    std::unique_ptr<char[]> code{new char[codeSize]};
+    NVRTC_SAFE_CALL(nvrtcGetPTX(prog, code.get()));
+#endif
     NVRTC_SAFE_CALL(nvrtcDestroyProgram(&prog));
 
     CUdevice cuDevice;
@@ -31,7 +37,7 @@
     CUDA_SAFE_CALL(cuInit(0));
     CUDA_SAFE_CALL(cuDeviceGet(&cuDevice, 0));
     CUDA_SAFE_CALL(cuCtxCreate(&context, 0, cuDevice));
-    CUDA_SAFE_CALL(cuModuleLoadDataEx(&module, ptx.get(), 0, 0, 0));
+    CUDA_SAFE_CALL(cuModuleLoadDataEx(&module, code.get(), 0, 0, 0));
     CUDA_SAFE_CALL(cuModuleGetFunction(&kernel, module, "main_kernel"));
     CUDA_SAFE_CALL(cuLaunchKernel(kernel,
         1, 1, 1,


### PR DESCRIPTION
We also want to test with nvrtc. 

The main problem is that we only ever want to test with a single configuration and neither cub and thrust.

For that I went with a new build job that should exclude all unwanted configurations

Fixes #141 