### PR TITLE
Fix `cudacc` and `nvcc` mixup.

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/containers/views/mdspan/mdspan.extents.cons/array.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/containers/views/mdspan/mdspan.extents.cons/array.pass.cpp
@@ -55,7 +55,7 @@ int main(int, char**)
 
     static_assert( is_array_cons_avail_v< cuda::std::dextents<   int,2>, my_int, 2 > == true , "" );
 
-#if !defined(TEST_COMPILER_NVCC_BELOW_11_3)
+#if !defined(TEST_COMPILER_CUDACC_BELOW_11_3)
     // Constraint: rank consistency
     static_assert( is_array_cons_avail_v< cuda::std::dextents<   int,1>, int   , 2 > == false, "" );
 
@@ -66,7 +66,7 @@ int main(int, char**)
 #ifndef TEST_COMPILER_NVHPC
     static_assert( is_array_cons_avail_v< cuda::std::dextents<   int,1>, my_int_non_nothrow_constructible, 1 > == false, "" );
 #endif // TEST_COMPILER_NVHPC
-#endif // !defined(TEST_COMPILER_NVCC_BELOW_11_3)
+#endif // !defined(TEST_COMPILER_CUDACC_BELOW_11_3)
 
     return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/containers/views/mdspan/mdspan.extents.cons/span.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/containers/views/mdspan/mdspan.extents.cons/span.pass.cpp
@@ -56,7 +56,7 @@ int main(int, char**)
 
     static_assert( is_span_cons_avail_v< cuda::std::dextents<int,2>, my_int, 2 > == true , "" );
 
-#if !defined(TEST_COMPILER_NVCC_BELOW_11_3)
+#if !defined(TEST_COMPILER_CUDACC_BELOW_11_3)
     // Constraint: rank consistency
     static_assert( is_span_cons_avail_v< cuda::std::dextents<int,1>, int   , 2 > == false, "" );
 
@@ -67,7 +67,7 @@ int main(int, char**)
 #ifndef TEST_COMPILER_NVHPC
     static_assert( is_span_cons_avail_v< cuda::std::dextents<int,1>, my_int_non_nothrow_constructible, 1 > == false, "" );
 #endif // TEST_COMPILER_NVHPC
-#endif // !defined(TEST_COMPILER_NVCC_BELOW_11_3)
+#endif // !defined(TEST_COMPILER_CUDACC_BELOW_11_3)
 
     return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.range/begin-end.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.range/begin-end.pass.cpp
@@ -147,7 +147,7 @@ void test_const_array( const T (&array)[Sz] ) {
 
 STATIC_TEST_GLOBAL_VAR TEST_CONSTEXPR_GLOBAL int global_array [] { 1, 2, 3 };
 #if TEST_STD_VER > 14
-#if !defined(TEST_COMPILER_NVCC_BELOW_11_3)
+#if !defined(TEST_COMPILER_CUDACC_BELOW_11_3)
 STATIC_TEST_GLOBAL_VAR TEST_CONSTEXPR_GLOBAL int global_const_array[] = {0,1,2,3,4};
 #endif // nvcc > 11.2
 #endif // TEST_STD_VER > 14
@@ -216,7 +216,7 @@ int main(int, char**) {
         static_assert ( *cuda::std::crbegin(local_const_array) == 4, "" );
     }
 
-#if !defined(TEST_COMPILER_NVCC_BELOW_11_3)
+#if !defined(TEST_COMPILER_CUDACC_BELOW_11_3)
     {
 
         static_assert ( *cuda::std::begin(global_const_array)   == 0, "" );

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
@@ -200,10 +200,10 @@ __host__ __device__ constexpr bool test() {
   return true;
 }
 
-#ifndef _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3 // nvcc segfaults here
+#ifndef _LIBCUDACXX_CUDACC_BELOW_11_3 // nvcc segfaults here
 static_assert(!cuda::std::is_invocable_v<IterMoveT, int*, int*>); // too many arguments
 static_assert(!cuda::std::is_invocable_v<IterMoveT, int>);
-#endif // _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3
+#endif // _LIBCUDACXX_CUDACC_BELOW_11_3
 
 #if TEST_STD_VER > 17
 // Test ADL-proofing.

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
@@ -146,9 +146,9 @@ __host__ __device__ void testException() {
 int main(int, char**) {
   test();
 #if defined(_LIBCUDACXX_ADDRESSOF)
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif // defined(_LIBCUDACXX_ADDRESSOF)
   testException();
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
@@ -147,9 +147,9 @@ __host__ __device__ void testException() {
 int main(int, char**) {
   test();
 #if defined(_LIBCUDACXX_ADDRESSOF)
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif // defined(_LIBCUDACXX_ADDRESSOF)
   testException();
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/monadic/and_then.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/monadic/and_then.pass.cpp
@@ -368,8 +368,8 @@ constexpr bool test() {
 
 int main(int, char**) {
   test();
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/monadic/or_else.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/monadic/or_else.pass.cpp
@@ -368,8 +368,8 @@ constexpr bool test() {
 
 int main(int, char**) {
   test();
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/monadic/and_then.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/monadic/and_then.pass.cpp
@@ -258,8 +258,8 @@ constexpr bool test() {
 
 int main(int, char**) {
   test();
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/monadic/or_else.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/monadic/or_else.pass.cpp
@@ -355,8 +355,8 @@ constexpr bool test() {
 
 int main(int, char**) {
   test();
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/monadic/transform.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/monadic/transform.pass.cpp
@@ -213,8 +213,8 @@ constexpr bool test() {
 
 int main(int, char**) {
   test();
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/observers/deref.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/observers/deref.pass.cpp
@@ -40,8 +40,8 @@ __host__ __device__ constexpr bool test() {
 
 int main(int, char**) {
   test();
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/observers/value.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/observers/value.pass.cpp
@@ -83,9 +83,9 @@ __host__ __device__ void testException() {
 
 int main(int, char**) {
   test();
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   testException();
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/equal.pass.cpp
@@ -74,9 +74,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/greater.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/greater.pass.cpp
@@ -74,9 +74,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/greater_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/greater_equal.pass.cpp
@@ -76,9 +76,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/less_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/less_equal.pass.cpp
@@ -76,9 +76,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/less_than.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/less_than.pass.cpp
@@ -74,9 +74,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/not_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.comp_with_t/not_equal.pass.cpp
@@ -74,9 +74,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.monadic/or_else.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.monadic/or_else.pass.cpp
@@ -128,7 +128,7 @@ TEST_CONSTEXPR_CXX17 bool test_nontrivial() {
 int main(int, char**) {
   test();
   test_nontrivial();
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   // GCC <9 incorrectly trips on the assertions in this, so disable it there
 #if TEST_STD_VER > 14 && (!defined(TEST_COMPILER_GCC) || __GNUC__ < 9)
   static_assert(test(), "");
@@ -138,6 +138,6 @@ int main(int, char**) {
   static_assert(test_nontrivial());
 #endif // defined(_LIBCUDACXX_ADDRESSOF)
 #endif // TEST_STD_VER > 17
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/equal.pass.cpp
@@ -46,9 +46,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/greater.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/greater.pass.cpp
@@ -46,9 +46,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/greater_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/greater_equal.pass.cpp
@@ -46,9 +46,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/less_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/less_equal.pass.cpp
@@ -47,9 +47,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/less_than.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/less_than.pass.cpp
@@ -46,9 +46,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/not_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.nullops/not_equal.pass.cpp
@@ -46,9 +46,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.assign/assign_value.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.assign/assign_value.pass.cpp
@@ -315,9 +315,9 @@ int main(int, char**)
     test_throws();
 
 #if !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     static_assert(pr38638(3) == 5, "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif // !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.assign/const_optional_U.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.assign/const_optional_U.pass.cpp
@@ -203,7 +203,7 @@ int main(int, char**)
 {
     test_with_test_type();
     test_ambiguous_assign();
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         optional<int> opt;
         constexpr optional<short> opt2;
@@ -236,7 +236,7 @@ int main(int, char**)
         assert(static_cast<bool>(opt) == static_cast<bool>(opt2));
         assert(*opt == *opt2);
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #ifndef TEST_HAS_NO_EXCEPTIONS
     {
         optional<X> opt;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.assign/copy.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.assign/copy.pass.cpp
@@ -59,10 +59,10 @@ int main(int, char**)
     {
         using O = optional<int>;
 #if !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
         static_assert(assign_empty(O{42}), "");
         static_assert(assign_value(O{42}), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif // !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
         assert(assign_empty(O{42}));
         assert(assign_value(O{42}));
@@ -70,10 +70,10 @@ int main(int, char**)
     {
         using O = optional<TrivialTestTypes::TestType>;
 #if !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
         static_assert(assign_empty(O{42}), "");
         static_assert(assign_value(O{42}), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif // !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
         assert(assign_empty(O{42}));
         assert(assign_value(O{42}));

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.assign/move.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.assign/move.pass.cpp
@@ -77,7 +77,7 @@ int main(int, char**)
         static_assert(static_cast<bool>(opt2) == false, "");
         assert(static_cast<bool>(opt) == static_cast<bool>(opt2));
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         optional<int> opt;
         constexpr optional<int> opt2(2);
@@ -87,7 +87,7 @@ int main(int, char**)
         assert(static_cast<bool>(opt) == static_cast<bool>(opt2));
         assert(*opt == *opt2);
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         optional<int> opt(3);
         constexpr optional<int> opt2;
@@ -106,7 +106,7 @@ int main(int, char**)
         assert(static_cast<bool>(opt2) == false);
         assert(static_cast<bool>(opt) == static_cast<bool>(opt2));
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         optional<int> opt(3);
         constexpr optional<int> opt2(2);
@@ -116,14 +116,14 @@ int main(int, char**)
         assert(static_cast<bool>(opt) == static_cast<bool>(opt2));
         assert(*opt == *opt2);
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         using O = optional<int>;
 #if !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
         static_assert(assign_empty(O{42}), "");
         static_assert(assign_value(O{42}), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif // !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
         assert(assign_empty(O{42}));
         assert(assign_value(O{42}));
@@ -131,10 +131,10 @@ int main(int, char**)
     {
         using O = optional<TrivialTestTypes::TestType>;
 #if !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
         static_assert(assign_empty(O{42}), "");
         static_assert(assign_value(O{42}), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif // !defined(TEST_COMPILER_GCC) || __GNUC__ > 6
         assert(assign_empty(O{42}));
         assert(assign_value(O{42}));

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/U.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/U.pass.cpp
@@ -74,25 +74,25 @@ constexpr bool explicit_conversion(Input&& in, const Expect& v)
 __host__ __device__
 void test_implicit()
 {
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         static_assert(implicit_conversion<long long>(42, 42), "");
     }
     {
         static_assert(implicit_conversion<double>(3.14, 3.14), "");
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         int x = 42;
         optional<void* const> o(&x);
         assert(*o == &x);
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         using T = TrivialTestTypes::TestType;
         static_assert(implicit_conversion<T>(42, 42), "");
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         using T = TestTypes::TestType;
         assert(implicit_conversion<T>(3, T(3)));
@@ -121,7 +121,7 @@ void test_implicit()
 
 __host__ __device__
 void test_explicit() {
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         using T = ExplicitTrivialTestTypes::TestType;
         static_assert(explicit_conversion<T>(42, 42), "");
@@ -131,7 +131,7 @@ void test_explicit() {
         static_assert(explicit_conversion<T>(42, 42), "");
         static_assert(!cuda::std::is_convertible<int, T>::value, "");
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         using T = ExplicitTestTypes::TestType;
         T::reset();

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/const_T.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/const_T.pass.cpp
@@ -27,7 +27,7 @@ using cuda::std::optional;
 
 int main(int, char**)
 {
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         typedef int T;
         constexpr T t(5);
@@ -58,7 +58,7 @@ int main(int, char**)
         };
 
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         const int x = 42;
         optional<const int> o(x);
@@ -85,7 +85,7 @@ int main(int, char**)
         assert(static_cast<bool>(opt) == true);
         assert(opt.value().value == 3);
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         typedef ConstexprTestTypes::TestType T;
         constexpr T t(3);
@@ -116,7 +116,7 @@ int main(int, char**)
         };
 
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #ifndef TEST_HAS_NO_EXCEPTIONS
     {
         struct Z {

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/copy.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/copy.pass.cpp
@@ -123,10 +123,10 @@ int main(int, char**)
 {
     test<int>();
     test<int>(3);
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     static_assert(constexpr_test<int>(), "" );
     static_assert(constexpr_test<int>(3), "" );
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
     {
         const optional<const int> o(42);
@@ -172,13 +172,13 @@ int main(int, char**)
     {
         test_reference_extension();
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr cuda::std::optional<int> o1{4};
         constexpr cuda::std::optional<int> o2 = o1;
         static_assert( *o2 == 4, "" );
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/default.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/default.pass.cpp
@@ -79,7 +79,7 @@ int main(int, char**)
 #endif
     test<optional<NonLiteralTypes::NoCtors>>();
 
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     static_assert(test_constexpr<optional<int>>(), "");
     static_assert(test_constexpr<optional<int*>>(), "");
 #if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER >= 17
@@ -87,7 +87,7 @@ int main(int, char**)
     static_assert(test_constexpr<optional<NonTrivialTypes::NoCtors>>(), "");
     static_assert(test_constexpr<optional<NonConstexprTypes::NoCtors>>(), "");
 #endif
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/in_place_t.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/in_place_t.pass.cpp
@@ -71,7 +71,7 @@ public:
 
 int main(int, char**)
 {
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<int> opt(in_place, 5);
         static_assert(static_cast<bool>(opt) == true, "");
@@ -86,7 +86,7 @@ int main(int, char**)
         };
 
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         optional<const int> opt(in_place, 5);
         assert(*opt == 5);
@@ -106,7 +106,7 @@ int main(int, char**)
         assert(static_cast<bool>(opt) == true);
         assert(*opt == X(5, 4));
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<Y> opt(in_place);
         static_assert(static_cast<bool>(opt) == true, "");
@@ -149,7 +149,7 @@ int main(int, char**)
         };
 
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #ifndef TEST_HAS_NO_EXCEPTIONS
     {
         try

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
@@ -110,13 +110,13 @@ int main(int, char**)
             assert(static_cast<bool>(opt) == true);
             assert((*opt == Y{3, 1}));
         }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
         {
             constexpr optional<Y> opt(in_place, {3, 1});
             static_assert(static_cast<bool>(opt) == true, "");
             static_assert(*opt == Y{3, 1}, "");
         }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
         struct test_constexpr_ctor
             : public optional<Y>

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/move.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/move.pass.cpp
@@ -156,10 +156,10 @@ int main(int, char**)
 {
     test<int>();
     test<int>(3);
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     static_assert(constexpr_test<int>(), "" );
     static_assert(constexpr_test<int>(3), "" );
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
     {
         optional<const int> o(42);
@@ -229,13 +229,13 @@ int main(int, char**)
     {
         test_reference_extension();
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
     constexpr cuda::std::optional<int> o1{4};
     constexpr cuda::std::optional<int> o2 = cuda::std::move(o1);
     static_assert( *o2 == 4, "" );
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
@@ -81,7 +81,7 @@ int main(int, char**)
 #endif
     test<optional<NonLiteralTypes::NoCtors>>();
 
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     static_assert(test_constexpr<optional<int>>(), "");
     static_assert(test_constexpr<optional<int*>>(), "");
 #if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER >= 17
@@ -89,7 +89,7 @@ int main(int, char**)
     static_assert(test_constexpr<optional<NonTrivialTypes::NoCtors>>(), "");
     static_assert(test_constexpr<optional<NonConstexprTypes::NoCtors>>(), "");
 #endif
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/rvalue_T.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.ctor/rvalue_T.pass.cpp
@@ -39,7 +39,7 @@ public:
 
 int main(int, char**)
 {
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         typedef int T;
         constexpr optional<T> opt(T(5));
@@ -66,7 +66,7 @@ int main(int, char**)
             constexpr test_constexpr_ctor(T&&) {}
         };
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         const int x = 42;
         optional<const int> o(cuda::std::move(x));
@@ -102,7 +102,7 @@ int main(int, char**)
         assert(static_cast<bool>(opt) == true);
         assert(opt.value().value == 3);
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         typedef ConstexprTestTypes::TestType T;
         constexpr optional<T> opt = {T(3)};
@@ -144,7 +144,7 @@ int main(int, char**)
         };
 
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #ifndef TEST_HAS_NO_EXCEPTIONS
     {
         try

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/bool.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/bool.pass.cpp
@@ -26,7 +26,7 @@ int main(int, char**)
         ASSERT_NOEXCEPT(bool(opt));
         static_assert(!cuda::std::is_convertible<optional<int>, bool>::value, "");
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<int> opt;
         static_assert(!opt, "");
@@ -35,7 +35,7 @@ int main(int, char**)
         constexpr optional<int> opt(0);
         static_assert(opt, "");
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/dereference.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/dereference.pass.cpp
@@ -65,9 +65,9 @@ int main(int, char**)
         optional<X> opt(X{});
         assert((*opt).test() == 4);
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     static_assert(test() == 7, "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
     return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/dereference_const.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/dereference_const.pass.cpp
@@ -53,7 +53,7 @@ int main(int, char**)
         // Regardless this function should still be noexcept(false) because
         // it has a narrow contract.
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<X> opt(X{});
         static_assert((*opt).test() == 3, "");
@@ -62,7 +62,7 @@ int main(int, char**)
         constexpr optional<Y> opt(Y{});
         assert((*opt).test() == 2);
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
     return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/dereference_const_rvalue.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/dereference_const_rvalue.pass.cpp
@@ -53,7 +53,7 @@ int main(int, char**)
         // Regardless this function should still be noexcept(false) because
         // it has a narrow contract.
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<X> opt(X{});
         static_assert((*cuda::std::move(opt)).test() == 5, "");
@@ -62,7 +62,7 @@ int main(int, char**)
         constexpr optional<Y> opt(Y{});
         assert((*cuda::std::move(opt)).test() == 2);
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
     return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/dereference_rvalue.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/dereference_rvalue.pass.cpp
@@ -65,9 +65,9 @@ int main(int, char**)
         optional<X> opt(X{});
         assert((*cuda::std::move(opt)).test() == 6);
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     static_assert(test() == 7, "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
     return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/has_value.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/has_value.pass.cpp
@@ -34,7 +34,7 @@ int main(int, char**)
         optional<int> opt(0);
         assert(opt.has_value());
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<int> opt;
         static_assert(!opt.has_value(), "");
@@ -43,7 +43,7 @@ int main(int, char**)
         constexpr optional<int> opt(0);
         static_assert(opt.has_value(), "");
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/op_arrow.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/op_arrow.pass.cpp
@@ -60,9 +60,9 @@ int main(int, char**)
     }
     {
 #if defined(_LIBCUDACXX_ADDRESSOF)
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
         static_assert(test() == 3, "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
     }
 

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/op_arrow_const.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/op_arrow_const.pass.cpp
@@ -54,7 +54,7 @@ int main(int, char**)
         // Regardless this function should still be noexcept(false) because
         // it has a narrow contract.
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<X> opt(X{});
 #if defined(_LIBCUDACXX_ADDRESSOF)
@@ -75,7 +75,7 @@ int main(int, char**)
         unused(opt);
 #endif
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
     return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value.pass.cpp
@@ -83,9 +83,9 @@ int main(int, char**)
     }
 #endif
     assert(test() == 7);
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     static_assert(test() == 7, "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value_const.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value_const.pass.cpp
@@ -50,12 +50,12 @@ int main(int, char**)
         ASSERT_NOT_NOEXCEPT(opt.value());
         ASSERT_SAME_TYPE(decltype(opt.value()), X const&);
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<X> opt(in_place);
         static_assert(opt.value().test() == 3, "");
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         const optional<X> opt(in_place);
         assert(opt.value().test() == 3);

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value_const_rvalue.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value_const_rvalue.pass.cpp
@@ -50,12 +50,12 @@ int main(int, char**)
         ASSERT_NOT_NOEXCEPT(cuda::std::move(opt).value());
         ASSERT_SAME_TYPE(decltype(cuda::std::move(opt).value()), X const&&);
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<X> opt(in_place);
         static_assert(cuda::std::move(opt).value().test() == 5, "");
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         const optional<X> opt(in_place);
         assert(cuda::std::move(opt).value().test() == 5);

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value_or_const.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value_or_const.pass.cpp
@@ -45,7 +45,7 @@ struct X
 
 int main(int, char**)
 {
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr optional<X> opt(2);
         constexpr Y y(3);
@@ -64,7 +64,7 @@ int main(int, char**)
         constexpr optional<X> opt;
         static_assert(opt.value_or(Y(3)) == 4, "");
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         const optional<X> opt(2);
         const Y y(3);

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value_rvalue.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.object/optional.object.observe/value_rvalue.pass.cpp
@@ -81,9 +81,9 @@ int main(int, char**)
     }
 #endif
     assert(test() == 7);
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     static_assert(test() == 7, "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 
   return 0;
 }

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/equal.pass.cpp
@@ -95,9 +95,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/greater_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/greater_equal.pass.cpp
@@ -93,9 +93,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/greater_than.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/greater_than.pass.cpp
@@ -91,9 +91,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/less_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/less_equal.pass.cpp
@@ -93,9 +93,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/less_than.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/less_than.pass.cpp
@@ -91,9 +91,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/not_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.relops/not_equal.pass.cpp
@@ -96,9 +96,9 @@ constexpr bool test() {
 int main(int, char**) {
   test();
 #if TEST_STD_VER >= 17
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test());
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
 
   return 0;

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.specalg/make_optional.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.specalg/make_optional.pass.cpp
@@ -38,13 +38,13 @@ int main(int, char**)
         ASSERT_SAME_TYPE(decltype(opt), cuda::std::optional<int*>);
         assert(*opt == arr);
     }
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr auto opt = cuda::std::make_optional(2);
         ASSERT_SAME_TYPE(decltype(opt), const cuda::std::optional<int>);
         static_assert(opt.value() == 2, "");
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         auto opt = cuda::std::make_optional(2);
         ASSERT_SAME_TYPE(decltype(opt), cuda::std::optional<int>);

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.specalg/make_optional_explicit.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.specalg/make_optional_explicit.pass.cpp
@@ -28,13 +28,13 @@
 
 int main(int, char**)
 {
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
     {
         constexpr auto opt = cuda::std::make_optional<int>('a');
         static_assert(*opt == int('a'), "");
         assert(*opt == int('a'));
     }
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #ifdef _LIBCUDACXX_HAS_STRING
     {
         cuda::std::string s = "123";

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.specalg/make_optional_explicit_initializer_list.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.specalg/make_optional_explicit_initializer_list.pass.cpp
@@ -57,9 +57,9 @@ int main(int, char**)
 {
   test();
 #if defined(_LIBCUDACXX_ADDRESSOF)
-#if !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#if !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
   static_assert(test(), "");
-#endif // !(defined(TEST_COMPILER_NVCC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
+#endif // !(defined(TEST_COMPILER_CUDACC_BELOW_11_3) && defined(TEST_COMPILER_CLANG))
 #endif
   /*
   {

--- a/libcudacxx/.upstream-tests/test/support/test_macros.h
+++ b/libcudacxx/.upstream-tests/test/support/test_macros.h
@@ -439,9 +439,9 @@ constexpr bool unused(T &&) {return true;}
 #define TEST_CONSTEXPR_GLOBAL _LIBCUDACXX_CONSTEXPR_GLOBAL
 
 // Some convenience macros for checking nvcc versions
-#if defined(TEST_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1103000
-#define TEST_COMPILER_NVCC_BELOW_11_3
-#endif // defined(TEST_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1103000
+#if defined(__CUDACC__) && _LIBCUDACXX_CUDACC_VER < 1103000
+#define TEST_COMPILER_CUDACC_BELOW_11_3
+#endif // defined(__CUDACC__) && _LIBCUDACXX_CUDACC_VER < 1103000
 
 #if defined(TEST_COMPILER_MSVC)
 #if _MSC_VER < 1920

--- a/libcudacxx/include/cuda/std/detail/__annotated_ptr
+++ b/libcudacxx/include/cuda/std/detail/__annotated_ptr
@@ -61,9 +61,9 @@ namespace __detail_ap {
     if (std::is_same<_Property, access_property::shared>::value == true) {
       bool __b = __isShared(__ptr);
       _LIBCUDACXX_ASSERT(__b, "");
-#if !defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_2)
+#if !defined(_LIBCUDACXX_CUDACC_BELOW_11_2)
       __builtin_assume(__b);
-#endif // !defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_2)
+#endif // !defined(_LIBCUDACXX_CUDACC_BELOW_11_2)
     } else if (std::is_same<_Property, access_property::global>::value == true ||
                std::is_same<_Property, access_property::normal>::value == true ||
                std::is_same<_Property, access_property::persisting>::value == true ||
@@ -71,9 +71,9 @@ namespace __detail_ap {
                std::is_same<_Property, access_property>::value) {
       bool __b = __isGlobal(__ptr);
       _LIBCUDACXX_ASSERT(__b, "");
-#if !defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_2)
+#if !defined(_LIBCUDACXX_CUDACC_BELOW_11_2)
       __builtin_assume(__b);
-#endif // !defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_2)
+#endif // !defined(_LIBCUDACXX_CUDACC_BELOW_11_2)
     }
 
     return __ptr;

--- a/libcudacxx/include/cuda/std/detail/__config
+++ b/libcudacxx/include/cuda/std/detail/__config
@@ -11,18 +11,6 @@
 #ifndef __cuda_std__
 #define __cuda_std__
 
-#ifdef __CUDACC__
-    #if defined(__clang__) || defined(__FLT16_MANT_DIG__)
-        #include <cuda_fp16.h>
-    #endif
-    #define _LIBCUDACXX_CUDACC_VER_MAJOR __CUDACC_VER_MAJOR__
-    #define _LIBCUDACXX_CUDACC_VER_MINOR __CUDACC_VER_MINOR__
-    #define _LIBCUDACXX_CUDACC_VER_BUILD __CUDACC_VER_BUILD__
-    #define _LIBCUDACXX_CUDACC_VER                                                  \
-        _LIBCUDACXX_CUDACC_VER_MAJOR * 100000 + _LIBCUDACXX_CUDACC_VER_MINOR * 1000 + \
-        _LIBCUDACXX_CUDACC_VER_BUILD
-#endif
-
 #define _LIBCUDACXX_CUDA_API_VERSION 2002000
 
 #define _LIBCUDACXX_CUDA_API_VERSION_MAJOR \

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -47,17 +47,31 @@
 #  define _LIBCUDACXX_COMPILER_CLANG_CUDA
 #endif
 
-// Some convenience macros to filter nvcc versions
-#if defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1102000
-#define _LIBCUDACXX_COMPILER_NVCC_BELOW_11_2
-#endif // defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1102000
-#if defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1103000
-#define _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3
-#endif // defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1103000
+#ifdef __CUDACC__
+#  define _LIBCUDACXX_CUDACC
+#  define _LIBCUDACXX_CUDACC_VER_MAJOR __CUDACC_VER_MAJOR__
+#  define _LIBCUDACXX_CUDACC_VER_MINOR __CUDACC_VER_MINOR__
+#  define _LIBCUDACXX_CUDACC_VER_BUILD __CUDACC_VER_BUILD__
+#  define _LIBCUDACXX_CUDACC_VER                                                  \
+      _LIBCUDACXX_CUDACC_VER_MAJOR * 100000 + _LIBCUDACXX_CUDACC_VER_MINOR * 1000 + \
+      _LIBCUDACXX_CUDACC_VER_BUILD
 
-#if defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1108000
-#define _LIBCUDACXX_COMPILER_NVCC_BELOW_11_8
-#endif // defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_CUDACC_VER < 1108000
+// TODO: Determine if this is necessary, I don't know why we automatically include this in <config>
+#  if defined(__clang__) || defined(__FLT16_MANT_DIG__)
+#    include <cuda_fp16.h>
+#  endif
+#endif
+
+// Some convenience macros to filter CUDACC versions
+#if defined(_LIBCUDACXX_CUDACC) && _LIBCUDACXX_CUDACC_VER < 1102000
+#define _LIBCUDACXX_CUDACC_BELOW_11_2
+#endif // defined(_LIBCUDACXX_CUDACC) && _LIBCUDACXX_CUDACC_VER < 1102000
+#if defined(_LIBCUDACXX_CUDACC) && _LIBCUDACXX_CUDACC_VER < 1103000
+#define _LIBCUDACXX_CUDACC_BELOW_11_3
+#endif // defined(_LIBCUDACXX_CUDACC) && _LIBCUDACXX_CUDACC_VER < 1103000
+#if defined(_LIBCUDACXX_CUDACC) && _LIBCUDACXX_CUDACC_VER < 1108000
+#define _LIBCUDACXX_CUDACC_BELOW_11_8
+#endif // defined(_LIBCUDACXX_CUDACC) && _LIBCUDACXX_CUDACC_VER < 1108000
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #  define _LIBCUDACXX_HAS_PRAGMA_MSVC_WARNING
@@ -651,7 +665,7 @@ extern "C++" {
 #define _LIBCUDACXX_IS_LVALUE_REFERENCE(...) __is_lvalue_reference(__VA_ARGS__)
 #endif // __check_builtin(is_lvalue_reference)
 
-#if defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+#if defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
 #define _LIBCUDACXX_USE_IS_LVALUE_REFERENCE_FALLBACK
 #endif // nvcc < 11.3
 
@@ -677,7 +691,7 @@ extern "C++" {
 #define _LIBCUDACXX_IS_OBJECT(...) __is_object(__VA_ARGS__)
 #endif // __check_builtin(is_object)
 
-#if defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+#if defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
 #define _LIBCUDACXX_USE_IS_OBJECT_FALLBACK
 #endif // nvcc < 11.3
 
@@ -779,7 +793,7 @@ extern "C++" {
 #define _LIBCUDACXX_IS_UNSIGNED(...) __is_unsigned(__VA_ARGS__)
 #endif // __check_builtin(is_unsigned)
 
-#if defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+#if defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
 #define _LIBCUDACXX_USE_IS_UNSIGNED_FALLBACK
 #endif // nvcc < 11.3
 
@@ -864,7 +878,7 @@ extern "C++" {
   _Pragma(_LIBCUDACXX_TOSTRING(diagnostic push)) \
   _Pragma(_LIBCUDACXX_TOSTRING(diag_suppress _WARNING))
 # define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING) _Pragma(_LIBCUDACXX_TOSTRING(diagnostic pop))
-#else // _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3
+#else // _LIBCUDACXX_CUDACC_BELOW_11_3
 # define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING) _Pragma(_LIBCUDACXX_TOSTRING(diag_suppress _WARNING))
 # define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING)  _Pragma(_LIBCUDACXX_TOSTRING(diag_default _WARNING))
 #endif // !__NVCC_DIAG_PRAGMA_SUPPORT__
@@ -1132,7 +1146,7 @@ typedef __char32_t char32_t;
 #endif // !_LIBCUDACXX_HAS_NO_INT128
 
 #ifndef _LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#if defined(__CUDACC__)
+#if defined(_LIBCUDACXX_CUDACC)
 #  define _LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #endif
 #endif // _LIBCUDACXX_HAS_NO_LONG_DOUBLE
@@ -1148,7 +1162,7 @@ typedef __char32_t char32_t;
 // [[msvc::no_unique_address]] though. If/when it does implement
 // [[msvc::no_unique_address]], this should be preferred though.
 #  define _LIBCUDACXX_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
-#elif defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) \
+#elif defined(_LIBCUDACXX_CUDACC_BELOW_11_3) \
  || (__has_cpp_attribute(no_unique_address) < 201803L)
 #  define _LIBCUDACXX_HAS_NO_ATTRIBUTE_NO_UNIQUE_ADDRESS
 #  define _LIBCUDACXX_NO_UNIQUE_ADDRESS
@@ -1421,17 +1435,17 @@ typedef __char32_t char32_t;
 #  define _LIBCUDACXX_HIDE_FROM_ABI_AFTER_V1 _LIBCUDACXX_HIDE_FROM_ABI
 #endif
 
-#ifdef __CUDACC__
-#define _LIBCUDACXX_HOST __host__
-#define _LIBCUDACXX_DEVICE __device__
-#define _LIBCUDACXX_HOST_DEVICE __host__ __device__
-#define _LIBCUDACXX_FORCE_INLINE __forceinline__
-#else // ^^^ __CUDACC__ ^^^ / vvv !__CUDACC__
-#define _LIBCUDACXX_HOST
-#define _LIBCUDACXX_DEVICE
-#define _LIBCUDACXX_HOST_DEVICE
-#define _LIBCUDACXX_FORCE_INLINE
-#endif // !__CUDACC__
+#ifdef _LIBCUDACXX_CUDACC
+#  define _LIBCUDACXX_HOST __host__
+#  define _LIBCUDACXX_DEVICE __device__
+#  define _LIBCUDACXX_HOST_DEVICE __host__ __device__
+#  define _LIBCUDACXX_FORCE_INLINE __forceinline__
+#else // ^^^ _LIBCUDACXX_CUDACC ^^^ / vvv !_LIBCUDACXX_CUDACC
+#  define _LIBCUDACXX_HOST
+#  define _LIBCUDACXX_DEVICE
+#  define _LIBCUDACXX_HOST_DEVICE
+#  define _LIBCUDACXX_FORCE_INLINE
+#endif // !_LIBCUDACXX_CUDACC
 
 // Just so we can migrate to the new macros gradually.
 
@@ -1671,7 +1685,7 @@ typedef unsigned int   char32_t;
 // by defining _LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS.
 // NVCC 11.1 and 11.2 are broken with the deprecated attribute, so disable it
 #if !defined(_LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS) \
- && !defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+ && !defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
 #  if __has_attribute(deprecated)
 #    define _LIBCUDACXX_DEPRECATED __attribute__ ((deprecated))
 #  elif _LIBCUDACXX_STD_VER > 11
@@ -1972,7 +1986,7 @@ extern "C" _LIBCUDACXX_FUNC_VIS void __sanitizer_annotate_contiguous_container(
 #endif
 
 // CUDA Atomics supersede host atomics in order to insert the host/device dispatch layer
-#if defined(_LIBCUDACXX_COMPILER_NVCC) || defined(_LIBCUDACXX_COMPILER_NVRTC) || defined(_LIBCUDACXX_COMPILER_NVHPC) || defined(__CUDACC__)
+#if defined(_LIBCUDACXX_COMPILER_NVCC) || defined(_LIBCUDACXX_COMPILER_NVRTC) || defined(_LIBCUDACXX_COMPILER_NVHPC) || defined(_LIBCUDACXX_CUDACC)
 #  define _LIBCUDACXX_HAS_CUDA_ATOMIC_IMPL
 #endif
 
@@ -2087,7 +2101,7 @@ extern "C" _LIBCUDACXX_FUNC_VIS void __sanitizer_annotate_contiguous_container(
 #define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
 #elif defined(_MSC_VER)
 #define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
-#elif defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_8)
+#elif defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
 #define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
 #endif
 
@@ -2224,7 +2238,7 @@ extern "C" _LIBCUDACXX_FUNC_VIS void __sanitizer_annotate_contiguous_container(
 #endif
 
 #if !defined(_LIBCUDACXX_DISABLE_EXEC_CHECK)
-#if defined(__CUDACC__)                       \
+#if defined(_LIBCUDACXX_CUDACC)                       \
  && !defined(_LIBCUDACXX_COMPILER_NVRTC)      \
  && !defined(_LIBCUDACXX_COMPILER_NVHPC_CUDA) \
  && !defined(_LIBCUDACXX_COMPILER_CLANG_CUDA)

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -861,30 +861,29 @@ extern "C++" {
 
 #define _LIBCUDACXX_TOSTRING2(_STR) #_STR
 #define _LIBCUDACXX_TOSTRING(_STR) _LIBCUDACXX_TOSTRING2(_STR)
-#if defined(_LIBCUDACXX_COMPILER_NVCC) \
- || defined(_LIBCUDACXX_COMPILER_NVRTC)
-#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
-#if defined(_LIBCUDACXX_COMPILER_MSVC)
-# define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING) __pragma(_LIBCUDACXX_TOSTRING(nv_diag_suppress _WARNING))
-# define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING)  __pragma(_LIBCUDACXX_TOSTRING(nv_diag_default _WARNING))
-#else // ^^^ MSVC ^^^ / vvv not MSVC
-# define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING)     \
-  _Pragma(_LIBCUDACXX_TOSTRING(nv_diagnostic push)) \
-  _Pragma(_LIBCUDACXX_TOSTRING(nv_diag_suppress _WARNING))
-# define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING) _Pragma(_LIBCUDACXX_TOSTRING(nv_diagnostic pop))
-#endif // not MSVC
-#elif defined(_LIBCUDACXX_COMPILER_NVHPC)
-# define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING)  \
-  _Pragma(_LIBCUDACXX_TOSTRING(diagnostic push)) \
-  _Pragma(_LIBCUDACXX_TOSTRING(diag_suppress _WARNING))
-# define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING) _Pragma(_LIBCUDACXX_TOSTRING(diagnostic pop))
-#else // _LIBCUDACXX_CUDACC_BELOW_11_3
-# define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING) _Pragma(_LIBCUDACXX_TOSTRING(diag_suppress _WARNING))
-# define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING)  _Pragma(_LIBCUDACXX_TOSTRING(diag_default _WARNING))
-#endif // !__NVCC_DIAG_PRAGMA_SUPPORT__
-#else // ^^^ _LIBCUDACXX_COMPILER_NVCC || _LIBCUDACXX_COMPILER_NVRTC ^^^ / vvv other compiler vvv
-# define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING)
-# define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING)
+#if defined(_LIBCUDACXX_CUDACC)
+#  if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
+#    if defined(_LIBCUDACXX_COMPILER_MSVC)
+#      define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING) __pragma(_LIBCUDACXX_TOSTRING(nv_diag_suppress _WARNING))
+#      define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING)  __pragma(_LIBCUDACXX_TOSTRING(nv_diag_default _WARNING))
+#    else // ^^^ MSVC ^^^ / vvv not MSVC
+#      define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING)     \
+         _Pragma(_LIBCUDACXX_TOSTRING(nv_diagnostic push)) \
+         _Pragma(_LIBCUDACXX_TOSTRING(nv_diag_suppress _WARNING))
+#      define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING) _Pragma(_LIBCUDACXX_TOSTRING(nv_diagnostic pop))
+#    endif // not MSVC
+#  elif defined(_LIBCUDACXX_COMPILER_NVHPC)
+#    define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING)  \
+       _Pragma(_LIBCUDACXX_TOSTRING(diagnostic push)) \
+       _Pragma(_LIBCUDACXX_TOSTRING(diag_suppress _WARNING))
+#    define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING) _Pragma(_LIBCUDACXX_TOSTRING(diagnostic pop))
+#  else // _LIBCUDACXX_CUDACC_BELOW_11_3
+#    define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING) _Pragma(_LIBCUDACXX_TOSTRING(diag_suppress _WARNING))
+#    define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING)  _Pragma(_LIBCUDACXX_TOSTRING(diag_default _WARNING))
+#  endif // !__NVCC_DIAG_PRAGMA_SUPPORT__
+#else // ^^^ _LIBCUDACXX_CUDACC ^^^ / vvv other compiler vvv
+#  define _LIBCUDACXX_NV_DIAG_SUPPRESS(_WARNING)
+#  define _LIBCUDACXX_NV_DIAG_DEFAULT(_WARNING)
 #endif // other compilers
 
 #if defined(_LIBCUDACXX_COMPILER_CLANG)

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__expected/expected_base.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__expected/expected_base.h
@@ -367,7 +367,7 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
 
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   constexpr __expected_storage() noexcept = default;
 
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -461,7 +461,7 @@ struct __expected_copy : __expected_storage<_Tp, _Err>
   using __base = __expected_storage<_Tp, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   constexpr __expected_copy() noexcept = default;
 
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -481,7 +481,7 @@ struct __expected_copy<_Tp, _Err, false> : __expected_storage<_Tp, _Err>
 
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_copy(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -519,7 +519,7 @@ struct __expected_move : __expected_copy<_Tp, _Err>
   using __base = __expected_copy<_Tp, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   constexpr __expected_move() noexcept = default;
 
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -538,7 +538,7 @@ struct __expected_move<_Tp, _Err, false> : __expected_copy<_Tp, _Err>
   using __base = __expected_copy<_Tp, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_move(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -580,7 +580,7 @@ struct __expected_copy_assign : __expected_move<_Tp, _Err>
   using __base = __expected_move<_Tp, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   constexpr __expected_copy_assign() noexcept = default;
 
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -599,7 +599,7 @@ struct __expected_copy_assign<_Tp, _Err, false> : __expected_move<_Tp, _Err>
   using __base = __expected_move<_Tp, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_copy_assign(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -649,7 +649,7 @@ struct __expected_move_assign : __expected_copy_assign<_Tp, _Err>
   using __base = __expected_copy_assign<_Tp, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   constexpr __expected_move_assign() noexcept = default;
 
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -668,7 +668,7 @@ struct __expected_move_assign<_Tp, _Err, false> : __expected_copy_assign<_Tp, _E
   using __base = __expected_copy_assign<_Tp, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_move_assign(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -852,7 +852,7 @@ struct __expected_storage<void, _Err> : __expected_destruct<void, _Err>
   using __base = __expected_destruct<void, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   constexpr __expected_storage() noexcept = default;
 
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -880,7 +880,7 @@ struct __expected_copy<void, _Err, false> : __expected_storage<void, _Err>
   using __base = __expected_storage<void, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_copy(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -913,7 +913,7 @@ struct __expected_move<void, _Err, false> : __expected_copy<void, _Err>
   using __base = __expected_copy<void, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_move(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -946,7 +946,7 @@ struct __expected_copy_assign<void, _Err, false> : __expected_move<void, _Err>
   using __base = __expected_move<void, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_copy_assign(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -988,7 +988,7 @@ struct __expected_move_assign<void, _Err, false> : __expected_copy_assign<void, 
   using __base = __expected_copy_assign<void, _Err>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_move_assign(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__mdspan/standard_layout_static_array.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__mdspan/standard_layout_static_array.h
@@ -614,7 +614,7 @@ struct __partially_static_sizes_tagged
   using __psa_impl_t = __standard_layout_psa<
       _Tag, T, _static_t, _CUDA_VSTD::integer_sequence<_static_t, __values_or_sentinals...>>;
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+ || defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __psa_impl_t, _Args...), int> = 0>
   __MDSPAN_FORCE_INLINE_FUNCTION constexpr
   __partially_static_sizes_tagged(_Args&&... __args) noexcept(noexcept(__psa_impl_t(_CUDA_VSTD::declval<_Args>()...)))
@@ -666,7 +666,7 @@ private:
   ) noexcept : __base_t(_CUDA_VSTD::move(__vals)) { }
 public:
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+ || defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
   template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base_t, _Args...), int> = 0>
   __MDSPAN_FORCE_INLINE_FUNCTION constexpr
   __partially_static_sizes(_Args&&... __args) noexcept(noexcept(__base_t(_CUDA_VSTD::declval<_Args>()...)))

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__mdspan/static_array.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__mdspan/static_array.h
@@ -263,7 +263,7 @@ private:
   using __base_t = typename __partially_static_array_impl_maker<_Tp, _static_t, _ValsSeq, __sentinal>::__impl_base;
 public:
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+ || defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
   constexpr __partially_static_array_with_sentinal() = default;
 
   template<class... _Args>
@@ -288,7 +288,7 @@ private:
     T, _static_t, _CUDA_VSTD::integer_sequence<_static_t, __values_or_sentinals...>>;
 public:
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+ || defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
   constexpr __partially_static_sizes() = default;
 
   template<class... _Args>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/bit
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/bit
@@ -192,7 +192,7 @@ int __fallback_popc64(uint64_t __x) {
 inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 int __libcpp_ctz(unsigned __x) noexcept {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
   if (!__libcpp_is_constant_evaluated()) {
     NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
@@ -212,7 +212,7 @@ int __libcpp_ctz(unsigned __x) noexcept {
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
 int __libcpp_ctz(unsigned long __x) noexcept {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
   if (!__libcpp_is_constant_evaluated()) {
     NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
@@ -252,7 +252,7 @@ int __libcpp_ctz(unsigned long long __x) _NOEXCEPT {
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
 int __libcpp_clz(unsigned __x)           _NOEXCEPT {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
   if (!__libcpp_is_constant_evaluated()) {
     NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
@@ -271,7 +271,7 @@ int __libcpp_clz(unsigned __x)           _NOEXCEPT {
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
 int __libcpp_clz(unsigned long __x)      _NOEXCEPT {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
   if (!__libcpp_is_constant_evaluated()) {
     NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
@@ -291,7 +291,7 @@ int __libcpp_clz(unsigned long __x)      _NOEXCEPT {
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
 int __libcpp_clz(unsigned long long __x) _NOEXCEPT {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
   if (!__libcpp_is_constant_evaluated()) {
     NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
@@ -311,7 +311,7 @@ int __libcpp_clz(unsigned long long __x) _NOEXCEPT {
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
 int __libcpp_popcount(unsigned __x)           _NOEXCEPT {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
   if (!__libcpp_is_constant_evaluated()) {
     NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
@@ -331,7 +331,7 @@ int __libcpp_popcount(unsigned __x)           _NOEXCEPT {
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
 int __libcpp_popcount(unsigned long __x)      _NOEXCEPT {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
   if (!__libcpp_is_constant_evaluated()) {
     NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
@@ -351,7 +351,7 @@ int __libcpp_popcount(unsigned long __x)      _NOEXCEPT {
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
 int __libcpp_popcount(unsigned long long __x) _NOEXCEPT {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
   if (!__libcpp_is_constant_evaluated()) {
     NV_IF_ELSE_TARGET(NV_IS_DEVICE, (

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -613,7 +613,7 @@ _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR __enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isnan(_A1 __lcpp_x) _NOEXCEPT
 {
-#if defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_8)
+#if defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
     return __isnan(__lcpp_x);
 #elif __has_builtin(__builtin_isnan)
     return __builtin_isnan(__lcpp_x);
@@ -635,7 +635,7 @@ _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR __enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isinf(_A1 __lcpp_x) _NOEXCEPT
 {
-#if defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_8)
+#if defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
     return __isinf(__lcpp_x);
 #elif __has_builtin(__builtin_isinf)
     return __builtin_isinf(__lcpp_x);
@@ -657,7 +657,7 @@ _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR __enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isfinite(_A1 __lcpp_x) _NOEXCEPT
 {
-#if defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_8)
+#if defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
     return !__isinf(__lcpp_x) && !__isnan(__lcpp_x);
 #elif __has_builtin(__builtin_isfinite)
     return __builtin_isfinite(__lcpp_x);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
@@ -98,13 +98,13 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 #pragma GCC system_header
 #endif
 
-#if defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_2)
+#if defined(_LIBCUDACXX_CUDACC_BELOW_11_2)
 #ifdef __CUDA_ARCH__
 #  define _LIBCUDACXX_UNREACHABLE() __trap()
 #else // ^^^ __CUDA_ARCH__ ^^^ / vvv !__CUDA_ARCH__ vvv
 #  define _LIBCUDACXX_UNREACHABLE() __builtin_unreachable()
 #endif // !__CUDA_ARCH__
-#elif defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+#elif defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
 #ifdef __CUDA_ARCH__
 #  define _LIBCUDACXX_UNREACHABLE() __builtin_assume(false)
 #else // ^^^ __CUDA_ARCH__ ^^^ / vvv !__CUDA_ARCH__ vvv

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -347,7 +347,7 @@ struct __optional_storage_base : __optional_destruct_base<_Tp>
 
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
     template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __optional_storage_base(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -433,7 +433,7 @@ struct __optional_copy_base : __optional_storage_base<_Tp>
 
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
     constexpr __optional_copy_base() noexcept = default;
 
     template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -453,7 +453,7 @@ struct __optional_copy_base<_Tp, false> : __optional_storage_base<_Tp>
 
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
     template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __optional_copy_base(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -486,7 +486,7 @@ struct __optional_move_base : __optional_copy_base<_Tp>
 
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
     constexpr __optional_move_base() noexcept = default;
 
     template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -507,7 +507,7 @@ struct __optional_move_base<_Tp, false> : __optional_copy_base<_Tp>
 
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
     template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __optional_move_base(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -540,7 +540,7 @@ struct __optional_copy_assign_base : __optional_move_base<_Tp>
     using __base = __optional_move_base<_Tp>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
     constexpr __optional_copy_assign_base() noexcept = default;
 
     template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -559,7 +559,7 @@ struct __optional_copy_assign_base<_Tp, false> : __optional_move_base<_Tp>
     using __base = __optional_move_base<_Tp>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
     template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __optional_copy_assign_base(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))
@@ -592,7 +592,7 @@ struct __optional_move_assign_base : __optional_copy_assign_base<_Tp>
     using __base = __optional_copy_assign_base<_Tp>;
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
     constexpr __optional_move_assign_base() noexcept = default;
 
     template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
@@ -613,7 +613,7 @@ struct __optional_move_assign_base<_Tp, false> : __optional_copy_assign_base<_Tp
 
 // nvbug3961621
 #if defined(_LIBCUDACXX_COMPILER_NVRTC)  \
- || (defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
+ || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3) && defined(_LIBCUDACXX_COMPILER_CLANG))
     template<class... _Args, __enable_if_t<_LIBCUDACXX_TRAIT(is_constructible, __base, _Args...), int> = 0>
    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __optional_move_assign_base(_Args&&... __args) noexcept(noexcept(__base(_CUDA_VSTD::declval<_Args>()...)))

--- a/libcudacxx/include/cuda/stream_ref
+++ b/libcudacxx/include/cuda/stream_ref
@@ -109,9 +109,9 @@ public:
    * \return true if equal, false if unequal
    */
 
-#if !defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+#if !defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE
-#endif // !defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+#endif // !defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
   friend constexpr bool operator==(const stream_ref& __lhs, const stream_ref& __rhs) noexcept
   {
     return __lhs.__stream == __rhs.__stream;
@@ -127,9 +127,9 @@ public:
    * \param rhs The second `stream_view` to compare
    * \return true if unequal, false if equal
    */
-#if !defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+#if !defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE
-#endif // !defined(_LIBCUDACXX_COMPILER_NVCC_BELOW_11_3)
+#endif // !defined(_LIBCUDACXX_CUDACC_BELOW_11_3)
   friend constexpr bool operator!=(const stream_ref& __lhs, const stream_ref& __rhs) noexcept
   {
     return __lhs.__stream != __rhs.__stream;


### PR DESCRIPTION
## Description

closes #328

This disconnects some logic based on the presence of NVCC from the presence of CUDACC.

Might be beneficial to `clang-cuda` as well.

Before patch:
```
PS C:\cccl> nvcc test.cpp -x c++ -std=c++14  -Icccl/thrust -Icccl/libcudacxx/include -Icccl/cub
test.cpp
C:\cccl\cccl\libcudacxx\include\cuda\std\detail\libcxx\include\__concepts\../__concepts/convertible_to.h(41): warning C4081: expected 'identifier'; found 'string'
C:\cccl\cccl\libcudacxx\include\cuda\std\detail\libcxx\include\__concepts\../__concepts/convertible_to.h(67): warning C4081: expected 'identifier'; found 'string'
C:\cccl\cccl\libcudacxx\include\cuda\std\detail\libcxx\include\__concepts\../__concepts/swappable.h(39): warning C4081: expected 'identifier'; found 'string'
C:\cccl\cccl\libcudacxx\include\cuda\std\detail\libcxx\include\__concepts\../__concepts/swappable.h(220): warning C4081: expected 'identifier'; found 'string'
```

After patch:
```
PS C:\cccl> nvcc test.cpp -x c++ -std=c++14  -Icccl/thrust -Icccl/libcudacxx/include -Icccl/cub
test.cpp
```

## Checklist
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
