### PR TITLE
Tune unique by key on A100

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
@@ -411,6 +411,283 @@ struct sm90_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::no, key_size
   using delay_constructor = detail::no_delay_constructor_t<1155>;
 };
 
+template <class KeyT,
+          class ValueT,
+          primitive_key PrimitiveKey   = is_primitive_key<KeyT>(),
+          primitive_val PrimitiveAccum = is_primitive_val<ValueT>(),
+          key_size KeySize             = classify_key_size<KeyT>(),
+          val_size AccumSize           = classify_val_size<ValueT>()>
+struct sm80_tuning
+{
+  static constexpr int threads = 64;
+
+  static constexpr int nominal_4b_items_per_thread = 11;
+
+  static constexpr int items = Nominal4BItemsToItems<KeyT>(nominal_4b_items_per_thread);
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_LDG;
+
+  using delay_constructor = detail::default_delay_constructor_t<int>;
+};
+
+// 8-bit key
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_1, val_size::_1>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 12;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<835>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_1, val_size::_2>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 12;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<765>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_1, val_size::_4>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 12;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1155>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_1, val_size::_8>
+{
+  static constexpr int threads = 224;
+
+  static constexpr int items = 10;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1065>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::no, key_size::_1, val_size::_16>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<248, 1200>;
+};
+
+// 16-bit key
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_2, val_size::_1>
+{
+  static constexpr int threads = 320;
+
+  static constexpr int items = 20;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1020>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_2, val_size::_2>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 22;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<328, 1080>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_2, val_size::_4>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 14;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<535>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_2, val_size::_8>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 10;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1055>;
+};
+
+// 32-bit key
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_4, val_size::_1>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 12;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1120>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_4, val_size::_2>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 14;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1185>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_4, val_size::_4>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 11;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1115>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_4, val_size::_8>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<320, 1115>;
+};
+
+// 64-bit key
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_8, val_size::_1>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<24, 555>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_8, val_size::_2>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<324, 1105>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_8, val_size::_4>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<740, 1105>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::yes, key_size::_8, val_size::_8>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<764, 1155>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_key::yes, primitive_val::no, key_size::_8, val_size::_16>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr CacheLoadModifier load_modifier = LOAD_DEFAULT;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<992, 1135>;
+};
+
 } // namespace unique_by_key
 } // namespace detail
 
@@ -438,8 +715,7 @@ struct DeviceUniqueByKeyPolicy
                                                       detail::default_delay_constructor_t<int>>;
   };
 
-  // SM520
-  struct Policy520 : ChainedPolicy<520, Policy520, Policy350>
+  struct DefaultTuning 
   {
     const static int INPUT_SIZE = sizeof(KeyT);
     enum
@@ -456,8 +732,33 @@ struct DeviceUniqueByKeyPolicy
                                                       detail::default_delay_constructor_t<int>>;
   };
 
+  // SM520
+  struct Policy520
+      : DefaultTuning
+      , ChainedPolicy<520, Policy520, Policy350>
+  {};
+
+  /// SM80
+  struct Policy800 : ChainedPolicy<800, Policy800, Policy520>
+  {
+    using tuning = detail::unique_by_key::sm80_tuning<KeyT, ValueT>;
+
+    using UniqueByKeyPolicyT = AgentUniqueByKeyPolicy<tuning::threads,
+                                                      tuning::items,
+                                                      tuning::load_algorithm,
+                                                      tuning::load_modifier,
+                                                      BLOCK_SCAN_WARP_SCANS,
+                                                      typename tuning::delay_constructor>;
+  };
+
+  // SM860
+  struct Policy860
+      : DefaultTuning
+      , ChainedPolicy<860, Policy860, Policy800>
+  {};
+
   /// SM90
-  struct Policy900 : ChainedPolicy<900, Policy900, Policy520>
+  struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
   {
     using tuning = detail::unique_by_key::sm90_tuning<KeyT, ValueT>;
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Partially addresses https://github.com/NVIDIA/cccl/issues/238

<!-- Provide a standalone description of changes in this PR. -->
### A100 SXM
#### Max Segment Size 2

| KeyT{ct}   | I8      | I16     | I32     | I64     | F32     | F64     |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -32.11% | -27.03% | -19.81% | -5.60%  | -19.73% | -5.43%  |
| I16        | -27.58% | -32.65% | -14.29% | -4.88%  | -13.83% | -4.80%  |
| I32        | -25.13% | -14.87% | -10.32% | -5.10%  | -10.41% | -5.12%  |
| I64        | -28.08% | -27.72% | -22.54% | -13.01% | -22.59% | -13.11% |

#### Max Segment Size 16

| KeyT{ct}   | I8      | I16     | I32     | I64     | F32     | F64     |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -31.92% | -29.20% | -22.21% | -19.24% | -22.23% | -19.29% |
| I16        | -32.47% | -38.83% | -32.07% | -19.74% | -32.12% | -19.77% |
| I32        | -32.64% | -34.54% | -27.59% | -15.71% | -27.47% | -15.76% |
| I64        | -42.60% | -45.65% | -40.30% | -30.18% | -40.34% | -30.21% |
#### Max Segment Size 256

| KeyT{ct}   | I8      | I16     | I32     | I64     | F32     | F64     |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -32.79% | -29.72% | -21.35% | -20.26% | -21.44% | -20.46% |
| I16        | -33.44% | -40.40% | -34.44% | -24.35% | -34.40% | -24.33% |
| I32        | -33.00% | -36.08% | -29.31% | -21.51% | -29.41% | -21.56% |
| I64        | -44.41% | -47.76% | -46.25% | -36.61% | -46.26% | -36.42% |

### A100 PCIe
#### Max Segment Size 2

| KeyT{ct}   | I8      | I16     | I32     | I64    | F32     | F64    |
|:-----------|:--------|:--------|:--------|:-------|:--------|:-------|
| I8         | -31.24% | -25.57% | -14.77% | -1.57% | -15.61% | -2.06% |
| I16        | -26.50% | -26.36% | -8.97%  | -2.35% | -10.30% | -2.39% |
| I32        | -19.70% | -10.64% | -5.45%  | -2.65% | -5.45%  | -2.63% |
| I64        | -20.59% | -18.57% | -12.92% | -6.58% | -12.91% | -6.63% |

#### Max Segment Size 16

| KeyT{ct}   | I8      | I16     | I32     | I64     | F32     | F64     |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -31.61% | -27.97% | -21.09% | -14.15% | -21.29% | -14.17% |
| I16        | -31.70% | -37.15% | -26.75% | -13.71% | -26.90% | -13.66% |
| I32        | -31.22% | -29.08% | -20.86% | -8.89%  | -20.83% | -8.88%  |
| I64        | -39.26% | -38.84% | -31.85% | -20.88% | -31.82% | -20.83% |

#### Max Segment Size 256

| KeyT{ct}   | I8      | I16     | I32     | I64     | F32     | F64     |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -32.39% | -29.16% | -21.12% | -16.78% | -21.11% | -16.75% |
| I16        | -32.88% | -38.95% | -30.44% | -17.48% | -29.92% | -17.42% |
| I32        | -32.18% | -32.17% | -24.15% | -12.24% | -23.96% | -12.21% |
| I64        | -42.86% | -43.47% | -37.58% | -26.41% | -37.56% | -26.42% |


<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
