### PR TITLE
Remove `util_device.cuh` from iterator headers to enable online compilation

### DIFF
--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -41,8 +41,8 @@
 #include <cub/detail/uninitialized_copy.cuh>
 #include <cub/thread/thread_load.cuh>
 #include <cub/thread/thread_store.cuh>
-#include <cub/util_device.cuh>
 #include <cub/warp/warp_reduce.cuh>
+#include <cub/util_temporary_storage.cuh>
 
 #include <nv/target>
 

--- a/cub/cub/cub.cuh
+++ b/cub/cub/cub.cuh
@@ -106,4 +106,5 @@
 #include "util_device.cuh"
 #include "util_macro.cuh"
 #include "util_ptx.cuh"
+#include "util_temporary_storage.cuh"
 #include "util_type.cuh"

--- a/cub/cub/detail/temporary_storage.cuh
+++ b/cub/cub/detail/temporary_storage.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cub/util_namespace.cuh>
-#include <cub/util_device.cuh>
+#include <cub/util_temporary_storage.cuh>
 
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -38,6 +38,8 @@
 #include <cub/agent/agent_histogram.cuh>
 #include <cub/config.cuh>
 #include <cub/detail/cpp_compatibility.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_temporary_storage.cuh>
 #include <cub/device/dispatch/tuning/tuning_histogram.cuh>
 #include <cub/grid/grid_queue.cuh>
 #include <cub/thread/thread_search.cuh>

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -46,6 +46,7 @@
 #include <cub/util_debug.cuh>
 #include <cub/util_deprecated.cuh>
 #include <cub/util_device.cuh>
+#include <cub/util_temporary_storage.cuh>
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -30,6 +30,7 @@
 #include <cub/agent/agent_histogram.cuh>
 #include <cub/block/block_load.cuh>
 #include <cub/config.cuh>
+#include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -33,6 +33,7 @@
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 #include <cub/config.cuh>
+#include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/device/dispatch/tuning/tuning_run_length_encode.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_run_length_encode.cuh
@@ -34,6 +34,7 @@
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 #include <cub/config.cuh>
+#include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -33,6 +33,7 @@
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
 #include <cub/config.cuh>
+#include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -34,6 +34,7 @@
 #include <cub/block/block_store.cuh>
 #include <cub/config.cuh>
 #include <cub/thread/thread_operators.cuh>
+#include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 #include <cub/util_type.cuh>
 

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -32,6 +32,7 @@
 #include <cub/block/block_load.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/config.cuh>
+#include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -32,6 +32,7 @@
 #include <cub/block/block_load.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/config.cuh>
+#include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 #include <cub/util_type.cuh>
 

--- a/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
@@ -32,6 +32,7 @@
 #include <cub/block/block_load.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/config.cuh>
+#include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 #include <cub/util_type.cuh>
 

--- a/cub/cub/iterator/arg_index_input_iterator.cuh
+++ b/cub/cub/iterator/arg_index_input_iterator.cuh
@@ -39,7 +39,6 @@
 #include "../config.cuh"
 #include "../thread/thread_load.cuh"
 #include "../thread/thread_store.cuh"
-#include "../util_device.cuh"
 
 #include <thrust/version.h>
 

--- a/cub/cub/iterator/cache_modified_input_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_input_iterator.cuh
@@ -39,7 +39,6 @@
 #include "../config.cuh"
 #include "../thread/thread_load.cuh"
 #include "../thread/thread_store.cuh"
-#include "../util_device.cuh"
 
 #if (THRUST_VERSION >= 100700)
     // This iterator is compatible with Thrust API 1.7 and newer

--- a/cub/cub/iterator/cache_modified_output_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_output_iterator.cuh
@@ -39,7 +39,6 @@
 #include "../thread/thread_load.cuh"
 #include "../thread/thread_store.cuh"
 #include "../config.cuh"
-#include "../util_device.cuh"
 
 #if (THRUST_VERSION >= 100700)
     // This iterator is compatible with Thrust API 1.7 and newer

--- a/cub/cub/iterator/counting_input_iterator.cuh
+++ b/cub/cub/iterator/counting_input_iterator.cuh
@@ -39,7 +39,6 @@
 #include "../thread/thread_load.cuh"
 #include "../thread/thread_store.cuh"
 #include "../config.cuh"
-#include "../util_device.cuh"
 
 #if (THRUST_VERSION >= 100700)
     // This iterator is compatible with Thrust API 1.7 and newer

--- a/cub/cub/iterator/tex_obj_input_iterator.cuh
+++ b/cub/cub/iterator/tex_obj_input_iterator.cuh
@@ -37,7 +37,6 @@
 #include <cub/thread/thread_load.cuh>
 #include <cub/thread/thread_store.cuh>
 #include <cub/util_debug.cuh>
-#include <cub/util_device.cuh>
 
 #include <nv/target>
 

--- a/cub/cub/iterator/transform_input_iterator.cuh
+++ b/cub/cub/iterator/transform_input_iterator.cuh
@@ -39,7 +39,6 @@
 #include "../thread/thread_load.cuh"
 #include "../thread/thread_store.cuh"
 #include "../config.cuh"
-#include "../util_device.cuh"
 
 #if (THRUST_VERSION >= 100700)
     // This iterator is compatible with Thrust API 1.7 and newer

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -28,7 +28,11 @@
 
 /**
  * \file
- * Properties of a given CUDA device and the corresponding PTX bundle
+ * Properties of a given CUDA device and the corresponding PTX bundle.
+ *
+ * \note
+ * This file contains __host__ only functions and utilities, and should not be
+ * included in code paths that could be online-compiled (ex: using NVRTC).
  */
 
 #pragma once

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -46,6 +46,8 @@
 #include <cub/util_macro.cuh>
 #include <cub/util_namespace.cuh>
 #include <cub/util_type.cuh>
+// for backward compatibility
+#include <cub/util_temporary_storage.cuh>
 
 #include <nv/target>
 

--- a/cub/cub/util_temporary_storage.cuh
+++ b/cub/cub/util_temporary_storage.cuh
@@ -1,0 +1,93 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * \file
+ * Properties of a given CUDA device and the corresponding PTX bundle
+ */
+
+#pragma once
+
+#include <cub/util_debug.cuh>
+#include <cub/util_namespace.cuh>
+
+
+CUB_NAMESPACE_BEGIN
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
+
+/**
+ * \brief Alias temporaries to externally-allocated device storage (or simply return the amount of storage needed).
+ */
+template <int ALLOCATIONS>
+__host__ __device__ __forceinline__
+cudaError_t AliasTemporaries(
+    void    *d_temp_storage,                    ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
+    size_t& temp_storage_bytes,                 ///< [in,out] Size in bytes of \t d_temp_storage allocation
+    void*   (&allocations)[ALLOCATIONS],        ///< [in,out] Pointers to device allocations needed
+    size_t  (&allocation_sizes)[ALLOCATIONS])   ///< [in] Sizes in bytes of device allocations needed
+{
+    const int ALIGN_BYTES   = 256;
+    const int ALIGN_MASK    = ~(ALIGN_BYTES - 1);
+
+    // Compute exclusive prefix sum over allocation requests
+    size_t allocation_offsets[ALLOCATIONS];
+    size_t bytes_needed = 0;
+    for (int i = 0; i < ALLOCATIONS; ++i)
+    {
+        size_t allocation_bytes = (allocation_sizes[i] + ALIGN_BYTES - 1) & ALIGN_MASK;
+        allocation_offsets[i] = bytes_needed;
+        bytes_needed += allocation_bytes;
+    }
+    bytes_needed += ALIGN_BYTES - 1;
+
+    // Check if the caller is simply requesting the size of the storage allocation
+    if (!d_temp_storage)
+    {
+        temp_storage_bytes = bytes_needed;
+        return cudaSuccess;
+    }
+
+    // Check if enough storage provided
+    if (temp_storage_bytes < bytes_needed)
+    {
+        return CubDebug(cudaErrorInvalidValue);
+    }
+
+    // Alias
+    d_temp_storage = (void *) ((size_t(d_temp_storage) + ALIGN_BYTES - 1) & ALIGN_MASK);
+    for (int i = 0; i < ALLOCATIONS; ++i)
+    {
+        allocations[i] = static_cast<char*>(d_temp_storage) + allocation_offsets[i];
+    }
+
+    return cudaSuccess;
+}
+
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
+
+CUB_NAMESPACE_END

--- a/cub/cub/util_temporary_storage.cuh
+++ b/cub/cub/util_temporary_storage.cuh
@@ -28,7 +28,7 @@
 
 /**
  * \file
- * Properties of a given CUDA device and the corresponding PTX bundle
+ * Utilities for device-accessible temporary storages.
  */
 
 #pragma once
@@ -38,6 +38,12 @@
 
 
 CUB_NAMESPACE_BEGIN
+
+/**
+ * \addtogroup UtilMgmt
+ * @{
+ */
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 
 /**
@@ -89,5 +95,7 @@ cudaError_t AliasTemporaries(
 }
 
 #endif  // DOXYGEN_SHOULD_SKIP_THIS
+
+/** @} */       // end group UtilMgmt
 
 CUB_NAMESPACE_END

--- a/thrust/thrust/system/cuda/detail/core/util.h
+++ b/thrust/thrust/system/cuda/detail/core/util.h
@@ -36,6 +36,7 @@
 #include <cub/block/block_load.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
+#include <cub/util_temporary_storage.cuh>
 
 #include <nv/target>
 


### PR DESCRIPTION
## Description
Related to #403.

When using NVRTC (+Jitify) to compile these two headers
```c++
#include <cub/block/block_reduce.cuh>
#include <cub/block/block_load.cuh>
```
`util_device.cuh` ended up being included by one of the CUB headers, and this function
https://github.com/NVIDIA/cccl/blob/eea703e55307d0d73b5fd71a9b74fca096bfdc82/cub/cub/util_device.cuh#L185-L192 causes the following compiler error
```
../util_device.cuh(191): error: dynamic initialization is not supported for a function-scope static __device__ variable within a __device__/__global__ function
```

Upon a closer look, I realized that by commenting out `DeviceCountCachedValue`, the struct `PerDeviceAttributeCache`, and everything depending on them (in the same file, so the radius of blast is small), I was able to make NVRTC happy. Basically, hiding all `__host__` only functions and structs from NVRTC should suffice.

@jrhemstad pointed out offline that this header doesn't seem to be used in `cache_modified_input_iterator.cuh`, and I checked locally that it's true for all iterator headers. Hence this patch.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
