### PR TITLE
Replace default, constexpr, and delete macros by original keywords

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__bit_reference
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__bit_reference
@@ -142,14 +142,14 @@ public:
     __bit_const_reference(const __bit_reference<_Cp>& __x) noexcept
         : __seg_(__x.__seg_), __mask_(__x.__mask_) {}
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR operator bool() const noexcept
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr operator bool() const noexcept
         {return static_cast<bool>(*__seg_ & __mask_);}
 
     _LIBCUDACXX_INLINE_VISIBILITY __bit_iterator<_Cp, true> operator&() const noexcept
         {return __bit_iterator<_Cp, true>(__seg_, static_cast<unsigned>(__libcpp_ctz(__mask_)));}
 private:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR
+    constexpr
     __bit_const_reference(__storage_pointer __s, __storage_type __m) noexcept
         : __seg_(__s), __mask_(__m) {}
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -1546,24 +1546,6 @@ typedef unsigned int   char32_t;
 # define decltype(...) __decltype(__VA_ARGS__)
 #endif  // _LIBCUDACXX_CXX03_LANG
 
-#ifdef _LIBCUDACXX_CXX03_LANG
-#  define _LIBCUDACXX_CONSTEXPR
-#else
-#  define _LIBCUDACXX_CONSTEXPR constexpr
-#endif
-
-#ifdef _LIBCUDACXX_CXX03_LANG
-#  define _LIBCUDACXX_DEFAULT {}
-#else
-#  define _LIBCUDACXX_DEFAULT = default;
-#endif
-
-#ifdef _LIBCUDACXX_CXX03_LANG
-#  define _LIBCUDACXX_EQUAL_DELETE
-#else
-#  define _LIBCUDACXX_EQUAL_DELETE = delete
-#endif
-
 #if defined(_LIBCUDACXX_COMPILER_GCC)   \
  || defined(_LIBCUDACXX_COMPILER_CLANG)
 #  define _LIBCUDACXX_NOALIAS __attribute__((__malloc__))

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/barrier.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/barrier.h
@@ -60,7 +60,7 @@ public:
     barrier(const barrier &) = delete;
     barrier & operator=(const barrier &) = delete;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     barrier(_CUDA_VSTD::ptrdiff_t __expected, _CompletionF __completion = _CompletionF())
         : _CUDA_VSTD::__barrier_base<_CompletionF, _Sco>(__expected, __completion) {
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/latch.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/latch.h
@@ -20,7 +20,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 template<thread_scope _Sco>
 class latch : public _CUDA_VSTD::__latch_base<_Sco> {
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     latch(_CUDA_VSTD::ptrdiff_t __count)
         : _CUDA_VSTD::__latch_base<_Sco>(__count) {
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/semaphore.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/semaphore.h
@@ -26,7 +26,7 @@ class counting_semaphore : public _CUDA_VSTD::__semaphore_base<__least_max_value
 {
     static_assert(__least_max_value <= _CUDA_VSTD::__semaphore_base<__least_max_value, _Sco>::max(), "");
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     counting_semaphore(ptrdiff_t __count = 0) : _CUDA_VSTD::__semaphore_base<__least_max_value, _Sco>(__count) { }
     ~counting_semaphore() = default;
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/function.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/function.h
@@ -612,7 +612,7 @@ struct __policy
     _LIBCUDACXX_INLINE_VISIBILITY
     static const __policy* __create_empty()
     {
-        static const _LIBCUDACXX_CONSTEXPR __policy __policy_ = {nullptr, nullptr,
+        static const constexpr __policy __policy_ = {nullptr, nullptr,
                                                              true,
 #ifndef _LIBCUDACXX_NO_RTTI
                                                              &typeid(void)
@@ -638,7 +638,7 @@ struct __policy
     template <typename _Fun>
     _LIBCUDACXX_INLINE_VISIBILITY static const __policy*
     __choose_policy(/* is_small = */ false_type) {
-      static const _LIBCUDACXX_CONSTEXPR __policy __policy_ = {
+      static const constexpr __policy __policy_ = {
           &__large_clone<_Fun>, &__large_destroy<_Fun>, false,
 #ifndef _LIBCUDACXX_NO_RTTI
           &typeid(typename _Fun::_Target)
@@ -653,7 +653,7 @@ struct __policy
     _LIBCUDACXX_INLINE_VISIBILITY static const __policy*
         __choose_policy(/* is_small = */ true_type)
     {
-        static const _LIBCUDACXX_CONSTEXPR __policy __policy_ = {
+        static const constexpr __policy __policy_ = {
             nullptr, nullptr, false,
 #ifndef _LIBCUDACXX_NO_RTTI
             &typeid(typename _Fun::_Target)

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/identity.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/identity.h
@@ -25,7 +25,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 struct __identity {
   template <class _Tp>
-  _LIBCUDACXX_NODISCARD_EXT _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR _Tp&& operator()(_Tp&& __t) const noexcept {
+  _LIBCUDACXX_NODISCARD_EXT _LIBCUDACXX_INLINE_VISIBILITY constexpr _Tp&& operator()(_Tp&& __t) const noexcept {
     return _CUDA_VSTD::forward<_Tp>(__t);
   }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/invoke.h
@@ -342,7 +342,7 @@ _LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0, class ..._Args,
           class = __enable_if_bullet1<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR decltype((_CUDA_VSTD::declval<_A0>().*_CUDA_VSTD::declval<_Fp>())(_CUDA_VSTD::declval<_Args>()...))
+constexpr decltype((_CUDA_VSTD::declval<_A0>().*_CUDA_VSTD::declval<_Fp>())(_CUDA_VSTD::declval<_Args>()...))
 __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
     noexcept(noexcept((static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...)))
     { return           (static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...); }
@@ -351,7 +351,7 @@ _LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0, class ..._Args,
           class = __enable_if_bullet2<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR decltype((_CUDA_VSTD::declval<_A0>().get().*_CUDA_VSTD::declval<_Fp>())(_CUDA_VSTD::declval<_Args>()...))
+constexpr decltype((_CUDA_VSTD::declval<_A0>().get().*_CUDA_VSTD::declval<_Fp>())(_CUDA_VSTD::declval<_Args>()...))
 __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
     noexcept(noexcept((__a0.get().*__f)(static_cast<_Args&&>(__args)...)))
     { return          (__a0.get().*__f)(static_cast<_Args&&>(__args)...); }
@@ -360,7 +360,7 @@ _LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0, class ..._Args,
           class = __enable_if_bullet3<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR decltype(((*_CUDA_VSTD::declval<_A0>()).*_CUDA_VSTD::declval<_Fp>())(_CUDA_VSTD::declval<_Args>()...))
+constexpr decltype(((*_CUDA_VSTD::declval<_A0>()).*_CUDA_VSTD::declval<_Fp>())(_CUDA_VSTD::declval<_Args>()...))
 __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
     noexcept(noexcept(((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...)))
     { return          ((*static_cast<_A0&&>(__a0)).*__f)(static_cast<_Args&&>(__args)...); }
@@ -371,7 +371,7 @@ _LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0,
           class = __enable_if_bullet4<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR decltype(_CUDA_VSTD::declval<_A0>().*_CUDA_VSTD::declval<_Fp>())
+constexpr decltype(_CUDA_VSTD::declval<_A0>().*_CUDA_VSTD::declval<_Fp>())
 __invoke(_Fp&& __f, _A0&& __a0)
     noexcept(noexcept(static_cast<_A0&&>(__a0).*__f))
     { return          static_cast<_A0&&>(__a0).*__f; }
@@ -380,7 +380,7 @@ _LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0,
           class = __enable_if_bullet5<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR decltype(_CUDA_VSTD::declval<_A0>().get().*_CUDA_VSTD::declval<_Fp>())
+constexpr decltype(_CUDA_VSTD::declval<_A0>().get().*_CUDA_VSTD::declval<_Fp>())
 __invoke(_Fp&& __f, _A0&& __a0)
     noexcept(noexcept(__a0.get().*__f))
     { return          __a0.get().*__f; }
@@ -389,7 +389,7 @@ _LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0,
           class = __enable_if_bullet6<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR decltype((*_CUDA_VSTD::declval<_A0>()).*_CUDA_VSTD::declval<_Fp>())
+constexpr decltype((*_CUDA_VSTD::declval<_A0>()).*_CUDA_VSTD::declval<_Fp>())
 __invoke(_Fp&& __f, _A0&& __a0)
     noexcept(noexcept((*static_cast<_A0&&>(__a0)).*__f))
     { return          (*static_cast<_A0&&>(__a0)).*__f; }
@@ -399,7 +399,7 @@ __invoke(_Fp&& __f, _A0&& __a0)
 _LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class ..._Args>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR decltype(_CUDA_VSTD::declval<_Fp>()(_CUDA_VSTD::declval<_Args>()...))
+constexpr decltype(_CUDA_VSTD::declval<_Fp>()(_CUDA_VSTD::declval<_Args>()...))
 __invoke(_Fp&& __f, _Args&& ...__args)
     noexcept(noexcept(static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...)))
     { return          static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...); }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/istream_iterator.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/istream_iterator.h
@@ -43,7 +43,7 @@ private:
     istream_type* __in_stream_;
     _Tp __value_;
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR istream_iterator() : __in_stream_(0), __value_() {}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr istream_iterator() : __in_stream_(0), __value_() {}
     _LIBCUDACXX_INLINE_VISIBILITY istream_iterator(istream_type& __s) : __in_stream_(_CUDA_VSTD::addressof(__s))
         {
             if (!(*__in_stream_ >> __value_))

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/istreambuf_iterator.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/istreambuf_iterator.h
@@ -63,7 +63,7 @@ private:
         return __sbuf_ == 0;
     }
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR istreambuf_iterator() noexcept : __sbuf_(0) {}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr istreambuf_iterator() noexcept : __sbuf_(0) {}
     _LIBCUDACXX_INLINE_VISIBILITY istreambuf_iterator(istream_type& __s) noexcept
         : __sbuf_(__s.rdbuf()) {}
     _LIBCUDACXX_INLINE_VISIBILITY istreambuf_iterator(streambuf_type* __s) noexcept

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__locale
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__locale
@@ -205,7 +205,7 @@ class _LIBCUDACXX_TYPE_VIS locale::id
 
     static int32_t __next_id;
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR id() :__id_(0) {}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr id() :__id_(0) {}
 private:
     void __init();
     void operator=(const id&); // = delete;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__memory/pointer_traits.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__memory/pointer_traits.h
@@ -306,7 +306,7 @@ template <class _Pointer, class = void>
 struct __to_address_helper;
 
 template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 _Tp* __to_address(_Tp* __p) noexcept {
     static_assert(!is_function<_Tp>::value, "_Tp is a function type");
     return __p;
@@ -337,7 +337,7 @@ struct _IsFancyPointer {
 template <class _Pointer, class = __enable_if_t<
     _And<is_class<_Pointer>, _IsFancyPointer<_Pointer> >::value
 > >
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 __decay_t<decltype(__to_address_helper<_Pointer>::__call(declval<const _Pointer&>()))>
 __to_address(const _Pointer& __p) noexcept {
     return __to_address_helper<_Pointer>::__call(__p);
@@ -345,7 +345,7 @@ __to_address(const _Pointer& __p) noexcept {
 
 template <class _Pointer, class>
 struct __to_address_helper {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     static decltype(_CUDA_VSTD::__to_address(declval<const _Pointer&>().operator->()))
     __call(const _Pointer& __p) noexcept {
         return _CUDA_VSTD::__to_address(__p.operator->());
@@ -354,7 +354,7 @@ struct __to_address_helper {
 
 template <class _Pointer>
 struct __to_address_helper<_Pointer, decltype((void)pointer_traits<_Pointer>::to_address(declval<const _Pointer&>()))> {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     static decltype(pointer_traits<_Pointer>::to_address(declval<const _Pointer&>()))
     __call(const _Pointer& __p) noexcept {
         return pointer_traits<_Pointer>::to_address(__p);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__mutex_base
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__mutex_base
@@ -44,7 +44,7 @@ class _LIBCUDACXX_TYPE_VIS _LIBCUDACXX_THREAD_SAFETY_ANNOTATION(capability("mute
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR mutex() = default;
+    constexpr mutex() = default;
 
     mutex(const mutex&) = delete;
     mutex& operator=(const mutex&) = delete;
@@ -106,8 +106,8 @@ public:
     ~lock_guard() _LIBCUDACXX_THREAD_SAFETY_ANNOTATION(release_capability()) {__m_.unlock();}
 
 private:
-    lock_guard(lock_guard const&) _LIBCUDACXX_EQUAL_DELETE;
-    lock_guard& operator=(lock_guard const&) _LIBCUDACXX_EQUAL_DELETE;
+    lock_guard(lock_guard const&) = delete;
+    lock_guard& operator=(lock_guard const&) = delete;
 };
 
 template <class _Mutex>
@@ -287,7 +287,7 @@ class _LIBCUDACXX_TYPE_VIS condition_variable
     __libcpp_condvar_t __cv_ = _LIBCUDACXX_CONDVAR_INITIALIZER;
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR condition_variable() noexcept = default;
+    constexpr condition_variable() noexcept = default;
 
 #ifdef _LIBCUDACXX_HAS_TRIVIAL_CONDVAR_DESTRUCTION
     ~condition_variable() = default;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__nullptr
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__nullptr
@@ -26,24 +26,24 @@ struct _LIBCUDACXX_TEMPLATE_VIS nullptr_t
 
     struct __nat {int __for_bool_;};
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR nullptr_t() : __lx(0) {}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR nullptr_t(int __nat::*) : __lx(0) {}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr nullptr_t() : __lx(0) {}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr nullptr_t(int __nat::*) : __lx(0) {}
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR operator int __nat::*() const {return 0;}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr operator int __nat::*() const {return 0;}
 
     template <class _Tp>
-        _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+        _LIBCUDACXX_INLINE_VISIBILITY constexpr
         operator _Tp* () const {return 0;}
 
     template <class _Tp, class _Up>
         _LIBCUDACXX_INLINE_VISIBILITY
         operator _Tp _Up::* () const {return 0;}
 
-    friend _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR bool operator==(nullptr_t, nullptr_t) {return true;}
-    friend _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR bool operator!=(nullptr_t, nullptr_t) {return false;}
+    friend _LIBCUDACXX_INLINE_VISIBILITY constexpr bool operator==(nullptr_t, nullptr_t) {return true;}
+    friend _LIBCUDACXX_INLINE_VISIBILITY constexpr bool operator!=(nullptr_t, nullptr_t) {return false;}
 };
 
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR nullptr_t __get_nullptr_t() {return nullptr_t(0);}
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr nullptr_t __get_nullptr_t() {return nullptr_t(0);}
 
 #define nullptr _CUDA_VSTD::__get_nullptr_t()
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -84,9 +84,9 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits
 
     static inline void _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
         assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool eq(char_type __c1, char_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool lt(char_type __c1, char_type __c2) noexcept
         {return __c1 < __c2;}
 
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
@@ -101,15 +101,15 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits
     _LIBCUDACXX_INLINE_VISIBILITY
     static char_type*       assign(char_type* __s, size_t __n, char_type __a);
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
+    static inline constexpr int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
+    static inline constexpr char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type  to_int_type(char_type __c) noexcept
+    static inline constexpr int_type  to_int_type(char_type __c) noexcept
         {return int_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool      eq_int_type(int_type __c1, int_type __c2) noexcept
+    static inline constexpr bool      eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type  eof() noexcept
+    static inline constexpr int_type  eof() noexcept
         {return int_type(EOF);}
 };
 
@@ -208,9 +208,9 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char>
 
     static inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
     void assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool eq(char_type __c1, char_type __c2) noexcept
             {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool lt(char_type __c1, char_type __c2) noexcept
         {return (unsigned char)__c1 < (unsigned char)__c2;}
 
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
@@ -229,15 +229,15 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char>
     static inline char_type* assign(char_type* __s, size_t __n, char_type __a) noexcept
         {return __n == 0 ? __s : (char_type*)memset(__s, to_int_type(__a), __n);}
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
+    static inline constexpr int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
+    static inline constexpr char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) noexcept
+    static inline constexpr int_type to_int_type(char_type __c) noexcept
         {return int_type((unsigned char)__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) noexcept
+    static inline constexpr bool eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type  eof() noexcept
+    static inline constexpr int_type  eof() noexcept
         {return int_type(EOF);}
 };
 
@@ -298,9 +298,9 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<wchar_t>
 
     static inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
     void assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool eq(char_type __c1, char_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool lt(char_type __c1, char_type __c2) noexcept
         {return __c1 < __c2;}
 
     static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
@@ -319,15 +319,15 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<wchar_t>
     static inline char_type* assign(char_type* __s, size_t __n, char_type __a) noexcept
         {return __n == 0 ? __s : (char_type*)wmemset(__s, __a, __n);}
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
+    static inline constexpr int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
+    static inline constexpr char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) noexcept
+    static inline constexpr int_type to_int_type(char_type __c) noexcept
         {return int_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) noexcept
+    static inline constexpr bool eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type eof() noexcept
+    static inline constexpr int_type eof() noexcept
         {return int_type(WEOF);}
 };
 
@@ -356,8 +356,7 @@ char_traits<wchar_t>::compare(const char_type* __s1, const char_type* __s2, size
 
 template <class _Traits>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-inline size_t __char_traits_length_checked(const typename _Traits::char_type* __s) noexcept {
+constexpr inline size_t __char_traits_length_checked(const typename _Traits::char_type* __s) noexcept {
 #if _LIBCUDACXX_DEBUG_LEVEL >= 1
   return __s ? _Traits::length(__s) : (_CUDA_VSTD::__libcpp_debug_function(_CUDA_VSTD::__libcpp_debug_info(__FILE__, __LINE__, "p == nullptr", "null pointer pass to non-null argument of char_traits<...>::length")), 0);
 #else
@@ -512,9 +511,9 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char16_t>
 
     static inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
     void assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool eq(char_type __c1, char_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool lt(char_type __c1, char_type __c2) noexcept
         {return __c1 < __c2;}
 
     _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
@@ -530,15 +529,15 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char16_t>
     _LIBCUDACXX_INLINE_VISIBILITY
     static char_type*       assign(char_type* __s, size_t __n, char_type __a) noexcept;
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
+    static inline constexpr int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
+    static inline constexpr char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) noexcept
+    static inline constexpr int_type to_int_type(char_type __c) noexcept
         {return int_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) noexcept
+    static inline constexpr bool eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type eof() noexcept
+    static inline constexpr int_type eof() noexcept
         {return int_type(0xFFFF);}
 };
 
@@ -631,9 +630,9 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char32_t>
 
     static inline _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
     void assign(char_type& __c1, const char_type& __c2) noexcept {__c1 = __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool eq(char_type __c1, char_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR bool lt(char_type __c1, char_type __c2) noexcept
+    static inline constexpr bool lt(char_type __c1, char_type __c2) noexcept
         {return __c1 < __c2;}
 
     _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
@@ -649,15 +648,15 @@ struct _LIBCUDACXX_TEMPLATE_VIS char_traits<char32_t>
     _LIBCUDACXX_INLINE_VISIBILITY
     static char_type*       assign(char_type* __s, size_t __n, char_type __a) noexcept;
 
-    static inline _LIBCUDACXX_CONSTEXPR int_type  not_eof(int_type __c) noexcept
+    static inline constexpr int_type  not_eof(int_type __c) noexcept
         {return eq_int_type(__c, eof()) ? ~eof() : __c;}
-    static inline _LIBCUDACXX_CONSTEXPR char_type to_char_type(int_type __c) noexcept
+    static inline constexpr char_type to_char_type(int_type __c) noexcept
         {return char_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR int_type to_int_type(char_type __c) noexcept
+    static inline constexpr int_type to_int_type(char_type __c) noexcept
         {return int_type(__c);}
-    static inline _LIBCUDACXX_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) noexcept
+    static inline constexpr bool eq_int_type(int_type __c1, int_type __c2) noexcept
         {return __c1 == __c2;}
-    static inline _LIBCUDACXX_CONSTEXPR int_type eof() noexcept
+    static inline constexpr int_type eof() noexcept
         {return int_type(0xFFFFFFFF);}
 };
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -356,7 +356,7 @@ char_traits<wchar_t>::compare(const char_type* __s1, const char_type* __s2, size
 
 template <class _Traits>
 _LIBCUDACXX_INLINE_VISIBILITY
-constexpr inline size_t __char_traits_length_checked(const typename _Traits::char_type* __s) noexcept {
+inline constexpr size_t __char_traits_length_checked(const typename _Traits::char_type* __s) noexcept {
 #if _LIBCUDACXX_DEBUG_LEVEL >= 1
   return __s ? _Traits::length(__s) : (_CUDA_VSTD::__libcpp_debug_function(_CUDA_VSTD::__libcpp_debug_info(__FILE__, __LINE__, "p == nullptr", "null pointer pass to non-null argument of char_traits<...>::length")), 0);
 #else

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__threading_support
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__threading_support
@@ -321,7 +321,7 @@ __libcpp_timespec_t __libcpp_to_timespec(const chrono::nanoseconds& __ns)
      seconds __s = duration_cast<seconds>(__ns);
      __libcpp_timespec_t __ts;
      typedef decltype(__ts.tv_sec) ts_sec;
-     _LIBCUDACXX_CONSTEXPR ts_sec __ts_sec_max = numeric_limits<ts_sec>::max();
+     constexpr ts_sec __ts_sec_max = numeric_limits<ts_sec>::max();
 
      if (__s.count() < __ts_sec_max)
      {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__tree
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__tree
@@ -742,9 +742,9 @@ public:
     }
 
 private:
-  ~__tree_node_base() _LIBCUDACXX_EQUAL_DELETE;
-  __tree_node_base(__tree_node_base const&) _LIBCUDACXX_EQUAL_DELETE;
-  __tree_node_base& operator=(__tree_node_base const&) _LIBCUDACXX_EQUAL_DELETE;
+  ~__tree_node_base() = delete;
+  __tree_node_base(__tree_node_base const&) = delete;
+  __tree_node_base& operator=(__tree_node_base const&) = delete;
 };
 
 template <class _Tp, class _VoidPtr>
@@ -757,9 +757,9 @@ public:
     __node_value_type __value_;
 
 private:
-  ~__tree_node() _LIBCUDACXX_EQUAL_DELETE;
-  __tree_node(__tree_node const&) _LIBCUDACXX_EQUAL_DELETE;
-  __tree_node& operator=(__tree_node const&) _LIBCUDACXX_EQUAL_DELETE;
+  ~__tree_node() = delete;
+  __tree_node(__tree_node const&) = delete;
+  __tree_node& operator=(__tree_node const&) = delete;
 };
 
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/integral_constant.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/integral_constant.h
@@ -23,11 +23,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp, _Tp __v>
 struct _LIBCUDACXX_TEMPLATE_VIS integral_constant
 {
-  static _LIBCUDACXX_CONSTEXPR const _Tp      value = __v;
+  static constexpr const _Tp      value = __v;
   typedef _Tp               value_type;
   typedef integral_constant type;
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR operator value_type() const noexcept {return value;}
+  constexpr operator value_type() const noexcept {return value;}
 #if _LIBCUDACXX_STD_VER > 11
   _LIBCUDACXX_INLINE_VISIBILITY
   constexpr value_type operator ()() const noexcept {return value;}
@@ -35,7 +35,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS integral_constant
 };
 
 template <class _Tp, _Tp __v>
-_LIBCUDACXX_CONSTEXPR const _Tp integral_constant<_Tp, __v>::value;
+constexpr const _Tp integral_constant<_Tp, __v>::value;
 
 typedef integral_constant<bool, true>  true_type;
 typedef integral_constant<bool, false> false_type;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_constant_evaluated.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__type_traits/is_constant_evaluated.h
@@ -28,10 +28,10 @@ inline constexpr bool is_constant_evaluated() noexcept {
 }
 #endif
 
-inline _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+inline constexpr _LIBCUDACXX_INLINE_VISIBILITY
 bool __libcpp_is_constant_evaluated() noexcept { return _LIBCUDACXX_IS_CONSTANT_EVALUATED(); }
 #else
-inline _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+inline constexpr _LIBCUDACXX_INLINE_VISIBILITY
 bool __libcpp_is_constant_evaluated() noexcept { return false; }
 #endif // defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED)
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/convert_to_integral.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/convert_to_integral.h
@@ -25,34 +25,34 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 int __convert_to_integral(int __val) { return __val; }
 
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 unsigned __convert_to_integral(unsigned __val) { return __val; }
 
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 long __convert_to_integral(long __val) { return __val; }
 
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 unsigned long __convert_to_integral(unsigned long __val) { return __val; }
 
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 long long __convert_to_integral(long long __val) { return __val; }
 
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 unsigned long long __convert_to_integral(unsigned long long __val) {return __val; }
 
 template<typename _Fp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 __enable_if_t<is_floating_point<_Fp>::value, long long>
  __convert_to_integral(_Fp __val) { return __val; }
 
 #ifndef _LIBCUDACXX_HAS_NO_INT128
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 __int128_t __convert_to_integral(__int128_t __val) { return __val; }
 
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 __uint128_t __convert_to_integral(__uint128_t __val) { return __val; }
 #endif
 
@@ -67,7 +67,7 @@ template <class _Tp>
 struct __sfinae_underlying_type<_Tp, false> {};
 
 template <class _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 typename __sfinae_underlying_type<_Tp>::__promoted_type
 __convert_to_integral(_Tp __val) { return __val; }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/exception_guard.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/exception_guard.h
@@ -139,7 +139,7 @@ using __exception_guard = __exception_guard_exceptions<_Rollback>;
 #endif
 
 template <class _Rollback>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 __exception_guard<_Rollback> __make_exception_guard(_Rollback __rollback) {
   return __exception_guard<_Rollback>(_CUDA_VSTD::move(__rollback));
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/forward.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/forward.h
@@ -26,13 +26,13 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR _Tp&&
+_LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _Tp&&
 forward(__libcpp_remove_reference_t<_Tp>& __t) noexcept {
   return static_cast<_Tp&&>(__t);
 }
 
 template <class _Tp>
-_LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR _Tp&&
+_LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _Tp&&
 forward(__libcpp_remove_reference_t<_Tp>&& __t) noexcept {
   static_assert(!is_lvalue_reference<_Tp>::value, "cannot forward an rvalue as an lvalue");
   return static_cast<_Tp&&>(__t);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/move.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/move.h
@@ -27,7 +27,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR __libcpp_remove_reference_t<_Tp>&&
+_LIBCUDACXX_NODISCARD_EXT inline _LIBCUDACXX_INLINE_VISIBILITY constexpr __libcpp_remove_reference_t<_Tp>&&
 move(_Tp&& __t) noexcept {
   typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tp> _Up;
   return static_cast<_Up&&>(__t);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/pair.h
@@ -68,7 +68,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_LIBCUDACXX_DEPRECATED_ABI_DISABLE_PAIR_TRIVIAL_COPY_CTOR)
 template <class, class>
 struct __non_trivially_copyable_base {
-  _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+  constexpr _LIBCUDACXX_INLINE_VISIBILITY
   __non_trivially_copyable_base() noexcept {}
   _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
   __non_trivially_copyable_base(__non_trivially_copyable_base const&) noexcept {}
@@ -158,7 +158,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     template<bool _Dummy = true, __enable_if_t<
             _CheckArgsDep<_Dummy>::__enable_explicit_default::value
     >* = nullptr>
-    explicit _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    explicit _LIBCUDACXX_INLINE_VISIBILITY constexpr
     pair() noexcept(is_nothrow_default_constructible<first_type>::value &&
                       is_nothrow_default_constructible<second_type>::value)
         : first(), second() {}
@@ -166,7 +166,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS pair
     template<bool _Dummy = true, __enable_if_t<
             _CheckArgsDep<_Dummy>::__enable_implicit_default::value
     >* = nullptr>
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     pair() noexcept(is_nothrow_default_constructible<first_type>::value &&
                       is_nothrow_default_constructible<second_type>::value)
         : first(), second() {}

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/pair.h
@@ -68,7 +68,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_LIBCUDACXX_DEPRECATED_ABI_DISABLE_PAIR_TRIVIAL_COPY_CTOR)
 template <class, class>
 struct __non_trivially_copyable_base {
-  constexpr _LIBCUDACXX_INLINE_VISIBILITY
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __non_trivially_copyable_base() noexcept {}
   _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
   __non_trivially_copyable_base(__non_trivially_copyable_base const&) noexcept {}

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
@@ -769,7 +769,7 @@ public:
 // Perform division by two quickly for positive integers (llvm.org/PR39129)
 
 template <typename _Integral>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 __enable_if_t
 <
     is_integral<_Integral>::value,
@@ -781,7 +781,7 @@ __half_positive(_Integral __value)
 }
 
 template <typename _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 __enable_if_t
 <
     !is_integral<_Tp>::value,
@@ -2676,7 +2676,7 @@ max(::std::initializer_list<_Tp> __t)
 // clamp
 template<class _Tp, class _Compare>
 _LIBCUDACXX_NODISCARD_EXT inline
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const _Tp&
 clamp(const _Tp& __v, const _Tp& __lo, const _Tp& __hi, _Compare __comp)
 {
@@ -2687,7 +2687,7 @@ clamp(const _Tp& __v, const _Tp& __lo, const _Tp& __hi, _Compare __comp)
 
 template<class _Tp>
 _LIBCUDACXX_NODISCARD_EXT inline
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const _Tp&
 clamp(const _Tp& __v, const _Tp& __lo, const _Tp& __hi)
 {
@@ -2892,12 +2892,12 @@ private:
     static const _Working_result_type _Rp = _Engine::_Max - _Engine::_Min
                                           + _Working_result_type(1);
 #else
-    static _LIBCUDACXX_CONSTEXPR const _Working_result_type _Rp = _Engine::max() - _Engine::min()
+    static constexpr const _Working_result_type _Rp = _Engine::max() - _Engine::min()
                                                       + _Working_result_type(1);
 #endif
-    static _LIBCUDACXX_CONSTEXPR const size_t __m = __log2<_Working_result_type, _Rp>::value;
-    static _LIBCUDACXX_CONSTEXPR const size_t _WDt = numeric_limits<_Working_result_type>::digits;
-    static _LIBCUDACXX_CONSTEXPR const size_t _EDt = numeric_limits<_Engine_result_type>::digits;
+    static constexpr const size_t __m = __log2<_Working_result_type, _Rp>::value;
+    static constexpr const size_t _WDt = numeric_limits<_Working_result_type>::digits;
+    static constexpr const size_t _EDt = numeric_limits<_Engine_result_type>::digits;
 
 public:
     // constructors and seeding functions
@@ -3101,8 +3101,8 @@ public:
 
     result_type operator()();
 
-    static _LIBCUDACXX_CONSTEXPR result_type min() {return _Min;}
-    static _LIBCUDACXX_CONSTEXPR result_type max() {return _Max;}
+    static constexpr result_type min() {return _Min;}
+    static constexpr result_type max() {return _Max;}
 
     friend _LIBCUDACXX_FUNC_VIS __rs_default __rs_get();
 };

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
@@ -2892,12 +2892,12 @@ private:
     static const _Working_result_type _Rp = _Engine::_Max - _Engine::_Min
                                           + _Working_result_type(1);
 #else
-    static constexpr const _Working_result_type _Rp = _Engine::max() - _Engine::min()
+    static constexpr _Working_result_type _Rp = _Engine::max() - _Engine::min()
                                                       + _Working_result_type(1);
 #endif
-    static constexpr const size_t __m = __log2<_Working_result_type, _Rp>::value;
-    static constexpr const size_t _WDt = numeric_limits<_Working_result_type>::digits;
-    static constexpr const size_t _EDt = numeric_limits<_Engine_result_type>::digits;
+    static constexpr size_t __m = __log2<_Working_result_type, _Rp>::value;
+    static constexpr size_t _WDt = numeric_limits<_Working_result_type>::digits;
+    static constexpr size_t _EDt = numeric_limits<_Engine_result_type>::digits;
 
 public:
     // constructors and seeding functions

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/array
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/array
@@ -215,11 +215,11 @@ struct _LIBCUDACXX_TEMPLATE_VIS array
 
     // capacity:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR size_type size() const noexcept {return _Size;}
+    constexpr size_type size() const noexcept {return _Size;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR size_type max_size() const noexcept {return _Size;}
+    constexpr size_type max_size() const noexcept {return _Size;}
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR bool empty() const noexcept {return false; }
+    constexpr bool empty() const noexcept {return false; }
 
     // element access:
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14
@@ -328,11 +328,11 @@ struct _LIBCUDACXX_TEMPLATE_VIS array<_Tp, 0>
 
     // capacity:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR size_type size() const noexcept {return 0; }
+    constexpr size_type size() const noexcept {return 0; }
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR size_type max_size() const noexcept {return 0;}
+    constexpr size_type max_size() const noexcept {return 0;}
     _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR bool empty() const noexcept {return true;}
+    constexpr bool empty() const noexcept {return true;}
 
     // element access:
     _LIBCUDACXX_INLINE_VISIBILITY

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/atomic
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/atomic
@@ -789,7 +789,7 @@ struct __cxx_atomic_lock_impl {
   _LIBCUDACXX_INLINE_VISIBILITY
   __cxx_atomic_lock_impl() noexcept
     : __a_value(), __a_lock(0) {}
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr explicit
   __cxx_atomic_lock_impl(_Tp value) noexcept
     : __a_value(value), __a_lock(0) {}
 
@@ -1098,8 +1098,8 @@ template <typename _Tp, int _Sco,
           typename _Base = __cxx_atomic_base_impl<_Tp, _Sco> >
 #endif //_LIBCUDACXX_ATOMIC_ONLY_USE_BUILTINS
 struct __cxx_atomic_impl : public _Base {
-  __cxx_atomic_impl() noexcept _LIBCUDACXX_DEFAULT
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit __cxx_atomic_impl(_Tp value) noexcept
+  __cxx_atomic_impl() noexcept = default;
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr explicit __cxx_atomic_impl(_Tp value) noexcept
     : _Base(value) {}
 };
 
@@ -1291,7 +1291,7 @@ struct __atomic_base_storage {
     __atomic_base_storage& operator=(const __atomic_base_storage&) = default;
     __atomic_base_storage& operator=(__atomic_base_storage&&) = default;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_base_storage(_Storage&& __a) noexcept : __a_(_CUDA_VSTD::forward<_Storage>(__a)) {}
 };
 
@@ -1304,11 +1304,11 @@ struct __atomic_base_core : public __atomic_base_storage<_Tp, _Storage>{
     __atomic_base_core& operator=(const __atomic_base_core&) = delete;
     __atomic_base_core& operator=(__atomic_base_core&&) = delete;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_base_core(_Storage&& __a) noexcept : __atomic_base_storage<_Tp, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
 #if defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
-    static _LIBCUDACXX_CONSTEXPR bool is_always_lock_free = _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+    static constexpr bool is_always_lock_free = _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
 #endif // defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1429,11 +1429,11 @@ struct __atomic_base_core<_Tp, true, _Storage> : public __atomic_base_storage<_T
     __atomic_base_core& operator=(const __atomic_base_core&) = default;
     __atomic_base_core& operator=(__atomic_base_core&&) = default;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_base_core(_Storage&& __a) noexcept : __atomic_base_storage<_Tp, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
 #if defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
-    static _LIBCUDACXX_CONSTEXPR bool is_always_lock_free = _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
+    static constexpr bool is_always_lock_free = _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(sizeof(_Tp), 0);
 #endif // defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1554,7 +1554,7 @@ struct __atomic_base_arithmetic : public __atomic_base_core<_Tp, _Cq, _Storage> 
     __atomic_base_arithmetic& operator=(const __atomic_base_arithmetic&) = delete;
     __atomic_base_arithmetic& operator=(__atomic_base_arithmetic&&) = delete;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_base_arithmetic(_Storage&& __a) noexcept : __atomic_base_core<_Tp, _Cq, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1605,7 +1605,7 @@ struct __atomic_base_arithmetic<_Tp, true, _Storage> : public __atomic_base_core
     __atomic_base_arithmetic& operator=(const __atomic_base_arithmetic&) = default;
     __atomic_base_arithmetic& operator=(__atomic_base_arithmetic&&) = default;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_base_arithmetic(_Storage&& __a) noexcept : __atomic_base_core<_Tp, true, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1656,7 +1656,7 @@ struct __atomic_base_bitwise : public __atomic_base_arithmetic<_Tp, _Cq, _Storag
     __atomic_base_bitwise& operator=(const __atomic_base_bitwise&) = delete;
     __atomic_base_bitwise& operator=(__atomic_base_bitwise&&) = delete;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_base_bitwise(_Storage&& __a) noexcept : __atomic_base_arithmetic<_Tp, _Cq, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1701,7 +1701,7 @@ struct __atomic_base_bitwise<_Tp, true, _Storage> : public __atomic_base_arithme
     __atomic_base_bitwise& operator=(const __atomic_base_bitwise&) = default;
     __atomic_base_bitwise& operator=(__atomic_base_bitwise&&) = default;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_base_bitwise(_Storage&& __a) noexcept : __atomic_base_arithmetic<_Tp, true, _Storage>(_CUDA_VSTD::forward<_Storage>(__a)) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1753,7 +1753,7 @@ struct __atomic_base : public _Base {
     __atomic_base& operator=(const __atomic_base&) = delete;
     __atomic_base& operator=(__atomic_base&&) = delete;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_base(const _Tp& __a) noexcept :
         _Base(__cxx_atomic_impl<_Tp, _Sco>(__a)) {}
 };
@@ -1767,14 +1767,14 @@ struct __atomic_base_ref : public _Base {
     __atomic_base_ref& operator=(const __atomic_base_ref&) = default;
     __atomic_base_ref& operator=(__atomic_base_ref&&) = default;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_base_ref(_Tp& __a) noexcept :
         _Base(__cxx_atomic_ref_impl<_Tp, _Sco>(__a)) {}
 };
 
 #if defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
 template <class _Tp, bool _Cq, typename _Storage>
-_LIBCUDACXX_CONSTEXPR bool __atomic_base_core<_Tp, _Cq, _Storage>::is_always_lock_free;
+constexpr bool __atomic_base_core<_Tp, _Cq, _Storage>::is_always_lock_free;
 #endif
 
 // atomic<T>
@@ -1787,9 +1787,9 @@ struct atomic
 #ifdef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
 #endif
-    atomic() noexcept _LIBCUDACXX_DEFAULT
+    atomic() noexcept = default;
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR atomic(_Tp __d) noexcept : __base(__d) {}
+    constexpr atomic(_Tp __d) noexcept : __base(__d) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp operator=(_Tp __d) volatile noexcept
@@ -1810,9 +1810,9 @@ struct atomic<_Tp*>
 #ifdef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
 #endif
-    atomic() noexcept _LIBCUDACXX_DEFAULT
+    atomic() noexcept = default;
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR atomic(_Tp* __d) noexcept : __base(__d) {}
+    constexpr atomic(_Tp* __d) noexcept : __base(__d) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* operator=(_Tp* __d) volatile noexcept
@@ -2627,9 +2627,9 @@ typedef struct atomic_flag
 #ifdef _LIBCUDACXX_CXX03_LANG
     _LIBCUDACXX_INLINE_VISIBILITY
 #endif
-    atomic_flag() noexcept _LIBCUDACXX_DEFAULT
+    atomic_flag() noexcept = default;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     atomic_flag(bool __b) noexcept : __a_(__b) {} // EXTENSION
 
 #ifndef _LIBCUDACXX_CXX03_LANG

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/barrier
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/barrier
@@ -385,7 +385,7 @@ private:
     _LIBCUDACXX_INLINE_VISIBILITY
     friend bool __call_try_wait_parity(const _Barrier& __b, bool __parity);
 
-    static _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    static _LIBCUDACXX_INLINE_VISIBILITY constexpr
     uint64_t __init(ptrdiff_t __count) noexcept
     {
 #if (_LIBCUDACXX_DEBUG_LEVEL >= 2)
@@ -473,7 +473,7 @@ public:
 template<class _CompletionF = __empty_completion>
 class barrier : public __barrier_base<_CompletionF> {
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     barrier(ptrdiff_t __count, _CompletionF __completion = _CompletionF())
         : __barrier_base<_CompletionF>(__count, __completion) {
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/bitset
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/bitset
@@ -167,13 +167,13 @@ protected:
     typedef __bit_iterator<__bitset, true>             const_iterator;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR __bitset() noexcept;
+    constexpr __bitset() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit _LIBCUDACXX_CONSTEXPR __bitset(unsigned long long __v) noexcept;
+    explicit constexpr __bitset(unsigned long long __v) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY reference __make_ref(size_t __pos) noexcept
         {return reference(__first_ + __pos / __bits_per_word, __storage_type(1) << __pos % __bits_per_word);}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR const_reference __make_ref(size_t __pos) const noexcept
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr const_reference __make_ref(size_t __pos) const noexcept
         {return const_reference(__first_ + __pos / __bits_per_word, __storage_type(1) << __pos % __bits_per_word);}
     _LIBCUDACXX_INLINE_VISIBILITY iterator __make_iter(size_t __pos) noexcept
         {return iterator(__first_ + __pos / __bits_per_word, __pos % __bits_per_word);}
@@ -215,8 +215,7 @@ private:
 };
 
 template <size_t _N_words, size_t _Size>
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 __bitset<_N_words, _Size>::__bitset() noexcept
 #ifndef _LIBCUDACXX_CXX03_LANG
     : __first_{0}
@@ -262,7 +261,7 @@ __bitset<_N_words, _Size>::__init(unsigned long long __v, true_type) noexcept
 
 template <size_t _N_words, size_t _Size>
 inline
-_LIBCUDACXX_CONSTEXPR
+constexpr
 __bitset<_N_words, _Size>::__bitset(unsigned long long __v) noexcept
 #ifndef _LIBCUDACXX_CXX03_LANG
 #if __SIZEOF_SIZE_T__ == 8
@@ -463,13 +462,13 @@ protected:
     typedef __bit_iterator<__bitset, true>             const_iterator;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR __bitset() noexcept;
+    constexpr __bitset() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit _LIBCUDACXX_CONSTEXPR __bitset(unsigned long long __v) noexcept;
+    explicit constexpr __bitset(unsigned long long __v) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY reference __make_ref(size_t __pos) noexcept
         {return reference(&__first_, __storage_type(1) << __pos);}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR const_reference __make_ref(size_t __pos) const noexcept
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr const_reference __make_ref(size_t __pos) const noexcept
         {return const_reference(&__first_, __storage_type(1) << __pos);}
     _LIBCUDACXX_INLINE_VISIBILITY iterator __make_iter(size_t __pos) noexcept
         {return iterator(&__first_ + __pos / __bits_per_word, __pos % __bits_per_word);}
@@ -501,16 +500,14 @@ protected:
 };
 
 template <size_t _Size>
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 __bitset<1, _Size>::__bitset() noexcept
     : __first_(0)
 {
 }
 
 template <size_t _Size>
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 __bitset<1, _Size>::__bitset(unsigned long long __v) noexcept
     : __first_(
         _Size == __bits_per_word ? static_cast<__storage_type>(__v)
@@ -620,13 +617,13 @@ protected:
     typedef __bit_iterator<__bitset, true>             const_iterator;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR __bitset() noexcept;
+    constexpr __bitset() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit _LIBCUDACXX_CONSTEXPR __bitset(unsigned long long) noexcept;
+    explicit constexpr __bitset(unsigned long long) noexcept;
 
     _LIBCUDACXX_INLINE_VISIBILITY reference __make_ref(size_t) noexcept
         {return reference(0, 1);}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR const_reference __make_ref(size_t) const noexcept
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr const_reference __make_ref(size_t) const noexcept
         {return const_reference(0, 1);}
     _LIBCUDACXX_INLINE_VISIBILITY iterator __make_iter(size_t) noexcept
         {return iterator(0, 0);}
@@ -649,13 +646,13 @@ protected:
 };
 
 inline
-_LIBCUDACXX_CONSTEXPR
+constexpr
 __bitset<0, 0>::__bitset() noexcept
 {
 }
 
 inline
-_LIBCUDACXX_CONSTEXPR
+constexpr
 __bitset<0, 0>::__bitset(unsigned long long) noexcept
 {
 }
@@ -676,8 +673,8 @@ public:
     typedef typename base::const_reference const_reference;
 
     // 23.3.5.1 constructors:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR bitset() noexcept {}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr bitset() noexcept {}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
         bitset(unsigned long long __v) noexcept : base(__v) {}
     template<class _CharT, class = _EnableIf<_IsCharLikeType<_CharT>::value> >
         explicit bitset(const _CharT* __str,
@@ -712,7 +709,7 @@ public:
     bitset& flip(size_t __pos);
 
     // element access:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
                               const_reference operator[](size_t __p) const {return base::__make_ref(__p);}
     _LIBCUDACXX_INLINE_VISIBILITY       reference operator[](size_t __p)       {return base::__make_ref(__p);}
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -735,7 +732,7 @@ public:
                                                                       char __one = '1') const;
     _LIBCUDACXX_INLINE_VISIBILITY
     size_t count() const noexcept;
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR size_t size() const noexcept {return _Size;}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr size_t size() const noexcept {return _Size;}
     _LIBCUDACXX_INLINE_VISIBILITY
     bool operator==(const bitset& __rhs) const noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/charconv
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/charconv
@@ -124,7 +124,7 @@ void from_chars(const char*, const char*, bool, int = 10) = delete;
 namespace __itoa
 {
 
-static _LIBCUDACXX_CONSTEXPR uint64_t __pow10_64[] = {
+static constexpr uint64_t __pow10_64[] = {
     UINT64_C(0),
     UINT64_C(10),
     UINT64_C(100),
@@ -147,7 +147,7 @@ static _LIBCUDACXX_CONSTEXPR uint64_t __pow10_64[] = {
     UINT64_C(10000000000000000000),
 };
 
-static _LIBCUDACXX_CONSTEXPR uint32_t __pow10_32[] = {
+static constexpr uint32_t __pow10_32[] = {
     UINT32_C(0),          UINT32_C(10),       UINT32_C(100),
     UINT32_C(1000),       UINT32_C(10000),    UINT32_C(100000),
     UINT32_C(1000000),    UINT32_C(10000000), UINT32_C(100000000),
@@ -239,7 +239,7 @@ __mul_overflowed(_Tp __a, _Up __b, _Tp& __r)
 template <typename _Tp>
 struct _LIBCUDACXX_HIDDEN __traits : __traits_base<_Tp>
 {
-    static _LIBCUDACXX_CONSTEXPR int digits = numeric_limits<_Tp>::digits10 + 1;
+    static constexpr int digits = numeric_limits<_Tp>::digits10 + 1;
     using __traits_base<_Tp>::__pow;
     using typename __traits_base<_Tp>::type;
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -920,7 +920,7 @@ struct __duration_cast;
 template <class _FromDuration, class _ToDuration, class _Period>
 struct __duration_cast<_FromDuration, _ToDuration, _Period, true, true>
 {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     _ToDuration operator()(const _FromDuration& __fd) const
     {
         return _ToDuration(static_cast<typename _ToDuration::rep>(__fd.count()));
@@ -930,7 +930,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, true, true>
 template <class _FromDuration, class _ToDuration, class _Period>
 struct __duration_cast<_FromDuration, _ToDuration, _Period, true, false>
 {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     _ToDuration operator()(const _FromDuration& __fd) const
     {
         typedef typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type _Ct;
@@ -942,7 +942,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, true, false>
 template <class _FromDuration, class _ToDuration, class _Period>
 struct __duration_cast<_FromDuration, _ToDuration, _Period, false, true>
 {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     _ToDuration operator()(const _FromDuration& __fd) const
     {
         typedef typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type _Ct;
@@ -954,7 +954,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, false, true>
 template <class _FromDuration, class _ToDuration, class _Period>
 struct __duration_cast<_FromDuration, _ToDuration, _Period, false, false>
 {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     _ToDuration operator()(const _FromDuration& __fd) const
     {
         typedef typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type _Ct;
@@ -966,7 +966,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, false, false>
 
 template <class _ToDuration, class _Rep, class _Period>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 __enable_if_t
 <
     __is_duration<_ToDuration>::value,
@@ -982,7 +982,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS treat_as_floating_point : is_floating_point<_Rep
 
 #if _LIBCUDACXX_STD_VER > 11 && !defined(_LIBCUDACXX_HAS_NO_VARIABLE_TEMPLATES)
 template <class _Rep>
-_LIBCUDACXX_INLINE_VAR _LIBCUDACXX_CONSTEXPR bool treat_as_floating_point_v
+_LIBCUDACXX_INLINE_VAR constexpr bool treat_as_floating_point_v
     = treat_as_floating_point<_Rep>::value;
 #endif // _LIBCUDACXX_STD_VER > 11 && !defined(_LIBCUDACXX_HAS_NO_VARIABLE_TEMPLATES)
 
@@ -990,9 +990,9 @@ template <class _Rep>
 struct _LIBCUDACXX_TEMPLATE_VIS duration_values
 {
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR _Rep zero() noexcept {return _Rep(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR _Rep max()  noexcept {return numeric_limits<_Rep>::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR _Rep min()  noexcept {return numeric_limits<_Rep>::lowest();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr _Rep zero() noexcept {return _Rep(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr _Rep max()  noexcept {return numeric_limits<_Rep>::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr _Rep min()  noexcept {return numeric_limits<_Rep>::lowest();}
 };
 
 #if _LIBCUDACXX_STD_VER > 11
@@ -1094,15 +1094,14 @@ private:
 public:
 
 #if !defined(_LIBCUDACXX_CXX03_LANG)
-    _LIBCUDACXX_CONSTEXPR
-        duration() = default;
+    constexpr duration() = default;
 #else
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
         duration() {}
 #endif
 
     template <class _Rep2>
-        _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+        _LIBCUDACXX_INLINE_VISIBILITY constexpr
         explicit duration(const _Rep2& __r,
             __enable_if_t
             <
@@ -1114,7 +1113,7 @@ public:
 
     // conversions
     template <class _Rep2, class _Period2>
-        _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+        _LIBCUDACXX_INLINE_VISIBILITY constexpr
         duration(const duration<_Rep2, _Period2>& __d,
             __enable_if_t
             <
@@ -1127,12 +1126,12 @@ public:
 
     // observer
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR rep count() const {return __rep_;}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr rep count() const {return __rep_;}
 
     // arithmetic
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR typename common_type<duration>::type operator+() const {return typename common_type<duration>::type(*this);}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR typename common_type<duration>::type operator-() const {return typename common_type<duration>::type(-__rep_);}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr typename common_type<duration>::type operator+() const {return typename common_type<duration>::type(*this);}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr typename common_type<duration>::type operator-() const {return typename common_type<duration>::type(-__rep_);}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 duration& operator++()      {++__rep_; return *this;}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 duration  operator++(int)   {return duration(__rep_++);}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 duration& operator--()      {--__rep_; return *this;}
@@ -1148,9 +1147,9 @@ public:
 
     // special values
 
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR duration zero() noexcept {return duration(duration_values<rep>::zero());}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR duration min()  noexcept {return duration(duration_values<rep>::min());}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR duration max()  noexcept {return duration(duration_values<rep>::max());}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr duration zero() noexcept {return duration(duration_values<rep>::zero());}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr duration min()  noexcept {return duration(duration_values<rep>::min());}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr duration max()  noexcept {return duration(duration_values<rep>::max());}
 };
 
 typedef duration<long long,         nano> nanoseconds;
@@ -1170,7 +1169,7 @@ typedef duration<     int, ratio_divide<years::period, ratio<12>>>           mon
 template <class _LhsDuration, class _RhsDuration>
 struct __duration_eq
 {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     bool operator()(const _LhsDuration& __lhs, const _RhsDuration& __rhs) const
         {
             typedef typename common_type<_LhsDuration, _RhsDuration>::type _Ct;
@@ -1181,15 +1180,14 @@ struct __duration_eq
 template <class _LhsDuration>
 struct __duration_eq<_LhsDuration, _LhsDuration>
 {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     bool operator()(const _LhsDuration& __lhs, const _LhsDuration& __rhs) const
         {return __lhs.count() == __rhs.count();}
 };
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-bool
+constexpr bool
 operator==(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
     return __duration_eq<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >()(__lhs, __rhs);
@@ -1199,8 +1197,7 @@ operator==(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-bool
+constexpr bool
 operator!=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
     return !(__lhs == __rhs);
@@ -1211,7 +1208,7 @@ operator!=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 template <class _LhsDuration, class _RhsDuration>
 struct __duration_lt
 {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     bool operator()(const _LhsDuration& __lhs, const _RhsDuration& __rhs) const
         {
             typedef typename common_type<_LhsDuration, _RhsDuration>::type _Ct;
@@ -1222,15 +1219,14 @@ struct __duration_lt
 template <class _LhsDuration>
 struct __duration_lt<_LhsDuration, _LhsDuration>
 {
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     bool operator()(const _LhsDuration& __lhs, const _LhsDuration& __rhs) const
         {return __lhs.count() < __rhs.count();}
 };
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-bool
+constexpr bool
 operator< (const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
     return __duration_lt<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >()(__lhs, __rhs);
@@ -1240,8 +1236,7 @@ operator< (const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-bool
+constexpr bool
 operator> (const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
     return __rhs < __lhs;
@@ -1251,8 +1246,7 @@ operator> (const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-bool
+constexpr bool
 operator<=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
     return !(__rhs < __lhs);
@@ -1262,8 +1256,7 @@ operator<=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-bool
+constexpr bool
 operator>=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
     return !(__lhs < __rhs);
@@ -1273,7 +1266,7 @@ operator>=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
 operator+(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
@@ -1285,7 +1278,7 @@ operator+(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
 operator-(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
@@ -1297,7 +1290,7 @@ operator-(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 
 template <class _Rep1, class _Period, class _Rep2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 __enable_if_t
 <
     is_convertible<_Rep2, typename common_type<_Rep1, _Rep2>::type>::value,
@@ -1312,7 +1305,7 @@ operator*(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
 
 template <class _Rep1, class _Period, class _Rep2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 __enable_if_t
 <
     is_convertible<_Rep1, typename common_type<_Rep1, _Rep2>::type>::value,
@@ -1327,7 +1320,7 @@ operator*(const _Rep1& __s, const duration<_Rep2, _Period>& __d)
 
 template <class _Rep1, class _Period, class _Rep2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 __enable_if_t
 <
     !__is_duration<_Rep2>::value &&
@@ -1343,7 +1336,7 @@ operator/(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 typename common_type<_Rep1, _Rep2>::type
 operator/(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
@@ -1355,7 +1348,7 @@ operator/(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 
 template <class _Rep1, class _Period, class _Rep2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 __enable_if_t
 <
     !__is_duration<_Rep2>::value &&
@@ -1371,7 +1364,7 @@ operator%(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
 operator%(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
@@ -1422,8 +1415,8 @@ public:
 
     // special values
 
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR time_point min() noexcept {return time_point(duration::min());}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR time_point max() noexcept {return time_point(duration::max());}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr time_point min() noexcept {return time_point(duration::min());}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr time_point max() noexcept {return time_point(duration::max());}
 };
 
 } // chrono
@@ -1447,7 +1440,7 @@ time_point_cast(const time_point<_Clock, _Duration>& __t)
 
 #if _LIBCUDACXX_STD_VER > 11
 template <class _ToDuration, class _Clock, class _Duration>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 __enable_if_t
 <
     __is_duration<_ToDuration>::value,
@@ -1459,7 +1452,7 @@ floor(const time_point<_Clock, _Duration>& __t)
 }
 
 template <class _ToDuration, class _Clock, class _Duration>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 __enable_if_t
 <
     __is_duration<_ToDuration>::value,
@@ -1471,7 +1464,7 @@ ceil(const time_point<_Clock, _Duration>& __t)
 }
 
 template <class _ToDuration, class _Clock, class _Duration>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 __enable_if_t
 <
     __is_duration<_ToDuration>::value,
@@ -1483,7 +1476,7 @@ round(const time_point<_Clock, _Duration>& __t)
 }
 
 template <class _Rep, class _Period>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 __enable_if_t
 <
     numeric_limits<_Rep>::is_signed,

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -610,7 +610,7 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) noexcept
 
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR __enable_if_t<is_floating_point<_A1>::value, bool>
+constexpr __enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isnan(_A1 __lcpp_x) noexcept
 {
 #if defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
@@ -624,7 +624,7 @@ __constexpr_isnan(_A1 __lcpp_x) noexcept
 
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR __enable_if_t<!is_floating_point<_A1>::value, bool>
+constexpr __enable_if_t<!is_floating_point<_A1>::value, bool>
 __constexpr_isnan(_A1 __lcpp_x) noexcept
 {
     return isnan(__lcpp_x);
@@ -632,7 +632,7 @@ __constexpr_isnan(_A1 __lcpp_x) noexcept
 
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR __enable_if_t<is_floating_point<_A1>::value, bool>
+constexpr __enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isinf(_A1 __lcpp_x) noexcept
 {
 #if defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
@@ -646,7 +646,7 @@ __constexpr_isinf(_A1 __lcpp_x) noexcept
 
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR __enable_if_t<!is_floating_point<_A1>::value, bool>
+constexpr __enable_if_t<!is_floating_point<_A1>::value, bool>
 __constexpr_isinf(_A1 __lcpp_x) noexcept
 {
     return isinf(__lcpp_x);
@@ -654,7 +654,7 @@ __constexpr_isinf(_A1 __lcpp_x) noexcept
 
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR __enable_if_t<is_floating_point<_A1>::value, bool>
+constexpr __enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isfinite(_A1 __lcpp_x) noexcept
 {
 #if defined(_LIBCUDACXX_CUDACC_BELOW_11_8)
@@ -668,7 +668,7 @@ __constexpr_isfinite(_A1 __lcpp_x) noexcept
 
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR __enable_if_t<!is_floating_point<_A1>::value, bool>
+constexpr __enable_if_t<!is_floating_point<_A1>::value, bool>
 __constexpr_isfinite(_A1 __lcpp_x) noexcept
 {
     return isfinite(__lcpp_x);
@@ -937,7 +937,7 @@ template <class _IntT, class _FloatT,
     bool _FloatBigger = (numeric_limits<_FloatT>::digits > numeric_limits<_IntT>::digits),
     int _Bits = (numeric_limits<_IntT>::digits - numeric_limits<_FloatT>::digits)>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR _IntT __max_representable_int_for_float() noexcept {
+constexpr _IntT __max_representable_int_for_float() noexcept {
   static_assert(is_floating_point<_FloatT>::value, "must be a floating point type");
   static_assert(is_integral<_IntT>::value, "must be an integral type");
   static_assert(numeric_limits<_FloatT>::radix == 2, "FloatT has incorrect radix");

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -403,12 +403,12 @@ class _LIBCUDACXX_TEMPLATE_VIS _LIBCUDACXX_COMPLEX_ALIGNAS(2*sizeof(float)) comp
 public:
     typedef float value_type;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR complex(float __re = 0.0f, float __im = 0.0f)
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr complex(float __re = 0.0f, float __im = 0.0f)
         : __re_(__re), __im_(__im) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit _LIBCUDACXX_CONSTEXPR complex(const complex<double>& __c);
+    explicit constexpr complex(const complex<double>& __c);
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit _LIBCUDACXX_CONSTEXPR complex(const complex<long double>& __c);
+    explicit constexpr complex(const complex<long double>& __c);
 
 #if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
     template <class _Up>
@@ -429,8 +429,8 @@ public:
     operator ::std::complex<float>() const { return { __re_, __im_ }; }
 #endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR float real() const {return __re_;}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR float imag() const {return __im_;}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr float real() const {return __re_;}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr float imag() const {return __im_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 void real(value_type __re) {__re_ = __re;}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 void imag(value_type __im) {__im_ = __im;}
@@ -498,12 +498,12 @@ class _LIBCUDACXX_TEMPLATE_VIS _LIBCUDACXX_COMPLEX_ALIGNAS(2*sizeof(double)) com
 public:
     typedef double value_type;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR complex(double __re = 0.0, double __im = 0.0)
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr complex(double __re = 0.0, double __im = 0.0)
         : __re_(__re), __im_(__im) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR complex(const complex<float>& __c);
+    constexpr complex(const complex<float>& __c);
     _LIBCUDACXX_INLINE_VISIBILITY
-    explicit _LIBCUDACXX_CONSTEXPR complex(const complex<long double>& __c);
+    explicit constexpr complex(const complex<long double>& __c);
 
 #if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
     template <class _Up>
@@ -524,8 +524,8 @@ public:
     operator ::std::complex<double>() const { return { __re_, __im_ }; }
 #endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR double real() const {return __re_;}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR double imag() const {return __im_;}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr double real() const {return __re_;}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr double imag() const {return __im_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 void real(value_type __re) {__re_ = __re;}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 void imag(value_type __im) {__im_ = __im;}
@@ -591,11 +591,11 @@ class _LIBCUDACXX_TEMPLATE_VIS _LIBCUDACXX_COMPLEX_ALIGNAS(2*sizeof(long double)
 #ifndef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
 public:
     template <typename _Dummy = void>
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR complex(long double __re = 0.0, long double __im = 0.0)
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr complex(long double __re = 0.0, long double __im = 0.0)
         {static_assert(is_same<_Dummy, void>::value, "complex<long double> is not supported");}
 
     template <typename _Tp, typename _Dummy = void>
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR complex(const complex<_Tp> &__c)
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr complex(const complex<_Tp> &__c)
         {static_assert(is_same<_Dummy, void>::value, "complex<long double> is not supported");}
 
 #else
@@ -604,12 +604,12 @@ public:
 public:
     typedef long double value_type;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR complex(long double __re = 0.0L, long double __im = 0.0L)
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr complex(long double __re = 0.0L, long double __im = 0.0L)
         : __re_(__re), __im_(__im) {}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR complex(const complex<float>& __c);
+    constexpr complex(const complex<float>& __c);
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR complex(const complex<double>& __c);
+    constexpr complex(const complex<double>& __c);
 
 #if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
     template <class _Up>
@@ -630,8 +630,8 @@ public:
     operator ::std::complex<long double>() const { return { __re_, __im_ }; }
 #endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR long double real() const {return __re_;}
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR long double imag() const {return __im_;}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr long double real() const {return __re_;}
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr long double imag() const {return __im_;}
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 void real(value_type __re) {__re_ = __re;}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 void imag(value_type __im) {__im_ = __im;}
@@ -698,34 +698,28 @@ public:
   #pragma warning(disable : 4244)
 #endif
 
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 complex<float>::complex(const complex<double>& __c)
     : __re_(__c.real()), __im_(__c.imag()) {}
 
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 complex<double>::complex(const complex<float>& __c)
     : __re_(__c.real()), __im_(__c.imag()) {}
 
 #ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 complex<float>::complex(const complex<long double>& __c)
     : __re_(__c.real()), __im_(__c.imag()) {}
 
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 complex<double>::complex(const complex<long double>& __c)
     : __re_(__c.real()), __im_(__c.imag()) {}
 
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 complex<long double>::complex(const complex<float>& __c)
     : __re_(__c.real()), __im_(__c.imag()) {}
 
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 complex<long double>::complex(const complex<double>& __c)
     : __re_(__c.real()), __im_(__c.imag()) {}
 #endif // _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/coroutine
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/coroutine
@@ -92,10 +92,10 @@ template <>
 class _LIBCUDACXX_TEMPLATE_VIS coroutine_handle<void> {
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR coroutine_handle() noexcept : __handle_(nullptr) {}
+    constexpr coroutine_handle() noexcept : __handle_(nullptr) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR coroutine_handle(nullptr_t) noexcept : __handle_(nullptr) {}
+    constexpr coroutine_handle(nullptr_t) noexcept : __handle_(nullptr) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     coroutine_handle& operator=(nullptr_t) noexcept {
@@ -104,10 +104,10 @@ public:
     }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR void* address() const noexcept { return __handle_; }
+    constexpr void* address() const noexcept { return __handle_; }
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR explicit operator bool() const noexcept { return __handle_; }
+    constexpr explicit operator bool() const noexcept { return __handle_; }
 
     _LIBCUDACXX_INLINE_VISIBILITY
     void operator()() { resume(); }
@@ -273,8 +273,8 @@ public:
       __builtin_coro_promise(this->__handle_, _LIBCUDACXX_ALIGNOF(_Promise), false));
   }
 
-  _LIBCUDACXX_CONSTEXPR explicit operator bool() const noexcept { return true; }
-  _LIBCUDACXX_CONSTEXPR bool done() const noexcept { return false; }
+  constexpr explicit operator bool() const noexcept { return true; }
+  constexpr bool done() const noexcept { return false; }
 
   _LIBCUDACXX_CONSTEXPR_AFTER_CXX17 void operator()() const noexcept {}
   _LIBCUDACXX_CONSTEXPR_AFTER_CXX17 void resume() const noexcept {}

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/propagate_const
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/propagate_const
@@ -124,11 +124,11 @@ template <class _Tp>
 class propagate_const;
 
 template <class _Up>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 const _Up& get_underlying(const propagate_const<_Up>& __pu) noexcept;
 
 template <class _Up>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 _Up& get_underlying(propagate_const<_Up>& __pu) noexcept;
 
 template <class _Tp>
@@ -148,25 +148,25 @@ public:
 
 private:
   template <class _Up>
-  static _LIBCUDACXX_CONSTEXPR element_type* __get_pointer(_Up* __u)
+  static constexpr element_type* __get_pointer(_Up* __u)
   {
     return __u;
   }
 
   template <class _Up>
-  static _LIBCUDACXX_CONSTEXPR element_type* __get_pointer(_Up& __u)
+  static constexpr element_type* __get_pointer(_Up& __u)
   {
     return __get_pointer(__u.get());
   }
 
   template <class _Up>
-  static _LIBCUDACXX_CONSTEXPR const element_type* __get_pointer(const _Up* __u)
+  static constexpr const element_type* __get_pointer(const _Up* __u)
   {
     return __u;
   }
 
   template <class _Up>
-  static _LIBCUDACXX_CONSTEXPR const element_type* __get_pointer(const _Up& __u)
+  static constexpr const element_type* __get_pointer(const _Up& __u)
   {
     return __get_pointer(__u.get());
   }
@@ -185,25 +185,25 @@ private:
 
 public:
 
-  template <class _Up> friend _LIBCUDACXX_CONSTEXPR const _Up& ::_CUDA_VSTD_LFTS_V2::get_underlying(const propagate_const<_Up>& __pu) noexcept;
-  template <class _Up> friend _LIBCUDACXX_CONSTEXPR _Up& ::_CUDA_VSTD_LFTS_V2::get_underlying(propagate_const<_Up>& __pu) noexcept;
+  template <class _Up> friend constexpr const _Up& ::_CUDA_VSTD_LFTS_V2::get_underlying(const propagate_const<_Up>& __pu) noexcept;
+  template <class _Up> friend constexpr _Up& ::_CUDA_VSTD_LFTS_V2::get_underlying(propagate_const<_Up>& __pu) noexcept;
 
-  _LIBCUDACXX_CONSTEXPR propagate_const() = default;
+  constexpr propagate_const() = default;
 
   propagate_const(const propagate_const&) = delete;
 
-  _LIBCUDACXX_CONSTEXPR propagate_const(propagate_const&&) = default;
+  constexpr propagate_const(propagate_const&&) = default;
 
   template <class _Up, enable_if_t<!is_convertible<_Up, _Tp>::value &&
                                  is_constructible<_Tp, _Up&&>::value,bool> = true>
-  explicit _LIBCUDACXX_CONSTEXPR propagate_const(propagate_const<_Up>&& __pu)
+  explicit constexpr propagate_const(propagate_const<_Up>&& __pu)
       : __t_(std::move(_CUDA_VSTD_LFTS_V2::get_underlying(__pu)))
   {
   }
 
   template <class _Up, enable_if_t<is_convertible<_Up&&, _Tp>::value &&
                                  is_constructible<_Tp, _Up&&>::value,bool> = false>
-  _LIBCUDACXX_CONSTEXPR propagate_const(propagate_const<_Up>&& __pu)
+  constexpr propagate_const(propagate_const<_Up>&& __pu)
       : __t_(std::move(_CUDA_VSTD_LFTS_V2::get_underlying(__pu)))
   {
   }
@@ -211,7 +211,7 @@ public:
   template <class _Up, enable_if_t<!is_convertible<_Up&&, _Tp>::value &&
                                  is_constructible<_Tp, _Up&&>::value &&
                                  !__is_propagate_const<decay_t<_Up>>::value,bool> = true>
-  explicit _LIBCUDACXX_CONSTEXPR propagate_const(_Up&& __u)
+  explicit constexpr propagate_const(_Up&& __u)
       : __t_(std::forward<_Up>(__u))
   {
   }
@@ -219,77 +219,77 @@ public:
   template <class _Up, enable_if_t<is_convertible<_Up&&, _Tp>::value &&
                                  is_constructible<_Tp, _Up&&>::value &&
                                  !__is_propagate_const<decay_t<_Up>>::value,bool> = false>
-  _LIBCUDACXX_CONSTEXPR propagate_const(_Up&& __u)
+  constexpr propagate_const(_Up&& __u)
       : __t_(std::forward<_Up>(__u))
   {
   }
 
   propagate_const& operator=(const propagate_const&) = delete;
 
-  _LIBCUDACXX_CONSTEXPR propagate_const& operator=(propagate_const&&) = default;
+  constexpr propagate_const& operator=(propagate_const&&) = default;
 
   template <class _Up>
-  _LIBCUDACXX_CONSTEXPR propagate_const& operator=(propagate_const<_Up>&& __pu)
+  constexpr propagate_const& operator=(propagate_const<_Up>&& __pu)
   {
     __t_ = std::move(_CUDA_VSTD_LFTS_V2::get_underlying(__pu));
     return *this;
   }
 
   template <class _Up, class _Vp = enable_if_t<!__is_propagate_const<decay_t<_Up>>::value>>
-  _LIBCUDACXX_CONSTEXPR propagate_const& operator=(_Up&& __u)
+  constexpr propagate_const& operator=(_Up&& __u)
   {
     __t_ = std::forward<_Up>(__u);
     return *this;
   }
 
-  _LIBCUDACXX_CONSTEXPR const element_type* get() const
+  constexpr const element_type* get() const
   {
     return __get_pointer(__t_);
   }
 
-  _LIBCUDACXX_CONSTEXPR element_type* get()
+  constexpr element_type* get()
   {
     return __get_pointer(__t_);
   }
 
-  explicit _LIBCUDACXX_CONSTEXPR operator bool() const
+  explicit constexpr operator bool() const
   {
     return get() != nullptr;
   }
 
-  _LIBCUDACXX_CONSTEXPR const element_type* operator->() const
+  constexpr const element_type* operator->() const
   {
     return get();
   }
 
   template <class _Tp_ = _Tp, class _Up = enable_if_t<is_convertible<
                                   const _Tp_, const element_type *>::value>>
-  _LIBCUDACXX_CONSTEXPR operator const element_type *() const {
+  constexpr operator const element_type *() const {
     return get();
   }
 
-  _LIBCUDACXX_CONSTEXPR const element_type& operator*() const
+  constexpr const element_type& operator*() const
   {
     return *get();
   }
 
-  _LIBCUDACXX_CONSTEXPR element_type* operator->()
+  constexpr element_type* operator->()
   {
     return get();
   }
 
   template <class _Tp_ = _Tp, class _Up = enable_if_t<
                                   is_convertible<_Tp_, element_type *>::value>>
-  _LIBCUDACXX_CONSTEXPR operator element_type *() {
+  constexpr operator element_type *() {
     return get();
   }
 
-  _LIBCUDACXX_CONSTEXPR element_type& operator*()
+  constexpr element_type& operator*()
   {
     return *get();
   }
 
-  _LIBCUDACXX_CONSTEXPR void swap(propagate_const& __pt) noexcept(__is_nothrow_swappable<_Tp>::value)
+  constexpr void swap(propagate_const& __pt) noexcept(__is_nothrow_swappable<_Tp>::value)
   {
     using _CUDA_VSTD::swap;
     swap(__t_, __pt.__t_);
@@ -299,35 +299,35 @@ public:
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator==(const propagate_const<_Tp>& __pt, nullptr_t)
+constexpr bool operator==(const propagate_const<_Tp>& __pt, nullptr_t)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) == nullptr;
 }
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator==(nullptr_t, const propagate_const<_Tp>& __pt)
+constexpr bool operator==(nullptr_t, const propagate_const<_Tp>& __pt)
 {
   return nullptr == _CUDA_VSTD_LFTS_V2::get_underlying(__pt);
 }
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator!=(const propagate_const<_Tp>& __pt, nullptr_t)
+constexpr bool operator!=(const propagate_const<_Tp>& __pt, nullptr_t)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) != nullptr;
 }
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator!=(nullptr_t, const propagate_const<_Tp>& __pt)
+constexpr bool operator!=(nullptr_t, const propagate_const<_Tp>& __pt)
 {
   return nullptr != _CUDA_VSTD_LFTS_V2::get_underlying(__pt);
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator==(const propagate_const<_Tp>& __pt,
+constexpr bool operator==(const propagate_const<_Tp>& __pt,
                           const propagate_const<_Up>& __pu)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) == _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
@@ -335,7 +335,7 @@ _LIBCUDACXX_CONSTEXPR bool operator==(const propagate_const<_Tp>& __pt,
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator!=(const propagate_const<_Tp>& __pt,
+constexpr bool operator!=(const propagate_const<_Tp>& __pt,
                           const propagate_const<_Up>& __pu)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) != _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
@@ -343,7 +343,7 @@ _LIBCUDACXX_CONSTEXPR bool operator!=(const propagate_const<_Tp>& __pt,
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator<(const propagate_const<_Tp>& __pt,
+constexpr bool operator<(const propagate_const<_Tp>& __pt,
                          const propagate_const<_Up>& __pu)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) < _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
@@ -351,7 +351,7 @@ _LIBCUDACXX_CONSTEXPR bool operator<(const propagate_const<_Tp>& __pt,
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator>(const propagate_const<_Tp>& __pt,
+constexpr bool operator>(const propagate_const<_Tp>& __pt,
                          const propagate_const<_Up>& __pu)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) > _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
@@ -359,7 +359,7 @@ _LIBCUDACXX_CONSTEXPR bool operator>(const propagate_const<_Tp>& __pt,
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator<=(const propagate_const<_Tp>& __pt,
+constexpr bool operator<=(const propagate_const<_Tp>& __pt,
                           const propagate_const<_Up>& __pu)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) <= _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
@@ -367,7 +367,7 @@ _LIBCUDACXX_CONSTEXPR bool operator<=(const propagate_const<_Tp>& __pt,
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator>=(const propagate_const<_Tp>& __pt,
+constexpr bool operator>=(const propagate_const<_Tp>& __pt,
                           const propagate_const<_Up>& __pu)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) >= _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
@@ -375,42 +375,42 @@ _LIBCUDACXX_CONSTEXPR bool operator>=(const propagate_const<_Tp>& __pt,
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator==(const propagate_const<_Tp>& __pt, const _Up& __u)
+constexpr bool operator==(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) == __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator!=(const propagate_const<_Tp>& __pt, const _Up& __u)
+constexpr bool operator!=(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) != __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator<(const propagate_const<_Tp>& __pt, const _Up& __u)
+constexpr bool operator<(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) < __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator>(const propagate_const<_Tp>& __pt, const _Up& __u)
+constexpr bool operator>(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) > __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator<=(const propagate_const<_Tp>& __pt, const _Up& __u)
+constexpr bool operator<=(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) <= __u;
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator>=(const propagate_const<_Tp>& __pt, const _Up& __u)
+constexpr bool operator>=(const propagate_const<_Tp>& __pt, const _Up& __u)
 {
   return _CUDA_VSTD_LFTS_V2::get_underlying(__pt) >= __u;
 }
@@ -418,61 +418,61 @@ _LIBCUDACXX_CONSTEXPR bool operator>=(const propagate_const<_Tp>& __pt, const _U
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator==(const _Tp& __t, const propagate_const<_Up>& __pu)
+constexpr bool operator==(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
   return __t == _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator!=(const _Tp& __t, const propagate_const<_Up>& __pu)
+constexpr bool operator!=(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
   return __t != _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator<(const _Tp& __t, const propagate_const<_Up>& __pu)
+constexpr bool operator<(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
   return __t < _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator>(const _Tp& __t, const propagate_const<_Up>& __pu)
+constexpr bool operator>(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
   return __t > _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator<=(const _Tp& __t, const propagate_const<_Up>& __pu)
+constexpr bool operator<=(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
   return __t <= _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
 }
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR bool operator>=(const _Tp& __t, const propagate_const<_Up>& __pu)
+constexpr bool operator>=(const _Tp& __t, const propagate_const<_Up>& __pu)
 {
   return __t >= _CUDA_VSTD_LFTS_V2::get_underlying(__pu);
 }
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR void swap(propagate_const<_Tp>& __pc1, propagate_const<_Tp>& __pc2) noexcept(__is_nothrow_swappable<_Tp>::value)
+constexpr void swap(propagate_const<_Tp>& __pc1, propagate_const<_Tp>& __pc2) noexcept(__is_nothrow_swappable<_Tp>::value)
 {
   __pc1.swap(__pc2);
 }
 
 template <class _Tp>
-_LIBCUDACXX_CONSTEXPR const _Tp& get_underlying(const propagate_const<_Tp>& __pt) noexcept
+constexpr const _Tp& get_underlying(const propagate_const<_Tp>& __pt) noexcept
 {
   return __pt.__t_;
 }
 
 template <class _Tp>
-_LIBCUDACXX_CONSTEXPR _Tp& get_underlying(propagate_const<_Tp>& __pt) noexcept
+constexpr _Tp& get_underlying(propagate_const<_Tp>& __pt) noexcept
 {
   return __pt.__t_;
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/type_traits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/experimental/type_traits
@@ -129,7 +129,7 @@ template <template<class...> class _Op, class... _Args>
 template <template<class...> class _Op, class... _Args>
   using detected_t = typename _DETECTOR<nonesuch, void, _Op, _Args...>::type;
 template <template<class...> class _Op, class... _Args>
-  _LIBCUDACXX_CONSTEXPR bool is_detected_v = is_detected<_Op, _Args...>::value;
+  constexpr bool is_detected_v = is_detected<_Op, _Args...>::value;
 
 template <class Default, template<class...> class _Op, class... _Args>
   using detected_or = _DETECTOR<Default, void, _Op, _Args...>;
@@ -139,12 +139,12 @@ template <class Default, template<class...> class _Op, class... _Args>
 template <class Expected, template<class...> class _Op, class... _Args>
   using is_detected_exact = is_same<Expected, detected_t<_Op, _Args...>>;
 template <class Expected, template<class...> class _Op, class... _Args>
-  _LIBCUDACXX_CONSTEXPR bool is_detected_exact_v = is_detected_exact<Expected, _Op, _Args...>::value;
+  constexpr bool is_detected_exact_v = is_detected_exact<Expected, _Op, _Args...>::value;
 
 template <class To, template<class...> class _Op, class... _Args>
   using is_detected_convertible = is_convertible<detected_t<_Op, _Args...>, To>;
 template <class To, template<class...> class _Op, class... _Args>
-  _LIBCUDACXX_CONSTEXPR bool is_detected_convertible_v = is_detected_convertible<To, _Op, _Args...>::value;  
+  constexpr bool is_detected_convertible_v = is_detected_convertible<To, _Op, _Args...>::value;  
 
 
 _LIBCUDACXX_END_NAMESPACE_LFTS

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/future
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/future
@@ -411,8 +411,7 @@ _LIBCUDACXX_DECLARE_STRONG_ENUM_EPILOG(launch)
 typedef underlying_type<launch>::type __launch_underlying_type;
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-launch
+constexpr launch
 operator&(launch __x, launch __y)
 {
     return static_cast<launch>(static_cast<__launch_underlying_type>(__x) &
@@ -420,8 +419,7 @@ operator&(launch __x, launch __y)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-launch
+constexpr launch
 operator|(launch __x, launch __y)
 {
     return static_cast<launch>(static_cast<__launch_underlying_type>(__x) |
@@ -429,8 +427,7 @@ operator|(launch __x, launch __y)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-launch
+constexpr launch
 operator^(launch __x, launch __y)
 {
     return static_cast<launch>(static_cast<__launch_underlying_type>(__x) ^
@@ -438,8 +435,7 @@ operator^(launch __x, launch __y)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
-launch
+constexpr launch
 operator~(launch __x)
 {
     return static_cast<launch>(~static_cast<__launch_underlying_type>(__x) & 3);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/latch
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/latch
@@ -75,7 +75,7 @@ class __latch_base
 {
     _LIBCUDACXX_LATCH_ALIGNMENT __atomic_base<ptrdiff_t, _Sco> __counter;
 public:
-    inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
     explicit __latch_base(ptrdiff_t __expected)
         : __counter(__expected) { }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/limits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/limits
@@ -154,55 +154,55 @@ class __libcpp_numeric_limits
 protected:
     typedef _Tp type;
 
-    static _LIBCUDACXX_CONSTEXPR const  bool is_specialized = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return type();}
+    static constexpr const  bool is_specialized = false;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return type();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  digits = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 0;
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = false;
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = false;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = false;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = 0;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return type();}
+    static constexpr const int  digits = 0;
+    static constexpr const int  digits10 = 0;
+    static constexpr const int  max_digits10 = 0;
+    static constexpr const bool is_signed = false;
+    static constexpr const bool is_integer = false;
+    static constexpr const bool is_exact = false;
+    static constexpr const int  radix = 0;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return type();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = 0;
+    static constexpr const int  min_exponent = 0;
+    static constexpr const int  min_exponent10 = 0;
+    static constexpr const int  max_exponent = 0;
+    static constexpr const int  max_exponent10 = 0;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = false;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = false;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = false;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_absent;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return type();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return type();}
+    static constexpr const bool has_infinity = false;
+    static constexpr const bool has_quiet_NaN = false;
+    static constexpr const bool has_signaling_NaN = false;
+    static constexpr const float_denorm_style has_denorm = denorm_absent;
+    static constexpr const bool has_denorm_loss = false;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return type();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return type();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = false;
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = false;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = false;
+    static constexpr const bool is_iec559 = false;
+    static constexpr const bool is_bounded = false;
+    static constexpr const bool is_modulo = false;
 
-    static _LIBCUDACXX_CONSTEXPR const bool traps = false;
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = false;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = round_toward_zero;
+    static constexpr const bool traps = false;
+    static constexpr const bool tinyness_before = false;
+    static constexpr const float_round_style round_style = round_toward_zero;
 };
 
 template <class _Tp, int __digits, bool _IsSigned>
 struct __libcpp_compute_min
 {
-    static _LIBCUDACXX_CONSTEXPR const _Tp value = static_cast<_Tp>(_Tp(1) << __digits);
+    static constexpr const _Tp value = static_cast<_Tp>(_Tp(1) << __digits);
 };
 
 template <class _Tp, int __digits>
 struct __libcpp_compute_min<_Tp, __digits, false>
 {
-    static _LIBCUDACXX_CONSTEXPR const _Tp value = _Tp(0);
+    static constexpr const _Tp value = _Tp(0);
 };
 
 template <class _Tp>
@@ -211,51 +211,51 @@ class __libcpp_numeric_limits<_Tp, true>
 protected:
     typedef _Tp type;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_specialized = true;
+    static constexpr const bool is_specialized = true;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = type(-1) < type(0);
-    static _LIBCUDACXX_CONSTEXPR const int  digits = static_cast<int>(sizeof(type) * __CHAR_BIT__ - is_signed);
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = digits * 3 / 10;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 0;
-    static _LIBCUDACXX_CONSTEXPR const type __min = __libcpp_compute_min<type, digits, is_signed>::value;
-    static _LIBCUDACXX_CONSTEXPR const type __max = is_signed ? type(type(~0) ^ __min) : type(~0);
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __min;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __max;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return min();}
+    static constexpr const bool is_signed = type(-1) < type(0);
+    static constexpr const int  digits = static_cast<int>(sizeof(type) * __CHAR_BIT__ - is_signed);
+    static constexpr const int  digits10 = digits * 3 / 10;
+    static constexpr const int  max_digits10 = 0;
+    static constexpr const type __min = __libcpp_compute_min<type, digits, is_signed>::value;
+    static constexpr const type __max = is_signed ? type(type(~0) ^ __min) : type(~0);
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __min;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __max;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return min();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = true;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = true;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = 2;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return type(0);}
+    static constexpr const bool is_integer = true;
+    static constexpr const bool is_exact = true;
+    static constexpr const int  radix = 2;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return type(0);}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = 0;
+    static constexpr const int  min_exponent = 0;
+    static constexpr const int  min_exponent10 = 0;
+    static constexpr const int  max_exponent = 0;
+    static constexpr const int  max_exponent10 = 0;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = false;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = false;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = false;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_absent;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return type(0);}
+    static constexpr const bool has_infinity = false;
+    static constexpr const bool has_quiet_NaN = false;
+    static constexpr const bool has_signaling_NaN = false;
+    static constexpr const float_denorm_style has_denorm = denorm_absent;
+    static constexpr const bool has_denorm_loss = false;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return type(0);}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = false;
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = true;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = !_CUDA_VSTD::is_signed<_Tp>::value;
+    static constexpr const bool is_iec559 = false;
+    static constexpr const bool is_bounded = true;
+    static constexpr const bool is_modulo = !_CUDA_VSTD::is_signed<_Tp>::value;
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__pnacl__) || \
     defined(__wasm__)
-    static _LIBCUDACXX_CONSTEXPR const bool traps = true;
+    static constexpr const bool traps = true;
 #else
-    static _LIBCUDACXX_CONSTEXPR const bool traps = false;
+    static constexpr const bool traps = false;
 #endif
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = false;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = round_toward_zero;
+    static constexpr const bool tinyness_before = false;
+    static constexpr const float_round_style round_style = round_toward_zero;
 };
 
 template <>
@@ -264,46 +264,46 @@ class __libcpp_numeric_limits<bool, true>
 protected:
     typedef bool type;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_specialized = true;
+    static constexpr const bool is_specialized = true;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = false;
-    static _LIBCUDACXX_CONSTEXPR const int  digits = 1;
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 0;
-    static _LIBCUDACXX_CONSTEXPR const type __min = false;
-    static _LIBCUDACXX_CONSTEXPR const type __max = true;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __min;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __max;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return min();}
+    static constexpr const bool is_signed = false;
+    static constexpr const int  digits = 1;
+    static constexpr const int  digits10 = 0;
+    static constexpr const int  max_digits10 = 0;
+    static constexpr const type __min = false;
+    static constexpr const type __max = true;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __min;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __max;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return min();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = true;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = true;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = 2;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return type(0);}
+    static constexpr const bool is_integer = true;
+    static constexpr const bool is_exact = true;
+    static constexpr const int  radix = 2;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return type(0);}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = 0;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = 0;
+    static constexpr const int  min_exponent = 0;
+    static constexpr const int  min_exponent10 = 0;
+    static constexpr const int  max_exponent = 0;
+    static constexpr const int  max_exponent10 = 0;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = false;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = false;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = false;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_absent;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return type(0);}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return type(0);}
+    static constexpr const bool has_infinity = false;
+    static constexpr const bool has_quiet_NaN = false;
+    static constexpr const bool has_signaling_NaN = false;
+    static constexpr const float_denorm_style has_denorm = denorm_absent;
+    static constexpr const bool has_denorm_loss = false;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return type(0);}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return type(0);}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = false;
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = true;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = false;
+    static constexpr const bool is_iec559 = false;
+    static constexpr const bool is_bounded = true;
+    static constexpr const bool is_modulo = false;
 
-    static _LIBCUDACXX_CONSTEXPR const bool traps = false;
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = false;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = round_toward_zero;
+    static constexpr const bool traps = false;
+    static constexpr const bool tinyness_before = false;
+    static constexpr const float_round_style round_style = round_toward_zero;
 };
 
 template <>
@@ -312,50 +312,50 @@ class __libcpp_numeric_limits<float, true>
 protected:
     typedef float type;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_specialized = true;
+    static constexpr const bool is_specialized = true;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = true;
-    static _LIBCUDACXX_CONSTEXPR const int  digits = __FLT_MANT_DIG__;
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = __FLT_DIG__;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 2+(digits * 30103l)/100000l;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __FLT_MIN__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __FLT_MAX__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return -max();}
+    static constexpr const bool is_signed = true;
+    static constexpr const int  digits = __FLT_MANT_DIG__;
+    static constexpr const int  digits10 = __FLT_DIG__;
+    static constexpr const int  max_digits10 = 2+(digits * 30103l)/100000l;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __FLT_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __FLT_MAX__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return -max();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = false;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = false;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = __FLT_RADIX__;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __FLT_EPSILON__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return 0.5F;}
+    static constexpr const bool is_integer = false;
+    static constexpr const bool is_exact = false;
+    static constexpr const int  radix = __FLT_RADIX__;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __FLT_EPSILON__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return 0.5F;}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __FLT_MIN_EXP__;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __FLT_MIN_10_EXP__;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = __FLT_MAX_EXP__;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = __FLT_MAX_10_EXP__;
+    static constexpr const int  min_exponent = __FLT_MIN_EXP__;
+    static constexpr const int  min_exponent10 = __FLT_MIN_10_EXP__;
+    static constexpr const int  max_exponent = __FLT_MAX_EXP__;
+    static constexpr const int  max_exponent10 = __FLT_MAX_10_EXP__;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = true;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = true;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = true;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
+    static constexpr const bool has_infinity = true;
+    static constexpr const bool has_quiet_NaN = true;
+    static constexpr const bool has_signaling_NaN = true;
+    static constexpr const float_denorm_style has_denorm = denorm_present;
+    static constexpr const bool has_denorm_loss = false;
 #ifdef _LIBCUDACXX_COMPILER_NVRTC
     _LIBCUDACXX_INLINE_VISIBILITY static type infinity() noexcept {return __builtin_huge_valf();}
     _LIBCUDACXX_INLINE_VISIBILITY static type quiet_NaN() noexcept {return __builtin_nanf("");}
     _LIBCUDACXX_INLINE_VISIBILITY static type signaling_NaN() noexcept {return __builtin_nansf("");}
 #else
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __builtin_huge_valf();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __builtin_nanf("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __builtin_nansf("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __builtin_huge_valf();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __builtin_nanf("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __builtin_nansf("");}
 #endif
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __FLT_DENORM_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __FLT_DENORM_MIN__;}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = true;
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = true;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = false;
+    static constexpr const bool is_iec559 = true;
+    static constexpr const bool is_bounded = true;
+    static constexpr const bool is_modulo = false;
 
-    static _LIBCUDACXX_CONSTEXPR const bool traps = false;
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = false;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = round_to_nearest;
+    static constexpr const bool traps = false;
+    static constexpr const bool tinyness_before = false;
+    static constexpr const float_round_style round_style = round_to_nearest;
 };
 
 template <>
@@ -364,50 +364,50 @@ class __libcpp_numeric_limits<double, true>
 protected:
     typedef double type;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_specialized = true;
+    static constexpr const bool is_specialized = true;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = true;
-    static _LIBCUDACXX_CONSTEXPR const int  digits = __DBL_MANT_DIG__;
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = __DBL_DIG__;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 2+(digits * 30103l)/100000l;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __DBL_MIN__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __DBL_MAX__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return -max();}
+    static constexpr const bool is_signed = true;
+    static constexpr const int  digits = __DBL_MANT_DIG__;
+    static constexpr const int  digits10 = __DBL_DIG__;
+    static constexpr const int  max_digits10 = 2+(digits * 30103l)/100000l;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __DBL_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __DBL_MAX__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return -max();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = false;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = false;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = __FLT_RADIX__;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __DBL_EPSILON__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return 0.5;}
+    static constexpr const bool is_integer = false;
+    static constexpr const bool is_exact = false;
+    static constexpr const int  radix = __FLT_RADIX__;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __DBL_EPSILON__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return 0.5;}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __DBL_MIN_EXP__;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __DBL_MIN_10_EXP__;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = __DBL_MAX_EXP__;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = __DBL_MAX_10_EXP__;
+    static constexpr const int  min_exponent = __DBL_MIN_EXP__;
+    static constexpr const int  min_exponent10 = __DBL_MIN_10_EXP__;
+    static constexpr const int  max_exponent = __DBL_MAX_EXP__;
+    static constexpr const int  max_exponent10 = __DBL_MAX_10_EXP__;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = true;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = true;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = true;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
+    static constexpr const bool has_infinity = true;
+    static constexpr const bool has_quiet_NaN = true;
+    static constexpr const bool has_signaling_NaN = true;
+    static constexpr const float_denorm_style has_denorm = denorm_present;
+    static constexpr const bool has_denorm_loss = false;
 #ifdef _LIBCUDACXX_COMPILER_NVRTC
     _LIBCUDACXX_INLINE_VISIBILITY static type infinity() noexcept {return __builtin_huge_val();}
     _LIBCUDACXX_INLINE_VISIBILITY static type quiet_NaN() noexcept {return __builtin_nan("");}
     _LIBCUDACXX_INLINE_VISIBILITY static type signaling_NaN() noexcept {return __builtin_nans("");}
 #else
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __builtin_huge_val();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __builtin_nan("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __builtin_nans("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __builtin_huge_val();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __builtin_nan("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __builtin_nans("");}
 #endif
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __DBL_DENORM_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __DBL_DENORM_MIN__;}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = true;
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = true;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = false;
+    static constexpr const bool is_iec559 = true;
+    static constexpr const bool is_bounded = true;
+    static constexpr const bool is_modulo = false;
 
-    static _LIBCUDACXX_CONSTEXPR const bool traps = false;
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = false;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = round_to_nearest;
+    static constexpr const bool traps = false;
+    static constexpr const bool tinyness_before = false;
+    static constexpr const float_round_style round_style = round_to_nearest;
 };
 
 template <>
@@ -417,48 +417,48 @@ class __libcpp_numeric_limits<long double, true>
 protected:
     typedef long double type;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_specialized = true;
+    static constexpr const bool is_specialized = true;
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = true;
-    static _LIBCUDACXX_CONSTEXPR const int  digits = __LDBL_MANT_DIG__;
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = __LDBL_DIG__;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = 2+(digits * 30103l)/100000l;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __LDBL_MIN__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __LDBL_MAX__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return -max();}
+    static constexpr const bool is_signed = true;
+    static constexpr const int  digits = __LDBL_MANT_DIG__;
+    static constexpr const int  digits10 = __LDBL_DIG__;
+    static constexpr const int  max_digits10 = 2+(digits * 30103l)/100000l;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __LDBL_MIN__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __LDBL_MAX__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return -max();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = false;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = false;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = __FLT_RADIX__;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __LDBL_EPSILON__;}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return 0.5L;}
+    static constexpr const bool is_integer = false;
+    static constexpr const bool is_exact = false;
+    static constexpr const int  radix = __FLT_RADIX__;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __LDBL_EPSILON__;}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return 0.5L;}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __LDBL_MIN_EXP__;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __LDBL_MIN_10_EXP__;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = __LDBL_MAX_EXP__;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = __LDBL_MAX_10_EXP__;
+    static constexpr const int  min_exponent = __LDBL_MIN_EXP__;
+    static constexpr const int  min_exponent10 = __LDBL_MIN_10_EXP__;
+    static constexpr const int  max_exponent = __LDBL_MAX_EXP__;
+    static constexpr const int  max_exponent10 = __LDBL_MAX_10_EXP__;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = true;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = true;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = true;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = false;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __builtin_huge_vall();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __builtin_nanl("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __builtin_nansl("");}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __LDBL_DENORM_MIN__;}
+    static constexpr const bool has_infinity = true;
+    static constexpr const bool has_quiet_NaN = true;
+    static constexpr const bool has_signaling_NaN = true;
+    static constexpr const float_denorm_style has_denorm = denorm_present;
+    static constexpr const bool has_denorm_loss = false;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __builtin_huge_vall();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __builtin_nanl("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __builtin_nansl("");}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __LDBL_DENORM_MIN__;}
 
 #if (defined(__ppc__) || defined(__ppc64__))
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = false;
+    static constexpr const bool is_iec559 = false;
 #else
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = true;
+    static constexpr const bool is_iec559 = true;
 #endif
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = true;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = false;
+    static constexpr const bool is_bounded = true;
+    static constexpr const bool is_modulo = false;
 
-    static _LIBCUDACXX_CONSTEXPR const bool traps = false;
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = false;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = round_to_nearest;
+    static constexpr const bool traps = false;
+    static constexpr const bool tinyness_before = false;
+    static constexpr const float_round_style round_style = round_to_nearest;
 #endif
 };
 
@@ -469,91 +469,91 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits
     typedef __libcpp_numeric_limits<__remove_cv_t<_Tp>> __base;
     typedef typename __base::type type;
 public:
-    static _LIBCUDACXX_CONSTEXPR const bool is_specialized = __base::is_specialized;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __base::min();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __base::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return __base::lowest();}
+    static constexpr const bool is_specialized = __base::is_specialized;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __base::min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __base::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return __base::lowest();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  digits = __base::digits;
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = __base::digits10;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = __base::max_digits10;
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = __base::is_signed;
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = __base::is_integer;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = __base::is_exact;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = __base::radix;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __base::epsilon();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return __base::round_error();}
+    static constexpr const int  digits = __base::digits;
+    static constexpr const int  digits10 = __base::digits10;
+    static constexpr const int  max_digits10 = __base::max_digits10;
+    static constexpr const bool is_signed = __base::is_signed;
+    static constexpr const bool is_integer = __base::is_integer;
+    static constexpr const bool is_exact = __base::is_exact;
+    static constexpr const int  radix = __base::radix;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __base::epsilon();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return __base::round_error();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __base::min_exponent;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __base::min_exponent10;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = __base::max_exponent;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = __base::max_exponent10;
+    static constexpr const int  min_exponent = __base::min_exponent;
+    static constexpr const int  min_exponent10 = __base::min_exponent10;
+    static constexpr const int  max_exponent = __base::max_exponent;
+    static constexpr const int  max_exponent10 = __base::max_exponent10;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = __base::has_infinity;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = __base::has_quiet_NaN;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = __base::has_signaling_NaN;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = __base::has_denorm;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = __base::has_denorm_loss;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __base::infinity();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __base::quiet_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __base::signaling_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __base::denorm_min();}
+    static constexpr const bool has_infinity = __base::has_infinity;
+    static constexpr const bool has_quiet_NaN = __base::has_quiet_NaN;
+    static constexpr const bool has_signaling_NaN = __base::has_signaling_NaN;
+    static constexpr const float_denorm_style has_denorm = __base::has_denorm;
+    static constexpr const bool has_denorm_loss = __base::has_denorm_loss;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __base::infinity();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __base::quiet_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __base::signaling_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __base::denorm_min();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = __base::is_iec559;
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = __base::is_bounded;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = __base::is_modulo;
+    static constexpr const bool is_iec559 = __base::is_iec559;
+    static constexpr const bool is_bounded = __base::is_bounded;
+    static constexpr const bool is_modulo = __base::is_modulo;
 
-    static _LIBCUDACXX_CONSTEXPR const bool traps = __base::traps;
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = __base::tinyness_before;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = __base::round_style;
+    static constexpr const bool traps = __base::traps;
+    static constexpr const bool tinyness_before = __base::tinyness_before;
+    static constexpr const float_round_style round_style = __base::round_style;
 };
 
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::is_specialized;
+    constexpr const bool numeric_limits<_Tp>::is_specialized;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<_Tp>::digits;
+    constexpr const int numeric_limits<_Tp>::digits;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<_Tp>::digits10;
+    constexpr const int numeric_limits<_Tp>::digits10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<_Tp>::max_digits10;
+    constexpr const int numeric_limits<_Tp>::max_digits10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::is_signed;
+    constexpr const bool numeric_limits<_Tp>::is_signed;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::is_integer;
+    constexpr const bool numeric_limits<_Tp>::is_integer;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::is_exact;
+    constexpr const bool numeric_limits<_Tp>::is_exact;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<_Tp>::radix;
+    constexpr const int numeric_limits<_Tp>::radix;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<_Tp>::min_exponent;
+    constexpr const int numeric_limits<_Tp>::min_exponent;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<_Tp>::min_exponent10;
+    constexpr const int numeric_limits<_Tp>::min_exponent10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<_Tp>::max_exponent;
+    constexpr const int numeric_limits<_Tp>::max_exponent;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<_Tp>::max_exponent10;
+    constexpr const int numeric_limits<_Tp>::max_exponent10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::has_infinity;
+    constexpr const bool numeric_limits<_Tp>::has_infinity;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::has_quiet_NaN;
+    constexpr const bool numeric_limits<_Tp>::has_quiet_NaN;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::has_signaling_NaN;
+    constexpr const bool numeric_limits<_Tp>::has_signaling_NaN;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const float_denorm_style numeric_limits<_Tp>::has_denorm;
+    constexpr const float_denorm_style numeric_limits<_Tp>::has_denorm;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::has_denorm_loss;
+    constexpr const bool numeric_limits<_Tp>::has_denorm_loss;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::is_iec559;
+    constexpr const bool numeric_limits<_Tp>::is_iec559;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::is_bounded;
+    constexpr const bool numeric_limits<_Tp>::is_bounded;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::is_modulo;
+    constexpr const bool numeric_limits<_Tp>::is_modulo;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::traps;
+    constexpr const bool numeric_limits<_Tp>::traps;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<_Tp>::tinyness_before;
+    constexpr const bool numeric_limits<_Tp>::tinyness_before;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const float_round_style numeric_limits<_Tp>::round_style;
+    constexpr const float_round_style numeric_limits<_Tp>::round_style;
 
 template <class _Tp>
 class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const _Tp>
@@ -562,91 +562,91 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const _Tp>
     typedef numeric_limits<_Tp> __base;
     typedef _Tp type;
 public:
-    static _LIBCUDACXX_CONSTEXPR const bool is_specialized = __base::is_specialized;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __base::min();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __base::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return __base::lowest();}
+    static constexpr const bool is_specialized = __base::is_specialized;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __base::min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __base::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return __base::lowest();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  digits = __base::digits;
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = __base::digits10;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = __base::max_digits10;
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = __base::is_signed;
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = __base::is_integer;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = __base::is_exact;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = __base::radix;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __base::epsilon();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return __base::round_error();}
+    static constexpr const int  digits = __base::digits;
+    static constexpr const int  digits10 = __base::digits10;
+    static constexpr const int  max_digits10 = __base::max_digits10;
+    static constexpr const bool is_signed = __base::is_signed;
+    static constexpr const bool is_integer = __base::is_integer;
+    static constexpr const bool is_exact = __base::is_exact;
+    static constexpr const int  radix = __base::radix;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __base::epsilon();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return __base::round_error();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __base::min_exponent;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __base::min_exponent10;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = __base::max_exponent;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = __base::max_exponent10;
+    static constexpr const int  min_exponent = __base::min_exponent;
+    static constexpr const int  min_exponent10 = __base::min_exponent10;
+    static constexpr const int  max_exponent = __base::max_exponent;
+    static constexpr const int  max_exponent10 = __base::max_exponent10;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = __base::has_infinity;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = __base::has_quiet_NaN;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = __base::has_signaling_NaN;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = __base::has_denorm;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = __base::has_denorm_loss;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __base::infinity();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __base::quiet_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __base::signaling_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __base::denorm_min();}
+    static constexpr const bool has_infinity = __base::has_infinity;
+    static constexpr const bool has_quiet_NaN = __base::has_quiet_NaN;
+    static constexpr const bool has_signaling_NaN = __base::has_signaling_NaN;
+    static constexpr const float_denorm_style has_denorm = __base::has_denorm;
+    static constexpr const bool has_denorm_loss = __base::has_denorm_loss;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __base::infinity();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __base::quiet_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __base::signaling_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __base::denorm_min();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = __base::is_iec559;
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = __base::is_bounded;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = __base::is_modulo;
+    static constexpr const bool is_iec559 = __base::is_iec559;
+    static constexpr const bool is_bounded = __base::is_bounded;
+    static constexpr const bool is_modulo = __base::is_modulo;
 
-    static _LIBCUDACXX_CONSTEXPR const bool traps = __base::traps;
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = __base::tinyness_before;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = __base::round_style;
+    static constexpr const bool traps = __base::traps;
+    static constexpr const bool tinyness_before = __base::tinyness_before;
+    static constexpr const float_round_style round_style = __base::round_style;
 };
 
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::is_specialized;
+    constexpr const bool numeric_limits<const _Tp>::is_specialized;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const _Tp>::digits;
+    constexpr const int numeric_limits<const _Tp>::digits;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const _Tp>::digits10;
+    constexpr const int numeric_limits<const _Tp>::digits10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const _Tp>::max_digits10;
+    constexpr const int numeric_limits<const _Tp>::max_digits10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::is_signed;
+    constexpr const bool numeric_limits<const _Tp>::is_signed;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::is_integer;
+    constexpr const bool numeric_limits<const _Tp>::is_integer;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::is_exact;
+    constexpr const bool numeric_limits<const _Tp>::is_exact;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const _Tp>::radix;
+    constexpr const int numeric_limits<const _Tp>::radix;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const _Tp>::min_exponent;
+    constexpr const int numeric_limits<const _Tp>::min_exponent;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const _Tp>::min_exponent10;
+    constexpr const int numeric_limits<const _Tp>::min_exponent10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const _Tp>::max_exponent;
+    constexpr const int numeric_limits<const _Tp>::max_exponent;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const _Tp>::max_exponent10;
+    constexpr const int numeric_limits<const _Tp>::max_exponent10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::has_infinity;
+    constexpr const bool numeric_limits<const _Tp>::has_infinity;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::has_quiet_NaN;
+    constexpr const bool numeric_limits<const _Tp>::has_quiet_NaN;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::has_signaling_NaN;
+    constexpr const bool numeric_limits<const _Tp>::has_signaling_NaN;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const float_denorm_style numeric_limits<const _Tp>::has_denorm;
+    constexpr const float_denorm_style numeric_limits<const _Tp>::has_denorm;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::has_denorm_loss;
+    constexpr const bool numeric_limits<const _Tp>::has_denorm_loss;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::is_iec559;
+    constexpr const bool numeric_limits<const _Tp>::is_iec559;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::is_bounded;
+    constexpr const bool numeric_limits<const _Tp>::is_bounded;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::is_modulo;
+    constexpr const bool numeric_limits<const _Tp>::is_modulo;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::traps;
+    constexpr const bool numeric_limits<const _Tp>::traps;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const _Tp>::tinyness_before;
+    constexpr const bool numeric_limits<const _Tp>::tinyness_before;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const float_round_style numeric_limits<const _Tp>::round_style;
+    constexpr const float_round_style numeric_limits<const _Tp>::round_style;
 
 template <class _Tp>
 class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<volatile _Tp>
@@ -655,91 +655,91 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<volatile _Tp>
     typedef numeric_limits<_Tp> __base;
     typedef _Tp type;
 public:
-    static _LIBCUDACXX_CONSTEXPR const bool is_specialized = __base::is_specialized;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __base::min();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __base::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return __base::lowest();}
+    static constexpr const bool is_specialized = __base::is_specialized;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __base::min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __base::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return __base::lowest();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  digits = __base::digits;
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = __base::digits10;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = __base::max_digits10;
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = __base::is_signed;
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = __base::is_integer;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = __base::is_exact;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = __base::radix;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __base::epsilon();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return __base::round_error();}
+    static constexpr const int  digits = __base::digits;
+    static constexpr const int  digits10 = __base::digits10;
+    static constexpr const int  max_digits10 = __base::max_digits10;
+    static constexpr const bool is_signed = __base::is_signed;
+    static constexpr const bool is_integer = __base::is_integer;
+    static constexpr const bool is_exact = __base::is_exact;
+    static constexpr const int  radix = __base::radix;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __base::epsilon();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return __base::round_error();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __base::min_exponent;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __base::min_exponent10;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = __base::max_exponent;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = __base::max_exponent10;
+    static constexpr const int  min_exponent = __base::min_exponent;
+    static constexpr const int  min_exponent10 = __base::min_exponent10;
+    static constexpr const int  max_exponent = __base::max_exponent;
+    static constexpr const int  max_exponent10 = __base::max_exponent10;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = __base::has_infinity;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = __base::has_quiet_NaN;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = __base::has_signaling_NaN;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = __base::has_denorm;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = __base::has_denorm_loss;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __base::infinity();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __base::quiet_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __base::signaling_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __base::denorm_min();}
+    static constexpr const bool has_infinity = __base::has_infinity;
+    static constexpr const bool has_quiet_NaN = __base::has_quiet_NaN;
+    static constexpr const bool has_signaling_NaN = __base::has_signaling_NaN;
+    static constexpr const float_denorm_style has_denorm = __base::has_denorm;
+    static constexpr const bool has_denorm_loss = __base::has_denorm_loss;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __base::infinity();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __base::quiet_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __base::signaling_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __base::denorm_min();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = __base::is_iec559;
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = __base::is_bounded;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = __base::is_modulo;
+    static constexpr const bool is_iec559 = __base::is_iec559;
+    static constexpr const bool is_bounded = __base::is_bounded;
+    static constexpr const bool is_modulo = __base::is_modulo;
 
-    static _LIBCUDACXX_CONSTEXPR const bool traps = __base::traps;
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = __base::tinyness_before;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = __base::round_style;
+    static constexpr const bool traps = __base::traps;
+    static constexpr const bool tinyness_before = __base::tinyness_before;
+    static constexpr const float_round_style round_style = __base::round_style;
 };
 
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::is_specialized;
+    constexpr const bool numeric_limits<volatile _Tp>::is_specialized;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<volatile _Tp>::digits;
+    constexpr const int numeric_limits<volatile _Tp>::digits;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<volatile _Tp>::digits10;
+    constexpr const int numeric_limits<volatile _Tp>::digits10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<volatile _Tp>::max_digits10;
+    constexpr const int numeric_limits<volatile _Tp>::max_digits10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::is_signed;
+    constexpr const bool numeric_limits<volatile _Tp>::is_signed;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::is_integer;
+    constexpr const bool numeric_limits<volatile _Tp>::is_integer;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::is_exact;
+    constexpr const bool numeric_limits<volatile _Tp>::is_exact;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<volatile _Tp>::radix;
+    constexpr const int numeric_limits<volatile _Tp>::radix;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<volatile _Tp>::min_exponent;
+    constexpr const int numeric_limits<volatile _Tp>::min_exponent;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<volatile _Tp>::min_exponent10;
+    constexpr const int numeric_limits<volatile _Tp>::min_exponent10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<volatile _Tp>::max_exponent;
+    constexpr const int numeric_limits<volatile _Tp>::max_exponent;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<volatile _Tp>::max_exponent10;
+    constexpr const int numeric_limits<volatile _Tp>::max_exponent10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::has_infinity;
+    constexpr const bool numeric_limits<volatile _Tp>::has_infinity;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::has_quiet_NaN;
+    constexpr const bool numeric_limits<volatile _Tp>::has_quiet_NaN;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::has_signaling_NaN;
+    constexpr const bool numeric_limits<volatile _Tp>::has_signaling_NaN;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const float_denorm_style numeric_limits<volatile _Tp>::has_denorm;
+    constexpr const float_denorm_style numeric_limits<volatile _Tp>::has_denorm;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::has_denorm_loss;
+    constexpr const bool numeric_limits<volatile _Tp>::has_denorm_loss;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::is_iec559;
+    constexpr const bool numeric_limits<volatile _Tp>::is_iec559;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::is_bounded;
+    constexpr const bool numeric_limits<volatile _Tp>::is_bounded;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::is_modulo;
+    constexpr const bool numeric_limits<volatile _Tp>::is_modulo;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::traps;
+    constexpr const bool numeric_limits<volatile _Tp>::traps;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<volatile _Tp>::tinyness_before;
+    constexpr const bool numeric_limits<volatile _Tp>::tinyness_before;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const float_round_style numeric_limits<volatile _Tp>::round_style;
+    constexpr const float_round_style numeric_limits<volatile _Tp>::round_style;
 
 template <class _Tp>
 class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const volatile _Tp>
@@ -748,91 +748,91 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const volatile _Tp>
     typedef numeric_limits<_Tp> __base;
     typedef _Tp type;
 public:
-    static _LIBCUDACXX_CONSTEXPR const bool is_specialized = __base::is_specialized;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type min() noexcept {return __base::min();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type max() noexcept {return __base::max();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type lowest() noexcept {return __base::lowest();}
+    static constexpr const bool is_specialized = __base::is_specialized;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __base::min();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __base::max();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return __base::lowest();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  digits = __base::digits;
-    static _LIBCUDACXX_CONSTEXPR const int  digits10 = __base::digits10;
-    static _LIBCUDACXX_CONSTEXPR const int  max_digits10 = __base::max_digits10;
-    static _LIBCUDACXX_CONSTEXPR const bool is_signed = __base::is_signed;
-    static _LIBCUDACXX_CONSTEXPR const bool is_integer = __base::is_integer;
-    static _LIBCUDACXX_CONSTEXPR const bool is_exact = __base::is_exact;
-    static _LIBCUDACXX_CONSTEXPR const int  radix = __base::radix;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type epsilon() noexcept {return __base::epsilon();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type round_error() noexcept {return __base::round_error();}
+    static constexpr const int  digits = __base::digits;
+    static constexpr const int  digits10 = __base::digits10;
+    static constexpr const int  max_digits10 = __base::max_digits10;
+    static constexpr const bool is_signed = __base::is_signed;
+    static constexpr const bool is_integer = __base::is_integer;
+    static constexpr const bool is_exact = __base::is_exact;
+    static constexpr const int  radix = __base::radix;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __base::epsilon();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return __base::round_error();}
 
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent = __base::min_exponent;
-    static _LIBCUDACXX_CONSTEXPR const int  min_exponent10 = __base::min_exponent10;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent = __base::max_exponent;
-    static _LIBCUDACXX_CONSTEXPR const int  max_exponent10 = __base::max_exponent10;
+    static constexpr const int  min_exponent = __base::min_exponent;
+    static constexpr const int  min_exponent10 = __base::min_exponent10;
+    static constexpr const int  max_exponent = __base::max_exponent;
+    static constexpr const int  max_exponent10 = __base::max_exponent10;
 
-    static _LIBCUDACXX_CONSTEXPR const bool has_infinity = __base::has_infinity;
-    static _LIBCUDACXX_CONSTEXPR const bool has_quiet_NaN = __base::has_quiet_NaN;
-    static _LIBCUDACXX_CONSTEXPR const bool has_signaling_NaN = __base::has_signaling_NaN;
-    static _LIBCUDACXX_CONSTEXPR const float_denorm_style has_denorm = __base::has_denorm;
-    static _LIBCUDACXX_CONSTEXPR const bool has_denorm_loss = __base::has_denorm_loss;
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type infinity() noexcept {return __base::infinity();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type quiet_NaN() noexcept {return __base::quiet_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type signaling_NaN() noexcept {return __base::signaling_NaN();}
-    _LIBCUDACXX_INLINE_VISIBILITY static _LIBCUDACXX_CONSTEXPR type denorm_min() noexcept {return __base::denorm_min();}
+    static constexpr const bool has_infinity = __base::has_infinity;
+    static constexpr const bool has_quiet_NaN = __base::has_quiet_NaN;
+    static constexpr const bool has_signaling_NaN = __base::has_signaling_NaN;
+    static constexpr const float_denorm_style has_denorm = __base::has_denorm;
+    static constexpr const bool has_denorm_loss = __base::has_denorm_loss;
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __base::infinity();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __base::quiet_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __base::signaling_NaN();}
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __base::denorm_min();}
 
-    static _LIBCUDACXX_CONSTEXPR const bool is_iec559 = __base::is_iec559;
-    static _LIBCUDACXX_CONSTEXPR const bool is_bounded = __base::is_bounded;
-    static _LIBCUDACXX_CONSTEXPR const bool is_modulo = __base::is_modulo;
+    static constexpr const bool is_iec559 = __base::is_iec559;
+    static constexpr const bool is_bounded = __base::is_bounded;
+    static constexpr const bool is_modulo = __base::is_modulo;
 
-    static _LIBCUDACXX_CONSTEXPR const bool traps = __base::traps;
-    static _LIBCUDACXX_CONSTEXPR const bool tinyness_before = __base::tinyness_before;
-    static _LIBCUDACXX_CONSTEXPR const float_round_style round_style = __base::round_style;
+    static constexpr const bool traps = __base::traps;
+    static constexpr const bool tinyness_before = __base::tinyness_before;
+    static constexpr const float_round_style round_style = __base::round_style;
 };
 
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::is_specialized;
+    constexpr const bool numeric_limits<const volatile _Tp>::is_specialized;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const volatile _Tp>::digits;
+    constexpr const int numeric_limits<const volatile _Tp>::digits;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const volatile _Tp>::digits10;
+    constexpr const int numeric_limits<const volatile _Tp>::digits10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const volatile _Tp>::max_digits10;
+    constexpr const int numeric_limits<const volatile _Tp>::max_digits10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::is_signed;
+    constexpr const bool numeric_limits<const volatile _Tp>::is_signed;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::is_integer;
+    constexpr const bool numeric_limits<const volatile _Tp>::is_integer;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::is_exact;
+    constexpr const bool numeric_limits<const volatile _Tp>::is_exact;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const volatile _Tp>::radix;
+    constexpr const int numeric_limits<const volatile _Tp>::radix;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const volatile _Tp>::min_exponent;
+    constexpr const int numeric_limits<const volatile _Tp>::min_exponent;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const volatile _Tp>::min_exponent10;
+    constexpr const int numeric_limits<const volatile _Tp>::min_exponent10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const volatile _Tp>::max_exponent;
+    constexpr const int numeric_limits<const volatile _Tp>::max_exponent;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const int numeric_limits<const volatile _Tp>::max_exponent10;
+    constexpr const int numeric_limits<const volatile _Tp>::max_exponent10;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::has_infinity;
+    constexpr const bool numeric_limits<const volatile _Tp>::has_infinity;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::has_quiet_NaN;
+    constexpr const bool numeric_limits<const volatile _Tp>::has_quiet_NaN;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::has_signaling_NaN;
+    constexpr const bool numeric_limits<const volatile _Tp>::has_signaling_NaN;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const float_denorm_style numeric_limits<const volatile _Tp>::has_denorm;
+    constexpr const float_denorm_style numeric_limits<const volatile _Tp>::has_denorm;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::has_denorm_loss;
+    constexpr const bool numeric_limits<const volatile _Tp>::has_denorm_loss;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::is_iec559;
+    constexpr const bool numeric_limits<const volatile _Tp>::is_iec559;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::is_bounded;
+    constexpr const bool numeric_limits<const volatile _Tp>::is_bounded;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::is_modulo;
+    constexpr const bool numeric_limits<const volatile _Tp>::is_modulo;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::traps;
+    constexpr const bool numeric_limits<const volatile _Tp>::traps;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const bool numeric_limits<const volatile _Tp>::tinyness_before;
+    constexpr const bool numeric_limits<const volatile _Tp>::tinyness_before;
 template <class _Tp>
-    _LIBCUDACXX_CONSTEXPR const float_round_style numeric_limits<const volatile _Tp>::round_style;
+    constexpr const float_round_style numeric_limits<const volatile _Tp>::round_style;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/limits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/limits
@@ -154,55 +154,55 @@ class __libcpp_numeric_limits
 protected:
     typedef _Tp type;
 
-    static constexpr const  bool is_specialized = false;
+    static constexpr bool is_specialized = false;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return type();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return type();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return type();}
 
-    static constexpr const int  digits = 0;
-    static constexpr const int  digits10 = 0;
-    static constexpr const int  max_digits10 = 0;
-    static constexpr const bool is_signed = false;
-    static constexpr const bool is_integer = false;
-    static constexpr const bool is_exact = false;
-    static constexpr const int  radix = 0;
+    static constexpr int  digits = 0;
+    static constexpr int  digits10 = 0;
+    static constexpr int  max_digits10 = 0;
+    static constexpr bool is_signed = false;
+    static constexpr bool is_integer = false;
+    static constexpr bool is_exact = false;
+    static constexpr int  radix = 0;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return type();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return type();}
 
-    static constexpr const int  min_exponent = 0;
-    static constexpr const int  min_exponent10 = 0;
-    static constexpr const int  max_exponent = 0;
-    static constexpr const int  max_exponent10 = 0;
+    static constexpr int  min_exponent = 0;
+    static constexpr int  min_exponent10 = 0;
+    static constexpr int  max_exponent = 0;
+    static constexpr int  max_exponent10 = 0;
 
-    static constexpr const bool has_infinity = false;
-    static constexpr const bool has_quiet_NaN = false;
-    static constexpr const bool has_signaling_NaN = false;
-    static constexpr const float_denorm_style has_denorm = denorm_absent;
-    static constexpr const bool has_denorm_loss = false;
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr float_denorm_style has_denorm = denorm_absent;
+    static constexpr bool has_denorm_loss = false;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return type();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return type();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return type();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return type();}
 
-    static constexpr const bool is_iec559 = false;
-    static constexpr const bool is_bounded = false;
-    static constexpr const bool is_modulo = false;
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = false;
+    static constexpr bool is_modulo = false;
 
-    static constexpr const bool traps = false;
-    static constexpr const bool tinyness_before = false;
-    static constexpr const float_round_style round_style = round_toward_zero;
+    static constexpr bool traps = false;
+    static constexpr bool tinyness_before = false;
+    static constexpr float_round_style round_style = round_toward_zero;
 };
 
 template <class _Tp, int __digits, bool _IsSigned>
 struct __libcpp_compute_min
 {
-    static constexpr const _Tp value = static_cast<_Tp>(_Tp(1) << __digits);
+    static constexpr _Tp value = static_cast<_Tp>(_Tp(1) << __digits);
 };
 
 template <class _Tp, int __digits>
 struct __libcpp_compute_min<_Tp, __digits, false>
 {
-    static constexpr const _Tp value = _Tp(0);
+    static constexpr _Tp value = _Tp(0);
 };
 
 template <class _Tp>
@@ -211,51 +211,51 @@ class __libcpp_numeric_limits<_Tp, true>
 protected:
     typedef _Tp type;
 
-    static constexpr const bool is_specialized = true;
+    static constexpr bool is_specialized = true;
 
-    static constexpr const bool is_signed = type(-1) < type(0);
-    static constexpr const int  digits = static_cast<int>(sizeof(type) * __CHAR_BIT__ - is_signed);
-    static constexpr const int  digits10 = digits * 3 / 10;
-    static constexpr const int  max_digits10 = 0;
-    static constexpr const type __min = __libcpp_compute_min<type, digits, is_signed>::value;
-    static constexpr const type __max = is_signed ? type(type(~0) ^ __min) : type(~0);
+    static constexpr bool is_signed = type(-1) < type(0);
+    static constexpr int  digits = static_cast<int>(sizeof(type) * __CHAR_BIT__ - is_signed);
+    static constexpr int  digits10 = digits * 3 / 10;
+    static constexpr int  max_digits10 = 0;
+    static constexpr type __min = __libcpp_compute_min<type, digits, is_signed>::value;
+    static constexpr type __max = is_signed ? type(type(~0) ^ __min) : type(~0);
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __min;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __max;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return min();}
 
-    static constexpr const bool is_integer = true;
-    static constexpr const bool is_exact = true;
-    static constexpr const int  radix = 2;
+    static constexpr bool is_integer = true;
+    static constexpr bool is_exact = true;
+    static constexpr int  radix = 2;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return type(0);}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return type(0);}
 
-    static constexpr const int  min_exponent = 0;
-    static constexpr const int  min_exponent10 = 0;
-    static constexpr const int  max_exponent = 0;
-    static constexpr const int  max_exponent10 = 0;
+    static constexpr int  min_exponent = 0;
+    static constexpr int  min_exponent10 = 0;
+    static constexpr int  max_exponent = 0;
+    static constexpr int  max_exponent10 = 0;
 
-    static constexpr const bool has_infinity = false;
-    static constexpr const bool has_quiet_NaN = false;
-    static constexpr const bool has_signaling_NaN = false;
-    static constexpr const float_denorm_style has_denorm = denorm_absent;
-    static constexpr const bool has_denorm_loss = false;
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr float_denorm_style has_denorm = denorm_absent;
+    static constexpr bool has_denorm_loss = false;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return type(0);}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return type(0);}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return type(0);}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return type(0);}
 
-    static constexpr const bool is_iec559 = false;
-    static constexpr const bool is_bounded = true;
-    static constexpr const bool is_modulo = !_CUDA_VSTD::is_signed<_Tp>::value;
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = !_CUDA_VSTD::is_signed<_Tp>::value;
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__pnacl__) || \
     defined(__wasm__)
-    static constexpr const bool traps = true;
+    static constexpr bool traps = true;
 #else
-    static constexpr const bool traps = false;
+    static constexpr bool traps = false;
 #endif
-    static constexpr const bool tinyness_before = false;
-    static constexpr const float_round_style round_style = round_toward_zero;
+    static constexpr bool tinyness_before = false;
+    static constexpr float_round_style round_style = round_toward_zero;
 };
 
 template <>
@@ -264,46 +264,46 @@ class __libcpp_numeric_limits<bool, true>
 protected:
     typedef bool type;
 
-    static constexpr const bool is_specialized = true;
+    static constexpr bool is_specialized = true;
 
-    static constexpr const bool is_signed = false;
-    static constexpr const int  digits = 1;
-    static constexpr const int  digits10 = 0;
-    static constexpr const int  max_digits10 = 0;
-    static constexpr const type __min = false;
-    static constexpr const type __max = true;
+    static constexpr bool is_signed = false;
+    static constexpr int  digits = 1;
+    static constexpr int  digits10 = 0;
+    static constexpr int  max_digits10 = 0;
+    static constexpr type __min = false;
+    static constexpr type __max = true;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __min;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __max;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return min();}
 
-    static constexpr const bool is_integer = true;
-    static constexpr const bool is_exact = true;
-    static constexpr const int  radix = 2;
+    static constexpr bool is_integer = true;
+    static constexpr bool is_exact = true;
+    static constexpr int  radix = 2;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return type(0);}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return type(0);}
 
-    static constexpr const int  min_exponent = 0;
-    static constexpr const int  min_exponent10 = 0;
-    static constexpr const int  max_exponent = 0;
-    static constexpr const int  max_exponent10 = 0;
+    static constexpr int  min_exponent = 0;
+    static constexpr int  min_exponent10 = 0;
+    static constexpr int  max_exponent = 0;
+    static constexpr int  max_exponent10 = 0;
 
-    static constexpr const bool has_infinity = false;
-    static constexpr const bool has_quiet_NaN = false;
-    static constexpr const bool has_signaling_NaN = false;
-    static constexpr const float_denorm_style has_denorm = denorm_absent;
-    static constexpr const bool has_denorm_loss = false;
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr float_denorm_style has_denorm = denorm_absent;
+    static constexpr bool has_denorm_loss = false;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return type(0);}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return type(0);}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return type(0);}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return type(0);}
 
-    static constexpr const bool is_iec559 = false;
-    static constexpr const bool is_bounded = true;
-    static constexpr const bool is_modulo = false;
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = false;
 
-    static constexpr const bool traps = false;
-    static constexpr const bool tinyness_before = false;
-    static constexpr const float_round_style round_style = round_toward_zero;
+    static constexpr bool traps = false;
+    static constexpr bool tinyness_before = false;
+    static constexpr float_round_style round_style = round_toward_zero;
 };
 
 template <>
@@ -312,32 +312,32 @@ class __libcpp_numeric_limits<float, true>
 protected:
     typedef float type;
 
-    static constexpr const bool is_specialized = true;
+    static constexpr bool is_specialized = true;
 
-    static constexpr const bool is_signed = true;
-    static constexpr const int  digits = __FLT_MANT_DIG__;
-    static constexpr const int  digits10 = __FLT_DIG__;
-    static constexpr const int  max_digits10 = 2+(digits * 30103l)/100000l;
+    static constexpr bool is_signed = true;
+    static constexpr int  digits = __FLT_MANT_DIG__;
+    static constexpr int  digits10 = __FLT_DIG__;
+    static constexpr int  max_digits10 = 2+(digits * 30103l)/100000l;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __FLT_MIN__;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __FLT_MAX__;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return -max();}
 
-    static constexpr const bool is_integer = false;
-    static constexpr const bool is_exact = false;
-    static constexpr const int  radix = __FLT_RADIX__;
+    static constexpr bool is_integer = false;
+    static constexpr bool is_exact = false;
+    static constexpr int  radix = __FLT_RADIX__;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __FLT_EPSILON__;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return 0.5F;}
 
-    static constexpr const int  min_exponent = __FLT_MIN_EXP__;
-    static constexpr const int  min_exponent10 = __FLT_MIN_10_EXP__;
-    static constexpr const int  max_exponent = __FLT_MAX_EXP__;
-    static constexpr const int  max_exponent10 = __FLT_MAX_10_EXP__;
+    static constexpr int  min_exponent = __FLT_MIN_EXP__;
+    static constexpr int  min_exponent10 = __FLT_MIN_10_EXP__;
+    static constexpr int  max_exponent = __FLT_MAX_EXP__;
+    static constexpr int  max_exponent10 = __FLT_MAX_10_EXP__;
 
-    static constexpr const bool has_infinity = true;
-    static constexpr const bool has_quiet_NaN = true;
-    static constexpr const bool has_signaling_NaN = true;
-    static constexpr const float_denorm_style has_denorm = denorm_present;
-    static constexpr const bool has_denorm_loss = false;
+    static constexpr bool has_infinity = true;
+    static constexpr bool has_quiet_NaN = true;
+    static constexpr bool has_signaling_NaN = true;
+    static constexpr float_denorm_style has_denorm = denorm_present;
+    static constexpr bool has_denorm_loss = false;
 #ifdef _LIBCUDACXX_COMPILER_NVRTC
     _LIBCUDACXX_INLINE_VISIBILITY static type infinity() noexcept {return __builtin_huge_valf();}
     _LIBCUDACXX_INLINE_VISIBILITY static type quiet_NaN() noexcept {return __builtin_nanf("");}
@@ -349,13 +349,13 @@ protected:
 #endif
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __FLT_DENORM_MIN__;}
 
-    static constexpr const bool is_iec559 = true;
-    static constexpr const bool is_bounded = true;
-    static constexpr const bool is_modulo = false;
+    static constexpr bool is_iec559 = true;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = false;
 
-    static constexpr const bool traps = false;
-    static constexpr const bool tinyness_before = false;
-    static constexpr const float_round_style round_style = round_to_nearest;
+    static constexpr bool traps = false;
+    static constexpr bool tinyness_before = false;
+    static constexpr float_round_style round_style = round_to_nearest;
 };
 
 template <>
@@ -364,32 +364,32 @@ class __libcpp_numeric_limits<double, true>
 protected:
     typedef double type;
 
-    static constexpr const bool is_specialized = true;
+    static constexpr bool is_specialized = true;
 
-    static constexpr const bool is_signed = true;
-    static constexpr const int  digits = __DBL_MANT_DIG__;
-    static constexpr const int  digits10 = __DBL_DIG__;
-    static constexpr const int  max_digits10 = 2+(digits * 30103l)/100000l;
+    static constexpr bool is_signed = true;
+    static constexpr int  digits = __DBL_MANT_DIG__;
+    static constexpr int  digits10 = __DBL_DIG__;
+    static constexpr int  max_digits10 = 2+(digits * 30103l)/100000l;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __DBL_MIN__;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __DBL_MAX__;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return -max();}
 
-    static constexpr const bool is_integer = false;
-    static constexpr const bool is_exact = false;
-    static constexpr const int  radix = __FLT_RADIX__;
+    static constexpr bool is_integer = false;
+    static constexpr bool is_exact = false;
+    static constexpr int  radix = __FLT_RADIX__;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __DBL_EPSILON__;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return 0.5;}
 
-    static constexpr const int  min_exponent = __DBL_MIN_EXP__;
-    static constexpr const int  min_exponent10 = __DBL_MIN_10_EXP__;
-    static constexpr const int  max_exponent = __DBL_MAX_EXP__;
-    static constexpr const int  max_exponent10 = __DBL_MAX_10_EXP__;
+    static constexpr int  min_exponent = __DBL_MIN_EXP__;
+    static constexpr int  min_exponent10 = __DBL_MIN_10_EXP__;
+    static constexpr int  max_exponent = __DBL_MAX_EXP__;
+    static constexpr int  max_exponent10 = __DBL_MAX_10_EXP__;
 
-    static constexpr const bool has_infinity = true;
-    static constexpr const bool has_quiet_NaN = true;
-    static constexpr const bool has_signaling_NaN = true;
-    static constexpr const float_denorm_style has_denorm = denorm_present;
-    static constexpr const bool has_denorm_loss = false;
+    static constexpr bool has_infinity = true;
+    static constexpr bool has_quiet_NaN = true;
+    static constexpr bool has_signaling_NaN = true;
+    static constexpr float_denorm_style has_denorm = denorm_present;
+    static constexpr bool has_denorm_loss = false;
 #ifdef _LIBCUDACXX_COMPILER_NVRTC
     _LIBCUDACXX_INLINE_VISIBILITY static type infinity() noexcept {return __builtin_huge_val();}
     _LIBCUDACXX_INLINE_VISIBILITY static type quiet_NaN() noexcept {return __builtin_nan("");}
@@ -401,13 +401,13 @@ protected:
 #endif
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __DBL_DENORM_MIN__;}
 
-    static constexpr const bool is_iec559 = true;
-    static constexpr const bool is_bounded = true;
-    static constexpr const bool is_modulo = false;
+    static constexpr bool is_iec559 = true;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = false;
 
-    static constexpr const bool traps = false;
-    static constexpr const bool tinyness_before = false;
-    static constexpr const float_round_style round_style = round_to_nearest;
+    static constexpr bool traps = false;
+    static constexpr bool tinyness_before = false;
+    static constexpr float_round_style round_style = round_to_nearest;
 };
 
 template <>
@@ -417,48 +417,48 @@ class __libcpp_numeric_limits<long double, true>
 protected:
     typedef long double type;
 
-    static constexpr const bool is_specialized = true;
+    static constexpr bool is_specialized = true;
 
-    static constexpr const bool is_signed = true;
-    static constexpr const int  digits = __LDBL_MANT_DIG__;
-    static constexpr const int  digits10 = __LDBL_DIG__;
-    static constexpr const int  max_digits10 = 2+(digits * 30103l)/100000l;
+    static constexpr bool is_signed = true;
+    static constexpr int  digits = __LDBL_MANT_DIG__;
+    static constexpr int  digits10 = __LDBL_DIG__;
+    static constexpr int  max_digits10 = 2+(digits * 30103l)/100000l;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __LDBL_MIN__;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __LDBL_MAX__;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return -max();}
 
-    static constexpr const bool is_integer = false;
-    static constexpr const bool is_exact = false;
-    static constexpr const int  radix = __FLT_RADIX__;
+    static constexpr bool is_integer = false;
+    static constexpr bool is_exact = false;
+    static constexpr int  radix = __FLT_RADIX__;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __LDBL_EPSILON__;}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return 0.5L;}
 
-    static constexpr const int  min_exponent = __LDBL_MIN_EXP__;
-    static constexpr const int  min_exponent10 = __LDBL_MIN_10_EXP__;
-    static constexpr const int  max_exponent = __LDBL_MAX_EXP__;
-    static constexpr const int  max_exponent10 = __LDBL_MAX_10_EXP__;
+    static constexpr int  min_exponent = __LDBL_MIN_EXP__;
+    static constexpr int  min_exponent10 = __LDBL_MIN_10_EXP__;
+    static constexpr int  max_exponent = __LDBL_MAX_EXP__;
+    static constexpr int  max_exponent10 = __LDBL_MAX_10_EXP__;
 
-    static constexpr const bool has_infinity = true;
-    static constexpr const bool has_quiet_NaN = true;
-    static constexpr const bool has_signaling_NaN = true;
-    static constexpr const float_denorm_style has_denorm = denorm_present;
-    static constexpr const bool has_denorm_loss = false;
+    static constexpr bool has_infinity = true;
+    static constexpr bool has_quiet_NaN = true;
+    static constexpr bool has_signaling_NaN = true;
+    static constexpr float_denorm_style has_denorm = denorm_present;
+    static constexpr bool has_denorm_loss = false;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __builtin_huge_vall();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __builtin_nanl("");}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __builtin_nansl("");}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __LDBL_DENORM_MIN__;}
 
 #if (defined(__ppc__) || defined(__ppc64__))
-    static constexpr const bool is_iec559 = false;
+    static constexpr bool is_iec559 = false;
 #else
-    static constexpr const bool is_iec559 = true;
+    static constexpr bool is_iec559 = true;
 #endif
-    static constexpr const bool is_bounded = true;
-    static constexpr const bool is_modulo = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = false;
 
-    static constexpr const bool traps = false;
-    static constexpr const bool tinyness_before = false;
-    static constexpr const float_round_style round_style = round_to_nearest;
+    static constexpr bool traps = false;
+    static constexpr bool tinyness_before = false;
+    static constexpr float_round_style round_style = round_to_nearest;
 #endif
 };
 
@@ -469,91 +469,91 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits
     typedef __libcpp_numeric_limits<__remove_cv_t<_Tp>> __base;
     typedef typename __base::type type;
 public:
-    static constexpr const bool is_specialized = __base::is_specialized;
+    static constexpr bool is_specialized = __base::is_specialized;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __base::min();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __base::max();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return __base::lowest();}
 
-    static constexpr const int  digits = __base::digits;
-    static constexpr const int  digits10 = __base::digits10;
-    static constexpr const int  max_digits10 = __base::max_digits10;
-    static constexpr const bool is_signed = __base::is_signed;
-    static constexpr const bool is_integer = __base::is_integer;
-    static constexpr const bool is_exact = __base::is_exact;
-    static constexpr const int  radix = __base::radix;
+    static constexpr int  digits = __base::digits;
+    static constexpr int  digits10 = __base::digits10;
+    static constexpr int  max_digits10 = __base::max_digits10;
+    static constexpr bool is_signed = __base::is_signed;
+    static constexpr bool is_integer = __base::is_integer;
+    static constexpr bool is_exact = __base::is_exact;
+    static constexpr int  radix = __base::radix;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __base::epsilon();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return __base::round_error();}
 
-    static constexpr const int  min_exponent = __base::min_exponent;
-    static constexpr const int  min_exponent10 = __base::min_exponent10;
-    static constexpr const int  max_exponent = __base::max_exponent;
-    static constexpr const int  max_exponent10 = __base::max_exponent10;
+    static constexpr int  min_exponent = __base::min_exponent;
+    static constexpr int  min_exponent10 = __base::min_exponent10;
+    static constexpr int  max_exponent = __base::max_exponent;
+    static constexpr int  max_exponent10 = __base::max_exponent10;
 
-    static constexpr const bool has_infinity = __base::has_infinity;
-    static constexpr const bool has_quiet_NaN = __base::has_quiet_NaN;
-    static constexpr const bool has_signaling_NaN = __base::has_signaling_NaN;
-    static constexpr const float_denorm_style has_denorm = __base::has_denorm;
-    static constexpr const bool has_denorm_loss = __base::has_denorm_loss;
+    static constexpr bool has_infinity = __base::has_infinity;
+    static constexpr bool has_quiet_NaN = __base::has_quiet_NaN;
+    static constexpr bool has_signaling_NaN = __base::has_signaling_NaN;
+    static constexpr float_denorm_style has_denorm = __base::has_denorm;
+    static constexpr bool has_denorm_loss = __base::has_denorm_loss;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __base::infinity();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __base::quiet_NaN();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __base::signaling_NaN();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __base::denorm_min();}
 
-    static constexpr const bool is_iec559 = __base::is_iec559;
-    static constexpr const bool is_bounded = __base::is_bounded;
-    static constexpr const bool is_modulo = __base::is_modulo;
+    static constexpr bool is_iec559 = __base::is_iec559;
+    static constexpr bool is_bounded = __base::is_bounded;
+    static constexpr bool is_modulo = __base::is_modulo;
 
-    static constexpr const bool traps = __base::traps;
-    static constexpr const bool tinyness_before = __base::tinyness_before;
-    static constexpr const float_round_style round_style = __base::round_style;
+    static constexpr bool traps = __base::traps;
+    static constexpr bool tinyness_before = __base::tinyness_before;
+    static constexpr float_round_style round_style = __base::round_style;
 };
 
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::is_specialized;
+    constexpr bool numeric_limits<_Tp>::is_specialized;
 template <class _Tp>
-    constexpr const int numeric_limits<_Tp>::digits;
+    constexpr int numeric_limits<_Tp>::digits;
 template <class _Tp>
-    constexpr const int numeric_limits<_Tp>::digits10;
+    constexpr int numeric_limits<_Tp>::digits10;
 template <class _Tp>
-    constexpr const int numeric_limits<_Tp>::max_digits10;
+    constexpr int numeric_limits<_Tp>::max_digits10;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::is_signed;
+    constexpr bool numeric_limits<_Tp>::is_signed;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::is_integer;
+    constexpr bool numeric_limits<_Tp>::is_integer;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::is_exact;
+    constexpr bool numeric_limits<_Tp>::is_exact;
 template <class _Tp>
-    constexpr const int numeric_limits<_Tp>::radix;
+    constexpr int numeric_limits<_Tp>::radix;
 template <class _Tp>
-    constexpr const int numeric_limits<_Tp>::min_exponent;
+    constexpr int numeric_limits<_Tp>::min_exponent;
 template <class _Tp>
-    constexpr const int numeric_limits<_Tp>::min_exponent10;
+    constexpr int numeric_limits<_Tp>::min_exponent10;
 template <class _Tp>
-    constexpr const int numeric_limits<_Tp>::max_exponent;
+    constexpr int numeric_limits<_Tp>::max_exponent;
 template <class _Tp>
-    constexpr const int numeric_limits<_Tp>::max_exponent10;
+    constexpr int numeric_limits<_Tp>::max_exponent10;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::has_infinity;
+    constexpr bool numeric_limits<_Tp>::has_infinity;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::has_quiet_NaN;
+    constexpr bool numeric_limits<_Tp>::has_quiet_NaN;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::has_signaling_NaN;
+    constexpr bool numeric_limits<_Tp>::has_signaling_NaN;
 template <class _Tp>
-    constexpr const float_denorm_style numeric_limits<_Tp>::has_denorm;
+    constexpr float_denorm_style numeric_limits<_Tp>::has_denorm;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::has_denorm_loss;
+    constexpr bool numeric_limits<_Tp>::has_denorm_loss;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::is_iec559;
+    constexpr bool numeric_limits<_Tp>::is_iec559;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::is_bounded;
+    constexpr bool numeric_limits<_Tp>::is_bounded;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::is_modulo;
+    constexpr bool numeric_limits<_Tp>::is_modulo;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::traps;
+    constexpr bool numeric_limits<_Tp>::traps;
 template <class _Tp>
-    constexpr const bool numeric_limits<_Tp>::tinyness_before;
+    constexpr bool numeric_limits<_Tp>::tinyness_before;
 template <class _Tp>
-    constexpr const float_round_style numeric_limits<_Tp>::round_style;
+    constexpr float_round_style numeric_limits<_Tp>::round_style;
 
 template <class _Tp>
 class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const _Tp>
@@ -562,91 +562,91 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const _Tp>
     typedef numeric_limits<_Tp> __base;
     typedef _Tp type;
 public:
-    static constexpr const bool is_specialized = __base::is_specialized;
+    static constexpr bool is_specialized = __base::is_specialized;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __base::min();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __base::max();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return __base::lowest();}
 
-    static constexpr const int  digits = __base::digits;
-    static constexpr const int  digits10 = __base::digits10;
-    static constexpr const int  max_digits10 = __base::max_digits10;
-    static constexpr const bool is_signed = __base::is_signed;
-    static constexpr const bool is_integer = __base::is_integer;
-    static constexpr const bool is_exact = __base::is_exact;
-    static constexpr const int  radix = __base::radix;
+    static constexpr int  digits = __base::digits;
+    static constexpr int  digits10 = __base::digits10;
+    static constexpr int  max_digits10 = __base::max_digits10;
+    static constexpr bool is_signed = __base::is_signed;
+    static constexpr bool is_integer = __base::is_integer;
+    static constexpr bool is_exact = __base::is_exact;
+    static constexpr int  radix = __base::radix;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __base::epsilon();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return __base::round_error();}
 
-    static constexpr const int  min_exponent = __base::min_exponent;
-    static constexpr const int  min_exponent10 = __base::min_exponent10;
-    static constexpr const int  max_exponent = __base::max_exponent;
-    static constexpr const int  max_exponent10 = __base::max_exponent10;
+    static constexpr int  min_exponent = __base::min_exponent;
+    static constexpr int  min_exponent10 = __base::min_exponent10;
+    static constexpr int  max_exponent = __base::max_exponent;
+    static constexpr int  max_exponent10 = __base::max_exponent10;
 
-    static constexpr const bool has_infinity = __base::has_infinity;
-    static constexpr const bool has_quiet_NaN = __base::has_quiet_NaN;
-    static constexpr const bool has_signaling_NaN = __base::has_signaling_NaN;
-    static constexpr const float_denorm_style has_denorm = __base::has_denorm;
-    static constexpr const bool has_denorm_loss = __base::has_denorm_loss;
+    static constexpr bool has_infinity = __base::has_infinity;
+    static constexpr bool has_quiet_NaN = __base::has_quiet_NaN;
+    static constexpr bool has_signaling_NaN = __base::has_signaling_NaN;
+    static constexpr float_denorm_style has_denorm = __base::has_denorm;
+    static constexpr bool has_denorm_loss = __base::has_denorm_loss;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __base::infinity();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __base::quiet_NaN();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __base::signaling_NaN();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __base::denorm_min();}
 
-    static constexpr const bool is_iec559 = __base::is_iec559;
-    static constexpr const bool is_bounded = __base::is_bounded;
-    static constexpr const bool is_modulo = __base::is_modulo;
+    static constexpr bool is_iec559 = __base::is_iec559;
+    static constexpr bool is_bounded = __base::is_bounded;
+    static constexpr bool is_modulo = __base::is_modulo;
 
-    static constexpr const bool traps = __base::traps;
-    static constexpr const bool tinyness_before = __base::tinyness_before;
-    static constexpr const float_round_style round_style = __base::round_style;
+    static constexpr bool traps = __base::traps;
+    static constexpr bool tinyness_before = __base::tinyness_before;
+    static constexpr float_round_style round_style = __base::round_style;
 };
 
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::is_specialized;
+    constexpr bool numeric_limits<const _Tp>::is_specialized;
 template <class _Tp>
-    constexpr const int numeric_limits<const _Tp>::digits;
+    constexpr int numeric_limits<const _Tp>::digits;
 template <class _Tp>
-    constexpr const int numeric_limits<const _Tp>::digits10;
+    constexpr int numeric_limits<const _Tp>::digits10;
 template <class _Tp>
-    constexpr const int numeric_limits<const _Tp>::max_digits10;
+    constexpr int numeric_limits<const _Tp>::max_digits10;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::is_signed;
+    constexpr bool numeric_limits<const _Tp>::is_signed;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::is_integer;
+    constexpr bool numeric_limits<const _Tp>::is_integer;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::is_exact;
+    constexpr bool numeric_limits<const _Tp>::is_exact;
 template <class _Tp>
-    constexpr const int numeric_limits<const _Tp>::radix;
+    constexpr int numeric_limits<const _Tp>::radix;
 template <class _Tp>
-    constexpr const int numeric_limits<const _Tp>::min_exponent;
+    constexpr int numeric_limits<const _Tp>::min_exponent;
 template <class _Tp>
-    constexpr const int numeric_limits<const _Tp>::min_exponent10;
+    constexpr int numeric_limits<const _Tp>::min_exponent10;
 template <class _Tp>
-    constexpr const int numeric_limits<const _Tp>::max_exponent;
+    constexpr int numeric_limits<const _Tp>::max_exponent;
 template <class _Tp>
-    constexpr const int numeric_limits<const _Tp>::max_exponent10;
+    constexpr int numeric_limits<const _Tp>::max_exponent10;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::has_infinity;
+    constexpr bool numeric_limits<const _Tp>::has_infinity;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::has_quiet_NaN;
+    constexpr bool numeric_limits<const _Tp>::has_quiet_NaN;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::has_signaling_NaN;
+    constexpr bool numeric_limits<const _Tp>::has_signaling_NaN;
 template <class _Tp>
-    constexpr const float_denorm_style numeric_limits<const _Tp>::has_denorm;
+    constexpr float_denorm_style numeric_limits<const _Tp>::has_denorm;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::has_denorm_loss;
+    constexpr bool numeric_limits<const _Tp>::has_denorm_loss;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::is_iec559;
+    constexpr bool numeric_limits<const _Tp>::is_iec559;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::is_bounded;
+    constexpr bool numeric_limits<const _Tp>::is_bounded;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::is_modulo;
+    constexpr bool numeric_limits<const _Tp>::is_modulo;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::traps;
+    constexpr bool numeric_limits<const _Tp>::traps;
 template <class _Tp>
-    constexpr const bool numeric_limits<const _Tp>::tinyness_before;
+    constexpr bool numeric_limits<const _Tp>::tinyness_before;
 template <class _Tp>
-    constexpr const float_round_style numeric_limits<const _Tp>::round_style;
+    constexpr float_round_style numeric_limits<const _Tp>::round_style;
 
 template <class _Tp>
 class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<volatile _Tp>
@@ -655,91 +655,91 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<volatile _Tp>
     typedef numeric_limits<_Tp> __base;
     typedef _Tp type;
 public:
-    static constexpr const bool is_specialized = __base::is_specialized;
+    static constexpr bool is_specialized = __base::is_specialized;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __base::min();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __base::max();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return __base::lowest();}
 
-    static constexpr const int  digits = __base::digits;
-    static constexpr const int  digits10 = __base::digits10;
-    static constexpr const int  max_digits10 = __base::max_digits10;
-    static constexpr const bool is_signed = __base::is_signed;
-    static constexpr const bool is_integer = __base::is_integer;
-    static constexpr const bool is_exact = __base::is_exact;
-    static constexpr const int  radix = __base::radix;
+    static constexpr int  digits = __base::digits;
+    static constexpr int  digits10 = __base::digits10;
+    static constexpr int  max_digits10 = __base::max_digits10;
+    static constexpr bool is_signed = __base::is_signed;
+    static constexpr bool is_integer = __base::is_integer;
+    static constexpr bool is_exact = __base::is_exact;
+    static constexpr int  radix = __base::radix;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __base::epsilon();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return __base::round_error();}
 
-    static constexpr const int  min_exponent = __base::min_exponent;
-    static constexpr const int  min_exponent10 = __base::min_exponent10;
-    static constexpr const int  max_exponent = __base::max_exponent;
-    static constexpr const int  max_exponent10 = __base::max_exponent10;
+    static constexpr int  min_exponent = __base::min_exponent;
+    static constexpr int  min_exponent10 = __base::min_exponent10;
+    static constexpr int  max_exponent = __base::max_exponent;
+    static constexpr int  max_exponent10 = __base::max_exponent10;
 
-    static constexpr const bool has_infinity = __base::has_infinity;
-    static constexpr const bool has_quiet_NaN = __base::has_quiet_NaN;
-    static constexpr const bool has_signaling_NaN = __base::has_signaling_NaN;
-    static constexpr const float_denorm_style has_denorm = __base::has_denorm;
-    static constexpr const bool has_denorm_loss = __base::has_denorm_loss;
+    static constexpr bool has_infinity = __base::has_infinity;
+    static constexpr bool has_quiet_NaN = __base::has_quiet_NaN;
+    static constexpr bool has_signaling_NaN = __base::has_signaling_NaN;
+    static constexpr float_denorm_style has_denorm = __base::has_denorm;
+    static constexpr bool has_denorm_loss = __base::has_denorm_loss;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __base::infinity();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __base::quiet_NaN();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __base::signaling_NaN();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __base::denorm_min();}
 
-    static constexpr const bool is_iec559 = __base::is_iec559;
-    static constexpr const bool is_bounded = __base::is_bounded;
-    static constexpr const bool is_modulo = __base::is_modulo;
+    static constexpr bool is_iec559 = __base::is_iec559;
+    static constexpr bool is_bounded = __base::is_bounded;
+    static constexpr bool is_modulo = __base::is_modulo;
 
-    static constexpr const bool traps = __base::traps;
-    static constexpr const bool tinyness_before = __base::tinyness_before;
-    static constexpr const float_round_style round_style = __base::round_style;
+    static constexpr bool traps = __base::traps;
+    static constexpr bool tinyness_before = __base::tinyness_before;
+    static constexpr float_round_style round_style = __base::round_style;
 };
 
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::is_specialized;
+    constexpr bool numeric_limits<volatile _Tp>::is_specialized;
 template <class _Tp>
-    constexpr const int numeric_limits<volatile _Tp>::digits;
+    constexpr int numeric_limits<volatile _Tp>::digits;
 template <class _Tp>
-    constexpr const int numeric_limits<volatile _Tp>::digits10;
+    constexpr int numeric_limits<volatile _Tp>::digits10;
 template <class _Tp>
-    constexpr const int numeric_limits<volatile _Tp>::max_digits10;
+    constexpr int numeric_limits<volatile _Tp>::max_digits10;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::is_signed;
+    constexpr bool numeric_limits<volatile _Tp>::is_signed;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::is_integer;
+    constexpr bool numeric_limits<volatile _Tp>::is_integer;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::is_exact;
+    constexpr bool numeric_limits<volatile _Tp>::is_exact;
 template <class _Tp>
-    constexpr const int numeric_limits<volatile _Tp>::radix;
+    constexpr int numeric_limits<volatile _Tp>::radix;
 template <class _Tp>
-    constexpr const int numeric_limits<volatile _Tp>::min_exponent;
+    constexpr int numeric_limits<volatile _Tp>::min_exponent;
 template <class _Tp>
-    constexpr const int numeric_limits<volatile _Tp>::min_exponent10;
+    constexpr int numeric_limits<volatile _Tp>::min_exponent10;
 template <class _Tp>
-    constexpr const int numeric_limits<volatile _Tp>::max_exponent;
+    constexpr int numeric_limits<volatile _Tp>::max_exponent;
 template <class _Tp>
-    constexpr const int numeric_limits<volatile _Tp>::max_exponent10;
+    constexpr int numeric_limits<volatile _Tp>::max_exponent10;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::has_infinity;
+    constexpr bool numeric_limits<volatile _Tp>::has_infinity;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::has_quiet_NaN;
+    constexpr bool numeric_limits<volatile _Tp>::has_quiet_NaN;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::has_signaling_NaN;
+    constexpr bool numeric_limits<volatile _Tp>::has_signaling_NaN;
 template <class _Tp>
-    constexpr const float_denorm_style numeric_limits<volatile _Tp>::has_denorm;
+    constexpr float_denorm_style numeric_limits<volatile _Tp>::has_denorm;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::has_denorm_loss;
+    constexpr bool numeric_limits<volatile _Tp>::has_denorm_loss;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::is_iec559;
+    constexpr bool numeric_limits<volatile _Tp>::is_iec559;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::is_bounded;
+    constexpr bool numeric_limits<volatile _Tp>::is_bounded;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::is_modulo;
+    constexpr bool numeric_limits<volatile _Tp>::is_modulo;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::traps;
+    constexpr bool numeric_limits<volatile _Tp>::traps;
 template <class _Tp>
-    constexpr const bool numeric_limits<volatile _Tp>::tinyness_before;
+    constexpr bool numeric_limits<volatile _Tp>::tinyness_before;
 template <class _Tp>
-    constexpr const float_round_style numeric_limits<volatile _Tp>::round_style;
+    constexpr float_round_style numeric_limits<volatile _Tp>::round_style;
 
 template <class _Tp>
 class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const volatile _Tp>
@@ -748,91 +748,91 @@ class _LIBCUDACXX_TEMPLATE_VIS numeric_limits<const volatile _Tp>
     typedef numeric_limits<_Tp> __base;
     typedef _Tp type;
 public:
-    static constexpr const bool is_specialized = __base::is_specialized;
+    static constexpr bool is_specialized = __base::is_specialized;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type min() noexcept {return __base::min();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type max() noexcept {return __base::max();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type lowest() noexcept {return __base::lowest();}
 
-    static constexpr const int  digits = __base::digits;
-    static constexpr const int  digits10 = __base::digits10;
-    static constexpr const int  max_digits10 = __base::max_digits10;
-    static constexpr const bool is_signed = __base::is_signed;
-    static constexpr const bool is_integer = __base::is_integer;
-    static constexpr const bool is_exact = __base::is_exact;
-    static constexpr const int  radix = __base::radix;
+    static constexpr int  digits = __base::digits;
+    static constexpr int  digits10 = __base::digits10;
+    static constexpr int  max_digits10 = __base::max_digits10;
+    static constexpr bool is_signed = __base::is_signed;
+    static constexpr bool is_integer = __base::is_integer;
+    static constexpr bool is_exact = __base::is_exact;
+    static constexpr int  radix = __base::radix;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type epsilon() noexcept {return __base::epsilon();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type round_error() noexcept {return __base::round_error();}
 
-    static constexpr const int  min_exponent = __base::min_exponent;
-    static constexpr const int  min_exponent10 = __base::min_exponent10;
-    static constexpr const int  max_exponent = __base::max_exponent;
-    static constexpr const int  max_exponent10 = __base::max_exponent10;
+    static constexpr int  min_exponent = __base::min_exponent;
+    static constexpr int  min_exponent10 = __base::min_exponent10;
+    static constexpr int  max_exponent = __base::max_exponent;
+    static constexpr int  max_exponent10 = __base::max_exponent10;
 
-    static constexpr const bool has_infinity = __base::has_infinity;
-    static constexpr const bool has_quiet_NaN = __base::has_quiet_NaN;
-    static constexpr const bool has_signaling_NaN = __base::has_signaling_NaN;
-    static constexpr const float_denorm_style has_denorm = __base::has_denorm;
-    static constexpr const bool has_denorm_loss = __base::has_denorm_loss;
+    static constexpr bool has_infinity = __base::has_infinity;
+    static constexpr bool has_quiet_NaN = __base::has_quiet_NaN;
+    static constexpr bool has_signaling_NaN = __base::has_signaling_NaN;
+    static constexpr float_denorm_style has_denorm = __base::has_denorm;
+    static constexpr bool has_denorm_loss = __base::has_denorm_loss;
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type infinity() noexcept {return __base::infinity();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type quiet_NaN() noexcept {return __base::quiet_NaN();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __base::signaling_NaN();}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __base::denorm_min();}
 
-    static constexpr const bool is_iec559 = __base::is_iec559;
-    static constexpr const bool is_bounded = __base::is_bounded;
-    static constexpr const bool is_modulo = __base::is_modulo;
+    static constexpr bool is_iec559 = __base::is_iec559;
+    static constexpr bool is_bounded = __base::is_bounded;
+    static constexpr bool is_modulo = __base::is_modulo;
 
-    static constexpr const bool traps = __base::traps;
-    static constexpr const bool tinyness_before = __base::tinyness_before;
-    static constexpr const float_round_style round_style = __base::round_style;
+    static constexpr bool traps = __base::traps;
+    static constexpr bool tinyness_before = __base::tinyness_before;
+    static constexpr float_round_style round_style = __base::round_style;
 };
 
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::is_specialized;
+    constexpr bool numeric_limits<const volatile _Tp>::is_specialized;
 template <class _Tp>
-    constexpr const int numeric_limits<const volatile _Tp>::digits;
+    constexpr int numeric_limits<const volatile _Tp>::digits;
 template <class _Tp>
-    constexpr const int numeric_limits<const volatile _Tp>::digits10;
+    constexpr int numeric_limits<const volatile _Tp>::digits10;
 template <class _Tp>
-    constexpr const int numeric_limits<const volatile _Tp>::max_digits10;
+    constexpr int numeric_limits<const volatile _Tp>::max_digits10;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::is_signed;
+    constexpr bool numeric_limits<const volatile _Tp>::is_signed;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::is_integer;
+    constexpr bool numeric_limits<const volatile _Tp>::is_integer;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::is_exact;
+    constexpr bool numeric_limits<const volatile _Tp>::is_exact;
 template <class _Tp>
-    constexpr const int numeric_limits<const volatile _Tp>::radix;
+    constexpr int numeric_limits<const volatile _Tp>::radix;
 template <class _Tp>
-    constexpr const int numeric_limits<const volatile _Tp>::min_exponent;
+    constexpr int numeric_limits<const volatile _Tp>::min_exponent;
 template <class _Tp>
-    constexpr const int numeric_limits<const volatile _Tp>::min_exponent10;
+    constexpr int numeric_limits<const volatile _Tp>::min_exponent10;
 template <class _Tp>
-    constexpr const int numeric_limits<const volatile _Tp>::max_exponent;
+    constexpr int numeric_limits<const volatile _Tp>::max_exponent;
 template <class _Tp>
-    constexpr const int numeric_limits<const volatile _Tp>::max_exponent10;
+    constexpr int numeric_limits<const volatile _Tp>::max_exponent10;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::has_infinity;
+    constexpr bool numeric_limits<const volatile _Tp>::has_infinity;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::has_quiet_NaN;
+    constexpr bool numeric_limits<const volatile _Tp>::has_quiet_NaN;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::has_signaling_NaN;
+    constexpr bool numeric_limits<const volatile _Tp>::has_signaling_NaN;
 template <class _Tp>
-    constexpr const float_denorm_style numeric_limits<const volatile _Tp>::has_denorm;
+    constexpr float_denorm_style numeric_limits<const volatile _Tp>::has_denorm;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::has_denorm_loss;
+    constexpr bool numeric_limits<const volatile _Tp>::has_denorm_loss;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::is_iec559;
+    constexpr bool numeric_limits<const volatile _Tp>::is_iec559;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::is_bounded;
+    constexpr bool numeric_limits<const volatile _Tp>::is_bounded;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::is_modulo;
+    constexpr bool numeric_limits<const volatile _Tp>::is_modulo;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::traps;
+    constexpr bool numeric_limits<const volatile _Tp>::traps;
 template <class _Tp>
-    constexpr const bool numeric_limits<const volatile _Tp>::tinyness_before;
+    constexpr bool numeric_limits<const volatile _Tp>::tinyness_before;
 template <class _Tp>
-    constexpr const float_round_style numeric_limits<const volatile _Tp>::round_style;
+    constexpr float_round_style numeric_limits<const volatile _Tp>::round_style;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/map
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/map
@@ -729,10 +729,10 @@ public:
     }
 
 private:
-    __value_type() _LIBCUDACXX_EQUAL_DELETE;
-    ~__value_type() _LIBCUDACXX_EQUAL_DELETE;
-    __value_type(const __value_type& __v) _LIBCUDACXX_EQUAL_DELETE;
-    __value_type(__value_type&& __v) _LIBCUDACXX_EQUAL_DELETE;
+    __value_type() = delete;
+    ~__value_type() = delete;
+    __value_type(const __value_type& __v) = delete;
+    __value_type(__value_type&& __v) = delete;
 };
 
 #else

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/memory
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/memory
@@ -862,7 +862,7 @@ struct __const_void_pointer<_Ptr, _Alloc, false>
 };
 
 template <class _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
 _Tp*
 __to_raw_pointer(_Tp* __p) noexcept
 {
@@ -2238,12 +2238,12 @@ public:
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR unique_ptr() noexcept : __ptr_(pointer()) {}
+  constexpr unique_ptr() noexcept : __ptr_(pointer()) {}
 
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR unique_ptr(nullptr_t) noexcept : __ptr_(pointer()) {}
+  constexpr unique_ptr(nullptr_t) noexcept : __ptr_(pointer()) {}
 
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
@@ -2461,12 +2461,12 @@ public:
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR unique_ptr() noexcept : __ptr_(pointer()) {}
+  constexpr unique_ptr() noexcept : __ptr_(pointer()) {}
 
   template <bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy> >
   _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_CONSTEXPR unique_ptr(nullptr_t) noexcept : __ptr_(pointer()) {}
+  constexpr unique_ptr(nullptr_t) noexcept : __ptr_(pointer()) {}
 
   template <class _Pp, bool _Dummy = true,
             class = _EnableIfDeleterDefaultConstructible<_Dummy>,
@@ -3388,9 +3388,9 @@ private:
     struct __nat {int __for_bool_;};
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR shared_ptr() noexcept;
+    constexpr shared_ptr() noexcept;
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR shared_ptr(nullptr_t) noexcept;
+    constexpr shared_ptr(nullptr_t) noexcept;
     template<class _Yp>
         explicit shared_ptr(_Yp* __p,
                             typename enable_if<is_convertible<_Yp*, element_type*>::value, __nat>::type = __nat());
@@ -3644,8 +3644,7 @@ private:
 
 
 template<class _Tp>
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 shared_ptr<_Tp>::shared_ptr() noexcept
     : __ptr_(0),
       __cntrl_(0)
@@ -3653,8 +3652,7 @@ shared_ptr<_Tp>::shared_ptr() noexcept
 }
 
 template<class _Tp>
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 shared_ptr<_Tp>::shared_ptr(nullptr_t) noexcept
     : __ptr_(0),
       __cntrl_(0)
@@ -4450,7 +4448,7 @@ private:
 
 public:
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR weak_ptr() noexcept;
+    constexpr weak_ptr() noexcept;
     template<class _Yp> _LIBCUDACXX_INLINE_VISIBILITY weak_ptr(shared_ptr<_Yp> const& __r,
                    typename enable_if<is_convertible<_Yp*, _Tp*>::value, __nat*>::type = 0)
                         noexcept;
@@ -4530,8 +4528,7 @@ public:
 };
 
 template<class _Tp>
-inline
-_LIBCUDACXX_CONSTEXPR
+inline constexpr
 weak_ptr<_Tp>::weak_ptr() noexcept
     : __ptr_(0),
       __cntrl_(0)
@@ -4786,7 +4783,7 @@ class _LIBCUDACXX_TEMPLATE_VIS enable_shared_from_this
 {
     mutable weak_ptr<_Tp> __weak_this_;
 protected:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     enable_shared_from_this() noexcept {}
     _LIBCUDACXX_INLINE_VISIBILITY
     enable_shared_from_this(enable_shared_from_this const&) noexcept {}
@@ -4845,7 +4842,7 @@ public:
     void unlock() noexcept;
 
 private:
-    _LIBCUDACXX_CONSTEXPR __sp_mut(void*) noexcept;
+    constexpr __sp_mut(void*) noexcept;
     __sp_mut(const __sp_mut&);
     __sp_mut& operator=(const __sp_mut&);
 
@@ -5109,7 +5106,7 @@ struct __builtin_new_allocator {
   struct __builtin_new_deleter {
     typedef void* pointer_type;
 
-    _LIBCUDACXX_CONSTEXPR explicit __builtin_new_deleter(size_t __size, size_t __align)
+    constexpr explicit __builtin_new_deleter(size_t __size, size_t __align)
         : __size_(__size), __align_(__align) {}
 
     void operator()(void* p) const noexcept {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/mutex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/mutex
@@ -573,8 +573,7 @@ void call_once(once_flag&, const _Callable&);
 struct _LIBCUDACXX_TEMPLATE_VIS once_flag
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR
-        once_flag() noexcept : __state_(0) {}
+    constexpr once_flag() noexcept : __state_(0) {}
 
 #if defined(_LIBCUDACXX_ABI_MICROSOFT)
    typedef uintptr_t _State_type;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/new
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/new
@@ -233,7 +233,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY void  operator delete[](void*, void*) noexc
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-_LIBCUDACXX_CONSTEXPR inline _LIBCUDACXX_INLINE_VISIBILITY bool __is_overaligned_for_new(size_t __align) noexcept {
+constexpr inline _LIBCUDACXX_INLINE_VISIBILITY bool __is_overaligned_for_new(size_t __align) noexcept {
 #ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
   return __align > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
 #else
@@ -353,7 +353,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY void __libcpp_deallocate_unsized(void* __pt
 
 template <class _Tp>
 _LIBCUDACXX_NODISCARD_AFTER_CXX17 inline
-_LIBCUDACXX_CONSTEXPR _Tp* __launder(_Tp* __p) noexcept
+constexpr _Tp* __launder(_Tp* __p) noexcept
 {
     static_assert (!(is_function<_Tp>::value), "can't launder functions" );
     static_assert (!(is_same<void, __remove_cv_t<_Tp>>::value), "can't launder cv-void" );

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/numeric
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/numeric
@@ -477,7 +477,7 @@ template <typename _Result, typename _Source, bool _IsSigned = is_signed<_Source
 
 template <typename _Result, typename _Source>
 struct __ct_abs<_Result, _Source, true> {
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     _Result operator()(_Source __t) const noexcept
     {
     if (__t >= 0) return __t;
@@ -488,13 +488,13 @@ struct __ct_abs<_Result, _Source, true> {
 
 template <typename _Result, typename _Source>
 struct __ct_abs<_Result, _Source, false> {
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     _Result operator()(_Source __t) const noexcept { return __t; }
 };
 
 
 template<class _Tp>
-_LIBCUDACXX_CONSTEXPR _LIBCUDACXX_HIDDEN
+constexpr _LIBCUDACXX_HIDDEN
 _Tp __gcd(_Tp __m, _Tp __n)
 {
     static_assert((!is_signed<_Tp>::value), "");
@@ -503,7 +503,7 @@ _Tp __gcd(_Tp __m, _Tp __n)
 
 
 template<class _Tp, class _Up>
-_LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+constexpr _LIBCUDACXX_INLINE_VISIBILITY
 common_type_t<_Tp,_Up>
 gcd(_Tp __m, _Up __n)
 {
@@ -518,7 +518,7 @@ gcd(_Tp __m, _Up __n)
 }
 
 template<class _Tp, class _Up>
-_LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+constexpr _LIBCUDACXX_INLINE_VISIBILITY
 common_type_t<_Tp,_Up>
 lcm(_Tp __m, _Up __n)
 {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/random
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/random
@@ -1660,7 +1660,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Sseq, class _Engine>
 struct __is_seed_sequence
 {
-    static _LIBCUDACXX_CONSTEXPR const bool value =
+    static constexpr const bool value =
               !is_convertible<_Sseq, typename _Engine::result_type>::value &&
               !is_same<__remove_cv_t<_Sseq>, _Engine>::value;
 };
@@ -1839,24 +1839,24 @@ public:
 private:
     result_type __x_;
 
-    static _LIBCUDACXX_CONSTEXPR const result_type _Mp = result_type(~0);
+    static constexpr const result_type _Mp = result_type(~0);
 
     static_assert(__m == 0 || __a < __m, "linear_congruential_engine invalid parameters");
     static_assert(__m == 0 || __c < __m, "linear_congruential_engine invalid parameters");
 public:
-    static _LIBCUDACXX_CONSTEXPR const result_type _Min = __c == 0u ? 1u: 0u;
-    static _LIBCUDACXX_CONSTEXPR const result_type _Max = __m - 1u;
+    static constexpr const result_type _Min = __c == 0u ? 1u: 0u;
+    static constexpr const result_type _Max = __m - 1u;
     static_assert(_Min < _Max,           "linear_congruential_engine invalid parameters");
 
     // engine characteristics
-    static _LIBCUDACXX_CONSTEXPR const result_type multiplier = __a;
-    static _LIBCUDACXX_CONSTEXPR const result_type increment = __c;
-    static _LIBCUDACXX_CONSTEXPR const result_type modulus = __m;
+    static constexpr const result_type multiplier = __a;
+    static constexpr const result_type increment = __c;
+    static constexpr const result_type modulus = __m;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type min() {return _Min;}
+    static constexpr result_type min() {return _Min;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type max() {return _Max;}
-    static _LIBCUDACXX_CONSTEXPR const result_type default_seed = 1u;
+    static constexpr result_type max() {return _Max;}
+    static constexpr const result_type default_seed = 1u;
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1932,19 +1932,19 @@ private:
 };
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-    _LIBCUDACXX_CONSTEXPR const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
+    constexpr const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
     linear_congruential_engine<_UIntType, __a, __c, __m>::multiplier;
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-    _LIBCUDACXX_CONSTEXPR const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
+    constexpr const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
     linear_congruential_engine<_UIntType, __a, __c, __m>::increment;
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-    _LIBCUDACXX_CONSTEXPR const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
+    constexpr const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
     linear_congruential_engine<_UIntType, __a, __c, __m>::modulus;
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-    _LIBCUDACXX_CONSTEXPR const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
+    constexpr const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
     linear_congruential_engine<_UIntType, __a, __c, __m>::default_seed;
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
@@ -2066,7 +2066,7 @@ private:
 
     static_assert(  0 <  __m, "mersenne_twister_engine invalid parameters");
     static_assert(__m <= __n, "mersenne_twister_engine invalid parameters");
-    static _LIBCUDACXX_CONSTEXPR const result_type _Dt = numeric_limits<result_type>::digits;
+    static constexpr const result_type _Dt = numeric_limits<result_type>::digits;
     static_assert(__w <= _Dt, "mersenne_twister_engine invalid parameters");
     static_assert(  2 <= __w, "mersenne_twister_engine invalid parameters");
     static_assert(__r <= __w, "mersenne_twister_engine invalid parameters");
@@ -2075,8 +2075,8 @@ private:
     static_assert(__t <= __w, "mersenne_twister_engine invalid parameters");
     static_assert(__l <= __w, "mersenne_twister_engine invalid parameters");
 public:
-    static _LIBCUDACXX_CONSTEXPR const result_type _Min = 0;
-    static _LIBCUDACXX_CONSTEXPR const result_type _Max = __w == _Dt ? result_type(~0) :
+    static constexpr const result_type _Min = 0;
+    static constexpr const result_type _Max = __w == _Dt ? result_type(~0) :
                                                       (result_type(1) << __w) - result_type(1);
     static_assert(_Min < _Max, "mersenne_twister_engine invalid parameters");
     static_assert(__a <= _Max, "mersenne_twister_engine invalid parameters");
@@ -2086,24 +2086,24 @@ public:
     static_assert(__f <= _Max, "mersenne_twister_engine invalid parameters");
 
     // engine characteristics
-    static _LIBCUDACXX_CONSTEXPR const size_t word_size = __w;
-    static _LIBCUDACXX_CONSTEXPR const size_t state_size = __n;
-    static _LIBCUDACXX_CONSTEXPR const size_t shift_size = __m;
-    static _LIBCUDACXX_CONSTEXPR const size_t mask_bits = __r;
-    static _LIBCUDACXX_CONSTEXPR const result_type xor_mask = __a;
-    static _LIBCUDACXX_CONSTEXPR const size_t tempering_u = __u;
-    static _LIBCUDACXX_CONSTEXPR const result_type tempering_d = __d;
-    static _LIBCUDACXX_CONSTEXPR const size_t tempering_s = __s;
-    static _LIBCUDACXX_CONSTEXPR const result_type tempering_b = __b;
-    static _LIBCUDACXX_CONSTEXPR const size_t tempering_t = __t;
-    static _LIBCUDACXX_CONSTEXPR const result_type tempering_c = __c;
-    static _LIBCUDACXX_CONSTEXPR const size_t tempering_l = __l;
-    static _LIBCUDACXX_CONSTEXPR const result_type initialization_multiplier = __f;
+    static constexpr const size_t word_size = __w;
+    static constexpr const size_t state_size = __n;
+    static constexpr const size_t shift_size = __m;
+    static constexpr const size_t mask_bits = __r;
+    static constexpr const result_type xor_mask = __a;
+    static constexpr const size_t tempering_u = __u;
+    static constexpr const result_type tempering_d = __d;
+    static constexpr const size_t tempering_s = __s;
+    static constexpr const result_type tempering_b = __b;
+    static constexpr const size_t tempering_t = __t;
+    static constexpr const result_type tempering_c = __c;
+    static constexpr const size_t tempering_l = __l;
+    static constexpr const result_type initialization_multiplier = __f;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type min() { return _Min; }
+    static constexpr result_type min() { return _Min; }
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type max() { return _Max; }
-    static _LIBCUDACXX_CONSTEXPR const result_type default_seed = 5489u;
+    static constexpr result_type max() { return _Max; }
+    static constexpr const result_type default_seed = 5489u;
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2220,85 +2220,85 @@ private:
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const size_t
+    constexpr const size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::word_size;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const size_t
+    constexpr const size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::state_size;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const size_t
+    constexpr const size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::shift_size;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const size_t
+    constexpr const size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::mask_bits;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::xor_mask;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const size_t
+    constexpr const size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_u;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_d;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const size_t
+    constexpr const size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_s;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_b;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const size_t
+    constexpr const size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_t;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_c;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const size_t
+    constexpr const size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_l;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::initialization_multiplier;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    _LIBCUDACXX_CONSTEXPR const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::default_seed;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
@@ -2540,26 +2540,26 @@ private:
     result_type  __c_;
     size_t      __i_;
 
-    static _LIBCUDACXX_CONSTEXPR const result_type _Dt = numeric_limits<result_type>::digits;
+    static constexpr const result_type _Dt = numeric_limits<result_type>::digits;
     static_assert(  0 <  __w, "subtract_with_carry_engine invalid parameters");
     static_assert(__w <= _Dt, "subtract_with_carry_engine invalid parameters");
     static_assert(  0 <  __s, "subtract_with_carry_engine invalid parameters");
     static_assert(__s <  __r, "subtract_with_carry_engine invalid parameters");
 public:
-    static _LIBCUDACXX_CONSTEXPR const result_type _Min = 0;
-    static _LIBCUDACXX_CONSTEXPR const result_type _Max = __w == _Dt ? result_type(~0) :
+    static constexpr const result_type _Min = 0;
+    static constexpr const result_type _Max = __w == _Dt ? result_type(~0) :
                                                       (result_type(1) << __w) - result_type(1);
     static_assert(_Min < _Max, "subtract_with_carry_engine invalid parameters");
 
     // engine characteristics
-    static _LIBCUDACXX_CONSTEXPR const size_t word_size = __w;
-    static _LIBCUDACXX_CONSTEXPR const size_t short_lag = __s;
-    static _LIBCUDACXX_CONSTEXPR const size_t long_lag = __r;
+    static constexpr const size_t word_size = __w;
+    static constexpr const size_t short_lag = __s;
+    static constexpr const size_t long_lag = __r;
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type min() { return _Min; }
+    static constexpr result_type min() { return _Min; }
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type max() { return _Max; }
-    static _LIBCUDACXX_CONSTEXPR const result_type default_seed = 19780503u;
+    static constexpr result_type max() { return _Max; }
+    static constexpr const result_type default_seed = 19780503u;
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2627,16 +2627,16 @@ private:
 };
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
-    _LIBCUDACXX_CONSTEXPR const size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::word_size;
+    constexpr const size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::word_size;
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
-    _LIBCUDACXX_CONSTEXPR const size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::short_lag;
+    constexpr const size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::short_lag;
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
-    _LIBCUDACXX_CONSTEXPR const size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::long_lag;
+    constexpr const size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::long_lag;
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
-    _LIBCUDACXX_CONSTEXPR const typename subtract_with_carry_engine<_UIntType, __w, __s, __r>::result_type
+    constexpr const typename subtract_with_carry_engine<_UIntType, __w, __s, __r>::result_type
     subtract_with_carry_engine<_UIntType, __w, __s, __r>::default_seed;
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
@@ -2825,21 +2825,21 @@ public:
     typedef typename _Engine::result_type result_type;
 
     // engine characteristics
-    static _LIBCUDACXX_CONSTEXPR const size_t block_size = __p;
-    static _LIBCUDACXX_CONSTEXPR const size_t used_block = __r;
+    static constexpr const size_t block_size = __p;
+    static constexpr const size_t used_block = __r;
 
 #ifdef _LIBCUDACXX_CXX03_LANG
     static const result_type _Min = _Engine::_Min;
     static const result_type _Max = _Engine::_Max;
 #else
-    static _LIBCUDACXX_CONSTEXPR const result_type _Min = _Engine::min();
-    static _LIBCUDACXX_CONSTEXPR const result_type _Max = _Engine::max();
+    static constexpr const result_type _Min = _Engine::min();
+    static constexpr const result_type _Max = _Engine::max();
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type min() { return _Engine::min(); }
+    static constexpr result_type min() { return _Engine::min(); }
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type max() { return _Engine::max(); }
+    static constexpr result_type max() { return _Engine::max(); }
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2912,10 +2912,10 @@ public:
 };
 
 template<class _Engine, size_t __p, size_t __r>
-    _LIBCUDACXX_CONSTEXPR const size_t discard_block_engine<_Engine, __p, __r>::block_size;
+    constexpr const size_t discard_block_engine<_Engine, __p, __r>::block_size;
 
 template<class _Engine, size_t __p, size_t __r>
-    _LIBCUDACXX_CONSTEXPR const size_t discard_block_engine<_Engine, __p, __r>::used_block;
+    constexpr const size_t discard_block_engine<_Engine, __p, __r>::used_block;
 
 template<class _Engine, size_t __p, size_t __r>
 typename discard_block_engine<_Engine, __p, __r>::result_type
@@ -2991,12 +2991,12 @@ class _LIBCUDACXX_TEMPLATE_VIS independent_bits_engine
     template <class _UInt, _UInt _R0, size_t _Wp, size_t _Mp>
     class __get_n
     {
-        static _LIBCUDACXX_CONSTEXPR const size_t _Dt = numeric_limits<_UInt>::digits;
-        static _LIBCUDACXX_CONSTEXPR const size_t _Np = _Wp / _Mp + (_Wp % _Mp != 0);
-        static _LIBCUDACXX_CONSTEXPR const size_t _W0 = _Wp / _Np;
-        static _LIBCUDACXX_CONSTEXPR const _UInt _Y0 = _W0 >= _Dt ? 0 : (_R0 >> _W0) << _W0;
+        static constexpr const size_t _Dt = numeric_limits<_UInt>::digits;
+        static constexpr const size_t _Np = _Wp / _Mp + (_Wp % _Mp != 0);
+        static constexpr const size_t _W0 = _Wp / _Np;
+        static constexpr const _UInt _Y0 = _W0 >= _Dt ? 0 : (_R0 >> _W0) << _W0;
     public:
-        static _LIBCUDACXX_CONSTEXPR const size_t value = _R0 - _Y0 > _Y0 / _Np ? _Np + 1 : _Np;
+        static constexpr const size_t value = _R0 - _Y0 > _Y0 / _Np ? _Np + 1 : _Np;
     };
 public:
     // types
@@ -3005,7 +3005,7 @@ public:
 private:
     _Engine __e_;
 
-    static _LIBCUDACXX_CONSTEXPR const result_type _Dt = numeric_limits<result_type>::digits;
+    static constexpr const result_type _Dt = numeric_limits<result_type>::digits;
     static_assert(  0 <  __w, "independent_bits_engine invalid parameters");
     static_assert(__w <= _Dt, "independent_bits_engine invalid parameters");
 
@@ -3020,36 +3020,36 @@ private:
     static const _Working_result_type _Rp = _Engine::_Max - _Engine::_Min
                                           + _Working_result_type(1);
 #else
-    static _LIBCUDACXX_CONSTEXPR const _Working_result_type _Rp = _Engine::max() - _Engine::min()
+    static constexpr const _Working_result_type _Rp = _Engine::max() - _Engine::min()
                                                             + _Working_result_type(1);
 #endif
-    static _LIBCUDACXX_CONSTEXPR const size_t __m = __log2<_Working_result_type, _Rp>::value;
-    static _LIBCUDACXX_CONSTEXPR const size_t __n = __get_n<_Working_result_type, _Rp, __w, __m>::value;
-    static _LIBCUDACXX_CONSTEXPR const size_t __w0 = __w / __n;
-    static _LIBCUDACXX_CONSTEXPR const size_t __n0 = __n - __w % __n;
-    static _LIBCUDACXX_CONSTEXPR const size_t _WDt = numeric_limits<_Working_result_type>::digits;
-    static _LIBCUDACXX_CONSTEXPR const size_t _EDt = numeric_limits<_Engine_result_type>::digits;
-    static _LIBCUDACXX_CONSTEXPR const _Working_result_type __y0 = __w0 >= _WDt ? 0 :
+    static constexpr const size_t __m = __log2<_Working_result_type, _Rp>::value;
+    static constexpr const size_t __n = __get_n<_Working_result_type, _Rp, __w, __m>::value;
+    static constexpr const size_t __w0 = __w / __n;
+    static constexpr const size_t __n0 = __n - __w % __n;
+    static constexpr const size_t _WDt = numeric_limits<_Working_result_type>::digits;
+    static constexpr const size_t _EDt = numeric_limits<_Engine_result_type>::digits;
+    static constexpr const _Working_result_type __y0 = __w0 >= _WDt ? 0 :
                                                                (_Rp >> __w0) << __w0;
-    static _LIBCUDACXX_CONSTEXPR const _Working_result_type __y1 = __w0 >= _WDt - 1 ? 0 :
+    static constexpr const _Working_result_type __y1 = __w0 >= _WDt - 1 ? 0 :
                                                                (_Rp >> (__w0+1)) << (__w0+1);
-    static _LIBCUDACXX_CONSTEXPR const _Engine_result_type __mask0 = __w0 > 0 ?
+    static constexpr const _Engine_result_type __mask0 = __w0 > 0 ?
                                 _Engine_result_type(~0) >> (_EDt - __w0) :
                                 _Engine_result_type(0);
-    static _LIBCUDACXX_CONSTEXPR const _Engine_result_type __mask1 = __w0 < _EDt - 1 ?
+    static constexpr const _Engine_result_type __mask1 = __w0 < _EDt - 1 ?
                                 _Engine_result_type(~0) >> (_EDt - (__w0 + 1)) :
                                 _Engine_result_type(~0);
 public:
-    static _LIBCUDACXX_CONSTEXPR const result_type _Min = 0;
-    static _LIBCUDACXX_CONSTEXPR const result_type _Max = __w == _Dt ? result_type(~0) :
+    static constexpr const result_type _Min = 0;
+    static constexpr const result_type _Max = __w == _Dt ? result_type(~0) :
                                                       (result_type(1) << __w) - result_type(1);
     static_assert(_Min < _Max, "independent_bits_engine invalid parameters");
 
     // engine characteristics
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type min() { return _Min; }
+    static constexpr result_type min() { return _Min; }
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type max() { return _Max; }
+    static constexpr result_type max() { return _Max; }
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -3228,23 +3228,23 @@ operator>>(basic_istream<_CharT, _Traits>& __is,
 template <uint64_t _Xp, uint64_t _Yp>
 struct __ugcd
 {
-    static _LIBCUDACXX_CONSTEXPR const uint64_t value = __ugcd<_Yp, _Xp % _Yp>::value;
+    static constexpr const uint64_t value = __ugcd<_Yp, _Xp % _Yp>::value;
 };
 
 template <uint64_t _Xp>
 struct __ugcd<_Xp, 0>
 {
-    static _LIBCUDACXX_CONSTEXPR const uint64_t value = _Xp;
+    static constexpr const uint64_t value = _Xp;
 };
 
 template <uint64_t _Np, uint64_t _Dp>
 class __uratio
 {
     static_assert(_Dp != 0, "__uratio divide by 0");
-    static _LIBCUDACXX_CONSTEXPR const uint64_t __gcd = __ugcd<_Np, _Dp>::value;
+    static constexpr const uint64_t __gcd = __ugcd<_Np, _Dp>::value;
 public:
-    static _LIBCUDACXX_CONSTEXPR const uint64_t num = _Np / __gcd;
-    static _LIBCUDACXX_CONSTEXPR const uint64_t den = _Dp / __gcd;
+    static constexpr const uint64_t num = _Np / __gcd;
+    static constexpr const uint64_t den = _Dp / __gcd;
 
     typedef __uratio<num, den> type;
 };
@@ -3264,22 +3264,22 @@ private:
 
 public:
     // engine characteristics
-    static _LIBCUDACXX_CONSTEXPR const size_t table_size = __k;
+    static constexpr const size_t table_size = __k;
 
 #ifdef _LIBCUDACXX_CXX03_LANG
     static const result_type _Min = _Engine::_Min;
     static const result_type _Max = _Engine::_Max;
 #else
-    static _LIBCUDACXX_CONSTEXPR const result_type _Min = _Engine::min();
-    static _LIBCUDACXX_CONSTEXPR const result_type _Max = _Engine::max();
+    static constexpr const result_type _Min = _Engine::min();
+    static constexpr const result_type _Max = _Engine::max();
 #endif
     static_assert(_Min < _Max, "shuffle_order_engine invalid parameters");
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type min() { return _Min; }
+    static constexpr result_type min() { return _Min; }
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type max() { return _Max; }
+    static constexpr result_type max() { return _Max; }
 
-    static _LIBCUDACXX_CONSTEXPR const unsigned long long _Rp = _Max - _Min + 1ull;
+    static constexpr const unsigned long long _Rp = _Max - _Min + 1ull;
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -3411,7 +3411,7 @@ private:
 };
 
 template<class _Engine, size_t __k>
-    _LIBCUDACXX_CONSTEXPR const size_t shuffle_order_engine<_Engine, __k>::table_size;
+    constexpr const size_t shuffle_order_engine<_Engine, __k>::table_size;
 
 template<class _Eng, size_t _Kp>
 bool
@@ -3487,13 +3487,13 @@ public:
     typedef unsigned result_type;
 
     // generator characteristics
-    static _LIBCUDACXX_CONSTEXPR const result_type _Min = 0;
-    static _LIBCUDACXX_CONSTEXPR const result_type _Max = 0xFFFFFFFFu;
+    static constexpr const result_type _Min = 0;
+    static constexpr const result_type _Max = 0xFFFFFFFFu;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type min() { return _Min;}
+    static constexpr result_type min() { return _Min;}
     _LIBCUDACXX_INLINE_VISIBILITY
-    static _LIBCUDACXX_CONSTEXPR result_type max() { return _Max;}
+    static constexpr result_type max() { return _Max;}
 
     // constructors
     explicit random_device(const string& __token = "/dev/urandom");

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/random
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/random
@@ -1660,7 +1660,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Sseq, class _Engine>
 struct __is_seed_sequence
 {
-    static constexpr const bool value =
+    static constexpr bool value =
               !is_convertible<_Sseq, typename _Engine::result_type>::value &&
               !is_same<__remove_cv_t<_Sseq>, _Engine>::value;
 };
@@ -1839,24 +1839,24 @@ public:
 private:
     result_type __x_;
 
-    static constexpr const result_type _Mp = result_type(~0);
+    static constexpr result_type _Mp = result_type(~0);
 
     static_assert(__m == 0 || __a < __m, "linear_congruential_engine invalid parameters");
     static_assert(__m == 0 || __c < __m, "linear_congruential_engine invalid parameters");
 public:
-    static constexpr const result_type _Min = __c == 0u ? 1u: 0u;
-    static constexpr const result_type _Max = __m - 1u;
+    static constexpr result_type _Min = __c == 0u ? 1u: 0u;
+    static constexpr result_type _Max = __m - 1u;
     static_assert(_Min < _Max,           "linear_congruential_engine invalid parameters");
 
     // engine characteristics
-    static constexpr const result_type multiplier = __a;
-    static constexpr const result_type increment = __c;
-    static constexpr const result_type modulus = __m;
+    static constexpr result_type multiplier = __a;
+    static constexpr result_type increment = __c;
+    static constexpr result_type modulus = __m;
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr result_type min() {return _Min;}
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr result_type max() {return _Max;}
-    static constexpr const result_type default_seed = 1u;
+    static constexpr result_type default_seed = 1u;
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1932,19 +1932,19 @@ private:
 };
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-    constexpr const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
+    constexpr typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
     linear_congruential_engine<_UIntType, __a, __c, __m>::multiplier;
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-    constexpr const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
+    constexpr typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
     linear_congruential_engine<_UIntType, __a, __c, __m>::increment;
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-    constexpr const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
+    constexpr typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
     linear_congruential_engine<_UIntType, __a, __c, __m>::modulus;
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-    constexpr const typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
+    constexpr typename linear_congruential_engine<_UIntType, __a, __c, __m>::result_type
     linear_congruential_engine<_UIntType, __a, __c, __m>::default_seed;
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
@@ -2066,7 +2066,7 @@ private:
 
     static_assert(  0 <  __m, "mersenne_twister_engine invalid parameters");
     static_assert(__m <= __n, "mersenne_twister_engine invalid parameters");
-    static constexpr const result_type _Dt = numeric_limits<result_type>::digits;
+    static constexpr result_type _Dt = numeric_limits<result_type>::digits;
     static_assert(__w <= _Dt, "mersenne_twister_engine invalid parameters");
     static_assert(  2 <= __w, "mersenne_twister_engine invalid parameters");
     static_assert(__r <= __w, "mersenne_twister_engine invalid parameters");
@@ -2075,8 +2075,8 @@ private:
     static_assert(__t <= __w, "mersenne_twister_engine invalid parameters");
     static_assert(__l <= __w, "mersenne_twister_engine invalid parameters");
 public:
-    static constexpr const result_type _Min = 0;
-    static constexpr const result_type _Max = __w == _Dt ? result_type(~0) :
+    static constexpr result_type _Min = 0;
+    static constexpr result_type _Max = __w == _Dt ? result_type(~0) :
                                                       (result_type(1) << __w) - result_type(1);
     static_assert(_Min < _Max, "mersenne_twister_engine invalid parameters");
     static_assert(__a <= _Max, "mersenne_twister_engine invalid parameters");
@@ -2086,24 +2086,24 @@ public:
     static_assert(__f <= _Max, "mersenne_twister_engine invalid parameters");
 
     // engine characteristics
-    static constexpr const size_t word_size = __w;
-    static constexpr const size_t state_size = __n;
-    static constexpr const size_t shift_size = __m;
-    static constexpr const size_t mask_bits = __r;
-    static constexpr const result_type xor_mask = __a;
-    static constexpr const size_t tempering_u = __u;
-    static constexpr const result_type tempering_d = __d;
-    static constexpr const size_t tempering_s = __s;
-    static constexpr const result_type tempering_b = __b;
-    static constexpr const size_t tempering_t = __t;
-    static constexpr const result_type tempering_c = __c;
-    static constexpr const size_t tempering_l = __l;
-    static constexpr const result_type initialization_multiplier = __f;
+    static constexpr size_t word_size = __w;
+    static constexpr size_t state_size = __n;
+    static constexpr size_t shift_size = __m;
+    static constexpr size_t mask_bits = __r;
+    static constexpr result_type xor_mask = __a;
+    static constexpr size_t tempering_u = __u;
+    static constexpr result_type tempering_d = __d;
+    static constexpr size_t tempering_s = __s;
+    static constexpr result_type tempering_b = __b;
+    static constexpr size_t tempering_t = __t;
+    static constexpr result_type tempering_c = __c;
+    static constexpr size_t tempering_l = __l;
+    static constexpr result_type initialization_multiplier = __f;
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr result_type min() { return _Min; }
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr result_type max() { return _Max; }
-    static constexpr const result_type default_seed = 5489u;
+    static constexpr result_type default_seed = 5489u;
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2220,85 +2220,85 @@ private:
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const size_t
+    constexpr size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::word_size;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const size_t
+    constexpr size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::state_size;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const size_t
+    constexpr size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::shift_size;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const size_t
+    constexpr size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::mask_bits;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::xor_mask;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const size_t
+    constexpr size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_u;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_d;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const size_t
+    constexpr size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_s;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_b;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const size_t
+    constexpr size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_t;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_c;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const size_t
+    constexpr size_t
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::tempering_l;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::initialization_multiplier;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
           _UIntType __a, size_t __u, _UIntType __d, size_t __s,
           _UIntType __b, size_t __t, _UIntType __c, size_t __l, _UIntType __f>
-    constexpr const typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
+    constexpr typename mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::result_type
     mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::default_seed;
 
 template <class _UIntType, size_t __w, size_t __n, size_t __m, size_t __r,
@@ -2540,26 +2540,26 @@ private:
     result_type  __c_;
     size_t      __i_;
 
-    static constexpr const result_type _Dt = numeric_limits<result_type>::digits;
+    static constexpr result_type _Dt = numeric_limits<result_type>::digits;
     static_assert(  0 <  __w, "subtract_with_carry_engine invalid parameters");
     static_assert(__w <= _Dt, "subtract_with_carry_engine invalid parameters");
     static_assert(  0 <  __s, "subtract_with_carry_engine invalid parameters");
     static_assert(__s <  __r, "subtract_with_carry_engine invalid parameters");
 public:
-    static constexpr const result_type _Min = 0;
-    static constexpr const result_type _Max = __w == _Dt ? result_type(~0) :
+    static constexpr result_type _Min = 0;
+    static constexpr result_type _Max = __w == _Dt ? result_type(~0) :
                                                       (result_type(1) << __w) - result_type(1);
     static_assert(_Min < _Max, "subtract_with_carry_engine invalid parameters");
 
     // engine characteristics
-    static constexpr const size_t word_size = __w;
-    static constexpr const size_t short_lag = __s;
-    static constexpr const size_t long_lag = __r;
+    static constexpr size_t word_size = __w;
+    static constexpr size_t short_lag = __s;
+    static constexpr size_t long_lag = __r;
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr result_type min() { return _Min; }
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr result_type max() { return _Max; }
-    static constexpr const result_type default_seed = 19780503u;
+    static constexpr result_type default_seed = 19780503u;
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2627,16 +2627,16 @@ private:
 };
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
-    constexpr const size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::word_size;
+    constexpr size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::word_size;
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
-    constexpr const size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::short_lag;
+    constexpr size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::short_lag;
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
-    constexpr const size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::long_lag;
+    constexpr size_t subtract_with_carry_engine<_UIntType, __w, __s, __r>::long_lag;
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
-    constexpr const typename subtract_with_carry_engine<_UIntType, __w, __s, __r>::result_type
+    constexpr typename subtract_with_carry_engine<_UIntType, __w, __s, __r>::result_type
     subtract_with_carry_engine<_UIntType, __w, __s, __r>::default_seed;
 
 template<class _UIntType, size_t __w, size_t __s, size_t __r>
@@ -2825,15 +2825,15 @@ public:
     typedef typename _Engine::result_type result_type;
 
     // engine characteristics
-    static constexpr const size_t block_size = __p;
-    static constexpr const size_t used_block = __r;
+    static constexpr size_t block_size = __p;
+    static constexpr size_t used_block = __r;
 
 #ifdef _LIBCUDACXX_CXX03_LANG
     static const result_type _Min = _Engine::_Min;
     static const result_type _Max = _Engine::_Max;
 #else
-    static constexpr const result_type _Min = _Engine::min();
-    static constexpr const result_type _Max = _Engine::max();
+    static constexpr result_type _Min = _Engine::min();
+    static constexpr result_type _Max = _Engine::max();
 #endif
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -2912,10 +2912,10 @@ public:
 };
 
 template<class _Engine, size_t __p, size_t __r>
-    constexpr const size_t discard_block_engine<_Engine, __p, __r>::block_size;
+    constexpr size_t discard_block_engine<_Engine, __p, __r>::block_size;
 
 template<class _Engine, size_t __p, size_t __r>
-    constexpr const size_t discard_block_engine<_Engine, __p, __r>::used_block;
+    constexpr size_t discard_block_engine<_Engine, __p, __r>::used_block;
 
 template<class _Engine, size_t __p, size_t __r>
 typename discard_block_engine<_Engine, __p, __r>::result_type
@@ -2991,12 +2991,12 @@ class _LIBCUDACXX_TEMPLATE_VIS independent_bits_engine
     template <class _UInt, _UInt _R0, size_t _Wp, size_t _Mp>
     class __get_n
     {
-        static constexpr const size_t _Dt = numeric_limits<_UInt>::digits;
-        static constexpr const size_t _Np = _Wp / _Mp + (_Wp % _Mp != 0);
-        static constexpr const size_t _W0 = _Wp / _Np;
-        static constexpr const _UInt _Y0 = _W0 >= _Dt ? 0 : (_R0 >> _W0) << _W0;
+        static constexpr size_t _Dt = numeric_limits<_UInt>::digits;
+        static constexpr size_t _Np = _Wp / _Mp + (_Wp % _Mp != 0);
+        static constexpr size_t _W0 = _Wp / _Np;
+        static constexpr _UInt _Y0 = _W0 >= _Dt ? 0 : (_R0 >> _W0) << _W0;
     public:
-        static constexpr const size_t value = _R0 - _Y0 > _Y0 / _Np ? _Np + 1 : _Np;
+        static constexpr size_t value = _R0 - _Y0 > _Y0 / _Np ? _Np + 1 : _Np;
     };
 public:
     // types
@@ -3005,7 +3005,7 @@ public:
 private:
     _Engine __e_;
 
-    static constexpr const result_type _Dt = numeric_limits<result_type>::digits;
+    static constexpr result_type _Dt = numeric_limits<result_type>::digits;
     static_assert(  0 <  __w, "independent_bits_engine invalid parameters");
     static_assert(__w <= _Dt, "independent_bits_engine invalid parameters");
 
@@ -3020,28 +3020,28 @@ private:
     static const _Working_result_type _Rp = _Engine::_Max - _Engine::_Min
                                           + _Working_result_type(1);
 #else
-    static constexpr const _Working_result_type _Rp = _Engine::max() - _Engine::min()
-                                                            + _Working_result_type(1);
+    static constexpr _Working_result_type _Rp = _Engine::max() - _Engine::min()
+                                                      + _Working_result_type(1);
 #endif
-    static constexpr const size_t __m = __log2<_Working_result_type, _Rp>::value;
-    static constexpr const size_t __n = __get_n<_Working_result_type, _Rp, __w, __m>::value;
-    static constexpr const size_t __w0 = __w / __n;
-    static constexpr const size_t __n0 = __n - __w % __n;
-    static constexpr const size_t _WDt = numeric_limits<_Working_result_type>::digits;
-    static constexpr const size_t _EDt = numeric_limits<_Engine_result_type>::digits;
-    static constexpr const _Working_result_type __y0 = __w0 >= _WDt ? 0 :
-                                                               (_Rp >> __w0) << __w0;
-    static constexpr const _Working_result_type __y1 = __w0 >= _WDt - 1 ? 0 :
-                                                               (_Rp >> (__w0+1)) << (__w0+1);
-    static constexpr const _Engine_result_type __mask0 = __w0 > 0 ?
-                                _Engine_result_type(~0) >> (_EDt - __w0) :
-                                _Engine_result_type(0);
-    static constexpr const _Engine_result_type __mask1 = __w0 < _EDt - 1 ?
-                                _Engine_result_type(~0) >> (_EDt - (__w0 + 1)) :
-                                _Engine_result_type(~0);
+    static constexpr size_t __m = __log2<_Working_result_type, _Rp>::value;
+    static constexpr size_t __n = __get_n<_Working_result_type, _Rp, __w, __m>::value;
+    static constexpr size_t __w0 = __w / __n;
+    static constexpr size_t __n0 = __n - __w % __n;
+    static constexpr size_t _WDt = numeric_limits<_Working_result_type>::digits;
+    static constexpr size_t _EDt = numeric_limits<_Engine_result_type>::digits;
+    static constexpr _Working_result_type __y0 = __w0 >= _WDt ? 0 :
+                                                         (_Rp >> __w0) << __w0;
+    static constexpr _Working_result_type __y1 = __w0 >= _WDt - 1 ? 0 :
+                                                         (_Rp >> (__w0+1)) << (__w0+1);
+    static constexpr _Engine_result_type __mask0 = __w0 > 0 ?
+                          _Engine_result_type(~0) >> (_EDt - __w0) :
+                          _Engine_result_type(0);
+    static constexpr _Engine_result_type __mask1 = __w0 < _EDt - 1 ?
+                          _Engine_result_type(~0) >> (_EDt - (__w0 + 1)) :
+                          _Engine_result_type(~0);
 public:
-    static constexpr const result_type _Min = 0;
-    static constexpr const result_type _Max = __w == _Dt ? result_type(~0) :
+    static constexpr result_type _Min = 0;
+    static constexpr result_type _Max = __w == _Dt ? result_type(~0) :
                                                       (result_type(1) << __w) - result_type(1);
     static_assert(_Min < _Max, "independent_bits_engine invalid parameters");
 
@@ -3228,23 +3228,23 @@ operator>>(basic_istream<_CharT, _Traits>& __is,
 template <uint64_t _Xp, uint64_t _Yp>
 struct __ugcd
 {
-    static constexpr const uint64_t value = __ugcd<_Yp, _Xp % _Yp>::value;
+    static constexpr uint64_t value = __ugcd<_Yp, _Xp % _Yp>::value;
 };
 
 template <uint64_t _Xp>
 struct __ugcd<_Xp, 0>
 {
-    static constexpr const uint64_t value = _Xp;
+    static constexpr uint64_t value = _Xp;
 };
 
 template <uint64_t _Np, uint64_t _Dp>
 class __uratio
 {
     static_assert(_Dp != 0, "__uratio divide by 0");
-    static constexpr const uint64_t __gcd = __ugcd<_Np, _Dp>::value;
+    static constexpr uint64_t __gcd = __ugcd<_Np, _Dp>::value;
 public:
-    static constexpr const uint64_t num = _Np / __gcd;
-    static constexpr const uint64_t den = _Dp / __gcd;
+    static constexpr uint64_t num = _Np / __gcd;
+    static constexpr uint64_t den = _Dp / __gcd;
 
     typedef __uratio<num, den> type;
 };
@@ -3264,14 +3264,14 @@ private:
 
 public:
     // engine characteristics
-    static constexpr const size_t table_size = __k;
+    static constexpr size_t table_size = __k;
 
 #ifdef _LIBCUDACXX_CXX03_LANG
     static const result_type _Min = _Engine::_Min;
     static const result_type _Max = _Engine::_Max;
 #else
-    static constexpr const result_type _Min = _Engine::min();
-    static constexpr const result_type _Max = _Engine::max();
+    static constexpr result_type _Min = _Engine::min();
+    static constexpr result_type _Max = _Engine::max();
 #endif
     static_assert(_Min < _Max, "shuffle_order_engine invalid parameters");
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -3279,7 +3279,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr result_type max() { return _Max; }
 
-    static constexpr const unsigned long long _Rp = _Max - _Min + 1ull;
+    static constexpr unsigned long long _Rp = _Max - _Min + 1ull;
 
     // constructors and seeding functions
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -3411,7 +3411,7 @@ private:
 };
 
 template<class _Engine, size_t __k>
-    constexpr const size_t shuffle_order_engine<_Engine, __k>::table_size;
+    constexpr size_t shuffle_order_engine<_Engine, __k>::table_size;
 
 template<class _Eng, size_t _Kp>
 bool
@@ -3487,8 +3487,8 @@ public:
     typedef unsigned result_type;
 
     // generator characteristics
-    static constexpr const result_type _Min = 0;
-    static constexpr const result_type _Max = 0xFFFFFFFFu;
+    static constexpr result_type _Min = 0;
+    static constexpr result_type _Max = 0xFFFFFFFFu;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr result_type min() { return _Min;}

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/ratio
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/ratio
@@ -255,22 +255,22 @@ class _LIBCUDACXX_TEMPLATE_VIS ratio
     static_assert(__static_abs<_Num>::value >= 0, "ratio numerator is out of range");
     static_assert(_Den != 0, "ratio divide by 0");
     static_assert(__static_abs<_Den>::value >  0, "ratio denominator is out of range");
-    static _LIBCUDACXX_CONSTEXPR const intmax_t __na = __static_abs<_Num>::value;
-    static _LIBCUDACXX_CONSTEXPR const intmax_t __da = __static_abs<_Den>::value;
-    static _LIBCUDACXX_CONSTEXPR const intmax_t __s = __static_sign<_Num>::value * __static_sign<_Den>::value;
-    static _LIBCUDACXX_CONSTEXPR const intmax_t __gcd = __static_gcd<__na, __da>::value;
+    static constexpr const intmax_t __na = __static_abs<_Num>::value;
+    static constexpr const intmax_t __da = __static_abs<_Den>::value;
+    static constexpr const intmax_t __s = __static_sign<_Num>::value * __static_sign<_Den>::value;
+    static constexpr const intmax_t __gcd = __static_gcd<__na, __da>::value;
 public:
-    static _LIBCUDACXX_CONSTEXPR const intmax_t num = __s * __na / __gcd;
-    static _LIBCUDACXX_CONSTEXPR const intmax_t den = __da / __gcd;
+    static constexpr const intmax_t num = __s * __na / __gcd;
+    static constexpr const intmax_t den = __da / __gcd;
 
     typedef ratio<num, den> type;
 };
 
 template <intmax_t _Num, intmax_t _Den>
-_LIBCUDACXX_CONSTEXPR const intmax_t ratio<_Num, _Den>::num;
+constexpr const intmax_t ratio<_Num, _Den>::num;
 
 template <intmax_t _Num, intmax_t _Den>
-_LIBCUDACXX_CONSTEXPR const intmax_t ratio<_Num, _Den>::den;
+constexpr const intmax_t ratio<_Num, _Den>::den;
 
 template <class _Tp>                    struct __is_ratio                     : false_type {};
 template <intmax_t _Num, intmax_t _Den> struct __is_ratio<ratio<_Num, _Den> > : true_type  {};
@@ -506,27 +506,27 @@ struct __ratio_gcd
 
 #if _LIBCUDACXX_STD_VER > 14 && !defined(_LIBCUDACXX_HAS_NO_VARIABLE_TEMPLATES)
 template <class _R1, class _R2>
-_LIBCUDACXX_INLINE_VAR _LIBCUDACXX_CONSTEXPR bool ratio_equal_v
+_LIBCUDACXX_INLINE_VAR constexpr bool ratio_equal_v
     = ratio_equal<_R1, _R2>::value;
 
 template <class _R1, class _R2>
-_LIBCUDACXX_INLINE_VAR _LIBCUDACXX_CONSTEXPR bool ratio_not_equal_v
+_LIBCUDACXX_INLINE_VAR constexpr bool ratio_not_equal_v
     = ratio_not_equal<_R1, _R2>::value;
 
 template <class _R1, class _R2>
-_LIBCUDACXX_INLINE_VAR _LIBCUDACXX_CONSTEXPR bool ratio_less_v
+_LIBCUDACXX_INLINE_VAR constexpr bool ratio_less_v
     = ratio_less<_R1, _R2>::value;
 
 template <class _R1, class _R2>
-_LIBCUDACXX_INLINE_VAR _LIBCUDACXX_CONSTEXPR bool ratio_less_equal_v
+_LIBCUDACXX_INLINE_VAR constexpr bool ratio_less_equal_v
     = ratio_less_equal<_R1, _R2>::value;
 
 template <class _R1, class _R2>
-_LIBCUDACXX_INLINE_VAR _LIBCUDACXX_CONSTEXPR bool ratio_greater_v
+_LIBCUDACXX_INLINE_VAR constexpr bool ratio_greater_v
     = ratio_greater<_R1, _R2>::value;
 
 template <class _R1, class _R2>
-_LIBCUDACXX_INLINE_VAR _LIBCUDACXX_CONSTEXPR bool ratio_greater_equal_v
+_LIBCUDACXX_INLINE_VAR constexpr bool ratio_greater_equal_v
     = ratio_greater_equal<_R1, _R2>::value;
 #endif
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/ratio
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/ratio
@@ -255,22 +255,22 @@ class _LIBCUDACXX_TEMPLATE_VIS ratio
     static_assert(__static_abs<_Num>::value >= 0, "ratio numerator is out of range");
     static_assert(_Den != 0, "ratio divide by 0");
     static_assert(__static_abs<_Den>::value >  0, "ratio denominator is out of range");
-    static constexpr const intmax_t __na = __static_abs<_Num>::value;
-    static constexpr const intmax_t __da = __static_abs<_Den>::value;
-    static constexpr const intmax_t __s = __static_sign<_Num>::value * __static_sign<_Den>::value;
-    static constexpr const intmax_t __gcd = __static_gcd<__na, __da>::value;
+    static constexpr intmax_t __na = __static_abs<_Num>::value;
+    static constexpr intmax_t __da = __static_abs<_Den>::value;
+    static constexpr intmax_t __s = __static_sign<_Num>::value * __static_sign<_Den>::value;
+    static constexpr intmax_t __gcd = __static_gcd<__na, __da>::value;
 public:
-    static constexpr const intmax_t num = __s * __na / __gcd;
-    static constexpr const intmax_t den = __da / __gcd;
+    static constexpr intmax_t num = __s * __na / __gcd;
+    static constexpr intmax_t den = __da / __gcd;
 
     typedef ratio<num, den> type;
 };
 
 template <intmax_t _Num, intmax_t _Den>
-constexpr const intmax_t ratio<_Num, _Den>::num;
+constexpr intmax_t ratio<_Num, _Den>::num;
 
 template <intmax_t _Num, intmax_t _Den>
-constexpr const intmax_t ratio<_Num, _Den>::den;
+constexpr intmax_t ratio<_Num, _Den>::den;
 
 template <class _Tp>                    struct __is_ratio                     : false_type {};
 template <intmax_t _Num, intmax_t _Den> struct __is_ratio<ratio<_Num, _Den> > : true_type  {};

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/regex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/regex
@@ -805,7 +805,7 @@ enum syntax_option_type
     egrep      = 1 << 8
 };
 
-inline _LIBCUDACXX_CONSTEXPR
+inline constexpr
 syntax_option_type __get_grammar(syntax_option_type __g)
 {
 #ifdef _LIBCUDACXX_ABI_REGEX_CONSTANTS_NONZERO
@@ -816,7 +816,7 @@ syntax_option_type __get_grammar(syntax_option_type __g)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 syntax_option_type
 operator~(syntax_option_type __x)
 {
@@ -824,7 +824,7 @@ operator~(syntax_option_type __x)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 syntax_option_type
 operator&(syntax_option_type __x, syntax_option_type __y)
 {
@@ -832,7 +832,7 @@ operator&(syntax_option_type __x, syntax_option_type __y)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 syntax_option_type
 operator|(syntax_option_type __x, syntax_option_type __y)
 {
@@ -840,7 +840,7 @@ operator|(syntax_option_type __x, syntax_option_type __y)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 syntax_option_type
 operator^(syntax_option_type __x, syntax_option_type __y)
 {
@@ -893,7 +893,7 @@ enum match_flag_type
 };
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 match_flag_type
 operator~(match_flag_type __x)
 {
@@ -901,7 +901,7 @@ operator~(match_flag_type __x)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 match_flag_type
 operator&(match_flag_type __x, match_flag_type __y)
 {
@@ -909,7 +909,7 @@ operator&(match_flag_type __x, match_flag_type __y)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 match_flag_type
 operator|(match_flag_type __x, match_flag_type __y)
 {
@@ -917,7 +917,7 @@ operator|(match_flag_type __x, match_flag_type __y)
 }
 
 inline _LIBCUDACXX_INLINE_VISIBILITY
-_LIBCUDACXX_CONSTEXPR
+constexpr
 match_flag_type
 operator^(match_flag_type __x, match_flag_type __y)
 {
@@ -4830,7 +4830,7 @@ public:
     bool matched;
 
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR sub_match() : matched() {}
+    constexpr sub_match() : matched() {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     difference_type length() const

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/semaphore
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/semaphore
@@ -124,7 +124,7 @@ public:
         return numeric_limits<ptrdiff_t>::max();
     }
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_semaphore_base(ptrdiff_t __count) noexcept : __count(__count) { }
 
     ~__atomic_semaphore_base() = default;
@@ -195,7 +195,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr ptrdiff_t max() noexcept { return 1; }
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __atomic_semaphore_base(ptrdiff_t __available) : __available(__available) { }
 
     ~__atomic_semaphore_base() = default;
@@ -434,7 +434,7 @@ class counting_semaphore : public __semaphore_base<__least_max_value, 0>
 {
     static_assert(__least_max_value <= __semaphore_base<__least_max_value, 0>::max(), "");
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     counting_semaphore(ptrdiff_t __count = 0) : __semaphore_base<__least_max_value, 0>(__count) { }
     ~counting_semaphore() = default;
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/string_view
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/string_view
@@ -208,7 +208,7 @@ public:
     typedef const_reverse_iterator                     reverse_iterator;
     typedef size_t                                     size_type;
     typedef ptrdiff_t                                  difference_type;
-    static _LIBCUDACXX_CONSTEXPR const size_type npos = -1; // size_type(-1);
+    static constexpr const size_type npos = -1; // size_type(-1);
 
     static_assert((!is_array<value_type>::value), "Character type of basic_string_view must not be an array");
     static_assert(( is_standard_layout<value_type>::value), "Character type of basic_string_view must be standard-layout");
@@ -217,16 +217,16 @@ public:
                   "traits_type::char_type must be the same type as CharT");
 
     // [string.view.cons], construct/copy
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     basic_string_view() noexcept : __data (nullptr), __size(0) {}
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     basic_string_view(const basic_string_view&) noexcept = default;
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
     basic_string_view& operator=(const basic_string_view&) noexcept = default;
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     basic_string_view(const _CharT* __s, size_type __len) noexcept
         : __data(__s), __size(__len)
     {
@@ -235,21 +235,21 @@ public:
 #endif
     }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     basic_string_view(const _CharT* __s)
         : __data(__s), __size(std::__char_traits_length_checked<_Traits>(__s)) {}
 
     // [string.view.iterators], iterators
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     const_iterator begin()  const noexcept { return cbegin(); }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     const_iterator end()    const noexcept { return cend(); }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     const_iterator cbegin() const noexcept { return __data; }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     const_iterator cend()   const noexcept { return __data + __size; }
 
     _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 _LIBCUDACXX_INLINE_VISIBILITY
@@ -265,23 +265,23 @@ public:
     const_reverse_iterator crend()    const noexcept { return const_reverse_iterator(cbegin()); }
 
     // [string.view.capacity], capacity
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     size_type size()     const noexcept { return __size; }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     size_type length()   const noexcept { return __size; }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     size_type max_size() const noexcept { return numeric_limits<size_type>::max(); }
 
-    _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY constexpr
     bool empty()         const noexcept { return __size == 0; }
 
     // [string.view.access], element access
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     const_reference operator[](size_type __pos) const noexcept { return __data[__pos]; }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     const_reference at(size_type __pos) const
     {
         return __pos >= size()
@@ -289,19 +289,19 @@ public:
             : __data[__pos];
     }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     const_reference front() const noexcept
     {
         return _LIBCUDACXX_ASSERT(!empty(), "string_view::front(): string is empty"), __data[0];
     }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     const_reference back() const noexcept
     {
         return _LIBCUDACXX_ASSERT(!empty(), "string_view::back(): string is empty"), __data[__size-1];
     }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     const_pointer data() const noexcept { return __data; }
 
     // [string.view.modifiers], modifiers:
@@ -342,7 +342,7 @@ public:
         return __rlen;
     }
 
-    _LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr _LIBCUDACXX_INLINE_VISIBILITY
     basic_string_view substr(size_type __pos = 0, size_type __n = npos) const
     {
         return __pos > size()
@@ -800,33 +800,33 @@ inline namespace literals
 {
   inline namespace string_view_literals
   {
-    inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
     basic_string_view<char> operator "" sv(const char *__str, size_t __len) noexcept
     {
         return basic_string_view<char> (__str, __len);
     }
 
-    inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
     basic_string_view<wchar_t> operator "" sv(const wchar_t *__str, size_t __len) noexcept
     {
         return basic_string_view<wchar_t> (__str, __len);
     }
 
 #ifndef _LIBCUDACXX_NO_HAS_CHAR8_T
-    inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
     basic_string_view<char8_t> operator "" sv(const char8_t *__str, size_t __len) noexcept
     {
         return basic_string_view<char8_t> (__str, __len);
     }
 #endif
 
-    inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
     basic_string_view<char16_t> operator "" sv(const char16_t *__str, size_t __len) noexcept
     {
         return basic_string_view<char16_t> (__str, __len);
     }
 
-    inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    inline _LIBCUDACXX_INLINE_VISIBILITY constexpr
     basic_string_view<char32_t> operator "" sv(const char32_t *__str, size_t __len) noexcept
     {
         return basic_string_view<char32_t> (__str, __len);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_base.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_base.h
@@ -19,7 +19,7 @@
 #define _LIBCUDACXX_ATOMIC_IS_LOCK_FREE(__x) __atomic_is_lock_free(__x, 0)
 #endif
 
-_LIBCUDACXX_INLINE_VISIBILITY inline _LIBCUDACXX_CONSTEXPR int __cxx_atomic_order_to_int(memory_order __order) {
+_LIBCUDACXX_INLINE_VISIBILITY inline constexpr int __cxx_atomic_order_to_int(memory_order __order) {
   // Avoid switch statement to make this a constexpr.
   return __order == memory_order_relaxed ? __ATOMIC_RELAXED:
          (__order == memory_order_acquire ? __ATOMIC_ACQUIRE:
@@ -29,7 +29,7 @@ _LIBCUDACXX_INLINE_VISIBILITY inline _LIBCUDACXX_CONSTEXPR int __cxx_atomic_orde
               __ATOMIC_CONSUME))));
 }
 
-_LIBCUDACXX_INLINE_VISIBILITY inline _LIBCUDACXX_CONSTEXPR int __cxx_atomic_failure_order_to_int(memory_order __order) {
+_LIBCUDACXX_INLINE_VISIBILITY inline constexpr int __cxx_atomic_failure_order_to_int(memory_order __order) {
   // Avoid switch statement to make this a constexpr.
   return __order == memory_order_relaxed ? __ATOMIC_RELAXED:
          (__order == memory_order_acquire ? __ATOMIC_ACQUIRE:

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_c11.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_c11.h
@@ -20,7 +20,7 @@ struct __cxx_atomic_base_impl {
 #else
     __cxx_atomic_base_impl() noexcept : __a_value() {}
 #endif // _LIBCUDACXX_CXX03_LANG
-  _LIBCUDACXX_CONSTEXPR explicit __cxx_atomic_base_impl(_Tp value) noexcept
+  constexpr explicit __cxx_atomic_base_impl(_Tp value) noexcept
     : __a_value(value) {}
   _LIBCUDACXX_DISABLE_EXTENSION_WARNING _Atomic(_Tp) __a_value;
 };

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_cuda.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/atomic_cuda.h
@@ -78,7 +78,7 @@ template <typename _Tp, int _Sco, bool _Ref = false>
 struct __cxx_atomic_base_heterogeneous_impl {
     __cxx_atomic_base_heterogeneous_impl() noexcept = default;
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr explicit
       __cxx_atomic_base_heterogeneous_impl(_Tp __value) : __a_value(__value) {
     }
 
@@ -95,7 +95,7 @@ struct __cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, true> {
     static_assert(sizeof(_Tp) >= 4, "atomic_ref does not support 1 or 2 byte types");
     static_assert(sizeof(_Tp) <= 8, "atomic_ref does not support types larger than 8 bytes");
 
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr explicit
       __cxx_atomic_base_heterogeneous_impl(_Tp& __value) : __a_value(__value) {
     }
 
@@ -106,25 +106,25 @@ struct __cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, true> {
 };
 
 template <typename _Tp, int _Sco, bool _Ref>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> * __a) noexcept {
   return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco, bool _Ref>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 volatile _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> volatile* __a) noexcept {
   return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco, bool _Ref>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> const* __a) noexcept {
   return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco, bool _Ref>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const volatile _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> const volatile* __a) noexcept {
   return __cxx_get_underlying_atomic(&__a->__a_value);
 }
@@ -134,12 +134,12 @@ using __cxx_atomic_small_to_32 = __conditional_t<is_signed<_Tp>::value, int32_t,
 
 // Arithmetic conversions to/from proxy types
 template<class _Tp, __enable_if_t<is_arithmetic<_Tp>::value, int> = 0>
-_LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY inline __cxx_atomic_small_to_32<_Tp> __cxx_small_to_32(_Tp __val) {
+constexpr _LIBCUDACXX_INLINE_VISIBILITY inline __cxx_atomic_small_to_32<_Tp> __cxx_small_to_32(_Tp __val) {
     return static_cast<__cxx_atomic_small_to_32<_Tp>>(__val);
 }
 
 template<class _Tp, __enable_if_t<is_arithmetic<_Tp>::value, int> = 0>
-_LIBCUDACXX_CONSTEXPR _LIBCUDACXX_INLINE_VISIBILITY inline _Tp __cxx_small_from_32(__cxx_atomic_small_to_32<_Tp> __val) {
+constexpr _LIBCUDACXX_INLINE_VISIBILITY inline _Tp __cxx_small_from_32(__cxx_atomic_small_to_32<_Tp> __val) {
     return static_cast<_Tp>(__val);
 }
 
@@ -161,7 +161,7 @@ _LIBCUDACXX_INLINE_VISIBILITY inline _Tp __cxx_small_from_32(__cxx_atomic_small_
 template <typename _Tp, int _Sco>
 struct __cxx_atomic_base_small_impl {
     __cxx_atomic_base_small_impl() noexcept = default;
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr explicit
       __cxx_atomic_base_small_impl(_Tp __value) : __a_value(__cxx_small_to_32(__value)) {
     }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/cxx_atomic.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/support/atomic/cxx_atomic.h
@@ -25,11 +25,11 @@ struct __cxx_atomic_base_impl {
     "std::atomic<Tp> requires that 'Tp' be a trivially copyable type");
 #endif
 
-  _LIBCUDACXX_CONSTEXPR
+  constexpr
   __cxx_atomic_base_impl() noexcept = default;
-  _LIBCUDACXX_CONSTEXPR
+  constexpr
   __cxx_atomic_base_impl(__cxx_atomic_base_impl &&) noexcept = default;
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr explicit
   __cxx_atomic_base_impl(_Tp value) noexcept : __a_value(value) {}
 
   __cxx_atomic_base_impl& operator=(const __cxx_atomic_base_impl &) noexcept = default;
@@ -38,42 +38,42 @@ struct __cxx_atomic_base_impl {
 };
 
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> * __a) noexcept {
   return &__a->__a_value;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> volatile* __a) noexcept {
   return &__a->__a_value;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> const* __a) noexcept {
   return &__a->__a_value;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> const volatile* __a) noexcept {
   return &__a->__a_value;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco>* __a) noexcept {
   return __a;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 volatile __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> volatile* __a) noexcept {
   return __a;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> const* __a) noexcept {
   return __a;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const volatile __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> const volatile* __a) noexcept {
   return __a;
 }
@@ -91,72 +91,72 @@ struct __cxx_atomic_ref_base_impl {
     "std::atomic_ref<Tp> requires that 'Tp' be a trivially copyable type");
 #endif
 
-  _LIBCUDACXX_CONSTEXPR
+  constexpr
   __cxx_atomic_ref_base_impl() noexcept = delete;
-  _LIBCUDACXX_CONSTEXPR
+  constexpr
   __cxx_atomic_ref_base_impl(__cxx_atomic_ref_base_impl &&) noexcept = default;
-  _LIBCUDACXX_CONSTEXPR
+  constexpr
   __cxx_atomic_ref_base_impl(const __cxx_atomic_ref_base_impl &) noexcept = default;
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr explicit
   __cxx_atomic_ref_base_impl(_Tp& value) noexcept : __a_value(&value) {}
 
   _Tp* __a_value;
 };
 
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco>* __a) noexcept {
   return __a->__a_value;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> volatile* __a) noexcept {
   return __a->__a_value;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> const* __a) noexcept {
   return __a->__a_value;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> const volatile* __a) noexcept {
   return __a->__a_value;
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco>* __a) noexcept {
   return __cxx_get_underlying_atomic(__a);
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 volatile _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> volatile* __a) noexcept {
   return __cxx_get_underlying_atomic(__a);
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> const* __a) noexcept {
   return __cxx_get_underlying_atomic(__a);
 }
 template <typename _Tp, int _Sco>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 const volatile _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> const volatile* __a) noexcept {
   return __cxx_get_underlying_atomic(__a);
 }
 
 template <typename _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 _Tp* __cxx_get_underlying_atomic(_Tp* __a) noexcept {
   return __a;
 }
 
 template <typename _Tp, typename _Up>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 auto __cxx_atomic_wrap_to_base(_Tp*, _Up __val) noexcept -> typename _Tp::__wrap_t {
   return typename _Tp::__wrap_t(__val);
 }
 template <typename _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_LIBCUDACXX_INLINE_VISIBILITY constexpr
 auto __cxx_atomic_base_temporary(_Tp*) noexcept -> typename _Tp::__temporary_t {
   return typename _Tp::__temporary_t();
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/system_error
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/system_error
@@ -203,7 +203,7 @@ public:
     error_category() noexcept;
 #else
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 error_category() noexcept _LIBCUDACXX_DEFAULT
+    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 error_category() noexcept = default;
 #endif
 private:
     error_category(const error_category&);// = delete;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/thread
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/thread
@@ -368,9 +368,9 @@ sleep_for(const chrono::duration<_Rep, _Period>& __d)
     {
 #if defined(_LIBCUDACXX_COMPILER_GCC) && (__powerpc__ || __POWERPC__)
     //  GCC's long double const folding is incomplete for IBM128 long doubles.
-        _LIBCUDACXX_CONSTEXPR duration<long double> _Max = nanoseconds::max();
+        constexpr duration<long double> _Max = nanoseconds::max();
 #else
-        _LIBCUDACXX_CONSTEXPR duration<long double> _Max = duration<long double>(ULLONG_MAX/1000000000ULL) ;
+        constexpr duration<long double> _Max = duration<long double>(ULLONG_MAX/1000000000ULL) ;
 #endif
         nanoseconds __ns;
         if (__d < _Max)

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -228,7 +228,7 @@ class __tuple_leaf
 
     _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf& operator=(const __tuple_leaf&);
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR __tuple_leaf()
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_leaf()
              noexcept(is_nothrow_default_constructible<_Hp>::value) : __value_()
        {static_assert(!is_reference<_Hp>::value,
               "Attempted to default construct a reference element in a tuple");}
@@ -317,7 +317,7 @@ class __tuple_leaf<_Ip, _Hp, true>
 
     _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf& operator=(const __tuple_leaf&);
 public:
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR __tuple_leaf()
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_leaf()
              noexcept(is_nothrow_default_constructible<_Hp>::value) {}
 
     template <class _Alloc>
@@ -404,7 +404,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
     : public __tuple_leaf<_Indx, _Tp>...
 {
     _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR __tuple_impl()
+    constexpr __tuple_impl()
         noexcept(__all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
 
 
@@ -747,11 +747,11 @@ public:
     };
 
     template <bool _Dummy = true, __enable_if_t<_EnableConstructor<_Dummy>::__implicit_default, bool> = false>
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr
     tuple() noexcept(__all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
 
     template <bool _Dummy = true, __enable_if_t<_EnableConstructor<_Dummy>::__explicit_default, bool> = false>
-    explicit _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    explicit _LIBCUDACXX_INLINE_VISIBILITY constexpr
     tuple() noexcept(__all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
 
     tuple(tuple const&) = default;
@@ -1012,7 +1012,7 @@ template <>
 class _LIBCUDACXX_TEMPLATE_VIS tuple<>
 {
 public:
-    _LIBCUDACXX_CONSTEXPR tuple() noexcept = default;
+    constexpr tuple() noexcept = default;
     template <class _Alloc>
     _LIBCUDACXX_INLINE_VISIBILITY
         tuple(allocator_arg_t, const _Alloc&) noexcept {}

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/typeinfo
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/typeinfo
@@ -160,11 +160,11 @@ struct __type_info_implementations {
   struct __string_impl_base {
     typedef const char* __type_name_t;
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    _LIBCUDACXX_CONSTEXPR static const char* __type_name_to_string(__type_name_t __v) noexcept {
+    constexpr static const char* __type_name_to_string(__type_name_t __v) noexcept {
       return __v;
     }
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_ALWAYS_INLINE
-    _LIBCUDACXX_CONSTEXPR static __type_name_t __string_to_type_name(const char* __v) noexcept {
+    constexpr static __type_name_t __string_to_type_name(const char* __v) noexcept {
       return __v;
     }
   };

--- a/libcudacxx/libcxx/src/chrono.cpp
+++ b/libcudacxx/libcxx/src/chrono.cpp
@@ -61,7 +61,7 @@ system_clock::now() noexcept
                                                     nanoseconds::period>>;
 
   // The Windows epoch is Jan 1 1601, the Unix epoch Jan 1 1970.
-  static _LIBCUDACXX_CONSTEXPR const seconds nt_to_unix_epoch{11644473600};
+  static constexpr const seconds nt_to_unix_epoch{11644473600};
 
   FILETIME ft;
 #if _WIN32_WINNT >= _WIN32_WINNT_WIN8

--- a/libcudacxx/libcxx/src/condition_variable.cpp
+++ b/libcudacxx/libcxx/src/condition_variable.cpp
@@ -60,7 +60,7 @@ condition_variable::__do_timed_wait(unique_lock<mutex>& lk,
     __libcpp_timespec_t ts;
     seconds s = duration_cast<seconds>(d);
     typedef decltype(ts.tv_sec) ts_sec;
-    _LIBCUDACXX_CONSTEXPR ts_sec ts_sec_max = numeric_limits<ts_sec>::max();
+    constexpr ts_sec ts_sec_max = numeric_limits<ts_sec>::max();
     if (s.count() < ts_sec_max)
     {
         ts.tv_sec = static_cast<ts_sec>(s.count());

--- a/libcudacxx/libcxx/src/locale.cpp
+++ b/libcudacxx/libcxx/src/locale.cpp
@@ -112,18 +112,14 @@ make(A0 a0, A1 a1, A2 a2)
 }
 
 template <typename T, size_t N>
-inline
-_LIBCUDACXX_CONSTEXPR
-size_t
+inline constexpr size_t
 countof(const T (&)[N])
 {
     return N;
 }
 
 template <typename T>
-inline
-_LIBCUDACXX_CONSTEXPR
-size_t
+inline constexpr size_t
 countof(const T * const begin, const T * const end)
 {
     return static_cast<size_t>(end - begin);
@@ -1029,7 +1025,7 @@ extern "C" const int ** __ctype_toupper_loc();
 const ctype<char>::mask*
 ctype<char>::classic_table()  noexcept
 {
-    static _LIBCUDACXX_CONSTEXPR const ctype<char>::mask builtin_table[table_size] = {
+    static constexpr const ctype<char>::mask builtin_table[table_size] = {
         cntrl,                          cntrl,
         cntrl,                          cntrl,
         cntrl,                          cntrl,

--- a/libcudacxx/libcxx/src/memory.cpp
+++ b/libcudacxx/libcxx/src/memory.cpp
@@ -145,7 +145,7 @@ _LIBCUDACXX_SAFE_STATIC static __libcpp_mutex_t mut_back[__sp_mut_count] =
     _LIBCUDACXX_MUTEX_INITIALIZER, _LIBCUDACXX_MUTEX_INITIALIZER, _LIBCUDACXX_MUTEX_INITIALIZER, _LIBCUDACXX_MUTEX_INITIALIZER
 };
 
-_LIBCUDACXX_CONSTEXPR __sp_mut::__sp_mut(void* p) noexcept
+constexpr __sp_mut::__sp_mut(void* p) noexcept
    : __lx(p)
 {
 }


### PR DESCRIPTION
As part of #127, code for unsupported compilation modes/platforms will be removed. `default`, `constexpr`, and `delete` are supported by all targeted compilers so that the conditional support can be removed.

All `_LIBCUDACXX_CONSTEXPR` macros are replaced by `constexpr`. All `_LIBCUDACXX_EQUAL_DEFAULT` macros are replaced by `= default;`. All `_LIBCUDACXX_EQUAL_DELETE` macros are replaced by `= delete;`.
## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
