### PR TITLE
Assorted fixes for MSVC 2017

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.compile.pass.cpp
@@ -60,10 +60,12 @@ static_assert(!cuda::std::indirectly_copyable<const MoveOnly*, MoveOnly*>);
 static_assert(!cuda::std::indirectly_copyable<const MoveOnly*, const MoveOnly*>);
 
 // Can copy copy-only objects.
+#ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
 static_assert( cuda::std::indirectly_copyable<CopyOnly*, CopyOnly*>);
 static_assert(!cuda::std::indirectly_copyable<CopyOnly*, const CopyOnly*>);
 static_assert( cuda::std::indirectly_copyable<const CopyOnly*, CopyOnly*>);
 static_assert(!cuda::std::indirectly_copyable<const CopyOnly*, const CopyOnly*>);
+#endif // TEST_COMPILER_MSVC_2017
 
 template<class T>
 struct PointerTo {
@@ -71,6 +73,7 @@ struct PointerTo {
   __host__ __device__ T& operator*() const;
 };
 
+#ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
 // Can copy through a dereferenceable class.
 static_assert( cuda::std::indirectly_copyable<int*, PointerTo<int>>);
 static_assert(!cuda::std::indirectly_copyable<int*, PointerTo<const int>>);
@@ -79,6 +82,7 @@ static_assert(!cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<const in
 static_assert( cuda::std::indirectly_copyable<CopyOnly*, PointerTo<CopyOnly>>);
 static_assert( cuda::std::indirectly_copyable<PointerTo<CopyOnly>, CopyOnly*>);
 static_assert( cuda::std::indirectly_copyable<PointerTo<CopyOnly>, PointerTo<CopyOnly>>);
+#endif // TEST_COMPILER_MSVC_2017
 
 int main(int, char**)
 {

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.compile.pass.cpp
@@ -41,11 +41,13 @@ static_assert(!cuda::std::indirectly_movable<int(), int()>);
 static_assert(!cuda::std::indirectly_movable<int*, int()>);
 static_assert(!cuda::std::indirectly_movable<void, void>);
 
+#ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
 // Can move move-only objects.
 static_assert( cuda::std::indirectly_movable<MoveOnly*, MoveOnly*>);
 static_assert(!cuda::std::indirectly_movable<MoveOnly*, const MoveOnly*>);
 static_assert(!cuda::std::indirectly_movable<const MoveOnly*, const MoveOnly*>);
 static_assert(!cuda::std::indirectly_movable<const MoveOnly*, MoveOnly*>);
+#endif // TEST_COMPILER_MSVC_2017
 
 template<class T>
 struct PointerTo {
@@ -53,6 +55,7 @@ struct PointerTo {
   __host__ __device__ T& operator*() const;
 };
 
+#ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
 // Can copy through a dereferenceable class.
 static_assert( cuda::std::indirectly_movable<int*, PointerTo<int>>);
 static_assert(!cuda::std::indirectly_movable<int*, PointerTo<const int>>);
@@ -61,6 +64,7 @@ static_assert(!cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<const in
 static_assert( cuda::std::indirectly_movable<MoveOnly*, PointerTo<MoveOnly>>);
 static_assert( cuda::std::indirectly_movable<PointerTo<MoveOnly>, MoveOnly*>);
 static_assert( cuda::std::indirectly_movable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>);
+#endif // TEST_COMPILER_MSVC_2017
 
 int main(int, char**)
 {

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable_storable.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable_storable.compile.pass.cpp
@@ -31,8 +31,10 @@ static_assert(!cuda::std::indirectly_movable_storable<int*, const int*>);
 static_assert(!cuda::std::indirectly_movable_storable<const int*, const int*>);
 static_assert( cuda::std::indirectly_movable_storable<int*, int[2]>);
 static_assert(!cuda::std::indirectly_movable_storable<int[2], int*>);
+#ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
 static_assert( cuda::std::indirectly_movable_storable<MoveOnly*, MoveOnly*>);
 static_assert( cuda::std::indirectly_movable_storable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>);
+#endif // TEST_COMPILER_MSVC_2017
 
 // The dereference operator returns a different type from `value_type` and the reference type cannot be assigned from a
 // `ValueType`.

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.input/input_iterator.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.input/input_iterator.compile.pass.cpp
@@ -15,6 +15,7 @@
 #include <cuda/std/iterator>
 
 #include "test_iterators.h"
+#include "test_macros.h"
 
 static_assert(cuda::std::input_iterator<cpp17_input_iterator<int*> >);
 static_assert(cuda::std::input_iterator<cpp20_input_iterator<int*> >);
@@ -36,8 +37,10 @@ struct no_explicit_iter_concept {
   __host__ __device__ no_explicit_iter_concept& operator++();
   __host__ __device__ void operator++(int);
 };
+#ifndef TEST_COMPILER_MSVC_2017
 // ITER-CONCEPT is `random_access_iterator_tag` >:(
 static_assert(cuda::std::input_iterator<no_explicit_iter_concept>);
+#endif // TEST_COMPILER_MSVC_2017
 
 static_assert(cuda::std::input_iterator<int*>);
 static_assert(cuda::std::input_iterator<int const*>);

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/contiguous_iterator.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/contiguous_iterator.compile.pass.cpp
@@ -15,6 +15,7 @@
 #include <cuda/std/iterator>
 
 #include "test_iterators.h"
+#include "test_macros.h"
 
 static_assert(!cuda::std::contiguous_iterator<cpp17_input_iterator<int*>>);
 static_assert(!cuda::std::contiguous_iterator<cpp20_input_iterator<int*>>);
@@ -23,10 +24,12 @@ static_assert(!cuda::std::contiguous_iterator<bidirectional_iterator<int*>>);
 static_assert(!cuda::std::contiguous_iterator<random_access_iterator<int*>>);
 static_assert(cuda::std::contiguous_iterator<contiguous_iterator<int*>>);
 
+#ifndef TEST_COMPILER_MSVC_2017
 static_assert(cuda::std::contiguous_iterator<int*>);
 static_assert(cuda::std::contiguous_iterator<int const*>);
 static_assert(cuda::std::contiguous_iterator<int volatile*>);
 static_assert(cuda::std::contiguous_iterator<int const volatile*>);
+#endif // TEST_COMPILER_MSVC_2017
 
 struct simple_contiguous_iterator {
     typedef cuda::std::contiguous_iterator_tag  iterator_category;

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/random_access_iterator.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/random_access_iterator.compile.pass.cpp
@@ -24,10 +24,12 @@ static_assert(!cuda::std::random_access_iterator<bidirectional_iterator<int*>>);
 static_assert( cuda::std::random_access_iterator<random_access_iterator<int*>>);
 static_assert( cuda::std::random_access_iterator<contiguous_iterator<int*>>);
 
+#ifndef TEST_COMPILER_MSVC_2017
 static_assert(cuda::std::random_access_iterator<int*>);
 static_assert(cuda::std::random_access_iterator<int const*>);
 static_assert(cuda::std::random_access_iterator<int volatile*>);
 static_assert(cuda::std::random_access_iterator<int const volatile*>);
+#endif // TEST_COMPILER_MSVC_2017
 
 struct wrong_iterator_category {
     typedef cuda::std::bidirectional_iterator_tag iterator_category;

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.sentinel/sentinel_for.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.sentinel/sentinel_for.compile.pass.cpp
@@ -14,6 +14,8 @@
 
 #include <cuda/std/iterator>
 
+#include "test_macros.h"
+
 static_assert(cuda::std::sentinel_for<int*, int*>);
 static_assert(!cuda::std::sentinel_for<int*, long*>);
 struct nth_element_sentinel {
@@ -60,9 +62,12 @@ struct move_only_iterator {
   __host__ __device__ bool operator==(move_only_iterator const&) const;
   __host__ __device__ bool operator!=(move_only_iterator const&) const;
 };
+
+#ifndef TEST_COMPILER_MSVC_2017
 static_assert(cuda::std::movable<move_only_iterator> && !cuda::std::copyable<move_only_iterator> &&
               cuda::std::input_or_output_iterator<move_only_iterator> &&
               !cuda::std::sentinel_for<move_only_iterator, move_only_iterator>);
+#endif // TEST_COMPILER_MSVC_2017
 
 int main(int, char**)
 {

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.winc/weakly_incrementable.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.winc/weakly_incrementable.compile.pass.cpp
@@ -66,9 +66,11 @@ static_assert(cuda::std::weakly_incrementable<not_default_initializable>);
 static_assert(cuda::std::weakly_incrementable<incrementable_with_difference_type>);
 static_assert(cuda::std::weakly_incrementable<incrementable_without_difference_type>);
 static_assert(cuda::std::weakly_incrementable<difference_type_and_void_minus>);
+#ifndef TEST_COMPILER_MSVC_2017
 static_assert(cuda::std::weakly_incrementable<noncopyable_with_difference_type>);
 static_assert(cuda::std::weakly_incrementable<noncopyable_without_difference_type>);
 static_assert(cuda::std::weakly_incrementable<noncopyable_with_difference_type_and_minus>);
+#endif // TEST_COMPILER_MSVC_2017
 
 int main(int, char**)
 {

--- a/libcudacxx/.upstream-tests/test/support/test_iterators.h
+++ b/libcudacxx/.upstream-tests/test/support/test_iterators.h
@@ -233,11 +233,11 @@ public:
 #if TEST_STD_VER > 14
   static_assert(cuda::std::random_access_iterator<random_access_iterator<int*>>, "");
 
-template <class It, class = cuda::std::enable_if_t<cuda::std::random_access_iterator<It>>>
+template <class It>
 class cpp20_random_access_iterator {
     It it_;
 
-    template <class U, class>
+    template <class U>
     friend class cpp20_random_access_iterator;
 
 public:

--- a/libcudacxx/.upstream-tests/test/support/test_iterators.h
+++ b/libcudacxx/.upstream-tests/test/support/test_iterators.h
@@ -1032,10 +1032,6 @@ TEST_NV_DIAG_SUPPRESS(1805) // MSVC complains that if we pass a pointer type, ad
     return *this;
   }
 
-#if defined(TEST_COMPILER_MSVC)
-TEST_NV_DIAG_DEFAULT(1805)
-#endif // TEST_COMPILER_MSVC
-
   // If `T` is a reference type, the implicitly-generated assignment operator will be deleted (and would take precedence
   // over the templated `operator=` above because it's a better match).
   __host__ __device__ constexpr Proxy& operator=(const Proxy& rhs) {

--- a/libcudacxx/.upstream-tests/test/support/test_iterators.h
+++ b/libcudacxx/.upstream-tests/test/support/test_iterators.h
@@ -609,8 +609,12 @@ public:
     using iterator_concept = cuda::std::input_iterator_tag;
 
     __host__ __device__ constexpr explicit cpp20_input_iterator(It it) : it_(it) {}
+
+#ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
     cpp20_input_iterator(cpp20_input_iterator&&) = default;
     cpp20_input_iterator& operator=(cpp20_input_iterator&&) = default;
+#endif // !TEST_COMPILER_MSVC_2017
+
     __host__ __device__ constexpr decltype(auto) operator*() const { return *it_; }
     __host__ __device__ constexpr cpp20_input_iterator& operator++() { ++it_; return *this; }
     __host__ __device__ constexpr void operator++(int) { ++it_; }
@@ -643,8 +647,11 @@ public:
     using difference_type = cuda::std::iter_difference_t<It>;
 
     __host__ __device__ constexpr explicit cpp20_output_iterator(It it) : it_(it) {}
+
+#ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
     cpp20_output_iterator(cpp20_output_iterator&&) = default;
     cpp20_output_iterator& operator=(cpp20_output_iterator&&) = default;
+#endif // !TEST_COMPILER_MSVC_2017
 
     __host__ __device__ constexpr decltype(auto) operator*() const { return *it_; }
     __host__ __device__ constexpr cpp20_output_iterator& operator++() {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -659,6 +659,57 @@ struct __is_std_optional<optional<_Tp>> : true_type
 {
 };
 
+// Constraits
+template <class _Tp, class _Up, class _Opt = optional<_Up>>
+using __opt_check_constructible_from_opt = _Or<
+    is_constructible<_Tp, _Opt&>,
+    is_constructible<_Tp, _Opt const&>,
+    is_constructible<_Tp, _Opt&&>,
+    is_constructible<_Tp, _Opt const&&>,
+    is_convertible<_Opt&, _Tp>,
+    is_convertible<_Opt const&, _Tp>,
+    is_convertible<_Opt&&, _Tp>,
+    is_convertible<_Opt const&&, _Tp>
+>;
+
+template <class _Tp, class _Up, class _Opt = optional<_Up>>
+using __opt_check_assignable_from_opt = _Or<
+    is_assignable<_Tp&, _Opt&>,
+    is_assignable<_Tp&, _Opt const&>,
+    is_assignable<_Tp&, _Opt&&>,
+    is_assignable<_Tp&, _Opt const&&>
+>;
+
+template<class _Tp, class _Up>
+_LIBCUDACXX_INLINE_VAR constexpr bool __opt_is_implictly_constructible =  _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Up)
+                                                                      &&  _LIBCUDACXX_TRAIT(is_convertible, _Up, _Tp);
+
+template<class _Tp, class _Up>
+_LIBCUDACXX_INLINE_VAR constexpr bool __opt_is_explictly_constructible =  _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Up)
+                                                                      && !_LIBCUDACXX_TRAIT(is_convertible, _Up, _Tp);
+
+template<class _Tp, class _Up>
+_LIBCUDACXX_INLINE_VAR constexpr bool __opt_is_constructible_from_U = !_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, in_place_t)
+                                                                   && !_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, optional<_Tp>);
+
+template<class _Tp, class _Up>
+_LIBCUDACXX_INLINE_VAR constexpr bool __opt_is_constructible_from_opt = !_LIBCUDACXX_TRAIT(is_same, _Up, _Tp)
+                                                                     && !__opt_check_constructible_from_opt<_Tp, _Up>::value;
+
+template<class _Tp, class _Up>
+_LIBCUDACXX_INLINE_VAR constexpr bool __opt_is_assignable = _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Up)
+                                                         && _LIBCUDACXX_TRAIT(is_assignable, _Tp&, _Up);
+
+template<class _Tp, class _Up>
+_LIBCUDACXX_INLINE_VAR constexpr bool __opt_is_assignable_from_U =  !_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, optional<_Tp>)
+                                                                && (!_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, _Tp)
+                                                                    || !_LIBCUDACXX_TRAIT(is_scalar, _Tp));
+
+template<class _Tp, class _Up>
+_LIBCUDACXX_INLINE_VAR constexpr bool __opt_is_assignable_from_opt = !_LIBCUDACXX_TRAIT(is_same, _Up, _Tp)
+                                                                  && !__opt_check_constructible_from_opt<_Tp, _Up>::value
+                                                                  && !__opt_check_assignable_from_opt<_Tp, _Up>::value;
+
 template <class _Tp>
 class optional
     : private __optional_move_assign_base<_Tp>
@@ -686,26 +737,6 @@ private:
     static_assert(!_LIBCUDACXX_TRAIT(is_array, value_type),
         "instantiation of optional with an array type is ill-formed");
 
-    template <class _Up, class _Opt = optional<_Up>>
-    using __check_constructible_from_opt = _Or<
-        is_constructible<_Tp, _Opt&>,
-        is_constructible<_Tp, _Opt const&>,
-        is_constructible<_Tp, _Opt&&>,
-        is_constructible<_Tp, _Opt const&&>,
-        is_convertible<_Opt&, _Tp>,
-        is_convertible<_Opt const&, _Tp>,
-        is_convertible<_Opt&&, _Tp>,
-        is_convertible<_Opt const&&, _Tp>
-    >;
-
-    template <class _Up, class _Opt = optional<_Up>>
-    using __check_assignable_from_opt = _Or<
-        is_assignable<_Tp&, _Opt&>,
-        is_assignable<_Tp&, _Opt const&>,
-        is_assignable<_Tp&, _Opt&&>,
-        is_assignable<_Tp&, _Opt const&&>
-    >;
-
 public:
 
     _LIBCUDACXX_INLINE_VISIBILITY constexpr optional() noexcept {}
@@ -726,61 +757,45 @@ public:
     explicit optional(in_place_t, initializer_list<_Up> __il, _Args&&... __args)
         : __base(in_place, __il, _CUDA_VSTD::forward<_Args>(__args)...) {}
 
-    template<class _Up>
-    static constexpr bool __is_implictly_constructible =  _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Up)
-                                                      &&  _LIBCUDACXX_TRAIT(is_convertible, _Up, _Tp);
-
-    template<class _Up>
-    static constexpr bool __is_explictly_constructible =  _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Up)
-                                                      && !_LIBCUDACXX_TRAIT(is_convertible, _Up, _Tp);
-
-    template<class _Up>
-    static constexpr bool __is_constructible_from_U = !_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, in_place_t)
-                                                   && !_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, optional);
-
     _LIBCUDACXX_TEMPLATE(class _Up = value_type)
-      (requires __is_constructible_from_U<_Up> _LIBCUDACXX_AND
-                __is_implictly_constructible<_Up>)
+      (requires __opt_is_constructible_from_U<_Tp, _Up> _LIBCUDACXX_AND
+                __opt_is_implictly_constructible<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional(_Up&& __v) : __base(in_place, _CUDA_VSTD::forward<_Up>(__v)) {}
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __is_constructible_from_U<_Up> _LIBCUDACXX_AND
-                __is_explictly_constructible<_Up>)
+      (requires __opt_is_constructible_from_U<_Tp, _Up> _LIBCUDACXX_AND
+                __opt_is_explictly_constructible<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     explicit optional(_Up&& __v) : __base(in_place, _CUDA_VSTD::forward<_Up>(__v)) {}
 
-    template<class _Up>
-    static constexpr bool __is_constructible_from_opt = !_LIBCUDACXX_TRAIT(is_same, _Up, _Tp)
-                                                     && !__check_constructible_from_opt<_Up>::value;
-
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __is_constructible_from_opt<_Up> _LIBCUDACXX_AND
-                __is_implictly_constructible<const _Up&>)
+      (requires __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+                __opt_is_implictly_constructible<_Tp, const _Up&>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional(const optional<_Up>& __v) {
         this->__construct_from(__v);
     }
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __is_constructible_from_opt<_Up> _LIBCUDACXX_AND
-                __is_explictly_constructible<const _Up&>)
+      (requires __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+                __opt_is_explictly_constructible<_Tp, const _Up&>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     explicit optional(const optional<_Up>& __v) {
         this->__construct_from(__v);
     }
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __is_constructible_from_opt<_Up> _LIBCUDACXX_AND
-                __is_implictly_constructible<_Up>)
+      (requires __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+                __opt_is_implictly_constructible<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional(optional<_Up>&& __v) {
         this->__construct_from(_CUDA_VSTD::move(__v));
     }
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __is_constructible_from_opt<_Up> _LIBCUDACXX_AND
-                __is_explictly_constructible<_Up>)
+      (requires __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+                __opt_is_explictly_constructible<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     explicit optional(optional<_Up>&& __v) {
         this->__construct_from(_CUDA_VSTD::move(__v));
@@ -804,19 +819,9 @@ public:
     constexpr optional& operator=(const optional&) = default;
     constexpr optional& operator=(optional&&) = default;
 
-    // Note: __is__assignable is potentially a built-in
-    template<class _Up>
-    static constexpr bool __is_assignable_from = _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Up)
-                                              && _LIBCUDACXX_TRAIT(is_assignable, _Tp&, _Up);
-
-    template<class _Up>
-    static constexpr bool __is_assignable_from_U =  !_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, optional)
-                                                && (!_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, _Tp)
-                                                 || !_LIBCUDACXX_TRAIT(is_scalar, _Tp));
-
     _LIBCUDACXX_TEMPLATE(class _Up = value_type)
-      (requires __is_assignable_from_U<_Up> _LIBCUDACXX_AND
-                __is_assignable_from<_Up>)
+      (requires __opt_is_assignable_from_U<_Tp, _Up> _LIBCUDACXX_AND
+                __opt_is_assignable<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional& operator=(_Up&& __v) {
         if (this->has_value())
@@ -826,14 +831,9 @@ public:
         return *this;
     }
 
-    template<class _Up>
-    static constexpr bool __is_assignable_from_opt = !_LIBCUDACXX_TRAIT(is_same, _Up, _Tp)
-                                                  && !__check_constructible_from_opt<_Up>::value
-                                                  && !__check_assignable_from_opt<_Up>::value;
-
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __is_assignable_from_opt<_Up> _LIBCUDACXX_AND
-                __is_assignable_from<const _Up&>)
+      (requires __opt_is_assignable_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+                __opt_is_assignable<_Tp, const _Up&>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional& operator=(const optional<_Up>& __v) {
         this->__assign_from(__v);
@@ -841,8 +841,8 @@ public:
     }
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __is_assignable_from_opt<_Up> _LIBCUDACXX_AND
-                __is_assignable_from<_Up>)
+      (requires __opt_is_assignable_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+                __opt_is_assignable<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional& operator=(optional<_Up>&& __v) {
         this->__assign_from(_CUDA_VSTD::move(__v));


### PR DESCRIPTION
There are some issues with MSVC 2017.

Namely it struggles mightily with `common_reference_with` and `weakly_incrementable`

I have no idea where things go wrong. Im my analysis of the failing tests each atom of `common_reference_with` was satisfied on its own but put together it would fail.

Given that 2017 is not receiving any updates I went ahead and simply ddisabled whatever is failing
