### PR TITLE
Enforce C++17 for benches

### DIFF
--- a/cub/benchmarks/CMakeLists.txt
+++ b/cub/benchmarks/CMakeLists.txt
@@ -105,7 +105,8 @@ function(add_bench target_name bench_name bench_src)
       ARCHIVE_OUTPUT_DIRECTORY "${CUB_LIBRARY_OUTPUT_DIR}"
       LIBRARY_OUTPUT_DIRECTORY "${CUB_LIBRARY_OUTPUT_DIR}"
       RUNTIME_OUTPUT_DIRECTORY "${CUB_EXECUTABLE_OUTPUT_DIR}"
-  )
+      CUDA_STANDARD 17
+      CXX_STANDARD 17)
 endfunction()
 
 function(add_bench_dir bench_dir)

--- a/cub/benchmarks/nvbench_helper/CMakeLists.txt
+++ b/cub/benchmarks/nvbench_helper/CMakeLists.txt
@@ -9,3 +9,4 @@ target_link_libraries(nvbench_helper PUBLIC CUB::CUB
                                      PRIVATE CUDA::curand)
 
 target_include_directories(nvbench_helper PUBLIC "${CMAKE_CURRENT_LIST_DIR}")
+set_target_properties(nvbench_helper PROPERTIES CUDA_STANDARD 17 CXX_STANDARD 17)


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Fixes issues discovered in https://github.com/NVIDIA/cccl/pull/270

<!-- Provide a standalone description of changes in this PR. -->
CUB benchmarks are written for C++17. This PR enforces C++17 for CUB benchmarks.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
