### PR TITLE
[libcu++] Fix use of `__ppc64__`

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/language.support/support.limits/limits/numeric.limits.members/is_iec559.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/language.support/support.limits/limits/numeric.limits.members/is_iec559.pass.cpp
@@ -54,7 +54,7 @@ int main(int, char**)
     test<float, true>();
     test<double, true>();
 #ifndef _LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#if (defined(__ppc__) || defined(__ppc64__))
+#if (defined(__ppc__) || defined(__ppc64__) || defined(__PPC64__))
     test<long double, false>();
 #else
     test<long double, true>();

--- a/libcudacxx/.upstream-tests/test/std/utilities/meta/meta.unary.prop.query/alignment_of.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/meta/meta.unary.prop.query/alignment_of.pass.cpp
@@ -53,7 +53,7 @@ int main(int, char**)
     // we should expect. In most cases it should be 8. But in i386 builds
     // with Clang >= 8 or GCC >= 8 the value is '4'.
     test_alignment_of<double, TEST_ALIGNOF(double)>();
-#if (defined(__ppc__) && !defined(__ppc64__))
+#if (defined(__ppc__) && !defined(__ppc64__) && !defined(__PPC64__))
     test_alignment_of<bool, 4>();   // 32-bit PPC has four byte bool
 #else
     test_alignment_of<bool, 1>();

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/limits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/limits
@@ -448,7 +448,7 @@ protected:
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type signaling_NaN() noexcept {return __builtin_nansl("");}
     _LIBCUDACXX_INLINE_VISIBILITY static constexpr type denorm_min() noexcept {return __LDBL_DENORM_MIN__;}
 
-#if (defined(__ppc__) || defined(__ppc64__))
+#if (defined(__ppc__) || defined(__ppc64__) || defined(__PPC64__))
     static constexpr bool is_iec559 = false;
 #else
     static constexpr bool is_iec559 = true;

--- a/libcudacxx/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/is_iec559.pass.cpp
+++ b/libcudacxx/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/is_iec559.pass.cpp
@@ -52,7 +52,7 @@ int main(int, char**)
 #endif
     test<float, true>();
     test<double, true>();
-#if (defined(__ppc__) || defined(__ppc64__))
+#if (defined(__ppc__) || defined(__ppc64__) || defined(__PPC64__))
     test<long double, false>();
 #else
     test<long double, true>();

--- a/libcudacxx/libcxx/test/std/utilities/meta/meta.unary.prop.query/alignment_of.pass.cpp
+++ b/libcudacxx/libcxx/test/std/utilities/meta/meta.unary.prop.query/alignment_of.pass.cpp
@@ -51,7 +51,7 @@ int main(int, char**)
     // we should expect. In most cases it should be 8. But in i386 builds
     // with Clang >= 8 or GCC >= 8 the value is '4'.
     test_alignment_of<double, TEST_ALIGNOF(double)>();
-#if (defined(__ppc__) && !defined(__ppc64__))
+#if (defined(__ppc__) && !defined(__ppc64__) && !defined(__PPC64__))
     test_alignment_of<bool, 4>();   // 32-bit PPC has four byte bool
 #else
     test_alignment_of<bool, 1>();

--- a/libcudacxx/libunwind/src/config.h
+++ b/libcudacxx/libunwind/src/config.h
@@ -109,7 +109,7 @@
 #define _LIBUNWIND_BUILD_SJLJ_APIS
 #endif
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__ppc__) || defined(__ppc64__) || defined(__powerpc64__)
+#if defined(__i386__) || defined(__x86_64__) || defined(__ppc__) || defined(__ppc64__) || defined(__PPC64__) || defined(__powerpc64__)
 #define _LIBUNWIND_SUPPORT_FRAME_APIS
 #endif
 


### PR DESCRIPTION
We had CI failures for PPC64 architectures. It turns out that on clang-16 the macro `__ppc64__` is not recognized anymore and we need to use `__PPC64__`.

Fixes nvbug4251875
