### PR TITLE
Clarify docstring for num_items parameter of DeviceSegmentedRadixSort

### DIFF
--- a/cub/cub/device/device_segmented_radix_sort.cuh
+++ b/cub/cub/device/device_segmented_radix_sort.cuh
@@ -182,10 +182,9 @@ struct DeviceSegmentedRadixSort
    *   sequence of associated value items
    *
    * @param[in] num_items 
-   *   The total number of items to sort (across all segments). If segments
-   *   are non-contiguous, this should include unused items in between
-   *   segments, namely all items between the start of the first and end
-   *   of the last segment.
+   *   The total number of items within the segmented array, including items not
+   *   covered by segments. `num_items` should match the largest element within
+   *   the range `[d_end_offsets, d_end_offsets + num_segments)`.
    *
    * @param[in] num_segments 
    *   The number of segments that comprise the sorting data
@@ -411,10 +410,9 @@ struct DeviceSegmentedRadixSort
    *   to the sorted output values
    *
    * @param[in] num_items 
-   *   The total number of items to sort (across all segments). If segments
-   *   are non-contiguous, this should include unused items in between
-   *   segments, namely all items between the start of the first and end
-   *   of the last segment.
+   *   The total number of items within the segmented array, including items not
+   *   covered by segments. `num_items` should match the largest element within
+   *   the range `[d_end_offsets, d_end_offsets + num_segments)`.
    *
    * @param[in] num_segments 
    *   The number of segments that comprise the sorting data
@@ -621,10 +619,9 @@ struct DeviceSegmentedRadixSort
    *   sequence of associated value items
    *
    * @param[in] num_items 
-   *   The total number of items to sort (across all segments). If segments
-   *   are non-contiguous, this should include unused items in between
-   *   segments, namely all items between the start of the first and end
-   *   of the last segment.
+   *   The total number of items within the segmented array, including items not
+   *   covered by segments. `num_items` should match the largest element within
+   *   the range `[d_end_offsets, d_end_offsets + num_segments)`.
    *
    * @param[in] num_segments 
    *   The number of segments that comprise the sorting data
@@ -852,10 +849,9 @@ struct DeviceSegmentedRadixSort
    *   to the sorted output values
    *
    * @param[in] num_items 
-   *   The total number of items to sort (across all segments). If segments
-   *   are non-contiguous, this should include unused items in between
-   *   segments, namely all items between the start of the first and end
-   *   of the last segment.
+   *   The total number of items within the segmented array, including items not
+   *   covered by segments. `num_items` should match the largest element within
+   *   the range `[d_end_offsets, d_end_offsets + num_segments)`.
    *
    * @param[in] num_segments 
    *   The number of segments that comprise the sorting data
@@ -1052,10 +1048,9 @@ struct DeviceSegmentedRadixSort
    *   Device-accessible pointer to the sorted output sequence of key data
    *
    * @param[in] num_items  
-   *   The total number of items to sort (across all segments). If segments
-   *   are non-contiguous, this should include unused items in between
-   *   segments, namely all items between the start of the first and end
-   *   of the last segment.
+   *   The total number of items within the segmented array, including items not
+   *   covered by segments. `num_items` should match the largest element within
+   *   the range `[d_end_offsets, d_end_offsets + num_segments)`.
    *
    * @param[in] num_segments  
    *   The number of segments that comprise the sorting data
@@ -1255,10 +1250,9 @@ struct DeviceSegmentedRadixSort
    *   point to the sorted output keys
    *
    * @param[in] num_items  
-   *   The total number of items to sort (across all segments). If segments
-   *   are non-contiguous, this should include unused items in between
-   *   segments, namely all items between the start of the first and end
-   *   of the last segment.
+   *   The total number of items within the segmented array, including items not
+   *   covered by segments. `num_items` should match the largest element within
+   *   the range `[d_end_offsets, d_end_offsets + num_segments)`.
    *
    * @param[in] num_segments  
    *   The number of segments that comprise the sorting data
@@ -1449,10 +1443,9 @@ struct DeviceSegmentedRadixSort
    *   Device-accessible pointer to the sorted output sequence of key data
    *
    * @param[in] num_items  
-   *   The total number of items to sort (across all segments). If segments
-   *   are non-contiguous, this should include unused items in between
-   *   segments, namely all items between the start of the first and end
-   *   of the last segment.
+   *   The total number of items within the segmented array, including items not
+   *   covered by segments. `num_items` should match the largest element within
+   *   the range `[d_end_offsets, d_end_offsets + num_segments)`.
    *
    * @param[in] num_segments  
    *   The number of segments that comprise the sorting data
@@ -1651,10 +1644,9 @@ struct DeviceSegmentedRadixSort
    *   point to the sorted output keys
    *
    * @param[in] num_items  
-   *   The total number of items to sort (across all segments). If segments
-   *   are non-contiguous, this should include unused items in between
-   *   segments, namely all items between the start of the first and end
-   *   of the last segment.
+   *   The total number of items within the segmented array, including items not
+   *   covered by segments. `num_items` should match the largest element within
+   *   the range `[d_end_offsets, d_end_offsets + num_segments)`.
    *
    * @param[in] num_segments  
    *   The number of segments that comprise the sorting data


### PR DESCRIPTION
## Description

In the case where the user specifies non-contiguous segments (segments which do not cover the entirety of `d_keys_in`), the `num_items` parameter must include non-covered items. It should be the length of the total range to sort, from the start of the first segment to the end of the last, inclusive of any unused elements.

I'm not sure if the wording I used in the docstring is the clearest so please feel free to suggest something better.

For more context / a code example, see: https://github.com/NVIDIA/cub/issues/731