### PR TITLE
[skip-tests] Also skip all CI runs that require a GPU when [skip-tests] is set

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -98,6 +98,7 @@ jobs:
 
   nvrtc:
     name: NVRTC CUDA${{matrix.cuda}} C++${{matrix.std}}
+    if: ${{ !contains(github.event.head_commit.message, 'skip-tests') }}
     needs: [compute-nvrtc-matrix, get-devcontainer-version]
     uses: ./.github/workflows/run-as-coder.yml
     strategy:
@@ -159,6 +160,7 @@ jobs:
 
   examples:
     name: CCCL Examples
+    if: ${{ !contains(github.event.head_commit.message, 'skip-tests') }}
     needs: [compute-nvcc-matrix, get-devcontainer-version]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Runners with GPUs are a bottle neck. 

If we do not need to run tests we want to be able to skip them completely