### PR TITLE
Tune reduce by key on A100

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -599,6 +599,489 @@ struct sm90_tuning<KeyT,
 
   using delay_constructor = detail::no_delay_constructor_t<1150>;
 };
+
+template <class KeyT,
+          class AccumT,
+          primitive_op PrimitiveOp,
+          primitive_key PrimitiveKey     = is_primitive_key<KeyT>(),
+          primitive_accum PrimitiveAccum = is_primitive_accum<AccumT>(),
+          key_size KeySize               = classify_key_size<KeyT>(),
+          accum_size AccumSize           = classify_accum_size<AccumT>()>
+struct sm80_tuning
+{
+  static constexpr int max_input_bytes      = CUB_MAX(sizeof(KeyT), sizeof(AccumT));
+  static constexpr int combined_input_bytes = sizeof(KeyT) + sizeof(AccumT);
+
+  static constexpr int threads = 128;
+
+  static constexpr int nominal_4b_items_per_thread = 6;
+  static constexpr int items =
+    (max_input_bytes <= 8)
+      ? 6
+      : CUB_MIN(nominal_4b_items_per_thread,
+                CUB_MAX(1,
+                        ((nominal_4b_items_per_thread * 8) + combined_input_bytes - 1) /
+                          combined_input_bytes));
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::default_reduce_by_key_delay_constructor_t<AccumT, int>;
+};
+
+// 8-bit key
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_1,
+                   accum_size::_1>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 13;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<975>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_1,
+                   accum_size::_2>
+{
+  static constexpr int threads = 224;
+
+  static constexpr int items = 12;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<840>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_1,
+                   accum_size::_4>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<760>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_1,
+                   accum_size::_8>
+{
+  static constexpr int threads = 224;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1070>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::no,
+                   key_size::_1,
+                   accum_size::_16>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 9;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1175>;
+};
+
+// 16-bit key
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_2,
+                   accum_size::_1>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 11;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<620>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_2,
+                   accum_size::_2>
+{
+  static constexpr int threads = 224;
+
+  static constexpr int items = 14;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<640>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_2,
+                   accum_size::_4>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 14;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<905>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_2,
+                   accum_size::_8>
+{
+  static constexpr int threads = 224;
+
+  static constexpr int items = 9;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<810>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::no,
+                   key_size::_2,
+                   accum_size::_16>
+{
+  static constexpr int threads = 160;
+
+  static constexpr int items = 9;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1115>;
+};
+
+// 32-bit key
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_4,
+                   accum_size::_1>
+{
+  static constexpr int threads = 288;
+
+  static constexpr int items = 11;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1110>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_4,
+                   accum_size::_2>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1200>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_4,
+                   accum_size::_4>
+{
+  static constexpr int threads = 256;
+
+  static constexpr int items = 15;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1110>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_4,
+                   accum_size::_8>
+{
+  static constexpr int threads = 224;
+
+  static constexpr int items = 9;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1165>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::no,
+                   key_size::_4,
+                   accum_size::_16>
+{
+  static constexpr int threads = 160;
+
+  static constexpr int items = 9;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1100>;
+};
+
+// 64-bit key
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_8,
+                   accum_size::_1>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 10;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1175>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_8,
+                   accum_size::_2>
+{
+  static constexpr int threads = 224;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1075>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_8,
+                   accum_size::_4>
+{
+  static constexpr int threads = 384;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1040>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::yes,
+                   key_size::_8,
+                   accum_size::_8>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 14;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1080>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::yes,
+                   primitive_accum::no,
+                   key_size::_8,
+                   accum_size::_16>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 11;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<430>;
+};
+
+// 128-bit key
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::no,
+                   primitive_accum::yes,
+                   key_size::_16,
+                   accum_size::_1>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1105>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::no,
+                   primitive_accum::yes,
+                   key_size::_16,
+                   accum_size::_2>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<755>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::no,
+                   primitive_accum::yes,
+                   key_size::_16,
+                   accum_size::_4>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<535>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::no,
+                   primitive_accum::yes,
+                   key_size::_16,
+                   accum_size::_8>
+{
+  static constexpr int threads = 192;
+
+  static constexpr int items = 7;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
+
+  using delay_constructor = detail::no_delay_constructor_t<1035>;
+};
+
+template <class KeyT, class AccumT>
+struct sm80_tuning<KeyT,
+                   AccumT,
+                   primitive_op::yes,
+                   primitive_key::no,
+                   primitive_accum::no,
+                   key_size::_16,
+                   accum_size::_16>
+{
+  static constexpr int threads = 128;
+
+  static constexpr int items = 11;
+
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+
+  using delay_constructor = detail::no_delay_constructor_t<1090>;
+};
 } // namespace reduce_by_key
 
 template <class ReductionOpT, class AccumT, class KeyT>
@@ -607,8 +1090,7 @@ struct device_reduce_by_key_policy_hub
   static constexpr int MAX_INPUT_BYTES = CUB_MAX(sizeof(KeyT), sizeof(AccumT));
   static constexpr int COMBINED_INPUT_BYTES = sizeof(KeyT) + sizeof(AccumT);
 
-  /// SM35
-  struct Policy350 : ChainedPolicy<350, Policy350, Policy350>
+  struct DefaultTuning
   {
     static constexpr int NOMINAL_4B_ITEMS_PER_THREAD = 6;
     static constexpr int ITEMS_PER_THREAD =
@@ -628,8 +1110,34 @@ struct device_reduce_by_key_policy_hub
                              detail::default_reduce_by_key_delay_constructor_t<AccumT, int>>;
   };
 
+  /// SM35
+  struct Policy350
+      : DefaultTuning
+      , ChainedPolicy<350, Policy350, Policy350>
+  {};
+
+  /// SM80
+  struct Policy800 : ChainedPolicy<800, Policy800, Policy350>
+  {
+    using tuning = detail::reduce_by_key::
+      sm80_tuning<KeyT, AccumT, detail::reduce_by_key::is_primitive_op<ReductionOpT>()>;
+
+    using ReduceByKeyPolicyT = AgentReduceByKeyPolicy<tuning::threads,
+                                                      tuning::items,
+                                                      tuning::load_algorithm,
+                                                      LOAD_DEFAULT,
+                                                      BLOCK_SCAN_WARP_SCANS,
+                                                      typename tuning::delay_constructor>;
+  };
+
+  /// SM86
+  struct Policy860
+      : DefaultTuning
+      , ChainedPolicy<860, Policy860, Policy800>
+  {};
+
   /// SM90
-  struct Policy900 : ChainedPolicy<900, Policy900, Policy350>
+  struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
   {
     using tuning = detail::reduce_by_key::
       sm90_tuning<KeyT, AccumT, detail::reduce_by_key::is_primitive_op<ReductionOpT>()>;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/238

<!-- Provide a standalone description of changes in this PR. -->

### A100 SXM

#### Max Segment Size 2

| KeyT \ ValueT   | I8      | I16     | I32     | I64     | F32     | F64     | I128    |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -37.45% | -22.42% | -25.01% | -15.31% | -25.73% | -16.95% | -45.48% |
| I16        | -34.03% | -26.55% | -19.86% | -6.60%  | -20.73% | -5.15%  | -46.10% |
| I32        | -30.00% | -23.91% | -11.19% | -5.42%  | -5.99%  | -4.67%  | -45.81% |
| I64        | -10.76% | -14.08% | -6.94%  | -2.52%  | 1.18%   | -2.93%  | -57.37% |
| I128       | -8.88%  | -1.46%  | -1.06%  | -13.44% | -1.52%  | -13.19% | -53.64% |
#### Max Segment Size 16

| KeyT \ ValueT   | I8      | I16     | I32     | I64     | F32     | F64     | I128    |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -44.72% | -34.67% | -34.20% | -16.45% | -35.19% | -18.53% | -52.85% |
| I16        | -38.65% | -36.81% | -39.82% | -16.23% | -40.75% | -10.68% | -52.19% |
| I32        | -34.55% | -30.70% | -31.49% | -16.94% | -18.01% | -11.72% | -52.68% |
| I64        | -17.69% | -17.24% | -16.22% | -12.38% | -1.21%  | -13.20% | -64.07% |
| I128       | -16.57% | -12.02% | -12.76% | -25.73% | -14.48% | -32.18% | -63.91% |
#### Max Segment Size 256

| KeyT{ct}   | I8      | I16     | I32     | I64     | F32     | F64     | I128    |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -44.09% | -35.67% | -36.89% | -18.18% | -37.85% | -20.73% | -54.32% |
| I16        | -40.02% | -36.94% | -41.94% | -16.19% | -43.01% | -12.04% | -53.37% |
| I32        | -36.03% | -30.43% | -32.70% | -17.54% | -18.53% | -11.83% | -53.96% |
| I64        | -16.09% | -17.95% | -21.98% | -16.40% | -0.96%  | -17.71% | -65.65% |
| I128       | -18.84% | -17.83% | -19.46% | -33.15% | -22.30% | -41.14% | -65.30% |
### A100 PCIe

#### Max Segment Size 2

| KeyT \ ValueT   | I8      | I16     | I32     | I64     | F32     | F64     | I128    |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -40.27% | -24.17% | -24.32% | -13.29% | -25.00% | -14.41% | -43.07% |
| I16        | -36.10% | -26.94% | -17.56% | -4.51%  | -18.21% | -3.16%  | -43.53% |
| I32        | -25.98% | -17.66% | -6.05%  | -3.66%  | -0.22%  | -2.60%  | -43.03% |
| I64        | -5.70%  | -9.05%  | -4.83%  | -1.58%  | 3.74%   | -1.86%  | -55.47% |
| I128       | -3.55%  | 3.49%   | 1.84%   | -10.01% | 1.35%   | -13.41% | -49.77% |
#### Max Segment Size 16

| KeyT \ ValueT   | I8      | I16     | I32     | I64     | F32     | F64     | I128    |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -47.83% | -37.84% | -37.89% | -22.06% | -38.10% | -23.76% | -51.33% |
| I16        | -45.01% | -39.61% | -42.67% | -20.04% | -43.19% | -15.67% | -50.67% |
| I32        | -36.39% | -33.15% | -33.49% | -16.71% | -22.64% | -15.35% | -51.26% |
| I64        | -18.48% | -16.57% | -15.87% | -7.14%  | -4.41%  | -9.10%  | -63.72% |
| I128       | -22.88% | -18.14% | -20.40% | -31.65% | -21.78% | -37.98% | -62.06% |

#### Max Segment Size 256

| KeyT \ ValueT | I8      | I16     | I32     | I64     | F32     | F64     | I128    |
|:-----------|:--------|:--------|:--------|:--------|:--------|:--------|:--------|
| I8         | -46.57% | -39.78% | -41.64% | -23.96% | -41.61% | -24.85% | -52.67% |
| I16        | -47.61% | -40.26% | -45.49% | -21.85% | -45.81% | -17.97% | -51.80% |
| I32        | -38.73% | -33.31% | -35.02% | -22.29% | -20.75% | -17.91% | -52.32% |
| I64        | -18.96% | -20.18% | -25.11% | -14.34% | -6.69%  | -16.79% | -66.11% |
| I128       | -29.15% | -27.42% | -30.40% | -36.79% | -30.57% | -45.73% | -63.86% |

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
