### PR TITLE
Project automation - Fix indentation for `continue-on-error`

### DIFF
--- a/.github/workflows/project_automation_set_in_progress.yml
+++ b/.github/workflows/project_automation_set_in_progress.yml
@@ -97,7 +97,7 @@ jobs:
             echo "PR is a draft, setting status to 'In Progress'"
             echo "STATUS_OPTION_ID=$IN_PROGRESS_PROJECT_OPTION_ID" >> $GITHUB_ENV
           fi
-          continue-on-error: true
+        continue-on-error: true
 
       - name: Get PR Project ID
         id: get_pr_id


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #424 

This PR corrects the indentation error causing failures in the workflow.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
