### PR TITLE
Port cub::DeviceSegmentedReduce tests to catch2

### DIFF
--- a/cub/benchmarks/nvbench_helper/nvbench_helper.cu
+++ b/cub/benchmarks/nvbench_helper/nvbench_helper.cu
@@ -540,13 +540,13 @@ INSTANTIATE(complex);
 #undef INSTANTIATE
 
 template <class T>
-struct gt_t
+struct ge_t
 {
   T val;
 
   __device__ bool operator()(T x)
   {
-    return x > val;
+    return x >= val;
   }
 };
 
@@ -561,7 +561,7 @@ thrust::device_vector<T> gen_uniform_offsets(seed_t seed,
   segment_offsets[total_elements] = total_elements + 1;
   thrust::exclusive_scan(segment_offsets.begin(), segment_offsets.end(), segment_offsets.begin());
   typename thrust::device_vector<T>::iterator iter =
-    thrust::find_if(segment_offsets.begin(), segment_offsets.end(), gt_t<T>{total_elements});
+    thrust::find_if(segment_offsets.begin(), segment_offsets.end(), ge_t<T>{total_elements});
   *iter = total_elements;
   segment_offsets.erase(iter + 1, segment_offsets.end());
   return segment_offsets;

--- a/cub/test/c2h/generators.cuh
+++ b/cub/test/c2h/generators.cuh
@@ -101,7 +101,10 @@ void gen(modulo_t mod, thrust::device_vector<T> &data);
 
 /**
  * @brief Generates an array of offsets with uniformly distributed segment sizes in the range
- * between [min_segment_size, max_segment_size].
+ * between [min_segment_size, max_segment_size]. The lasst offset in the array corresponds to
+ * `total_element`. At most `total_element+2` offsets (or `total_elements+1` segments) and, because
+ * the very last offset must corresponds to `total_element`, the last segment may comprise more than
+ * `max_segment_size` items.
  */
 template <typename T>
 thrust::device_vector<T>

--- a/cub/test/c2h/generators.cuh
+++ b/cub/test/c2h/generators.cuh
@@ -99,5 +99,13 @@ void gen(seed_t seed,
 template <typename T>
 void gen(modulo_t mod, thrust::device_vector<T> &data);
 
+/**
+ * @brief Generates an array of offsets with uniformly distributed segment sizes in the range
+ * between [min_segment_size, max_segment_size].
+ */
+template <typename T>
+thrust::device_vector<T>
+gen_uniform_offsets(seed_t seed, T total_elements, T min_segment_size, T max_segment_size);
+
 } // c2h
 

--- a/cub/test/c2h/generators.cuh
+++ b/cub/test/c2h/generators.cuh
@@ -101,7 +101,7 @@ void gen(modulo_t mod, thrust::device_vector<T> &data);
 
 /**
  * @brief Generates an array of offsets with uniformly distributed segment sizes in the range
- * between [min_segment_size, max_segment_size]. The lasst offset in the array corresponds to
+ * between [min_segment_size, max_segment_size]. The last offset in the array corresponds to
  * `total_element`. At most `total_element+2` offsets (or `total_elements+1` segments) and, because
  * the very last offset must corresponds to `total_element`, the last segment may comprise more than
  * `max_segment_size` items.

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -42,7 +42,6 @@
 #include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
-#include <nv/target>
 
 DECLARE_CDP_WRAPPER(cub::DeviceReduce::Reduce, device_reduce);
 DECLARE_CDP_WRAPPER(cub::DeviceReduce::Sum, device_sum);

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -333,9 +333,10 @@ void compute_segmented_problem_reference(const thrust::device_vector<item_t> &d_
 {
   thrust::host_vector<item_t> h_items(d_in);
   thrust::host_vector<offset_t> h_offsets(d_offsets);
+  auto offsets_it   = h_offsets.cbegin();
   auto seg_sizes_it = thrust::make_transform_iterator(
     thrust::make_counting_iterator(std::size_t{0}),
-    [offsets_it = h_offsets.cbegin()](std::size_t i) { return offsets_it[i + 1] - offsets_it[i]; });
+    [offsets_it](std::size_t i) { return offsets_it[i + 1] - offsets_it[i]; });
   std::size_t num_segments = h_offsets.size() - 1;
 
   compute_host_reference(h_items.cbegin(),
@@ -363,9 +364,10 @@ void compute_segmented_problem_reference(in_it_t in_it,
                                          result_it_t h_results)
 {
   thrust::host_vector<offset_t> h_offsets(d_offsets);
+  auto offsets_it   = h_offsets.cbegin();
   auto seg_sizes_it = thrust::make_transform_iterator(
     thrust::make_counting_iterator(std::size_t{0}),
-    [offsets_it = h_offsets.cbegin()](std::size_t i) { return offsets_it[i + 1] - offsets_it[i]; });
+    [offsets_it](std::size_t i) { return offsets_it[i + 1] - offsets_it[i]; });
   std::size_t num_segments = h_offsets.size() - 1;
 
   compute_host_reference(in_it,

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -335,7 +335,7 @@ void compute_segmented_problem_reference(const thrust::device_vector<item_t> &d_
   thrust::host_vector<offset_t> h_offsets(d_offsets);
   auto seg_sizes_it = thrust::make_transform_iterator(
     thrust::make_counting_iterator(std::size_t{0}),
-    [offsets_it = h_offsets.cbegin()](auto i) { return offsets_it[i + 1] - offsets_it[i]; });
+    [offsets_it = h_offsets.cbegin()](std::size_t i) { return offsets_it[i + 1] - offsets_it[i]; });
   std::size_t num_segments = h_offsets.size() - 1;
 
   compute_host_reference(h_items.cbegin(),
@@ -365,7 +365,7 @@ void compute_segmented_problem_reference(in_it_t in_it,
   thrust::host_vector<offset_t> h_offsets(d_offsets);
   auto seg_sizes_it = thrust::make_transform_iterator(
     thrust::make_counting_iterator(std::size_t{0}),
-    [offsets_it = h_offsets.cbegin()](auto i) { return offsets_it[i + 1] - offsets_it[i]; });
+    [offsets_it = h_offsets.cbegin()](std::size_t i) { return offsets_it[i + 1] - offsets_it[i]; });
   std::size_t num_segments = h_offsets.size() - 1;
 
   compute_host_reference(in_it,

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -393,11 +393,18 @@ void compute_segmented_argmin_reference(const thrust::device_vector<item_t> &d_i
   const auto num_segments = h_offsets.size() - 1;
   for (std::size_t seg = 0; seg < num_segments; seg++)
   {
-    auto expected_result_it = std::min_element(h_items.cbegin() + h_offsets[seg],
-                                               h_items.cbegin() + h_offsets[seg + 1]);
-    int result_offset =
-      static_cast<int>(thrust::distance((h_items.cbegin() + h_offsets[seg]), expected_result_it));
-    h_results[seg] = {result_offset, *expected_result_it};
+    if (h_offsets[seg] >= h_offsets[seg + 1])
+    {
+      h_results[seg] = {1, cub::Traits<item_t>::Max()};
+    }
+    else
+    {
+      auto expected_result_it = std::min_element(h_items.cbegin() + h_offsets[seg],
+                                                 h_items.cbegin() + h_offsets[seg + 1]);
+      int result_offset =
+        static_cast<int>(thrust::distance((h_items.cbegin() + h_offsets[seg]), expected_result_it));
+      h_results[seg] = {result_offset, *expected_result_it};
+    }
   }
 }
 
@@ -415,11 +422,18 @@ void compute_segmented_argmax_reference(const thrust::device_vector<item_t> &d_i
   const auto num_segments = h_offsets.size() - 1;
   for (std::size_t seg = 0; seg < num_segments; seg++)
   {
-    auto expected_result_it = std::max_element(h_items.cbegin() + h_offsets[seg],
-                                               h_items.cbegin() + h_offsets[seg + 1]);
-    int result_offset =
-      static_cast<int>(thrust::distance((h_items.cbegin() + h_offsets[seg]), expected_result_it));
-    h_results[seg] = {result_offset, *expected_result_it};
+    if (h_offsets[seg] >= h_offsets[seg + 1])
+    {
+      h_results[seg] = {1, cub::Traits<item_t>::Lowest()};
+    }
+    else
+    {
+      auto expected_result_it = std::max_element(h_items.cbegin() + h_offsets[seg],
+                                                 h_items.cbegin() + h_offsets[seg + 1]);
+      int result_offset =
+        static_cast<int>(thrust::distance((h_items.cbegin() + h_offsets[seg]), expected_result_it));
+      h_results[seg] = {result_offset, *expected_result_it};
+    }
   }
 }
 

--- a/cub/test/catch2_test_device_reduce_fp_inf.cu
+++ b/cub/test/catch2_test_device_reduce_fp_inf.cu
@@ -36,7 +36,6 @@
 #include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
-#include <nv/target>
 
 DECLARE_CDP_WRAPPER(cub::DeviceReduce::ArgMin, device_arg_min);
 DECLARE_CDP_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max);

--- a/cub/test/catch2_test_device_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_iterators.cu
@@ -42,7 +42,6 @@
 #include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
-#include <nv/target>
 
 DECLARE_CDP_WRAPPER(cub::DeviceReduce::Reduce, device_reduce);
 DECLARE_CDP_WRAPPER(cub::DeviceReduce::Sum, device_sum);

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -100,6 +100,7 @@ CUB_TEST("Device reduce works with all device interfaces",
   INFO("Test num_items: " << num_items);
 
   // Range of segment sizes to generate
+  // Note that the segment range [0, 1] may also include one last segment with more than 1 items
   const std::tuple<offset_t, offset_t> seg_size_range =
     GENERATE_COPY(table<offset_t, offset_t>({{0, 1}, {1, num_items}, {num_items, num_items}}));
   INFO("Test seg_size_range: [" << std::get<0>(seg_size_range) << ", "

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -41,7 +41,6 @@
 #include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
-#include <nv/target>
 
 DECLARE_CDP_WRAPPER(cub::DeviceSegmentedReduce::Reduce, device_segmented_reduce);
 DECLARE_CDP_WRAPPER(cub::DeviceSegmentedReduce::Sum, device_segmented_sum);

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -101,7 +101,7 @@ CUB_TEST("Device reduce works with all device interfaces",
 
   // Range of segment sizes to generate
   const std::tuple<offset_t, offset_t> seg_size_range =
-    GENERATE_COPY(table<offset_t, offset_t>({{1, 1}, {1, num_items}, {num_items, num_items}}));
+    GENERATE_COPY(table<offset_t, offset_t>({{0, 1}, {1, num_items}, {num_items, num_items}}));
   INFO("Test seg_size_range: [" << std::get<0>(seg_size_range) << ", "
                                 << std::get<1>(seg_size_range) << "]");
 
@@ -187,7 +187,7 @@ CUB_TEST("Device reduce works with all device interfaces",
     compute_segmented_problem_reference(in_items,
                                         segment_offsets,
                                         op_t{},
-                                        cub::NumericTraits<accum_t>::Max(),
+                                        cub::NumericTraits<item_t>::Max(),
                                         expected_result.begin());
 
     // Run test
@@ -213,7 +213,7 @@ CUB_TEST("Device reduce works with all device interfaces",
     compute_segmented_problem_reference(in_items,
                                         segment_offsets,
                                         op_t{},
-                                        cub::NumericTraits<accum_t>::Lowest(),
+                                        cub::NumericTraits<item_t>::Lowest(),
                                         expected_result.begin());
 
     // Run test

--- a/cub/test/catch2_test_device_segmented_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_iterators.cu
@@ -1,0 +1,125 @@
+/******************************************************************************
+ * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <cub/device/device_segmented_reduce.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/discard_iterator.h>
+
+#include <cstdint>
+
+#include "catch2_test_device_reduce.cuh"
+
+// Has to go after all cub headers. Otherwise, this test won't catch unused
+// variables in cub kernels.
+#include "c2h/custom_type.cuh"
+#include "catch2/catch.hpp"
+#include "catch2_test_cdp_helper.h"
+#include "catch2_test_helper.h"
+#include <nv/target>
+
+DECLARE_CDP_WRAPPER(cub::DeviceSegmentedReduce::Reduce, device_segmented_reduce);
+DECLARE_CDP_WRAPPER(cub::DeviceSegmentedReduce::Sum, device_segmented_sum);
+
+// %PARAM% TEST_CDP cdp 0:1
+
+// List of types to test
+using custom_t           = c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t>;
+using iterator_type_list = c2h::type_list<type_pair<custom_t>, type_pair<std::int64_t>>;
+
+CUB_TEST("Device segmented reduce works with fancy input iterators",
+         "[reduce][device]",
+         iterator_type_list)
+{
+  using params   = params_t<TestType>;
+  using item_t   = typename params::item_t;
+  using output_t = typename params::output_t;
+  using offset_t = uint32_t;
+
+  constexpr int min_items = 1;
+  constexpr int max_items = 1000000;
+
+  // Number of items
+  const int num_items = GENERATE_COPY(take(2, random(min_items, max_items)),
+                                      values({
+                                        min_items,
+                                        max_items,
+                                      }));
+  INFO("Test num_items: " << num_items);
+
+  // Range of segment sizes to generate
+  const std::tuple<offset_t, offset_t> seg_size_range =
+    GENERATE_COPY(table<offset_t, offset_t>({{1, 1}, {1, num_items}, {num_items, num_items}}));
+  INFO("Test seg_size_range: [" << std::get<0>(seg_size_range) << ", "
+                                << std::get<1>(seg_size_range) << "]");
+
+  // Generate input segments
+  thrust::device_vector<offset_t> segment_offsets =
+    c2h::gen_uniform_offsets<offset_t>(CUB_SEED(1),
+                                       num_items,
+                                       std::get<0>(seg_size_range),
+                                       std::get<1>(seg_size_range));
+  const offset_t num_segments = segment_offsets.size() - 1;
+  auto d_offsets_it           = thrust::raw_pointer_cast(segment_offsets.data());
+
+  // Prepare input data
+  item_t default_constant{};
+  init_default_constant(default_constant);
+  auto in_it = thrust::make_constant_iterator(default_constant);
+
+  using op_t   = cub::Sum;
+  using init_t = output_t;
+
+  // Binary reduction operator
+  auto reduction_op = op_t{};
+
+  // Prepare verification data
+  using accum_t = cub::detail::accumulator_t<op_t, init_t, item_t>;
+  thrust::host_vector<output_t> expected_result(num_segments);
+  compute_segmented_problem_reference(in_it,
+                                      segment_offsets,
+                                      reduction_op,
+                                      accum_t{},
+                                      expected_result.begin());
+
+  // Run test
+  thrust::device_vector<output_t> out_result(num_segments);
+  auto d_out_it = thrust::raw_pointer_cast(out_result.data());
+  device_segmented_reduce(in_it,
+                          d_out_it,
+                          num_segments,
+                          d_offsets_it,
+                          d_offsets_it + 1,
+                          reduction_op,
+                          init_t{});
+
+  // Verify result
+  REQUIRE(expected_result == out_result);
+}

--- a/cub/test/catch2_test_device_segmented_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_iterators.cu
@@ -43,7 +43,6 @@
 #include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
-#include <nv/target>
 
 DECLARE_CDP_WRAPPER(cub::DeviceSegmentedReduce::Reduce, device_segmented_reduce);
 DECLARE_CDP_WRAPPER(cub::DeviceSegmentedReduce::Sum, device_segmented_sum);


### PR DESCRIPTION
## Description

This PR partially addresses https://github.com/NVIDIA/cccl/issues/85. It migrates tests for `DeviceSegmentedReduce`, i.e., segmented-problem reduction algorithms, to Catch2. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
