### PR TITLE
Implement `iter_swap` CPO

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.compile.pass.cpp
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// template<class I1, class I2>
+// concept indirectly_swappable;
+
+#include <cuda/std/iterator>
+
+#include "test_macros.h"
+
+template<class T, class ValueType = T>
+struct PointerTo {
+  using value_type = ValueType;
+  __host__ __device__ T& operator*() const;
+};
+
+static_assert(cuda::std::indirectly_swappable<PointerTo<int>>);
+static_assert(cuda::std::indirectly_swappable<PointerTo<int>, PointerTo<int>>);
+
+struct B;
+
+struct A {
+  __host__ __device__ friend void iter_swap(const PointerTo<A>&, const PointerTo<A>&);
+};
+
+// Is indirectly swappable.
+struct B {
+  __host__ __device__ friend void iter_swap(const PointerTo<B>&, const PointerTo<B>&);
+  __host__ __device__ friend void iter_swap(const PointerTo<A>&, const PointerTo<B>&);
+  __host__ __device__ friend void iter_swap(const PointerTo<B>&, const PointerTo<A>&);
+};
+
+// Valid except ranges::iter_swap(i2, i1).
+struct C {
+  __host__ __device__ friend void iter_swap(const PointerTo<C>&, const PointerTo<C>&);
+  __host__ __device__ friend void iter_swap(const PointerTo<A>&, const PointerTo<C>&);
+  __host__ __device__ friend void iter_swap(const PointerTo<C>&, const PointerTo<A>&) = delete;
+};
+
+// Valid except ranges::iter_swap(i1, i2).
+struct D {
+  __host__ __device__ friend void iter_swap(const PointerTo<D>&, const PointerTo<D>&);
+  __host__ __device__ friend void iter_swap(const PointerTo<A>&, const PointerTo<D>&) = delete;
+  __host__ __device__ friend void iter_swap(const PointerTo<D>&, const PointerTo<A>&);
+};
+
+// Valid except ranges::iter_swap(i2, i2).
+struct E {
+  E operator=(const E&) = delete;
+  __host__ __device__ friend void iter_swap(const PointerTo<E>&, const PointerTo<E>&) = delete;
+  __host__ __device__ friend void iter_swap(const PointerTo<A>&, const PointerTo<E>&);
+  __host__ __device__ friend void iter_swap(const PointerTo<E>&, const PointerTo<A>&);
+};
+
+struct F {
+  __host__ __device__ friend void iter_swap(const PointerTo<F>&, const PointerTo<F>&) = delete;
+};
+
+// Valid except ranges::iter_swap(i1, i1).
+struct G {
+  __host__ __device__ friend void iter_swap(const PointerTo<G>&, const PointerTo<G>&);
+  __host__ __device__ friend void iter_swap(const PointerTo<F>&, const PointerTo<G>&);
+  __host__ __device__ friend void iter_swap(const PointerTo<G>&, const PointerTo<F>&);
+};
+
+
+static_assert( cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<B>>);
+static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<C>>);
+static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<D>>);
+static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<E>>);
+static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<G>>);
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.subsumption.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.subsumption.compile.pass.cpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// template<class I1, class I2>
+// concept indirectly_swappable;
+
+#include <cuda/std/iterator>
+
+#include <cuda/std/concepts>
+
+template<class I1, class I2>
+  requires cuda::std::indirectly_readable<I1> && cuda::std::indirectly_readable<I2>
+__host__ __device__ constexpr bool indirectly_swappable_subsumption() {
+  return false;
+}
+
+template<class I1, class I2>
+  requires cuda::std::indirectly_swappable<I1, I2>
+__host__ __device__ constexpr bool indirectly_swappable_subsumption() {
+  return true;
+}
+
+static_assert(indirectly_swappable_subsumption<int*, int*>());
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
@@ -1,0 +1,240 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// template<class I>
+// unspecified iter_swap;
+
+#include <cuda/std/iterator>
+
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+#include "../unqualified_lookup_wrapper.h"
+
+using IterSwapT = decltype(cuda::std::ranges::iter_swap);
+
+struct HasIterSwap {
+  int &value_;
+  __host__ __device__ constexpr explicit HasIterSwap(int &value) : value_(value) { assert(value == 0); }
+
+  __host__ __device__ friend constexpr void iter_swap(HasIterSwap& a, HasIterSwap& b) {
+    a.value_ = 1;
+    b.value_ = 1;
+  }
+  __host__ __device__ friend constexpr void iter_swap(HasIterSwap& a, int& b) {
+    a.value_ = 2;
+    b = 2;
+  }
+};
+
+#ifndef _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3 // nvcc segfaults here
+static_assert( cuda::std::is_invocable_v<IterSwapT, HasIterSwap&, HasIterSwap&>);
+static_assert( cuda::std::is_invocable_v<IterSwapT, HasIterSwap&, int&>);
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int&, HasIterSwap&>);
+
+static_assert( cuda::std::is_invocable_v<IterSwapT&, HasIterSwap&, HasIterSwap&>);
+static_assert( cuda::std::is_invocable_v<IterSwapT&, HasIterSwap&, int&>);
+static_assert(!cuda::std::is_invocable_v<IterSwapT&, int&, HasIterSwap&>);
+
+static_assert( cuda::std::is_invocable_v<IterSwapT&&, HasIterSwap&, HasIterSwap&>);
+static_assert( cuda::std::is_invocable_v<IterSwapT&&, HasIterSwap&, int&>);
+static_assert(!cuda::std::is_invocable_v<IterSwapT&&, int&, HasIterSwap&>);
+#endif // _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3
+
+struct NodiscardIterSwap {
+  __host__ __device__ friend _LIBCUDACXX_NODISCARD_EXT int iter_swap(NodiscardIterSwap&, NodiscardIterSwap&) { return 0; }
+};
+
+__host__ __device__
+void ensureVoidCast(NodiscardIterSwap& a, NodiscardIterSwap& b) { cuda::std::ranges::iter_swap(a, b); }
+
+struct HasRangesSwap {
+  int &value_;
+  __host__ __device__ constexpr explicit HasRangesSwap(int &value) : value_(value) { assert(value == 0); }
+
+  __host__ __device__ friend constexpr void swap(HasRangesSwap& a, HasRangesSwap& b) {
+    a.value_ = 1;
+    b.value_ = 1;
+  }
+  __host__ __device__ friend constexpr void swap(HasRangesSwap& a, int& b) {
+    a.value_ = 2;
+    b = 2;
+  }
+};
+
+struct HasRangesSwapWrapper {
+  using value_type = HasRangesSwap;
+
+  HasRangesSwap &value_;
+  __host__ __device__ constexpr explicit HasRangesSwapWrapper(HasRangesSwap &value) : value_(value) {}
+
+  __host__ __device__ constexpr HasRangesSwap& operator*() const { return value_; }
+};
+
+#ifndef _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3 // nvcc segfaults here
+static_assert( cuda::std::is_invocable_v<IterSwapT, HasRangesSwapWrapper&, HasRangesSwapWrapper&>);
+// Does not satisfy swappable_with, even though swap(X, Y) is valid.
+static_assert(!cuda::std::is_invocable_v<IterSwapT, HasRangesSwapWrapper&, int&>);
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int&, HasRangesSwapWrapper&>);
+#endif // _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3
+
+struct B;
+
+struct A {
+  bool value = false;
+  __host__ __device__ constexpr A& operator=(const B&) {
+    value = true;
+    return *this;
+  };
+};
+
+struct B {
+  bool value = false;
+  __host__ __device__ constexpr B& operator=(const A&) {
+    value = true;
+    return *this;
+  };
+};
+
+struct MoveOnly2;
+
+struct MoveOnly1 {
+  bool value = false;
+
+  MoveOnly1() = default;
+  MoveOnly1(MoveOnly1&&) = default;
+  MoveOnly1& operator=(MoveOnly1&&) = default;
+  MoveOnly1(const MoveOnly1&) = delete;
+  MoveOnly1& operator=(const MoveOnly1&) = delete;
+
+  __host__ __device__ constexpr MoveOnly1& operator=(MoveOnly2 &&) {
+    value = true;
+    return *this;
+  };
+};
+
+struct MoveOnly2 {
+  bool value = false;
+
+  MoveOnly2() = default;
+  MoveOnly2(MoveOnly2&&) = default;
+  MoveOnly2& operator=(MoveOnly2&&) = default;
+  MoveOnly2(const MoveOnly2&) = delete;
+  MoveOnly2& operator=(const MoveOnly2&) = delete;
+
+  __host__ __device__ constexpr MoveOnly2& operator=(MoveOnly1 &&) {
+    value = true;
+    return *this;
+  };
+};
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    int value1 = 0;
+    int value2 = 0;
+    HasIterSwap a(value1), b(value2);
+    cuda::std::ranges::iter_swap(a, b);
+    assert(value1 == 1 && value2 == 1);
+  }
+  {
+    int value1 = 0;
+    int value2 = 0;
+    HasRangesSwap c(value1), d(value2);
+    HasRangesSwapWrapper cWrapper(c), dWrapper(d);
+    cuda::std::ranges::iter_swap(cWrapper, dWrapper);
+    assert(value1 == 1 && value2 == 1);
+  }
+  {
+    int value1 = 0;
+    int value2 = 0;
+    HasRangesSwap c(value1), d(value2);
+    cuda::std::ranges::iter_swap(HasRangesSwapWrapper(c), HasRangesSwapWrapper(d));
+    assert(value1 == 1 && value2 == 1);
+  }
+  {
+    A e; B f;
+    A *ePtr = &e;
+    B *fPtr = &f;
+    cuda::std::ranges::iter_swap(ePtr, fPtr);
+    assert(e.value && f.value);
+  }
+  {
+    MoveOnly1 g; MoveOnly2 h;
+    cuda::std::ranges::iter_swap(&g, &h);
+    assert(g.value && h.value);
+  }
+#if TEST_HAS_BUILTIN(__builtin_is_constant_evaluated)
+  {
+    move_tracker arr[2];
+    cuda::std::ranges::iter_swap(cuda::std::begin(arr), cuda::std::begin(arr) + 1);
+    if (__builtin_is_constant_evaluated()) {
+      assert(arr[0].moves() == 1 && arr[1].moves() == 3);
+    } else
+    {
+      assert(arr[0].moves() == 1 && arr[1].moves() == 2);
+    }
+  }
+#endif
+  {
+    int buff[2] = {1, 2};
+    cuda::std::ranges::iter_swap(buff + 0, buff + 1);
+    assert(buff[0] == 2 && buff[1] == 1);
+
+    cuda::std::ranges::iter_swap(cpp20_input_iterator<int*>(buff), cpp20_input_iterator<int*>(buff + 1));
+    assert(buff[0] == 1 && buff[1] == 2);
+
+    cuda::std::ranges::iter_swap(cpp17_input_iterator<int*>(buff), cpp17_input_iterator<int*>(buff + 1));
+    assert(buff[0] == 2 && buff[1] == 1);
+
+    cuda::std::ranges::iter_swap(forward_iterator<int*>(buff), forward_iterator<int*>(buff + 1));
+    assert(buff[0] == 1 && buff[1] == 2);
+
+    cuda::std::ranges::iter_swap(bidirectional_iterator<int*>(buff), bidirectional_iterator<int*>(buff + 1));
+    assert(buff[0] == 2 && buff[1] == 1);
+
+    cuda::std::ranges::iter_swap(random_access_iterator<int*>(buff), random_access_iterator<int*>(buff + 1));
+    assert(buff[0] == 1 && buff[1] == 2);
+
+    cuda::std::ranges::iter_swap(contiguous_iterator<int*>(buff), contiguous_iterator<int*>(buff + 1));
+    assert(buff[0] == 2 && buff[1] == 1);
+  }
+  return true;
+}
+
+#ifndef _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3 // nvcc segfaults here
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int*>); // too few arguments
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int*, int*, int*>); // too many arguments
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int, int*>);
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int*, int>);
+static_assert(!cuda::std::is_invocable_v<IterSwapT, void*, void*>);
+#endif // _LIBCUDACXX_COMPILER_NVCC_BELOW_11_3
+
+#if TEST_STD_VER > 17
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**, Holder<Incomplete>**>);
+static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**, Holder<Incomplete>**&>);
+static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**&, Holder<Incomplete>**>);
+static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**&, Holder<Incomplete>**&>);
+#endif
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.monadic/or_else.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/optional/optional.monadic/or_else.pass.cpp
@@ -13,10 +13,10 @@
 // template<class F> constexpr optional or_else(F&&) &&;
 // template<class F> constexpr optional or_else(F&&) const&;
 
-#include "MoveOnly.h"
-
 #include <cuda/std/cassert>
 #include <cuda/std/optional>
+
+#include "MoveOnly.h"
 
 struct NonMovable {
   NonMovable() = default;

--- a/libcudacxx/.upstream-tests/test/support/pointer_comparison_test_helper.h
+++ b/libcudacxx/.upstream-tests/test/support/pointer_comparison_test_helper.h
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef POINTER_COMPARISON_TEST_HELPER_H
+#define POINTER_COMPARISON_TEST_HELPER_H
+
+#include <cuda/std/cstdint>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+template <template <class> class CompareTemplate>
+__host__ __device__ void do_pointer_comparison_test() {
+  typedef CompareTemplate<int*> Compare;
+  typedef CompareTemplate<cuda::std::uintptr_t> UIntCompare;
+#if TEST_STD_VER > 11
+  typedef CompareTemplate<void> VoidCompare;
+#else
+  typedef Compare VoidCompare;
+#endif
+
+  Compare comp;
+  UIntCompare ucomp;
+  VoidCompare vcomp;
+  struct {
+    int a, b;
+  } local;
+  int* pointers[] = {&local.a, &local.b, nullptr, &local.a + 1};
+  for (int* lhs : pointers) {
+    for (int* rhs : pointers) {
+      cuda::std::uintptr_t lhs_uint = reinterpret_cast<cuda::std::uintptr_t>(lhs);
+      cuda::std::uintptr_t rhs_uint = reinterpret_cast<cuda::std::uintptr_t>(rhs);
+      assert(comp(lhs, rhs) == ucomp(lhs_uint, rhs_uint));
+      assert(vcomp(lhs, rhs) == ucomp(lhs_uint, rhs_uint));
+    }
+  }
+}
+
+template <class Comp>
+__host__ __device__ void do_pointer_comparison_test(Comp comp) {
+  struct {
+    int a, b;
+  } local;
+  int* pointers[] = {&local.a, &local.b, nullptr, &local.a + 1};
+  for (int* lhs : pointers) {
+    for (int* rhs : pointers) {
+      cuda::std::uintptr_t lhs_uint = reinterpret_cast<cuda::std::uintptr_t>(lhs);
+      cuda::std::uintptr_t rhs_uint = reinterpret_cast<cuda::std::uintptr_t>(rhs);
+      void*          lhs_void = static_cast<void*>(lhs);
+      void*          rhs_void = static_cast<void*>(rhs);
+      assert(comp(lhs, rhs) == comp(lhs_uint, rhs_uint));
+      assert(comp(lhs_void, rhs_void) == comp(lhs_uint, rhs_uint));
+    }
+  }
+}
+
+#endif // POINTER_COMPARISON_TEST_HELPER_H

--- a/libcudacxx/.upstream-tests/test/support/test_iterators.h
+++ b/libcudacxx/.upstream-tests/test/support/test_iterators.h
@@ -935,6 +935,13 @@ class Iterator {
     return prev;
   }
 
+  __host__ __device__ TEST_CONSTEXPR_CXX20 friend void iter_swap(Iterator a, Iterator b) {
+    cuda::std::swap(a.ptr_, b.ptr_);
+    if (a.iter_swaps_) {
+      ++(*a.iter_swaps_);
+    }
+  }
+
   __host__ __device__ constexpr friend value_type&& iter_move(Iterator iter) {
     if (iter.iter_moves_) {
       ++(*iter.iter_moves_);
@@ -1154,6 +1161,13 @@ struct ProxyIterator : ProxyIteratorBase<Base> {
   // it will likely result in a copy rather than a move
   __host__ __device__ friend constexpr Proxy<cuda::std::iter_rvalue_reference_t<Base>> iter_move(const ProxyIterator& p) noexcept {
     return {cuda::std::ranges::iter_move(p.base_)};
+  }
+
+  // Specialization of iter_swap
+  // Note cuda::std::swap(*x, *y) would fail to compile as operator* returns prvalues
+  // and cuda::std::swap takes non-const lvalue references
+  __host__ __device__ friend constexpr void iter_swap(const ProxyIterator& x, const ProxyIterator& y) noexcept {
+    cuda::std::ranges::iter_swap(x.base_, y.base_);
   }
 
   // to satisfy input_iterator

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
@@ -95,6 +95,7 @@ set(files
   __iterator/istream_iterator.h
   __iterator/istreambuf_iterator.h
   __iterator/iter_move.h
+  __iterator/iter_swap.h
   __iterator/iterator.h
   __iterator/iterator_traits.h
   __iterator/move_iterator.h

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__hash_table
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__hash_table
@@ -2429,7 +2429,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__rehash(size_type __nbc)
             size_type __chash = __constrain_hash(__cp->__hash(), __nbc);
             __bucket_list_[__chash] = __pp;
             size_type __phash = __chash;
-            for (__pp = __cp, __cp = __cp->__next_; __cp != nullptr;
+            for (__pp = __cp, void(), __cp = __cp->__next_; __cp != nullptr;
                                                            __cp = __pp->__next_)
             {
                 __chash = __constrain_hash(__cp->__hash(), __nbc);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iter_swap.h
@@ -1,0 +1,176 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+#ifndef _LIBCUDACXX___ITERATOR_ITER_SWAP_H
+#define _LIBCUDACXX___ITERATOR_ITER_SWAP_H
+
+#ifndef __cuda_std__
+#include <__config>
+#endif // __cuda_std__
+
+#include "../__concepts/class_or_enum.h"
+#include "../__concepts/swappable.h"
+#include "../__iterator/concepts.h"
+#include "../__iterator/iter_move.h"
+#include "../__iterator/iterator_traits.h"
+#include "../__iterator/readable_traits.h"
+#include "../__type_traits/remove_cvref.h"
+#include "../__utility/forward.h"
+#include "../__utility/move.h"
+
+#if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+#if _LIBCUDACXX_STD_VER > 14
+
+// [iter.cust.swap]
+
+_LIBCUDACXX_BEGIN_NAMESPACE_RANGES
+_LIBCUDACXX_BEGIN_NAMESPACE_CPO(__iter_swap)
+  template<class _I1, class _I2>
+  void iter_swap(_I1, _I2) = delete;
+
+#if _LIBCUDACXX_STD_VER > 17
+  template<class _T1, class _T2>
+  concept __unqualified_iter_swap =
+    (__class_or_enum<remove_cvref_t<_T1>> || __class_or_enum<remove_cvref_t<_T2>>) &&
+    requires (_T1&& __x, _T2&& __y) {
+      iter_swap(_CUDA_VSTD::forward<_T1>(__x), _CUDA_VSTD::forward<_T2>(__y));
+    };
+
+  template<class _T1, class _T2>
+  concept __readable_swappable = !__unqualified_iter_swap<_T1, _T2>
+                              && indirectly_readable<_T1>
+                              && indirectly_readable<_T2>
+                              && swappable_with<iter_reference_t<_T1>, iter_reference_t<_T2>>;
+
+  template<class _T1, class _T2>
+  concept __moveable_storable = !__unqualified_iter_swap<_T1, _T2>
+                             && !__readable_swappable<_T1, _T2>
+                             && indirectly_movable_storable<_T1, _T2>
+                             && indirectly_movable_storable<_T2, _T1>;
+#else
+  template<class _T1, class _T2>
+  _LIBCUDACXX_CONCEPT_FRAGMENT(
+    __unqualified_iter_swap_,
+    requires(_T1&& __x, _T2&& __y)(
+      requires(__class_or_enum<remove_cvref_t<_T1>> || __class_or_enum<remove_cvref_t<_T2>>),
+      ((void) iter_swap(_CUDA_VSTD::forward<_T1>(__x), _CUDA_VSTD::forward<_T2>(__y)))
+    ));
+
+  template<class _T1, class _T2>
+  _LIBCUDACXX_CONCEPT __unqualified_iter_swap = _LIBCUDACXX_FRAGMENT(__unqualified_iter_swap_, _T1, _T2);
+
+  template<class _T1, class _T2>
+  _LIBCUDACXX_CONCEPT_FRAGMENT(
+    __readable_swappable_,
+    requires()(
+      requires(!__unqualified_iter_swap<_T1, _T2>),
+      requires(indirectly_readable<_T1>),
+      requires(indirectly_readable<_T2>),
+      requires(swappable_with<iter_reference_t<_T1>, iter_reference_t<_T2>>)
+    ));
+
+  template<class _T1, class _T2>
+  _LIBCUDACXX_CONCEPT __readable_swappable = _LIBCUDACXX_FRAGMENT(__readable_swappable_, _T1, _T2);
+
+  template<class _T1, class _T2>
+  _LIBCUDACXX_CONCEPT_FRAGMENT(
+    __moveable_storable_,
+    requires()(
+      requires(!__unqualified_iter_swap<_T1, _T2>),
+      requires(!__readable_swappable<_T1, _T2>),
+      requires(indirectly_movable_storable<_T1, _T2>),
+      requires(indirectly_movable_storable<_T2, _T1>)
+    ));
+
+  template<class _T1, class _T2>
+  _LIBCUDACXX_CONCEPT __moveable_storable = _LIBCUDACXX_FRAGMENT(__moveable_storable_, _T1, _T2);
+#endif // _LIBCUDACXX_STD_VER > 11
+
+  struct __fn {
+  _LIBCUDACXX_TEMPLATE(class _T1, class _T2)
+    (requires __unqualified_iter_swap<_T1, _T2>)
+    _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr void operator()(_T1&& __x, _T2&& __y) const
+      noexcept(noexcept(iter_swap(_CUDA_VSTD::forward<_T1>(__x), _CUDA_VSTD::forward<_T2>(__y))))
+    {
+      (void)iter_swap(_CUDA_VSTD::forward<_T1>(__x), _CUDA_VSTD::forward<_T2>(__y));
+    }
+
+  _LIBCUDACXX_TEMPLATE(class _T1, class _T2)
+    (requires __readable_swappable<_T1, _T2>)
+    _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr void operator()(_T1&& __x, _T2&& __y) const
+      noexcept(noexcept(_CUDA_VRANGES::swap(*_CUDA_VSTD::forward<_T1>(__x), *_CUDA_VSTD::forward<_T2>(__y))))
+    {
+      _CUDA_VRANGES::swap(*_CUDA_VSTD::forward<_T1>(__x), *_CUDA_VSTD::forward<_T2>(__y));
+    }
+
+  _LIBCUDACXX_TEMPLATE(class _T1, class _T2)
+    (requires __moveable_storable<_T2, _T1>)
+    _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr void operator()(_T1&& __x, _T2&& __y) const
+      noexcept(noexcept(iter_value_t<_T2>(_CUDA_VRANGES::iter_move(__y))) &&
+               noexcept(*__y = _CUDA_VRANGES::iter_move(__x)) &&
+               noexcept(*_CUDA_VSTD::forward<_T1>(__x) = declval<iter_value_t<_T2>>()))
+    {
+      iter_value_t<_T2> __old(_CUDA_VRANGES::iter_move(__y));
+      *__y = _CUDA_VRANGES::iter_move(__x);
+      *_CUDA_VSTD::forward<_T1>(__x) = _CUDA_VSTD::move(__old);
+    }
+  };
+_LIBCUDACXX_END_NAMESPACE_CPO
+
+inline namespace __cpo {
+  _LIBCUDACXX_CPO_ACCESSIBILITY auto iter_swap = __iter_swap::__fn{};
+} // namespace __cpo
+_LIBCUDACXX_END_NAMESPACE_RANGES
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+#if _LIBCUDACXX_STD_VER > 17
+template<class _I1, class _I2 = _I1>
+concept indirectly_swappable =
+  indirectly_readable<_I1> && indirectly_readable<_I2> &&
+  requires(const _I1 __i1, const _I2 __i2) {
+    _CUDA_VRANGES::iter_swap(__i1, __i1);
+    _CUDA_VRANGES::iter_swap(__i2, __i2);
+    _CUDA_VRANGES::iter_swap(__i1, __i2);
+    _CUDA_VRANGES::iter_swap(__i2, __i1);
+  };
+#else
+template<class _I1, class _I2>
+_LIBCUDACXX_CONCEPT_FRAGMENT(
+  __indirectly_swappable_,
+  requires(const _I1 __i1, const _I2 __i2)(
+    requires(indirectly_readable<_I1>),
+    requires(indirectly_readable<_I2>),
+    (_CUDA_VRANGES::iter_swap(__i1, __i1)),
+    (_CUDA_VRANGES::iter_swap(__i2, __i2)),
+    (_CUDA_VRANGES::iter_swap(__i1, __i2)),
+    (_CUDA_VRANGES::iter_swap(__i2, __i1))
+  ));
+
+template<class _I1, class _I2 = _I1>
+_LIBCUDACXX_CONCEPT indirectly_swappable = _LIBCUDACXX_FRAGMENT(__indirectly_swappable_, _I1, _I2);
+#endif // _LIBCUDACXX_STD_VER > 17
+
+template<class _I1, class _I2 = _I1, class = void>
+_LIBCUDACXX_INLINE_VAR constexpr bool __noexcept_swappable = false;
+
+template<class _I1, class _I2>
+_LIBCUDACXX_INLINE_VAR constexpr bool __noexcept_swappable<_I1, _I2, __enable_if_t<indirectly_swappable<_I1, _I2>>>
+  = noexcept(_CUDA_VRANGES::iter_swap(_CUDA_VSTD::declval<_I1&>(), _CUDA_VSTD::declval<_I2&>()));
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX_STD_VER > 14
+
+#endif // _LIBCUDACXX___ITERATOR_ITER_SWAP_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__split_buffer
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__split_buffer
@@ -251,7 +251,7 @@ __split_buffer<_Tp, _Allocator>::__construct_at_end(_InputIter __first, _InputIt
             size_type __old_cap = __end_cap() - __first_;
             size_type __new_cap = _CUDA_VSTD::max<size_type>(2 * __old_cap, 8);
             __split_buffer __buf(__new_cap, 0, __a);
-            for (pointer __p = __begin_; __p != __end_; ++__p, ++__buf.__end_)
+            for (pointer __p = __begin_; __p != __end_; ++__p, (void)++__buf.__end_)
                 __alloc_traits::construct(__buf.__alloc(),
                         _CUDA_VSTD::__to_raw_pointer(__buf.__end_), _CUDA_VSTD::move(*__p));
             swap(__buf);
@@ -271,7 +271,7 @@ typename enable_if
 __split_buffer<_Tp, _Allocator>::__construct_at_end(_ForwardIterator __first, _ForwardIterator __last)
 {
     _ConstructTransaction __tx(&this->__end_, std::distance(__first, __last));
-    for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_, ++__first) {
+    for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_, (void)++__first) {
         __alloc_traits::construct(this->__alloc(),
             _CUDA_VSTD::__to_raw_pointer(__tx.__pos_), *__first);
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/deque
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/deque
@@ -2334,7 +2334,7 @@ deque<_Tp, _Allocator>::insert(const_iterator __p, _BiIter __f, _BiIter __l,
         if (__n > 0)
         {
             iterator __oen = __old_end - __n;
-            for (iterator __j = __oen; __j != __old_end; ++__i, ++__j, ++__base::size())
+            for (iterator __j = __oen; __j != __old_end; ++__i, (void)++__j, ++__base::size())
                 __alloc_traits::construct(__a, _CUDA_VSTD::addressof(*__i), _CUDA_VSTD::move(*__j));
             if (__n < __de)
                 __old_end = _CUDA_VSTD::move_backward(__old_end - __de, __oen, __old_end);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/iterator
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/iterator
@@ -695,6 +695,7 @@ template <class E> constexpr const E* data(initializer_list<E> il) noexcept;    
 #include "__iterator/istream_iterator.h"
 #include "__iterator/istreambuf_iterator.h"
 #include "__iterator/iter_move.h"
+#include "__iterator/iter_swap.h"
 #include "__iterator/iterator.h"
 #include "__iterator/iterator_traits.h"
 #include "__iterator/move_iterator.h"

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/list
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/list
@@ -1407,7 +1407,7 @@ list<_Tp, _Alloc>::assign(_InpIter __f, _InpIter __l,
 {
     iterator __i = begin();
     iterator __e = end();
-    for (; __f != __l && __i != __e; ++__f, ++__i)
+    for (; __f != __l && __i != __e; ++__f, (void)++__i)
         *__i = *__f;
     if (__i == __e)
         insert(__e, __f, __l);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/vector
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/vector
@@ -1751,7 +1751,7 @@ vector<_Tp, _Allocator>::__move_range(pointer __from_s, pointer __from_e, pointe
     {
       pointer __i = __from_s + __n;
       _ConstructTransaction __tx(*this, __from_e - __i);
-      for (; __i < __from_e; ++__i, ++__tx.__pos_) {
+      for (; __i < __from_e; ++__i, (void)++__tx.__pos_) {
           __alloc_traits::construct(this->__alloc(),
                                     _CUDA_VSTD::__to_raw_pointer(__tx.__pos_),
                                     _CUDA_VSTD::move(*__i));

--- a/libcudacxx/libcxx/test/libcxx/utilities/tuple/tuple.tuple/tuple.cnstr/enable_reduced_arity_initialization_extension.pass.cpp
+++ b/libcudacxx/libcxx/test/libcxx/utilities/tuple/tuple.tuple/tuple.cnstr/enable_reduced_arity_initialization_extension.pass.cpp
@@ -108,6 +108,7 @@ int main(int, char**)
         assert(std::get<0>(t) == 0);
         assert(std::get<1>(t) == E());
         assert(std::get<2>(t) == E());
+        unused(t2);
     }
     // Check that SFINAE is properly applied with the default reduced arity
     // constructor extensions.

--- a/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp
@@ -59,11 +59,11 @@ test(int P, const C& c0, const C& c2)
     assert(c1.size() == c1_osize + c2.size());
     assert(static_cast<std::size_t>(distance(c1.begin(), c1.end())) == c1.size());
     i = c1.begin();
-    for (int j = 0; j < P; ++j, ++i)
+    for (int j = 0; j < P; ++j, (void)++i)
         assert(*i == j);
-    for (int j = 0; static_cast<std::size_t>(j) < c2.size(); ++j, ++i)
+    for (int j = 0; static_cast<std::size_t>(j) < c2.size(); ++j, (void)++i)
         assert(*i == j);
-    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, ++i)
+    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, (void)++i)
         assert(*i == j);
     }
     {
@@ -76,11 +76,11 @@ test(int P, const C& c0, const C& c2)
     assert(c1.size() == c1_osize + c2.size());
     assert(static_cast<std::size_t>(distance(c1.begin(), c1.end())) == c1.size());
     i = c1.begin();
-    for (int j = 0; j < P; ++j, ++i)
+    for (int j = 0; j < P; ++j, (void)++i)
         assert(*i == j);
-    for (int j = 0; static_cast<std::size_t>(j) < c2.size(); ++j, ++i)
+    for (int j = 0; static_cast<std::size_t>(j) < c2.size(); ++j, (void)++i)
         assert(*i == j);
-    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, ++i)
+    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, (void)++i)
         assert(*i == j);
     }
     {
@@ -93,11 +93,11 @@ test(int P, const C& c0, const C& c2)
     assert(c1.size() == c1_osize + c2.size());
     assert(static_cast<std::size_t>(distance(c1.begin(), c1.end())) == c1.size());
     i = c1.begin();
-    for (int j = 0; j < P; ++j, ++i)
+    for (int j = 0; j < P; ++j, (void)++i)
         assert(*i == j);
-    for (int j = 0; static_cast<std::size_t>(j) < c2.size(); ++j, ++i)
+    for (int j = 0; static_cast<std::size_t>(j) < c2.size(); ++j, (void)++i)
         assert(*i == j);
-    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, ++i)
+    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, (void)++i)
         assert(*i == j);
     }
 }
@@ -174,11 +174,11 @@ testI(int P, C& c1, const C& c2)
     assert(c1.size() == c1_osize + c2.size());
     assert(static_cast<std::size_t>(distance(c1.begin(), c1.end())) == c1.size());
     i = c1.begin();
-    for (int j = 0; j < P; ++j, ++i)
+    for (int j = 0; j < P; ++j, (void)++i)
         assert(*i == j);
-    for (int j = 0; static_cast<std::size_t>(j) < c2.size(); ++j, ++i)
+    for (int j = 0; static_cast<std::size_t>(j) < c2.size(); ++j, (void)++i)
         assert(*i == j);
-    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, ++i)
+    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, (void)++i)
         assert(*i == j);
 }
 
@@ -246,7 +246,7 @@ test_move()
         c.insert(c.end(), std::move_iterator<I>(&mo), std::move_iterator<I>(&mo+1));
     }
     int j = 0;
-    for (CI i = c.begin(); i != c.end(); ++i, ++j)
+    for (CI i = c.begin(); i != c.end(); ++i, (void)++j)
         assert(*i == MoveOnly(j));
     {
         MoveOnly mo(1);
@@ -254,7 +254,7 @@ test_move()
         c.insert(c.end(), std::move_iterator<I>(I(&mo)), std::move_iterator<I>(I(&mo+1)));
     }
     j = 0;
-    for (CI i = c.begin(); i != c.end(); ++i, ++j)
+    for (CI i = c.begin(); i != c.end(); ++i, (void)++j)
         assert(*i == MoveOnly(j));
 #endif
 }

--- a/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_rvalue.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_rvalue.pass.cpp
@@ -54,11 +54,11 @@ test(int P, C& c1, int x)
     assert(c1.size() == c1_osize + 1);
     assert(static_cast<std::size_t>(distance(c1.begin(), c1.end())) == c1.size());
     i = c1.begin();
-    for (int j = 0; j < P; ++j, ++i)
+    for (int j = 0; j < P; ++j, (void)++i)
         assert(*i == MoveOnly(j));
     assert(*i == MoveOnly(x));
     ++i;
-    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, ++i)
+    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, (void)++i)
         assert(*i == MoveOnly(j));
 }
 

--- a/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_size_value.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_size_value.pass.cpp
@@ -52,11 +52,11 @@ test(int P, C& c1, int size, int x)
     assert(c1.size() == c1_osize + size);
     assert(static_cast<std::size_t>(distance(c1.begin(), c1.end())) == c1.size());
     i = c1.begin();
-    for (int j = 0; j < P; ++j, ++i)
+    for (int j = 0; j < P; ++j, (void)++i)
         assert(*i == j);
-    for (int j = 0; j < size; ++j, ++i)
+    for (int j = 0; j < size; ++j, (void)++i)
         assert(*i == x);
-    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, ++i)
+    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, (void)++i)
         assert(*i == j);
 }
 

--- a/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_value.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/insert_value.pass.cpp
@@ -50,11 +50,11 @@ test(int P, C& c1, int x)
     assert(c1.size() == c1_osize + 1);
     assert(static_cast<std::size_t>(distance(c1.begin(), c1.end())) == c1.size());
     i = c1.begin();
-    for (int j = 0; j < P; ++j, ++i)
+    for (int j = 0; j < P; ++j, (void)++i)
         assert(*i == j);
     assert(*i == x);
     ++i;
-    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, ++i)
+    for (int j = P; static_cast<std::size_t>(j) < c1_osize; ++j, (void)++i)
         assert(*i == j);
 }
 

--- a/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_back.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_back.pass.cpp
@@ -49,7 +49,7 @@ void test(int size)
     {
         C c = make<C>(size, rng[j]);
         typename C::const_iterator it = c.begin();
-        for (int i = 0; i < size; ++i, ++it)
+        for (int i = 0; i < size; ++i, (void)++it)
             assert(*it == i);
     }
 }

--- a/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_back_rvalue.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_back_rvalue.pass.cpp
@@ -53,7 +53,7 @@ void test(int size)
     {
         C c = make<C>(size, rng[j]);
         typename C::const_iterator it = c.begin();
-        for (int i = 0; i < size; ++i, ++it)
+        for (int i = 0; i < size; ++i, (void)++it)
             assert(*it == MoveOnly(i));
     }
 }

--- a/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_front_rvalue.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/deque/deque.modifiers/push_front_rvalue.pass.cpp
@@ -55,7 +55,7 @@ test(C& c1, int x)
     I i = c1.begin();
     assert(*i == MoveOnly(x));
     ++i;
-    for (int j = 0; static_cast<std::size_t>(j) < c1_osize; ++j, ++i)
+    for (int j = 0; static_cast<std::size_t>(j) < c1_osize; ++j, (void)++i)
         assert(*i == MoveOnly(j));
 }
 

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_init.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_init.pass.cpp
@@ -28,7 +28,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c.assign({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
     }
@@ -39,7 +39,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c.assign({10, 11, 12, 13});
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
     }
@@ -50,7 +50,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c.assign({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
     }
@@ -61,7 +61,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c.assign({10, 11, 12, 13});
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
     }

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_move.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_move.pass.cpp
@@ -34,7 +34,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A(10));
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
         assert(c1.get_allocator() == A(10));
@@ -51,7 +51,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A(11));
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
         assert(c1.get_allocator() == A(11));
@@ -68,7 +68,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A(10));
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
         assert(c1.get_allocator() == A(10));
@@ -85,7 +85,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A(11));
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
         assert(c1.get_allocator() == A(11));
@@ -103,7 +103,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A(10));
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
         assert(c1.get_allocator() == A(10));
@@ -120,7 +120,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A(11));
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
         assert(c1.get_allocator() == A(10));
@@ -137,7 +137,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A(10));
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
         assert(c1.get_allocator() == A(10));
@@ -154,7 +154,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A(11));
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
         assert(c1.get_allocator() == A(10));
@@ -171,7 +171,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A());
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
         assert(c1.get_allocator() == A());
@@ -188,7 +188,7 @@ int main(int, char**)
         C c1(I(std::begin(t1)), I(std::end(t1)), A());
         c1 = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, ++n)
+        for (C::const_iterator i = c1.cbegin(); i != c1.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
         assert(c1.get_allocator() == A());

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_op_init.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_op_init.pass.cpp
@@ -28,7 +28,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
     }
@@ -39,7 +39,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c = {10, 11, 12, 13};
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
     }
@@ -50,7 +50,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
     }
@@ -61,7 +61,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c = {10, 11, 12, 13};
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
     }

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_range.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_range.pass.cpp
@@ -30,7 +30,7 @@ int main(int, char**)
         typedef cpp17_input_iterator<const T*> I;
         c.assign(I(std::begin(t0)), I(std::end(t0)));
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
     }
@@ -43,7 +43,7 @@ int main(int, char**)
         typedef cpp17_input_iterator<const T*> I;
         c.assign(I(std::begin(t0)), I(std::end(t0)));
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == 10+n);
         assert(n == 4);
     }
@@ -57,7 +57,7 @@ int main(int, char**)
         typedef cpp17_input_iterator<const T*> I;
         c.assign(I(std::begin(t0)), I(std::end(t0)));
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
     }

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_size_value.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_size_value.pass.cpp
@@ -26,7 +26,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c.assign(10, 1);
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == 1);
         assert(n == 10);
     }
@@ -37,7 +37,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c.assign(4, 10);
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == 10);
         assert(n == 4);
     }
@@ -49,7 +49,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c.assign(10, 1);
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == 1);
         assert(n == 10);
     }
@@ -60,7 +60,7 @@ int main(int, char**)
         C c(std::begin(t1), std::end(t1));
         c.assign(4, 10);
         int n = 0;
-        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, ++n)
+        for (C::const_iterator i = c.cbegin(); i != c.cend(); ++i, (void)++n)
             assert(*i == 10);
         assert(n == 4);
     }

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/copy.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/copy.pass.cpp
@@ -28,7 +28,7 @@ int main(int, char**)
         C c0(std::begin(t), std::end(t), A(10));
         C c = c0;
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c == c0);
@@ -43,7 +43,7 @@ int main(int, char**)
         C c0(std::begin(t), std::end(t), A(10));
         C c = c0;
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c == c0);
@@ -57,7 +57,7 @@ int main(int, char**)
         C c0(std::begin(t), std::end(t), A());
         C c = c0;
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c == c0);

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/copy_alloc.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/copy_alloc.pass.cpp
@@ -28,7 +28,7 @@ int main(int, char**)
         C c0(std::begin(t), std::end(t), A(10));
         C c(c0, A(9));
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c == c0);
@@ -42,7 +42,7 @@ int main(int, char**)
         C c0(std::begin(t), std::end(t), A(10));
         C c(c0, A(9));
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c == c0);
@@ -57,7 +57,7 @@ int main(int, char**)
         C c0(std::begin(t), std::end(t), A());
         C c(c0, A());
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c == c0);

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/init.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/init.pass.cpp
@@ -25,7 +25,7 @@ int main(int, char**)
         typedef std::forward_list<T> C;
         C c = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
     }
@@ -34,7 +34,7 @@ int main(int, char**)
         typedef std::forward_list<T, min_allocator<T>> C;
         C c = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
     }

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/init_alloc.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/init_alloc.pass.cpp
@@ -27,7 +27,7 @@ int main(int, char**)
         typedef std::forward_list<T, A> C;
         C c({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, A(14));
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
         assert(c.get_allocator() == A(14));
@@ -38,7 +38,7 @@ int main(int, char**)
         typedef std::forward_list<T, A> C;
         C c({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, A());
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == 10);
         assert(c.get_allocator() == A());

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/move.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/move.pass.cpp
@@ -32,7 +32,7 @@ int main(int, char**)
         C c0(I(std::begin(t)), I(std::end(t)), A(10));
         C c = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c0.empty());
@@ -47,7 +47,7 @@ int main(int, char**)
         C c0(I(std::begin(t)), I(std::end(t)), A(10));
         C c = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c0.empty());
@@ -62,7 +62,7 @@ int main(int, char**)
         C c0(I(std::begin(t)), I(std::end(t)), A());
         C c = std::move(c0);
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c0.empty());

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/move_alloc.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/move_alloc.pass.cpp
@@ -32,7 +32,7 @@ int main(int, char**)
         C c0(I(std::begin(t)), I(std::end(t)), A(10));
         C c(std::move(c0), A(10));
         unsigned n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == static_cast<unsigned>(std::end(t) - std::begin(t)));
         assert(c0.empty());
@@ -47,7 +47,7 @@ int main(int, char**)
         C c0(I(std::begin(t)), I(std::end(t)), A(10));
         C c(std::move(c0), A(9));
         unsigned n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == static_cast<unsigned>(std::end(t) - std::begin(t)));
         assert(!c0.empty());
@@ -62,7 +62,7 @@ int main(int, char**)
         C c0(I(std::begin(t)), I(std::end(t)), A());
         C c(std::move(c0), A());
         unsigned n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == static_cast<unsigned>(std::end(t) - std::begin(t)));
         assert(c0.empty());

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/range.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/range.pass.cpp
@@ -28,7 +28,7 @@ int main(int, char**)
         const T t[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         C c(I(std::begin(t)), I(std::end(t)));
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
     }
@@ -40,7 +40,7 @@ int main(int, char**)
         const T t[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         C c(I(std::begin(t)), I(std::end(t)));
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
     }

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/range_alloc.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/range_alloc.pass.cpp
@@ -31,7 +31,7 @@ int main(int, char**)
         const T t[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         C c(I(std::begin(t)), I(std::end(t)), A(13));
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c.get_allocator() == A(13));
@@ -45,7 +45,7 @@ int main(int, char**)
         const T t[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         C c(I(std::begin(t)), I(std::end(t)), A());
         int n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == n);
         assert(n == std::end(t) - std::begin(t));
         assert(c.get_allocator() == A());

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/size.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/size.pass.cpp
@@ -47,7 +47,7 @@ int main(int, char**)
         C c(N);
         unsigned n = 0;
 
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n) {
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n) {
 #if TEST_STD_VER >= 11
             assert(*i == T());
 #else
@@ -63,7 +63,7 @@ int main(int, char**)
         unsigned N = 10;
         C c(N);
         unsigned n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == T());
         assert(n == N);
         check_allocator<T, min_allocator<T>> ( 0 );

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/size_value.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/size_value.pass.cpp
@@ -25,7 +25,7 @@ int main(int, char**)
         unsigned N = 10;
         C c(N, v);
         unsigned n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == v);
         assert(n == N);
     }
@@ -37,7 +37,7 @@ int main(int, char**)
         unsigned N = 10;
         C c(N, v);
         unsigned n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == v);
         assert(n == N);
     }

--- a/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/size_value_alloc.pass.cpp
+++ b/libcudacxx/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/size_value_alloc.pass.cpp
@@ -27,7 +27,7 @@ int main(int, char**)
         unsigned N = 10;
         C c(N, v, A(12));
         unsigned n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == v);
         assert(n == N);
         assert(c.get_allocator() == A(12));
@@ -41,7 +41,7 @@ int main(int, char**)
         unsigned N = 10;
         C c(N, v, A());
         unsigned n = 0;
-        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, ++n)
+        for (C::const_iterator i = c.begin(), e = c.end(); i != e; ++i, (void)++n)
             assert(*i == v);
         assert(n == N);
         assert(c.get_allocator() == A());

--- a/libcudacxx/libcxx/test/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.compile.pass.cpp
+++ b/libcudacxx/libcxx/test/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.compile.pass.cpp
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// template<class I1, class I2>
+// concept indirectly_swappable;
+
+#include <iterator>
+
+#include "test_macros.h"
+
+template<class T, class ValueType = T>
+struct PointerTo {
+  using value_type = ValueType;
+  T& operator*() const;
+};
+
+static_assert(std::indirectly_swappable<PointerTo<int>>);
+static_assert(std::indirectly_swappable<PointerTo<int>, PointerTo<int>>);
+
+struct B;
+
+struct A {
+  friend void iter_swap(const PointerTo<A>&, const PointerTo<A>&);
+};
+
+// Is indirectly swappable.
+struct B {
+  friend void iter_swap(const PointerTo<B>&, const PointerTo<B>&);
+  friend void iter_swap(const PointerTo<A>&, const PointerTo<B>&);
+  friend void iter_swap(const PointerTo<B>&, const PointerTo<A>&);
+};
+
+// Valid except ranges::iter_swap(i2, i1).
+struct C {
+  friend void iter_swap(const PointerTo<C>&, const PointerTo<C>&);
+  friend void iter_swap(const PointerTo<A>&, const PointerTo<C>&);
+  friend void iter_swap(const PointerTo<C>&, const PointerTo<A>&) = delete;
+};
+
+// Valid except ranges::iter_swap(i1, i2).
+struct D {
+  friend void iter_swap(const PointerTo<D>&, const PointerTo<D>&);
+  friend void iter_swap(const PointerTo<A>&, const PointerTo<D>&) = delete;
+  friend void iter_swap(const PointerTo<D>&, const PointerTo<A>&);
+};
+
+// Valid except ranges::iter_swap(i2, i2).
+struct E {
+  E operator=(const E&) = delete;
+  friend void iter_swap(const PointerTo<E>&, const PointerTo<E>&) = delete;
+  friend void iter_swap(const PointerTo<A>&, const PointerTo<E>&);
+  friend void iter_swap(const PointerTo<E>&, const PointerTo<A>&);
+};
+
+struct F {
+  friend void iter_swap(const PointerTo<F>&, const PointerTo<F>&) = delete;
+};
+
+// Valid except ranges::iter_swap(i1, i1).
+struct G {
+  friend void iter_swap(const PointerTo<G>&, const PointerTo<G>&);
+  friend void iter_swap(const PointerTo<F>&, const PointerTo<G>&);
+  friend void iter_swap(const PointerTo<G>&, const PointerTo<F>&);
+};
+
+
+static_assert( std::indirectly_swappable<PointerTo<A>, PointerTo<B>>);
+static_assert(!std::indirectly_swappable<PointerTo<A>, PointerTo<C>>);
+static_assert(!std::indirectly_swappable<PointerTo<A>, PointerTo<D>>);
+static_assert(!std::indirectly_swappable<PointerTo<A>, PointerTo<E>>);
+static_assert(!std::indirectly_swappable<PointerTo<A>, PointerTo<G>>);
+
+int main(int, char**) {
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.subsumption.compile.pass.cpp
+++ b/libcudacxx/libcxx/test/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.subsumption.compile.pass.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// template<class I1, class I2>
+// concept indirectly_swappable;
+
+#include <iterator>
+
+#include <concepts>
+
+template<class I1, class I2>
+  requires std::indirectly_readable<I1> && std::indirectly_readable<I2>
+constexpr bool indirectly_swappable_subsumption() {
+  return false;
+}
+
+template<class I1, class I2>
+  requires std::indirectly_swappable<I1, I2>
+constexpr bool indirectly_swappable_subsumption() {
+  return true;
+}
+
+static_assert(indirectly_swappable_subsumption<int*, int*>());
+
+int main(int, char**) {
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
+++ b/libcudacxx/libcxx/test/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
@@ -1,0 +1,225 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// template<class I>
+// unspecified iter_swap;
+
+#include <iterator>
+
+#include <array>
+#include <cassert>
+
+#include "../unqualified_lookup_wrapper.h"
+#include "test_iterators.h"
+
+using IterSwapT = decltype(std::ranges::iter_swap);
+
+struct HasIterSwap {
+  int &value_;
+  constexpr explicit HasIterSwap(int &value) : value_(value) { assert(value == 0); }
+
+  friend constexpr void iter_swap(HasIterSwap& a, HasIterSwap& b) {
+    a.value_ = 1;
+    b.value_ = 1;
+  }
+  friend constexpr void iter_swap(HasIterSwap& a, int& b) {
+    a.value_ = 2;
+    b = 2;
+  }
+};
+
+static_assert( std::is_invocable_v<IterSwapT, HasIterSwap&, HasIterSwap&>);
+static_assert( std::is_invocable_v<IterSwapT, HasIterSwap&, int&>);
+static_assert(!std::is_invocable_v<IterSwapT, int&, HasIterSwap&>);
+
+static_assert( std::is_invocable_v<IterSwapT&, HasIterSwap&, HasIterSwap&>);
+static_assert( std::is_invocable_v<IterSwapT&, HasIterSwap&, int&>);
+static_assert(!std::is_invocable_v<IterSwapT&, int&, HasIterSwap&>);
+
+static_assert( std::is_invocable_v<IterSwapT&&, HasIterSwap&, HasIterSwap&>);
+static_assert( std::is_invocable_v<IterSwapT&&, HasIterSwap&, int&>);
+static_assert(!std::is_invocable_v<IterSwapT&&, int&, HasIterSwap&>);
+
+struct NodiscardIterSwap {
+  [[nodiscard]] friend int iter_swap(NodiscardIterSwap&, NodiscardIterSwap&) { return 0; }
+};
+
+void ensureVoidCast(NodiscardIterSwap& a, NodiscardIterSwap& b) { std::ranges::iter_swap(a, b); }
+
+struct HasRangesSwap {
+  int &value_;
+  constexpr explicit HasRangesSwap(int &value) : value_(value) { assert(value == 0); }
+
+  friend constexpr void swap(HasRangesSwap& a, HasRangesSwap& b) {
+    a.value_ = 1;
+    b.value_ = 1;
+  }
+  friend constexpr void swap(HasRangesSwap& a, int& b) {
+    a.value_ = 2;
+    b = 2;
+  }
+};
+
+struct HasRangesSwapWrapper {
+  using value_type = HasRangesSwap;
+
+  HasRangesSwap &value_;
+  constexpr explicit HasRangesSwapWrapper(HasRangesSwap &value) : value_(value) {}
+
+  constexpr HasRangesSwap& operator*() const { return value_; }
+};
+
+static_assert( std::is_invocable_v<IterSwapT, HasRangesSwapWrapper&, HasRangesSwapWrapper&>);
+// Does not satisfy swappable_with, even though swap(X, Y) is valid.
+static_assert(!std::is_invocable_v<IterSwapT, HasRangesSwapWrapper&, int&>);
+static_assert(!std::is_invocable_v<IterSwapT, int&, HasRangesSwapWrapper&>);
+
+struct B;
+
+struct A {
+  bool value = false;
+  constexpr A& operator=(const B&) {
+    value = true;
+    return *this;
+  };
+};
+
+struct B {
+  bool value = false;
+  constexpr B& operator=(const A&) {
+    value = true;
+    return *this;
+  };
+};
+
+struct MoveOnly2;
+
+struct MoveOnly1 {
+  bool value = false;
+
+  MoveOnly1() = default;
+  MoveOnly1(MoveOnly1&&) = default;
+  MoveOnly1& operator=(MoveOnly1&&) = default;
+  MoveOnly1(const MoveOnly1&) = delete;
+  MoveOnly1& operator=(const MoveOnly1&) = delete;
+
+  constexpr MoveOnly1& operator=(MoveOnly2 &&) {
+    value = true;
+    return *this;
+  };
+};
+
+struct MoveOnly2 {
+  bool value = false;
+
+  MoveOnly2() = default;
+  MoveOnly2(MoveOnly2&&) = default;
+  MoveOnly2& operator=(MoveOnly2&&) = default;
+  MoveOnly2(const MoveOnly2&) = delete;
+  MoveOnly2& operator=(const MoveOnly2&) = delete;
+
+  constexpr MoveOnly2& operator=(MoveOnly1 &&) {
+    value = true;
+    return *this;
+  };
+};
+
+constexpr bool test()
+{
+  {
+    int value1 = 0;
+    int value2 = 0;
+    HasIterSwap a(value1), b(value2);
+    std::ranges::iter_swap(a, b);
+    assert(value1 == 1 && value2 == 1);
+  }
+  {
+    int value1 = 0;
+    int value2 = 0;
+    HasRangesSwap c(value1), d(value2);
+    HasRangesSwapWrapper cWrapper(c), dWrapper(d);
+    std::ranges::iter_swap(cWrapper, dWrapper);
+    assert(value1 == 1 && value2 == 1);
+  }
+  {
+    int value1 = 0;
+    int value2 = 0;
+    HasRangesSwap c(value1), d(value2);
+    std::ranges::iter_swap(HasRangesSwapWrapper(c), HasRangesSwapWrapper(d));
+    assert(value1 == 1 && value2 == 1);
+  }
+  {
+    A e; B f;
+    A *ePtr = &e;
+    B *fPtr = &f;
+    std::ranges::iter_swap(ePtr, fPtr);
+    assert(e.value && f.value);
+  }
+  {
+    MoveOnly1 g; MoveOnly2 h;
+    std::ranges::iter_swap(&g, &h);
+    assert(g.value && h.value);
+  }
+  {
+    auto arr = std::array<move_tracker, 2>();
+    std::ranges::iter_swap(arr.begin(), arr.begin() + 1);
+    if (std::is_constant_evaluated()) {
+      assert(arr[0].moves() == 1 && arr[1].moves() == 3);
+    } else {
+      assert(arr[0].moves() == 1 && arr[1].moves() == 2);
+    }
+  }
+  {
+    int buff[2] = {1, 2};
+    std::ranges::iter_swap(buff + 0, buff + 1);
+    assert(buff[0] == 2 && buff[1] == 1);
+
+    std::ranges::iter_swap(cpp20_input_iterator(buff), cpp20_input_iterator(buff + 1));
+    assert(buff[0] == 1 && buff[1] == 2);
+
+    std::ranges::iter_swap(cpp17_input_iterator(buff), cpp17_input_iterator(buff + 1));
+    assert(buff[0] == 2 && buff[1] == 1);
+
+    std::ranges::iter_swap(forward_iterator(buff), forward_iterator(buff + 1));
+    assert(buff[0] == 1 && buff[1] == 2);
+
+    std::ranges::iter_swap(bidirectional_iterator(buff), bidirectional_iterator(buff + 1));
+    assert(buff[0] == 2 && buff[1] == 1);
+
+    std::ranges::iter_swap(random_access_iterator(buff), random_access_iterator(buff + 1));
+    assert(buff[0] == 1 && buff[1] == 2);
+
+    std::ranges::iter_swap(contiguous_iterator(buff), contiguous_iterator(buff + 1));
+    assert(buff[0] == 2 && buff[1] == 1);
+  }
+  return true;
+}
+
+static_assert(!std::is_invocable_v<IterSwapT, int*>); // too few arguments
+static_assert(!std::is_invocable_v<IterSwapT, int*, int*, int*>); // too many arguments
+static_assert(!std::is_invocable_v<IterSwapT, int, int*>);
+static_assert(!std::is_invocable_v<IterSwapT, int*, int>);
+static_assert(!std::is_invocable_v<IterSwapT, void*, void*>);
+
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(std::is_invocable_v<IterSwapT, Holder<Incomplete>**, Holder<Incomplete>**>);
+static_assert(std::is_invocable_v<IterSwapT, Holder<Incomplete>**, Holder<Incomplete>**&>);
+static_assert(std::is_invocable_v<IterSwapT, Holder<Incomplete>**&, Holder<Incomplete>**>);
+static_assert(std::is_invocable_v<IterSwapT, Holder<Incomplete>**&, Holder<Incomplete>**&>);
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}


### PR DESCRIPTION
This implements the `iter_swap` CPO from c++ 20 ranges backported to C++17