### PR TITLE
Fix BibTeX syntax in CITATION.md [skip-tests]

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -4,8 +4,8 @@
 If you use CCCL in a publication, please use citations in the following format (BibTeX entry for LaTeX):
 ```tex
 @Manual{,
-  title = {CCCL: CUDA C++ Core Libraries},
-  author = {CCCL Development Team},
+  title = {{CCCL}: {CUDA} {C++} {C}ore {L}ibraries},
+  author = {{CCCL Development Team}},
   year = {2023},
   url = {https://github.com/NVIDIA/cccl},
 }


### PR DESCRIPTION
## Description

Since the author list is just a "team name" it should be enclosed in an additional set of braces (so that BibTeX does not think it is a single author C. D. Team). Additionally, explicitly add braces around the parts of the title that should be capitalised (otherwise many BibTeX styles will produce "Cccl: cuda c++ core libraries").
## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
