### PR TITLE
Tune scan by key on A100

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -541,6 +541,464 @@ struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size
   using delay_constructor = detail::fixed_delay_constructor_t<364, 1050>;
 };
 #endif
+
+template <class KeyT,
+          class AccumT,
+          primitive_op PrimitiveOp,
+          key_size KeySize                     = classify_key_size<KeyT>(),
+          val_size AccumSize                   = classify_val_size<AccumT>(),
+          primitive_accum PrimitiveAccumulator = is_primitive_accum<AccumT>()>
+struct sm80_tuning
+{
+  static constexpr int nominal_4b_items_per_thread = 9;
+
+  static constexpr int threads = 256;
+
+  static constexpr size_t max_input_bytes = (cub::max)(sizeof(KeyT), sizeof(AccumT));
+
+  static constexpr size_t combined_input_bytes = sizeof(KeyT) + sizeof(AccumT);
+
+  static constexpr int items =
+    ((max_input_bytes <= 8)
+       ? 9
+       : Nominal4BItemsToItemsCombined(nominal_4b_items_per_thread, combined_input_bytes));
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::default_reduce_by_key_delay_constructor_t<AccumT, int>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 12;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<795>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads = 288;
+
+  static constexpr int items = 12;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<825>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<640>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 10;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<124, 1040>;
+};
+
+#if CUB_IS_INT128_ENABLED 
+template <class KeyT>
+struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 19;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1095>;
+};
+
+template <class KeyT>
+struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 19;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1095>;
+};
+#endif
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 8;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1070>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads = 320;
+
+  static constexpr int items = 14;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<625>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1055>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads = 160;
+
+  static constexpr int items = 17;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<160, 695>;
+};
+
+#if CUB_IS_INT128_ENABLED 
+template <class KeyT>
+struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 160;
+
+  static constexpr int items = 14;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1105>;
+};
+
+template <class KeyT>
+struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 160;
+
+  static constexpr int items = 14;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1105>;
+};
+#endif
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 12;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1130>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 12;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1130>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1140>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 9;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<888, 635>;
+};
+
+#if CUB_IS_INT128_ENABLED 
+template <class KeyT>
+struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 17;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1100>;
+};
+
+template <class KeyT>
+struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 17;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1100>;
+};
+#endif
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 11;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1120>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 10;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1115>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads = 224;
+
+  static constexpr int items = 13;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<24, 1060>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads = 224;
+
+  static constexpr int items = 10;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1160>;
+};
+
+#if CUB_IS_INT128_ENABLED 
+template <class KeyT>
+struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 320;
+
+  static constexpr int items = 8;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<220>;
+};
+
+template <class KeyT>
+struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 320;
+
+  static constexpr int items = 8;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<220>;
+};
+#endif
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<144, 1120>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<364, 780>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1170>;
+};
+
+template <class KeyT, class ValueT>
+struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1030>;
+};
+
+#if CUB_IS_INT128_ENABLED 
+template <class KeyT>
+struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1160>;
+};
+
+template <class KeyT>
+struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1160>;
+};
+#endif
 } // namespace scan_by_key
 } // namespace detail
 
@@ -578,8 +1036,7 @@ struct DeviceScanByKeyPolicy
                            detail::default_reduce_by_key_delay_constructor_t<AccumT, int>>;
   };
 
-  // SM520
-  struct Policy520 : ChainedPolicy<520, Policy520, Policy350>
+  struct DefaultTuning
   {
     static constexpr int NOMINAL_4B_ITEMS_PER_THREAD = 9;
     static constexpr int ITEMS_PER_THREAD =
@@ -598,8 +1055,35 @@ struct DeviceScanByKeyPolicy
                            detail::default_reduce_by_key_delay_constructor_t<AccumT, int>>;
   };
 
+  // SM520
+  struct Policy520
+      : DefaultTuning
+      , ChainedPolicy<520, Policy520, Policy350>
+  {};
+
+  // SM800
+  struct Policy800 : ChainedPolicy<800, Policy800, Policy520>
+  {
+    using tuning =
+      detail::scan_by_key::sm80_tuning<KeyT, ValueT, detail::scan_by_key::is_primitive_op<ScanOpT>()>;
+
+    using ScanByKeyPolicyT = AgentScanByKeyPolicy<tuning::threads,
+                                                  tuning::items,
+                                                  tuning::load_algorithm,
+                                                  LOAD_DEFAULT,
+                                                  BLOCK_SCAN_WARP_SCANS,
+                                                  tuning::store_algorithm,
+                                                  typename tuning::delay_constructor>;
+  };
+
+  // SM860
+  struct Policy860
+      : DefaultTuning
+      , ChainedPolicy<860, Policy860, Policy800>
+  {};
+
   // SM900
-  struct Policy900 : ChainedPolicy<900, Policy900, Policy520>
+  struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
   {
     using tuning =
       detail::scan_by_key::sm90_tuning<KeyT, ValueT, detail::scan_by_key::is_primitive_op<ScanOpT>()>;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Partially addresses https://github.com/NVIDIA/cccl/issues/238

<!-- Provide a standalone description of changes in this PR. -->

### A100 SXM


| KeyT \ ValueT  | I8      | I16     | I32     | I64    | I128    |
|:-----------|:--------|:--------|:--------|:-------|:--------|
| I8         | -23.74% | -23.35% | -8.71%  | -3.94% | -38.25% |
| I16        | -13.91% | -22.75% | -7.76%  | -4.97% | -36.40% |
| I32        | -15.59% | -15.64% | -4.27%  | -1.11% | -42.41% |
| F32        | -16.91% | -17.44% | -4.56%  | -1.62% | -42.50% |
| C64        | -0.21%  | 3.08%   | -4.12%  | -5.18% | -29.36% |
| I64        | -0.24%  | -2.91%  | -4.12%  | -5.19% | -29.02% |
| F64        | -0.64%  | -3.69%  | -4.10%  | -4.88% | -29.40% |
| I128       | -25.47% | -20.13% | -12.39% | -9.78% | -45.06% |

<details>

| KeyT{ct}   | ValueT{ct}   | OffsetT{ct}   | Elements{io}   | Cmp Noise   | %Diff   |
|:-----------|:-------------|:--------------|:---------------|:------------|:--------|
| I8         | I8           | I32           | 2^16           | 1.80%       | -4.55%  |
| I8         | I8           | I32           | 2^20           | 11.11%      | -19.93% |
| I8         | I8           | I32           | 2^24           | 4.27%       | -23.19% |
| I8         | I8           | I32           | 2^28           | 1.01%       | -23.74% |
| I8         | I16          | I32           | 2^16           | 1.67%       | 4.86%   |
| I8         | I16          | I32           | 2^20           | 1.22%       | -12.01% |
| I8         | I16          | I32           | 2^24           | 1.59%       | -20.61% |
| I8         | I16          | I32           | 2^28           | 0.58%       | -23.35% |
| I8         | I32          | I32           | 2^16           | 1.67%       | 1.42%   |
| I8         | I32          | I32           | 2^20           | 3.08%       | -2.56%  |
| I8         | I32          | I32           | 2^24           | 2.89%       | -9.93%  |
| I8         | I32          | I32           | 2^28           | 1.57%       | -8.71%  |
| I8         | I64          | I32           | 2^16           | 1.77%       | 2.21%   |
| I8         | I64          | I32           | 2^20           | 2.66%       | -2.55%  |
| I8         | I64          | I32           | 2^24           | 1.24%       | -3.54%  |
| I8         | I64          | I32           | 2^28           | 0.50%       | -3.94%  |
| I8         | I128         | I32           | 2^16           | 1.66%       | -1.85%  |
| I8         | I128         | I32           | 2^20           | 1.09%       | -15.45% |
| I8         | I128         | I32           | 2^24           | 0.66%       | -36.31% |
| I8         | I128         | I32           | 2^28           | 0.50%       | -38.25% |
| I16        | I8           | I32           | 2^16           | 1.86%       | -1.81%  |
| I16        | I8           | I32           | 2^20           | 20.04%      | -5.50%  |
| I16        | I8           | I32           | 2^24           | 1.66%       | -13.00% |
| I16        | I8           | I32           | 2^28           | 0.33%       | -13.91% |
| I16        | I16          | I32           | 2^16           | 1.49%       | 5.60%   |
| I16        | I16          | I32           | 2^20           | 2.09%       | -18.63% |
| I16        | I16          | I32           | 2^24           | 0.72%       | -18.59% |
| I16        | I16          | I32           | 2^28           | 0.50%       | -22.75% |
| I16        | I32          | I32           | 2^16           | 1.77%       | 2.15%   |
| I16        | I32          | I32           | 2^20           | 1.39%       | -1.52%  |
| I16        | I32          | I32           | 2^24           | 2.36%       | -7.33%  |
| I16        | I32          | I32           | 2^28           | 0.89%       | -7.76%  |
| I16        | I64          | I32           | 2^16           | 1.80%       | 7.25%   |
| I16        | I64          | I32           | 2^20           | 1.31%       | -7.62%  |
| I16        | I64          | I32           | 2^24           | 1.42%       | -3.48%  |
| I16        | I64          | I32           | 2^28           | 0.50%       | -4.97%  |
| I16        | I128         | I32           | 2^16           | 1.78%       | -0.40%  |
| I16        | I128         | I32           | 2^20           | 1.22%       | -13.94% |
| I16        | I128         | I32           | 2^24           | 0.66%       | -34.55% |
| I16        | I128         | I32           | 2^28           | 0.50%       | -36.40% |
| I32        | I8           | I32           | 2^16           | 1.94%       | -3.87%  |
| I32        | I8           | I32           | 2^20           | 0.97%       | -7.74%  |
| I32        | I8           | I32           | 2^24           | 3.84%       | -14.58% |
| I32        | I8           | I32           | 2^28           | 0.70%       | -15.59% |
| I32        | I16          | I32           | 2^16           | 1.64%       | 1.10%   |
| I32        | I16          | I32           | 2^20           | 27.79%      | -6.07%  |
| I32        | I16          | I32           | 2^24           | 1.84%       | -11.97% |
| I32        | I16          | I32           | 2^28           | 0.48%       | -15.64% |
| I32        | I32          | I32           | 2^16           | 1.23%       | 3.04%   |
| I32        | I32          | I32           | 2^20           | 1.77%       | -9.70%  |
| I32        | I32          | I32           | 2^24           | 2.58%       | -3.57%  |
| I32        | I32          | I32           | 2^28           | 1.01%       | -4.27%  |
| I32        | I64          | I32           | 2^16           | 1.38%       | -0.20%  |
| I32        | I64          | I32           | 2^20           | 10.05%      | -2.97%  |
| I32        | I64          | I32           | 2^24           | 1.02%       | -0.72%  |
| I32        | I64          | I32           | 2^28           | 0.50%       | -1.11%  |
| I32        | I128         | I32           | 2^16           | 1.83%       | 1.71%   |
| I32        | I128         | I32           | 2^20           | 0.92%       | -14.87% |
| I32        | I128         | I32           | 2^24           | 0.64%       | -40.45% |
| I32        | I128         | I32           | 2^28           | 0.50%       | -42.41% |
| I64        | I8           | I32           | 2^16           | 2.01%       | 0.92%   |
| I64        | I8           | I32           | 2^20           | 1.30%       | -5.08%  |
| I64        | I8           | I32           | 2^24           | 5.04%       | -0.23%  |
| I64        | I8           | I32           | 2^28           | 1.23%       | -0.24%  |
| I64        | I16          | I32           | 2^16           | 2.09%       | -1.08%  |
| I64        | I16          | I32           | 2^20           | 3.29%       | -5.53%  |
| I64        | I16          | I32           | 2^24           | 1.99%       | -2.19%  |
| I64        | I16          | I32           | 2^28           | 0.67%       | -2.91%  |
| I64        | I32          | I32           | 2^16           | 1.62%       | 1.03%   |
| I64        | I32          | I32           | 2^20           | 5.71%       | -6.32%  |
| I64        | I32          | I32           | 2^24           | 1.71%       | -2.19%  |
| I64        | I32          | I32           | 2^28           | 0.54%       | -4.12%  |
| I64        | I64          | I32           | 2^16           | 1.56%       | -1.30%  |
| I64        | I64          | I32           | 2^20           | 30.26%      | 21.61%  |
| I64        | I64          | I32           | 2^24           | 2.21%       | -4.78%  |
| I64        | I64          | I32           | 2^28           | 0.68%       | -5.19%  |
| I64        | I128         | I32           | 2^16           | 1.42%       | 9.21%   |
| I64        | I128         | I32           | 2^20           | 0.91%       | -3.01%  |
| I64        | I128         | I32           | 2^24           | 0.47%       | -26.97% |
| I64        | I128         | I32           | 2^28           | 0.45%       | -29.02% |
| I128       | I8           | I32           | 2^16           | 2.15%       | 1.11%   |
| I128       | I8           | I32           | 2^20           | 1.13%       | -5.48%  |
| I128       | I8           | I32           | 2^24           | 1.29%       | -21.88% |
| I128       | I8           | I32           | 2^28           | 0.50%       | -25.47% |
| I128       | I16          | I32           | 2^16           | 1.60%       | -1.32%  |
| I128       | I16          | I32           | 2^20           | 1.22%       | -6.13%  |
| I128       | I16          | I32           | 2^24           | 1.42%       | -17.68% |
| I128       | I16          | I32           | 2^28           | 0.50%       | -20.13% |
| I128       | I32          | I32           | 2^16           | 1.94%       | -1.19%  |
| I128       | I32          | I32           | 2^20           | 3.22%       | -5.36%  |
| I128       | I32          | I32           | 2^24           | 2.41%       | -10.76% |
| I128       | I32          | I32           | 2^28           | 0.80%       | -12.39% |
| I128       | I64          | I32           | 2^16           | 1.69%       | 3.27%   |
| I128       | I64          | I32           | 2^20           | 7.03%       | -4.24%  |
| I128       | I64          | I32           | 2^24           | 1.75%       | -8.25%  |
| I128       | I64          | I32           | 2^28           | 0.63%       | -9.78%  |
| I128       | I128         | I32           | 2^16           | 1.67%       | -9.78%  |
| I128       | I128         | I32           | 2^20           | 0.92%       | -22.47% |
| I128       | I128         | I32           | 2^24           | 0.52%       | -43.65% |
| I128       | I128         | I32           | 2^28           | 0.50%       | -45.06% |
| F32        | I8           | I32           | 2^16           | 2.24%       | -3.63%  |
| F32        | I8           | I32           | 2^20           | 2.49%       | -8.08%  |
| F32        | I8           | I32           | 2^24           | 3.20%       | -15.68% |
| F32        | I8           | I32           | 2^28           | 0.65%       | -16.91% |
| F32        | I16          | I32           | 2^16           | 5.87%       | 1.24%   |
| F32        | I16          | I32           | 2^20           | 3.24%       | -6.79%  |
| F32        | I16          | I32           | 2^24           | 1.85%       | -13.53% |
| F32        | I16          | I32           | 2^28           | 0.46%       | -17.44% |
| F32        | I32          | I32           | 2^16           | 1.89%       | 2.56%   |
| F32        | I32          | I32           | 2^20           | 1.55%       | -8.72%  |
| F32        | I32          | I32           | 2^24           | 2.81%       | -4.09%  |
| F32        | I32          | I32           | 2^28           | 0.99%       | -4.56%  |
| F32        | I64          | I32           | 2^16           | 1.97%       | 6.32%   |
| F32        | I64          | I32           | 2^20           | 3.52%       | -2.22%  |
| F32        | I64          | I32           | 2^24           | 1.04%       | -1.15%  |
| F32        | I64          | I32           | 2^28           | 0.50%       | -1.62%  |
| F32        | I128         | I32           | 2^16           | 1.91%       | -2.54%  |
| F32        | I128         | I32           | 2^20           | 0.93%       | -14.82% |
| F32        | I128         | I32           | 2^24           | 0.62%       | -40.61% |
| F32        | I128         | I32           | 2^28           | 0.50%       | -42.50% |
| F64        | I8           | I32           | 2^16           | 2.13%       | 0.91%   |
| F64        | I8           | I32           | 2^20           | 8.74%       | -5.17%  |
| F64        | I8           | I32           | 2^24           | 3.15%       | -1.78%  |
| F64        | I8           | I32           | 2^28           | 1.28%       | -0.64%  |
| F64        | I16          | I32           | 2^16           | 1.77%       | 0.30%   |
| F64        | I16          | I32           | 2^20           | 3.92%       | -6.12%  |
| F64        | I16          | I32           | 2^24           | 2.36%       | -2.30%  |
| F64        | I16          | I32           | 2^28           | 0.78%       | -3.69%  |
| F64        | I32          | I32           | 2^16           | 1.68%       | 0.03%   |
| F64        | I32          | I32           | 2^20           | 1.51%       | -7.25%  |
| F64        | I32          | I32           | 2^24           | 1.89%       | -2.21%  |
| F64        | I32          | I32           | 2^28           | 0.52%       | -4.10%  |
| F64        | I64          | I32           | 2^16           | 1.85%       | -1.24%  |
| F64        | I64          | I32           | 2^20           | 18.91%      | 6.20%   |
| F64        | I64          | I32           | 2^24           | 2.60%       | -4.22%  |
| F64        | I64          | I32           | 2^28           | 0.73%       | -4.88%  |
| F64        | I128         | I32           | 2^16           | 1.27%       | 8.37%   |
| F64        | I128         | I32           | 2^20           | 1.14%       | -2.06%  |
| F64        | I128         | I32           | 2^24           | 0.44%       | -27.51% |
| F64        | I128         | I32           | 2^28           | 0.50%       | -29.40% |
| C64        | I8           | I32           | 2^16           | 1.97%       | 0.79%   |
| C64        | I8           | I32           | 2^20           | 1.41%       | -4.94%  |
| C64        | I8           | I32           | 2^24           | 4.34%       | -0.12%  |
| C64        | I8           | I32           | 2^28           | 1.06%       | -0.21%  |
| C64        | I16          | I32           | 2^16           | 1.84%       | 2.42%   |
| C64        | I16          | I32           | 2^20           | 2.26%       | 1.08%   |
| C64        | I16          | I32           | 2^24           | 2.01%       | 5.77%   |
| C64        | I16          | I32           | 2^28           | 0.57%       | 3.08%   |
| C64        | I32          | I32           | 2^16           | 1.70%       | 0.25%   |
| C64        | I32          | I32           | 2^20           | 6.16%       | -10.66% |
| C64        | I32          | I32           | 2^24           | 1.66%       | -2.29%  |
| C64        | I32          | I32           | 2^28           | 0.51%       | -4.12%  |
| C64        | I64          | I32           | 2^16           | 1.80%       | -1.21%  |
| C64        | I64          | I32           | 2^20           | 12.77%      | 1.89%   |
| C64        | I64          | I32           | 2^24           | 2.65%       | -4.72%  |
| C64        | I64          | I32           | 2^28           | 0.68%       | -5.18%  |
| C64        | I128         | I32           | 2^16           | 1.82%       | 9.30%   |
| C64        | I128         | I32           | 2^20           | 1.23%       | 0.20%   |
| C64        | I128         | I32           | 2^24           | 0.43%       | -27.57% |
| C64        | I128         | I32           | 2^28           | 0.49%       | -29.36% |

</details>

### A100 PCIe

| KeyT \ ValueT  | I8      | I16     | I32     | I64    | I128    |
|:-----------|:--------|:--------|:-------|:-------|:--------|
| I8         | -27.97% | -26.32% | -3.68% | -1.27% | -27.60% |
| I16        | -19.24% | -23.83% | -2.27% | -1.75% | -26.04% |
| I32        | -20.47% | -14.36% | -1.88% | -0.11% | -30.78% |
| F32        | -21.07% | -15.78% | -1.98% | -0.22% | -30.89% |
| I64        | -7.19%  | -3.48%  | -1.52% | -1.72% | -21.73% |
| F64        | -8.04%  | -3.96%  | -1.61% | -1.68% | -21.72% |
| C64        | -7.09%  | 0.71%   | -1.56% | -1.80% | -21.91% |
| I128       | -21.03% | -16.32% | -9.27% | -4.06% | -32.52% |

<details>

| KeyT{ct}   | ValueT{ct}   | OffsetT{ct}   | Elements{io}   | Cmp Noise   | %Diff   |
|:-----------|:-------------|:--------------|:---------------|:------------|:--------|
| I8         | I8           | I32           | 2^16           | 14.50%      | -5.46%  |
| I8         | I8           | I32           | 2^20           | 29.01%      | -3.76%  |
| I8         | I8           | I32           | 2^24           | 8.14%       | -26.26% |
| I8         | I8           | I32           | 2^28           | 0.87%       | -27.97% |
| I8         | I16          | I32           | 2^16           | 3.19%       | 2.07%   |
| I8         | I16          | I32           | 2^20           | 35.87%      | 18.02%  |
| I8         | I16          | I32           | 2^24           | 2.83%       | -23.65% |
| I8         | I16          | I32           | 2^28           | 1.17%       | -26.32% |
| I8         | I32          | I32           | 2^16           | 3.46%       | 0.74%   |
| I8         | I32          | I32           | 2^20           | 13.30%      | -32.99% |
| I8         | I32          | I32           | 2^24           | 3.30%       | -6.40%  |
| I8         | I32          | I32           | 2^28           | 1.23%       | -3.68%  |
| I8         | I64          | I32           | 2^16           | 3.99%       | -1.47%  |
| I8         | I64          | I32           | 2^20           | 2.69%       | -6.62%  |
| I8         | I64          | I32           | 2^24           | 0.49%       | -1.09%  |
| I8         | I64          | I32           | 2^28           | 0.50%       | -1.27%  |
| I8         | I128         | I32           | 2^16           | 3.08%       | -2.78%  |
| I8         | I128         | I32           | 2^20           | 1.40%       | -12.48% |
| I8         | I128         | I32           | 2^24           | 0.42%       | -26.08% |
| I8         | I128         | I32           | 2^28           | 0.50%       | -27.60% |
| I16        | I8           | I32           | 2^16           | 4.08%       | -3.74%  |
| I16        | I8           | I32           | 2^20           | 30.92%      | -27.50% |
| I16        | I8           | I32           | 2^24           | 0.89%       | -18.82% |
| I16        | I8           | I32           | 2^28           | 0.39%       | -19.24% |
| I16        | I16          | I32           | 2^16           | 3.88%       | 2.38%   |
| I16        | I16          | I32           | 2^20           | 2.45%       | -32.74% |
| I16        | I16          | I32           | 2^24           | 1.35%       | -18.67% |
| I16        | I16          | I32           | 2^28           | 0.50%       | -23.83% |
| I16        | I32          | I32           | 2^16           | 3.82%       | 5.43%   |
| I16        | I32          | I32           | 2^20           | 2.17%       | -7.88%  |
| I16        | I32          | I32           | 2^24           | 1.24%       | -4.86%  |
| I16        | I32          | I32           | 2^28           | 0.62%       | -2.27%  |
| I16        | I64          | I32           | 2^16           | 3.53%       | 2.52%   |
| I16        | I64          | I32           | 2^20           | 34.36%      | 30.13%  |
| I16        | I64          | I32           | 2^24           | 0.52%       | -1.54%  |
| I16        | I64          | I32           | 2^28           | 0.50%       | -1.75%  |
| I16        | I128         | I32           | 2^16           | 3.13%       | -2.04%  |
| I16        | I128         | I32           | 2^20           | 1.71%       | -10.34% |
| I16        | I128         | I32           | 2^24           | 0.44%       | -24.48% |
| I16        | I128         | I32           | 2^28           | 0.50%       | -26.04% |
| I32        | I8           | I32           | 2^16           | 4.30%       | -9.15%  |
| I32        | I8           | I32           | 2^20           | 14.82%      | -12.99% |
| I32        | I8           | I32           | 2^24           | 3.53%       | -17.17% |
| I32        | I8           | I32           | 2^28           | 0.57%       | -20.47% |
| I32        | I16          | I32           | 2^16           | 3.91%       | -0.88%  |
| I32        | I16          | I32           | 2^20           | 18.44%      | -6.44%  |
| I32        | I16          | I32           | 2^24           | 1.76%       | -11.30% |
| I32        | I16          | I32           | 2^28           | 0.50%       | -14.36% |
| I32        | I32          | I32           | 2^16           | 3.69%       | 4.42%   |
| I32        | I32          | I32           | 2^20           | 2.27%       | -3.97%  |
| I32        | I32          | I32           | 2^24           | 1.89%       | -2.46%  |
| I32        | I32          | I32           | 2^28           | 0.58%       | -1.88%  |
| I32        | I64          | I32           | 2^16           | 3.74%       | -0.98%  |
| I32        | I64          | I32           | 2^20           | 1.90%       | -0.38%  |
| I32        | I64          | I32           | 2^24           | 0.47%       | -0.27%  |
| I32        | I64          | I32           | 2^28           | 0.50%       | -0.11%  |
| I32        | I128         | I32           | 2^16           | 3.01%       | -3.03%  |
| I32        | I128         | I32           | 2^20           | 1.32%       | -9.55%  |
| I32        | I128         | I32           | 2^24           | 0.41%       | -28.94% |
| I32        | I128         | I32           | 2^28           | 0.50%       | -30.78% |
| I64        | I8           | I32           | 2^16           | 4.07%       | 1.52%   |
| I64        | I8           | I32           | 2^20           | 2.14%       | -4.95%  |
| I64        | I8           | I32           | 2^24           | 2.99%       | -4.67%  |
| I64        | I8           | I32           | 2^28           | 0.96%       | -7.19%  |
| I64        | I16          | I32           | 2^16           | 3.64%       | -3.72%  |
| I64        | I16          | I32           | 2^20           | 1.76%       | -6.36%  |
| I64        | I16          | I32           | 2^24           | 1.32%       | -3.02%  |
| I64        | I16          | I32           | 2^28           | 0.50%       | -3.48%  |
| I64        | I32          | I32           | 2^16           | 3.94%       | -0.44%  |
| I64        | I32          | I32           | 2^20           | 2.48%       | -5.46%  |
| I64        | I32          | I32           | 2^24           | 0.54%       | -0.85%  |
| I64        | I32          | I32           | 2^28           | 0.50%       | -1.52%  |
| I64        | I64          | I32           | 2^16           | 3.26%       | -2.75%  |
| I64        | I64          | I32           | 2^20           | 33.70%      | 61.57%  |
| I64        | I64          | I32           | 2^24           | 1.23%       | -2.28%  |
| I64        | I64          | I32           | 2^28           | 0.50%       | -1.72%  |
| I64        | I128         | I32           | 2^16           | 2.78%       | 9.64%   |
| I64        | I128         | I32           | 2^20           | 1.67%       | 4.01%   |
| I64        | I128         | I32           | 2^24           | 0.40%       | -19.75% |
| I64        | I128         | I32           | 2^28           | 0.50%       | -21.73% |
| I128       | I8           | I32           | 2^16           | 3.59%       | -0.02%  |
| I128       | I8           | I32           | 2^20           | 1.49%       | -4.42%  |
| I128       | I8           | I32           | 2^24           | 0.71%       | -18.31% |
| I128       | I8           | I32           | 2^28           | 0.50%       | -21.03% |
| I128       | I16          | I32           | 2^16           | 3.87%       | 0.46%   |
| I128       | I16          | I32           | 2^20           | 1.38%       | -5.66%  |
| I128       | I16          | I32           | 2^24           | 0.67%       | -14.51% |
| I128       | I16          | I32           | 2^28           | 0.50%       | -16.32% |
| I128       | I32          | I32           | 2^16           | 3.78%       | 0.82%   |
| I128       | I32          | I32           | 2^20           | 4.58%       | -8.68%  |
| I128       | I32          | I32           | 2^24           | 1.39%       | -8.42%  |
| I128       | I32          | I32           | 2^28           | 0.50%       | -9.27%  |
| I128       | I64          | I32           | 2^16           | 3.68%       | 6.74%   |
| I128       | I64          | I32           | 2^20           | 15.42%      | -0.98%  |
| I128       | I64          | I32           | 2^24           | 0.84%       | -3.63%  |
| I128       | I64          | I32           | 2^28           | 0.50%       | -4.06%  |
| I128       | I128         | I32           | 2^16           | 3.09%       | -4.15%  |
| I128       | I128         | I32           | 2^20           | 1.09%       | -15.46% |
| I128       | I128         | I32           | 2^24           | 0.43%       | -31.25% |
| I128       | I128         | I32           | 2^28           | 0.50%       | -32.52% |
| F32        | I8           | I32           | 2^16           | 4.46%       | -6.12%  |
| F32        | I8           | I32           | 2^20           | 2.33%       | -8.63%  |
| F32        | I8           | I32           | 2^24           | 6.06%       | -16.91% |
| F32        | I8           | I32           | 2^28           | 0.50%       | -21.07% |
| F32        | I16          | I32           | 2^16           | 3.79%       | 2.39%   |
| F32        | I16          | I32           | 2^20           | 23.93%      | -1.34%  |
| F32        | I16          | I32           | 2^24           | 1.45%       | -11.72% |
| F32        | I16          | I32           | 2^28           | 0.50%       | -15.78% |
| F32        | I32          | I32           | 2^16           | 3.61%       | 4.58%   |
| F32        | I32          | I32           | 2^20           | 2.11%       | -2.44%  |
| F32        | I32          | I32           | 2^24           | 1.47%       | -2.61%  |
| F32        | I32          | I32           | 2^28           | 0.57%       | -1.98%  |
| F32        | I64          | I32           | 2^16           | 4.05%       | 0.86%   |
| F32        | I64          | I32           | 2^20           | 2.01%       | -0.62%  |
| F32        | I64          | I32           | 2^24           | 0.46%       | -0.31%  |
| F32        | I64          | I32           | 2^28           | 0.50%       | -0.22%  |
| F32        | I128         | I32           | 2^16           | 3.14%       | -0.92%  |
| F32        | I128         | I32           | 2^20           | 1.29%       | -9.46%  |
| F32        | I128         | I32           | 2^24           | 0.41%       | -29.11% |
| F32        | I128         | I32           | 2^28           | 0.50%       | -30.89% |
| F64        | I8           | I32           | 2^16           | 4.17%       | 0.17%   |
| F64        | I8           | I32           | 2^20           | 1.84%       | -6.24%  |
| F64        | I8           | I32           | 2^24           | 2.71%       | -5.74%  |
| F64        | I8           | I32           | 2^28           | 0.87%       | -8.04%  |
| F64        | I16          | I32           | 2^16           | 3.11%       | -5.04%  |
| F64        | I16          | I32           | 2^20           | 7.53%       | -6.48%  |
| F64        | I16          | I32           | 2^24           | 1.29%       | -2.99%  |
| F64        | I16          | I32           | 2^28           | 0.56%       | -3.96%  |
| F64        | I32          | I32           | 2^16           | 2.99%       | -1.55%  |
| F64        | I32          | I32           | 2^20           | 2.06%       | -6.91%  |
| F64        | I32          | I32           | 2^24           | 0.58%       | -1.15%  |
| F64        | I32          | I32           | 2^28           | 0.50%       | -1.61%  |
| F64        | I64          | I32           | 2^16           | 2.91%       | -3.31%  |
| F64        | I64          | I32           | 2^20           | 23.18%      | 9.65%   |
| F64        | I64          | I32           | 2^24           | 4.08%       | 0.64%   |
| F64        | I64          | I32           | 2^28           | 0.50%       | -1.68%  |
| F64        | I128         | I32           | 2^16           | 2.69%       | 7.92%   |
| F64        | I128         | I32           | 2^20           | 1.52%       | 3.30%   |
| F64        | I128         | I32           | 2^24           | 0.44%       | -19.49% |
| F64        | I128         | I32           | 2^28           | 0.50%       | -21.72% |
| C64        | I8           | I32           | 2^16           | 4.15%       | -2.58%  |
| C64        | I8           | I32           | 2^20           | 1.94%       | -4.78%  |
| C64        | I8           | I32           | 2^24           | 4.82%       | -3.55%  |
| C64        | I8           | I32           | 2^28           | 0.72%       | -7.09%  |
| C64        | I16          | I32           | 2^16           | 4.06%       | -4.93%  |
| C64        | I16          | I32           | 2^20           | 2.33%       | -0.81%  |
| C64        | I16          | I32           | 2^24           | 1.32%       | 2.55%   |
| C64        | I16          | I32           | 2^28           | 0.54%       | 0.71%   |
| C64        | I32          | I32           | 2^16           | 3.29%       | -0.75%  |
| C64        | I32          | I32           | 2^20           | 8.66%       | -4.03%  |
| C64        | I32          | I32           | 2^24           | 0.55%       | -1.02%  |
| C64        | I32          | I32           | 2^28           | 0.50%       | -1.56%  |
| C64        | I64          | I32           | 2^16           | 3.86%       | -3.12%  |
| C64        | I64          | I32           | 2^20           | 25.93%      | 12.76%  |
| C64        | I64          | I32           | 2^24           | 3.67%       | -0.10%  |
| C64        | I64          | I32           | 2^28           | 0.50%       | -1.80%  |
| C64        | I128         | I32           | 2^16           | 2.74%       | 7.89%   |
| C64        | I128         | I32           | 2^20           | 1.30%       | 2.63%   |
| C64        | I128         | I32           | 2^24           | 0.45%       | -19.71% |
| C64        | I128         | I32           | 2^28           | 0.50%       | -21.91% |

</details>

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
