### PR TITLE
Factor out build job logic into a "run-as-coder" reusable workflow.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,4 +43,3 @@ jobs:
       command: |
         nvidia-smi
         ${{ inputs.test_script }} "${{inputs.compiler_exe}}" "${{inputs.std}}" "${{inputs.gpu_build_archs}}"
-      env: '{ "NVIDIA_VISIBLE_DEVICES": "$${{ env.NVIDIA_VISIBLE_DEVICES }}" }'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,4 +43,4 @@ jobs:
       command: |
         nvidia-smi
         ${{ inputs.test_script }} "${{inputs.compiler_exe}}" "${{inputs.std}}" "${{inputs.gpu_build_archs}}"
-      env: '{ "NVIDIA_VISIBLE_DEVICES": "${{ env.NVIDIA_VISIBLE_DEVICES }}" }'
+      env: '{ "NVIDIA_VISIBLE_DEVICES": "$${{ env.NVIDIA_VISIBLE_DEVICES }}" }'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,7 @@ jobs:
     name: Build ${{inputs.compiler}}${{inputs.compiler_version}}/C++${{inputs.std}}
     uses: ./.github/workflows/run-as-coder.yml
     with:
+      name: Build ${{inputs.compiler}}${{inputs.compiler_version}}/C++${{inputs.std}}
       runner: linux-${{inputs.cpu}}-cpu16
       image: ${{inputs.build_image}}
       command: |
@@ -38,6 +39,7 @@ jobs:
     name: Test ${{inputs.compiler}}${{inputs.compiler_version}}/C++${{inputs.std}}
     uses: ./.github/workflows/run-as-coder.yml
     with:
+      name: Test ${{inputs.compiler}}${{inputs.compiler_version}}/C++${{inputs.std}}
       runner: linux-${{inputs.cpu}}-gpu-v100-latest-1
       image: ${{inputs.test_image}}
       command: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,34 +29,19 @@ jobs:
     with:
       runner: linux-${{inputs.cpu}}-cpu16
       image: ${{inputs.build_image}}
-      command: "${{ inputs.build_script }} \"${{inputs.compiler_exe}}\" \"${{inputs.std}}\" \"${{inputs.gpu_build_archs}}\""
+      command: |
+        ${{ inputs.build_script }} "${{inputs.compiler_exe}}" "${{inputs.std}}" "${{inputs.gpu_build_archs}}"
+
   test:
     needs: build
     if:  ${{ !cancelled() && ( needs.build.result == 'success' || needs.build.result == 'skipped' ) && inputs.test_script != '' && inputs.test_image != '' && inputs.run_tests}}
     name: Test ${{inputs.compiler}}${{inputs.compiler_version}}/C++${{inputs.std}}
-    runs-on: linux-${{inputs.cpu}}-gpu-v100-latest-1
-    container: 
-      options: -u root
-      image: ${{ inputs.test_image }}
+    uses: ./.github/workflows/run-as-coder.yml
+    with:
+      runner: linux-${{inputs.cpu}}-gpu-v100-latest-1
+      image: ${{inputs.test_image}}
+      command: |
+        nvidia-smi
+        ${{ inputs.test_script }} "${{inputs.compiler_exe}}" "${{inputs.std}}" "${{inputs.gpu_build_archs}}"
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    permissions:
-      id-token: write
-    steps:
-      - name: nvidia-smi
-        run: nvidia-smi
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          path: cccl
-      - name: Move files to coder user home directory
-        run: |
-          cp -R cccl /home/coder/cccl
-          chown -R coder:coder /home/coder/
-      - name: Configure credentials and environment variables for sccache
-        uses: ./cccl/.github/actions/configure_cccl_sccache
-      - name: Run test script
-        shell: su coder {0}
-        run: | 
-            cd ~/cccl
-            time ./${{ inputs.test_script }} "${{inputs.compiler_exe}}" "${{inputs.std}}" "${{inputs.gpu_build_archs}}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,5 +43,4 @@ jobs:
       command: |
         nvidia-smi
         ${{ inputs.test_script }} "${{inputs.compiler_exe}}" "${{inputs.std}}" "${{inputs.gpu_build_archs}}"
-      env:
-        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+      env: '{ "NVIDIA_VISIBLE_DEVICES": "${{ env.NVIDIA_VISIBLE_DEVICES }}" }'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,42 +25,11 @@ jobs:
   build:
     if: inputs.build_script != '' && inputs.build_image != ''
     name: Build ${{inputs.compiler}}${{inputs.compiler_version}}/C++${{inputs.std}}
-    runs-on: linux-${{inputs.cpu}}-cpu16
-    container: 
-      options: -u root
-      image: ${{ inputs.build_image }}
-    permissions:
-      id-token: write
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          path: cccl
-      # In order for sccache to be shared between CI and lcaal devcontainers, code needs to be in the same absolute path
-      # This ensures the code is in the same path as it is within the devcontainer
-      - name: Move files to coder user home directory
-        run: |
-          cp -R cccl /home/coder/cccl
-          chown -R coder:coder /home/coder/
-      - name: Configure credentials and environment variables for sccache
-        uses: ./cccl/.github/actions/configure_cccl_sccache
-      - name: Run build script
-        shell: su coder {0}
-        run: | 
-            cd ~/cccl
-            cmd="${{ inputs.build_script }} \"${{inputs.compiler_exe}}\" \"${{inputs.std}}\" \"${{inputs.gpu_build_archs}}\""
-            eval $cmd || exit_code=$?
-            if [ ! -z "$exit_code" ]; then
-                echo "::error::Build failed! To checkout the corresponding code and reproduce this build locally, run the following commands:" 
-                echo "git clone --branch $GITHUB_REF_NAME --single-branch --recurse-submodules https://github.com/$GITHUB_REPOSITORY.git && cd $(echo $GITHUB_REPOSITORY | cut -d'/' -f2) && git checkout $GITHUB_SHA"
-                echo "docker run --rm -it --gpus all --pull=always --volume \$PWD:/repo --workdir /repo ${{ inputs.build_image }} $cmd"
-                echo "Alternatively, for a more convenient, interactive environment to reproduce the issue, you can launch a devcontainer in vscode:"
-                echo "git clone --branch $GITHUB_REF_NAME --single-branch --recurse-submodules https://github.com/$GITHUB_REPOSITORY.git && cd $(echo $GITHUB_REPOSITORY | cut -d'/' -f2) && git checkout $GITHUB_SHA"
-                echo ".devcontainer/launch.sh ${{inputs.cuda_version}} ${{inputs.compiler}}${{inputs.compiler_version}}"
-                echo "Then, open a terminal inside vscode (ctrl+shift+\`) and run:"
-                echo "$cmd"
-                exit $exit_code
-            fi
+    uses: ./.github/workflows/run-as-coder.yml
+    with:
+      runner: linux-${{inputs.cpu}}-cpu16
+      image: ${{inputs.build_image}}
+      command: "${{ inputs.build_script }} \"${{inputs.compiler_exe}}\" \"${{inputs.std}}\" \"${{inputs.gpu_build_archs}}\""
   test:
     needs: build
     if:  ${{ !cancelled() && ( needs.build.result == 'success' || needs.build.result == 'skipped' ) && inputs.test_script != '' && inputs.test_image != '' && inputs.run_tests}}

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -20,7 +20,8 @@ jobs:
     container:
       options: -u root
       image: ${{inputs.image}}
-      env: ${{ fromJSON(inputs.env) }}
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -11,7 +11,7 @@ on:
       image: {type: string, required: true}
       runner: {type: string, required: true}
       command: {type: string, required: true}
-      env: { type: object, required: false, default: {} }
+      env: { type: string, required: false, default: "" }
 
 jobs:
   run-as-coder:
@@ -20,7 +20,7 @@ jobs:
     container:
       options: -u root
       image: ${{inputs.image}}
-      env: ${{inputs.env}}
+      env: ${{ fromJSON(inputs.env) }}
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: cccl
+          persist-credentials: false
       - name: Move files to coder user home directory
         run: |
           cp -R cccl /home/coder/cccl

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -11,10 +11,7 @@ on:
       image: {type: string, required: true}
       runner: {type: string, required: true}
       command: {type: string, required: true}
-      env:
-        type: object
-        required: false
-        default: {}
+      env: { type: object, required: false, default: {} }
 
 jobs:
   run-as-coder:

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -11,6 +11,10 @@ on:
       image: {type: string, required: true}
       runner: {type: string, required: true}
       command: {type: string, required: true}
+      env:
+        type: object
+        required: false
+        default: {}
 
 jobs:
   run-as-coder:
@@ -19,6 +23,7 @@ jobs:
     container:
       options: -u root
       image: ${{inputs.image}}
+      env: ${{inputs.env}}
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -40,7 +40,7 @@ jobs:
         shell: su coder {0}
         run: | 
             cd ~/cccl
-            eval ${{inputs.command}} || exit_code=$?
+            eval "${{inputs.command}}" || exit_code=$?
             if [ ! -z "$exit_code" ]; then
                 echo "::error::Error! To checkout the corresponding code and reproduce locally, run the following commands:" 
                 echo "git clone --branch $GITHUB_REF_NAME --single-branch --recurse-submodules https://github.com/$GITHUB_REPOSITORY.git && cd $(echo $GITHUB_REPOSITORY | cut -d'/' -f2) && git checkout $GITHUB_SHA"

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -1,0 +1,46 @@
+name: Run as coder user
+
+defaults:
+  run:
+    shel:: bash -exo pipefail {0}
+
+
+on:
+  workflow_call:
+    inputs:
+      image: {type: string, required: true}
+      runner: {type: string, required: true}
+      command: {type: string, required: true}
+
+jobs:
+  run-as-coder:
+    name: Run ${{inputs.command}}
+    runs-on: ${{inputs.runner}}
+    container:
+      options: -u root
+      image: ${{inputs.image}}
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: cccl
+      - name: Move files to coder user home directory
+        run: |
+          cp -R cccl /home/coder/cccl
+          chown -R coder:coder /home/coder/
+      - name: Configure credentials and environment variables for sccache
+        uses: ./cccl/.github/actions/configure_cccl_sccache
+      - name: Run command
+        shell: su coder {0}
+        run: | 
+            cd ~/cccl
+            eval ${{inputs.command}} || exit_code=$?
+            if [ ! -z "$exit_code" ]; then
+                echo "::error::Error! To checkout the corresponding code and reproduce locally, run the following commands:" 
+                echo "git clone --branch $GITHUB_REF_NAME --single-branch --recurse-submodules https://github.com/$GITHUB_REPOSITORY.git && cd $(echo $GITHUB_REPOSITORY | cut -d'/' -f2) && git checkout $GITHUB_SHA"
+                echo "docker run --rm -it --gpus all --pull=always --volume \$PWD:/repo --workdir /repo ${{ inputs.image }} ${{inputs.command}}"
+                exit $exit_code
+            fi
+

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -2,7 +2,7 @@ name: Run as coder user
 
 defaults:
   run:
-    shel:: bash -exo pipefail {0}
+    shell: bash -exo pipefail {0}
 
 
 on:

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -8,6 +8,7 @@ defaults:
 on:
   workflow_call:
     inputs:
+      name: {type: string, required: true}
       image: {type: string, required: true}
       runner: {type: string, required: true}
       command: {type: string, required: true}
@@ -15,7 +16,7 @@ on:
 
 jobs:
   run-as-coder:
-    name: Run ${{inputs.command}}
+    name: ${{inputs.name}}
     runs-on: ${{inputs.runner}}
     container:
       options: -u root


### PR DESCRIPTION
## Description


closes https://github.com/NVIDIA/cccl/issues/204

Factors out the logic for cloning the cccl repo into the `/home/coder/cccl` directory and executing a command as the coder user into a reusable workflow.  


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
