### PR TITLE
[skip-tests] Guard inline variables with `_LIBCUDACXX_INLINE_VAR` macro

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/concepts.h
@@ -399,7 +399,7 @@ template<class _Sp, class _Ip>
 _LIBCUDACXX_CONCEPT sentinel_for = _LIBCUDACXX_FRAGMENT(__sentinel_for_, _Sp, _Ip);
 
 template<class, class>
-inline constexpr bool disable_sized_sentinel_for = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool disable_sized_sentinel_for = false;
 
 template<class _Sp, class _Ip>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
@@ -699,16 +699,16 @@ template<class _In, class _Out>
 _LIBCUDACXX_CONCEPT indirectly_copyable_storable =_LIBCUDACXX_FRAGMENT(__indirectly_copyable_storable_, _In, _Out);
 
 template<class _Ip, class = void>
-inline constexpr bool __has_iter_category = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_iter_category = false;
 
 template<class _Ip>
-inline constexpr bool __has_iter_category<_Ip, void_t<typename _Ip::iterator_category>> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_iter_category<_Ip, void_t<typename _Ip::iterator_category>> = true;
 
 template<class _Ip, class = void>
-inline constexpr bool __has_iter_concept = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_iter_concept = false;
 
 template<class _Ip>
-inline constexpr bool __has_iter_concept<_Ip, void_t<typename _Ip::iterator_concept>> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_iter_concept<_Ip, void_t<typename _Ip::iterator_concept>> = true;
 
 #endif // _LIBCUDACXX_STD_VER > 14
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/incrementable_traits.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/incrementable_traits.h
@@ -92,18 +92,18 @@ template<class _Ip>
 struct incrementable_traits<const _Ip> : incrementable_traits<_Ip> {};
 
 template<class _Tp, class = void>
-inline constexpr bool __has_member_difference_type = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_difference_type = false;
 
 template<class _Tp>
-inline constexpr bool __has_member_difference_type<_Tp, void_t<typename _Tp::difference_type>> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_difference_type<_Tp, void_t<typename _Tp::difference_type>> = true;
 
 template<class _Tp,class = void, class = void>
-inline constexpr bool __has_integral_minus = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_integral_minus = false;
 
 // In C++17 we get issues trying to bind void* to a const& so special case it here
 template<class _Tp>
-inline constexpr bool __has_integral_minus<_Tp, enable_if_t<!same_as<_Tp, void*>>,
-                                                void_t<decltype(_CUDA_VSTD::declval<const _Tp&>() - _CUDA_VSTD::declval<const _Tp&>())>>
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_integral_minus<_Tp, enable_if_t<!same_as<_Tp, void*>>,
+                                                                void_t<decltype(_CUDA_VSTD::declval<const _Tp&>() - _CUDA_VSTD::declval<const _Tp&>())>>
   = integral<decltype(_CUDA_VSTD::declval<const _Tp&>() - _CUDA_VSTD::declval<const _Tp&>())>;
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iterator_traits.h
@@ -502,22 +502,22 @@ _LIBCUDACXX_CONCEPT __cpp17_random_access_iterator =
 } // namespace __iterator_traits_detail
 
 template<class, class = void>
-inline constexpr bool __has_member_reference = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_reference = false;
 
 template<class _Tp>
-inline constexpr bool __has_member_reference<_Tp, void_t<typename _Tp::reference>> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_reference<_Tp, void_t<typename _Tp::reference>> = true;
 
 template<class, class = void>
-inline constexpr bool __has_member_pointer = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_pointer = false;
 
 template<class _Tp>
-inline constexpr bool __has_member_pointer<_Tp, void_t<typename _Tp::pointer>> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_pointer<_Tp, void_t<typename _Tp::pointer>> = true;
 
 template<class, class = void>
-inline constexpr bool __has_member_iterator_category = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_iterator_category = false;
 
 template<class _Tp>
-inline constexpr bool __has_member_iterator_category<_Tp, void_t<typename _Tp::iterator_category>> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_iterator_category<_Tp, void_t<typename _Tp::iterator_category>> = true;
 
 template<class _Ip>
 _LIBCUDACXX_CONCEPT __specifies_members =

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/readable_traits.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/readable_traits.h
@@ -101,16 +101,16 @@ template<class _Tp>
 struct __cond_value_type<_Tp, enable_if_t<_LIBCUDACXX_TRAIT(is_object, _Tp)>> { using value_type = remove_cv_t<_Tp>; };
 
 template<class _Tp, class = void>
-inline constexpr bool __has_member_value_type = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_value_type = false;
 
 template<class _Tp>
-inline constexpr bool __has_member_value_type<_Tp, void_t<typename _Tp::value_type>> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_value_type<_Tp, void_t<typename _Tp::value_type>> = true;
 
 template<class _Tp, class = void>
-inline constexpr bool __has_member_element_type = false;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_element_type = false;
 
 template<class _Tp>
-inline constexpr bool __has_member_element_type<_Tp, void_t<typename _Tp::element_type>> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_member_element_type<_Tp, void_t<typename _Tp::element_type>> = true;
 
 template<class, class = void> struct indirectly_readable_traits {};
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_scoped_enum.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_scoped_enum.h
@@ -38,7 +38,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS is_scoped_enum
     : public __is_scoped_enum_helper<_Tp> {};
 
 template <class _Tp>
-inline constexpr bool is_scoped_enum_v = is_scoped_enum<_Tp>::value;
+_LIBCUDACXX_INLINE_VAR constexpr bool is_scoped_enum_v = is_scoped_enum<_Tp>::value;
 #endif
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_trivially_copy_assignable.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_trivially_copy_assignable.h
@@ -50,7 +50,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS is_trivially_copy_assignable
 
 #if _LIBCUDACXX_STD_VER > 11 && !defined(_LIBCUDACXX_HAS_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
-inline constexpr bool is_trivially_copy_assignable_v = is_trivially_copy_assignable<_Tp>::value;
+_LIBCUDACXX_INLINE_VAR constexpr bool is_trivially_copy_assignable_v = is_trivially_copy_assignable<_Tp>::value;
 #endif
 
 #endif // defined(_LIBCUDACXX_IS_TRIVIALLY_ASSIGNABLE) && !defined(_LIBCUDACXX_USE_IS_TRIVIALLY_ASSIGNABLE_FALLBACK)


### PR DESCRIPTION
gcc-6 cannot handle inline variables, so we need to guard against them.

This prevents cuDNN from switching to C++17 