### PR TITLE
Add commit information to the test output

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -90,7 +90,7 @@ echo "GPU_ARCHS=$GPU_ARCHS"
 echo "PARALLEL_LEVEL=$PARALLEL_LEVEL"
 echo "BUILD_DIR=$BUILD_DIR"
 echo "Current commit is:"
-git show --pretty=oneline --abbrev-commit
+git log -1
 echo "========================================"
 
 function configure(){

--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -89,6 +89,8 @@ echo "CXX_STANDARD=$CXX_STANDARD"
 echo "GPU_ARCHS=$GPU_ARCHS"
 echo "PARALLEL_LEVEL=$PARALLEL_LEVEL"
 echo "BUILD_DIR=$BUILD_DIR"
+echo "Current commit is:"
+git show --pretty=oneline --abbrev-commit
 echo "========================================"
 
 function configure(){


### PR DESCRIPTION
We occasionally have bug reports, of issues that are already fixed.

To save time print the current commit the cccl repo is at, so that we can easily verify whether the branch was stale