### PR TITLE
Update to 23.08 devcontainers and CUDA 12.2 

### DIFF
--- a/.devcontainer/cuda11.1-gcc6/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc6/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc6-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc6-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda11.1-gcc7/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc7-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc7-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda11.1-gcc8/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc8-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc8-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda11.1-gcc9/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc9-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc9-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda11.1-llvm9/devcontainer.json
+++ b/.devcontainer/cuda11.1-llvm9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-llvm9-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-llvm9-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.2-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-llvm15-cuda12.1-ubuntu22.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc10-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-llvm15"
+    "DEVCONTAINER_NAME": "cuda12.2-gcc10"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-llvm15"
+  "name": "cuda12.2-gcc10"
 }

--- a/.devcontainer/cuda12.2-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc8-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc11-cuda12.2-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-gcc8"
+    "DEVCONTAINER_NAME": "cuda12.2-gcc11"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-gcc8"
+  "name": "cuda12.2-gcc11"
 }

--- a/.devcontainer/cuda12.2-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-llvm13-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc12-cuda12.2-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-llvm13"
+    "DEVCONTAINER_NAME": "cuda12.2-gcc12"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-llvm13"
+  "name": "cuda12.2-gcc12"
 }

--- a/.devcontainer/cuda12.2-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-llvm9-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc7-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-llvm9"
+    "DEVCONTAINER_NAME": "cuda12.2-gcc7"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-llvm9"
+  "name": "cuda12.2-gcc7"
 }

--- a/.devcontainer/cuda12.2-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc12-cuda12.1-ubuntu22.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc8-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-gcc12"
+    "DEVCONTAINER_NAME": "cuda12.2-gcc8"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-gcc12"
+  "name": "cuda12.2-gcc8"
 }

--- a/.devcontainer/cuda12.2-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc10-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-gcc9-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-gcc10"
+    "DEVCONTAINER_NAME": "cuda12.2-gcc9"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-gcc10"
+  "name": "cuda12.2-gcc9"
 }

--- a/.devcontainer/cuda12.2-llvm10/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-llvm12-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-llvm10-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-llvm12"
+    "DEVCONTAINER_NAME": "cuda12.2-llvm10"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-llvm12"
+  "name": "cuda12.2-llvm10"
 }

--- a/.devcontainer/cuda12.2-llvm11/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-llvm11-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-llvm11-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-llvm11"
+    "DEVCONTAINER_NAME": "cuda12.2-llvm11"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-llvm11"
+  "name": "cuda12.2-llvm11"
 }

--- a/.devcontainer/cuda12.2-llvm12/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc11-cuda12.1-ubuntu22.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-llvm12-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-gcc11"
+    "DEVCONTAINER_NAME": "cuda12.2-llvm12"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-gcc11"
+  "name": "cuda12.2-llvm12"
 }

--- a/.devcontainer/cuda12.2-llvm13/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-llvm10-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-llvm13-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-llvm10"
+    "DEVCONTAINER_NAME": "cuda12.2-llvm13"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-llvm10"
+  "name": "cuda12.2-llvm13"
 }

--- a/.devcontainer/cuda12.2-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc9-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-llvm14-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-gcc9"
+    "DEVCONTAINER_NAME": "cuda12.2-llvm14"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-gcc9"
+  "name": "cuda12.2-llvm14"
 }

--- a/.devcontainer/cuda12.2-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-llvm14-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-llvm15-cuda12.2-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-llvm14"
+    "DEVCONTAINER_NAME": "cuda12.2-llvm15"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-llvm14"
+  "name": "cuda12.2-llvm15"
 }

--- a/.devcontainer/cuda12.2-llvm9/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.06-cpp-gcc7-cuda12.1-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.08-cpp-llvm9-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -14,7 +14,7 @@
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
-    "DEVCONTAINER_NAME": "cuda12.1-gcc7"
+    "DEVCONTAINER_NAME": "cuda12.2-llvm9"
   },
   "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
@@ -35,5 +35,5 @@
       }
     }
   },
-  "name": "cuda12.1-gcc7"
+  "name": "cuda12.2-llvm9"
 }

--- a/.devcontainer/make_devcontainers.sh
+++ b/.devcontainer/make_devcontainers.sh
@@ -13,11 +13,14 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 # by replacing the `image:` field with the appropriate image name
 base_devcontainer_file="./devcontainer.json"
 
-# Define image root
-IMAGE_ROOT="rapidsai/devcontainers:23.06-cpp-"
 
 # Read matrix.yaml and convert it to json
 matrix_json=$(yq -o json ../ci/matrix.yaml)
+
+
+# Get the devcontainer image version and define image tag root
+DEVCONTAINER_VERSION=$(echo "$matrix_json" | jq -r '.devcontainer_version')
+IMAGE_ROOT="rapidsai/devcontainers:${DEVCONTAINER_VERSION}-cpp-"
 
 # Get unique combinations of cuda version, compiler name/version, and Ubuntu version
 combinations=$(echo "$matrix_json" | jq -c '[.pull_request.nvcc[] | {cuda: .cuda, compiler_name: .compiler.name, compiler_version: .compiler.version, os: .os}] | unique | .[]')

--- a/.github/workflows/dispatch-build-and-test.yml
+++ b/.github/workflows/dispatch-build-and-test.yml
@@ -6,6 +6,7 @@ on:
       per_cuda_compiler_matrix: {type: string, required: true}
       build_script: {type: string, required: false}
       test_script: {type: string, required: false}
+      devcontainer_version: {type: string, required: true}
 
 jobs:
   # Using a matrix to dispatch to the build-and-test reusable workflow for each build configuration
@@ -28,8 +29,8 @@ jobs:
       cpu: ${{ matrix.cpu }}
       os: ${{ matrix.os }}
       build_script: ${{ inputs.build_script }}
-      build_image: rapidsai/devcontainers:23.06-cpp-${{matrix.compiler.name}}${{matrix.compiler.version}}-cuda${{matrix.cuda}}-${{matrix.os}}
+      build_image: rapidsai/devcontainers:${{inputs.devcontainer_version}}-cpp-${{matrix.compiler.name}}${{matrix.compiler.version}}-cuda${{matrix.cuda}}-${{matrix.os}}
       test_script: ${{ inputs.test_script }}
       run_tests: ${{ contains(matrix.jobs, 'test') && !contains(github.event.head_commit.message, 'skip-tests') }}
-      test_image: rapidsai/devcontainers:23.06-cpp-${{matrix.compiler.name}}${{matrix.compiler.version}}-cuda${{matrix.cuda}}-${{matrix.os}}
+      test_image: rapidsai/devcontainers:${{inputs.devcontainer_version}}-cpp-${{matrix.compiler.name}}${{matrix.compiler.version}}-cuda${{matrix.cuda}}-${{matrix.os}}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,15 +28,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Get devcontainer version
-        id: get-devcontainer-version
-        uses: ./.github/actions/compute-matrix
-        with:
-          matrix_file: './ci/matrix.yaml'
-          matrix_query: '.devcontainer_version'
-      - name: Set outputs
         id: set-outputs
         run: |
-          DEVCONTAINER_VERSION='${{steps.get-devcontainer-version.outputs.matrix}}'
+          DEVCONTAINER_VERSION=$(yq -o json ci/matrix.yaml | jq -r '.devcontainer_version')
           echo "DEVCONTAINER_VERSION=$DEVCONTAINER_VERSION" | tee -a "$GITHUB_OUTPUT"
 
   compute-nvcc-matrix:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  
+  get-devcontainer-version:
+    name: Get the version of the devcontainer image to use
+    runs-on: ubuntu-latest
+    outputs:
+      DEVCONTAINER_VERSION: ${{ steps.set-outputs.outputs.DEVCONTAINER_VERSION }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Get devcontainer version
+        id: get-devcontainer-version
+        uses: ./.github/actions/compute-matrix
+        with:
+          matrix_file: './ci/matrix.yaml'
+          matrix_query: '.devcontainer_version'
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          DEVCONTAINER_VERSION='${{steps.get-devcontainer-version.outputs.matrix}}'
+          echo "DEVCONTAINER_VERSION=$DEVCONTAINER_VERSION" | tee -a "$GITHUB_OUTPUT"
+
   compute-nvcc-matrix:
     name: Compute NVCC matrix
     runs-on: ubuntu-latest
@@ -47,7 +68,7 @@ jobs:
 
   thrust:
     name: Thrust CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
-    needs: compute-nvcc-matrix
+    needs: [compute-nvcc-matrix, get-devcontainer-version]
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
       fail-fast: false
@@ -58,10 +79,11 @@ jobs:
       per_cuda_compiler_matrix: ${{ toJSON(fromJSON(needs.compute-nvcc-matrix.outputs.PER_CUDA_COMPILER_MATRIX)[ format('{0}-{1}', matrix.cuda_version, matrix.compiler) ]) }}
       build_script: "./ci/build_thrust.sh"
       test_script: "./ci/test_thrust.sh"
+      devcontainer_version: ${{ needs.get-devcontainer-version.outputs.DEVCONTAINER_VERSION }}
 
   cub:
     name: CUB CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
-    needs: compute-nvcc-matrix
+    needs: [compute-nvcc-matrix, get-devcontainer-version]
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
       fail-fast: false
@@ -72,10 +94,11 @@ jobs:
       per_cuda_compiler_matrix: ${{ toJSON(fromJSON(needs.compute-nvcc-matrix.outputs.PER_CUDA_COMPILER_MATRIX)[ format('{0}-{1}', matrix.cuda_version, matrix.compiler) ]) }}
       build_script: "./ci/build_cub.sh"
       test_script: "./ci/test_cub.sh"
+      devcontainer_version: ${{ needs.get-devcontainer-version.outputs.DEVCONTAINER_VERSION }}
   
   libcudacxx:
     name: libcudacxx CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
-    needs: compute-nvcc-matrix
+    needs: [compute-nvcc-matrix, get-devcontainer-version]
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
       fail-fast: false
@@ -86,6 +109,7 @@ jobs:
       per_cuda_compiler_matrix: ${{ toJSON(fromJSON(needs.compute-nvcc-matrix.outputs.PER_CUDA_COMPILER_MATRIX)[ format('{0}-{1}', matrix.cuda_version, matrix.compiler) ]) }}
       build_script: "./ci/build_libcudacxx.sh"
       test_script: "./ci/test_libcudacxx.sh" 
+      devcontainer_version: ${{ needs.get-devcontainer-version.outputs.DEVCONTAINER_VERSION }}
 
   # This job is the final job that runs after all other jobs and is used for branch protection status checks.
   # See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   
   get-devcontainer-version:
-    name: Get the version of the devcontainer image to use
+    name: Get devcontainer version
     runs-on: ubuntu-latest
     outputs:
       DEVCONTAINER_VERSION: ${{ steps.set-outputs.outputs.DEVCONTAINER_VERSION }}

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -1,6 +1,6 @@
 
 cuda_oldest: &cuda_oldest '11.1'
-cuda_newest: &cuda_newest '12.1'
+cuda_newest: &cuda_newest '12.2'
 
 # The GPUs to test on
 # Note: This assumes that the appropriate gpu_build_archs are set to include building for the GPUs listed here
@@ -9,7 +9,7 @@ gpus:
   - 'v100'
 
 # The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers 
-devcontainer_version: '23.06'
+devcontainer_version: '23.08'
 
 # Each environment below will generate a unique build/test job
 # See the "compute-matrix" job in the workflow for how this is parsed and used

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -1,5 +1,6 @@
-#gcc
 
+cuda_oldest: &cuda_oldest '11.1'
+cuda_newest: &cuda_newest '12.1'
 
 # The GPUs to test on
 # Note: This assumes that the appropriate gpu_build_archs are set to include building for the GPUs listed here
@@ -26,21 +27,21 @@ devcontainer_version: '23.06'
 # Configurations that will run for every PR
 pull_request:
   nvcc:
-    - {cuda: '11.1', os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'gcc', version: '6', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14], jobs: ['build']}
-    - {cuda: '11.1', os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'gcc', version: '7', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
-    - {cuda: '11.1', os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'gcc', version: '8', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
-    - {cuda: '11.1', os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'gcc', version: '9', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'gcc', version: '7', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'gcc', version: '8', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'gcc', version: '9', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'gcc', version: '10', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'gcc', version: '11', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'gcc', version: '12', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build', 'test']}
-    - {cuda: '11.1', os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'llvm', version: '9', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '9', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '10', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '11', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '12', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '13', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '14', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
-    - {cuda: '12.1', os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'llvm', version: '15', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build', 'test']}
+    - {cuda: *cuda_oldest, os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'gcc', version: '6', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14], jobs: ['build']}
+    - {cuda: *cuda_oldest, os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'gcc', version: '7', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
+    - {cuda: *cuda_oldest, os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'gcc', version: '8', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
+    - {cuda: *cuda_oldest, os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'gcc', version: '9', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'gcc', version: '7', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'gcc', version: '8', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'gcc', version: '9', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'gcc', version: '10', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'gcc', version: '11', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'gcc', version: '12', exe: 'g++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build', 'test']}
+    - {cuda: *cuda_oldest, os: 'ubuntu18.04', cpu: 'amd64', compiler: {name: 'llvm', version: '9', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '9', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '10', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '11', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '12', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '13', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu20.04', cpu: 'amd64', compiler: {name: 'llvm', version: '14', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'llvm', version: '15', exe: 'clang++'}, gpu_build_archs: '70', std: [11, 14, 17, 20], jobs: ['build', 'test']}

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -7,6 +7,9 @@ gpus:
   - 'a100'
   - 'v100'
 
+# The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers 
+devcontainer_version: '23.06'
+
 # Each environment below will generate a unique build/test job
 # See the "compute-matrix" job in the workflow for how this is parsed and used
 # cuda: The CUDA Toolkit version


### PR DESCRIPTION
Depends on https://github.com/NVIDIA/cccl/pull/269

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/245

Updates to the 23.08 version of the devcontainers and likewise updates the newest CUDA version tested to 12.2. 

Also removes old devcontainer.json for CUDA 12.1 and adds new ones for 12.2. 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
