### PR TITLE
Avoid integer promotion warnings with MSVC

### DIFF
--- a/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
@@ -108,7 +108,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeft works with iterators", "[device
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin());
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
 
   adjacent_difference_subtract_left(in.begin(),
                                     num_items);
@@ -127,7 +127,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with iterators", "[de
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin());
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
 
   adjacent_difference_subtract_left_copy(in.begin(),
                                          out.begin(),
@@ -146,7 +146,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeft works with pointers", "[device]
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin());
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
 
   adjacent_difference_subtract_left(thrust::raw_pointer_cast(in.data()),
                                     num_items);
@@ -165,7 +165,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with pointers", "[dev
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin());
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
 
   adjacent_difference_subtract_left_copy(thrust::raw_pointer_cast(in.data()),
                                          thrust::raw_pointer_cast(out.data()),
@@ -174,9 +174,10 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with pointers", "[dev
   REQUIRE(reference == out);
 }
 
+template<class T>
 struct cust_diff {
-  template<class T>
-  __host__ __device__ constexpr T operator()(const T& lhs, const T& rhs) const noexcept {
+  template<class T2, cuda::std::__enable_if_t<cuda::std::is_same<T, T2>::value, int> = 0>
+  __host__ __device__ constexpr T2 operator()(const T2& lhs, const T2& rhs) const noexcept {
     return lhs - rhs;
   }
 
@@ -195,11 +196,11 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeft works with custom difference", 
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), cust_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), cust_diff<type>{});
 
   adjacent_difference_subtract_left(in.begin(),
                                     num_items,
-                                    cust_diff{});
+                                    cust_diff<type>{});
 
   REQUIRE(reference == in);
 }
@@ -215,12 +216,12 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with custom differenc
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), cust_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), cust_diff<type>{});
 
   adjacent_difference_subtract_left_copy(in.begin(),
                                          out.begin(),
                                          num_items,
-                                         cust_diff{});
+                                         cust_diff<type>{});
 
   REQUIRE(reference == out);
 }
@@ -249,12 +250,12 @@ CUB_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with a different outp
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), cust_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), cust_diff<type>{});
 
   adjacent_difference_subtract_left_copy(in.begin(),
                                          out.begin(),
                                          num_items,
-                                         cust_diff{});
+                                         cust_diff<type>{});
 
   REQUIRE(reference == out);
 }

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -98,9 +98,10 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy does not change the input"
   REQUIRE(reference == in);
 }
 
+template<class T>
 struct ref_diff {
-  template<class T>
-  __host__ __device__ constexpr T operator()(const T& lhs, const T& rhs) const noexcept {
+  template<class T2, cuda::std::__enable_if_t<cuda::std::is_same<T, T2>::value, int> = 0>
+  __host__ __device__ constexpr T2 operator()(const T2& lhs, const T2& rhs) const noexcept {
     return rhs - lhs;
   }
 
@@ -128,7 +129,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRight works with iterators", "[devic
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 
@@ -149,7 +150,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with iterators", "[d
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 
@@ -170,7 +171,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRight works with pointers", "[device
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 
@@ -191,7 +192,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with pointers", "[de
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 
@@ -231,7 +232,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRight works with custom difference",
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 
@@ -253,7 +254,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with custom differen
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 
@@ -289,7 +290,7 @@ CUB_TEST("DeviceAdjacentDifference::SubtractRightCopy works with a different out
 
   thrust::host_vector<type> h_in = in;
   thrust::host_vector<type> reference(num_items);
-  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff{});
+  std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), ref_diff<type>{});
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 


### PR DESCRIPTION
It seems that MSVC introduces an integer promotion when calling a templated call operator, e.g. with `std::minus`

We can work around this issue by explicitly passing in the type w want. See https://godbolt.org/z/b5qP86dTE

Fixes thrust build issues on MSVC