### PR TITLE
Tune Select and Partition on A100

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -33,7 +33,6 @@
 #include <cub/block/block_scan.cuh>
 #include <cub/config.cuh>
 #include <cub/util_type.cuh>
-#include "cub/util_device.cuh"
 
 CUB_NAMESPACE_BEGIN
 
@@ -434,7 +433,7 @@ struct sm80_tuning<Input, flagged::no, keep_rejects::no, offset_size::_4, primit
     static constexpr int threads = 256;
     static constexpr int items = 18;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::no_delay_constructor_t<1130>;
 };
@@ -445,7 +444,7 @@ struct sm80_tuning<Input, flagged::no, keep_rejects::no, offset_size::_4, primit
     static constexpr int threads = 192;
     static constexpr int items = 10;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<832, 1165>;
 };
@@ -492,7 +491,7 @@ struct sm80_tuning<Input, flagged::yes, keep_rejects::no, offset_size::_4, primi
     static constexpr int threads = 256;
     static constexpr int items = 20;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::no_delay_constructor_t<1155>;
 };
@@ -561,7 +560,7 @@ struct sm80_tuning<Input, flagged::no, keep_rejects::yes, offset_size::_4, primi
     static constexpr int threads = 224;
     static constexpr int items = 18;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::no_delay_constructor_t<1045>;
 };
@@ -583,7 +582,7 @@ struct sm80_tuning<Input, flagged::no, keep_rejects::yes, offset_size::_4, primi
     static constexpr int threads = 192;
     static constexpr int items = 10;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<68, 1160>;
 };
@@ -595,7 +594,7 @@ struct sm80_tuning<__int128_t, flagged::no, keep_rejects::yes, offset_size::_4, 
     static constexpr int threads = 256;
     static constexpr int items = 5;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<400, 1090>;
 };
@@ -606,7 +605,7 @@ struct sm80_tuning<__uint128_t, flagged::no, keep_rejects::yes, offset_size::_4,
     static constexpr int threads = 256;
     static constexpr int items = 5;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<400, 1090>;
 };
@@ -630,7 +629,7 @@ struct sm80_tuning<Input, flagged::yes, keep_rejects::yes, offset_size::_4, prim
     static constexpr int threads = 224;
     static constexpr int items = 18;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::no_delay_constructor_t<1105>;
 };
@@ -652,7 +651,7 @@ struct sm80_tuning<Input, flagged::yes, keep_rejects::yes, offset_size::_4, prim
     static constexpr int threads = 192;
     static constexpr int items = 12;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<884, 1130>;
 };
@@ -664,7 +663,7 @@ struct sm80_tuning<__int128_t, flagged::yes, keep_rejects::yes, offset_size::_4,
     static constexpr int threads = 256;
     static constexpr int items = 5;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<400, 1090>;
 };
@@ -675,7 +674,7 @@ struct sm80_tuning<__uint128_t, flagged::yes, keep_rejects::yes, offset_size::_4
     static constexpr int threads = 256;
     static constexpr int items = 5;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<400, 1090>;
 };

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -125,7 +125,7 @@ struct sm90_tuning<Input, flagged::no, keep_rejects::no, offset_size::_4, primit
     static constexpr int threads = 256;
     static constexpr int items = 22;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<320, 605>;
 };
@@ -136,7 +136,7 @@ struct sm90_tuning<Input, flagged::no, keep_rejects::no, offset_size::_4, primit
     static constexpr int threads = 384;
     static constexpr int items = 17;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<76, 1150>;
 };
@@ -147,7 +147,7 @@ struct sm90_tuning<Input, flagged::no, keep_rejects::no, offset_size::_4, primit
     static constexpr int threads = 384;
     static constexpr int items = 11;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<380, 1140>;
 };
@@ -285,7 +285,7 @@ struct sm90_tuning<Input, flagged::no, keep_rejects::yes, offset_size::_4, primi
     static constexpr int threads = 128;
     static constexpr int items = 12;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<512, 1075>;
 };
@@ -297,7 +297,7 @@ struct sm90_tuning<__int128_t, flagged::no, keep_rejects::yes, offset_size::_4, 
     static constexpr int threads = 192;
     static constexpr int items = 5;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<1616, 1115>;
 };
@@ -308,7 +308,7 @@ struct sm90_tuning<__uint128_t, flagged::no, keep_rejects::yes, offset_size::_4,
     static constexpr int threads = 192;
     static constexpr int items = 5;
 
-    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
     using delay_constructor = detail::fixed_delay_constructor_t<1616, 1115>;
 };

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -33,6 +33,7 @@
 #include <cub/block/block_scan.cuh>
 #include <cub/config.cuh>
 #include <cub/util_type.cuh>
+#include "cub/util_device.cuh"
 
 CUB_NAMESPACE_BEGIN
 
@@ -382,12 +383,172 @@ struct sm90_tuning<__uint128_t, flagged::yes, keep_rejects::yes, offset_size::_4
 };
 #endif
 
+
+template <class InputT,
+          flagged,
+          keep_rejects,
+          offset_size OffsetSize,
+          primitive            = is_primitive<InputT>(),
+          input_size InputSize = classify_input_size<InputT>()>
+struct sm80_tuning
+{
+    static constexpr int threads = 128;
+
+    static constexpr int nominal_4b_items_per_thread = 10;
+
+    static constexpr int items =
+      CUB_MIN(nominal_4b_items_per_thread,
+              CUB_MAX(1, (nominal_4b_items_per_thread * 4 / sizeof(InputT))));
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<350, 450>;
+};
+
+// partition::if
+template <class Input>
+struct sm80_tuning<Input, flagged::no, keep_rejects::yes, offset_size::_4, primitive::yes, input_size::_1>
+{
+    static constexpr int threads = 512;
+    static constexpr int items = 20;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::no_delay_constructor_t<510>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::no, keep_rejects::yes, offset_size::_4, primitive::yes, input_size::_2>
+{
+    static constexpr int threads = 224;
+    static constexpr int items = 18;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::no_delay_constructor_t<1045>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::no, keep_rejects::yes, offset_size::_4, primitive::yes, input_size::_4>
+{
+    static constexpr int threads = 192;
+    static constexpr int items = 15;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::no_delay_constructor_t<1040>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::no, keep_rejects::yes, offset_size::_4, primitive::yes, input_size::_8>
+{
+    static constexpr int threads = 192;
+    static constexpr int items = 10;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<68, 1160>;
+};
+
+#if CUB_IS_INT128_ENABLED 
+template <>
+struct sm80_tuning<__int128_t, flagged::no, keep_rejects::yes, offset_size::_4, primitive::no, input_size::_16>
+{
+    static constexpr int threads = 256;
+    static constexpr int items = 5;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<400, 1090>;
+};
+
+template <>
+struct sm80_tuning<__uint128_t, flagged::no, keep_rejects::yes, offset_size::_4, primitive::no, input_size::_16>
+{
+    static constexpr int threads = 256;
+    static constexpr int items = 5;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<400, 1090>;
+};
+#endif
+
+// partition::flagged
+template <class Input>
+struct sm80_tuning<Input, flagged::yes, keep_rejects::yes, offset_size::_4, primitive::yes, input_size::_1>
+{
+    static constexpr int threads = 512;
+    static constexpr int items = 20;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::no_delay_constructor_t<595>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::yes, keep_rejects::yes, offset_size::_4, primitive::yes, input_size::_2>
+{
+    static constexpr int threads = 224;
+    static constexpr int items = 18;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::no_delay_constructor_t<1105>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::yes, keep_rejects::yes, offset_size::_4, primitive::yes, input_size::_4>
+{
+    static constexpr int threads = 192;
+    static constexpr int items = 12;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<912, 1025>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::yes, keep_rejects::yes, offset_size::_4, primitive::yes, input_size::_8>
+{
+    static constexpr int threads = 192;
+    static constexpr int items = 12;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<884, 1130>;
+};
+
+#if CUB_IS_INT128_ENABLED 
+template <>
+struct sm80_tuning<__int128_t, flagged::yes, keep_rejects::yes, offset_size::_4, primitive::no, input_size::_16>
+{
+    static constexpr int threads = 256;
+    static constexpr int items = 5;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<400, 1090>;
+};
+
+template <>
+struct sm80_tuning<__uint128_t, flagged::yes, keep_rejects::yes, offset_size::_4, primitive::no, input_size::_16>
+{
+    static constexpr int threads = 256;
+    static constexpr int items = 5;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<400, 1090>;
+};
+#endif
+
 } // namespace select
 
 template <class InputT, class FlagT, class OffsetT, bool MayAlias, bool KeepRejects>
 struct device_select_policy_hub
 {
-    struct Policy350 : ChainedPolicy<350, Policy350, Policy350>
+    struct DefaultTuning
     {
       static constexpr int NOMINAL_4B_ITEMS_PER_THREAD = 10;
 
@@ -403,7 +564,32 @@ struct device_select_policy_hub
                                                   detail::fixed_delay_constructor_t<350, 450>>;
     };
 
-    struct Policy900 : ChainedPolicy<900, Policy900, Policy350>
+    struct Policy350
+        : DefaultTuning
+        , ChainedPolicy<350, Policy350, Policy350>
+    {};
+
+    struct Policy800 : ChainedPolicy<800, Policy800, Policy350>
+    {
+      using tuning = detail::select::sm80_tuning<InputT,
+                                                 select::is_flagged<FlagT>(),
+                                                 select::are_rejects_kept<KeepRejects>(),
+                                                 select::classify_offset_size<OffsetT>()>;
+
+      using SelectIfPolicyT = AgentSelectIfPolicy<tuning::threads,
+                                                  tuning::items,
+                                                  tuning::load_algorithm,
+                                                  LOAD_DEFAULT,
+                                                  BLOCK_SCAN_WARP_SCANS,
+                                                  typename tuning::delay_constructor>;
+    };
+
+    struct Policy860
+        : DefaultTuning
+        , ChainedPolicy<860, Policy860, Policy800>
+    {};
+
+    struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
     {
       using tuning = detail::select::sm90_tuning<InputT,
                                                  select::is_flagged<FlagT>(),

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -405,6 +405,144 @@ struct sm80_tuning
     using delay_constructor = detail::fixed_delay_constructor_t<350, 450>;
 };
 
+// select::if
+template <class Input>
+struct sm80_tuning<Input, flagged::no, keep_rejects::no, offset_size::_4, primitive::yes, input_size::_1>
+{
+    static constexpr int threads = 992;
+    static constexpr int items = 20;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::no_delay_constructor_t<395>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::no, keep_rejects::no, offset_size::_4, primitive::yes, input_size::_2>
+{
+    static constexpr int threads = 576;
+    static constexpr int items = 14;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::no_delay_constructor_t<870>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::no, keep_rejects::no, offset_size::_4, primitive::yes, input_size::_4>
+{
+    static constexpr int threads = 256;
+    static constexpr int items = 18;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::no_delay_constructor_t<1130>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::no, keep_rejects::no, offset_size::_4, primitive::yes, input_size::_8>
+{
+    static constexpr int threads = 192;
+    static constexpr int items = 10;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<832, 1165>;
+};
+
+#if CUB_IS_INT128_ENABLED 
+template <>
+struct sm80_tuning<__int128_t, flagged::no, keep_rejects::no, offset_size::_4, primitive::no, input_size::_16>
+{
+    static constexpr int threads = 384;
+    static constexpr int items = 4;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::no_delay_constructor_t<1140>;
+};
+
+template <>
+struct sm80_tuning<__uint128_t, flagged::no, keep_rejects::no, offset_size::_4, primitive::no, input_size::_16>
+{
+    static constexpr int threads = 384;
+    static constexpr int items = 4;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::no_delay_constructor_t<1140>;
+};
+#endif
+
+// select::flagged
+template <class Input>
+struct sm80_tuning<Input, flagged::yes, keep_rejects::no, offset_size::_4, primitive::yes, input_size::_1>
+{
+    static constexpr int threads = 224;
+    static constexpr int items = 20;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::no_delay_constructor_t<735>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::yes, keep_rejects::no, offset_size::_4, primitive::yes, input_size::_2>
+{
+    static constexpr int threads = 256;
+    static constexpr int items = 20;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+
+    using delay_constructor = detail::no_delay_constructor_t<1155>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::yes, keep_rejects::no, offset_size::_4, primitive::yes, input_size::_4>
+{
+    static constexpr int threads = 320;
+    static constexpr int items = 10;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<124, 1115>;
+};
+
+template <class Input>
+struct sm80_tuning<Input, flagged::yes, keep_rejects::no, offset_size::_4, primitive::yes, input_size::_8>
+{
+    static constexpr int threads = 384;
+    static constexpr int items = 6;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::no_delay_constructor_t<1130>;
+};
+
+#if CUB_IS_INT128_ENABLED 
+template <>
+struct sm80_tuning<__int128_t, flagged::yes, keep_rejects::no, offset_size::_4, primitive::no, input_size::_16>
+{
+    static constexpr int threads = 256;
+    static constexpr int items = 5;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<464, 1025>;
+};
+
+template <>
+struct sm80_tuning<__uint128_t, flagged::yes, keep_rejects::no, offset_size::_4, primitive::no, input_size::_16>
+{
+    static constexpr int threads = 256;
+    static constexpr int items = 5;
+
+    static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+    using delay_constructor = detail::fixed_delay_constructor_t<464, 1025>;
+};
+#endif
+
 // partition::if
 template <class Input>
 struct sm80_tuning<Input, flagged::no, keep_rejects::yes, offset_size::_4, primitive::yes, input_size::_1>

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -134,7 +134,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_8, offset_size::_4>
   static constexpr int threads = 384;
   static constexpr int items   = 7;
 
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
   using delay_constructor = detail::fixed_delay_constructor_t<464, 1165>;
 };
@@ -145,7 +145,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_16, offset_size::_4>
   static constexpr int threads = 128;
   static constexpr int items   = 7;
 
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
   using delay_constructor = detail::no_delay_constructor_t<1040>;
 };
@@ -167,7 +167,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_2, offset_size::_8>
   static constexpr int threads = 640;
   static constexpr int items   = 24;
 
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
   using delay_constructor = detail::no_delay_constructor_t<245>;
 };
@@ -178,7 +178,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_4, offset_size::_8>
   static constexpr int threads = 256;
   static constexpr int items   = 23;
 
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
   using delay_constructor = detail::no_delay_constructor_t<910>;
 };
@@ -189,7 +189,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_8, offset_size::_8>
   static constexpr int threads = 256;
   static constexpr int items   = 18;
 
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
   using delay_constructor = detail::no_delay_constructor_t<1145>;
 };
@@ -200,7 +200,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_16, offset_size::_8>
   static constexpr int threads = 256;
   static constexpr int items   = 11;
 
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_TRANSPOSE;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
 
   using delay_constructor = detail::no_delay_constructor_t<1050>;
 };


### PR DESCRIPTION

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Partially addresses https://github.com/NVIDIA/cccl/issues/238

<!-- Provide a standalone description of changes in this PR. -->

### H100 
This PR provides a few improvements (4-5%) for select and partition on H100. 
It also improves three-way partition on H100:

#### H100 HBM3

|   Entropy | I64     | F64     |
|----------:|:--------|:--------|
|     0     | -18.12% | -17.48% |
|     0.544 | -17.82% | -17.37% |
|     1     | -17.42% | -16.90% |

#### H100 HBM2e

|   Entropy | I64     | F64     |
|----------:|:--------|:--------|
|     0     | -23.94% | -22.25% |
|     0.544 | -20.63% | -21.96% |
|     1     | -20.33% | -22.02% |

The main focus of this PR is tuning of select and partition on A100.

### A100 SXM4

#### Three-Way Partition

|   Entropy | I8     | I16     | I32     | I64     | I128    | F32     | F64     |
|----------:|:-------|:--------|:--------|:--------|:--------|:--------|:--------|
|     0     | 0.02%  | -20.05% | -14.96% | -12.78% | -18.44% | -15.37% | -17.35% |
|     0.544 | -0.04% | -19.94% | -15.22% | -12.45% | -18.33% | -15.62% | -16.51% |
|     1     | 0.01%  | -19.72% | -15.31% | -12.26% | -18.38% | -15.65% | -16.49% |

#### Partition::If

|   Entropy | I8      | I16     | I32     | I64     | I128    | F32     | F64     |
|----------:|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
|     0     | -39.48% | -35.47% | -23.12% | -20.40% | -24.30% | -23.16% | -20.33% |
|     0.544 | -35.51% | -31.32% | -22.54% | -21.15% | -24.30% | -22.69% | -20.86% |
|     1     | -39.48% | -35.45% | -23.06% | -20.35% | -24.29% | -22.71% | -20.28% |

#### Partition::Flagged

|   Entropy | I8      | I16     | I32     | I64     | I128    | F32     | F64     |
|----------:|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
|     0     | -33.28% | -28.39% | -14.78% | -21.24% | -21.53% | -14.76% | -21.24% |
|     0.544 | -30.66% | -25.00% | -15.17% | -22.62% | -21.13% | -15.14% | -22.63% |
|     1     | -33.28% | -28.63% | -14.86% | -21.22% | -21.50% | -14.80% | -21.22% |


#### Select::If

|   Entropy | I8      | I16     | I32     | I64     | I128    | F32     | F64     |
|----------:|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
|     0     | -46.80% | -39.65% | -41.89% | -42.23% | -47.01% | -41.58% | -42.22% |
|     0.544 | -39.13% | -31.71% | -30.17% | -28.33% | -31.21% | -40.76% | -37.80% |
|     1     | -39.94% | -32.06% | -21.70% | -20.99% | -21.44% | -21.04% | -20.82% |

#### Select::Flagged

|   Entropy | I8      | I16     | I32     | I64     | I128    | F32     | F64     |
|----------:|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
|     0     | -32.77% | -34.21% | -22.93% | -36.07% | -44.48% | -22.87% | -36.43% |
|     0.544 | -30.02% | -31.23% | -21.23% | -23.43% | -30.03% | -21.16% | -23.45% |
|     1     | -31.42% | -30.00% | -14.46% | -16.80% | -22.08% | -14.46% | -16.82% |


### A100 PCIe

#### Three-Way Partition

|   Entropy | I8     | I16     | I32     | I64    | I128    | F32     | F64     |
|----------:|:-------|:--------|:--------|:-------|:--------|:--------|:--------|
|     0     | 0.01%  | -20.09% | -12.79% | -7.64% | -11.08% | -12.91% | -10.55% |
|     0.544 | -0.02% | -17.98% | -13.11% | -8.24% | -11.01% | -13.14% | -10.54% |
|     1     | -0.01% | -16.47% | -14.37% | -9.39% | -11.59% | -14.16% | -11.80% |

#### Partition::If

|   Entropy | I8      | I16     | I32     | I64     | I128    | F32     | F64     |
|----------:|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
|     0     | -38.02% | -31.86% | -18.12% | -12.86% | -14.24% | -18.13% | -12.76% |
|     0.544 | -33.25% | -27.55% | -18.24% | -14.22% | -14.94% | -18.37% | -14.01% |
|     1     | -37.74% | -31.67% | -18.34% | -13.06% | -14.28% | -17.93% | -12.77% |

#### Partition::Flagged

|   Entropy | I8      | I16     | I32     | I64     | I128    | F32     | F64     |
|----------:|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
|     0     | -32.21% | -23.91% | -11.92% | -14.51% | -12.63% | -11.83% | -14.56% |
|     0.544 | -29.10% | -20.90% | -12.62% | -15.90% | -13.01% | -12.74% | -16.11% |
|     1     | -32.17% | -23.74% | -11.79% | -14.34% | -12.56% | -12.14% | -14.42% |

#### Select::If

|   Entropy | I8      | I16     | I32     | I64     | I128    | F32     | F64     |
|----------:|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
|     0     | -46.97% | -39.52% | -37.61% | -34.74% | -38.57% | -37.74% | -34.68% |
|     0.544 | -39.56% | -29.54% | -25.10% | -20.99% | -21.70% | -34.68% | -31.73% |
|     1     | -39.08% | -29.03% | -15.97% | -13.54% | -12.40% | -15.22% | -13.60% |

#### Select::Flagged

|   Entropy | I8      | I16     | I32     | I64     | I128    | F32     | F64     |
|----------:|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
|     0     | -32.37% | -32.54% | -21.85% | -31.53% | -36.33% | -22.14% | -31.70% |
|     0.544 | -28.58% | -28.06% | -18.37% | -17.87% | -20.89% | -18.25% | -18.08% |
|     1     | -29.50% | -26.29% | -11.65% | -10.77% | -12.81% | -11.52% | -11.00% |

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
