### PR TITLE
Remove _NOEXCEPT macro in favor of noexcept in libcu++

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__bit_reference
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__bit_reference
@@ -50,13 +50,13 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     __bit_reference(const __bit_reference&) = default;
 
-    _LIBCUDACXX_INLINE_VISIBILITY operator bool() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY operator bool() const noexcept
         {return static_cast<bool>(*__seg_ & __mask_);}
-    _LIBCUDACXX_INLINE_VISIBILITY bool operator ~() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY bool operator ~() const noexcept
         {return !static_cast<bool>(*this);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __bit_reference& operator=(bool __x) _NOEXCEPT
+    __bit_reference& operator=(bool __x) noexcept
     {
         if (__x)
             *__seg_ |= __mask_;
@@ -66,15 +66,15 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __bit_reference& operator=(const __bit_reference& __x) _NOEXCEPT
+    __bit_reference& operator=(const __bit_reference& __x) noexcept
         {return operator=(static_cast<bool>(__x));}
 
-    _LIBCUDACXX_INLINE_VISIBILITY void flip() _NOEXCEPT {*__seg_ ^= __mask_;}
-    _LIBCUDACXX_INLINE_VISIBILITY __bit_iterator<_Cp, false> operator&() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void flip() noexcept {*__seg_ ^= __mask_;}
+    _LIBCUDACXX_INLINE_VISIBILITY __bit_iterator<_Cp, false> operator&() const noexcept
         {return __bit_iterator<_Cp, false>(__seg_, static_cast<unsigned>(__libcpp_ctz(__mask_)));}
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-    __bit_reference(__storage_pointer __s, __storage_type __m) _NOEXCEPT
+    __bit_reference(__storage_pointer __s, __storage_type __m) noexcept
         : __seg_(__s), __mask_(__m) {}
 };
 
@@ -86,7 +86,7 @@ class __bit_reference<_Cp, false>
 template <class _Cp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(__bit_reference<_Cp> __x, __bit_reference<_Cp> __y) _NOEXCEPT
+swap(__bit_reference<_Cp> __x, __bit_reference<_Cp> __y) noexcept
 {
     bool __t = __x;
     __x = __y;
@@ -96,7 +96,7 @@ swap(__bit_reference<_Cp> __x, __bit_reference<_Cp> __y) _NOEXCEPT
 template <class _Cp, class _Dp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(__bit_reference<_Cp> __x, __bit_reference<_Dp> __y) _NOEXCEPT
+swap(__bit_reference<_Cp> __x, __bit_reference<_Dp> __y) noexcept
 {
     bool __t = __x;
     __x = __y;
@@ -106,7 +106,7 @@ swap(__bit_reference<_Cp> __x, __bit_reference<_Dp> __y) _NOEXCEPT
 template <class _Cp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(__bit_reference<_Cp> __x, bool& __y) _NOEXCEPT
+swap(__bit_reference<_Cp> __x, bool& __y) noexcept
 {
     bool __t = __x;
     __x = __y;
@@ -116,7 +116,7 @@ swap(__bit_reference<_Cp> __x, bool& __y) _NOEXCEPT
 template <class _Cp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(bool& __x, __bit_reference<_Cp> __y) _NOEXCEPT
+swap(bool& __x, __bit_reference<_Cp> __y) noexcept
 {
     bool __t = __x;
     __x = __y;
@@ -139,18 +139,18 @@ public:
     __bit_const_reference(const __bit_const_reference&) = default;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __bit_const_reference(const __bit_reference<_Cp>& __x) _NOEXCEPT
+    __bit_const_reference(const __bit_reference<_Cp>& __x) noexcept
         : __seg_(__x.__seg_), __mask_(__x.__mask_) {}
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR operator bool() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR operator bool() const noexcept
         {return static_cast<bool>(*__seg_ & __mask_);}
 
-    _LIBCUDACXX_INLINE_VISIBILITY __bit_iterator<_Cp, true> operator&() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY __bit_iterator<_Cp, true> operator&() const noexcept
         {return __bit_iterator<_Cp, true>(__seg_, static_cast<unsigned>(__libcpp_ctz(__mask_)));}
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
     _LIBCUDACXX_CONSTEXPR
-    __bit_const_reference(__storage_pointer __s, __storage_type __m) _NOEXCEPT
+    __bit_const_reference(__storage_pointer __s, __storage_type __m) noexcept
         : __seg_(__s), __mask_(__m) {}
 
     __bit_const_reference& operator=(const __bit_const_reference&) = delete;
@@ -1108,7 +1108,7 @@ private:
     unsigned          __ctz_;
 
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY __bit_iterator() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY __bit_iterator() noexcept
 #if _LIBCUDACXX_STD_VER > 11
     : __seg_(nullptr), __ctz_(0)
 #endif
@@ -1118,10 +1118,10 @@ public:
       _If<_IsConst, __bit_iterator<_Cp, false>, struct __private_nat>;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __bit_iterator(const __type_for_copy_to_const& __it) _NOEXCEPT
+    __bit_iterator(const __type_for_copy_to_const& __it) noexcept
         : __seg_(__it.__seg_), __ctz_(__it.__ctz_) {}
 
-    _LIBCUDACXX_INLINE_VISIBILITY reference operator*() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY reference operator*() const noexcept
         {return reference(__seg_, __storage_type(1) << __ctz_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY __bit_iterator& operator++()
@@ -1222,7 +1222,7 @@ public:
 
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-    __bit_iterator(__storage_pointer __s, unsigned __ctz) _NOEXCEPT
+    __bit_iterator(__storage_pointer __s, unsigned __ctz) noexcept
         : __seg_(__s), __ctz_(__ctz) {}
 
     friend typename _Cp::__self;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/chrono.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/chrono.h
@@ -26,7 +26,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 namespace chrono {
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-system_clock::time_point system_clock::now() _NOEXCEPT
+system_clock::time_point system_clock::now() noexcept
 {
 NV_DISPATCH_TARGET(
 NV_IS_DEVICE, (
@@ -44,13 +44,13 @@ NV_IS_HOST, (
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-time_t system_clock::to_time_t(const system_clock::time_point& __t) _NOEXCEPT
+time_t system_clock::to_time_t(const system_clock::time_point& __t) noexcept
 {
     return time_t(duration_cast<seconds>(__t.time_since_epoch()).count());
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-system_clock::time_point system_clock::from_time_t(time_t __t) _NOEXCEPT
+system_clock::time_point system_clock::from_time_t(time_t __t) noexcept
 {
     return time_point(seconds(__t));;
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/function.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/function.h
@@ -59,9 +59,9 @@ class _LIBCUDACXX_EXCEPTION_ABI bad_function_call
 {
 #ifdef _LIBCUDACXX_ABI_BAD_FUNCTION_CALL_KEY_FUNCTION
 public:
-    virtual ~bad_function_call() _NOEXCEPT;
+    virtual ~bad_function_call() noexcept;
 
-    virtual const char* what() const _NOEXCEPT;
+    virtual const char* what() const noexcept;
 #endif
 };
 
@@ -201,7 +201,7 @@ class __alloc_func<_Fp, _Ap, _Rp(_ArgTypes...)>
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void destroy() _NOEXCEPT { __f_.~__compressed_pair<_Target, _Alloc>(); }
+    void destroy() noexcept { __f_.~__compressed_pair<_Target, _Alloc>(); }
 
     static void __destroy_and_delete(__alloc_func* __f) {
       typedef allocator_traits<_Alloc> __alloc_traits;
@@ -245,7 +245,7 @@ public:
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  void destroy() _NOEXCEPT { __f_.~_Target(); }
+  void destroy() noexcept { __f_.~_Target(); }
 
   static void __destroy_and_delete(__default_alloc_func* __f) {
     __f->destroy();
@@ -267,12 +267,12 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY virtual ~__base() {}
     virtual __base* __clone() const = 0;
     virtual void __clone(__base*) const = 0;
-    virtual void destroy() _NOEXCEPT = 0;
-    virtual void destroy_deallocate() _NOEXCEPT = 0;
+    virtual void destroy() noexcept = 0;
+    virtual void destroy_deallocate() noexcept = 0;
     virtual _Rp operator()(_ArgTypes&& ...) = 0;
 #ifndef _LIBCUDACXX_NO_RTTI
-    virtual const void* target(const type_info&) const _NOEXCEPT = 0;
-    virtual const type_info& target_type() const _NOEXCEPT = 0;
+    virtual const void* target(const type_info&) const noexcept = 0;
+    virtual const type_info& target_type() const noexcept = 0;
 #endif // _LIBCUDACXX_NO_RTTI
 };
 
@@ -304,12 +304,12 @@ public:
 
     virtual __base<_Rp(_ArgTypes...)>* __clone() const;
     virtual void __clone(__base<_Rp(_ArgTypes...)>*) const;
-    virtual void destroy() _NOEXCEPT;
-    virtual void destroy_deallocate() _NOEXCEPT;
+    virtual void destroy() noexcept;
+    virtual void destroy_deallocate() noexcept;
     virtual _Rp operator()(_ArgTypes&&... __arg);
 #ifndef _LIBCUDACXX_NO_RTTI
-    virtual const void* target(const type_info&) const _NOEXCEPT;
-    virtual const type_info& target_type() const _NOEXCEPT;
+    virtual const void* target(const type_info&) const noexcept;
+    virtual const type_info& target_type() const noexcept;
 #endif // _LIBCUDACXX_NO_RTTI
 };
 
@@ -335,14 +335,14 @@ __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::__clone(__base<_Rp(_ArgTypes...)>* __p) 
 
 template<class _Fp, class _Alloc, class _Rp, class ..._ArgTypes>
 void
-__func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy() _NOEXCEPT
+__func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy() noexcept
 {
     __f_.destroy();
 }
 
 template<class _Fp, class _Alloc, class _Rp, class ..._ArgTypes>
 void
-__func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy_deallocate() _NOEXCEPT
+__func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy_deallocate() noexcept
 {
     typedef allocator_traits<_Alloc> __alloc_traits;
     typedef typename __rebind_alloc_helper<__alloc_traits, __func>::type _Ap;
@@ -362,7 +362,7 @@ __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::operator()(_ArgTypes&& ... __arg)
 
 template<class _Fp, class _Alloc, class _Rp, class ..._ArgTypes>
 const void*
-__func<_Fp, _Alloc, _Rp(_ArgTypes...)>::target(const type_info& __ti) const _NOEXCEPT
+__func<_Fp, _Alloc, _Rp(_ArgTypes...)>::target(const type_info& __ti) const noexcept
 {
     if (__ti == typeid(_Fp))
         return _CUDA_VSTD::addressof(__f_.__target());
@@ -371,7 +371,7 @@ __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::target(const type_info& __ti) const _NOE
 
 template<class _Fp, class _Alloc, class _Rp, class ..._ArgTypes>
 const type_info&
-__func<_Fp, _Alloc, _Rp(_ArgTypes...)>::target_type() const _NOEXCEPT
+__func<_Fp, _Alloc, _Rp(_ArgTypes...)>::target_type() const noexcept
 {
     return typeid(_Fp);
 }
@@ -396,7 +396,7 @@ template <class _Rp, class... _ArgTypes> class __value_func<_Rp(_ArgTypes...)>
 
   public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    __value_func() _NOEXCEPT : __f_(nullptr) {}
+    __value_func() noexcept : __f_(nullptr) {}
 
     template <class _Fp, class _Alloc>
     _LIBCUDACXX_INLINE_VISIBILITY __value_func(_Fp&& __f, const _Alloc& __a)
@@ -446,7 +446,7 @@ template <class _Rp, class... _ArgTypes> class __value_func<_Rp(_ArgTypes...)>
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __value_func(__value_func&& __f) _NOEXCEPT
+    __value_func(__value_func&& __f) noexcept
     {
         if (__f.__f_ == nullptr)
             __f_ = nullptr;
@@ -511,7 +511,7 @@ template <class _Rp, class... _ArgTypes> class __value_func<_Rp(_ArgTypes...)>
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(__value_func& __f) _NOEXCEPT
+    void swap(__value_func& __f) noexcept
     {
         if (&__f == this)
             return;
@@ -549,11 +549,11 @@ template <class _Rp, class... _ArgTypes> class __value_func<_Rp(_ArgTypes...)>
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_EXPLICIT operator bool() const _NOEXCEPT { return __f_ != nullptr; }
+    _LIBCUDACXX_EXPLICIT operator bool() const noexcept { return __f_ != nullptr; }
 
 #ifndef _LIBCUDACXX_NO_RTTI
     _LIBCUDACXX_INLINE_VISIBILITY
-    const type_info& target_type() const _NOEXCEPT
+    const type_info& target_type() const noexcept
     {
         if (__f_ == nullptr)
             return typeid(void);
@@ -561,7 +561,7 @@ template <class _Rp, class... _ArgTypes> class __value_func<_Rp(_ArgTypes...)>
     }
 
     template <typename _Tp>
-    _LIBCUDACXX_INLINE_VISIBILITY const _Tp* target() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY const _Tp* target() const noexcept
     {
         if (__f_ == nullptr)
             return nullptr;
@@ -854,20 +854,20 @@ template <class _Rp, class... _ArgTypes> class __policy_func<_Rp(_ArgTypes...)>
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit operator bool() const _NOEXCEPT
+    explicit operator bool() const noexcept
     {
         return !__policy_->__is_null;
     }
 
 #ifndef _LIBCUDACXX_NO_RTTI
     _LIBCUDACXX_INLINE_VISIBILITY
-    const type_info& target_type() const _NOEXCEPT
+    const type_info& target_type() const noexcept
     {
         return *__policy_->__type_info;
     }
 
     template <typename _Tp>
-    _LIBCUDACXX_INLINE_VISIBILITY const _Tp* target() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY const _Tp* target() const noexcept
     {
         if (__policy_->__is_null || typeid(_Tp) != *__policy_->__type_info)
             return nullptr;
@@ -924,7 +924,7 @@ public:
         ::new ((void*)__p) __func(__f_);
     }
 
-    virtual void destroy() _NOEXCEPT {
+    virtual void destroy() noexcept {
 #ifndef _LIBCUDACXX_HAS_OBJC_ARC
         if (__f_)
             _Block_release(__f_);
@@ -932,7 +932,7 @@ public:
         __f_ = 0;
     }
 
-    virtual void destroy_deallocate() _NOEXCEPT {
+    virtual void destroy_deallocate() noexcept {
         _LIBCUDACXX_ASSERT(false,
             "Block pointers are just pointers, so they should always fit into "
             "std::function's small buffer optimization. This function should "
@@ -944,13 +944,13 @@ public:
     }
 
 #ifndef _LIBCUDACXX_NO_RTTI
-    virtual const void* target(type_info const& __ti) const _NOEXCEPT {
+    virtual const void* target(type_info const& __ti) const noexcept {
         if (__ti == typeid(__func::__block_type))
             return &__f_;
         return (const void*)nullptr;
     }
 
-    virtual const type_info& target_type() const _NOEXCEPT {
+    virtual const type_info& target_type() const noexcept {
         return typeid(__func::__block_type);
     }
 #endif // _LIBCUDACXX_NO_RTTI
@@ -998,21 +998,21 @@ public:
 
     // construct/copy/destroy:
     _LIBCUDACXX_INLINE_VISIBILITY
-    function() _NOEXCEPT { }
+    function() noexcept { }
     _LIBCUDACXX_INLINE_VISIBILITY
-    function(nullptr_t) _NOEXCEPT {}
+    function(nullptr_t) noexcept {}
     function(const function&);
-    function(function&&) _NOEXCEPT;
+    function(function&&) noexcept;
     template<class _Fp, class = _EnableIfLValueCallable<_Fp>>
     function(_Fp);
 
 #if _LIBCUDACXX_STD_VER <= 14
     template<class _Alloc>
       _LIBCUDACXX_INLINE_VISIBILITY
-      function(allocator_arg_t, const _Alloc&) _NOEXCEPT {}
+      function(allocator_arg_t, const _Alloc&) noexcept {}
     template<class _Alloc>
       _LIBCUDACXX_INLINE_VISIBILITY
-      function(allocator_arg_t, const _Alloc&, nullptr_t) _NOEXCEPT {}
+      function(allocator_arg_t, const _Alloc&, nullptr_t) noexcept {}
     template<class _Alloc>
       function(allocator_arg_t, const _Alloc&, const function&);
     template<class _Alloc>
@@ -1022,15 +1022,15 @@ public:
 #endif
 
     function& operator=(const function&);
-    function& operator=(function&&) _NOEXCEPT;
-    function& operator=(nullptr_t) _NOEXCEPT;
+    function& operator=(function&&) noexcept;
+    function& operator=(nullptr_t) noexcept;
     template<class _Fp, class = _EnableIfLValueCallable<__decay_t<_Fp>>>
     function& operator=(_Fp&&);
 
     ~function();
 
     // function modifiers:
-    void swap(function&) _NOEXCEPT;
+    void swap(function&) noexcept;
 
 #if _LIBCUDACXX_STD_VER <= 14
     template<class _Fp, class _Alloc>
@@ -1041,7 +1041,7 @@ public:
 
     // function capacity:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_EXPLICIT operator bool() const _NOEXCEPT {
+    _LIBCUDACXX_EXPLICIT operator bool() const noexcept {
       return static_cast<bool>(__f_);
     }
 
@@ -1056,9 +1056,9 @@ public:
 
 #ifndef _LIBCUDACXX_NO_RTTI
     // function target access:
-    const type_info& target_type() const _NOEXCEPT;
-    template <typename _Tp> _Tp* target() _NOEXCEPT;
-    template <typename _Tp> const _Tp* target() const _NOEXCEPT;
+    const type_info& target_type() const noexcept;
+    template <typename _Tp> _Tp* target() noexcept;
+    template <typename _Tp> const _Tp* target() const noexcept;
 #endif // _LIBCUDACXX_NO_RTTI
 };
 
@@ -1120,7 +1120,7 @@ function<_Rp(_ArgTypes...)>::function(allocator_arg_t, const _Alloc&,
 #endif
 
 template <class _Rp, class... _ArgTypes>
-function<_Rp(_ArgTypes...)>::function(function&& __f) _NOEXCEPT
+function<_Rp(_ArgTypes...)>::function(function&& __f) noexcept
     : __f_(_CUDA_VSTD::move(__f.__f_)) {}
 
 #if _LIBCUDACXX_STD_VER <= 14
@@ -1153,7 +1153,7 @@ function<_Rp(_ArgTypes...)>::operator=(const function& __f)
 
 template<class _Rp, class ..._ArgTypes>
 function<_Rp(_ArgTypes...)>&
-function<_Rp(_ArgTypes...)>::operator=(function&& __f) _NOEXCEPT
+function<_Rp(_ArgTypes...)>::operator=(function&& __f) noexcept
 {
     __f_ = _CUDA_VSTD::move(__f.__f_);
     return *this;
@@ -1161,7 +1161,7 @@ function<_Rp(_ArgTypes...)>::operator=(function&& __f) _NOEXCEPT
 
 template<class _Rp, class ..._ArgTypes>
 function<_Rp(_ArgTypes...)>&
-function<_Rp(_ArgTypes...)>::operator=(nullptr_t) _NOEXCEPT
+function<_Rp(_ArgTypes...)>::operator=(nullptr_t) noexcept
 {
     __f_ = nullptr;
     return *this;
@@ -1181,7 +1181,7 @@ function<_Rp(_ArgTypes...)>::~function() {}
 
 template<class _Rp, class ..._ArgTypes>
 void
-function<_Rp(_ArgTypes...)>::swap(function& __f) _NOEXCEPT
+function<_Rp(_ArgTypes...)>::swap(function& __f) noexcept
 {
     __f_.swap(__f.__f_);
 }
@@ -1197,7 +1197,7 @@ function<_Rp(_ArgTypes...)>::operator()(_ArgTypes... __arg) const
 
 template<class _Rp, class ..._ArgTypes>
 const type_info&
-function<_Rp(_ArgTypes...)>::target_type() const _NOEXCEPT
+function<_Rp(_ArgTypes...)>::target_type() const noexcept
 {
     return __f_.target_type();
 }
@@ -1205,7 +1205,7 @@ function<_Rp(_ArgTypes...)>::target_type() const _NOEXCEPT
 template<class _Rp, class ..._ArgTypes>
 template <typename _Tp>
 _Tp*
-function<_Rp(_ArgTypes...)>::target() _NOEXCEPT
+function<_Rp(_ArgTypes...)>::target() noexcept
 {
     return (_Tp*)(__f_.template target<_Tp>());
 }
@@ -1213,7 +1213,7 @@ function<_Rp(_ArgTypes...)>::target() _NOEXCEPT
 template<class _Rp, class ..._ArgTypes>
 template <typename _Tp>
 const _Tp*
-function<_Rp(_ArgTypes...)>::target() const _NOEXCEPT
+function<_Rp(_ArgTypes...)>::target() const noexcept
 {
     return __f_.template target<_Tp>();
 }
@@ -1223,27 +1223,27 @@ function<_Rp(_ArgTypes...)>::target() const _NOEXCEPT
 template <class _Rp, class... _ArgTypes>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(const function<_Rp(_ArgTypes...)>& __f, nullptr_t) _NOEXCEPT {return !__f;}
+operator==(const function<_Rp(_ArgTypes...)>& __f, nullptr_t) noexcept {return !__f;}
 
 template <class _Rp, class... _ArgTypes>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(nullptr_t, const function<_Rp(_ArgTypes...)>& __f) _NOEXCEPT {return !__f;}
+operator==(nullptr_t, const function<_Rp(_ArgTypes...)>& __f) noexcept {return !__f;}
 
 template <class _Rp, class... _ArgTypes>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(const function<_Rp(_ArgTypes...)>& __f, nullptr_t) _NOEXCEPT {return (bool)__f;}
+operator!=(const function<_Rp(_ArgTypes...)>& __f, nullptr_t) noexcept {return (bool)__f;}
 
 template <class _Rp, class... _ArgTypes>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(nullptr_t, const function<_Rp(_ArgTypes...)>& __f) _NOEXCEPT {return (bool)__f;}
+operator!=(nullptr_t, const function<_Rp(_ArgTypes...)>& __f) noexcept {return (bool)__f;}
 
 template <class _Rp, class... _ArgTypes>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(function<_Rp(_ArgTypes...)>& __x, function<_Rp(_ArgTypes...)>& __y) _NOEXCEPT
+swap(function<_Rp(_ArgTypes...)>& __x, function<_Rp(_ArgTypes...)>& __y) noexcept
 {return __x.swap(__y);}
 
 #else // _LIBCUDACXX_CXX03_LANG

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/hash.h
@@ -281,7 +281,7 @@ struct __scalar_hash<_Tp, 0>
     : public __unary_function<_Tp, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(_Tp __v) const _NOEXCEPT
+    size_t operator()(_Tp __v) const noexcept
     {
         union
         {
@@ -299,7 +299,7 @@ struct __scalar_hash<_Tp, 1>
     : public __unary_function<_Tp, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(_Tp __v) const _NOEXCEPT
+    size_t operator()(_Tp __v) const noexcept
     {
         union
         {
@@ -316,7 +316,7 @@ struct __scalar_hash<_Tp, 2>
     : public __unary_function<_Tp, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(_Tp __v) const _NOEXCEPT
+    size_t operator()(_Tp __v) const noexcept
     {
         union
         {
@@ -337,7 +337,7 @@ struct __scalar_hash<_Tp, 3>
     : public __unary_function<_Tp, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(_Tp __v) const _NOEXCEPT
+    size_t operator()(_Tp __v) const noexcept
     {
         union
         {
@@ -359,7 +359,7 @@ struct __scalar_hash<_Tp, 4>
     : public __unary_function<_Tp, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(_Tp __v) const _NOEXCEPT
+    size_t operator()(_Tp __v) const noexcept
     {
         union
         {
@@ -383,7 +383,7 @@ struct _PairT {
 };
 
 _LIBCUDACXX_INLINE_VISIBILITY
-inline size_t __hash_combine(size_t __lhs, size_t __rhs) _NOEXCEPT {
+inline size_t __hash_combine(size_t __lhs, size_t __rhs) noexcept {
     typedef __scalar_hash<_PairT> _HashT;
     const _PairT __p = {__lhs, __rhs};
     return _HashT()(__p);
@@ -394,7 +394,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<_Tp*>
     : public __unary_function<_Tp*, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(_Tp* __v) const _NOEXCEPT
+    size_t operator()(_Tp* __v) const noexcept
     {
         union
         {
@@ -411,7 +411,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<bool>
     : public __unary_function<bool, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(bool __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(bool __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -419,7 +419,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<char>
     : public __unary_function<char, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(char __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(char __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -427,7 +427,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<signed char>
     : public __unary_function<signed char, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(signed char __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(signed char __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -435,7 +435,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<unsigned char>
     : public __unary_function<unsigned char, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(unsigned char __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(unsigned char __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 #ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
@@ -444,7 +444,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<char16_t>
     : public __unary_function<char16_t, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(char16_t __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(char16_t __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -452,7 +452,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<char32_t>
     : public __unary_function<char32_t, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(char32_t __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(char32_t __v) const noexcept {return static_cast<size_t>(__v);}
 };
 #endif  // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 
@@ -462,7 +462,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<wchar_t>
     : public __unary_function<wchar_t, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(wchar_t __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(wchar_t __v) const noexcept {return static_cast<size_t>(__v);}
 };
 #endif // _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
 
@@ -471,7 +471,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<short>
     : public __unary_function<short, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(short __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(short __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -479,7 +479,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<unsigned short>
     : public __unary_function<unsigned short, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(unsigned short __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(unsigned short __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -487,7 +487,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<int>
     : public __unary_function<int, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(int __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(int __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -495,7 +495,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<unsigned int>
     : public __unary_function<unsigned int, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(unsigned int __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(unsigned int __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -503,7 +503,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<long>
     : public __unary_function<long, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(long __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(long __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -511,7 +511,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<unsigned long>
     : public __unary_function<unsigned long, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(unsigned long __v) const _NOEXCEPT {return static_cast<size_t>(__v);}
+    size_t operator()(unsigned long __v) const noexcept {return static_cast<size_t>(__v);}
 };
 
 template <>
@@ -547,7 +547,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<float>
     : public __scalar_hash<float>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(float __v) const _NOEXCEPT
+    size_t operator()(float __v) const noexcept
     {
         // -0.0 and 0.0 should return same hash
        if (__v == 0.0f)
@@ -561,7 +561,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<double>
     : public __scalar_hash<double>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(double __v) const _NOEXCEPT
+    size_t operator()(double __v) const noexcept
     {
         // -0.0 and 0.0 should return same hash
        if (__v == 0.0)
@@ -575,7 +575,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<long double>
     : public __scalar_hash<long double>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(long double __v) const _NOEXCEPT
+    size_t operator()(long double __v) const noexcept
     {
         // -0.0 and 0.0 should return same hash
         if (__v == 0.0L)
@@ -625,7 +625,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS __enum_hash
     : public __unary_function<_Tp, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(_Tp __v) const _NOEXCEPT
+    size_t operator()(_Tp __v) const noexcept
     {
         typedef typename underlying_type<_Tp>::type type;
         return hash<type>()(static_cast<type>(__v));
@@ -650,7 +650,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<nullptr_t>
   : public __unary_function<nullptr_t, size_t>
 {
   _LIBCUDACXX_INLINE_VISIBILITY
-  size_t operator()(nullptr_t) const _NOEXCEPT {
+  size_t operator()(nullptr_t) const noexcept {
     return 662607004ull;
   }
 };

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/identity.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/identity.h
@@ -25,7 +25,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 struct __identity {
   template <class _Tp>
-  _LIBCUDACXX_NODISCARD_EXT _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR _Tp&& operator()(_Tp&& __t) const _NOEXCEPT {
+  _LIBCUDACXX_NODISCARD_EXT _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR _Tp&& operator()(_Tp&& __t) const noexcept {
     return _CUDA_VSTD::forward<_Tp>(__t);
   }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/invoke.h
@@ -344,7 +344,7 @@ template <class _Fp, class _A0, class ..._Args,
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR decltype((_CUDA_VSTD::declval<_A0>().*_CUDA_VSTD::declval<_Fp>())(_CUDA_VSTD::declval<_Args>()...))
 __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
-    _NOEXCEPT_(noexcept((static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...)))
+    noexcept(noexcept((static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...)))
     { return           (static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...); }
 
 _LIBCUDACXX_DISABLE_EXEC_CHECK
@@ -353,7 +353,7 @@ template <class _Fp, class _A0, class ..._Args,
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR decltype((_CUDA_VSTD::declval<_A0>().get().*_CUDA_VSTD::declval<_Fp>())(_CUDA_VSTD::declval<_Args>()...))
 __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
-    _NOEXCEPT_(noexcept((__a0.get().*__f)(static_cast<_Args&&>(__args)...)))
+    noexcept(noexcept((__a0.get().*__f)(static_cast<_Args&&>(__args)...)))
     { return          (__a0.get().*__f)(static_cast<_Args&&>(__args)...); }
 
 _LIBCUDACXX_DISABLE_EXEC_CHECK
@@ -362,7 +362,7 @@ template <class _Fp, class _A0, class ..._Args,
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR decltype(((*_CUDA_VSTD::declval<_A0>()).*_CUDA_VSTD::declval<_Fp>())(_CUDA_VSTD::declval<_Args>()...))
 __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
-    _NOEXCEPT_(noexcept(((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...)))
+    noexcept(noexcept(((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...)))
     { return          ((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...); }
 
 // bullets 4, 5 and 6
@@ -373,7 +373,7 @@ template <class _Fp, class _A0,
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR decltype(_CUDA_VSTD::declval<_A0>().*_CUDA_VSTD::declval<_Fp>())
 __invoke(_Fp&& __f, _A0&& __a0)
-    _NOEXCEPT_(noexcept(static_cast<_A0&&>(__a0).*__f))
+    noexcept(noexcept(static_cast<_A0&&>(__a0).*__f))
     { return          static_cast<_A0&&>(__a0).*__f; }
 
 _LIBCUDACXX_DISABLE_EXEC_CHECK
@@ -382,7 +382,7 @@ template <class _Fp, class _A0,
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR decltype(_CUDA_VSTD::declval<_A0>().get().*_CUDA_VSTD::declval<_Fp>())
 __invoke(_Fp&& __f, _A0&& __a0)
-    _NOEXCEPT_(noexcept(__a0.get().*__f))
+    noexcept(noexcept(__a0.get().*__f))
     { return          __a0.get().*__f; }
 
 _LIBCUDACXX_DISABLE_EXEC_CHECK
@@ -391,7 +391,7 @@ template <class _Fp, class _A0,
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR decltype((*_CUDA_VSTD::declval<_A0>()).*_CUDA_VSTD::declval<_Fp>())
 __invoke(_Fp&& __f, _A0&& __a0)
-    _NOEXCEPT_(noexcept((*static_cast<_A0&&>(__a0)).*__f))
+    noexcept(noexcept((*static_cast<_A0&&>(__a0)).*__f))
     { return          (*static_cast<_A0&&>(__a0)).*__f; }
 
 // bullet 7
@@ -401,7 +401,7 @@ template <class _Fp, class ..._Args>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR decltype(_CUDA_VSTD::declval<_Fp>()(_CUDA_VSTD::declval<_Args>()...))
 __invoke(_Fp&& __f, _Args&& ...__args)
-    _NOEXCEPT_(noexcept(static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...)))
+    noexcept(noexcept(static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...)))
     { return          static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...); }
 
 // __invokable
@@ -441,7 +441,7 @@ struct __nothrow_invokable_r_imp<true, false, _Ret, _Fp, _Args...>
 
     template <class _Tp>
     _LIBCUDACXX_INLINE_VISIBILITY
-    static void __test_noexcept(_Tp) _NOEXCEPT;
+    static void __test_noexcept(_Tp) noexcept;
 
     static const bool value = noexcept(_ThisT::__test_noexcept<_Ret>(
         _CUDA_VSTD::__invoke(declval<_Fp>(), _CUDA_VSTD::declval<_Args>()...)));

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/mem_fn.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/mem_fn.h
@@ -37,7 +37,7 @@ private:
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    __mem_fn(type __f) _NOEXCEPT : __f_(__f) {}
+    __mem_fn(type __f) noexcept : __f_(__f) {}
 
     // invoke
     template <class... _ArgTypes>
@@ -51,7 +51,7 @@ public:
 template<class _Rp, class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
 __mem_fn<_Rp _Tp::*>
-mem_fn(_Rp _Tp::* __pm) _NOEXCEPT
+mem_fn(_Rp _Tp::* __pm) noexcept
 {
     return __mem_fn<_Rp _Tp::*>(__pm);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/reference_wrapper.h
@@ -32,22 +32,22 @@ public:
 private:
     type* __f_;
 
-    static _LIBCUDACXX_INLINE_VISIBILITY void __fun(_Tp&) _NOEXCEPT;
+    static _LIBCUDACXX_INLINE_VISIBILITY void __fun(_Tp&) noexcept;
     static void __fun(_Tp&&) = delete;
 
 public:
     template <class _Up, class = __enable_if_t<!__is_same_uncvref<_Up, reference_wrapper>::value, decltype(__fun(declval<_Up>())) > >
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    reference_wrapper(_Up&& __u) _NOEXCEPT_(noexcept(__fun(declval<_Up>()))) {
+    reference_wrapper(_Up&& __u) noexcept(noexcept(__fun(declval<_Up>()))) {
         type& __f = static_cast<_Up&&>(__u);
         __f_ = _CUDA_VSTD::addressof(__f);
     }
 
     // access
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    operator type&() const _NOEXCEPT {return *__f_;}
+    operator type&() const noexcept {return *__f_;}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    type& get() const _NOEXCEPT {return *__f_;}
+    type& get() const noexcept {return *__f_;}
 
     // invoke
     template <class... _ArgTypes>
@@ -66,7 +66,7 @@ reference_wrapper(_Tp&) -> reference_wrapper<_Tp>;
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
 reference_wrapper<_Tp>
-ref(_Tp& __t) _NOEXCEPT
+ref(_Tp& __t) noexcept
 {
     return reference_wrapper<_Tp>(__t);
 }
@@ -74,7 +74,7 @@ ref(_Tp& __t) _NOEXCEPT
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
 reference_wrapper<_Tp>
-ref(reference_wrapper<_Tp> __t) _NOEXCEPT
+ref(reference_wrapper<_Tp> __t) noexcept
 {
     return __t;
 }
@@ -82,7 +82,7 @@ ref(reference_wrapper<_Tp> __t) _NOEXCEPT
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
 reference_wrapper<const _Tp>
-cref(const _Tp& __t) _NOEXCEPT
+cref(const _Tp& __t) noexcept
 {
     return reference_wrapper<const _Tp>(__t);
 }
@@ -90,7 +90,7 @@ cref(const _Tp& __t) _NOEXCEPT
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
 reference_wrapper<const _Tp>
-cref(reference_wrapper<_Tp> __t) _NOEXCEPT
+cref(reference_wrapper<_Tp> __t) noexcept
 {
     return __t;
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__fwd/get.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__fwd/get.h
@@ -31,67 +31,67 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <size_t _Ip, class ..._Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 typename tuple_element<_Ip, tuple<_Tp...> >::type&
-get(tuple<_Tp...>&) _NOEXCEPT;
+get(tuple<_Tp...>&) noexcept;
 
 template <size_t _Ip, class ..._Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const typename tuple_element<_Ip, tuple<_Tp...> >::type&
-get(const tuple<_Tp...>&) _NOEXCEPT;
+get(const tuple<_Tp...>&) noexcept;
 
 template <size_t _Ip, class ..._Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 typename tuple_element<_Ip, tuple<_Tp...> >::type&&
-get(tuple<_Tp...>&&) _NOEXCEPT;
+get(tuple<_Tp...>&&) noexcept;
 
 template <size_t _Ip, class ..._Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const typename tuple_element<_Ip, tuple<_Tp...> >::type&&
-get(const tuple<_Tp...>&&) _NOEXCEPT;
+get(const tuple<_Tp...>&&) noexcept;
 
 #endif // _LIBCUDACXX_CXX03_LANG
 
 template <size_t _Ip, class _T1, class _T2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 typename tuple_element<_Ip, pair<_T1, _T2> >::type&
-get(pair<_T1, _T2>&) _NOEXCEPT;
+get(pair<_T1, _T2>&) noexcept;
 
 template <size_t _Ip, class _T1, class _T2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&
-get(const pair<_T1, _T2>&) _NOEXCEPT;
+get(const pair<_T1, _T2>&) noexcept;
 
 #ifndef _LIBCUDACXX_CXX03_LANG
 template <size_t _Ip, class _T1, class _T2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
-get(pair<_T1, _T2>&&) _NOEXCEPT;
+get(pair<_T1, _T2>&&) noexcept;
 
 template <size_t _Ip, class _T1, class _T2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
-get(const pair<_T1, _T2>&&) _NOEXCEPT;
+get(const pair<_T1, _T2>&&) noexcept;
 #endif // _LIBCUDACXX_CXX03_LANG
 
 template <size_t _Ip, class _Tp, size_t _Size>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 _Tp&
-get(array<_Tp, _Size>&) _NOEXCEPT;
+get(array<_Tp, _Size>&) noexcept;
 
 template <size_t _Ip, class _Tp, size_t _Size>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const _Tp&
-get(const array<_Tp, _Size>&) _NOEXCEPT;
+get(const array<_Tp, _Size>&) noexcept;
 
 #ifndef _LIBCUDACXX_CXX03_LANG
 template <size_t _Ip, class _Tp, size_t _Size>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 _Tp&&
-get(array<_Tp, _Size>&&) _NOEXCEPT;
+get(array<_Tp, _Size>&&) noexcept;
 
 template <size_t _Ip, class _Tp, size_t _Size>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const _Tp&&
-get(const array<_Tp, _Size>&&) _NOEXCEPT;
+get(const array<_Tp, _Size>&&) noexcept;
 #endif // _LIBCUDACXX_CXX03_LANG
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__hash_table
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__hash_table
@@ -72,23 +72,23 @@ struct __hash_node_base
     __next_pointer    __next_;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __next_pointer __ptr() _NOEXCEPT {
+    __next_pointer __ptr() noexcept {
         return static_cast<__next_pointer>(
             pointer_traits<__node_base_pointer>::pointer_to(*this));
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __node_pointer __upcast() _NOEXCEPT {
+    __node_pointer __upcast() noexcept {
         return static_cast<__node_pointer>(
             pointer_traits<__node_base_pointer>::pointer_to(*this));
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t __hash() const _NOEXCEPT {
+    size_t __hash() const noexcept {
         return static_cast<__node_type const&>(*this).__hash_;
     }
 
-    _LIBCUDACXX_INLINE_VISIBILITY __hash_node_base() _NOEXCEPT : __next_(nullptr) {}
+    _LIBCUDACXX_INLINE_VISIBILITY __hash_node_base() noexcept : __next_(nullptr) {}
 };
 
 template <class _Tp, class _VoidPtr>
@@ -295,7 +295,7 @@ public:
     typedef value_type&                                    reference;
     typedef typename _NodeTypes::__node_value_type_pointer pointer;
 
-    _LIBCUDACXX_INLINE_VISIBILITY __hash_iterator() _NOEXCEPT : __node_(nullptr) {
+    _LIBCUDACXX_INLINE_VISIBILITY __hash_iterator() noexcept : __node_(nullptr) {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_DEBUG_MODE(__get_db()->__insert_i(this));
 #endif
@@ -369,14 +369,14 @@ public:
 private:
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_iterator(__next_pointer __node, const void* __c) _NOEXCEPT
+    __hash_iterator(__next_pointer __node, const void* __c) noexcept
         : __node_(__node)
         {
             __get_db()->__insert_ic(this, __c);
         }
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_iterator(__next_pointer __node) _NOEXCEPT
+    __hash_iterator(__next_pointer __node) noexcept
         : __node_(__node)
         {}
 #endif
@@ -407,14 +407,14 @@ public:
     typedef typename _NodeTypes::__const_node_value_type_pointer pointer;
 
 
-    _LIBCUDACXX_INLINE_VISIBILITY __hash_const_iterator() _NOEXCEPT : __node_(nullptr) {
+    _LIBCUDACXX_INLINE_VISIBILITY __hash_const_iterator() noexcept : __node_(nullptr) {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_DEBUG_MODE(__get_db()->__insert_i(this));
 #endif
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_const_iterator(const __non_const_iterator& __x) _NOEXCEPT
+    __hash_const_iterator(const __non_const_iterator& __x) noexcept
         : __node_(__x.__node_)
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -489,14 +489,14 @@ public:
 private:
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_const_iterator(__next_pointer __node, const void* __c) _NOEXCEPT
+    __hash_const_iterator(__next_pointer __node, const void* __c) noexcept
         : __node_(__node)
         {
             __get_db()->__insert_ic(this, __c);
         }
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_const_iterator(__next_pointer __node) _NOEXCEPT
+    __hash_const_iterator(__next_pointer __node) noexcept
         : __node_(__node)
         {}
 #endif
@@ -524,7 +524,7 @@ public:
     typedef value_type&                                         reference;
     typedef typename _NodeTypes::__node_value_type_pointer      pointer;
 
-    _LIBCUDACXX_INLINE_VISIBILITY __hash_local_iterator() _NOEXCEPT : __node_(nullptr) {
+    _LIBCUDACXX_INLINE_VISIBILITY __hash_local_iterator() noexcept : __node_(nullptr) {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_DEBUG_MODE(__get_db()->__insert_i(this));
 #endif
@@ -605,7 +605,7 @@ private:
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_INLINE_VISIBILITY
     __hash_local_iterator(__next_pointer __node, size_t __bucket,
-                          size_t __bucket_count, const void* __c) _NOEXCEPT
+                          size_t __bucket_count, const void* __c) noexcept
         : __node_(__node),
           __bucket_(__bucket),
           __bucket_count_(__bucket_count)
@@ -617,7 +617,7 @@ private:
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
     __hash_local_iterator(__next_pointer __node, size_t __bucket,
-                          size_t __bucket_count) _NOEXCEPT
+                          size_t __bucket_count) noexcept
         : __node_(__node),
           __bucket_(__bucket),
           __bucket_count_(__bucket_count)
@@ -658,14 +658,14 @@ public:
     typedef typename _NodeTypes::__const_node_value_type_pointer pointer;
 
 
-    _LIBCUDACXX_INLINE_VISIBILITY __hash_const_local_iterator() _NOEXCEPT : __node_(nullptr) {
+    _LIBCUDACXX_INLINE_VISIBILITY __hash_const_local_iterator() noexcept : __node_(nullptr) {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_DEBUG_MODE(__get_db()->__insert_i(this));
 #endif
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_const_local_iterator(const __non_const_iterator& __x) _NOEXCEPT
+    __hash_const_local_iterator(const __non_const_iterator& __x) noexcept
         : __node_(__x.__node_),
           __bucket_(__x.__bucket_),
           __bucket_count_(__x.__bucket_count_)
@@ -750,7 +750,7 @@ private:
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_INLINE_VISIBILITY
     __hash_const_local_iterator(__next_pointer __node, size_t __bucket,
-                                size_t __bucket_count, const void* __c) _NOEXCEPT
+                                size_t __bucket_count, const void* __c) noexcept
         : __node_(__node),
           __bucket_(__bucket),
           __bucket_count_(__bucket_count)
@@ -762,7 +762,7 @@ private:
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
     __hash_const_local_iterator(__next_pointer __node, size_t __bucket,
-                                size_t __bucket_count) _NOEXCEPT
+                                size_t __bucket_count) noexcept
         : __node_(__node),
           __bucket_(__bucket),
           __bucket_count_(__bucket_count)
@@ -788,18 +788,18 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __bucket_list_deallocator()
-        _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
+        noexcept(is_nothrow_default_constructible<allocator_type>::value)
         : __data_(0) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __bucket_list_deallocator(const allocator_type& __a, size_type __size)
-        _NOEXCEPT_(is_nothrow_copy_constructible<allocator_type>::value)
+        noexcept(is_nothrow_copy_constructible<allocator_type>::value)
         : __data_(__size, __a) {}
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     __bucket_list_deallocator(__bucket_list_deallocator&& __x)
-        _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
+        noexcept(is_nothrow_move_constructible<allocator_type>::value)
         : __data_(_CUDA_VSTD::move(__x.__data_))
     {
         __x.size() = 0;
@@ -807,17 +807,17 @@ public:
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type& size() _NOEXCEPT {return __data_.first();}
+    size_type& size() noexcept {return __data_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type  size() const _NOEXCEPT {return __data_.first();}
+    size_type  size() const noexcept {return __data_.first();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type& __alloc() _NOEXCEPT {return __data_.second();}
+    allocator_type& __alloc() noexcept {return __data_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const allocator_type& __alloc() const _NOEXCEPT {return __data_.second();}
+    const allocator_type& __alloc() const noexcept {return __data_.second();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator()(pointer __p) _NOEXCEPT
+    void operator()(pointer __p) noexcept
     {
         __alloc_traits::deallocate(__alloc(), __p, size());
     }
@@ -846,13 +846,13 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit __hash_node_destructor(allocator_type& __na,
-                                    bool __constructed = false) _NOEXCEPT
+                                    bool __constructed = false) noexcept
         : __na_(__na),
           __value_constructed(__constructed)
         {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator()(pointer __p) _NOEXCEPT
+    void operator()(pointer __p) noexcept
     {
         if (__value_constructed)
             __alloc_traits::destroy(__na_, _NodeTypes::__get_ptr(__p->__value_));
@@ -972,30 +972,30 @@ private:
     // --- Member data end ---
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type& size() _NOEXCEPT {return __p2_.first();}
+    size_type& size() noexcept {return __p2_.first();}
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type  size() const _NOEXCEPT {return __p2_.first();}
+    size_type  size() const noexcept {return __p2_.first();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    hasher& hash_function() _NOEXCEPT {return __p2_.second();}
+    hasher& hash_function() noexcept {return __p2_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const hasher& hash_function() const _NOEXCEPT {return __p2_.second();}
+    const hasher& hash_function() const noexcept {return __p2_.second();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    float& max_load_factor() _NOEXCEPT {return __p3_.first();}
+    float& max_load_factor() noexcept {return __p3_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    float  max_load_factor() const _NOEXCEPT {return __p3_.first();}
+    float  max_load_factor() const noexcept {return __p3_.first();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    key_equal& key_eq() _NOEXCEPT {return __p3_.second();}
+    key_equal& key_eq() noexcept {return __p3_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const key_equal& key_eq() const _NOEXCEPT {return __p3_.second();}
+    const key_equal& key_eq() const noexcept {return __p3_.second();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __node_allocator& __node_alloc() _NOEXCEPT {return __p1_.second();}
+    __node_allocator& __node_alloc() noexcept {return __p1_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const __node_allocator& __node_alloc() const _NOEXCEPT
+    const __node_allocator& __node_alloc() const noexcept
         {return __p1_.second();}
 
 public:
@@ -1006,7 +1006,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __hash_table()
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<__bucket_list>::value &&
             is_nothrow_default_constructible<__first_node>::value &&
             is_nothrow_default_constructible<__node_allocator>::value &&
@@ -1021,7 +1021,7 @@ public:
     __hash_table(const __hash_table& __u, const allocator_type& __a);
 #ifndef _LIBCUDACXX_CXX03_LANG
     __hash_table(__hash_table&& __u)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_move_constructible<__bucket_list>::value &&
             is_nothrow_move_constructible<__first_node>::value &&
             is_nothrow_move_constructible<__node_allocator>::value &&
@@ -1035,7 +1035,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     __hash_table& operator=(__hash_table&& __u)
-        _NOEXCEPT_(
+        noexcept(
             __node_traits::propagate_on_container_move_assignment::value &&
             is_nothrow_move_assignable<__node_allocator>::value &&
             is_nothrow_move_assignable<hasher>::value &&
@@ -1047,7 +1047,7 @@ public:
         void __assign_multi(_InputIterator __first, _InputIterator __last);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT
+    size_type max_size() const noexcept
     {
         return std::min<size_type>(
             __node_traits::max_size(__node_alloc()),
@@ -1061,13 +1061,13 @@ private:
                                                value_type& __cp_val);
     _LIBCUDACXX_INLINE_VISIBILITY
     void __node_insert_multi_perform(__node_pointer __cp,
-                                     __next_pointer __pn) _NOEXCEPT;
+                                     __next_pointer __pn) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __next_pointer __node_insert_unique_prepare(size_t __nd_hash,
                                                 value_type& __nd_val);
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __node_insert_unique_perform(__node_pointer __ptr) _NOEXCEPT;
+    void __node_insert_unique_perform(__node_pointer __ptr) noexcept;
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1207,25 +1207,25 @@ public:
     _NodeHandle __node_handle_extract(const_iterator __it);
 #endif
 
-    void clear() _NOEXCEPT;
+    void clear() noexcept;
     void rehash(size_type __n);
     _LIBCUDACXX_INLINE_VISIBILITY void reserve(size_type __n)
         {rehash(static_cast<size_type>(ceil(__n / max_load_factor())));}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type bucket_count() const _NOEXCEPT
+    size_type bucket_count() const noexcept
     {
         return __bucket_list_.get_deleter().size();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       begin() _NOEXCEPT;
+    iterator       begin() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       end() _NOEXCEPT;
+    iterator       end() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT;
+    const_iterator begin() const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end() const _NOEXCEPT;
+    const_iterator end() const noexcept;
 
     template <class _Key>
         _LIBCUDACXX_INLINE_VISIBILITY
@@ -1250,7 +1250,7 @@ public:
         size_type __erase_unique(const _Key& __k);
     template <class _Key>
         size_type __erase_multi(const _Key& __k);
-    __node_holder remove(const_iterator __p) _NOEXCEPT;
+    __node_holder remove(const_iterator __p) noexcept;
 
     template <class _Key>
         _LIBCUDACXX_INLINE_VISIBILITY
@@ -1274,7 +1274,7 @@ public:
 
     void swap(__hash_table& __u)
 #if _LIBCUDACXX_STD_VER <= 11
-        _NOEXCEPT_(
+        noexcept(
             __is_nothrow_swappable<hasher>::value && __is_nothrow_swappable<key_equal>::value
             && (!allocator_traits<__pointer_allocator>::propagate_on_container_swap::value
                   || __is_nothrow_swappable<__pointer_allocator>::value)
@@ -1282,19 +1282,19 @@ public:
                   || __is_nothrow_swappable<__node_allocator>::value)
             );
 #else
-     _NOEXCEPT_(__is_nothrow_swappable<hasher>::value && __is_nothrow_swappable<key_equal>::value);
+     noexcept(__is_nothrow_swappable<hasher>::value && __is_nothrow_swappable<key_equal>::value);
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_bucket_count() const _NOEXCEPT
+    size_type max_bucket_count() const noexcept
         {return max_size(); }
     size_type bucket_size(size_type __n) const;
-    _LIBCUDACXX_INLINE_VISIBILITY float load_factor() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY float load_factor() const noexcept
     {
         size_type __bc = bucket_count();
         return __bc != 0 ? (float)size() / __bc : 0.f;
     }
-    _LIBCUDACXX_INLINE_VISIBILITY void max_load_factor(float __mlf) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void max_load_factor(float __mlf) noexcept
     {
         _LIBCUDACXX_ASSERT(__mlf > 0,
             "unordered container::max_load_factor(lf) called with lf <= 0");
@@ -1388,13 +1388,13 @@ private:
 #ifndef _LIBCUDACXX_CXX03_LANG
     void __move_assign(__hash_table& __u, false_type);
     void __move_assign(__hash_table& __u, true_type)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_move_assignable<__node_allocator>::value &&
             is_nothrow_move_assignable<hasher>::value &&
             is_nothrow_move_assignable<key_equal>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__hash_table& __u)
-        _NOEXCEPT_(
+        noexcept(
             !__node_traits::propagate_on_container_move_assignment::value ||
             (is_nothrow_move_assignable<__pointer_allocator>::value &&
              is_nothrow_move_assignable<__node_allocator>::value))
@@ -1402,7 +1402,7 @@ private:
              __node_traits::propagate_on_container_move_assignment::value>());}
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__hash_table& __u, true_type)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_move_assignable<__pointer_allocator>::value &&
             is_nothrow_move_assignable<__node_allocator>::value)
     {
@@ -1411,11 +1411,11 @@ private:
         __node_alloc() = _CUDA_VSTD::move(__u.__node_alloc());
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-        void __move_assign_alloc(__hash_table&, false_type) _NOEXCEPT {}
+        void __move_assign_alloc(__hash_table&, false_type) noexcept {}
 #endif // _LIBCUDACXX_CXX03_LANG
 
-    void __deallocate_node(__next_pointer __np) _NOEXCEPT;
-    __next_pointer __detach() _NOEXCEPT;
+    void __deallocate_node(__next_pointer __np) noexcept;
+    __next_pointer __detach() noexcept;
 
     template <class, class, class, class, class> friend class _LIBCUDACXX_TEMPLATE_VIS unordered_map;
     template <class, class, class, class, class> friend class _LIBCUDACXX_TEMPLATE_VIS unordered_multimap;
@@ -1424,7 +1424,7 @@ private:
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 inline
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__hash_table()
-    _NOEXCEPT_(
+    noexcept(
         is_nothrow_default_constructible<__bucket_list>::value &&
         is_nothrow_default_constructible<__first_node>::value &&
         is_nothrow_default_constructible<__node_allocator>::value &&
@@ -1493,7 +1493,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__hash_table(const __hash_table& __u,
 
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__hash_table(__hash_table&& __u)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_move_constructible<__bucket_list>::value &&
             is_nothrow_move_constructible<__first_node>::value &&
             is_nothrow_move_constructible<__node_allocator>::value &&
@@ -1589,7 +1589,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::operator=(const __hash_table& __u)
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 void
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__deallocate_node(__next_pointer __np)
-    _NOEXCEPT
+    noexcept
 {
     __node_allocator& __na = __node_alloc();
     while (__np != nullptr)
@@ -1619,7 +1619,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__deallocate_node(__next_pointer __np)
 
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::__next_pointer
-__hash_table<_Tp, _Hash, _Equal, _Alloc>::__detach() _NOEXCEPT
+__hash_table<_Tp, _Hash, _Equal, _Alloc>::__detach() noexcept
 {
     size_type __bc = bucket_count();
     for (size_type __i = 0; __i < __bc; ++__i)
@@ -1636,7 +1636,7 @@ template <class _Tp, class _Hash, class _Equal, class _Alloc>
 void
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__move_assign(
         __hash_table& __u, true_type)
-    _NOEXCEPT_(
+    noexcept(
         is_nothrow_move_assignable<__node_allocator>::value &&
         is_nothrow_move_assignable<hasher>::value &&
         is_nothrow_move_assignable<key_equal>::value)
@@ -1715,7 +1715,7 @@ template <class _Tp, class _Hash, class _Equal, class _Alloc>
 inline
 __hash_table<_Tp, _Hash, _Equal, _Alloc>&
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::operator=(__hash_table&& __u)
-    _NOEXCEPT_(
+    noexcept(
         __node_traits::propagate_on_container_move_assignment::value &&
         is_nothrow_move_assignable<__node_allocator>::value &&
         is_nothrow_move_assignable<hasher>::value &&
@@ -1810,7 +1810,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__assign_multi(_InputIterator __first,
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 inline
 typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::iterator
-__hash_table<_Tp, _Hash, _Equal, _Alloc>::begin() _NOEXCEPT
+__hash_table<_Tp, _Hash, _Equal, _Alloc>::begin() noexcept
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     return iterator(__p1_.first().__next_, this);
@@ -1822,7 +1822,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::begin() _NOEXCEPT
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 inline
 typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::iterator
-__hash_table<_Tp, _Hash, _Equal, _Alloc>::end() _NOEXCEPT
+__hash_table<_Tp, _Hash, _Equal, _Alloc>::end() noexcept
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     return iterator(nullptr, this);
@@ -1834,7 +1834,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::end() _NOEXCEPT
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 inline
 typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::const_iterator
-__hash_table<_Tp, _Hash, _Equal, _Alloc>::begin() const _NOEXCEPT
+__hash_table<_Tp, _Hash, _Equal, _Alloc>::begin() const noexcept
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     return const_iterator(__p1_.first().__next_, this);
@@ -1846,7 +1846,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::begin() const _NOEXCEPT
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 inline
 typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::const_iterator
-__hash_table<_Tp, _Hash, _Equal, _Alloc>::end() const _NOEXCEPT
+__hash_table<_Tp, _Hash, _Equal, _Alloc>::end() const noexcept
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     return const_iterator(nullptr, this);
@@ -1857,7 +1857,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::end() const _NOEXCEPT
 
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 void
-__hash_table<_Tp, _Hash, _Equal, _Alloc>::clear() _NOEXCEPT
+__hash_table<_Tp, _Hash, _Equal, _Alloc>::clear() noexcept
 {
     if (size() > 0)
     {
@@ -1917,7 +1917,7 @@ template <class _Tp, class _Hash, class _Equal, class _Alloc>
 _LIBCUDACXX_INLINE_VISIBILITY
 void
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_insert_unique_perform(
-    __node_pointer __nd) _NOEXCEPT
+    __node_pointer __nd) noexcept
 {
     size_type __bc = bucket_count();
     size_t __chash = __constrain_hash(__nd->__hash(), __bc);
@@ -2017,7 +2017,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_insert_multi_prepare(
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 void
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_insert_multi_perform(
-    __node_pointer __cp, __next_pointer __pn) _NOEXCEPT
+    __node_pointer __cp, __next_pointer __pn) noexcept
 {
     size_type __bc = bucket_count();
     size_t __chash = __constrain_hash(__cp->__hash_, __bc);
@@ -2672,7 +2672,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__erase_multi(const _Key& __k)
 
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 typename __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_holder
-__hash_table<_Tp, _Hash, _Equal, _Alloc>::remove(const_iterator __p) _NOEXCEPT
+__hash_table<_Tp, _Hash, _Equal, _Alloc>::remove(const_iterator __p) noexcept
 {
     // current node
     __next_pointer __cn = __p.__node_;
@@ -2821,7 +2821,7 @@ template <class _Tp, class _Hash, class _Equal, class _Alloc>
 void
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::swap(__hash_table& __u)
 #if _LIBCUDACXX_STD_VER <= 11
-    _NOEXCEPT_(
+    noexcept(
         __is_nothrow_swappable<hasher>::value && __is_nothrow_swappable<key_equal>::value
         && (!allocator_traits<__pointer_allocator>::propagate_on_container_swap::value
               || __is_nothrow_swappable<__pointer_allocator>::value)
@@ -2829,7 +2829,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::swap(__hash_table& __u)
               || __is_nothrow_swappable<__node_allocator>::value)
             )
 #else
-  _NOEXCEPT_(__is_nothrow_swappable<hasher>::value && __is_nothrow_swappable<key_equal>::value)
+  noexcept(__is_nothrow_swappable<hasher>::value && __is_nothrow_swappable<key_equal>::value)
 #endif
 {
     _LIBCUDACXX_ASSERT(__node_traits::propagate_on_container_swap::value ||
@@ -2883,7 +2883,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__hash_table<_Tp, _Hash, _Equal, _Alloc>& __x,
      __hash_table<_Tp, _Hash, _Equal, _Alloc>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/istreambuf_iterator.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/istreambuf_iterator.h
@@ -63,12 +63,12 @@ private:
         return __sbuf_ == 0;
     }
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR istreambuf_iterator() _NOEXCEPT : __sbuf_(0) {}
-    _LIBCUDACXX_INLINE_VISIBILITY istreambuf_iterator(istream_type& __s) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR istreambuf_iterator() noexcept : __sbuf_(0) {}
+    _LIBCUDACXX_INLINE_VISIBILITY istreambuf_iterator(istream_type& __s) noexcept
         : __sbuf_(__s.rdbuf()) {}
-    _LIBCUDACXX_INLINE_VISIBILITY istreambuf_iterator(streambuf_type* __s) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY istreambuf_iterator(streambuf_type* __s) noexcept
         : __sbuf_(__s) {}
-    _LIBCUDACXX_INLINE_VISIBILITY istreambuf_iterator(const __proxy& __p) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY istreambuf_iterator(const __proxy& __p) noexcept
         : __sbuf_(__p.__sbuf_) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY char_type  operator*() const

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/ostream_iterator.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/ostream_iterator.h
@@ -43,9 +43,9 @@ private:
     ostream_type* __out_stream_;
     const char_type* __delim_;
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY ostream_iterator(ostream_type& __s) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY ostream_iterator(ostream_type& __s) noexcept
         : __out_stream_(_CUDA_VSTD::addressof(__s)), __delim_(0) {}
-    _LIBCUDACXX_INLINE_VISIBILITY ostream_iterator(ostream_type& __s, const _CharT* __delimiter) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY ostream_iterator(ostream_type& __s, const _CharT* __delimiter) noexcept
         : __out_stream_(_CUDA_VSTD::addressof(__s)), __delim_(__delimiter) {}
     _LIBCUDACXX_INLINE_VISIBILITY ostream_iterator& operator=(const _Tp& __value_)
         {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/ostreambuf_iterator.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/ostreambuf_iterator.h
@@ -42,9 +42,9 @@ public:
 private:
     streambuf_type* __sbuf_;
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY ostreambuf_iterator(ostream_type& __s) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY ostreambuf_iterator(ostream_type& __s) noexcept
         : __sbuf_(__s.rdbuf()) {}
-    _LIBCUDACXX_INLINE_VISIBILITY ostreambuf_iterator(streambuf_type* __s) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY ostreambuf_iterator(streambuf_type* __s) noexcept
         : __sbuf_(__s) {}
     _LIBCUDACXX_INLINE_VISIBILITY ostreambuf_iterator& operator=(_CharT __c)
         {
@@ -55,7 +55,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY ostreambuf_iterator& operator*()     {return *this;}
     _LIBCUDACXX_INLINE_VISIBILITY ostreambuf_iterator& operator++()    {return *this;}
     _LIBCUDACXX_INLINE_VISIBILITY ostreambuf_iterator& operator++(int) {return *this;}
-    _LIBCUDACXX_INLINE_VISIBILITY bool failed() const _NOEXCEPT {return __sbuf_ == 0;}
+    _LIBCUDACXX_INLINE_VISIBILITY bool failed() const noexcept {return __sbuf_ == 0;}
 
     template <class _Ch, class _Tr>
     friend

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/wrap_iter.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/wrap_iter.h
@@ -37,50 +37,50 @@ template <class _Iter> class __wrap_iter;
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator==(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+operator==(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator<(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+operator<(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator!=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+operator!=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator>(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+operator>(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator>=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+operator>=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator<=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+operator<=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
 #ifndef _LIBCUDACXX_CXX03_LANG
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 auto
-operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
 -> decltype(__x.base() - __y.base());
 #else
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_INLINE_VISIBILITY
 typename __wrap_iter<_Iter1>::difference_type
-operator-(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+operator-(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 #endif
 
 template <class _Iter>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 __wrap_iter<_Iter>
-operator+(typename __wrap_iter<_Iter>::difference_type, __wrap_iter<_Iter>) _NOEXCEPT;
+operator+(typename __wrap_iter<_Iter>::difference_type, __wrap_iter<_Iter>) noexcept;
 
 template <class _Ip, class _Op> _Op _LIBCUDACXX_INLINE_VISIBILITY copy(_Ip, _Ip, _Op);
 template <class _B1, class _B2> _B2 _LIBCUDACXX_INLINE_VISIBILITY copy_backward(_B1, _B1, _B2);
@@ -124,7 +124,7 @@ public:
 private:
     iterator_type __i;
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter() noexcept
 #if _LIBCUDACXX_STD_VER > 11
                 : __i{}
 #endif
@@ -135,7 +135,7 @@ public:
     }
     template <class _Up> _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
         __wrap_iter(const __wrap_iter<_Up>& __u,
-            __enable_if_t<is_convertible<_Up, iterator_type>::value>* = 0) _NOEXCEPT
+            __enable_if_t<is_convertible<_Up, iterator_type>::value>* = 0) noexcept
             : __i(__u.base())
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -165,7 +165,7 @@ public:
         __get_db()->__erase_i(this);
     }
 #endif
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG reference operator*() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG reference operator*() const noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_ASSERT(__get_const_db()->__dereferenceable(this),
@@ -173,7 +173,7 @@ public:
 #endif
         return *__i;
     }
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG pointer  operator->() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG pointer  operator->() const noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_ASSERT(__get_const_db()->__dereferenceable(this),
@@ -181,7 +181,7 @@ public:
 #endif
         return (pointer)_CUDA_VSTD::addressof(*__i);
     }
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter& operator++() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter& operator++() noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_ASSERT(__get_const_db()->__dereferenceable(this),
@@ -190,10 +190,10 @@ public:
         ++__i;
         return *this;
     }
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter  operator++(int) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter  operator++(int) noexcept
         {__wrap_iter __tmp(*this); ++(*this); return __tmp;}
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter& operator--() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter& operator--() noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_ASSERT(__get_const_db()->__decrementable(this),
@@ -202,11 +202,11 @@ public:
         --__i;
         return *this;
     }
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter  operator--(int) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter  operator--(int) noexcept
         {__wrap_iter __tmp(*this); --(*this); return __tmp;}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter  operator+ (difference_type __n) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter  operator+ (difference_type __n) const noexcept
         {__wrap_iter __w(*this); __w += __n; return __w;}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter& operator+=(difference_type __n) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter& operator+=(difference_type __n) noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_ASSERT(__get_const_db()->__addable(this, __n),
@@ -215,11 +215,11 @@ public:
         __i += __n;
         return *this;
     }
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter  operator- (difference_type __n) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter  operator- (difference_type __n) const noexcept
         {return *this + (-__n);}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter& operator-=(difference_type __n) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter& operator-=(difference_type __n) noexcept
         {*this += -__n; return *this;}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG reference    operator[](difference_type __n) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG reference    operator[](difference_type __n) const noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         _LIBCUDACXX_ASSERT(__get_const_db()->__subscriptable(this, __n),
@@ -228,7 +228,7 @@ public:
         return __i[__n];
     }
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG iterator_type base() const _NOEXCEPT {return __i;}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG iterator_type base() const noexcept {return __i;}
 
 private:
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -237,7 +237,7 @@ private:
         __get_db()->__insert_ic(this, __p);
     }
 #else
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter(iterator_type __x) _NOEXCEPT : __i(__x) {}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG __wrap_iter(iterator_type __x) noexcept : __i(__x) {}
 #endif
 
     template <class _Up> friend class __wrap_iter;
@@ -248,50 +248,50 @@ private:
     template <class _Iter1, class _Iter2>
     _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_CONSTEXPR_IF_NODEBUG friend
     bool
-    operator==(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+    operator==(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
     template <class _Iter1, class _Iter2>
     _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_CONSTEXPR_IF_NODEBUG friend
     bool
-    operator<(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+    operator<(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
     template <class _Iter1, class _Iter2>
     _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_CONSTEXPR_IF_NODEBUG friend
     bool
-    operator!=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+    operator!=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
     template <class _Iter1, class _Iter2>
     _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_CONSTEXPR_IF_NODEBUG friend
     bool
-    operator>(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+    operator>(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
     template <class _Iter1, class _Iter2>
     _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_CONSTEXPR_IF_NODEBUG friend
     bool
-    operator>=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+    operator>=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
     template <class _Iter1, class _Iter2>
     _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_CONSTEXPR_IF_NODEBUG friend
     bool
-    operator<=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+    operator<=(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     template <class _Iter1, class _Iter2>
     _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_CONSTEXPR_IF_NODEBUG friend
     auto
-    operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+    operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
     -> decltype(__x.base() - __y.base());
 #else
     template <class _Iter1, class _Iter2>
     _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_CONSTEXPR_IF_NODEBUG friend
     typename __wrap_iter<_Iter1>::difference_type
-    operator-(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) _NOEXCEPT;
+    operator-(const __wrap_iter<_Iter1>&, const __wrap_iter<_Iter2>&) noexcept;
 #endif
 
     template <class _Iter1>
     _LIBCUDACXX_HOST_DEVICE _LIBCUDACXX_CONSTEXPR_IF_NODEBUG friend
     __wrap_iter<_Iter1>
-    operator+(typename __wrap_iter<_Iter1>::difference_type, __wrap_iter<_Iter1>) _NOEXCEPT;
+    operator+(typename __wrap_iter<_Iter1>::difference_type, __wrap_iter<_Iter1>) noexcept;
 
     template <class _Ip, class _Op> _LIBCUDACXX_HOST_DEVICE friend _Op copy(_Ip, _Ip, _Op);
     template <class _B1, class _B2> _LIBCUDACXX_HOST_DEVICE friend _B2 copy_backward(_B1, _B1, _B2);
@@ -322,7 +322,7 @@ private:
 template <class _Iter1, class _Iter2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator==(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+operator==(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
 {
     return __x.base() == __y.base();
 }
@@ -330,7 +330,7 @@ operator==(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEX
 template <class _Iter1, class _Iter2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator<(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+operator<(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_ASSERT(__get_const_db()->__less_than_comparable(&__x, &__y),
@@ -342,7 +342,7 @@ operator<(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXC
 template <class _Iter1, class _Iter2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator!=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+operator!=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
 {
     return !(__x == __y);
 }
@@ -350,7 +350,7 @@ operator!=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEX
 template <class _Iter1, class _Iter2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+operator>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
 {
     return __y < __x;
 }
@@ -358,7 +358,7 @@ operator>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXC
 template <class _Iter1, class _Iter2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator>=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+operator>=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
 {
     return !(__x < __y);
 }
@@ -366,7 +366,7 @@ operator>=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEX
 template <class _Iter1, class _Iter2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator<=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+operator<=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
 {
     return !(__y < __x);
 }
@@ -374,7 +374,7 @@ operator<=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEX
 template <class _Iter1>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator!=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXCEPT
+operator!=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) noexcept
 {
     return !(__x == __y);
 }
@@ -382,7 +382,7 @@ operator!=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEX
 template <class _Iter1>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXCEPT
+operator>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) noexcept
 {
     return __y < __x;
 }
@@ -390,7 +390,7 @@ operator>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXC
 template <class _Iter1>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator>=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXCEPT
+operator>=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) noexcept
 {
     return !(__x < __y);
 }
@@ -398,7 +398,7 @@ operator>=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEX
 template <class _Iter1>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 bool
-operator<=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXCEPT
+operator<=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) noexcept
 {
     return !(__y < __x);
 }
@@ -407,7 +407,7 @@ operator<=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEX
 template <class _Iter1, class _Iter2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 auto
-operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
 -> decltype(__x.base() - __y.base())
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -420,7 +420,7 @@ operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXC
 template <class _Iter1, class _Iter2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 typename __wrap_iter<_Iter1>::difference_type
-operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_ASSERT(__get_const_db()->__less_than_comparable(&__x, &__y),
@@ -434,7 +434,7 @@ template <class _Iter>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_IF_NODEBUG
 __wrap_iter<_Iter>
 operator+(typename __wrap_iter<_Iter>::difference_type __n,
-          __wrap_iter<_Iter> __x) _NOEXCEPT
+          __wrap_iter<_Iter> __x) noexcept
 {
     __x += __n;
     return __x;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__locale
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__locale
@@ -111,7 +111,7 @@ class _LIBCUDACXX_TYPE_VIS locale;
 template <class _Facet>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-has_facet(const locale&) _NOEXCEPT;
+has_facet(const locale&) noexcept;
 
 template <class _Facet>
 _LIBCUDACXX_INLINE_VISIBILITY
@@ -138,8 +138,8 @@ public:
         all = collate | ctype | monetary | numeric | time | messages;
 
     // construct/copy/destroy:
-    locale()  _NOEXCEPT;
-    locale(const locale&)  _NOEXCEPT;
+    locale()  noexcept;
+    locale(const locale&)  noexcept;
     explicit locale(const char*);
     explicit locale(const string&);
     locale(const locale&, const char*, category);
@@ -150,7 +150,7 @@ public:
 
     ~locale();
 
-    const locale& operator=(const locale&)  _NOEXCEPT;
+    const locale& operator=(const locale&)  noexcept;
 
     template <class _Facet>
       _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -178,7 +178,7 @@ private:
     bool has_facet(id&) const;
     const facet* use_facet(id&) const;
 
-    template <class _Facet> friend bool has_facet(const locale&)  _NOEXCEPT;
+    template <class _Facet> friend bool has_facet(const locale&)  noexcept;
     template <class _Facet> friend const _Facet& use_facet(const locale&);
 };
 
@@ -195,7 +195,7 @@ protected:
 //    facet(const facet&) = delete;     // effectively done in __shared_count
 //    void operator=(const facet&) = delete;
 private:
-    virtual void __on_zero_shared() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
 };
 
 class _LIBCUDACXX_TYPE_VIS locale::id
@@ -237,7 +237,7 @@ locale::combine(const locale& __other) const
 template <class _Facet>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-has_facet(const locale& __l)  _NOEXCEPT
+has_facet(const locale& __l)  noexcept
 {
     return __l.has_facet(_Facet::id);
 }
@@ -706,15 +706,15 @@ public:
 #else
     static const size_t table_size = 256;  // FIXME: Don't hardcode this.
 #endif
-    _LIBCUDACXX_INLINE_VISIBILITY const mask* table() const  _NOEXCEPT {return __tab_;}
-    static const mask* classic_table()  _NOEXCEPT;
+    _LIBCUDACXX_INLINE_VISIBILITY const mask* table() const  noexcept {return __tab_;}
+    static const mask* classic_table()  noexcept;
 #if defined(__GLIBC__) || defined(__EMSCRIPTEN__)
-    static const int* __classic_upper_table() _NOEXCEPT;
-    static const int* __classic_lower_table() _NOEXCEPT;
+    static const int* __classic_upper_table() noexcept;
+    static const int* __classic_lower_table() noexcept;
 #endif
 #if defined(__NetBSD__)
-    static const short* __classic_upper_table() _NOEXCEPT;
-    static const short* __classic_lower_table() _NOEXCEPT;
+    static const short* __classic_upper_table() noexcept;
+    static const short* __classic_lower_table() noexcept;
 #endif
 
 protected:
@@ -934,13 +934,13 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int encoding() const  _NOEXCEPT
+    int encoding() const  noexcept
     {
         return do_encoding();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool always_noconv() const  _NOEXCEPT
+    bool always_noconv() const  noexcept
     {
         return do_always_noconv();
     }
@@ -952,7 +952,7 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int max_length() const  _NOEXCEPT
+    int max_length() const  noexcept
     {
         return do_max_length();
     }
@@ -974,10 +974,10 @@ protected:
                          intern_type* __to, intern_type* __to_end, intern_type*& __to_nxt) const;
     virtual result do_unshift(state_type& __st,
                               extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const  _NOEXCEPT;
-    virtual bool do_always_noconv() const  _NOEXCEPT;
+    virtual int do_encoding() const  noexcept;
+    virtual bool do_always_noconv() const  noexcept;
     virtual int do_length(state_type& __st, const extern_type* __frm, const extern_type* __end, size_t __mx) const;
-    virtual int do_max_length() const  _NOEXCEPT;
+    virtual int do_max_length() const  noexcept;
 };
 
 // template <> class codecvt<wchar_t, char, mbstate_t>
@@ -1019,13 +1019,13 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int encoding() const  _NOEXCEPT
+    int encoding() const  noexcept
     {
         return do_encoding();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool always_noconv() const  _NOEXCEPT
+    bool always_noconv() const  noexcept
     {
         return do_always_noconv();
     }
@@ -1037,7 +1037,7 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int max_length() const  _NOEXCEPT
+    int max_length() const  noexcept
     {
         return do_max_length();
     }
@@ -1057,10 +1057,10 @@ protected:
                          intern_type* __to, intern_type* __to_end, intern_type*& __to_nxt) const;
     virtual result do_unshift(state_type& __st,
                               extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const  _NOEXCEPT;
-    virtual bool do_always_noconv() const  _NOEXCEPT;
+    virtual int do_encoding() const  noexcept;
+    virtual bool do_always_noconv() const  noexcept;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const;
-    virtual int do_max_length() const  _NOEXCEPT;
+    virtual int do_max_length() const  noexcept;
 };
 
 // template <> class codecvt<char16_t, char, mbstate_t>
@@ -1103,13 +1103,13 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int encoding() const  _NOEXCEPT
+    int encoding() const  noexcept
     {
         return do_encoding();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool always_noconv() const  _NOEXCEPT
+    bool always_noconv() const  noexcept
     {
         return do_always_noconv();
     }
@@ -1121,7 +1121,7 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int max_length() const  _NOEXCEPT
+    int max_length() const  noexcept
     {
         return do_max_length();
     }
@@ -1143,10 +1143,10 @@ protected:
                          intern_type* __to, intern_type* __to_end, intern_type*& __to_nxt) const;
     virtual result do_unshift(state_type& __st,
                               extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const  _NOEXCEPT;
-    virtual bool do_always_noconv() const  _NOEXCEPT;
+    virtual int do_encoding() const  noexcept;
+    virtual bool do_always_noconv() const  noexcept;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const;
-    virtual int do_max_length() const  _NOEXCEPT;
+    virtual int do_max_length() const  noexcept;
 };
 
 // template <> class codecvt<char32_t, char, mbstate_t>
@@ -1189,13 +1189,13 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int encoding() const  _NOEXCEPT
+    int encoding() const  noexcept
     {
         return do_encoding();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool always_noconv() const  _NOEXCEPT
+    bool always_noconv() const  noexcept
     {
         return do_always_noconv();
     }
@@ -1207,7 +1207,7 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int max_length() const  _NOEXCEPT
+    int max_length() const  noexcept
     {
         return do_max_length();
     }
@@ -1229,10 +1229,10 @@ protected:
                          intern_type* __to, intern_type* __to_end, intern_type*& __to_nxt) const;
     virtual result do_unshift(state_type& __st,
                               extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const  _NOEXCEPT;
-    virtual bool do_always_noconv() const  _NOEXCEPT;
+    virtual int do_encoding() const  noexcept;
+    virtual bool do_always_noconv() const  noexcept;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const;
-    virtual int do_max_length() const  _NOEXCEPT;
+    virtual int do_max_length() const  noexcept;
 };
 
 // template <class _InternT, class _ExternT, class _StateT> class codecvt_byname

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__memory/addressof.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__memory/addressof.h
@@ -29,7 +29,7 @@ template <class _Tp>
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 _LIBCUDACXX_NO_CFI _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
-addressof(_Tp& __x) _NOEXCEPT
+addressof(_Tp& __x) noexcept
 {
     return __builtin_addressof(__x);
 }
@@ -39,7 +39,7 @@ addressof(_Tp& __x) _NOEXCEPT
 template <class _Tp>
 inline _LIBCUDACXX_NO_CFI _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
-addressof(_Tp& __x) _NOEXCEPT
+addressof(_Tp& __x) noexcept
 {
   return reinterpret_cast<_Tp *>(
       const_cast<char *>(&reinterpret_cast<const volatile char &>(__x)));
@@ -55,7 +55,7 @@ addressof(_Tp& __x) _NOEXCEPT
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 __strong _Tp*
-addressof(__strong _Tp& __x) _NOEXCEPT
+addressof(__strong _Tp& __x) noexcept
 {
   return &__x;
 }
@@ -64,7 +64,7 @@ addressof(__strong _Tp& __x) _NOEXCEPT
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 __weak _Tp*
-addressof(__weak _Tp& __x) _NOEXCEPT
+addressof(__weak _Tp& __x) noexcept
 {
   return &__x;
 }
@@ -73,7 +73,7 @@ addressof(__weak _Tp& __x) _NOEXCEPT
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 __autoreleasing _Tp*
-addressof(__autoreleasing _Tp& __x) _NOEXCEPT
+addressof(__autoreleasing _Tp& __x) noexcept
 {
   return &__x;
 }
@@ -81,7 +81,7 @@ addressof(__autoreleasing _Tp& __x) _NOEXCEPT
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 __unsafe_unretained _Tp*
-addressof(__unsafe_unretained _Tp& __x) _NOEXCEPT
+addressof(__unsafe_unretained _Tp& __x) noexcept
 {
   return &__x;
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__memory/pointer_traits.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__memory/pointer_traits.h
@@ -287,7 +287,7 @@ private:
     struct __nat {};
 public:
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    static pointer pointer_to(__conditional_t<is_void<element_type>::value, __nat, element_type>& __r) _NOEXCEPT
+    static pointer pointer_to(__conditional_t<is_void<element_type>::value, __nat, element_type>& __r) noexcept
         {return _CUDA_VSTD::addressof(__r);}
 };
 
@@ -307,7 +307,7 @@ struct __to_address_helper;
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-_Tp* __to_address(_Tp* __p) _NOEXCEPT {
+_Tp* __to_address(_Tp* __p) noexcept {
     static_assert(!is_function<_Tp>::value, "_Tp is a function type");
     return __p;
 }
@@ -339,7 +339,7 @@ template <class _Pointer, class = __enable_if_t<
 > >
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 __decay_t<decltype(__to_address_helper<_Pointer>::__call(declval<const _Pointer&>()))>
-__to_address(const _Pointer& __p) _NOEXCEPT {
+__to_address(const _Pointer& __p) noexcept {
     return __to_address_helper<_Pointer>::__call(__p);
 }
 
@@ -347,7 +347,7 @@ template <class _Pointer, class>
 struct __to_address_helper {
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
     static decltype(_CUDA_VSTD::__to_address(declval<const _Pointer&>().operator->()))
-    __call(const _Pointer& __p) _NOEXCEPT {
+    __call(const _Pointer& __p) noexcept {
         return _CUDA_VSTD::__to_address(__p.operator->());
     }
 };
@@ -356,7 +356,7 @@ template <class _Pointer>
 struct __to_address_helper<_Pointer, decltype((void)pointer_traits<_Pointer>::to_address(declval<const _Pointer&>()))> {
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
     static decltype(pointer_traits<_Pointer>::to_address(declval<const _Pointer&>()))
-    __call(const _Pointer& __p) _NOEXCEPT {
+    __call(const _Pointer& __p) noexcept {
         return pointer_traits<_Pointer>::to_address(__p);
     }
 };

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__mutex_base
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__mutex_base
@@ -52,12 +52,12 @@ public:
 #if defined(_LIBCUDACXX_HAS_TRIVIAL_MUTEX_DESTRUCTION)
     ~mutex() = default;
 #else
-    ~mutex() _NOEXCEPT;
+    ~mutex() noexcept;
 #endif
 
     void lock() _LIBCUDACXX_THREAD_SAFETY_ANNOTATION(acquire_capability());
-    bool try_lock() _NOEXCEPT _LIBCUDACXX_THREAD_SAFETY_ANNOTATION(try_acquire_capability(true));
-    void unlock() _NOEXCEPT _LIBCUDACXX_THREAD_SAFETY_ANNOTATION(release_capability());
+    bool try_lock() noexcept _LIBCUDACXX_THREAD_SAFETY_ANNOTATION(try_acquire_capability(true));
+    void unlock() noexcept _LIBCUDACXX_THREAD_SAFETY_ANNOTATION(release_capability());
 
     typedef __libcpp_mutex_t* native_handle_type;
     _LIBCUDACXX_INLINE_VISIBILITY native_handle_type native_handle() {return &__m_;}
@@ -122,12 +122,12 @@ private:
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    unique_lock() _NOEXCEPT : __m_(nullptr), __owns_(false) {}
+    unique_lock() noexcept : __m_(nullptr), __owns_(false) {}
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit unique_lock(mutex_type& __m)
         : __m_(_CUDA_VSTD::addressof(__m)), __owns_(true) {__m_->lock();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    unique_lock(mutex_type& __m, defer_lock_t) _NOEXCEPT
+    unique_lock(mutex_type& __m, defer_lock_t) noexcept
         : __m_(_CUDA_VSTD::addressof(__m)), __owns_(false) {}
     _LIBCUDACXX_INLINE_VISIBILITY
     unique_lock(mutex_type& __m, try_to_lock_t)
@@ -157,11 +157,11 @@ private:
 public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
-    unique_lock(unique_lock&& __u) _NOEXCEPT
+    unique_lock(unique_lock&& __u) noexcept
         : __m_(__u.__m_), __owns_(__u.__owns_)
         {__u.__m_ = nullptr; __u.__owns_ = false;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    unique_lock& operator=(unique_lock&& __u) _NOEXCEPT
+    unique_lock& operator=(unique_lock&& __u) noexcept
         {
             if (__owns_)
                 __m_->unlock();
@@ -185,13 +185,13 @@ public:
     void unlock();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(unique_lock& __u) _NOEXCEPT
+    void swap(unique_lock& __u) noexcept
     {
         _CUDA_VSTD::swap(__m_, __u.__m_);
         _CUDA_VSTD::swap(__owns_, __u.__owns_);
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    mutex_type* release() _NOEXCEPT
+    mutex_type* release() noexcept
     {
         mutex_type* __m = __m_;
         __m_ = nullptr;
@@ -200,12 +200,12 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool owns_lock() const _NOEXCEPT {return __owns_;}
+    bool owns_lock() const noexcept {return __owns_;}
     _LIBCUDACXX_INLINE_VISIBILITY
     _LIBCUDACXX_EXPLICIT
-        operator bool () const _NOEXCEPT {return __owns_;}
+        operator bool () const noexcept {return __owns_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    mutex_type* mutex() const _NOEXCEPT {return __m_;}
+    mutex_type* mutex() const noexcept {return __m_;}
 };
 
 template <class _Mutex>
@@ -271,7 +271,7 @@ unique_lock<_Mutex>::unlock()
 template <class _Mutex>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(unique_lock<_Mutex>& __x, unique_lock<_Mutex>& __y) _NOEXCEPT
+swap(unique_lock<_Mutex>& __x, unique_lock<_Mutex>& __y) noexcept
     {__x.swap(__y);}
 
 //enum class cv_status
@@ -287,7 +287,7 @@ class _LIBCUDACXX_TYPE_VIS condition_variable
     __libcpp_condvar_t __cv_ = _LIBCUDACXX_CONDVAR_INITIALIZER;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR condition_variable() _NOEXCEPT = default;
+    _LIBCUDACXX_CONSTEXPR condition_variable() noexcept = default;
 
 #ifdef _LIBCUDACXX_HAS_TRIVIAL_CONDVAR_DESTRUCTION
     ~condition_variable() = default;
@@ -298,10 +298,10 @@ public:
     condition_variable(const condition_variable&) = delete;
     condition_variable& operator=(const condition_variable&) = delete;
 
-    void notify_one() _NOEXCEPT;
-    void notify_all() _NOEXCEPT;
+    void notify_one() noexcept;
+    void notify_all() noexcept;
 
-    void wait(unique_lock<mutex>& __lk) _NOEXCEPT;
+    void wait(unique_lock<mutex>& __lk) noexcept;
     template <class _Predicate>
         _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
         void wait(unique_lock<mutex>& __lk, _Predicate __pred);
@@ -337,14 +337,14 @@ public:
 
 private:
     void __do_timed_wait(unique_lock<mutex>& __lk,
-       chrono::time_point<chrono::system_clock, chrono::nanoseconds>) _NOEXCEPT;
+       chrono::time_point<chrono::system_clock, chrono::nanoseconds>) noexcept;
 #if defined(_LIBCUDACXX_HAS_COND_CLOCKWAIT)
     void __do_timed_wait(unique_lock<mutex>& __lk,
-       chrono::time_point<chrono::steady_clock, chrono::nanoseconds>) _NOEXCEPT;
+       chrono::time_point<chrono::steady_clock, chrono::nanoseconds>) noexcept;
 #endif
     template <class _Clock>
     void __do_timed_wait(unique_lock<mutex>& __lk,
-       chrono::time_point<_Clock, chrono::nanoseconds>) _NOEXCEPT;
+       chrono::time_point<_Clock, chrono::nanoseconds>) noexcept;
 };
 #endif // !_LIBCUDACXX_HAS_NO_THREADS
 
@@ -496,7 +496,7 @@ condition_variable::wait_for(unique_lock<mutex>& __lk,
 inline
 void
 condition_variable::__do_timed_wait(unique_lock<mutex>& __lk,
-     chrono::time_point<chrono::steady_clock, chrono::nanoseconds> __tp) _NOEXCEPT
+     chrono::time_point<chrono::steady_clock, chrono::nanoseconds> __tp) noexcept
 {
     using namespace chrono;
     if (!__lk.owns_lock())
@@ -527,7 +527,7 @@ template <class _Clock>
 inline
 void
 condition_variable::__do_timed_wait(unique_lock<mutex>& __lk,
-     chrono::time_point<_Clock, chrono::nanoseconds> __tp) _NOEXCEPT
+     chrono::time_point<_Clock, chrono::nanoseconds> __tp) noexcept
 {
     wait_for(__lk, __tp - _Clock::now());
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__split_buffer
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__split_buffer
@@ -53,14 +53,14 @@ public:
     typedef __add_lvalue_reference_t<allocator_type> __alloc_ref;
     typedef __add_lvalue_reference_t<allocator_type> __alloc_const_ref;
 
-    _LIBCUDACXX_INLINE_VISIBILITY __alloc_rr&           __alloc() _NOEXCEPT         {return __end_cap_.second();}
-    _LIBCUDACXX_INLINE_VISIBILITY const __alloc_rr&     __alloc() const _NOEXCEPT   {return __end_cap_.second();}
-    _LIBCUDACXX_INLINE_VISIBILITY pointer&              __end_cap() _NOEXCEPT       {return __end_cap_.first();}
-    _LIBCUDACXX_INLINE_VISIBILITY const pointer&        __end_cap() const _NOEXCEPT {return __end_cap_.first();}
+    _LIBCUDACXX_INLINE_VISIBILITY __alloc_rr&           __alloc() noexcept         {return __end_cap_.second();}
+    _LIBCUDACXX_INLINE_VISIBILITY const __alloc_rr&     __alloc() const noexcept   {return __end_cap_.second();}
+    _LIBCUDACXX_INLINE_VISIBILITY pointer&              __end_cap() noexcept       {return __end_cap_.first();}
+    _LIBCUDACXX_INLINE_VISIBILITY const pointer&        __end_cap() const noexcept {return __end_cap_.first();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __split_buffer()
-        _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value);
+        noexcept(is_nothrow_default_constructible<allocator_type>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit __split_buffer(__alloc_rr& __a);
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -70,21 +70,21 @@ public:
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     __split_buffer(__split_buffer&& __c)
-        _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value);
+        noexcept(is_nothrow_move_constructible<allocator_type>::value);
     __split_buffer(__split_buffer&& __c, const __alloc_rr& __a);
     __split_buffer& operator=(__split_buffer&& __c)
-        _NOEXCEPT_((__alloc_traits::propagate_on_container_move_assignment::value &&
+        noexcept((__alloc_traits::propagate_on_container_move_assignment::value &&
                 is_nothrow_move_assignable<allocator_type>::value) ||
                !__alloc_traits::propagate_on_container_move_assignment::value);
 #endif  // _LIBCUDACXX_CXX03_LANG
 
-    _LIBCUDACXX_INLINE_VISIBILITY       iterator begin() _NOEXCEPT       {return __begin_;}
-    _LIBCUDACXX_INLINE_VISIBILITY const_iterator begin() const _NOEXCEPT {return __begin_;}
-    _LIBCUDACXX_INLINE_VISIBILITY       iterator end() _NOEXCEPT         {return __end_;}
-    _LIBCUDACXX_INLINE_VISIBILITY const_iterator end() const _NOEXCEPT   {return __end_;}
+    _LIBCUDACXX_INLINE_VISIBILITY       iterator begin() noexcept       {return __begin_;}
+    _LIBCUDACXX_INLINE_VISIBILITY const_iterator begin() const noexcept {return __begin_;}
+    _LIBCUDACXX_INLINE_VISIBILITY       iterator end() noexcept         {return __end_;}
+    _LIBCUDACXX_INLINE_VISIBILITY const_iterator end() const noexcept   {return __end_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT
+    void clear() noexcept
         {__destruct_at_end(__begin_);}
     _LIBCUDACXX_INLINE_VISIBILITY size_type size() const {return static_cast<size_type>(__end_ - __begin_);}
     _LIBCUDACXX_INLINE_VISIBILITY bool empty()     const {return __end_ == __begin_;}
@@ -98,7 +98,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY const_reference back() const  {return *(__end_ - 1);}
 
     void reserve(size_type __n);
-    void shrink_to_fit() _NOEXCEPT;
+    void shrink_to_fit() noexcept;
     void push_front(const_reference __x);
     _LIBCUDACXX_INLINE_VISIBILITY void push_back(const_reference __x);
 #ifndef _LIBCUDACXX_CXX03_LANG
@@ -137,15 +137,15 @@ public:
         void __destruct_at_begin(pointer __new_begin, true_type);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __destruct_at_end(pointer __new_last) _NOEXCEPT
+    void __destruct_at_end(pointer __new_last) noexcept
         {__destruct_at_end(__new_last, false_type());}
     _LIBCUDACXX_INLINE_VISIBILITY
-        void __destruct_at_end(pointer __new_last, false_type) _NOEXCEPT;
+        void __destruct_at_end(pointer __new_last, false_type) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-        void __destruct_at_end(pointer __new_last, true_type) _NOEXCEPT;
+        void __destruct_at_end(pointer __new_last, true_type) noexcept;
 
     void swap(__split_buffer& __x)
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value||
                    __is_nothrow_swappable<__alloc_rr>::value);
 
     bool __invariants() const;
@@ -153,17 +153,17 @@ public:
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__split_buffer& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+        noexcept(is_nothrow_move_assignable<allocator_type>::value)
         {
             __alloc() = _CUDA_VSTD::move(__c.__alloc());
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __move_assign_alloc(__split_buffer&, false_type) _NOEXCEPT
+    void __move_assign_alloc(__split_buffer&, false_type) noexcept
         {}
 
     struct _ConstructTransaction {
-      explicit _ConstructTransaction(pointer* __p, size_type __n) _NOEXCEPT
+      explicit _ConstructTransaction(pointer* __p, size_type __n) noexcept
       : __pos_(*__p), __end_(*__p + __n), __dest_(__p) {
       }
       ~_ConstructTransaction() {
@@ -297,7 +297,7 @@ __split_buffer<_Tp, _Allocator>::__destruct_at_begin(pointer __new_begin, true_t
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-__split_buffer<_Tp, _Allocator>::__destruct_at_end(pointer __new_last, false_type) _NOEXCEPT
+__split_buffer<_Tp, _Allocator>::__destruct_at_end(pointer __new_last, false_type) noexcept
 {
     while (__new_last != __end_)
         __alloc_traits::destroy(__alloc(), __to_raw_pointer(--__end_));
@@ -306,7 +306,7 @@ __split_buffer<_Tp, _Allocator>::__destruct_at_end(pointer __new_last, false_typ
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-__split_buffer<_Tp, _Allocator>::__destruct_at_end(pointer __new_last, true_type) _NOEXCEPT
+__split_buffer<_Tp, _Allocator>::__destruct_at_end(pointer __new_last, true_type) noexcept
 {
     __end_ = __new_last;
 }
@@ -323,7 +323,7 @@ __split_buffer<_Tp, _Allocator>::__split_buffer(size_type __cap, size_type __sta
 template <class _Tp, class _Allocator>
 inline
 __split_buffer<_Tp, _Allocator>::__split_buffer()
-    _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
+    noexcept(is_nothrow_default_constructible<allocator_type>::value)
     : __first_(nullptr), __begin_(nullptr), __end_(nullptr), __end_cap_(nullptr)
 {
 }
@@ -354,7 +354,7 @@ __split_buffer<_Tp, _Allocator>::~__split_buffer()
 
 template <class _Tp, class _Allocator>
 __split_buffer<_Tp, _Allocator>::__split_buffer(__split_buffer&& __c)
-    _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
+    noexcept(is_nothrow_move_constructible<allocator_type>::value)
     : __first_(_CUDA_VSTD::move(__c.__first_)),
       __begin_(_CUDA_VSTD::move(__c.__begin_)),
       __end_(_CUDA_VSTD::move(__c.__end_)),
@@ -395,7 +395,7 @@ __split_buffer<_Tp, _Allocator>::__split_buffer(__split_buffer&& __c, const __al
 template <class _Tp, class _Allocator>
 __split_buffer<_Tp, _Allocator>&
 __split_buffer<_Tp, _Allocator>::operator=(__split_buffer&& __c)
-    _NOEXCEPT_((__alloc_traits::propagate_on_container_move_assignment::value &&
+    noexcept((__alloc_traits::propagate_on_container_move_assignment::value &&
                 is_nothrow_move_assignable<allocator_type>::value) ||
                !__alloc_traits::propagate_on_container_move_assignment::value)
 {
@@ -417,7 +417,7 @@ __split_buffer<_Tp, _Allocator>::operator=(__split_buffer&& __c)
 template <class _Tp, class _Allocator>
 void
 __split_buffer<_Tp, _Allocator>::swap(__split_buffer& __x)
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value||
                    __is_nothrow_swappable<__alloc_rr>::value)
 {
     _CUDA_VSTD::swap(__first_, __x.__first_);
@@ -445,7 +445,7 @@ __split_buffer<_Tp, _Allocator>::reserve(size_type __n)
 
 template <class _Tp, class _Allocator>
 void
-__split_buffer<_Tp, _Allocator>::shrink_to_fit() _NOEXCEPT
+__split_buffer<_Tp, _Allocator>::shrink_to_fit() noexcept
 {
     if (capacity() > size())
     {
@@ -632,7 +632,7 @@ template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__split_buffer<_Tp, _Allocator>& __x, __split_buffer<_Tp, _Allocator>& __y)
-        _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+        noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -83,10 +83,10 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits
     typedef mbstate_t state_type;
 
     static inline void _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-        assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) _NOEXCEPT
+        assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
+    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
         {return __c1 < __c2;}
 
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
@@ -101,15 +101,15 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits
     _LIBCUDACXX_INLINE_VISIBILITY
     static char_type*       assign(char_type* __s, size_t __n, char_type __a);
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type  to_int_type(char_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type  to_int_type(char_type __c) noexcept
         {return int_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool      eq_int_type(int_type __c1, int_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool      eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type  eof() _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type  eof() noexcept
         {return int_type(EOF);}
 };
 
@@ -207,43 +207,43 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char>
     typedef mbstate_t state_type;
 
     static inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    void assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) _NOEXCEPT
+    void assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
+    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
             {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
         {return (unsigned char)__c1 < (unsigned char)__c2;}
 
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    int compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
+    int compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept;
     static inline size_t _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    length(const char_type* __s)  _NOEXCEPT {return __builtin_strlen(__s);}
+    length(const char_type* __s)  noexcept {return __builtin_strlen(__s);}
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT;
-    static inline char_type* move(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) noexcept;
+    static inline char_type* move(char_type* __s1, const char_type* __s2, size_t __n) noexcept
         {return __n == 0 ? __s1 : (char_type*) memmove(__s1, __s2, __n);}
-    static inline char_type* copy(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+    static inline char_type* copy(char_type* __s1, const char_type* __s2, size_t __n) noexcept
         {
             _LIBCUDACXX_ASSERT(__s2 < __s1 || __s2 >= __s1+__n, "char_traits::copy overlapped range");
             return __n == 0 ? __s1 : (char_type*)memcpy(__s1, __s2, __n);
         }
-    static inline char_type* assign(char_type* __s, size_t __n, char_type __a) _NOEXCEPT
+    static inline char_type* assign(char_type* __s, size_t __n, char_type __a) noexcept
         {return __n == 0 ? __s : (char_type*)memset(__s, to_int_type(__a), __n);}
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) noexcept
         {return int_type((unsigned char)__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type  eof() _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type  eof() noexcept
         {return int_type(EOF);}
 };
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 int
-char_traits<char>::compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+char_traits<char>::compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept
 {
     if (__n == 0)
         return 0;
@@ -265,7 +265,7 @@ char_traits<char>::compare(const char_type* __s1, const char_type* __s2, size_t 
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 const char*
-char_traits<char>::find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT
+char_traits<char>::find(const char_type* __s, size_t __n, const char_type& __a) noexcept
 {
     if (__n == 0)
         return nullptr;
@@ -297,43 +297,43 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<wchar_t>
     typedef mbstate_t state_type;
 
     static inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    void assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) _NOEXCEPT
+    void assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
+    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
         {return __c1 < __c2;}
 
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    int compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
+    int compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept;
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    size_t length(const char_type* __s) _NOEXCEPT;
+    size_t length(const char_type* __s) noexcept;
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT;
-    static inline char_type* move(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) noexcept;
+    static inline char_type* move(char_type* __s1, const char_type* __s2, size_t __n) noexcept
         {return __n == 0 ? __s1 : (char_type*)wmemmove(__s1, __s2, __n);}
-    static inline char_type* copy(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+    static inline char_type* copy(char_type* __s1, const char_type* __s2, size_t __n) noexcept
         {
             _LIBCUDACXX_ASSERT(__s2 < __s1 || __s2 >= __s1+__n, "char_traits::copy overlapped range");
             return __n == 0 ? __s1 : (char_type*)wmemcpy(__s1, __s2, __n);
         }
-    static inline char_type* assign(char_type* __s, size_t __n, char_type __a) _NOEXCEPT
+    static inline char_type* assign(char_type* __s, size_t __n, char_type __a) noexcept
         {return __n == 0 ? __s : (char_type*)wmemset(__s, __a, __n);}
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) noexcept
         {return int_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type eof() _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type eof() noexcept
         {return int_type(WEOF);}
 };
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 int
-char_traits<wchar_t>::compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+char_traits<wchar_t>::compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept
 {
     if (__n == 0)
         return 0;
@@ -357,7 +357,7 @@ char_traits<wchar_t>::compare(const char_type* __s1, const char_type* __s2, size
 template <class _Traits>
 _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR
-inline size_t __char_traits_length_checked(const typename _Traits::char_type* __s) _NOEXCEPT {
+inline size_t __char_traits_length_checked(const typename _Traits::char_type* __s) noexcept {
 #if _LIBCUDACXX_DEBUG_LEVEL >= 1
   return __s ? _Traits::length(__s) : (_CUDA_VSTD::__libcpp_debug_function(_CUDA_VSTD::__libcpp_debug_info(__FILE__, __LINE__, "p == nullptr", "null pointer pass to non-null argument of char_traits<...>::length")), 0);
 #else
@@ -367,7 +367,7 @@ inline size_t __char_traits_length_checked(const typename _Traits::char_type* __
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 size_t
-char_traits<wchar_t>::length(const char_type* __s) _NOEXCEPT
+char_traits<wchar_t>::length(const char_type* __s) noexcept
 {
 #if __has_feature(cxx_constexpr_string_builtins)
     return __builtin_wcslen(__s);
@@ -383,7 +383,7 @@ char_traits<wchar_t>::length(const char_type* __s) _NOEXCEPT
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 const wchar_t*
-char_traits<wchar_t>::find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT
+char_traits<wchar_t>::find(const char_type* __s, size_t __n, const char_type& __a) noexcept
 {
     if (__n == 0)
         return nullptr;
@@ -422,24 +422,24 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char8_t>
         {return __c1 < __c2;}
 
     static constexpr
-    int              compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
+    int              compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept;
 
     static constexpr
-    size_t           length(const char_type* __s) _NOEXCEPT;
+    size_t           length(const char_type* __s) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr
-    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT;
+    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) noexcept;
 
-    static char_type*       move(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+    static char_type*       move(char_type* __s1, const char_type* __s2, size_t __n) noexcept
         {return __n == 0 ? __s1 : (char_type*) memmove(__s1, __s2, __n);}
 
-    static char_type*       copy(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+    static char_type*       copy(char_type* __s1, const char_type* __s2, size_t __n) noexcept
        {
             _LIBCUDACXX_ASSERT(__s2 < __s1 || __s2 >= __s1+__n, "char_traits::copy overlapped range");
             return __n == 0 ? __s1 : (char_type*)memcpy(__s1, __s2, __n);
        }
 
-    static char_type*       assign(char_type* __s, size_t __n, char_type __a) _NOEXCEPT
+    static char_type*       assign(char_type* __s, size_t __n, char_type __a) noexcept
         {return __n == 0 ? __s : (char_type*)memset(__s, to_int_type(__a), __n);}
 
     static inline constexpr int_type  not_eof(int_type __c) noexcept
@@ -457,7 +457,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char8_t>
 // TODO use '__builtin_strlen' if it ever supports char8_t ??
 inline constexpr
 size_t
-char_traits<char8_t>::length(const char_type* __s) _NOEXCEPT
+char_traits<char8_t>::length(const char_type* __s) noexcept
 {
     size_t __len = 0;
     for (; !eq(*__s, char_type(0)); ++__s)
@@ -467,7 +467,7 @@ char_traits<char8_t>::length(const char_type* __s) _NOEXCEPT
 
 inline constexpr
 int
-char_traits<char8_t>::compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+char_traits<char8_t>::compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept
 {
 #if __has_feature(cxx_constexpr_string_builtins)
     return __builtin_memcmp(__s1, __s2, __n);
@@ -486,7 +486,7 @@ char_traits<char8_t>::compare(const char_type* __s1, const char_type* __s2, size
 // TODO use '__builtin_char_memchr' if it ever supports char8_t ??
 inline constexpr
 const char8_t*
-char_traits<char8_t>::find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT
+char_traits<char8_t>::find(const char_type* __s, size_t __n, const char_type& __a) noexcept
 {
     for (; __n; --__n)
     {
@@ -511,40 +511,40 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char16_t>
     typedef mbstate_t      state_type;
 
     static inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    void assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) _NOEXCEPT
+    void assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
+    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
         {return __c1 < __c2;}
 
     _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    int              compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
+    int              compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    size_t           length(const char_type* __s) _NOEXCEPT;
+    size_t           length(const char_type* __s) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT;
+    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static char_type*       move(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
+    static char_type*       move(char_type* __s1, const char_type* __s2, size_t __n) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static char_type*       copy(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
+    static char_type*       copy(char_type* __s1, const char_type* __s2, size_t __n) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static char_type*       assign(char_type* __s, size_t __n, char_type __a) _NOEXCEPT;
+    static char_type*       assign(char_type* __s, size_t __n, char_type __a) noexcept;
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) noexcept
         {return int_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type eof() _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type eof() noexcept
         {return int_type(0xFFFF);}
 };
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 int
-char_traits<char16_t>::compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+char_traits<char16_t>::compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept
 {
     for (; __n; --__n, ++__s1, ++__s2)
     {
@@ -558,7 +558,7 @@ char_traits<char16_t>::compare(const char_type* __s1, const char_type* __s2, siz
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 size_t
-char_traits<char16_t>::length(const char_type* __s) _NOEXCEPT
+char_traits<char16_t>::length(const char_type* __s) noexcept
 {
     size_t __len = 0;
     for (; !eq(*__s, char_type(0)); ++__s)
@@ -568,7 +568,7 @@ char_traits<char16_t>::length(const char_type* __s) _NOEXCEPT
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 const char16_t*
-char_traits<char16_t>::find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT
+char_traits<char16_t>::find(const char_type* __s, size_t __n, const char_type& __a) noexcept
 {
     for (; __n; --__n)
     {
@@ -581,7 +581,7 @@ char_traits<char16_t>::find(const char_type* __s, size_t __n, const char_type& _
 
 inline
 char16_t*
-char_traits<char16_t>::move(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+char_traits<char16_t>::move(char_type* __s1, const char_type* __s2, size_t __n) noexcept
 {
     char_type* __r = __s1;
     if (__s1 < __s2)
@@ -601,7 +601,7 @@ char_traits<char16_t>::move(char_type* __s1, const char_type* __s2, size_t __n) 
 
 inline
 char16_t*
-char_traits<char16_t>::copy(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+char_traits<char16_t>::copy(char_type* __s1, const char_type* __s2, size_t __n) noexcept
 {
     _LIBCUDACXX_ASSERT(__s2 < __s1 || __s2 >= __s1+__n, "char_traits::copy overlapped range");
     char_type* __r = __s1;
@@ -612,7 +612,7 @@ char_traits<char16_t>::copy(char_type* __s1, const char_type* __s2, size_t __n) 
 
 inline
 char16_t*
-char_traits<char16_t>::assign(char_type* __s, size_t __n, char_type __a) _NOEXCEPT
+char_traits<char16_t>::assign(char_type* __s, size_t __n, char_type __a) noexcept
 {
     char_type* __r = __s;
     for (; __n; --__n, ++__s)
@@ -630,40 +630,40 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char32_t>
     typedef mbstate_t      state_type;
 
     static inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    void assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) _NOEXCEPT
+    void assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
+    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
         {return __c1 < __c2;}
 
     _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    int              compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
+    int              compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    size_t           length(const char_type* __s) _NOEXCEPT;
+    size_t           length(const char_type* __s) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT;
+    const char_type* find(const char_type* __s, size_t __n, const char_type& __a) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static char_type*       move(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
+    static char_type*       move(char_type* __s1, const char_type* __s2, size_t __n) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static char_type*       copy(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
+    static char_type*       copy(char_type* __s1, const char_type* __s2, size_t __n) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static char_type*       assign(char_type* __s, size_t __n, char_type __a) _NOEXCEPT;
+    static char_type*       assign(char_type* __s, size_t __n, char_type __a) noexcept;
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) noexcept
         {return int_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type eof() _NOEXCEPT
+    static inline _LIBCUDACXX_CONSTEXPR int_type eof() noexcept
         {return int_type(0xFFFFFFFF);}
 };
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 int
-char_traits<char32_t>::compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+char_traits<char32_t>::compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept
 {
     for (; __n; --__n, ++__s1, ++__s2)
     {
@@ -677,7 +677,7 @@ char_traits<char32_t>::compare(const char_type* __s1, const char_type* __s2, siz
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 size_t
-char_traits<char32_t>::length(const char_type* __s) _NOEXCEPT
+char_traits<char32_t>::length(const char_type* __s) noexcept
 {
     size_t __len = 0;
     for (; !eq(*__s, char_type(0)); ++__s)
@@ -687,7 +687,7 @@ char_traits<char32_t>::length(const char_type* __s) _NOEXCEPT
 
 inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
 const char32_t*
-char_traits<char32_t>::find(const char_type* __s, size_t __n, const char_type& __a) _NOEXCEPT
+char_traits<char32_t>::find(const char_type* __s, size_t __n, const char_type& __a) noexcept
 {
     for (; __n; --__n)
     {
@@ -700,7 +700,7 @@ char_traits<char32_t>::find(const char_type* __s, size_t __n, const char_type& _
 
 inline
 char32_t*
-char_traits<char32_t>::move(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+char_traits<char32_t>::move(char_type* __s1, const char_type* __s2, size_t __n) noexcept
 {
     char_type* __r = __s1;
     if (__s1 < __s2)
@@ -720,7 +720,7 @@ char_traits<char32_t>::move(char_type* __s1, const char_type* __s2, size_t __n) 
 
 inline
 char32_t*
-char_traits<char32_t>::copy(char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT
+char_traits<char32_t>::copy(char_type* __s1, const char_type* __s2, size_t __n) noexcept
 {
     _LIBCUDACXX_ASSERT(__s2 < __s1 || __s2 >= __s1+__n, "char_traits::copy overlapped range");
     char_type* __r = __s1;
@@ -731,7 +731,7 @@ char_traits<char32_t>::copy(char_type* __s1, const char_type* __s2, size_t __n) 
 
 inline
 char32_t*
-char_traits<char32_t>::assign(char_type* __s, size_t __n, char_type __a) _NOEXCEPT
+char_traits<char32_t>::assign(char_type* __s, size_t __n, char_type __a) noexcept
 {
     char_type* __r = __s;
     for (; __n; --__n, ++__s)
@@ -747,7 +747,7 @@ char_traits<char32_t>::assign(char_type* __s, size_t __n, char_type __a) _NOEXCE
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_find(const _CharT *__p, _SizeT __sz,
-             _CharT __c, _SizeT __pos) _NOEXCEPT
+             _CharT __c, _SizeT __pos) noexcept
 {
     if (__pos >= __sz)
         return __npos;
@@ -799,7 +799,7 @@ __search_substring(const _CharT *__first1, const _CharT *__last1,
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_find(const _CharT *__p, _SizeT __sz,
-       const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT
+       const _CharT* __s, _SizeT __pos, _SizeT __n) noexcept
 {
     if (__pos > __sz)
         return __npos;
@@ -821,7 +821,7 @@ __str_find(const _CharT *__p, _SizeT __sz,
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_rfind(const _CharT *__p, _SizeT __sz,
-              _CharT __c, _SizeT __pos) _NOEXCEPT
+              _CharT __c, _SizeT __pos) noexcept
 {
     if (__sz < 1)
         return __npos;
@@ -840,7 +840,7 @@ __str_rfind(const _CharT *__p, _SizeT __sz,
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_rfind(const _CharT *__p, _SizeT __sz,
-        const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT
+        const _CharT* __s, _SizeT __pos, _SizeT __n) noexcept
 {
     __pos = _CUDA_VSTD::min(__pos, __sz);
     if (__n < __sz - __pos)
@@ -859,7 +859,7 @@ __str_rfind(const _CharT *__p, _SizeT __sz,
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_find_first_of(const _CharT *__p, _SizeT __sz,
-                const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT
+                const _CharT* __s, _SizeT __pos, _SizeT __n) noexcept
 {
     if (__pos >= __sz || __n == 0)
         return __npos;
@@ -875,7 +875,7 @@ __str_find_first_of(const _CharT *__p, _SizeT __sz,
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_find_last_of(const _CharT *__p, _SizeT __sz,
-               const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT
+               const _CharT* __s, _SizeT __pos, _SizeT __n) noexcept
     {
     if (__n != 0)
     {
@@ -898,7 +898,7 @@ __str_find_last_of(const _CharT *__p, _SizeT __sz,
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_find_first_not_of(const _CharT *__p, _SizeT __sz,
-                    const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT
+                    const _CharT* __s, _SizeT __pos, _SizeT __n) noexcept
 {
     if (__pos < __sz)
     {
@@ -914,7 +914,7 @@ __str_find_first_not_of(const _CharT *__p, _SizeT __sz,
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_find_first_not_of(const _CharT *__p, _SizeT __sz,
-                          _CharT __c, _SizeT __pos) _NOEXCEPT
+                          _CharT __c, _SizeT __pos) noexcept
 {
     if (__pos < __sz)
     {
@@ -931,7 +931,7 @@ __str_find_first_not_of(const _CharT *__p, _SizeT __sz,
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_find_last_not_of(const _CharT *__p, _SizeT __sz,
-                   const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT
+                   const _CharT* __s, _SizeT __pos, _SizeT __n) noexcept
 {
     if (__pos < __sz)
         ++__pos;
@@ -947,7 +947,7 @@ __str_find_last_not_of(const _CharT *__p, _SizeT __sz,
 template<class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 __str_find_last_not_of(const _CharT *__p, _SizeT __sz,
-                         _CharT __c, _SizeT __pos) _NOEXCEPT
+                         _CharT __c, _SizeT __pos) noexcept
 {
     if (__pos < __sz)
         ++__pos;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__threading_support
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__threading_support
@@ -683,7 +683,7 @@ struct alignas(64) __libcpp_contention_t {
 };
 
 _LIBCUDACXX_FUNC_VIS
-__libcpp_contention_t * __libcpp_contention_state(void const volatile * p) _NOEXCEPT;
+__libcpp_contention_t * __libcpp_contention_state(void const volatile * p) noexcept;
 
 #endif // _LIBCUDACXX_HAS_NO_THREAD_CONTENTION_TABLE
 
@@ -702,7 +702,7 @@ class _LIBCUDACXX_TYPE_VIS __thread_id;
 namespace this_thread
 {
 
-_LIBCUDACXX_INLINE_VISIBILITY __thread_id get_id() _NOEXCEPT;
+_LIBCUDACXX_INLINE_VISIBILITY __thread_id get_id() noexcept;
 
 }  // this_thread
 
@@ -717,33 +717,33 @@ class _LIBCUDACXX_TEMPLATE_VIS __thread_id
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    __thread_id() _NOEXCEPT : __id_(0) {}
+    __thread_id() noexcept : __id_(0) {}
 
     friend _LIBCUDACXX_INLINE_VISIBILITY
-        bool operator==(__thread_id __x, __thread_id __y) _NOEXCEPT
+        bool operator==(__thread_id __x, __thread_id __y) noexcept
         { // don't pass id==0 to underlying routines
         if (__x.__id_ == 0) return __y.__id_ == 0;
         if (__y.__id_ == 0) return false;
         return __libcpp_thread_id_equal(__x.__id_, __y.__id_);
         }
     friend _LIBCUDACXX_INLINE_VISIBILITY
-        bool operator!=(__thread_id __x, __thread_id __y) _NOEXCEPT
+        bool operator!=(__thread_id __x, __thread_id __y) noexcept
         {return !(__x == __y);}
     friend _LIBCUDACXX_INLINE_VISIBILITY
-        bool operator< (__thread_id __x, __thread_id __y) _NOEXCEPT
+        bool operator< (__thread_id __x, __thread_id __y) noexcept
         { // id==0 is always less than any other thread_id
         if (__x.__id_ == 0) return __y.__id_ != 0;
         if (__y.__id_ == 0) return false;
         return  __libcpp_thread_id_less(__x.__id_, __y.__id_);
         }
     friend _LIBCUDACXX_INLINE_VISIBILITY
-        bool operator<=(__thread_id __x, __thread_id __y) _NOEXCEPT
+        bool operator<=(__thread_id __x, __thread_id __y) noexcept
         {return !(__y < __x);}
     friend _LIBCUDACXX_INLINE_VISIBILITY
-        bool operator> (__thread_id __x, __thread_id __y) _NOEXCEPT
+        bool operator> (__thread_id __x, __thread_id __y) noexcept
         {return   __y < __x ;}
     friend _LIBCUDACXX_INLINE_VISIBILITY
-        bool operator>=(__thread_id __x, __thread_id __y) _NOEXCEPT
+        bool operator>=(__thread_id __x, __thread_id __y) noexcept
         {return !(__x < __y);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -761,7 +761,7 @@ private:
     _LIBCUDACXX_INLINE_VISIBILITY
     __thread_id(__libcpp_thread_id __id) : __id_(__id) {}
 
-    friend __thread_id this_thread::get_id() _NOEXCEPT;
+    friend __thread_id this_thread::get_id() noexcept;
     friend class _LIBCUDACXX_TYPE_VIS thread;
     friend struct _LIBCUDACXX_TEMPLATE_VIS hash<__thread_id>;
 };
@@ -771,7 +771,7 @@ namespace this_thread
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 __thread_id
-get_id() _NOEXCEPT
+get_id() noexcept
 {
     return __libcpp_thread_get_current_id();
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__tree
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__tree
@@ -76,7 +76,7 @@ __root, have a non-null __parent_ field.
 template <class _NodePtr>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__tree_is_left_child(_NodePtr __x) _NOEXCEPT
+__tree_is_left_child(_NodePtr __x) noexcept
 {
     return __x == __x->__parent_->__left_;
 }
@@ -142,7 +142,7 @@ __tree_invariant(_NodePtr __root)
 template <class _NodePtr>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _NodePtr
-__tree_min(_NodePtr __x) _NOEXCEPT
+__tree_min(_NodePtr __x) noexcept
 {
     while (__x->__left_ != nullptr)
         __x = __x->__left_;
@@ -154,7 +154,7 @@ __tree_min(_NodePtr __x) _NOEXCEPT
 template <class _NodePtr>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _NodePtr
-__tree_max(_NodePtr __x) _NOEXCEPT
+__tree_max(_NodePtr __x) noexcept
 {
     while (__x->__right_ != nullptr)
         __x = __x->__right_;
@@ -165,7 +165,7 @@ __tree_max(_NodePtr __x) _NOEXCEPT
 // Precondition:  __x != nullptr.
 template <class _NodePtr>
 _NodePtr
-__tree_next(_NodePtr __x) _NOEXCEPT
+__tree_next(_NodePtr __x) noexcept
 {
     if (__x->__right_ != nullptr)
         return __tree_min(__x->__right_);
@@ -177,7 +177,7 @@ __tree_next(_NodePtr __x) _NOEXCEPT
 template <class _EndNodePtr, class _NodePtr>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _EndNodePtr
-__tree_next_iter(_NodePtr __x) _NOEXCEPT
+__tree_next_iter(_NodePtr __x) noexcept
 {
     if (__x->__right_ != nullptr)
         return static_cast<_EndNodePtr>(__tree_min(__x->__right_));
@@ -192,7 +192,7 @@ __tree_next_iter(_NodePtr __x) _NOEXCEPT
 template <class _NodePtr, class _EndNodePtr>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _NodePtr
-__tree_prev_iter(_EndNodePtr __x) _NOEXCEPT
+__tree_prev_iter(_EndNodePtr __x) noexcept
 {
     if (__x->__left_ != nullptr)
         return __tree_max(__x->__left_);
@@ -206,7 +206,7 @@ __tree_prev_iter(_EndNodePtr __x) _NOEXCEPT
 // Precondition:  __x != nullptr.
 template <class _NodePtr>
 _NodePtr
-__tree_leaf(_NodePtr __x) _NOEXCEPT
+__tree_leaf(_NodePtr __x) noexcept
 {
     while (true)
     {
@@ -230,7 +230,7 @@ __tree_leaf(_NodePtr __x) _NOEXCEPT
 // Precondition:  __x->__right_ != nullptr
 template <class _NodePtr>
 void
-__tree_left_rotate(_NodePtr __x) _NOEXCEPT
+__tree_left_rotate(_NodePtr __x) noexcept
 {
     _NodePtr __y = __x->__right_;
     __x->__right_ = __y->__left_;
@@ -250,7 +250,7 @@ __tree_left_rotate(_NodePtr __x) _NOEXCEPT
 // Precondition:  __x->__left_ != nullptr
 template <class _NodePtr>
 void
-__tree_right_rotate(_NodePtr __x) _NOEXCEPT
+__tree_right_rotate(_NodePtr __x) noexcept
 {
     _NodePtr __y = __x->__left_;
     __x->__left_ = __y->__right_;
@@ -275,7 +275,7 @@ __tree_right_rotate(_NodePtr __x) _NOEXCEPT
 //                may be different than the value passed in as __root.
 template <class _NodePtr>
 void
-__tree_balance_after_insert(_NodePtr __root, _NodePtr __x) _NOEXCEPT
+__tree_balance_after_insert(_NodePtr __root, _NodePtr __x) noexcept
 {
     __x->__is_black_ = __x == __root;
     while (__x != __root && !__x->__parent_unsafe()->__is_black_)
@@ -345,7 +345,7 @@ __tree_balance_after_insert(_NodePtr __root, _NodePtr __x) _NOEXCEPT
 //                may be different than the value passed in as __root.
 template <class _NodePtr>
 void
-__tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEPT
+__tree_remove(_NodePtr __root, _NodePtr __z) noexcept
 {
     // __z will be removed from the tree.  Client still needs to destruct/deallocate it
     // __y is either __z, or if __z has two children, __tree_next(__z).
@@ -716,7 +716,7 @@ public:
     pointer __left_;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __tree_end_node() _NOEXCEPT : __left_() {}
+    __tree_end_node() noexcept : __left_() {}
 };
 
 template <class _VoidPtr>
@@ -782,13 +782,13 @@ public:
     __tree_node_destructor& operator=(const __tree_node_destructor&) = delete;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __tree_node_destructor(allocator_type& __na, bool __val = false) _NOEXCEPT
+    explicit __tree_node_destructor(allocator_type& __na, bool __val = false) noexcept
         : __na_(__na),
           __value_constructed(__val)
         {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator()(pointer __p) _NOEXCEPT
+    void operator()(pointer __p) noexcept
     {
         if (__value_constructed)
             __alloc_traits::destroy(__na_, _NodeTypes::__get_ptr(__p->__value_));
@@ -829,7 +829,7 @@ public:
     typedef value_type&                                    reference;
     typedef typename _NodeTypes::__node_value_type_pointer pointer;
 
-    _LIBCUDACXX_INLINE_VISIBILITY __tree_iterator() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY __tree_iterator() noexcept
 #if _LIBCUDACXX_STD_VER > 11
     : __ptr_(nullptr)
 #endif
@@ -869,9 +869,9 @@ public:
 
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __tree_iterator(__node_pointer __p) _NOEXCEPT : __ptr_(__p) {}
+    explicit __tree_iterator(__node_pointer __p) noexcept : __ptr_(__p) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __tree_iterator(__end_node_pointer __p) _NOEXCEPT : __ptr_(__p) {}
+    explicit __tree_iterator(__end_node_pointer __p) noexcept : __ptr_(__p) {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __node_pointer __get_np() const { return static_cast<__node_pointer>(__ptr_); }
     template <class, class, class> friend class __tree;
@@ -902,7 +902,7 @@ public:
     typedef const value_type&                                    reference;
     typedef typename _NodeTypes::__const_node_value_type_pointer pointer;
 
-    _LIBCUDACXX_INLINE_VISIBILITY __tree_const_iterator() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY __tree_const_iterator() noexcept
 #if _LIBCUDACXX_STD_VER > 11
     : __ptr_(nullptr)
 #endif
@@ -913,7 +913,7 @@ private:
                                                            __non_const_iterator;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    __tree_const_iterator(__non_const_iterator __p) _NOEXCEPT
+    __tree_const_iterator(__non_const_iterator __p) noexcept
         : __ptr_(__p.__ptr_) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY reference operator*() const
@@ -952,10 +952,10 @@ public:
 
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __tree_const_iterator(__node_pointer __p) _NOEXCEPT
+    explicit __tree_const_iterator(__node_pointer __p) noexcept
         : __ptr_(__p) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __tree_const_iterator(__end_node_pointer __p) _NOEXCEPT
+    explicit __tree_const_iterator(__end_node_pointer __p) noexcept
         : __ptr_(__p) {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __node_pointer __get_np() const { return static_cast<__node_pointer>(__ptr_); }
@@ -1036,14 +1036,14 @@ private:
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    __iter_pointer __end_node() _NOEXCEPT
+    __iter_pointer __end_node() noexcept
     {
         return static_cast<__iter_pointer>(
                 pointer_traits<__end_node_ptr>::pointer_to(__pair1_.first())
         );
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    __iter_pointer __end_node() const _NOEXCEPT
+    __iter_pointer __end_node() const noexcept
     {
         return static_cast<__iter_pointer>(
             pointer_traits<__end_node_ptr>::pointer_to(
@@ -1052,37 +1052,37 @@ public:
         );
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-          __node_allocator& __node_alloc() _NOEXCEPT {return __pair1_.second();}
+          __node_allocator& __node_alloc() noexcept {return __pair1_.second();}
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-    const __node_allocator& __node_alloc() const _NOEXCEPT
+    const __node_allocator& __node_alloc() const noexcept
         {return __pair1_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-          __iter_pointer& __begin_node() _NOEXCEPT {return __begin_node_;}
+          __iter_pointer& __begin_node() noexcept {return __begin_node_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const __iter_pointer& __begin_node() const _NOEXCEPT {return __begin_node_;}
+    const __iter_pointer& __begin_node() const noexcept {return __begin_node_;}
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type __alloc() const _NOEXCEPT
+    allocator_type __alloc() const noexcept
         {return allocator_type(__node_alloc());}
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-          size_type& size() _NOEXCEPT {return __pair3_.first();}
+          size_type& size() noexcept {return __pair3_.first();}
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    const size_type& size() const _NOEXCEPT {return __pair3_.first();}
+    const size_type& size() const noexcept {return __pair3_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY
-          value_compare& value_comp() _NOEXCEPT {return __pair3_.second();}
+          value_compare& value_comp() noexcept {return __pair3_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const value_compare& value_comp() const _NOEXCEPT
+    const value_compare& value_comp() const noexcept
         {return __pair3_.second();}
 public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __node_pointer __root() const _NOEXCEPT
+    __node_pointer __root() const noexcept
         {return static_cast<__node_pointer>(__end_node()->__left_);}
 
-    __node_base_pointer* __root_ptr() const _NOEXCEPT {
+    __node_base_pointer* __root_ptr() const noexcept {
         return _CUDA_VSTD::addressof(__end_node()->__left_);
     }
 
@@ -1090,7 +1090,7 @@ public:
     typedef __tree_const_iterator<value_type, __node_pointer, difference_type> const_iterator;
 
     explicit __tree(const value_compare& __comp)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<__node_allocator>::value &&
             is_nothrow_copy_constructible<value_compare>::value);
     explicit __tree(const allocator_type& __a);
@@ -1103,12 +1103,12 @@ public:
         void __assign_multi(_InputIterator __first, _InputIterator __last);
 #ifndef _LIBCUDACXX_CXX03_LANG
     __tree(__tree&& __t)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_move_constructible<__node_allocator>::value &&
             is_nothrow_move_constructible<value_compare>::value);
     __tree(__tree&& __t, const allocator_type& __a);
     __tree& operator=(__tree&& __t)
-        _NOEXCEPT_(
+        noexcept(
             __node_traits::propagate_on_container_move_assignment::value &&
             is_nothrow_move_assignable<value_compare>::value &&
             is_nothrow_move_assignable<__node_allocator>::value);
@@ -1117,31 +1117,31 @@ public:
     ~__tree();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator begin()  _NOEXCEPT {return       iterator(__begin_node());}
+          iterator begin()  noexcept {return       iterator(__begin_node());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT {return const_iterator(__begin_node());}
+    const_iterator begin() const noexcept {return const_iterator(__begin_node());}
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator end() _NOEXCEPT {return       iterator(__end_node());}
+          iterator end() noexcept {return       iterator(__end_node());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end() const _NOEXCEPT {return const_iterator(__end_node());}
+    const_iterator end() const noexcept {return const_iterator(__end_node());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT
+    size_type max_size() const noexcept
         {return std::min<size_type>(
                 __node_traits::max_size(__node_alloc()),
                 numeric_limits<difference_type >::max());}
 
-    void clear() _NOEXCEPT;
+    void clear() noexcept;
 
     void swap(__tree& __t)
 #if _LIBCUDACXX_STD_VER <= 11
-        _NOEXCEPT_(
+        noexcept(
             __is_nothrow_swappable<value_compare>::value
             && (!__node_traits::propagate_on_container_swap::value ||
                  __is_nothrow_swappable<__node_allocator>::value)
             );
 #else
-        _NOEXCEPT_(__is_nothrow_swappable<value_compare>::value);
+        noexcept(__is_nothrow_swappable<value_compare>::value);
 #endif
 
 #ifndef _LIBCUDACXX_CXX03_LANG
@@ -1342,7 +1342,7 @@ public:
 
 
     _LIBCUDACXX_INLINE_VISIBILITY iterator
-    __remove_node_pointer(__node_pointer) _NOEXCEPT;
+    __remove_node_pointer(__node_pointer) noexcept;
 
 #if _LIBCUDACXX_STD_VER > 14
     template <class _NodeHandle, class _InsertReturnType>
@@ -1383,7 +1383,7 @@ public:
 
     void __insert_node_at(__parent_pointer     __parent,
                           __node_base_pointer& __child,
-                          __node_base_pointer __new_node) _NOEXCEPT;
+                          __node_base_pointer __new_node) noexcept;
 
     template <class _Key>
         iterator find(const _Key& __v);
@@ -1444,7 +1444,7 @@ public:
     typedef __tree_node_destructor<__node_allocator> _Dp;
     typedef unique_ptr<__node, _Dp> __node_holder;
 
-    __node_holder remove(const_iterator __p) _NOEXCEPT;
+    __node_holder remove(const_iterator __p) noexcept;
 private:
     __node_base_pointer&
         __find_leaf_low(__parent_pointer& __parent, const key_type& __v);
@@ -1476,7 +1476,7 @@ private:
     __node_holder __construct_node(const __container_value_type& __v);
 #endif
 
-    void destroy(__node_pointer __nd) _NOEXCEPT;
+    void destroy(__node_pointer __nd) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __copy_assign_alloc(const __tree& __t)
@@ -1495,12 +1495,12 @@ private:
 
     void __move_assign(__tree& __t, false_type);
     void __move_assign(__tree& __t, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<value_compare>::value &&
+        noexcept(is_nothrow_move_assignable<value_compare>::value &&
                    is_nothrow_move_assignable<__node_allocator>::value);
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__tree& __t)
-        _NOEXCEPT_(
+        noexcept(
             !__node_traits::propagate_on_container_move_assignment::value ||
             is_nothrow_move_assignable<__node_allocator>::value)
         {__move_assign_alloc(__t, integral_constant<bool,
@@ -1508,25 +1508,25 @@ private:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__tree& __t, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<__node_allocator>::value)
+        noexcept(is_nothrow_move_assignable<__node_allocator>::value)
         {__node_alloc() = _CUDA_VSTD::move(__t.__node_alloc());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __move_assign_alloc(__tree&, false_type) _NOEXCEPT {}
+    void __move_assign_alloc(__tree&, false_type) noexcept {}
 
     struct _DetachedTreeCache {
       _LIBCUDACXX_INLINE_VISIBILITY
-      explicit _DetachedTreeCache(__tree *__t) _NOEXCEPT : __t_(__t),
+      explicit _DetachedTreeCache(__tree *__t) noexcept : __t_(__t),
         __cache_root_(__detach_from_tree(__t)) {
           __advance();
         }
 
       _LIBCUDACXX_INLINE_VISIBILITY
-      __node_pointer __get() const _NOEXCEPT {
+      __node_pointer __get() const noexcept {
         return __cache_elem_;
       }
 
       _LIBCUDACXX_INLINE_VISIBILITY
-      void __advance() _NOEXCEPT {
+      void __advance() noexcept {
         __cache_elem_ = __cache_root_;
         if (__cache_root_) {
           __cache_root_ = __detach_next(__cache_root_);
@@ -1548,9 +1548,9 @@ private:
 
     private:
       _LIBCUDACXX_INLINE_VISIBILITY
-      static __node_pointer __detach_from_tree(__tree *__t) _NOEXCEPT;
+      static __node_pointer __detach_from_tree(__tree *__t) noexcept;
       _LIBCUDACXX_INLINE_VISIBILITY
-      static __node_pointer __detach_next(__node_pointer) _NOEXCEPT;
+      static __node_pointer __detach_next(__node_pointer) noexcept;
 
       __tree *__t_;
       __node_pointer __cache_root_;
@@ -1564,7 +1564,7 @@ private:
 
 template <class _Tp, class _Compare, class _Allocator>
 __tree<_Tp, _Compare, _Allocator>::__tree(const value_compare& __comp)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<__node_allocator>::value &&
             is_nothrow_copy_constructible<value_compare>::value)
     : __pair3_(0, __comp)
@@ -1594,7 +1594,7 @@ __tree<_Tp, _Compare, _Allocator>::__tree(const value_compare& __comp,
 // Precondition:  size() != 0
 template <class _Tp, class _Compare, class _Allocator>
 typename __tree<_Tp, _Compare, _Allocator>::__node_pointer
-__tree<_Tp, _Compare, _Allocator>::_DetachedTreeCache::__detach_from_tree(__tree *__t) _NOEXCEPT
+__tree<_Tp, _Compare, _Allocator>::_DetachedTreeCache::__detach_from_tree(__tree *__t) noexcept
 {
     __node_pointer __cache = static_cast<__node_pointer>(__t->__begin_node());
     __t->__begin_node() = __t->__end_node();
@@ -1615,7 +1615,7 @@ __tree<_Tp, _Compare, _Allocator>::_DetachedTreeCache::__detach_from_tree(__tree
 //    This is no longer a red-black tree
 template <class _Tp, class _Compare, class _Allocator>
 typename __tree<_Tp, _Compare, _Allocator>::__node_pointer
-__tree<_Tp, _Compare, _Allocator>::_DetachedTreeCache::__detach_next(__node_pointer __cache) _NOEXCEPT
+__tree<_Tp, _Compare, _Allocator>::_DetachedTreeCache::__detach_next(__node_pointer __cache) noexcept
 {
     if (__cache->__parent_ == nullptr)
         return nullptr;
@@ -1708,7 +1708,7 @@ __tree<_Tp, _Compare, _Allocator>::__tree(const __tree& __t)
 
 template <class _Tp, class _Compare, class _Allocator>
 __tree<_Tp, _Compare, _Allocator>::__tree(__tree&& __t)
-    _NOEXCEPT_(
+    noexcept(
         is_nothrow_move_constructible<__node_allocator>::value &&
         is_nothrow_move_constructible<value_compare>::value)
     : __begin_node_(_CUDA_VSTD::move(__t.__begin_node_)),
@@ -1755,7 +1755,7 @@ __tree<_Tp, _Compare, _Allocator>::__tree(__tree&& __t, const allocator_type& __
 template <class _Tp, class _Compare, class _Allocator>
 void
 __tree<_Tp, _Compare, _Allocator>::__move_assign(__tree& __t, true_type)
-    _NOEXCEPT_(is_nothrow_move_assignable<value_compare>::value &&
+    noexcept(is_nothrow_move_assignable<value_compare>::value &&
                is_nothrow_move_assignable<__node_allocator>::value)
 {
     destroy(static_cast<__node_pointer>(__end_node()->__left_));
@@ -1801,7 +1801,7 @@ __tree<_Tp, _Compare, _Allocator>::__move_assign(__tree& __t, false_type)
 template <class _Tp, class _Compare, class _Allocator>
 __tree<_Tp, _Compare, _Allocator>&
 __tree<_Tp, _Compare, _Allocator>::operator=(__tree&& __t)
-    _NOEXCEPT_(
+    noexcept(
         __node_traits::propagate_on_container_move_assignment::value &&
         is_nothrow_move_assignable<value_compare>::value &&
         is_nothrow_move_assignable<__node_allocator>::value)
@@ -1824,7 +1824,7 @@ __tree<_Tp, _Compare, _Allocator>::~__tree()
 
 template <class _Tp, class _Compare, class _Allocator>
 void
-__tree<_Tp, _Compare, _Allocator>::destroy(__node_pointer __nd) _NOEXCEPT
+__tree<_Tp, _Compare, _Allocator>::destroy(__node_pointer __nd) noexcept
 {
     if (__nd != nullptr)
     {
@@ -1840,13 +1840,13 @@ template <class _Tp, class _Compare, class _Allocator>
 void
 __tree<_Tp, _Compare, _Allocator>::swap(__tree& __t)
 #if _LIBCUDACXX_STD_VER <= 11
-        _NOEXCEPT_(
+        noexcept(
             __is_nothrow_swappable<value_compare>::value
             && (!__node_traits::propagate_on_container_swap::value ||
                  __is_nothrow_swappable<__node_allocator>::value)
             )
 #else
-        _NOEXCEPT_(__is_nothrow_swappable<value_compare>::value)
+        noexcept(__is_nothrow_swappable<value_compare>::value)
 #endif
 {
     using _CUDA_VSTD::swap;
@@ -1866,7 +1866,7 @@ __tree<_Tp, _Compare, _Allocator>::swap(__tree& __t)
 
 template <class _Tp, class _Compare, class _Allocator>
 void
-__tree<_Tp, _Compare, _Allocator>::clear() _NOEXCEPT
+__tree<_Tp, _Compare, _Allocator>::clear() noexcept
 {
     destroy(__root());
     size() = 0;
@@ -2102,7 +2102,7 @@ __tree<_Tp, _Compare, _Allocator>::__find_equal(const_iterator __hint,
 template <class _Tp, class _Compare, class _Allocator>
 void __tree<_Tp, _Compare, _Allocator>::__insert_node_at(
     __parent_pointer __parent, __node_base_pointer& __child,
-    __node_base_pointer __new_node) _NOEXCEPT
+    __node_base_pointer __new_node) noexcept
 {
     __new_node->__left_   = nullptr;
     __new_node->__right_  = nullptr;
@@ -2339,7 +2339,7 @@ __tree<_Tp, _Compare, _Allocator>::__node_insert_multi(const_iterator __p,
 
 template <class _Tp, class _Compare, class _Allocator>
 typename __tree<_Tp, _Compare, _Allocator>::iterator
-__tree<_Tp, _Compare, _Allocator>::__remove_node_pointer(__node_pointer __ptr) _NOEXCEPT
+__tree<_Tp, _Compare, _Allocator>::__remove_node_pointer(__node_pointer __ptr) noexcept
 {
     iterator __r(__ptr);
     ++__r;
@@ -2811,7 +2811,7 @@ __tree<_Tp, _Compare, _Allocator>::__equal_range_multi(const _Key& __k) const
 
 template <class _Tp, class _Compare, class _Allocator>
 typename __tree<_Tp, _Compare, _Allocator>::__node_holder
-__tree<_Tp, _Compare, _Allocator>::remove(const_iterator __p) _NOEXCEPT
+__tree<_Tp, _Compare, _Allocator>::remove(const_iterator __p) noexcept
 {
     __node_pointer __np = __p.__get_np();
     if (__begin_node() == __p.__ptr_)
@@ -2832,7 +2832,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__tree<_Tp, _Compare, _Allocator>& __x,
      __tree<_Tp, _Compare, _Allocator>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/integral_constant.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/integral_constant.h
@@ -27,10 +27,10 @@ struct _LIBCUDACXX_TEMPLATE_VIS integral_constant
   typedef _Tp               value_type;
   typedef integral_constant type;
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR operator value_type() const _NOEXCEPT {return value;}
+  _LIBCUDACXX_CONSTEXPR operator value_type() const noexcept {return value;}
 #if _LIBCUDACXX_STD_VER > 11
   _LIBCUDACXX_INLINE_VISIBILITY
-  constexpr value_type operator ()() const _NOEXCEPT {return value;}
+  constexpr value_type operator ()() const noexcept {return value;}
 #endif
 };
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_constant_evaluated.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_constant_evaluated.h
@@ -29,10 +29,10 @@ inline constexpr bool is_constant_evaluated() noexcept {
 #endif
 
 inline _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-bool __libcpp_is_constant_evaluated() _NOEXCEPT { return _LIBCUDACXX_IS_CONSTANT_EVALUATED(); }
+bool __libcpp_is_constant_evaluated() noexcept { return _LIBCUDACXX_IS_CONSTANT_EVALUATED(); }
 #else
 inline _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-bool __libcpp_is_constant_evaluated() _NOEXCEPT { return false; }
+bool __libcpp_is_constant_evaluated() noexcept { return false; }
 #endif // defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED)
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/declval.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/declval.h
@@ -30,7 +30,7 @@ _LIBCUDACXX_INLINE_VISIBILITY _Tp __declval(long);
 _LIBCUDACXX_SUPPRESS_DEPRECATED_POP
 
 template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY decltype(_CUDA_VSTD::__declval<_Tp>(0)) declval() _NOEXCEPT;
+_LIBCUDACXX_INLINE_VISIBILITY decltype(_CUDA_VSTD::__declval<_Tp>(0)) declval() noexcept;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/exception_guard.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/exception_guard.h
@@ -115,7 +115,7 @@ struct __exception_guard_noexceptions {
   __exception_guard_noexceptions& operator=(__exception_guard_noexceptions&&)      = delete;
 
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17 _LIBCUDACXX_NODEBUG
-  void __complete() _NOEXCEPT {
+  void __complete() noexcept {
     __completed_ = true;
   }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/forward.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/forward.h
@@ -27,13 +27,13 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 _LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR _Tp&&
-forward(__libcpp_remove_reference_t<_Tp>& __t) _NOEXCEPT {
+forward(__libcpp_remove_reference_t<_Tp>& __t) noexcept {
   return static_cast<_Tp&&>(__t);
 }
 
 template <class _Tp>
 _LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR _Tp&&
-forward(__libcpp_remove_reference_t<_Tp>&& __t) _NOEXCEPT {
+forward(__libcpp_remove_reference_t<_Tp>&& __t) noexcept {
   static_assert(!is_lvalue_reference<_Tp>::value, "cannot forward an rvalue as an lvalue");
   return static_cast<_Tp&&>(__t);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/move.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/move.h
@@ -28,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 _LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR __libcpp_remove_reference_t<_Tp>&&
-move(_Tp&& __t) _NOEXCEPT {
+move(_Tp&& __t) noexcept {
   typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tp> _Up;
   return static_cast<_Up&&>(__t);
 }
@@ -39,7 +39,7 @@ using __move_if_noexcept_result_t =
 
 template <class _Tp>
 _LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __move_if_noexcept_result_t<_Tp>
-move_if_noexcept(_Tp& __x) _NOEXCEPT {
+move_if_noexcept(_Tp& __x) noexcept {
   return _CUDA_VSTD::move(__x);
 }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/pair.h
@@ -69,9 +69,9 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class, class>
 struct __non_trivially_copyable_base {
   _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-  __non_trivially_copyable_base() _NOEXCEPT {}
+  __non_trivially_copyable_base() noexcept {}
   _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-  __non_trivially_copyable_base(__non_trivially_copyable_base const&) _NOEXCEPT {}
+  __non_trivially_copyable_base(__non_trivially_copyable_base const&) noexcept {}
 };
 #endif
 
@@ -159,7 +159,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
             _CheckArgsDep<_Dummy>::__enable_explicit_default::value
     >* = nullptr>
     explicit _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    pair() _NOEXCEPT_(is_nothrow_default_constructible<first_type>::value &&
+    pair() noexcept(is_nothrow_default_constructible<first_type>::value &&
                       is_nothrow_default_constructible<second_type>::value)
         : first(), second() {}
 
@@ -167,7 +167,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
             _CheckArgsDep<_Dummy>::__enable_implicit_default::value
     >* = nullptr>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    pair() _NOEXCEPT_(is_nothrow_default_constructible<first_type>::value &&
+    pair() noexcept(is_nothrow_default_constructible<first_type>::value &&
                       is_nothrow_default_constructible<second_type>::value)
         : first(), second() {}
 
@@ -176,7 +176,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     explicit pair(_T1 const& __t1, _T2 const& __t2)
-        _NOEXCEPT_(is_nothrow_copy_constructible<first_type>::value &&
+        noexcept(is_nothrow_copy_constructible<first_type>::value &&
                    is_nothrow_copy_constructible<second_type>::value)
         : first(__t1), second(__t2) {}
 
@@ -185,7 +185,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     pair(_T1 const& __t1, _T2 const& __t2)
-        _NOEXCEPT_(is_nothrow_copy_constructible<first_type>::value &&
+        noexcept(is_nothrow_copy_constructible<first_type>::value &&
                    is_nothrow_copy_constructible<second_type>::value)
         : first(__t1), second(__t2) {}
 
@@ -199,7 +199,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     explicit pair(_U1&& __u1, _U2&& __u2)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1>::value &&
                     is_nothrow_constructible<second_type, _U2>::value))
         : first(_CUDA_VSTD::forward<_U1>(__u1)), second(_CUDA_VSTD::forward<_U2>(__u2)) {}
 
@@ -213,7 +213,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     pair(_U1&& __u1, _U2&& __u2)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1>::value &&
                     is_nothrow_constructible<second_type, _U2>::value))
         : first(_CUDA_VSTD::forward<_U1>(__u1)), second(_CUDA_VSTD::forward<_U2>(__u2)) {}
 
@@ -244,7 +244,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     explicit pair(pair<_U1, _U2> const& __p)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1 const&>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1 const&>::value &&
                     is_nothrow_constructible<second_type, _U2 const&>::value))
         : first(__p.first), second(__p.second) {}
 
@@ -254,7 +254,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     explicit pair(::std::pair<_U1, _U2> const& __p)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1 const&>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1 const&>::value &&
                     is_nothrow_constructible<second_type, _U2 const&>::value))
         : first(__p.first), second(__p.second) {}
 #endif // defined(__cuda_std__) && !defined(__CUDACC_RTC__)
@@ -264,7 +264,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     pair(pair<_U1, _U2> const& __p)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1 const&>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1 const&>::value &&
                     is_nothrow_constructible<second_type, _U2 const&>::value))
         : first(__p.first), second(__p.second) {}
 
@@ -274,7 +274,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     pair(::std::pair<_U1, _U2> const& __p)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1 const&>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1 const&>::value &&
                     is_nothrow_constructible<second_type, _U2 const&>::value))
         : first(__p.first), second(__p.second) {}
 #endif // defined(__cuda_std__) && !defined(__CUDACC_RTC__)
@@ -284,7 +284,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     explicit pair(pair<_U1, _U2>&&__p)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1&&>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1&&>::value &&
                     is_nothrow_constructible<second_type, _U2&&>::value))
         : first(_CUDA_VSTD::forward<_U1>(__p.first)), second(_CUDA_VSTD::forward<_U2>(__p.second)) {}
 
@@ -294,7 +294,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     explicit pair(::std::pair<_U1, _U2>&&__p)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1&&>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1&&>::value &&
                     is_nothrow_constructible<second_type, _U2&&>::value))
         : first(_CUDA_VSTD::forward<_U1>(__p.first)), second(_CUDA_VSTD::forward<_U2>(__p.second)) {}
 #endif // defined(__cuda_std__) && !defined(__CUDACC_RTC__)
@@ -304,7 +304,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     pair(pair<_U1, _U2>&& __p)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1&&>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1&&>::value &&
                     is_nothrow_constructible<second_type, _U2&&>::value))
         : first(_CUDA_VSTD::forward<_U1>(__p.first)), second(_CUDA_VSTD::forward<_U2>(__p.second)) {}
 
@@ -314,7 +314,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     >* = nullptr>
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     pair(::std::pair<_U1, _U2>&& __p)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _U1&&>::value &&
+        noexcept((is_nothrow_constructible<first_type, _U1&&>::value &&
                     is_nothrow_constructible<second_type, _U2&&>::value))
         : first(_CUDA_VSTD::forward<_U1>(__p.first)), second(_CUDA_VSTD::forward<_U2>(__p.second)) {}
 #endif // defined(__cuda_std__) && !defined(__CUDACC_RTC__)
@@ -363,7 +363,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
     pair(piecewise_construct_t __pc,
          tuple<_Args1...> __first_args, tuple<_Args2...> __second_args)
-        _NOEXCEPT_((is_nothrow_constructible<first_type, _Args1...>::value &&
+        noexcept((is_nothrow_constructible<first_type, _Args1...>::value &&
                     is_nothrow_constructible<second_type, _Args2...>::value))
         : pair(__pc, __first_args, __second_args,
                 typename __make_tuple_indices<sizeof...(_Args1)>::type(),
@@ -374,7 +374,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
                         is_copy_assignable<first_type>::value &&
                         is_copy_assignable<second_type>::value,
                     pair, __nat> const& __p)
-        _NOEXCEPT_(is_nothrow_copy_assignable<first_type>::value &&
+        noexcept(is_nothrow_copy_assignable<first_type>::value &&
                    is_nothrow_copy_assignable<second_type>::value)
     {
         first = __p.first;
@@ -387,7 +387,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
                                              is_copy_assignable<_T2>::value, int> = 0>
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
     pair& operator=(::std::pair<_T1, _T2> const& __p)
-        _NOEXCEPT_(is_nothrow_copy_assignable<first_type>::value &&
+        noexcept(is_nothrow_copy_assignable<first_type>::value &&
                    is_nothrow_copy_assignable<second_type>::value)
     {
         first = __p.first;
@@ -401,7 +401,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
                         is_move_assignable<first_type>::value &&
                         is_move_assignable<second_type>::value,
                     pair, __nat>&& __p)
-        _NOEXCEPT_(is_nothrow_move_assignable<first_type>::value &&
+        noexcept(is_nothrow_move_assignable<first_type>::value &&
                    is_nothrow_move_assignable<second_type>::value)
     {
         first = _CUDA_VSTD::forward<first_type>(__p.first);
@@ -414,7 +414,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
                                              is_move_assignable<_T2>::value, int> = 0>
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
     pair& operator=(::std::pair<_T1, _T2>&& __p)
-        _NOEXCEPT_(is_nothrow_move_assignable<first_type>::value &&
+        noexcept(is_nothrow_move_assignable<first_type>::value &&
                    is_nothrow_move_assignable<second_type>::value)
     {
         first = _CUDA_VSTD::forward<first_type>(__p.first);
@@ -528,7 +528,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    void swap(pair& __p) _NOEXCEPT_(__is_nothrow_swappable<first_type>::value &&
+    void swap(pair& __p) noexcept(__is_nothrow_swappable<first_type>::value &&
                                     __is_nothrow_swappable<second_type>::value)
     {
         using _CUDA_VSTD::swap;
@@ -661,7 +661,7 @@ __enable_if_t
     void
 >
 swap(pair<_T1, _T2>& __x, pair<_T1, _T2>& __y)
-                     _NOEXCEPT_((__is_nothrow_swappable<_T1>::value &&
+                     noexcept((__is_nothrow_swappable<_T1>::value &&
                                  __is_nothrow_swappable<_T2>::value))
 {
     __x.swap(__y);
@@ -719,25 +719,25 @@ struct __get_pair<0>
     static
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     _T1&
-    get(pair<_T1, _T2>& __p) _NOEXCEPT {return __p.first;}
+    get(pair<_T1, _T2>& __p) noexcept {return __p.first;}
 
     template <class _T1, class _T2>
     static
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     const _T1&
-    get(const pair<_T1, _T2>& __p) _NOEXCEPT {return __p.first;}
+    get(const pair<_T1, _T2>& __p) noexcept {return __p.first;}
 
     template <class _T1, class _T2>
     static
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     _T1&&
-    get(pair<_T1, _T2>&& __p) _NOEXCEPT {return _CUDA_VSTD::forward<_T1>(__p.first);}
+    get(pair<_T1, _T2>&& __p) noexcept {return _CUDA_VSTD::forward<_T1>(__p.first);}
 
     template <class _T1, class _T2>
     static
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     const _T1&&
-    get(const pair<_T1, _T2>&& __p) _NOEXCEPT {return _CUDA_VSTD::forward<const _T1>(__p.first);}
+    get(const pair<_T1, _T2>&& __p) noexcept {return _CUDA_VSTD::forward<const _T1>(__p.first);}
 };
 
 template <>
@@ -747,31 +747,31 @@ struct __get_pair<1>
     static
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     _T2&
-    get(pair<_T1, _T2>& __p) _NOEXCEPT {return __p.second;}
+    get(pair<_T1, _T2>& __p) noexcept {return __p.second;}
 
     template <class _T1, class _T2>
     static
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     const _T2&
-    get(const pair<_T1, _T2>& __p) _NOEXCEPT {return __p.second;}
+    get(const pair<_T1, _T2>& __p) noexcept {return __p.second;}
 
     template <class _T1, class _T2>
     static
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     _T2&&
-    get(pair<_T1, _T2>&& __p) _NOEXCEPT {return _CUDA_VSTD::forward<_T2>(__p.second);}
+    get(pair<_T1, _T2>&& __p) noexcept {return _CUDA_VSTD::forward<_T2>(__p.second);}
 
     template <class _T1, class _T2>
     static
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     const _T2&&
-    get(const pair<_T1, _T2>&& __p) _NOEXCEPT {return _CUDA_VSTD::forward<const _T2>(__p.second);}
+    get(const pair<_T1, _T2>&& __p) noexcept {return _CUDA_VSTD::forward<const _T2>(__p.second);}
 };
 
 template <size_t _Ip, class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 typename tuple_element<_Ip, pair<_T1, _T2> >::type&
-get(pair<_T1, _T2>& __p) _NOEXCEPT
+get(pair<_T1, _T2>& __p) noexcept
 {
     return __get_pair<_Ip>::get(__p);
 }
@@ -779,7 +779,7 @@ get(pair<_T1, _T2>& __p) _NOEXCEPT
 template <size_t _Ip, class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&
-get(const pair<_T1, _T2>& __p) _NOEXCEPT
+get(const pair<_T1, _T2>& __p) noexcept
 {
     return __get_pair<_Ip>::get(__p);
 }
@@ -787,7 +787,7 @@ get(const pair<_T1, _T2>& __p) _NOEXCEPT
 template <size_t _Ip, class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
-get(pair<_T1, _T2>&& __p) _NOEXCEPT
+get(pair<_T1, _T2>&& __p) noexcept
 {
     return __get_pair<_Ip>::get(_CUDA_VSTD::move(__p));
 }
@@ -795,7 +795,7 @@ get(pair<_T1, _T2>&& __p) _NOEXCEPT
 template <size_t _Ip, class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
-get(const pair<_T1, _T2>&& __p) _NOEXCEPT
+get(const pair<_T1, _T2>&& __p) noexcept
 {
     return __get_pair<_Ip>::get(_CUDA_VSTD::move(__p));
 }
@@ -803,56 +803,56 @@ get(const pair<_T1, _T2>&& __p) _NOEXCEPT
 #if _LIBCUDACXX_STD_VER > 11
 template <class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-constexpr _T1 & get(pair<_T1, _T2>& __p) _NOEXCEPT
+constexpr _T1 & get(pair<_T1, _T2>& __p) noexcept
 {
     return __get_pair<0>::get(__p);
 }
 
 template <class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-constexpr _T1 const & get(pair<_T1, _T2> const& __p) _NOEXCEPT
+constexpr _T1 const & get(pair<_T1, _T2> const& __p) noexcept
 {
     return __get_pair<0>::get(__p);
 }
 
 template <class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-constexpr _T1 && get(pair<_T1, _T2>&& __p) _NOEXCEPT
+constexpr _T1 && get(pair<_T1, _T2>&& __p) noexcept
 {
     return __get_pair<0>::get(_CUDA_VSTD::move(__p));
 }
 
 template <class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-constexpr _T1 const && get(pair<_T1, _T2> const&& __p) _NOEXCEPT
+constexpr _T1 const && get(pair<_T1, _T2> const&& __p) noexcept
 {
     return __get_pair<0>::get(_CUDA_VSTD::move(__p));
 }
 
 template <class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-constexpr _T1 & get(pair<_T2, _T1>& __p) _NOEXCEPT
+constexpr _T1 & get(pair<_T2, _T1>& __p) noexcept
 {
     return __get_pair<1>::get(__p);
 }
 
 template <class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-constexpr _T1 const & get(pair<_T2, _T1> const& __p) _NOEXCEPT
+constexpr _T1 const & get(pair<_T2, _T1> const& __p) noexcept
 {
     return __get_pair<1>::get(__p);
 }
 
 template <class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-constexpr _T1 && get(pair<_T2, _T1>&& __p) _NOEXCEPT
+constexpr _T1 && get(pair<_T2, _T1>&& __p) noexcept
 {
     return __get_pair<1>::get(_CUDA_VSTD::move(__p));
 }
 
 template <class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-constexpr _T1 const && get(pair<_T2, _T1> const&& __p) _NOEXCEPT
+constexpr _T1 const && get(pair<_T2, _T1> const&& __p) noexcept
 {
     return __get_pair<1>::get(_CUDA_VSTD::move(__p));
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/any
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/any
@@ -96,7 +96,7 @@ namespace std {
 class _LIBCUDACXX_EXCEPTION_ABI _LIBCUDACXX_AVAILABILITY_BAD_ANY_CAST bad_any_cast : public bad_cast
 {
 public:
-    virtual const char* what() const _NOEXCEPT;
+    virtual const char* what() const noexcept;
 };
 } // namespace std
 
@@ -121,11 +121,11 @@ class _LIBCUDACXX_TEMPLATE_VIS any;
 template <class _ValueType>
 _LIBCUDACXX_INLINE_VISIBILITY
 add_pointer_t<add_const_t<_ValueType>>
-any_cast(any const *) _NOEXCEPT;
+any_cast(any const *) noexcept;
 
 template <class _ValueType>
 _LIBCUDACXX_INLINE_VISIBILITY
-add_pointer_t<_ValueType> any_cast(any *) _NOEXCEPT;
+add_pointer_t<_ValueType> any_cast(any *) noexcept;
 
 namespace __any_imp
 {
@@ -184,7 +184,7 @@ class _LIBCUDACXX_TEMPLATE_VIS any
 public:
   // construct/destruct
   _LIBCUDACXX_INLINE_VISIBILITY
-  constexpr any() _NOEXCEPT : __h(nullptr) {}
+  constexpr any() noexcept : __h(nullptr) {}
 
   _LIBCUDACXX_INLINE_VISIBILITY
   any(any const & __other) : __h(nullptr)
@@ -193,7 +193,7 @@ public:
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  any(any && __other) _NOEXCEPT : __h(nullptr)
+  any(any && __other) noexcept : __h(nullptr)
   {
     if (__other.__h) __other.__call(_Action::_Move, this);
   }
@@ -239,7 +239,7 @@ public:
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  any & operator=(any && __rhs) _NOEXCEPT {
+  any & operator=(any && __rhs) noexcept {
     any(_CUDA_VSTD::move(__rhs)).swap(*this);
     return *this;
   }
@@ -274,18 +274,18 @@ public:
 
   // 6.3.3 any modifiers
   _LIBCUDACXX_INLINE_VISIBILITY
-  void reset() _NOEXCEPT { if (__h) this->__call(_Action::_Destroy); }
+  void reset() noexcept { if (__h) this->__call(_Action::_Destroy); }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  void swap(any & __rhs) _NOEXCEPT;
+  void swap(any & __rhs) noexcept;
 
   // 6.3.4 any observers
   _LIBCUDACXX_INLINE_VISIBILITY
-  bool has_value() const _NOEXCEPT { return __h != nullptr; }
+  bool has_value() const noexcept { return __h != nullptr; }
 
 #if !defined(_LIBCUDACXX_NO_RTTI)
   _LIBCUDACXX_INLINE_VISIBILITY
-  const type_info & type() const _NOEXCEPT {
+  const type_info & type() const noexcept {
     if (__h) {
         return *static_cast<type_info const *>(this->__call(_Action::_TypeInfo));
     } else {
@@ -328,11 +328,11 @@ private:
 
     template <class _ValueType>
     friend add_pointer_t<add_const_t<_ValueType>>
-    any_cast(any const *) _NOEXCEPT;
+    any_cast(any const *) noexcept;
 
     template <class _ValueType>
     friend add_pointer_t<_ValueType>
-    any_cast(any *) _NOEXCEPT;
+    any_cast(any *) noexcept;
 
     _HandleFuncPtr __h = nullptr;
     _Storage __s;
@@ -537,7 +537,7 @@ _Tp& any::emplace(initializer_list<_Up> __il, _Args&&... __args) {
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-void any::swap(any & __rhs) _NOEXCEPT
+void any::swap(any & __rhs) noexcept
 {
     if (this == &__rhs)
       return;
@@ -558,7 +558,7 @@ void any::swap(any & __rhs) _NOEXCEPT
 // 6.4 Non-member functions
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-void swap(any & __lhs, any & __rhs) _NOEXCEPT
+void swap(any & __lhs, any & __rhs) noexcept
 {
     __lhs.swap(__rhs);
 }
@@ -623,7 +623,7 @@ _ValueType any_cast(any && __v)
 template <class _ValueType>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 add_pointer_t<add_const_t<_ValueType>>
-any_cast(any const * __any) _NOEXCEPT
+any_cast(any const * __any) noexcept
 {
     static_assert(!is_reference<_ValueType>::value,
                   "_ValueType may not be a reference.");
@@ -644,7 +644,7 @@ _RetType __pointer_or_func_cast(void*, /*IsFunction*/true_type) noexcept {
 
 template <class _ValueType>
 add_pointer_t<_ValueType>
-any_cast(any * __any) _NOEXCEPT
+any_cast(any * __any) noexcept
 {
     using __any_imp::_Action;
     static_assert(!is_reference<_ValueType>::value,

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/array
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/array
@@ -181,64 +181,64 @@ struct _LIBCUDACXX_TEMPLATE_VIS array
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(array& __a) _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value) {
+    void swap(array& __a) noexcept(__is_nothrow_swappable<_Tp>::value) {
       _CUDA_VSTD::swap_ranges(__elems_, __elems_ + _Size, __a.__elems_);
     }
 
     // iterators:
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    iterator begin() _NOEXCEPT {return iterator(data());}
+    iterator begin() noexcept {return iterator(data());}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const_iterator begin() const _NOEXCEPT {return const_iterator(data());}
+    const_iterator begin() const noexcept {return const_iterator(data());}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    iterator end() _NOEXCEPT {return iterator(data() + _Size);}
+    iterator end() noexcept {return iterator(data() + _Size);}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const_iterator end() const _NOEXCEPT {return const_iterator(data() + _Size);}
+    const_iterator end() const noexcept {return const_iterator(data() + _Size);}
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    reverse_iterator rbegin() _NOEXCEPT {return reverse_iterator(end());}
+    reverse_iterator rbegin() noexcept {return reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const_reverse_iterator rbegin() const _NOEXCEPT {return const_reverse_iterator(end());}
+    const_reverse_iterator rbegin() const noexcept {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    reverse_iterator rend() _NOEXCEPT {return reverse_iterator(begin());}
+    reverse_iterator rend() noexcept {return reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const_reverse_iterator rend() const _NOEXCEPT {return const_reverse_iterator(begin());}
+    const_reverse_iterator rend() const noexcept {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const_iterator cbegin() const _NOEXCEPT {return begin();}
+    const_iterator cbegin() const noexcept {return begin();}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const_iterator cend() const _NOEXCEPT {return end();}
+    const_iterator cend() const noexcept {return end();}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const_reverse_iterator crbegin() const _NOEXCEPT {return rbegin();}
+    const_reverse_iterator crbegin() const noexcept {return rbegin();}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const_reverse_iterator crend() const _NOEXCEPT {return rend();}
+    const_reverse_iterator crend() const noexcept {return rend();}
 
     // capacity:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR size_type size() const _NOEXCEPT {return _Size;}
+    _LIBCUDACXX_CONSTEXPR size_type size() const noexcept {return _Size;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR size_type max_size() const _NOEXCEPT {return _Size;}
+    _LIBCUDACXX_CONSTEXPR size_type max_size() const noexcept {return _Size;}
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR bool empty() const _NOEXCEPT {return false; }
+    _LIBCUDACXX_CONSTEXPR bool empty() const noexcept {return false; }
 
     // element access:
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    reference operator[](size_type __n)             _NOEXCEPT {return __elems_[__n];}
+    reference operator[](size_type __n)             noexcept {return __elems_[__n];}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    const_reference operator[](size_type __n) const _NOEXCEPT {return __elems_[__n];}
+    const_reference operator[](size_type __n) const noexcept {return __elems_[__n];}
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14       reference at(size_type __n);
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const_reference at(size_type __n) const;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 reference front()             _NOEXCEPT {return __elems_[0];}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const_reference front() const _NOEXCEPT {return __elems_[0];}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 reference back()              _NOEXCEPT {return __elems_[_Size - 1];}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const_reference back() const  _NOEXCEPT {return __elems_[_Size - 1];}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 reference front()             noexcept {return __elems_[0];}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const_reference front() const noexcept {return __elems_[0];}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 reference back()              noexcept {return __elems_[_Size - 1];}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const_reference back() const  noexcept {return __elems_[_Size - 1];}
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    value_type* data() _NOEXCEPT {return __elems_;}
+    value_type* data() noexcept {return __elems_;}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
-    const value_type* data() const _NOEXCEPT {return __elems_;}
+    const value_type* data() const noexcept {return __elems_;}
 };
 
 
@@ -293,56 +293,56 @@ struct _LIBCUDACXX_TEMPLATE_VIS array<_Tp, 0>
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(array&) _NOEXCEPT {
+    void swap(array&) noexcept {
       static_assert(!is_const<_Tp>::value,
                     "cannot swap zero-sized array of type 'const T'");
     }
 
     // iterators:
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator begin() _NOEXCEPT {return iterator(data());}
+    iterator begin() noexcept {return iterator(data());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT {return const_iterator(data());}
+    const_iterator begin() const noexcept {return const_iterator(data());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator end() _NOEXCEPT {return iterator(data());}
+    iterator end() noexcept {return iterator(data());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end() const _NOEXCEPT {return const_iterator(data());}
+    const_iterator end() const noexcept {return const_iterator(data());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator rbegin() _NOEXCEPT {return reverse_iterator(end());}
+    reverse_iterator rbegin() noexcept {return reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin() const _NOEXCEPT {return const_reverse_iterator(end());}
+    const_reverse_iterator rbegin() const noexcept {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator rend() _NOEXCEPT {return reverse_iterator(begin());}
+    reverse_iterator rend() noexcept {return reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend() const _NOEXCEPT {return const_reverse_iterator(begin());}
+    const_reverse_iterator rend() const noexcept {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT {return begin();}
+    const_iterator cbegin() const noexcept {return begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend() const _NOEXCEPT {return end();}
+    const_iterator cend() const noexcept {return end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT {return rbegin();}
+    const_reverse_iterator crbegin() const noexcept {return rbegin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend() const _NOEXCEPT {return rend();}
+    const_reverse_iterator crend() const noexcept {return rend();}
 
     // capacity:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR size_type size() const _NOEXCEPT {return 0; }
+    _LIBCUDACXX_CONSTEXPR size_type size() const noexcept {return 0; }
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR size_type max_size() const _NOEXCEPT {return 0;}
+    _LIBCUDACXX_CONSTEXPR size_type max_size() const noexcept {return 0;}
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR bool empty() const _NOEXCEPT {return true;}
+    _LIBCUDACXX_CONSTEXPR bool empty() const noexcept {return true;}
 
     // element access:
     _LIBCUDACXX_INLINE_VISIBILITY
-    reference operator[](size_type) _NOEXCEPT {
+    reference operator[](size_type) noexcept {
       _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::operator[] on a zero-sized array");
       _LIBCUDACXX_UNREACHABLE();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    const_reference operator[](size_type) const _NOEXCEPT {
+    const_reference operator[](size_type) const noexcept {
       _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::operator[] on a zero-sized array");
       _LIBCUDACXX_UNREACHABLE();
     }
@@ -360,33 +360,33 @@ struct _LIBCUDACXX_TEMPLATE_VIS array<_Tp, 0>
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    reference front() _NOEXCEPT {
+    reference front() noexcept {
       _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::front() on a zero-sized array");
       _LIBCUDACXX_UNREACHABLE();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reference front() const _NOEXCEPT {
+    const_reference front() const noexcept {
       _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::front() on a zero-sized array");
       _LIBCUDACXX_UNREACHABLE();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    reference back() _NOEXCEPT {
+    reference back() noexcept {
       _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::back() on a zero-sized array");
       _LIBCUDACXX_UNREACHABLE();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reference back() const _NOEXCEPT {
+    const_reference back() const noexcept {
       _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::back() on a zero-sized array");
       _LIBCUDACXX_UNREACHABLE();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    value_type* data() _NOEXCEPT {return reinterpret_cast<value_type*>(__elems_);}
+    value_type* data() noexcept {return reinterpret_cast<value_type*>(__elems_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const value_type* data() const _NOEXCEPT {return reinterpret_cast<const value_type*>(__elems_);}
+    const value_type* data() const noexcept {return reinterpret_cast<const value_type*>(__elems_);}
 };
 
 
@@ -456,7 +456,7 @@ __enable_if_t
     void
 >
 swap(array<_Tp, _Size>& __x, array<_Tp, _Size>& __y)
-                                  _NOEXCEPT_(noexcept(__x.swap(__y)))
+                                  noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -475,7 +475,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS tuple_element<_Ip, array<_Tp, _Size> >
 template <size_t _Ip, class _Tp, size_t _Size>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 _Tp&
-get(array<_Tp, _Size>& __a) _NOEXCEPT
+get(array<_Tp, _Size>& __a) noexcept
 {
     static_assert(_Ip < _Size, "Index out of bounds in std::get<> (std::array)");
     return __a.__elems_[_Ip];
@@ -484,7 +484,7 @@ get(array<_Tp, _Size>& __a) _NOEXCEPT
 template <size_t _Ip, class _Tp, size_t _Size>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const _Tp&
-get(const array<_Tp, _Size>& __a) _NOEXCEPT
+get(const array<_Tp, _Size>& __a) noexcept
 {
     static_assert(_Ip < _Size, "Index out of bounds in std::get<> (const std::array)");
     return __a.__elems_[_Ip];
@@ -495,7 +495,7 @@ get(const array<_Tp, _Size>& __a) _NOEXCEPT
 template <size_t _Ip, class _Tp, size_t _Size>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 _Tp&&
-get(array<_Tp, _Size>&& __a) _NOEXCEPT
+get(array<_Tp, _Size>&& __a) noexcept
 {
     static_assert(_Ip < _Size, "Index out of bounds in std::get<> (std::array &&)");
     return _CUDA_VSTD::move(__a.__elems_[_Ip]);
@@ -504,7 +504,7 @@ get(array<_Tp, _Size>&& __a) _NOEXCEPT
 template <size_t _Ip, class _Tp, size_t _Size>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const _Tp&&
-get(const array<_Tp, _Size>&& __a) _NOEXCEPT
+get(const array<_Tp, _Size>&& __a) noexcept
 {
     static_assert(_Ip < _Size, "Index out of bounds in std::get<> (const std::array &&)");
     return _CUDA_VSTD::move(__a.__elems_[_Ip]);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/atomic
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/atomic
@@ -752,7 +752,7 @@ using __detail::__cxx_atomic_fetch_xor;
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp kill_dependency(_Tp __y) _NOEXCEPT
+_Tp kill_dependency(_Tp __y) noexcept
 {
     return __y;
 }
@@ -787,10 +787,10 @@ template<typename _Tp, int _Sco>
 struct __cxx_atomic_lock_impl {
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  __cxx_atomic_lock_impl() _NOEXCEPT
+  __cxx_atomic_lock_impl() noexcept
     : __a_value(), __a_lock(0) {}
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
-  __cxx_atomic_lock_impl(_Tp value) _NOEXCEPT
+  __cxx_atomic_lock_impl(_Tp value) noexcept
     : __a_value(value), __a_lock(0) {}
 
   _Tp __a_value;
@@ -1098,8 +1098,8 @@ template <typename _Tp, int _Sco,
           typename _Base = __cxx_atomic_base_impl<_Tp, _Sco> >
 #endif //_LIBCUDACXX_ATOMIC_ONLY_USE_BUILTINS
 struct __cxx_atomic_impl : public _Base {
-  __cxx_atomic_impl() _NOEXCEPT _LIBCUDACXX_DEFAULT
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit __cxx_atomic_impl(_Tp value) _NOEXCEPT
+  __cxx_atomic_impl() noexcept _LIBCUDACXX_DEFAULT
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit __cxx_atomic_impl(_Tp value) noexcept
     : _Base(value) {}
 };
 
@@ -1292,7 +1292,7 @@ struct __atomic_base_storage {
     __atomic_base_storage& operator=(__atomic_base_storage&&) = default;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base_storage(_Storage&& __a) _NOEXCEPT : __a_(_CUDA_VSTD::forward<_Storage>(__a)) {}
+    __atomic_base_storage(_Storage&& __a) noexcept : __a_(_CUDA_VSTD::forward<_Storage>(__a)) {}
 };
 
 template <class _Tp, bool _Cq, typename _Storage>
@@ -1305,69 +1305,69 @@ struct __atomic_base_core : public __atomic_base_storage<_Tp, _Storage>{
     __atomic_base_core& operator=(__atomic_base_core&&) = delete;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base_core(_Storage&& __a) _NOEXCEPT : __atomic_base_storage<_Tp, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
+    __atomic_base_core(_Storage&& __a) noexcept : __atomic_base_storage<_Tp, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
 #if defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
     static _LIBCUDACXX_CONSTEXPR bool is_always_lock_free = _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
 #endif // defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool is_lock_free() const volatile _NOEXCEPT
+    bool is_lock_free() const volatile noexcept
         {return _LIBCUDACXX_ATOMIC_IS_LOCK_FREE(sizeof(_Tp));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool is_lock_free() const _NOEXCEPT
+    bool is_lock_free() const noexcept
         {return static_cast<__atomic_base_core const volatile*>(this)->is_lock_free();}
     _LIBCUDACXX_INLINE_VISIBILITY
 
-    void store(_Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+    void store(_Tp __d, memory_order __m = memory_order_seq_cst) volatile noexcept
       _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)
         {__cxx_atomic_store(&this->__a_, __d, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void store(_Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    void store(_Tp __d, memory_order __m = memory_order_seq_cst) noexcept
       _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)
         {__cxx_atomic_store(&this->__a_, __d, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp load(memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _Tp load(memory_order __m = memory_order_seq_cst) const volatile noexcept
       _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
         {return __cxx_atomic_load(&this->__a_, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp load(memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _Tp load(memory_order __m = memory_order_seq_cst) const noexcept
       _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
         {return __cxx_atomic_load(&this->__a_, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    operator _Tp() const volatile _NOEXCEPT {return load();}
+    operator _Tp() const volatile noexcept {return load();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    operator _Tp() const _NOEXCEPT          {return load();}
+    operator _Tp() const noexcept          {return load();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) volatile noexcept
         {return __cxx_atomic_exchange(&this->__a_, __d, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) noexcept
         {return __cxx_atomic_exchange(&this->__a_, __d, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_weak(_Tp& __e, _Tp __d,
-                               memory_order __s, memory_order __f) volatile _NOEXCEPT
+                               memory_order __s, memory_order __f) volatile noexcept
       _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
         {return __cxx_atomic_compare_exchange_weak(&this->__a_, &__e, __d, __s, __f);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_weak(_Tp& __e, _Tp __d,
-                               memory_order __s, memory_order __f) _NOEXCEPT
+                               memory_order __s, memory_order __f) noexcept
       _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
         {return __cxx_atomic_compare_exchange_weak(&this->__a_, &__e, __d, __s, __f);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_strong(_Tp& __e, _Tp __d,
-                                 memory_order __s, memory_order __f) volatile _NOEXCEPT
+                                 memory_order __s, memory_order __f) volatile noexcept
       _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
         {return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __s, __f);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_strong(_Tp& __e, _Tp __d,
-                                 memory_order __s, memory_order __f) _NOEXCEPT
+                                 memory_order __s, memory_order __f) noexcept
       _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
         {return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __s, __f);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_weak(_Tp& __e, _Tp __d,
-                              memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+                              memory_order __m = memory_order_seq_cst) volatile noexcept {
         if (memory_order_acq_rel == __m)
             return __cxx_atomic_compare_exchange_weak(&this->__a_, &__e, __d, __m, memory_order_acquire);
         else if (memory_order_release == __m)
@@ -1377,7 +1377,7 @@ struct __atomic_base_core : public __atomic_base_storage<_Tp, _Storage>{
     }
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_weak(_Tp& __e, _Tp __d,
-                               memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+                               memory_order __m = memory_order_seq_cst) noexcept {
         if(memory_order_acq_rel == __m)
             return __cxx_atomic_compare_exchange_weak(&this->__a_, &__e, __d, __m, memory_order_acquire);
         else if(memory_order_release == __m)
@@ -1387,7 +1387,7 @@ struct __atomic_base_core : public __atomic_base_storage<_Tp, _Storage>{
     }
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_strong(_Tp& __e, _Tp __d,
-                              memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+                              memory_order __m = memory_order_seq_cst) volatile noexcept {
         if (memory_order_acq_rel == __m)
             return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __m, memory_order_acquire);
         else if (memory_order_release == __m)
@@ -1397,7 +1397,7 @@ struct __atomic_base_core : public __atomic_base_storage<_Tp, _Storage>{
     }
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_strong(_Tp& __e, _Tp __d,
-                                 memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+                                 memory_order __m = memory_order_seq_cst) noexcept {
         if (memory_order_acq_rel == __m)
             return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __m, memory_order_acquire);
         else if (memory_order_release == __m)
@@ -1406,17 +1406,17 @@ struct __atomic_base_core : public __atomic_base_storage<_Tp, _Storage>{
             return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __m, __m);
     }
 
-    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const volatile noexcept
         {__cxx_atomic_wait(&this->__a_, __v, __m);}
-    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const noexcept
         {__cxx_atomic_wait(&this->__a_, __v, __m);}
-    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() volatile _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() volatile noexcept
         {__cxx_atomic_notify_one(&this->__a_);}
-    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() noexcept
         {__cxx_atomic_notify_one(&this->__a_);}
-    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() volatile _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() volatile noexcept
         {__cxx_atomic_notify_all(&this->__a_);}
-    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() noexcept
         {__cxx_atomic_notify_all(&this->__a_);}
 };
 
@@ -1430,69 +1430,69 @@ struct __atomic_base_core<_Tp, true, _Storage> : public __atomic_base_storage<_T
     __atomic_base_core& operator=(__atomic_base_core&&) = default;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base_core(_Storage&& __a) _NOEXCEPT : __atomic_base_storage<_Tp, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
+    __atomic_base_core(_Storage&& __a) noexcept : __atomic_base_storage<_Tp, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
 #if defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
     static _LIBCUDACXX_CONSTEXPR bool is_always_lock_free = _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
 #endif // defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool is_lock_free() const volatile _NOEXCEPT
+    bool is_lock_free() const volatile noexcept
         {return _LIBCUDACXX_ATOMIC_IS_LOCK_FREE(sizeof(_Tp));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool is_lock_free() const _NOEXCEPT
+    bool is_lock_free() const noexcept
         {return static_cast<__atomic_base_core const volatile*>(this)->is_lock_free();}
     _LIBCUDACXX_INLINE_VISIBILITY
 
-    void store(_Tp __d, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    void store(_Tp __d, memory_order __m = memory_order_seq_cst) const volatile noexcept
       _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)
         {__cxx_atomic_store(&this->__a_, __d, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void store(_Tp __d, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    void store(_Tp __d, memory_order __m = memory_order_seq_cst) const noexcept
       _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)
         {__cxx_atomic_store(&this->__a_, __d, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp load(memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _Tp load(memory_order __m = memory_order_seq_cst) const volatile noexcept
       _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
         {return __cxx_atomic_load(&this->__a_, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp load(memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _Tp load(memory_order __m = memory_order_seq_cst) const noexcept
       _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
         {return __cxx_atomic_load(&this->__a_, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    operator _Tp() const volatile _NOEXCEPT {return load();}
+    operator _Tp() const volatile noexcept {return load();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    operator _Tp() const _NOEXCEPT          {return load();}
+    operator _Tp() const noexcept          {return load();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) const volatile noexcept
         {return __cxx_atomic_exchange(&this->__a_, __d, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) const noexcept
         {return __cxx_atomic_exchange(&this->__a_, __d, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_weak(_Tp& __e, _Tp __d,
-                               memory_order __s, memory_order __f) const volatile _NOEXCEPT
+                               memory_order __s, memory_order __f) const volatile noexcept
       _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
         {return __cxx_atomic_compare_exchange_weak(&this->__a_, &__e, __d, __s, __f);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_weak(_Tp& __e, _Tp __d,
-                               memory_order __s, memory_order __f) const _NOEXCEPT
+                               memory_order __s, memory_order __f) const noexcept
       _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
         {return __cxx_atomic_compare_exchange_weak(&this->__a_, &__e, __d, __s, __f);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_strong(_Tp& __e, _Tp __d,
-                                 memory_order __s, memory_order __f) const volatile _NOEXCEPT
+                                 memory_order __s, memory_order __f) const volatile noexcept
       _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
         {return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __s, __f);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_strong(_Tp& __e, _Tp __d,
-                                 memory_order __s, memory_order __f) const _NOEXCEPT
+                                 memory_order __s, memory_order __f) const noexcept
       _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
         {return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __s, __f);}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_weak(_Tp& __e, _Tp __d,
-                              memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
+                              memory_order __m = memory_order_seq_cst) const volatile noexcept {
         if (memory_order_acq_rel == __m)
             return __cxx_atomic_compare_exchange_weak(&this->__a_, &__e, __d, __m, memory_order_acquire);
         else if (memory_order_release == __m)
@@ -1502,7 +1502,7 @@ struct __atomic_base_core<_Tp, true, _Storage> : public __atomic_base_storage<_T
     }
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_weak(_Tp& __e, _Tp __d,
-                               memory_order __m = memory_order_seq_cst) const _NOEXCEPT {
+                               memory_order __m = memory_order_seq_cst) const noexcept {
         if(memory_order_acq_rel == __m)
             return __cxx_atomic_compare_exchange_weak(&this->__a_, &__e, __d, __m, memory_order_acquire);
         else if(memory_order_release == __m)
@@ -1512,7 +1512,7 @@ struct __atomic_base_core<_Tp, true, _Storage> : public __atomic_base_storage<_T
     }
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_strong(_Tp& __e, _Tp __d,
-                              memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
+                              memory_order __m = memory_order_seq_cst) const volatile noexcept {
         if (memory_order_acq_rel == __m)
             return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __m, memory_order_acquire);
         else if (memory_order_release == __m)
@@ -1522,7 +1522,7 @@ struct __atomic_base_core<_Tp, true, _Storage> : public __atomic_base_storage<_T
     }
     _LIBCUDACXX_INLINE_VISIBILITY
     bool compare_exchange_strong(_Tp& __e, _Tp __d,
-                                 memory_order __m = memory_order_seq_cst) const _NOEXCEPT {
+                                 memory_order __m = memory_order_seq_cst) const noexcept {
         if (memory_order_acq_rel == __m)
             return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __m, memory_order_acquire);
         else if (memory_order_release == __m)
@@ -1531,17 +1531,17 @@ struct __atomic_base_core<_Tp, true, _Storage> : public __atomic_base_storage<_T
             return __cxx_atomic_compare_exchange_strong(&this->__a_, &__e, __d, __m, __m);
     }
 
-    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const volatile noexcept
         {__cxx_atomic_wait(&this->__a_, __v, __m);}
-    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const noexcept
         {__cxx_atomic_wait(&this->__a_, __v, __m);}
-    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() const volatile _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() const volatile noexcept
         {__cxx_atomic_notify_one(&this->__a_);}
-    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() const noexcept
         {__cxx_atomic_notify_one(&this->__a_);}
-    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() const volatile _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() const volatile noexcept
         {__cxx_atomic_notify_all(&this->__a_);}
-    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() const noexcept
         {__cxx_atomic_notify_all(&this->__a_);}
 };
 
@@ -1555,45 +1555,45 @@ struct __atomic_base_arithmetic : public __atomic_base_core<_Tp, _Cq, _Storage> 
     __atomic_base_arithmetic& operator=(__atomic_base_arithmetic&&) = delete;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base_arithmetic(_Storage&& __a) _NOEXCEPT : __atomic_base_core<_Tp, _Cq, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
+    __atomic_base_arithmetic(_Storage&& __a) noexcept : __atomic_base_core<_Tp, _Cq, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator++(int) volatile _NOEXCEPT      {return fetch_add(_Tp(1));}
+    _Tp operator++(int) volatile noexcept      {return fetch_add(_Tp(1));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator++(int) _NOEXCEPT               {return fetch_add(_Tp(1));}
+    _Tp operator++(int) noexcept               {return fetch_add(_Tp(1));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator--(int) volatile _NOEXCEPT      {return fetch_sub(_Tp(1));}
+    _Tp operator--(int) volatile noexcept      {return fetch_sub(_Tp(1));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator--(int) _NOEXCEPT               {return fetch_sub(_Tp(1));}
+    _Tp operator--(int) noexcept               {return fetch_sub(_Tp(1));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator++() volatile _NOEXCEPT         {return fetch_add(_Tp(1)) + _Tp(1);}
+    _Tp operator++() volatile noexcept         {return fetch_add(_Tp(1)) + _Tp(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator++() _NOEXCEPT                  {return fetch_add(_Tp(1)) + _Tp(1);}
+    _Tp operator++() noexcept                  {return fetch_add(_Tp(1)) + _Tp(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator--() volatile _NOEXCEPT         {return fetch_sub(_Tp(1)) - _Tp(1);}
+    _Tp operator--() volatile noexcept         {return fetch_sub(_Tp(1)) - _Tp(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator--() _NOEXCEPT                  {return fetch_sub(_Tp(1)) - _Tp(1);}
+    _Tp operator--() noexcept                  {return fetch_sub(_Tp(1)) - _Tp(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator+=(_Tp __op) volatile _NOEXCEPT {return fetch_add(__op) + __op;}
+    _Tp operator+=(_Tp __op) volatile noexcept {return fetch_add(__op) + __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator+=(_Tp __op) _NOEXCEPT          {return fetch_add(__op) + __op;}
+    _Tp operator+=(_Tp __op) noexcept          {return fetch_add(__op) + __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator-=(_Tp __op) volatile _NOEXCEPT {return fetch_sub(__op) - __op;}
+    _Tp operator-=(_Tp __op) volatile noexcept {return fetch_sub(__op) - __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator-=(_Tp __op) _NOEXCEPT          {return fetch_sub(__op) - __op;}
+    _Tp operator-=(_Tp __op) noexcept          {return fetch_sub(__op) - __op;}
 };
 
 template <class _Tp, typename _Storage>
@@ -1606,45 +1606,45 @@ struct __atomic_base_arithmetic<_Tp, true, _Storage> : public __atomic_base_core
     __atomic_base_arithmetic& operator=(__atomic_base_arithmetic&&) = default;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base_arithmetic(_Storage&& __a) _NOEXCEPT : __atomic_base_core<_Tp, true, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
+    __atomic_base_arithmetic(_Storage&& __a) noexcept : __atomic_base_core<_Tp, true, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile noexcept
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) const noexcept
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile noexcept
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) const noexcept
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator++(int) const volatile _NOEXCEPT      {return fetch_add(_Tp(1));}
+    _Tp operator++(int) const volatile noexcept      {return fetch_add(_Tp(1));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator++(int) const _NOEXCEPT               {return fetch_add(_Tp(1));}
+    _Tp operator++(int) const noexcept               {return fetch_add(_Tp(1));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator--(int) const volatile _NOEXCEPT      {return fetch_sub(_Tp(1));}
+    _Tp operator--(int) const volatile noexcept      {return fetch_sub(_Tp(1));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator--(int) const _NOEXCEPT               {return fetch_sub(_Tp(1));}
+    _Tp operator--(int) const noexcept               {return fetch_sub(_Tp(1));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator++() const volatile _NOEXCEPT         {return fetch_add(_Tp(1)) + _Tp(1);}
+    _Tp operator++() const volatile noexcept         {return fetch_add(_Tp(1)) + _Tp(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator++() const _NOEXCEPT                  {return fetch_add(_Tp(1)) + _Tp(1);}
+    _Tp operator++() const noexcept                  {return fetch_add(_Tp(1)) + _Tp(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator--() const volatile _NOEXCEPT         {return fetch_sub(_Tp(1)) - _Tp(1);}
+    _Tp operator--() const volatile noexcept         {return fetch_sub(_Tp(1)) - _Tp(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator--() const _NOEXCEPT                  {return fetch_sub(_Tp(1)) - _Tp(1);}
+    _Tp operator--() const noexcept                  {return fetch_sub(_Tp(1)) - _Tp(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator+=(_Tp __op) const volatile _NOEXCEPT {return fetch_add(__op) + __op;}
+    _Tp operator+=(_Tp __op) const volatile noexcept {return fetch_add(__op) + __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator+=(_Tp __op) const _NOEXCEPT          {return fetch_add(__op) + __op;}
+    _Tp operator+=(_Tp __op) const noexcept          {return fetch_add(__op) + __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator-=(_Tp __op) const volatile _NOEXCEPT {return fetch_sub(__op) - __op;}
+    _Tp operator-=(_Tp __op) const volatile noexcept {return fetch_sub(__op) - __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator-=(_Tp __op) const _NOEXCEPT          {return fetch_sub(__op) - __op;}
+    _Tp operator-=(_Tp __op) const noexcept          {return fetch_sub(__op) - __op;}
 };
 
 template <class _Tp, bool _Cq, typename _Storage>
@@ -1657,39 +1657,39 @@ struct __atomic_base_bitwise : public __atomic_base_arithmetic<_Tp, _Cq, _Storag
     __atomic_base_bitwise& operator=(__atomic_base_bitwise&&) = delete;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base_bitwise(_Storage&& __a) _NOEXCEPT : __atomic_base_arithmetic<_Tp, _Cq, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
+    __atomic_base_bitwise(_Storage&& __a) noexcept : __atomic_base_arithmetic<_Tp, _Cq, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
         {return __cxx_atomic_fetch_and(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept
         {return __cxx_atomic_fetch_and(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
         {return __cxx_atomic_fetch_or(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept
         {return __cxx_atomic_fetch_or(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
         {return __cxx_atomic_fetch_xor(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept
         {return __cxx_atomic_fetch_xor(&this->__a_, __op, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator&=(_Tp __op) volatile _NOEXCEPT {return fetch_and(__op) & __op;}
+    _Tp operator&=(_Tp __op) volatile noexcept {return fetch_and(__op) & __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator&=(_Tp __op) _NOEXCEPT          {return fetch_and(__op) & __op;}
+    _Tp operator&=(_Tp __op) noexcept          {return fetch_and(__op) & __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator|=(_Tp __op) volatile _NOEXCEPT {return fetch_or(__op) | __op;}
+    _Tp operator|=(_Tp __op) volatile noexcept {return fetch_or(__op) | __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator|=(_Tp __op) _NOEXCEPT          {return fetch_or(__op) | __op;}
+    _Tp operator|=(_Tp __op) noexcept          {return fetch_or(__op) | __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator^=(_Tp __op) volatile _NOEXCEPT {return fetch_xor(__op) ^ __op;}
+    _Tp operator^=(_Tp __op) volatile noexcept {return fetch_xor(__op) ^ __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator^=(_Tp __op) _NOEXCEPT          {return fetch_xor(__op) ^ __op;}
+    _Tp operator^=(_Tp __op) noexcept          {return fetch_xor(__op) ^ __op;}
 };
 
 template <class _Tp, typename _Storage>
@@ -1702,39 +1702,39 @@ struct __atomic_base_bitwise<_Tp, true, _Storage> : public __atomic_base_arithme
     __atomic_base_bitwise& operator=(__atomic_base_bitwise&&) = default;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base_bitwise(_Storage&& __a) _NOEXCEPT : __atomic_base_arithmetic<_Tp, true, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
+    __atomic_base_bitwise(_Storage&& __a) noexcept : __atomic_base_arithmetic<_Tp, true, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile noexcept
         {return __cxx_atomic_fetch_and(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) const noexcept
         {return __cxx_atomic_fetch_and(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile noexcept
         {return __cxx_atomic_fetch_or(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) const noexcept
         {return __cxx_atomic_fetch_or(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile noexcept
         {return __cxx_atomic_fetch_xor(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) const noexcept
         {return __cxx_atomic_fetch_xor(&this->__a_, __op, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator&=(_Tp __op) const volatile _NOEXCEPT {return fetch_and(__op) & __op;}
+    _Tp operator&=(_Tp __op) const volatile noexcept {return fetch_and(__op) & __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator&=(_Tp __op) const _NOEXCEPT          {return fetch_and(__op) & __op;}
+    _Tp operator&=(_Tp __op) const noexcept          {return fetch_and(__op) & __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator|=(_Tp __op) const volatile _NOEXCEPT {return fetch_or(__op) | __op;}
+    _Tp operator|=(_Tp __op) const volatile noexcept {return fetch_or(__op) | __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator|=(_Tp __op) const _NOEXCEPT          {return fetch_or(__op) | __op;}
+    _Tp operator|=(_Tp __op) const noexcept          {return fetch_or(__op) | __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator^=(_Tp __op) const volatile _NOEXCEPT {return fetch_xor(__op) ^ __op;}
+    _Tp operator^=(_Tp __op) const volatile noexcept {return fetch_xor(__op) ^ __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator^=(_Tp __op) const _NOEXCEPT          {return fetch_xor(__op) ^ __op;}
+    _Tp operator^=(_Tp __op) const noexcept          {return fetch_xor(__op) ^ __op;}
 };
 
 template <typename _Tp, bool _Cq, typename _Storage>
@@ -1754,7 +1754,7 @@ struct __atomic_base : public _Base {
     __atomic_base& operator=(__atomic_base&&) = delete;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base(const _Tp& __a) _NOEXCEPT :
+    __atomic_base(const _Tp& __a) noexcept :
         _Base(__cxx_atomic_impl<_Tp, _Sco>(__a)) {}
 };
 
@@ -1768,7 +1768,7 @@ struct __atomic_base_ref : public _Base {
     __atomic_base_ref& operator=(__atomic_base_ref&&) = default;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base_ref(_Tp& __a) _NOEXCEPT :
+    __atomic_base_ref(_Tp& __a) noexcept :
         _Base(__cxx_atomic_ref_impl<_Tp, _Sco>(__a)) {}
 };
 
@@ -1787,15 +1787,15 @@ struct atomic
 #ifdef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
 #endif
-    atomic() _NOEXCEPT _LIBCUDACXX_DEFAULT
+    atomic() noexcept _LIBCUDACXX_DEFAULT
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR atomic(_Tp __d) _NOEXCEPT : __base(__d) {}
+    _LIBCUDACXX_CONSTEXPR atomic(_Tp __d) noexcept : __base(__d) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator=(_Tp __d) volatile _NOEXCEPT
+    _Tp operator=(_Tp __d) volatile noexcept
         {__base::store(__d); return __d;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp operator=(_Tp __d) _NOEXCEPT
+    _Tp operator=(_Tp __d) noexcept
         {__base::store(__d); return __d;}
 };
 
@@ -1810,58 +1810,58 @@ struct atomic<_Tp*>
 #ifdef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
 #endif
-    atomic() _NOEXCEPT _LIBCUDACXX_DEFAULT
+    atomic() noexcept _LIBCUDACXX_DEFAULT
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR atomic(_Tp* __d) _NOEXCEPT : __base(__d) {}
+    _LIBCUDACXX_CONSTEXPR atomic(_Tp* __d) noexcept : __base(__d) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator=(_Tp* __d) volatile _NOEXCEPT
+    _Tp* operator=(_Tp* __d) volatile noexcept
         {__base::store(__d); return __d;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator=(_Tp* __d) _NOEXCEPT
+    _Tp* operator=(_Tp* __d) noexcept
         {__base::store(__d); return __d;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
-                                                                        volatile _NOEXCEPT
+                                                                        volatile noexcept
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
-                                                                        _NOEXCEPT
+                                                                        noexcept
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
-                                                                        volatile _NOEXCEPT
+                                                                        volatile noexcept
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
-                                                                        _NOEXCEPT
+                                                                        noexcept
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator++(int) volatile _NOEXCEPT            {return fetch_add(1);}
+    _Tp* operator++(int) volatile noexcept            {return fetch_add(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator++(int) _NOEXCEPT                     {return fetch_add(1);}
+    _Tp* operator++(int) noexcept                     {return fetch_add(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator--(int) volatile _NOEXCEPT            {return fetch_sub(1);}
+    _Tp* operator--(int) volatile noexcept            {return fetch_sub(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator--(int) _NOEXCEPT                     {return fetch_sub(1);}
+    _Tp* operator--(int) noexcept                     {return fetch_sub(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator++() volatile _NOEXCEPT               {return fetch_add(1) + 1;}
+    _Tp* operator++() volatile noexcept               {return fetch_add(1) + 1;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator++() _NOEXCEPT                        {return fetch_add(1) + 1;}
+    _Tp* operator++() noexcept                        {return fetch_add(1) + 1;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator--() volatile _NOEXCEPT               {return fetch_sub(1) - 1;}
+    _Tp* operator--() volatile noexcept               {return fetch_sub(1) - 1;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator--() _NOEXCEPT                        {return fetch_sub(1) - 1;}
+    _Tp* operator--() noexcept                        {return fetch_sub(1) - 1;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator+=(ptrdiff_t __op) volatile _NOEXCEPT {return fetch_add(__op) + __op;}
+    _Tp* operator+=(ptrdiff_t __op) volatile noexcept {return fetch_add(__op) + __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator+=(ptrdiff_t __op) _NOEXCEPT          {return fetch_add(__op) + __op;}
+    _Tp* operator+=(ptrdiff_t __op) noexcept          {return fetch_add(__op) + __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator-=(ptrdiff_t __op) volatile _NOEXCEPT {return fetch_sub(__op) - __op;}
+    _Tp* operator-=(ptrdiff_t __op) volatile noexcept {return fetch_sub(__op) - __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator-=(ptrdiff_t __op) _NOEXCEPT          {return fetch_sub(__op) - __op;}
+    _Tp* operator-=(ptrdiff_t __op) noexcept          {return fetch_sub(__op) - __op;}
 };
 
 // atomic_ref<T>
@@ -1909,45 +1909,45 @@ template <class _Tp>
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
-                                                                        const volatile _NOEXCEPT
+                                                                        const volatile noexcept
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
-                                                                        const _NOEXCEPT
+                                                                        const noexcept
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
-                                                                        const volatile _NOEXCEPT
+                                                                        const volatile noexcept
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
-                                                                        const _NOEXCEPT
+                                                                        const noexcept
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator++(int) const volatile _NOEXCEPT            {return fetch_add(1);}
+    _Tp* operator++(int) const volatile noexcept            {return fetch_add(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator++(int) const _NOEXCEPT                     {return fetch_add(1);}
+    _Tp* operator++(int) const noexcept                     {return fetch_add(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator--(int) const volatile _NOEXCEPT            {return fetch_sub(1);}
+    _Tp* operator--(int) const volatile noexcept            {return fetch_sub(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator--(int) const _NOEXCEPT                     {return fetch_sub(1);}
+    _Tp* operator--(int) const noexcept                     {return fetch_sub(1);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator++() const volatile _NOEXCEPT               {return fetch_add(1) + 1;}
+    _Tp* operator++() const volatile noexcept               {return fetch_add(1) + 1;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator++() const _NOEXCEPT                        {return fetch_add(1) + 1;}
+    _Tp* operator++() const noexcept                        {return fetch_add(1) + 1;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator--() const volatile _NOEXCEPT               {return fetch_sub(1) - 1;}
+    _Tp* operator--() const volatile noexcept               {return fetch_sub(1) - 1;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator--() const _NOEXCEPT                        {return fetch_sub(1) - 1;}
+    _Tp* operator--() const noexcept                        {return fetch_sub(1) - 1;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator+=(ptrdiff_t __op) const volatile _NOEXCEPT {return fetch_add(__op) + __op;}
+    _Tp* operator+=(ptrdiff_t __op) const volatile noexcept {return fetch_add(__op) + __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator+=(ptrdiff_t __op) const _NOEXCEPT          {return fetch_add(__op) + __op;}
+    _Tp* operator+=(ptrdiff_t __op) const noexcept          {return fetch_add(__op) + __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator-=(ptrdiff_t __op) const volatile _NOEXCEPT {return fetch_sub(__op) - __op;}
+    _Tp* operator-=(ptrdiff_t __op) const volatile noexcept {return fetch_sub(__op) - __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* operator-=(ptrdiff_t __op) const _NOEXCEPT          {return fetch_sub(__op) - __op;}
+    _Tp* operator-=(ptrdiff_t __op) const noexcept          {return fetch_sub(__op) - __op;}
 };
 
 // atomic_is_lock_free
@@ -1955,7 +1955,7 @@ template <class _Tp>
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_is_lock_free(const volatile atomic<_Tp>* __o) _NOEXCEPT
+atomic_is_lock_free(const volatile atomic<_Tp>* __o) noexcept
 {
     return __o->is_lock_free();
 }
@@ -1963,7 +1963,7 @@ atomic_is_lock_free(const volatile atomic<_Tp>* __o) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_is_lock_free(const atomic<_Tp>* __o) _NOEXCEPT
+atomic_is_lock_free(const atomic<_Tp>* __o) noexcept
 {
     return __o->is_lock_free();
 }
@@ -1973,7 +1973,7 @@ atomic_is_lock_free(const atomic<_Tp>* __o) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_init(volatile atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
+atomic_init(volatile atomic<_Tp>* __o, _Tp __d) noexcept
 {
     __cxx_atomic_init(&__o->__a_, __d);
 }
@@ -1981,7 +1981,7 @@ atomic_init(volatile atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_init(atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
+atomic_init(atomic<_Tp>* __o, _Tp __d) noexcept
 {
     __cxx_atomic_init(&__o->__a_, __d);
 }
@@ -1991,7 +1991,7 @@ atomic_init(atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_store(volatile atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
+atomic_store(volatile atomic<_Tp>* __o, _Tp __d) noexcept
 {
     __o->store(__d);
 }
@@ -1999,7 +1999,7 @@ atomic_store(volatile atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_store(atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
+atomic_store(atomic<_Tp>* __o, _Tp __d) noexcept
 {
     __o->store(__d);
 }
@@ -2009,7 +2009,7 @@ atomic_store(atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_store_explicit(volatile atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOEXCEPT
+atomic_store_explicit(volatile atomic<_Tp>* __o, _Tp __d, memory_order __m) noexcept
   _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)
 {
     __o->store(__d, __m);
@@ -2018,7 +2018,7 @@ atomic_store_explicit(volatile atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOE
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_store_explicit(atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOEXCEPT
+atomic_store_explicit(atomic<_Tp>* __o, _Tp __d, memory_order __m) noexcept
   _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)
 {
     __o->store(__d, __m);
@@ -2029,7 +2029,7 @@ atomic_store_explicit(atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp
-atomic_load(const volatile atomic<_Tp>* __o) _NOEXCEPT
+atomic_load(const volatile atomic<_Tp>* __o) noexcept
 {
     return __o->load();
 }
@@ -2037,7 +2037,7 @@ atomic_load(const volatile atomic<_Tp>* __o) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp
-atomic_load(const atomic<_Tp>* __o) _NOEXCEPT
+atomic_load(const atomic<_Tp>* __o) noexcept
 {
     return __o->load();
 }
@@ -2047,7 +2047,7 @@ atomic_load(const atomic<_Tp>* __o) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp
-atomic_load_explicit(const volatile atomic<_Tp>* __o, memory_order __m) _NOEXCEPT
+atomic_load_explicit(const volatile atomic<_Tp>* __o, memory_order __m) noexcept
   _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
 {
     return __o->load(__m);
@@ -2056,7 +2056,7 @@ atomic_load_explicit(const volatile atomic<_Tp>* __o, memory_order __m) _NOEXCEP
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp
-atomic_load_explicit(const atomic<_Tp>* __o, memory_order __m) _NOEXCEPT
+atomic_load_explicit(const atomic<_Tp>* __o, memory_order __m) noexcept
   _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
 {
     return __o->load(__m);
@@ -2067,7 +2067,7 @@ atomic_load_explicit(const atomic<_Tp>* __o, memory_order __m) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp
-atomic_exchange(volatile atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
+atomic_exchange(volatile atomic<_Tp>* __o, _Tp __d) noexcept
 {
     return __o->exchange(__d);
 }
@@ -2075,7 +2075,7 @@ atomic_exchange(volatile atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp
-atomic_exchange(atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
+atomic_exchange(atomic<_Tp>* __o, _Tp __d) noexcept
 {
     return __o->exchange(__d);
 }
@@ -2085,7 +2085,7 @@ atomic_exchange(atomic<_Tp>* __o, _Tp __d) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp
-atomic_exchange_explicit(volatile atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOEXCEPT
+atomic_exchange_explicit(volatile atomic<_Tp>* __o, _Tp __d, memory_order __m) noexcept
 {
     return __o->exchange(__d, __m);
 }
@@ -2093,7 +2093,7 @@ atomic_exchange_explicit(volatile atomic<_Tp>* __o, _Tp __d, memory_order __m) _
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp
-atomic_exchange_explicit(atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOEXCEPT
+atomic_exchange_explicit(atomic<_Tp>* __o, _Tp __d, memory_order __m) noexcept
 {
     return __o->exchange(__d, __m);
 }
@@ -2103,7 +2103,7 @@ atomic_exchange_explicit(atomic<_Tp>* __o, _Tp __d, memory_order __m) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_compare_exchange_weak(volatile atomic<_Tp>* __o, _Tp* __e, _Tp __d) _NOEXCEPT
+atomic_compare_exchange_weak(volatile atomic<_Tp>* __o, _Tp* __e, _Tp __d) noexcept
 {
     return __o->compare_exchange_weak(*__e, __d);
 }
@@ -2111,7 +2111,7 @@ atomic_compare_exchange_weak(volatile atomic<_Tp>* __o, _Tp* __e, _Tp __d) _NOEX
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_compare_exchange_weak(atomic<_Tp>* __o, _Tp* __e, _Tp __d) _NOEXCEPT
+atomic_compare_exchange_weak(atomic<_Tp>* __o, _Tp* __e, _Tp __d) noexcept
 {
     return __o->compare_exchange_weak(*__e, __d);
 }
@@ -2121,7 +2121,7 @@ atomic_compare_exchange_weak(atomic<_Tp>* __o, _Tp* __e, _Tp __d) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_compare_exchange_strong(volatile atomic<_Tp>* __o, _Tp* __e, _Tp __d) _NOEXCEPT
+atomic_compare_exchange_strong(volatile atomic<_Tp>* __o, _Tp* __e, _Tp __d) noexcept
 {
     return __o->compare_exchange_strong(*__e, __d);
 }
@@ -2129,7 +2129,7 @@ atomic_compare_exchange_strong(volatile atomic<_Tp>* __o, _Tp* __e, _Tp __d) _NO
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_compare_exchange_strong(atomic<_Tp>* __o, _Tp* __e, _Tp __d) _NOEXCEPT
+atomic_compare_exchange_strong(atomic<_Tp>* __o, _Tp* __e, _Tp __d) noexcept
 {
     return __o->compare_exchange_strong(*__e, __d);
 }
@@ -2141,7 +2141,7 @@ _LIBCUDACXX_INLINE_VISIBILITY
 bool
 atomic_compare_exchange_weak_explicit(volatile atomic<_Tp>* __o, _Tp* __e,
                                       _Tp __d,
-                                      memory_order __s, memory_order __f) _NOEXCEPT
+                                      memory_order __s, memory_order __f) noexcept
   _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
 {
     return __o->compare_exchange_weak(*__e, __d, __s, __f);
@@ -2151,7 +2151,7 @@ template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
 atomic_compare_exchange_weak_explicit(atomic<_Tp>* __o, _Tp* __e, _Tp __d,
-                                      memory_order __s, memory_order __f) _NOEXCEPT
+                                      memory_order __s, memory_order __f) noexcept
   _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
 {
     return __o->compare_exchange_weak(*__e, __d, __s, __f);
@@ -2164,7 +2164,7 @@ _LIBCUDACXX_INLINE_VISIBILITY
 bool
 atomic_compare_exchange_strong_explicit(volatile atomic<_Tp>* __o,
                                         _Tp* __e, _Tp __d,
-                                        memory_order __s, memory_order __f) _NOEXCEPT
+                                        memory_order __s, memory_order __f) noexcept
   _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
 {
     return __o->compare_exchange_strong(*__e, __d, __s, __f);
@@ -2175,7 +2175,7 @@ _LIBCUDACXX_INLINE_VISIBILITY
 bool
 atomic_compare_exchange_strong_explicit(atomic<_Tp>* __o, _Tp* __e,
                                         _Tp __d,
-                                        memory_order __s, memory_order __f) _NOEXCEPT
+                                        memory_order __s, memory_order __f) noexcept
   _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
 {
     return __o->compare_exchange_strong(*__e, __d, __s, __f);
@@ -2186,7 +2186,7 @@ atomic_compare_exchange_strong_explicit(atomic<_Tp>* __o, _Tp* __e,
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void atomic_wait(const volatile atomic<_Tp>* __o,
-                    typename atomic<_Tp>::value_type __v) _NOEXCEPT
+                    typename atomic<_Tp>::value_type __v) noexcept
 {
     return __o->wait(__v);
 }
@@ -2194,7 +2194,7 @@ void atomic_wait(const volatile atomic<_Tp>* __o,
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void atomic_wait(const atomic<_Tp>* __o,
-                    typename atomic<_Tp>::value_type __v) _NOEXCEPT
+                    typename atomic<_Tp>::value_type __v) noexcept
 {
     return __o->wait(__v);
 }
@@ -2205,7 +2205,7 @@ template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void atomic_wait_explicit(const volatile atomic<_Tp>* __o,
                             typename atomic<_Tp>::value_type __v,
-                            memory_order __m) _NOEXCEPT
+                            memory_order __m) noexcept
   _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
 {
     return __o->wait(__v, __m);
@@ -2215,7 +2215,7 @@ template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 void atomic_wait_explicit(const atomic<_Tp>* __o,
                             typename atomic<_Tp>::value_type __v,
-                            memory_order __m) _NOEXCEPT
+                            memory_order __m) noexcept
   _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
 {
     return __o->wait(__v, __m);
@@ -2225,13 +2225,13 @@ void atomic_wait_explicit(const atomic<_Tp>* __o,
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-void atomic_notify_one(volatile atomic<_Tp>* __o) _NOEXCEPT
+void atomic_notify_one(volatile atomic<_Tp>* __o) noexcept
 {
     __o->notify_one();
 }
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-void atomic_notify_one(atomic<_Tp>* __o) _NOEXCEPT
+void atomic_notify_one(atomic<_Tp>* __o) noexcept
 {
     __o->notify_one();
 }
@@ -2240,13 +2240,13 @@ void atomic_notify_one(atomic<_Tp>* __o) _NOEXCEPT
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-void atomic_notify_all(volatile atomic<_Tp>* __o) _NOEXCEPT
+void atomic_notify_all(volatile atomic<_Tp>* __o) noexcept
 {
     __o->notify_all();
 }
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-void atomic_notify_all(atomic<_Tp>* __o) _NOEXCEPT
+void atomic_notify_all(atomic<_Tp>* __o) noexcept
 {
     __o->notify_all();
 }
@@ -2260,7 +2260,7 @@ __enable_if_t
     (is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
     _Tp
 >
-atomic_fetch_add(volatile atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_add(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_add(__op);
 }
@@ -2272,7 +2272,7 @@ __enable_if_t
     (is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
     _Tp
 >
-atomic_fetch_add(atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_add(atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_add(__op);
 }
@@ -2280,7 +2280,7 @@ atomic_fetch_add(atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
-atomic_fetch_add(volatile atomic<_Tp*>* __o, ptrdiff_t __op) _NOEXCEPT
+atomic_fetch_add(volatile atomic<_Tp*>* __o, ptrdiff_t __op) noexcept
 {
     return __o->fetch_add(__op);
 }
@@ -2288,7 +2288,7 @@ atomic_fetch_add(volatile atomic<_Tp*>* __o, ptrdiff_t __op) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
-atomic_fetch_add(atomic<_Tp*>* __o, ptrdiff_t __op) _NOEXCEPT
+atomic_fetch_add(atomic<_Tp*>* __o, ptrdiff_t __op) noexcept
 {
     return __o->fetch_add(__op);
 }
@@ -2302,7 +2302,7 @@ __enable_if_t
     (is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
     _Tp
 >
-atomic_fetch_add_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_add_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_add(__op, __m);
 }
@@ -2314,7 +2314,7 @@ __enable_if_t
     (is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
     _Tp
 >
-atomic_fetch_add_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_add_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_add(__op, __m);
 }
@@ -2323,7 +2323,7 @@ template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
 atomic_fetch_add_explicit(volatile atomic<_Tp*>* __o, ptrdiff_t __op,
-                          memory_order __m) _NOEXCEPT
+                          memory_order __m) noexcept
 {
     return __o->fetch_add(__op, __m);
 }
@@ -2331,7 +2331,7 @@ atomic_fetch_add_explicit(volatile atomic<_Tp*>* __o, ptrdiff_t __op,
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
-atomic_fetch_add_explicit(atomic<_Tp*>* __o, ptrdiff_t __op, memory_order __m) _NOEXCEPT
+atomic_fetch_add_explicit(atomic<_Tp*>* __o, ptrdiff_t __op, memory_order __m) noexcept
 {
     return __o->fetch_add(__op, __m);
 }
@@ -2345,7 +2345,7 @@ __enable_if_t
     (is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
     _Tp
 >
-atomic_fetch_sub(volatile atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_sub(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_sub(__op);
 }
@@ -2357,7 +2357,7 @@ __enable_if_t
     (is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
     _Tp
 >
-atomic_fetch_sub(atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_sub(atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_sub(__op);
 }
@@ -2365,7 +2365,7 @@ atomic_fetch_sub(atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
-atomic_fetch_sub(volatile atomic<_Tp*>* __o, ptrdiff_t __op) _NOEXCEPT
+atomic_fetch_sub(volatile atomic<_Tp*>* __o, ptrdiff_t __op) noexcept
 {
     return __o->fetch_sub(__op);
 }
@@ -2373,7 +2373,7 @@ atomic_fetch_sub(volatile atomic<_Tp*>* __o, ptrdiff_t __op) _NOEXCEPT
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
-atomic_fetch_sub(atomic<_Tp*>* __o, ptrdiff_t __op) _NOEXCEPT
+atomic_fetch_sub(atomic<_Tp*>* __o, ptrdiff_t __op) noexcept
 {
     return __o->fetch_sub(__op);
 }
@@ -2387,7 +2387,7 @@ __enable_if_t
     (is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
     _Tp
 >
-atomic_fetch_sub_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_sub_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_sub(__op, __m);
 }
@@ -2399,7 +2399,7 @@ __enable_if_t
     (is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
     _Tp
 >
-atomic_fetch_sub_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_sub_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_sub(__op, __m);
 }
@@ -2408,7 +2408,7 @@ template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
 atomic_fetch_sub_explicit(volatile atomic<_Tp*>* __o, ptrdiff_t __op,
-                          memory_order __m) _NOEXCEPT
+                          memory_order __m) noexcept
 {
     return __o->fetch_sub(__op, __m);
 }
@@ -2416,7 +2416,7 @@ atomic_fetch_sub_explicit(volatile atomic<_Tp*>* __o, ptrdiff_t __op,
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
 _Tp*
-atomic_fetch_sub_explicit(atomic<_Tp*>* __o, ptrdiff_t __op, memory_order __m) _NOEXCEPT
+atomic_fetch_sub_explicit(atomic<_Tp*>* __o, ptrdiff_t __op, memory_order __m) noexcept
 {
     return __o->fetch_sub(__op, __m);
 }
@@ -2430,7 +2430,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_and(volatile atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_and(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_and(__op);
 }
@@ -2442,7 +2442,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_and(atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_and(atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_and(__op);
 }
@@ -2456,7 +2456,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_and_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_and_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_and(__op, __m);
 }
@@ -2468,7 +2468,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_and_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_and_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_and(__op, __m);
 }
@@ -2482,7 +2482,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_or(volatile atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_or(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_or(__op);
 }
@@ -2494,7 +2494,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_or(atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_or(atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_or(__op);
 }
@@ -2508,7 +2508,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_or_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_or_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_or(__op, __m);
 }
@@ -2520,7 +2520,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_or_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_or_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_or(__op, __m);
 }
@@ -2534,7 +2534,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_xor(volatile atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_xor(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_xor(__op);
 }
@@ -2546,7 +2546,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_xor(atomic<_Tp>* __o, _Tp __op) _NOEXCEPT
+atomic_fetch_xor(atomic<_Tp>* __o, _Tp __op) noexcept
 {
     return __o->fetch_xor(__op);
 }
@@ -2560,7 +2560,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_xor_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_xor_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_xor(__op, __m);
 }
@@ -2572,7 +2572,7 @@ __enable_if_t
     is_integral<_Tp>::value && !is_same<_Tp, bool>::value,
     _Tp
 >
-atomic_fetch_xor_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
+atomic_fetch_xor_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
     return __o->fetch_xor(__op, __m);
 }
@@ -2584,53 +2584,53 @@ typedef struct atomic_flag
     __cxx_atomic_impl<_LIBCUDACXX_ATOMIC_FLAG_TYPE, 0> __a_;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool test(memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    bool test(memory_order __m = memory_order_seq_cst) const volatile noexcept
         {return _LIBCUDACXX_ATOMIC_FLAG_TYPE(true)==__cxx_atomic_load(&__a_, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool test(memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    bool test(memory_order __m = memory_order_seq_cst) const noexcept
         {return _LIBCUDACXX_ATOMIC_FLAG_TYPE(true)==__cxx_atomic_load(&__a_, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool test_and_set(memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+    bool test_and_set(memory_order __m = memory_order_seq_cst) volatile noexcept
         {return __cxx_atomic_exchange(&__a_, _LIBCUDACXX_ATOMIC_FLAG_TYPE(true), __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool test_and_set(memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    bool test_and_set(memory_order __m = memory_order_seq_cst) noexcept
         {return __cxx_atomic_exchange(&__a_, _LIBCUDACXX_ATOMIC_FLAG_TYPE(true), __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear(memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+    void clear(memory_order __m = memory_order_seq_cst) volatile noexcept
         {__cxx_atomic_store(&__a_, _LIBCUDACXX_ATOMIC_FLAG_TYPE(false), __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear(memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    void clear(memory_order __m = memory_order_seq_cst) noexcept
         {__cxx_atomic_store(&__a_, _LIBCUDACXX_ATOMIC_FLAG_TYPE(false), __m);}
 
 #if !defined(__CUDA_MINIMUM_ARCH__) || __CUDA_MINIMUM_ARCH__ >= 700
     _LIBCUDACXX_INLINE_VISIBILITY
-    void wait(bool __v, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+    void wait(bool __v, memory_order __m = memory_order_seq_cst) const volatile noexcept
         {__cxx_atomic_wait(&__a_, _LIBCUDACXX_ATOMIC_FLAG_TYPE(__v), __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void wait(bool __v, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+    void wait(bool __v, memory_order __m = memory_order_seq_cst) const noexcept
         {__cxx_atomic_wait(&__a_, _LIBCUDACXX_ATOMIC_FLAG_TYPE(__v), __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void notify_one() volatile _NOEXCEPT
+    void notify_one() volatile noexcept
         {__cxx_atomic_notify_one(&__a_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void notify_one() _NOEXCEPT
+    void notify_one() noexcept
         {__cxx_atomic_notify_one(&__a_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void notify_all() volatile _NOEXCEPT
+    void notify_all() volatile noexcept
         {__cxx_atomic_notify_all(&__a_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void notify_all() _NOEXCEPT
+    void notify_all() noexcept
         {__cxx_atomic_notify_all(&__a_);}
 #endif
 
 #ifdef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
 #endif
-    atomic_flag() _NOEXCEPT _LIBCUDACXX_DEFAULT
+    atomic_flag() noexcept _LIBCUDACXX_DEFAULT
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    atomic_flag(bool __b) _NOEXCEPT : __a_(__b) {} // EXTENSION
+    atomic_flag(bool __b) noexcept : __a_(__b) {} // EXTENSION
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     atomic_flag(const atomic_flag&) = delete;
@@ -2650,84 +2650,84 @@ private:
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_flag_test(const volatile atomic_flag* __o) _NOEXCEPT
+atomic_flag_test(const volatile atomic_flag* __o) noexcept
 {
     return __o->test();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_flag_test(const atomic_flag* __o) _NOEXCEPT
+atomic_flag_test(const atomic_flag* __o) noexcept
 {
     return __o->test();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_flag_test_explicit(const volatile atomic_flag* __o, memory_order __m) _NOEXCEPT
+atomic_flag_test_explicit(const volatile atomic_flag* __o, memory_order __m) noexcept
 {
     return __o->test(__m);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_flag_test_explicit(const atomic_flag* __o, memory_order __m) _NOEXCEPT
+atomic_flag_test_explicit(const atomic_flag* __o, memory_order __m) noexcept
 {
     return __o->test(__m);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_flag_test_and_set(volatile atomic_flag* __o) _NOEXCEPT
+atomic_flag_test_and_set(volatile atomic_flag* __o) noexcept
 {
     return __o->test_and_set();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_flag_test_and_set(atomic_flag* __o) _NOEXCEPT
+atomic_flag_test_and_set(atomic_flag* __o) noexcept
 {
     return __o->test_and_set();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_flag_test_and_set_explicit(volatile atomic_flag* __o, memory_order __m) _NOEXCEPT
+atomic_flag_test_and_set_explicit(volatile atomic_flag* __o, memory_order __m) noexcept
 {
     return __o->test_and_set(__m);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-atomic_flag_test_and_set_explicit(atomic_flag* __o, memory_order __m) _NOEXCEPT
+atomic_flag_test_and_set_explicit(atomic_flag* __o, memory_order __m) noexcept
 {
     return __o->test_and_set(__m);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_clear(volatile atomic_flag* __o) _NOEXCEPT
+atomic_flag_clear(volatile atomic_flag* __o) noexcept
 {
     __o->clear();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_clear(atomic_flag* __o) _NOEXCEPT
+atomic_flag_clear(atomic_flag* __o) noexcept
 {
     __o->clear();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_clear_explicit(volatile atomic_flag* __o, memory_order __m) _NOEXCEPT
+atomic_flag_clear_explicit(volatile atomic_flag* __o, memory_order __m) noexcept
 {
     __o->clear(__m);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_clear_explicit(atomic_flag* __o, memory_order __m) _NOEXCEPT
+atomic_flag_clear_explicit(atomic_flag* __o, memory_order __m) noexcept
 {
     __o->clear(__m);
 }
@@ -2736,14 +2736,14 @@ atomic_flag_clear_explicit(atomic_flag* __o, memory_order __m) _NOEXCEPT
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_wait(const volatile atomic_flag* __o, bool __v) _NOEXCEPT
+atomic_flag_wait(const volatile atomic_flag* __o, bool __v) noexcept
 {
     __o->wait(__v);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_wait(const atomic_flag* __o, bool __v) _NOEXCEPT
+atomic_flag_wait(const atomic_flag* __o, bool __v) noexcept
 {
     __o->wait(__v);
 }
@@ -2751,7 +2751,7 @@ atomic_flag_wait(const atomic_flag* __o, bool __v) _NOEXCEPT
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 atomic_flag_wait_explicit(const volatile atomic_flag* __o,
-                          bool __v, memory_order __m) _NOEXCEPT
+                          bool __v, memory_order __m) noexcept
 {
     __o->wait(__v, __m);
 }
@@ -2759,35 +2759,35 @@ atomic_flag_wait_explicit(const volatile atomic_flag* __o,
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 atomic_flag_wait_explicit(const atomic_flag* __o,
-                          bool __v, memory_order __m) _NOEXCEPT
+                          bool __v, memory_order __m) noexcept
 {
     __o->wait(__v, __m);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_notify_one(volatile atomic_flag* __o) _NOEXCEPT
+atomic_flag_notify_one(volatile atomic_flag* __o) noexcept
 {
     __o->notify_one();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_notify_one(atomic_flag* __o) _NOEXCEPT
+atomic_flag_notify_one(atomic_flag* __o) noexcept
 {
     __o->notify_one();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_notify_all(volatile atomic_flag* __o) _NOEXCEPT
+atomic_flag_notify_all(volatile atomic_flag* __o) noexcept
 {
     __o->notify_all();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_flag_notify_all(atomic_flag* __o) _NOEXCEPT
+atomic_flag_notify_all(atomic_flag* __o) noexcept
 {
     __o->notify_all();
 }
@@ -2798,14 +2798,14 @@ atomic_flag_notify_all(atomic_flag* __o) _NOEXCEPT
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_thread_fence(memory_order __m) _NOEXCEPT
+atomic_thread_fence(memory_order __m) noexcept
 {
     __cxx_atomic_thread_fence(__m);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-atomic_signal_fence(memory_order __m) _NOEXCEPT
+atomic_signal_fence(memory_order __m) noexcept
 {
     __cxx_atomic_signal_fence(__m);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/barrier
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/barrier
@@ -352,7 +352,7 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static constexpr ptrdiff_t max() _NOEXCEPT
+    static constexpr ptrdiff_t max() noexcept
     {
         return numeric_limits<ptrdiff_t>::max();
     }
@@ -386,7 +386,7 @@ private:
     friend bool __call_try_wait_parity(const _Barrier& __b, bool __parity);
 
     static _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    uint64_t __init(ptrdiff_t __count) _NOEXCEPT
+    uint64_t __init(ptrdiff_t __count) noexcept
     {
 #if (_LIBCUDACXX_DEBUG_LEVEL >= 2)
         _LIBCUDACXX_DEBUG_ASSERT(__count >= 0);
@@ -462,7 +462,7 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static constexpr ptrdiff_t max() _NOEXCEPT
+    static constexpr ptrdiff_t max() noexcept
     {
         return numeric_limits<int32_t>::max();
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/bit
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/bit
@@ -85,40 +85,40 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #define _LIBCUDACXX_BIT_CONSTEXPR constexpr
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __binary_ctz2(uint64_t __x, int __c)           _NOEXCEPT {
+int __binary_ctz2(uint64_t __x, int __c)           noexcept {
   return (__x & 0x1) ? __c : __c + 1;
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __binary_ctz4(uint64_t __x, int __c)           _NOEXCEPT {
+int __binary_ctz4(uint64_t __x, int __c)           noexcept {
   return __binary_ctz2(
             __x >> 2*!(__x & 0x3),
             __c + 2*!(__x & 0x3));
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __binary_ctz8(uint64_t __x, int __c)           _NOEXCEPT {
+int __binary_ctz8(uint64_t __x, int __c)           noexcept {
   return __binary_ctz4(
             __x >> 4*!(__x & 0x0F),
             __c + 4*!(__x & 0x0F));
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __binary_ctz16(uint64_t __x, int __c)           _NOEXCEPT {
+int __binary_ctz16(uint64_t __x, int __c)           noexcept {
   return __binary_ctz8(
             __x >> 8*!(__x & 0x00FF),
             __c + 8*!(__x & 0x00FF));
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __binary_ctz32(uint64_t __x, int __c)           _NOEXCEPT {
+int __binary_ctz32(uint64_t __x, int __c)           noexcept {
   return __binary_ctz16(
             __x >> 16*!(__x & 0x0000FFFF),
             __c + 16*!(__x & 0x0000FFFF));
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __binary_ctz64(uint64_t __x)           _NOEXCEPT {
+int __binary_ctz64(uint64_t __x)           noexcept {
   return __binary_ctz32(
             __x >> 32*!(__x & 0x00000000FFFFFFFF),
             32*!(__x & 0x00000000FFFFFFFF));
@@ -230,7 +230,7 @@ int __libcpp_ctz(unsigned long __x) noexcept {
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __libcpp_ctz(unsigned long long __x) _NOEXCEPT {
+int __libcpp_ctz(unsigned long long __x) noexcept {
 // For whatever reason __builtin_ctzll does not compile although it should
 #if 1 //def _LIBCUDACXX_COMPILER_NVRTC
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
@@ -250,7 +250,7 @@ int __libcpp_ctz(unsigned long long __x) _NOEXCEPT {
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __libcpp_clz(unsigned __x)           _NOEXCEPT {
+int __libcpp_clz(unsigned __x)           noexcept {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
  || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
@@ -269,7 +269,7 @@ int __libcpp_clz(unsigned __x)           _NOEXCEPT {
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __libcpp_clz(unsigned long __x)      _NOEXCEPT {
+int __libcpp_clz(unsigned long __x)      noexcept {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
  || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
@@ -289,7 +289,7 @@ int __libcpp_clz(unsigned long __x)      _NOEXCEPT {
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __libcpp_clz(unsigned long long __x) _NOEXCEPT {
+int __libcpp_clz(unsigned long long __x) noexcept {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
  || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
@@ -309,7 +309,7 @@ int __libcpp_clz(unsigned long long __x) _NOEXCEPT {
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __libcpp_popcount(unsigned __x)           _NOEXCEPT {
+int __libcpp_popcount(unsigned __x)           noexcept {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
  || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
@@ -329,7 +329,7 @@ int __libcpp_popcount(unsigned __x)           _NOEXCEPT {
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __libcpp_popcount(unsigned long __x)      _NOEXCEPT {
+int __libcpp_popcount(unsigned long __x)      noexcept {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
  || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
@@ -349,7 +349,7 @@ int __libcpp_popcount(unsigned long __x)      _NOEXCEPT {
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __libcpp_popcount(unsigned long long __x) _NOEXCEPT {
+int __libcpp_popcount(unsigned long long __x) noexcept {
 #if defined(_LIBCUDACXX_COMPILER_NVRTC) \
  || (defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED) && (_LIBCUDACXX_STD_VER >= 14)
@@ -500,7 +500,7 @@ constexpr int __libcpp_popcount(unsigned long long __x) {
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-_Tp __rotl(_Tp __t, unsigned int __cnt) _NOEXCEPT
+_Tp __rotl(_Tp __t, unsigned int __cnt) noexcept
 {
     static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__rotl requires unsigned");
     using __nlt = numeric_limits<_Tp>;
@@ -513,7 +513,7 @@ _Tp __rotl(_Tp __t, unsigned int __cnt) _NOEXCEPT
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-_Tp __rotr(_Tp __t, unsigned int __cnt) _NOEXCEPT
+_Tp __rotr(_Tp __t, unsigned int __cnt) noexcept
 {
     static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__rotr requires unsigned");
     using __nlt = numeric_limits<_Tp>;
@@ -526,18 +526,18 @@ _Tp __rotr(_Tp __t, unsigned int __cnt) _NOEXCEPT
 // Forward decl for recursive use in split word operations
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __countr_zero(_Tp __t) _NOEXCEPT;
+int __countr_zero(_Tp __t) noexcept;
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-__enable_if_t<sizeof(_Tp) <= sizeof(unsigned int), int> __countr_zero_dispatch(_Tp __t) _NOEXCEPT
+__enable_if_t<sizeof(_Tp) <= sizeof(unsigned int), int> __countr_zero_dispatch(_Tp __t) noexcept
 {
   return __libcpp_ctz(static_cast<unsigned int>(__t));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-__enable_if_t<sizeof(_Tp) == sizeof(unsigned long long), int> __countr_zero_dispatch(_Tp __t) _NOEXCEPT
+__enable_if_t<sizeof(_Tp) == sizeof(unsigned long long), int> __countr_zero_dispatch(_Tp __t) noexcept
 {
   return __libcpp_ctz(static_cast<unsigned long long>(__t));
 }
@@ -571,12 +571,12 @@ struct __countr_zero_rsh_impl<_Tp, 1> {
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-__enable_if_t<(sizeof(_Tp) > sizeof(unsigned long long)), int> __countr_zero_dispatch(_Tp __t) _NOEXCEPT
+__enable_if_t<(sizeof(_Tp) > sizeof(unsigned long long)), int> __countr_zero_dispatch(_Tp __t) noexcept
 { return __countr_zero_rsh_impl<_Tp>::__count(__t, 0); }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __countr_zero(_Tp __t) _NOEXCEPT
+int __countr_zero(_Tp __t) noexcept
 {
     static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countr_zero requires unsigned");
 
@@ -586,11 +586,11 @@ int __countr_zero(_Tp __t) _NOEXCEPT
 // Forward decl for recursive use in split word operations
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __countl_zero(_Tp __t) _NOEXCEPT;
+int __countl_zero(_Tp __t) noexcept;
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-__enable_if_t<sizeof(_Tp) <= sizeof(unsigned int), int> __countl_zero_dispatch(_Tp __t) _NOEXCEPT
+__enable_if_t<sizeof(_Tp) <= sizeof(unsigned int), int> __countl_zero_dispatch(_Tp __t) noexcept
 {
   return __libcpp_clz(static_cast<unsigned int>(__t))
               - (numeric_limits<unsigned int>::digits - numeric_limits<_Tp>::digits);
@@ -598,7 +598,7 @@ __enable_if_t<sizeof(_Tp) <= sizeof(unsigned int), int> __countl_zero_dispatch(_
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-__enable_if_t<sizeof(_Tp) == sizeof(unsigned long long), int> __countl_zero_dispatch(_Tp __t) _NOEXCEPT
+__enable_if_t<sizeof(_Tp) == sizeof(unsigned long long), int> __countl_zero_dispatch(_Tp __t) noexcept
 {
   return __libcpp_clz(static_cast<unsigned long long>(__t))
               - (numeric_limits<unsigned long long>::digits - numeric_limits<_Tp>::digits);
@@ -639,12 +639,12 @@ struct __countl_zero_rotl_impl<_Tp, 1> {
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-__enable_if_t<(sizeof(_Tp) > sizeof(unsigned long long)), int> __countl_zero_dispatch(_Tp __t) _NOEXCEPT
+__enable_if_t<(sizeof(_Tp) > sizeof(unsigned long long)), int> __countl_zero_dispatch(_Tp __t) noexcept
 { return __countl_zero_rotl_impl<_Tp>::__count(__t); }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __countl_zero(_Tp __t) _NOEXCEPT
+int __countl_zero(_Tp __t) noexcept
 {
     static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countl_zero requires unsigned");
     return __t ? __countl_zero_dispatch(__t) : numeric_limits<_Tp>::digits;
@@ -652,7 +652,7 @@ int __countl_zero(_Tp __t) _NOEXCEPT
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __countl_one(_Tp __t) _NOEXCEPT
+int __countl_one(_Tp __t) noexcept
 {
     static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countl_one requires unsigned");
     return __t != numeric_limits<_Tp>::max()
@@ -663,7 +663,7 @@ int __countl_one(_Tp __t) _NOEXCEPT
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __countr_one(_Tp __t) _NOEXCEPT
+int __countr_one(_Tp __t) noexcept
 {
     static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countr_one requires unsigned");
     return __t != numeric_limits<_Tp>::max()
@@ -673,12 +673,12 @@ int __countr_one(_Tp __t) _NOEXCEPT
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-__enable_if_t<sizeof(_Tp) <= sizeof(unsigned int), int> __popcount_dispatch(_Tp __t) _NOEXCEPT
+__enable_if_t<sizeof(_Tp) <= sizeof(unsigned int), int> __popcount_dispatch(_Tp __t) noexcept
 { return __libcpp_popcount(static_cast<unsigned int>(__t)); }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-__enable_if_t<sizeof(_Tp) == sizeof(unsigned long long), int> __popcount_dispatch(_Tp __t) _NOEXCEPT
+__enable_if_t<sizeof(_Tp) == sizeof(unsigned long long), int> __popcount_dispatch(_Tp __t) noexcept
 { return __libcpp_popcount(static_cast<unsigned long long>(__t)); }
 
 template <typename _Tp, int _St = sizeof(_Tp)/sizeof(unsigned long long)>
@@ -701,12 +701,12 @@ struct __popcount_rsh_impl<_Tp, 1> {
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-__enable_if_t<(sizeof(_Tp) > sizeof(unsigned long long)), int> __popcount_dispatch(_Tp __t) _NOEXCEPT
+__enable_if_t<(sizeof(_Tp) > sizeof(unsigned long long)), int> __popcount_dispatch(_Tp __t) noexcept
 { return __popcount_rsh_impl<_Tp>::__count(__t); }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-int __popcount(_Tp __t) _NOEXCEPT
+int __popcount(_Tp __t) noexcept
 {
     static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__libcpp_popcount requires unsigned");
 
@@ -717,7 +717,7 @@ int __popcount(_Tp __t) _NOEXCEPT
 // integral log base 2
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-unsigned __bit_log2(_Tp __t) _NOEXCEPT
+unsigned __bit_log2(_Tp __t) noexcept
 {
     static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__bit_log2 requires unsigned");
     return std::numeric_limits<_Tp>::digits - 1 - __countl_zero(__t);
@@ -725,7 +725,7 @@ unsigned __bit_log2(_Tp __t) _NOEXCEPT
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_BIT_CONSTEXPR
-bool __has_single_bit(_Tp __t) _NOEXCEPT
+bool __has_single_bit(_Tp __t) noexcept
 {
     static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__has_single_bit requires unsigned");
 	return __t != 0 && (((__t & (__t - 1)) == 0));

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/bitset
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/bitset
@@ -167,41 +167,41 @@ protected:
     typedef __bit_iterator<__bitset, true>             const_iterator;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR __bitset() _NOEXCEPT;
+    _LIBCUDACXX_CONSTEXPR __bitset() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit _LIBCUDACXX_CONSTEXPR __bitset(unsigned long long __v) _NOEXCEPT;
+    explicit _LIBCUDACXX_CONSTEXPR __bitset(unsigned long long __v) noexcept;
 
-    _LIBCUDACXX_INLINE_VISIBILITY reference __make_ref(size_t __pos) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY reference __make_ref(size_t __pos) noexcept
         {return reference(__first_ + __pos / __bits_per_word, __storage_type(1) << __pos % __bits_per_word);}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR const_reference __make_ref(size_t __pos) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR const_reference __make_ref(size_t __pos) const noexcept
         {return const_reference(__first_ + __pos / __bits_per_word, __storage_type(1) << __pos % __bits_per_word);}
-    _LIBCUDACXX_INLINE_VISIBILITY iterator __make_iter(size_t __pos) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY iterator __make_iter(size_t __pos) noexcept
         {return iterator(__first_ + __pos / __bits_per_word, __pos % __bits_per_word);}
-    _LIBCUDACXX_INLINE_VISIBILITY const_iterator __make_iter(size_t __pos) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY const_iterator __make_iter(size_t __pos) const noexcept
         {return const_iterator(__first_ + __pos / __bits_per_word, __pos % __bits_per_word);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator&=(const __bitset& __v) _NOEXCEPT;
+    void operator&=(const __bitset& __v) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator|=(const __bitset& __v) _NOEXCEPT;
+    void operator|=(const __bitset& __v) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator^=(const __bitset& __v) _NOEXCEPT;
+    void operator^=(const __bitset& __v) noexcept;
 
-    void flip() _NOEXCEPT;
+    void flip() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY unsigned long to_ulong() const
         {return to_ulong(integral_constant<bool, _Size < sizeof(unsigned long) * CHAR_BIT>());}
     _LIBCUDACXX_INLINE_VISIBILITY unsigned long long to_ullong() const
         {return to_ullong(integral_constant<bool, _Size < sizeof(unsigned long long) * CHAR_BIT>());}
 
-    bool all() const _NOEXCEPT;
-    bool any() const _NOEXCEPT;
+    bool all() const noexcept;
+    bool any() const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t __hash_code() const _NOEXCEPT;
+    size_t __hash_code() const noexcept;
 private:
 #ifdef _LIBCUDACXX_CXX03_LANG
-    void __init(unsigned long long __v, false_type) _NOEXCEPT;
+    void __init(unsigned long long __v, false_type) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __init(unsigned long long __v, true_type) _NOEXCEPT;
+    void __init(unsigned long long __v, true_type) noexcept;
 #endif  // _LIBCUDACXX_CXX03_LANG
     unsigned long to_ulong(false_type) const;
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -217,7 +217,7 @@ private:
 template <size_t _N_words, size_t _Size>
 inline
 _LIBCUDACXX_CONSTEXPR
-__bitset<_N_words, _Size>::__bitset() _NOEXCEPT
+__bitset<_N_words, _Size>::__bitset() noexcept
 #ifndef _LIBCUDACXX_CXX03_LANG
     : __first_{0}
 #endif
@@ -231,7 +231,7 @@ __bitset<_N_words, _Size>::__bitset() _NOEXCEPT
 
 template <size_t _N_words, size_t _Size>
 void
-__bitset<_N_words, _Size>::__init(unsigned long long __v, false_type) _NOEXCEPT
+__bitset<_N_words, _Size>::__init(unsigned long long __v, false_type) noexcept
 {
     __storage_type __t[sizeof(unsigned long long) / sizeof(__storage_type)];
     size_t __sz = _Size;
@@ -249,7 +249,7 @@ __bitset<_N_words, _Size>::__init(unsigned long long __v, false_type) _NOEXCEPT
 template <size_t _N_words, size_t _Size>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-__bitset<_N_words, _Size>::__init(unsigned long long __v, true_type) _NOEXCEPT
+__bitset<_N_words, _Size>::__init(unsigned long long __v, true_type) noexcept
 {
     __first_[0] = __v;
     if (_Size < __bits_per_word)
@@ -263,7 +263,7 @@ __bitset<_N_words, _Size>::__init(unsigned long long __v, true_type) _NOEXCEPT
 template <size_t _N_words, size_t _Size>
 inline
 _LIBCUDACXX_CONSTEXPR
-__bitset<_N_words, _Size>::__bitset(unsigned long long __v) _NOEXCEPT
+__bitset<_N_words, _Size>::__bitset(unsigned long long __v) noexcept
 #ifndef _LIBCUDACXX_CXX03_LANG
 #if __SIZEOF_SIZE_T__ == 8
     : __first_{__v}
@@ -284,7 +284,7 @@ __bitset<_N_words, _Size>::__bitset(unsigned long long __v) _NOEXCEPT
 template <size_t _N_words, size_t _Size>
 inline
 void
-__bitset<_N_words, _Size>::operator&=(const __bitset& __v) _NOEXCEPT
+__bitset<_N_words, _Size>::operator&=(const __bitset& __v) noexcept
 {
     for (size_type __i = 0; __i < _N_words; ++__i)
         __first_[__i] &= __v.__first_[__i];
@@ -293,7 +293,7 @@ __bitset<_N_words, _Size>::operator&=(const __bitset& __v) _NOEXCEPT
 template <size_t _N_words, size_t _Size>
 inline
 void
-__bitset<_N_words, _Size>::operator|=(const __bitset& __v) _NOEXCEPT
+__bitset<_N_words, _Size>::operator|=(const __bitset& __v) noexcept
 {
     for (size_type __i = 0; __i < _N_words; ++__i)
         __first_[__i] |= __v.__first_[__i];
@@ -302,7 +302,7 @@ __bitset<_N_words, _Size>::operator|=(const __bitset& __v) _NOEXCEPT
 template <size_t _N_words, size_t _Size>
 inline
 void
-__bitset<_N_words, _Size>::operator^=(const __bitset& __v) _NOEXCEPT
+__bitset<_N_words, _Size>::operator^=(const __bitset& __v) noexcept
 {
     for (size_type __i = 0; __i < _N_words; ++__i)
         __first_[__i] ^= __v.__first_[__i];
@@ -310,7 +310,7 @@ __bitset<_N_words, _Size>::operator^=(const __bitset& __v) _NOEXCEPT
 
 template <size_t _N_words, size_t _Size>
 void
-__bitset<_N_words, _Size>::flip() _NOEXCEPT
+__bitset<_N_words, _Size>::flip() noexcept
 {
     // do middle whole words
     size_type __n = _Size;
@@ -387,7 +387,7 @@ __bitset<_N_words, _Size>::to_ullong(true_type, true_type) const
 
 template <size_t _N_words, size_t _Size>
 bool
-__bitset<_N_words, _Size>::all() const _NOEXCEPT
+__bitset<_N_words, _Size>::all() const noexcept
 {
     // do middle whole words
     size_type __n = _Size;
@@ -407,7 +407,7 @@ __bitset<_N_words, _Size>::all() const _NOEXCEPT
 
 template <size_t _N_words, size_t _Size>
 bool
-__bitset<_N_words, _Size>::any() const _NOEXCEPT
+__bitset<_N_words, _Size>::any() const noexcept
 {
     // do middle whole words
     size_type __n = _Size;
@@ -428,7 +428,7 @@ __bitset<_N_words, _Size>::any() const _NOEXCEPT
 template <size_t _N_words, size_t _Size>
 inline
 size_t
-__bitset<_N_words, _Size>::__hash_code() const _NOEXCEPT
+__bitset<_N_words, _Size>::__hash_code() const noexcept
 {
     size_t __h = 0;
     for (size_type __i = 0; __i < _N_words; ++__i)
@@ -463,28 +463,28 @@ protected:
     typedef __bit_iterator<__bitset, true>             const_iterator;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR __bitset() _NOEXCEPT;
+    _LIBCUDACXX_CONSTEXPR __bitset() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit _LIBCUDACXX_CONSTEXPR __bitset(unsigned long long __v) _NOEXCEPT;
+    explicit _LIBCUDACXX_CONSTEXPR __bitset(unsigned long long __v) noexcept;
 
-    _LIBCUDACXX_INLINE_VISIBILITY reference __make_ref(size_t __pos) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY reference __make_ref(size_t __pos) noexcept
         {return reference(&__first_, __storage_type(1) << __pos);}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR const_reference __make_ref(size_t __pos) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR const_reference __make_ref(size_t __pos) const noexcept
         {return const_reference(&__first_, __storage_type(1) << __pos);}
-    _LIBCUDACXX_INLINE_VISIBILITY iterator __make_iter(size_t __pos) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY iterator __make_iter(size_t __pos) noexcept
         {return iterator(&__first_ + __pos / __bits_per_word, __pos % __bits_per_word);}
-    _LIBCUDACXX_INLINE_VISIBILITY const_iterator __make_iter(size_t __pos) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY const_iterator __make_iter(size_t __pos) const noexcept
         {return const_iterator(&__first_ + __pos / __bits_per_word, __pos % __bits_per_word);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator&=(const __bitset& __v) _NOEXCEPT;
+    void operator&=(const __bitset& __v) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator|=(const __bitset& __v) _NOEXCEPT;
+    void operator|=(const __bitset& __v) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator^=(const __bitset& __v) _NOEXCEPT;
+    void operator^=(const __bitset& __v) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void flip() _NOEXCEPT;
+    void flip() noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     unsigned long to_ulong() const;
@@ -492,18 +492,18 @@ protected:
     unsigned long long to_ullong() const;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool all() const _NOEXCEPT;
+    bool all() const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool any() const _NOEXCEPT;
+    bool any() const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t __hash_code() const _NOEXCEPT;
+    size_t __hash_code() const noexcept;
 };
 
 template <size_t _Size>
 inline
 _LIBCUDACXX_CONSTEXPR
-__bitset<1, _Size>::__bitset() _NOEXCEPT
+__bitset<1, _Size>::__bitset() noexcept
     : __first_(0)
 {
 }
@@ -511,7 +511,7 @@ __bitset<1, _Size>::__bitset() _NOEXCEPT
 template <size_t _Size>
 inline
 _LIBCUDACXX_CONSTEXPR
-__bitset<1, _Size>::__bitset(unsigned long long __v) _NOEXCEPT
+__bitset<1, _Size>::__bitset(unsigned long long __v) noexcept
     : __first_(
         _Size == __bits_per_word ? static_cast<__storage_type>(__v)
                                  : static_cast<__storage_type>(__v) & ((__storage_type(1) << _Size) - 1)
@@ -522,7 +522,7 @@ __bitset<1, _Size>::__bitset(unsigned long long __v) _NOEXCEPT
 template <size_t _Size>
 inline
 void
-__bitset<1, _Size>::operator&=(const __bitset& __v) _NOEXCEPT
+__bitset<1, _Size>::operator&=(const __bitset& __v) noexcept
 {
     __first_ &= __v.__first_;
 }
@@ -530,7 +530,7 @@ __bitset<1, _Size>::operator&=(const __bitset& __v) _NOEXCEPT
 template <size_t _Size>
 inline
 void
-__bitset<1, _Size>::operator|=(const __bitset& __v) _NOEXCEPT
+__bitset<1, _Size>::operator|=(const __bitset& __v) noexcept
 {
     __first_ |= __v.__first_;
 }
@@ -538,7 +538,7 @@ __bitset<1, _Size>::operator|=(const __bitset& __v) _NOEXCEPT
 template <size_t _Size>
 inline
 void
-__bitset<1, _Size>::operator^=(const __bitset& __v) _NOEXCEPT
+__bitset<1, _Size>::operator^=(const __bitset& __v) noexcept
 {
     __first_ ^= __v.__first_;
 }
@@ -546,7 +546,7 @@ __bitset<1, _Size>::operator^=(const __bitset& __v) _NOEXCEPT
 template <size_t _Size>
 inline
 void
-__bitset<1, _Size>::flip() _NOEXCEPT
+__bitset<1, _Size>::flip() noexcept
 {
     __storage_type __m = ~__storage_type(0) >> (__bits_per_word - _Size);
     __first_ = ~__first_;
@@ -572,7 +572,7 @@ __bitset<1, _Size>::to_ullong() const
 template <size_t _Size>
 inline
 bool
-__bitset<1, _Size>::all() const _NOEXCEPT
+__bitset<1, _Size>::all() const noexcept
 {
     __storage_type __m = ~__storage_type(0) >> (__bits_per_word - _Size);
     return !(~__first_ & __m);
@@ -581,7 +581,7 @@ __bitset<1, _Size>::all() const _NOEXCEPT
 template <size_t _Size>
 inline
 bool
-__bitset<1, _Size>::any() const _NOEXCEPT
+__bitset<1, _Size>::any() const noexcept
 {
     __storage_type __m = ~__storage_type(0) >> (__bits_per_word - _Size);
     return __first_ & __m;
@@ -590,7 +590,7 @@ __bitset<1, _Size>::any() const _NOEXCEPT
 template <size_t _Size>
 inline
 size_t
-__bitset<1, _Size>::__hash_code() const _NOEXCEPT
+__bitset<1, _Size>::__hash_code() const noexcept
 {
     return __first_;
 }
@@ -620,43 +620,43 @@ protected:
     typedef __bit_iterator<__bitset, true>             const_iterator;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR __bitset() _NOEXCEPT;
+    _LIBCUDACXX_CONSTEXPR __bitset() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit _LIBCUDACXX_CONSTEXPR __bitset(unsigned long long) _NOEXCEPT;
+    explicit _LIBCUDACXX_CONSTEXPR __bitset(unsigned long long) noexcept;
 
-    _LIBCUDACXX_INLINE_VISIBILITY reference __make_ref(size_t) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY reference __make_ref(size_t) noexcept
         {return reference(0, 1);}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR const_reference __make_ref(size_t) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR const_reference __make_ref(size_t) const noexcept
         {return const_reference(0, 1);}
-    _LIBCUDACXX_INLINE_VISIBILITY iterator __make_iter(size_t) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY iterator __make_iter(size_t) noexcept
         {return iterator(0, 0);}
-    _LIBCUDACXX_INLINE_VISIBILITY const_iterator __make_iter(size_t) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY const_iterator __make_iter(size_t) const noexcept
         {return const_iterator(0, 0);}
 
-    _LIBCUDACXX_INLINE_VISIBILITY void operator&=(const __bitset&) _NOEXCEPT {}
-    _LIBCUDACXX_INLINE_VISIBILITY void operator|=(const __bitset&) _NOEXCEPT {}
-    _LIBCUDACXX_INLINE_VISIBILITY void operator^=(const __bitset&) _NOEXCEPT {}
+    _LIBCUDACXX_INLINE_VISIBILITY void operator&=(const __bitset&) noexcept {}
+    _LIBCUDACXX_INLINE_VISIBILITY void operator|=(const __bitset&) noexcept {}
+    _LIBCUDACXX_INLINE_VISIBILITY void operator^=(const __bitset&) noexcept {}
 
-    _LIBCUDACXX_INLINE_VISIBILITY void flip() _NOEXCEPT {}
+    _LIBCUDACXX_INLINE_VISIBILITY void flip() noexcept {}
 
     _LIBCUDACXX_INLINE_VISIBILITY unsigned long to_ulong() const {return 0;}
     _LIBCUDACXX_INLINE_VISIBILITY unsigned long long to_ullong() const {return 0;}
 
-    _LIBCUDACXX_INLINE_VISIBILITY bool all() const _NOEXCEPT {return true;}
-    _LIBCUDACXX_INLINE_VISIBILITY bool any() const _NOEXCEPT {return false;}
+    _LIBCUDACXX_INLINE_VISIBILITY bool all() const noexcept {return true;}
+    _LIBCUDACXX_INLINE_VISIBILITY bool any() const noexcept {return false;}
 
-    _LIBCUDACXX_INLINE_VISIBILITY size_t __hash_code() const _NOEXCEPT {return 0;}
+    _LIBCUDACXX_INLINE_VISIBILITY size_t __hash_code() const noexcept {return 0;}
 };
 
 inline
 _LIBCUDACXX_CONSTEXPR
-__bitset<0, 0>::__bitset() _NOEXCEPT
+__bitset<0, 0>::__bitset() noexcept
 {
 }
 
 inline
 _LIBCUDACXX_CONSTEXPR
-__bitset<0, 0>::__bitset(unsigned long long) _NOEXCEPT
+__bitset<0, 0>::__bitset(unsigned long long) noexcept
 {
 }
 
@@ -676,9 +676,9 @@ public:
     typedef typename base::const_reference const_reference;
 
     // 23.3.5.1 constructors:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR bitset() _NOEXCEPT {}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR bitset() noexcept {}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-        bitset(unsigned long long __v) _NOEXCEPT : base(__v) {}
+        bitset(unsigned long long __v) noexcept : base(__v) {}
     template<class _CharT, class = _EnableIf<_IsCharLikeType<_CharT>::value> >
         explicit bitset(const _CharT* __str,
                         typename basic_string<_CharT>::size_type __n = basic_string<_CharT>::npos,
@@ -692,23 +692,23 @@ public:
 
     // 23.3.5.2 bitset operations:
     _LIBCUDACXX_INLINE_VISIBILITY
-    bitset& operator&=(const bitset& __rhs) _NOEXCEPT;
+    bitset& operator&=(const bitset& __rhs) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bitset& operator|=(const bitset& __rhs) _NOEXCEPT;
+    bitset& operator|=(const bitset& __rhs) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bitset& operator^=(const bitset& __rhs) _NOEXCEPT;
-    bitset& operator<<=(size_t __pos) _NOEXCEPT;
-    bitset& operator>>=(size_t __pos) _NOEXCEPT;
+    bitset& operator^=(const bitset& __rhs) noexcept;
+    bitset& operator<<=(size_t __pos) noexcept;
+    bitset& operator>>=(size_t __pos) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bitset& set() _NOEXCEPT;
+    bitset& set() noexcept;
     bitset& set(size_t __pos, bool __val = true);
     _LIBCUDACXX_INLINE_VISIBILITY
-    bitset& reset() _NOEXCEPT;
+    bitset& reset() noexcept;
     bitset& reset(size_t __pos);
     _LIBCUDACXX_INLINE_VISIBILITY
-    bitset  operator~() const _NOEXCEPT;
+    bitset  operator~() const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bitset& flip() _NOEXCEPT;
+    bitset& flip() noexcept;
     bitset& flip(size_t __pos);
 
     // element access:
@@ -734,27 +734,27 @@ public:
     basic_string<char, char_traits<char>, allocator<char> > to_string(char __zero = '0',
                                                                       char __one = '1') const;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t count() const _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR size_t size() const _NOEXCEPT {return _Size;}
+    size_t count() const noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR size_t size() const noexcept {return _Size;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator==(const bitset& __rhs) const _NOEXCEPT;
+    bool operator==(const bitset& __rhs) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator!=(const bitset& __rhs) const _NOEXCEPT;
+    bool operator!=(const bitset& __rhs) const noexcept;
     bool test(size_t __pos) const;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool all() const _NOEXCEPT;
+    bool all() const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool any() const _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY bool none() const _NOEXCEPT {return !any();}
+    bool any() const noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY bool none() const noexcept {return !any();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bitset operator<<(size_t __pos) const _NOEXCEPT;
+    bitset operator<<(size_t __pos) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bitset operator>>(size_t __pos) const _NOEXCEPT;
+    bitset operator>>(size_t __pos) const noexcept;
 
 private:
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t __hash_code() const _NOEXCEPT {return base::__hash_code();}
+    size_t __hash_code() const noexcept {return base::__hash_code();}
 
     friend struct hash<bitset>;
 };
@@ -814,7 +814,7 @@ bitset<_Size>::bitset(const basic_string<_CharT,_Traits,_Allocator>& __str,
 template <size_t _Size>
 inline
 bitset<_Size>&
-bitset<_Size>::operator&=(const bitset& __rhs) _NOEXCEPT
+bitset<_Size>::operator&=(const bitset& __rhs) noexcept
 {
     base::operator&=(__rhs);
     return *this;
@@ -823,7 +823,7 @@ bitset<_Size>::operator&=(const bitset& __rhs) _NOEXCEPT
 template <size_t _Size>
 inline
 bitset<_Size>&
-bitset<_Size>::operator|=(const bitset& __rhs) _NOEXCEPT
+bitset<_Size>::operator|=(const bitset& __rhs) noexcept
 {
     base::operator|=(__rhs);
     return *this;
@@ -832,7 +832,7 @@ bitset<_Size>::operator|=(const bitset& __rhs) _NOEXCEPT
 template <size_t _Size>
 inline
 bitset<_Size>&
-bitset<_Size>::operator^=(const bitset& __rhs) _NOEXCEPT
+bitset<_Size>::operator^=(const bitset& __rhs) noexcept
 {
     base::operator^=(__rhs);
     return *this;
@@ -840,7 +840,7 @@ bitset<_Size>::operator^=(const bitset& __rhs) _NOEXCEPT
 
 template <size_t _Size>
 bitset<_Size>&
-bitset<_Size>::operator<<=(size_t __pos) _NOEXCEPT
+bitset<_Size>::operator<<=(size_t __pos) noexcept
 {
     __pos = _CUDA_VSTD::min(__pos, _Size);
     _CUDA_VSTD::copy_backward(base::__make_iter(0), base::__make_iter(_Size - __pos), base::__make_iter(_Size));
@@ -850,7 +850,7 @@ bitset<_Size>::operator<<=(size_t __pos) _NOEXCEPT
 
 template <size_t _Size>
 bitset<_Size>&
-bitset<_Size>::operator>>=(size_t __pos) _NOEXCEPT
+bitset<_Size>::operator>>=(size_t __pos) noexcept
 {
     __pos = _CUDA_VSTD::min(__pos, _Size);
     _CUDA_VSTD::copy(base::__make_iter(__pos), base::__make_iter(_Size), base::__make_iter(0));
@@ -861,7 +861,7 @@ bitset<_Size>::operator>>=(size_t __pos) _NOEXCEPT
 template <size_t _Size>
 inline
 bitset<_Size>&
-bitset<_Size>::set() _NOEXCEPT
+bitset<_Size>::set() noexcept
 {
     _CUDA_VSTD::fill_n(base::__make_iter(0), _Size, true);
     return *this;
@@ -881,7 +881,7 @@ bitset<_Size>::set(size_t __pos, bool __val)
 template <size_t _Size>
 inline
 bitset<_Size>&
-bitset<_Size>::reset() _NOEXCEPT
+bitset<_Size>::reset() noexcept
 {
     _CUDA_VSTD::fill_n(base::__make_iter(0), _Size, false);
     return *this;
@@ -901,7 +901,7 @@ bitset<_Size>::reset(size_t __pos)
 template <size_t _Size>
 inline
 bitset<_Size>
-bitset<_Size>::operator~() const _NOEXCEPT
+bitset<_Size>::operator~() const noexcept
 {
     bitset __x(*this);
     __x.flip();
@@ -911,7 +911,7 @@ bitset<_Size>::operator~() const _NOEXCEPT
 template <size_t _Size>
 inline
 bitset<_Size>&
-bitset<_Size>::flip() _NOEXCEPT
+bitset<_Size>::flip() noexcept
 {
     base::flip();
     return *this;
@@ -988,7 +988,7 @@ bitset<_Size>::to_string(char __zero, char __one) const
 template <size_t _Size>
 inline
 size_t
-bitset<_Size>::count() const _NOEXCEPT
+bitset<_Size>::count() const noexcept
 {
     return static_cast<size_t>(__count_bool_true(base::__make_iter(0), _Size));
 }
@@ -996,7 +996,7 @@ bitset<_Size>::count() const _NOEXCEPT
 template <size_t _Size>
 inline
 bool
-bitset<_Size>::operator==(const bitset& __rhs) const _NOEXCEPT
+bitset<_Size>::operator==(const bitset& __rhs) const noexcept
 {
     return _CUDA_VSTD::equal(base::__make_iter(0), base::__make_iter(_Size), __rhs.__make_iter(0));
 }
@@ -1004,7 +1004,7 @@ bitset<_Size>::operator==(const bitset& __rhs) const _NOEXCEPT
 template <size_t _Size>
 inline
 bool
-bitset<_Size>::operator!=(const bitset& __rhs) const _NOEXCEPT
+bitset<_Size>::operator!=(const bitset& __rhs) const noexcept
 {
     return !(*this == __rhs);
 }
@@ -1022,7 +1022,7 @@ bitset<_Size>::test(size_t __pos) const
 template <size_t _Size>
 inline
 bool
-bitset<_Size>::all() const _NOEXCEPT
+bitset<_Size>::all() const noexcept
 {
     return base::all();
 }
@@ -1030,7 +1030,7 @@ bitset<_Size>::all() const _NOEXCEPT
 template <size_t _Size>
 inline
 bool
-bitset<_Size>::any() const _NOEXCEPT
+bitset<_Size>::any() const noexcept
 {
     return base::any();
 }
@@ -1038,7 +1038,7 @@ bitset<_Size>::any() const _NOEXCEPT
 template <size_t _Size>
 inline
 bitset<_Size>
-bitset<_Size>::operator<<(size_t __pos) const _NOEXCEPT
+bitset<_Size>::operator<<(size_t __pos) const noexcept
 {
     bitset __r = *this;
     __r <<= __pos;
@@ -1048,7 +1048,7 @@ bitset<_Size>::operator<<(size_t __pos) const _NOEXCEPT
 template <size_t _Size>
 inline
 bitset<_Size>
-bitset<_Size>::operator>>(size_t __pos) const _NOEXCEPT
+bitset<_Size>::operator>>(size_t __pos) const noexcept
 {
     bitset __r = *this;
     __r >>= __pos;
@@ -1058,7 +1058,7 @@ bitset<_Size>::operator>>(size_t __pos) const _NOEXCEPT
 template <size_t _Size>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bitset<_Size>
-operator&(const bitset<_Size>& __x, const bitset<_Size>& __y) _NOEXCEPT
+operator&(const bitset<_Size>& __x, const bitset<_Size>& __y) noexcept
 {
     bitset<_Size> __r = __x;
     __r &= __y;
@@ -1068,7 +1068,7 @@ operator&(const bitset<_Size>& __x, const bitset<_Size>& __y) _NOEXCEPT
 template <size_t _Size>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bitset<_Size>
-operator|(const bitset<_Size>& __x, const bitset<_Size>& __y) _NOEXCEPT
+operator|(const bitset<_Size>& __x, const bitset<_Size>& __y) noexcept
 {
     bitset<_Size> __r = __x;
     __r |= __y;
@@ -1078,7 +1078,7 @@ operator|(const bitset<_Size>& __x, const bitset<_Size>& __y) _NOEXCEPT
 template <size_t _Size>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bitset<_Size>
-operator^(const bitset<_Size>& __x, const bitset<_Size>& __y) _NOEXCEPT
+operator^(const bitset<_Size>& __x, const bitset<_Size>& __y) noexcept
 {
     bitset<_Size> __r = __x;
     __r ^= __y;
@@ -1090,7 +1090,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<bitset<_Size> >
     : public __unary_function<bitset<_Size>, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(const bitset<_Size>& __bs) const _NOEXCEPT
+    size_t operator()(const bitset<_Size>& __bs) const noexcept
         {return __bs.__hash_code();}
 };
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -990,9 +990,9 @@ template <class _Rep>
 struct _LIBCUDACXX_TEMPLATE_VIS duration_values
 {
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR _Rep zero() _NOEXCEPT {return _Rep(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR _Rep max()  _NOEXCEPT {return numeric_limits<_Rep>::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR _Rep min()  _NOEXCEPT {return numeric_limits<_Rep>::lowest();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR _Rep zero() noexcept {return _Rep(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR _Rep max()  noexcept {return numeric_limits<_Rep>::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR _Rep min()  noexcept {return numeric_limits<_Rep>::lowest();}
 };
 
 #if _LIBCUDACXX_STD_VER > 11
@@ -1148,9 +1148,9 @@ public:
 
     // special values
 
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR duration zero() _NOEXCEPT {return duration(duration_values<rep>::zero());}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR duration min()  _NOEXCEPT {return duration(duration_values<rep>::min());}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR duration max()  _NOEXCEPT {return duration(duration_values<rep>::max());}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR duration zero() noexcept {return duration(duration_values<rep>::zero());}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR duration min()  noexcept {return duration(duration_values<rep>::min());}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR duration max()  noexcept {return duration(duration_values<rep>::max());}
 };
 
 typedef duration<long long,         nano> nanoseconds;
@@ -1422,8 +1422,8 @@ public:
 
     // special values
 
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR time_point min() _NOEXCEPT {return time_point(duration::min());}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR time_point max() _NOEXCEPT {return time_point(duration::max());}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR time_point min() noexcept {return time_point(duration::min());}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR time_point max() noexcept {return time_point(duration::max());}
 };
 
 } // chrono
@@ -1610,11 +1610,11 @@ public:
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const bool is_steady = false;
 
     _LIBCUDACXX_HOST_DEVICE
-    static time_point now() _NOEXCEPT;
+    static time_point now() noexcept;
     _LIBCUDACXX_HOST_DEVICE
-    static time_t     to_time_t  (const time_point& __t) _NOEXCEPT;
+    static time_t     to_time_t  (const time_point& __t) noexcept;
     _LIBCUDACXX_HOST_DEVICE
-    static time_point from_time_t(time_t __t) _NOEXCEPT;
+    static time_point from_time_t(time_t __t) noexcept;
 };
 
 #ifndef _LIBCUDACXX_HAS_NO_MONOTONIC_CLOCK
@@ -1627,7 +1627,7 @@ public:
     typedef chrono::time_point<steady_clock, duration>    time_point;
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const bool is_steady = true;
 
-    static time_point now() _NOEXCEPT;
+    static time_point now() noexcept;
 };
 
 typedef steady_clock high_resolution_clock;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -592,7 +592,7 @@ __enable_if_t
     is_arithmetic<_A3>::value,
     __promote<_A1, _A2, _A3>
 >
-hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT
+hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) noexcept
 {
     typedef typename __promote<_A1, _A2, _A3>::type __result_type;
     static_assert((!(is_same<_A1, __result_type>::value &&
@@ -611,7 +611,7 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR __enable_if_t<is_floating_point<_A1>::value, bool>
-__constexpr_isnan(_A1 __lcpp_x) _NOEXCEPT
+__constexpr_isnan(_A1 __lcpp_x) noexcept
 {
 #if defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
     return __isnan(__lcpp_x);
@@ -625,7 +625,7 @@ __constexpr_isnan(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR __enable_if_t<!is_floating_point<_A1>::value, bool>
-__constexpr_isnan(_A1 __lcpp_x) _NOEXCEPT
+__constexpr_isnan(_A1 __lcpp_x) noexcept
 {
     return isnan(__lcpp_x);
 }
@@ -633,7 +633,7 @@ __constexpr_isnan(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR __enable_if_t<is_floating_point<_A1>::value, bool>
-__constexpr_isinf(_A1 __lcpp_x) _NOEXCEPT
+__constexpr_isinf(_A1 __lcpp_x) noexcept
 {
 #if defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
     return __isinf(__lcpp_x);
@@ -647,7 +647,7 @@ __constexpr_isinf(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR __enable_if_t<!is_floating_point<_A1>::value, bool>
-__constexpr_isinf(_A1 __lcpp_x) _NOEXCEPT
+__constexpr_isinf(_A1 __lcpp_x) noexcept
 {
     return isinf(__lcpp_x);
 }
@@ -655,7 +655,7 @@ __constexpr_isinf(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR __enable_if_t<is_floating_point<_A1>::value, bool>
-__constexpr_isfinite(_A1 __lcpp_x) _NOEXCEPT
+__constexpr_isfinite(_A1 __lcpp_x) noexcept
 {
 #if defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
     return !__isinf(__lcpp_x) && !__isnan(__lcpp_x);
@@ -669,7 +669,7 @@ __constexpr_isfinite(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR __enable_if_t<!is_floating_point<_A1>::value, bool>
-__constexpr_isfinite(_A1 __lcpp_x) _NOEXCEPT
+__constexpr_isfinite(_A1 __lcpp_x) noexcept
 {
     return isfinite(__lcpp_x);
 }
@@ -677,23 +677,23 @@ __constexpr_isfinite(_A1 __lcpp_x) _NOEXCEPT
 #if defined(_MSC_VER) || defined(__CUDACC_RTC__)
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
-_A1 __constexpr_copysign(_A1 __x, _A1 __y) _NOEXCEPT
+_A1 __constexpr_copysign(_A1 __x, _A1 __y) noexcept
 {
     return copysign(__x, __y);
 }
 #else
 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 float __constexpr_copysign(float __x, float __y) _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 float __constexpr_copysign(float __x, float __y) noexcept {
     return __builtin_copysignf(__x, __y);
 }
 
 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 double __constexpr_copysign(double __x, double __y) _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 double __constexpr_copysign(double __x, double __y) noexcept {
     return __builtin_copysign(__x, __y);
 }
 
 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 long double __constexpr_copysign(long double __x, long double __y) _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 long double __constexpr_copysign(long double __x, long double __y) noexcept {
     return __builtin_copysignl(__x, __y);
 }
 
@@ -701,7 +701,7 @@ template <class _A1, class _A2>
 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 typename __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value,
                                 __promote<_A1, _A2> >::type
-    __constexpr_copysign(_A1 __x, _A2 __y) _NOEXCEPT {
+    __constexpr_copysign(_A1 __x, _A2 __y) noexcept {
     typedef typename __promote<_A1, _A2>::type __result_type;
     static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
     return __builtin_copysign((__result_type)__x, (__result_type)__y);
@@ -711,29 +711,29 @@ _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 typename __enable_if_t<is_arithmetic<_A1>::val
 #if defined(_MSC_VER) || defined(__CUDACC_RTC__)
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
-_A1 __constexpr_fabs(_A1 __x) _NOEXCEPT
+_A1 __constexpr_fabs(_A1 __x) noexcept
 {
     return fabs(__x);
 }
 #else
 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 float __constexpr_fabs(float __x) _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 float __constexpr_fabs(float __x) noexcept {
     return __builtin_fabsf(__x);
 }
 
 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 double __constexpr_fabs(double __x) _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 double __constexpr_fabs(double __x) noexcept {
     return __builtin_fabs(__x);
 }
 
 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 long double __constexpr_fabs(long double __x) _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 long double __constexpr_fabs(long double __x) noexcept {
     return __builtin_fabsl(__x);
 }
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value, int> = 0>
 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 double __constexpr_fabs(_Tp __x) _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR_AFTER_CXX11 double __constexpr_fabs(_Tp __x) noexcept {
     return __builtin_fabs(static_cast<double>(__x));
 }
 #endif // !_MSC_VER
@@ -741,7 +741,7 @@ _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 double __constexpr_fabs(_Tp __x) _NOEXCEPT {
 #if defined(_MSC_VER) || defined(__CUDACC_RTC__)
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
-_A1 __constexpr_fmax(_A1 __x, _A1 __y) _NOEXCEPT
+_A1 __constexpr_fmax(_A1 __x, _A1 __y) noexcept
 {
     return fmax(__x, __y);
 }
@@ -791,7 +791,7 @@ _LIBCUDACXX_CONSTEXPR_AFTER_CXX11_COMPLEX long double __constexpr_fmax(long doub
 template <class _Tp, class _Up, __enable_if_t<is_arithmetic<_Tp>::value && is_arithmetic<_Up>::value, int> = 0>
 inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11_COMPLEX typename __promote<_Tp, _Up>::type
-__constexpr_fmax(_Tp __x, _Up __y) _NOEXCEPT {
+__constexpr_fmax(_Tp __x, _Up __y) noexcept {
   using __result_type = typename __promote<_Tp, _Up>::type;
   return _CUDA_VSTD::__constexpr_fmax(static_cast<__result_type>(__x), static_cast<__result_type>(__y));
 }
@@ -921,15 +921,15 @@ constexpr _Fp __lerp(_Fp __a, _Fp __b, _Fp __t) noexcept {
 
 _LIBCUDACXX_INLINE_VISIBILITY
 constexpr float
-lerp(float __a, float __b, float __t)                   _NOEXCEPT { return __lerp(__a, __b, __t); }
+lerp(float __a, float __b, float __t)                   noexcept { return __lerp(__a, __b, __t); }
 
 _LIBCUDACXX_INLINE_VISIBILITY
 constexpr double
-lerp(double __a, double __b, double __t)                _NOEXCEPT { return __lerp(__a, __b, __t); }
+lerp(double __a, double __b, double __t)                noexcept { return __lerp(__a, __b, __t); }
 
 _LIBCUDACXX_INLINE_VISIBILITY
 constexpr long double
-lerp(long double __a, long double __b, long double __t) _NOEXCEPT { return __lerp(__a, __b, __t); }
+lerp(long double __a, long double __b, long double __t) noexcept { return __lerp(__a, __b, __t); }
 
 #endif // _LIBCUDACXX_STD_VER > 17
 
@@ -937,7 +937,7 @@ template <class _IntT, class _FloatT,
     bool _FloatBigger = (numeric_limits<_FloatT>::digits > numeric_limits<_IntT>::digits),
     int _Bits = (numeric_limits<_IntT>::digits - numeric_limits<_FloatT>::digits)>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR _IntT __max_representable_int_for_float() _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR _IntT __max_representable_int_for_float() noexcept {
   static_assert(is_floating_point<_FloatT>::value, "must be a floating point type");
   static_assert(is_integral<_IntT>::value, "must be an integral type");
   static_assert(numeric_limits<_FloatT>::radix == 2, "FloatT has incorrect radix");
@@ -957,7 +957,7 @@ _LIBCUDACXX_CONSTEXPR _IntT __max_representable_int_for_float() _NOEXCEPT {
 // The behavior is undefined if `__r` is NaN.
 template <class _IntT, class _RealT>
 _LIBCUDACXX_INLINE_VISIBILITY
-_IntT __clamp_to_integral(_RealT __r) _NOEXCEPT {
+_IntT __clamp_to_integral(_RealT __r) noexcept {
   using _Lim = _CUDA_VSTD::numeric_limits<_IntT>;
   const _IntT _MaxVal = _CUDA_VSTD::__max_representable_int_for_float<_IntT, _RealT>();
   if (__r >= ::nextafter(static_cast<_RealT>(_MaxVal), INFINITY)) {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/condition_variable
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/condition_variable
@@ -127,9 +127,9 @@ public:
     condition_variable_any();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void notify_one() _NOEXCEPT;
+    void notify_one() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    void notify_all() _NOEXCEPT;
+    void notify_all() noexcept;
 
     template <class _Lock>
         _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -171,7 +171,7 @@ condition_variable_any::condition_variable_any()
 
 inline
 void
-condition_variable_any::notify_one() _NOEXCEPT
+condition_variable_any::notify_one() noexcept
 {
     {lock_guard<mutex> __lx(*__mut_);}
     __cv_.notify_one();
@@ -179,7 +179,7 @@ condition_variable_any::notify_one() _NOEXCEPT
 
 inline
 void
-condition_variable_any::notify_all() _NOEXCEPT
+condition_variable_any::notify_all() noexcept
 {
     {lock_guard<mutex> __lx(*__mut_);}
     __cv_.notify_all();

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/deque
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/deque
@@ -303,7 +303,7 @@ public:
     typedef random_access_iterator_tag  iterator_category;
     typedef _Reference                  reference;
 
-    _LIBCUDACXX_INLINE_VISIBILITY __deque_iterator() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY __deque_iterator() noexcept
 #if _LIBCUDACXX_STD_VER > 11
      : __m_iter_(nullptr), __ptr_(nullptr)
 #endif
@@ -312,7 +312,7 @@ public:
     template <class _Pp, class _Rp, class _MP>
     _LIBCUDACXX_INLINE_VISIBILITY
     __deque_iterator(const __deque_iterator<value_type, _Pp, _Rp, _MP, difference_type, _BS>& __it,
-                typename enable_if<is_convertible<_Pp, pointer>::value>::type* = 0) _NOEXCEPT
+                typename enable_if<is_convertible<_Pp, pointer>::value>::type* = 0) noexcept
         : __m_iter_(__it.__m_iter_), __ptr_(__it.__ptr_) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY reference operator*() const {return *__ptr_;}
@@ -435,7 +435,7 @@ public:
         {return !(__x < __y);}
 
 private:
-    _LIBCUDACXX_INLINE_VISIBILITY __deque_iterator(__map_iterator __m, pointer __p) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY __deque_iterator(__map_iterator __m, pointer __p) noexcept
         : __m_iter_(__m), __ptr_(__p) {}
 
     template <class _Tp, class _Ap> friend class __deque_base;
@@ -957,7 +957,7 @@ public:
                              difference_type>    const_iterator;
 
     struct __deque_block_range {
-      explicit __deque_block_range(pointer __b, pointer __e) _NOEXCEPT : __begin_(__b), __end_(__e) {}
+      explicit __deque_block_range(pointer __b, pointer __e) noexcept : __begin_(__b), __end_(__e) {}
       const pointer __begin_;
       const pointer __end_;
     };
@@ -966,10 +966,10 @@ public:
       iterator __pos_;
       const iterator __end_;
 
-      __deque_range(iterator __pos, iterator __e) _NOEXCEPT
+      __deque_range(iterator __pos, iterator __e) noexcept
         : __pos_(__pos), __end_(__e) {}
 
-      explicit operator bool() const _NOEXCEPT {
+      explicit operator bool() const noexcept {
         return __pos_ != __end_;
       }
 
@@ -980,14 +980,14 @@ public:
       __deque_range end() const {
         return __deque_range(__end_, __end_);
       }
-      __deque_block_range operator*() const _NOEXCEPT {
+      __deque_block_range operator*() const noexcept {
          if (__pos_.__m_iter_ == __end_.__m_iter_) {
           return __deque_block_range(__pos_.__ptr_, __end_.__ptr_);
         }
         return __deque_block_range(__pos_.__ptr_, *__pos_.__m_iter_ + __block_size);
       }
 
-      __deque_range& operator++() _NOEXCEPT {
+      __deque_range& operator++() noexcept {
         if (__pos_.__m_iter_ == __end_.__m_iter_) {
           __pos_ = __end_;
         } else {
@@ -1029,21 +1029,21 @@ protected:
     size_type __start_;
     __compressed_pair<size_type, allocator_type> __size_;
 
-    iterator       begin() _NOEXCEPT;
-    const_iterator begin() const _NOEXCEPT;
-    iterator       end() _NOEXCEPT;
-    const_iterator end() const _NOEXCEPT;
+    iterator       begin() noexcept;
+    const_iterator begin() const noexcept;
+    iterator       end() noexcept;
+    const_iterator end() const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY size_type&            size()          {return __size_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const size_type& size() const _NOEXCEPT {return __size_.first();}
+    const size_type& size() const noexcept {return __size_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY allocator_type&       __alloc()       {return __size_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const allocator_type& __alloc() const _NOEXCEPT {return __size_.second();}
+    const allocator_type& __alloc() const noexcept {return __size_.second();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __deque_base()
-        _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value);
+        noexcept(is_nothrow_default_constructible<allocator_type>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit __deque_base(const allocator_type& __a);
 public:
@@ -1051,25 +1051,25 @@ public:
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     __deque_base(__deque_base&& __c)
-        _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value);
+        noexcept(is_nothrow_move_constructible<allocator_type>::value);
     __deque_base(__deque_base&& __c, const allocator_type& __a);
 #endif  // _LIBCUDACXX_CXX03_LANG
 
     void swap(__deque_base& __c)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                     __is_nothrow_swappable<allocator_type>::value);
 #endif
 protected:
-    void clear() _NOEXCEPT;
+    void clear() noexcept;
 
     bool __invariants() const;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign(__deque_base& __c)
-        _NOEXCEPT_(__alloc_traits::propagate_on_container_move_assignment::value &&
+        noexcept(__alloc_traits::propagate_on_container_move_assignment::value &&
                    is_nothrow_move_assignable<allocator_type>::value)
     {
         __map_ = _CUDA_VSTD::move(__c.__map_);
@@ -1081,7 +1081,7 @@ protected:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__deque_base& __c)
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_move_assignment::value ||
+        noexcept(!__alloc_traits::propagate_on_container_move_assignment::value ||
                    is_nothrow_move_assignable<allocator_type>::value)
         {__move_assign_alloc(__c, integral_constant<bool,
                       __alloc_traits::propagate_on_container_move_assignment::value>());}
@@ -1089,13 +1089,13 @@ protected:
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__deque_base& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+        noexcept(is_nothrow_move_assignable<allocator_type>::value)
         {
             __alloc() = _CUDA_VSTD::move(__c.__alloc());
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __move_assign_alloc(__deque_base&, false_type) _NOEXCEPT
+    void __move_assign_alloc(__deque_base&, false_type) noexcept
         {}
 };
 
@@ -1135,7 +1135,7 @@ __deque_base<_Tp, _Allocator>::__invariants() const
 
 template <class _Tp, class _Allocator>
 typename __deque_base<_Tp, _Allocator>::iterator
-__deque_base<_Tp, _Allocator>::begin() _NOEXCEPT
+__deque_base<_Tp, _Allocator>::begin() noexcept
 {
     __map_pointer __mp = __map_.begin() + __start_ / __block_size;
     return iterator(__mp, __map_.empty() ? 0 : *__mp + __start_ % __block_size);
@@ -1143,7 +1143,7 @@ __deque_base<_Tp, _Allocator>::begin() _NOEXCEPT
 
 template <class _Tp, class _Allocator>
 typename __deque_base<_Tp, _Allocator>::const_iterator
-__deque_base<_Tp, _Allocator>::begin() const _NOEXCEPT
+__deque_base<_Tp, _Allocator>::begin() const noexcept
 {
     __map_const_pointer __mp = static_cast<__map_const_pointer>(__map_.begin() + __start_ / __block_size);
     return const_iterator(__mp, __map_.empty() ? 0 : *__mp + __start_ % __block_size);
@@ -1151,7 +1151,7 @@ __deque_base<_Tp, _Allocator>::begin() const _NOEXCEPT
 
 template <class _Tp, class _Allocator>
 typename __deque_base<_Tp, _Allocator>::iterator
-__deque_base<_Tp, _Allocator>::end() _NOEXCEPT
+__deque_base<_Tp, _Allocator>::end() noexcept
 {
     size_type __p = size() + __start_;
     __map_pointer __mp = __map_.begin() + __p / __block_size;
@@ -1160,7 +1160,7 @@ __deque_base<_Tp, _Allocator>::end() _NOEXCEPT
 
 template <class _Tp, class _Allocator>
 typename __deque_base<_Tp, _Allocator>::const_iterator
-__deque_base<_Tp, _Allocator>::end() const _NOEXCEPT
+__deque_base<_Tp, _Allocator>::end() const noexcept
 {
     size_type __p = size() + __start_;
     __map_const_pointer __mp = static_cast<__map_const_pointer>(__map_.begin() + __p / __block_size);
@@ -1170,7 +1170,7 @@ __deque_base<_Tp, _Allocator>::end() const _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline
 __deque_base<_Tp, _Allocator>::__deque_base()
-    _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
+    noexcept(is_nothrow_default_constructible<allocator_type>::value)
     : __start_(0), __size_(0) {}
 
 template <class _Tp, class _Allocator>
@@ -1192,7 +1192,7 @@ __deque_base<_Tp, _Allocator>::~__deque_base()
 
 template <class _Tp, class _Allocator>
 __deque_base<_Tp, _Allocator>::__deque_base(__deque_base&& __c)
-    _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
+    noexcept(is_nothrow_move_constructible<allocator_type>::value)
     : __map_(_CUDA_VSTD::move(__c.__map_)),
       __start_(_CUDA_VSTD::move(__c.__start_)),
       __size_(_CUDA_VSTD::move(__c.__size_))
@@ -1226,9 +1226,9 @@ template <class _Tp, class _Allocator>
 void
 __deque_base<_Tp, _Allocator>::swap(__deque_base& __c)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT
+        noexcept
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                     __is_nothrow_swappable<allocator_type>::value)
 #endif
 {
@@ -1240,7 +1240,7 @@ __deque_base<_Tp, _Allocator>::swap(__deque_base& __c)
 
 template <class _Tp, class _Allocator>
 void
-__deque_base<_Tp, _Allocator>::clear() _NOEXCEPT
+__deque_base<_Tp, _Allocator>::clear() noexcept
 {
     allocator_type& __a = __alloc();
     for (iterator __i = begin(), __e = end(); __i != __e; ++__i)
@@ -1297,7 +1297,7 @@ public:
     // construct/copy/destroy:
     _LIBCUDACXX_INLINE_VISIBILITY
     deque()
-        _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
+        noexcept(is_nothrow_default_constructible<allocator_type>::value)
         {}
     _LIBCUDACXX_INLINE_VISIBILITY explicit deque(const allocator_type& __a) : __base(__a) {}
     explicit deque(size_type __n);
@@ -1325,12 +1325,12 @@ public:
     deque& operator=(initializer_list<value_type> __il) {assign(__il); return *this;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    deque(deque&& __c) _NOEXCEPT_(is_nothrow_move_constructible<__base>::value);
+    deque(deque&& __c) noexcept(is_nothrow_move_constructible<__base>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     deque(deque&& __c, const allocator_type& __a);
     _LIBCUDACXX_INLINE_VISIBILITY
     deque& operator=(deque&& __c)
-        _NOEXCEPT_(__alloc_traits::propagate_on_container_move_assignment::value &&
+        noexcept(__alloc_traits::propagate_on_container_move_assignment::value &&
                    is_nothrow_move_assignable<allocator_type>::value);
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1347,76 +1347,76 @@ public:
     void assign(size_type __n, const value_type& __v);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT;
+    allocator_type get_allocator() const noexcept;
 
     // iterators:
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       begin() _NOEXCEPT       {return __base::begin();}
+    iterator       begin() noexcept       {return __base::begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT {return __base::begin();}
+    const_iterator begin() const noexcept {return __base::begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       end() _NOEXCEPT         {return __base::end();}
+    iterator       end() noexcept         {return __base::end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()   const _NOEXCEPT {return __base::end();}
+    const_iterator end()   const noexcept {return __base::end();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator       rbegin() _NOEXCEPT
+    reverse_iterator       rbegin() noexcept
         {return       reverse_iterator(__base::end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin() const _NOEXCEPT
+    const_reverse_iterator rbegin() const noexcept
         {return const_reverse_iterator(__base::end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator       rend() _NOEXCEPT
+    reverse_iterator       rend() noexcept
         {return       reverse_iterator(__base::begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend()   const _NOEXCEPT
+    const_reverse_iterator rend()   const noexcept
         {return const_reverse_iterator(__base::begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator         cbegin()  const _NOEXCEPT
+    const_iterator         cbegin()  const noexcept
         {return __base::begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator         cend()    const _NOEXCEPT
+    const_iterator         cend()    const noexcept
         {return __base::end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT
+    const_reverse_iterator crbegin() const noexcept
         {return const_reverse_iterator(__base::end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend()   const _NOEXCEPT
+    const_reverse_iterator crend()   const noexcept
         {return const_reverse_iterator(__base::begin());}
 
     // capacity:
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT {return __base::size();}
+    size_type size() const noexcept {return __base::size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT
+    size_type max_size() const noexcept
         {return std::min<size_type>(
             __alloc_traits::max_size(__base::__alloc()),
             numeric_limits<difference_type>::max());}
     void resize(size_type __n);
     void resize(size_type __n, const value_type& __v);
-    void shrink_to_fit() _NOEXCEPT;
+    void shrink_to_fit() noexcept;
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT {return __base::size() == 0;}
+    bool empty() const noexcept {return __base::size() == 0;}
 
     // element access:
     _LIBCUDACXX_INLINE_VISIBILITY
-    reference operator[](size_type __i) _NOEXCEPT;
+    reference operator[](size_type __i) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reference operator[](size_type __i) const _NOEXCEPT;
+    const_reference operator[](size_type __i) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
     reference at(size_type __i);
     _LIBCUDACXX_INLINE_VISIBILITY
     const_reference at(size_type __i) const;
     _LIBCUDACXX_INLINE_VISIBILITY
-    reference front() _NOEXCEPT;
+    reference front() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reference front() const _NOEXCEPT;
+    const_reference front() const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    reference back() _NOEXCEPT;
+    reference back() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reference back() const _NOEXCEPT;
+    const_reference back() const noexcept;
 
     // 23.2.2.3 modifiers:
     void push_front(const value_type& __v);
@@ -1461,13 +1461,13 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(deque& __c)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                    __is_nothrow_swappable<allocator_type>::value);
 #endif
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT;
+    void clear() noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     bool __invariants() const {return __base::__invariants();}
@@ -1578,7 +1578,7 @@ public:
         {}
 
     void __move_assign(deque& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value);
+        noexcept(is_nothrow_move_assignable<allocator_type>::value);
     void __move_assign(deque& __c, false_type);
 };
 
@@ -1692,7 +1692,7 @@ deque<_Tp, _Allocator>::deque(initializer_list<value_type> __il, const allocator
 template <class _Tp, class _Allocator>
 inline
 deque<_Tp, _Allocator>::deque(deque&& __c)
-    _NOEXCEPT_(is_nothrow_move_constructible<__base>::value)
+    noexcept(is_nothrow_move_constructible<__base>::value)
     : __base(_CUDA_VSTD::move(__c))
 {
 }
@@ -1713,7 +1713,7 @@ template <class _Tp, class _Allocator>
 inline
 deque<_Tp, _Allocator>&
 deque<_Tp, _Allocator>::operator=(deque&& __c)
-        _NOEXCEPT_(__alloc_traits::propagate_on_container_move_assignment::value &&
+        noexcept(__alloc_traits::propagate_on_container_move_assignment::value &&
                    is_nothrow_move_assignable<allocator_type>::value)
 {
     __move_assign(__c, integral_constant<bool,
@@ -1737,7 +1737,7 @@ deque<_Tp, _Allocator>::__move_assign(deque& __c, false_type)
 template <class _Tp, class _Allocator>
 void
 deque<_Tp, _Allocator>::__move_assign(deque& __c, true_type)
-    _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+    noexcept(is_nothrow_move_assignable<allocator_type>::value)
 {
     clear();
     shrink_to_fit();
@@ -1796,7 +1796,7 @@ deque<_Tp, _Allocator>::assign(size_type __n, const value_type& __v)
 template <class _Tp, class _Allocator>
 inline
 _Allocator
-deque<_Tp, _Allocator>::get_allocator() const _NOEXCEPT
+deque<_Tp, _Allocator>::get_allocator() const noexcept
 {
     return __base::__alloc();
 }
@@ -1823,7 +1823,7 @@ deque<_Tp, _Allocator>::resize(size_type __n, const value_type& __v)
 
 template <class _Tp, class _Allocator>
 void
-deque<_Tp, _Allocator>::shrink_to_fit() _NOEXCEPT
+deque<_Tp, _Allocator>::shrink_to_fit() noexcept
 {
     allocator_type& __a = __base::__alloc();
     if (empty())
@@ -1846,7 +1846,7 @@ deque<_Tp, _Allocator>::shrink_to_fit() _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline
 typename deque<_Tp, _Allocator>::reference
-deque<_Tp, _Allocator>::operator[](size_type __i) _NOEXCEPT
+deque<_Tp, _Allocator>::operator[](size_type __i) noexcept
 {
     size_type __p = __base::__start_ + __i;
     return *(*(__base::__map_.begin() + __p / __base::__block_size) + __p % __base::__block_size);
@@ -1855,7 +1855,7 @@ deque<_Tp, _Allocator>::operator[](size_type __i) _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline
 typename deque<_Tp, _Allocator>::const_reference
-deque<_Tp, _Allocator>::operator[](size_type __i) const _NOEXCEPT
+deque<_Tp, _Allocator>::operator[](size_type __i) const noexcept
 {
     size_type __p = __base::__start_ + __i;
     return *(*(__base::__map_.begin() + __p / __base::__block_size) + __p % __base::__block_size);
@@ -1886,7 +1886,7 @@ deque<_Tp, _Allocator>::at(size_type __i) const
 template <class _Tp, class _Allocator>
 inline
 typename deque<_Tp, _Allocator>::reference
-deque<_Tp, _Allocator>::front() _NOEXCEPT
+deque<_Tp, _Allocator>::front() noexcept
 {
     return *(*(__base::__map_.begin() + __base::__start_ / __base::__block_size)
                                       + __base::__start_ % __base::__block_size);
@@ -1895,7 +1895,7 @@ deque<_Tp, _Allocator>::front() _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline
 typename deque<_Tp, _Allocator>::const_reference
-deque<_Tp, _Allocator>::front() const _NOEXCEPT
+deque<_Tp, _Allocator>::front() const noexcept
 {
     return *(*(__base::__map_.begin() + __base::__start_ / __base::__block_size)
                                       + __base::__start_ % __base::__block_size);
@@ -1904,7 +1904,7 @@ deque<_Tp, _Allocator>::front() const _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline
 typename deque<_Tp, _Allocator>::reference
-deque<_Tp, _Allocator>::back() _NOEXCEPT
+deque<_Tp, _Allocator>::back() noexcept
 {
     size_type __p = __base::size() + __base::__start_ - 1;
     return *(*(__base::__map_.begin() + __p / __base::__block_size) + __p % __base::__block_size);
@@ -1913,7 +1913,7 @@ deque<_Tp, _Allocator>::back() _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline
 typename deque<_Tp, _Allocator>::const_reference
-deque<_Tp, _Allocator>::back() const _NOEXCEPT
+deque<_Tp, _Allocator>::back() const noexcept
 {
     size_type __p = __base::size() + __base::__start_ - 1;
     return *(*(__base::__map_.begin() + __p / __base::__block_size) + __p % __base::__block_size);
@@ -2944,9 +2944,9 @@ inline
 void
 deque<_Tp, _Allocator>::swap(deque& __c)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT
+        noexcept
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                     __is_nothrow_swappable<allocator_type>::value)
 #endif
 {
@@ -2956,7 +2956,7 @@ deque<_Tp, _Allocator>::swap(deque& __c)
 template <class _Tp, class _Allocator>
 inline
 void
-deque<_Tp, _Allocator>::clear() _NOEXCEPT
+deque<_Tp, _Allocator>::clear() noexcept
 {
     __base::clear();
 }
@@ -3014,7 +3014,7 @@ template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(deque<_Tp, _Allocator>& __x, deque<_Tp, _Allocator>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/exception
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/exception
@@ -97,18 +97,18 @@ namespace std  // purposefully not using versioning namespace
 class _LIBCUDACXX_EXCEPTION_ABI exception
 {
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY exception() _NOEXCEPT {}
-    virtual ~exception() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
+    _LIBCUDACXX_INLINE_VISIBILITY exception() noexcept {}
+    virtual ~exception() noexcept;
+    virtual const char* what() const noexcept;
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI bad_exception
     : public exception
 {
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY bad_exception() _NOEXCEPT {}
-    virtual ~bad_exception() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
+    _LIBCUDACXX_INLINE_VISIBILITY bad_exception() noexcept {}
+    virtual ~bad_exception() noexcept;
+    virtual const char* what() const noexcept;
 };
 #endif // !_LIBCUDACXX_ABI_VCRUNTIME
 
@@ -116,22 +116,22 @@ public:
     || defined(_LIBCUDACXX_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS) \
     || defined(_LIBCUDACXX_BUILDING_LIBRARY)
 typedef void (*unexpected_handler)();
-_LIBCUDACXX_FUNC_VIS unexpected_handler set_unexpected(unexpected_handler) _NOEXCEPT;
-_LIBCUDACXX_FUNC_VIS unexpected_handler get_unexpected() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS unexpected_handler set_unexpected(unexpected_handler) noexcept;
+_LIBCUDACXX_FUNC_VIS unexpected_handler get_unexpected() noexcept;
 _LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void unexpected();
 #endif
 
 typedef void (*terminate_handler)();
-_LIBCUDACXX_FUNC_VIS terminate_handler set_terminate(terminate_handler) _NOEXCEPT;
-_LIBCUDACXX_FUNC_VIS terminate_handler get_terminate() _NOEXCEPT;
-_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void terminate() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS terminate_handler set_terminate(terminate_handler) noexcept;
+_LIBCUDACXX_FUNC_VIS terminate_handler get_terminate() noexcept;
+_LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void terminate() noexcept;
 
-_LIBCUDACXX_FUNC_VIS bool uncaught_exception() _NOEXCEPT;
-_LIBCUDACXX_FUNC_VIS _LIBCUDACXX_AVAILABILITY_UNCAUGHT_EXCEPTIONS int uncaught_exceptions() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS bool uncaught_exception() noexcept;
+_LIBCUDACXX_FUNC_VIS _LIBCUDACXX_AVAILABILITY_UNCAUGHT_EXCEPTIONS int uncaught_exceptions() noexcept;
 
 class _LIBCUDACXX_TYPE_VIS exception_ptr;
 
-_LIBCUDACXX_FUNC_VIS exception_ptr current_exception() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS exception_ptr current_exception() noexcept;
 _LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void rethrow_exception(exception_ptr);
 
 #ifndef _LIBCUDACXX_ABI_MICROSOFT
@@ -140,31 +140,31 @@ class _LIBCUDACXX_TYPE_VIS exception_ptr
 {
     void* __ptr_;
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY exception_ptr() _NOEXCEPT : __ptr_() {}
-    _LIBCUDACXX_INLINE_VISIBILITY exception_ptr(nullptr_t) _NOEXCEPT : __ptr_() {}
+    _LIBCUDACXX_INLINE_VISIBILITY exception_ptr() noexcept : __ptr_() {}
+    _LIBCUDACXX_INLINE_VISIBILITY exception_ptr(nullptr_t) noexcept : __ptr_() {}
 
-    exception_ptr(const exception_ptr&) _NOEXCEPT;
-    exception_ptr& operator=(const exception_ptr&) _NOEXCEPT;
-    ~exception_ptr() _NOEXCEPT;
+    exception_ptr(const exception_ptr&) noexcept;
+    exception_ptr& operator=(const exception_ptr&) noexcept;
+    ~exception_ptr() noexcept;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_EXPLICIT operator bool() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_EXPLICIT operator bool() const noexcept
     {return __ptr_ != nullptr;}
 
     friend _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator==(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT
+    bool operator==(const exception_ptr& __x, const exception_ptr& __y) noexcept
         {return __x.__ptr_ == __y.__ptr_;}
 
     friend _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator!=(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT
+    bool operator!=(const exception_ptr& __x, const exception_ptr& __y) noexcept
         {return !(__x == __y);}
 
-    friend _LIBCUDACXX_FUNC_VIS exception_ptr current_exception() _NOEXCEPT;
+    friend _LIBCUDACXX_FUNC_VIS exception_ptr current_exception() noexcept;
     friend _LIBCUDACXX_FUNC_VIS void rethrow_exception(exception_ptr);
 };
 
 template<class _Ep>
 _LIBCUDACXX_INLINE_VISIBILITY exception_ptr
-make_exception_ptr(_Ep __e) _NOEXCEPT
+make_exception_ptr(_Ep __e) noexcept
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     try
@@ -195,26 +195,26 @@ class _LIBCUDACXX_TYPE_VIS exception_ptr
 #pragma clang diagnostic pop
 #endif
 public:
-    exception_ptr() _NOEXCEPT;
-    exception_ptr(nullptr_t) _NOEXCEPT;
-    exception_ptr(const exception_ptr& __other) _NOEXCEPT;
-    exception_ptr& operator=(const exception_ptr& __other) _NOEXCEPT;
-    exception_ptr& operator=(nullptr_t) _NOEXCEPT;
-    ~exception_ptr() _NOEXCEPT;
-    _LIBCUDACXX_EXPLICIT operator bool() const _NOEXCEPT;
+    exception_ptr() noexcept;
+    exception_ptr(nullptr_t) noexcept;
+    exception_ptr(const exception_ptr& __other) noexcept;
+    exception_ptr& operator=(const exception_ptr& __other) noexcept;
+    exception_ptr& operator=(nullptr_t) noexcept;
+    ~exception_ptr() noexcept;
+    _LIBCUDACXX_EXPLICIT operator bool() const noexcept;
 };
 
 _LIBCUDACXX_FUNC_VIS
-bool operator==(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT;
+bool operator==(const exception_ptr& __x, const exception_ptr& __y) noexcept;
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator!=(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT
+bool operator!=(const exception_ptr& __x, const exception_ptr& __y) noexcept
     {return !(__x == __y);}
 
-_LIBCUDACXX_FUNC_VIS void swap(exception_ptr&, exception_ptr&) _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS void swap(exception_ptr&, exception_ptr&) noexcept;
 
 _LIBCUDACXX_FUNC_VIS exception_ptr __copy_exception_ptr(void *__except, const void* __ptr);
-_LIBCUDACXX_FUNC_VIS exception_ptr current_exception() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS exception_ptr current_exception() noexcept;
 _LIBCUDACXX_NORETURN _LIBCUDACXX_FUNC_VIS void rethrow_exception(exception_ptr p);
 
 // This is a built-in template function which automagically extracts the required
@@ -223,7 +223,7 @@ template <class _E> void *__GetExceptionInfo(_E);
 
 template<class _Ep>
 _LIBCUDACXX_INLINE_VISIBILITY exception_ptr
-make_exception_ptr(_Ep __e) _NOEXCEPT
+make_exception_ptr(_Ep __e) noexcept
 {
   return __copy_exception_ptr(_CUDA_VSTD::addressof(__e), __GetExceptionInfo(__e));
 }
@@ -235,14 +235,14 @@ class _LIBCUDACXX_EXCEPTION_ABI nested_exception
 {
     exception_ptr __ptr_;
 public:
-    nested_exception() _NOEXCEPT;
+    nested_exception() noexcept;
 //     nested_exception(const nested_exception&) noexcept = default;
 //     nested_exception& operator=(const nested_exception&) noexcept = default;
-    virtual ~nested_exception() _NOEXCEPT;
+    virtual ~nested_exception() noexcept;
 
     // access functions
     _LIBCUDACXX_NORETURN void rethrow_nested() const;
-    _LIBCUDACXX_INLINE_VISIBILITY exception_ptr nested_ptr() const _NOEXCEPT {return __ptr_;}
+    _LIBCUDACXX_INLINE_VISIBILITY exception_ptr nested_ptr() const noexcept {return __ptr_;}
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/coroutine
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/coroutine
@@ -26,12 +26,12 @@ class coroutine_traits;
 template <typename Promise = void>
 class coroutine_handle;
 // 18.11.2.7 comparison operators:
-bool operator==(coroutine_handle<> x, coroutine_handle<> y) _NOEXCEPT;
-bool operator!=(coroutine_handle<> x, coroutine_handle<> y) _NOEXCEPT;
-bool operator<(coroutine_handle<> x, coroutine_handle<> y) _NOEXCEPT;
-bool operator<=(coroutine_handle<> x, coroutine_handle<> y) _NOEXCEPT;
-bool operator>=(coroutine_handle<> x, coroutine_handle<> y) _NOEXCEPT;
-bool operator>(coroutine_handle<> x, coroutine_handle<> y) _NOEXCEPT;
+bool operator==(coroutine_handle<> x, coroutine_handle<> y) noexcept;
+bool operator!=(coroutine_handle<> x, coroutine_handle<> y) noexcept;
+bool operator<(coroutine_handle<> x, coroutine_handle<> y) noexcept;
+bool operator<=(coroutine_handle<> x, coroutine_handle<> y) noexcept;
+bool operator>=(coroutine_handle<> x, coroutine_handle<> y) noexcept;
+bool operator>(coroutine_handle<> x, coroutine_handle<> y) noexcept;
 // 18.11.3 trivial awaitables
 struct suspend_never;
 struct suspend_always;
@@ -92,22 +92,22 @@ template <>
 class _LIBCUDACXX_TEMPLATE_VIS coroutine_handle<void> {
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR coroutine_handle() _NOEXCEPT : __handle_(nullptr) {}
+    _LIBCUDACXX_CONSTEXPR coroutine_handle() noexcept : __handle_(nullptr) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR coroutine_handle(nullptr_t) _NOEXCEPT : __handle_(nullptr) {}
+    _LIBCUDACXX_CONSTEXPR coroutine_handle(nullptr_t) noexcept : __handle_(nullptr) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    coroutine_handle& operator=(nullptr_t) _NOEXCEPT {
+    coroutine_handle& operator=(nullptr_t) noexcept {
         __handle_ = nullptr;
         return *this;
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR void* address() const _NOEXCEPT { return __handle_; }
+    _LIBCUDACXX_CONSTEXPR void* address() const noexcept { return __handle_; }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR explicit operator bool() const _NOEXCEPT { return __handle_; }
+    _LIBCUDACXX_CONSTEXPR explicit operator bool() const noexcept { return __handle_; }
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void operator()() { resume(); }
@@ -137,7 +137,7 @@ public:
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    static coroutine_handle from_address(void* __addr) _NOEXCEPT {
+    static coroutine_handle from_address(void* __addr) noexcept {
         coroutine_handle __tmp;
         __tmp.__handle_ = __addr;
         return __tmp;
@@ -145,7 +145,7 @@ public:
 
     // FIXME: Should from_address(nullptr) be allowed?
     _LIBCUDACXX_INLINE_VISIBILITY
-    static coroutine_handle from_address(nullptr_t) _NOEXCEPT {
+    static coroutine_handle from_address(nullptr_t) noexcept {
       return coroutine_handle(nullptr);
     }
 
@@ -157,7 +157,7 @@ public:
     }
 
 private:
-  bool __is_suspended() const _NOEXCEPT  {
+  bool __is_suspended() const noexcept  {
     // FIXME actually implement a check for if the coro is suspended.
     return __handle_;
   }
@@ -168,27 +168,27 @@ private:
 
 // 18.11.2.7 comparison operators:
 inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator==(coroutine_handle<> __x, coroutine_handle<> __y) _NOEXCEPT {
+bool operator==(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
     return __x.address() == __y.address();
 }
 inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator!=(coroutine_handle<> __x, coroutine_handle<> __y) _NOEXCEPT {
+bool operator!=(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
     return !(__x == __y);
 }
 inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator<(coroutine_handle<> __x, coroutine_handle<> __y) _NOEXCEPT {
+bool operator<(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
     return less<void*>()(__x.address(), __y.address());
 }
 inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator>(coroutine_handle<> __x, coroutine_handle<> __y) _NOEXCEPT {
+bool operator>(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
     return __y < __x;
 }
 inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator<=(coroutine_handle<> __x, coroutine_handle<> __y) _NOEXCEPT {
+bool operator<=(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
     return !(__x > __y);
 }
 inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator>=(coroutine_handle<> __x, coroutine_handle<> __y) _NOEXCEPT {
+bool operator>=(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
     return !(__x < __y);
 }
 
@@ -200,11 +200,11 @@ public:
     // 18.11.2.1 construct/reset
     using coroutine_handle<>::coroutine_handle;
 #else
-    _LIBCUDACXX_INLINE_VISIBILITY coroutine_handle() _NOEXCEPT : _Base() {}
-    _LIBCUDACXX_INLINE_VISIBILITY coroutine_handle(nullptr_t) _NOEXCEPT : _Base(nullptr) {}
+    _LIBCUDACXX_INLINE_VISIBILITY coroutine_handle() noexcept : _Base() {}
+    _LIBCUDACXX_INLINE_VISIBILITY coroutine_handle(nullptr_t) noexcept : _Base(nullptr) {}
 #endif
     _LIBCUDACXX_INLINE_VISIBILITY
-    coroutine_handle& operator=(nullptr_t) _NOEXCEPT {
+    coroutine_handle& operator=(nullptr_t) noexcept {
         _Base::operator=(nullptr);
         return *this;
     }
@@ -217,7 +217,7 @@ public:
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    static coroutine_handle from_address(void* __addr) _NOEXCEPT {
+    static coroutine_handle from_address(void* __addr) noexcept {
         coroutine_handle __tmp;
         __tmp.__handle_ = __addr;
         return __tmp;
@@ -228,7 +228,7 @@ public:
     // ambiguous.
     // FIXME: should from_address work with nullptr?
     _LIBCUDACXX_INLINE_VISIBILITY
-    static coroutine_handle from_address(nullptr_t) _NOEXCEPT {
+    static coroutine_handle from_address(nullptr_t) noexcept {
       return coroutine_handle(nullptr);
     }
 
@@ -247,7 +247,7 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static coroutine_handle from_promise(_Promise& __promise) _NOEXCEPT {
+    static coroutine_handle from_promise(_Promise& __promise) noexcept {
         typedef __remove_cv_t<_Promise> _RawPromise;
         coroutine_handle __tmp;
         __tmp.__handle_ = __builtin_coro_promise(
@@ -273,18 +273,18 @@ public:
       __builtin_coro_promise(this->__handle_, _LIBCUDACXX_ALIGNOF(_Promise), false));
   }
 
-  _LIBCUDACXX_CONSTEXPR explicit operator bool() const _NOEXCEPT { return true; }
-  _LIBCUDACXX_CONSTEXPR bool done() const _NOEXCEPT { return false; }
+  _LIBCUDACXX_CONSTEXPR explicit operator bool() const noexcept { return true; }
+  _LIBCUDACXX_CONSTEXPR bool done() const noexcept { return false; }
 
-  _LIBCUDACXX_CONSTEXPR_AFTER_CXX17 void operator()() const _NOEXCEPT {}
-  _LIBCUDACXX_CONSTEXPR_AFTER_CXX17 void resume() const _NOEXCEPT {}
-  _LIBCUDACXX_CONSTEXPR_AFTER_CXX17 void destroy() const _NOEXCEPT {}
+  _LIBCUDACXX_CONSTEXPR_AFTER_CXX17 void operator()() const noexcept {}
+  _LIBCUDACXX_CONSTEXPR_AFTER_CXX17 void resume() const noexcept {}
+  _LIBCUDACXX_CONSTEXPR_AFTER_CXX17 void destroy() const noexcept {}
 
 private:
   _LIBCUDACXX_INLINE_VISIBILITY
-  friend coroutine_handle<noop_coroutine_promise> noop_coroutine() _NOEXCEPT;
+  friend coroutine_handle<noop_coroutine_promise> noop_coroutine() noexcept;
 
-  _LIBCUDACXX_INLINE_VISIBILITY coroutine_handle() _NOEXCEPT {
+  _LIBCUDACXX_INLINE_VISIBILITY coroutine_handle() noexcept {
     this->__handle_ = __builtin_coro_noop();
   }
 };
@@ -292,27 +292,27 @@ private:
 using noop_coroutine_handle = coroutine_handle<noop_coroutine_promise>;
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-noop_coroutine_handle noop_coroutine() _NOEXCEPT {
+noop_coroutine_handle noop_coroutine() noexcept {
   return noop_coroutine_handle();
 }
 #endif // __has_builtin(__builtin_coro_noop)
 
 struct suspend_never {
   _LIBCUDACXX_INLINE_VISIBILITY
-  bool await_ready() const _NOEXCEPT { return true; }
+  bool await_ready() const noexcept { return true; }
   _LIBCUDACXX_INLINE_VISIBILITY
-  void await_suspend(coroutine_handle<>) const _NOEXCEPT {}
+  void await_suspend(coroutine_handle<>) const noexcept {}
   _LIBCUDACXX_INLINE_VISIBILITY
-  void await_resume() const _NOEXCEPT {}
+  void await_resume() const noexcept {}
 };
 
 struct suspend_always {
   _LIBCUDACXX_INLINE_VISIBILITY
-  bool await_ready() const _NOEXCEPT { return false; }
+  bool await_ready() const noexcept { return false; }
   _LIBCUDACXX_INLINE_VISIBILITY
-  void await_suspend(coroutine_handle<>) const _NOEXCEPT {}
+  void await_suspend(coroutine_handle<>) const noexcept {}
   _LIBCUDACXX_INLINE_VISIBILITY
-  void await_resume() const _NOEXCEPT {}
+  void await_resume() const noexcept {}
 };
 
 _LIBCUDACXX_END_NAMESPACE_EXPERIMENTAL_COROUTINES
@@ -323,7 +323,7 @@ template <class _Tp>
 struct hash<_CUDA_VSTD_CORO::coroutine_handle<_Tp> > {
     using __arg_type = _CUDA_VSTD_CORO::coroutine_handle<_Tp>;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(__arg_type const& __v) const _NOEXCEPT
+    size_t operator()(__arg_type const& __v) const noexcept
     {return hash<void*>()(__v.address());}
 };
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/iterator
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/iterator
@@ -90,9 +90,9 @@ public:
         return *this;
     }
 
-    ostream_joiner& operator*()     _NOEXCEPT { return *this; }
-    ostream_joiner& operator++()    _NOEXCEPT { return *this; }
-    ostream_joiner& operator++(int) _NOEXCEPT { return *this; }
+    ostream_joiner& operator*()     noexcept { return *this; }
+    ostream_joiner& operator++()    noexcept { return *this; }
+    ostream_joiner& operator++(int) noexcept { return *this; }
 
 private:
     ostream_type*   __output_iter;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/memory_resource
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/memory_resource
@@ -88,7 +88,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_LFTS_PMR
 
 // Round __s up to next multiple of __a.
 inline _LIBCUDACXX_INLINE_VISIBILITY
-size_t __aligned_allocation_size(size_t __s, size_t __a) _NOEXCEPT
+size_t __aligned_allocation_size(size_t __s, size_t __a) noexcept
 {
     _LIBCUDACXX_ASSERT(__s + __a > __s, "aligned allocation size overflows");
     return (__s + __a - 1) & ~(__a - 1);
@@ -112,42 +112,42 @@ public:
         { do_deallocate(__p, __bytes, __align); }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool is_equal(memory_resource const & __other) const _NOEXCEPT
+    bool is_equal(memory_resource const & __other) const noexcept
         { return do_is_equal(__other); }
 
 // 8.5.3, memory.resource.priv
 protected:
     virtual void* do_allocate(size_t, size_t) = 0;
     virtual void do_deallocate(void*, size_t, size_t) = 0;
-    virtual bool do_is_equal(memory_resource const &) const _NOEXCEPT = 0;
+    virtual bool do_is_equal(memory_resource const &) const noexcept = 0;
 };
 
 // 8.5.4, memory.resource.eq
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool operator==(memory_resource const & __lhs,
-                memory_resource const & __rhs) _NOEXCEPT
+                memory_resource const & __rhs) noexcept
 {
     return &__lhs == &__rhs || __lhs.is_equal(__rhs);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool operator!=(memory_resource const & __lhs,
-                memory_resource const & __rhs) _NOEXCEPT
+                memory_resource const & __rhs) noexcept
 {
     return !(__lhs == __rhs);
 }
 
 _LIBCUDACXX_FUNC_VIS
-memory_resource * new_delete_resource() _NOEXCEPT;
+memory_resource * new_delete_resource() noexcept;
 
 _LIBCUDACXX_FUNC_VIS
-memory_resource * null_memory_resource() _NOEXCEPT;
+memory_resource * null_memory_resource() noexcept;
 
 _LIBCUDACXX_FUNC_VIS
-memory_resource * get_default_resource() _NOEXCEPT;
+memory_resource * get_default_resource() noexcept;
 
 _LIBCUDACXX_FUNC_VIS
-memory_resource * set_default_resource(memory_resource * __new_res) _NOEXCEPT;
+memory_resource * set_default_resource(memory_resource * __new_res) noexcept;
 
 // 8.6, memory.polymorphic.allocator.class
 
@@ -160,12 +160,12 @@ public:
 
     // 8.6.2, memory.polymorphic.allocator.ctor
     _LIBCUDACXX_INLINE_VISIBILITY
-    polymorphic_allocator() _NOEXCEPT
+    polymorphic_allocator() noexcept
       : __res_(_CUDA_VSTD_LFTS_PMR::get_default_resource())
     {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    polymorphic_allocator(memory_resource * __r) _NOEXCEPT
+    polymorphic_allocator(memory_resource * __r) noexcept
       : __res_(__r)
     {}
 
@@ -173,7 +173,7 @@ public:
 
     template <class _Tp>
     _LIBCUDACXX_INLINE_VISIBILITY
-    polymorphic_allocator(polymorphic_allocator<_Tp> const & __other) _NOEXCEPT
+    polymorphic_allocator(polymorphic_allocator<_Tp> const & __other) noexcept
       : __res_(__other.resource())
     {}
 
@@ -194,7 +194,7 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void deallocate(_ValueType * __p, size_t __n) _NOEXCEPT {
+    void deallocate(_ValueType * __p, size_t __n) noexcept {
         _LIBCUDACXX_ASSERT(__n <= __max_size(),
                        "deallocate called for size which exceeds max_size()");
         __res_->deallocate(__p, __n * sizeof(_ValueType), _LIBCUDACXX_ALIGNOF(_ValueType));
@@ -264,16 +264,16 @@ public:
 
     template <class _Tp>
     _LIBCUDACXX_INLINE_VISIBILITY
-    void destroy(_Tp * __p) _NOEXCEPT
+    void destroy(_Tp * __p) noexcept
         { __p->~_Tp(); }
 
     _LIBCUDACXX_INLINE_VISIBILITY
     polymorphic_allocator
-    select_on_container_copy_construction() const _NOEXCEPT
+    select_on_container_copy_construction() const noexcept
         { return polymorphic_allocator(); }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    memory_resource * resource() const _NOEXCEPT
+    memory_resource * resource() const noexcept
         { return __res_; }
 
 private:
@@ -308,7 +308,7 @@ private:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t __max_size() const _NOEXCEPT
+    size_t __max_size() const noexcept
         { return numeric_limits<size_t>::max() / sizeof(value_type); }
 
     memory_resource * __res_;
@@ -319,7 +319,7 @@ private:
 template <class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool operator==(polymorphic_allocator<_Tp> const & __lhs,
-                polymorphic_allocator<_Up> const & __rhs) _NOEXCEPT
+                polymorphic_allocator<_Up> const & __rhs) noexcept
 {
     return *__lhs.resource() == *__rhs.resource();
 }
@@ -327,7 +327,7 @@ bool operator==(polymorphic_allocator<_Tp> const & __lhs,
 template <class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool operator!=(polymorphic_allocator<_Tp> const & __lhs,
-                polymorphic_allocator<_Up> const & __rhs) _NOEXCEPT
+                polymorphic_allocator<_Up> const & __rhs) noexcept
 {
     return !(__lhs == __rhs);
 }
@@ -401,7 +401,7 @@ protected:
         __alloc_.deallocate((_ValueType*)__p, __s);
     }
 
-    virtual bool do_is_equal(memory_resource const & __other) const _NOEXCEPT {
+    virtual bool do_is_equal(memory_resource const & __other) const noexcept {
         __resource_adaptor_imp const * __p
           = dynamic_cast<__resource_adaptor_imp const *>(&__other);
         return __p  ? __alloc_ == __p->__alloc_ : false;
@@ -409,7 +409,7 @@ protected:
 
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t __max_size() const _NOEXCEPT {
+    size_t __max_size() const noexcept {
         return numeric_limits<size_t>::max() - _MaxAlign;
     }
 };

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/propagate_const
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/propagate_const
@@ -125,11 +125,11 @@ class propagate_const;
 
 template <class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const _Up& get_underlying(const propagate_const<_Up>& __pu) _NOEXCEPT;
+const _Up& get_underlying(const propagate_const<_Up>& __pu) noexcept;
 
 template <class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-_Up& get_underlying(propagate_const<_Up>& __pu) _NOEXCEPT;
+_Up& get_underlying(propagate_const<_Up>& __pu) noexcept;
 
 template <class _Tp>
 class propagate_const
@@ -185,8 +185,8 @@ private:
 
 public:
 
-  template <class _Up> friend _LIBCUDACXX_CONSTEXPR const _Up& ::_CUDA_VSTD_LFTS_V2::get_underlying(const propagate_const<_Up>& __pu) _NOEXCEPT;
-  template <class _Up> friend _LIBCUDACXX_CONSTEXPR _Up& ::_CUDA_VSTD_LFTS_V2::get_underlying(propagate_const<_Up>& __pu) _NOEXCEPT;
+  template <class _Up> friend _LIBCUDACXX_CONSTEXPR const _Up& ::_CUDA_VSTD_LFTS_V2::get_underlying(const propagate_const<_Up>& __pu) noexcept;
+  template <class _Up> friend _LIBCUDACXX_CONSTEXPR _Up& ::_CUDA_VSTD_LFTS_V2::get_underlying(propagate_const<_Up>& __pu) noexcept;
 
   _LIBCUDACXX_CONSTEXPR propagate_const() = default;
 
@@ -289,7 +289,7 @@ public:
     return *get();
   }
 
-  _LIBCUDACXX_CONSTEXPR void swap(propagate_const& __pt) _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value)
+  _LIBCUDACXX_CONSTEXPR void swap(propagate_const& __pt) noexcept(__is_nothrow_swappable<_Tp>::value)
   {
     using _CUDA_VSTD::swap;
     swap(__t_, __pt.__t_);
@@ -460,19 +460,19 @@ _LIBCUDACXX_CONSTEXPR bool operator>=(const _Tp& __t, const propagate_const<_Up>
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR void swap(propagate_const<_Tp>& __pc1, propagate_const<_Tp>& __pc2) _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value)
+_LIBCUDACXX_CONSTEXPR void swap(propagate_const<_Tp>& __pc1, propagate_const<_Tp>& __pc2) noexcept(__is_nothrow_swappable<_Tp>::value)
 {
   __pc1.swap(__pc2);
 }
 
 template <class _Tp>
-_LIBCUDACXX_CONSTEXPR const _Tp& get_underlying(const propagate_const<_Tp>& __pt) _NOEXCEPT
+_LIBCUDACXX_CONSTEXPR const _Tp& get_underlying(const propagate_const<_Tp>& __pt) noexcept
 {
   return __pt.__t_;
 }
 
 template <class _Tp>
-_LIBCUDACXX_CONSTEXPR _Tp& get_underlying(propagate_const<_Tp>& __pt) _NOEXCEPT
+_LIBCUDACXX_CONSTEXPR _Tp& get_underlying(propagate_const<_Tp>& __pt) noexcept
 {
   return __pt.__t_;
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/ext/__hash
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/ext/__hash
@@ -23,7 +23,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<const char*>
  : public std::__unary_function<const char*, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(const char *__c) const _NOEXCEPT
+    size_t operator()(const char *__c) const noexcept
     {
         return std::__do_string_hash(__c, __c + strlen(__c));
     }
@@ -33,7 +33,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<char *>
  : public std::__unary_function<char*, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(char *__c) const _NOEXCEPT
+    size_t operator()(char *__c) const noexcept
     {
         return std::__do_string_hash<const char *>(__c, __c + strlen(__c));
     }
@@ -43,7 +43,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<char>
  : public std::__unary_function<char, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(char __c) const _NOEXCEPT
+    size_t operator()(char __c) const noexcept
     {
         return __c;
     }
@@ -53,7 +53,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<signed char>
  : public std::__unary_function<signed char, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(signed char __c) const _NOEXCEPT
+    size_t operator()(signed char __c) const noexcept
     {
         return __c;
     }
@@ -63,7 +63,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<unsigned char>
  : public std::__unary_function<unsigned char, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(unsigned char __c) const _NOEXCEPT
+    size_t operator()(unsigned char __c) const noexcept
     {
         return __c;
     }
@@ -73,7 +73,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<short>
  : public std::__unary_function<short, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(short __c) const _NOEXCEPT
+    size_t operator()(short __c) const noexcept
     {
         return __c;
     }
@@ -83,7 +83,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<unsigned short>
  : public std::__unary_function<unsigned short, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(unsigned short __c) const _NOEXCEPT
+    size_t operator()(unsigned short __c) const noexcept
     {
         return __c;
     }
@@ -93,7 +93,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<int>
     : public std::__unary_function<int, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(int __c) const _NOEXCEPT
+    size_t operator()(int __c) const noexcept
     {
         return __c;
     }
@@ -103,7 +103,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<unsigned int>
     : public std::__unary_function<unsigned int, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(unsigned int __c) const _NOEXCEPT
+    size_t operator()(unsigned int __c) const noexcept
     {
         return __c;
     }
@@ -113,7 +113,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<long>
     : public std::__unary_function<long, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(long __c) const _NOEXCEPT
+    size_t operator()(long __c) const noexcept
     {
         return __c;
     }
@@ -123,7 +123,7 @@ template <> struct _LIBCUDACXX_TEMPLATE_VIS hash<unsigned long>
     : public std::__unary_function<unsigned long, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(unsigned long __c) const _NOEXCEPT
+    size_t operator()(unsigned long __c) const noexcept
     {
         return __c;
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/forward_list
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/forward_list
@@ -305,14 +305,14 @@ class _LIBCUDACXX_TEMPLATE_VIS __forward_list_iterator
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __forward_list_iterator(nullptr_t) _NOEXCEPT : __ptr_(nullptr) {}
+    explicit __forward_list_iterator(nullptr_t) noexcept : __ptr_(nullptr) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __forward_list_iterator(__begin_node_pointer __p) _NOEXCEPT
+    explicit __forward_list_iterator(__begin_node_pointer __p) noexcept
         : __ptr_(__traits::__as_iter_node(__p)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __forward_list_iterator(__node_pointer __p) _NOEXCEPT
+    explicit __forward_list_iterator(__node_pointer __p) noexcept
         : __ptr_(__traits::__as_iter_node(__p)) {}
 
     template<class, class> friend class _LIBCUDACXX_TEMPLATE_VIS forward_list;
@@ -327,7 +327,7 @@ public:
     typedef typename __rebind_pointer<__node_pointer, value_type>::type pointer;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __forward_list_iterator() _NOEXCEPT : __ptr_(nullptr) {}
+    __forward_list_iterator() noexcept : __ptr_(nullptr) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     reference operator*() const {return __get_unsafe_node_pointer()->__value_;}
@@ -385,15 +385,15 @@ class _LIBCUDACXX_TEMPLATE_VIS __forward_list_const_iterator
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __forward_list_const_iterator(nullptr_t) _NOEXCEPT
+    explicit __forward_list_const_iterator(nullptr_t) noexcept
         : __ptr_(nullptr) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __forward_list_const_iterator(__begin_node_pointer __p) _NOEXCEPT
+    explicit __forward_list_const_iterator(__begin_node_pointer __p) noexcept
         : __ptr_(__traits::__as_iter_node(__p)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __forward_list_const_iterator(__node_pointer __p) _NOEXCEPT
+    explicit __forward_list_const_iterator(__node_pointer __p) noexcept
         : __ptr_(__traits::__as_iter_node(__p)) {}
 
 
@@ -409,9 +409,9 @@ public:
                                                               pointer;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __forward_list_const_iterator() _NOEXCEPT : __ptr_(nullptr) {}
+    __forward_list_const_iterator() noexcept : __ptr_(nullptr) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    __forward_list_const_iterator(__forward_list_iterator<__node_pointer> __p) _NOEXCEPT
+    __forward_list_const_iterator(__forward_list_iterator<__node_pointer> __p) noexcept
         : __ptr_(__p.__ptr_) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -471,17 +471,17 @@ protected:
     __compressed_pair<__begin_node, __node_allocator> __before_begin_;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __begin_node_pointer        __before_begin() _NOEXCEPT
+    __begin_node_pointer        __before_begin() noexcept
         {return pointer_traits<__begin_node_pointer>::pointer_to(__before_begin_.first());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    __begin_node_pointer __before_begin() const _NOEXCEPT
+    __begin_node_pointer __before_begin() const noexcept
         {return pointer_traits<__begin_node_pointer>::pointer_to(const_cast<__begin_node&>(__before_begin_.first()));}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          __node_allocator& __alloc() _NOEXCEPT
+          __node_allocator& __alloc() noexcept
             {return __before_begin_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const __node_allocator& __alloc() const _NOEXCEPT
+    const __node_allocator& __alloc() const noexcept
         {return __before_begin_.second();}
 
     typedef __forward_list_iterator<__node_pointer>             iterator;
@@ -489,7 +489,7 @@ protected:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __forward_list_base()
-        _NOEXCEPT_(is_nothrow_default_constructible<__node_allocator>::value)
+        noexcept(is_nothrow_default_constructible<__node_allocator>::value)
         : __before_begin_(__begin_node()) {}
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit __forward_list_base(const allocator_type& __a)
@@ -501,7 +501,7 @@ protected:
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     __forward_list_base(__forward_list_base&& __x)
-        _NOEXCEPT_(is_nothrow_move_constructible<__node_allocator>::value);
+        noexcept(is_nothrow_move_constructible<__node_allocator>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     __forward_list_base(__forward_list_base&& __x, const allocator_type& __a);
 #endif  // _LIBCUDACXX_CXX03_LANG
@@ -521,7 +521,7 @@ protected:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__forward_list_base& __x)
-        _NOEXCEPT_(!__node_traits::propagate_on_container_move_assignment::value ||
+        noexcept(!__node_traits::propagate_on_container_move_assignment::value ||
                    is_nothrow_move_assignable<__node_allocator>::value)
         {__move_assign_alloc(__x, integral_constant<bool,
               __node_traits::propagate_on_container_move_assignment::value>());}
@@ -530,13 +530,13 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(__forward_list_base& __x)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(!__node_traits::propagate_on_container_move_assignment::value ||
+        noexcept(!__node_traits::propagate_on_container_move_assignment::value ||
                     __is_nothrow_swappable<__node_allocator>::value);
 #endif
 protected:
-    void clear() _NOEXCEPT;
+    void clear() noexcept;
 
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -550,11 +550,11 @@ private:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __move_assign_alloc(__forward_list_base&, false_type) _NOEXCEPT
+    void __move_assign_alloc(__forward_list_base&, false_type) noexcept
         {}
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__forward_list_base& __x, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<__node_allocator>::value)
+        noexcept(is_nothrow_move_assignable<__node_allocator>::value)
         {__alloc() = _CUDA_VSTD::move(__x.__alloc());}
 };
 
@@ -563,7 +563,7 @@ private:
 template <class _Tp, class _Alloc>
 inline
 __forward_list_base<_Tp, _Alloc>::__forward_list_base(__forward_list_base&& __x)
-        _NOEXCEPT_(is_nothrow_move_constructible<__node_allocator>::value)
+        noexcept(is_nothrow_move_constructible<__node_allocator>::value)
     : __before_begin_(_CUDA_VSTD::move(__x.__before_begin_))
 {
     __x.__before_begin()->__next_ = nullptr;
@@ -595,9 +595,9 @@ inline
 void
 __forward_list_base<_Tp, _Alloc>::swap(__forward_list_base& __x)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT
+        noexcept
 #else
-        _NOEXCEPT_(!__node_traits::propagate_on_container_move_assignment::value ||
+        noexcept(!__node_traits::propagate_on_container_move_assignment::value ||
                     __is_nothrow_swappable<__node_allocator>::value)
 #endif
 {
@@ -609,7 +609,7 @@ __forward_list_base<_Tp, _Alloc>::swap(__forward_list_base& __x)
 
 template <class _Tp, class _Alloc>
 void
-__forward_list_base<_Tp, _Alloc>::clear() _NOEXCEPT
+__forward_list_base<_Tp, _Alloc>::clear() noexcept
 {
     __node_allocator& __a = __alloc();
     for (__node_pointer __p = __before_begin()->__next_; __p != nullptr;)
@@ -657,7 +657,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     forward_list()
-        _NOEXCEPT_(is_nothrow_default_constructible<__node_allocator>::value)
+        noexcept(is_nothrow_default_constructible<__node_allocator>::value)
         {} // = default;
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit forward_list(const allocator_type& __a);
@@ -686,7 +686,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     forward_list(forward_list&& __x)
-        _NOEXCEPT_(is_nothrow_move_constructible<base>::value)
+        noexcept(is_nothrow_move_constructible<base>::value)
         : base(_CUDA_VSTD::move(__x)) {}
     forward_list(forward_list&& __x, const allocator_type& __a);
 
@@ -695,7 +695,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     forward_list& operator=(forward_list&& __x)
-        _NOEXCEPT_(
+        noexcept(
              __node_traits::propagate_on_container_move_assignment::value &&
              is_nothrow_move_assignable<allocator_type>::value);
 
@@ -718,44 +718,44 @@ public:
     void assign(size_type __n, const value_type& __v);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT
+    allocator_type get_allocator() const noexcept
         {return allocator_type(base::__alloc());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       begin() _NOEXCEPT
+    iterator       begin() noexcept
         {return       iterator(base::__before_begin()->__next_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT
+    const_iterator begin() const noexcept
         {return const_iterator(base::__before_begin()->__next_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       end() _NOEXCEPT
+    iterator       end() noexcept
         {return       iterator(nullptr);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end() const _NOEXCEPT
+    const_iterator end() const noexcept
         {return const_iterator(nullptr);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT
+    const_iterator cbegin() const noexcept
         {return const_iterator(base::__before_begin()->__next_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend() const _NOEXCEPT
+    const_iterator cend() const noexcept
         {return const_iterator(nullptr);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       before_begin() _NOEXCEPT
+    iterator       before_begin() noexcept
         {return       iterator(base::__before_begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator before_begin() const _NOEXCEPT
+    const_iterator before_begin() const noexcept
         {return const_iterator(base::__before_begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbefore_begin() const _NOEXCEPT
+    const_iterator cbefore_begin() const noexcept
         {return const_iterator(base::__before_begin());}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT
+    bool empty() const noexcept
         {return base::__before_begin()->__next_ == nullptr;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {
+    size_type max_size() const noexcept {
         return std::min<size_type>(
             __node_traits::max_size(base::__alloc()),
             numeric_limits<difference_type>::max());
@@ -803,9 +803,9 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(forward_list& __x)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT
+        noexcept
 #else
-        _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value ||
+        noexcept(!__node_traits::propagate_on_container_swap::value ||
                    __is_nothrow_swappable<__node_allocator>::value)
 #endif
         {base::swap(__x);}
@@ -813,7 +813,7 @@ public:
     void resize(size_type __n);
     void resize(size_type __n, const value_type& __v);
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {base::clear();}
+    void clear() noexcept {base::clear();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void splice_after(const_iterator __p, forward_list&& __x);
@@ -845,13 +845,13 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     void sort() {sort(__less<value_type>());}
     template <class _Compare> _LIBCUDACXX_INLINE_VISIBILITY void sort(_Compare __comp);
-    void reverse() _NOEXCEPT;
+    void reverse() noexcept;
 
 private:
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     void __move_assign(forward_list& __x, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value);
+        noexcept(is_nothrow_move_assignable<allocator_type>::value);
     void __move_assign(forward_list& __x, false_type);
 #endif  // _LIBCUDACXX_CXX03_LANG
 
@@ -1025,7 +1025,7 @@ forward_list<_Tp, _Alloc>::forward_list(initializer_list<value_type> __il,
 template <class _Tp, class _Alloc>
 void
 forward_list<_Tp, _Alloc>::__move_assign(forward_list& __x, true_type)
-    _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+    noexcept(is_nothrow_move_assignable<allocator_type>::value)
 {
     clear();
     base::__move_assign_alloc(__x);
@@ -1050,7 +1050,7 @@ template <class _Tp, class _Alloc>
 inline
 forward_list<_Tp, _Alloc>&
 forward_list<_Tp, _Alloc>::operator=(forward_list&& __x)
-    _NOEXCEPT_(
+    noexcept(
              __node_traits::propagate_on_container_move_assignment::value &&
              is_nothrow_move_assignable<allocator_type>::value)
 {
@@ -1678,7 +1678,7 @@ forward_list<_Tp, _Alloc>::__sort(__node_pointer __f1, difference_type __sz,
 
 template <class _Tp, class _Alloc>
 void
-forward_list<_Tp, _Alloc>::reverse() _NOEXCEPT
+forward_list<_Tp, _Alloc>::reverse() noexcept
 {
     __node_pointer __p = base::__before_begin()->__next_;
     if (__p != nullptr)
@@ -1757,7 +1757,7 @@ template <class _Tp, class _Alloc>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(forward_list<_Tp, _Alloc>& __x, forward_list<_Tp, _Alloc>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/fstream
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/fstream
@@ -247,7 +247,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     inline static const char*
-    __make_mdstring(ios_base::openmode __mode) _NOEXCEPT;
+    __make_mdstring(ios_base::openmode __mode) noexcept;
 
   protected:
     // 27.9.1.5 Overridden virtual functions:
@@ -504,7 +504,7 @@ basic_filebuf<_CharT, _Traits>::is_open() const
 
 template <class _CharT, class _Traits>
 const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(
-    ios_base::openmode __mode) _NOEXCEPT {
+    ios_base::openmode __mode) noexcept {
   switch (__mode & ~ios_base::ate) {
   case ios_base::out:
   case ios_base::out | ios_base::trunc:

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/future
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/future
@@ -478,18 +478,18 @@ _LIBCUDACXX_DECLARE_STRONG_ENUM(future_status)
 _LIBCUDACXX_DECLARE_STRONG_ENUM_EPILOG(future_status)
 
 _LIBCUDACXX_FUNC_VIS
-const error_category& future_category() _NOEXCEPT;
+const error_category& future_category() noexcept;
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 error_code
-make_error_code(future_errc __e) _NOEXCEPT
+make_error_code(future_errc __e) noexcept
 {
     return error_code(static_cast<int>(__e), future_category());
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 error_condition
-make_error_condition(future_errc __e) _NOEXCEPT
+make_error_condition(future_errc __e) noexcept
 {
     return error_condition(static_cast<int>(__e), future_category());
 }
@@ -504,9 +504,9 @@ public:
     explicit future_error(future_errc _Ev) : logic_error(), __ec_(make_error_code(_Ev)) {}
 #endif
     _LIBCUDACXX_INLINE_VISIBILITY
-    const error_code& code() const _NOEXCEPT {return __ec_;}
+    const error_code& code() const noexcept {return __ec_;}
 
-    virtual ~future_error() _NOEXCEPT;
+    virtual ~future_error() noexcept;
 };
 
 _LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -532,7 +532,7 @@ protected:
     mutable condition_variable __cv_;
     unsigned __state_;
 
-    virtual void __on_zero_shared() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
     void __sub_wait(unique_lock<mutex>& __lk);
 public:
     enum
@@ -619,7 +619,7 @@ class _LIBCUDACXX_AVAILABILITY_FUTURE __assoc_state
 protected:
     _Up __value_;
 
-    virtual void __on_zero_shared() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
 public:
 
     template <class _Arg>
@@ -642,7 +642,7 @@ public:
 
 template <class _Rp>
 void
-__assoc_state<_Rp>::__on_zero_shared() _NOEXCEPT
+__assoc_state<_Rp>::__on_zero_shared() noexcept
 {
     if (this->__state_ & base::__constructed)
         reinterpret_cast<_Rp*>(&__value_)->~_Rp();
@@ -715,7 +715,7 @@ class _LIBCUDACXX_AVAILABILITY_FUTURE __assoc_state<_Rp&>
 protected:
     _Up __value_;
 
-    virtual void __on_zero_shared() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
 public:
 
     void set_value(_Rp& __arg);
@@ -726,7 +726,7 @@ public:
 
 template <class _Rp>
 void
-__assoc_state<_Rp&>::__on_zero_shared() _NOEXCEPT
+__assoc_state<_Rp&>::__on_zero_shared() noexcept
 {
     delete this;
 }
@@ -773,7 +773,7 @@ class _LIBCUDACXX_AVAILABILITY_FUTURE __assoc_state_alloc
     typedef __assoc_state<_Rp> base;
     _Alloc __alloc_;
 
-    virtual void __on_zero_shared() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit __assoc_state_alloc(const _Alloc& __a)
@@ -782,7 +782,7 @@ public:
 
 template <class _Rp, class _Alloc>
 void
-__assoc_state_alloc<_Rp, _Alloc>::__on_zero_shared() _NOEXCEPT
+__assoc_state_alloc<_Rp, _Alloc>::__on_zero_shared() noexcept
 {
     if (this->__state_ & base::__constructed)
         reinterpret_cast<_Rp*>(_CUDA_VSTD::addressof(this->__value_))->~_Rp();
@@ -801,7 +801,7 @@ class _LIBCUDACXX_AVAILABILITY_FUTURE __assoc_state_alloc<_Rp&, _Alloc>
     typedef __assoc_state<_Rp&> base;
     _Alloc __alloc_;
 
-    virtual void __on_zero_shared() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit __assoc_state_alloc(const _Alloc& __a)
@@ -810,7 +810,7 @@ public:
 
 template <class _Rp, class _Alloc>
 void
-__assoc_state_alloc<_Rp&, _Alloc>::__on_zero_shared() _NOEXCEPT
+__assoc_state_alloc<_Rp&, _Alloc>::__on_zero_shared() noexcept
 {
     typedef typename __allocator_traits_rebind<_Alloc, __assoc_state_alloc>::type _Al;
     typedef allocator_traits<_Al> _ATraits;
@@ -827,7 +827,7 @@ class _LIBCUDACXX_AVAILABILITY_FUTURE __assoc_sub_state_alloc
     typedef __assoc_sub_state base;
     _Alloc __alloc_;
 
-    virtual void __on_zero_shared() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit __assoc_sub_state_alloc(const _Alloc& __a)
@@ -836,7 +836,7 @@ public:
 
 template <class _Alloc>
 void
-__assoc_sub_state_alloc<_Alloc>::__on_zero_shared() _NOEXCEPT
+__assoc_sub_state_alloc<_Alloc>::__on_zero_shared() noexcept
 {
     typedef typename __allocator_traits_rebind<_Alloc, __assoc_sub_state_alloc>::type _Al;
     typedef allocator_traits<_Al> _ATraits;
@@ -949,7 +949,7 @@ class _LIBCUDACXX_AVAILABILITY_FUTURE __async_assoc_state
 
     _Fp __func_;
 
-    virtual void __on_zero_shared() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
 public:
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -990,7 +990,7 @@ __async_assoc_state<_Rp, _Fp>::__execute()
 
 template <class _Rp, class _Fp>
 void
-__async_assoc_state<_Rp, _Fp>::__on_zero_shared() _NOEXCEPT
+__async_assoc_state<_Rp, _Fp>::__on_zero_shared() noexcept
 {
     this->wait();
     base::__on_zero_shared();
@@ -1004,7 +1004,7 @@ class _LIBCUDACXX_AVAILABILITY_FUTURE __async_assoc_state<void, _Fp>
 
     _Fp __func_;
 
-    virtual void __on_zero_shared() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
 public:
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1046,7 +1046,7 @@ __async_assoc_state<void, _Fp>::__execute()
 
 template <class _Fp>
 void
-__async_assoc_state<void, _Fp>::__on_zero_shared() _NOEXCEPT
+__async_assoc_state<void, _Fp>::__on_zero_shared() noexcept
 {
     this->wait();
     base::__on_zero_shared();
@@ -1099,15 +1099,15 @@ class _LIBCUDACXX_TEMPLATE_VIS _LIBCUDACXX_AVAILABILITY_FUTURE future
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    future() _NOEXCEPT : __state_(nullptr) {}
+    future() noexcept : __state_(nullptr) {}
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    future(future&& __rhs) _NOEXCEPT
+    future(future&& __rhs) noexcept
         : __state_(__rhs.__state_) {__rhs.__state_ = nullptr;}
     future(const future&) = delete;
     future& operator=(const future&) = delete;
     _LIBCUDACXX_INLINE_VISIBILITY
-    future& operator=(future&& __rhs) _NOEXCEPT
+    future& operator=(future&& __rhs) noexcept
         {
             future(std::move(__rhs)).swap(*this);
             return *this;
@@ -1120,17 +1120,17 @@ public:
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     ~future();
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future<_Rp> share() _NOEXCEPT;
+    shared_future<_Rp> share() noexcept;
 
     // retrieving the value
     _Rp get();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(future& __rhs) _NOEXCEPT {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(future& __rhs) noexcept {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool valid() const _NOEXCEPT {return __state_ != nullptr;}
+    bool valid() const noexcept {return __state_ != nullptr;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void wait() const {__state_->wait();}
@@ -1199,15 +1199,15 @@ class _LIBCUDACXX_TEMPLATE_VIS _LIBCUDACXX_AVAILABILITY_FUTURE future<_Rp&>
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    future() _NOEXCEPT : __state_(nullptr) {}
+    future() noexcept : __state_(nullptr) {}
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    future(future&& __rhs) _NOEXCEPT
+    future(future&& __rhs) noexcept
         : __state_(__rhs.__state_) {__rhs.__state_ = nullptr;}
     future(const future&) = delete;
     future& operator=(const future&) = delete;
     _LIBCUDACXX_INLINE_VISIBILITY
-    future& operator=(future&& __rhs) _NOEXCEPT
+    future& operator=(future&& __rhs) noexcept
         {
             future(std::move(__rhs)).swap(*this);
             return *this;
@@ -1220,17 +1220,17 @@ public:
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     ~future();
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future<_Rp&> share() _NOEXCEPT;
+    shared_future<_Rp&> share() noexcept;
 
     // retrieving the value
     _Rp& get();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(future& __rhs) _NOEXCEPT {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(future& __rhs) noexcept {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool valid() const _NOEXCEPT {return __state_ != nullptr;}
+    bool valid() const noexcept {return __state_ != nullptr;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void wait() const {__state_->wait();}
@@ -1294,15 +1294,15 @@ class _LIBCUDACXX_TYPE_VIS _LIBCUDACXX_AVAILABILITY_FUTURE future<void>
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    future() _NOEXCEPT : __state_(nullptr) {}
+    future() noexcept : __state_(nullptr) {}
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    future(future&& __rhs) _NOEXCEPT
+    future(future&& __rhs) noexcept
         : __state_(__rhs.__state_) {__rhs.__state_ = nullptr;}
     future(const future&) = delete;
     future& operator=(const future&) = delete;
     _LIBCUDACXX_INLINE_VISIBILITY
-    future& operator=(future&& __rhs) _NOEXCEPT
+    future& operator=(future&& __rhs) noexcept
         {
             future(std::move(__rhs)).swap(*this);
             return *this;
@@ -1315,17 +1315,17 @@ public:
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     ~future();
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future<void> share() _NOEXCEPT;
+    shared_future<void> share() noexcept;
 
     // retrieving the value
     void get();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(future& __rhs) _NOEXCEPT {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(future& __rhs) noexcept {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool valid() const _NOEXCEPT {return __state_ != nullptr;}
+    bool valid() const noexcept {return __state_ != nullptr;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void wait() const {__state_->wait();}
@@ -1344,7 +1344,7 @@ public:
 template <class _Rp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(future<_Rp>& __x, future<_Rp>& __y) _NOEXCEPT
+swap(future<_Rp>& __x, future<_Rp>& __y) noexcept
 {
     __x.swap(__y);
 }
@@ -1359,7 +1359,7 @@ class _LIBCUDACXX_TEMPLATE_VIS _LIBCUDACXX_AVAILABILITY_FUTURE promise
     __assoc_state<_Rp>* __state_;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit promise(nullptr_t) _NOEXCEPT : __state_(nullptr) {}
+    explicit promise(nullptr_t) noexcept : __state_(nullptr) {}
 
     template <class> friend class packaged_task;
 public:
@@ -1368,7 +1368,7 @@ public:
         promise(allocator_arg_t, const _Alloc& __a);
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    promise(promise&& __rhs) _NOEXCEPT
+    promise(promise&& __rhs) noexcept
         : __state_(__rhs.__state_) {__rhs.__state_ = nullptr;}
     promise(const promise& __rhs) = delete;
 #else  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
@@ -1381,7 +1381,7 @@ public:
     // assignment
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    promise& operator=(promise&& __rhs) _NOEXCEPT
+    promise& operator=(promise&& __rhs) noexcept
         {
             promise(std::move(__rhs)).swap(*this);
             return *this;
@@ -1393,7 +1393,7 @@ private:
 public:
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(promise& __rhs) _NOEXCEPT {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(promise& __rhs) noexcept {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
 
     // retrieving the result
     future<_Rp> get_future();
@@ -1526,7 +1526,7 @@ class _LIBCUDACXX_TEMPLATE_VIS _LIBCUDACXX_AVAILABILITY_FUTURE promise<_Rp&>
     __assoc_state<_Rp&>* __state_;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit promise(nullptr_t) _NOEXCEPT : __state_(nullptr) {}
+    explicit promise(nullptr_t) noexcept : __state_(nullptr) {}
 
     template <class> friend class packaged_task;
 
@@ -1536,7 +1536,7 @@ public:
         promise(allocator_arg_t, const _Allocator& __a);
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    promise(promise&& __rhs) _NOEXCEPT
+    promise(promise&& __rhs) noexcept
         : __state_(__rhs.__state_) {__rhs.__state_ = nullptr;}
     promise(const promise& __rhs) = delete;
 #else  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
@@ -1549,7 +1549,7 @@ public:
     // assignment
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    promise& operator=(promise&& __rhs) _NOEXCEPT
+    promise& operator=(promise&& __rhs) noexcept
         {
             promise(std::move(__rhs)).swap(*this);
             return *this;
@@ -1561,7 +1561,7 @@ private:
 public:
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(promise& __rhs) _NOEXCEPT {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(promise& __rhs) noexcept {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
 
     // retrieving the result
     future<_Rp&> get_future();
@@ -1662,7 +1662,7 @@ class _LIBCUDACXX_TYPE_VIS _LIBCUDACXX_AVAILABILITY_FUTURE promise<void>
     __assoc_sub_state* __state_;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit promise(nullptr_t) _NOEXCEPT : __state_(nullptr) {}
+    explicit promise(nullptr_t) noexcept : __state_(nullptr) {}
 
     template <class> friend class packaged_task;
 
@@ -1673,7 +1673,7 @@ public:
         promise(allocator_arg_t, const _Allocator& __a);
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    promise(promise&& __rhs) _NOEXCEPT
+    promise(promise&& __rhs) noexcept
         : __state_(__rhs.__state_) {__rhs.__state_ = nullptr;}
     promise(const promise& __rhs) = delete;
 #else  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
@@ -1686,7 +1686,7 @@ public:
     // assignment
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    promise& operator=(promise&& __rhs) _NOEXCEPT
+    promise& operator=(promise&& __rhs) noexcept
         {
             promise(std::move(__rhs)).swap(*this);
             return *this;
@@ -1698,7 +1698,7 @@ private:
 public:
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(promise& __rhs) _NOEXCEPT {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(promise& __rhs) noexcept {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
 
     // retrieving the result
     future<void> get_future();
@@ -1727,7 +1727,7 @@ promise<void>::promise(allocator_arg_t, const _Alloc& __a0)
 template <class _Rp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(promise<_Rp>& __x, promise<_Rp>& __y) _NOEXCEPT
+swap(promise<_Rp>& __x, promise<_Rp>& __y) noexcept
 {
     __x.swap(__y);
 }
@@ -1752,7 +1752,7 @@ public:
     __packaged_task_base() {}
     _LIBCUDACXX_INLINE_VISIBILITY
     virtual ~__packaged_task_base() {}
-    virtual void __move_to(__packaged_task_base*) _NOEXCEPT = 0;
+    virtual void __move_to(__packaged_task_base*) noexcept = 0;
     virtual void destroy() = 0;
     virtual void destroy_deallocate() = 0;
     virtual _Rp operator()(_ArgTypes&& ...) = 0;
@@ -1776,7 +1776,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     __packaged_task_func(_Fp&& __f, const _Alloc& __a)
         : __f_(_CUDA_VSTD::move(__f), __a) {}
-    virtual void __move_to(__packaged_task_base<_Rp(_ArgTypes...)>*) _NOEXCEPT;
+    virtual void __move_to(__packaged_task_base<_Rp(_ArgTypes...)>*) noexcept;
     virtual void destroy();
     virtual void destroy_deallocate();
     virtual _Rp operator()(_ArgTypes&& ... __args);
@@ -1785,7 +1785,7 @@ public:
 template<class _Fp, class _Alloc, class _Rp, class ..._ArgTypes>
 void
 __packaged_task_func<_Fp, _Alloc, _Rp(_ArgTypes...)>::__move_to(
-                              __packaged_task_base<_Rp(_ArgTypes...)>* __p) _NOEXCEPT
+                              __packaged_task_base<_Rp(_ArgTypes...)>* __p) noexcept
 {
     ::new (__p) __packaged_task_func(_CUDA_VSTD::move(__f_.first()), _CUDA_VSTD::move(__f_.second()));
 }
@@ -1830,28 +1830,28 @@ public:
 
     // construct/copy/destroy:
     _LIBCUDACXX_INLINE_VISIBILITY
-    __packaged_task_function() _NOEXCEPT : __f_(nullptr) {}
+    __packaged_task_function() noexcept : __f_(nullptr) {}
     template<class _Fp>
       __packaged_task_function(_Fp&& __f);
     template<class _Fp, class _Alloc>
       __packaged_task_function(allocator_arg_t, const _Alloc& __a, _Fp&& __f);
 
-    __packaged_task_function(__packaged_task_function&&) _NOEXCEPT;
-    __packaged_task_function& operator=(__packaged_task_function&&) _NOEXCEPT;
+    __packaged_task_function(__packaged_task_function&&) noexcept;
+    __packaged_task_function& operator=(__packaged_task_function&&) noexcept;
 
     __packaged_task_function(const __packaged_task_function&) =  delete;
     __packaged_task_function& operator=(const __packaged_task_function&) =  delete;
 
     ~__packaged_task_function();
 
-    void swap(__packaged_task_function&) _NOEXCEPT;
+    void swap(__packaged_task_function&) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _Rp operator()(_ArgTypes...) const;
 };
 
 template<class _Rp, class ..._ArgTypes>
-__packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(__packaged_task_function&& __f) _NOEXCEPT
+__packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(__packaged_task_function&& __f) noexcept
 {
     if (__f.__f_ == nullptr)
         __f_ = nullptr;
@@ -1917,7 +1917,7 @@ __packaged_task_function<_Rp(_ArgTypes...)>::__packaged_task_function(
 
 template<class _Rp, class ..._ArgTypes>
 __packaged_task_function<_Rp(_ArgTypes...)>&
-__packaged_task_function<_Rp(_ArgTypes...)>::operator=(__packaged_task_function&& __f) _NOEXCEPT
+__packaged_task_function<_Rp(_ArgTypes...)>::operator=(__packaged_task_function&& __f) noexcept
 {
     if (__f_ == (__base*)&__buf_)
         __f_->destroy();
@@ -1950,7 +1950,7 @@ __packaged_task_function<_Rp(_ArgTypes...)>::~__packaged_task_function()
 
 template<class _Rp, class ..._ArgTypes>
 void
-__packaged_task_function<_Rp(_ArgTypes...)>::swap(__packaged_task_function& __f) _NOEXCEPT
+__packaged_task_function<_Rp(_ArgTypes...)>::swap(__packaged_task_function& __f) noexcept
 {
     if (__f_ == (__base*)&__buf_ && __f.__f_ == (__base*)&__f.__buf_)
     {
@@ -2006,7 +2006,7 @@ private:
 public:
     // construction and destruction
     _LIBCUDACXX_INLINE_VISIBILITY
-    packaged_task() _NOEXCEPT : __p_(nullptr) {}
+    packaged_task() noexcept : __p_(nullptr) {}
     template <class _Fp,
               class = typename enable_if
               <
@@ -2039,24 +2039,24 @@ public:
 
     // move support
     _LIBCUDACXX_INLINE_VISIBILITY
-    packaged_task(packaged_task&& __other) _NOEXCEPT
+    packaged_task(packaged_task&& __other) noexcept
         : __f_(_CUDA_VSTD::move(__other.__f_)), __p_(_CUDA_VSTD::move(__other.__p_)) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    packaged_task& operator=(packaged_task&& __other) _NOEXCEPT
+    packaged_task& operator=(packaged_task&& __other) noexcept
     {
         __f_ = _CUDA_VSTD::move(__other.__f_);
         __p_ = _CUDA_VSTD::move(__other.__p_);
         return *this;
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(packaged_task& __other) _NOEXCEPT
+    void swap(packaged_task& __other) noexcept
     {
         __f_.swap(__other.__f_);
         __p_.swap(__other.__p_);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool valid() const _NOEXCEPT {return __p_.__state_ != nullptr;}
+    bool valid() const noexcept {return __p_.__state_ != nullptr;}
 
     // result retrieval
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2135,7 +2135,7 @@ private:
 public:
     // construction and destruction
     _LIBCUDACXX_INLINE_VISIBILITY
-    packaged_task() _NOEXCEPT : __p_(nullptr) {}
+    packaged_task() noexcept : __p_(nullptr) {}
     template <class _Fp,
               class = typename enable_if
               <
@@ -2168,24 +2168,24 @@ public:
 
     // move support
     _LIBCUDACXX_INLINE_VISIBILITY
-    packaged_task(packaged_task&& __other) _NOEXCEPT
+    packaged_task(packaged_task&& __other) noexcept
         : __f_(_CUDA_VSTD::move(__other.__f_)), __p_(_CUDA_VSTD::move(__other.__p_)) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    packaged_task& operator=(packaged_task&& __other) _NOEXCEPT
+    packaged_task& operator=(packaged_task&& __other) noexcept
     {
         __f_ = _CUDA_VSTD::move(__other.__f_);
         __p_ = _CUDA_VSTD::move(__other.__p_);
         return *this;
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(packaged_task& __other) _NOEXCEPT
+    void swap(packaged_task& __other) noexcept
     {
         __f_.swap(__other.__f_);
         __p_.swap(__other.__p_);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool valid() const _NOEXCEPT {return __p_.__state_ != nullptr;}
+    bool valid() const noexcept {return __p_.__state_ != nullptr;}
 
     // result retrieval
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2256,7 +2256,7 @@ packaged_task<void(_ArgTypes...)>::reset()
 template <class _Callable>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(packaged_task<_Callable>& __x, packaged_task<_Callable>& __y) _NOEXCEPT
+swap(packaged_task<_Callable>& __x, packaged_task<_Callable>& __y) noexcept
 {
     __x.swap(__y);
 }
@@ -2370,23 +2370,23 @@ class _LIBCUDACXX_TEMPLATE_VIS shared_future
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future() _NOEXCEPT : __state_(nullptr) {}
+    shared_future() noexcept : __state_(nullptr) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future(const shared_future& __rhs)  _NOEXCEPT : __state_(__rhs.__state_)
+    shared_future(const shared_future& __rhs)  noexcept : __state_(__rhs.__state_)
         {if (__state_) __state_->__add_shared();}
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future(future<_Rp>&& __f) _NOEXCEPT : __state_(__f.__state_)
+    shared_future(future<_Rp>&& __f) noexcept : __state_(__f.__state_)
         {__f.__state_ = nullptr;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future(shared_future&& __rhs) _NOEXCEPT : __state_(__rhs.__state_)
+    shared_future(shared_future&& __rhs) noexcept : __state_(__rhs.__state_)
         {__rhs.__state_ = nullptr;}
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     ~shared_future();
-    shared_future& operator=(const shared_future& __rhs) _NOEXCEPT;
+    shared_future& operator=(const shared_future& __rhs) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future& operator=(shared_future&& __rhs) _NOEXCEPT
+    shared_future& operator=(shared_future&& __rhs) noexcept
         {
             shared_future(std::move(__rhs)).swap(*this);
             return *this;
@@ -2398,11 +2398,11 @@ public:
     const _Rp& get() const {return __state_->copy();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(shared_future& __rhs) _NOEXCEPT {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(shared_future& __rhs) noexcept {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool valid() const _NOEXCEPT {return __state_ != nullptr;}
+    bool valid() const noexcept {return __state_ != nullptr;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void wait() const {__state_->wait();}
@@ -2427,7 +2427,7 @@ shared_future<_Rp>::~shared_future()
 
 template <class _Rp>
 shared_future<_Rp>&
-shared_future<_Rp>::operator=(const shared_future& __rhs) _NOEXCEPT
+shared_future<_Rp>::operator=(const shared_future& __rhs) noexcept
 {
     if (__rhs.__state_)
         __rhs.__state_->__add_shared();
@@ -2444,23 +2444,23 @@ class _LIBCUDACXX_TEMPLATE_VIS shared_future<_Rp&>
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future() _NOEXCEPT : __state_(nullptr) {}
+    shared_future() noexcept : __state_(nullptr) {}
     _LIBCUDACXX_INLINE_VISIBILITY
     shared_future(const shared_future& __rhs) : __state_(__rhs.__state_)
         {if (__state_) __state_->__add_shared();}
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future(future<_Rp&>&& __f) _NOEXCEPT : __state_(__f.__state_)
+    shared_future(future<_Rp&>&& __f) noexcept : __state_(__f.__state_)
         {__f.__state_ = nullptr;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future(shared_future&& __rhs) _NOEXCEPT : __state_(__rhs.__state_)
+    shared_future(shared_future&& __rhs) noexcept : __state_(__rhs.__state_)
         {__rhs.__state_ = nullptr;}
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     ~shared_future();
     shared_future& operator=(const shared_future& __rhs);
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future& operator=(shared_future&& __rhs) _NOEXCEPT
+    shared_future& operator=(shared_future&& __rhs) noexcept
         {
             shared_future(std::move(__rhs)).swap(*this);
             return *this;
@@ -2472,11 +2472,11 @@ public:
     _Rp& get() const {return __state_->copy();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(shared_future& __rhs) _NOEXCEPT {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(shared_future& __rhs) noexcept {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool valid() const _NOEXCEPT {return __state_ != nullptr;}
+    bool valid() const noexcept {return __state_ != nullptr;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void wait() const {__state_->wait();}
@@ -2518,23 +2518,23 @@ class _LIBCUDACXX_TYPE_VIS _LIBCUDACXX_AVAILABILITY_FUTURE shared_future<void>
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future() _NOEXCEPT : __state_(nullptr) {}
+    shared_future() noexcept : __state_(nullptr) {}
     _LIBCUDACXX_INLINE_VISIBILITY
     shared_future(const shared_future& __rhs) : __state_(__rhs.__state_)
         {if (__state_) __state_->__add_shared();}
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future(future<void>&& __f) _NOEXCEPT : __state_(__f.__state_)
+    shared_future(future<void>&& __f) noexcept : __state_(__f.__state_)
         {__f.__state_ = nullptr;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future(shared_future&& __rhs) _NOEXCEPT : __state_(__rhs.__state_)
+    shared_future(shared_future&& __rhs) noexcept : __state_(__rhs.__state_)
         {__rhs.__state_ = nullptr;}
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     ~shared_future();
     shared_future& operator=(const shared_future& __rhs);
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_future& operator=(shared_future&& __rhs) _NOEXCEPT
+    shared_future& operator=(shared_future&& __rhs) noexcept
         {
             shared_future(std::move(__rhs)).swap(*this);
             return *this;
@@ -2546,11 +2546,11 @@ public:
     void get() const {__state_->copy();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(shared_future& __rhs) _NOEXCEPT {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
+    void swap(shared_future& __rhs) noexcept {_CUDA_VSTD::swap(__state_, __rhs.__state_);}
 
     // functions to check state
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool valid() const _NOEXCEPT {return __state_ != nullptr;}
+    bool valid() const noexcept {return __state_ != nullptr;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void wait() const {__state_->wait();}
@@ -2569,7 +2569,7 @@ public:
 template <class _Rp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(shared_future<_Rp>& __x, shared_future<_Rp>& __y) _NOEXCEPT
+swap(shared_future<_Rp>& __x, shared_future<_Rp>& __y) noexcept
 {
     __x.swap(__y);
 }
@@ -2577,7 +2577,7 @@ swap(shared_future<_Rp>& __x, shared_future<_Rp>& __y) _NOEXCEPT
 template <class _Rp>
 inline
 shared_future<_Rp>
-future<_Rp>::share() _NOEXCEPT
+future<_Rp>::share() noexcept
 {
     return shared_future<_Rp>(_CUDA_VSTD::move(*this));
 }
@@ -2585,7 +2585,7 @@ future<_Rp>::share() _NOEXCEPT
 template <class _Rp>
 inline
 shared_future<_Rp&>
-future<_Rp&>::share() _NOEXCEPT
+future<_Rp&>::share() noexcept
 {
     return shared_future<_Rp&>(_CUDA_VSTD::move(*this));
 }
@@ -2594,7 +2594,7 @@ future<_Rp&>::share() _NOEXCEPT
 
 inline
 shared_future<void>
-future<void>::share() _NOEXCEPT
+future<void>::share() noexcept
 {
     return shared_future<void>(_CUDA_VSTD::move(*this));
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/initializer_list
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/initializer_list
@@ -64,7 +64,7 @@ class _LIBCUDACXX_TEMPLATE_VIS initializer_list
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    initializer_list(const _Ep* __b, size_t __s) _NOEXCEPT
+    initializer_list(const _Ep* __b, size_t __s) noexcept
         : __begin_(__b),
           __size_(__s)
         {}
@@ -79,26 +79,26 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    initializer_list() _NOEXCEPT : __begin_(nullptr), __size_(0) {}
+    initializer_list() noexcept : __begin_(nullptr), __size_(0) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    size_t    size()  const _NOEXCEPT {return __size_;}
+    size_t    size()  const noexcept {return __size_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    const _Ep* begin() const _NOEXCEPT {return __begin_;}
+    const _Ep* begin() const noexcept {return __begin_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    const _Ep* end()   const _NOEXCEPT {return __begin_ + __size_;}
+    const _Ep* end()   const noexcept {return __begin_ + __size_;}
 };
 
 template<class _Ep>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const _Ep*
-begin(initializer_list<_Ep> __il) _NOEXCEPT
+begin(initializer_list<_Ep> __il) noexcept
 {
     return __il.begin();
 }
@@ -107,7 +107,7 @@ template<class _Ep>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const _Ep*
-end(initializer_list<_Ep> __il) _NOEXCEPT
+end(initializer_list<_Ep> __il) noexcept
 {
     return __il.end();
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/ios
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/ios
@@ -357,7 +357,7 @@ protected:
     void __call_callbacks(event);
     void copyfmt(const ios_base&);
     void move(ios_base&);
-    void swap(ios_base&) _NOEXCEPT;
+    void swap(ios_base&) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void set_rdbuf(void* __sb)
@@ -409,18 +409,18 @@ struct _LIBCUDACXX_TEMPLATE_VIS is_error_code_enum<io_errc::__lx> : public true_
 #endif
 
 _LIBCUDACXX_FUNC_VIS
-const error_category& iostream_category() _NOEXCEPT;
+const error_category& iostream_category() noexcept;
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 error_code
-make_error_code(io_errc __e) _NOEXCEPT
+make_error_code(io_errc __e) noexcept
 {
     return error_code(static_cast<int>(__e), iostream_category());
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 error_condition
-make_error_condition(io_errc __e) _NOEXCEPT
+make_error_condition(io_errc __e) noexcept
 {
     return error_condition(static_cast<int>(__e), iostream_category());
 }
@@ -683,7 +683,7 @@ protected:
     void move(basic_ios&& __rhs) {move(__rhs);}
 #endif
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(basic_ios& __rhs) _NOEXCEPT;
+    void swap(basic_ios& __rhs) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
     void set_rdbuf(basic_streambuf<char_type, traits_type>* __sb);
 private:
@@ -827,7 +827,7 @@ basic_ios<_CharT, _Traits>::move(basic_ios& __rhs)
 template <class _CharT, class _Traits>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-basic_ios<_CharT, _Traits>::swap(basic_ios& __rhs) _NOEXCEPT
+basic_ios<_CharT, _Traits>::swap(basic_ios& __rhs) noexcept
 {
     ios_base::swap(__rhs);
     _CUDA_VSTD::swap(__tie_, __rhs.__tie_);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/limits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/limits
@@ -155,9 +155,9 @@ protected:
     typedef _Tp type;
 
     static _LIBCUDACXX_CONSTEXPR const  bool is_specialized = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return type();}
 
     static _LIBCUDACXX_CONSTEXPR const int  digits = 0;
     static _LIBCUDACXX_CONSTEXPR const int  digits10 = 0;
@@ -166,8 +166,8 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = false;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = false;
     static _LIBCUDACXX_CONSTEXPR const int  radix = 0;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return type();}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = 0;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = 0;
@@ -179,10 +179,10 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = false;
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_absent;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return type();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = false;
     static _LIBCUDACXX_CONSTEXPR const bool is_bounded = false;
@@ -219,15 +219,15 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 0;
     static _LIBCUDACXX_CONSTEXPR const type __min = __libcpp_compute_min<type, digits, is_signed>::value;
     static _LIBCUDACXX_CONSTEXPR const type __max = is_signed ? type(type(~0) ^ __min) : type(~0);
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return __min;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return __max;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __min;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __max;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return min();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = true;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = true;
     static _LIBCUDACXX_CONSTEXPR const int  radix = 2;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return type(0);}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = 0;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = 0;
@@ -239,10 +239,10 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = false;
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_absent;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return type(0);}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = false;
     static _LIBCUDACXX_CONSTEXPR const bool is_bounded = true;
@@ -272,15 +272,15 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 0;
     static _LIBCUDACXX_CONSTEXPR const type __min = false;
     static _LIBCUDACXX_CONSTEXPR const type __max = true;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return __min;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return __max;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __min;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __max;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return min();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = true;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = true;
     static _LIBCUDACXX_CONSTEXPR const int  radix = 2;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return type(0);}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = 0;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = 0;
@@ -292,10 +292,10 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = false;
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_absent;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return type(0);}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = false;
     static _LIBCUDACXX_CONSTEXPR const bool is_bounded = true;
@@ -318,15 +318,15 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const int  digits = __FLT_MANT_DIG__;
     static _LIBCUDACXX_CONSTEXPR const int  digits10 = __FLT_DIG__;
     static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 2+(digits * 30103l)/100000l;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return __FLT_MIN__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return __FLT_MAX__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return -max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __FLT_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __FLT_MAX__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return -max();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = false;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = false;
     static _LIBCUDACXX_CONSTEXPR const int  radix = __FLT_RADIX__;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return __FLT_EPSILON__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return 0.5F;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __FLT_EPSILON__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return 0.5F;}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __FLT_MIN_EXP__;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __FLT_MIN_10_EXP__;
@@ -339,15 +339,15 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
 #ifdef _LIBCUDACXX_COMPILER_NVRTC
-    _LIBCUDACXX_INLINE_VISIBILITY static type infinity() _NOEXCEPT {return __builtin_huge_valf();}
-    _LIBCUDACXX_INLINE_VISIBILITY static type quiet_NaN() _NOEXCEPT {return __builtin_nanf("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static type signaling_NaN() _NOEXCEPT {return __builtin_nansf("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static type infinity() noexcept {return __builtin_huge_valf();}
+    _LIBCUDACXX_INLINE_VISIBILITY static type quiet_NaN() noexcept {return __builtin_nanf("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static type signaling_NaN() noexcept {return __builtin_nansf("");}
 #else
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return __builtin_huge_valf();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __builtin_nanf("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __builtin_nansf("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __builtin_huge_valf();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __builtin_nanf("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __builtin_nansf("");}
 #endif
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return __FLT_DENORM_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __FLT_DENORM_MIN__;}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = true;
     static _LIBCUDACXX_CONSTEXPR const bool is_bounded = true;
@@ -370,15 +370,15 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const int  digits = __DBL_MANT_DIG__;
     static _LIBCUDACXX_CONSTEXPR const int  digits10 = __DBL_DIG__;
     static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 2+(digits * 30103l)/100000l;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return __DBL_MIN__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return __DBL_MAX__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return -max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __DBL_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __DBL_MAX__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return -max();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = false;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = false;
     static _LIBCUDACXX_CONSTEXPR const int  radix = __FLT_RADIX__;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return __DBL_EPSILON__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return 0.5;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __DBL_EPSILON__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return 0.5;}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __DBL_MIN_EXP__;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __DBL_MIN_10_EXP__;
@@ -391,15 +391,15 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
 #ifdef _LIBCUDACXX_COMPILER_NVRTC
-    _LIBCUDACXX_INLINE_VISIBILITY static type infinity() _NOEXCEPT {return __builtin_huge_val();}
-    _LIBCUDACXX_INLINE_VISIBILITY static type quiet_NaN() _NOEXCEPT {return __builtin_nan("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static type signaling_NaN() _NOEXCEPT {return __builtin_nans("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static type infinity() noexcept {return __builtin_huge_val();}
+    _LIBCUDACXX_INLINE_VISIBILITY static type quiet_NaN() noexcept {return __builtin_nan("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static type signaling_NaN() noexcept {return __builtin_nans("");}
 #else
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return __builtin_huge_val();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __builtin_nan("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __builtin_nans("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __builtin_huge_val();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __builtin_nan("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __builtin_nans("");}
 #endif
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return __DBL_DENORM_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __DBL_DENORM_MIN__;}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = true;
     static _LIBCUDACXX_CONSTEXPR const bool is_bounded = true;
@@ -423,15 +423,15 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const int  digits = __LDBL_MANT_DIG__;
     static _LIBCUDACXX_CONSTEXPR const int  digits10 = __LDBL_DIG__;
     static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 2+(digits * 30103l)/100000l;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return __LDBL_MIN__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return __LDBL_MAX__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return -max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __LDBL_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __LDBL_MAX__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return -max();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = false;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = false;
     static _LIBCUDACXX_CONSTEXPR const int  radix = __FLT_RADIX__;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return __LDBL_EPSILON__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return 0.5L;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __LDBL_EPSILON__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return 0.5L;}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __LDBL_MIN_EXP__;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __LDBL_MIN_10_EXP__;
@@ -443,10 +443,10 @@ protected:
     static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = true;
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return __builtin_huge_vall();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __builtin_nanl("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __builtin_nansl("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return __LDBL_DENORM_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __builtin_huge_vall();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __builtin_nanl("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __builtin_nansl("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __LDBL_DENORM_MIN__;}
 
 #if (defined(__ppc__) || defined(__ppc64__))
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = false;
@@ -470,9 +470,9 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits
     typedef typename __base::type type;
 public:
     static _LIBCUDACXX_CONSTEXPR const bool is_specialized = __base::is_specialized;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return __base::min();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return __base::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return __base::lowest();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __base::min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __base::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return __base::lowest();}
 
     static _LIBCUDACXX_CONSTEXPR const int  digits = __base::digits;
     static _LIBCUDACXX_CONSTEXPR const int  digits10 = __base::digits10;
@@ -481,8 +481,8 @@ public:
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = __base::is_integer;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = __base::is_exact;
     static _LIBCUDACXX_CONSTEXPR const int  radix = __base::radix;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return __base::epsilon();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return __base::round_error();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __base::epsilon();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return __base::round_error();}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __base::min_exponent;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __base::min_exponent10;
@@ -494,10 +494,10 @@ public:
     static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = __base::has_signaling_NaN;
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = __base::has_denorm;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = __base::has_denorm_loss;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return __base::infinity();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __base::quiet_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __base::signaling_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return __base::denorm_min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __base::infinity();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __base::quiet_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __base::signaling_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __base::denorm_min();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = __base::is_iec559;
     static _LIBCUDACXX_CONSTEXPR const bool is_bounded = __base::is_bounded;
@@ -563,9 +563,9 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const _Tp>
     typedef _Tp type;
 public:
     static _LIBCUDACXX_CONSTEXPR const bool is_specialized = __base::is_specialized;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return __base::min();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return __base::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return __base::lowest();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __base::min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __base::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return __base::lowest();}
 
     static _LIBCUDACXX_CONSTEXPR const int  digits = __base::digits;
     static _LIBCUDACXX_CONSTEXPR const int  digits10 = __base::digits10;
@@ -574,8 +574,8 @@ public:
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = __base::is_integer;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = __base::is_exact;
     static _LIBCUDACXX_CONSTEXPR const int  radix = __base::radix;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return __base::epsilon();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return __base::round_error();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __base::epsilon();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return __base::round_error();}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __base::min_exponent;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __base::min_exponent10;
@@ -587,10 +587,10 @@ public:
     static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = __base::has_signaling_NaN;
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = __base::has_denorm;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = __base::has_denorm_loss;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return __base::infinity();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __base::quiet_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __base::signaling_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return __base::denorm_min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __base::infinity();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __base::quiet_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __base::signaling_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __base::denorm_min();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = __base::is_iec559;
     static _LIBCUDACXX_CONSTEXPR const bool is_bounded = __base::is_bounded;
@@ -656,9 +656,9 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<volatile _Tp>
     typedef _Tp type;
 public:
     static _LIBCUDACXX_CONSTEXPR const bool is_specialized = __base::is_specialized;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return __base::min();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return __base::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return __base::lowest();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __base::min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __base::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return __base::lowest();}
 
     static _LIBCUDACXX_CONSTEXPR const int  digits = __base::digits;
     static _LIBCUDACXX_CONSTEXPR const int  digits10 = __base::digits10;
@@ -667,8 +667,8 @@ public:
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = __base::is_integer;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = __base::is_exact;
     static _LIBCUDACXX_CONSTEXPR const int  radix = __base::radix;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return __base::epsilon();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return __base::round_error();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __base::epsilon();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return __base::round_error();}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __base::min_exponent;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __base::min_exponent10;
@@ -680,10 +680,10 @@ public:
     static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = __base::has_signaling_NaN;
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = __base::has_denorm;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = __base::has_denorm_loss;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return __base::infinity();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __base::quiet_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __base::signaling_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return __base::denorm_min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __base::infinity();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __base::quiet_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __base::signaling_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __base::denorm_min();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = __base::is_iec559;
     static _LIBCUDACXX_CONSTEXPR const bool is_bounded = __base::is_bounded;
@@ -749,9 +749,9 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const volatile _Tp>
     typedef _Tp type;
 public:
     static _LIBCUDACXX_CONSTEXPR const bool is_specialized = __base::is_specialized;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() _NOEXCEPT {return __base::min();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() _NOEXCEPT {return __base::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() _NOEXCEPT {return __base::lowest();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __base::min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __base::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return __base::lowest();}
 
     static _LIBCUDACXX_CONSTEXPR const int  digits = __base::digits;
     static _LIBCUDACXX_CONSTEXPR const int  digits10 = __base::digits10;
@@ -760,8 +760,8 @@ public:
     static _LIBCUDACXX_CONSTEXPR const bool is_integer = __base::is_integer;
     static _LIBCUDACXX_CONSTEXPR const bool is_exact = __base::is_exact;
     static _LIBCUDACXX_CONSTEXPR const int  radix = __base::radix;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() _NOEXCEPT {return __base::epsilon();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() _NOEXCEPT {return __base::round_error();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __base::epsilon();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return __base::round_error();}
 
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __base::min_exponent;
     static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __base::min_exponent10;
@@ -773,10 +773,10 @@ public:
     static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = __base::has_signaling_NaN;
     static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = __base::has_denorm;
     static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = __base::has_denorm_loss;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() _NOEXCEPT {return __base::infinity();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() _NOEXCEPT {return __base::quiet_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() _NOEXCEPT {return __base::signaling_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() _NOEXCEPT {return __base::denorm_min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __base::infinity();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __base::quiet_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __base::signaling_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __base::denorm_min();}
 
     static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = __base::is_iec559;
     static _LIBCUDACXX_CONSTEXPR const bool is_bounded = __base::is_bounded;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/list
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/list
@@ -293,14 +293,14 @@ class _LIBCUDACXX_TEMPLATE_VIS __list_iterator
 
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __list_iterator(__link_pointer __p, const void* __c) _NOEXCEPT
+    explicit __list_iterator(__link_pointer __p, const void* __c) noexcept
         : __ptr_(__p)
     {
         __get_db()->__insert_ic(this, __c);
     }
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __list_iterator(__link_pointer __p) _NOEXCEPT : __ptr_(__p) {}
+    explicit __list_iterator(__link_pointer __p) noexcept : __ptr_(__p) {}
 #endif
 
 
@@ -316,7 +316,7 @@ public:
     typedef typename pointer_traits<pointer>::difference_type difference_type;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __list_iterator() _NOEXCEPT : __ptr_(nullptr)
+    __list_iterator() noexcept : __ptr_(nullptr)
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         __get_db()->__insert_i(this);
@@ -416,14 +416,14 @@ class _LIBCUDACXX_TEMPLATE_VIS __list_const_iterator
 
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __list_const_iterator(__link_pointer __p, const void* __c) _NOEXCEPT
+    explicit __list_const_iterator(__link_pointer __p, const void* __c) noexcept
         : __ptr_(__p)
     {
         __get_db()->__insert_ic(this, __c);
     }
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __list_const_iterator(__link_pointer __p) _NOEXCEPT : __ptr_(__p) {}
+    explicit __list_const_iterator(__link_pointer __p) noexcept : __ptr_(__p) {}
 #endif
 
     template<class, class> friend class list;
@@ -436,14 +436,14 @@ public:
     typedef typename pointer_traits<pointer>::difference_type difference_type;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __list_const_iterator() _NOEXCEPT : __ptr_(nullptr)
+    __list_const_iterator() noexcept : __ptr_(nullptr)
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         __get_db()->__insert_i(this);
 #endif
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    __list_const_iterator(const __list_iterator<_Tp, _VoidPtr>& __p) _NOEXCEPT
+    __list_const_iterator(const __list_iterator<_Tp, _VoidPtr>& __p) noexcept
         : __ptr_(__p.__ptr_)
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -570,47 +570,47 @@ protected:
     __compressed_pair<size_type, __node_allocator> __size_alloc_;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __link_pointer __end_as_link() const _NOEXCEPT {
+    __link_pointer __end_as_link() const noexcept {
         return __node_pointer_traits::__unsafe_link_pointer_cast(
                 const_cast<__node_base&>(__end_).__self());
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          size_type& __sz() _NOEXCEPT {return __size_alloc_.first();}
+          size_type& __sz() noexcept {return __size_alloc_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const size_type& __sz() const _NOEXCEPT
+    const size_type& __sz() const noexcept
         {return __size_alloc_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY
-          __node_allocator& __node_alloc() _NOEXCEPT
+          __node_allocator& __node_alloc() noexcept
           {return __size_alloc_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const __node_allocator& __node_alloc() const _NOEXCEPT
+    const __node_allocator& __node_alloc() const noexcept
         {return __size_alloc_.second();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type __node_alloc_max_size() const _NOEXCEPT {
+    size_type __node_alloc_max_size() const noexcept {
         return __node_alloc_traits::max_size(__node_alloc());
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    static void __unlink_nodes(__link_pointer __f, __link_pointer __l) _NOEXCEPT;
+    static void __unlink_nodes(__link_pointer __f, __link_pointer __l) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __list_imp()
-        _NOEXCEPT_(is_nothrow_default_constructible<__node_allocator>::value);
+        noexcept(is_nothrow_default_constructible<__node_allocator>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     __list_imp(const allocator_type& __a);
     _LIBCUDACXX_INLINE_VISIBILITY
     __list_imp(const __node_allocator& __a);
 #ifndef _LIBCUDACXX_CXX03_LANG
-    __list_imp(__node_allocator&& __a) _NOEXCEPT;
+    __list_imp(__node_allocator&& __a) noexcept;
 #endif
     ~__list_imp();
-    void clear() _NOEXCEPT;
+    void clear() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT {return __sz() == 0;}
+    bool empty() const noexcept {return __sz() == 0;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator begin() _NOEXCEPT
+    iterator begin() noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         return iterator(__end_.__next_, this);
@@ -619,7 +619,7 @@ protected:
 #endif
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const  _NOEXCEPT
+    const_iterator begin() const  noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         return const_iterator(__end_.__next_, this);
@@ -628,7 +628,7 @@ protected:
 #endif
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator end() _NOEXCEPT
+    iterator end() noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         return iterator(__end_as_link(), this);
@@ -637,7 +637,7 @@ protected:
 #endif
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end() const _NOEXCEPT
+    const_iterator end() const noexcept
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         return const_iterator(__end_as_link(), this);
@@ -648,9 +648,9 @@ protected:
 
     void swap(__list_imp& __c)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                     __is_nothrow_swappable<allocator_type>::value);
 #endif
 
@@ -661,7 +661,7 @@ protected:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__list_imp& __c)
-        _NOEXCEPT_(
+        noexcept(
             !__node_alloc_traits::propagate_on_container_move_assignment::value ||
             is_nothrow_move_assignable<__node_allocator>::value)
         {__move_assign_alloc(__c, integral_constant<bool,
@@ -682,14 +682,14 @@ private:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__list_imp& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<__node_allocator>::value)
+        noexcept(is_nothrow_move_assignable<__node_allocator>::value)
         {
             __node_alloc() = _CUDA_VSTD::move(__c.__node_alloc());
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__list_imp&, false_type)
-        _NOEXCEPT
+        noexcept
         {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -705,7 +705,7 @@ template <class _Tp, class _Alloc>
 inline
 void
 __list_imp<_Tp, _Alloc>::__unlink_nodes(__link_pointer __f, __link_pointer __l)
-    _NOEXCEPT
+    noexcept
 {
     __f->__prev_->__next_ = __l->__next_;
     __l->__next_->__prev_ = __f->__prev_;
@@ -714,7 +714,7 @@ __list_imp<_Tp, _Alloc>::__unlink_nodes(__link_pointer __f, __link_pointer __l)
 template <class _Tp, class _Alloc>
 inline
 __list_imp<_Tp, _Alloc>::__list_imp()
-        _NOEXCEPT_(is_nothrow_default_constructible<__node_allocator>::value)
+        noexcept(is_nothrow_default_constructible<__node_allocator>::value)
     : __size_alloc_(0)
 {
 }
@@ -732,7 +732,7 @@ inline __list_imp<_Tp, _Alloc>::__list_imp(const __node_allocator& __a)
 
 #ifndef _LIBCUDACXX_CXX03_LANG
 template <class _Tp, class _Alloc>
-inline __list_imp<_Tp, _Alloc>::__list_imp(__node_allocator&& __a) _NOEXCEPT
+inline __list_imp<_Tp, _Alloc>::__list_imp(__node_allocator&& __a) noexcept
     : __size_alloc_(0, std::move(__a)) {}
 #endif
 
@@ -746,7 +746,7 @@ __list_imp<_Tp, _Alloc>::~__list_imp() {
 
 template <class _Tp, class _Alloc>
 void
-__list_imp<_Tp, _Alloc>::clear() _NOEXCEPT
+__list_imp<_Tp, _Alloc>::clear() noexcept
 {
     if (!empty())
     {
@@ -770,9 +770,9 @@ template <class _Tp, class _Alloc>
 void
 __list_imp<_Tp, _Alloc>::swap(__list_imp& __c)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT
+        noexcept
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                     __is_nothrow_swappable<allocator_type>::value)
 #endif
 {
@@ -866,7 +866,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     list()
-        _NOEXCEPT_(is_nothrow_default_constructible<__node_allocator>::value)
+        noexcept(is_nothrow_default_constructible<__node_allocator>::value)
     {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
         __get_db()->__insert_c(this);
@@ -902,12 +902,12 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     list(list&& __c)
-        _NOEXCEPT_(is_nothrow_move_constructible<__node_allocator>::value);
+        noexcept(is_nothrow_move_constructible<__node_allocator>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     list(list&& __c, const allocator_type& __a);
     _LIBCUDACXX_INLINE_VISIBILITY
     list& operator=(list&& __c)
-        _NOEXCEPT_(
+        noexcept(
             __node_alloc_traits::propagate_on_container_move_assignment::value &&
             is_nothrow_move_assignable<__node_allocator>::value);
 
@@ -926,14 +926,14 @@ public:
     void assign(size_type __n, const value_type& __x);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT;
+    allocator_type get_allocator() const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT     {return base::__sz();}
+    size_type size() const noexcept     {return base::__sz();}
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT         {return base::empty();}
+    bool empty() const noexcept         {return base::empty();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT
+    size_type max_size() const noexcept
         {
             return std::min<size_type>(
                 base::__node_alloc_max_size(),
@@ -941,35 +941,35 @@ public:
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator begin() _NOEXCEPT        {return base::begin();}
+          iterator begin() noexcept        {return base::begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin()  const _NOEXCEPT {return base::begin();}
+    const_iterator begin()  const noexcept {return base::begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator end() _NOEXCEPT          {return base::end();}
+          iterator end() noexcept          {return base::end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()    const _NOEXCEPT {return base::end();}
+    const_iterator end()    const noexcept {return base::end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT {return base::begin();}
+    const_iterator cbegin() const noexcept {return base::begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend()   const _NOEXCEPT {return base::end();}
+    const_iterator cend()   const noexcept {return base::end();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rbegin() _NOEXCEPT
+          reverse_iterator rbegin() noexcept
             {return       reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin()  const _NOEXCEPT
+    const_reverse_iterator rbegin()  const noexcept
         {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rend() _NOEXCEPT
+          reverse_iterator rend() noexcept
             {return       reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend()    const _NOEXCEPT
+    const_reverse_iterator rend()    const noexcept
         {return const_reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT
+    const_reverse_iterator crbegin() const noexcept
         {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend()   const _NOEXCEPT
+    const_reverse_iterator crend()   const noexcept
         {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1044,14 +1044,14 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(list& __c)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT
+        noexcept
 #else
-        _NOEXCEPT_(!__node_alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__node_alloc_traits::propagate_on_container_swap::value ||
                    __is_nothrow_swappable<__node_allocator>::value)
 #endif
         {base::swap(__c);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {base::clear();}
+    void clear() noexcept {base::clear();}
 
     void pop_front();
     void pop_back();
@@ -1101,7 +1101,7 @@ public:
         _LIBCUDACXX_INLINE_VISIBILITY
         void sort(_Comp __comp);
 
-    void reverse() _NOEXCEPT;
+    void reverse() noexcept;
 
     bool __invariants() const;
 
@@ -1136,7 +1136,7 @@ private:
         static iterator __sort(iterator __f1, iterator __e2, size_type __n, _Comp& __comp);
 
     void __move_assign(list& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<__node_allocator>::value);
+        noexcept(is_nothrow_move_assignable<__node_allocator>::value);
     void __move_assign(list& __c, false_type);
 };
 
@@ -1323,7 +1323,7 @@ list<_Tp, _Alloc>::list(initializer_list<value_type> __il)
 
 template <class _Tp, class _Alloc>
 inline list<_Tp, _Alloc>::list(list&& __c)
-    _NOEXCEPT_(is_nothrow_move_constructible<__node_allocator>::value)
+    noexcept(is_nothrow_move_constructible<__node_allocator>::value)
     : base(_CUDA_VSTD::move(__c.__node_alloc())) {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     __get_db()->__insert_c(this);
@@ -1352,7 +1352,7 @@ template <class _Tp, class _Alloc>
 inline
 list<_Tp, _Alloc>&
 list<_Tp, _Alloc>::operator=(list&& __c)
-        _NOEXCEPT_(
+        noexcept(
             __node_alloc_traits::propagate_on_container_move_assignment::value &&
             is_nothrow_move_assignable<__node_allocator>::value)
 {
@@ -1377,7 +1377,7 @@ list<_Tp, _Alloc>::__move_assign(list& __c, false_type)
 template <class _Tp, class _Alloc>
 void
 list<_Tp, _Alloc>::__move_assign(list& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<__node_allocator>::value)
+        noexcept(is_nothrow_move_assignable<__node_allocator>::value)
 {
     clear();
     base::__move_assign_alloc(__c);
@@ -1438,7 +1438,7 @@ list<_Tp, _Alloc>::assign(size_type __n, const value_type& __x)
 template <class _Tp, class _Alloc>
 inline
 _Alloc
-list<_Tp, _Alloc>::get_allocator() const _NOEXCEPT
+list<_Tp, _Alloc>::get_allocator() const noexcept
 {
     return allocator_type(base::__node_alloc());
 }
@@ -2359,7 +2359,7 @@ list<_Tp, _Alloc>::__sort(iterator __f1, iterator __e2, size_type __n, _Comp& __
 
 template <class _Tp, class _Alloc>
 void
-list<_Tp, _Alloc>::reverse() _NOEXCEPT
+list<_Tp, _Alloc>::reverse() noexcept
 {
     if (base::__sz() > 1)
     {
@@ -2464,7 +2464,7 @@ template <class _Tp, class _Alloc>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(list<_Tp, _Alloc>& __x, list<_Tp, _Alloc>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/locale
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/locale
@@ -3689,7 +3689,7 @@ public:
     byte_string to_bytes(const _Elem* __first, const _Elem* __last);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t converted() const _NOEXCEPT {return __cvtcount_;}
+    size_t converted() const noexcept {return __cvtcount_;}
     _LIBCUDACXX_INLINE_VISIBILITY
     state_type state() const {return __cvtstate_;}
 };

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/map
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/map
@@ -500,14 +500,14 @@ class __map_value_compare
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     __map_value_compare()
-        _NOEXCEPT_(is_nothrow_default_constructible<_Compare>::value)
+        noexcept(is_nothrow_default_constructible<_Compare>::value)
         : _Compare() {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __map_value_compare(_Compare c)
-        _NOEXCEPT_(is_nothrow_copy_constructible<_Compare>::value)
+        noexcept(is_nothrow_copy_constructible<_Compare>::value)
         : _Compare(c) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const _Compare& key_comp() const _NOEXCEPT {return *this;}
+    const _Compare& key_comp() const noexcept {return *this;}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool operator()(const _CP& __x, const _CP& __y) const
         {return static_cast<const _Compare&>(*this)(__x.__get_value().first, __y.__get_value().first);}
@@ -518,7 +518,7 @@ public:
     bool operator()(const _Key& __x, const _CP& __y) const
         {return static_cast<const _Compare&>(*this)(__x, __y.__get_value().first);}
     void swap(__map_value_compare&__y)
-        _NOEXCEPT_(__is_nothrow_swappable<_Compare>::value)
+        noexcept(__is_nothrow_swappable<_Compare>::value)
     {
       using _CUDA_VSTD::swap;
       swap(static_cast<_Compare&>(*this), static_cast<_Compare&>(__y));
@@ -547,14 +547,14 @@ class __map_value_compare<_Key, _CP, _Compare, false>
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     __map_value_compare()
-        _NOEXCEPT_(is_nothrow_default_constructible<_Compare>::value)
+        noexcept(is_nothrow_default_constructible<_Compare>::value)
         : comp() {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __map_value_compare(_Compare c)
-        _NOEXCEPT_(is_nothrow_copy_constructible<_Compare>::value)
+        noexcept(is_nothrow_copy_constructible<_Compare>::value)
         : comp(c) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const _Compare& key_comp() const _NOEXCEPT {return comp;}
+    const _Compare& key_comp() const noexcept {return comp;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     bool operator()(const _CP& __x, const _CP& __y) const
@@ -566,7 +566,7 @@ public:
     bool operator()(const _Key& __x, const _CP& __y) const
         {return comp(__x, __y.__get_value().first);}
     void swap(__map_value_compare&__y)
-        _NOEXCEPT_(__is_nothrow_swappable<_Compare>::value)
+        noexcept(__is_nothrow_swappable<_Compare>::value)
     {
         using _CUDA_VSTD::swap;
         swap(comp, __y.comp);
@@ -592,7 +592,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__map_value_compare<_Key, _CP, _Compare, __b>& __x,
      __map_value_compare<_Key, _CP, _Compare, __b>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -616,7 +616,7 @@ public:
     bool __second_constructed;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __map_node_destructor(allocator_type& __na) _NOEXCEPT
+    explicit __map_node_destructor(allocator_type& __na) noexcept
         : __na_(__na),
           __first_constructed(false),
           __second_constructed(false)
@@ -624,7 +624,7 @@ public:
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
-    __map_node_destructor(__tree_node_destructor<allocator_type>&& __x) _NOEXCEPT
+    __map_node_destructor(__tree_node_destructor<allocator_type>&& __x) noexcept
         : __na_(__x.__na_),
           __first_constructed(__x.__value_constructed),
           __second_constructed(__x.__value_constructed)
@@ -634,7 +634,7 @@ public:
 #endif  // _LIBCUDACXX_CXX03_LANG
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator()(pointer __p) _NOEXCEPT
+    void operator()(pointer __p) noexcept
     {
         if (__second_constructed)
             __alloc_traits::destroy(__na_, _CUDA_VSTD::addressof(__p->__value_.__get_value().second));
@@ -788,10 +788,10 @@ public:
     typedef typename _NodeTypes::__map_value_type_pointer        pointer;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __map_iterator() _NOEXCEPT {}
+    __map_iterator() noexcept {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __map_iterator(_TreeIterator __i) _NOEXCEPT : __i_(__i) {}
+    __map_iterator(_TreeIterator __i) noexcept : __i_(__i) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     reference operator*() const {return __i_->__get_value();}
@@ -847,13 +847,13 @@ public:
     typedef typename _NodeTypes::__const_map_value_type_pointer  pointer;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __map_const_iterator() _NOEXCEPT {}
+    __map_const_iterator() noexcept {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __map_const_iterator(_TreeIterator __i) _NOEXCEPT : __i_(__i) {}
+    __map_const_iterator(_TreeIterator __i) noexcept : __i_(__i) {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __map_const_iterator(__map_iterator<
-        typename _TreeIterator::__non_const_iterator> __i) _NOEXCEPT
+        typename _TreeIterator::__non_const_iterator> __i) noexcept
         : __i_(__i.__i_) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -958,7 +958,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     map()
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<allocator_type>::value &&
             is_nothrow_default_constructible<key_compare>::value &&
             is_nothrow_copy_constructible<key_compare>::value)
@@ -966,7 +966,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit map(const key_compare& __comp)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<allocator_type>::value &&
             is_nothrow_copy_constructible<key_compare>::value)
         : __tree_(__vc(__comp)) {}
@@ -1027,7 +1027,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     map(map&& __m)
-        _NOEXCEPT_(is_nothrow_move_constructible<__base>::value)
+        noexcept(is_nothrow_move_constructible<__base>::value)
         : __tree_(_CUDA_VSTD::move(__m.__tree_))
         {
         }
@@ -1036,7 +1036,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     map& operator=(map&& __m)
-        _NOEXCEPT_(is_nothrow_move_assignable<__base>::value)
+        noexcept(is_nothrow_move_assignable<__base>::value)
         {
             __tree_ = _CUDA_VSTD::move(__m.__tree_);
             return *this;
@@ -1090,41 +1090,41 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator begin() _NOEXCEPT {return __tree_.begin();}
+          iterator begin() noexcept {return __tree_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT {return __tree_.begin();}
+    const_iterator begin() const noexcept {return __tree_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator end() _NOEXCEPT {return __tree_.end();}
+          iterator end() noexcept {return __tree_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end() const _NOEXCEPT {return __tree_.end();}
+    const_iterator end() const noexcept {return __tree_.end();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rbegin() _NOEXCEPT {return reverse_iterator(end());}
+          reverse_iterator rbegin() noexcept {return reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin() const _NOEXCEPT
+    const_reverse_iterator rbegin() const noexcept
         {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rend() _NOEXCEPT
+          reverse_iterator rend() noexcept
             {return       reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend() const _NOEXCEPT
+    const_reverse_iterator rend() const noexcept
         {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT {return begin();}
+    const_iterator cbegin() const noexcept {return begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend() const _NOEXCEPT {return end();}
+    const_iterator cend() const noexcept {return end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT {return rbegin();}
+    const_reverse_iterator crbegin() const noexcept {return rbegin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend() const _NOEXCEPT {return rend();}
+    const_reverse_iterator crend() const noexcept {return rend();}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool      empty() const _NOEXCEPT {return __tree_.size() == 0;}
+    bool      empty() const noexcept {return __tree_.size() == 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT {return __tree_.size();}
+    size_type size() const noexcept {return __tree_.size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {return __tree_.max_size();}
+    size_type max_size() const noexcept {return __tree_.max_size();}
 
     mapped_type& operator[](const key_type& __k);
 #ifndef _LIBCUDACXX_CXX03_LANG
@@ -1135,7 +1135,7 @@ public:
     const mapped_type& at(const key_type& __k) const;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT {return allocator_type(__tree_.__alloc());}
+    allocator_type get_allocator() const noexcept {return allocator_type(__tree_.__alloc());}
     _LIBCUDACXX_INLINE_VISIBILITY
     key_compare    key_comp()      const {return __tree_.value_comp().key_comp();}
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1306,7 +1306,7 @@ public:
     iterator  erase(const_iterator __f, const_iterator __l)
         {return __tree_.erase(__f.__i_, __l.__i_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {__tree_.clear();}
+    void clear() noexcept {__tree_.clear();}
 
 #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1371,7 +1371,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(map& __m)
-        _NOEXCEPT_(__is_nothrow_swappable<__base>::value)
+        noexcept(__is_nothrow_swappable<__base>::value)
         {__tree_.swap(__m.__tree_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1647,7 +1647,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(map<_Key, _Tp, _Compare, _Allocator>& __x,
      map<_Key, _Tp, _Compare, _Allocator>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -1725,7 +1725,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     multimap()
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<allocator_type>::value &&
             is_nothrow_default_constructible<key_compare>::value &&
             is_nothrow_copy_constructible<key_compare>::value)
@@ -1733,7 +1733,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit multimap(const key_compare& __comp)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<allocator_type>::value &&
             is_nothrow_copy_constructible<key_compare>::value)
         : __tree_(__vc(__comp)) {}
@@ -1795,7 +1795,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     multimap(multimap&& __m)
-        _NOEXCEPT_(is_nothrow_move_constructible<__base>::value)
+        noexcept(is_nothrow_move_constructible<__base>::value)
         : __tree_(_CUDA_VSTD::move(__m.__tree_))
         {
         }
@@ -1804,7 +1804,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     multimap& operator=(multimap&& __m)
-        _NOEXCEPT_(is_nothrow_move_assignable<__base>::value)
+        noexcept(is_nothrow_move_assignable<__base>::value)
         {
             __tree_ = _CUDA_VSTD::move(__m.__tree_);
             return *this;
@@ -1858,43 +1858,43 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator begin() _NOEXCEPT {return __tree_.begin();}
+          iterator begin() noexcept {return __tree_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT {return __tree_.begin();}
+    const_iterator begin() const noexcept {return __tree_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator end() _NOEXCEPT {return __tree_.end();}
+          iterator end() noexcept {return __tree_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end() const _NOEXCEPT {return __tree_.end();}
+    const_iterator end() const noexcept {return __tree_.end();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rbegin() _NOEXCEPT {return reverse_iterator(end());}
+          reverse_iterator rbegin() noexcept {return reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin() const _NOEXCEPT
+    const_reverse_iterator rbegin() const noexcept
         {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rend() _NOEXCEPT {return reverse_iterator(begin());}
+          reverse_iterator rend() noexcept {return reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend() const _NOEXCEPT
+    const_reverse_iterator rend() const noexcept
         {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin()  const _NOEXCEPT {return begin();}
+    const_iterator cbegin()  const noexcept {return begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend() const _NOEXCEPT {return end();}
+    const_iterator cend() const noexcept {return end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT {return rbegin();}
+    const_reverse_iterator crbegin() const noexcept {return rbegin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend() const _NOEXCEPT {return rend();}
+    const_reverse_iterator crend() const noexcept {return rend();}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT {return __tree_.size() == 0;}
+    bool empty() const noexcept {return __tree_.size() == 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT {return __tree_.size();}
+    size_type size() const noexcept {return __tree_.size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {return __tree_.max_size();}
+    size_type max_size() const noexcept {return __tree_.max_size();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT {return allocator_type(__tree_.__alloc());}
+    allocator_type get_allocator() const noexcept {return allocator_type(__tree_.__alloc());}
     _LIBCUDACXX_INLINE_VISIBILITY
     key_compare    key_comp() const {return __tree_.value_comp().key_comp();}
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2030,11 +2030,11 @@ public:
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {__tree_.clear();}
+    void clear() noexcept {__tree_.clear();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(multimap& __m)
-        _NOEXCEPT_(__is_nothrow_swappable<__base>::value)
+        noexcept(__is_nothrow_swappable<__base>::value)
         {__tree_.swap(__m.__tree_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2229,7 +2229,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(multimap<_Key, _Tp, _Compare, _Allocator>& __x,
      multimap<_Key, _Tp, _Compare, _Allocator>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/math.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/math.h
@@ -318,7 +318,7 @@ extern "C++" {
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_signbit(_A1 __lcpp_x) _NOEXCEPT
+__libcpp_signbit(_A1 __lcpp_x) noexcept
 {
     return signbit(__lcpp_x);
 }
@@ -328,7 +328,7 @@ __libcpp_signbit(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_floating_point<_A1>::value, bool>::type
-signbit(_A1 __lcpp_x) _NOEXCEPT
+signbit(_A1 __lcpp_x) noexcept
 {
     return __libcpp_signbit((typename std::__promote<_A1>::type)__lcpp_x);
 }
@@ -337,14 +337,14 @@ template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<
     std::is_integral<_A1>::value && std::is_signed<_A1>::value, bool>::type
-signbit(_A1 __lcpp_x) _NOEXCEPT
+signbit(_A1 __lcpp_x) noexcept
 { return __lcpp_x < 0; }
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<
     std::is_integral<_A1>::value && !std::is_signed<_A1>::value, bool>::type
-signbit(_A1) _NOEXCEPT
+signbit(_A1) noexcept
 { return false; }
 
 #elif defined(_LIBCUDACXX_MSVCRT)
@@ -352,7 +352,7 @@ signbit(_A1) _NOEXCEPT
 template <typename _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_floating_point<_A1>::value, bool>::type
-signbit(_A1 __lcpp_x) _NOEXCEPT
+signbit(_A1 __lcpp_x) noexcept
 {
   return ::signbit(static_cast<typename std::__promote<_A1>::type>(__lcpp_x));
 }
@@ -361,14 +361,14 @@ template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<
     std::is_integral<_A1>::value && std::is_signed<_A1>::value, bool>::type
-signbit(_A1 __lcpp_x) _NOEXCEPT
+signbit(_A1 __lcpp_x) noexcept
 { return __lcpp_x < 0; }
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<
     std::is_integral<_A1>::value && !std::is_signed<_A1>::value, bool>::type
-signbit(_A1) _NOEXCEPT
+signbit(_A1) noexcept
 { return false; }
 
 #endif  // signbit
@@ -380,7 +380,7 @@ signbit(_A1) _NOEXCEPT
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 int
-__libcpp_fpclassify(_A1 __lcpp_x) _NOEXCEPT
+__libcpp_fpclassify(_A1 __lcpp_x) noexcept
 {
     return fpclassify(__lcpp_x);
 }
@@ -390,7 +390,7 @@ __libcpp_fpclassify(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_floating_point<_A1>::value, int>::type
-fpclassify(_A1 __lcpp_x) _NOEXCEPT
+fpclassify(_A1 __lcpp_x) noexcept
 {
     return __libcpp_fpclassify((typename std::__promote<_A1>::type)__lcpp_x);
 }
@@ -398,7 +398,7 @@ fpclassify(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, int>::type
-fpclassify(_A1 __lcpp_x) _NOEXCEPT
+fpclassify(_A1 __lcpp_x) noexcept
 { return __lcpp_x == 0 ? FP_ZERO : FP_NORMAL; }
 
 #elif defined(_LIBCUDACXX_MSVCRT)
@@ -406,7 +406,7 @@ fpclassify(_A1 __lcpp_x) _NOEXCEPT
 template <typename _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_floating_point<_A1>::value, bool>::type
-fpclassify(_A1 __lcpp_x) _NOEXCEPT
+fpclassify(_A1 __lcpp_x) noexcept
 {
   return ::fpclassify(static_cast<typename std::__promote<_A1>::type>(__lcpp_x));
 }
@@ -414,7 +414,7 @@ fpclassify(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, int>::type
-fpclassify(_A1 __lcpp_x) _NOEXCEPT
+fpclassify(_A1 __lcpp_x) noexcept
 { return __lcpp_x == 0 ? FP_ZERO : FP_NORMAL; }
 
 #endif  // fpclassify
@@ -426,7 +426,7 @@ fpclassify(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_isfinite(_A1 __lcpp_x) _NOEXCEPT
+__libcpp_isfinite(_A1 __lcpp_x) noexcept
 {
     return isfinite(__lcpp_x);
 }
@@ -438,7 +438,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<
     std::is_arithmetic<_A1>::value && std::numeric_limits<_A1>::has_infinity,
     bool>::type
-isfinite(_A1 __lcpp_x) _NOEXCEPT
+isfinite(_A1 __lcpp_x) noexcept
 {
     return __libcpp_isfinite((typename std::__promote<_A1>::type)__lcpp_x);
 }
@@ -448,7 +448,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<
     std::is_arithmetic<_A1>::value && !std::numeric_limits<_A1>::has_infinity,
     bool>::type
-isfinite(_A1) _NOEXCEPT
+isfinite(_A1) noexcept
 { return true; }
 
 #endif  // isfinite
@@ -460,7 +460,7 @@ isfinite(_A1) _NOEXCEPT
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_isinf(_A1 __lcpp_x) _NOEXCEPT
+__libcpp_isinf(_A1 __lcpp_x) noexcept
 {
     return isinf(__lcpp_x);
 }
@@ -472,7 +472,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<
     std::is_arithmetic<_A1>::value && std::numeric_limits<_A1>::has_infinity,
     bool>::type
-isinf(_A1 __lcpp_x) _NOEXCEPT
+isinf(_A1 __lcpp_x) noexcept
 {
     return __libcpp_isinf((typename std::__promote<_A1>::type)__lcpp_x);
 }
@@ -482,21 +482,21 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<
     std::is_arithmetic<_A1>::value && !std::numeric_limits<_A1>::has_infinity,
     bool>::type
-isinf(_A1) _NOEXCEPT
+isinf(_A1) noexcept
 { return false; }
 
 #ifdef _LIBCUDACXX_PREFERRED_OVERLOAD
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-isinf(float __lcpp_x) _NOEXCEPT { return __libcpp_isinf(__lcpp_x); }
+isinf(float __lcpp_x) noexcept { return __libcpp_isinf(__lcpp_x); }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_PREFERRED_OVERLOAD
 bool
-isinf(double __lcpp_x) _NOEXCEPT { return __libcpp_isinf(__lcpp_x); }
+isinf(double __lcpp_x) noexcept { return __libcpp_isinf(__lcpp_x); }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-isinf(long double __lcpp_x) _NOEXCEPT { return __libcpp_isinf(__lcpp_x); }
+isinf(long double __lcpp_x) noexcept { return __libcpp_isinf(__lcpp_x); }
 #endif
 
 #endif  // isinf
@@ -508,7 +508,7 @@ isinf(long double __lcpp_x) _NOEXCEPT { return __libcpp_isinf(__lcpp_x); }
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_isnan(_A1 __lcpp_x) _NOEXCEPT
+__libcpp_isnan(_A1 __lcpp_x) noexcept
 {
     return isnan(__lcpp_x);
 }
@@ -518,7 +518,7 @@ __libcpp_isnan(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_floating_point<_A1>::value, bool>::type
-isnan(_A1 __lcpp_x) _NOEXCEPT
+isnan(_A1 __lcpp_x) noexcept
 {
     return __libcpp_isnan((typename std::__promote<_A1>::type)__lcpp_x);
 }
@@ -526,21 +526,21 @@ isnan(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, bool>::type
-isnan(_A1) _NOEXCEPT
+isnan(_A1) noexcept
 { return false; }
 
 #ifdef _LIBCUDACXX_PREFERRED_OVERLOAD
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-isnan(float __lcpp_x) _NOEXCEPT { return __libcpp_isnan(__lcpp_x); }
+isnan(float __lcpp_x) noexcept { return __libcpp_isnan(__lcpp_x); }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_PREFERRED_OVERLOAD
 bool
-isnan(double __lcpp_x) _NOEXCEPT { return __libcpp_isnan(__lcpp_x); }
+isnan(double __lcpp_x) noexcept { return __libcpp_isnan(__lcpp_x); }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-isnan(long double __lcpp_x) _NOEXCEPT { return __libcpp_isnan(__lcpp_x); }
+isnan(long double __lcpp_x) noexcept { return __libcpp_isnan(__lcpp_x); }
 #endif
 
 #endif  // isnan
@@ -552,7 +552,7 @@ isnan(long double __lcpp_x) _NOEXCEPT { return __libcpp_isnan(__lcpp_x); }
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_isnormal(_A1 __lcpp_x) _NOEXCEPT
+__libcpp_isnormal(_A1 __lcpp_x) noexcept
 {
     return isnormal(__lcpp_x);
 }
@@ -562,7 +562,7 @@ __libcpp_isnormal(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_floating_point<_A1>::value, bool>::type
-isnormal(_A1 __lcpp_x) _NOEXCEPT
+isnormal(_A1 __lcpp_x) noexcept
 {
     return __libcpp_isnormal((typename std::__promote<_A1>::type)__lcpp_x);
 }
@@ -570,7 +570,7 @@ isnormal(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, bool>::type
-isnormal(_A1 __lcpp_x) _NOEXCEPT
+isnormal(_A1 __lcpp_x) noexcept
 { return __lcpp_x != 0; }
 
 #endif  // isnormal
@@ -582,7 +582,7 @@ isnormal(_A1 __lcpp_x) _NOEXCEPT
 template <class _A1, class _A2>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_isgreater(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+__libcpp_isgreater(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     return isgreater(__lcpp_x, __lcpp_y);
 }
@@ -597,7 +597,7 @@ typename std::enable_if
     std::is_arithmetic<_A2>::value,
     bool
 >::type
-isgreater(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+isgreater(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type type;
     return __libcpp_isgreater((type)__lcpp_x, (type)__lcpp_y);
@@ -612,7 +612,7 @@ isgreater(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 template <class _A1, class _A2>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_isgreaterequal(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+__libcpp_isgreaterequal(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     return isgreaterequal(__lcpp_x, __lcpp_y);
 }
@@ -627,7 +627,7 @@ typename std::enable_if
     std::is_arithmetic<_A2>::value,
     bool
 >::type
-isgreaterequal(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+isgreaterequal(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type type;
     return __libcpp_isgreaterequal((type)__lcpp_x, (type)__lcpp_y);
@@ -642,7 +642,7 @@ isgreaterequal(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 template <class _A1, class _A2>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_isless(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+__libcpp_isless(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     return isless(__lcpp_x, __lcpp_y);
 }
@@ -657,7 +657,7 @@ typename std::enable_if
     std::is_arithmetic<_A2>::value,
     bool
 >::type
-isless(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+isless(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type type;
     return __libcpp_isless((type)__lcpp_x, (type)__lcpp_y);
@@ -672,7 +672,7 @@ isless(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 template <class _A1, class _A2>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_islessequal(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+__libcpp_islessequal(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     return islessequal(__lcpp_x, __lcpp_y);
 }
@@ -687,7 +687,7 @@ typename std::enable_if
     std::is_arithmetic<_A2>::value,
     bool
 >::type
-islessequal(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+islessequal(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type type;
     return __libcpp_islessequal((type)__lcpp_x, (type)__lcpp_y);
@@ -702,7 +702,7 @@ islessequal(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 template <class _A1, class _A2>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_islessgreater(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+__libcpp_islessgreater(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     return islessgreater(__lcpp_x, __lcpp_y);
 }
@@ -717,7 +717,7 @@ typename std::enable_if
     std::is_arithmetic<_A2>::value,
     bool
 >::type
-islessgreater(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+islessgreater(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type type;
     return __libcpp_islessgreater((type)__lcpp_x, (type)__lcpp_y);
@@ -732,7 +732,7 @@ islessgreater(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 template <class _A1, class _A2>
 _LIBCUDACXX_INLINE_VISIBILITY
 bool
-__libcpp_isunordered(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+__libcpp_isunordered(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     return isunordered(__lcpp_x, __lcpp_y);
 }
@@ -747,7 +747,7 @@ typename std::enable_if
     std::is_arithmetic<_A2>::value,
     bool
 >::type
-isunordered(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+isunordered(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type type;
     return __libcpp_isunordered((type)__lcpp_x, (type)__lcpp_y);
@@ -765,11 +765,11 @@ isunordered(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 
 // MSVCRT already has the correct prototype in <stdlib.h> if __cplusplus is defined
 #if !defined(_LIBCUDACXX_MSVCRT) && !defined(__sun__) && !defined(_AIX)
-inline _LIBCUDACXX_INLINE_VISIBILITY long abs(long __x) _NOEXCEPT {
+inline _LIBCUDACXX_INLINE_VISIBILITY long abs(long __x) noexcept {
   return ::labs(__x);
 }
 #ifndef _LIBCUDACXX_HAS_NO_LONG_LONG
-inline _LIBCUDACXX_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {
+inline _LIBCUDACXX_INLINE_VISIBILITY long long abs(long long __x) noexcept {
   return ::llabs(__x);
 }
 #endif // _LIBCUDACXX_HAS_NO_LONG_LONG
@@ -777,16 +777,16 @@ inline _LIBCUDACXX_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {
 
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float abs(float __lcpp_x) _NOEXCEPT {
+inline _LIBCUDACXX_INLINE_VISIBILITY float abs(float __lcpp_x) noexcept {
   return ::fabsf(__lcpp_x);
 }
 
-inline _LIBCUDACXX_INLINE_VISIBILITY double abs(double __lcpp_x) _NOEXCEPT {
+inline _LIBCUDACXX_INLINE_VISIBILITY double abs(double __lcpp_x) noexcept {
   return ::fabs(__lcpp_x);
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY long double
-abs(long double __lcpp_x) _NOEXCEPT {
+abs(long double __lcpp_x) noexcept {
   return ::fabsl(__lcpp_x);
 }
 #endif // !(defined(_AIX) || defined(__sun__))
@@ -801,12 +801,12 @@ abs(long double __lcpp_x) _NOEXCEPT {
 
 // MSVCRT already has the correct prototype in <stdlib.h> if __cplusplus is defined
 #if !defined(_LIBCUDACXX_MSVCRT) && !defined(__sun__) && !defined(_AIX)
-inline _LIBCUDACXX_INLINE_VISIBILITY ldiv_t div(long __x, long __y) _NOEXCEPT {
+inline _LIBCUDACXX_INLINE_VISIBILITY ldiv_t div(long __x, long __y) noexcept {
   return ::ldiv(__x, __y);
 }
 #ifndef _LIBCUDACXX_HAS_NO_LONG_LONG
 inline _LIBCUDACXX_INLINE_VISIBILITY lldiv_t div(long long __x,
-                                             long long __y) _NOEXCEPT {
+                                             long long __y) noexcept {
   return ::lldiv(__x, __y);
 }
 #endif // _LIBCUDACXX_HAS_NO_LONG_LONG
@@ -815,44 +815,44 @@ inline _LIBCUDACXX_INLINE_VISIBILITY lldiv_t div(long long __x,
 // acos
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       acos(float __lcpp_x) _NOEXCEPT       {return ::acosf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double acos(long double __lcpp_x) _NOEXCEPT {return ::acosl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       acos(float __lcpp_x) noexcept       {return ::acosf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double acos(long double __lcpp_x) noexcept {return ::acosl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-acos(_A1 __lcpp_x) _NOEXCEPT {return ::acos((double)__lcpp_x);}
+acos(_A1 __lcpp_x) noexcept {return ::acos((double)__lcpp_x);}
 
 // asin
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       asin(float __lcpp_x) _NOEXCEPT       {return ::asinf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double asin(long double __lcpp_x) _NOEXCEPT {return ::asinl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       asin(float __lcpp_x) noexcept       {return ::asinf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double asin(long double __lcpp_x) noexcept {return ::asinl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-asin(_A1 __lcpp_x) _NOEXCEPT {return ::asin((double)__lcpp_x);}
+asin(_A1 __lcpp_x) noexcept {return ::asin((double)__lcpp_x);}
 
 // atan
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       atan(float __lcpp_x) _NOEXCEPT       {return ::atanf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double atan(long double __lcpp_x) _NOEXCEPT {return ::atanl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       atan(float __lcpp_x) noexcept       {return ::atanf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double atan(long double __lcpp_x) noexcept {return ::atanl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-atan(_A1 __lcpp_x) _NOEXCEPT {return ::atan((double)__lcpp_x);}
+atan(_A1 __lcpp_x) noexcept {return ::atan((double)__lcpp_x);}
 
 // atan2
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       atan2(float __lcpp_y, float __lcpp_x) _NOEXCEPT             {return ::atan2f(__lcpp_y, __lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double atan2(long double __lcpp_y, long double __lcpp_x) _NOEXCEPT {return ::atan2l(__lcpp_y, __lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       atan2(float __lcpp_y, float __lcpp_x) noexcept             {return ::atan2f(__lcpp_y, __lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double atan2(long double __lcpp_y, long double __lcpp_x) noexcept {return ::atan2l(__lcpp_y, __lcpp_x);}
 #endif
 
 template <class _A1, class _A2>
@@ -863,7 +863,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-atan2(_A1 __lcpp_y, _A2 __lcpp_x) _NOEXCEPT
+atan2(_A1 __lcpp_y, _A2 __lcpp_x) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -874,80 +874,80 @@ atan2(_A1 __lcpp_y, _A2 __lcpp_x) _NOEXCEPT
 // ceil
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       ceil(float __lcpp_x) _NOEXCEPT       {return ::ceilf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double ceil(long double __lcpp_x) _NOEXCEPT {return ::ceill(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       ceil(float __lcpp_x) noexcept       {return ::ceilf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double ceil(long double __lcpp_x) noexcept {return ::ceill(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-ceil(_A1 __lcpp_x) _NOEXCEPT {return ::ceil((double)__lcpp_x);}
+ceil(_A1 __lcpp_x) noexcept {return ::ceil((double)__lcpp_x);}
 
 // cos
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       cos(float __lcpp_x) _NOEXCEPT       {return ::cosf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double cos(long double __lcpp_x) _NOEXCEPT {return ::cosl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       cos(float __lcpp_x) noexcept       {return ::cosf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double cos(long double __lcpp_x) noexcept {return ::cosl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-cos(_A1 __lcpp_x) _NOEXCEPT {return ::cos((double)__lcpp_x);}
+cos(_A1 __lcpp_x) noexcept {return ::cos((double)__lcpp_x);}
 
 // cosh
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       cosh(float __lcpp_x) _NOEXCEPT       {return ::coshf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double cosh(long double __lcpp_x) _NOEXCEPT {return ::coshl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       cosh(float __lcpp_x) noexcept       {return ::coshf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double cosh(long double __lcpp_x) noexcept {return ::coshl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-cosh(_A1 __lcpp_x) _NOEXCEPT {return ::cosh((double)__lcpp_x);}
+cosh(_A1 __lcpp_x) noexcept {return ::cosh((double)__lcpp_x);}
 
 // exp
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       exp(float __lcpp_x) _NOEXCEPT       {return ::expf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double exp(long double __lcpp_x) _NOEXCEPT {return ::expl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       exp(float __lcpp_x) noexcept       {return ::expf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double exp(long double __lcpp_x) noexcept {return ::expl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-exp(_A1 __lcpp_x) _NOEXCEPT {return ::exp((double)__lcpp_x);}
+exp(_A1 __lcpp_x) noexcept {return ::exp((double)__lcpp_x);}
 
 // fabs
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       fabs(float __lcpp_x) _NOEXCEPT       {return ::fabsf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double fabs(long double __lcpp_x) _NOEXCEPT {return ::fabsl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       fabs(float __lcpp_x) noexcept       {return ::fabsf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double fabs(long double __lcpp_x) noexcept {return ::fabsl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-fabs(_A1 __lcpp_x) _NOEXCEPT {return ::fabs((double)__lcpp_x);}
+fabs(_A1 __lcpp_x) noexcept {return ::fabs((double)__lcpp_x);}
 
 // floor
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       floor(float __lcpp_x) _NOEXCEPT       {return ::floorf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double floor(long double __lcpp_x) _NOEXCEPT {return ::floorl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       floor(float __lcpp_x) noexcept       {return ::floorf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double floor(long double __lcpp_x) noexcept {return ::floorl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-floor(_A1 __lcpp_x) _NOEXCEPT {return ::floor((double)__lcpp_x);}
+floor(_A1 __lcpp_x) noexcept {return ::floor((double)__lcpp_x);}
 
 // fmod
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       fmod(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fmodf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double fmod(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::fmodl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       fmod(float __lcpp_x, float __lcpp_y) noexcept             {return ::fmodf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double fmod(long double __lcpp_x, long double __lcpp_y) noexcept {return ::fmodl(__lcpp_x, __lcpp_y);}
 #endif
 
 template <class _A1, class _A2>
@@ -958,7 +958,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-fmod(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+fmod(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -969,63 +969,63 @@ fmod(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 // frexp
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       frexp(float __lcpp_x, int* __lcpp_e) _NOEXCEPT       {return ::frexpf(__lcpp_x, __lcpp_e);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double frexp(long double __lcpp_x, int* __lcpp_e) _NOEXCEPT {return ::frexpl(__lcpp_x, __lcpp_e);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       frexp(float __lcpp_x, int* __lcpp_e) noexcept       {return ::frexpf(__lcpp_x, __lcpp_e);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double frexp(long double __lcpp_x, int* __lcpp_e) noexcept {return ::frexpl(__lcpp_x, __lcpp_e);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-frexp(_A1 __lcpp_x, int* __lcpp_e) _NOEXCEPT {return ::frexp((double)__lcpp_x, __lcpp_e);}
+frexp(_A1 __lcpp_x, int* __lcpp_e) noexcept {return ::frexp((double)__lcpp_x, __lcpp_e);}
 
 // ldexp
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       ldexp(float __lcpp_x, int __lcpp_e) _NOEXCEPT       {return ::ldexpf(__lcpp_x, __lcpp_e);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double ldexp(long double __lcpp_x, int __lcpp_e) _NOEXCEPT {return ::ldexpl(__lcpp_x, __lcpp_e);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       ldexp(float __lcpp_x, int __lcpp_e) noexcept       {return ::ldexpf(__lcpp_x, __lcpp_e);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double ldexp(long double __lcpp_x, int __lcpp_e) noexcept {return ::ldexpl(__lcpp_x, __lcpp_e);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-ldexp(_A1 __lcpp_x, int __lcpp_e) _NOEXCEPT {return ::ldexp((double)__lcpp_x, __lcpp_e);}
+ldexp(_A1 __lcpp_x, int __lcpp_e) noexcept {return ::ldexp((double)__lcpp_x, __lcpp_e);}
 
 // log
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       log(float __lcpp_x) _NOEXCEPT       {return ::logf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double log(long double __lcpp_x) _NOEXCEPT {return ::logl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       log(float __lcpp_x) noexcept       {return ::logf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double log(long double __lcpp_x) noexcept {return ::logl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-log(_A1 __lcpp_x) _NOEXCEPT {return ::log((double)__lcpp_x);}
+log(_A1 __lcpp_x) noexcept {return ::log((double)__lcpp_x);}
 
 // log10
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       log10(float __lcpp_x) _NOEXCEPT       {return ::log10f(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double log10(long double __lcpp_x) _NOEXCEPT {return ::log10l(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       log10(float __lcpp_x) noexcept       {return ::log10f(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double log10(long double __lcpp_x) noexcept {return ::log10l(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-log10(_A1 __lcpp_x) _NOEXCEPT {return ::log10((double)__lcpp_x);}
+log10(_A1 __lcpp_x) noexcept {return ::log10((double)__lcpp_x);}
 
 // modf
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       modf(float __lcpp_x, float* __lcpp_y) _NOEXCEPT             {return ::modff(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double modf(long double __lcpp_x, long double* __lcpp_y) _NOEXCEPT {return ::modfl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       modf(float __lcpp_x, float* __lcpp_y) noexcept             {return ::modff(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double modf(long double __lcpp_x, long double* __lcpp_y) noexcept {return ::modfl(__lcpp_x, __lcpp_y);}
 #endif
 
 // pow
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       pow(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::powf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double pow(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::powl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       pow(float __lcpp_x, float __lcpp_y) noexcept             {return ::powf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double pow(long double __lcpp_x, long double __lcpp_y) noexcept {return ::powl(__lcpp_x, __lcpp_y);}
 #endif
 
 template <class _A1, class _A2>
@@ -1036,7 +1036,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+pow(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1047,111 +1047,111 @@ pow(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 // sin
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       sin(float __lcpp_x) _NOEXCEPT       {return ::sinf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double sin(long double __lcpp_x) _NOEXCEPT {return ::sinl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       sin(float __lcpp_x) noexcept       {return ::sinf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double sin(long double __lcpp_x) noexcept {return ::sinl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-sin(_A1 __lcpp_x) _NOEXCEPT {return ::sin((double)__lcpp_x);}
+sin(_A1 __lcpp_x) noexcept {return ::sin((double)__lcpp_x);}
 
 // sinh
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       sinh(float __lcpp_x) _NOEXCEPT       {return ::sinhf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double sinh(long double __lcpp_x) _NOEXCEPT {return ::sinhl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       sinh(float __lcpp_x) noexcept       {return ::sinhf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double sinh(long double __lcpp_x) noexcept {return ::sinhl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-sinh(_A1 __lcpp_x) _NOEXCEPT {return ::sinh((double)__lcpp_x);}
+sinh(_A1 __lcpp_x) noexcept {return ::sinh((double)__lcpp_x);}
 
 // sqrt
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       sqrt(float __lcpp_x) _NOEXCEPT       {return ::sqrtf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double sqrt(long double __lcpp_x) _NOEXCEPT {return ::sqrtl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       sqrt(float __lcpp_x) noexcept       {return ::sqrtf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double sqrt(long double __lcpp_x) noexcept {return ::sqrtl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-sqrt(_A1 __lcpp_x) _NOEXCEPT {return ::sqrt((double)__lcpp_x);}
+sqrt(_A1 __lcpp_x) noexcept {return ::sqrt((double)__lcpp_x);}
 
 // tan
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       tan(float __lcpp_x) _NOEXCEPT       {return ::tanf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double tan(long double __lcpp_x) _NOEXCEPT {return ::tanl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       tan(float __lcpp_x) noexcept       {return ::tanf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double tan(long double __lcpp_x) noexcept {return ::tanl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-tan(_A1 __lcpp_x) _NOEXCEPT {return ::tan((double)__lcpp_x);}
+tan(_A1 __lcpp_x) noexcept {return ::tan((double)__lcpp_x);}
 
 // tanh
 
 #if !(defined(_AIX) || defined(__sun__))
-inline _LIBCUDACXX_INLINE_VISIBILITY float       tanh(float __lcpp_x) _NOEXCEPT       {return ::tanhf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double tanh(long double __lcpp_x) _NOEXCEPT {return ::tanhl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       tanh(float __lcpp_x) noexcept       {return ::tanhf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double tanh(long double __lcpp_x) noexcept {return ::tanhl(__lcpp_x);}
 #endif
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-tanh(_A1 __lcpp_x) _NOEXCEPT {return ::tanh((double)__lcpp_x);}
+tanh(_A1 __lcpp_x) noexcept {return ::tanh((double)__lcpp_x);}
 
 // acosh
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       acosh(float __lcpp_x) _NOEXCEPT       {return ::acoshf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double acosh(long double __lcpp_x) _NOEXCEPT {return ::acoshl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       acosh(float __lcpp_x) noexcept       {return ::acoshf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double acosh(long double __lcpp_x) noexcept {return ::acoshl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-acosh(_A1 __lcpp_x) _NOEXCEPT {return ::acosh((double)__lcpp_x);}
+acosh(_A1 __lcpp_x) noexcept {return ::acosh((double)__lcpp_x);}
 
 // asinh
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       asinh(float __lcpp_x) _NOEXCEPT       {return ::asinhf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double asinh(long double __lcpp_x) _NOEXCEPT {return ::asinhl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       asinh(float __lcpp_x) noexcept       {return ::asinhf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double asinh(long double __lcpp_x) noexcept {return ::asinhl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-asinh(_A1 __lcpp_x) _NOEXCEPT {return ::asinh((double)__lcpp_x);}
+asinh(_A1 __lcpp_x) noexcept {return ::asinh((double)__lcpp_x);}
 
 // atanh
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       atanh(float __lcpp_x) _NOEXCEPT       {return ::atanhf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double atanh(long double __lcpp_x) _NOEXCEPT {return ::atanhl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       atanh(float __lcpp_x) noexcept       {return ::atanhf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double atanh(long double __lcpp_x) noexcept {return ::atanhl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-atanh(_A1 __lcpp_x) _NOEXCEPT {return ::atanh((double)__lcpp_x);}
+atanh(_A1 __lcpp_x) noexcept {return ::atanh((double)__lcpp_x);}
 
 // cbrt
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       cbrt(float __lcpp_x) _NOEXCEPT       {return ::cbrtf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double cbrt(long double __lcpp_x) _NOEXCEPT {return ::cbrtl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       cbrt(float __lcpp_x) noexcept       {return ::cbrtf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double cbrt(long double __lcpp_x) noexcept {return ::cbrtl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-cbrt(_A1 __lcpp_x) _NOEXCEPT {return ::cbrt((double)__lcpp_x);}
+cbrt(_A1 __lcpp_x) noexcept {return ::cbrt((double)__lcpp_x);}
 
 // copysign
 
 inline _LIBCUDACXX_INLINE_VISIBILITY float copysign(float __lcpp_x,
-                                                float __lcpp_y) _NOEXCEPT {
+                                                float __lcpp_y) noexcept {
   return ::copysignf(__lcpp_x, __lcpp_y);
 }
 inline _LIBCUDACXX_INLINE_VISIBILITY long double
-copysign(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {
+copysign(long double __lcpp_x, long double __lcpp_y) noexcept {
   return ::copysignl(__lcpp_x, __lcpp_y);
 }
 
@@ -1163,7 +1163,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-copysign(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+copysign(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1173,48 +1173,48 @@ copysign(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 
 // erf
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       erf(float __lcpp_x) _NOEXCEPT       {return ::erff(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double erf(long double __lcpp_x) _NOEXCEPT {return ::erfl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       erf(float __lcpp_x) noexcept       {return ::erff(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double erf(long double __lcpp_x) noexcept {return ::erfl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-erf(_A1 __lcpp_x) _NOEXCEPT {return ::erf((double)__lcpp_x);}
+erf(_A1 __lcpp_x) noexcept {return ::erf((double)__lcpp_x);}
 
 // erfc
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       erfc(float __lcpp_x) _NOEXCEPT       {return ::erfcf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double erfc(long double __lcpp_x) _NOEXCEPT {return ::erfcl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       erfc(float __lcpp_x) noexcept       {return ::erfcf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double erfc(long double __lcpp_x) noexcept {return ::erfcl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-erfc(_A1 __lcpp_x) _NOEXCEPT {return ::erfc((double)__lcpp_x);}
+erfc(_A1 __lcpp_x) noexcept {return ::erfc((double)__lcpp_x);}
 
 // exp2
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       exp2(float __lcpp_x) _NOEXCEPT       {return ::exp2f(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double exp2(long double __lcpp_x) _NOEXCEPT {return ::exp2l(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       exp2(float __lcpp_x) noexcept       {return ::exp2f(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double exp2(long double __lcpp_x) noexcept {return ::exp2l(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-exp2(_A1 __lcpp_x) _NOEXCEPT {return ::exp2((double)__lcpp_x);}
+exp2(_A1 __lcpp_x) noexcept {return ::exp2((double)__lcpp_x);}
 
 // expm1
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       expm1(float __lcpp_x) _NOEXCEPT       {return ::expm1f(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double expm1(long double __lcpp_x) _NOEXCEPT {return ::expm1l(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       expm1(float __lcpp_x) noexcept       {return ::expm1f(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double expm1(long double __lcpp_x) noexcept {return ::expm1l(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-expm1(_A1 __lcpp_x) _NOEXCEPT {return ::expm1((double)__lcpp_x);}
+expm1(_A1 __lcpp_x) noexcept {return ::expm1((double)__lcpp_x);}
 
 // fdim
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       fdim(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fdimf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double fdim(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::fdiml(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       fdim(float __lcpp_x, float __lcpp_y) noexcept             {return ::fdimf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double fdim(long double __lcpp_x, long double __lcpp_y) noexcept {return ::fdiml(__lcpp_x, __lcpp_y);}
 
 template <class _A1, class _A2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -1224,7 +1224,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-fdim(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+fdim(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1234,8 +1234,8 @@ fdim(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 
 // fma
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       fma(float __lcpp_x, float __lcpp_y, float __lcpp_z) _NOEXCEPT                   {return ::fmaf(__lcpp_x, __lcpp_y, __lcpp_z);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double fma(long double __lcpp_x, long double __lcpp_y, long double __lcpp_z) _NOEXCEPT {return ::fmal(__lcpp_x, __lcpp_y, __lcpp_z);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       fma(float __lcpp_x, float __lcpp_y, float __lcpp_z) noexcept                   {return ::fmaf(__lcpp_x, __lcpp_y, __lcpp_z);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double fma(long double __lcpp_x, long double __lcpp_y, long double __lcpp_z) noexcept {return ::fmal(__lcpp_x, __lcpp_y, __lcpp_z);}
 
 template <class _A1, class _A2, class _A3>
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -1246,7 +1246,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A3>::value,
     std::__promote<_A1, _A2, _A3>
 >::type
-fma(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT
+fma(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) noexcept
 {
     typedef typename std::__promote<_A1, _A2, _A3>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1257,8 +1257,8 @@ fma(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT
 
 // fmax
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       fmax(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fmaxf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double fmax(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::fmaxl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       fmax(float __lcpp_x, float __lcpp_y) noexcept             {return ::fmaxf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double fmax(long double __lcpp_x, long double __lcpp_y) noexcept {return ::fmaxl(__lcpp_x, __lcpp_y);}
 
 template <class _A1, class _A2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -1268,7 +1268,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-fmax(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+fmax(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1278,8 +1278,8 @@ fmax(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 
 // fmin
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       fmin(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::fminf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double fmin(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::fminl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       fmin(float __lcpp_x, float __lcpp_y) noexcept             {return ::fminf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double fmin(long double __lcpp_x, long double __lcpp_y) noexcept {return ::fminl(__lcpp_x, __lcpp_y);}
 
 template <class _A1, class _A2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -1289,7 +1289,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-fmin(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+fmin(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1299,8 +1299,8 @@ fmin(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 
 // hypot
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       hypot(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::hypotf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double hypot(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::hypotl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       hypot(float __lcpp_x, float __lcpp_y) noexcept             {return ::hypotf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double hypot(long double __lcpp_x, long double __lcpp_y) noexcept {return ::hypotl(__lcpp_x, __lcpp_y);}
 
 template <class _A1, class _A2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -1310,7 +1310,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-hypot(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+hypot(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1320,110 +1320,110 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 
 // ilogb
 
-inline _LIBCUDACXX_INLINE_VISIBILITY int ilogb(float __lcpp_x) _NOEXCEPT       {return ::ilogbf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY int ilogb(long double __lcpp_x) _NOEXCEPT {return ::ilogbl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY int ilogb(float __lcpp_x) noexcept       {return ::ilogbf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY int ilogb(long double __lcpp_x) noexcept {return ::ilogbl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, int>::type
-ilogb(_A1 __lcpp_x) _NOEXCEPT {return ::ilogb((double)__lcpp_x);}
+ilogb(_A1 __lcpp_x) noexcept {return ::ilogb((double)__lcpp_x);}
 
 // lgamma
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       lgamma(float __lcpp_x) _NOEXCEPT       {return ::lgammaf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double lgamma(long double __lcpp_x) _NOEXCEPT {return ::lgammal(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       lgamma(float __lcpp_x) noexcept       {return ::lgammaf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double lgamma(long double __lcpp_x) noexcept {return ::lgammal(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-lgamma(_A1 __lcpp_x) _NOEXCEPT {return ::lgamma((double)__lcpp_x);}
+lgamma(_A1 __lcpp_x) noexcept {return ::lgamma((double)__lcpp_x);}
 
 // llrint
 
-inline _LIBCUDACXX_INLINE_VISIBILITY long long llrint(float __lcpp_x) _NOEXCEPT       {return ::llrintf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long long llrint(long double __lcpp_x) _NOEXCEPT {return ::llrintl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long long llrint(float __lcpp_x) noexcept       {return ::llrintf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long long llrint(long double __lcpp_x) noexcept {return ::llrintl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, long long>::type
-llrint(_A1 __lcpp_x) _NOEXCEPT {return ::llrint((double)__lcpp_x);}
+llrint(_A1 __lcpp_x) noexcept {return ::llrint((double)__lcpp_x);}
 
 // llround
 
-inline _LIBCUDACXX_INLINE_VISIBILITY long long llround(float __lcpp_x) _NOEXCEPT       {return ::llroundf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long long llround(long double __lcpp_x) _NOEXCEPT {return ::llroundl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long long llround(float __lcpp_x) noexcept       {return ::llroundf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long long llround(long double __lcpp_x) noexcept {return ::llroundl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, long long>::type
-llround(_A1 __lcpp_x) _NOEXCEPT {return ::llround((double)__lcpp_x);}
+llround(_A1 __lcpp_x) noexcept {return ::llround((double)__lcpp_x);}
 
 // log1p
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       log1p(float __lcpp_x) _NOEXCEPT       {return ::log1pf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double log1p(long double __lcpp_x) _NOEXCEPT {return ::log1pl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       log1p(float __lcpp_x) noexcept       {return ::log1pf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double log1p(long double __lcpp_x) noexcept {return ::log1pl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-log1p(_A1 __lcpp_x) _NOEXCEPT {return ::log1p((double)__lcpp_x);}
+log1p(_A1 __lcpp_x) noexcept {return ::log1p((double)__lcpp_x);}
 
 // log2
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       log2(float __lcpp_x) _NOEXCEPT       {return ::log2f(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double log2(long double __lcpp_x) _NOEXCEPT {return ::log2l(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       log2(float __lcpp_x) noexcept       {return ::log2f(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double log2(long double __lcpp_x) noexcept {return ::log2l(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-log2(_A1 __lcpp_x) _NOEXCEPT {return ::log2((double)__lcpp_x);}
+log2(_A1 __lcpp_x) noexcept {return ::log2((double)__lcpp_x);}
 
 // logb
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       logb(float __lcpp_x) _NOEXCEPT       {return ::logbf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double logb(long double __lcpp_x) _NOEXCEPT {return ::logbl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       logb(float __lcpp_x) noexcept       {return ::logbf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double logb(long double __lcpp_x) noexcept {return ::logbl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-logb(_A1 __lcpp_x) _NOEXCEPT {return ::logb((double)__lcpp_x);}
+logb(_A1 __lcpp_x) noexcept {return ::logb((double)__lcpp_x);}
 
 // lrint
 
-inline _LIBCUDACXX_INLINE_VISIBILITY long lrint(float __lcpp_x) _NOEXCEPT       {return ::lrintf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long lrint(long double __lcpp_x) _NOEXCEPT {return ::lrintl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long lrint(float __lcpp_x) noexcept       {return ::lrintf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long lrint(long double __lcpp_x) noexcept {return ::lrintl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, long>::type
-lrint(_A1 __lcpp_x) _NOEXCEPT {return ::lrint((double)__lcpp_x);}
+lrint(_A1 __lcpp_x) noexcept {return ::lrint((double)__lcpp_x);}
 
 // lround
 
-inline _LIBCUDACXX_INLINE_VISIBILITY long lround(float __lcpp_x) _NOEXCEPT       {return ::lroundf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long lround(long double __lcpp_x) _NOEXCEPT {return ::lroundl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long lround(float __lcpp_x) noexcept       {return ::lroundf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long lround(long double __lcpp_x) noexcept {return ::lroundl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, long>::type
-lround(_A1 __lcpp_x) _NOEXCEPT {return ::lround((double)__lcpp_x);}
+lround(_A1 __lcpp_x) noexcept {return ::lround((double)__lcpp_x);}
 
 // nan
 
 // nearbyint
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       nearbyint(float __lcpp_x) _NOEXCEPT       {return ::nearbyintf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double nearbyint(long double __lcpp_x) _NOEXCEPT {return ::nearbyintl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       nearbyint(float __lcpp_x) noexcept       {return ::nearbyintf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double nearbyint(long double __lcpp_x) noexcept {return ::nearbyintl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-nearbyint(_A1 __lcpp_x) _NOEXCEPT {return ::nearbyint((double)__lcpp_x);}
+nearbyint(_A1 __lcpp_x) noexcept {return ::nearbyint((double)__lcpp_x);}
 
 // nextafter
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       nextafter(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::nextafterf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double nextafter(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nextafterl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       nextafter(float __lcpp_x, float __lcpp_y) noexcept             {return ::nextafterf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double nextafter(long double __lcpp_x, long double __lcpp_y) noexcept {return ::nextafterl(__lcpp_x, __lcpp_y);}
 
 template <class _A1, class _A2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -1433,7 +1433,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-nextafter(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+nextafter(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1443,18 +1443,18 @@ nextafter(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 
 // nexttoward
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       nexttoward(float __lcpp_x, long double __lcpp_y) _NOEXCEPT       {return ::nexttowardf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double nexttoward(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nexttowardl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       nexttoward(float __lcpp_x, long double __lcpp_y) noexcept       {return ::nexttowardf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double nexttoward(long double __lcpp_x, long double __lcpp_y) noexcept {return ::nexttowardl(__lcpp_x, __lcpp_y);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-nexttoward(_A1 __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::nexttoward((double)__lcpp_x, __lcpp_y);}
+nexttoward(_A1 __lcpp_x, long double __lcpp_y) noexcept {return ::nexttoward((double)__lcpp_x, __lcpp_y);}
 
 // remainder
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       remainder(float __lcpp_x, float __lcpp_y) _NOEXCEPT             {return ::remainderf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double remainder(long double __lcpp_x, long double __lcpp_y) _NOEXCEPT {return ::remainderl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       remainder(float __lcpp_x, float __lcpp_y) noexcept             {return ::remainderf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double remainder(long double __lcpp_x, long double __lcpp_y) noexcept {return ::remainderl(__lcpp_x, __lcpp_y);}
 
 template <class _A1, class _A2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -1464,7 +1464,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-remainder(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
+remainder(_A1 __lcpp_x, _A2 __lcpp_y) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1474,8 +1474,8 @@ remainder(_A1 __lcpp_x, _A2 __lcpp_y) _NOEXCEPT
 
 // remquo
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       remquo(float __lcpp_x, float __lcpp_y, int* __lcpp_z) _NOEXCEPT             {return ::remquof(__lcpp_x, __lcpp_y, __lcpp_z);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double remquo(long double __lcpp_x, long double __lcpp_y, int* __lcpp_z) _NOEXCEPT {return ::remquol(__lcpp_x, __lcpp_y, __lcpp_z);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       remquo(float __lcpp_x, float __lcpp_y, int* __lcpp_z) noexcept             {return ::remquof(__lcpp_x, __lcpp_y, __lcpp_z);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double remquo(long double __lcpp_x, long double __lcpp_y, int* __lcpp_z) noexcept {return ::remquol(__lcpp_x, __lcpp_y, __lcpp_z);}
 
 template <class _A1, class _A2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -1485,7 +1485,7 @@ typename std::_EnableIf
     std::is_arithmetic<_A2>::value,
     std::__promote<_A1, _A2>
 >::type
-remquo(_A1 __lcpp_x, _A2 __lcpp_y, int* __lcpp_z) _NOEXCEPT
+remquo(_A1 __lcpp_x, _A2 __lcpp_y, int* __lcpp_z) noexcept
 {
     typedef typename std::__promote<_A1, _A2>::type __result_type;
     static_assert((!(std::_IsSame<_A1, __result_type>::value &&
@@ -1495,63 +1495,63 @@ remquo(_A1 __lcpp_x, _A2 __lcpp_y, int* __lcpp_z) _NOEXCEPT
 
 // rint
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       rint(float __lcpp_x) _NOEXCEPT       {return ::rintf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double rint(long double __lcpp_x) _NOEXCEPT {return ::rintl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       rint(float __lcpp_x) noexcept       {return ::rintf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double rint(long double __lcpp_x) noexcept {return ::rintl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-rint(_A1 __lcpp_x) _NOEXCEPT {return ::rint((double)__lcpp_x);}
+rint(_A1 __lcpp_x) noexcept {return ::rint((double)__lcpp_x);}
 
 // round
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       round(float __lcpp_x) _NOEXCEPT       {return ::roundf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double round(long double __lcpp_x) _NOEXCEPT {return ::roundl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       round(float __lcpp_x) noexcept       {return ::roundf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double round(long double __lcpp_x) noexcept {return ::roundl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-round(_A1 __lcpp_x) _NOEXCEPT {return ::round((double)__lcpp_x);}
+round(_A1 __lcpp_x) noexcept {return ::round((double)__lcpp_x);}
 
 // scalbln
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       scalbln(float __lcpp_x, long __lcpp_y) _NOEXCEPT       {return ::scalblnf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double scalbln(long double __lcpp_x, long __lcpp_y) _NOEXCEPT {return ::scalblnl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       scalbln(float __lcpp_x, long __lcpp_y) noexcept       {return ::scalblnf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double scalbln(long double __lcpp_x, long __lcpp_y) noexcept {return ::scalblnl(__lcpp_x, __lcpp_y);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-scalbln(_A1 __lcpp_x, long __lcpp_y) _NOEXCEPT {return ::scalbln((double)__lcpp_x, __lcpp_y);}
+scalbln(_A1 __lcpp_x, long __lcpp_y) noexcept {return ::scalbln((double)__lcpp_x, __lcpp_y);}
 
 // scalbn
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       scalbn(float __lcpp_x, int __lcpp_y) _NOEXCEPT       {return ::scalbnf(__lcpp_x, __lcpp_y);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double scalbn(long double __lcpp_x, int __lcpp_y) _NOEXCEPT {return ::scalbnl(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       scalbn(float __lcpp_x, int __lcpp_y) noexcept       {return ::scalbnf(__lcpp_x, __lcpp_y);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double scalbn(long double __lcpp_x, int __lcpp_y) noexcept {return ::scalbnl(__lcpp_x, __lcpp_y);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-scalbn(_A1 __lcpp_x, int __lcpp_y) _NOEXCEPT {return ::scalbn((double)__lcpp_x, __lcpp_y);}
+scalbn(_A1 __lcpp_x, int __lcpp_y) noexcept {return ::scalbn((double)__lcpp_x, __lcpp_y);}
 
 // tgamma
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       tgamma(float __lcpp_x) _NOEXCEPT       {return ::tgammaf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double tgamma(long double __lcpp_x) _NOEXCEPT {return ::tgammal(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       tgamma(float __lcpp_x) noexcept       {return ::tgammaf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double tgamma(long double __lcpp_x) noexcept {return ::tgammal(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-tgamma(_A1 __lcpp_x) _NOEXCEPT {return ::tgamma((double)__lcpp_x);}
+tgamma(_A1 __lcpp_x) noexcept {return ::tgamma((double)__lcpp_x);}
 
 // trunc
 
-inline _LIBCUDACXX_INLINE_VISIBILITY float       trunc(float __lcpp_x) _NOEXCEPT       {return ::truncf(__lcpp_x);}
-inline _LIBCUDACXX_INLINE_VISIBILITY long double trunc(long double __lcpp_x) _NOEXCEPT {return ::truncl(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY float       trunc(float __lcpp_x) noexcept       {return ::truncf(__lcpp_x);}
+inline _LIBCUDACXX_INLINE_VISIBILITY long double trunc(long double __lcpp_x) noexcept {return ::truncl(__lcpp_x);}
 
 template <class _A1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename std::enable_if<std::is_integral<_A1>::value, double>::type
-trunc(_A1 __lcpp_x) _NOEXCEPT {return ::trunc((double)__lcpp_x);}
+trunc(_A1 __lcpp_x) noexcept {return ::trunc((double)__lcpp_x);}
 
 } // extern "C++"
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/memory
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/memory
@@ -864,7 +864,7 @@ struct __const_void_pointer<_Ptr, _Alloc, false>
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 _Tp*
-__to_raw_pointer(_Tp* __p) _NOEXCEPT
+__to_raw_pointer(_Tp* __p) noexcept
 {
     return __p;
 }
@@ -873,7 +873,7 @@ __to_raw_pointer(_Tp* __p) _NOEXCEPT
 template <class _Pointer>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename pointer_traits<_Pointer>::element_type*
-__to_raw_pointer(_Pointer __p) _NOEXCEPT
+__to_raw_pointer(_Pointer __p) noexcept
 {
     return _CUDA_VSTD::__to_raw_pointer(__p.operator->());
 }
@@ -881,7 +881,7 @@ __to_raw_pointer(_Pointer __p) _NOEXCEPT
 template <class _Pointer>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 auto
-__to_raw_pointer(const _Pointer& __p) _NOEXCEPT
+__to_raw_pointer(const _Pointer& __p) noexcept
 -> decltype(pointer_traits<_Pointer>::to_address(__p))
 {
     return pointer_traits<_Pointer>::to_address(__p);
@@ -890,7 +890,7 @@ __to_raw_pointer(const _Pointer& __p) _NOEXCEPT
 template <class _Pointer, class... _None>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 auto
-__to_raw_pointer(const _Pointer& __p, _None...) _NOEXCEPT
+__to_raw_pointer(const _Pointer& __p, _None...) noexcept
 {
     return _CUDA_VSTD::__to_raw_pointer(__p.operator->());
 }
@@ -1320,7 +1320,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS allocator_traits
             __has_allocate_hint<allocator_type, size_type, const_void_pointer>());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static void deallocate(allocator_type& __a, pointer __p, size_type __n) _NOEXCEPT
+    static void deallocate(allocator_type& __a, pointer __p, size_type __n) noexcept
         {__a.deallocate(__p, __n);}
 
 #ifndef _LIBCUDACXX_HAS_NO_VARIADICS
@@ -1365,7 +1365,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS allocator_traits
             {__destroy(__has_destroy<allocator_type, _Tp*>(), __a, __p);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static size_type max_size(const allocator_type& __a) _NOEXCEPT
+    static size_type max_size(const allocator_type& __a) noexcept
         {return __max_size(__has_max_size<const allocator_type>(), __a);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1534,10 +1534,10 @@ private:
             }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static size_type __max_size(true_type, const allocator_type& __a) _NOEXCEPT
+    static size_type __max_size(true_type, const allocator_type& __a) noexcept
             {return __a.max_size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    static size_type __max_size(false_type, const allocator_type&) _NOEXCEPT
+    static size_type __max_size(false_type, const allocator_type&) noexcept
             {return numeric_limits<size_type>::max() / sizeof(value_type);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1580,15 +1580,15 @@ public:
     template <class _Up> struct rebind {typedef allocator<_Up> other;};
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    allocator() _NOEXCEPT {}
+    allocator() noexcept {}
 
     template <class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    allocator(const allocator<_Up>&) _NOEXCEPT {}
+    allocator(const allocator<_Up>&) noexcept {}
 
-    _LIBCUDACXX_INLINE_VISIBILITY pointer address(reference __x) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY pointer address(reference __x) const noexcept
         {return _CUDA_VSTD::addressof(__x);}
-    _LIBCUDACXX_INLINE_VISIBILITY const_pointer address(const_reference __x) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY const_pointer address(const_reference __x) const noexcept
         {return _CUDA_VSTD::addressof(__x);}
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
     pointer allocate(size_type __n, allocator<void>::const_pointer = 0)
@@ -1598,9 +1598,9 @@ public:
                                  " 'n' exceeds maximum supported size");
         return static_cast<pointer>(_CUDA_VSTD::__libcpp_allocate(__n * sizeof(_Tp), _LIBCUDACXX_ALIGNOF(_Tp)));
         }
-    _LIBCUDACXX_INLINE_VISIBILITY void deallocate(pointer __p, size_type __n) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void deallocate(pointer __p, size_type __n) noexcept
         {_CUDA_VSTD::__libcpp_deallocate((void*)__p, __n * sizeof(_Tp), _LIBCUDACXX_ALIGNOF(_Tp));}
-    _LIBCUDACXX_INLINE_VISIBILITY size_type max_size() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY size_type max_size() const noexcept
         {return size_type(~0) / sizeof(_Tp);}
 #if !defined(_LIBCUDACXX_HAS_NO_RVALUE_REFERENCES) && !defined(_LIBCUDACXX_HAS_NO_VARIADICS)
     template <class _Up, class... _Args>
@@ -1684,13 +1684,13 @@ public:
     template <class _Up> struct rebind {typedef allocator<_Up> other;};
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    allocator() _NOEXCEPT {}
+    allocator() noexcept {}
 
     template <class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-    allocator(const allocator<_Up>&) _NOEXCEPT {}
+    allocator(const allocator<_Up>&) noexcept {}
 
-    _LIBCUDACXX_INLINE_VISIBILITY const_pointer address(const_reference __x) const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY const_pointer address(const_reference __x) const noexcept
         {return _CUDA_VSTD::addressof(__x);}
     _LIBCUDACXX_INLINE_VISIBILITY pointer allocate(size_type __n, allocator<void>::const_pointer = 0)
     {
@@ -1699,9 +1699,9 @@ public:
                                  " 'n' exceeds maximum supported size");
         return static_cast<pointer>(_CUDA_VSTD::__libcpp_allocate(__n * sizeof(_Tp), _LIBCUDACXX_ALIGNOF(_Tp)));
     }
-    _LIBCUDACXX_INLINE_VISIBILITY void deallocate(pointer __p, size_type __n) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void deallocate(pointer __p, size_type __n) noexcept
         {_CUDA_VSTD::__libcpp_deallocate((void*) const_cast<_Tp *>(__p), __n * sizeof(_Tp), _LIBCUDACXX_ALIGNOF(_Tp));}
-    _LIBCUDACXX_INLINE_VISIBILITY size_type max_size() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY size_type max_size() const noexcept
         {return size_type(~0) / sizeof(_Tp);}
 #if !defined(_LIBCUDACXX_HAS_NO_RVALUE_REFERENCES) && !defined(_LIBCUDACXX_HAS_NO_VARIADICS)
     template <class _Up, class... _Args>
@@ -1769,11 +1769,11 @@ public:
 
 template <class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator==(const allocator<_Tp>&, const allocator<_Up>&) _NOEXCEPT {return true;}
+bool operator==(const allocator<_Tp>&, const allocator<_Up>&) noexcept {return true;}
 
 template <class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-bool operator!=(const allocator<_Tp>&, const allocator<_Up>&) _NOEXCEPT {return false;}
+bool operator!=(const allocator<_Tp>&, const allocator<_Up>&) noexcept {return false;}
 
 template <class _OutputIterator, class _Tp>
 class _LIBCUDACXX_TEMPLATE_VIS raw_storage_iterator
@@ -1805,7 +1805,7 @@ public:
 template <class _Tp>
 _LIBCUDACXX_NODISCARD_EXT _LIBCUDACXX_NO_CFI
 pair<_Tp*, ptrdiff_t>
-get_temporary_buffer(ptrdiff_t __n) _NOEXCEPT
+get_temporary_buffer(ptrdiff_t __n) noexcept
 {
     pair<_Tp*, ptrdiff_t> __r(0, 0);
     const ptrdiff_t __m = (~ptrdiff_t(0) ^
@@ -1849,7 +1849,7 @@ get_temporary_buffer(ptrdiff_t __n) _NOEXCEPT
 
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-void return_temporary_buffer(_Tp* __p) _NOEXCEPT
+void return_temporary_buffer(_Tp* __p) noexcept
 {
   _CUDA_VSTD::__libcpp_deallocate_unsized((void*)__p, _LIBCUDACXX_ALIGNOF(_Tp));
 }
@@ -1945,9 +1945,9 @@ struct __compressed_pair_elem {
   __compressed_pair_elem(_ParamT __p) : __value_(std::forward<_ParamT>(__p)) {}
 #endif
 
-  _LIBCUDACXX_INLINE_VISIBILITY reference __get() _NOEXCEPT { return __value_; }
+  _LIBCUDACXX_INLINE_VISIBILITY reference __get() noexcept { return __value_; }
   _LIBCUDACXX_INLINE_VISIBILITY
-  const_reference __get() const _NOEXCEPT { return __value_; }
+  const_reference __get() const noexcept { return __value_; }
 
 private:
   _Tp __value_;
@@ -1984,9 +1984,9 @@ struct __compressed_pair_elem<_Tp, _Idx, true> : private _Tp {
       : __value_type(std::forward<_ParamT>(__p)) {}
 #endif
 
-  _LIBCUDACXX_INLINE_VISIBILITY reference __get() _NOEXCEPT { return *this; }
+  _LIBCUDACXX_INLINE_VISIBILITY reference __get() noexcept { return *this; }
   _LIBCUDACXX_INLINE_VISIBILITY
-  const_reference __get() const _NOEXCEPT { return *this; }
+  const_reference __get() const noexcept { return *this; }
 };
 
 // Tag used to construct the second element of the compressed pair.
@@ -2061,28 +2061,28 @@ public:
 #endif
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  typename _Base1::reference first() _NOEXCEPT {
+  typename _Base1::reference first() noexcept {
     return static_cast<_Base1&>(*this).__get();
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  typename _Base1::const_reference first() const _NOEXCEPT {
+  typename _Base1::const_reference first() const noexcept {
     return static_cast<_Base1 const&>(*this).__get();
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  typename _Base2::reference second() _NOEXCEPT {
+  typename _Base2::reference second() noexcept {
     return static_cast<_Base2&>(*this).__get();
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  typename _Base2::const_reference second() const _NOEXCEPT {
+  typename _Base2::const_reference second() const noexcept {
     return static_cast<_Base2 const&>(*this).__get();
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
   void swap(__compressed_pair& __x)
-    _NOEXCEPT_(__is_nothrow_swappable<_T1>::value &&
+    noexcept(__is_nothrow_swappable<_T1>::value &&
                __is_nothrow_swappable<_T2>::value)
   {
     using std::swap;
@@ -2094,7 +2094,7 @@ public:
 template <class _T1, class _T2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void swap(__compressed_pair<_T1, _T2>& __x, __compressed_pair<_T1, _T2>& __y)
-    _NOEXCEPT_(__is_nothrow_swappable<_T1>::value &&
+    noexcept(__is_nothrow_swappable<_T1>::value &&
                __is_nothrow_swappable<_T2>::value) {
   __x.swap(__y);
 }
@@ -2106,7 +2106,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS default_delete {
     static_assert(!is_function<_Tp>::value,
                   "default_delete cannot be instantiated for function types");
 #ifndef _LIBCUDACXX_CXX03_LANG
-  _LIBCUDACXX_INLINE_VISIBILITY constexpr default_delete() _NOEXCEPT = default;
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr default_delete() noexcept = default;
 #else
   _LIBCUDACXX_INLINE_VISIBILITY default_delete() {}
 #endif
@@ -2114,9 +2114,9 @@ struct _LIBCUDACXX_TEMPLATE_VIS default_delete {
   _LIBCUDACXX_INLINE_VISIBILITY
   default_delete(const default_delete<_Up>&,
                  typename enable_if<is_convertible<_Up*, _Tp*>::value>::type* =
-                     0) _NOEXCEPT {}
+                     0) noexcept {}
 
-  _LIBCUDACXX_INLINE_VISIBILITY void operator()(_Tp* __ptr) const _NOEXCEPT {
+  _LIBCUDACXX_INLINE_VISIBILITY void operator()(_Tp* __ptr) const noexcept {
     static_assert(sizeof(_Tp) > 0,
                   "default_delete can not delete incomplete type");
     static_assert(!is_void<_Tp>::value,
@@ -2134,7 +2134,7 @@ private:
 
 public:
 #ifndef _LIBCUDACXX_CXX03_LANG
-  _LIBCUDACXX_INLINE_VISIBILITY constexpr default_delete() _NOEXCEPT = default;
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr default_delete() noexcept = default;
 #else
   _LIBCUDACXX_INLINE_VISIBILITY default_delete() {}
 #endif
@@ -2142,12 +2142,12 @@ public:
   template <class _Up>
   _LIBCUDACXX_INLINE_VISIBILITY
   default_delete(const default_delete<_Up[]>&,
-                 typename _EnableIfConvertible<_Up>::type* = 0) _NOEXCEPT {}
+                 typename _EnableIfConvertible<_Up>::type* = 0) noexcept {}
 
   template <class _Up>
   _LIBCUDACXX_INLINE_VISIBILITY
   typename _EnableIfConvertible<_Up>::type
-  operator()(_Up* __ptr) const _NOEXCEPT {
+  operator()(_Up* __ptr) const noexcept {
     static_assert(sizeof(_Tp) > 0,
                   "default_delete can not delete incomplete type");
     static_assert(!is_void<_Tp>::value,
@@ -2238,28 +2238,28 @@ public:
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR unique_ptr() _NOEXCEPT : __ptr_(pointer()) {}
+  _LIBCUDACXX_CONSTEXPR unique_ptr() noexcept : __ptr_(pointer()) {}
 
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR unique_ptr(nullptr_t) _NOEXCEPT : __ptr_(pointer()) {}
+  _LIBCUDACXX_CONSTEXPR unique_ptr(nullptr_t) noexcept : __ptr_(pointer()) {}
 
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  explicit unique_ptr(pointer __p) _NOEXCEPT : __ptr_(__p) {}
+  explicit unique_ptr(pointer __p) noexcept : __ptr_(__p) {}
 
   template <bool _Dummy = true,
             class = _EnableIfDeleterConstructible<_LValRefType<_Dummy> > >
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(pointer __p, _LValRefType<_Dummy> __d) _NOEXCEPT
+  unique_ptr(pointer __p, _LValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, __d) {}
 
   template <bool _Dummy = true,
             class = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy> > >
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(pointer __p, _GoodRValRefType<_Dummy> __d) _NOEXCEPT
+  unique_ptr(pointer __p, _GoodRValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, _CUDA_VSTD::move(__d)) {
     static_assert(!is_reference<deleter_type>::value,
                   "rvalue deleter bound to reference");
@@ -2271,7 +2271,7 @@ public:
   unique_ptr(pointer __p, _BadRValRefType<_Dummy> __d) = delete;
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(unique_ptr&& __u) _NOEXCEPT
+  unique_ptr(unique_ptr&& __u) noexcept
       : __ptr_(__u.release(), _CUDA_VSTD::forward<deleter_type>(__u.get_deleter())) {
   }
 
@@ -2280,7 +2280,7 @@ public:
       class = _EnableIfDeleterConvertible<_Ep>
   >
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT
+  unique_ptr(unique_ptr<_Up, _Ep>&& __u) noexcept
       : __ptr_(__u.release(), _CUDA_VSTD::forward<_Ep>(__u.get_deleter())) {}
 
 #if _LIBCUDACXX_STD_VER <= 14 || defined(_LIBCUDACXX_ENABLE_CXX17_REMOVED_AUTO_PTR)
@@ -2289,12 +2289,12 @@ public:
   unique_ptr(auto_ptr<_Up>&& __p,
              typename enable_if<is_convertible<_Up*, _Tp*>::value &&
                                     is_same<_Dp, default_delete<_Tp> >::value,
-                                __nat>::type = __nat()) _NOEXCEPT
+                                __nat>::type = __nat()) noexcept
       : __ptr_(__p.release()) {}
 #endif
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr& operator=(unique_ptr&& __u) _NOEXCEPT {
+  unique_ptr& operator=(unique_ptr&& __u) noexcept {
     reset(__u.release());
     __ptr_.second() = _CUDA_VSTD::forward<deleter_type>(__u.get_deleter());
     return *this;
@@ -2305,7 +2305,7 @@ public:
       class = _EnableIfDeleterAssignable<_Ep>
   >
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT {
+  unique_ptr& operator=(unique_ptr<_Up, _Ep>&& __u) noexcept {
     reset(__u.release());
     __ptr_.second() = _CUDA_VSTD::forward<_Ep>(__u.get_deleter());
     return *this;
@@ -2333,7 +2333,7 @@ public:
   ~unique_ptr() { reset(); }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr& operator=(nullptr_t) _NOEXCEPT {
+  unique_ptr& operator=(nullptr_t) noexcept {
     reset();
     return *this;
   }
@@ -2344,35 +2344,35 @@ public:
     return *__ptr_.first();
   }
   _LIBCUDACXX_INLINE_VISIBILITY
-  pointer operator->() const _NOEXCEPT {
+  pointer operator->() const noexcept {
     return __ptr_.first();
   }
   _LIBCUDACXX_INLINE_VISIBILITY
-  pointer get() const _NOEXCEPT {
+  pointer get() const noexcept {
     return __ptr_.first();
   }
   _LIBCUDACXX_INLINE_VISIBILITY
-  deleter_type& get_deleter() _NOEXCEPT {
+  deleter_type& get_deleter() noexcept {
     return __ptr_.second();
   }
   _LIBCUDACXX_INLINE_VISIBILITY
-  const deleter_type& get_deleter() const _NOEXCEPT {
+  const deleter_type& get_deleter() const noexcept {
     return __ptr_.second();
   }
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_EXPLICIT operator bool() const _NOEXCEPT {
+  _LIBCUDACXX_EXPLICIT operator bool() const noexcept {
     return __ptr_.first() != nullptr;
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  pointer release() _NOEXCEPT {
+  pointer release() noexcept {
     pointer __t = __ptr_.first();
     __ptr_.first() = pointer();
     return __t;
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  void reset(pointer __p = pointer()) _NOEXCEPT {
+  void reset(pointer __p = pointer()) noexcept {
     pointer __tmp = __ptr_.first();
     __ptr_.first() = __p;
     if (__tmp)
@@ -2380,7 +2380,7 @@ public:
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  void swap(unique_ptr& __u) _NOEXCEPT {
+  void swap(unique_ptr& __u) noexcept {
     __ptr_.swap(__u.__ptr_);
   }
 };
@@ -2461,38 +2461,38 @@ public:
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR unique_ptr() _NOEXCEPT : __ptr_(pointer()) {}
+  _LIBCUDACXX_CONSTEXPR unique_ptr() noexcept : __ptr_(pointer()) {}
 
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR unique_ptr(nullptr_t) _NOEXCEPT : __ptr_(pointer()) {}
+  _LIBCUDACXX_CONSTEXPR unique_ptr(nullptr_t) noexcept : __ptr_(pointer()) {}
 
   template <class _Pp, bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy>,
             class = _EnableIfPointerConvertible<_Pp> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  explicit unique_ptr(_Pp __p) _NOEXCEPT
+  explicit unique_ptr(_Pp __p) noexcept
       : __ptr_(__p) {}
 
   template <class _Pp, bool _Dummy = true,
             class = _EnableIfDeleterConstructible<_LValRefType<_Dummy> >,
             class = _EnableIfPointerConvertible<_Pp> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(_Pp __p, _LValRefType<_Dummy> __d) _NOEXCEPT
+  unique_ptr(_Pp __p, _LValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, __d) {}
 
   template <bool _Dummy = true,
             class = _EnableIfDeleterConstructible<_LValRefType<_Dummy> > >
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(nullptr_t, _LValRefType<_Dummy> __d) _NOEXCEPT
+  unique_ptr(nullptr_t, _LValRefType<_Dummy> __d) noexcept
       : __ptr_(nullptr, __d) {}
 
   template <class _Pp, bool _Dummy = true,
             class = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy> >,
             class = _EnableIfPointerConvertible<_Pp> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(_Pp __p, _GoodRValRefType<_Dummy> __d) _NOEXCEPT
+  unique_ptr(_Pp __p, _GoodRValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, _CUDA_VSTD::move(__d)) {
     static_assert(!is_reference<deleter_type>::value,
                   "rvalue deleter bound to reference");
@@ -2501,7 +2501,7 @@ public:
   template <bool _Dummy = true,
             class = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy> > >
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(nullptr_t, _GoodRValRefType<_Dummy> __d) _NOEXCEPT
+  unique_ptr(nullptr_t, _GoodRValRefType<_Dummy> __d) noexcept
       : __ptr_(nullptr, _CUDA_VSTD::move(__d)) {
     static_assert(!is_reference<deleter_type>::value,
                   "rvalue deleter bound to reference");
@@ -2514,12 +2514,12 @@ public:
   unique_ptr(_Pp __p, _BadRValRefType<_Dummy> __d) = delete;
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(unique_ptr&& __u) _NOEXCEPT
+  unique_ptr(unique_ptr&& __u) noexcept
       : __ptr_(__u.release(), _CUDA_VSTD::forward<deleter_type>(__u.get_deleter())) {
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr& operator=(unique_ptr&& __u) _NOEXCEPT {
+  unique_ptr& operator=(unique_ptr&& __u) noexcept {
     reset(__u.release());
     __ptr_.second() = _CUDA_VSTD::forward<deleter_type>(__u.get_deleter());
     return *this;
@@ -2530,7 +2530,7 @@ public:
       class = _EnableIfDeleterConvertible<_Ep>
   >
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT
+  unique_ptr(unique_ptr<_Up, _Ep>&& __u) noexcept
       : __ptr_(__u.release(), _CUDA_VSTD::forward<_Ep>(__u.get_deleter())) {
   }
 
@@ -2540,7 +2540,7 @@ public:
   >
   _LIBCUDACXX_INLINE_VISIBILITY
   unique_ptr&
-  operator=(unique_ptr<_Up, _Ep>&& __u) _NOEXCEPT {
+  operator=(unique_ptr<_Up, _Ep>&& __u) noexcept {
     reset(__u.release());
     __ptr_.second() = _CUDA_VSTD::forward<_Ep>(__u.get_deleter());
     return *this;
@@ -2556,7 +2556,7 @@ public:
   ~unique_ptr() { reset(); }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  unique_ptr& operator=(nullptr_t) _NOEXCEPT {
+  unique_ptr& operator=(nullptr_t) noexcept {
     reset();
     return *this;
   }
@@ -2567,26 +2567,26 @@ public:
     return __ptr_.first()[__i];
   }
   _LIBCUDACXX_INLINE_VISIBILITY
-  pointer get() const _NOEXCEPT {
+  pointer get() const noexcept {
     return __ptr_.first();
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  deleter_type& get_deleter() _NOEXCEPT {
+  deleter_type& get_deleter() noexcept {
     return __ptr_.second();
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  const deleter_type& get_deleter() const _NOEXCEPT {
+  const deleter_type& get_deleter() const noexcept {
     return __ptr_.second();
   }
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_EXPLICIT operator bool() const _NOEXCEPT {
+  _LIBCUDACXX_EXPLICIT operator bool() const noexcept {
     return __ptr_.first() != nullptr;
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  pointer release() _NOEXCEPT {
+  pointer release() noexcept {
     pointer __t = __ptr_.first();
     __ptr_.first() = pointer();
     return __t;
@@ -2597,7 +2597,7 @@ public:
   typename enable_if<
       _CheckArrayPointerConversion<_Pp>::value
   >::type
-  reset(_Pp __p) _NOEXCEPT {
+  reset(_Pp __p) noexcept {
     pointer __tmp = __ptr_.first();
     __ptr_.first() = __p;
     if (__tmp)
@@ -2605,7 +2605,7 @@ public:
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  void reset(nullptr_t = nullptr) _NOEXCEPT {
+  void reset(nullptr_t = nullptr) noexcept {
     pointer __tmp = __ptr_.first();
     __ptr_.first() = nullptr;
     if (__tmp)
@@ -2613,7 +2613,7 @@ public:
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY
-  void swap(unique_ptr& __u) _NOEXCEPT {
+  void swap(unique_ptr& __u) noexcept {
     __ptr_.swap(__u.__ptr_);
   }
 
@@ -2625,7 +2625,7 @@ typename enable_if<
     __is_swappable<_Dp>::value,
     void
 >::type
-swap(unique_ptr<_Tp, _Dp>& __x, unique_ptr<_Tp, _Dp>& __y) _NOEXCEPT {__x.swap(__y);}
+swap(unique_ptr<_Tp, _Dp>& __x, unique_ptr<_Tp, _Dp>& __y) noexcept {__x.swap(__y);}
 
 template <class _T1, class _Dest1, class _T2, class _Dest2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -2666,7 +2666,7 @@ operator>=(const unique_ptr<_T1, _Dest1>& __x, const unique_ptr<_T2, _Dest2>& __
 template <class _T1, class _Dest1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(const unique_ptr<_T1, _Dest1>& __x, nullptr_t) _NOEXCEPT
+operator==(const unique_ptr<_T1, _Dest1>& __x, nullptr_t) noexcept
 {
     return !__x;
 }
@@ -2674,7 +2674,7 @@ operator==(const unique_ptr<_T1, _Dest1>& __x, nullptr_t) _NOEXCEPT
 template <class _T1, class _Dest1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(nullptr_t, const unique_ptr<_T1, _Dest1>& __x) _NOEXCEPT
+operator==(nullptr_t, const unique_ptr<_T1, _Dest1>& __x) noexcept
 {
     return !__x;
 }
@@ -2682,7 +2682,7 @@ operator==(nullptr_t, const unique_ptr<_T1, _Dest1>& __x) _NOEXCEPT
 template <class _T1, class _Dest1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(const unique_ptr<_T1, _Dest1>& __x, nullptr_t) _NOEXCEPT
+operator!=(const unique_ptr<_T1, _Dest1>& __x, nullptr_t) noexcept
 {
     return static_cast<bool>(__x);
 }
@@ -2690,7 +2690,7 @@ operator!=(const unique_ptr<_T1, _Dest1>& __x, nullptr_t) _NOEXCEPT
 template <class _T1, class _Dest1>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(nullptr_t, const unique_ptr<_T1, _Dest1>& __x) _NOEXCEPT
+operator!=(nullptr_t, const unique_ptr<_T1, _Dest1>& __x) noexcept
 {
     return static_cast<bool>(__x);
 }
@@ -2828,36 +2828,36 @@ private:
     size_t __size_;
 
     template <class _Tp>
-    _LIBCUDACXX_INLINE_VISIBILITY void __process(_Tp* __p, false_type) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void __process(_Tp* __p, false_type) noexcept
         {for (size_t __i = 0; __i < __size_; ++__i, ++__p) __p->~_Tp();}
 
     template <class _Tp>
-    _LIBCUDACXX_INLINE_VISIBILITY void __process(_Tp*, true_type) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void __process(_Tp*, true_type) noexcept
         {}
 
-    _LIBCUDACXX_INLINE_VISIBILITY void __incr(false_type) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void __incr(false_type) noexcept
         {++__size_;}
-    _LIBCUDACXX_INLINE_VISIBILITY void __incr(true_type) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void __incr(true_type) noexcept
         {}
 
-    _LIBCUDACXX_INLINE_VISIBILITY void __set(size_t __s, false_type) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void __set(size_t __s, false_type) noexcept
         {__size_ = __s;}
-    _LIBCUDACXX_INLINE_VISIBILITY void __set(size_t, true_type) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void __set(size_t, true_type) noexcept
         {}
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY explicit __destruct_n(size_t __s) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY explicit __destruct_n(size_t __s) noexcept
         : __size_(__s) {}
 
     template <class _Tp>
-    _LIBCUDACXX_INLINE_VISIBILITY void __incr(_Tp*) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void __incr(_Tp*) noexcept
         {__incr(integral_constant<bool, is_trivially_destructible<_Tp>::value>());}
 
     template <class _Tp>
-    _LIBCUDACXX_INLINE_VISIBILITY void __set(size_t __s, _Tp*) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void __set(size_t __s, _Tp*) noexcept
         {__set(__s, integral_constant<bool, is_trivially_destructible<_Tp>::value>());}
 
     template <class _Tp>
-    _LIBCUDACXX_INLINE_VISIBILITY void operator()(_Tp* __p) _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY void operator()(_Tp* __p) noexcept
         {__process(__p, integral_constant<bool, is_trivially_destructible<_Tp>::value>());}
 };
 
@@ -2873,10 +2873,10 @@ private:
     size_type __s_;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY __allocator_destructor(_Alloc& __a, size_type __s)
-             _NOEXCEPT
+             noexcept
         : __alloc_(__a), __s_(__s) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator()(pointer __p) _NOEXCEPT
+    void operator()(pointer __p) noexcept
         {__alloc_traits::deallocate(__alloc_, __p, __s_);}
 };
 
@@ -3109,7 +3109,7 @@ uninitialized_move_n(_InputIt __first, _Size __n, _ForwardIt __first_res) {
 
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _Tp
-__libcpp_atomic_refcount_increment(_Tp& __t) _NOEXCEPT
+__libcpp_atomic_refcount_increment(_Tp& __t) noexcept
 {
 #if defined(_LIBCUDACXX_HAS_BUILTIN_ATOMIC_SUPPORT) && !defined(_LIBCUDACXX_HAS_NO_THREADS)
     return __atomic_add_fetch(&__t, 1, __ATOMIC_RELAXED);
@@ -3120,7 +3120,7 @@ __libcpp_atomic_refcount_increment(_Tp& __t) _NOEXCEPT
 
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _Tp
-__libcpp_atomic_refcount_decrement(_Tp& __t) _NOEXCEPT
+__libcpp_atomic_refcount_decrement(_Tp& __t) noexcept
 {
 #if defined(_LIBCUDACXX_HAS_BUILTIN_ATOMIC_SUPPORT) && !defined(_LIBCUDACXX_HAS_NO_THREADS)
     return __atomic_add_fetch(&__t, -1, __ATOMIC_ACQ_REL);
@@ -3133,8 +3133,8 @@ class _LIBCUDACXX_EXCEPTION_ABI bad_weak_ptr
     : public std::exception
 {
 public:
-    virtual ~bad_weak_ptr() _NOEXCEPT;
-    virtual const char* what() const  _NOEXCEPT;
+    virtual ~bad_weak_ptr() noexcept;
+    virtual const char* what() const  noexcept;
 };
 
 _LIBCUDACXX_NORETURN inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -3158,24 +3158,24 @@ protected:
     long __shared_owners_;
     virtual ~__shared_count();
 private:
-    virtual void __on_zero_shared() _NOEXCEPT = 0;
+    virtual void __on_zero_shared() noexcept = 0;
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __shared_count(long __refs = 0) _NOEXCEPT
+    explicit __shared_count(long __refs = 0) noexcept
         : __shared_owners_(__refs) {}
 
 #if defined(_LIBCUDACXX_BUILDING_LIBRARY) && \
     defined(_LIBCUDACXX_DEPRECATED_ABI_LEGACY_LIBRARY_DEFINITIONS_FOR_INLINE_FUNCTIONS)
-    void __add_shared() _NOEXCEPT;
-    bool __release_shared() _NOEXCEPT;
+    void __add_shared() noexcept;
+    bool __release_shared() noexcept;
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __add_shared() _NOEXCEPT {
+    void __add_shared() noexcept {
       __libcpp_atomic_refcount_increment(__shared_owners_);
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool __release_shared() _NOEXCEPT {
+    bool __release_shared() noexcept {
       if (__libcpp_atomic_refcount_decrement(__shared_owners_) == -1) {
         __on_zero_shared();
         return true;
@@ -3184,7 +3184,7 @@ public:
     }
 #endif
     _LIBCUDACXX_INLINE_VISIBILITY
-    long use_count() const _NOEXCEPT {
+    long use_count() const noexcept {
         return __libcpp_relaxed_load(&__shared_owners_) + 1;
     }
 };
@@ -3196,7 +3196,7 @@ class _LIBCUDACXX_TYPE_VIS __shared_weak_count
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __shared_weak_count(long __refs = 0) _NOEXCEPT
+    explicit __shared_weak_count(long __refs = 0) noexcept
         : __shared_count(__refs),
           __shared_weak_owners_(__refs) {}
 protected:
@@ -3205,38 +3205,38 @@ protected:
 public:
 #if defined(_LIBCUDACXX_BUILDING_LIBRARY) && \
     defined(_LIBCUDACXX_DEPRECATED_ABI_LEGACY_LIBRARY_DEFINITIONS_FOR_INLINE_FUNCTIONS)
-    void __add_shared() _NOEXCEPT;
-    void __add_weak() _NOEXCEPT;
-    void __release_shared() _NOEXCEPT;
+    void __add_shared() noexcept;
+    void __add_weak() noexcept;
+    void __release_shared() noexcept;
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __add_shared() _NOEXCEPT {
+    void __add_shared() noexcept {
       __shared_count::__add_shared();
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __add_weak() _NOEXCEPT {
+    void __add_weak() noexcept {
       __libcpp_atomic_refcount_increment(__shared_weak_owners_);
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __release_shared() _NOEXCEPT {
+    void __release_shared() noexcept {
       if (__shared_count::__release_shared())
         __release_weak();
     }
 #endif
-    void __release_weak() _NOEXCEPT;
+    void __release_weak() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    long use_count() const _NOEXCEPT {return __shared_count::use_count();}
-    __shared_weak_count* lock() _NOEXCEPT;
+    long use_count() const noexcept {return __shared_count::use_count();}
+    __shared_weak_count* lock() noexcept;
 
     // Define the function out only if we build static libc++ without RTTI.
     // Otherwise we may break clients who need to compile their projects with
     // -fno-rtti and yet link against a libc++.dylib compiled
     // without -fno-rtti.
 #if !defined(_LIBCUDACXX_NO_RTTI) || !defined(_LIBCUDACXX_BUILD_STATIC)
-    virtual const void* __get_deleter(const type_info&) const _NOEXCEPT;
+    virtual const void* __get_deleter(const type_info&) const noexcept;
 #endif
 private:
-    virtual void __on_zero_shared_weak() _NOEXCEPT = 0;
+    virtual void __on_zero_shared_weak() noexcept = 0;
 };
 
 template <class _Tp, class _Dp, class _Alloc>
@@ -3250,19 +3250,19 @@ public:
         :  __data_(__compressed_pair<_Tp, _Dp>(__p, _CUDA_VSTD::move(__d)), _CUDA_VSTD::move(__a)) {}
 
 #ifndef _LIBCUDACXX_NO_RTTI
-    virtual const void* __get_deleter(const type_info&) const _NOEXCEPT;
+    virtual const void* __get_deleter(const type_info&) const noexcept;
 #endif
 
 private:
-    virtual void __on_zero_shared() _NOEXCEPT;
-    virtual void __on_zero_shared_weak() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
+    virtual void __on_zero_shared_weak() noexcept;
 };
 
 #ifndef _LIBCUDACXX_NO_RTTI
 
 template <class _Tp, class _Dp, class _Alloc>
 const void*
-__shared_ptr_pointer<_Tp, _Dp, _Alloc>::__get_deleter(const type_info& __t) const _NOEXCEPT
+__shared_ptr_pointer<_Tp, _Dp, _Alloc>::__get_deleter(const type_info& __t) const noexcept
 {
     return __t == typeid(_Dp) ? _CUDA_VSTD::addressof(__data_.first().second()) : nullptr;
 }
@@ -3271,7 +3271,7 @@ __shared_ptr_pointer<_Tp, _Dp, _Alloc>::__get_deleter(const type_info& __t) cons
 
 template <class _Tp, class _Dp, class _Alloc>
 void
-__shared_ptr_pointer<_Tp, _Dp, _Alloc>::__on_zero_shared() _NOEXCEPT
+__shared_ptr_pointer<_Tp, _Dp, _Alloc>::__on_zero_shared() noexcept
 {
     __data_.first().second()(__data_.first().first());
     __data_.first().second().~_Dp();
@@ -3279,7 +3279,7 @@ __shared_ptr_pointer<_Tp, _Dp, _Alloc>::__on_zero_shared() _NOEXCEPT
 
 template <class _Tp, class _Dp, class _Alloc>
 void
-__shared_ptr_pointer<_Tp, _Dp, _Alloc>::__on_zero_shared_weak() _NOEXCEPT
+__shared_ptr_pointer<_Tp, _Dp, _Alloc>::__on_zero_shared_weak() noexcept
 {
     typedef typename __allocator_traits_rebind<_Alloc, __shared_ptr_pointer>::type _Al;
     typedef allocator_traits<_Al> _ATraits;
@@ -3332,23 +3332,23 @@ public:
 #endif  // _LIBCUDACXX_HAS_NO_VARIADICS
 
 private:
-    virtual void __on_zero_shared() _NOEXCEPT;
-    virtual void __on_zero_shared_weak() _NOEXCEPT;
+    virtual void __on_zero_shared() noexcept;
+    virtual void __on_zero_shared_weak() noexcept;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* get() _NOEXCEPT {return _CUDA_VSTD::addressof(__data_.second());}
+    _Tp* get() noexcept {return _CUDA_VSTD::addressof(__data_.second());}
 };
 
 template <class _Tp, class _Alloc>
 void
-__shared_ptr_emplace<_Tp, _Alloc>::__on_zero_shared() _NOEXCEPT
+__shared_ptr_emplace<_Tp, _Alloc>::__on_zero_shared() noexcept
 {
     __data_.second().~_Tp();
 }
 
 template <class _Tp, class _Alloc>
 void
-__shared_ptr_emplace<_Tp, _Alloc>::__on_zero_shared_weak() _NOEXCEPT
+__shared_ptr_emplace<_Tp, _Alloc>::__on_zero_shared_weak() noexcept
 {
     typedef typename __allocator_traits_rebind<_Alloc, __shared_ptr_emplace>::type _Al;
     typedef allocator_traits<_Al> _ATraits;
@@ -3388,9 +3388,9 @@ private:
     struct __nat {int __for_bool_;};
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR shared_ptr() _NOEXCEPT;
+    _LIBCUDACXX_CONSTEXPR shared_ptr() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR shared_ptr(nullptr_t) _NOEXCEPT;
+    _LIBCUDACXX_CONSTEXPR shared_ptr(nullptr_t) noexcept;
     template<class _Yp>
         explicit shared_ptr(_Yp* __p,
                             typename enable_if<is_convertible<_Yp*, element_type*>::value, __nat>::type = __nat());
@@ -3402,20 +3402,20 @@ public:
                    typename enable_if<is_convertible<_Yp*, element_type*>::value, __nat>::type = __nat());
     template <class _Dp> shared_ptr(nullptr_t __p, _Dp __d);
     template <class _Dp, class _Alloc> shared_ptr(nullptr_t __p, _Dp __d, _Alloc __a);
-    template<class _Yp> _LIBCUDACXX_INLINE_VISIBILITY shared_ptr(const shared_ptr<_Yp>& __r, element_type* __p) _NOEXCEPT;
+    template<class _Yp> _LIBCUDACXX_INLINE_VISIBILITY shared_ptr(const shared_ptr<_Yp>& __r, element_type* __p) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_ptr(const shared_ptr& __r) _NOEXCEPT;
+    shared_ptr(const shared_ptr& __r) noexcept;
     template<class _Yp>
         _LIBCUDACXX_INLINE_VISIBILITY
         shared_ptr(const shared_ptr<_Yp>& __r,
                    typename enable_if<is_convertible<_Yp*, element_type*>::value, __nat>::type = __nat())
-                       _NOEXCEPT;
+                       noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_ptr(shared_ptr&& __r) _NOEXCEPT;
+    shared_ptr(shared_ptr&& __r) noexcept;
     template<class _Yp> _LIBCUDACXX_INLINE_VISIBILITY  shared_ptr(shared_ptr<_Yp>&& __r,
                    typename enable_if<is_convertible<_Yp*, element_type*>::value, __nat>::type = __nat())
-                       _NOEXCEPT;
+                       noexcept;
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     template<class _Yp> explicit shared_ptr(const weak_ptr<_Yp>& __r,
                    typename enable_if<is_convertible<_Yp*, element_type*>::value, __nat>::type= __nat());
@@ -3473,7 +3473,7 @@ public:
     ~shared_ptr();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_ptr& operator=(const shared_ptr& __r) _NOEXCEPT;
+    shared_ptr& operator=(const shared_ptr& __r) noexcept;
     template<class _Yp>
         typename enable_if
         <
@@ -3481,10 +3481,10 @@ public:
             shared_ptr&
         >::type
         _LIBCUDACXX_INLINE_VISIBILITY
-        operator=(const shared_ptr<_Yp>& __r) _NOEXCEPT;
+        operator=(const shared_ptr<_Yp>& __r) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_ptr& operator=(shared_ptr&& __r) _NOEXCEPT;
+    shared_ptr& operator=(shared_ptr&& __r) noexcept;
     template<class _Yp>
         typename enable_if
         <
@@ -3533,9 +3533,9 @@ public:
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(shared_ptr& __r) _NOEXCEPT;
+    void swap(shared_ptr& __r) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    void reset() _NOEXCEPT;
+    void reset() noexcept;
     template<class _Yp>
         typename enable_if
         <
@@ -3562,25 +3562,25 @@ public:
         reset(_Yp* __p, _Dp __d, _Alloc __a);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    element_type* get() const _NOEXCEPT {return __ptr_;}
+    element_type* get() const noexcept {return __ptr_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    __add_lvalue_reference_t<element_type> operator*() const _NOEXCEPT
+    __add_lvalue_reference_t<element_type> operator*() const noexcept
         {return *__ptr_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    element_type* operator->() const _NOEXCEPT {return __ptr_;}
+    element_type* operator->() const noexcept {return __ptr_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    long use_count() const _NOEXCEPT {return __cntrl_ ? __cntrl_->use_count() : 0;}
+    long use_count() const noexcept {return __cntrl_ ? __cntrl_->use_count() : 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool unique() const _NOEXCEPT {return use_count() == 1;}
+    bool unique() const noexcept {return use_count() == 1;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_EXPLICIT operator bool() const _NOEXCEPT {return get() != 0;}
+    _LIBCUDACXX_EXPLICIT operator bool() const noexcept {return get() != 0;}
     template <class _Up>
         _LIBCUDACXX_INLINE_VISIBILITY
-        bool owner_before(shared_ptr<_Up> const& __p) const _NOEXCEPT
+        bool owner_before(shared_ptr<_Up> const& __p) const noexcept
         {return __cntrl_ < __p.__cntrl_;}
     template <class _Up>
         _LIBCUDACXX_INLINE_VISIBILITY
-        bool owner_before(weak_ptr<_Up> const& __p) const _NOEXCEPT
+        bool owner_before(weak_ptr<_Up> const& __p) const noexcept
         {return __cntrl_ < __p.__cntrl_;}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool
@@ -3590,7 +3590,7 @@ public:
 #ifndef _LIBCUDACXX_NO_RTTI
     template <class _Dp>
         _LIBCUDACXX_INLINE_VISIBILITY
-        _Dp* __get_deleter() const _NOEXCEPT
+        _Dp* __get_deleter() const noexcept
             {return static_cast<_Dp*>(__cntrl_
                     ? const_cast<void *>(__cntrl_->__get_deleter(typeid(_Dp)))
                       : nullptr);}
@@ -3626,7 +3626,7 @@ private:
         >::value,
             void>::type
         __enable_weak_this(const enable_shared_from_this<_Yp>* __e,
-                           _OrigPtr* __ptr) _NOEXCEPT
+                           _OrigPtr* __ptr) noexcept
         {
             typedef __remove_cv_t<_Yp> _RawYp;
             if (__e && __e->__weak_this_.expired())
@@ -3636,7 +3636,7 @@ private:
             }
         }
 
-    _LIBCUDACXX_INLINE_VISIBILITY void __enable_weak_this(...) _NOEXCEPT {}
+    _LIBCUDACXX_INLINE_VISIBILITY void __enable_weak_this(...) noexcept {}
 
     template <class _Up> friend class _LIBCUDACXX_TEMPLATE_VIS shared_ptr;
     template <class _Up> friend class _LIBCUDACXX_TEMPLATE_VIS weak_ptr;
@@ -3646,7 +3646,7 @@ private:
 template<class _Tp>
 inline
 _LIBCUDACXX_CONSTEXPR
-shared_ptr<_Tp>::shared_ptr() _NOEXCEPT
+shared_ptr<_Tp>::shared_ptr() noexcept
     : __ptr_(0),
       __cntrl_(0)
 {
@@ -3655,7 +3655,7 @@ shared_ptr<_Tp>::shared_ptr() _NOEXCEPT
 template<class _Tp>
 inline
 _LIBCUDACXX_CONSTEXPR
-shared_ptr<_Tp>::shared_ptr(nullptr_t) _NOEXCEPT
+shared_ptr<_Tp>::shared_ptr(nullptr_t) noexcept
     : __ptr_(0),
       __cntrl_(0)
 {
@@ -3780,7 +3780,7 @@ shared_ptr<_Tp>::shared_ptr(nullptr_t __p, _Dp __d, _Alloc __a)
 template<class _Tp>
 template<class _Yp>
 inline
-shared_ptr<_Tp>::shared_ptr(const shared_ptr<_Yp>& __r, element_type *__p) _NOEXCEPT
+shared_ptr<_Tp>::shared_ptr(const shared_ptr<_Yp>& __r, element_type *__p) noexcept
     : __ptr_(__p),
       __cntrl_(__r.__cntrl_)
 {
@@ -3790,7 +3790,7 @@ shared_ptr<_Tp>::shared_ptr(const shared_ptr<_Yp>& __r, element_type *__p) _NOEX
 
 template<class _Tp>
 inline
-shared_ptr<_Tp>::shared_ptr(const shared_ptr& __r) _NOEXCEPT
+shared_ptr<_Tp>::shared_ptr(const shared_ptr& __r) noexcept
     : __ptr_(__r.__ptr_),
       __cntrl_(__r.__cntrl_)
 {
@@ -3803,7 +3803,7 @@ template<class _Yp>
 inline
 shared_ptr<_Tp>::shared_ptr(const shared_ptr<_Yp>& __r,
                             typename enable_if<is_convertible<_Yp*, element_type*>::value, __nat>::type)
-         _NOEXCEPT
+         noexcept
     : __ptr_(__r.__ptr_),
       __cntrl_(__r.__cntrl_)
 {
@@ -3815,7 +3815,7 @@ shared_ptr<_Tp>::shared_ptr(const shared_ptr<_Yp>& __r,
 
 template<class _Tp>
 inline
-shared_ptr<_Tp>::shared_ptr(shared_ptr&& __r) _NOEXCEPT
+shared_ptr<_Tp>::shared_ptr(shared_ptr&& __r) noexcept
     : __ptr_(__r.__ptr_),
       __cntrl_(__r.__cntrl_)
 {
@@ -3828,7 +3828,7 @@ template<class _Yp>
 inline
 shared_ptr<_Tp>::shared_ptr(shared_ptr<_Yp>&& __r,
                             typename enable_if<is_convertible<_Yp*, element_type*>::value, __nat>::type)
-         _NOEXCEPT
+         noexcept
     : __ptr_(__r.__ptr_),
       __cntrl_(__r.__cntrl_)
 {
@@ -3967,7 +3967,7 @@ shared_ptr<_Tp>::~shared_ptr()
 template<class _Tp>
 inline
 shared_ptr<_Tp>&
-shared_ptr<_Tp>::operator=(const shared_ptr& __r) _NOEXCEPT
+shared_ptr<_Tp>::operator=(const shared_ptr& __r) noexcept
 {
     shared_ptr(__r).swap(*this);
     return *this;
@@ -3981,7 +3981,7 @@ typename enable_if
     is_convertible<_Yp*, typename shared_ptr<_Tp>::element_type*>::value,
     shared_ptr<_Tp>&
 >::type
-shared_ptr<_Tp>::operator=(const shared_ptr<_Yp>& __r) _NOEXCEPT
+shared_ptr<_Tp>::operator=(const shared_ptr<_Yp>& __r) noexcept
 {
     shared_ptr(__r).swap(*this);
     return *this;
@@ -3992,7 +3992,7 @@ shared_ptr<_Tp>::operator=(const shared_ptr<_Yp>& __r) _NOEXCEPT
 template<class _Tp>
 inline
 shared_ptr<_Tp>&
-shared_ptr<_Tp>::operator=(shared_ptr&& __r) _NOEXCEPT
+shared_ptr<_Tp>::operator=(shared_ptr&& __r) noexcept
 {
     shared_ptr(_CUDA_VSTD::move(__r)).swap(*this);
     return *this;
@@ -4085,7 +4085,7 @@ shared_ptr<_Tp>::operator=(unique_ptr<_Yp, _Dp> __r)
 template<class _Tp>
 inline
 void
-shared_ptr<_Tp>::swap(shared_ptr& __r) _NOEXCEPT
+shared_ptr<_Tp>::swap(shared_ptr& __r) noexcept
 {
     _CUDA_VSTD::swap(__ptr_, __r.__ptr_);
     _CUDA_VSTD::swap(__cntrl_, __r.__cntrl_);
@@ -4094,7 +4094,7 @@ shared_ptr<_Tp>::swap(shared_ptr& __r) _NOEXCEPT
 template<class _Tp>
 inline
 void
-shared_ptr<_Tp>::reset() _NOEXCEPT
+shared_ptr<_Tp>::reset() noexcept
 {
     shared_ptr().swap(*this);
 }
@@ -4235,7 +4235,7 @@ allocate_shared(const _Alloc& __a, _A0& __a0, _A1& __a1, _A2& __a2)
 template<class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
+operator==(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) noexcept
 {
     return __x.get() == __y.get();
 }
@@ -4243,7 +4243,7 @@ operator==(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
 template<class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
+operator!=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) noexcept
 {
     return !(__x == __y);
 }
@@ -4251,7 +4251,7 @@ operator!=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
 template<class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator<(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
+operator<(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) noexcept
 {
 #if _LIBCUDACXX_STD_VER <= 11
     typedef typename common_type<_Tp*, _Up*>::type _Vp;
@@ -4265,7 +4265,7 @@ operator<(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
 template<class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator>(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
+operator>(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) noexcept
 {
     return __y < __x;
 }
@@ -4273,7 +4273,7 @@ operator>(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
 template<class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator<=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
+operator<=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) noexcept
 {
     return !(__y < __x);
 }
@@ -4281,7 +4281,7 @@ operator<=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
 template<class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator>=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
+operator>=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) noexcept
 {
     return !(__x < __y);
 }
@@ -4289,7 +4289,7 @@ operator>=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
+operator==(const shared_ptr<_Tp>& __x, nullptr_t) noexcept
 {
     return !__x;
 }
@@ -4297,7 +4297,7 @@ operator==(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
+operator==(nullptr_t, const shared_ptr<_Tp>& __x) noexcept
 {
     return !__x;
 }
@@ -4305,7 +4305,7 @@ operator==(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
+operator!=(const shared_ptr<_Tp>& __x, nullptr_t) noexcept
 {
     return static_cast<bool>(__x);
 }
@@ -4313,7 +4313,7 @@ operator!=(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
+operator!=(nullptr_t, const shared_ptr<_Tp>& __x) noexcept
 {
     return static_cast<bool>(__x);
 }
@@ -4321,7 +4321,7 @@ operator!=(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator<(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
+operator<(const shared_ptr<_Tp>& __x, nullptr_t) noexcept
 {
     return less<_Tp*>()(__x.get(), nullptr);
 }
@@ -4329,7 +4329,7 @@ operator<(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator<(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
+operator<(nullptr_t, const shared_ptr<_Tp>& __x) noexcept
 {
     return less<_Tp*>()(nullptr, __x.get());
 }
@@ -4337,7 +4337,7 @@ operator<(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator>(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
+operator>(const shared_ptr<_Tp>& __x, nullptr_t) noexcept
 {
     return nullptr < __x;
 }
@@ -4345,7 +4345,7 @@ operator>(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator>(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
+operator>(nullptr_t, const shared_ptr<_Tp>& __x) noexcept
 {
     return __x < nullptr;
 }
@@ -4353,7 +4353,7 @@ operator>(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator<=(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
+operator<=(const shared_ptr<_Tp>& __x, nullptr_t) noexcept
 {
     return !(nullptr < __x);
 }
@@ -4361,7 +4361,7 @@ operator<=(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator<=(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
+operator<=(nullptr_t, const shared_ptr<_Tp>& __x) noexcept
 {
     return !(__x < nullptr);
 }
@@ -4369,7 +4369,7 @@ operator<=(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator>=(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
+operator>=(const shared_ptr<_Tp>& __x, nullptr_t) noexcept
 {
     return !(__x < nullptr);
 }
@@ -4377,7 +4377,7 @@ operator>=(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator>=(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
+operator>=(nullptr_t, const shared_ptr<_Tp>& __x) noexcept
 {
     return !(nullptr < __x);
 }
@@ -4385,7 +4385,7 @@ operator>=(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(shared_ptr<_Tp>& __x, shared_ptr<_Tp>& __y) _NOEXCEPT
+swap(shared_ptr<_Tp>& __x, shared_ptr<_Tp>& __y) noexcept
 {
     __x.swap(__y);
 }
@@ -4397,7 +4397,7 @@ typename enable_if
     !is_array<_Tp>::value && !is_array<_Up>::value,
     shared_ptr<_Tp>
 >::type
-static_pointer_cast(const shared_ptr<_Up>& __r) _NOEXCEPT
+static_pointer_cast(const shared_ptr<_Up>& __r) noexcept
 {
     return shared_ptr<_Tp>(__r, static_cast<_Tp*>(__r.get()));
 }
@@ -4409,7 +4409,7 @@ typename enable_if
     !is_array<_Tp>::value && !is_array<_Up>::value,
     shared_ptr<_Tp>
 >::type
-dynamic_pointer_cast(const shared_ptr<_Up>& __r) _NOEXCEPT
+dynamic_pointer_cast(const shared_ptr<_Up>& __r) noexcept
 {
     _Tp* __p = dynamic_cast<_Tp*>(__r.get());
     return __p ? shared_ptr<_Tp>(__r, __p) : shared_ptr<_Tp>();
@@ -4421,7 +4421,7 @@ typename enable_if
     is_array<_Tp>::value == is_array<_Up>::value,
     shared_ptr<_Tp>
 >::type
-const_pointer_cast(const shared_ptr<_Up>& __r) _NOEXCEPT
+const_pointer_cast(const shared_ptr<_Up>& __r) noexcept
 {
     typedef typename remove_extent<_Tp>::type _RTp;
     return shared_ptr<_Tp>(__r, const_cast<_RTp*>(__r.get()));
@@ -4432,7 +4432,7 @@ const_pointer_cast(const shared_ptr<_Up>& __r) _NOEXCEPT
 template<class _Dp, class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _Dp*
-get_deleter(const shared_ptr<_Tp>& __p) _NOEXCEPT
+get_deleter(const shared_ptr<_Tp>& __p) noexcept
 {
     return __p.template __get_deleter<_Dp>();
 }
@@ -4450,27 +4450,27 @@ private:
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR weak_ptr() _NOEXCEPT;
+    _LIBCUDACXX_CONSTEXPR weak_ptr() noexcept;
     template<class _Yp> _LIBCUDACXX_INLINE_VISIBILITY weak_ptr(shared_ptr<_Yp> const& __r,
                    typename enable_if<is_convertible<_Yp*, _Tp*>::value, __nat*>::type = 0)
-                        _NOEXCEPT;
+                        noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    weak_ptr(weak_ptr const& __r) _NOEXCEPT;
+    weak_ptr(weak_ptr const& __r) noexcept;
     template<class _Yp> _LIBCUDACXX_INLINE_VISIBILITY weak_ptr(weak_ptr<_Yp> const& __r,
                    typename enable_if<is_convertible<_Yp*, _Tp*>::value, __nat*>::type = 0)
-                         _NOEXCEPT;
+                         noexcept;
 
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     _LIBCUDACXX_INLINE_VISIBILITY
-    weak_ptr(weak_ptr&& __r) _NOEXCEPT;
+    weak_ptr(weak_ptr&& __r) noexcept;
     template<class _Yp> _LIBCUDACXX_INLINE_VISIBILITY weak_ptr(weak_ptr<_Yp>&& __r,
                    typename enable_if<is_convertible<_Yp*, _Tp*>::value, __nat*>::type = 0)
-                         _NOEXCEPT;
+                         noexcept;
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
     ~weak_ptr();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    weak_ptr& operator=(weak_ptr const& __r) _NOEXCEPT;
+    weak_ptr& operator=(weak_ptr const& __r) noexcept;
     template<class _Yp>
         typename enable_if
         <
@@ -4478,12 +4478,12 @@ public:
             weak_ptr&
         >::type
         _LIBCUDACXX_INLINE_VISIBILITY
-        operator=(weak_ptr<_Yp> const& __r) _NOEXCEPT;
+        operator=(weak_ptr<_Yp> const& __r) noexcept;
 
 #ifndef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    weak_ptr& operator=(weak_ptr&& __r) _NOEXCEPT;
+    weak_ptr& operator=(weak_ptr&& __r) noexcept;
     template<class _Yp>
         typename enable_if
         <
@@ -4491,7 +4491,7 @@ public:
             weak_ptr&
         >::type
         _LIBCUDACXX_INLINE_VISIBILITY
-        operator=(weak_ptr<_Yp>&& __r) _NOEXCEPT;
+        operator=(weak_ptr<_Yp>&& __r) noexcept;
 
 #endif  // _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES
 
@@ -4502,27 +4502,27 @@ public:
             weak_ptr&
         >::type
         _LIBCUDACXX_INLINE_VISIBILITY
-        operator=(shared_ptr<_Yp> const& __r) _NOEXCEPT;
+        operator=(shared_ptr<_Yp> const& __r) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(weak_ptr& __r) _NOEXCEPT;
+    void swap(weak_ptr& __r) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    void reset() _NOEXCEPT;
+    void reset() noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    long use_count() const _NOEXCEPT
+    long use_count() const noexcept
         {return __cntrl_ ? __cntrl_->use_count() : 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool expired() const _NOEXCEPT
+    bool expired() const noexcept
         {return __cntrl_ == 0 || __cntrl_->use_count() == 0;}
-    shared_ptr<_Tp> lock() const _NOEXCEPT;
+    shared_ptr<_Tp> lock() const noexcept;
     template<class _Up>
         _LIBCUDACXX_INLINE_VISIBILITY
-        bool owner_before(const shared_ptr<_Up>& __r) const _NOEXCEPT
+        bool owner_before(const shared_ptr<_Up>& __r) const noexcept
         {return __cntrl_ < __r.__cntrl_;}
     template<class _Up>
         _LIBCUDACXX_INLINE_VISIBILITY
-        bool owner_before(const weak_ptr<_Up>& __r) const _NOEXCEPT
+        bool owner_before(const weak_ptr<_Up>& __r) const noexcept
         {return __cntrl_ < __r.__cntrl_;}
 
     template <class _Up> friend class _LIBCUDACXX_TEMPLATE_VIS weak_ptr;
@@ -4532,7 +4532,7 @@ public:
 template<class _Tp>
 inline
 _LIBCUDACXX_CONSTEXPR
-weak_ptr<_Tp>::weak_ptr() _NOEXCEPT
+weak_ptr<_Tp>::weak_ptr() noexcept
     : __ptr_(0),
       __cntrl_(0)
 {
@@ -4540,7 +4540,7 @@ weak_ptr<_Tp>::weak_ptr() _NOEXCEPT
 
 template<class _Tp>
 inline
-weak_ptr<_Tp>::weak_ptr(weak_ptr const& __r) _NOEXCEPT
+weak_ptr<_Tp>::weak_ptr(weak_ptr const& __r) noexcept
     : __ptr_(__r.__ptr_),
       __cntrl_(__r.__cntrl_)
 {
@@ -4553,7 +4553,7 @@ template<class _Yp>
 inline
 weak_ptr<_Tp>::weak_ptr(shared_ptr<_Yp> const& __r,
                         typename enable_if<is_convertible<_Yp*, _Tp*>::value, __nat*>::type)
-                         _NOEXCEPT
+                         noexcept
     : __ptr_(__r.__ptr_),
       __cntrl_(__r.__cntrl_)
 {
@@ -4566,7 +4566,7 @@ template<class _Yp>
 inline
 weak_ptr<_Tp>::weak_ptr(weak_ptr<_Yp> const& __r,
                         typename enable_if<is_convertible<_Yp*, _Tp*>::value, __nat*>::type)
-         _NOEXCEPT
+         noexcept
     : __ptr_(__r.__ptr_),
       __cntrl_(__r.__cntrl_)
 {
@@ -4578,7 +4578,7 @@ weak_ptr<_Tp>::weak_ptr(weak_ptr<_Yp> const& __r,
 
 template<class _Tp>
 inline
-weak_ptr<_Tp>::weak_ptr(weak_ptr&& __r) _NOEXCEPT
+weak_ptr<_Tp>::weak_ptr(weak_ptr&& __r) noexcept
     : __ptr_(__r.__ptr_),
       __cntrl_(__r.__cntrl_)
 {
@@ -4591,7 +4591,7 @@ template<class _Yp>
 inline
 weak_ptr<_Tp>::weak_ptr(weak_ptr<_Yp>&& __r,
                         typename enable_if<is_convertible<_Yp*, _Tp*>::value, __nat*>::type)
-         _NOEXCEPT
+         noexcept
     : __ptr_(__r.__ptr_),
       __cntrl_(__r.__cntrl_)
 {
@@ -4611,7 +4611,7 @@ weak_ptr<_Tp>::~weak_ptr()
 template<class _Tp>
 inline
 weak_ptr<_Tp>&
-weak_ptr<_Tp>::operator=(weak_ptr const& __r) _NOEXCEPT
+weak_ptr<_Tp>::operator=(weak_ptr const& __r) noexcept
 {
     weak_ptr(__r).swap(*this);
     return *this;
@@ -4625,7 +4625,7 @@ typename enable_if
     is_convertible<_Yp*, _Tp*>::value,
     weak_ptr<_Tp>&
 >::type
-weak_ptr<_Tp>::operator=(weak_ptr<_Yp> const& __r) _NOEXCEPT
+weak_ptr<_Tp>::operator=(weak_ptr<_Yp> const& __r) noexcept
 {
     weak_ptr(__r).swap(*this);
     return *this;
@@ -4636,7 +4636,7 @@ weak_ptr<_Tp>::operator=(weak_ptr<_Yp> const& __r) _NOEXCEPT
 template<class _Tp>
 inline
 weak_ptr<_Tp>&
-weak_ptr<_Tp>::operator=(weak_ptr&& __r) _NOEXCEPT
+weak_ptr<_Tp>::operator=(weak_ptr&& __r) noexcept
 {
     weak_ptr(_CUDA_VSTD::move(__r)).swap(*this);
     return *this;
@@ -4650,7 +4650,7 @@ typename enable_if
     is_convertible<_Yp*, _Tp*>::value,
     weak_ptr<_Tp>&
 >::type
-weak_ptr<_Tp>::operator=(weak_ptr<_Yp>&& __r) _NOEXCEPT
+weak_ptr<_Tp>::operator=(weak_ptr<_Yp>&& __r) noexcept
 {
     weak_ptr(_CUDA_VSTD::move(__r)).swap(*this);
     return *this;
@@ -4666,7 +4666,7 @@ typename enable_if
     is_convertible<_Yp*, _Tp*>::value,
     weak_ptr<_Tp>&
 >::type
-weak_ptr<_Tp>::operator=(shared_ptr<_Yp> const& __r) _NOEXCEPT
+weak_ptr<_Tp>::operator=(shared_ptr<_Yp> const& __r) noexcept
 {
     weak_ptr(__r).swap(*this);
     return *this;
@@ -4675,7 +4675,7 @@ weak_ptr<_Tp>::operator=(shared_ptr<_Yp> const& __r) _NOEXCEPT
 template<class _Tp>
 inline
 void
-weak_ptr<_Tp>::swap(weak_ptr& __r) _NOEXCEPT
+weak_ptr<_Tp>::swap(weak_ptr& __r) noexcept
 {
     _CUDA_VSTD::swap(__ptr_, __r.__ptr_);
     _CUDA_VSTD::swap(__cntrl_, __r.__cntrl_);
@@ -4684,7 +4684,7 @@ weak_ptr<_Tp>::swap(weak_ptr& __r) _NOEXCEPT
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(weak_ptr<_Tp>& __x, weak_ptr<_Tp>& __y) _NOEXCEPT
+swap(weak_ptr<_Tp>& __x, weak_ptr<_Tp>& __y) noexcept
 {
     __x.swap(__y);
 }
@@ -4692,7 +4692,7 @@ swap(weak_ptr<_Tp>& __x, weak_ptr<_Tp>& __y) _NOEXCEPT
 template<class _Tp>
 inline
 void
-weak_ptr<_Tp>::reset() _NOEXCEPT
+weak_ptr<_Tp>::reset() noexcept
 {
     weak_ptr().swap(*this);
 }
@@ -4710,7 +4710,7 @@ shared_ptr<_Tp>::shared_ptr(const weak_ptr<_Yp>& __r,
 
 template<class _Tp>
 shared_ptr<_Tp>
-weak_ptr<_Tp>::lock() const _NOEXCEPT
+weak_ptr<_Tp>::lock() const noexcept
 {
     shared_ptr<_Tp> __r;
     __r.__cntrl_ = __cntrl_ ? __cntrl_->lock() : __cntrl_;
@@ -4731,13 +4731,13 @@ struct _LIBCUDACXX_TEMPLATE_VIS owner_less<shared_ptr<_Tp> >
 {
     typedef bool result_type;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()(shared_ptr<_Tp> const& __x, shared_ptr<_Tp> const& __y) const _NOEXCEPT
+    bool operator()(shared_ptr<_Tp> const& __x, shared_ptr<_Tp> const& __y) const noexcept
         {return __x.owner_before(__y);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()(shared_ptr<_Tp> const& __x,   weak_ptr<_Tp> const& __y) const _NOEXCEPT
+    bool operator()(shared_ptr<_Tp> const& __x,   weak_ptr<_Tp> const& __y) const noexcept
         {return __x.owner_before(__y);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()(  weak_ptr<_Tp> const& __x, shared_ptr<_Tp> const& __y) const _NOEXCEPT
+    bool operator()(  weak_ptr<_Tp> const& __x, shared_ptr<_Tp> const& __y) const noexcept
         {return __x.owner_before(__y);}
 };
 
@@ -4747,13 +4747,13 @@ struct _LIBCUDACXX_TEMPLATE_VIS owner_less<weak_ptr<_Tp> >
 {
     typedef bool result_type;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()(  weak_ptr<_Tp> const& __x,   weak_ptr<_Tp> const& __y) const _NOEXCEPT
+    bool operator()(  weak_ptr<_Tp> const& __x,   weak_ptr<_Tp> const& __y) const noexcept
         {return __x.owner_before(__y);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()(shared_ptr<_Tp> const& __x,   weak_ptr<_Tp> const& __y) const _NOEXCEPT
+    bool operator()(shared_ptr<_Tp> const& __x,   weak_ptr<_Tp> const& __y) const noexcept
         {return __x.owner_before(__y);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()(  weak_ptr<_Tp> const& __x, shared_ptr<_Tp> const& __y) const _NOEXCEPT
+    bool operator()(  weak_ptr<_Tp> const& __x, shared_ptr<_Tp> const& __y) const noexcept
         {return __x.owner_before(__y);}
 };
 
@@ -4763,19 +4763,19 @@ struct _LIBCUDACXX_TEMPLATE_VIS owner_less<void>
 {
     template <class _Tp, class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()( shared_ptr<_Tp> const& __x, shared_ptr<_Up> const& __y) const _NOEXCEPT
+    bool operator()( shared_ptr<_Tp> const& __x, shared_ptr<_Up> const& __y) const noexcept
         {return __x.owner_before(__y);}
     template <class _Tp, class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()( shared_ptr<_Tp> const& __x,   weak_ptr<_Up> const& __y) const _NOEXCEPT
+    bool operator()( shared_ptr<_Tp> const& __x,   weak_ptr<_Up> const& __y) const noexcept
         {return __x.owner_before(__y);}
     template <class _Tp, class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()(   weak_ptr<_Tp> const& __x, shared_ptr<_Up> const& __y) const _NOEXCEPT
+    bool operator()(   weak_ptr<_Tp> const& __x, shared_ptr<_Up> const& __y) const noexcept
         {return __x.owner_before(__y);}
     template <class _Tp, class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()(   weak_ptr<_Tp> const& __x,   weak_ptr<_Up> const& __y) const _NOEXCEPT
+    bool operator()(   weak_ptr<_Tp> const& __x,   weak_ptr<_Up> const& __y) const noexcept
         {return __x.owner_before(__y);}
     typedef void is_transparent;
 };
@@ -4787,11 +4787,11 @@ class _LIBCUDACXX_TEMPLATE_VIS enable_shared_from_this
     mutable weak_ptr<_Tp> __weak_this_;
 protected:
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    enable_shared_from_this() _NOEXCEPT {}
+    enable_shared_from_this() noexcept {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    enable_shared_from_this(enable_shared_from_this const&) _NOEXCEPT {}
+    enable_shared_from_this(enable_shared_from_this const&) noexcept {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    enable_shared_from_this& operator=(enable_shared_from_this const&) _NOEXCEPT
+    enable_shared_from_this& operator=(enable_shared_from_this const&) noexcept
         {return *this;}
     _LIBCUDACXX_INLINE_VISIBILITY
     ~enable_shared_from_this() {}
@@ -4805,11 +4805,11 @@ public:
 
 #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_INLINE_VISIBILITY
-    weak_ptr<_Tp> weak_from_this() _NOEXCEPT
+    weak_ptr<_Tp> weak_from_this() noexcept
        { return __weak_this_; }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    weak_ptr<const _Tp> weak_from_this() const _NOEXCEPT
+    weak_ptr<const _Tp> weak_from_this() const noexcept
         { return __weak_this_; }
 #endif // _LIBCUDACXX_STD_VER > 14
 
@@ -4823,7 +4823,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<shared_ptr<_Tp> >
     typedef size_t               result_type;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    result_type operator()(const argument_type& __ptr) const _NOEXCEPT
+    result_type operator()(const argument_type& __ptr) const noexcept
     {
         return hash<_Tp*>()(__ptr.get());
     }
@@ -4841,11 +4841,11 @@ class _LIBCUDACXX_TYPE_VIS __sp_mut
 {
     void* __lx;
 public:
-    void lock() _NOEXCEPT;
-    void unlock() _NOEXCEPT;
+    void lock() noexcept;
+    void unlock() noexcept;
 
 private:
-    _LIBCUDACXX_CONSTEXPR __sp_mut(void*) _NOEXCEPT;
+    _LIBCUDACXX_CONSTEXPR __sp_mut(void*) noexcept;
     __sp_mut(const __sp_mut&);
     __sp_mut& operator=(const __sp_mut&);
 
@@ -5010,12 +5010,12 @@ struct _LIBCUDACXX_TYPE_VIS pointer_safety
 
 #if !defined(_LIBCUDACXX_ABI_POINTER_SAFETY_ENUM_TYPE) && \
     defined(_LIBCUDACXX_BUILDING_LIBRARY)
-_LIBCUDACXX_FUNC_VIS pointer_safety get_pointer_safety() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS pointer_safety get_pointer_safety() noexcept;
 #else
 // This function is only offered in C++03 under ABI v1.
 # if !defined(_LIBCUDACXX_ABI_POINTER_SAFETY_ENUM_TYPE) || !defined(_LIBCUDACXX_CXX03_LANG)
 inline _LIBCUDACXX_INLINE_VISIBILITY
-pointer_safety get_pointer_safety() _NOEXCEPT {
+pointer_safety get_pointer_safety() noexcept {
   return pointer_safety::relaxed;
 }
 # endif
@@ -5042,9 +5042,9 @@ template <typename _Alloc>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void __swap_allocator(_Alloc & __a1, _Alloc & __a2)
 #if _LIBCUDACXX_STD_VER >= 14
-    _NOEXCEPT
+    noexcept
 #else
-    _NOEXCEPT_(__is_nothrow_swappable<_Alloc>::value)
+    noexcept(__is_nothrow_swappable<_Alloc>::value)
 #endif
 {
     __swap_allocator(__a1, __a2,
@@ -5055,9 +5055,9 @@ template <typename _Alloc>
 _LIBCUDACXX_INLINE_VISIBILITY
 void __swap_allocator(_Alloc & __a1, _Alloc & __a2, true_type)
 #if _LIBCUDACXX_STD_VER >= 14
-    _NOEXCEPT
+    noexcept
 #else
-    _NOEXCEPT_(__is_nothrow_swappable<_Alloc>::value)
+    noexcept(__is_nothrow_swappable<_Alloc>::value)
 #endif
 {
     using _CUDA_VSTD::swap;
@@ -5066,7 +5066,7 @@ void __swap_allocator(_Alloc & __a1, _Alloc & __a2, true_type)
 
 template <typename _Alloc>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-void __swap_allocator(_Alloc &, _Alloc &, false_type) _NOEXCEPT {}
+void __swap_allocator(_Alloc &, _Alloc &, false_type) noexcept {}
 
 template <typename _Alloc, typename _Traits=allocator_traits<_Alloc> >
 struct __noexcept_move_assign_container : public integral_constant<bool,
@@ -5112,7 +5112,7 @@ struct __builtin_new_allocator {
     _LIBCUDACXX_CONSTEXPR explicit __builtin_new_deleter(size_t __size, size_t __align)
         : __size_(__size), __align_(__align) {}
 
-    void operator()(void* p) const _NOEXCEPT {
+    void operator()(void* p) const noexcept {
         std::__libcpp_deallocate(p, __size_, __align_);
     }
 
@@ -5129,7 +5129,7 @@ struct __builtin_new_allocator {
   }
 
   static void __deallocate_bytes(void* __p, size_t __s,
-                                 size_t __align) _NOEXCEPT {
+                                 size_t __align) noexcept {
       std::__libcpp_deallocate(__p, __s, __align);
   }
 
@@ -5141,7 +5141,7 @@ struct __builtin_new_allocator {
 
   template <class _Tp>
   _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_ALWAYS_INLINE
-  static void __deallocate_type(void* __p, size_t __n) _NOEXCEPT {
+  static void __deallocate_type(void* __p, size_t __n) noexcept {
       __deallocate_bytes(__p, __n * sizeof(_Tp), _LIBCUDACXX_ALIGNOF(_Tp));
   }
 };

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/mutex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/mutex
@@ -223,8 +223,8 @@ private:
 
 public:
     void lock();
-    bool try_lock() _NOEXCEPT;
-    void unlock()  _NOEXCEPT;
+    bool try_lock() noexcept;
+    void unlock()  noexcept;
 
     typedef __libcpp_recursive_mutex_t* native_handle_type;
 
@@ -247,7 +247,7 @@ private:
 
 public:
     void lock();
-    bool try_lock() _NOEXCEPT;
+    bool try_lock() noexcept;
     template <class _Rep, class _Period>
         _LIBCUDACXX_INLINE_VISIBILITY
         bool try_lock_for(const chrono::duration<_Rep, _Period>& __d)
@@ -255,7 +255,7 @@ public:
     template <class _Clock, class _Duration>
         _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
         bool try_lock_until(const chrono::time_point<_Clock, _Duration>& __t);
-    void unlock() _NOEXCEPT;
+    void unlock() noexcept;
 };
 
 template <class _Clock, class _Duration>
@@ -291,7 +291,7 @@ private:
 
 public:
     void lock();
-    bool try_lock() _NOEXCEPT;
+    bool try_lock() noexcept;
     template <class _Rep, class _Period>
         _LIBCUDACXX_INLINE_VISIBILITY
         bool try_lock_for(const chrono::duration<_Rep, _Period>& __d)
@@ -299,7 +299,7 @@ public:
     template <class _Clock, class _Duration>
         _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
         bool try_lock_until(const chrono::time_point<_Clock, _Duration>& __t);
-    void unlock() _NOEXCEPT;
+    void unlock() noexcept;
 };
 
 template <class _Clock, class _Duration>
@@ -574,7 +574,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS once_flag
 {
     _LIBCUDACXX_INLINE_VISIBILITY
     _LIBCUDACXX_CONSTEXPR
-        once_flag() _NOEXCEPT : __state_(0) {}
+        once_flag() noexcept : __state_(0) {}
 
 #if defined(_LIBCUDACXX_ABI_MICROSOFT)
    typedef uintptr_t _State_type;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/new
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/new
@@ -140,23 +140,23 @@ class _LIBCUDACXX_EXCEPTION_ABI bad_alloc
     : public exception
 {
 public:
-    bad_alloc() _NOEXCEPT;
-    virtual ~bad_alloc() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
+    bad_alloc() noexcept;
+    virtual ~bad_alloc() noexcept;
+    virtual const char* what() const noexcept;
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI bad_array_new_length
     : public bad_alloc
 {
 public:
-    bad_array_new_length() _NOEXCEPT;
-    virtual ~bad_array_new_length() _NOEXCEPT;
-    virtual const char* what() const _NOEXCEPT;
+    bad_array_new_length() noexcept;
+    virtual ~bad_array_new_length() noexcept;
+    virtual const char* what() const noexcept;
 };
 
 typedef void (*new_handler)();
-_LIBCUDACXX_FUNC_VIS new_handler set_new_handler(new_handler) _NOEXCEPT;
-_LIBCUDACXX_FUNC_VIS new_handler get_new_handler() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS new_handler set_new_handler(new_handler) noexcept;
+_LIBCUDACXX_FUNC_VIS new_handler get_new_handler() noexcept;
 
 #endif // !_LIBCUDACXX_ABI_VCRUNTIME
 
@@ -191,49 +191,49 @@ _LIBCUDACXX_INLINE_VAR constexpr destroying_delete_t destroying_delete{};
 #if !defined(_LIBCUDACXX_ABI_VCRUNTIME)
 
 _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz) _THROW_BAD_ALLOC;
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, const std::nothrow_t&) _NOEXCEPT _LIBCUDACXX_NOALIAS;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p) _NOEXCEPT;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, const std::nothrow_t&) _NOEXCEPT;
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, const std::nothrow_t&) noexcept _LIBCUDACXX_NOALIAS;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p) noexcept;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, const std::nothrow_t&) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz) _NOEXCEPT;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz) noexcept;
 #endif
 
 _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz) _THROW_BAD_ALLOC;
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, const std::nothrow_t&) _NOEXCEPT _LIBCUDACXX_NOALIAS;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p) _NOEXCEPT;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, const std::nothrow_t&) _NOEXCEPT;
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, const std::nothrow_t&) noexcept _LIBCUDACXX_NOALIAS;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p) noexcept;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, const std::nothrow_t&) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete[](void* __p, std::size_t __sz) _NOEXCEPT;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete[](void* __p, std::size_t __sz) noexcept;
 #endif
 
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_ALIGNED_ALLOCATION
 _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCUDACXX_NOALIAS;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, std::align_val_t) _NOEXCEPT;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, std::align_val_t, const std::nothrow_t&) noexcept _LIBCUDACXX_NOALIAS;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, std::align_val_t) noexcept;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete(void* __p, std::align_val_t, const std::nothrow_t&) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz, std::align_val_t) _NOEXCEPT;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz, std::align_val_t) noexcept;
 #endif
 
 _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCUDACXX_NOALIAS;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, std::align_val_t) _NOEXCEPT;
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, std::align_val_t, const std::nothrow_t&) noexcept _LIBCUDACXX_NOALIAS;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, std::align_val_t) noexcept;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS void  operator delete[](void* __p, std::align_val_t, const std::nothrow_t&) noexcept;
 #ifndef _LIBCUDACXX_HAS_NO_LIBRARY_SIZED_DEALLOCATION
-_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete[](void* __p, std::size_t __sz, std::align_val_t) _NOEXCEPT;
+_LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete[](void* __p, std::size_t __sz, std::align_val_t) noexcept;
 #endif
 #endif
 
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_INLINE_VISIBILITY void* operator new  (std::size_t, void* __p) _NOEXCEPT {return __p;}
-_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_INLINE_VISIBILITY void* operator new[](std::size_t, void* __p) _NOEXCEPT {return __p;}
-inline _LIBCUDACXX_INLINE_VISIBILITY void  operator delete  (void*, void*) _NOEXCEPT {}
-inline _LIBCUDACXX_INLINE_VISIBILITY void  operator delete[](void*, void*) _NOEXCEPT {}
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_INLINE_VISIBILITY void* operator new  (std::size_t, void* __p) noexcept {return __p;}
+_LIBCUDACXX_NODISCARD_AFTER_CXX17 inline _LIBCUDACXX_INLINE_VISIBILITY void* operator new[](std::size_t, void* __p) noexcept {return __p;}
+inline _LIBCUDACXX_INLINE_VISIBILITY void  operator delete  (void*, void*) noexcept {}
+inline _LIBCUDACXX_INLINE_VISIBILITY void  operator delete[](void*, void*) noexcept {}
 
 #endif // !_LIBCUDACXX_ABI_VCRUNTIME
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-_LIBCUDACXX_CONSTEXPR inline _LIBCUDACXX_INLINE_VISIBILITY bool __is_overaligned_for_new(size_t __align) _NOEXCEPT {
+_LIBCUDACXX_CONSTEXPR inline _LIBCUDACXX_INLINE_VISIBILITY bool __is_overaligned_for_new(size_t __align) noexcept {
 #ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
   return __align > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
 #else
@@ -353,7 +353,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY void __libcpp_deallocate_unsized(void* __pt
 
 template <class _Tp>
 _LIBCUDACXX_NODISCARD_AFTER_CXX17 inline
-_LIBCUDACXX_CONSTEXPR _Tp* __launder(_Tp* __p) _NOEXCEPT
+_LIBCUDACXX_CONSTEXPR _Tp* __launder(_Tp* __p) noexcept
 {
     static_assert (!(is_function<_Tp>::value), "can't launder functions" );
     static_assert (!(is_same<void, __remove_cv_t<_Tp>>::value), "can't launder cv-void" );

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -218,8 +218,8 @@ class _LIBCUDACXX_EXCEPTION_ABI _LIBCUDACXX_AVAILABILITY_BAD_OPTIONAL_ACCESS bad
 {
 public:
     // Get the key function ~bad_optional_access() into the dylib
-    ~bad_optional_access() _NOEXCEPT override;
-    const char* what() const _NOEXCEPT override;
+    ~bad_optional_access() noexcept override;
+    const char* what() const noexcept override;
 };
 
 } // namespace std

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/queue
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/queue
@@ -226,7 +226,7 @@ protected:
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     queue()
-        _NOEXCEPT_(is_nothrow_default_constructible<container_type>::value)
+        noexcept(is_nothrow_default_constructible<container_type>::value)
         : c() {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -238,12 +238,12 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     queue(queue&& __q)
-        _NOEXCEPT_(is_nothrow_move_constructible<container_type>::value)
+        noexcept(is_nothrow_move_constructible<container_type>::value)
         : c(_CUDA_VSTD::move(__q.c)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     queue& operator=(queue&& __q)
-        _NOEXCEPT_(is_nothrow_move_assignable<container_type>::value)
+        noexcept(is_nothrow_move_assignable<container_type>::value)
         {c = _CUDA_VSTD::move(__q.c); return *this;}
 #endif  // _LIBCUDACXX_CXX03_LANG
 
@@ -321,7 +321,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(queue& __q)
-        _NOEXCEPT_(__is_nothrow_swappable<container_type>::value)
+        noexcept(__is_nothrow_swappable<container_type>::value)
     {
         using _CUDA_VSTD::swap;
         swap(c, __q.c);
@@ -411,7 +411,7 @@ typename enable_if<
     void
 >::type
 swap(queue<_Tp, _Container>& __x, queue<_Tp, _Container>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -442,7 +442,7 @@ protected:
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     priority_queue()
-        _NOEXCEPT_(is_nothrow_default_constructible<container_type>::value &&
+        noexcept(is_nothrow_default_constructible<container_type>::value &&
                    is_nothrow_default_constructible<value_compare>::value)
         : c(), comp() {}
 
@@ -456,13 +456,13 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     priority_queue(priority_queue&& __q)
-        _NOEXCEPT_(is_nothrow_move_constructible<container_type>::value &&
+        noexcept(is_nothrow_move_constructible<container_type>::value &&
                    is_nothrow_move_constructible<value_compare>::value)
         : c(_CUDA_VSTD::move(__q.c)), comp(_CUDA_VSTD::move(__q.comp)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     priority_queue& operator=(priority_queue&& __q)
-        _NOEXCEPT_(is_nothrow_move_assignable<container_type>::value &&
+        noexcept(is_nothrow_move_assignable<container_type>::value &&
                    is_nothrow_move_assignable<value_compare>::value)
         {c = _CUDA_VSTD::move(__q.c); comp = _CUDA_VSTD::move(__q.comp); return *this;}
 #endif  // _LIBCUDACXX_CXX03_LANG
@@ -546,7 +546,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(priority_queue& __q)
-        _NOEXCEPT_(__is_nothrow_swappable<container_type>::value &&
+        noexcept(__is_nothrow_swappable<container_type>::value &&
                    __is_nothrow_swappable<value_compare>::value);
 };
 
@@ -770,7 +770,7 @@ template <class _Tp, class _Container, class _Compare>
 inline
 void
 priority_queue<_Tp, _Container, _Compare>::swap(priority_queue& __q)
-        _NOEXCEPT_(__is_nothrow_swappable<container_type>::value &&
+        noexcept(__is_nothrow_swappable<container_type>::value &&
                    __is_nothrow_swappable<value_compare>::value)
 {
     using _CUDA_VSTD::swap;
@@ -787,7 +787,7 @@ typename enable_if<
 >::type
 swap(priority_queue<_Tp, _Container, _Compare>& __x,
      priority_queue<_Tp, _Container, _Compare>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/random
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/random
@@ -2880,7 +2880,7 @@ public:
 
     // property functions
     _LIBCUDACXX_INLINE_VISIBILITY
-    const _Engine& base() const _NOEXCEPT {return __e_;}
+    const _Engine& base() const noexcept {return __e_;}
 
     template<class _Eng, size_t _Pp, size_t _Rp>
     friend
@@ -3091,7 +3091,7 @@ public:
 
     // property functions
     _LIBCUDACXX_INLINE_VISIBILITY
-    const _Engine& base() const _NOEXCEPT {return __e_;}
+    const _Engine& base() const noexcept {return __e_;}
 
     template<class _Eng, size_t _Wp, class _UInt>
     friend
@@ -3321,7 +3321,7 @@ public:
 
     // property functions
     _LIBCUDACXX_INLINE_VISIBILITY
-    const _Engine& base() const _NOEXCEPT {return __e_;}
+    const _Engine& base() const noexcept {return __e_;}
 
 private:
     template<class _Eng, size_t _Kp>
@@ -3503,7 +3503,7 @@ public:
     result_type operator()();
 
     // property functions
-    double entropy() const _NOEXCEPT;
+    double entropy() const noexcept;
 
 private:
     // no copy functions
@@ -3527,7 +3527,7 @@ private:
 public:
     // constructors
     _LIBCUDACXX_INLINE_VISIBILITY
-    seed_seq() _NOEXCEPT {}
+    seed_seq() noexcept {}
 #ifndef _LIBCUDACXX_CXX03_LANG
     template<class _Tp>
         _LIBCUDACXX_INLINE_VISIBILITY
@@ -3545,7 +3545,7 @@ public:
 
     // property functions
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t size() const _NOEXCEPT {return __v_.size();}
+    size_t size() const noexcept {return __v_.size();}
     template<class _OutputIterator>
         _LIBCUDACXX_INLINE_VISIBILITY
         void param(_OutputIterator __dest) const

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/regex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/regex
@@ -2610,7 +2610,7 @@ public:
         {return *this = __that;}
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
-    basic_regex& assign(basic_regex&& __that) _NOEXCEPT
+    basic_regex& assign(basic_regex&& __that) noexcept
         {return *this = _CUDA_VSTD::move(__that);}
 #endif
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -5278,11 +5278,11 @@ public:
 
     // size:
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT {return __matches_.size();}
+    size_type size() const noexcept {return __matches_.size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {return __matches_.max_size();}
+    size_type max_size() const noexcept {return __matches_.max_size();}
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT {return size() == 0;}
+    bool empty() const noexcept {return size() == 0;}
 
     // element access:
     _LIBCUDACXX_INLINE_VISIBILITY

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/scoped_allocator
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/scoped_allocator
@@ -206,7 +206,7 @@ private:
 protected:
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __scoped_allocator_storage() _NOEXCEPT {}
+    __scoped_allocator_storage() noexcept {}
 
     template <class _OuterA2,
               class = typename enable_if<
@@ -214,7 +214,7 @@ protected:
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
         __scoped_allocator_storage(_OuterA2&& __outerAlloc,
-                                   const _InnerAllocs& ...__innerAllocs) _NOEXCEPT
+                                   const _InnerAllocs& ...__innerAllocs) noexcept
             : outer_allocator_type(_CUDA_VSTD::forward<_OuterA2>(__outerAlloc)),
               __inner_(__innerAllocs...) {}
 
@@ -224,7 +224,7 @@ protected:
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
         __scoped_allocator_storage(
-            const __scoped_allocator_storage<_OuterA2, _InnerAllocs...>& __other) _NOEXCEPT
+            const __scoped_allocator_storage<_OuterA2, _InnerAllocs...>& __other) noexcept
             : outer_allocator_type(__other.outer_allocator()),
               __inner_(__other.inner_allocator()) {}
 
@@ -234,7 +234,7 @@ protected:
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
         __scoped_allocator_storage(
-            __scoped_allocator_storage<_OuterA2, _InnerAllocs...>&& __other) _NOEXCEPT
+            __scoped_allocator_storage<_OuterA2, _InnerAllocs...>&& __other) noexcept
             : outer_allocator_type(_CUDA_VSTD::move(__other.outer_allocator())),
               __inner_(_CUDA_VSTD::move(__other.inner_allocator())) {}
 
@@ -244,27 +244,27 @@ protected:
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
         __scoped_allocator_storage(_OuterA2&& __o,
-                                   const inner_allocator_type& __i) _NOEXCEPT
+                                   const inner_allocator_type& __i) noexcept
             : outer_allocator_type(_CUDA_VSTD::forward<_OuterA2>(__o)),
               __inner_(__i)
         {
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    inner_allocator_type& inner_allocator() _NOEXCEPT             {return __inner_;}
+    inner_allocator_type& inner_allocator() noexcept             {return __inner_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const inner_allocator_type& inner_allocator() const _NOEXCEPT {return __inner_;}
+    const inner_allocator_type& inner_allocator() const noexcept {return __inner_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    outer_allocator_type& outer_allocator() _NOEXCEPT
+    outer_allocator_type& outer_allocator() noexcept
         {return static_cast<outer_allocator_type&>(*this);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const outer_allocator_type& outer_allocator() const _NOEXCEPT
+    const outer_allocator_type& outer_allocator() const noexcept
         {return static_cast<const outer_allocator_type&>(*this);}
 
     scoped_allocator_adaptor<outer_allocator_type, _InnerAllocs...>
     _LIBCUDACXX_INLINE_VISIBILITY
-    select_on_container_copy_construction() const _NOEXCEPT
+    select_on_container_copy_construction() const noexcept
         {
             return scoped_allocator_adaptor<outer_allocator_type, _InnerAllocs...>
             (
@@ -287,14 +287,14 @@ protected:
     typedef scoped_allocator_adaptor<_OuterAlloc> inner_allocator_type;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __scoped_allocator_storage() _NOEXCEPT {}
+    __scoped_allocator_storage() noexcept {}
 
     template <class _OuterA2,
               class = typename enable_if<
                         is_constructible<outer_allocator_type, _OuterA2>::value
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
-        __scoped_allocator_storage(_OuterA2&& __outerAlloc) _NOEXCEPT
+        __scoped_allocator_storage(_OuterA2&& __outerAlloc) noexcept
             : outer_allocator_type(_CUDA_VSTD::forward<_OuterA2>(__outerAlloc)) {}
 
     template <class _OuterA2,
@@ -303,7 +303,7 @@ protected:
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
         __scoped_allocator_storage(
-            const __scoped_allocator_storage<_OuterA2>& __other) _NOEXCEPT
+            const __scoped_allocator_storage<_OuterA2>& __other) noexcept
             : outer_allocator_type(__other.outer_allocator()) {}
 
     template <class _OuterA2,
@@ -312,33 +312,33 @@ protected:
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
         __scoped_allocator_storage(
-            __scoped_allocator_storage<_OuterA2>&& __other) _NOEXCEPT
+            __scoped_allocator_storage<_OuterA2>&& __other) noexcept
             : outer_allocator_type(_CUDA_VSTD::move(__other.outer_allocator())) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    inner_allocator_type& inner_allocator() _NOEXCEPT
+    inner_allocator_type& inner_allocator() noexcept
         {return static_cast<inner_allocator_type&>(*this);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const inner_allocator_type& inner_allocator() const _NOEXCEPT
+    const inner_allocator_type& inner_allocator() const noexcept
         {return static_cast<const inner_allocator_type&>(*this);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    outer_allocator_type& outer_allocator() _NOEXCEPT
+    outer_allocator_type& outer_allocator() noexcept
         {return static_cast<outer_allocator_type&>(*this);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const outer_allocator_type& outer_allocator() const _NOEXCEPT
+    const outer_allocator_type& outer_allocator() const noexcept
         {return static_cast<const outer_allocator_type&>(*this);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     scoped_allocator_adaptor<outer_allocator_type>
-    select_on_container_copy_construction() const _NOEXCEPT
+    select_on_container_copy_construction() const noexcept
         {return scoped_allocator_adaptor<outer_allocator_type>(
             allocator_traits<outer_allocator_type>::
                 select_on_container_copy_construction(outer_allocator())
         );}
 
     __scoped_allocator_storage(const outer_allocator_type& __o,
-                               const inner_allocator_type& __i) _NOEXCEPT;
+                               const inner_allocator_type& __i) noexcept;
 
     template <class...> friend class __scoped_allocator_storage;
 };
@@ -367,7 +367,7 @@ struct __outermost
 {
     typedef _Alloc type;
     _LIBCUDACXX_INLINE_VISIBILITY
-    type& operator()(type& __a) const _NOEXCEPT {return __a;}
+    type& operator()(type& __a) const noexcept {return __a;}
 };
 
 template <class _Alloc>
@@ -379,7 +379,7 @@ struct __outermost<_Alloc, true>
                      >::type                                    _OuterAlloc;
     typedef typename __outermost<_OuterAlloc>::type             type;
     _LIBCUDACXX_INLINE_VISIBILITY
-    type& operator()(_Alloc& __a) const _NOEXCEPT
+    type& operator()(_Alloc& __a) const noexcept
         {return __outermost<_OuterAlloc>()(__a.outer_allocator());}
 };
 
@@ -432,14 +432,14 @@ public:
     };
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    scoped_allocator_adaptor() _NOEXCEPT {}
+    scoped_allocator_adaptor() noexcept {}
     template <class _OuterA2,
               class = typename enable_if<
                         is_constructible<outer_allocator_type, _OuterA2>::value
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
         scoped_allocator_adaptor(_OuterA2&& __outerAlloc,
-                                 const _InnerAllocs& ...__innerAllocs) _NOEXCEPT
+                                 const _InnerAllocs& ...__innerAllocs) noexcept
             : base(_CUDA_VSTD::forward<_OuterA2>(__outerAlloc), __innerAllocs...) {}
     // scoped_allocator_adaptor(const scoped_allocator_adaptor& __other) = default;
     template <class _OuterA2,
@@ -448,7 +448,7 @@ public:
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
         scoped_allocator_adaptor(
-            const scoped_allocator_adaptor<_OuterA2, _InnerAllocs...>& __other) _NOEXCEPT
+            const scoped_allocator_adaptor<_OuterA2, _InnerAllocs...>& __other) noexcept
                 : base(__other) {}
     template <class _OuterA2,
               class = typename enable_if<
@@ -456,7 +456,7 @@ public:
                       >::type>
         _LIBCUDACXX_INLINE_VISIBILITY
         scoped_allocator_adaptor(
-            scoped_allocator_adaptor<_OuterA2, _InnerAllocs...>&& __other) _NOEXCEPT
+            scoped_allocator_adaptor<_OuterA2, _InnerAllocs...>&& __other) noexcept
                 : base(_CUDA_VSTD::move(__other)) {}
 
     // scoped_allocator_adaptor& operator=(const scoped_allocator_adaptor&) = default;
@@ -464,17 +464,17 @@ public:
     // ~scoped_allocator_adaptor() = default;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    inner_allocator_type& inner_allocator() _NOEXCEPT
+    inner_allocator_type& inner_allocator() noexcept
         {return base::inner_allocator();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const inner_allocator_type& inner_allocator() const _NOEXCEPT
+    const inner_allocator_type& inner_allocator() const noexcept
         {return base::inner_allocator();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    outer_allocator_type& outer_allocator() _NOEXCEPT
+    outer_allocator_type& outer_allocator() noexcept
         {return base::outer_allocator();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const outer_allocator_type& outer_allocator() const _NOEXCEPT
+    const outer_allocator_type& outer_allocator() const noexcept
         {return base::outer_allocator();}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
@@ -487,7 +487,7 @@ public:
             allocate(outer_allocator(), __n, __hint);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void deallocate(pointer __p, size_type __n) _NOEXCEPT
+    void deallocate(pointer __p, size_type __n) noexcept
         {allocator_traits<outer_allocator_type>::
             deallocate(outer_allocator(), __p, __n);}
 
@@ -560,7 +560,7 @@ public:
             }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    scoped_allocator_adaptor select_on_container_copy_construction() const _NOEXCEPT
+    scoped_allocator_adaptor select_on_container_copy_construction() const noexcept
         {return base::select_on_container_copy_construction();}
 
 private:
@@ -572,7 +572,7 @@ private:
                       >::type>
     _LIBCUDACXX_INLINE_VISIBILITY
     scoped_allocator_adaptor(_OuterA2&& __o,
-                             const inner_allocator_type& __i) _NOEXCEPT
+                             const inner_allocator_type& __i) noexcept
         : base(_CUDA_VSTD::forward<_OuterA2>(__o), __i) {}
 
     template <class _Tp, class... _Args>
@@ -652,7 +652,7 @@ template <class _OuterA1, class _OuterA2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator==(const scoped_allocator_adaptor<_OuterA1>& __a,
-           const scoped_allocator_adaptor<_OuterA2>& __b) _NOEXCEPT
+           const scoped_allocator_adaptor<_OuterA2>& __b) noexcept
 {
     return __a.outer_allocator() == __b.outer_allocator();
 }
@@ -661,7 +661,7 @@ template <class _OuterA1, class _OuterA2, class _InnerA0, class... _InnerAllocs>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator==(const scoped_allocator_adaptor<_OuterA1, _InnerA0, _InnerAllocs...>& __a,
-           const scoped_allocator_adaptor<_OuterA2, _InnerA0, _InnerAllocs...>& __b) _NOEXCEPT
+           const scoped_allocator_adaptor<_OuterA2, _InnerA0, _InnerAllocs...>& __b) noexcept
 {
     return __a.outer_allocator() == __b.outer_allocator() &&
            __a.inner_allocator() == __b.inner_allocator();
@@ -671,7 +671,7 @@ template <class _OuterA1, class _OuterA2, class... _InnerAllocs>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator!=(const scoped_allocator_adaptor<_OuterA1, _InnerAllocs...>& __a,
-           const scoped_allocator_adaptor<_OuterA2, _InnerAllocs...>& __b) _NOEXCEPT
+           const scoped_allocator_adaptor<_OuterA2, _InnerAllocs...>& __b) noexcept
 {
     return !(__a == __b);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/set
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/set
@@ -484,7 +484,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     set()
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<allocator_type>::value &&
             is_nothrow_default_constructible<key_compare>::value &&
             is_nothrow_copy_constructible<key_compare>::value)
@@ -492,7 +492,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit set(const value_compare& __comp)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<allocator_type>::value &&
             is_nothrow_copy_constructible<key_compare>::value)
         : __tree_(__comp) {}
@@ -542,7 +542,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     set(set&& __s)
-        _NOEXCEPT_(is_nothrow_move_constructible<__base>::value)
+        noexcept(is_nothrow_move_constructible<__base>::value)
         : __tree_(_CUDA_VSTD::move(__s.__tree_)) {}
 #endif  // _LIBCUDACXX_CXX03_LANG
 
@@ -590,7 +590,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     set& operator=(set&& __s)
-        _NOEXCEPT_(is_nothrow_move_assignable<__base>::value)
+        noexcept(is_nothrow_move_assignable<__base>::value)
         {
             __tree_ = _CUDA_VSTD::move(__s.__tree_);
             return *this;
@@ -603,42 +603,42 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator begin() _NOEXCEPT       {return __tree_.begin();}
+          iterator begin() noexcept       {return __tree_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT {return __tree_.begin();}
+    const_iterator begin() const noexcept {return __tree_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator end() _NOEXCEPT         {return __tree_.end();}
+          iterator end() noexcept         {return __tree_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()   const _NOEXCEPT {return __tree_.end();}
+    const_iterator end()   const noexcept {return __tree_.end();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rbegin() _NOEXCEPT
+          reverse_iterator rbegin() noexcept
             {return reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin() const _NOEXCEPT
+    const_reverse_iterator rbegin() const noexcept
         {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rend() _NOEXCEPT
+          reverse_iterator rend() noexcept
             {return reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend() const _NOEXCEPT
+    const_reverse_iterator rend() const noexcept
         {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin()  const _NOEXCEPT {return begin();}
+    const_iterator cbegin()  const noexcept {return begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend() const _NOEXCEPT {return end();}
+    const_iterator cend() const noexcept {return end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT {return rbegin();}
+    const_reverse_iterator crbegin() const noexcept {return rbegin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend() const _NOEXCEPT {return rend();}
+    const_reverse_iterator crend() const noexcept {return rend();}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT {return __tree_.size() == 0;}
+    bool empty() const noexcept {return __tree_.size() == 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT {return __tree_.size();}
+    size_type size() const noexcept {return __tree_.size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {return __tree_.max_size();}
+    size_type max_size() const noexcept {return __tree_.max_size();}
 
     // modifiers:
 #ifndef _LIBCUDACXX_CXX03_LANG
@@ -690,7 +690,7 @@ public:
     iterator  erase(const_iterator __f, const_iterator __l)
         {return __tree_.erase(__f, __l);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {__tree_.clear();}
+    void clear() noexcept {__tree_.clear();}
 
 #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -754,11 +754,11 @@ public:
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(set& __s) _NOEXCEPT_(__is_nothrow_swappable<__base>::value)
+    void swap(set& __s) noexcept(__is_nothrow_swappable<__base>::value)
         {__tree_.swap(__s.__tree_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT {return __tree_.__alloc();}
+    allocator_type get_allocator() const noexcept {return __tree_.__alloc();}
     _LIBCUDACXX_INLINE_VISIBILITY
     key_compare    key_comp()      const {return __tree_.value_comp();}
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -952,7 +952,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(set<_Key, _Compare, _Allocator>& __x,
      set<_Key, _Compare, _Allocator>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -1010,7 +1010,7 @@ public:
     // construct/copy/destroy:
     _LIBCUDACXX_INLINE_VISIBILITY
     multiset()
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<allocator_type>::value &&
             is_nothrow_default_constructible<key_compare>::value &&
             is_nothrow_copy_constructible<key_compare>::value)
@@ -1018,7 +1018,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     explicit multiset(const value_compare& __comp)
-        _NOEXCEPT_(
+        noexcept(
             is_nothrow_default_constructible<allocator_type>::value &&
             is_nothrow_copy_constructible<key_compare>::value)
         : __tree_(__comp) {}
@@ -1069,7 +1069,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     multiset(multiset&& __s)
-        _NOEXCEPT_(is_nothrow_move_constructible<__base>::value)
+        noexcept(is_nothrow_move_constructible<__base>::value)
         : __tree_(_CUDA_VSTD::move(__s.__tree_)) {}
 
     multiset(multiset&& __s, const allocator_type& __a);
@@ -1115,7 +1115,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     multiset& operator=(multiset&& __s)
-        _NOEXCEPT_(is_nothrow_move_assignable<__base>::value)
+        noexcept(is_nothrow_move_assignable<__base>::value)
         {
             __tree_ = _CUDA_VSTD::move(__s.__tree_);
             return *this;
@@ -1128,42 +1128,42 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator begin() _NOEXCEPT       {return __tree_.begin();}
+          iterator begin() noexcept       {return __tree_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT {return __tree_.begin();}
+    const_iterator begin() const noexcept {return __tree_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-          iterator end() _NOEXCEPT         {return __tree_.end();}
+          iterator end() noexcept         {return __tree_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()   const _NOEXCEPT {return __tree_.end();}
+    const_iterator end()   const noexcept {return __tree_.end();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rbegin() _NOEXCEPT
+          reverse_iterator rbegin() noexcept
             {return reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin() const _NOEXCEPT
+    const_reverse_iterator rbegin() const noexcept
         {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-          reverse_iterator rend() _NOEXCEPT
+          reverse_iterator rend() noexcept
             {return       reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend() const _NOEXCEPT
+    const_reverse_iterator rend() const noexcept
         {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin()  const _NOEXCEPT {return begin();}
+    const_iterator cbegin()  const noexcept {return begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend() const _NOEXCEPT {return end();}
+    const_iterator cend() const noexcept {return end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT {return rbegin();}
+    const_reverse_iterator crbegin() const noexcept {return rbegin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend() const _NOEXCEPT {return rend();}
+    const_reverse_iterator crend() const noexcept {return rend();}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT {return __tree_.size() == 0;}
+    bool empty() const noexcept {return __tree_.size() == 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT {return __tree_.size();}
+    size_type size() const noexcept {return __tree_.size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {return __tree_.max_size();}
+    size_type max_size() const noexcept {return __tree_.max_size();}
 
     // modifiers:
 #ifndef _LIBCUDACXX_CXX03_LANG
@@ -1214,7 +1214,7 @@ public:
     iterator  erase(const_iterator __f, const_iterator __l)
         {return __tree_.erase(__f, __l);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {__tree_.clear();}
+    void clear() noexcept {__tree_.clear();}
 
 #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1279,11 +1279,11 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(multiset& __s)
-        _NOEXCEPT_(__is_nothrow_swappable<__base>::value)
+        noexcept(__is_nothrow_swappable<__base>::value)
         {__tree_.swap(__s.__tree_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT {return __tree_.__alloc();}
+    allocator_type get_allocator() const noexcept {return __tree_.__alloc();}
     _LIBCUDACXX_INLINE_VISIBILITY
     key_compare    key_comp()      const {return __tree_.value_comp();}
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1476,7 +1476,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(multiset<_Key, _Compare, _Allocator>& __x,
      multiset<_Key, _Compare, _Allocator>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/shared_mutex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/shared_mutex
@@ -317,7 +317,7 @@ private:
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_lock() _NOEXCEPT
+    shared_lock() noexcept
         : __m_(nullptr),
           __owns_(false)
         {}
@@ -329,7 +329,7 @@ public:
         {__m_->lock_shared();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_lock(mutex_type& __m, defer_lock_t) _NOEXCEPT
+    shared_lock(mutex_type& __m, defer_lock_t) noexcept
         : __m_(_CUDA_VSTD::addressof(__m)),
           __owns_(false)
         {}
@@ -373,7 +373,7 @@ public:
     shared_lock& operator=(shared_lock const&) = delete;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_lock(shared_lock&& __u) _NOEXCEPT
+    shared_lock(shared_lock&& __u) noexcept
         : __m_(__u.__m_),
           __owns_(__u.__owns_)
         {
@@ -382,7 +382,7 @@ public:
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    shared_lock& operator=(shared_lock&& __u) _NOEXCEPT
+    shared_lock& operator=(shared_lock&& __u) noexcept
     {
         if (__owns_)
             __m_->unlock_shared();
@@ -405,14 +405,14 @@ public:
 
     // Setters
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(shared_lock& __u) _NOEXCEPT
+    void swap(shared_lock& __u) noexcept
     {
         _CUDA_VSTD::swap(__m_, __u.__m_);
         _CUDA_VSTD::swap(__owns_, __u.__owns_);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    mutex_type* release() _NOEXCEPT
+    mutex_type* release() noexcept
     {
         mutex_type* __m = __m_;
         __m_ = nullptr;
@@ -422,13 +422,13 @@ public:
 
     // Getters
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool owns_lock() const _NOEXCEPT {return __owns_;}
+    bool owns_lock() const noexcept {return __owns_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit operator bool () const _NOEXCEPT {return __owns_;}
+    explicit operator bool () const noexcept {return __owns_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    mutex_type* mutex() const _NOEXCEPT {return __m_;}
+    mutex_type* mutex() const noexcept {return __m_;}
 };
 
 template <class _Mutex>
@@ -494,7 +494,7 @@ shared_lock<_Mutex>::unlock()
 template <class _Mutex>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(shared_lock<_Mutex>& __x, shared_lock<_Mutex>& __y) _NOEXCEPT
+swap(shared_lock<_Mutex>& __x, shared_lock<_Mutex>& __y) noexcept
     {__x.swap(__y);}
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/stack
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/stack
@@ -125,7 +125,7 @@ protected:
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     stack()
-        _NOEXCEPT_(is_nothrow_default_constructible<container_type>::value)
+        noexcept(is_nothrow_default_constructible<container_type>::value)
         : c() {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -138,12 +138,12 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     stack(stack&& __q)
-        _NOEXCEPT_(is_nothrow_move_constructible<container_type>::value)
+        noexcept(is_nothrow_move_constructible<container_type>::value)
         : c(_CUDA_VSTD::move(__q.c)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     stack& operator=(stack&& __q)
-        _NOEXCEPT_(is_nothrow_move_assignable<container_type>::value)
+        noexcept(is_nothrow_move_assignable<container_type>::value)
         {c = _CUDA_VSTD::move(__q.c); return *this;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -217,7 +217,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(stack& __s)
-        _NOEXCEPT_(__is_nothrow_swappable<container_type>::value)
+        noexcept(__is_nothrow_swappable<container_type>::value)
     {
         using _CUDA_VSTD::swap;
         swap(c, __s.c);
@@ -305,7 +305,7 @@ typename enable_if<
     void
 >::type
 swap(stack<_Tp, _Container>& __x, stack<_Tp, _Container>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/stdexcept
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/stdexcept
@@ -70,11 +70,11 @@ class _LIBCUDACXX_HIDDEN __libcpp_refstring
     _LIBCUDACXX_HOST_DEVICE bool __uses_refcount() const;
 public:
     _LIBCUDACXX_HOST_DEVICE explicit __libcpp_refstring(const char* __msg);
-    _LIBCUDACXX_HOST_DEVICE __libcpp_refstring(const __libcpp_refstring& __s) _NOEXCEPT;
-    _LIBCUDACXX_HOST_DEVICE __libcpp_refstring& operator=(const __libcpp_refstring& __s) _NOEXCEPT;
+    _LIBCUDACXX_HOST_DEVICE __libcpp_refstring(const __libcpp_refstring& __s) noexcept;
+    _LIBCUDACXX_HOST_DEVICE __libcpp_refstring& operator=(const __libcpp_refstring& __s) noexcept;
     _LIBCUDACXX_HOST_DEVICE ~__libcpp_refstring();
 
-    _LIBCUDACXX_HOST_DEVICE const char* c_str() const _NOEXCEPT {return __imp_;}
+    _LIBCUDACXX_HOST_DEVICE const char* c_str() const noexcept {return __imp_;}
 };
 #endif // !_LIBCUDACXX_ABI_VCRUNTIME
 
@@ -98,12 +98,12 @@ public:
     explicit logic_error(const string&);
     explicit logic_error(const char*);
 
-    logic_error(const logic_error&) _NOEXCEPT;
-    logic_error& operator=(const logic_error&) _NOEXCEPT;
+    logic_error(const logic_error&) noexcept;
+    logic_error& operator=(const logic_error&) noexcept;
 
-    virtual ~logic_error() _NOEXCEPT;
+    virtual ~logic_error() noexcept;
 
-    virtual const char* what() const _NOEXCEPT;
+    virtual const char* what() const noexcept;
 #else
 public:
     explicit logic_error(const _CUDA_VSTD::string&); // Symbol uses versioned std::string
@@ -121,12 +121,12 @@ public:
     explicit runtime_error(const string&);
     explicit runtime_error(const char*);
 
-    runtime_error(const runtime_error&) _NOEXCEPT;
-    runtime_error& operator=(const runtime_error&) _NOEXCEPT;
+    runtime_error(const runtime_error&) noexcept;
+    runtime_error& operator=(const runtime_error&) noexcept;
 
-    virtual ~runtime_error() _NOEXCEPT;
+    virtual ~runtime_error() noexcept;
 
-    virtual const char* what() const _NOEXCEPT;
+    virtual const char* what() const noexcept;
 #else
 public:
    explicit runtime_error(const _CUDA_VSTD::string&); // Symbol uses versioned std::string
@@ -142,7 +142,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit domain_error(const char* __s)   : logic_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~domain_error() _NOEXCEPT;
+    virtual ~domain_error() noexcept;
 #endif
 };
 
@@ -154,7 +154,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit invalid_argument(const char* __s)   : logic_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~invalid_argument() _NOEXCEPT;
+    virtual ~invalid_argument() noexcept;
 #endif
 };
 
@@ -165,7 +165,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit length_error(const string& __s) : logic_error(__s) {}
     _LIBCUDACXX_INLINE_VISIBILITY explicit length_error(const char* __s)   : logic_error(__s) {}
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~length_error() _NOEXCEPT;
+    virtual ~length_error() noexcept;
 #endif
 };
 
@@ -177,7 +177,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit out_of_range(const char* __s)   : logic_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~out_of_range() _NOEXCEPT;
+    virtual ~out_of_range() noexcept;
 #endif
 };
 
@@ -189,7 +189,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit range_error(const char* __s)   : runtime_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~range_error() _NOEXCEPT;
+    virtual ~range_error() noexcept;
 #endif
 };
 
@@ -201,7 +201,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit overflow_error(const char* __s)   : runtime_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~overflow_error() _NOEXCEPT;
+    virtual ~overflow_error() noexcept;
 #endif
 };
 
@@ -213,7 +213,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY explicit underflow_error(const char* __s)   : runtime_error(__s) {}
 
 #ifndef _LIBCUDACXX_ABI_VCRUNTIME
-    virtual ~underflow_error() _NOEXCEPT;
+    virtual ~underflow_error() noexcept;
 #endif
 };
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/string
@@ -789,13 +789,13 @@ public:
     static const size_type npos = static_cast<size_type>(-1);
 
     _LIBCUDACXX_INLINE_VISIBILITY basic_string()
-        _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value);
+        noexcept(is_nothrow_default_constructible<allocator_type>::value);
 
     _LIBCUDACXX_INLINE_VISIBILITY explicit basic_string(const allocator_type& __a)
 #if _LIBCUDACXX_STD_VER <= 14
-        _NOEXCEPT_(is_nothrow_copy_constructible<allocator_type>::value);
+        noexcept(is_nothrow_copy_constructible<allocator_type>::value);
 #else
-        _NOEXCEPT;
+        noexcept;
 #endif
 
     basic_string(const basic_string& __str);
@@ -805,9 +805,9 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     basic_string(basic_string&& __str)
 #if _LIBCUDACXX_STD_VER <= 14
-        _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value);
+        noexcept(is_nothrow_move_constructible<allocator_type>::value);
 #else
-        _NOEXCEPT;
+        noexcept;
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -874,7 +874,7 @@ public:
     inline ~basic_string();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    operator __self_view() const _NOEXCEPT { return __self_view(data(), size()); }
+    operator __self_view() const noexcept { return __self_view(data(), size()); }
 
     basic_string& operator=(const basic_string& __str);
 
@@ -885,7 +885,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     basic_string& operator=(basic_string&& __str)
-        _NOEXCEPT_((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value));
+        noexcept((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value));
      _LIBCUDACXX_INLINE_VISIBILITY
     basic_string& operator=(initializer_list<value_type> __il) {return assign(__il.begin(), __il.size());}
 #endif
@@ -894,62 +894,62 @@ public:
 
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator begin() _NOEXCEPT
+    iterator begin() noexcept
         {return iterator(this, __get_pointer());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT
+    const_iterator begin() const noexcept
         {return const_iterator(this, __get_pointer());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator end() _NOEXCEPT
+    iterator end() noexcept
         {return iterator(this, __get_pointer() + size());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end() const _NOEXCEPT
+    const_iterator end() const noexcept
         {return const_iterator(this, __get_pointer() + size());}
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator begin() _NOEXCEPT
+    iterator begin() noexcept
         {return iterator(__get_pointer());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT
+    const_iterator begin() const noexcept
         {return const_iterator(__get_pointer());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator end() _NOEXCEPT
+    iterator end() noexcept
         {return iterator(__get_pointer() + size());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end() const _NOEXCEPT
+    const_iterator end() const noexcept
         {return const_iterator(__get_pointer() + size());}
 #endif  // _LIBCUDACXX_ENABLE_DEBUG_MODE
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator rbegin() _NOEXCEPT
+    reverse_iterator rbegin() noexcept
         {return reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin() const _NOEXCEPT
+    const_reverse_iterator rbegin() const noexcept
         {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator rend() _NOEXCEPT
+    reverse_iterator rend() noexcept
         {return reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend() const _NOEXCEPT
+    const_reverse_iterator rend() const noexcept
         {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT
+    const_iterator cbegin() const noexcept
         {return begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend() const _NOEXCEPT
+    const_iterator cend() const noexcept
         {return end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT
+    const_reverse_iterator crbegin() const noexcept
         {return rbegin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend() const _NOEXCEPT
+    const_reverse_iterator crend() const noexcept
         {return rend();}
 
-    _LIBCUDACXX_INLINE_VISIBILITY size_type size() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY size_type size() const noexcept
         {return __is_long() ? __get_long_size() : __get_short_size();}
-    _LIBCUDACXX_INLINE_VISIBILITY size_type length() const _NOEXCEPT {return size();}
-    _LIBCUDACXX_INLINE_VISIBILITY size_type max_size() const _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY size_type capacity() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY size_type length() const noexcept {return size();}
+    _LIBCUDACXX_INLINE_VISIBILITY size_type max_size() const noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY size_type capacity() const noexcept
         {return (__is_long() ? __get_long_cap()
                              : static_cast<size_type>(__min_cap)) - 1;}
 
@@ -960,16 +960,16 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY void __resize_default_init(size_type __n);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void reserve() _NOEXCEPT {reserve(0);}
+    void reserve() noexcept {reserve(0);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void shrink_to_fit() _NOEXCEPT {reserve();}
+    void shrink_to_fit() noexcept {reserve();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT;
+    void clear() noexcept;
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT {return size() == 0;}
+    bool empty() const noexcept {return size() == 0;}
 
-    _LIBCUDACXX_INLINE_VISIBILITY const_reference operator[](size_type __pos) const _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY reference       operator[](size_type __pos)       _NOEXCEPT;
+    _LIBCUDACXX_INLINE_VISIBILITY const_reference operator[](size_type __pos) const noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY reference       operator[](size_type __pos)       noexcept;
 
     const_reference at(size_type __n) const;
     reference       at(size_type __n);
@@ -1056,10 +1056,10 @@ public:
     void push_back(value_type __c);
     _LIBCUDACXX_INLINE_VISIBILITY
     void pop_back();
-    _LIBCUDACXX_INLINE_VISIBILITY reference       front() _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY const_reference front() const _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY reference       back() _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY const_reference back() const _NOEXCEPT;
+    _LIBCUDACXX_INLINE_VISIBILITY reference       front() noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY const_reference front() const noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY reference       back() noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY const_reference back() const noexcept;
 
     template <class _Tp>
     _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -1074,7 +1074,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     basic_string& assign(basic_string&& __str)
-        _NOEXCEPT_((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value))
+        noexcept((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value))
         {*this = _CUDA_VSTD::move(__str); return *this;}
 #endif
     basic_string& assign(const basic_string& __str, size_type __pos, size_type __n=npos);
@@ -1232,26 +1232,26 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(basic_string& __str)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                     __is_nothrow_swappable<allocator_type>::value);
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const value_type* c_str() const _NOEXCEPT {return data();}
+    const value_type* c_str() const noexcept {return data();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const value_type* data() const _NOEXCEPT  {return _CUDA_VSTD::__to_raw_pointer(__get_pointer());}
+    const value_type* data() const noexcept  {return _CUDA_VSTD::__to_raw_pointer(__get_pointer());}
 #if _LIBCUDACXX_STD_VER > 14 || defined(_LIBCUDACXX_BUILDING_LIBRARY)
     _LIBCUDACXX_INLINE_VISIBILITY
-    value_type* data()             _NOEXCEPT  {return _CUDA_VSTD::__to_raw_pointer(__get_pointer());}
+    value_type* data()             noexcept  {return _CUDA_VSTD::__to_raw_pointer(__get_pointer());}
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT {return __alloc();}
+    allocator_type get_allocator() const noexcept {return __alloc();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find(const basic_string& __str, size_type __pos = 0) const _NOEXCEPT;
+    size_type find(const basic_string& __str, size_type __pos = 0) const noexcept;
 
     template <class _Tp>
     _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -1261,13 +1261,13 @@ public:
             size_type
         >::type
               find(const _Tp& __t, size_type __pos = 0) const;
-    size_type find(const value_type* __s, size_type __pos, size_type __n) const _NOEXCEPT;
+    size_type find(const value_type* __s, size_type __pos, size_type __n) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find(const value_type* __s, size_type __pos = 0) const _NOEXCEPT;
-    size_type find(value_type __c, size_type __pos = 0) const _NOEXCEPT;
+    size_type find(const value_type* __s, size_type __pos = 0) const noexcept;
+    size_type find(value_type __c, size_type __pos = 0) const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type rfind(const basic_string& __str, size_type __pos = npos) const _NOEXCEPT;
+    size_type rfind(const basic_string& __str, size_type __pos = npos) const noexcept;
 
     template <class _Tp>
     _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -1277,13 +1277,13 @@ public:
             size_type
         >::type
               rfind(const _Tp& __t, size_type __pos = npos) const;
-    size_type rfind(const value_type* __s, size_type __pos, size_type __n) const _NOEXCEPT;
+    size_type rfind(const value_type* __s, size_type __pos, size_type __n) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type rfind(const value_type* __s, size_type __pos = npos) const _NOEXCEPT;
-    size_type rfind(value_type __c, size_type __pos = npos) const _NOEXCEPT;
+    size_type rfind(const value_type* __s, size_type __pos = npos) const noexcept;
+    size_type rfind(value_type __c, size_type __pos = npos) const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_of(const basic_string& __str, size_type __pos = 0) const _NOEXCEPT;
+    size_type find_first_of(const basic_string& __str, size_type __pos = 0) const noexcept;
 
     template <class _Tp>
     _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -1293,14 +1293,14 @@ public:
             size_type
         >::type
               find_first_of(const _Tp& __t, size_type __pos = 0) const;
-    size_type find_first_of(const value_type* __s, size_type __pos, size_type __n) const _NOEXCEPT;
+    size_type find_first_of(const value_type* __s, size_type __pos, size_type __n) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_of(const value_type* __s, size_type __pos = 0) const _NOEXCEPT;
+    size_type find_first_of(const value_type* __s, size_type __pos = 0) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_of(value_type __c, size_type __pos = 0) const _NOEXCEPT;
+    size_type find_first_of(value_type __c, size_type __pos = 0) const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_of(const basic_string& __str, size_type __pos = npos) const _NOEXCEPT;
+    size_type find_last_of(const basic_string& __str, size_type __pos = npos) const noexcept;
 
     template <class _Tp>
     _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -1310,14 +1310,14 @@ public:
             size_type
         >::type
               find_last_of(const _Tp& __t, size_type __pos = npos) const;
-    size_type find_last_of(const value_type* __s, size_type __pos, size_type __n) const _NOEXCEPT;
+    size_type find_last_of(const value_type* __s, size_type __pos, size_type __n) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_of(const value_type* __s, size_type __pos = npos) const _NOEXCEPT;
+    size_type find_last_of(const value_type* __s, size_type __pos = npos) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_of(value_type __c, size_type __pos = npos) const _NOEXCEPT;
+    size_type find_last_of(value_type __c, size_type __pos = npos) const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_not_of(const basic_string& __str, size_type __pos = 0) const _NOEXCEPT;
+    size_type find_first_not_of(const basic_string& __str, size_type __pos = 0) const noexcept;
 
     template <class _Tp>
     _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -1327,14 +1327,14 @@ public:
             size_type
         >::type
               find_first_not_of(const _Tp &__t, size_type __pos = 0) const;
-    size_type find_first_not_of(const value_type* __s, size_type __pos, size_type __n) const _NOEXCEPT;
+    size_type find_first_not_of(const value_type* __s, size_type __pos, size_type __n) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_not_of(const value_type* __s, size_type __pos = 0) const _NOEXCEPT;
+    size_type find_first_not_of(const value_type* __s, size_type __pos = 0) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_not_of(value_type __c, size_type __pos = 0) const _NOEXCEPT;
+    size_type find_first_not_of(value_type __c, size_type __pos = 0) const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_not_of(const basic_string& __str, size_type __pos = npos) const _NOEXCEPT;
+    size_type find_last_not_of(const basic_string& __str, size_type __pos = npos) const noexcept;
 
     template <class _Tp>
     _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -1344,14 +1344,14 @@ public:
             size_type
         >::type
               find_last_not_of(const _Tp& __t, size_type __pos = npos) const;
-    size_type find_last_not_of(const value_type* __s, size_type __pos, size_type __n) const _NOEXCEPT;
+    size_type find_last_not_of(const value_type* __s, size_type __pos, size_type __n) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_not_of(const value_type* __s, size_type __pos = npos) const _NOEXCEPT;
+    size_type find_last_not_of(const value_type* __s, size_type __pos = npos) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_not_of(value_type __c, size_type __pos = npos) const _NOEXCEPT;
+    size_type find_last_not_of(value_type __c, size_type __pos = npos) const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int compare(const basic_string& __str) const _NOEXCEPT;
+    int compare(const basic_string& __str) const noexcept;
 
     template <class _Tp>
     _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -1383,42 +1383,42 @@ public:
             int
         >::type
         compare(size_type __pos1, size_type __n1, const _Tp& __t, size_type __pos2, size_type __n2=npos) const;
-    int compare(const value_type* __s) const _NOEXCEPT;
+    int compare(const value_type* __s) const noexcept;
     int compare(size_type __pos1, size_type __n1, const value_type* __s) const;
     int compare(size_type __pos1, size_type __n1, const value_type* __s, size_type __n2) const;
 
 #if _LIBCUDACXX_STD_VER > 17
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool starts_with(__self_view __sv) const _NOEXCEPT
+    bool starts_with(__self_view __sv) const noexcept
     { return __self_view(data(), size()).starts_with(__sv); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool starts_with(value_type __c) const _NOEXCEPT
+    bool starts_with(value_type __c) const noexcept
     { return !empty() && _Traits::eq(front(), __c); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool starts_with(const value_type* __s) const _NOEXCEPT
+    bool starts_with(const value_type* __s) const noexcept
     { return starts_with(__self_view(__s)); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool ends_with(__self_view __sv) const _NOEXCEPT
+    bool ends_with(__self_view __sv) const noexcept
     { return __self_view(data(), size()).ends_with( __sv); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool ends_with(value_type __c) const _NOEXCEPT
+    bool ends_with(value_type __c) const noexcept
     { return !empty() && _Traits::eq(back(), __c); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool ends_with(const value_type* __s) const _NOEXCEPT
+    bool ends_with(const value_type* __s) const noexcept
     { return ends_with(__self_view(__s)); }
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY bool __invariants() const;
 
-    _LIBCUDACXX_INLINE_VISIBILITY void __clear_and_shrink() _NOEXCEPT;
+    _LIBCUDACXX_INLINE_VISIBILITY void __clear_and_shrink() noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool __is_long() const _NOEXCEPT
+    bool __is_long() const noexcept
         {return bool(__r_.first().__s.__size_ & __short_mask);}
 
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -1432,16 +1432,16 @@ public:
 
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type& __alloc() _NOEXCEPT
+    allocator_type& __alloc() noexcept
         {return __r_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const allocator_type& __alloc() const _NOEXCEPT
+    const allocator_type& __alloc() const noexcept
         {return __r_.second();}
 
 #ifdef _LIBCUDACXX_ABI_ALTERNATE_STRING_LAYOUT
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __set_short_size(size_type __s) _NOEXCEPT
+    void __set_short_size(size_type __s) noexcept
 #   ifdef _LIBCUDACXX_BIG_ENDIAN
         {__r_.first().__s.__size_ = (unsigned char)(__s << 1);}
 #   else
@@ -1449,7 +1449,7 @@ private:
 #   endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type __get_short_size() const _NOEXCEPT
+    size_type __get_short_size() const noexcept
 #   ifdef _LIBCUDACXX_BIG_ENDIAN
         {return __r_.first().__s.__size_ >> 1;}
 #   else
@@ -1459,7 +1459,7 @@ private:
 #else  // _LIBCUDACXX_ABI_ALTERNATE_STRING_LAYOUT
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __set_short_size(size_type __s) _NOEXCEPT
+    void __set_short_size(size_type __s) noexcept
 #   ifdef _LIBCUDACXX_BIG_ENDIAN
         {__r_.first().__s.__size_ = (unsigned char)(__s);}
 #   else
@@ -1467,7 +1467,7 @@ private:
 #   endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type __get_short_size() const _NOEXCEPT
+    size_type __get_short_size() const noexcept
 #   ifdef _LIBCUDACXX_BIG_ENDIAN
         {return __r_.first().__s.__size_;}
 #   else
@@ -1477,46 +1477,46 @@ private:
 #endif  // _LIBCUDACXX_ABI_ALTERNATE_STRING_LAYOUT
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __set_long_size(size_type __s) _NOEXCEPT
+    void __set_long_size(size_type __s) noexcept
         {__r_.first().__l.__size_ = __s;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type __get_long_size() const _NOEXCEPT
+    size_type __get_long_size() const noexcept
         {return __r_.first().__l.__size_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __set_size(size_type __s) _NOEXCEPT
+    void __set_size(size_type __s) noexcept
         {if (__is_long()) __set_long_size(__s); else __set_short_size(__s);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __set_long_cap(size_type __s) _NOEXCEPT
+    void __set_long_cap(size_type __s) noexcept
         {__r_.first().__l.__cap_  = __long_mask | __s;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type __get_long_cap() const _NOEXCEPT
+    size_type __get_long_cap() const noexcept
         {return __r_.first().__l.__cap_ & size_type(~__long_mask);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __set_long_pointer(pointer __p) _NOEXCEPT
+    void __set_long_pointer(pointer __p) noexcept
         {__r_.first().__l.__data_ = __p;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    pointer __get_long_pointer() _NOEXCEPT
+    pointer __get_long_pointer() noexcept
         {return __r_.first().__l.__data_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_pointer __get_long_pointer() const _NOEXCEPT
+    const_pointer __get_long_pointer() const noexcept
         {return __r_.first().__l.__data_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    pointer __get_short_pointer() _NOEXCEPT
+    pointer __get_short_pointer() noexcept
         {return pointer_traits<pointer>::pointer_to(__r_.first().__s.__data_[0]);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_pointer __get_short_pointer() const _NOEXCEPT
+    const_pointer __get_short_pointer() const noexcept
         {return pointer_traits<const_pointer>::pointer_to(__r_.first().__s.__data_[0]);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    pointer __get_pointer() _NOEXCEPT
+    pointer __get_pointer() noexcept
         {return __is_long() ? __get_long_pointer() : __get_short_pointer();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_pointer __get_pointer() const _NOEXCEPT
+    const_pointer __get_pointer() const noexcept
         {return __is_long() ? __get_long_pointer() : __get_short_pointer();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __zero() _NOEXCEPT
+    void __zero() noexcept
         {
             size_type (&__a)[__n_words] = __r_.first().__r.__words;
             for (unsigned __i = 0; __i < __n_words; ++__i)
@@ -1525,11 +1525,11 @@ private:
 
     template <size_type __a> static
         _LIBCUDACXX_INLINE_VISIBILITY
-        size_type __align_it(size_type __s) _NOEXCEPT
+        size_type __align_it(size_type __s) noexcept
             {return (__s + (__a-1)) & ~(__a-1);}
     enum {__alignment = 16};
     static _LIBCUDACXX_INLINE_VISIBILITY
-    size_type __recommend(size_type __s) _NOEXCEPT
+    size_type __recommend(size_type __s) noexcept
         {
         if (__s < __min_cap) return static_cast<size_type>(__min_cap) - 1;
         size_type __guess = __align_it<sizeof(value_type) < __alignment ?
@@ -1603,26 +1603,26 @@ private:
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __copy_assign_alloc(const basic_string&, false_type) _NOEXCEPT
+    void __copy_assign_alloc(const basic_string&, false_type) noexcept
         {}
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign(basic_string& __str, false_type)
-        _NOEXCEPT_(__alloc_traits::is_always_equal::value);
+        noexcept(__alloc_traits::is_always_equal::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign(basic_string& __str, true_type)
 #if _LIBCUDACXX_STD_VER > 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value);
+        noexcept(is_nothrow_move_assignable<allocator_type>::value);
 #endif
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void
     __move_assign_alloc(basic_string& __str)
-        _NOEXCEPT_(
+        noexcept(
             !__alloc_traits::propagate_on_container_move_assignment::value ||
             is_nothrow_move_assignable<allocator_type>::value)
     {__move_assign_alloc(__str, integral_constant<bool,
@@ -1630,14 +1630,14 @@ private:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(basic_string& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+        noexcept(is_nothrow_move_assignable<allocator_type>::value)
         {
             __alloc() = _CUDA_VSTD::move(__c.__alloc());
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(basic_string&, false_type)
-        _NOEXCEPT
+        noexcept
         {}
 
     _LIBCUDACXX_INLINE_VISIBILITY void __invalidate_all_iterators();
@@ -1722,7 +1722,7 @@ basic_string<_CharT, _Traits, _Allocator>::__invalidate_iterators_past(size_type
 template <class _CharT, class _Traits, class _Allocator>
 inline
 basic_string<_CharT, _Traits, _Allocator>::basic_string()
-    _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
+    noexcept(is_nothrow_default_constructible<allocator_type>::value)
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     __get_db()->__insert_c(this);
@@ -1734,9 +1734,9 @@ template <class _CharT, class _Traits, class _Allocator>
 inline
 basic_string<_CharT, _Traits, _Allocator>::basic_string(const allocator_type& __a)
 #if _LIBCUDACXX_STD_VER <= 14
-        _NOEXCEPT_(is_nothrow_copy_constructible<allocator_type>::value)
+        noexcept(is_nothrow_copy_constructible<allocator_type>::value)
 #else
-        _NOEXCEPT
+        noexcept
 #endif
 : __r_(__second_tag(), __a)
 {
@@ -1863,9 +1863,9 @@ template <class _CharT, class _Traits, class _Allocator>
 inline
 basic_string<_CharT, _Traits, _Allocator>::basic_string(basic_string&& __str)
 #if _LIBCUDACXX_STD_VER <= 14
-        _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
+        noexcept(is_nothrow_move_constructible<allocator_type>::value)
 #else
-        _NOEXCEPT
+        noexcept
 #endif
     : __r_(_CUDA_VSTD::move(__str.__r_))
 {
@@ -2273,7 +2273,7 @@ template <class _CharT, class _Traits, class _Allocator>
 inline
 void
 basic_string<_CharT, _Traits, _Allocator>::__move_assign(basic_string& __str, false_type)
-    _NOEXCEPT_(__alloc_traits::is_always_equal::value)
+    noexcept(__alloc_traits::is_always_equal::value)
 {
     if (__alloc() != __str.__alloc())
         assign(__str);
@@ -2286,9 +2286,9 @@ inline
 void
 basic_string<_CharT, _Traits, _Allocator>::__move_assign(basic_string& __str, true_type)
 #if _LIBCUDACXX_STD_VER > 14
-    _NOEXCEPT
+    noexcept
 #else
-    _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+    noexcept(is_nothrow_move_assignable<allocator_type>::value)
 #endif
 {
     __clear_and_shrink();
@@ -2301,7 +2301,7 @@ template <class _CharT, class _Traits, class _Allocator>
 inline
 basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::operator=(basic_string&& __str)
-    _NOEXCEPT_((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value))
+    noexcept((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value))
 {
     __move_assign(__str, integral_constant<bool,
           __alloc_traits::propagate_on_container_move_assignment::value>());
@@ -3059,7 +3059,7 @@ basic_string<_CharT, _Traits, _Allocator>::pop_back()
 template <class _CharT, class _Traits, class _Allocator>
 inline
 void
-basic_string<_CharT, _Traits, _Allocator>::clear() _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::clear() noexcept
 {
     __invalidate_all_iterators();
     if (__is_long())
@@ -3117,7 +3117,7 @@ basic_string<_CharT, _Traits, _Allocator>::__resize_default_init(size_type __n)
 template <class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
-basic_string<_CharT, _Traits, _Allocator>::max_size() const _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::max_size() const noexcept
 {
     size_type __m = __alloc_traits::max_size(__alloc());
 #ifdef _LIBCUDACXX_BIG_ENDIAN
@@ -3193,7 +3193,7 @@ basic_string<_CharT, _Traits, _Allocator>::reserve(size_type __res_arg)
 template <class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::const_reference
-basic_string<_CharT, _Traits, _Allocator>::operator[](size_type __pos) const _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::operator[](size_type __pos) const noexcept
 {
     _LIBCUDACXX_ASSERT(__pos <= size(), "string index out of bounds");
     return *(data() + __pos);
@@ -3202,7 +3202,7 @@ basic_string<_CharT, _Traits, _Allocator>::operator[](size_type __pos) const _NO
 template <class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::reference
-basic_string<_CharT, _Traits, _Allocator>::operator[](size_type __pos) _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::operator[](size_type __pos) noexcept
 {
     _LIBCUDACXX_ASSERT(__pos <= size(), "string index out of bounds");
     return *(__get_pointer() + __pos);
@@ -3229,7 +3229,7 @@ basic_string<_CharT, _Traits, _Allocator>::at(size_type __n)
 template <class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::reference
-basic_string<_CharT, _Traits, _Allocator>::front() _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::front() noexcept
 {
     _LIBCUDACXX_ASSERT(!empty(), "string::front(): string is empty");
     return *__get_pointer();
@@ -3238,7 +3238,7 @@ basic_string<_CharT, _Traits, _Allocator>::front() _NOEXCEPT
 template <class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::const_reference
-basic_string<_CharT, _Traits, _Allocator>::front() const _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::front() const noexcept
 {
     _LIBCUDACXX_ASSERT(!empty(), "string::front(): string is empty");
     return *data();
@@ -3247,7 +3247,7 @@ basic_string<_CharT, _Traits, _Allocator>::front() const _NOEXCEPT
 template <class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::reference
-basic_string<_CharT, _Traits, _Allocator>::back() _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::back() noexcept
 {
     _LIBCUDACXX_ASSERT(!empty(), "string::back(): string is empty");
     return *(__get_pointer() + size() - 1);
@@ -3256,7 +3256,7 @@ basic_string<_CharT, _Traits, _Allocator>::back() _NOEXCEPT
 template <class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::const_reference
-basic_string<_CharT, _Traits, _Allocator>::back() const _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::back() const noexcept
 {
     _LIBCUDACXX_ASSERT(!empty(), "string::back(): string is empty");
     return *(data() + size() - 1);
@@ -3287,9 +3287,9 @@ inline
 void
 basic_string<_CharT, _Traits, _Allocator>::swap(basic_string& __str)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT
+        noexcept
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                     __is_nothrow_swappable<allocator_type>::value)
 #endif
 {
@@ -3315,7 +3315,7 @@ struct _LIBCUDACXX_HIDDEN __traits_eq
 {
     typedef typename _Traits::char_type char_type;
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator()(const char_type& __x, const char_type& __y) _NOEXCEPT
+    bool operator()(const char_type& __x, const char_type& __y) noexcept
         {return _Traits::eq(__x, __y);}
 };
 
@@ -3323,7 +3323,7 @@ template<class _CharT, class _Traits, class _Allocator>
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find(const value_type* __s,
                                                 size_type __pos,
-                                                size_type __n) const _NOEXCEPT
+                                                size_type __n) const noexcept
 {
     _LIBCUDACXX_ASSERT(__n == 0 || __s != nullptr, "string::find(): received nullptr");
     return __str_find<value_type, size_type, traits_type, npos>
@@ -3334,7 +3334,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find(const basic_string& __str,
-                                                size_type __pos) const _NOEXCEPT
+                                                size_type __pos) const noexcept
 {
     return __str_find<value_type, size_type, traits_type, npos>
         (data(), size(), __str.data(), __pos, __str.size());
@@ -3359,7 +3359,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find(const value_type* __s,
-                                                size_type __pos) const _NOEXCEPT
+                                                size_type __pos) const noexcept
 {
     _LIBCUDACXX_ASSERT(__s != nullptr, "string::find(): received nullptr");
     return __str_find<value_type, size_type, traits_type, npos>
@@ -3369,7 +3369,7 @@ basic_string<_CharT, _Traits, _Allocator>::find(const value_type* __s,
 template<class _CharT, class _Traits, class _Allocator>
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find(value_type __c,
-                                                size_type __pos) const _NOEXCEPT
+                                                size_type __pos) const noexcept
 {
     return __str_find<value_type, size_type, traits_type, npos>
         (data(), size(), __c, __pos);
@@ -3381,7 +3381,7 @@ template<class _CharT, class _Traits, class _Allocator>
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::rfind(const value_type* __s,
                                                  size_type __pos,
-                                                 size_type __n) const _NOEXCEPT
+                                                 size_type __n) const noexcept
 {
     _LIBCUDACXX_ASSERT(__n == 0 || __s != nullptr, "string::rfind(): received nullptr");
     return __str_rfind<value_type, size_type, traits_type, npos>
@@ -3392,7 +3392,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::rfind(const basic_string& __str,
-                                                 size_type __pos) const _NOEXCEPT
+                                                 size_type __pos) const noexcept
 {
     return __str_rfind<value_type, size_type, traits_type, npos>
         (data(), size(), __str.data(), __pos, __str.size());
@@ -3417,7 +3417,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::rfind(const value_type* __s,
-                                                 size_type __pos) const _NOEXCEPT
+                                                 size_type __pos) const noexcept
 {
     _LIBCUDACXX_ASSERT(__s != nullptr, "string::rfind(): received nullptr");
     return __str_rfind<value_type, size_type, traits_type, npos>
@@ -3427,7 +3427,7 @@ basic_string<_CharT, _Traits, _Allocator>::rfind(const value_type* __s,
 template<class _CharT, class _Traits, class _Allocator>
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::rfind(value_type __c,
-                                                 size_type __pos) const _NOEXCEPT
+                                                 size_type __pos) const noexcept
 {
     return __str_rfind<value_type, size_type, traits_type, npos>
         (data(), size(), __c, __pos);
@@ -3439,7 +3439,7 @@ template<class _CharT, class _Traits, class _Allocator>
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_first_of(const value_type* __s,
                                                          size_type __pos,
-                                                         size_type __n) const _NOEXCEPT
+                                                         size_type __n) const noexcept
 {
     _LIBCUDACXX_ASSERT(__n == 0 || __s != nullptr, "string::find_first_of(): received nullptr");
     return __str_find_first_of<value_type, size_type, traits_type, npos>
@@ -3450,7 +3450,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_first_of(const basic_string& __str,
-                                                         size_type __pos) const _NOEXCEPT
+                                                         size_type __pos) const noexcept
 {
     return __str_find_first_of<value_type, size_type, traits_type, npos>
         (data(), size(), __str.data(), __pos, __str.size());
@@ -3475,7 +3475,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_first_of(const value_type* __s,
-                                                         size_type __pos) const _NOEXCEPT
+                                                         size_type __pos) const noexcept
 {
     _LIBCUDACXX_ASSERT(__s != nullptr, "string::find_first_of(): received nullptr");
     return __str_find_first_of<value_type, size_type, traits_type, npos>
@@ -3486,7 +3486,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_first_of(value_type __c,
-                                                         size_type __pos) const _NOEXCEPT
+                                                         size_type __pos) const noexcept
 {
     return find(__c, __pos);
 }
@@ -3497,7 +3497,7 @@ template<class _CharT, class _Traits, class _Allocator>
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_last_of(const value_type* __s,
                                                         size_type __pos,
-                                                        size_type __n) const _NOEXCEPT
+                                                        size_type __n) const noexcept
 {
     _LIBCUDACXX_ASSERT(__n == 0 || __s != nullptr, "string::find_last_of(): received nullptr");
     return __str_find_last_of<value_type, size_type, traits_type, npos>
@@ -3508,7 +3508,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_last_of(const basic_string& __str,
-                                                        size_type __pos) const _NOEXCEPT
+                                                        size_type __pos) const noexcept
 {
     return __str_find_last_of<value_type, size_type, traits_type, npos>
         (data(), size(), __str.data(), __pos, __str.size());
@@ -3533,7 +3533,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_last_of(const value_type* __s,
-                                                        size_type __pos) const _NOEXCEPT
+                                                        size_type __pos) const noexcept
 {
     _LIBCUDACXX_ASSERT(__s != nullptr, "string::find_last_of(): received nullptr");
     return __str_find_last_of<value_type, size_type, traits_type, npos>
@@ -3544,7 +3544,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_last_of(value_type __c,
-                                                        size_type __pos) const _NOEXCEPT
+                                                        size_type __pos) const noexcept
 {
     return rfind(__c, __pos);
 }
@@ -3555,7 +3555,7 @@ template<class _CharT, class _Traits, class _Allocator>
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_first_not_of(const value_type* __s,
                                                              size_type __pos,
-                                                             size_type __n) const _NOEXCEPT
+                                                             size_type __n) const noexcept
 {
     _LIBCUDACXX_ASSERT(__n == 0 || __s != nullptr, "string::find_first_not_of(): received nullptr");
     return __str_find_first_not_of<value_type, size_type, traits_type, npos>
@@ -3566,7 +3566,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_first_not_of(const basic_string& __str,
-                                                             size_type __pos) const _NOEXCEPT
+                                                             size_type __pos) const noexcept
 {
     return __str_find_first_not_of<value_type, size_type, traits_type, npos>
         (data(), size(), __str.data(), __pos, __str.size());
@@ -3591,7 +3591,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_first_not_of(const value_type* __s,
-                                                             size_type __pos) const _NOEXCEPT
+                                                             size_type __pos) const noexcept
 {
     _LIBCUDACXX_ASSERT(__s != nullptr, "string::find_first_not_of(): received nullptr");
     return __str_find_first_not_of<value_type, size_type, traits_type, npos>
@@ -3602,7 +3602,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_first_not_of(value_type __c,
-                                                             size_type __pos) const _NOEXCEPT
+                                                             size_type __pos) const noexcept
 {
     return __str_find_first_not_of<value_type, size_type, traits_type, npos>
         (data(), size(), __c, __pos);
@@ -3614,7 +3614,7 @@ template<class _CharT, class _Traits, class _Allocator>
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_last_not_of(const value_type* __s,
                                                             size_type __pos,
-                                                            size_type __n) const _NOEXCEPT
+                                                            size_type __n) const noexcept
 {
     _LIBCUDACXX_ASSERT(__n == 0 || __s != nullptr, "string::find_last_not_of(): received nullptr");
     return __str_find_last_not_of<value_type, size_type, traits_type, npos>
@@ -3625,7 +3625,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_last_not_of(const basic_string& __str,
-                                                            size_type __pos) const _NOEXCEPT
+                                                            size_type __pos) const noexcept
 {
     return __str_find_last_not_of<value_type, size_type, traits_type, npos>
         (data(), size(), __str.data(), __pos, __str.size());
@@ -3650,7 +3650,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_last_not_of(const value_type* __s,
-                                                            size_type __pos) const _NOEXCEPT
+                                                            size_type __pos) const noexcept
 {
     _LIBCUDACXX_ASSERT(__s != nullptr, "string::find_last_not_of(): received nullptr");
     return __str_find_last_not_of<value_type, size_type, traits_type, npos>
@@ -3661,7 +3661,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline
 typename basic_string<_CharT, _Traits, _Allocator>::size_type
 basic_string<_CharT, _Traits, _Allocator>::find_last_not_of(value_type __c,
-                                                            size_type __pos) const _NOEXCEPT
+                                                            size_type __pos) const noexcept
 {
     return __str_find_last_not_of<value_type, size_type, traits_type, npos>
         (data(), size(), __c, __pos);
@@ -3695,7 +3695,7 @@ basic_string<_CharT, _Traits, _Allocator>::compare(const _Tp& __t) const
 template <class _CharT, class _Traits, class _Allocator>
 inline
 int
-basic_string<_CharT, _Traits, _Allocator>::compare(const basic_string& __str) const _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::compare(const basic_string& __str) const noexcept
 {
     return compare(__self_view(__str));
 }
@@ -3778,7 +3778,7 @@ basic_string<_CharT, _Traits, _Allocator>::compare(size_type __pos1,
 
 template <class _CharT, class _Traits, class _Allocator>
 int
-basic_string<_CharT, _Traits, _Allocator>::compare(const value_type* __s) const _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::compare(const value_type* __s) const noexcept
 {
     _LIBCUDACXX_ASSERT(__s != nullptr, "string::compare(): received nullptr");
     return compare(0, npos, __s, traits_type::length(__s));
@@ -3817,7 +3817,7 @@ basic_string<_CharT, _Traits, _Allocator>::__invariants() const
 template<class _CharT, class _Traits, class _Allocator>
 inline
 void
-basic_string<_CharT, _Traits, _Allocator>::__clear_and_shrink() _NOEXCEPT
+basic_string<_CharT, _Traits, _Allocator>::__clear_and_shrink() noexcept
 {
     clear();
     if(__is_long())
@@ -3834,7 +3834,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator==(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     size_t __lhs_sz = __lhs.size();
     return __lhs_sz == __rhs.size() && _Traits::compare(__lhs.data(),
@@ -3846,7 +3846,7 @@ template<class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator==(const basic_string<char, char_traits<char>, _Allocator>& __lhs,
-           const basic_string<char, char_traits<char>, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<char, char_traits<char>, _Allocator>& __rhs) noexcept
 {
     size_t __lhs_sz = __lhs.size();
     if (__lhs_sz != __rhs.size())
@@ -3865,7 +3865,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator==(const _CharT* __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     typedef basic_string<_CharT, _Traits, _Allocator> _String;
     _LIBCUDACXX_ASSERT(__lhs != nullptr, "operator==(char*, basic_string): received nullptr");
@@ -3878,7 +3878,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator==(const basic_string<_CharT,_Traits,_Allocator>& __lhs,
-           const _CharT* __rhs) _NOEXCEPT
+           const _CharT* __rhs) noexcept
 {
     typedef basic_string<_CharT, _Traits, _Allocator> _String;
     _LIBCUDACXX_ASSERT(__rhs != nullptr, "operator==(basic_string, char*): received nullptr");
@@ -3891,7 +3891,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator!=(const basic_string<_CharT,_Traits,_Allocator>& __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return !(__lhs == __rhs);
 }
@@ -3900,7 +3900,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator!=(const _CharT* __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return !(__lhs == __rhs);
 }
@@ -3909,7 +3909,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator!=(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const _CharT* __rhs) _NOEXCEPT
+           const _CharT* __rhs) noexcept
 {
     return !(__lhs == __rhs);
 }
@@ -3920,7 +3920,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator< (const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return __lhs.compare(__rhs) < 0;
 }
@@ -3929,7 +3929,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator< (const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const _CharT* __rhs) _NOEXCEPT
+           const _CharT* __rhs) noexcept
 {
     return __lhs.compare(__rhs) < 0;
 }
@@ -3938,7 +3938,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator< (const _CharT* __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return __rhs.compare(__lhs) > 0;
 }
@@ -3949,7 +3949,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator> (const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return __rhs < __lhs;
 }
@@ -3958,7 +3958,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator> (const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const _CharT* __rhs) _NOEXCEPT
+           const _CharT* __rhs) noexcept
 {
     return __rhs < __lhs;
 }
@@ -3967,7 +3967,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator> (const _CharT* __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return __rhs < __lhs;
 }
@@ -3978,7 +3978,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator<=(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return !(__rhs < __lhs);
 }
@@ -3987,7 +3987,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator<=(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const _CharT* __rhs) _NOEXCEPT
+           const _CharT* __rhs) noexcept
 {
     return !(__rhs < __lhs);
 }
@@ -3996,7 +3996,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator<=(const _CharT* __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return !(__rhs < __lhs);
 }
@@ -4007,7 +4007,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator>=(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return !(__lhs < __rhs);
 }
@@ -4016,7 +4016,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator>=(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
-           const _CharT* __rhs) _NOEXCEPT
+           const _CharT* __rhs) noexcept
 {
     return !(__lhs < __rhs);
 }
@@ -4025,7 +4025,7 @@ template<class _CharT, class _Traits, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
 operator>=(const _CharT* __lhs,
-           const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT
+           const basic_string<_CharT, _Traits, _Allocator>& __rhs) noexcept
 {
     return !(__lhs < __rhs);
 }
@@ -4161,7 +4161,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(basic_string<_CharT, _Traits, _Allocator>& __lhs,
      basic_string<_CharT, _Traits, _Allocator>& __rhs)
-     _NOEXCEPT_(_NOEXCEPT_(__lhs.swap(__rhs)))
+     noexcept(_NOEXCEPT_(__lhs.swap(__rhs)))
 {
     __lhs.swap(__rhs);
 }
@@ -4226,7 +4226,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS
           basic_string<_CharT, char_traits<_CharT>, _Allocator>, size_t>
 {
     size_t
-    operator()(const basic_string<_CharT, char_traits<_CharT>, _Allocator>& __val) const _NOEXCEPT
+    operator()(const basic_string<_CharT, char_traits<_CharT>, _Allocator>& __val) const noexcept
     { return __do_string_hash(__val.data(), __val.data() + __val.size()); }
 };
 
@@ -4339,7 +4339,7 @@ inline namespace literals
 
 #ifndef _LIBCUDACXX_NO_HAS_CHAR8_T
     inline _LIBCUDACXX_INLINE_VISIBILITY
-    basic_string<char8_t> operator "" s(const char8_t *__str, size_t __len) _NOEXCEPT
+    basic_string<char8_t> operator "" s(const char8_t *__str, size_t __len) noexcept
     {
         return basic_string<char8_t> (__str, __len);
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/string_view
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/string_view
@@ -218,16 +218,16 @@ public:
 
     // [string.view.cons], construct/copy
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    basic_string_view() _NOEXCEPT : __data (nullptr), __size(0) {}
+    basic_string_view() noexcept : __data (nullptr), __size(0) {}
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    basic_string_view(const basic_string_view&) _NOEXCEPT = default;
+    basic_string_view(const basic_string_view&) noexcept = default;
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    basic_string_view& operator=(const basic_string_view&) _NOEXCEPT = default;
+    basic_string_view& operator=(const basic_string_view&) noexcept = default;
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    basic_string_view(const _CharT* __s, size_type __len) _NOEXCEPT
+    basic_string_view(const _CharT* __s, size_type __len) noexcept
         : __data(__s), __size(__len)
     {
 #if _LIBCUDACXX_STD_VER > 11
@@ -241,45 +241,45 @@ public:
 
     // [string.view.iterators], iterators
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin()  const _NOEXCEPT { return cbegin(); }
+    const_iterator begin()  const noexcept { return cbegin(); }
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()    const _NOEXCEPT { return cend(); }
+    const_iterator end()    const noexcept { return cend(); }
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT { return __data; }
+    const_iterator cbegin() const noexcept { return __data; }
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend()   const _NOEXCEPT { return __data + __size; }
+    const_iterator cend()   const noexcept { return __data + __size; }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin()   const _NOEXCEPT { return const_reverse_iterator(cend()); }
+    const_reverse_iterator rbegin()   const noexcept { return const_reverse_iterator(cend()); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend()     const _NOEXCEPT { return const_reverse_iterator(cbegin()); }
+    const_reverse_iterator rend()     const noexcept { return const_reverse_iterator(cbegin()); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin()  const _NOEXCEPT { return const_reverse_iterator(cend()); }
+    const_reverse_iterator crbegin()  const noexcept { return const_reverse_iterator(cend()); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend()    const _NOEXCEPT { return const_reverse_iterator(cbegin()); }
+    const_reverse_iterator crend()    const noexcept { return const_reverse_iterator(cbegin()); }
 
     // [string.view.capacity], capacity
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size()     const _NOEXCEPT { return __size; }
+    size_type size()     const noexcept { return __size; }
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    size_type length()   const _NOEXCEPT { return __size; }
+    size_type length()   const noexcept { return __size; }
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT { return numeric_limits<size_type>::max(); }
+    size_type max_size() const noexcept { return numeric_limits<size_type>::max(); }
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    bool empty()         const _NOEXCEPT { return __size == 0; }
+    bool empty()         const noexcept { return __size == 0; }
 
     // [string.view.access], element access
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    const_reference operator[](size_type __pos) const _NOEXCEPT { return __data[__pos]; }
+    const_reference operator[](size_type __pos) const noexcept { return __data[__pos]; }
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
     const_reference at(size_type __pos) const
@@ -290,23 +290,23 @@ public:
     }
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    const_reference front() const _NOEXCEPT
+    const_reference front() const noexcept
     {
         return _LIBCUDACXX_ASSERT(!empty(), "string_view::front(): string is empty"), __data[0];
     }
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    const_reference back() const _NOEXCEPT
+    const_reference back() const noexcept
     {
         return _LIBCUDACXX_ASSERT(!empty(), "string_view::back(): string is empty"), __data[__size-1];
     }
 
     _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
-    const_pointer data() const _NOEXCEPT { return __data; }
+    const_pointer data() const noexcept { return __data; }
 
     // [string.view.modifiers], modifiers:
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    void remove_prefix(size_type __n) _NOEXCEPT
+    void remove_prefix(size_type __n) noexcept
     {
         _LIBCUDACXX_ASSERT(__n <= size(), "remove_prefix() can't remove more than size()");
         __data += __n;
@@ -314,14 +314,14 @@ public:
     }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    void remove_suffix(size_type __n) _NOEXCEPT
+    void remove_suffix(size_type __n) noexcept
     {
         _LIBCUDACXX_ASSERT(__n <= size(), "remove_suffix() can't remove more than size()");
         __size -= __n;
     }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(basic_string_view& __other) _NOEXCEPT
+    void swap(basic_string_view& __other) noexcept
     {
         const value_type *__p = __data;
         __data = __other.__data;
@@ -350,7 +350,7 @@ public:
             : basic_string_view(data() + __pos, _CUDA_VSTD::min(__n, size() - __pos));
     }
 
-    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 int compare(basic_string_view __sv) const _NOEXCEPT
+    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 int compare(basic_string_view __sv) const noexcept
     {
         size_type __rlen = _CUDA_VSTD::min( size(), __sv.size());
         int __retval = _Traits::compare(data(), __sv.data(), __rlen);
@@ -373,7 +373,7 @@ public:
     }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    int compare(const _CharT* __s) const _NOEXCEPT
+    int compare(const _CharT* __s) const noexcept
     {
         return compare(basic_string_view(__s));
     }
@@ -392,7 +392,7 @@ public:
 
     // find
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find(basic_string_view __s, size_type __pos = 0) const _NOEXCEPT
+    size_type find(basic_string_view __s, size_type __pos = 0) const noexcept
     {
         _LIBCUDACXX_ASSERT(__s.size() == 0 || __s.data() != nullptr, "string_view::find(): received nullptr");
         return __str_find<value_type, size_type, traits_type, npos>
@@ -400,7 +400,7 @@ public:
     }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find(_CharT __c, size_type __pos = 0) const _NOEXCEPT
+    size_type find(_CharT __c, size_type __pos = 0) const noexcept
     {
         return __str_find<value_type, size_type, traits_type, npos>
             (data(), size(), __c, __pos);
@@ -424,7 +424,7 @@ public:
 
     // rfind
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type rfind(basic_string_view __s, size_type __pos = npos) const _NOEXCEPT
+    size_type rfind(basic_string_view __s, size_type __pos = npos) const noexcept
     {
         _LIBCUDACXX_ASSERT(__s.size() == 0 || __s.data() != nullptr, "string_view::find(): received nullptr");
         return __str_rfind<value_type, size_type, traits_type, npos>
@@ -432,7 +432,7 @@ public:
     }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type rfind(_CharT __c, size_type __pos = npos) const _NOEXCEPT
+    size_type rfind(_CharT __c, size_type __pos = npos) const noexcept
     {
         return __str_rfind<value_type, size_type, traits_type, npos>
             (data(), size(), __c, __pos);
@@ -456,7 +456,7 @@ public:
 
     // find_first_of
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_of(basic_string_view __s, size_type __pos = 0) const _NOEXCEPT
+    size_type find_first_of(basic_string_view __s, size_type __pos = 0) const noexcept
     {
         _LIBCUDACXX_ASSERT(__s.size() == 0 || __s.data() != nullptr, "string_view::find_first_of(): received nullptr");
         return __str_find_first_of<value_type, size_type, traits_type, npos>
@@ -464,7 +464,7 @@ public:
     }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_of(_CharT __c, size_type __pos = 0) const _NOEXCEPT
+    size_type find_first_of(_CharT __c, size_type __pos = 0) const noexcept
     { return find(__c, __pos); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
@@ -485,7 +485,7 @@ public:
 
     // find_last_of
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_of(basic_string_view __s, size_type __pos=npos) const _NOEXCEPT
+    size_type find_last_of(basic_string_view __s, size_type __pos=npos) const noexcept
     {
         _LIBCUDACXX_ASSERT(__s.size() == 0 || __s.data() != nullptr, "string_view::find_last_of(): received nullptr");
         return __str_find_last_of<value_type, size_type, traits_type, npos>
@@ -493,7 +493,7 @@ public:
     }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_of(_CharT __c, size_type __pos = npos) const _NOEXCEPT
+    size_type find_last_of(_CharT __c, size_type __pos = npos) const noexcept
     { return rfind(__c, __pos); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
@@ -514,7 +514,7 @@ public:
 
     // find_first_not_of
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_not_of(basic_string_view __s, size_type __pos=0) const _NOEXCEPT
+    size_type find_first_not_of(basic_string_view __s, size_type __pos=0) const noexcept
     {
         _LIBCUDACXX_ASSERT(__s.size() == 0 || __s.data() != nullptr, "string_view::find_first_not_of(): received nullptr");
         return __str_find_first_not_of<value_type, size_type, traits_type, npos>
@@ -522,7 +522,7 @@ public:
     }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_first_not_of(_CharT __c, size_type __pos=0) const _NOEXCEPT
+    size_type find_first_not_of(_CharT __c, size_type __pos=0) const noexcept
     {
         return __str_find_first_not_of<value_type, size_type, traits_type, npos>
             (data(), size(), __c, __pos);
@@ -546,7 +546,7 @@ public:
 
     // find_last_not_of
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_not_of(basic_string_view __s, size_type __pos=npos) const _NOEXCEPT
+    size_type find_last_not_of(basic_string_view __s, size_type __pos=npos) const noexcept
     {
         _LIBCUDACXX_ASSERT(__s.size() == 0 || __s.data() != nullptr, "string_view::find_last_not_of(): received nullptr");
         return __str_find_last_not_of<value_type, size_type, traits_type, npos>
@@ -554,7 +554,7 @@ public:
     }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    size_type find_last_not_of(_CharT __c, size_type __pos=npos) const _NOEXCEPT
+    size_type find_last_not_of(_CharT __c, size_type __pos=npos) const noexcept
     {
         return __str_find_last_not_of<value_type, size_type, traits_type, npos>
             (data(), size(), __c, __pos);
@@ -578,27 +578,27 @@ public:
 
 #if _LIBCUDACXX_STD_VER > 17
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool starts_with(basic_string_view __s) const _NOEXCEPT
+    bool starts_with(basic_string_view __s) const noexcept
     { return size() >= __s.size() && compare(0, __s.size(), __s) == 0; }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool starts_with(value_type __c) const _NOEXCEPT
+    bool starts_with(value_type __c) const noexcept
     { return !empty() && _Traits::eq(front(), __c); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool starts_with(const value_type* __s) const _NOEXCEPT
+    bool starts_with(const value_type* __s) const noexcept
     { return starts_with(basic_string_view(__s)); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool ends_with(basic_string_view __s) const _NOEXCEPT
+    bool ends_with(basic_string_view __s) const noexcept
     { return size() >= __s.size() && compare(size() - __s.size(), npos, __s) == 0; }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool ends_with(value_type __c) const _NOEXCEPT
+    bool ends_with(value_type __c) const noexcept
     { return !empty() && _Traits::eq(back(), __c); }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-    bool ends_with(const value_type* __s) const _NOEXCEPT
+    bool ends_with(const value_type* __s) const noexcept
     { return ends_with(basic_string_view(__s)); }
 #endif
 
@@ -613,7 +613,7 @@ private:
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator==(basic_string_view<_CharT, _Traits> __lhs,
-                basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+                basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     if ( __lhs.size() != __rhs.size()) return false;
     return __lhs.compare(__rhs) == 0;
@@ -622,7 +622,7 @@ bool operator==(basic_string_view<_CharT, _Traits> __lhs,
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator==(basic_string_view<_CharT, _Traits> __lhs,
-                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) _NOEXCEPT
+                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) noexcept
 {
     if ( __lhs.size() != __rhs.size()) return false;
     return __lhs.compare(__rhs) == 0;
@@ -631,7 +631,7 @@ bool operator==(basic_string_view<_CharT, _Traits> __lhs,
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator==(typename common_type<basic_string_view<_CharT, _Traits> >::type __lhs,
-                basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+                basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     if ( __lhs.size() != __rhs.size()) return false;
     return __lhs.compare(__rhs) == 0;
@@ -641,7 +641,7 @@ bool operator==(typename common_type<basic_string_view<_CharT, _Traits> >::type 
 // operator !=
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-bool operator!=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+bool operator!=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     if ( __lhs.size() != __rhs.size())
         return true;
@@ -651,7 +651,7 @@ bool operator!=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_Cha
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator!=(basic_string_view<_CharT, _Traits> __lhs,
-                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) _NOEXCEPT
+                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) noexcept
 {
     if ( __lhs.size() != __rhs.size())
         return true;
@@ -661,7 +661,7 @@ bool operator!=(basic_string_view<_CharT, _Traits> __lhs,
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator!=(typename common_type<basic_string_view<_CharT, _Traits> >::type __lhs,
-                basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+                basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     if ( __lhs.size() != __rhs.size())
         return true;
@@ -672,7 +672,7 @@ bool operator!=(typename common_type<basic_string_view<_CharT, _Traits> >::type 
 // operator <
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-bool operator<(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+bool operator<(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     return __lhs.compare(__rhs) < 0;
 }
@@ -680,7 +680,7 @@ bool operator<(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_Char
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator<(basic_string_view<_CharT, _Traits> __lhs,
-                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) _NOEXCEPT
+                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) noexcept
 {
     return __lhs.compare(__rhs) < 0;
 }
@@ -688,7 +688,7 @@ bool operator<(basic_string_view<_CharT, _Traits> __lhs,
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator<(typename common_type<basic_string_view<_CharT, _Traits> >::type __lhs,
-                basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+                basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     return __lhs.compare(__rhs) < 0;
 }
@@ -697,7 +697,7 @@ bool operator<(typename common_type<basic_string_view<_CharT, _Traits> >::type _
 // operator >
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-bool operator> (basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+bool operator> (basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     return __lhs.compare(__rhs) > 0;
 }
@@ -705,7 +705,7 @@ bool operator> (basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_Cha
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator>(basic_string_view<_CharT, _Traits> __lhs,
-                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) _NOEXCEPT
+                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) noexcept
 {
     return __lhs.compare(__rhs) > 0;
 }
@@ -713,7 +713,7 @@ bool operator>(basic_string_view<_CharT, _Traits> __lhs,
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator>(typename common_type<basic_string_view<_CharT, _Traits> >::type __lhs,
-                basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+                basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     return __lhs.compare(__rhs) > 0;
 }
@@ -722,7 +722,7 @@ bool operator>(typename common_type<basic_string_view<_CharT, _Traits> >::type _
 // operator <=
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-bool operator<=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+bool operator<=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     return __lhs.compare(__rhs) <= 0;
 }
@@ -730,7 +730,7 @@ bool operator<=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_Cha
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator<=(basic_string_view<_CharT, _Traits> __lhs,
-                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) _NOEXCEPT
+                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) noexcept
 {
     return __lhs.compare(__rhs) <= 0;
 }
@@ -738,7 +738,7 @@ bool operator<=(basic_string_view<_CharT, _Traits> __lhs,
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator<=(typename common_type<basic_string_view<_CharT, _Traits> >::type __lhs,
-                basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+                basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     return __lhs.compare(__rhs) <= 0;
 }
@@ -747,7 +747,7 @@ bool operator<=(typename common_type<basic_string_view<_CharT, _Traits> >::type 
 // operator >=
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-bool operator>=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+bool operator>=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     return __lhs.compare(__rhs) >= 0;
 }
@@ -756,7 +756,7 @@ bool operator>=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_Cha
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator>=(basic_string_view<_CharT, _Traits> __lhs,
-                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) _NOEXCEPT
+                typename common_type<basic_string_view<_CharT, _Traits> >::type __rhs) noexcept
 {
     return __lhs.compare(__rhs) >= 0;
 }
@@ -764,7 +764,7 @@ bool operator>=(basic_string_view<_CharT, _Traits> __lhs,
 template<class _CharT, class _Traits>
 _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
 bool operator>=(typename common_type<basic_string_view<_CharT, _Traits> >::type __lhs,
-                basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
+                basic_string_view<_CharT, _Traits> __rhs) noexcept
 {
     return __lhs.compare(__rhs) >= 0;
 }
@@ -789,7 +789,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<basic_string_view<_CharT, char_traits<_Char
     : public __unary_function<basic_string_view<_CharT, char_traits<_CharT> >, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(const basic_string_view<_CharT, char_traits<_CharT> > __val) const _NOEXCEPT {
+    size_t operator()(const basic_string_view<_CharT, char_traits<_CharT> > __val) const noexcept {
         return __do_string_hash(__val.data(), __val.data() + __val.size());
     }
 };
@@ -801,33 +801,33 @@ inline namespace literals
   inline namespace string_view_literals
   {
     inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    basic_string_view<char> operator "" sv(const char *__str, size_t __len) _NOEXCEPT
+    basic_string_view<char> operator "" sv(const char *__str, size_t __len) noexcept
     {
         return basic_string_view<char> (__str, __len);
     }
 
     inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    basic_string_view<wchar_t> operator "" sv(const wchar_t *__str, size_t __len) _NOEXCEPT
+    basic_string_view<wchar_t> operator "" sv(const wchar_t *__str, size_t __len) noexcept
     {
         return basic_string_view<wchar_t> (__str, __len);
     }
 
 #ifndef _LIBCUDACXX_NO_HAS_CHAR8_T
     inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    basic_string_view<char8_t> operator "" sv(const char8_t *__str, size_t __len) _NOEXCEPT
+    basic_string_view<char8_t> operator "" sv(const char8_t *__str, size_t __len) noexcept
     {
         return basic_string_view<char8_t> (__str, __len);
     }
 #endif
 
     inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    basic_string_view<char16_t> operator "" sv(const char16_t *__str, size_t __len) _NOEXCEPT
+    basic_string_view<char16_t> operator "" sv(const char16_t *__str, size_t __len) noexcept
     {
         return basic_string_view<char16_t> (__str, __len);
     }
 
     inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    basic_string_view<char32_t> operator "" sv(const char32_t *__str, size_t __len) _NOEXCEPT
+    basic_string_view<char32_t> operator "" sv(const char32_t *__str, size_t __len) noexcept
     {
         return basic_string_view<char32_t> (__str, __len);
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_c11.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_c11.h
@@ -16,11 +16,11 @@ struct __cxx_atomic_base_impl {
 
   _LIBCUDACXX_INLINE_VISIBILITY
 #ifndef _LIBCUDACXX_CXX03_LANG
-    __cxx_atomic_base_impl() _NOEXCEPT = default;
+    __cxx_atomic_base_impl() noexcept = default;
 #else
-    __cxx_atomic_base_impl() _NOEXCEPT : __a_value() {}
+    __cxx_atomic_base_impl() noexcept : __a_value() {}
 #endif // _LIBCUDACXX_CXX03_LANG
-  _LIBCUDACXX_CONSTEXPR explicit __cxx_atomic_base_impl(_Tp value) _NOEXCEPT
+  _LIBCUDACXX_CONSTEXPR explicit __cxx_atomic_base_impl(_Tp value) noexcept
     : __a_value(value) {}
   _LIBCUDACXX_DISABLE_EXTENSION_WARNING _Atomic(_Tp) __a_value;
 };
@@ -30,155 +30,155 @@ struct __cxx_atomic_base_impl {
 #endif
 
 _LIBCUDACXX_INLINE_VISIBILITY inline
-void __cxx_atomic_thread_fence(memory_order __order) _NOEXCEPT {
+void __cxx_atomic_thread_fence(memory_order __order) noexcept {
     __c11_atomic_thread_fence(static_cast<__memory_order_underlying_t>(__order));
 }
 
 _LIBCUDACXX_INLINE_VISIBILITY inline
-void __cxx_atomic_signal_fence(memory_order __order) _NOEXCEPT {
+void __cxx_atomic_signal_fence(memory_order __order) noexcept {
     __c11_atomic_signal_fence(static_cast<__memory_order_underlying_t>(__order));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __val) _NOEXCEPT {
+void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __val) noexcept {
     __c11_atomic_init(&__a->__a_value, __val);
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp> * __a, _Tp __val) _NOEXCEPT {
+void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp> * __a, _Tp __val) noexcept {
     __c11_atomic_init(&__a->__a_value, __val);
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-void __cxx_atomic_store(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __val, memory_order __order) _NOEXCEPT {
+void __cxx_atomic_store(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __val, memory_order __order) noexcept {
     __c11_atomic_store(&__a->__a_value, __val, static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-void __cxx_atomic_store(__cxx_atomic_base_impl<_Tp> * __a, _Tp __val, memory_order __order) _NOEXCEPT {
+void __cxx_atomic_store(__cxx_atomic_base_impl<_Tp> * __a, _Tp __val, memory_order __order) noexcept {
     __c11_atomic_store(&__a->__a_value, __val, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_load(__cxx_atomic_base_impl<_Tp> const volatile* __a, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_load(__cxx_atomic_base_impl<_Tp> const volatile* __a, memory_order __order) noexcept {
     using __ptr_type = typename remove_const<decltype(__a->__a_value)>::type*;
     return __c11_atomic_load(const_cast<__ptr_type>(&__a->__a_value), static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_load(__cxx_atomic_base_impl<_Tp> const* __a, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_load(__cxx_atomic_base_impl<_Tp> const* __a, memory_order __order) noexcept {
     using __ptr_type = typename remove_const<decltype(__a->__a_value)>::type*;
     return __c11_atomic_load(const_cast<__ptr_type>(&__a->__a_value), static_cast<__memory_order_underlying_t>(__order));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __value, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __value, memory_order __order) noexcept {
     return __c11_atomic_exchange(&__a->__a_value, __value, static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp> * __a, _Tp __value, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp> * __a, _Tp __value, memory_order __order) noexcept {
     return __c11_atomic_exchange(&__a->__a_value, __value, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-bool __cxx_atomic_compare_exchange_strong(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) _NOEXCEPT {
+bool __cxx_atomic_compare_exchange_strong(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) noexcept {
     return __c11_atomic_compare_exchange_strong(&__a->__a_value, __expected, __value, static_cast<__memory_order_underlying_t>(__success), static_cast<__memory_order_underlying_t>(__failure));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-bool __cxx_atomic_compare_exchange_strong(__cxx_atomic_base_impl<_Tp> * __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) _NOEXCEPT {
+bool __cxx_atomic_compare_exchange_strong(__cxx_atomic_base_impl<_Tp> * __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) noexcept {
     return __c11_atomic_compare_exchange_strong(&__a->__a_value, __expected, __value, static_cast<__memory_order_underlying_t>(__success), static_cast<__memory_order_underlying_t>(__failure));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-bool __cxx_atomic_compare_exchange_weak(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) _NOEXCEPT {
+bool __cxx_atomic_compare_exchange_weak(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) noexcept {
     return __c11_atomic_compare_exchange_weak(&__a->__a_value, __expected, __value, static_cast<__memory_order_underlying_t>(__success), static_cast<__memory_order_underlying_t>(__failure));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-bool __cxx_atomic_compare_exchange_weak(__cxx_atomic_base_impl<_Tp> * __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) _NOEXCEPT {
+bool __cxx_atomic_compare_exchange_weak(__cxx_atomic_base_impl<_Tp> * __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) noexcept {
     return __c11_atomic_compare_exchange_weak(&__a->__a_value, __expected, __value,  static_cast<__memory_order_underlying_t>(__success), static_cast<__memory_order_underlying_t>(__failure));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __delta, memory_order __order) noexcept {
     return __c11_atomic_fetch_add(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp> * __a, _Tp __delta, memory_order __order) _NOEXCEPT {
-    return __c11_atomic_fetch_add(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
-}
-
-template<class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY
-_Tp* __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp*> volatile* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
-    return __c11_atomic_fetch_add(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
-}
-template<class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY
-_Tp* __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp*> * __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp> * __a, _Tp __delta, memory_order __order) noexcept {
     return __c11_atomic_fetch_add(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
+_Tp* __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp*> volatile* __a, ptrdiff_t __delta, memory_order __order) noexcept {
+    return __c11_atomic_fetch_add(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
+}
+template<class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY
+_Tp* __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp*> * __a, ptrdiff_t __delta, memory_order __order) noexcept {
+    return __c11_atomic_fetch_add(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
+}
+
+template<class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY
+_Tp __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __delta, memory_order __order) noexcept {
     return __c11_atomic_fetch_sub(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp> * __a, _Tp __delta, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp> * __a, _Tp __delta, memory_order __order) noexcept {
     return __c11_atomic_fetch_sub(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp* __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp*> volatile* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
+_Tp* __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp*> volatile* __a, ptrdiff_t __delta, memory_order __order) noexcept {
     return __c11_atomic_fetch_sub(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp* __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp*> * __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
+_Tp* __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp*> * __a, ptrdiff_t __delta, memory_order __order) noexcept {
     return __c11_atomic_fetch_sub(&__a->__a_value, __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) noexcept {
     return __c11_atomic_fetch_and(&__a->__a_value, __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp> * __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp> * __a, _Tp __pattern, memory_order __order) noexcept {
     return __c11_atomic_fetch_and(&__a->__a_value, __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) noexcept {
     return __c11_atomic_fetch_or(&__a->__a_value, __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp> * __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp> * __a, _Tp __pattern, memory_order __order) noexcept {
     return __c11_atomic_fetch_or(&__a->__a_value, __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) noexcept {
     return __c11_atomic_fetch_xor(&__a->__a_value, __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 template<class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_Tp __cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp> * __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp> * __a, _Tp __pattern, memory_order __order) noexcept {
     return __c11_atomic_fetch_xor(&__a->__a_value, __pattern, static_cast<__memory_order_underlying_t>(__order));
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_cuda.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_cuda.h
@@ -107,25 +107,25 @@ struct __cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, true> {
 
 template <typename _Tp, int _Sco, bool _Ref>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-_Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> * __a) _NOEXCEPT {
+_Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> * __a) noexcept {
   return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco, bool _Ref>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-volatile _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> volatile* __a) _NOEXCEPT {
+volatile _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> volatile* __a) noexcept {
   return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco, bool _Ref>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> const* __a) _NOEXCEPT {
+const _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> const* __a) noexcept {
   return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco, bool _Ref>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const volatile _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> const volatile* __a) _NOEXCEPT {
+const volatile _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> const volatile* __a) noexcept {
   return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/cxx_atomic.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/cxx_atomic.h
@@ -26,55 +26,55 @@ struct __cxx_atomic_base_impl {
 #endif
 
   _LIBCUDACXX_CONSTEXPR
-  __cxx_atomic_base_impl() _NOEXCEPT = default;
+  __cxx_atomic_base_impl() noexcept = default;
   _LIBCUDACXX_CONSTEXPR
-  __cxx_atomic_base_impl(__cxx_atomic_base_impl &&) _NOEXCEPT = default;
+  __cxx_atomic_base_impl(__cxx_atomic_base_impl &&) noexcept = default;
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
-  __cxx_atomic_base_impl(_Tp value) _NOEXCEPT : __a_value(value) {}
+  __cxx_atomic_base_impl(_Tp value) noexcept : __a_value(value) {}
 
-  __cxx_atomic_base_impl& operator=(const __cxx_atomic_base_impl &) _NOEXCEPT = default;
+  __cxx_atomic_base_impl& operator=(const __cxx_atomic_base_impl &) noexcept = default;
 
   _ALIGNAS(sizeof(_Tp)) _Tp __a_value;
 };
 
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-_Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> * __a) _NOEXCEPT {
+_Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> * __a) noexcept {
   return &__a->__a_value;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> volatile* __a) _NOEXCEPT {
+volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> volatile* __a) noexcept {
   return &__a->__a_value;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> const* __a) _NOEXCEPT {
+const _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> const* __a) noexcept {
   return &__a->__a_value;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> const volatile* __a) _NOEXCEPT {
+const volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> const volatile* __a) noexcept {
   return &__a->__a_value;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-__cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco>* __a) _NOEXCEPT {
+__cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco>* __a) noexcept {
   return __a;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-volatile __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> volatile* __a) _NOEXCEPT {
+volatile __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> volatile* __a) noexcept {
   return __a;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> const* __a) _NOEXCEPT {
+const __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> const* __a) noexcept {
   return __a;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const volatile __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> const volatile* __a) _NOEXCEPT {
+const volatile __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> const volatile* __a) noexcept {
   return __a;
 }
 
@@ -92,72 +92,72 @@ struct __cxx_atomic_ref_base_impl {
 #endif
 
   _LIBCUDACXX_CONSTEXPR
-  __cxx_atomic_ref_base_impl() _NOEXCEPT = delete;
+  __cxx_atomic_ref_base_impl() noexcept = delete;
   _LIBCUDACXX_CONSTEXPR
-  __cxx_atomic_ref_base_impl(__cxx_atomic_ref_base_impl &&) _NOEXCEPT = default;
+  __cxx_atomic_ref_base_impl(__cxx_atomic_ref_base_impl &&) noexcept = default;
   _LIBCUDACXX_CONSTEXPR
-  __cxx_atomic_ref_base_impl(const __cxx_atomic_ref_base_impl &) _NOEXCEPT = default;
+  __cxx_atomic_ref_base_impl(const __cxx_atomic_ref_base_impl &) noexcept = default;
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
-  __cxx_atomic_ref_base_impl(_Tp& value) _NOEXCEPT : __a_value(&value) {}
+  __cxx_atomic_ref_base_impl(_Tp& value) noexcept : __a_value(&value) {}
 
   _Tp* __a_value;
 };
 
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-_Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco>* __a) _NOEXCEPT {
+_Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco>* __a) noexcept {
   return __a->__a_value;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> volatile* __a) _NOEXCEPT {
+volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> volatile* __a) noexcept {
   return __a->__a_value;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> const* __a) _NOEXCEPT {
+const _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> const* __a) noexcept {
   return __a->__a_value;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> const volatile* __a) _NOEXCEPT {
+const volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> const volatile* __a) noexcept {
   return __a->__a_value;
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-_Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco>* __a) _NOEXCEPT {
+_Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco>* __a) noexcept {
   return __cxx_get_underlying_atomic(__a);
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-volatile _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> volatile* __a) _NOEXCEPT {
+volatile _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> volatile* __a) noexcept {
   return __cxx_get_underlying_atomic(__a);
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> const* __a) _NOEXCEPT {
+const _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> const* __a) noexcept {
   return __cxx_get_underlying_atomic(__a);
 }
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-const volatile _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> const volatile* __a) _NOEXCEPT {
+const volatile _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> const volatile* __a) noexcept {
   return __cxx_get_underlying_atomic(__a);
 }
 
 template <typename _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-_Tp* __cxx_get_underlying_atomic(_Tp* __a) _NOEXCEPT {
+_Tp* __cxx_get_underlying_atomic(_Tp* __a) noexcept {
   return __a;
 }
 
 template <typename _Tp, typename _Up>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-auto __cxx_atomic_wrap_to_base(_Tp*, _Up __val) _NOEXCEPT -> typename _Tp::__wrap_t {
+auto __cxx_atomic_wrap_to_base(_Tp*, _Up __val) noexcept -> typename _Tp::__wrap_t {
   return typename _Tp::__wrap_t(__val);
 }
 template <typename _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-auto __cxx_atomic_base_temporary(_Tp*) _NOEXCEPT -> typename _Tp::__temporary_t {
+auto __cxx_atomic_base_temporary(_Tp*) noexcept -> typename _Tp::__temporary_t {
   return typename _Tp::__temporary_t();
 }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/system_error
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/system_error
@@ -196,34 +196,34 @@ class _LIBCUDACXX_HIDDEN __do_message;
 class _LIBCUDACXX_TYPE_VIS error_category
 {
 public:
-    virtual ~error_category() _NOEXCEPT;
+    virtual ~error_category() noexcept;
 
 #if defined(_LIBCUDACXX_BUILDING_LIBRARY) && \
     defined(_LIBCUDACXX_DEPRECATED_ABI_LEGACY_LIBRARY_DEFINITIONS_FOR_INLINE_FUNCTIONS)
-    error_category() _NOEXCEPT;
+    error_category() noexcept;
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 error_category() _NOEXCEPT _LIBCUDACXX_DEFAULT
+    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 error_category() noexcept _LIBCUDACXX_DEFAULT
 #endif
 private:
     error_category(const error_category&);// = delete;
     error_category& operator=(const error_category&);// = delete;
 
 public:
-    virtual const char* name() const _NOEXCEPT = 0;
-    virtual error_condition default_error_condition(int __ev) const _NOEXCEPT;
-    virtual bool equivalent(int __code, const error_condition& __condition) const _NOEXCEPT;
-    virtual bool equivalent(const error_code& __code, int __condition) const _NOEXCEPT;
+    virtual const char* name() const noexcept = 0;
+    virtual error_condition default_error_condition(int __ev) const noexcept;
+    virtual bool equivalent(int __code, const error_condition& __condition) const noexcept;
+    virtual bool equivalent(const error_code& __code, int __condition) const noexcept;
     virtual string message(int __ev) const = 0;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator==(const error_category& __rhs) const _NOEXCEPT {return this == &__rhs;}
+    bool operator==(const error_category& __rhs) const noexcept {return this == &__rhs;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator!=(const error_category& __rhs) const _NOEXCEPT {return !(*this == __rhs);}
+    bool operator!=(const error_category& __rhs) const noexcept {return !(*this == __rhs);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator< (const error_category& __rhs) const _NOEXCEPT {return this < &__rhs;}
+    bool operator< (const error_category& __rhs) const noexcept {return this < &__rhs;}
 
     friend class _LIBCUDACXX_HIDDEN __do_message;
 };
@@ -235,8 +235,8 @@ public:
     virtual string message(int ev) const;
 };
 
-_LIBCUDACXX_FUNC_VIS const error_category& generic_category() _NOEXCEPT;
-_LIBCUDACXX_FUNC_VIS const error_category& system_category() _NOEXCEPT;
+_LIBCUDACXX_FUNC_VIS const error_category& generic_category() noexcept;
+_LIBCUDACXX_FUNC_VIS const error_category& system_category() noexcept;
 
 class _LIBCUDACXX_TYPE_VIS error_condition
 {
@@ -244,21 +244,21 @@ class _LIBCUDACXX_TYPE_VIS error_condition
     const error_category* __cat_;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    error_condition() _NOEXCEPT : __val_(0), __cat_(&generic_category()) {}
+    error_condition() noexcept : __val_(0), __cat_(&generic_category()) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    error_condition(int __val, const error_category& __cat) _NOEXCEPT
+    error_condition(int __val, const error_category& __cat) noexcept
         : __val_(__val), __cat_(&__cat) {}
 
     template <class _Ep>
         _LIBCUDACXX_INLINE_VISIBILITY
         error_condition(_Ep __e,
               typename enable_if<is_error_condition_enum<_Ep>::value>::type* = 0
-                                                                     ) _NOEXCEPT
+                                                                     ) noexcept
             {*this = make_error_condition(__e);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void assign(int __val, const error_category& __cat) _NOEXCEPT
+    void assign(int __val, const error_category& __cat) noexcept
     {
         __val_ = __val;
         __cat_ = &__cat;
@@ -271,38 +271,38 @@ public:
             is_error_condition_enum<_Ep>::value,
             error_condition&
         >::type
-        operator=(_Ep __e) _NOEXCEPT
+        operator=(_Ep __e) noexcept
             {*this = make_error_condition(__e); return *this;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT
+    void clear() noexcept
     {
         __val_ = 0;
         __cat_ = &generic_category();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int value() const _NOEXCEPT {return __val_;}
+    int value() const noexcept {return __val_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const error_category& category() const _NOEXCEPT {return *__cat_;}
+    const error_category& category() const noexcept {return *__cat_;}
     string message() const;
 
     _LIBCUDACXX_INLINE_VISIBILITY
         _LIBCUDACXX_EXPLICIT
-        operator bool() const _NOEXCEPT {return __val_ != 0;}
+        operator bool() const noexcept {return __val_ != 0;}
 };
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 error_condition
-make_error_condition(errc __e) _NOEXCEPT
+make_error_condition(errc __e) noexcept
 {
     return error_condition(static_cast<int>(__e), generic_category());
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator<(const error_condition& __x, const error_condition& __y) _NOEXCEPT
+operator<(const error_condition& __x, const error_condition& __y) noexcept
 {
     return __x.category() < __y.category()
         || (__x.category() == __y.category() && __x.value() < __y.value());
@@ -316,21 +316,21 @@ class _LIBCUDACXX_TYPE_VIS error_code
     const error_category* __cat_;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    error_code() _NOEXCEPT : __val_(0), __cat_(&system_category()) {}
+    error_code() noexcept : __val_(0), __cat_(&system_category()) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    error_code(int __val, const error_category& __cat) _NOEXCEPT
+    error_code(int __val, const error_category& __cat) noexcept
         : __val_(__val), __cat_(&__cat) {}
 
     template <class _Ep>
         _LIBCUDACXX_INLINE_VISIBILITY
         error_code(_Ep __e,
                    typename enable_if<is_error_code_enum<_Ep>::value>::type* = 0
-                                                                     ) _NOEXCEPT
+                                                                     ) noexcept
             {*this = make_error_code(__e);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void assign(int __val, const error_category& __cat) _NOEXCEPT
+    void assign(int __val, const error_category& __cat) noexcept
     {
         __val_ = __val;
         __cat_ = &__cat;
@@ -343,43 +343,43 @@ public:
             is_error_code_enum<_Ep>::value,
             error_code&
         >::type
-        operator=(_Ep __e) _NOEXCEPT
+        operator=(_Ep __e) noexcept
             {*this = make_error_code(__e); return *this;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT
+    void clear() noexcept
     {
         __val_ = 0;
         __cat_ = &system_category();
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int value() const _NOEXCEPT {return __val_;}
+    int value() const noexcept {return __val_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const error_category& category() const _NOEXCEPT {return *__cat_;}
+    const error_category& category() const noexcept {return *__cat_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    error_condition default_error_condition() const _NOEXCEPT
+    error_condition default_error_condition() const noexcept
         {return __cat_->default_error_condition(__val_);}
 
     string message() const;
 
     _LIBCUDACXX_INLINE_VISIBILITY
         _LIBCUDACXX_EXPLICIT
-        operator bool() const _NOEXCEPT {return __val_ != 0;}
+        operator bool() const noexcept {return __val_ != 0;}
 };
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 error_code
-make_error_code(errc __e) _NOEXCEPT
+make_error_code(errc __e) noexcept
 {
     return error_code(static_cast<int>(__e), generic_category());
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator<(const error_code& __x, const error_code& __y) _NOEXCEPT
+operator<(const error_code& __x, const error_code& __y) noexcept
 {
     return __x.category() < __y.category()
         || (__x.category() == __y.category() && __x.value() < __y.value());
@@ -387,14 +387,14 @@ operator<(const error_code& __x, const error_code& __y) _NOEXCEPT
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(const error_code& __x, const error_code& __y) _NOEXCEPT
+operator==(const error_code& __x, const error_code& __y) noexcept
 {
     return __x.category() == __y.category() && __x.value() == __y.value();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(const error_code& __x, const error_condition& __y) _NOEXCEPT
+operator==(const error_code& __x, const error_condition& __y) noexcept
 {
     return __x.category().equivalent(__x.value(), __y)
         || __y.category().equivalent(__x, __y.value());
@@ -402,36 +402,36 @@ operator==(const error_code& __x, const error_condition& __y) _NOEXCEPT
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(const error_condition& __x, const error_code& __y) _NOEXCEPT
+operator==(const error_condition& __x, const error_code& __y) noexcept
 {
     return __y == __x;
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator==(const error_condition& __x, const error_condition& __y) _NOEXCEPT
+operator==(const error_condition& __x, const error_condition& __y) noexcept
 {
     return __x.category() == __y.category() && __x.value() == __y.value();
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(const error_code& __x, const error_code& __y) _NOEXCEPT
+operator!=(const error_code& __x, const error_code& __y) noexcept
 {return !(__x == __y);}
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(const error_code& __x, const error_condition& __y) _NOEXCEPT
+operator!=(const error_code& __x, const error_condition& __y) noexcept
 {return !(__x == __y);}
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(const error_condition& __x, const error_code& __y) _NOEXCEPT
+operator!=(const error_condition& __x, const error_code& __y) noexcept
 {return !(__x == __y);}
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
 bool
-operator!=(const error_condition& __x, const error_condition& __y) _NOEXCEPT
+operator!=(const error_condition& __x, const error_condition& __y) noexcept
 {return !(__x == __y);}
 
 template <>
@@ -439,7 +439,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<error_code>
     : public __unary_function<error_code, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(const error_code& __ec) const _NOEXCEPT
+    size_t operator()(const error_code& __ec) const noexcept
     {
         return static_cast<size_t>(__ec.value());
     }
@@ -450,7 +450,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<error_condition>
     : public __unary_function<error_condition, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(const error_condition& __ec) const _NOEXCEPT
+    size_t operator()(const error_condition& __ec) const noexcept
     {
         return static_cast<size_t>(__ec.value());
     }
@@ -469,10 +469,10 @@ public:
     system_error(int __ev, const error_category& __ecat, const string& __what_arg);
     system_error(int __ev, const error_category& __ecat, const char* __what_arg);
     system_error(int __ev, const error_category& __ecat);
-    ~system_error() _NOEXCEPT;
+    ~system_error() noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const error_code& code() const _NOEXCEPT {return __ec_;}
+    const error_code& code() const noexcept {return __ec_;}
 
 private:
     static string __init(const error_code&, string);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/thread
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/thread
@@ -201,7 +201,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<__thread_id>
     : public __unary_function<__thread_id, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(__thread_id __v) const _NOEXCEPT
+    size_t operator()(__thread_id __v) const noexcept
     {
         return hash<__libcpp_thread_id>()(__v.__id_);
     }
@@ -224,7 +224,7 @@ public:
     typedef __libcpp_thread_t native_handle_type;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    thread() _NOEXCEPT : __t_(_LIBCUDACXX_NULL_THREAD) {}
+    thread() noexcept : __t_(_LIBCUDACXX_NULL_THREAD) {}
 #ifndef _LIBCUDACXX_CXX03_LANG
     template <class _Fp, class ..._Args,
               class = typename enable_if
@@ -243,24 +243,24 @@ public:
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
-    thread(thread&& __t) _NOEXCEPT : __t_(__t.__t_) {__t.__t_ = _LIBCUDACXX_NULL_THREAD;}
+    thread(thread&& __t) noexcept : __t_(__t.__t_) {__t.__t_ = _LIBCUDACXX_NULL_THREAD;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    thread& operator=(thread&& __t) _NOEXCEPT;
+    thread& operator=(thread&& __t) noexcept;
 #endif  // _LIBCUDACXX_CXX03_LANG
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(thread& __t) _NOEXCEPT {_CUDA_VSTD::swap(__t_, __t.__t_);}
+    void swap(thread& __t) noexcept {_CUDA_VSTD::swap(__t_, __t.__t_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool joinable() const _NOEXCEPT {return !__libcpp_thread_isnull(&__t_);}
+    bool joinable() const noexcept {return !__libcpp_thread_isnull(&__t_);}
     void join();
     void detach();
     _LIBCUDACXX_INLINE_VISIBILITY
-    id get_id() const _NOEXCEPT {return __libcpp_thread_get_id(&__t_);}
+    id get_id() const noexcept {return __libcpp_thread_get_id(&__t_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    native_handle_type native_handle() _NOEXCEPT {return __t_;}
+    native_handle_type native_handle() noexcept {return __t_;}
 
-    static unsigned hardware_concurrency() _NOEXCEPT;
+    static unsigned hardware_concurrency() noexcept;
 };
 
 #ifndef _LIBCUDACXX_CXX03_LANG
@@ -305,7 +305,7 @@ thread::thread(_Fp&& __f, _Args&&... __args)
 
 inline
 thread&
-thread::operator=(thread&& __t) _NOEXCEPT
+thread::operator=(thread&& __t) noexcept
 {
     if (!__libcpp_thread_isnull(&__t_))
         terminate();
@@ -352,7 +352,7 @@ thread::thread(_Fp __f)
 #endif  // _LIBCUDACXX_CXX03_LANG
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-void swap(thread& __x, thread& __y) _NOEXCEPT {__x.swap(__y);}
+void swap(thread& __x, thread& __y) noexcept {__x.swap(__y);}
 
 namespace this_thread
 {
@@ -407,7 +407,7 @@ sleep_until(const chrono::time_point<chrono::steady_clock, _Duration>& __t)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-void yield() _NOEXCEPT {__libcpp_thread_yield();}
+void yield() noexcept {__libcpp_thread_yield();}
 
 }  // this_thread
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -206,7 +206,7 @@ class __tuple_leaf;
 template <size_t _Ip, class _Hp, bool _Ep>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void swap(__tuple_leaf<_Ip, _Hp, _Ep>& __x, __tuple_leaf<_Ip, _Hp, _Ep>& __y)
-    _NOEXCEPT_(__is_nothrow_swappable<_Hp>::value)
+    noexcept(__is_nothrow_swappable<_Hp>::value)
 {
     swap(__x.get(), __y.get());
 }
@@ -229,7 +229,7 @@ class __tuple_leaf
     _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf& operator=(const __tuple_leaf&);
 public:
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR __tuple_leaf()
-             _NOEXCEPT_(is_nothrow_default_constructible<_Hp>::value) : __value_()
+             noexcept(is_nothrow_default_constructible<_Hp>::value) : __value_()
        {static_assert(!is_reference<_Hp>::value,
               "Attempted to default construct a reference element in a tuple");}
 
@@ -261,7 +261,7 @@ public:
     template <class _Tp,
               __enable_if_t<__can_forward<_Tp>::value, int> = 0>
         _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-        explicit __tuple_leaf(_Tp&& __t) _NOEXCEPT_((is_nothrow_constructible<_Hp, _Tp>::value))
+        explicit __tuple_leaf(_Tp&& __t) noexcept((is_nothrow_constructible<_Hp, _Tp>::value))
             : __value_(_CUDA_VSTD::forward<_Tp>(__t))
         {static_assert(__can_bind_reference<_Tp&&>(),
        "Attempted construction of reference element binds to a temporary whose lifetime has ended");}
@@ -293,21 +293,21 @@ public:
     template <class _Tp>
         _LIBCUDACXX_INLINE_VISIBILITY
         __tuple_leaf&
-        operator=(_Tp&& __t) _NOEXCEPT_((is_nothrow_assignable<_Hp&, _Tp>::value))
+        operator=(_Tp&& __t) noexcept((is_nothrow_assignable<_Hp&, _Tp>::value))
         {
             __value_ = _CUDA_VSTD::forward<_Tp>(__t);
             return *this;
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    int swap(__tuple_leaf& __t) _NOEXCEPT_(__is_nothrow_swappable<__tuple_leaf>::value)
+    int swap(__tuple_leaf& __t) noexcept(__is_nothrow_swappable<__tuple_leaf>::value)
     {
         _CUDA_VSTD::swap(*this, __t);
         return 0;
     }
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11       _Hp& get()       _NOEXCEPT {return __value_;}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const _Hp& get() const _NOEXCEPT {return __value_;}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11       _Hp& get()       noexcept {return __value_;}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const _Hp& get() const noexcept {return __value_;}
 };
 
 template <size_t _Ip, class _Hp>
@@ -318,7 +318,7 @@ class __tuple_leaf<_Ip, _Hp, true>
     _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf& operator=(const __tuple_leaf&);
 public:
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR __tuple_leaf()
-             _NOEXCEPT_(is_nothrow_default_constructible<_Hp>::value) {}
+             noexcept(is_nothrow_default_constructible<_Hp>::value) {}
 
     template <class _Alloc>
         _LIBCUDACXX_INLINE_VISIBILITY
@@ -341,7 +341,7 @@ public:
     template <class _Tp,
               __enable_if_t<__can_forward<_Tp>::value, int> = 0>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    explicit __tuple_leaf(_Tp&& __t) _NOEXCEPT_((is_nothrow_constructible<_Hp, _Tp>::value))
+    explicit __tuple_leaf(_Tp&& __t) noexcept((is_nothrow_constructible<_Hp, _Tp>::value))
         : _Hp(_CUDA_VSTD::forward<_Tp>(__t)) {}
 
     template <class _Tp, class _Alloc>
@@ -365,7 +365,7 @@ public:
     template <class _Tp>
         _LIBCUDACXX_INLINE_VISIBILITY
         __tuple_leaf&
-        operator=(_Tp&& __t) _NOEXCEPT_((is_nothrow_assignable<_Hp&, _Tp>::value))
+        operator=(_Tp&& __t) noexcept((is_nothrow_assignable<_Hp&, _Tp>::value))
         {
             _Hp::operator=(_CUDA_VSTD::forward<_Tp>(__t));
             return *this;
@@ -373,19 +373,19 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     int
-    swap(__tuple_leaf& __t) _NOEXCEPT_(__is_nothrow_swappable<__tuple_leaf>::value)
+    swap(__tuple_leaf& __t) noexcept(__is_nothrow_swappable<__tuple_leaf>::value)
     {
         _CUDA_VSTD::swap(*this, __t);
         return 0;
     }
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11       _Hp& get()       _NOEXCEPT {return static_cast<_Hp&>(*this);}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const _Hp& get() const _NOEXCEPT {return static_cast<const _Hp&>(*this);}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11       _Hp& get()       noexcept {return static_cast<_Hp&>(*this);}
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const _Hp& get() const noexcept {return static_cast<const _Hp&>(*this);}
 };
 
 template <class ..._Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-void __swallow(_Tp&&...) _NOEXCEPT {}
+void __swallow(_Tp&&...) noexcept {}
 
 template <class _Tp>
 struct __all_default_constructible;
@@ -405,7 +405,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
 {
     _LIBCUDACXX_INLINE_VISIBILITY
     _LIBCUDACXX_CONSTEXPR __tuple_impl()
-        _NOEXCEPT_(__all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
+        noexcept(__all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
 
 
     // Handle non-allocator, full initialization
@@ -417,7 +417,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
         __tuple_impl(__tuple_indices<_Uf...>, __tuple_types<_Tf...>,
                      __tuple_indices<_Ul...>, __tuple_types<_Tl...>,
                      _Up&&... __u)
-                     _NOEXCEPT_((__all<is_nothrow_constructible<_Tf, _Up>::value...>::value)) :
+                     noexcept((__all<is_nothrow_constructible<_Tf, _Up>::value...>::value)) :
             __tuple_leaf<_Uf, _Tf>(_CUDA_VSTD::forward<_Up>(__u))...
             {}
 
@@ -430,7 +430,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
         __tuple_impl(__tuple_indices<_Uf...>, __tuple_types<_Tf...>,
                      __tuple_indices<_Ul...>, __tuple_types<_Tl...>,
                      _Up&&... __u)
-                     _NOEXCEPT_((__all<is_nothrow_constructible<_Tf, _Up>::value...>::value &&
+                     noexcept((__all<is_nothrow_constructible<_Tf, _Up>::value...>::value &&
                                  __all<is_nothrow_default_constructible<_Tl>::value...>::value)) :
             __tuple_leaf<_Uf, _Tf>(_CUDA_VSTD::forward<_Up>(__u))...,
             __tuple_leaf<_Ul, _Tl>()...
@@ -445,7 +445,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
         __tuple_impl(__tuple_indices<_Uf...>, __tuple_types<_Tf...>,
                      __tuple_indices<_Ul...>, __tuple_types<_Tl...>,
                      _Up&&...)
-                     _NOEXCEPT_((__all<is_nothrow_default_constructible<_Tl>::value...>::value)) :
+                     noexcept((__all<is_nothrow_default_constructible<_Tl>::value...>::value)) :
             __tuple_leaf<_Ul, _Tl>()...
             {}
 
@@ -499,7 +499,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
                 > = false
              >
         _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-        __tuple_impl(_Tuple&& __t) _NOEXCEPT_((__all<is_nothrow_constructible<_Tp, typename tuple_element<_Indx,
+        __tuple_impl(_Tuple&& __t) noexcept((__all<is_nothrow_constructible<_Tp, typename tuple_element<_Indx,
                                        typename __make_tuple_types<_Tuple>::type>::type>::value...>::value))
             : __tuple_leaf<_Indx, _Tp>(_CUDA_VSTD::forward<typename tuple_element<_Indx,
                                        typename __make_tuple_types<_Tuple>::type>::type>(_CUDA_VSTD::get<_Indx>(__t)))...
@@ -526,7 +526,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
             __tuple_assignable<_Tuple, tuple<_Tp...> >::value,
             __tuple_impl&
         >::type
-        operator=(_Tuple&& __t) _NOEXCEPT_((__all<is_nothrow_assignable<_Tp&, typename tuple_element<_Indx,
+        operator=(_Tuple&& __t) noexcept((__all<is_nothrow_assignable<_Tp&, typename tuple_element<_Indx,
                                        typename __make_tuple_types<_Tuple>::type>::type>::value...>::value))
         {
             __swallow(__tuple_leaf<_Indx, _Tp>::operator=(_CUDA_VSTD::forward<typename tuple_element<_Indx,
@@ -539,7 +539,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __tuple_impl&
-    operator=(const __tuple_impl& __t) _NOEXCEPT_((__all<is_nothrow_copy_assignable<_Tp>::value...>::value))
+    operator=(const __tuple_impl& __t) noexcept((__all<is_nothrow_copy_assignable<_Tp>::value...>::value))
     {
         __swallow(__tuple_leaf<_Indx, _Tp>::operator=(static_cast<const __tuple_leaf<_Indx, _Tp>&>(__t).get())...);
         return *this;
@@ -547,7 +547,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __tuple_impl&
-    operator=(__tuple_impl&& __t) _NOEXCEPT_((__all<is_nothrow_move_assignable<_Tp>::value...>::value))
+    operator=(__tuple_impl&& __t) noexcept((__all<is_nothrow_move_assignable<_Tp>::value...>::value))
     {
         __swallow(__tuple_leaf<_Indx, _Tp>::operator=(_CUDA_VSTD::forward<_Tp>(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t).get()))...);
         return *this;
@@ -555,7 +555,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(__tuple_impl& __t)
-        _NOEXCEPT_(__all<__is_nothrow_swappable<_Tp>::value...>::value)
+        noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
     {
         __swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t))...);
     }
@@ -721,16 +721,16 @@ class _LIBCUDACXX_TEMPLATE_VIS tuple
 
     template <size_t _Jp, class ..._Up> friend
         _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-        typename tuple_element<_Jp, tuple<_Up...> >::type& get(tuple<_Up...>&) _NOEXCEPT;
+        typename tuple_element<_Jp, tuple<_Up...> >::type& get(tuple<_Up...>&) noexcept;
     template <size_t _Jp, class ..._Up> friend
         _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-        const typename tuple_element<_Jp, tuple<_Up...> >::type& get(const tuple<_Up...>&) _NOEXCEPT;
+        const typename tuple_element<_Jp, tuple<_Up...> >::type& get(const tuple<_Up...>&) noexcept;
     template <size_t _Jp, class ..._Up> friend
         _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-        typename tuple_element<_Jp, tuple<_Up...> >::type&& get(tuple<_Up...>&&) _NOEXCEPT;
+        typename tuple_element<_Jp, tuple<_Up...> >::type&& get(tuple<_Up...>&&) noexcept;
     template <size_t _Jp, class ..._Up> friend
         _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
-        const typename tuple_element<_Jp, tuple<_Up...> >::type&& get(const tuple<_Up...>&&) _NOEXCEPT;
+        const typename tuple_element<_Jp, tuple<_Up...> >::type&& get(const tuple<_Up...>&&) noexcept;
 public:
 
     template<bool _Dummy>
@@ -748,11 +748,11 @@ public:
 
     template <bool _Dummy = true, __enable_if_t<_EnableConstructor<_Dummy>::__implicit_default, bool> = false>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    tuple() _NOEXCEPT_(__all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
+    tuple() noexcept(__all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
 
     template <bool _Dummy = true, __enable_if_t<_EnableConstructor<_Dummy>::__explicit_default, bool> = false>
     explicit _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    tuple() _NOEXCEPT_(__all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
+    tuple() noexcept(__all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
 
     tuple(tuple const&) = default;
     tuple(tuple&&) = default;
@@ -785,7 +785,7 @@ public:
 
     template <bool _Dummy = true, __enable_if_t<_EnableConstructor<_Dummy>::__implicit_variadic, bool> = false>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    tuple(const _Tp& ... __t) _NOEXCEPT_((__all<is_nothrow_copy_constructible<_Tp>::value...>::value))
+    tuple(const _Tp& ... __t) noexcept((__all<is_nothrow_copy_constructible<_Tp>::value...>::value))
         : __base_(typename __make_tuple_indices<sizeof...(_Tp)>::type(),
                 typename __make_tuple_types<tuple, sizeof...(_Tp)>::type(),
                 typename __make_tuple_indices<0>::type(),
@@ -795,7 +795,7 @@ public:
 
     template <bool _Dummy = true, __enable_if_t<_EnableConstructor<_Dummy>::__explicit_variadic, bool> = false>
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-    explicit tuple(const _Tp& ... __t) _NOEXCEPT_((__all<is_nothrow_copy_constructible<_Tp>::value...>::value))
+    explicit tuple(const _Tp& ... __t) noexcept((__all<is_nothrow_copy_constructible<_Tp>::value...>::value))
         : __base_(typename __make_tuple_indices<sizeof...(_Tp)>::type(),
                 typename __make_tuple_types<tuple, sizeof...(_Tp)>::type(),
                 typename __make_tuple_indices<0>::type(),
@@ -859,7 +859,7 @@ public:
               __enable_if_t<_EnableVariadicConvertingConstructor<_Up...>::__implicit, bool> = false>
         _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
         tuple(_Up&&... __u)
-            _NOEXCEPT_((
+            noexcept((
                 __base_noexcept_constructible<
                     typename __make_tuple_indices<sizeof...(_Up)>::type,
                     typename __make_tuple_types<tuple, sizeof...(_Up)>::type,
@@ -879,7 +879,7 @@ public:
         _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
         explicit
         tuple(_Up&&... __u)
-            _NOEXCEPT_((
+            noexcept((
                 __base_noexcept_constructible<
                     typename __make_tuple_indices<sizeof...(_Up)>::type,
                     typename __make_tuple_types<tuple, sizeof...(_Up)>::type,
@@ -941,24 +941,24 @@ public:
 
     template <class _Tuple, __enable_if_t<_EnableTupleLikeConstructor<_Tuple, true>::__implicit, bool> = false>
         _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-        tuple(_Tuple&& __t) _NOEXCEPT_((is_nothrow_constructible<_BaseT, _Tuple>::value))
+        tuple(_Tuple&& __t) noexcept((is_nothrow_constructible<_BaseT, _Tuple>::value))
             : __base_(_CUDA_VSTD::forward<_Tuple>(__t)) {}
 
     template <class _Tuple, __enable_if_t<_EnableTupleLikeConstructor<const _Tuple&, false>::__implicit, bool> = false>
         _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-        tuple(const _Tuple& __t) _NOEXCEPT_((is_nothrow_constructible<_BaseT, const _Tuple&>::value))
+        tuple(const _Tuple& __t) noexcept((is_nothrow_constructible<_BaseT, const _Tuple&>::value))
             : __base_(__t) {}
 
     template <class _Tuple, __enable_if_t<_EnableTupleLikeConstructor<_Tuple, true>::__explicit, bool> = false>
         _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
         explicit
-        tuple(_Tuple&& __t) _NOEXCEPT_((is_nothrow_constructible<_BaseT, _Tuple>::value))
+        tuple(_Tuple&& __t) noexcept((is_nothrow_constructible<_BaseT, _Tuple>::value))
             : __base_(_CUDA_VSTD::forward<_Tuple>(__t)) {}
 
     template <class _Tuple, __enable_if_t<_EnableTupleLikeConstructor<const _Tuple&, false>::__explicit, bool> = false>
         _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
         explicit
-        tuple(const _Tuple& __t) _NOEXCEPT_((is_nothrow_constructible<_BaseT, const _Tuple&>::value))
+        tuple(const _Tuple& __t) noexcept((is_nothrow_constructible<_BaseT, const _Tuple&>::value))
             : __base_(__t) {}
 
     template <class _Alloc, class _Tuple,
@@ -979,7 +979,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     tuple& operator=(__conditional_t<_CanCopyAssign::value, tuple, __nat> const& __t)
-        _NOEXCEPT_((__all<is_nothrow_copy_assignable<_Tp>::value...>::value))
+        noexcept((__all<is_nothrow_copy_assignable<_Tp>::value...>::value))
     {
         __base_.operator=(__t.__base_);
         return *this;
@@ -987,7 +987,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     tuple& operator=(__conditional_t<_CanMoveAssign::value, tuple, __nat>&& __t)
-        _NOEXCEPT_((__all<is_nothrow_move_assignable<_Tp>::value...>::value))
+        noexcept((__all<is_nothrow_move_assignable<_Tp>::value...>::value))
     {
         __base_.operator=(static_cast<_BaseT&&>(__t.__base_));
         return *this;
@@ -997,14 +997,14 @@ public:
               __enable_if_t<__tuple_assignable<_Tuple, tuple>::value, bool> = false>
         _LIBCUDACXX_INLINE_VISIBILITY
         tuple&
-        operator=(_Tuple&& __t) _NOEXCEPT_((is_nothrow_assignable<_BaseT&, _Tuple>::value))
+        operator=(_Tuple&& __t) noexcept((is_nothrow_assignable<_BaseT&, _Tuple>::value))
         {
             __base_.operator=(_CUDA_VSTD::forward<_Tuple>(__t));
             return *this;
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(tuple& __t) _NOEXCEPT_(__all<__is_nothrow_swappable<_Tp>::value...>::value)
+    void swap(tuple& __t) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
         {__base_.swap(__t.__base_);}
 };
 
@@ -1012,21 +1012,21 @@ template <>
 class _LIBCUDACXX_TEMPLATE_VIS tuple<>
 {
 public:
-    _LIBCUDACXX_CONSTEXPR tuple() _NOEXCEPT = default;
+    _LIBCUDACXX_CONSTEXPR tuple() noexcept = default;
     template <class _Alloc>
     _LIBCUDACXX_INLINE_VISIBILITY
-        tuple(allocator_arg_t, const _Alloc&) _NOEXCEPT {}
+        tuple(allocator_arg_t, const _Alloc&) noexcept {}
     template <class _Alloc>
     _LIBCUDACXX_INLINE_VISIBILITY
-        tuple(allocator_arg_t, const _Alloc&, const tuple&) _NOEXCEPT {}
+        tuple(allocator_arg_t, const _Alloc&, const tuple&) noexcept {}
     template <class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
-        tuple(array<_Up, 0>) _NOEXCEPT {}
+        tuple(array<_Up, 0>) noexcept {}
     template <class _Alloc, class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
-        tuple(allocator_arg_t, const _Alloc&, array<_Up, 0>) _NOEXCEPT {}
+        tuple(allocator_arg_t, const _Alloc&, array<_Up, 0>) noexcept {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(tuple&) _NOEXCEPT {}
+    void swap(tuple&) noexcept {}
 };
 
 #ifndef _LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES
@@ -1045,7 +1045,7 @@ tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>;
 template <class ..._Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 __enable_if_t<_And<__is_swappable<_Tp>...>::value, void>
-swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) _NOEXCEPT_(__all<__is_nothrow_swappable<_Tp>::value...>::value) {
+swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value) {
     __t.swap(__u);
 }
 
@@ -1053,7 +1053,7 @@ swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) _NOEXCEPT_(__all<__is_nothrow_swapp
 template <size_t _Ip, class ..._Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 typename tuple_element<_Ip, tuple<_Tp...> >::type&
-get(tuple<_Tp...>& __t) _NOEXCEPT
+get(tuple<_Tp...>& __t) noexcept
 {
     typedef _LIBCUDACXX_NODEBUG_TYPE typename tuple_element<_Ip, tuple<_Tp...> >::type type;
     return static_cast<__tuple_leaf<_Ip, type>&>(__t.__base_).get();
@@ -1062,7 +1062,7 @@ get(tuple<_Tp...>& __t) _NOEXCEPT
 template <size_t _Ip, class ..._Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const typename tuple_element<_Ip, tuple<_Tp...> >::type&
-get(const tuple<_Tp...>& __t) _NOEXCEPT
+get(const tuple<_Tp...>& __t) noexcept
 {
     typedef _LIBCUDACXX_NODEBUG_TYPE typename tuple_element<_Ip, tuple<_Tp...> >::type type;
     return static_cast<const __tuple_leaf<_Ip, type>&>(__t.__base_).get();
@@ -1071,7 +1071,7 @@ get(const tuple<_Tp...>& __t) _NOEXCEPT
 template <size_t _Ip, class ..._Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 typename tuple_element<_Ip, tuple<_Tp...> >::type&&
-get(tuple<_Tp...>&& __t) _NOEXCEPT
+get(tuple<_Tp...>&& __t) noexcept
 {
     typedef _LIBCUDACXX_NODEBUG_TYPE typename tuple_element<_Ip, tuple<_Tp...> >::type type;
     return static_cast<type&&>(
@@ -1081,7 +1081,7 @@ get(tuple<_Tp...>&& __t) _NOEXCEPT
 template <size_t _Ip, class ..._Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 const typename tuple_element<_Ip, tuple<_Tp...> >::type&&
-get(const tuple<_Tp...>&& __t) _NOEXCEPT
+get(const tuple<_Tp...>&& __t) noexcept
 {
     typedef _LIBCUDACXX_NODEBUG_TYPE typename tuple_element<_Ip, tuple<_Tp...> >::type type;
     return static_cast<const type&&>(
@@ -1163,7 +1163,7 @@ constexpr _T1 const&& get(tuple<_Args...> const&& __tup) noexcept
 template <class ..._Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 tuple<_Tp&...>
-tie(_Tp&... __t) _NOEXCEPT
+tie(_Tp&... __t) noexcept
 {
     return tuple<_Tp&...>(__t...);
 }
@@ -1194,7 +1194,7 @@ make_tuple(_Tp&&... __t)
 template <class... _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 tuple<_Tp&&...>
-forward_as_tuple(_Tp&&... __t) _NOEXCEPT
+forward_as_tuple(_Tp&&... __t) noexcept
 {
     return tuple<_Tp&&...>(_CUDA_VSTD::forward<_Tp>(__t)...);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/type_traits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/type_traits
@@ -623,8 +623,8 @@ template <class _ForwardIterator1, class _ForwardIterator2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
 void
 iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
-    //                                  _NOEXCEPT_(_NOEXCEPT_(swap(*__a, *__b)))
-               _NOEXCEPT_(_NOEXCEPT_(swap(*_CUDA_VSTD::declval<_ForwardIterator1>(),
+    //                                  noexcept(_NOEXCEPT_(swap(*__a, *__b)))
+               noexcept(_NOEXCEPT_(swap(*_CUDA_VSTD::declval<_ForwardIterator1>(),
                                           *_CUDA_VSTD::declval<_ForwardIterator2>())))
 {
     swap(*__a, *__b);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/typeindex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/typeindex
@@ -59,31 +59,31 @@ class _LIBCUDACXX_TEMPLATE_VIS type_index
     const type_info* __t_;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    type_index(const type_info& __y) _NOEXCEPT : __t_(&__y) {}
+    type_index(const type_info& __y) noexcept : __t_(&__y) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator==(const type_index& __y) const _NOEXCEPT
+    bool operator==(const type_index& __y) const noexcept
         {return *__t_ == *__y.__t_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator!=(const type_index& __y) const _NOEXCEPT
+    bool operator!=(const type_index& __y) const noexcept
         {return *__t_ != *__y.__t_;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator< (const type_index& __y) const _NOEXCEPT
+    bool operator< (const type_index& __y) const noexcept
         {return  __t_->before(*__y.__t_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator<=(const type_index& __y) const _NOEXCEPT
+    bool operator<=(const type_index& __y) const noexcept
         {return !__y.__t_->before(*__t_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator> (const type_index& __y) const _NOEXCEPT
+    bool operator> (const type_index& __y) const noexcept
         {return  __y.__t_->before(*__t_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator>=(const type_index& __y) const _NOEXCEPT
+    bool operator>=(const type_index& __y) const noexcept
         {return !__t_->before(*__y.__t_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t hash_code() const _NOEXCEPT {return __t_->hash_code();}
+    size_t hash_code() const noexcept {return __t_->hash_code();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const char* name() const _NOEXCEPT {return __t_->name();}
+    const char* name() const noexcept {return __t_->name();}
 };
 
 template <class _Tp> struct _LIBCUDACXX_TEMPLATE_VIS hash;
@@ -93,7 +93,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<type_index>
     : public __unary_function<type_index, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(type_index __index) const _NOEXCEPT
+    size_t operator()(type_index __index) const noexcept
         {return __index.hash_code();}
 };
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/typeinfo
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/typeinfo
@@ -88,28 +88,28 @@ class _LIBCUDACXX_EXCEPTION_ABI type_info
       const char __decorated_name[1];
     } __data;
 
-    int __compare(const type_info &__rhs) const _NOEXCEPT;
+    int __compare(const type_info &__rhs) const noexcept;
 
 public:
     _LIBCUDACXX_AVAILABILITY_TYPEINFO_VTABLE
     virtual ~type_info();
 
-    const char *name() const _NOEXCEPT;
+    const char *name() const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool before(const type_info& __arg) const _NOEXCEPT {
+    bool before(const type_info& __arg) const noexcept {
       return __compare(__arg) < 0;
     }
 
-    size_t hash_code() const _NOEXCEPT;
+    size_t hash_code() const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator==(const type_info& __arg) const _NOEXCEPT {
+    bool operator==(const type_info& __arg) const noexcept {
       return __compare(__arg) == 0;
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator!=(const type_info& __arg) const _NOEXCEPT
+    bool operator!=(const type_info& __arg) const noexcept
     { return !operator==(__arg); }
 };
 
@@ -160,44 +160,44 @@ struct __type_info_implementations {
   struct __string_impl_base {
     typedef const char* __type_name_t;
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    _LIBCUDACXX_CONSTEXPR static const char* __type_name_to_string(__type_name_t __v) _NOEXCEPT {
+    _LIBCUDACXX_CONSTEXPR static const char* __type_name_to_string(__type_name_t __v) noexcept {
       return __v;
     }
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    _LIBCUDACXX_CONSTEXPR static __type_name_t __string_to_type_name(const char* __v) _NOEXCEPT {
+    _LIBCUDACXX_CONSTEXPR static __type_name_t __string_to_type_name(const char* __v) noexcept {
       return __v;
     }
   };
 
   struct __unique_impl : __string_impl_base {
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static size_t __hash(__type_name_t __v) _NOEXCEPT {
+    static size_t __hash(__type_name_t __v) noexcept {
       return reinterpret_cast<size_t>(__v);
     }
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static bool __eq(__type_name_t __lhs, __type_name_t __rhs) _NOEXCEPT {
+    static bool __eq(__type_name_t __lhs, __type_name_t __rhs) noexcept {
       return __lhs == __rhs;
     }
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static bool __lt(__type_name_t __lhs, __type_name_t __rhs) _NOEXCEPT {
+    static bool __lt(__type_name_t __lhs, __type_name_t __rhs) noexcept {
       return __lhs < __rhs;
     }
   };
 
   struct __non_unique_impl : __string_impl_base {
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static size_t __hash(__type_name_t __ptr) _NOEXCEPT {
+    static size_t __hash(__type_name_t __ptr) noexcept {
       size_t __hash = 5381;
       while (unsigned char __c = static_cast<unsigned char>(*__ptr++))
         __hash = (__hash * 33) ^ __c;
       return __hash;
     }
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static bool __eq(__type_name_t __lhs, __type_name_t __rhs) _NOEXCEPT {
+    static bool __eq(__type_name_t __lhs, __type_name_t __rhs) noexcept {
       return __lhs == __rhs || __builtin_strcmp(__lhs, __rhs) == 0;
     }
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static bool __lt(__type_name_t __lhs, __type_name_t __rhs) _NOEXCEPT {
+    static bool __lt(__type_name_t __lhs, __type_name_t __rhs) noexcept {
       return __builtin_strcmp(__lhs, __rhs) < 0;
     }
   };
@@ -206,23 +206,23 @@ struct __type_info_implementations {
     typedef uintptr_t __type_name_t;
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static const char* __type_name_to_string(__type_name_t __v) _NOEXCEPT {
+    static const char* __type_name_to_string(__type_name_t __v) noexcept {
       return reinterpret_cast<const char*>(__v &
           ~__non_unique_rtti_bit::value);
     }
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static __type_name_t __string_to_type_name(const char* __v) _NOEXCEPT {
+    static __type_name_t __string_to_type_name(const char* __v) noexcept {
       return reinterpret_cast<__type_name_t>(__v);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static size_t __hash(__type_name_t __v) _NOEXCEPT {
+    static size_t __hash(__type_name_t __v) noexcept {
       if (__is_type_name_unique(__v))
         return reinterpret_cast<size_t>(__v);
       return __non_unique_impl::__hash(__type_name_to_string(__v));
     }
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static bool __eq(__type_name_t __lhs, __type_name_t __rhs) _NOEXCEPT {
+    static bool __eq(__type_name_t __lhs, __type_name_t __rhs) noexcept {
       if (__lhs == __rhs)
         return true;
       if (__is_type_name_unique(__lhs, __rhs))
@@ -230,7 +230,7 @@ struct __type_info_implementations {
       return __builtin_strcmp(__type_name_to_string(__lhs), __type_name_to_string(__rhs)) == 0;
     }
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    static bool __lt(__type_name_t __lhs, __type_name_t __rhs) _NOEXCEPT {
+    static bool __lt(__type_name_t __lhs, __type_name_t __rhs) noexcept {
       if (__is_type_name_unique(__lhs, __rhs))
         return __lhs < __rhs;
       return __builtin_strcmp(__type_name_to_string(__lhs), __type_name_to_string(__rhs)) < 0;
@@ -243,11 +243,11 @@ struct __type_info_implementations {
       (1ULL << ((__CHAR_BIT__ * sizeof(__type_name_t)) - 1))> __non_unique_rtti_bit;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static bool __is_type_name_unique(__type_name_t __lhs) _NOEXCEPT {
+    static bool __is_type_name_unique(__type_name_t __lhs) noexcept {
       return !(__lhs & __non_unique_rtti_bit::value);
     }
     _LIBCUDACXX_INLINE_VISIBILITY
-    static bool __is_type_name_unique(__type_name_t __lhs, __type_name_t __rhs) _NOEXCEPT {
+    static bool __is_type_name_unique(__type_name_t __lhs, __type_name_t __rhs) noexcept {
       return !((__lhs & __rhs) & __non_unique_rtti_bit::value);
     }
   };
@@ -284,31 +284,31 @@ public:
     virtual ~type_info();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const char* name() const _NOEXCEPT
+    const char* name() const noexcept
     {
       return __impl::__type_name_to_string(__type_name);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool before(const type_info& __arg) const _NOEXCEPT
+    bool before(const type_info& __arg) const noexcept
     {
       return __impl::__lt(__type_name, __arg.__type_name);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t hash_code() const _NOEXCEPT
+    size_t hash_code() const noexcept
     {
       return __impl::__hash(__type_name);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator==(const type_info& __arg) const _NOEXCEPT
+    bool operator==(const type_info& __arg) const noexcept
     {
       return __impl::__eq(__type_name, __arg.__type_name);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    bool operator!=(const type_info& __arg) const _NOEXCEPT
+    bool operator!=(const type_info& __arg) const noexcept
     { return !operator==(__arg); }
 };
 #endif // defined(_LIBCUDACXX_ABI_MICROSOFT)
@@ -317,18 +317,18 @@ class _LIBCUDACXX_EXCEPTION_ABI bad_cast
     : public exception
 {
  public:
-  bad_cast() _NOEXCEPT;
-  virtual ~bad_cast() _NOEXCEPT;
-  virtual const char* what() const _NOEXCEPT;
+  bad_cast() noexcept;
+  virtual ~bad_cast() noexcept;
+  virtual const char* what() const noexcept;
 };
 
 class _LIBCUDACXX_EXCEPTION_ABI bad_typeid
     : public exception
 {
  public:
-  bad_typeid() _NOEXCEPT;
-  virtual ~bad_typeid() _NOEXCEPT;
-  virtual const char* what() const _NOEXCEPT;
+  bad_typeid() noexcept;
+  virtual ~bad_typeid() noexcept;
+  virtual const char* what() const noexcept;
 };
 
 }  // std

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/unordered_map
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/unordered_map
@@ -429,14 +429,14 @@ class __unordered_map_hasher
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     __unordered_map_hasher()
-        _NOEXCEPT_(is_nothrow_default_constructible<_Hash>::value)
+        noexcept(is_nothrow_default_constructible<_Hash>::value)
         : _Hash() {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __unordered_map_hasher(const _Hash& __h)
-        _NOEXCEPT_(is_nothrow_copy_constructible<_Hash>::value)
+        noexcept(is_nothrow_copy_constructible<_Hash>::value)
         : _Hash(__h) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const _Hash& hash_function() const _NOEXCEPT {return *this;}
+    const _Hash& hash_function() const noexcept {return *this;}
     _LIBCUDACXX_INLINE_VISIBILITY
     size_t operator()(const _Cp& __x) const
         {return static_cast<const _Hash&>(*this)(__x.__get_value().first);}
@@ -444,7 +444,7 @@ public:
     size_t operator()(const _Key& __x) const
         {return static_cast<const _Hash&>(*this)(__x);}
     void swap(__unordered_map_hasher&__y)
-        _NOEXCEPT_(__is_nothrow_swappable<_Hash>::value)
+        noexcept(__is_nothrow_swappable<_Hash>::value)
     {
         using _CUDA_VSTD::swap;
         swap(static_cast<_Hash&>(*this), static_cast<_Hash&>(__y));
@@ -458,14 +458,14 @@ class __unordered_map_hasher<_Key, _Cp, _Hash, false>
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     __unordered_map_hasher()
-        _NOEXCEPT_(is_nothrow_default_constructible<_Hash>::value)
+        noexcept(is_nothrow_default_constructible<_Hash>::value)
         : __hash_() {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __unordered_map_hasher(const _Hash& __h)
-        _NOEXCEPT_(is_nothrow_copy_constructible<_Hash>::value)
+        noexcept(is_nothrow_copy_constructible<_Hash>::value)
         : __hash_(__h) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const _Hash& hash_function() const _NOEXCEPT {return __hash_;}
+    const _Hash& hash_function() const noexcept {return __hash_;}
     _LIBCUDACXX_INLINE_VISIBILITY
     size_t operator()(const _Cp& __x) const
         {return __hash_(__x.__get_value().first);}
@@ -473,7 +473,7 @@ public:
     size_t operator()(const _Key& __x) const
         {return __hash_(__x);}
     void swap(__unordered_map_hasher&__y)
-        _NOEXCEPT_(__is_nothrow_swappable<_Hash>::value)
+        noexcept(__is_nothrow_swappable<_Hash>::value)
     {
         using _CUDA_VSTD::swap;
         swap(__hash_, __y.__hash_);
@@ -485,7 +485,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__unordered_map_hasher<_Key, _Cp, _Hash, __b>& __x,
      __unordered_map_hasher<_Key, _Cp, _Hash, __b>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -498,14 +498,14 @@ class __unordered_map_equal
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     __unordered_map_equal()
-        _NOEXCEPT_(is_nothrow_default_constructible<_Pred>::value)
+        noexcept(is_nothrow_default_constructible<_Pred>::value)
         : _Pred() {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __unordered_map_equal(const _Pred& __p)
-        _NOEXCEPT_(is_nothrow_copy_constructible<_Pred>::value)
+        noexcept(is_nothrow_copy_constructible<_Pred>::value)
         : _Pred(__p) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const _Pred& key_eq() const _NOEXCEPT {return *this;}
+    const _Pred& key_eq() const noexcept {return *this;}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool operator()(const _Cp& __x, const _Cp& __y) const
         {return static_cast<const _Pred&>(*this)(__x.__get_value().first, __y.__get_value().first);}
@@ -516,7 +516,7 @@ public:
     bool operator()(const _Key& __x, const _Cp& __y) const
         {return static_cast<const _Pred&>(*this)(__x, __y.__get_value().first);}
     void swap(__unordered_map_equal&__y)
-        _NOEXCEPT_(__is_nothrow_swappable<_Pred>::value)
+        noexcept(__is_nothrow_swappable<_Pred>::value)
     {
         using _CUDA_VSTD::swap;
         swap(static_cast<_Pred&>(*this), static_cast<_Pred&>(__y));
@@ -530,14 +530,14 @@ class __unordered_map_equal<_Key, _Cp, _Pred, false>
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
     __unordered_map_equal()
-        _NOEXCEPT_(is_nothrow_default_constructible<_Pred>::value)
+        noexcept(is_nothrow_default_constructible<_Pred>::value)
         : __pred_() {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __unordered_map_equal(const _Pred& __p)
-        _NOEXCEPT_(is_nothrow_copy_constructible<_Pred>::value)
+        noexcept(is_nothrow_copy_constructible<_Pred>::value)
         : __pred_(__p) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const _Pred& key_eq() const _NOEXCEPT {return __pred_;}
+    const _Pred& key_eq() const noexcept {return __pred_;}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool operator()(const _Cp& __x, const _Cp& __y) const
         {return __pred_(__x.__get_value().first, __y.__get_value().first);}
@@ -548,7 +548,7 @@ public:
     bool operator()(const _Key& __x, const _Cp& __y) const
         {return __pred_(__x, __y.__get_value().first);}
     void swap(__unordered_map_equal&__y)
-        _NOEXCEPT_(__is_nothrow_swappable<_Pred>::value)
+        noexcept(__is_nothrow_swappable<_Pred>::value)
     {
         using _CUDA_VSTD::swap;
         swap(__pred_, __y.__pred_);
@@ -560,7 +560,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__unordered_map_equal<_Key, _Cp, _Pred, __b>& __x,
      __unordered_map_equal<_Key, _Cp, _Pred, __b>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -585,7 +585,7 @@ public:
     bool __second_constructed;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit __hash_map_node_destructor(allocator_type& __na) _NOEXCEPT
+    explicit __hash_map_node_destructor(allocator_type& __na) noexcept
         : __na_(__na),
           __first_constructed(false),
           __second_constructed(false)
@@ -594,7 +594,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     __hash_map_node_destructor(__hash_node_destructor<allocator_type>&& __x)
-        _NOEXCEPT
+        noexcept
         : __na_(__x.__na_),
           __first_constructed(__x.__value_constructed),
           __second_constructed(__x.__value_constructed)
@@ -613,7 +613,7 @@ public:
 #endif  // _LIBCUDACXX_CXX03_LANG
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void operator()(pointer __p) _NOEXCEPT
+    void operator()(pointer __p) noexcept
     {
         if (__second_constructed)
             __alloc_traits::destroy(__na_, _CUDA_VSTD::addressof(__p->__value_.__get_value().second));
@@ -748,10 +748,10 @@ public:
     typedef typename _NodeTypes::__map_value_type_pointer       pointer;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_map_iterator() _NOEXCEPT {}
+    __hash_map_iterator() noexcept {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_map_iterator(_HashIterator __i) _NOEXCEPT : __i_(__i) {}
+    __hash_map_iterator(_HashIterator __i) noexcept : __i_(__i) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     reference operator*() const {return __i_->__get_value();}
@@ -797,14 +797,14 @@ public:
     typedef typename _NodeTypes::__const_map_value_type_pointer  pointer;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_map_const_iterator() _NOEXCEPT {}
+    __hash_map_const_iterator() noexcept {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    __hash_map_const_iterator(_HashIterator __i) _NOEXCEPT : __i_(__i) {}
+    __hash_map_const_iterator(_HashIterator __i) noexcept : __i_(__i) {}
     _LIBCUDACXX_INLINE_VISIBILITY
     __hash_map_const_iterator(
             __hash_map_iterator<typename _HashIterator::__non_const_iterator> __i)
-                 _NOEXCEPT
+                 noexcept
                 : __i_(__i.__i_) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -902,7 +902,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_map()
-        _NOEXCEPT_(is_nothrow_default_constructible<__table>::value)
+        noexcept(is_nothrow_default_constructible<__table>::value)
         {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
             __get_db()->__insert_c(this);
@@ -931,7 +931,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_map(unordered_map&& __u)
-        _NOEXCEPT_(is_nothrow_move_constructible<__table>::value);
+        noexcept(is_nothrow_move_constructible<__table>::value);
     unordered_map(unordered_map&& __u, const allocator_type& __a);
     unordered_map(initializer_list<value_type> __il);
     unordered_map(initializer_list<value_type> __il, size_type __n,
@@ -989,34 +989,34 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_map& operator=(unordered_map&& __u)
-        _NOEXCEPT_(is_nothrow_move_assignable<__table>::value);
+        noexcept(is_nothrow_move_assignable<__table>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_map& operator=(initializer_list<value_type> __il);
 #endif  // _LIBCUDACXX_CXX03_LANG
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT
+    allocator_type get_allocator() const noexcept
         {return allocator_type(__table_.__node_alloc());}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool      empty() const _NOEXCEPT {return __table_.size() == 0;}
+    bool      empty() const noexcept {return __table_.size() == 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT  {return __table_.size();}
+    size_type size() const noexcept  {return __table_.size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {return __table_.max_size();}
+    size_type max_size() const noexcept {return __table_.max_size();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       begin() _NOEXCEPT        {return __table_.begin();}
+    iterator       begin() noexcept        {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       end() _NOEXCEPT          {return __table_.end();}
+    iterator       end() noexcept          {return __table_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin()  const _NOEXCEPT {return __table_.begin();}
+    const_iterator begin()  const noexcept {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()    const _NOEXCEPT {return __table_.end();}
+    const_iterator end()    const noexcept {return __table_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT {return __table_.begin();}
+    const_iterator cbegin() const noexcept {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend()   const _NOEXCEPT {return __table_.end();}
+    const_iterator cend()   const noexcept {return __table_.end();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     pair<iterator, bool> insert(const value_type& __x)
@@ -1197,7 +1197,7 @@ public:
     iterator erase(const_iterator __first, const_iterator __last)
         {return __table_.erase(__first.__i_, __last.__i_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-        void clear() _NOEXCEPT {__table_.clear();}
+        void clear() noexcept {__table_.clear();}
 
 #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1264,7 +1264,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(unordered_map& __u)
-        _NOEXCEPT_(__is_nothrow_swappable<__table>::value)
+        noexcept(__is_nothrow_swappable<__table>::value)
         { __table_.swap(__u.__table_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1300,9 +1300,9 @@ public:
     const mapped_type& at(const key_type& __k) const;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type bucket_count() const _NOEXCEPT {return __table_.bucket_count();}
+    size_type bucket_count() const noexcept {return __table_.bucket_count();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_bucket_count() const _NOEXCEPT {return __table_.max_bucket_count();}
+    size_type max_bucket_count() const noexcept {return __table_.max_bucket_count();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     size_type bucket_size(size_type __n) const
@@ -1324,9 +1324,9 @@ public:
     const_local_iterator cend(size_type __n) const   {return __table_.cend(__n);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    float load_factor() const _NOEXCEPT {return __table_.load_factor();}
+    float load_factor() const noexcept {return __table_.load_factor();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    float max_load_factor() const _NOEXCEPT {return __table_.max_load_factor();}
+    float max_load_factor() const noexcept {return __table_.max_load_factor();}
     _LIBCUDACXX_INLINE_VISIBILITY
     void max_load_factor(float __mlf) {__table_.max_load_factor(__mlf);}
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1524,7 +1524,7 @@ template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 inline
 unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(
         unordered_map&& __u)
-    _NOEXCEPT_(is_nothrow_move_constructible<__table>::value)
+    noexcept(is_nothrow_move_constructible<__table>::value)
     : __table_(_CUDA_VSTD::move(__u.__table_))
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -1595,7 +1595,7 @@ template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 inline
 unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>&
 unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator=(unordered_map&& __u)
-    _NOEXCEPT_(is_nothrow_move_assignable<__table>::value)
+    noexcept(is_nothrow_move_assignable<__table>::value)
 {
     __table_ = _CUDA_VSTD::move(__u.__table_);
     return *this;
@@ -1698,7 +1698,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
      unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -1799,7 +1799,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_multimap()
-        _NOEXCEPT_(is_nothrow_default_constructible<__table>::value)
+        noexcept(is_nothrow_default_constructible<__table>::value)
         {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
             __get_db()->__insert_c(this);
@@ -1828,7 +1828,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_multimap(unordered_multimap&& __u)
-        _NOEXCEPT_(is_nothrow_move_constructible<__table>::value);
+        noexcept(is_nothrow_move_constructible<__table>::value);
     unordered_multimap(unordered_multimap&& __u, const allocator_type& __a);
     unordered_multimap(initializer_list<value_type> __il);
     unordered_multimap(initializer_list<value_type> __il, size_type __n,
@@ -1887,34 +1887,34 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_multimap& operator=(unordered_multimap&& __u)
-        _NOEXCEPT_(is_nothrow_move_assignable<__table>::value);
+        noexcept(is_nothrow_move_assignable<__table>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_multimap& operator=(initializer_list<value_type> __il);
 #endif  // _LIBCUDACXX_CXX03_LANG
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT
+    allocator_type get_allocator() const noexcept
         {return allocator_type(__table_.__node_alloc());}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool      empty() const _NOEXCEPT {return __table_.size() == 0;}
+    bool      empty() const noexcept {return __table_.size() == 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT  {return __table_.size();}
+    size_type size() const noexcept  {return __table_.size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {return __table_.max_size();}
+    size_type max_size() const noexcept {return __table_.max_size();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       begin() _NOEXCEPT        {return __table_.begin();}
+    iterator       begin() noexcept        {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       end() _NOEXCEPT          {return __table_.end();}
+    iterator       end() noexcept          {return __table_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin()  const _NOEXCEPT {return __table_.begin();}
+    const_iterator begin()  const noexcept {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()    const _NOEXCEPT {return __table_.end();}
+    const_iterator end()    const noexcept {return __table_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT {return __table_.begin();}
+    const_iterator cbegin() const noexcept {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend()   const _NOEXCEPT {return __table_.end();}
+    const_iterator cend()   const noexcept {return __table_.end();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     iterator insert(const value_type& __x) {return __table_.__insert_multi(__x);}
@@ -1972,7 +1972,7 @@ public:
     iterator erase(const_iterator __first, const_iterator __last)
         {return __table_.erase(__first.__i_, __last.__i_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {__table_.clear();}
+    void clear() noexcept {__table_.clear();}
 
 #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2039,7 +2039,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(unordered_multimap& __u)
-        _NOEXCEPT_(__is_nothrow_swappable<__table>::value)
+        noexcept(__is_nothrow_swappable<__table>::value)
         {__table_.swap(__u.__table_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2067,9 +2067,9 @@ public:
         {return __table_.__equal_range_multi(__k);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type bucket_count() const _NOEXCEPT {return __table_.bucket_count();}
+    size_type bucket_count() const noexcept {return __table_.bucket_count();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_bucket_count() const _NOEXCEPT
+    size_type max_bucket_count() const noexcept
         {return __table_.max_bucket_count();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2092,9 +2092,9 @@ public:
     const_local_iterator cend(size_type __n) const   {return __table_.cend(__n);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    float load_factor() const _NOEXCEPT {return __table_.load_factor();}
+    float load_factor() const noexcept {return __table_.load_factor();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    float max_load_factor() const _NOEXCEPT {return __table_.max_load_factor();}
+    float max_load_factor() const noexcept {return __table_.max_load_factor();}
     _LIBCUDACXX_INLINE_VISIBILITY
     void max_load_factor(float __mlf) {__table_.max_load_factor(__mlf);}
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2288,7 +2288,7 @@ template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 inline
 unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_multimap(
         unordered_multimap&& __u)
-    _NOEXCEPT_(is_nothrow_move_constructible<__table>::value)
+    noexcept(is_nothrow_move_constructible<__table>::value)
     : __table_(_CUDA_VSTD::move(__u.__table_))
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -2360,7 +2360,7 @@ template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 inline
 unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>&
 unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::operator=(unordered_multimap&& __u)
-    _NOEXCEPT_(is_nothrow_move_assignable<__table>::value)
+    noexcept(is_nothrow_move_assignable<__table>::value)
 {
     __table_ = _CUDA_VSTD::move(__u.__table_);
     return *this;
@@ -2396,7 +2396,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
      unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/unordered_set
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/unordered_set
@@ -421,7 +421,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_set()
-        _NOEXCEPT_(is_nothrow_default_constructible<__table>::value)
+        noexcept(is_nothrow_default_constructible<__table>::value)
         {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
             __get_db()->__insert_c(this);
@@ -467,7 +467,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_set(unordered_set&& __u)
-        _NOEXCEPT_(is_nothrow_move_constructible<__table>::value);
+        noexcept(is_nothrow_move_constructible<__table>::value);
     unordered_set(unordered_set&& __u, const allocator_type& __a);
     unordered_set(initializer_list<value_type> __il);
     unordered_set(initializer_list<value_type> __il, size_type __n,
@@ -501,34 +501,34 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_set& operator=(unordered_set&& __u)
-        _NOEXCEPT_(is_nothrow_move_assignable<__table>::value);
+        noexcept(is_nothrow_move_assignable<__table>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_set& operator=(initializer_list<value_type> __il);
 #endif  // _LIBCUDACXX_CXX03_LANG
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT
+    allocator_type get_allocator() const noexcept
         {return allocator_type(__table_.__node_alloc());}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool      empty() const _NOEXCEPT {return __table_.size() == 0;}
+    bool      empty() const noexcept {return __table_.size() == 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT  {return __table_.size();}
+    size_type size() const noexcept  {return __table_.size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {return __table_.max_size();}
+    size_type max_size() const noexcept {return __table_.max_size();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       begin() _NOEXCEPT        {return __table_.begin();}
+    iterator       begin() noexcept        {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       end() _NOEXCEPT          {return __table_.end();}
+    iterator       end() noexcept          {return __table_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin()  const _NOEXCEPT {return __table_.begin();}
+    const_iterator begin()  const noexcept {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()    const _NOEXCEPT {return __table_.end();}
+    const_iterator end()    const noexcept {return __table_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT {return __table_.begin();}
+    const_iterator cbegin() const noexcept {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend()   const _NOEXCEPT {return __table_.end();}
+    const_iterator cend()   const noexcept {return __table_.end();}
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     template <class... _Args>
@@ -599,7 +599,7 @@ public:
     iterator erase(const_iterator __first, const_iterator __last)
         {return __table_.erase(__first, __last);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {__table_.clear();}
+    void clear() noexcept {__table_.clear();}
 
 #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -665,7 +665,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(unordered_set& __u)
-        _NOEXCEPT_(__is_nothrow_swappable<__table>::value)
+        noexcept(__is_nothrow_swappable<__table>::value)
         {__table_.swap(__u.__table_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -691,9 +691,9 @@ public:
         {return __table_.__equal_range_unique(__k);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type bucket_count() const _NOEXCEPT {return __table_.bucket_count();}
+    size_type bucket_count() const noexcept {return __table_.bucket_count();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_bucket_count() const _NOEXCEPT {return __table_.max_bucket_count();}
+    size_type max_bucket_count() const noexcept {return __table_.max_bucket_count();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     size_type bucket_size(size_type __n) const {return __table_.bucket_size(__n);}
@@ -714,9 +714,9 @@ public:
     const_local_iterator cend(size_type __n) const   {return __table_.cend(__n);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    float load_factor() const _NOEXCEPT {return __table_.load_factor();}
+    float load_factor() const noexcept {return __table_.load_factor();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    float max_load_factor() const _NOEXCEPT {return __table_.max_load_factor();}
+    float max_load_factor() const noexcept {return __table_.max_load_factor();}
     _LIBCUDACXX_INLINE_VISIBILITY
     void max_load_factor(float __mlf) {__table_.max_load_factor(__mlf);}
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -897,7 +897,7 @@ template <class _Value, class _Hash, class _Pred, class _Alloc>
 inline
 unordered_set<_Value, _Hash, _Pred, _Alloc>::unordered_set(
         unordered_set&& __u)
-    _NOEXCEPT_(is_nothrow_move_constructible<__table>::value)
+    noexcept(is_nothrow_move_constructible<__table>::value)
     : __table_(_CUDA_VSTD::move(__u.__table_))
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -966,7 +966,7 @@ template <class _Value, class _Hash, class _Pred, class _Alloc>
 inline
 unordered_set<_Value, _Hash, _Pred, _Alloc>&
 unordered_set<_Value, _Hash, _Pred, _Alloc>::operator=(unordered_set&& __u)
-    _NOEXCEPT_(is_nothrow_move_assignable<__table>::value)
+    noexcept(is_nothrow_move_assignable<__table>::value)
 {
     __table_ = _CUDA_VSTD::move(__u.__table_);
     return *this;
@@ -1000,7 +1000,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(unordered_set<_Value, _Hash, _Pred, _Alloc>& __x,
      unordered_set<_Value, _Hash, _Pred, _Alloc>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -1083,7 +1083,7 @@ public:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_multiset()
-        _NOEXCEPT_(is_nothrow_default_constructible<__table>::value)
+        noexcept(is_nothrow_default_constructible<__table>::value)
         {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
             __get_db()->__insert_c(this);
@@ -1130,7 +1130,7 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_multiset(unordered_multiset&& __u)
-        _NOEXCEPT_(is_nothrow_move_constructible<__table>::value);
+        noexcept(is_nothrow_move_constructible<__table>::value);
     unordered_multiset(unordered_multiset&& __u, const allocator_type& __a);
     unordered_multiset(initializer_list<value_type> __il);
     unordered_multiset(initializer_list<value_type> __il, size_type __n,
@@ -1162,33 +1162,33 @@ public:
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
     unordered_multiset& operator=(unordered_multiset&& __u)
-        _NOEXCEPT_(is_nothrow_move_assignable<__table>::value);
+        noexcept(is_nothrow_move_assignable<__table>::value);
     unordered_multiset& operator=(initializer_list<value_type> __il);
 #endif  // _LIBCUDACXX_CXX03_LANG
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT
+    allocator_type get_allocator() const noexcept
         {return allocator_type(__table_.__node_alloc());}
 
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool      empty() const _NOEXCEPT {return __table_.size() == 0;}
+    bool      empty() const noexcept {return __table_.size() == 0;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT  {return __table_.size();}
+    size_type size() const noexcept  {return __table_.size();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_size() const _NOEXCEPT {return __table_.max_size();}
+    size_type max_size() const noexcept {return __table_.max_size();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       begin() _NOEXCEPT        {return __table_.begin();}
+    iterator       begin() noexcept        {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       end() _NOEXCEPT          {return __table_.end();}
+    iterator       end() noexcept          {return __table_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin()  const _NOEXCEPT {return __table_.begin();}
+    const_iterator begin()  const noexcept {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()    const _NOEXCEPT {return __table_.end();}
+    const_iterator end()    const noexcept {return __table_.end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cbegin() const _NOEXCEPT {return __table_.begin();}
+    const_iterator cbegin() const noexcept {return __table_.begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator cend()   const _NOEXCEPT {return __table_.end();}
+    const_iterator cend()   const noexcept {return __table_.end();}
 
 #ifndef _LIBCUDACXX_CXX03_LANG
     template <class... _Args>
@@ -1292,11 +1292,11 @@ public:
     iterator erase(const_iterator __first, const_iterator __last)
         {return __table_.erase(__first, __last);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {__table_.clear();}
+    void clear() noexcept {__table_.clear();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void swap(unordered_multiset& __u)
-        _NOEXCEPT_(__is_nothrow_swappable<__table>::value)
+        noexcept(__is_nothrow_swappable<__table>::value)
         {__table_.swap(__u.__table_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1322,9 +1322,9 @@ public:
         {return __table_.__equal_range_multi(__k);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type bucket_count() const _NOEXCEPT {return __table_.bucket_count();}
+    size_type bucket_count() const noexcept {return __table_.bucket_count();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type max_bucket_count() const _NOEXCEPT {return __table_.max_bucket_count();}
+    size_type max_bucket_count() const noexcept {return __table_.max_bucket_count();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     size_type bucket_size(size_type __n) const {return __table_.bucket_size(__n);}
@@ -1345,9 +1345,9 @@ public:
     const_local_iterator cend(size_type __n) const   {return __table_.cend(__n);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    float load_factor() const _NOEXCEPT {return __table_.load_factor();}
+    float load_factor() const noexcept {return __table_.load_factor();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    float max_load_factor() const _NOEXCEPT {return __table_.max_load_factor();}
+    float max_load_factor() const noexcept {return __table_.max_load_factor();}
     _LIBCUDACXX_INLINE_VISIBILITY
     void max_load_factor(float __mlf) {__table_.max_load_factor(__mlf);}
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1527,7 +1527,7 @@ template <class _Value, class _Hash, class _Pred, class _Alloc>
 inline
 unordered_multiset<_Value, _Hash, _Pred, _Alloc>::unordered_multiset(
         unordered_multiset&& __u)
-    _NOEXCEPT_(is_nothrow_move_constructible<__table>::value)
+    noexcept(is_nothrow_move_constructible<__table>::value)
     : __table_(_CUDA_VSTD::move(__u.__table_))
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
@@ -1597,7 +1597,7 @@ inline
 unordered_multiset<_Value, _Hash, _Pred, _Alloc>&
 unordered_multiset<_Value, _Hash, _Pred, _Alloc>::operator=(
         unordered_multiset&& __u)
-    _NOEXCEPT_(is_nothrow_move_assignable<__table>::value)
+    noexcept(is_nothrow_move_assignable<__table>::value)
 {
     __table_ = _CUDA_VSTD::move(__u.__table_);
     return *this;
@@ -1631,7 +1631,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __x,
      unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/valarray
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/valarray
@@ -847,7 +847,7 @@ public:
     valarray(const valarray& __v);
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
-    valarray(valarray&& __v) _NOEXCEPT;
+    valarray(valarray&& __v) noexcept;
     valarray(initializer_list<value_type> __il);
 #endif // _LIBCUDACXX_CXX03_LANG
     valarray(const slice_array<value_type>& __sa);
@@ -861,7 +861,7 @@ public:
     valarray& operator=(const valarray& __v);
 #ifndef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
-    valarray& operator=(valarray&& __v) _NOEXCEPT;
+    valarray& operator=(valarray&& __v) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
     valarray& operator=(initializer_list<value_type>);
 #endif // _LIBCUDACXX_CXX03_LANG
@@ -1046,7 +1046,7 @@ public:
 
     // member functions:
     _LIBCUDACXX_INLINE_VISIBILITY
-    void swap(valarray& __v) _NOEXCEPT;
+    void swap(valarray& __v) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     size_t size() const {return static_cast<size_t>(__end_ - __begin_);}
@@ -2893,7 +2893,7 @@ valarray<_Tp>::valarray(const valarray& __v)
 
 template <class _Tp>
 inline
-valarray<_Tp>::valarray(valarray&& __v) _NOEXCEPT
+valarray<_Tp>::valarray(valarray&& __v) noexcept
     : __begin_(__v.__begin_),
       __end_(__v.__end_)
 {
@@ -3081,7 +3081,7 @@ valarray<_Tp>::operator=(const valarray& __v)
 template <class _Tp>
 inline
 valarray<_Tp>&
-valarray<_Tp>::operator=(valarray&& __v) _NOEXCEPT
+valarray<_Tp>::operator=(valarray&& __v) noexcept
 {
     __clear(size());
     __begin_ = __v.__begin_;
@@ -3602,7 +3602,7 @@ valarray<_Tp>::operator>>=(const _Expr& __v)
 template <class _Tp>
 inline
 void
-valarray<_Tp>::swap(valarray& __v) _NOEXCEPT
+valarray<_Tp>::swap(valarray& __v) noexcept
 {
     _CUDA_VSTD::swap(__begin_, __v.__begin_);
     _CUDA_VSTD::swap(__end_, __v.__end_);
@@ -3768,7 +3768,7 @@ valarray<_Tp>::resize(size_t __n, value_type __x)
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-swap(valarray<_Tp>& __x, valarray<_Tp>& __y) _NOEXCEPT
+swap(valarray<_Tp>& __x, valarray<_Tp>& __y) noexcept
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/variant
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/variant
@@ -219,7 +219,7 @@ namespace std { // explicitly not using versioning namespace
 
 class _LIBCUDACXX_EXCEPTION_ABI _LIBCUDACXX_AVAILABILITY_BAD_VARIANT_ACCESS bad_variant_access : public exception {
 public:
-  virtual const char* what() const _NOEXCEPT;
+  virtual const char* what() const noexcept;
 };
 
 } // namespace std
@@ -1653,7 +1653,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<monostate> {
   using result_type = size_t;
 
   inline _LIBCUDACXX_INLINE_VISIBILITY
-  result_type operator()(const argument_type&) const _NOEXCEPT {
+  result_type operator()(const argument_type&) const noexcept {
     return 66740831; // return a fundamentally attractive random value.
   }
 };

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/vector
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/vector
@@ -344,35 +344,35 @@ protected:
     __compressed_pair<pointer, allocator_type> __end_cap_;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type& __alloc() _NOEXCEPT
+    allocator_type& __alloc() noexcept
         {return __end_cap_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const allocator_type& __alloc() const _NOEXCEPT
+    const allocator_type& __alloc() const noexcept
         {return __end_cap_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    pointer& __end_cap() _NOEXCEPT
+    pointer& __end_cap() noexcept
         {return __end_cap_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const pointer& __end_cap() const _NOEXCEPT
+    const pointer& __end_cap() const noexcept
         {return __end_cap_.first();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     __vector_base()
-        _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value);
+        noexcept(is_nothrow_default_constructible<allocator_type>::value);
     _LIBCUDACXX_INLINE_VISIBILITY __vector_base(const allocator_type& __a);
 #ifndef _LIBCUDACXX_CXX03_LANG
-    _LIBCUDACXX_INLINE_VISIBILITY __vector_base(allocator_type&& __a) _NOEXCEPT;
+    _LIBCUDACXX_INLINE_VISIBILITY __vector_base(allocator_type&& __a) noexcept;
 #endif
     ~__vector_base();
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {__destruct_at_end(__begin_);}
+    void clear() noexcept {__destruct_at_end(__begin_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type capacity() const _NOEXCEPT
+    size_type capacity() const noexcept
         {return static_cast<size_type>(__end_cap() - __begin_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __destruct_at_end(pointer __new_last) _NOEXCEPT;
+    void __destruct_at_end(pointer __new_last) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __copy_assign_alloc(const __vector_base& __c)
@@ -381,7 +381,7 @@ protected:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__vector_base& __c)
-        _NOEXCEPT_(
+        noexcept(
             !__alloc_traits::propagate_on_container_move_assignment::value ||
             is_nothrow_move_assignable<allocator_type>::value)
         {__move_assign_alloc(__c, integral_constant<bool,
@@ -405,21 +405,21 @@ private:
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__vector_base& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+        noexcept(is_nothrow_move_assignable<allocator_type>::value)
         {
             __alloc() = _CUDA_VSTD::move(__c.__alloc());
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(__vector_base&, false_type)
-        _NOEXCEPT
+        noexcept
         {}
 };
 
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
-__vector_base<_Tp, _Allocator>::__destruct_at_end(pointer __new_last) _NOEXCEPT
+__vector_base<_Tp, _Allocator>::__destruct_at_end(pointer __new_last) noexcept
 {
     pointer __soon_to_be_end = __end_;
     while (__new_last != __soon_to_be_end)
@@ -430,7 +430,7 @@ __vector_base<_Tp, _Allocator>::__destruct_at_end(pointer __new_last) _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 __vector_base<_Tp, _Allocator>::__vector_base()
-        _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
+        noexcept(is_nothrow_default_constructible<allocator_type>::value)
     : __begin_(nullptr),
       __end_(nullptr),
       __end_cap_(nullptr)
@@ -449,7 +449,7 @@ __vector_base<_Tp, _Allocator>::__vector_base(const allocator_type& __a)
 #ifndef _LIBCUDACXX_CXX03_LANG
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-__vector_base<_Tp, _Allocator>::__vector_base(allocator_type&& __a) _NOEXCEPT
+__vector_base<_Tp, _Allocator>::__vector_base(allocator_type&& __a) noexcept
     : __begin_(nullptr),
       __end_(nullptr),
       __end_cap_(nullptr, std::move(__a)) {}
@@ -492,7 +492,7 @@ public:
                   "Allocator::value_type must be same type as value_type");
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
+    vector() noexcept(is_nothrow_default_constructible<allocator_type>::value)
         {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
             __get_db()->__insert_c(this);
@@ -500,9 +500,9 @@ public:
         }
     _LIBCUDACXX_INLINE_VISIBILITY explicit vector(const allocator_type& __a)
 #if _LIBCUDACXX_STD_VER <= 14
-        _NOEXCEPT_(is_nothrow_copy_constructible<allocator_type>::value)
+        noexcept(is_nothrow_copy_constructible<allocator_type>::value)
 #else
-        _NOEXCEPT
+        noexcept
 #endif
         : __base(__a)
     {
@@ -569,16 +569,16 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     vector(vector&& __x)
 #if _LIBCUDACXX_STD_VER > 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value);
+        noexcept(is_nothrow_move_constructible<allocator_type>::value);
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
     vector(vector&& __x, const allocator_type& __a);
     _LIBCUDACXX_INLINE_VISIBILITY
     vector& operator=(vector&& __x)
-        _NOEXCEPT_((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value));
+        noexcept((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value));
 
     _LIBCUDACXX_INLINE_VISIBILITY
     vector& operator=(initializer_list<value_type> __il)
@@ -617,84 +617,84 @@ public:
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    allocator_type get_allocator() const _NOEXCEPT
+    allocator_type get_allocator() const noexcept
         {return this->__alloc();}
 
-    _LIBCUDACXX_INLINE_VISIBILITY iterator               begin() _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY const_iterator         begin()   const _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY iterator               end() _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY const_iterator         end()     const _NOEXCEPT;
+    _LIBCUDACXX_INLINE_VISIBILITY iterator               begin() noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY const_iterator         begin()   const noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY iterator               end() noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY const_iterator         end()     const noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator       rbegin() _NOEXCEPT
+    reverse_iterator       rbegin() noexcept
         {return       reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin()  const _NOEXCEPT
+    const_reverse_iterator rbegin()  const noexcept
         {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator       rend() _NOEXCEPT
+    reverse_iterator       rend() noexcept
         {return       reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend()    const _NOEXCEPT
+    const_reverse_iterator rend()    const noexcept
         {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator         cbegin()  const _NOEXCEPT
+    const_iterator         cbegin()  const noexcept
         {return begin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator         cend()    const _NOEXCEPT
+    const_iterator         cend()    const noexcept
         {return end();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT
+    const_reverse_iterator crbegin() const noexcept
         {return rbegin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend()   const _NOEXCEPT
+    const_reverse_iterator crend()   const noexcept
         {return rend();}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT
+    size_type size() const noexcept
         {return static_cast<size_type>(this->__end_ - this->__begin_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type capacity() const _NOEXCEPT
+    size_type capacity() const noexcept
         {return __base::capacity();}
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT
+    bool empty() const noexcept
         {return this->__begin_ == this->__end_;}
-    size_type max_size() const _NOEXCEPT;
+    size_type max_size() const noexcept;
     void reserve(size_type __n);
-    void shrink_to_fit() _NOEXCEPT;
+    void shrink_to_fit() noexcept;
 
-    _LIBCUDACXX_INLINE_VISIBILITY reference       operator[](size_type __n) _NOEXCEPT;
-    _LIBCUDACXX_INLINE_VISIBILITY const_reference operator[](size_type __n) const _NOEXCEPT;
+    _LIBCUDACXX_INLINE_VISIBILITY reference       operator[](size_type __n) noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY const_reference operator[](size_type __n) const noexcept;
     reference       at(size_type __n);
     const_reference at(size_type __n) const;
 
-    _LIBCUDACXX_INLINE_VISIBILITY reference       front() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY reference       front() noexcept
     {
         _LIBCUDACXX_ASSERT(!empty(), "front() called for empty vector");
         return *this->__begin_;
     }
-    _LIBCUDACXX_INLINE_VISIBILITY const_reference front() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY const_reference front() const noexcept
     {
         _LIBCUDACXX_ASSERT(!empty(), "front() called for empty vector");
         return *this->__begin_;
     }
-    _LIBCUDACXX_INLINE_VISIBILITY reference       back() _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY reference       back() noexcept
     {
         _LIBCUDACXX_ASSERT(!empty(), "back() called for empty vector");
         return *(this->__end_ - 1);
     }
-    _LIBCUDACXX_INLINE_VISIBILITY const_reference back()  const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY const_reference back()  const noexcept
     {
         _LIBCUDACXX_ASSERT(!empty(), "back() called for empty vector");
         return *(this->__end_ - 1);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    value_type*       data() _NOEXCEPT
+    value_type*       data() noexcept
         {return _CUDA_VSTD::__to_raw_pointer(this->__begin_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const value_type* data() const _NOEXCEPT
+    const value_type* data() const noexcept
         {return _CUDA_VSTD::__to_raw_pointer(this->__begin_);}
 
 #ifdef _LIBCUDACXX_CXX03_LANG
@@ -766,7 +766,7 @@ public:
     iterator erase(const_iterator __first, const_iterator __last);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT
+    void clear() noexcept
     {
         size_type __old_size = size();
         __base::clear();
@@ -779,9 +779,9 @@ public:
 
     void swap(vector&)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                     __is_nothrow_swappable<allocator_type>::value);
 #endif
 
@@ -800,7 +800,7 @@ private:
     _LIBCUDACXX_INLINE_VISIBILITY void __invalidate_all_iterators();
     _LIBCUDACXX_INLINE_VISIBILITY void __invalidate_iterators_past(pointer __new_last);
     void __vallocate(size_type __n);
-    void __vdeallocate() _NOEXCEPT;
+    void __vdeallocate() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY size_type __recommend(size_type __new_size) const;
     void __construct_at_end(size_type __n);
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -815,18 +815,18 @@ private:
     void __append(size_type __n);
     void __append(size_type __n, const_reference __x);
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator       __make_iter(pointer __p) _NOEXCEPT;
+    iterator       __make_iter(pointer __p) noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator __make_iter(const_pointer __p) const _NOEXCEPT;
+    const_iterator __make_iter(const_pointer __p) const noexcept;
     void __swap_out_circular_buffer(__split_buffer<value_type, allocator_type&>& __v);
     pointer __swap_out_circular_buffer(__split_buffer<value_type, allocator_type&>& __v, pointer __p);
     void __move_range(pointer __from_s, pointer __from_e, pointer __to);
     void __move_assign(vector& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value);
+        noexcept(is_nothrow_move_assignable<allocator_type>::value);
     void __move_assign(vector& __c, false_type)
-        _NOEXCEPT_(__alloc_traits::is_always_equal::value);
+        noexcept(__alloc_traits::is_always_equal::value);
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __destruct_at_end(pointer __new_last) _NOEXCEPT
+    void __destruct_at_end(pointer __new_last) noexcept
     {
         __invalidate_iterators_past(__new_last);
         size_type __old_size = size();
@@ -864,29 +864,29 @@ private:
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
     void __annotate_contiguous_container(const void*, const void*, const void*,
-                                         const void*) const _NOEXCEPT {}
+                                         const void*) const noexcept {}
 #endif
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __annotate_new(size_type __current_size) const _NOEXCEPT {
+    void __annotate_new(size_type __current_size) const noexcept {
       __annotate_contiguous_container(data(), data() + capacity(),
                                       data() + capacity(), data() + __current_size);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __annotate_delete() const _NOEXCEPT {
+    void __annotate_delete() const noexcept {
       __annotate_contiguous_container(data(), data() + capacity(),
                                       data() + size(), data() + capacity());
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __annotate_increase(size_type __n) const _NOEXCEPT
+    void __annotate_increase(size_type __n) const noexcept
     {
       __annotate_contiguous_container(data(), data() + capacity(),
                                       data() + size(), data() + size() + __n);
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void __annotate_shrink(size_type __old_size) const _NOEXCEPT
+    void __annotate_shrink(size_type __old_size) const noexcept
     {
       __annotate_contiguous_container(data(), data() + capacity(),
                                       data() + __old_size, data() + size());
@@ -998,7 +998,7 @@ vector<_Tp, _Allocator>::__vallocate(size_type __n)
 
 template <class _Tp, class _Allocator>
 void
-vector<_Tp, _Allocator>::__vdeallocate() _NOEXCEPT
+vector<_Tp, _Allocator>::__vdeallocate() noexcept
 {
     if (this->__begin_ != nullptr)
     {
@@ -1010,7 +1010,7 @@ vector<_Tp, _Allocator>::__vdeallocate() _NOEXCEPT
 
 template <class _Tp, class _Allocator>
 typename vector<_Tp, _Allocator>::size_type
-vector<_Tp, _Allocator>::max_size() const _NOEXCEPT
+vector<_Tp, _Allocator>::max_size() const noexcept
 {
     return _CUDA_VSTD::min<size_type>(__alloc_traits::max_size(this->__alloc()),
                                  numeric_limits<difference_type>::max());
@@ -1280,9 +1280,9 @@ template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 vector<_Tp, _Allocator>::vector(vector&& __x)
 #if _LIBCUDACXX_STD_VER > 14
-        _NOEXCEPT
+        noexcept
 #else
-        _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
+        noexcept(is_nothrow_move_constructible<allocator_type>::value)
 #endif
     : __base(_CUDA_VSTD::move(__x.__alloc()))
 {
@@ -1354,7 +1354,7 @@ template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 vector<_Tp, _Allocator>&
 vector<_Tp, _Allocator>::operator=(vector&& __x)
-    _NOEXCEPT_((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value))
+    noexcept((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value))
 {
     __move_assign(__x, integral_constant<bool,
           __alloc_traits::propagate_on_container_move_assignment::value>());
@@ -1364,7 +1364,7 @@ vector<_Tp, _Allocator>::operator=(vector&& __x)
 template <class _Tp, class _Allocator>
 void
 vector<_Tp, _Allocator>::__move_assign(vector& __c, false_type)
-    _NOEXCEPT_(__alloc_traits::is_always_equal::value)
+    noexcept(__alloc_traits::is_always_equal::value)
 {
     if (__base::__alloc() != __c.__alloc())
     {
@@ -1378,7 +1378,7 @@ vector<_Tp, _Allocator>::__move_assign(vector& __c, false_type)
 template <class _Tp, class _Allocator>
 void
 vector<_Tp, _Allocator>::__move_assign(vector& __c, true_type)
-    _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+    noexcept(is_nothrow_move_assignable<allocator_type>::value)
 {
     __vdeallocate();
     __base::__move_assign_alloc(__c); // this can throw
@@ -1487,7 +1487,7 @@ vector<_Tp, _Allocator>::assign(size_type __n, const_reference __u)
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename vector<_Tp, _Allocator>::iterator
-vector<_Tp, _Allocator>::__make_iter(pointer __p) _NOEXCEPT
+vector<_Tp, _Allocator>::__make_iter(pointer __p) noexcept
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     return iterator(this, __p);
@@ -1499,7 +1499,7 @@ vector<_Tp, _Allocator>::__make_iter(pointer __p) _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename vector<_Tp, _Allocator>::const_iterator
-vector<_Tp, _Allocator>::__make_iter(const_pointer __p) const _NOEXCEPT
+vector<_Tp, _Allocator>::__make_iter(const_pointer __p) const noexcept
 {
 #ifdef _LIBCUDACXX_ENABLE_DEBUG_MODE
     return const_iterator(this, __p);
@@ -1511,7 +1511,7 @@ vector<_Tp, _Allocator>::__make_iter(const_pointer __p) const _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename vector<_Tp, _Allocator>::iterator
-vector<_Tp, _Allocator>::begin() _NOEXCEPT
+vector<_Tp, _Allocator>::begin() noexcept
 {
     return __make_iter(this->__begin_);
 }
@@ -1519,7 +1519,7 @@ vector<_Tp, _Allocator>::begin() _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename vector<_Tp, _Allocator>::const_iterator
-vector<_Tp, _Allocator>::begin() const _NOEXCEPT
+vector<_Tp, _Allocator>::begin() const noexcept
 {
     return __make_iter(this->__begin_);
 }
@@ -1527,7 +1527,7 @@ vector<_Tp, _Allocator>::begin() const _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename vector<_Tp, _Allocator>::iterator
-vector<_Tp, _Allocator>::end() _NOEXCEPT
+vector<_Tp, _Allocator>::end() noexcept
 {
     return __make_iter(this->__end_);
 }
@@ -1535,7 +1535,7 @@ vector<_Tp, _Allocator>::end() _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename vector<_Tp, _Allocator>::const_iterator
-vector<_Tp, _Allocator>::end() const _NOEXCEPT
+vector<_Tp, _Allocator>::end() const noexcept
 {
     return __make_iter(this->__end_);
 }
@@ -1543,7 +1543,7 @@ vector<_Tp, _Allocator>::end() const _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename vector<_Tp, _Allocator>::reference
-vector<_Tp, _Allocator>::operator[](size_type __n) _NOEXCEPT
+vector<_Tp, _Allocator>::operator[](size_type __n) noexcept
 {
     _LIBCUDACXX_ASSERT(__n < size(), "vector[] index out of bounds");
     return this->__begin_[__n];
@@ -1552,7 +1552,7 @@ vector<_Tp, _Allocator>::operator[](size_type __n) _NOEXCEPT
 template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 typename vector<_Tp, _Allocator>::const_reference
-vector<_Tp, _Allocator>::operator[](size_type __n) const _NOEXCEPT
+vector<_Tp, _Allocator>::operator[](size_type __n) const noexcept
 {
     _LIBCUDACXX_ASSERT(__n < size(), "vector[] index out of bounds");
     return this->__begin_[__n];
@@ -1590,7 +1590,7 @@ vector<_Tp, _Allocator>::reserve(size_type __n)
 
 template <class _Tp, class _Allocator>
 void
-vector<_Tp, _Allocator>::shrink_to_fit() _NOEXCEPT
+vector<_Tp, _Allocator>::shrink_to_fit() noexcept
 {
     if (capacity() > size())
     {
@@ -2039,9 +2039,9 @@ template <class _Tp, class _Allocator>
 void
 vector<_Tp, _Allocator>::swap(vector& __x)
 #if _LIBCUDACXX_STD_VER >= 14
-    _NOEXCEPT
+    noexcept
 #else
-    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+    noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                 __is_nothrow_swappable<allocator_type>::value)
 #endif
 {
@@ -2191,36 +2191,36 @@ public:
     typedef __bit_const_reference<vector>            const_reference;
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type& __cap() _NOEXCEPT
+    size_type& __cap() noexcept
         {return __cap_alloc_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const size_type& __cap() const _NOEXCEPT
+    const size_type& __cap() const noexcept
         {return __cap_alloc_.first();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    __storage_allocator& __alloc() _NOEXCEPT
+    __storage_allocator& __alloc() noexcept
         {return __cap_alloc_.second();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const __storage_allocator& __alloc() const _NOEXCEPT
+    const __storage_allocator& __alloc() const noexcept
         {return __cap_alloc_.second();}
 
     static const unsigned __bits_per_word = static_cast<unsigned>(sizeof(__storage_type) * CHAR_BIT);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static size_type __internal_cap_to_external(size_type __n) _NOEXCEPT
+    static size_type __internal_cap_to_external(size_type __n) noexcept
         {return __n * __bits_per_word;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    static size_type __external_cap_to_internal(size_type __n) _NOEXCEPT
+    static size_type __external_cap_to_internal(size_type __n) noexcept
         {return (__n - 1) / __bits_per_word + 1;}
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value);
+    vector() noexcept(is_nothrow_default_constructible<allocator_type>::value);
 
     _LIBCUDACXX_INLINE_VISIBILITY explicit vector(const allocator_type& __a)
 #if _LIBCUDACXX_STD_VER <= 14
-        _NOEXCEPT_(is_nothrow_copy_constructible<allocator_type>::value);
+        noexcept(is_nothrow_copy_constructible<allocator_type>::value);
 #else
-        _NOEXCEPT;
+        noexcept;
 #endif
     ~vector();
     explicit vector(size_type __n);
@@ -2255,14 +2255,14 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     vector(vector&& __v)
 #if _LIBCUDACXX_STD_VER > 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value);
+        noexcept(is_nothrow_move_constructible<allocator_type>::value);
 #endif
     vector(vector&& __v, const allocator_type& __a);
     _LIBCUDACXX_INLINE_VISIBILITY
     vector& operator=(vector&& __v)
-        _NOEXCEPT_((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value));
+        noexcept((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value));
 
     _LIBCUDACXX_INLINE_VISIBILITY
     vector& operator=(initializer_list<value_type> __il)
@@ -2294,59 +2294,59 @@ public:
         {assign(__il.begin(), __il.end());}
 #endif
 
-    _LIBCUDACXX_INLINE_VISIBILITY allocator_type get_allocator() const _NOEXCEPT
+    _LIBCUDACXX_INLINE_VISIBILITY allocator_type get_allocator() const noexcept
         {return allocator_type(this->__alloc());}
 
-    size_type max_size() const _NOEXCEPT;
+    size_type max_size() const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type capacity() const _NOEXCEPT
+    size_type capacity() const noexcept
         {return __internal_cap_to_external(__cap());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_type size() const _NOEXCEPT
+    size_type size() const noexcept
         {return __size_;}
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    bool empty() const _NOEXCEPT
+    bool empty() const noexcept
         {return __size_ == 0;}
     void reserve(size_type __n);
-    void shrink_to_fit() _NOEXCEPT;
+    void shrink_to_fit() noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator begin() _NOEXCEPT
+    iterator begin() noexcept
         {return __make_iter(0);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator begin() const _NOEXCEPT
+    const_iterator begin() const noexcept
         {return __make_iter(0);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator end() _NOEXCEPT
+    iterator end() noexcept
         {return __make_iter(__size_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator end()   const _NOEXCEPT
+    const_iterator end()   const noexcept
         {return __make_iter(__size_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator rbegin() _NOEXCEPT
+    reverse_iterator rbegin() noexcept
         {return       reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rbegin() const _NOEXCEPT
+    const_reverse_iterator rbegin() const noexcept
         {return const_reverse_iterator(end());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    reverse_iterator rend() _NOEXCEPT
+    reverse_iterator rend() noexcept
         {return       reverse_iterator(begin());}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator rend()   const _NOEXCEPT
+    const_reverse_iterator rend()   const noexcept
         {return const_reverse_iterator(begin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator         cbegin()  const _NOEXCEPT
+    const_iterator         cbegin()  const noexcept
         {return __make_iter(0);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator         cend()    const _NOEXCEPT
+    const_iterator         cend()    const noexcept
         {return __make_iter(__size_);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crbegin() const _NOEXCEPT
+    const_reverse_iterator crbegin() const noexcept
         {return rbegin();}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reverse_iterator crend()   const _NOEXCEPT
+    const_reverse_iterator crend()   const noexcept
         {return rend();}
 
     _LIBCUDACXX_INLINE_VISIBILITY reference       operator[](size_type __n)       {return __make_ref(__n);}
@@ -2412,28 +2412,28 @@ public:
     iterator erase(const_iterator __first, const_iterator __last);
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    void clear() _NOEXCEPT {__size_ = 0;}
+    void clear() noexcept {__size_ = 0;}
 
     void swap(vector&)
 #if _LIBCUDACXX_STD_VER >= 14
-        _NOEXCEPT;
+        noexcept;
 #else
-        _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+        noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                     __is_nothrow_swappable<allocator_type>::value);
 #endif
-    static void swap(reference __x, reference __y) _NOEXCEPT { _CUDA_VSTD::swap(__x, __y); }
+    static void swap(reference __x, reference __y) noexcept { _CUDA_VSTD::swap(__x, __y); }
 
     void resize(size_type __sz, value_type __x = false);
-    void flip() _NOEXCEPT;
+    void flip() noexcept;
 
     bool __invariants() const;
 
 private:
     _LIBCUDACXX_INLINE_VISIBILITY void __invalidate_all_iterators();
     void __vallocate(size_type __n);
-    void __vdeallocate() _NOEXCEPT;
+    void __vdeallocate() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static size_type __align_it(size_type __new_size) _NOEXCEPT
+    static size_type __align_it(size_type __new_size) noexcept
         {return __new_size + (__bits_per_word-1) & ~((size_type)__bits_per_word-1);}
     _LIBCUDACXX_INLINE_VISIBILITY  size_type __recommend(size_type __new_size) const;
     _LIBCUDACXX_INLINE_VISIBILITY void __construct_at_end(size_type __n, bool __x);
@@ -2446,19 +2446,19 @@ private:
         __construct_at_end(_ForwardIterator __first, _ForwardIterator __last);
     void __append(size_type __n, const_reference __x);
     _LIBCUDACXX_INLINE_VISIBILITY
-    reference __make_ref(size_type __pos) _NOEXCEPT
+    reference __make_ref(size_type __pos) noexcept
         {return reference(__begin_ + __pos / __bits_per_word, __storage_type(1) << __pos % __bits_per_word);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_reference __make_ref(size_type __pos) const _NOEXCEPT
+    const_reference __make_ref(size_type __pos) const noexcept
         {return const_reference(__begin_ + __pos / __bits_per_word, __storage_type(1) << __pos % __bits_per_word);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator __make_iter(size_type __pos) _NOEXCEPT
+    iterator __make_iter(size_type __pos) noexcept
         {return iterator(__begin_ + __pos / __bits_per_word, static_cast<unsigned>(__pos % __bits_per_word));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    const_iterator __make_iter(size_type __pos) const _NOEXCEPT
+    const_iterator __make_iter(size_type __pos) const noexcept
         {return const_iterator(__begin_ + __pos / __bits_per_word, static_cast<unsigned>(__pos % __bits_per_word));}
     _LIBCUDACXX_INLINE_VISIBILITY
-    iterator __const_iterator_cast(const_iterator __p) _NOEXCEPT
+    iterator __const_iterator_cast(const_iterator __p) noexcept
         {return begin() + (__p - cbegin());}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2479,27 +2479,27 @@ private:
 
     void __move_assign(vector& __c, false_type);
     void __move_assign(vector& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value);
+        noexcept(is_nothrow_move_assignable<allocator_type>::value);
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(vector& __c)
-        _NOEXCEPT_(
+        noexcept(
             !__storage_traits::propagate_on_container_move_assignment::value ||
             is_nothrow_move_assignable<allocator_type>::value)
         {__move_assign_alloc(__c, integral_constant<bool,
                       __storage_traits::propagate_on_container_move_assignment::value>());}
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(vector& __c, true_type)
-        _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+        noexcept(is_nothrow_move_assignable<allocator_type>::value)
         {
             __alloc() = _CUDA_VSTD::move(__c.__alloc());
         }
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void __move_assign_alloc(vector&, false_type)
-        _NOEXCEPT
+        noexcept
         {}
 
-    size_t __hash_code() const _NOEXCEPT;
+    size_t __hash_code() const noexcept;
 
     friend class __bit_reference<vector>;
     friend class __bit_const_reference<vector>;
@@ -2537,7 +2537,7 @@ vector<bool, _Allocator>::__vallocate(size_type __n)
 
 template <class _Allocator>
 void
-vector<bool, _Allocator>::__vdeallocate() _NOEXCEPT
+vector<bool, _Allocator>::__vdeallocate() noexcept
 {
     if (this->__begin_ != nullptr)
     {
@@ -2550,7 +2550,7 @@ vector<bool, _Allocator>::__vdeallocate() _NOEXCEPT
 
 template <class _Allocator>
 typename vector<bool, _Allocator>::size_type
-vector<bool, _Allocator>::max_size() const _NOEXCEPT
+vector<bool, _Allocator>::max_size() const noexcept
 {
     size_type __amax = __storage_traits::max_size(__alloc());
     size_type __nmax = numeric_limits<size_type>::max() / 2;  // end() >= begin(), always
@@ -2619,7 +2619,7 @@ vector<bool, _Allocator>::__construct_at_end(_ForwardIterator __first, _ForwardI
 template <class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 vector<bool, _Allocator>::vector()
-    _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
+    noexcept(is_nothrow_default_constructible<allocator_type>::value)
     : __begin_(nullptr),
       __size_(0),
       __cap_alloc_(0)
@@ -2630,9 +2630,9 @@ template <class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 vector<bool, _Allocator>::vector(const allocator_type& __a)
 #if _LIBCUDACXX_STD_VER <= 14
-        _NOEXCEPT_(is_nothrow_copy_constructible<allocator_type>::value)
+        noexcept(is_nothrow_copy_constructible<allocator_type>::value)
 #else
-        _NOEXCEPT
+        noexcept
 #endif
     : __begin_(nullptr),
       __size_(0),
@@ -2872,9 +2872,9 @@ vector<bool, _Allocator>::operator=(const vector& __v)
 template <class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY vector<bool, _Allocator>::vector(vector&& __v)
 #if _LIBCUDACXX_STD_VER > 14
-    _NOEXCEPT
+    noexcept
 #else
-    _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
+    noexcept(is_nothrow_move_constructible<allocator_type>::value)
 #endif
     : __begin_(__v.__begin_),
       __size_(__v.__size_),
@@ -2909,7 +2909,7 @@ template <class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 vector<bool, _Allocator>&
 vector<bool, _Allocator>::operator=(vector&& __v)
-    _NOEXCEPT_((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value))
+    noexcept((__noexcept_move_assign_container<_Allocator, __alloc_traits>::value))
 {
     __move_assign(__v, integral_constant<bool,
           __storage_traits::propagate_on_container_move_assignment::value>());
@@ -2929,7 +2929,7 @@ vector<bool, _Allocator>::__move_assign(vector& __c, false_type)
 template <class _Allocator>
 void
 vector<bool, _Allocator>::__move_assign(vector& __c, true_type)
-    _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value)
+    noexcept(is_nothrow_move_assignable<allocator_type>::value)
 {
     __vdeallocate();
     __move_assign_alloc(__c);
@@ -3019,7 +3019,7 @@ vector<bool, _Allocator>::reserve(size_type __n)
 
 template <class _Allocator>
 void
-vector<bool, _Allocator>::shrink_to_fit() _NOEXCEPT
+vector<bool, _Allocator>::shrink_to_fit() noexcept
 {
     if (__external_cap_to_internal(size()) > __cap())
     {
@@ -3221,9 +3221,9 @@ template <class _Allocator>
 void
 vector<bool, _Allocator>::swap(vector& __x)
 #if _LIBCUDACXX_STD_VER >= 14
-    _NOEXCEPT
+    noexcept
 #else
-    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value ||
+    noexcept(!__alloc_traits::propagate_on_container_swap::value ||
                 __is_nothrow_swappable<allocator_type>::value)
 #endif
 {
@@ -3265,7 +3265,7 @@ vector<bool, _Allocator>::resize(size_type __sz, value_type __x)
 
 template <class _Allocator>
 void
-vector<bool, _Allocator>::flip() _NOEXCEPT
+vector<bool, _Allocator>::flip() noexcept
 {
     // do middle whole words
     size_type __n = __size_;
@@ -3303,7 +3303,7 @@ vector<bool, _Allocator>::__invariants() const
 
 template <class _Allocator>
 size_t
-vector<bool, _Allocator>::__hash_code() const _NOEXCEPT
+vector<bool, _Allocator>::__hash_code() const noexcept
 {
     size_t __h = 0;
     // do middle whole words
@@ -3325,7 +3325,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS hash<vector<bool, _Allocator> >
     : public __unary_function<vector<bool, _Allocator>, size_t>
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    size_t operator()(const vector<bool, _Allocator>& __vec) const _NOEXCEPT
+    size_t operator()(const vector<bool, _Allocator>& __vec) const noexcept
         {return __vec.__hash_code();}
 };
 
@@ -3382,7 +3382,7 @@ template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(vector<_Tp, _Allocator>& __x, vector<_Tp, _Allocator>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(_NOEXCEPT_(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/libcxx/docs/DesignDocs/AvailabilityMarkup.rst
+++ b/libcudacxx/libcxx/docs/DesignDocs/AvailabilityMarkup.rst
@@ -49,7 +49,7 @@ type info from the library for example::
 
 or on a particular symbol:
 
-    _LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz) _NOEXCEPT;
+    _LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_AVAILABILITY_SIZED_NEW_DELETE void  operator delete(void* __p, std::size_t __sz) noexcept;
 
 Furthermore, a lit feature should be added to match that availability macro,
 so that tests depending on that feature can be marked to XFAIL if the feature

--- a/libcudacxx/libcxx/src/any.cpp
+++ b/libcudacxx/libcxx/src/any.cpp
@@ -9,7 +9,7 @@
 #include "any"
 
 namespace std {
-const char* bad_any_cast::what() const _NOEXCEPT {
+const char* bad_any_cast::what() const noexcept {
     return "bad any cast";
 }
 }
@@ -24,10 +24,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_LFTS
 class _LIBCUDACXX_EXCEPTION_ABI _LIBCUDACXX_AVAILABILITY_BAD_ANY_CAST bad_any_cast : public bad_cast
 {
 public:
-    virtual const char* what() const _NOEXCEPT;
+    virtual const char* what() const noexcept;
 };
 
-const char* bad_any_cast::what() const _NOEXCEPT {
+const char* bad_any_cast::what() const noexcept {
     return "bad any cast";
 }
 

--- a/libcudacxx/libcxx/src/atomic.cpp
+++ b/libcudacxx/libcxx/src/atomic.cpp
@@ -16,7 +16,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 __libcpp_contention_t __libcpp_contention_state_[ 256 /* < there's no magic in this number */ ];
 
 _LIBCUDACXX_FUNC_VIS
-__libcpp_contention_t * __libcpp_contention_state(void const volatile * p) _NOEXCEPT {
+__libcpp_contention_t * __libcpp_contention_state(void const volatile * p) noexcept {
     return __libcpp_contention_state_ + ((std::uintptr_t)p & 255);
 }
 

--- a/libcudacxx/libcxx/src/chrono.cpp
+++ b/libcudacxx/libcxx/src/chrono.cpp
@@ -51,7 +51,7 @@ namespace chrono
 const bool system_clock::is_steady;
 
 system_clock::time_point
-system_clock::now() _NOEXCEPT
+system_clock::now() noexcept
 {
 #if defined(_LIBCUDACXX_WIN32API)
   // FILETIME is in 100ns units
@@ -92,13 +92,13 @@ system_clock::now() _NOEXCEPT
 }
 
 time_t
-system_clock::to_time_t(const time_point& t) _NOEXCEPT
+system_clock::to_time_t(const time_point& t) noexcept
 {
     return time_t(duration_cast<seconds>(t.time_since_epoch()).count());
 }
 
 system_clock::time_point
-system_clock::from_time_t(time_t t) _NOEXCEPT
+system_clock::from_time_t(time_t t) noexcept
 {
     return system_clock::time_point(seconds(t));
 }
@@ -117,7 +117,7 @@ const bool steady_clock::is_steady;
 // Darwin libc versions >= 1133 provide ns precision via CLOCK_UPTIME_RAW
 #if defined(_LIBCUDACXX_USE_CLOCK_GETTIME) && defined(CLOCK_UPTIME_RAW)
 steady_clock::time_point
-steady_clock::now() _NOEXCEPT
+steady_clock::now() noexcept
 {
     struct timespec tp;
     if (0 != clock_gettime(CLOCK_UPTIME_RAW, &tp))
@@ -172,7 +172,7 @@ init_steady_clock()
 }
 
 steady_clock::time_point
-steady_clock::now() _NOEXCEPT
+steady_clock::now() noexcept
 {
     static FP fp = init_steady_clock();
     return time_point(duration(fp()));
@@ -195,7 +195,7 @@ __QueryPerformanceFrequency()
 }
 
 steady_clock::time_point
-steady_clock::now() _NOEXCEPT
+steady_clock::now() noexcept
 {
   static const LARGE_INTEGER freq = __QueryPerformanceFrequency();
 
@@ -214,7 +214,7 @@ steady_clock::now() _NOEXCEPT
 #endif
 
 steady_clock::time_point
-steady_clock::now() _NOEXCEPT
+steady_clock::now() noexcept
 {
     struct timespec tp;
     if (0 != clock_gettime(CLOCK_MONOTONIC, &tp))

--- a/libcudacxx/libcxx/src/condition_variable.cpp
+++ b/libcudacxx/libcxx/src/condition_variable.cpp
@@ -24,19 +24,19 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // ~condition_variable is defined elsewhere.
 
 void
-condition_variable::notify_one() _NOEXCEPT
+condition_variable::notify_one() noexcept
 {
     __libcpp_condvar_signal(&__cv_);
 }
 
 void
-condition_variable::notify_all() _NOEXCEPT
+condition_variable::notify_all() noexcept
 {
     __libcpp_condvar_broadcast(&__cv_);
 }
 
 void
-condition_variable::wait(unique_lock<mutex>& lk) _NOEXCEPT
+condition_variable::wait(unique_lock<mutex>& lk) noexcept
 {
     if (!lk.owns_lock())
         __throw_system_error(EPERM,
@@ -48,7 +48,7 @@ condition_variable::wait(unique_lock<mutex>& lk) _NOEXCEPT
 
 void
 condition_variable::__do_timed_wait(unique_lock<mutex>& lk,
-     chrono::time_point<chrono::system_clock, chrono::nanoseconds> tp) _NOEXCEPT
+     chrono::time_point<chrono::system_clock, chrono::nanoseconds> tp) noexcept
 {
     using namespace chrono;
     if (!lk.owns_lock())

--- a/libcudacxx/libcxx/src/experimental/memory_resource.cpp
+++ b/libcudacxx/libcxx/src/experimental/memory_resource.cpp
@@ -40,7 +40,7 @@ class _LIBCUDACXX_TYPE_VIS __new_delete_memory_resource_imp
       _CUDA_VSTD::__libcpp_deallocate(p, n, align);
     }
 
-    bool do_is_equal(memory_resource const & other) const _NOEXCEPT override
+    bool do_is_equal(memory_resource const & other) const noexcept override
         { return &other == this; }
 
 public:
@@ -60,7 +60,7 @@ protected:
         __throw_bad_alloc();
     }
     virtual void do_deallocate(void *, size_t, size_t) {}
-    virtual bool do_is_equal(memory_resource const & __other) const _NOEXCEPT
+    virtual bool do_is_equal(memory_resource const & __other) const noexcept
     { return &__other == this; }
 };
 
@@ -96,18 +96,18 @@ ResourceInitHelper res_init _LIBCUDACXX_INIT_PRIORITY_MAX;
 } // end namespace
 
 
-memory_resource * new_delete_resource() _NOEXCEPT {
+memory_resource * new_delete_resource() noexcept {
     return &res_init.resources.new_delete_res;
 }
 
-memory_resource * null_memory_resource() _NOEXCEPT {
+memory_resource * null_memory_resource() noexcept {
     return &res_init.resources.null_res;
 }
 
 // default_memory_resource()
 
 static memory_resource *
-__default_memory_resource(bool set = false, memory_resource * new_res = nullptr) _NOEXCEPT
+__default_memory_resource(bool set = false, memory_resource * new_res = nullptr) noexcept
 {
 #ifndef _LIBCUDACXX_HAS_NO_ATOMIC_HEADER
     _LIBCUDACXX_SAFE_STATIC static atomic<memory_resource*> __res =
@@ -148,12 +148,12 @@ __default_memory_resource(bool set = false, memory_resource * new_res = nullptr)
 #endif
 }
 
-memory_resource * get_default_resource() _NOEXCEPT
+memory_resource * get_default_resource() noexcept
 {
     return __default_memory_resource();
 }
 
-memory_resource * set_default_resource(memory_resource * __new_res) _NOEXCEPT
+memory_resource * set_default_resource(memory_resource * __new_res) noexcept
 {
     return __default_memory_resource(true, __new_res);
 }

--- a/libcudacxx/libcxx/src/functional.cpp
+++ b/libcudacxx/libcxx/src/functional.cpp
@@ -11,12 +11,12 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #ifdef _LIBCUDACXX_ABI_BAD_FUNCTION_CALL_KEY_FUNCTION
-bad_function_call::~bad_function_call() _NOEXCEPT
+bad_function_call::~bad_function_call() noexcept
 {
 }
 
 const char*
-bad_function_call::what() const _NOEXCEPT
+bad_function_call::what() const noexcept
 {
     return "std::bad_function_call";
 }

--- a/libcudacxx/libcxx/src/future.cpp
+++ b/libcudacxx/libcxx/src/future.cpp
@@ -19,12 +19,12 @@ class _LIBCUDACXX_HIDDEN __future_error_category
     : public __do_message
 {
 public:
-    virtual const char* name() const _NOEXCEPT;
+    virtual const char* name() const noexcept;
     virtual string message(int ev) const;
 };
 
 const char*
-__future_error_category::name() const _NOEXCEPT
+__future_error_category::name() const noexcept
 {
     return "future";
 }
@@ -65,7 +65,7 @@ __future_error_category::message(int ev) const
 #endif
 
 const error_category&
-future_category() _NOEXCEPT
+future_category() noexcept
 {
     static __future_error_category __f;
     return __f;
@@ -77,12 +77,12 @@ future_error::future_error(error_code __ec)
 {
 }
 
-future_error::~future_error() _NOEXCEPT
+future_error::~future_error() noexcept
 {
 }
 
 void
-__assoc_sub_state::__on_zero_shared() _NOEXCEPT
+__assoc_sub_state::__on_zero_shared() noexcept
 {
     delete this;
 }

--- a/libcudacxx/libcxx/src/include/refstring.h
+++ b/libcudacxx/libcxx/src/include/refstring.h
@@ -42,7 +42,7 @@ inline char * data_from_rep(_Rep_base *rep) noexcept {
 
 #if defined(__APPLE__)
 inline
-const char* compute_gcc_empty_string_storage() _NOEXCEPT
+const char* compute_gcc_empty_string_storage() noexcept
 {
     void* handle = dlopen("/usr/lib/libstdc++.6.dylib", RTLD_NOLOAD);
     if (handle == nullptr)
@@ -55,7 +55,7 @@ const char* compute_gcc_empty_string_storage() _NOEXCEPT
 
 inline
 const char*
-get_gcc_empty_string_storage() _NOEXCEPT
+get_gcc_empty_string_storage() noexcept
 {
     static const char* p = compute_gcc_empty_string_storage();
     return p;
@@ -79,7 +79,7 @@ __libcpp_refstring::__libcpp_refstring(const char* msg) {
 }
 
 inline
-__libcpp_refstring::__libcpp_refstring(const __libcpp_refstring &s) _NOEXCEPT
+__libcpp_refstring::__libcpp_refstring(const __libcpp_refstring &s) noexcept
     : __imp_(s.__imp_)
 {
     if (__uses_refcount())
@@ -87,7 +87,7 @@ __libcpp_refstring::__libcpp_refstring(const __libcpp_refstring &s) _NOEXCEPT
 }
 
 inline
-__libcpp_refstring& __libcpp_refstring::operator=(__libcpp_refstring const& s) _NOEXCEPT {
+__libcpp_refstring& __libcpp_refstring::operator=(__libcpp_refstring const& s) noexcept {
     bool adjust_old_count = __uses_refcount();
     struct _Rep_base *old_rep = rep_from_data(__imp_);
     __imp_ = s.__imp_;

--- a/libcudacxx/libcxx/src/ios.cpp
+++ b/libcudacxx/libcxx/src/ios.cpp
@@ -43,12 +43,12 @@ class _LIBCUDACXX_HIDDEN __iostream_category
     : public __do_message
 {
 public:
-    virtual const char* name() const _NOEXCEPT;
+    virtual const char* name() const noexcept;
     virtual string message(int ev) const;
 };
 
 const char*
-__iostream_category::name() const _NOEXCEPT
+__iostream_category::name() const noexcept
 {
     return "iostream";
 }
@@ -66,7 +66,7 @@ __iostream_category::message(int ev) const
 }
 
 const error_category&
-iostream_category() _NOEXCEPT
+iostream_category() noexcept
 {
     static __iostream_category s;
     return s;
@@ -403,7 +403,7 @@ ios_base::move(ios_base& rhs)
 }
 
 void
-ios_base::swap(ios_base& rhs) _NOEXCEPT
+ios_base::swap(ios_base& rhs) noexcept
 {
     _CUDA_VSTD::swap(__fmtflags_, rhs.__fmtflags_);
     _CUDA_VSTD::swap(__precision_, rhs.__precision_);

--- a/libcudacxx/libcxx/src/locale.cpp
+++ b/libcudacxx/libcxx/src/locale.cpp
@@ -508,13 +508,13 @@ locale::__global()
     return g;
 }
 
-locale::locale()  _NOEXCEPT
+locale::locale()  noexcept
     : __locale_(__global().__locale_)
 {
     __locale_->__add_shared();
 }
 
-locale::locale(const locale& l)  _NOEXCEPT
+locale::locale(const locale& l)  noexcept
     : __locale_(l.__locale_)
 {
     __locale_->__add_shared();
@@ -526,7 +526,7 @@ locale::~locale()
 }
 
 const locale&
-locale::operator=(const locale& other)  _NOEXCEPT
+locale::operator=(const locale& other)  noexcept
 {
     other.__locale_->__add_shared();
     __locale_->__release_shared();
@@ -619,7 +619,7 @@ locale::facet::~facet()
 }
 
 void
-locale::facet::__on_zero_shared() _NOEXCEPT
+locale::facet::__on_zero_shared() noexcept
 {
     delete this;
 }
@@ -1027,7 +1027,7 @@ extern "C" const int ** __ctype_toupper_loc();
 
 #ifdef _LIBCUDACXX_PROVIDES_DEFAULT_RUNE_TABLE
 const ctype<char>::mask*
-ctype<char>::classic_table()  _NOEXCEPT
+ctype<char>::classic_table()  noexcept
 {
     static _LIBCUDACXX_CONSTEXPR const ctype<char>::mask builtin_table[table_size] = {
         cntrl,                          cntrl,
@@ -1107,7 +1107,7 @@ ctype<char>::classic_table()  _NOEXCEPT
 }
 #else
 const ctype<char>::mask*
-ctype<char>::classic_table()  _NOEXCEPT
+ctype<char>::classic_table()  noexcept
 {
 #if defined(__APPLE__) || defined(__FreeBSD__)
     return _DefaultRuneLocale.__runetype;
@@ -1139,38 +1139,38 @@ ctype<char>::classic_table()  _NOEXCEPT
 
 #if defined(__GLIBC__)
 const int*
-ctype<char>::__classic_lower_table() _NOEXCEPT
+ctype<char>::__classic_lower_table() noexcept
 {
     return _LIBCUDACXX_GET_C_LOCALE->__ctype_tolower;
 }
 
 const int*
-ctype<char>::__classic_upper_table() _NOEXCEPT
+ctype<char>::__classic_upper_table() noexcept
 {
     return _LIBCUDACXX_GET_C_LOCALE->__ctype_toupper;
 }
 #elif __NetBSD__
 const short*
-ctype<char>::__classic_lower_table() _NOEXCEPT
+ctype<char>::__classic_lower_table() noexcept
 {
     return _C_tolower_tab_ + 1;
 }
 
 const short*
-ctype<char>::__classic_upper_table() _NOEXCEPT
+ctype<char>::__classic_upper_table() noexcept
 {
     return _C_toupper_tab_ + 1;
 }
 
 #elif defined(__EMSCRIPTEN__)
 const int*
-ctype<char>::__classic_lower_table() _NOEXCEPT
+ctype<char>::__classic_lower_table() noexcept
 {
     return *__ctype_tolower_loc();
 }
 
 const int*
-ctype<char>::__classic_upper_table() _NOEXCEPT
+ctype<char>::__classic_upper_table() noexcept
 {
     return *__ctype_toupper_loc();
 }
@@ -1468,13 +1468,13 @@ codecvt<char, char, mbstate_t>::do_unshift(state_type&,
 }
 
 int
-codecvt<char, char, mbstate_t>::do_encoding() const  _NOEXCEPT
+codecvt<char, char, mbstate_t>::do_encoding() const  noexcept
 {
     return 1;
 }
 
 bool
-codecvt<char, char, mbstate_t>::do_always_noconv() const  _NOEXCEPT
+codecvt<char, char, mbstate_t>::do_always_noconv() const  noexcept
 {
     return true;
 }
@@ -1487,7 +1487,7 @@ codecvt<char, char, mbstate_t>::do_length(state_type&,
 }
 
 int
-codecvt<char, char, mbstate_t>::do_max_length() const  _NOEXCEPT
+codecvt<char, char, mbstate_t>::do_max_length() const  noexcept
 {
     return 1;
 }
@@ -1658,7 +1658,7 @@ codecvt<wchar_t, char, mbstate_t>::do_unshift(state_type& st,
 }
 
 int
-codecvt<wchar_t, char, mbstate_t>::do_encoding() const  _NOEXCEPT
+codecvt<wchar_t, char, mbstate_t>::do_encoding() const  noexcept
 {
     if (__libcpp_mbtowc_l(nullptr, nullptr, MB_LEN_MAX, __l) != 0)
         return -1;
@@ -1670,7 +1670,7 @@ codecvt<wchar_t, char, mbstate_t>::do_encoding() const  _NOEXCEPT
 }
 
 bool
-codecvt<wchar_t, char, mbstate_t>::do_always_noconv() const  _NOEXCEPT
+codecvt<wchar_t, char, mbstate_t>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -1702,7 +1702,7 @@ codecvt<wchar_t, char, mbstate_t>::do_length(state_type& st,
 }
 
 int
-codecvt<wchar_t, char, mbstate_t>::do_max_length() const  _NOEXCEPT
+codecvt<wchar_t, char, mbstate_t>::do_max_length() const  noexcept
 {
     return __l == 0 ? 1 : static_cast<int>(__libcpp_mb_cur_max_l(__l));
 }
@@ -3145,13 +3145,13 @@ codecvt<char16_t, char, mbstate_t>::do_unshift(state_type&,
 }
 
 int
-codecvt<char16_t, char, mbstate_t>::do_encoding() const  _NOEXCEPT
+codecvt<char16_t, char, mbstate_t>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-codecvt<char16_t, char, mbstate_t>::do_always_noconv() const  _NOEXCEPT
+codecvt<char16_t, char, mbstate_t>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3166,7 +3166,7 @@ codecvt<char16_t, char, mbstate_t>::do_length(state_type&,
 }
 
 int
-codecvt<char16_t, char, mbstate_t>::do_max_length() const  _NOEXCEPT
+codecvt<char16_t, char, mbstate_t>::do_max_length() const  noexcept
 {
     return 4;
 }
@@ -3222,13 +3222,13 @@ codecvt<char32_t, char, mbstate_t>::do_unshift(state_type&,
 }
 
 int
-codecvt<char32_t, char, mbstate_t>::do_encoding() const  _NOEXCEPT
+codecvt<char32_t, char, mbstate_t>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-codecvt<char32_t, char, mbstate_t>::do_always_noconv() const  _NOEXCEPT
+codecvt<char32_t, char, mbstate_t>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3243,7 +3243,7 @@ codecvt<char32_t, char, mbstate_t>::do_length(state_type&,
 }
 
 int
-codecvt<char32_t, char, mbstate_t>::do_max_length() const  _NOEXCEPT
+codecvt<char32_t, char, mbstate_t>::do_max_length() const  noexcept
 {
     return 4;
 }
@@ -3314,13 +3314,13 @@ __codecvt_utf8<wchar_t>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf8<wchar_t>::do_encoding() const  _NOEXCEPT
+__codecvt_utf8<wchar_t>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf8<wchar_t>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf8<wchar_t>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3335,7 +3335,7 @@ __codecvt_utf8<wchar_t>::do_length(state_type&,
 }
 
 int
-__codecvt_utf8<wchar_t>::do_max_length() const  _NOEXCEPT
+__codecvt_utf8<wchar_t>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 7;
@@ -3389,13 +3389,13 @@ __codecvt_utf8<char16_t>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf8<char16_t>::do_encoding() const  _NOEXCEPT
+__codecvt_utf8<char16_t>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf8<char16_t>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf8<char16_t>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3410,7 +3410,7 @@ __codecvt_utf8<char16_t>::do_length(state_type&,
 }
 
 int
-__codecvt_utf8<char16_t>::do_max_length() const  _NOEXCEPT
+__codecvt_utf8<char16_t>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 6;
@@ -3464,13 +3464,13 @@ __codecvt_utf8<char32_t>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf8<char32_t>::do_encoding() const  _NOEXCEPT
+__codecvt_utf8<char32_t>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf8<char32_t>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf8<char32_t>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3485,7 +3485,7 @@ __codecvt_utf8<char32_t>::do_length(state_type&,
 }
 
 int
-__codecvt_utf8<char32_t>::do_max_length() const  _NOEXCEPT
+__codecvt_utf8<char32_t>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 7;
@@ -3539,13 +3539,13 @@ __codecvt_utf16<wchar_t, false>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf16<wchar_t, false>::do_encoding() const  _NOEXCEPT
+__codecvt_utf16<wchar_t, false>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf16<wchar_t, false>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf16<wchar_t, false>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3560,7 +3560,7 @@ __codecvt_utf16<wchar_t, false>::do_length(state_type&,
 }
 
 int
-__codecvt_utf16<wchar_t, false>::do_max_length() const  _NOEXCEPT
+__codecvt_utf16<wchar_t, false>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 6;
@@ -3614,13 +3614,13 @@ __codecvt_utf16<wchar_t, true>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf16<wchar_t, true>::do_encoding() const  _NOEXCEPT
+__codecvt_utf16<wchar_t, true>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf16<wchar_t, true>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf16<wchar_t, true>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3635,7 +3635,7 @@ __codecvt_utf16<wchar_t, true>::do_length(state_type&,
 }
 
 int
-__codecvt_utf16<wchar_t, true>::do_max_length() const  _NOEXCEPT
+__codecvt_utf16<wchar_t, true>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 6;
@@ -3689,13 +3689,13 @@ __codecvt_utf16<char16_t, false>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf16<char16_t, false>::do_encoding() const  _NOEXCEPT
+__codecvt_utf16<char16_t, false>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf16<char16_t, false>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf16<char16_t, false>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3710,7 +3710,7 @@ __codecvt_utf16<char16_t, false>::do_length(state_type&,
 }
 
 int
-__codecvt_utf16<char16_t, false>::do_max_length() const  _NOEXCEPT
+__codecvt_utf16<char16_t, false>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 4;
@@ -3764,13 +3764,13 @@ __codecvt_utf16<char16_t, true>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf16<char16_t, true>::do_encoding() const  _NOEXCEPT
+__codecvt_utf16<char16_t, true>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf16<char16_t, true>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf16<char16_t, true>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3785,7 +3785,7 @@ __codecvt_utf16<char16_t, true>::do_length(state_type&,
 }
 
 int
-__codecvt_utf16<char16_t, true>::do_max_length() const  _NOEXCEPT
+__codecvt_utf16<char16_t, true>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 4;
@@ -3839,13 +3839,13 @@ __codecvt_utf16<char32_t, false>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf16<char32_t, false>::do_encoding() const  _NOEXCEPT
+__codecvt_utf16<char32_t, false>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf16<char32_t, false>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf16<char32_t, false>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3860,7 +3860,7 @@ __codecvt_utf16<char32_t, false>::do_length(state_type&,
 }
 
 int
-__codecvt_utf16<char32_t, false>::do_max_length() const  _NOEXCEPT
+__codecvt_utf16<char32_t, false>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 6;
@@ -3914,13 +3914,13 @@ __codecvt_utf16<char32_t, true>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf16<char32_t, true>::do_encoding() const  _NOEXCEPT
+__codecvt_utf16<char32_t, true>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf16<char32_t, true>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf16<char32_t, true>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -3935,7 +3935,7 @@ __codecvt_utf16<char32_t, true>::do_length(state_type&,
 }
 
 int
-__codecvt_utf16<char32_t, true>::do_max_length() const  _NOEXCEPT
+__codecvt_utf16<char32_t, true>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 6;
@@ -3989,13 +3989,13 @@ __codecvt_utf8_utf16<wchar_t>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf8_utf16<wchar_t>::do_encoding() const  _NOEXCEPT
+__codecvt_utf8_utf16<wchar_t>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf8_utf16<wchar_t>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf8_utf16<wchar_t>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -4010,7 +4010,7 @@ __codecvt_utf8_utf16<wchar_t>::do_length(state_type&,
 }
 
 int
-__codecvt_utf8_utf16<wchar_t>::do_max_length() const  _NOEXCEPT
+__codecvt_utf8_utf16<wchar_t>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 7;
@@ -4064,13 +4064,13 @@ __codecvt_utf8_utf16<char16_t>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf8_utf16<char16_t>::do_encoding() const  _NOEXCEPT
+__codecvt_utf8_utf16<char16_t>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf8_utf16<char16_t>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf8_utf16<char16_t>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -4085,7 +4085,7 @@ __codecvt_utf8_utf16<char16_t>::do_length(state_type&,
 }
 
 int
-__codecvt_utf8_utf16<char16_t>::do_max_length() const  _NOEXCEPT
+__codecvt_utf8_utf16<char16_t>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 7;
@@ -4139,13 +4139,13 @@ __codecvt_utf8_utf16<char32_t>::do_unshift(state_type&,
 }
 
 int
-__codecvt_utf8_utf16<char32_t>::do_encoding() const  _NOEXCEPT
+__codecvt_utf8_utf16<char32_t>::do_encoding() const  noexcept
 {
     return 0;
 }
 
 bool
-__codecvt_utf8_utf16<char32_t>::do_always_noconv() const  _NOEXCEPT
+__codecvt_utf8_utf16<char32_t>::do_always_noconv() const  noexcept
 {
     return false;
 }
@@ -4160,7 +4160,7 @@ __codecvt_utf8_utf16<char32_t>::do_length(state_type&,
 }
 
 int
-__codecvt_utf8_utf16<char32_t>::do_max_length() const  _NOEXCEPT
+__codecvt_utf8_utf16<char32_t>::do_max_length() const  noexcept
 {
     if (_Mode_ & consume_header)
         return 7;

--- a/libcudacxx/libcxx/src/memory.cpp
+++ b/libcudacxx/libcxx/src/memory.cpp
@@ -20,10 +20,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 const allocator_arg_t allocator_arg = allocator_arg_t();
 
-bad_weak_ptr::~bad_weak_ptr() _NOEXCEPT {}
+bad_weak_ptr::~bad_weak_ptr() noexcept {}
 
 const char*
-bad_weak_ptr::what() const _NOEXCEPT
+bad_weak_ptr::what() const noexcept
 {
     return "bad_weak_ptr";
 }
@@ -38,13 +38,13 @@ __shared_weak_count::~__shared_weak_count()
 
 #if defined(_LIBCUDACXX_DEPRECATED_ABI_LEGACY_LIBRARY_DEFINITIONS_FOR_INLINE_FUNCTIONS)
 void
-__shared_count::__add_shared() _NOEXCEPT
+__shared_count::__add_shared() noexcept
 {
     __libcpp_atomic_refcount_increment(__shared_owners_);
 }
 
 bool
-__shared_count::__release_shared() _NOEXCEPT
+__shared_count::__release_shared() noexcept
 {
     if (__libcpp_atomic_refcount_decrement(__shared_owners_) == -1)
     {
@@ -55,19 +55,19 @@ __shared_count::__release_shared() _NOEXCEPT
 }
 
 void
-__shared_weak_count::__add_shared() _NOEXCEPT
+__shared_weak_count::__add_shared() noexcept
 {
     __shared_count::__add_shared();
 }
 
 void
-__shared_weak_count::__add_weak() _NOEXCEPT
+__shared_weak_count::__add_weak() noexcept
 {
     __libcpp_atomic_refcount_increment(__shared_weak_owners_);
 }
 
 void
-__shared_weak_count::__release_shared() _NOEXCEPT
+__shared_weak_count::__release_shared() noexcept
 {
     if (__shared_count::__release_shared())
         __release_weak();
@@ -76,7 +76,7 @@ __shared_weak_count::__release_shared() _NOEXCEPT
 #endif // _LIBCUDACXX_DEPRECATED_ABI_LEGACY_LIBRARY_DEFINITIONS_FOR_INLINE_FUNCTIONS
 
 void
-__shared_weak_count::__release_weak() _NOEXCEPT
+__shared_weak_count::__release_weak() noexcept
 {
     // NOTE: The acquire load here is an optimization of the very
     // common case where a shared pointer is being destructed while
@@ -111,7 +111,7 @@ __shared_weak_count::__release_weak() _NOEXCEPT
 }
 
 __shared_weak_count*
-__shared_weak_count::lock() _NOEXCEPT
+__shared_weak_count::lock() noexcept
 {
     long object_owners = __libcpp_atomic_load(&__shared_owners_);
     while (object_owners != -1)
@@ -127,7 +127,7 @@ __shared_weak_count::lock() _NOEXCEPT
 #if !defined(_LIBCUDACXX_NO_RTTI) || !defined(_LIBCUDACXX_BUILD_STATIC)
 
 const void*
-__shared_weak_count::__get_deleter(const type_info&) const _NOEXCEPT
+__shared_weak_count::__get_deleter(const type_info&) const noexcept
 {
     return nullptr;
 }
@@ -145,13 +145,13 @@ _LIBCUDACXX_SAFE_STATIC static __libcpp_mutex_t mut_back[__sp_mut_count] =
     _LIBCUDACXX_MUTEX_INITIALIZER, _LIBCUDACXX_MUTEX_INITIALIZER, _LIBCUDACXX_MUTEX_INITIALIZER, _LIBCUDACXX_MUTEX_INITIALIZER
 };
 
-_LIBCUDACXX_CONSTEXPR __sp_mut::__sp_mut(void* p) _NOEXCEPT
+_LIBCUDACXX_CONSTEXPR __sp_mut::__sp_mut(void* p) noexcept
    : __lx(p)
 {
 }
 
 void
-__sp_mut::lock() _NOEXCEPT
+__sp_mut::lock() noexcept
 {
     auto m = static_cast<__libcpp_mutex_t*>(__lx);
     unsigned count = 0;
@@ -167,7 +167,7 @@ __sp_mut::lock() _NOEXCEPT
 }
 
 void
-__sp_mut::unlock() _NOEXCEPT
+__sp_mut::unlock() noexcept
 {
     __libcpp_mutex_unlock(static_cast<__libcpp_mutex_t*>(__lx));
 }
@@ -203,7 +203,7 @@ undeclare_no_pointers(char*, size_t)
 }
 
 #if !defined(_LIBCUDACXX_ABI_POINTER_SAFETY_ENUM_TYPE)
-pointer_safety get_pointer_safety() _NOEXCEPT
+pointer_safety get_pointer_safety() noexcept
 {
     return pointer_safety::relaxed;
 }

--- a/libcudacxx/libcxx/src/mutex.cpp
+++ b/libcudacxx/libcxx/src/mutex.cpp
@@ -36,13 +36,13 @@ mutex::lock()
 }
 
 bool
-mutex::try_lock() _NOEXCEPT
+mutex::try_lock() noexcept
 {
     return __libcpp_mutex_trylock(&__m_);
 }
 
 void
-mutex::unlock() _NOEXCEPT
+mutex::unlock() noexcept
 {
     int ec = __libcpp_mutex_unlock(&__m_);
     (void)ec;
@@ -74,7 +74,7 @@ recursive_mutex::lock()
 }
 
 void
-recursive_mutex::unlock() _NOEXCEPT
+recursive_mutex::unlock() noexcept
 {
     int e = __libcpp_recursive_mutex_unlock(&__m_);
     (void)e;
@@ -82,7 +82,7 @@ recursive_mutex::unlock() _NOEXCEPT
 }
 
 bool
-recursive_mutex::try_lock() _NOEXCEPT
+recursive_mutex::try_lock() noexcept
 {
     return __libcpp_recursive_mutex_trylock(&__m_);
 }
@@ -109,7 +109,7 @@ timed_mutex::lock()
 }
 
 bool
-timed_mutex::try_lock() _NOEXCEPT
+timed_mutex::try_lock() noexcept
 {
     unique_lock<mutex> lk(__m_, try_to_lock);
     if (lk.owns_lock() && !__locked_)
@@ -121,7 +121,7 @@ timed_mutex::try_lock() _NOEXCEPT
 }
 
 void
-timed_mutex::unlock() _NOEXCEPT
+timed_mutex::unlock() noexcept
 {
     lock_guard<mutex> _(__m_);
     __locked_ = false;
@@ -160,7 +160,7 @@ recursive_timed_mutex::lock()
 }
 
 bool
-recursive_timed_mutex::try_lock() _NOEXCEPT
+recursive_timed_mutex::try_lock() noexcept
 {
     __thread_id id = this_thread::get_id();
     unique_lock<mutex> lk(__m_, try_to_lock);
@@ -176,7 +176,7 @@ recursive_timed_mutex::try_lock() _NOEXCEPT
 }
 
 void
-recursive_timed_mutex::unlock() _NOEXCEPT
+recursive_timed_mutex::unlock() noexcept
 {
     unique_lock<mutex> lk(__m_);
     if (--__count_ == 0)

--- a/libcudacxx/libcxx/src/mutex_destructor.cpp
+++ b/libcudacxx/libcxx/src/mutex_destructor.cpp
@@ -41,7 +41,7 @@ public:
 };
 
 
-mutex::~mutex() _NOEXCEPT
+mutex::~mutex() noexcept
 {
     __libcpp_mutex_destroy(&__m_);
 }

--- a/libcudacxx/libcxx/src/new.cpp
+++ b/libcudacxx/libcxx/src/new.cpp
@@ -83,7 +83,7 @@ operator new(std::size_t size) _THROW_BAD_ALLOC
 
 _LIBCUDACXX_WEAK
 void*
-operator new(size_t size, const std::nothrow_t&) _NOEXCEPT
+operator new(size_t size, const std::nothrow_t&) noexcept
 {
     void* p = 0;
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
@@ -109,7 +109,7 @@ operator new[](size_t size) _THROW_BAD_ALLOC
 
 _LIBCUDACXX_WEAK
 void*
-operator new[](size_t size, const std::nothrow_t&) _NOEXCEPT
+operator new[](size_t size, const std::nothrow_t&) noexcept
 {
     void* p = 0;
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
@@ -128,42 +128,42 @@ operator new[](size_t size, const std::nothrow_t&) _NOEXCEPT
 
 _LIBCUDACXX_WEAK
 void
-operator delete(void* ptr) _NOEXCEPT
+operator delete(void* ptr) noexcept
 {
     ::free(ptr);
 }
 
 _LIBCUDACXX_WEAK
 void
-operator delete(void* ptr, const std::nothrow_t&) _NOEXCEPT
+operator delete(void* ptr, const std::nothrow_t&) noexcept
 {
     ::operator delete(ptr);
 }
 
 _LIBCUDACXX_WEAK
 void
-operator delete(void* ptr, size_t) _NOEXCEPT
+operator delete(void* ptr, size_t) noexcept
 {
     ::operator delete(ptr);
 }
 
 _LIBCUDACXX_WEAK
 void
-operator delete[] (void* ptr) _NOEXCEPT
+operator delete[] (void* ptr) noexcept
 {
     ::operator delete(ptr);
 }
 
 _LIBCUDACXX_WEAK
 void
-operator delete[] (void* ptr, const std::nothrow_t&) _NOEXCEPT
+operator delete[] (void* ptr, const std::nothrow_t&) noexcept
 {
     ::operator delete[](ptr);
 }
 
 _LIBCUDACXX_WEAK
 void
-operator delete[] (void* ptr, size_t) _NOEXCEPT
+operator delete[] (void* ptr, size_t) noexcept
 {
     ::operator delete[](ptr);
 }
@@ -204,7 +204,7 @@ operator new(std::size_t size, std::align_val_t alignment) _THROW_BAD_ALLOC
 
 _LIBCUDACXX_WEAK
 void*
-operator new(size_t size, std::align_val_t alignment, const std::nothrow_t&) _NOEXCEPT
+operator new(size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept
 {
     void* p = 0;
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
@@ -230,7 +230,7 @@ operator new[](size_t size, std::align_val_t alignment) _THROW_BAD_ALLOC
 
 _LIBCUDACXX_WEAK
 void*
-operator new[](size_t size, std::align_val_t alignment, const std::nothrow_t&) _NOEXCEPT
+operator new[](size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept
 {
     void* p = 0;
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
@@ -249,7 +249,7 @@ operator new[](size_t size, std::align_val_t alignment, const std::nothrow_t&) _
 
 _LIBCUDACXX_WEAK
 void
-operator delete(void* ptr, std::align_val_t) _NOEXCEPT
+operator delete(void* ptr, std::align_val_t) noexcept
 {
 #if defined(_LIBCUDACXX_MSVCRT_LIKE)
     ::_aligned_free(ptr);
@@ -260,35 +260,35 @@ operator delete(void* ptr, std::align_val_t) _NOEXCEPT
 
 _LIBCUDACXX_WEAK
 void
-operator delete(void* ptr, std::align_val_t alignment, const std::nothrow_t&) _NOEXCEPT
+operator delete(void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept
 {
     ::operator delete(ptr, alignment);
 }
 
 _LIBCUDACXX_WEAK
 void
-operator delete(void* ptr, size_t, std::align_val_t alignment) _NOEXCEPT
+operator delete(void* ptr, size_t, std::align_val_t alignment) noexcept
 {
     ::operator delete(ptr, alignment);
 }
 
 _LIBCUDACXX_WEAK
 void
-operator delete[] (void* ptr, std::align_val_t alignment) _NOEXCEPT
+operator delete[] (void* ptr, std::align_val_t alignment) noexcept
 {
     ::operator delete(ptr, alignment);
 }
 
 _LIBCUDACXX_WEAK
 void
-operator delete[] (void* ptr, std::align_val_t alignment, const std::nothrow_t&) _NOEXCEPT
+operator delete[] (void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept
 {
     ::operator delete[](ptr, alignment);
 }
 
 _LIBCUDACXX_WEAK
 void
-operator delete[] (void* ptr, size_t, std::align_val_t alignment) _NOEXCEPT
+operator delete[] (void* ptr, size_t, std::align_val_t alignment) noexcept
 {
     ::operator delete[](ptr, alignment);
 }

--- a/libcudacxx/libcxx/src/optional.cpp
+++ b/libcudacxx/libcxx/src/optional.cpp
@@ -11,9 +11,9 @@
 namespace std
 {
 
-bad_optional_access::~bad_optional_access() _NOEXCEPT = default;
+bad_optional_access::~bad_optional_access() noexcept = default;
 
-const char* bad_optional_access::what() const _NOEXCEPT {
+const char* bad_optional_access::what() const noexcept {
   return "bad_optional_access";
   }
 
@@ -33,9 +33,9 @@ public:
 	bad_optional_access() : std::logic_error("Bad optional Access") {}
 
 //	Get the key function ~bad_optional_access() into the dylib
-    virtual ~bad_optional_access() _NOEXCEPT;
+    virtual ~bad_optional_access() noexcept;
 };
 
-bad_optional_access::~bad_optional_access() _NOEXCEPT = default;
+bad_optional_access::~bad_optional_access() noexcept = default;
 
 _LIBCUDACXX_END_NAMESPACE_EXPERIMENTAL

--- a/libcudacxx/libcxx/src/random.cpp
+++ b/libcudacxx/libcxx/src/random.cpp
@@ -170,7 +170,7 @@ random_device::operator()()
 #endif
 
 double
-random_device::entropy() const _NOEXCEPT
+random_device::entropy() const noexcept
 {
     return 0;
 }

--- a/libcudacxx/libcxx/src/support/runtime/exception_fallback.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/exception_fallback.ipp
@@ -17,13 +17,13 @@ _LIBCUDACXX_SAFE_STATIC static std::unexpected_handler __unexpected_handler;
 
 // libcxxrt provides implementations of these functions itself.
 unexpected_handler
-set_unexpected(unexpected_handler func) _NOEXCEPT
+set_unexpected(unexpected_handler func) noexcept
 {
   return __libcpp_atomic_exchange(&__unexpected_handler, func);
 }
 
 unexpected_handler
-get_unexpected() _NOEXCEPT
+get_unexpected() noexcept
 {
   return __libcpp_atomic_load(&__unexpected_handler);
 
@@ -38,13 +38,13 @@ void unexpected()
 }
 
 terminate_handler
-set_terminate(terminate_handler func) _NOEXCEPT
+set_terminate(terminate_handler func) noexcept
 {
   return __libcpp_atomic_exchange(&__terminate_handler, func);
 }
 
 terminate_handler
-get_terminate() _NOEXCEPT
+get_terminate() noexcept
 {
   return __libcpp_atomic_load(&__terminate_handler);
 }
@@ -52,7 +52,7 @@ get_terminate() _NOEXCEPT
 #ifndef __EMSCRIPTEN__ // We provide this in JS
 _LIBCUDACXX_NORETURN
 void
-terminate() _NOEXCEPT
+terminate() noexcept
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     try
@@ -75,9 +75,9 @@ terminate() _NOEXCEPT
 #endif // !__EMSCRIPTEN__
 
 #if !defined(__EMSCRIPTEN__)
-bool uncaught_exception() _NOEXCEPT { return uncaught_exceptions() > 0; }
+bool uncaught_exception() noexcept { return uncaught_exceptions() > 0; }
 
-int uncaught_exceptions() _NOEXCEPT
+int uncaught_exceptions() noexcept
 {
 #warning uncaught_exception not yet implemented
   fprintf(stderr, "uncaught_exceptions not yet implemented\n");
@@ -86,77 +86,77 @@ int uncaught_exceptions() _NOEXCEPT
 #endif // !__EMSCRIPTEN__
 
 
-exception::~exception() _NOEXCEPT
+exception::~exception() noexcept
 {
 }
 
-const char* exception::what() const _NOEXCEPT
+const char* exception::what() const noexcept
 {
   return "std::exception";
 }
 
-bad_exception::~bad_exception() _NOEXCEPT
+bad_exception::~bad_exception() noexcept
 {
 }
 
-const char* bad_exception::what() const _NOEXCEPT
+const char* bad_exception::what() const noexcept
 {
   return "std::bad_exception";
 }
 
 
-bad_alloc::bad_alloc() _NOEXCEPT
+bad_alloc::bad_alloc() noexcept
 {
 }
 
-bad_alloc::~bad_alloc() _NOEXCEPT
+bad_alloc::~bad_alloc() noexcept
 {
 }
 
 const char*
-bad_alloc::what() const _NOEXCEPT
+bad_alloc::what() const noexcept
 {
     return "std::bad_alloc";
 }
 
-bad_array_new_length::bad_array_new_length() _NOEXCEPT
+bad_array_new_length::bad_array_new_length() noexcept
 {
 }
 
-bad_array_new_length::~bad_array_new_length() _NOEXCEPT
+bad_array_new_length::~bad_array_new_length() noexcept
 {
 }
 
 const char*
-bad_array_new_length::what() const _NOEXCEPT
+bad_array_new_length::what() const noexcept
 {
     return "bad_array_new_length";
 }
 
-bad_cast::bad_cast() _NOEXCEPT
+bad_cast::bad_cast() noexcept
 {
 }
 
-bad_typeid::bad_typeid() _NOEXCEPT
+bad_typeid::bad_typeid() noexcept
 {
 }
 
-bad_cast::~bad_cast() _NOEXCEPT
+bad_cast::~bad_cast() noexcept
 {
 }
 
 const char*
-bad_cast::what() const _NOEXCEPT
+bad_cast::what() const noexcept
 {
   return "std::bad_cast";
 }
 
-bad_typeid::~bad_typeid() _NOEXCEPT
+bad_typeid::~bad_typeid() noexcept
 {
 }
 
 const char*
-bad_typeid::what() const _NOEXCEPT
+bad_typeid::what() const noexcept
 {
   return "std::bad_typeid";
 }

--- a/libcudacxx/libcxx/src/support/runtime/exception_glibcxx.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/exception_glibcxx.ipp
@@ -13,19 +13,19 @@
 
 namespace std {
 
-bad_alloc::bad_alloc() _NOEXCEPT
+bad_alloc::bad_alloc() noexcept
 {
 }
 
-bad_array_new_length::bad_array_new_length() _NOEXCEPT
+bad_array_new_length::bad_array_new_length() noexcept
 {
 }
 
-bad_cast::bad_cast() _NOEXCEPT
+bad_cast::bad_cast() noexcept
 {
 }
 
-bad_typeid::bad_typeid() _NOEXCEPT
+bad_typeid::bad_typeid() noexcept
 {
 }
 

--- a/libcudacxx/libcxx/src/support/runtime/exception_libcxxabi.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/exception_libcxxabi.ipp
@@ -13,9 +13,9 @@
 
 namespace std {
 
-bool uncaught_exception() _NOEXCEPT { return uncaught_exceptions() > 0; }
+bool uncaught_exception() noexcept { return uncaught_exceptions() > 0; }
 
-int uncaught_exceptions() _NOEXCEPT
+int uncaught_exceptions() noexcept
 {
 # if _LIBCUDACXXABI_VERSION > 1001
     return __cxa_uncaught_exceptions();

--- a/libcudacxx/libcxx/src/support/runtime/exception_libcxxrt.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/exception_libcxxrt.ipp
@@ -13,11 +13,11 @@
 
 namespace std {
 
-bad_exception::~bad_exception() _NOEXCEPT
+bad_exception::~bad_exception() noexcept
 {
 }
 
-const char* bad_exception::what() const _NOEXCEPT
+const char* bad_exception::what() const noexcept
 {
   return "std::bad_exception";
 }

--- a/libcudacxx/libcxx/src/support/runtime/exception_msvc.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/exception_msvc.ipp
@@ -31,11 +31,11 @@ int __cdecl __uncaught_exceptions();
 namespace std {
 
 unexpected_handler
-set_unexpected(unexpected_handler func) _NOEXCEPT {
+set_unexpected(unexpected_handler func) noexcept {
   return ::set_unexpected(func);
 }
 
-unexpected_handler get_unexpected() _NOEXCEPT {
+unexpected_handler get_unexpected() noexcept {
   return ::_get_unexpected();
 }
 
@@ -46,16 +46,16 @@ void unexpected() {
     terminate();
 }
 
-terminate_handler set_terminate(terminate_handler func) _NOEXCEPT {
+terminate_handler set_terminate(terminate_handler func) noexcept {
   return ::set_terminate(func);
 }
 
-terminate_handler get_terminate() _NOEXCEPT {
+terminate_handler get_terminate() noexcept {
   return ::_get_terminate();
 }
 
 _LIBCUDACXX_NORETURN
-void terminate() _NOEXCEPT
+void terminate() noexcept
 {
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS
     try
@@ -76,85 +76,85 @@ void terminate() _NOEXCEPT
 #endif  // _LIBCUDACXX_NO_EXCEPTIONS
 }
 
-bool uncaught_exception() _NOEXCEPT { return uncaught_exceptions() > 0; }
+bool uncaught_exception() noexcept { return uncaught_exceptions() > 0; }
 
-int uncaught_exceptions() _NOEXCEPT {
+int uncaught_exceptions() noexcept {
     return __uncaught_exceptions();
 }
 
 #if !defined(_LIBCUDACXX_ABI_VCRUNTIME)
-bad_cast::bad_cast() _NOEXCEPT
+bad_cast::bad_cast() noexcept
 {
 }
 
-bad_cast::~bad_cast() _NOEXCEPT
+bad_cast::~bad_cast() noexcept
 {
 }
 
 const char *
-bad_cast::what() const _NOEXCEPT
+bad_cast::what() const noexcept
 {
   return "std::bad_cast";
 }
 
-bad_typeid::bad_typeid() _NOEXCEPT
+bad_typeid::bad_typeid() noexcept
 {
 }
 
-bad_typeid::~bad_typeid() _NOEXCEPT
+bad_typeid::~bad_typeid() noexcept
 {
 }
 
 const char *
-bad_typeid::what() const _NOEXCEPT
+bad_typeid::what() const noexcept
 {
   return "std::bad_typeid";
 }
 
-exception::~exception() _NOEXCEPT
+exception::~exception() noexcept
 {
 }
 
-const char* exception::what() const _NOEXCEPT
+const char* exception::what() const noexcept
 {
   return "std::exception";
 }
 
 
-bad_exception::~bad_exception() _NOEXCEPT
+bad_exception::~bad_exception() noexcept
 {
 }
 
-const char* bad_exception::what() const _NOEXCEPT
+const char* bad_exception::what() const noexcept
 {
   return "std::bad_exception";
 }
 
 
-bad_alloc::bad_alloc() _NOEXCEPT
+bad_alloc::bad_alloc() noexcept
 {
 }
 
-bad_alloc::~bad_alloc() _NOEXCEPT
+bad_alloc::~bad_alloc() noexcept
 {
 }
 
 const char*
-bad_alloc::what() const _NOEXCEPT
+bad_alloc::what() const noexcept
 {
     return "std::bad_alloc";
 }
 
-bad_array_new_length::bad_array_new_length() _NOEXCEPT
+bad_array_new_length::bad_array_new_length() noexcept
 {
 }
 
-bad_array_new_length::~bad_array_new_length() _NOEXCEPT
+bad_array_new_length::~bad_array_new_length() noexcept
 {
 }
 
 const char*
-bad_array_new_length::what() const _NOEXCEPT
+bad_array_new_length::what() const noexcept
 {
     return "bad_array_new_length";
 }

--- a/libcudacxx/libcxx/src/support/runtime/exception_pointer_cxxabi.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/exception_pointer_cxxabi.ipp
@@ -13,17 +13,17 @@
 
 namespace std {
 
-exception_ptr::~exception_ptr() _NOEXCEPT {
+exception_ptr::~exception_ptr() noexcept {
   __cxa_decrement_exception_refcount(__ptr_);
 }
 
-exception_ptr::exception_ptr(const exception_ptr& other) _NOEXCEPT
+exception_ptr::exception_ptr(const exception_ptr& other) noexcept
     : __ptr_(other.__ptr_)
 {
     __cxa_increment_exception_refcount(__ptr_);
 }
 
-exception_ptr& exception_ptr::operator=(const exception_ptr& other) _NOEXCEPT
+exception_ptr& exception_ptr::operator=(const exception_ptr& other) noexcept
 {
     if (__ptr_ != other.__ptr_)
     {
@@ -34,12 +34,12 @@ exception_ptr& exception_ptr::operator=(const exception_ptr& other) _NOEXCEPT
     return *this;
 }
 
-nested_exception::nested_exception() _NOEXCEPT
+nested_exception::nested_exception() noexcept
     : __ptr_(current_exception())
 {
 }
 
-nested_exception::~nested_exception() _NOEXCEPT
+nested_exception::~nested_exception() noexcept
 {
 }
 
@@ -52,7 +52,7 @@ nested_exception::rethrow_nested() const
     rethrow_exception(__ptr_);
 }
 
-exception_ptr current_exception() _NOEXCEPT
+exception_ptr current_exception() noexcept
 {
     // be nicer if there was a constructor that took a ptr, then
     // this whole function would be just:

--- a/libcudacxx/libcxx/src/support/runtime/exception_pointer_glibcxx.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/exception_pointer_glibcxx.ipp
@@ -25,35 +25,35 @@ struct exception_ptr
 {
     void* __ptr_;
 
-    exception_ptr(const exception_ptr&) _NOEXCEPT;
-    exception_ptr& operator=(const exception_ptr&) _NOEXCEPT;
-    ~exception_ptr() _NOEXCEPT;
+    exception_ptr(const exception_ptr&) noexcept;
+    exception_ptr& operator=(const exception_ptr&) noexcept;
+    ~exception_ptr() noexcept;
 };
 
 }
 
 _LIBCUDACXX_NORETURN void rethrow_exception(__exception_ptr::exception_ptr);
 
-exception_ptr::~exception_ptr() _NOEXCEPT
+exception_ptr::~exception_ptr() noexcept
 {
     reinterpret_cast<__exception_ptr::exception_ptr*>(this)->~exception_ptr();
 }
 
-exception_ptr::exception_ptr(const exception_ptr& other) _NOEXCEPT
+exception_ptr::exception_ptr(const exception_ptr& other) noexcept
     : __ptr_(other.__ptr_)
 {
     new (reinterpret_cast<void*>(this)) __exception_ptr::exception_ptr(
         reinterpret_cast<const __exception_ptr::exception_ptr&>(other));
 }
 
-exception_ptr& exception_ptr::operator=(const exception_ptr& other) _NOEXCEPT
+exception_ptr& exception_ptr::operator=(const exception_ptr& other) noexcept
 {
     *reinterpret_cast<__exception_ptr::exception_ptr*>(this) =
         reinterpret_cast<const __exception_ptr::exception_ptr&>(other);
     return *this;
 }
 
-nested_exception::nested_exception() _NOEXCEPT
+nested_exception::nested_exception() noexcept
     : __ptr_(current_exception())
 {
 }

--- a/libcudacxx/libcxx/src/support/runtime/exception_pointer_msvc.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/exception_pointer_msvc.ipp
@@ -24,35 +24,35 @@ __ExceptionPtrCopyException(void*, const void*, const void*);
 
 namespace std {
 
-exception_ptr::exception_ptr() _NOEXCEPT { __ExceptionPtrCreate(this); }
-exception_ptr::exception_ptr(nullptr_t) _NOEXCEPT { __ExceptionPtrCreate(this); }
+exception_ptr::exception_ptr() noexcept { __ExceptionPtrCreate(this); }
+exception_ptr::exception_ptr(nullptr_t) noexcept { __ExceptionPtrCreate(this); }
 
-exception_ptr::exception_ptr(const exception_ptr& __other) _NOEXCEPT {
+exception_ptr::exception_ptr(const exception_ptr& __other) noexcept {
   __ExceptionPtrCopy(this, &__other);
 }
-exception_ptr& exception_ptr::operator=(const exception_ptr& __other) _NOEXCEPT {
+exception_ptr& exception_ptr::operator=(const exception_ptr& __other) noexcept {
   __ExceptionPtrAssign(this, &__other);
   return *this;
 }
 
-exception_ptr& exception_ptr::operator=(nullptr_t) _NOEXCEPT {
+exception_ptr& exception_ptr::operator=(nullptr_t) noexcept {
   exception_ptr dummy;
   __ExceptionPtrAssign(this, &dummy);
   return *this;
 }
 
-exception_ptr::~exception_ptr() _NOEXCEPT { __ExceptionPtrDestroy(this); }
+exception_ptr::~exception_ptr() noexcept { __ExceptionPtrDestroy(this); }
 
-exception_ptr::operator bool() const _NOEXCEPT {
+exception_ptr::operator bool() const noexcept {
   return __ExceptionPtrToBool(this);
 }
 
-bool operator==(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT {
+bool operator==(const exception_ptr& __x, const exception_ptr& __y) noexcept {
   return __ExceptionPtrCompare(&__x, &__y);
 }
 
 
-void swap(exception_ptr& lhs, exception_ptr& rhs) _NOEXCEPT {
+void swap(exception_ptr& lhs, exception_ptr& rhs) noexcept {
   __ExceptionPtrSwap(&rhs, &lhs);
 }
 
@@ -63,7 +63,7 @@ exception_ptr __copy_exception_ptr(void* __except, const void* __ptr) {
   return __ret;
 }
 
-exception_ptr current_exception() _NOEXCEPT {
+exception_ptr current_exception() noexcept {
   exception_ptr __ret;
   __ExceptionPtrCurrentException(&__ret);
   return __ret;
@@ -72,9 +72,9 @@ exception_ptr current_exception() _NOEXCEPT {
 _LIBCUDACXX_NORETURN
 void rethrow_exception(exception_ptr p) { __ExceptionPtrRethrow(&p); }
 
-nested_exception::nested_exception() _NOEXCEPT : __ptr_(current_exception()) {}
+nested_exception::nested_exception() noexcept : __ptr_(current_exception()) {}
 
-nested_exception::~nested_exception() _NOEXCEPT {}
+nested_exception::~nested_exception() noexcept {}
 
 _LIBCUDACXX_NORETURN
 void nested_exception::rethrow_nested() const {

--- a/libcudacxx/libcxx/src/support/runtime/exception_pointer_unimplemented.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/exception_pointer_unimplemented.ipp
@@ -12,14 +12,14 @@
 
 namespace std {
 
-exception_ptr::~exception_ptr() _NOEXCEPT
+exception_ptr::~exception_ptr() noexcept
 {
 #  warning exception_ptr not yet implemented
   fprintf(stderr, "exception_ptr not yet implemented\n");
   ::abort();
 }
 
-exception_ptr::exception_ptr(const exception_ptr& other) _NOEXCEPT
+exception_ptr::exception_ptr(const exception_ptr& other) noexcept
     : __ptr_(other.__ptr_)
 {
 #  warning exception_ptr not yet implemented
@@ -27,21 +27,21 @@ exception_ptr::exception_ptr(const exception_ptr& other) _NOEXCEPT
   ::abort();
 }
 
-exception_ptr& exception_ptr::operator=(const exception_ptr& other) _NOEXCEPT
+exception_ptr& exception_ptr::operator=(const exception_ptr& other) noexcept
 {
 #  warning exception_ptr not yet implemented
   fprintf(stderr, "exception_ptr not yet implemented\n");
   ::abort();
 }
 
-nested_exception::nested_exception() _NOEXCEPT
+nested_exception::nested_exception() noexcept
     : __ptr_(current_exception())
 {
 }
 
 #if !defined(__GLIBCXX__)
 
-nested_exception::~nested_exception() _NOEXCEPT
+nested_exception::~nested_exception() noexcept
 {
 }
 
@@ -61,7 +61,7 @@ nested_exception::rethrow_nested() const
 #endif // FIXME
 }
 
-exception_ptr current_exception() _NOEXCEPT
+exception_ptr current_exception() noexcept
 {
 #  warning exception_ptr not yet implemented
   fprintf(stderr, "exception_ptr not yet implemented\n");

--- a/libcudacxx/libcxx/src/support/runtime/new_handler_fallback.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/new_handler_fallback.ipp
@@ -12,13 +12,13 @@ namespace std {
 _LIBCUDACXX_SAFE_STATIC static std::new_handler __new_handler;
 
 new_handler
-set_new_handler(new_handler handler) _NOEXCEPT
+set_new_handler(new_handler handler) noexcept
 {
     return __libcpp_atomic_exchange(&__new_handler, handler);
 }
 
 new_handler
-get_new_handler() _NOEXCEPT
+get_new_handler() noexcept
 {
     return __libcpp_atomic_load(&__new_handler);
 }

--- a/libcudacxx/libcxx/src/support/runtime/stdexcept_default.ipp
+++ b/libcudacxx/libcxx/src/support/runtime/stdexcept_default.ipp
@@ -23,9 +23,9 @@ logic_error::logic_error(const string& msg) : __imp_(msg.c_str()) {}
 
 logic_error::logic_error(const char* msg) : __imp_(msg) {}
 
-logic_error::logic_error(const logic_error& le) _NOEXCEPT : __imp_(le.__imp_) {}
+logic_error::logic_error(const logic_error& le) noexcept : __imp_(le.__imp_) {}
 
-logic_error& logic_error::operator=(const logic_error& le) _NOEXCEPT {
+logic_error& logic_error::operator=(const logic_error& le) noexcept {
   __imp_ = le.__imp_;
   return *this;
 }
@@ -34,30 +34,30 @@ runtime_error::runtime_error(const string& msg) : __imp_(msg.c_str()) {}
 
 runtime_error::runtime_error(const char* msg) : __imp_(msg) {}
 
-runtime_error::runtime_error(const runtime_error& re) _NOEXCEPT
+runtime_error::runtime_error(const runtime_error& re) noexcept
     : __imp_(re.__imp_) {}
 
-runtime_error& runtime_error::operator=(const runtime_error& re) _NOEXCEPT {
+runtime_error& runtime_error::operator=(const runtime_error& re) noexcept {
   __imp_ = re.__imp_;
   return *this;
 }
 
 #if !defined(_LIBCUDACXXABI_VERSION) && !defined(LIBSTDCXX)
 
-const char* logic_error::what() const _NOEXCEPT { return __imp_.c_str(); }
+const char* logic_error::what() const noexcept { return __imp_.c_str(); }
 
-const char* runtime_error::what() const _NOEXCEPT { return __imp_.c_str(); }
+const char* runtime_error::what() const noexcept { return __imp_.c_str(); }
 
-logic_error::~logic_error() _NOEXCEPT {}
-domain_error::~domain_error() _NOEXCEPT {}
-invalid_argument::~invalid_argument() _NOEXCEPT {}
-length_error::~length_error() _NOEXCEPT {}
-out_of_range::~out_of_range() _NOEXCEPT {}
+logic_error::~logic_error() noexcept {}
+domain_error::~domain_error() noexcept {}
+invalid_argument::~invalid_argument() noexcept {}
+length_error::~length_error() noexcept {}
+out_of_range::~out_of_range() noexcept {}
 
-runtime_error::~runtime_error() _NOEXCEPT {}
-range_error::~range_error() _NOEXCEPT {}
-overflow_error::~overflow_error() _NOEXCEPT {}
-underflow_error::~underflow_error() _NOEXCEPT {}
+runtime_error::~runtime_error() noexcept {}
+range_error::~range_error() noexcept {}
+overflow_error::~overflow_error() noexcept {}
+underflow_error::~underflow_error() noexcept {}
 
 #endif
 

--- a/libcudacxx/libcxx/src/system_error.cpp
+++ b/libcudacxx/libcxx/src/system_error.cpp
@@ -28,29 +28,29 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // class error_category
 
 #if defined(_LIBCUDACXX_DEPRECATED_ABI_LEGACY_LIBRARY_DEFINITIONS_FOR_INLINE_FUNCTIONS)
-error_category::error_category() _NOEXCEPT
+error_category::error_category() noexcept
 {
 }
 #endif
 
-error_category::~error_category() _NOEXCEPT
+error_category::~error_category() noexcept
 {
 }
 
 error_condition
-error_category::default_error_condition(int ev) const _NOEXCEPT
+error_category::default_error_condition(int ev) const noexcept
 {
     return error_condition(ev, *this);
 }
 
 bool
-error_category::equivalent(int code, const error_condition& condition) const _NOEXCEPT
+error_category::equivalent(int code, const error_condition& condition) const noexcept
 {
     return default_error_condition(code) == condition;
 }
 
 bool
-error_category::equivalent(const error_code& code, int condition) const _NOEXCEPT
+error_category::equivalent(const error_code& code, int condition) const noexcept
 {
     return *this == code.category() && code.value() == condition;
 }
@@ -141,12 +141,12 @@ class _LIBCUDACXX_HIDDEN __generic_error_category
     : public __do_message
 {
 public:
-    virtual const char* name() const _NOEXCEPT;
+    virtual const char* name() const noexcept;
     virtual string message(int ev) const;
 };
 
 const char*
-__generic_error_category::name() const _NOEXCEPT
+__generic_error_category::name() const noexcept
 {
     return "generic";
 }
@@ -162,7 +162,7 @@ __generic_error_category::message(int ev) const
 }
 
 const error_category&
-generic_category() _NOEXCEPT
+generic_category() noexcept
 {
     static __generic_error_category s;
     return s;
@@ -172,13 +172,13 @@ class _LIBCUDACXX_HIDDEN __system_error_category
     : public __do_message
 {
 public:
-    virtual const char* name() const _NOEXCEPT;
+    virtual const char* name() const noexcept;
     virtual string message(int ev) const;
-    virtual error_condition default_error_condition(int ev) const _NOEXCEPT;
+    virtual error_condition default_error_condition(int ev) const noexcept;
 };
 
 const char*
-__system_error_category::name() const _NOEXCEPT
+__system_error_category::name() const noexcept
 {
     return "system";
 }
@@ -194,7 +194,7 @@ __system_error_category::message(int ev) const
 }
 
 error_condition
-__system_error_category::default_error_condition(int ev) const _NOEXCEPT
+__system_error_category::default_error_condition(int ev) const noexcept
 {
 #ifdef _LIBCUDACXX_ELAST
     if (ev > _LIBCUDACXX_ELAST)
@@ -204,7 +204,7 @@ __system_error_category::default_error_condition(int ev) const _NOEXCEPT
 }
 
 const error_category&
-system_category() _NOEXCEPT
+system_category() noexcept
 {
     static __system_error_category s;
     return s;
@@ -276,7 +276,7 @@ system_error::system_error(int ev, const error_category& ecat)
 {
 }
 
-system_error::~system_error() _NOEXCEPT
+system_error::~system_error() noexcept
 {
 }
 

--- a/libcudacxx/libcxx/src/thread.cpp
+++ b/libcudacxx/libcxx/src/thread.cpp
@@ -78,7 +78,7 @@ thread::detach()
 }
 
 unsigned
-thread::hardware_concurrency() _NOEXCEPT
+thread::hardware_concurrency() noexcept
 {
 #if defined(CTL_HW) && defined(HW_NCPU)
     unsigned n;

--- a/libcudacxx/libcxx/src/typeinfo.cpp
+++ b/libcudacxx/libcxx/src/typeinfo.cpp
@@ -11,18 +11,18 @@
 #if defined(_LIBCUDACXX_ABI_MICROSOFT) && !defined(_LIBCUDACXX_ABI_VCRUNTIME)
 #include <string.h>
 
-int std::type_info::__compare(const type_info &__rhs) const _NOEXCEPT {
+int std::type_info::__compare(const type_info &__rhs) const noexcept {
   if (&__data == &__rhs.__data)
     return 0;
   return strcmp(&__data.__decorated_name[1], &__rhs.__data.__decorated_name[1]);
 }
 
-const char *std::type_info::name() const _NOEXCEPT {
+const char *std::type_info::name() const noexcept {
   // TODO(compnerd) cache demangled &__data.__decorated_name[1]
   return &__data.__decorated_name[1];
 }
 
-size_t std::type_info::hash_code() const _NOEXCEPT {
+size_t std::type_info::hash_code() const noexcept {
 #if defined(_WIN64)
   constexpr size_t fnv_offset_basis = 14695981039346656037ull;
   constexpr size_t fnv_prime = 10995116282110ull;

--- a/libcudacxx/libcxxabi/src/cxa_default_handlers.cpp
+++ b/libcudacxx/libcxxabi/src/cxa_default_handlers.cpp
@@ -104,7 +104,7 @@ namespace std
 {
 
 unexpected_handler
-set_unexpected(unexpected_handler func) _NOEXCEPT
+set_unexpected(unexpected_handler func) noexcept
 {
     if (func == 0)
         func = default_unexpected_handler;
@@ -113,7 +113,7 @@ set_unexpected(unexpected_handler func) _NOEXCEPT
 }
 
 terminate_handler
-set_terminate(terminate_handler func) _NOEXCEPT
+set_terminate(terminate_handler func) noexcept
 {
     if (func == 0)
         func = default_terminate_handler;

--- a/libcudacxx/libcxxabi/src/cxa_handlers.cpp
+++ b/libcudacxx/libcxxabi/src/cxa_handlers.cpp
@@ -23,7 +23,7 @@ namespace std
 {
 
 unexpected_handler
-get_unexpected() _NOEXCEPT
+get_unexpected() noexcept
 {
     return __libcpp_atomic_load(&__cxa_unexpected_handler, _AO_Acquire);
 }
@@ -44,13 +44,13 @@ unexpected()
 }
 
 terminate_handler
-get_terminate() _NOEXCEPT
+get_terminate() noexcept
 {
     return __libcpp_atomic_load(&__cxa_terminate_handler, _AO_Acquire);
 }
 
 void
-__terminate(terminate_handler func) _NOEXCEPT
+__terminate(terminate_handler func) noexcept
 {
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
     try
@@ -71,7 +71,7 @@ __terminate(terminate_handler func) _NOEXCEPT
 
 __attribute__((noreturn))
 void
-terminate() _NOEXCEPT
+terminate() noexcept
 {
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
     // If there might be an uncaught exception
@@ -97,13 +97,13 @@ new_handler __cxa_new_handler = 0;
 }
 
 new_handler
-set_new_handler(new_handler handler) _NOEXCEPT
+set_new_handler(new_handler handler) noexcept
 {
     return __libcpp_atomic_exchange(&__cxa_new_handler, handler, _AO_Acq_Rel);
 }
 
 new_handler
-get_new_handler() _NOEXCEPT
+get_new_handler() noexcept
 {
     return __libcpp_atomic_load(&__cxa_new_handler, _AO_Acquire);
 }

--- a/libcudacxx/libcxxabi/src/cxa_handlers.h
+++ b/libcudacxx/libcxxabi/src/cxa_handlers.h
@@ -25,7 +25,7 @@ __unexpected(unexpected_handler func);
 
 _LIBCXXABI_HIDDEN _LIBCXXABI_NORETURN
 void
-__terminate(terminate_handler func) _NOEXCEPT;
+__terminate(terminate_handler func) noexcept;
 
 }  // std
 

--- a/libcudacxx/libcxxabi/src/include/refstring.h
+++ b/libcudacxx/libcxxabi/src/include/refstring.h
@@ -46,7 +46,7 @@ inline char * data_from_rep(_Rep_base *rep) noexcept {
 
 #if defined(__APPLE__)
 inline
-const char* compute_gcc_empty_string_storage() _NOEXCEPT
+const char* compute_gcc_empty_string_storage() noexcept
 {
     void* handle = dlopen("/usr/lib/libstdc++.6.dylib", RTLD_NOLOAD);
     if (handle == nullptr)
@@ -59,7 +59,7 @@ const char* compute_gcc_empty_string_storage() _NOEXCEPT
 
 inline
 const char*
-get_gcc_empty_string_storage() _NOEXCEPT
+get_gcc_empty_string_storage() noexcept
 {
     static const char* p = compute_gcc_empty_string_storage();
     return p;
@@ -83,7 +83,7 @@ __libcpp_refstring::__libcpp_refstring(const char* msg) {
 }
 
 inline
-__libcpp_refstring::__libcpp_refstring(const __libcpp_refstring &s) _NOEXCEPT
+__libcpp_refstring::__libcpp_refstring(const __libcpp_refstring &s) noexcept
     : __imp_(s.__imp_)
 {
     if (__uses_refcount())
@@ -91,7 +91,7 @@ __libcpp_refstring::__libcpp_refstring(const __libcpp_refstring &s) _NOEXCEPT
 }
 
 inline
-__libcpp_refstring& __libcpp_refstring::operator=(__libcpp_refstring const& s) _NOEXCEPT {
+__libcpp_refstring& __libcpp_refstring::operator=(__libcpp_refstring const& s) noexcept {
     bool adjust_old_count = __uses_refcount();
     struct _Rep_base *old_rep = rep_from_data(__imp_);
     __imp_ = s.__imp_;

--- a/libcudacxx/libcxxabi/src/stdlib_exception.cpp
+++ b/libcudacxx/libcxxabi/src/stdlib_exception.cpp
@@ -15,22 +15,22 @@ namespace std
 
 // exception
 
-exception::~exception() _NOEXCEPT
+exception::~exception() noexcept
 {
 }
 
-const char* exception::what() const _NOEXCEPT
+const char* exception::what() const noexcept
 {
   return "std::exception";
 }
 
 // bad_exception
 
-bad_exception::~bad_exception() _NOEXCEPT
+bad_exception::~bad_exception() noexcept
 {
 }
 
-const char* bad_exception::what() const _NOEXCEPT
+const char* bad_exception::what() const noexcept
 {
   return "std::bad_exception";
 }
@@ -38,32 +38,32 @@ const char* bad_exception::what() const _NOEXCEPT
 
 //  bad_alloc
 
-bad_alloc::bad_alloc() _NOEXCEPT
+bad_alloc::bad_alloc() noexcept
 {
 }
 
-bad_alloc::~bad_alloc() _NOEXCEPT
+bad_alloc::~bad_alloc() noexcept
 {
 }
 
 const char*
-bad_alloc::what() const _NOEXCEPT
+bad_alloc::what() const noexcept
 {
     return "std::bad_alloc";
 }
 
 // bad_array_new_length
 
-bad_array_new_length::bad_array_new_length() _NOEXCEPT
+bad_array_new_length::bad_array_new_length() noexcept
 {
 }
 
-bad_array_new_length::~bad_array_new_length() _NOEXCEPT
+bad_array_new_length::~bad_array_new_length() noexcept
 {
 }
 
 const char*
-bad_array_new_length::what() const _NOEXCEPT
+bad_array_new_length::what() const noexcept
 {
     return "bad_array_new_length";
 }

--- a/libcudacxx/libcxxabi/src/stdlib_new_delete.cpp
+++ b/libcudacxx/libcxxabi/src/stdlib_new_delete.cpp
@@ -14,7 +14,7 @@
 #include <cstdlib>
 
 #if !defined(_THROW_BAD_ALLOC) || !defined(_NOEXCEPT) || !defined(_LIBCXXABI_WEAK)
-#error The _THROW_BAD_ALLOC, _NOEXCEPT, and _LIBCXXABI_WEAK libc++ macros must \
+#error The _THROW_BAD_ALLOC, noexcept, and _LIBCXXABI_WEAK libc++ macros must \
        already be defined by libc++.
 #endif
 // Implement all new and delete operators as weak definitions
@@ -47,7 +47,7 @@ operator new(std::size_t size) _THROW_BAD_ALLOC
 
 _LIBCXXABI_WEAK
 void*
-operator new(size_t size, const std::nothrow_t&) _NOEXCEPT
+operator new(size_t size, const std::nothrow_t&) noexcept
 {
     void* p = 0;
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
@@ -73,7 +73,7 @@ operator new[](size_t size) _THROW_BAD_ALLOC
 
 _LIBCXXABI_WEAK
 void*
-operator new[](size_t size, const std::nothrow_t&) _NOEXCEPT
+operator new[](size_t size, const std::nothrow_t&) noexcept
 {
     void* p = 0;
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
@@ -92,7 +92,7 @@ operator new[](size_t size, const std::nothrow_t&) _NOEXCEPT
 
 _LIBCXXABI_WEAK
 void
-operator delete(void* ptr) _NOEXCEPT
+operator delete(void* ptr) noexcept
 {
     if (ptr)
         ::free(ptr);
@@ -100,35 +100,35 @@ operator delete(void* ptr) _NOEXCEPT
 
 _LIBCXXABI_WEAK
 void
-operator delete(void* ptr, const std::nothrow_t&) _NOEXCEPT
+operator delete(void* ptr, const std::nothrow_t&) noexcept
 {
     ::operator delete(ptr);
 }
 
 _LIBCXXABI_WEAK
 void
-operator delete(void* ptr, size_t) _NOEXCEPT
+operator delete(void* ptr, size_t) noexcept
 {
     ::operator delete(ptr);
 }
 
 _LIBCXXABI_WEAK
 void
-operator delete[] (void* ptr) _NOEXCEPT
+operator delete[] (void* ptr) noexcept
 {
     ::operator delete(ptr);
 }
 
 _LIBCXXABI_WEAK
 void
-operator delete[] (void* ptr, const std::nothrow_t&) _NOEXCEPT
+operator delete[] (void* ptr, const std::nothrow_t&) noexcept
 {
     ::operator delete[](ptr);
 }
 
 _LIBCXXABI_WEAK
 void
-operator delete[] (void* ptr, size_t) _NOEXCEPT
+operator delete[] (void* ptr, size_t) noexcept
 {
     ::operator delete[](ptr);
 }
@@ -169,7 +169,7 @@ operator new(std::size_t size, std::align_val_t alignment) _THROW_BAD_ALLOC
 
 _LIBCXXABI_WEAK
 void*
-operator new(size_t size, std::align_val_t alignment, const std::nothrow_t&) _NOEXCEPT
+operator new(size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept
 {
     void* p = 0;
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
@@ -195,7 +195,7 @@ operator new[](size_t size, std::align_val_t alignment) _THROW_BAD_ALLOC
 
 _LIBCXXABI_WEAK
 void*
-operator new[](size_t size, std::align_val_t alignment, const std::nothrow_t&) _NOEXCEPT
+operator new[](size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept
 {
     void* p = 0;
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
@@ -214,7 +214,7 @@ operator new[](size_t size, std::align_val_t alignment, const std::nothrow_t&) _
 
 _LIBCXXABI_WEAK
 void
-operator delete(void* ptr, std::align_val_t) _NOEXCEPT
+operator delete(void* ptr, std::align_val_t) noexcept
 {
     if (ptr)
 #if defined(_LIBCUDACXX_WIN32API)
@@ -226,35 +226,35 @@ operator delete(void* ptr, std::align_val_t) _NOEXCEPT
 
 _LIBCXXABI_WEAK
 void
-operator delete(void* ptr, std::align_val_t alignment, const std::nothrow_t&) _NOEXCEPT
+operator delete(void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept
 {
     ::operator delete(ptr, alignment);
 }
 
 _LIBCXXABI_WEAK
 void
-operator delete(void* ptr, size_t, std::align_val_t alignment) _NOEXCEPT
+operator delete(void* ptr, size_t, std::align_val_t alignment) noexcept
 {
     ::operator delete(ptr, alignment);
 }
 
 _LIBCXXABI_WEAK
 void
-operator delete[] (void* ptr, std::align_val_t alignment) _NOEXCEPT
+operator delete[] (void* ptr, std::align_val_t alignment) noexcept
 {
     ::operator delete(ptr, alignment);
 }
 
 _LIBCXXABI_WEAK
 void
-operator delete[] (void* ptr, std::align_val_t alignment, const std::nothrow_t&) _NOEXCEPT
+operator delete[] (void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept
 {
     ::operator delete[](ptr, alignment);
 }
 
 _LIBCXXABI_WEAK
 void
-operator delete[] (void* ptr, size_t, std::align_val_t alignment) _NOEXCEPT
+operator delete[] (void* ptr, size_t, std::align_val_t alignment) noexcept
 {
     ::operator delete[](ptr, alignment);
 }

--- a/libcudacxx/libcxxabi/src/stdlib_stdexcept.cpp
+++ b/libcudacxx/libcxxabi/src/stdlib_stdexcept.cpp
@@ -19,29 +19,29 @@ static_assert(sizeof(std::__libcpp_refstring) == sizeof(const char *), "");
 namespace std  // purposefully not using versioning namespace
 {
 
-logic_error::~logic_error() _NOEXCEPT {}
+logic_error::~logic_error() noexcept {}
 
 const char*
-logic_error::what() const _NOEXCEPT
+logic_error::what() const noexcept
 {
     return __imp_.c_str();
 }
 
-runtime_error::~runtime_error() _NOEXCEPT {}
+runtime_error::~runtime_error() noexcept {}
 
 const char*
-runtime_error::what() const _NOEXCEPT
+runtime_error::what() const noexcept
 {
     return __imp_.c_str();
 }
 
-domain_error::~domain_error() _NOEXCEPT {}
-invalid_argument::~invalid_argument() _NOEXCEPT {}
-length_error::~length_error() _NOEXCEPT {}
-out_of_range::~out_of_range() _NOEXCEPT {}
+domain_error::~domain_error() noexcept {}
+invalid_argument::~invalid_argument() noexcept {}
+length_error::~length_error() noexcept {}
+out_of_range::~out_of_range() noexcept {}
 
-range_error::~range_error() _NOEXCEPT {}
-overflow_error::~overflow_error() _NOEXCEPT {}
-underflow_error::~underflow_error() _NOEXCEPT {}
+range_error::~range_error() noexcept {}
+overflow_error::~overflow_error() noexcept {}
+underflow_error::~underflow_error() noexcept {}
 
 }  // std

--- a/libcudacxx/libcxxabi/src/stdlib_typeinfo.cpp
+++ b/libcudacxx/libcxxabi/src/stdlib_typeinfo.cpp
@@ -19,32 +19,32 @@ type_info::~type_info()
 
 // bad_cast
 
-bad_cast::bad_cast() _NOEXCEPT
+bad_cast::bad_cast() noexcept
 {
 }
 
-bad_cast::~bad_cast() _NOEXCEPT
+bad_cast::~bad_cast() noexcept
 {
 }
 
 const char*
-bad_cast::what() const _NOEXCEPT
+bad_cast::what() const noexcept
 {
   return "std::bad_cast";
 }
 
 // bad_typeid
 
-bad_typeid::bad_typeid() _NOEXCEPT
+bad_typeid::bad_typeid() noexcept
 {
 }
 
-bad_typeid::~bad_typeid() _NOEXCEPT
+bad_typeid::~bad_typeid() noexcept
 {
 }
 
 const char*
-bad_typeid::what() const _NOEXCEPT
+bad_typeid::what() const noexcept
 {
   return "std::bad_typeid";
 }


### PR DESCRIPTION
## Description

As part of https://github.com/NVIDIA/cccl/issues/127, code for unsupported compilation modes/platforms will be removed.
`noexcept` is supported by all targeted compilers, so the conditional support can be removed.
All uses of the `_NOEXCEPT` macro are replaced by `noexcept`.

## Checklist
[x] I am familiar with the [Contributing Guidelines]().
