### PR TITLE
Add new CCCL:: CMake targets

### DIFF
--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -137,9 +137,9 @@ function(cub_add_test target_name_var test_name test_src cub_target)
 
   if (is_catch2_test)
     set(use_rdc_for_catch2_utils OFF)
-  if (CUB_ENABLE_RDC_TESTS OR CUB_FORCE_RDC)
-    set(use_rdc_for_catch2_utils ON)
-  endif()
+    if (CUB_ENABLE_RDC_TESTS OR CUB_FORCE_RDC)
+      set(use_rdc_for_catch2_utils ON)
+    endif()
 
     # Per config helper library:
     set(config_c2h_target ${config_prefix}.test.catch2_helper)

--- a/lib/cmake/cccl/cccl-config.cmake
+++ b/lib/cmake/cccl/cccl-config.cmake
@@ -20,7 +20,7 @@ else()
 endif()
 
 if (NOT TARGET CCCL::CCCL)
-  add_library(CCCL::CCCL INTERFACE IMPORTED)
+  add_library(CCCL::CCCL INTERFACE IMPORTED GLOBAL)
 endif()
 
 foreach(component IN LISTS components)

--- a/lib/cmake/cccl/cccl-config.cmake
+++ b/lib/cmake/cccl/cccl-config.cmake
@@ -19,6 +19,10 @@ else()
   set(components Thrust CUB libcudacxx)
 endif()
 
+if (NOT TARGET CCCL::CCCL)
+  add_library(CCCL::CCCL INTERFACE IMPORTED)
+endif()
+
 foreach(component IN LISTS components)
   string(TOLOWER "${component}" component_lower)
 
@@ -36,6 +40,12 @@ foreach(component IN LISTS components)
         "${cccl_cmake_dir}/../../../libcudacxx/lib/cmake/" # Source layout (GitHub)
         "${cccl_cmake_dir}/.."                             # Install layout
     )
+    # Can't alias other alias targets, so use the uglified target name instead
+    # of libcudacxx::libcudacxx:
+    if (TARGET _libcudacxx_libcudacxx)
+      add_library(CCCL::libcudacxx ALIAS _libcudacxx_libcudacxx)
+      target_link_libraries(CCCL::CCCL INTERFACE CCCL::libcudacxx)
+    endif()
   elseif(component_lower STREQUAL "cub")
     find_package(CUB ${CCCL_VERSION} EXACT CONFIG
       ${cccl_quiet_flag}
@@ -45,6 +55,12 @@ foreach(component IN LISTS components)
         "${cccl_cmake_dir}/../../../cub/cub/cmake/" # Source layout (GitHub)
         "${cccl_cmake_dir}/.."                      # Install layout
     )
+    # Can't alias other alias targets, so use the uglified target name instead
+    # of CUB::CUB:
+    if (TARGET _CUB_CUB)
+      add_library(CCCL::CUB ALIAS _CUB_CUB)
+      target_link_libraries(CCCL::CCCL INTERFACE CCCL::CUB)
+    endif()
   elseif(component_lower STREQUAL "thrust")
     find_package(Thrust ${CCCL_VERSION} EXACT CONFIG
       ${cccl_quiet_flag}
@@ -54,6 +70,25 @@ foreach(component IN LISTS components)
         "${cccl_cmake_dir}/../../../thrust/thrust/cmake/" # Source layout (GitHub)
         "${cccl_cmake_dir}/.."                            # Install layout
     )
+
+    if (TARGET Thrust::Thrust)
+      # By default, configure a CCCL::Thrust target with host=cpp device=cuda
+      option(CCCL_ENABLE_DEFAULT_THRUST_TARGET
+        "Create a CCCL::Thrust target using CCCL_THRUST_[HOST|DEVICE]_SYSTEM."
+        ON
+      )
+      if (CCCL_ENABLE_DEFAULT_THRUST_TARGET)
+        thrust_create_target(CCCL::Thrust FROM_OPTIONS
+          HOST_OPTION CCCL_THRUST_HOST_SYSTEM
+          DEVICE_OPTION CCCL_THRUST_DEVICE_SYSTEM
+          HOST_OPTION_DOC
+            "Host system for CCCL::Thrust target."
+          DEVICE_OPTION_DOC
+            "Device system for CCCL::Thrust target."
+        )
+        target_link_libraries(CCCL::CCCL INTERFACE CCCL::Thrust)
+      endif()
+    endif()
   else()
     message(FATAL_ERROR "Invalid CCCL component requested: '${component}'")
   endif()

--- a/lib/cmake/cccl/cccl-config.cmake
+++ b/lib/cmake/cccl/cccl-config.cmake
@@ -77,6 +77,7 @@ foreach(component IN LISTS components)
         "Create a CCCL::Thrust target using CCCL_THRUST_[HOST|DEVICE]_SYSTEM."
         ON
       )
+      mark_as_advanced(CCCL_ENABLE_DEFAULT_THRUST_TARGET)
       if (CCCL_ENABLE_DEFAULT_THRUST_TARGET)
         thrust_create_target(CCCL::Thrust FROM_OPTIONS
           HOST_OPTION CCCL_THRUST_HOST_SYSTEM
@@ -85,6 +86,7 @@ foreach(component IN LISTS components)
             "Host system for CCCL::Thrust target."
           DEVICE_OPTION_DOC
             "Device system for CCCL::Thrust target."
+          ADVANCED
         )
         target_link_libraries(CCCL::CCCL INTERFACE CCCL::Thrust)
       endif()

--- a/lib/cmake/cccl/cccl-config.cmake
+++ b/lib/cmake/cccl/cccl-config.cmake
@@ -42,7 +42,7 @@ foreach(component IN LISTS components)
     )
     # Can't alias other alias targets, so use the uglified target name instead
     # of libcudacxx::libcudacxx:
-    if (TARGET _libcudacxx_libcudacxx)
+    if (TARGET _libcudacxx_libcudacxx AND NOT TARGET CCCL::libcudacxx)
       add_library(CCCL::libcudacxx ALIAS _libcudacxx_libcudacxx)
       target_link_libraries(CCCL::CCCL INTERFACE CCCL::libcudacxx)
     endif()
@@ -57,7 +57,7 @@ foreach(component IN LISTS components)
     )
     # Can't alias other alias targets, so use the uglified target name instead
     # of CUB::CUB:
-    if (TARGET _CUB_CUB)
+    if (TARGET _CUB_CUB AND NOT TARGET CCCL::CUB)
       add_library(CCCL::CUB ALIAS _CUB_CUB)
       target_link_libraries(CCCL::CCCL INTERFACE CCCL::CUB)
     endif()
@@ -71,7 +71,7 @@ foreach(component IN LISTS components)
         "${cccl_cmake_dir}/.."                            # Install layout
     )
 
-    if (TARGET Thrust::Thrust)
+    if (TARGET Thrust::Thrust AND NOT CCCL::Thrust)
       # By default, configure a CCCL::Thrust target with host=cpp device=cuda
       option(CCCL_ENABLE_DEFAULT_THRUST_TARGET
         "Create a CCCL::Thrust target using CCCL_THRUST_[HOST|DEVICE]_SYSTEM."


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #203

<!-- Provide a standalone description of changes in this PR. -->
Add CCCL::CCCL, CCCL::libcudacxx, CCCL::CUB, and CCCL::Thrust targets.

The Thrust target is configured via cache options as discussed in #203.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
