### PR TITLE
Fixes a race in DeviceRunLengthEncode::NonTrivialRuns

### DIFF
--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -468,6 +468,10 @@ struct AgentRle
 
             tile_aggregate = scan_op(tile_aggregate, temp_storage.aliasable.scan_storage.warp_aggregates.Alias()[WARP]);
         }
+
+        // Ensure all threads have read warp aggregates before temp_storage is repurposed in the
+        // subsequent scatter stage
+        CTA_SYNC();
     }
 
 


### PR DESCRIPTION
## Description

This PR addresses https://github.com/NVIDIA/cccl/issues/351. 

`WarpScanAllocations()` and `Scatter()` alias/repurpose the same shared memory allocation. Previously it could happen that some threads may have reached the `Scatter()` stage, overwriting shared memory that was yet-to-be-read by other threads still within `WarpScanAllocations()` stage. A `CTA_SYNC` was added to `WarpScanAllocations` to make sure other threads wouldn't race ahead to the `Scatter()` stage.

Lines that were reading potentially corrupted data:
```
        warp_aggregate = temp_storage.aliasable.scan_storage.warp_aggregates.Alias()[warp_id];
        ...
        tile_aggregate = temp_storage.aliasable.scan_storage.warp_aggregates.Alias()[0];
```

This fix resolves the race condition being reported by compute-sanitizer and has had more than 90k successful test runs (previously avg. failure rate was one in ~1300 runs).

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
