### PR TITLE
Allow building CUB tests without cuRand

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -28,9 +28,10 @@ do
   -h)     usage ;;
   -help)  usage ;;
   --help) usage ;;
-  --verbose) VERBOSE=1; shift ;;
-  -v)        VERBOSE=1; shift ;;
-  -nvcc) CUDA_COMPILER="${2}"; shift 2;;
+  --verbose)           VERBOSE=1; shift ;;
+  -v)                  VERBOSE=1; shift ;;
+  -nvcc)               CUDA_COMPILER="${2}"; shift 2;;
+  -disable-benchmarks) ENABLE_CUB_BENCHMARKS="false"; shift ;;
   *) usage ;;
   esac
 done

--- a/ci/build_cub.sh
+++ b/ci/build_cub.sh
@@ -12,7 +12,7 @@ version_compare() {
         echo "false"
     fi
 }
-readonly ENABLE_CUB_BENCHMARKS=$(version_compare $NVCC_VERSION 11.5)
+readonly ENABLE_CUB_BENCHMARKS=${ENABLE_CUB_BENCHMARKS:=$(version_compare $NVCC_VERSION 11.5)}
 
 if [[ $ENABLE_CUB_BENCHMARKS == "true" ]]; then
     echo "CUDA version is $NVCC_VERSION. Building CUB benchmarks."

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -19,7 +19,7 @@ CPMAddPackage("gh:brunocodutra/metal@2.1.4")
 find_package(CUDAToolkit)
 
 set(curand_default OFF)
-if (CUDAToolkit_FOUND)
+if (CUDA_curand_LIBRARY)
   set(curand_default ON)
 endif()
 
@@ -197,6 +197,7 @@ function(cub_add_test target_name_var test_name test_src cub_target)
           ${config_c2h_target}
           Metal
           Catch2::Catch2
+          CUDA::curand
         )
         cub_clone_target_properties(${config_c2run_target} ${cub_target})
         cub_configure_cuda_target(${config_c2run_target} RDC ${use_rdc_for_catch2_utils})

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -16,7 +16,14 @@ option(METAL_BUILD_EXAMPLES OFF)
 option(METAL_BUILD_TESTS OFF)
 CPMAddPackage("gh:brunocodutra/metal@2.1.4")
 
-find_package(CUDAToolkit REQUIRED)
+find_package(CUDAToolkit)
+
+set(curand_default OFF)
+if (CUDAToolkit_FOUND)
+  set(curand_default ON)
+endif()
+
+option(CUB_C2H_ENABLE_CURAND "Use CUDA CURAND library" ${curand_default})
 
 # The function below reads the filepath `src`, extracts the %PARAM% comments,
 # and fills `labels_var` with a list of `label1_value1.label2_value2...`
@@ -160,7 +167,14 @@ function(cub_add_test target_name_var test_name test_src cub_target)
 
       cub_clone_target_properties(${config_c2h_target} ${cub_target})
       cub_configure_cuda_target(${config_c2h_target} RDC ${use_rdc_for_catch2_utils})
-      target_link_libraries(${config_c2h_target} PRIVATE CUDA::curand ${cub_target})
+
+      target_link_libraries(${config_c2h_target} PRIVATE ${cub_target})
+      if (CUB_C2H_ENABLE_CURAND)
+        target_link_libraries(${config_c2h_target} PRIVATE CUDA::curand)
+        target_compile_definitions(${config_c2h_target} PRIVATE C2H_HAS_CURAND=1)
+      else()
+        target_compile_definitions(${config_c2h_target} PRIVATE C2H_HAS_CURAND=0)
+      endif()
 
       if (CUB_IN_THRUST)
         thrust_fix_clang_nvcc_build_for(${config_c2h_target})

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -197,7 +197,6 @@ function(cub_add_test target_name_var test_name test_src cub_target)
           ${config_c2h_target}
           Metal
           Catch2::Catch2
-          CUDA::cudart
         )
         cub_clone_target_properties(${config_c2run_target} ${cub_target})
         cub_configure_cuda_target(${config_c2run_target} RDC ${use_rdc_for_catch2_utils})


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/249

<!-- Provide a standalone description of changes in this PR. -->

This PR allows building CUB tests without cuRand. The cuRand usage is disabled by default if there's no CTK found. To force this behavior, one can provide `-DCUB_C2H_ENABLE_CURAND=NO` CMake option.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
