### PR TITLE
Attempt to fix codeowners 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,17 @@
+# general codeowners for all files
+# (Order matters. This needs to be at the top)
+* @nvidia/cccl-codeowners
+
 # Libraries
-thrust/ @nvidia/cccl-thrust-codeowners
-cub/ @nvidia/cccl-cub-codeowners
-libcudacxx/ @nvidia/cccl-libcudacxx-codeowners
+thrust/ @nvidia/cccl-thrust-codeowners @nvidia/cccl-codeowners 
+cub/ @nvidia/cccl-cub-codeowners @nvidia/cccl-codeowners
+libcudacxx/ @nvidia/cccl-libcudacxx-codeowners @nvidia/cccl-codeowners
 
 # Infrastructure
-.github/ @nvidia/cccl-infra-codeowners
-ci/ @nvidia/cccl-infra-codeowners
-.devcontainer/ @nvidia/cccl-infra-codeowners
+.github/ @nvidia/cccl-infra-codeowners @nvidia/cccl-codeowners
+ci/ @nvidia/cccl-infra-codeowners @nvidia/cccl-codeowners
+.devcontainer/ @nvidia/cccl-infra-codeowners @nvidia/cccl-codeowners
 
 # cmake
-**/CMakeLists.txt @nvidia/cccl-cmake-codeowners
-**/cmake/ @nvidia/cccl-cmake-codeowners
-
-# general codeowners for all files
-* @nvidia/cccl-codeowners
+**/CMakeLists.txt @nvidia/cccl-cmake-codeowners @nvidia/cccl-codeowners
+**/cmake/ @nvidia/cccl-cmake-codeowners  @nvidia/cccl-codeowners


### PR DESCRIPTION
## Description

As https://github.com/NVIDIA/cccl/pull/230 showed, the codeowner review assignment isn't working as expected. 

I believe this is two things:

1. Order matters. The _last_ pattern to match takes precedence
2. If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.

So in order to get the behavior of requesting a review from a specific pool and a general pool, I I think we need to list each pool as a codeowner for a given pattern. 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
