### PR TITLE
Add WarpExchangeAlgorithm customization for WarpExchange class

### DIFF
--- a/cub/cub/warp/specializations/warp_exchange_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_exchange_shfl.cuh
@@ -1,0 +1,327 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cub/config.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/util_type.cuh>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+
+template <typename InputT,
+          int ITEMS_PER_THREAD,
+          int LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS>
+class WarpExchangeShfl
+{
+  static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE,
+                "LOGICAL_WARP_THREADS must be a power of two");
+
+  static_assert(ITEMS_PER_THREAD == LOGICAL_WARP_THREADS,
+                "WARP_EXCHANGE_SHUFFLE currently only works when ITEMS_PER_THREAD == "
+                "LOGICAL_WARP_THREADS");
+
+  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
+
+  template <typename OutputT, int IDX>
+  class CompileTimeArrayImpl;
+
+  template <typename OutputT> // terminating partial specialization
+  class CompileTimeArrayImpl<OutputT, ITEMS_PER_THREAD>
+  {
+  protected:
+    // used for dumping back the individual values after transposing
+    InputT (&output_items)[ITEMS_PER_THREAD];
+
+    template <int>
+    __device__ void Foreach(bool, unsigned)
+    {}
+
+  public:
+    __device__ CompileTimeArrayImpl(const InputT (&)[ITEMS_PER_THREAD],
+                                    OutputT (&output_items)[ITEMS_PER_THREAD])
+        : output_items{output_items}
+    {}
+  };
+
+  template <typename OutputT, int IDX> // concrete recursion class
+  class CompileTimeArrayImpl : protected CompileTimeArrayImpl<OutputT, IDX + 1>
+  {
+  protected:
+    InputT val;
+
+    template <int NUM_ENTRIES>
+    __device__ void Foreach(const bool xor_bit_set, const unsigned mask)
+    {
+      // The implementation here is a recursive divide-and-conquer approach
+      // that takes inspiration from:
+      // https://forums.developer.nvidia.com/t/transposing-register-held-matrices-with-warp-shuffles-need-help/38652/2
+      //
+      // At its core, the problem can be boiled down to transposing the matrix
+      //
+      //   A B
+      //   C D
+      //
+      // by swapping the off-diagonal elements/sub-matrices B and C recursively.
+      //
+      // This implementation requires power-of-two matrices. In order to avoid
+      // the use of local or shared memory, all index computation has to occur
+      // at compile-time, since registers cannot be indexed dynamically.
+      // Furthermore, using recursive templates reduces the mental load on the
+      // optimizer, since lowering for-loops into registers oftentimes requires
+      // finagling them with #pragma unroll, which leads to brittle code.
+      //
+      // To illustrate this algorithm, let's pretend we have warpSize = 8,
+      // where t0, ..., t7 denote the 8 threads, and thread i has an array of
+      // size 8 with data = [Ai, Bi, ..., Hi] (the columns in the schematics).
+      //
+      // In the first round, we exchange the largest 4x4 off-diagonal
+      // submatrix. Boxes illustrate the submatrices to be exchanged.
+      //
+      //       ROUND 1
+      //       =======
+      //  t0  t1  t2  t3  t4  t5  t6  t7
+      //                 ┌──────────────┐
+      //  A0  A1  A2  A3 │A4  A5  A6  A7│    NUM_ENTRIES == 4 tells us how many
+      //                 │              │       entries we have in a submatrix,
+      //                 │              │       in this case 4 and the size of
+      //  B0  B1  B2  B3 │B4  B5  B6  B7│       the jumps between submatrices.
+      //                 │              │
+      //                 │              │  1. t[0,1,2,3] data[4] swap with t[4,5,6,7]'s data[0]
+      //  C0  C1  C2  C3 │C4  C5  C6  C7│  2. t[0,1,2,3] data[5] swap with t[4,5,6,7]'s data[1]
+      //                 │              │  3. t[0,1,2,3] data[6] swap with t[4,5,6,7]'s data[2]
+      //                 │              │  4. t[0,1,2,3] data[7] swap with t[4,5,6,7]'s data[3]
+      //  D0  D1  D2  D3 │D4  D5  D6  D7│
+      //                 └──────────────┘
+      // ┌──────────────┐
+      // │E0  E1  E2  E3│ E4  E5  E6  E7
+      // │              │
+      // │              │
+      // │F0  F1  F2  F3│ F4  F5  F6  F7
+      // │              │
+      // │              │
+      // │G0  G1  G2  G3│ G4  G5  G6  G7
+      // │              │
+      // │              │
+      // │H0  H1  H2  H3│ H4  H5  H6  H7
+      // └──────────────┘
+      //
+      //       ROUND 2
+      //       =======
+      //  t0  t1  t2  t3  t4  t5  t6  t7
+      //         ┌──────┐        ┌──────┐
+      //  A0  A1 │A2  A3│ E0  E1 │E2  E3│    NUM_ENTRIES == 2 so we have 2
+      //         │      │        │      │       submatrices per thread and there
+      //         │      │        │      │       are 2 elements between these
+      //  B0  B1 │B2  B3│ F0  F1 │F2  F3│       submatrices.
+      //         └──────┘        └──────┘
+      // ┌──────┐        ┌──────┐          1. t[0,1,4,5] data[2] swap with t[2,3,6,7]'s data[0]
+      // │C0  C1│ C2  C3 │G0  G1│ G2  G3   2. t[0,1,4,5] data[3] swap with t[2,3,6,7]'s data[1]
+      // │      │        │      │          3. t[0,1,4,5] data[6] swap with t[2,3,6,7]'s data[4]
+      // │      │        │      │          4. t[0,1,4,5] data[7] swap with t[2,3,6,7]'s data[5]
+      // │D0  D1│ D2  D3 │H0  H1│ H2  H3
+      // └──────┘        └──────┘
+      //         ┌──────┐        ┌──────┐
+      //  A4  A5 │A6  A7│ E4  E5 │E6  E7│
+      //         │      │        │      │
+      //         │      │        │      │
+      //  B4  B5 │B6  B7│ F4  F5 │F6  F7│
+      //         └──────┘        └──────┘
+      // ┌──────┐        ┌──────┐
+      // │C4  C5│ C6  C7 │G4  G5│ G6  G7
+      // │      │        │      │
+      // │      │        │      │
+      // │D4  D5│ D6  D7 │H4  H5│ H6  H7
+      // └──────┘        └──────┘
+      //
+      //       ROUND 3
+      //       =======
+      //  t0  t1  t2  t3  t4  t5  t6  t7
+      //     ┌──┐    ┌──┐    ┌──┐    ┌──┐
+      //  A0 │A1│ C0 │C1│ E0 │E1│ G0 │G1│    NUM_ENTRIES == 1 so we have 4
+      //     └──┘    └──┘    └──┘    └──┘       submatrices per thread and there
+      // ┌──┐    ┌──┐    ┌──┐    ┌──┐           is 1 element between these
+      // │B0│ B1 │D0│ D1 │F0│ F1 │H0│ H1        submatrices.
+      // └──┘    └──┘    └──┘    └──┘
+      //     ┌──┐    ┌──┐    ┌──┐    ┌──┐  1. t[0,2,4,6] data[1] swap with t[1,3,5,7]'s data[0]
+      //  A2 │A3│ C2 │C3│ E2 │E3│ G2 │G3│  2. t[0,2,4,6] data[3] swap with t[1,3,5,7]'s data[2]
+      //     └──┘    └──┘    └──┘    └──┘  3. t[0,2,4,6] data[5] swap with t[1,3,5,7]'s data[4]
+      // ┌──┐    ┌──┐    ┌──┐    ┌──┐      4. t[0,2,4,6] data[7] swap with t[1,3,5,7]'s data[6]
+      // │B2│ B3 │D2│ D3 │F2│ F3 │H2│ H3
+      // └──┘    └──┘    └──┘    └──┘
+      //     ┌──┐    ┌──┐    ┌──┐    ┌──┐
+      //  A4 │A5│ C4 │C5│ E4 │E5│ G4 │G5│
+      //     └──┘    └──┘    └──┘    └──┘
+      // ┌──┐    ┌──┐    ┌──┐    ┌──┐
+      // │B4│ B5 │D4│ D5 │F4│ F5 │H4│ H5
+      // └──┘    └──┘    └──┘    └──┘
+      //     ┌──┐    ┌──┐    ┌──┐    ┌──┐
+      //  A6 │A7│ C6 │C7│ E6 │E7│ G6 │G7│
+      //     └──┘    └──┘    └──┘    └──┘
+      // ┌──┐    ┌──┐    ┌──┐    ┌──┐
+      // │B6│ B7 │D6│ D7 │F6│ F7 │H6│ H7
+      // └──┘    └──┘    └──┘    └──┘
+      //
+      //       RESULT
+      //       ======
+      //  t0  t1  t2  t3  t4  t5  t6  t7
+      //
+      //  A0  B0  C0  D0  E0  F0  G0  H0
+      //
+      //
+      //  A1  B1  C1  D1  E1  F1  G1  H1
+      //
+      //
+      //  A2  B2  C2  D2  E2  F2  G2  H2
+      //
+      //
+      //  A3  B3  C3  D3  E3  F3  G3  H3
+      //
+      //
+      //  A4  B4  C4  D4  E4  F4  G4  H4
+      //
+      //
+      //  A5  B5  C5  D5  E5  F5  G5  H5
+      //
+      //
+      //  A6  B6  C6  D6  E6  F6  G6  H6
+      //
+      //
+      //  A7  B7  C7  D7  E7  F7  G7  H7
+      //
+
+      // NOTE: Do *NOT* try to refactor this code to use a reference, since nvcc
+      //       tends to choke on it and then drop everything into local memory.
+      const InputT send_val = (xor_bit_set ? CompileTimeArrayImpl<OutputT, IDX>::val
+                                           : CompileTimeArrayImpl<OutputT, IDX + NUM_ENTRIES>::val);
+      const InputT recv_val = __shfl_xor_sync(mask, send_val, NUM_ENTRIES, LOGICAL_WARP_THREADS);
+      (xor_bit_set ? CompileTimeArrayImpl<OutputT, IDX>::val
+                   : CompileTimeArrayImpl<OutputT, IDX + NUM_ENTRIES>::val) = recv_val;
+
+      constexpr int next_idx = IDX + 1 + ((IDX + 1) % NUM_ENTRIES == 0) * NUM_ENTRIES;
+      CompileTimeArrayImpl<OutputT, next_idx>::template Foreach<NUM_ENTRIES>(xor_bit_set, mask);
+    }
+
+    // terminate recursion
+    __device__ void TransposeImpl(unsigned int, unsigned int, Int2Type<0>) {}
+
+    template <int NUM_ENTRIES>
+    __device__ void TransposeImpl(const unsigned int lane_id,
+                                  const unsigned int mask,
+                                  Int2Type<NUM_ENTRIES>)
+    {
+      const bool xor_bit_set = lane_id & NUM_ENTRIES;
+      Foreach<NUM_ENTRIES>(xor_bit_set, mask);
+
+      TransposeImpl(lane_id, mask, Int2Type<NUM_ENTRIES / 2>());
+    }
+
+  public:
+    __device__ CompileTimeArrayImpl(const InputT (&input_items)[ITEMS_PER_THREAD],
+                                    OutputT (&output_items)[ITEMS_PER_THREAD])
+        : CompileTimeArrayImpl<OutputT, IDX + 1>{input_items, output_items}
+        , val{input_items[IDX]}
+    {}
+
+    __device__ ~CompileTimeArrayImpl() { this->output_items[IDX] = val; }
+
+    __device__ void Transpose(const unsigned int lane_id, const unsigned int mask)
+    {
+      TransposeImpl(lane_id, mask, Int2Type<ITEMS_PER_THREAD / 2>());
+    }
+  };
+
+  const unsigned int lane_id;
+  const unsigned int warp_id;
+  const unsigned int member_mask;
+
+public:
+  using TempStorage = NullType;
+
+  WarpExchangeShfl() = delete;
+
+  explicit __device__ __forceinline__ WarpExchangeShfl(TempStorage &)
+      : lane_id(IS_ARCH_WARP ? LaneId() : (LaneId() % LOGICAL_WARP_THREADS))
+      , warp_id(IS_ARCH_WARP ? 0 : (LaneId() / LOGICAL_WARP_THREADS))
+      , member_mask(WarpMask<LOGICAL_WARP_THREADS>(warp_id))
+  {}
+
+  template <typename OutputT>
+  __device__ __forceinline__ void BlockedToStriped(const InputT (&input_items)[ITEMS_PER_THREAD],
+                                                   OutputT (&output_items)[ITEMS_PER_THREAD])
+  {
+    CompileTimeArrayImpl<OutputT, 0> arr{input_items, output_items};
+    arr.Transpose(lane_id, member_mask);
+  }
+
+  template <typename OutputT>
+  __device__ __forceinline__ void StripedToBlocked(const InputT (&input_items)[ITEMS_PER_THREAD],
+                                                   OutputT (&output_items)[ITEMS_PER_THREAD])
+  {
+    BlockedToStriped(input_items, output_items);
+  }
+
+  // Trick to keep the compiler from inferring that the
+  // condition in the static_assert is always false.
+  template <typename T>
+  struct dependent_false
+  {
+    static constexpr bool value = false;
+  };
+
+  template <typename OffsetT>
+  __device__ __forceinline__ void
+  ScatterToStriped(InputT (&)[ITEMS_PER_THREAD],
+                   OffsetT (&)[ITEMS_PER_THREAD])
+  {
+    static_assert(dependent_false<OffsetT>::value,
+                  "Shuffle specialization of warp exchange does not support\n"
+                  "ScatterToStriped(InputT (&items)[ITEMS_PER_THREAD],\n"
+                  "                 OffsetT (&ranks)[ITEMS_PER_THREAD])");
+  }
+
+  template <typename OutputT,
+            typename OffsetT>
+  __device__ __forceinline__ void
+  ScatterToStriped(const InputT (&)[ITEMS_PER_THREAD],
+                   OutputT (&)[ITEMS_PER_THREAD],
+                   OffsetT (&)[ITEMS_PER_THREAD])
+  {
+    static_assert(dependent_false<OffsetT>::value,
+                  "Shuffle specialization of warp exchange does not support\n"
+                  "ScatterToStriped(const InputT (&input_items)[ITEMS_PER_THREAD],\n"
+                  "                 OutputT (&output_items)[ITEMS_PER_THREAD],\n"
+                  "                 OffsetT (&ranks)[ITEMS_PER_THREAD])");
+  }
+};
+
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/warp/specializations/warp_exchange_smem.cuh
+++ b/cub/cub/warp/specializations/warp_exchange_smem.cuh
@@ -1,0 +1,178 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * @file
+ * The cub::WarpExchangeSmem class provides [<em>collective</em>](index.html#sec0)
+ * methods for rearranging data partitioned across a CUDA warp.
+ */
+
+#pragma once
+
+#include <cub/config.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/util_type.cuh>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+
+template <typename InputT,
+          int ITEMS_PER_THREAD,
+          int LOGICAL_WARP_THREADS  = CUB_PTX_WARP_THREADS>
+class WarpExchangeSmem
+{
+  static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE,
+                "LOGICAL_WARP_THREADS must be a power of two");
+
+  constexpr static int ITEMS_PER_TILE =
+    ITEMS_PER_THREAD * LOGICAL_WARP_THREADS + 1;
+
+  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
+
+  constexpr static int LOG_SMEM_BANKS = CUB_LOG_SMEM_BANKS(0);
+
+  // Insert padding if the number of items per thread is a power of two
+  // and > 4 (otherwise we can typically use 128b loads)
+  constexpr static bool INSERT_PADDING = (ITEMS_PER_THREAD > 4) &&
+                                         (PowerOfTwo<ITEMS_PER_THREAD>::VALUE);
+
+  constexpr static int PADDING_ITEMS = INSERT_PADDING
+                                     ? (ITEMS_PER_TILE >> LOG_SMEM_BANKS)
+                                     : 0;
+
+  union _TempStorage
+  {
+    InputT items_shared[ITEMS_PER_TILE + PADDING_ITEMS];
+  }; // union TempStorage
+
+  /// Shared storage reference
+  _TempStorage &temp_storage;
+
+  const unsigned int lane_id;
+  const unsigned int warp_id;
+  const unsigned int member_mask;
+
+public:
+
+  struct TempStorage : Uninitialized<_TempStorage> {};
+
+  WarpExchangeSmem() = delete;
+
+  explicit __device__ __forceinline__
+  WarpExchangeSmem(TempStorage &temp_storage)
+      : temp_storage(temp_storage.Alias())
+      , lane_id(IS_ARCH_WARP ? LaneId() : (LaneId() % LOGICAL_WARP_THREADS))
+      , warp_id(IS_ARCH_WARP ? 0 : (LaneId() / LOGICAL_WARP_THREADS))
+      , member_mask(WarpMask<LOGICAL_WARP_THREADS>(warp_id))
+  {}
+
+  template <typename OutputT>
+  __device__ __forceinline__ void
+  BlockedToStriped(const InputT (&input_items)[ITEMS_PER_THREAD],
+                   OutputT (&output_items)[ITEMS_PER_THREAD])
+  {
+    for (int item = 0; item < ITEMS_PER_THREAD; item++)
+    {
+      const int idx = ITEMS_PER_THREAD * lane_id + item;
+      temp_storage.items_shared[idx] = input_items[item];
+    }
+    WARP_SYNC(member_mask);
+
+    for (int item = 0; item < ITEMS_PER_THREAD; item++)
+    {
+      const int idx = LOGICAL_WARP_THREADS * item + lane_id;
+      output_items[item] = temp_storage.items_shared[idx];
+    }
+  }
+
+  template <typename OutputT>
+  __device__ __forceinline__ void
+  StripedToBlocked(const InputT (&input_items)[ITEMS_PER_THREAD],
+                   OutputT (&output_items)[ITEMS_PER_THREAD])
+  {
+    for (int item = 0; item < ITEMS_PER_THREAD; item++)
+    {
+      const int idx = LOGICAL_WARP_THREADS * item + lane_id;
+      temp_storage.items_shared[idx] = input_items[item];
+    }
+    WARP_SYNC(member_mask);
+
+    for (int item = 0; item < ITEMS_PER_THREAD; item++)
+    {
+      const int idx = ITEMS_PER_THREAD * lane_id + item;
+      output_items[item] = temp_storage.items_shared[idx];
+    }
+  }
+
+  template <typename OffsetT>
+  __device__ __forceinline__ void
+  ScatterToStriped(InputT (&items)[ITEMS_PER_THREAD],
+                   OffsetT (&ranks)[ITEMS_PER_THREAD])
+  {
+    ScatterToStriped(items, items, ranks);
+  }
+
+  template <typename OutputT,
+            typename OffsetT>
+  __device__ __forceinline__ void
+  ScatterToStriped(const InputT (&input_items)[ITEMS_PER_THREAD],
+                   OutputT (&output_items)[ITEMS_PER_THREAD],
+                   OffsetT (&ranks)[ITEMS_PER_THREAD])
+  {
+    #pragma unroll
+    for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
+    {
+      if (INSERT_PADDING)
+      {
+        ranks[ITEM] = SHR_ADD(ranks[ITEM], LOG_SMEM_BANKS, ranks[ITEM]);
+      }
+
+      temp_storage.items_shared[ranks[ITEM]] = input_items[ITEM];
+    }
+
+    WARP_SYNC(member_mask);
+
+    #pragma unroll
+    for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
+    {
+      int item_offset = (ITEM * LOGICAL_WARP_THREADS) + lane_id;
+
+      if (INSERT_PADDING)
+      {
+        item_offset = SHR_ADD(item_offset, LOG_SMEM_BANKS, item_offset);
+      }
+
+      output_items[ITEM] = temp_storage.items_shared[item_offset];
+    }
+  }
+};
+
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/test/catch2_test_warp_exchange.cuh
+++ b/cub/test/catch2_test_warp_exchange.cuh
@@ -25,6 +25,8 @@
  *
  ******************************************************************************/
 
+#pragma once
+
 #include <cub/util_macro.cuh>
 #include <cub/warp/warp_exchange.cuh>
 
@@ -40,13 +42,14 @@
 // variables in cub kernels.
 #include "catch2_test_helper.h"
 
-template <typename InputT, typename OutputT, int ItemsPerThread, typename = void>
+template <typename InputT, typename OutputT, int ItemsPerThread, cub::WarpExchangeAlgorithm Alg, typename = void>
 struct exchange_data_t;
 
-template <typename InputT, typename OutputT, int ItemsPerThread>
+template <typename InputT, typename OutputT, int ItemsPerThread, cub::WarpExchangeAlgorithm Alg>
 struct exchange_data_t<InputT,
                        OutputT,
                        ItemsPerThread,
+                       Alg,
                        typename std::enable_if<std::is_same<InputT, OutputT>::value>::type>
 {
   InputT input[ItemsPerThread];
@@ -54,17 +57,18 @@ struct exchange_data_t<InputT,
 
   template <int LogicalWarpThreads>
   inline __device__ void
-  scatter(cub::WarpExchange<InputT, ItemsPerThread, LogicalWarpThreads> &exchange,
+  scatter(cub::WarpExchange<InputT, ItemsPerThread, LogicalWarpThreads, 0, Alg> &exchange,
           int (&ranks)[ItemsPerThread])
   {
     exchange.ScatterToStriped(input, ranks);
   }
 };
 
-template <typename InputT, typename OutputT, int ItemsPerThread>
+template <typename InputT, typename OutputT, int ItemsPerThread, cub::WarpExchangeAlgorithm Alg>
 struct exchange_data_t<InputT,
                        OutputT,
                        ItemsPerThread,
+                       Alg,
                        typename std::enable_if<!std::is_same<InputT, OutputT>::value>::type>
 {
   InputT input[ItemsPerThread];
@@ -72,7 +76,7 @@ struct exchange_data_t<InputT,
 
   template <int LogicalWarpThreads>
   inline __device__ void
-  scatter(cub::WarpExchange<InputT, ItemsPerThread, LogicalWarpThreads> &exchange,
+  scatter(cub::WarpExchange<InputT, ItemsPerThread, LogicalWarpThreads, 0, Alg> &exchange,
           int (&ranks)[ItemsPerThread])
   {
     exchange.ScatterToStriped(input, output, ranks);
@@ -82,11 +86,12 @@ struct exchange_data_t<InputT,
 template <int LOGICAL_WARP_THREADS,
           int ITEMS_PER_THREAD,
           int TOTAL_WARPS,
+          cub::WarpExchangeAlgorithm Alg,
           typename InputT,
           typename OutputT>
 __global__ void scatter_kernel(const InputT *input_data, OutputT *output_data)
 {
-  using warp_exchange_t = cub::WarpExchange<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>;
+  using warp_exchange_t = cub::WarpExchange<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS, 0, Alg>;
   using storage_t       = typename warp_exchange_t::TempStorage;
 
   constexpr int tile_size = ITEMS_PER_THREAD * LOGICAL_WARP_THREADS;
@@ -100,7 +105,7 @@ __global__ void scatter_kernel(const InputT *input_data, OutputT *output_data)
 
   warp_exchange_t exchange(temp_storage[warp_id]);
 
-  exchange_data_t<InputT, OutputT, ITEMS_PER_THREAD> exchange_data;
+  exchange_data_t<InputT, OutputT, ITEMS_PER_THREAD, Alg> exchange_data;
 
   // Reverse data
   int ranks[ITEMS_PER_THREAD];
@@ -127,11 +132,12 @@ __global__ void scatter_kernel(const InputT *input_data, OutputT *output_data)
 template <int LOGICAL_WARP_THREADS,
           int ITEMS_PER_THREAD,
           int TOTAL_WARPS,
+          cub::WarpExchangeAlgorithm Alg,
           typename InputT,
           typename OutputT>
 void warp_scatter_strided(thrust::device_vector<InputT> &in, thrust::device_vector<OutputT> &out)
 {
-  scatter_kernel<LOGICAL_WARP_THREADS, ITEMS_PER_THREAD, TOTAL_WARPS, InputT, OutputT>
+  scatter_kernel<LOGICAL_WARP_THREADS, ITEMS_PER_THREAD, TOTAL_WARPS, Alg, InputT, OutputT>
     <<<1, LOGICAL_WARP_THREADS * TOTAL_WARPS>>>(thrust::raw_pointer_cast(in.data()),
                                                 thrust::raw_pointer_cast(out.data()));
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
@@ -141,12 +147,13 @@ void warp_scatter_strided(thrust::device_vector<InputT> &in, thrust::device_vect
 template <int LOGICAL_WARP_THREADS,
           int ITEMS_PER_THREAD,
           int TOTAL_WARPS,
+          cub::WarpExchangeAlgorithm Alg,
           typename InputT,
           typename OutputT,
           typename ActionT>
 __global__ void kernel(const InputT *input_data, OutputT *output_data, ActionT action)
 {
-  using warp_exchange_t = cub::WarpExchange<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>;
+  using warp_exchange_t = cub::WarpExchange<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS, 0, Alg>;
   using storage_t       = typename warp_exchange_t::TempStorage;
 
   constexpr int tile_size = ITEMS_PER_THREAD * LOGICAL_WARP_THREADS;
@@ -160,7 +167,7 @@ __global__ void kernel(const InputT *input_data, OutputT *output_data, ActionT a
 
   warp_exchange_t exchange(temp_storage[warp_id]);
 
-  exchange_data_t<InputT, OutputT, ITEMS_PER_THREAD> exchange_data;
+  exchange_data_t<InputT, OutputT, ITEMS_PER_THREAD, Alg> exchange_data;
 
   input_data += warp_id * tile_size;
   output_data += warp_id * tile_size;
@@ -181,6 +188,7 @@ __global__ void kernel(const InputT *input_data, OutputT *output_data, ActionT a
 template <int LOGICAL_WARP_THREADS,
           int ITEMS_PER_THREAD,
           int TOTAL_WARPS,
+          cub::WarpExchangeAlgorithm Alg,
           typename InputT,
           typename OutputT,
           typename ActionT>
@@ -188,7 +196,7 @@ void warp_exchange(thrust::device_vector<InputT> &in,
                    thrust::device_vector<OutputT> &out,
                    ActionT action)
 {
-  kernel<LOGICAL_WARP_THREADS, ITEMS_PER_THREAD, TOTAL_WARPS, InputT, OutputT, ActionT>
+  kernel<LOGICAL_WARP_THREADS, ITEMS_PER_THREAD, TOTAL_WARPS, Alg, InputT, OutputT, ActionT>
     <<<1, LOGICAL_WARP_THREADS * TOTAL_WARPS>>>(thrust::raw_pointer_cast(in.data()),
                                                 thrust::raw_pointer_cast(out.data()),
                                                 action);
@@ -202,10 +210,11 @@ struct blocked_to_striped
             typename OutputT,
             int LogicalWarpThreads,
             int ItemsPerThread,
-            int ITEMS_PER_THREAD>
+            int ITEMS_PER_THREAD,
+            cub::WarpExchangeAlgorithm Alg>
   __device__ void operator()(InputT (&input)[ITEMS_PER_THREAD],
                              OutputT (&output)[ITEMS_PER_THREAD],
-                             cub::WarpExchange<InputT, ItemsPerThread, LogicalWarpThreads> &exchange)
+                             cub::WarpExchange<InputT, ItemsPerThread, LogicalWarpThreads, 0, Alg> &exchange)
   {
     exchange.BlockedToStriped(input, output);
   }
@@ -217,10 +226,11 @@ struct striped_to_blocked
             typename OutputT,
             int LogicalWarpThreads,
             int ItemsPerThread,
-            int ITEMS_PER_THREAD>
+            int ITEMS_PER_THREAD,
+            cub::WarpExchangeAlgorithm Alg>
   __device__ void operator()(InputT (&input)[ITEMS_PER_THREAD],
                              OutputT (&output)[ITEMS_PER_THREAD],
-                             cub::WarpExchange<InputT, ItemsPerThread, LogicalWarpThreads> &exchange)
+                             cub::WarpExchange<InputT, ItemsPerThread, LogicalWarpThreads, 0, Alg> &exchange)
   {
     exchange.StripedToBlocked(input, output);
   }
@@ -242,16 +252,6 @@ thrust::host_vector<T> compute_host_reference(const thrust::device_vector<T> &d_
   return input;
 }
 
-using inout_types = c2h::type_list<c2h::pair<std::uint16_t, std::int64_t>,
-                                   c2h::pair<std::uint16_t, std::uint32_t>,
-                                   c2h::pair<std::int32_t, std::int32_t>,
-                                   c2h::pair<std::int64_t, std::int64_t>,
-                                   c2h::pair<uchar3, uchar3>,
-                                   c2h::pair<ulonglong4, ulonglong4>>;
-
-using logical_warp_threads = c2h::enum_type_list<int, 4, 16, 32>;
-using items_per_thread     = c2h::enum_type_list<int, 1, 4, 7>;
-
 template <int logical_warp_threads>
 struct total_warps_t
 {
@@ -264,91 +264,3 @@ private:
 public:
   static constexpr int value() { return total_warps; }
 };
-
-template <class TestType>
-struct params_t
-{
-  using in_type  = typename c2h::first<c2h::get<0, TestType>>;
-  using out_type = typename c2h::second<c2h::get<0, TestType>>;
-
-  static constexpr int logical_warp_threads = c2h::get<1, TestType>::value;
-  static constexpr int items_per_thread     = c2h::get<2, TestType>::value;
-  static constexpr int total_warps          = total_warps_t<logical_warp_threads>::value();
-  static constexpr int tile_size            = logical_warp_threads * items_per_thread;
-  static constexpr int total_item_count     = total_warps * tile_size;
-};
-
-CUB_TEST("Scatter to striped works",
-         "[exchange][warp]",
-         inout_types,
-         logical_warp_threads,
-         items_per_thread)
-{
-  using params   = params_t<TestType>;
-  using in_type  = typename params::in_type;
-  using out_type = typename params::out_type;
-  thrust::device_vector<out_type> d_out(params::total_item_count);
-  thrust::device_vector<in_type> d_in(params::total_item_count);
-
-  c2h::gen(c2h::modulo_t{d_in.size()}, d_in);
-
-  warp_scatter_strided<params::logical_warp_threads, params::items_per_thread, params::total_warps>(
-    d_in,
-    d_out);
-
-  auto h_expected_output = compute_host_reference(d_in, params::tile_size);
-  REQUIRE(h_expected_output == d_out);
-}
-
-CUB_TEST("Blocked to striped works",
-         "[exchange][warp]",
-         inout_types,
-         logical_warp_threads,
-         items_per_thread)
-{
-  using params   = params_t<TestType>;
-  using in_type  = typename params::in_type;
-  using out_type = typename params::out_type;
-  thrust::device_vector<out_type> d_out(params::total_item_count, out_type{});
-  thrust::device_vector<in_type> d_in(params::total_item_count);
-
-  c2h::gen(c2h::modulo_t{d_in.size()}, d_in);
-
-  warp_exchange<params::logical_warp_threads, params::items_per_thread, params::total_warps>(
-    d_in,
-    d_out,
-    blocked_to_striped{});
-  thrust::host_vector<out_type> h_expected_output(d_out.size());
-  fill_striped<params::logical_warp_threads,
-               params::items_per_thread,
-               params::logical_warp_threads * params::total_warps>(h_expected_output.begin());
-
-  REQUIRE(h_expected_output == d_out);
-}
-
-CUB_TEST("Striped to blocked works",
-         "[exchange][warp]",
-         inout_types,
-         logical_warp_threads,
-         items_per_thread)
-{
-  using params   = params_t<TestType>;
-  using in_type  = typename params::in_type;
-  using out_type = typename params::out_type;
-  thrust::device_vector<out_type> d_out(params::total_item_count, out_type{});
-
-  thrust::host_vector<in_type> h_in(params::total_item_count);
-  fill_striped<params::logical_warp_threads,
-               params::items_per_thread,
-               params::logical_warp_threads * params::total_warps>(h_in.begin());
-  thrust::device_vector<in_type> d_in = h_in;
-
-  warp_exchange<params::logical_warp_threads, params::items_per_thread, params::total_warps>(
-    d_in,
-    d_out,
-    striped_to_blocked{});
-  thrust::device_vector<out_type> d_expected_output(d_out.size());
-  c2h::gen(c2h::modulo_t{d_out.size()}, d_expected_output);
-
-  REQUIRE(d_expected_output == d_out);
-}

--- a/cub/test/catch2_test_warp_exchange_shfl.cu
+++ b/cub/test/catch2_test_warp_exchange_shfl.cu
@@ -1,0 +1,103 @@
+/******************************************************************************
+ * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include "catch2_test_warp_exchange.cuh"
+
+namespace {
+
+using inout_types = c2h::type_list<std::uint16_t,
+                                   std::int32_t,
+                                   std::int64_t,
+                                   double>;
+
+using items_per_thread = c2h::enum_type_list<int, 2, 4, 8, 16, 32>;
+
+template <class TestType>
+struct params_t
+{
+  using in_type  = c2h::get<0, TestType>;
+  using out_type = c2h::get<0, TestType>;
+
+  static constexpr int logical_warp_threads = c2h::get<1, TestType>::value;
+  static constexpr int items_per_thread     = c2h::get<1, TestType>::value;
+  static constexpr int total_warps          = total_warps_t<logical_warp_threads>::value();
+  static constexpr int tile_size            = logical_warp_threads * items_per_thread;
+  static constexpr int total_item_count     = total_warps * tile_size;
+};
+
+} // namespace
+
+CUB_TEST("Blocked to striped works",
+         "[exchange][warp][shfl]",
+         inout_types,
+         items_per_thread)
+{
+  using params   = params_t<TestType>;
+  using in_type  = typename params::in_type;
+  using out_type = typename params::out_type;
+  thrust::device_vector<out_type> d_out(params::total_item_count, out_type{});
+  thrust::device_vector<in_type> d_in(params::total_item_count);
+
+  c2h::gen(c2h::modulo_t{d_in.size()}, d_in);
+
+  warp_exchange<params::logical_warp_threads, params::items_per_thread, params::total_warps, cub::WARP_EXCHANGE_SHUFFLE>(
+    d_in,
+    d_out,
+    blocked_to_striped{});
+  thrust::host_vector<out_type> h_expected_output(d_out.size());
+  fill_striped<params::logical_warp_threads,
+               params::items_per_thread,
+               params::logical_warp_threads * params::total_warps>(h_expected_output.begin());
+
+  REQUIRE(h_expected_output == d_out);
+}
+
+CUB_TEST("Striped to blocked works",
+         "[exchange][warp][shfl]",
+         inout_types,
+         items_per_thread)
+{
+  using params   = params_t<TestType>;
+  using in_type  = typename params::in_type;
+  using out_type = typename params::out_type;
+  thrust::device_vector<out_type> d_out(params::total_item_count, out_type{});
+
+  thrust::host_vector<in_type> h_in(params::total_item_count);
+  fill_striped<params::logical_warp_threads,
+               params::items_per_thread,
+               params::logical_warp_threads * params::total_warps>(h_in.begin());
+  thrust::device_vector<in_type> d_in = h_in;
+
+  warp_exchange<params::logical_warp_threads, params::items_per_thread, params::total_warps, cub::WARP_EXCHANGE_SHUFFLE>(
+    d_in,
+    d_out,
+    striped_to_blocked{});
+  thrust::device_vector<out_type> d_expected_output(d_out.size());
+  c2h::gen(c2h::modulo_t{d_out.size()}, d_expected_output);
+
+  REQUIRE(d_expected_output == d_out);
+}

--- a/cub/test/catch2_test_warp_exchange_smem.cu
+++ b/cub/test/catch2_test_warp_exchange_smem.cu
@@ -1,0 +1,130 @@
+/******************************************************************************
+ * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include "catch2_test_warp_exchange.cuh"
+
+namespace {
+
+using inout_types = c2h::type_list<c2h::pair<std::uint16_t, std::int64_t>,
+                                   c2h::pair<std::uint16_t, std::uint32_t>,
+                                   c2h::pair<std::int32_t, std::int32_t>,
+                                   c2h::pair<std::int64_t, std::int64_t>,
+                                   c2h::pair<uchar3, uchar3>,
+                                   c2h::pair<ulonglong4, ulonglong4>>;
+
+using logical_warp_threads = c2h::enum_type_list<int, 4, 16, 32>;
+using items_per_thread     = c2h::enum_type_list<int, 1, 4, 7>;
+
+template <class TestType>
+struct params_t
+{
+  using in_type  = typename c2h::first<c2h::get<0, TestType>>;
+  using out_type = typename c2h::second<c2h::get<0, TestType>>;
+
+  static constexpr int logical_warp_threads = c2h::get<1, TestType>::value;
+  static constexpr int items_per_thread     = c2h::get<2, TestType>::value;
+  static constexpr int total_warps          = total_warps_t<logical_warp_threads>::value();
+  static constexpr int tile_size            = logical_warp_threads * items_per_thread;
+  static constexpr int total_item_count     = total_warps * tile_size;
+};
+
+} // namespace
+
+CUB_TEST("Scatter to striped works",
+         "[exchange][warp][smem]",
+         inout_types,
+         logical_warp_threads,
+         items_per_thread)
+{
+  using params   = params_t<TestType>;
+  using in_type  = typename params::in_type;
+  using out_type = typename params::out_type;
+  thrust::device_vector<out_type> d_out(params::total_item_count);
+  thrust::device_vector<in_type> d_in(params::total_item_count);
+
+  c2h::gen(c2h::modulo_t{d_in.size()}, d_in);
+
+  warp_scatter_strided<params::logical_warp_threads, params::items_per_thread, params::total_warps, cub::WARP_EXCHANGE_SMEM>(
+    d_in,
+    d_out);
+
+  auto h_expected_output = compute_host_reference(d_in, params::tile_size);
+  REQUIRE(h_expected_output == d_out);
+}
+
+CUB_TEST("Blocked to striped works",
+         "[exchange][warp][smem]",
+         inout_types,
+         logical_warp_threads,
+         items_per_thread)
+{
+  using params   = params_t<TestType>;
+  using in_type  = typename params::in_type;
+  using out_type = typename params::out_type;
+  thrust::device_vector<out_type> d_out(params::total_item_count, out_type{});
+  thrust::device_vector<in_type> d_in(params::total_item_count);
+
+  c2h::gen(c2h::modulo_t{d_in.size()}, d_in);
+
+  warp_exchange<params::logical_warp_threads, params::items_per_thread, params::total_warps, cub::WARP_EXCHANGE_SMEM>(
+    d_in,
+    d_out,
+    blocked_to_striped{});
+  thrust::host_vector<out_type> h_expected_output(d_out.size());
+  fill_striped<params::logical_warp_threads,
+               params::items_per_thread,
+               params::logical_warp_threads * params::total_warps>(h_expected_output.begin());
+
+  REQUIRE(h_expected_output == d_out);
+}
+
+CUB_TEST("Striped to blocked works",
+         "[exchange][warp][smem]",
+         inout_types,
+         logical_warp_threads,
+         items_per_thread)
+{
+  using params   = params_t<TestType>;
+  using in_type  = typename params::in_type;
+  using out_type = typename params::out_type;
+  thrust::device_vector<out_type> d_out(params::total_item_count, out_type{});
+
+  thrust::host_vector<in_type> h_in(params::total_item_count);
+  fill_striped<params::logical_warp_threads,
+               params::items_per_thread,
+               params::logical_warp_threads * params::total_warps>(h_in.begin());
+  thrust::device_vector<in_type> d_in = h_in;
+
+  warp_exchange<params::logical_warp_threads, params::items_per_thread, params::total_warps, cub::WARP_EXCHANGE_SMEM>(
+    d_in,
+    d_out,
+    striped_to_blocked{});
+  thrust::device_vector<out_type> d_expected_output(d_out.size());
+  c2h::gen(c2h::modulo_t{d_out.size()}, d_expected_output);
+
+  REQUIRE(d_expected_output == d_out);
+}


### PR DESCRIPTION
## Description

* `WARP_EXCHANGE_SHUFFLE` works like `WARP_EXCHANGE_SMEM` semantically, but uses warp shuffles internally instead of shared memory. This pattern is useful in a number of situations:
  * Kernels that only need to exchange a small number of items. When exchanging 2, 4 or 8 items per thread, the number of warp shuffles is 1, 4 and 12, respectively, which is lower than a total of 4, 8 and 16 shared memory transactions, respectively.
  * Kernels that already have a high shared memory budget but still need to exchange data to maintain ILP.
  * Kernels running on GPUs that are shared memory starved, such as Turing or Pascal.

  Inspired by
  * https://forums.developer.nvidia.com/t/transposing-register-held-matrices-with-warp-shuffles-need-help/38652/2

Issue [#cub/667](https://github.com/NVIDIA/cub/issues/667)

- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

@senior-zero 