### PR TITLE
Do not use static member functions to initialize static member variables.

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -3101,6 +3101,14 @@ inline constexpr year_month_weekday_last& year_month_weekday_last::operator+=(co
 _LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_weekday_last& year_month_weekday_last::operator-=(const years& __dy)  noexcept { *this = *this - __dy; return *this; }
 
+_LIBCUDACXX_NODISCARD_ATTRIBUTE inline _LIBCUDACXX_INLINE_VISIBILITY
+constexpr unsigned __hh_mm_ss_width(uint64_t __n, uint64_t __d = 10, unsigned __w = 0)
+{
+    if (__n >= 2 && __d != 0 && __w < 19)
+        return 1 + __hh_mm_ss_width(__n, __d % __n * 10, __w+1);
+    return 0;
+}
+
 template <class _Duration>
 class hh_mm_ss
 {
@@ -3116,18 +3124,9 @@ private:
             __ret *= 10U;
         return __ret;
     }
-
-    _LIBCUDACXX_INLINE_VISIBILITY
-    static constexpr unsigned __width(uint64_t __n, uint64_t __d = 10, unsigned __w = 0)
-    {
-        if (__n >= 2 && __d != 0 && __w < 19)
-            return 1 + __width(__n, __d % __n * 10, __w+1);
-        return 0;
-    }
-
 public:
-    static unsigned constexpr fractional_width = __width(__CommonType::period::den) < 19 ?
-                                                 __width(__CommonType::period::den) : 6u;
+    static unsigned constexpr fractional_width = __hh_mm_ss_width(__CommonType::period::den) < 19 ?
+                                                 __hh_mm_ss_width(__CommonType::period::den) : 6u;
     using precision = duration<typename __CommonType::rep, ratio<1, __pow10(fractional_width)>>;
 
     _LIBCUDACXX_INLINE_VISIBILITY


### PR DESCRIPTION
This is technically invalid, as the class is not yet complete during initialization of static member variables.

Fixes nvbug4197970