### PR TITLE
Fix a shadow warning in thrust's execute_with_dependencies.h

### DIFF
--- a/thrust/thrust/detail/execute_with_dependencies.h
+++ b/thrust/thrust/detail/execute_with_dependencies.h
@@ -61,8 +61,8 @@ private:
 
 public:
     __host__
-    execute_with_dependencies(super_t const &super, Dependencies && ...dependencies)
-        : super_t(super), dependencies(std::forward<Dependencies>(dependencies)...)
+    execute_with_dependencies(super_t const &super, Dependencies && ...deps)
+        : super_t(super), dependencies(std::forward<Dependencies>(deps)...)
     {
     }
 


### PR DESCRIPTION
[skip-tests]

Fix https://github.com/NVIDIA/thrust/issues/1980
Fix #335 

Moved to here from https://github.com/NVIDIA/thrust/pull/1981#issuecomment-1678908015

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [?] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
