### PR TITLE
Fix merge conflict from two inflight PRs

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.compile.pass.cpp
@@ -158,42 +158,42 @@ struct DeletedCopyCtor {
   DeletedCopyCtor& operator=(DeletedCopyCtor const&) = default;
 };
 
-#if TEST_STD_VER > 17 || !defined(TEST_COMPILER_C1XX) //  multiple versions of a defaulted special member functions are not allowed
+#if TEST_STD_VER > 17 || !defined(TEST_COMPILER_MSVC) //  multiple versions of a defaulted special member functions are not allowed
 struct DeletedNonconstCopyCtor {
   DeletedNonconstCopyCtor(DeletedNonconstCopyCtor const&) = default;
   DeletedNonconstCopyCtor(DeletedNonconstCopyCtor&) = delete;
   DeletedNonconstCopyCtor& operator=(DeletedNonconstCopyCtor const&) = default;
 };
 static_assert(!cuda::std::indirectly_copyable_storable<DeletedNonconstCopyCtor*, DeletedNonconstCopyCtor*>);
-#endif // TEST_STD_VER > 17 || !defined(TEST_COMPILER_C1XX)
+#endif // TEST_STD_VER > 17 || !defined(TEST_COMPILER_MSVC)
 
 struct DeletedMoveCtor {
   DeletedMoveCtor(DeletedMoveCtor&&) = delete;
   DeletedMoveCtor& operator=(DeletedMoveCtor&&) = default;
 };
 
-#if TEST_STD_VER > 17 || !defined(TEST_COMPILER_C1XX) //  multiple versions of a defaulted special member functions are not allowed
+#if TEST_STD_VER > 17 || !defined(TEST_COMPILER_MSVC) //  multiple versions of a defaulted special member functions are not allowed
 struct DeletedConstMoveCtor {
   DeletedConstMoveCtor(DeletedConstMoveCtor&&) = default;
   DeletedConstMoveCtor(DeletedConstMoveCtor const&&) = delete;
   DeletedConstMoveCtor& operator=(DeletedConstMoveCtor&&) = default;
 };
 static_assert(!cuda::std::indirectly_copyable_storable<DeletedConstMoveCtor*, DeletedConstMoveCtor*>);
-#endif // TEST_STD_VER > 17 || !defined(TEST_COMPILER_C1XX)
+#endif // TEST_STD_VER > 17 || !defined(TEST_COMPILER_MSVC)
 
 struct DeletedCopyAssignment {
   DeletedCopyAssignment(DeletedCopyAssignment const&) = default;
   DeletedCopyAssignment& operator=(DeletedCopyAssignment const&) = delete;
 };
 
-#if TEST_STD_VER > 17 || !defined(TEST_COMPILER_C1XX) //  multiple versions of a defaulted special member functions are not allowed
+#if TEST_STD_VER > 17 || !defined(TEST_COMPILER_MSVC) //  multiple versions of a defaulted special member functions are not allowed
 struct DeletedNonconstCopyAssignment {
   DeletedNonconstCopyAssignment(DeletedNonconstCopyAssignment const&) = default;
   DeletedNonconstCopyAssignment& operator=(DeletedNonconstCopyAssignment const&) = default;
   DeletedNonconstCopyAssignment& operator=(DeletedNonconstCopyAssignment&) = delete;
 };
 static_assert(!cuda::std::indirectly_copyable_storable<DeletedNonconstCopyAssignment*, DeletedNonconstCopyAssignment*>);
-#endif // TEST_STD_VER > 17 || !defined(TEST_COMPILER_C1XX)
+#endif // TEST_STD_VER > 17 || !defined(TEST_COMPILER_MSVC)
 
 struct DeletedMoveAssignment {
   DeletedMoveAssignment(DeletedMoveAssignment&&) = default;

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/incrementable.h
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/incrementable.h
@@ -102,9 +102,9 @@ struct postinc_not_declared {
   using difference_type = int;
 
   __host__ __device__ postinc_not_declared& operator++();
-#if defined(TEST_COMPILER_C1XX) // MSVC complains about "single-argument function used for postfix "++" (anachronism)""
+#if defined(TEST_COMPILER_MSVC) // MSVC complains about "single-argument function used for postfix "++" (anachronism)""
   __host__ __device__ postinc_not_declared& operator++(int) = delete;
-#endif // TEST_COMPILER_C1XX
+#endif // TEST_COMPILER_MSVC
 };
 
 struct incrementable_with_difference_type {

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.bidir/bidirectional_iterator.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.bidir/bidirectional_iterator.compile.pass.cpp
@@ -144,9 +144,9 @@ struct no_postdecrement {
   __host__ __device__ no_postdecrement operator++(int);
 
   __host__ __device__ no_postdecrement& operator--();
-#if defined(TEST_COMPILER_C1XX) //  single-argument function used for postfix "--" (anachronism)
+#if defined(TEST_COMPILER_MSVC) //  single-argument function used for postfix "--" (anachronism)
   __host__ __device__ no_postdecrement& operator--(int) = delete;
-#endif // TEST_COMPILER_C1XX
+#endif // TEST_COMPILER_MSVC
 
 #if TEST_STD_VER > 17
   bool operator==(no_postdecrement const&) const = default;

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.input/input_iterator.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.input/input_iterator.compile.pass.cpp
@@ -58,11 +58,11 @@ struct not_weakly_incrementable {
 
   __host__ __device__ int operator*() const;
 
-#if defined(TEST_COMPILER_C1XX) // nvbug4119179
+#if defined(TEST_COMPILER_MSVC) // nvbug4119179
   __host__ __device__ void operator++(int);
 #else
   __host__ __device__ not_weakly_incrementable& operator++();
-#endif // TEST_COMPILER_C1XX
+#endif // TEST_COMPILER_MSVC
 };
 static_assert(!cuda::std::input_or_output_iterator<not_weakly_incrementable> &&
               !cuda::std::input_iterator<not_weakly_incrementable>);

--- a/libcudacxx/.upstream-tests/test/support/test_iterators.h
+++ b/libcudacxx/.upstream-tests/test/support/test_iterators.h
@@ -1019,9 +1019,9 @@ struct Proxy {
     return *this;
   }
 
-#if defined(TEST_COMPILER_C1XX)
+#if defined(TEST_COMPILER_MSVC)
 TEST_NV_DIAG_SUPPRESS(1805) // MSVC complains that if we pass a pointer type, adding const is useless
-#endif // TEST_COMPILER_C1XX
+#endif // TEST_COMPILER_MSVC
 
   // const assignment required to make ProxyIterator model cuda::std::indirectly_writable
   _LIBCUDACXX_TEMPLATE(class Other)
@@ -1032,9 +1032,9 @@ TEST_NV_DIAG_SUPPRESS(1805) // MSVC complains that if we pass a pointer type, ad
     return *this;
   }
 
-#if defined(TEST_COMPILER_C1XX)
+#if defined(TEST_COMPILER_MSVC)
 TEST_NV_DIAG_DEFAULT(1805)
-#endif // TEST_COMPILER_C1XX
+#endif // TEST_COMPILER_MSVC
 
   // If `T` is a reference type, the implicitly-generated assignment operator will be deleted (and would take precedence
   // over the templated `operator=` above because it's a better match).

--- a/libcudacxx/libcxx/test/support/test_iterators.h
+++ b/libcudacxx/libcxx/test/support/test_iterators.h
@@ -1036,9 +1036,9 @@ struct Proxy {
     return *this;
   }
 
-#if defined(TEST_COMPILER_C1XX)
+#if defined(TEST_COMPILER_MSVC)
 TEST_NV_DIAG_SUPPRESS(1805) // MSVC complains that if we pass a pointer type, adding const is useless
-#endif // TEST_COMPILER_C1XX
+#endif // TEST_COMPILER_MSVC
 
   // const assignment required to make ProxyIterator model std::indirectly_writable
   _LIBCUDACXX_TEMPLATE(class Other)
@@ -1049,9 +1049,9 @@ TEST_NV_DIAG_SUPPRESS(1805) // MSVC complains that if we pass a pointer type, ad
     return *this;
   }
 
-#if defined(TEST_COMPILER_C1XX)
+#if defined(TEST_COMPILER_MSVC)
 TEST_NV_DIAG_DEFAULT(1805)
-#endif // TEST_COMPILER_C1XX
+#endif // TEST_COMPILER_MSVC
 
   // If `T` is a reference type, the implicitly-generated assignment operator will be deleted (and would take precedence
   // over the templated `operator=` above because it's a better match).


### PR DESCRIPTION
We renamed `TEST_COMPILER_C1XX` to `TEST_COMPILER_MSVC` because the former does not make sense and the latter is the convention we have for the internal macro

However, an inflight PR did miss the macro rename

Skipping tests because this is only related to libcudacxx tests

Fixes nvbug3853157