### PR TITLE
Factor devcontainer image version into matrix.yaml 

### DIFF
--- a/.devcontainer/make_devcontainers.sh
+++ b/.devcontainer/make_devcontainers.sh
@@ -13,11 +13,14 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 # by replacing the `image:` field with the appropriate image name
 base_devcontainer_file="./devcontainer.json"
 
-# Define image root
-IMAGE_ROOT="rapidsai/devcontainers:23.06-cpp-"
 
 # Read matrix.yaml and convert it to json
 matrix_json=$(yq -o json ../ci/matrix.yaml)
+
+
+# Get the devcontainer image version and define image tag root
+DEVCONTAINER_VERSION=$(echo "$matrix_json" | jq -r '.devcontainer_version')
+IMAGE_ROOT="rapidsai/devcontainers:${DEVCONTAINER_VERSION}-cpp-"
 
 # Get unique combinations of cuda version, compiler name/version, and Ubuntu version
 combinations=$(echo "$matrix_json" | jq -c '[.pull_request.nvcc[] | {cuda: .cuda, compiler_name: .compiler.name, compiler_version: .compiler.version, os: .os}] | unique | .[]')

--- a/.github/workflows/dispatch-build-and-test.yml
+++ b/.github/workflows/dispatch-build-and-test.yml
@@ -6,6 +6,7 @@ on:
       per_cuda_compiler_matrix: {type: string, required: true}
       build_script: {type: string, required: false}
       test_script: {type: string, required: false}
+      devcontainer_version: {type: string, required: true}
 
 jobs:
   # Using a matrix to dispatch to the build-and-test reusable workflow for each build configuration
@@ -28,8 +29,8 @@ jobs:
       cpu: ${{ matrix.cpu }}
       os: ${{ matrix.os }}
       build_script: ${{ inputs.build_script }}
-      build_image: rapidsai/devcontainers:23.06-cpp-${{matrix.compiler.name}}${{matrix.compiler.version}}-cuda${{matrix.cuda}}-${{matrix.os}}
+      build_image: rapidsai/devcontainers:${{inputs.devcontainer_version}}-cpp-${{matrix.compiler.name}}${{matrix.compiler.version}}-cuda${{matrix.cuda}}-${{matrix.os}}
       test_script: ${{ inputs.test_script }}
       run_tests: ${{ contains(matrix.jobs, 'test') && !contains(github.event.head_commit.message, 'skip-tests') }}
-      test_image: rapidsai/devcontainers:23.06-cpp-${{matrix.compiler.name}}${{matrix.compiler.version}}-cuda${{matrix.cuda}}-${{matrix.os}}
+      test_image: rapidsai/devcontainers:${{inputs.devcontainer_version}}-cpp-${{matrix.compiler.name}}${{matrix.compiler.version}}-cuda${{matrix.cuda}}-${{matrix.os}}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  
+  get-devcontainer-version:
+    name: Get the version of the devcontainer image to use
+    runs-on: ubuntu-latest
+    outputs:
+      DEVCONTAINER_VERSION: ${{ steps.set-outputs.outputs.DEVCONTAINER_VERSION }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Get devcontainer version
+        id: get-devcontainer-version
+        uses: ./.github/actions/compute-matrix
+        with:
+          matrix_file: './ci/matrix.yaml'
+          matrix_query: '.devcontainer_version'
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          DEVCONTAINER_VERSION='${{steps.get-devcontainer-version.outputs.matrix}}'
+          echo "DEVCONTAINER_VERSION=$DEVCONTAINER_VERSION" | tee -a "$GITHUB_OUTPUT"
+
   compute-nvcc-matrix:
     name: Compute NVCC matrix
     runs-on: ubuntu-latest
@@ -47,7 +68,7 @@ jobs:
 
   thrust:
     name: Thrust CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
-    needs: compute-nvcc-matrix
+    needs: [compute-nvcc-matrix, get-devcontainer-version]
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
       fail-fast: false
@@ -58,10 +79,11 @@ jobs:
       per_cuda_compiler_matrix: ${{ toJSON(fromJSON(needs.compute-nvcc-matrix.outputs.PER_CUDA_COMPILER_MATRIX)[ format('{0}-{1}', matrix.cuda_version, matrix.compiler) ]) }}
       build_script: "./ci/build_thrust.sh"
       test_script: "./ci/test_thrust.sh"
+      devcontainer_version: ${{ needs.get-devcontainer-version.outputs.DEVCONTAINER_VERSION }}
 
   cub:
     name: CUB CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
-    needs: compute-nvcc-matrix
+    needs: [compute-nvcc-matrix, get-devcontainer-version]
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
       fail-fast: false
@@ -72,10 +94,11 @@ jobs:
       per_cuda_compiler_matrix: ${{ toJSON(fromJSON(needs.compute-nvcc-matrix.outputs.PER_CUDA_COMPILER_MATRIX)[ format('{0}-{1}', matrix.cuda_version, matrix.compiler) ]) }}
       build_script: "./ci/build_cub.sh"
       test_script: "./ci/test_cub.sh"
+      devcontainer_version: ${{ needs.get-devcontainer-version.outputs.DEVCONTAINER_VERSION }}
   
   libcudacxx:
     name: libcudacxx CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
-    needs: compute-nvcc-matrix
+    needs: [compute-nvcc-matrix, get-devcontainer-version]
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
       fail-fast: false
@@ -86,6 +109,7 @@ jobs:
       per_cuda_compiler_matrix: ${{ toJSON(fromJSON(needs.compute-nvcc-matrix.outputs.PER_CUDA_COMPILER_MATRIX)[ format('{0}-{1}', matrix.cuda_version, matrix.compiler) ]) }}
       build_script: "./ci/build_libcudacxx.sh"
       test_script: "./ci/test_libcudacxx.sh" 
+      devcontainer_version: ${{ needs.get-devcontainer-version.outputs.DEVCONTAINER_VERSION }}
 
   # This job is the final job that runs after all other jobs and is used for branch protection status checks.
   # See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -7,6 +7,9 @@ gpus:
   - 'a100'
   - 'v100'
 
+# The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers 
+devcontainer_version: '23.06'
+
 # Each environment below will generate a unique build/test job
 # See the "compute-matrix" job in the workflow for how this is parsed and used
 # cuda: The CUDA Toolkit version


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/241

Factors out the devcontainer image tag version to a single source of truth defined in the `matrix.yaml` and updates all uses to derive from this source of truth. 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
