### PR TITLE
Add NVRTC_SKIP_KERNEL_RUN tag to compile, but skip running NVRTC test

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/skip_nvrtc_launch.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/skip_nvrtc_launch.pass.cpp
@@ -1,0 +1,32 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: libcpp-has-no-threads
+// NVRTC_SKIP_KERNEL_RUN // do compile, but do not run under nvrtc
+
+#include <cuda/std/cassert>
+#include <nv/target>
+
+// This is a test of the NVRTC_SKIP_KERNEL_RUN tag that indicates that a test
+// should compiler under NVRTC, but should not be run.
+int main(int, char**)
+{
+  NV_DISPATCH_TARGET(
+        NV_IS_DEVICE, (
+          // Ensure that code fails at runtime when run under NVRTC.
+#ifdef _LIBCUDACXX_COMPILER_NVRTC
+          assert(false);
+#endif
+        )
+    );
+
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/utils/nvidia/nvrtc/post_tail.cu.in
+++ b/libcudacxx/.upstream-tests/utils/nvidia/nvrtc/post_tail.cu.in
@@ -1,5 +1,8 @@
-        NULL,
-        NULL, 0));
+            NULL,
+            NULL, 0));
+    } else {
+        printf("Skipped running NVRTC-compiled kernel.\n");
+    }
 
     CUDA_API_CALL(cudaGetLastError());
     CUDA_API_CALL(cudaDeviceSynchronize());

--- a/libcudacxx/.upstream-tests/utils/nvidia/nvrtc/tail.cu.in
+++ b/libcudacxx/.upstream-tests/utils/nvidia/nvrtc/tail.cu.in
@@ -39,5 +39,6 @@
     CUDA_SAFE_CALL(cuCtxCreate(&context, 0, cuDevice));
     CUDA_SAFE_CALL(cuModuleLoadDataEx(&module, code.get(), 0, 0, 0));
     CUDA_SAFE_CALL(cuModuleGetFunction(&kernel, module, "main_kernel"));
-    CUDA_SAFE_CALL(cuLaunchKernel(kernel,
-        1, 1, 1,
+    if (nvrtc_do_run_kernel) {
+        CUDA_SAFE_CALL(cuLaunchKernel(kernel,
+            1, 1, 1,


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #433

<!-- Provide a standalone description of changes in this PR. -->
This PR adds the NVRTC_SKIP_KERNEL_RUN tag that, if present in the source code of a test, changes how the test is executed under NVRTC. Specifically:
- it is still compiled under NVRTC
- but running device code is skipped

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes. (Perhaps we should have some documentation of the test framework?)
