### PR TITLE
[NFC] We missed some `_NOEXCEPT_` macro uses

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -1528,14 +1528,6 @@ _LIBCUDACXX_BEGIN_NAMESPACE_RANGES _LIBCUDACXX_END_NAMESPACE_RANGES
 #  endif
 #endif
 
-#ifndef _LIBCUDACXX_HAS_NO_NOEXCEPT
-#  define _NOEXCEPT noexcept
-#  define _NOEXCEPT_(x) noexcept(x)
-#else
-#  define _NOEXCEPT throw()
-#  define _NOEXCEPT_(x)
-#endif
-
 #ifdef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 typedef unsigned short char16_t;
 typedef unsigned int   char32_t;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__hash_table
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__hash_table
@@ -2883,7 +2883,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__hash_table<_Tp, _Hash, _Equal, _Alloc>& __x,
      __hash_table<_Tp, _Hash, _Equal, _Alloc>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/data.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/data.h
@@ -29,14 +29,14 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Cont> constexpr
 _LIBCUDACXX_INLINE_VISIBILITY
 auto data(_Cont& __c)
-_NOEXCEPT_(noexcept(__c.data()))
+noexcept(noexcept(__c.data()))
 -> decltype        (__c.data())
 { return            __c.data(); }
 
 template <class _Cont> constexpr
 _LIBCUDACXX_INLINE_VISIBILITY
 auto data(const _Cont& __c)
-_NOEXCEPT_(noexcept(__c.data()))
+noexcept(noexcept(__c.data()))
 -> decltype        (__c.data())
 { return            __c.data(); }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/empty.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/empty.h
@@ -29,7 +29,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Cont>
 _LIBCUDACXX_NODISCARD_AFTER_CXX17 _LIBCUDACXX_INLINE_VISIBILITY
 constexpr auto empty(const _Cont& __c)
-_NOEXCEPT_(noexcept(__c.empty()))
+noexcept(noexcept(__c.empty()))
 -> decltype        (__c.empty())
 { return            __c.empty(); }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/size.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/size.h
@@ -29,7 +29,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Cont>
 _LIBCUDACXX_INLINE_VISIBILITY
 constexpr auto size(const _Cont& __c)
-_NOEXCEPT_(noexcept(__c.size()))
+noexcept(noexcept(__c.size()))
 -> decltype        (__c.size())
 { return            __c.size(); }
 
@@ -42,7 +42,7 @@ constexpr size_t size(const _Tp (&)[_Sz]) noexcept { return _Sz; }
 template <class _Cont>
 _LIBCUDACXX_INLINE_VISIBILITY
 constexpr auto ssize(const _Cont& __c)
-_NOEXCEPT_(noexcept(static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>>(__c.size())))
+noexcept(noexcept(static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>>(__c.size())))
 ->                              common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>
 { return            static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>>(__c.size()); }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__split_buffer
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__split_buffer
@@ -632,7 +632,7 @@ template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__split_buffer<_Tp, _Allocator>& __x, __split_buffer<_Tp, _Allocator>& __y)
-        noexcept(_NOEXCEPT_(__x.swap(__y)))
+        noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__tree
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__tree
@@ -2832,7 +2832,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__tree<_Tp, _Compare, _Allocator>& __x,
      __tree<_Tp, _Compare, _Allocator>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/deque
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/deque
@@ -3014,7 +3014,7 @@ template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(deque<_Tp, _Allocator>& __x, deque<_Tp, _Allocator>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/forward_list
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/forward_list
@@ -1757,7 +1757,7 @@ template <class _Tp, class _Alloc>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(forward_list<_Tp, _Alloc>& __x, forward_list<_Tp, _Alloc>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/list
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/list
@@ -2464,7 +2464,7 @@ template <class _Tp, class _Alloc>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(list<_Tp, _Alloc>& __x, list<_Tp, _Alloc>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/map
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/map
@@ -592,7 +592,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__map_value_compare<_Key, _CP, _Compare, __b>& __x,
      __map_value_compare<_Key, _CP, _Compare, __b>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -1647,7 +1647,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(map<_Key, _Tp, _Compare, _Allocator>& __x,
      map<_Key, _Tp, _Compare, _Allocator>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -2229,7 +2229,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(multimap<_Key, _Tp, _Compare, _Allocator>& __x,
      multimap<_Key, _Tp, _Compare, _Allocator>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/queue
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/queue
@@ -411,7 +411,7 @@ typename enable_if<
     void
 >::type
 swap(queue<_Tp, _Container>& __x, queue<_Tp, _Container>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -787,7 +787,7 @@ typename enable_if<
 >::type
 swap(priority_queue<_Tp, _Container, _Compare>& __x,
      priority_queue<_Tp, _Container, _Compare>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/set
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/set
@@ -952,7 +952,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(set<_Key, _Compare, _Allocator>& __x,
      set<_Key, _Compare, _Allocator>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -1476,7 +1476,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(multiset<_Key, _Compare, _Allocator>& __x,
      multiset<_Key, _Compare, _Allocator>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/stack
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/stack
@@ -305,7 +305,7 @@ typename enable_if<
     void
 >::type
 swap(stack<_Tp, _Container>& __x, stack<_Tp, _Container>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/string
@@ -4161,7 +4161,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(basic_string<_CharT, _Traits, _Allocator>& __lhs,
      basic_string<_CharT, _Traits, _Allocator>& __rhs)
-     noexcept(_NOEXCEPT_(__lhs.swap(__rhs)))
+     noexcept(noexcept(__lhs.swap(__rhs)))
 {
     __lhs.swap(__rhs);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/type_traits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/type_traits
@@ -623,8 +623,8 @@ template <class _ForwardIterator1, class _ForwardIterator2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
 void
 iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
-    //                                  noexcept(_NOEXCEPT_(swap(*__a, *__b)))
-               noexcept(_NOEXCEPT_(swap(*_CUDA_VSTD::declval<_ForwardIterator1>(),
+    //                                  noexcept(noexcept(swap(*__a, *__b)))
+               noexcept(noexcept(swap(*_CUDA_VSTD::declval<_ForwardIterator1>(),
                                           *_CUDA_VSTD::declval<_ForwardIterator2>())))
 {
     swap(*__a, *__b);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/unordered_map
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/unordered_map
@@ -485,7 +485,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__unordered_map_hasher<_Key, _Cp, _Hash, __b>& __x,
      __unordered_map_hasher<_Key, _Cp, _Hash, __b>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -560,7 +560,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(__unordered_map_equal<_Key, _Cp, _Pred, __b>& __x,
      __unordered_map_equal<_Key, _Cp, _Pred, __b>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -1698,7 +1698,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
      unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -2396,7 +2396,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
      unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/unordered_set
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/unordered_set
@@ -1000,7 +1000,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(unordered_set<_Value, _Hash, _Pred, _Alloc>& __x,
      unordered_set<_Value, _Hash, _Pred, _Alloc>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }
@@ -1631,7 +1631,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __x,
      unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/vector
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/vector
@@ -3382,7 +3382,7 @@ template <class _Tp, class _Allocator>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 void
 swap(vector<_Tp, _Allocator>& __x, vector<_Tp, _Allocator>& __y)
-    noexcept(_NOEXCEPT_(__x.swap(__y)))
+    noexcept(noexcept(__x.swap(__y)))
 {
     __x.swap(__y);
 }

--- a/libcudacxx/libcxxabi/src/stdlib_new_delete.cpp
+++ b/libcudacxx/libcxxabi/src/stdlib_new_delete.cpp
@@ -13,7 +13,7 @@
 #include <new>
 #include <cstdlib>
 
-#if !defined(_THROW_BAD_ALLOC) || !defined(_NOEXCEPT) || !defined(_LIBCXXABI_WEAK)
+#if !defined(_THROW_BAD_ALLOC) || !defined(_LIBCXXABI_WEAK)
 #error The _THROW_BAD_ALLOC, noexcept, and _LIBCXXABI_WEAK libc++ macros must \
        already be defined by libc++.
 #endif


### PR DESCRIPTION
Also remove the macros from the config for good. They serve no purpose and forgetting to replace them is easy