### PR TITLE
Ensure that any CMake re-rooting doesn't break our find_file

### DIFF
--- a/libcudacxx/lib/cmake/libcudacxx/libcudacxx-header-search.cmake.in
+++ b/libcudacxx/lib/cmake/libcudacxx/libcudacxx-header-search.cmake.in
@@ -5,6 +5,7 @@ unset(_libcudacxx_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
 set(from_install_prefix "@from_install_prefix@")
 
 find_path(_libcudacxx_VERSION_INCLUDE_DIR cuda/std/detail/__config
+  NO_CMAKE_FIND_ROOT_PATH # Don't allow CMake to re-root the search
   NO_DEFAULT_PATH # Only search explicit paths below:
   PATHS
     "${CMAKE_CURRENT_LIST_DIR}/${from_install_prefix}/@CMAKE_INSTALL_INCLUDEDIR@" # Install tree

--- a/thrust/thrust/cmake/thrust-header-search.cmake.in
+++ b/thrust/thrust/cmake/thrust-header-search.cmake.in
@@ -11,6 +11,7 @@ list(TRANSFORM from_install_prefix REPLACE ".+" "../")
 list(JOIN from_install_prefix "" from_install_prefix)
 
 find_path(_THRUST_VERSION_INCLUDE_DIR thrust/version.h
+  NO_CMAKE_FIND_ROOT_PATH # Don't allow CMake to re-root the search
   NO_DEFAULT_PATH # Only search explicit paths below:
   PATHS
     "${CMAKE_CURRENT_LIST_DIR}/${from_install_prefix}/@CMAKE_INSTALL_INCLUDEDIR@"


### PR DESCRIPTION
This replaces https://github.com/NVIDIA/libcudacxx/pull/490 and https://github.com/NVIDIA/thrust/pull/1969