### PR TITLE
Use global qualification for internal use

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/invocable.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/invocable.h
@@ -49,8 +49,9 @@ concept __invoke_constructible = requires(_Fun&& __fun, _Args&&... __args) {
 template<class _Fn, class... _Args>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   _Invocable_,
-  requires(_Fn&& __fn, _Args&&... __args) //
-  (_CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fn>(__fn), _CUDA_VSTD::forward<_Args>(__args)...)));
+  requires(_Fn&& __fn, _Args&&... __args)(
+    (_CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fn>(__fn), _CUDA_VSTD::forward<_Args>(__args)...))
+  ));
 
 template<class _Fn, class... _Args>
 _LIBCUDACXX_CONCEPT invocable = _LIBCUDACXX_FRAGMENT(_Invocable_, _Fn, _Args...);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -1455,13 +1455,13 @@ typedef __char32_t char32_t;
 #ifdef __cuda_std__
 #  define _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION namespace cuda { namespace std {
 #  define _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION } }
-#  define _CUDA_VSTD cuda::std::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_VRANGES cuda::std::ranges::_LIBCUDACXX_ABI_NAMESPACE
+#  define _CUDA_VSTD ::cuda::std::_LIBCUDACXX_ABI_NAMESPACE
+#  define _CUDA_VRANGES ::cuda::std::ranges::_LIBCUDACXX_ABI_NAMESPACE
 #else
 #  define _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION namespace std {
 #  define _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION }
-#  define _CUDA_VSTD std::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_VRANGES std::ranges::_LIBCUDACXX_ABI_NAMESPACE
+#  define _CUDA_VSTD ::std::_LIBCUDACXX_ABI_NAMESPACE
+#  define _CUDA_VRANGES ::std::ranges::_LIBCUDACXX_ABI_NAMESPACE
 #endif
 
 #ifdef __cuda_std__


### PR DESCRIPTION
Currently our `_CUDA_VSTD` macro uses relative qualification via `cuda::std::`

This might give issues depending on the namespaces a project uses (aka an internal cuda::std namespace)

While defining an internal namespace is evil we should be more resilient against those kind of issues and always fully qualify as `::cuda::std` so that no ambiguities arise