### PR TITLE
[libcu++] Try to avoid gcc misscompilation issues

### DIFF
--- a/thrust/testing/adjacent_difference.cu
+++ b/thrust/testing/adjacent_difference.cu
@@ -10,33 +10,36 @@ void TestAdjacentDifferenceSimple(void)
 {
     typedef typename Vector::value_type T;
 
-    Vector input(3);
-    Vector output(3);
-    input[0] = 1; input[1] = 4; input[2] = 6;
+    Vector input(4);
+    Vector output(4);
+    input[0] = 1; input[1] = 4; input[2] = 6; input[3] = 7;
 
     typename Vector::iterator result;
 
     result = thrust::adjacent_difference(input.begin(), input.end(), output.begin());
 
-    ASSERT_EQUAL(result - output.begin(), 3);
+    ASSERT_EQUAL(result - output.begin(), 4);
     ASSERT_EQUAL(output[0], T(1));
     ASSERT_EQUAL(output[1], T(3));
     ASSERT_EQUAL(output[2], T(2));
+    ASSERT_EQUAL(output[3], T(1));
 
     result = thrust::adjacent_difference(input.begin(), input.end(), output.begin(), thrust::plus<T>());
 
-    ASSERT_EQUAL(result - output.begin(), 3);
+    ASSERT_EQUAL(result - output.begin(), 4);
     ASSERT_EQUAL(output[0], T( 1));
     ASSERT_EQUAL(output[1], T( 5));
     ASSERT_EQUAL(output[2], T(10));
+    ASSERT_EQUAL(output[3], T(13));
 
     // test in-place operation, result and first are permitted to be the same
     result = thrust::adjacent_difference(input.begin(), input.end(), input.begin());
 
-    ASSERT_EQUAL(result - input.begin(), 3);
+    ASSERT_EQUAL(result - input.begin(), 4);
     ASSERT_EQUAL(input[0], T(1));
     ASSERT_EQUAL(input[1], T(3));
     ASSERT_EQUAL(input[2], T(2));
+    ASSERT_EQUAL(input[3], T(1));
 }
 DECLARE_VECTOR_UNITTEST(TestAdjacentDifferenceSimple);
 

--- a/thrust/testing/copy_n.cu
+++ b/thrust/testing/copy_n.cu
@@ -130,7 +130,7 @@ void TestCopyNVectorBool(void)
 
     thrust::host_vector<bool> h(3);
     thrust::device_vector<bool> d(3);
-    
+
     thrust::copy_n(v.begin(), v.size(), h.begin());
     thrust::copy_n(v.begin(), v.size(), d.begin());
 
@@ -157,7 +157,7 @@ void TestCopyNListTo(void)
     l.push_back(2);
     l.push_back(3);
     l.push_back(4);
-   
+
     Vector v(l.size());
 
     typename Vector::iterator v_result = thrust::copy_n(l.begin(), l.size(), v.begin());
@@ -208,13 +208,13 @@ void TestCopyNZipIterator(void)
 {
     typedef typename Vector::value_type T;
 
-    Vector v1(3); v1[0] = 1; v1[1] = 2; v1[2] = 3;
-    Vector v2(3); v2[0] = 4; v2[1] = 5; v2[2] = 6; 
-    Vector v3(3, T(0));
-    Vector v4(3, T(0));
+    Vector v1(4); v1[0] = 1; v1[1] = 2; v1[2] = 3; v1[3] = 4;
+    Vector v2(4); v2[0] = 4; v2[1] = 5; v2[2] = 6; v2[3] = 7;
+    Vector v3(4, T(0));
+    Vector v4(4, T(0));
 
     thrust::copy_n(thrust::make_zip_iterator(thrust::make_tuple(v1.begin(),v2.begin())),
-                   3,
+                   4,
                    thrust::make_zip_iterator(thrust::make_tuple(v3.begin(),v4.begin())));
 
     ASSERT_EQUAL(v1, v3);
@@ -227,8 +227,8 @@ void TestCopyNConstantIteratorToZipIterator(void)
 {
     typedef typename Vector::value_type T;
 
-    Vector v1(3, T(0));
-    Vector v2(3, T(0));
+    Vector v1(4, T(0));
+    Vector v2(4, T(0));
 
     thrust::copy_n(thrust::make_constant_iterator(thrust::tuple<T,T>(4,7)),
                    v1.size(),
@@ -237,9 +237,11 @@ void TestCopyNConstantIteratorToZipIterator(void)
     ASSERT_EQUAL(v1[0], T(4));
     ASSERT_EQUAL(v1[1], T(4));
     ASSERT_EQUAL(v1[2], T(4));
+    ASSERT_EQUAL(v1[3], T(4));
     ASSERT_EQUAL(v2[0], T(7));
     ASSERT_EQUAL(v2[1], T(7));
     ASSERT_EQUAL(v2[2], T(7));
+    ASSERT_EQUAL(v2[3], T(7));
 };
 DECLARE_VECTOR_UNITTEST(TestCopyNConstantIteratorToZipIterator);
 

--- a/thrust/testing/functional.cu
+++ b/thrust/testing/functional.cu
@@ -6,7 +6,7 @@
 #include <algorithm>
 
 THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
-    
+
 const size_t NUM_SAMPLES = 10000;
 
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
@@ -14,7 +14,7 @@ void TestUnaryFunctional(void)
 {
     typedef typename InputVector::value_type  InputType;
     typedef typename OutputVector::value_type OutputType;
-    
+
     thrust::host_vector<InputType>  std_input = unittest::random_samples<InputType>(NUM_SAMPLES);
     thrust::host_vector<OutputType> std_output(NUM_SAMPLES);
 
@@ -32,7 +32,7 @@ void TestBinaryFunctional(void)
 {
     typedef typename InputVector::value_type  InputType;
     typedef typename OutputVector::value_type OutputType;
-    
+
     thrust::host_vector<InputType>  std_input1 = unittest::random_samples<InputType>(NUM_SAMPLES);
     thrust::host_vector<InputType>  std_input2 = unittest::random_samples<InputType>(NUM_SAMPLES);
     thrust::host_vector<OutputType> std_output(NUM_SAMPLES);
@@ -40,8 +40,8 @@ void TestBinaryFunctional(void)
     // Replace zeros to avoid divide by zero exceptions
     std::replace(std_input2.begin(), std_input2.end(), (InputType) 0, (InputType) 1);
 
-    InputVector input1 = std_input1; 
-    InputVector input2 = std_input2; 
+    InputVector input1 = std_input1;
+    InputVector input2 = std_input2;
     OutputVector output(NUM_SAMPLES);
 
     thrust::transform(    input1.begin(),     input1.end(),      input2.begin(),     output.begin(),          Operator());
@@ -179,10 +179,10 @@ void TestIdentityFunctional(void)
 {
     typedef typename Vector::value_type T;
 
-    Vector input(3);
-    input[0] = 0; input[1] = 1; input[2] = 2;
+    Vector input(4);
+    input[0] = 0; input[1] = 1; input[2] = 2; input[3] = 3;
 
-    Vector output(3);
+    Vector output(4);
 
     thrust::transform(input.begin(), input.end(), output.begin(), thrust::identity<T>());
 
@@ -195,13 +195,14 @@ void TestProject1stFunctional(void)
 {
     typedef typename Vector::value_type T;
 
-    Vector lhs(3);
-    Vector rhs(3);
-    lhs[0] = 0;  rhs[0] = 3; 
+    Vector lhs(4);
+    Vector rhs(4);
+    lhs[0] = 0;  rhs[0] = 3;
     lhs[1] = 1;  rhs[1] = 4;
     lhs[2] = 2;  rhs[2] = 5;
+    lhs[2] = 3;  rhs[2] = 6;
 
-    Vector output(3);
+    Vector output(4);
 
     thrust::transform(lhs.begin(), lhs.end(), rhs.begin(), output.begin(), thrust::project1st<T,T>());
 
@@ -214,13 +215,14 @@ void TestProject2ndFunctional(void)
 {
     typedef typename Vector::value_type T;
 
-    Vector lhs(3);
-    Vector rhs(3);
-    lhs[0] = 0;  rhs[0] = 3; 
+    Vector lhs(4);
+    Vector rhs(4);
+    lhs[0] = 0;  rhs[0] = 3;
     lhs[1] = 1;  rhs[1] = 4;
     lhs[2] = 2;  rhs[2] = 5;
+    lhs[2] = 3;  rhs[2] = 6;
 
-    Vector output(3);
+    Vector output(4);
 
     thrust::transform(lhs.begin(), lhs.end(), rhs.begin(), output.begin(), thrust::project2nd<T,T>());
 
@@ -233,21 +235,22 @@ void TestMaximumFunctional(void)
 {
     typedef typename Vector::value_type T;
 
-    Vector input1(3);
-    Vector input2(3);
-    input1[0] = 8; input1[1] = 3; input1[2] = 7;
-    input2[0] = 5; input2[1] = 6; input2[2] = 9;
+    Vector input1(4);
+    Vector input2(4);
+    input1[0] = 8; input1[1] = 3; input1[2] = 7; input1[3] = 7;
+    input2[0] = 5; input2[1] = 6; input2[2] = 9; input2[3] = 3;
 
-    Vector output(3);
+    Vector output(4);
 
-    thrust::transform(input1.begin(), input1.end(), 
-                      input2.begin(), 
-                      output.begin(), 
+    thrust::transform(input1.begin(), input1.end(),
+                      input2.begin(),
+                      output.begin(),
                       thrust::maximum<T>());
 
     ASSERT_EQUAL(output[0], 8);
     ASSERT_EQUAL(output[1], 6);
     ASSERT_EQUAL(output[2], 9);
+    ASSERT_EQUAL(output[3], 7);
 }
 DECLARE_VECTOR_UNITTEST(TestMaximumFunctional);
 
@@ -256,21 +259,22 @@ void TestMinimumFunctional(void)
 {
     typedef typename Vector::value_type T;
 
-    Vector input1(3);
-    Vector input2(3);
-    input1[0] = 8; input1[1] = 3; input1[2] = 7;
-    input2[0] = 5; input2[1] = 6; input2[2] = 9;
+    Vector input1(4);
+    Vector input2(4);
+    input1[0] = 8; input1[1] = 3; input1[2] = 7; input1[3] = 7;
+    input2[0] = 5; input2[1] = 6; input2[2] = 9; input2[3] = 3;
 
-    Vector output(3);
+    Vector output(4);
 
-    thrust::transform(input1.begin(), input1.end(), 
-                      input2.begin(), 
-                      output.begin(), 
+    thrust::transform(input1.begin(), input1.end(),
+                      input2.begin(),
+                      output.begin(),
                       thrust::minimum<T>());
 
     ASSERT_EQUAL(output[0], 5);
     ASSERT_EQUAL(output[1], 3);
     ASSERT_EQUAL(output[2], 7);
+    ASSERT_EQUAL(output[3], 3);
 }
 DECLARE_VECTOR_UNITTEST(TestMinimumFunctional);
 
@@ -284,8 +288,8 @@ void TestNot1(void)
 
     Vector output(5);
 
-    thrust::transform(input.begin(), input.end(), 
-                      output.begin(), 
+    thrust::transform(input.begin(), input.end(),
+                      output.begin(),
                       thrust::not1(thrust::identity<T>()));
 
     ASSERT_EQUAL(output[0], 0);
@@ -321,9 +325,9 @@ void TestNot2(void)
 
     Vector output(5);
 
-    thrust::transform(input1.begin(), input1.end(), 
+    thrust::transform(input1.begin(), input1.end(),
                       input2.begin(),
-                      output.begin(), 
+                      output.begin(),
                       thrust::not2(thrust::equal_to<T>()));
 
     ASSERT_EQUAL(output[0], 0);


### PR DESCRIPTION
We experience gcc backend misscompilations in some of the thrust unit tests. Those are all tests that use an array of 3 elements. It seems the optimizer has some very volatile issues and often just increasing the range to 4 elements "solves" the issue
