### PR TITLE
Enable additional arguments in build_common.sh

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -1,18 +1,48 @@
 #!/bin/bash
 
-set -euo pipefail
-
 # Ensure the script is being executed in its containing directory
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 
+# Script defaults
+CUDA_COMPILER=nvcc
+
 # Check if the correct number of arguments has been provided
-if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <HOST_COMPILER> <CXX_STANDARD> <GPU_ARCHS>"
+function usage {
+    echo "Usage: $0 [OPTIONS] <HOST_COMPILER> <CXX_STANDARD> <GPU_ARCHS>"
     echo "The PARALLEL_LEVEL environment variable controls the amount of build parallelism. Default is the number of cores."
     echo "Example: PARALLEL_LEVEL=8 $0 g++-8 14 \"70\" "
     echo "Example: $0 clang++-8 17 \"70;75;80-virtual\" "
+    echo "Possible options: "
+    echo "  -nvcc: path/to/nvcc"
+    echo "  -v/--verbose: enable shell echo for debugging"
     exit 1
+}
+
+# Check for extra options
+# NARGS
+while [ "$#" -gt 3 ]
+do
+  case "${1}" in
+  -h)     usage ;;
+  -help)  usage ;;
+  --help) usage ;;
+  --verbose) VERBOSE=1; shift ;;
+  -v)        VERBOSE=1; shift ;;
+  -nvcc) CUDA_COMPILER="${2}"; shift 2;;
+  *) usage ;;
+  esac
+done
+
+if [ $VERBOSE ]; then
+    set -x
 fi
+
+if [ "$#" -ne 3 ]; then
+    usage
+fi
+
+# Begin processing failures after option parsing
+set -euo pipefail
 
 # Assign command line arguments to variables
 readonly HOST_COMPILER=$(which $1)
@@ -22,7 +52,7 @@ readonly CXX_STANDARD=$2
 readonly GPU_ARCHS=$(echo $3 | tr ' ,' ';')
 
 readonly PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
-readonly NVCC_VERSION=$(nvcc --version | grep release | awk '{print $6}' | cut -c2-)
+readonly NVCC_VERSION=$($CUDA_COMPILER --version | grep release | awk '{print $6}' | cut -c2-)
 
 if [ -z ${DEVCONTAINER_NAME+x} ]; then
     BUILD_DIR=../build/local
@@ -40,6 +70,7 @@ COMMON_CMAKE_OPTIONS="
     -DCMAKE_CXX_STANDARD=${CXX_STANDARD} \
     -DCMAKE_CUDA_STANDARD=${CXX_STANDARD} \
     -DCMAKE_CXX_COMPILER=${HOST_COMPILER} \
+    -DCMAKE_CUDA_COMPILER=${CUDA_COMPILER} \
     -DCMAKE_CUDA_HOST_COMPILER=${HOST_COMPILER} \
     -DCMAKE_CUDA_ARCHITECTURES=${GPU_ARCHS} \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \

--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 # Ensure the script is being executed in its containing directory
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 
@@ -19,7 +21,7 @@ function usage {
 }
 
 # Check for extra options
-# NARGS
+# While there are more than 3 arguments, parse switches/options
 while [ "$#" -gt 3 ]
 do
   case "${1}" in
@@ -38,11 +40,12 @@ if [ $VERBOSE ]; then
 fi
 
 if [ "$#" -ne 3 ]; then
+    echo "Invalid number of arguments"
     usage
 fi
 
-# Begin processing failures after option parsing
-set -euo pipefail
+# Begin processing unsets after option parsing
+set -u
 
 # Assign command line arguments to variables
 readonly HOST_COMPILER=$(which $1)


### PR DESCRIPTION
## Description

closes #171 

Allows passing options into build_[test].sh scripts.

Might be a little hacky.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
