### PR TITLE
Implement ranges comparison objects

### DIFF
--- a/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/equal_to.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/equal_to.pass.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// <cuda/std/functional>
+
+// ranges::equal_to
+
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotEqualityComparable {
+  __host__ __device__ friend bool operator==(const NotEqualityComparable&, const NotEqualityComparable&);
+  __host__ __device__ friend bool operator!=(const NotEqualityComparable&, const NotEqualityComparable&) = delete;
+};
+
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::equal_to, NotEqualityComparable, NotEqualityComparable>);
+#if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17 // MSVC considers implict conversions in C++17
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::equal_to, int, MoveOnly>);
+#endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17
+static_assert( cuda::std::is_invocable_v<cuda::std::ranges::equal_to, explicit_operators, explicit_operators>);
+
+#if TEST_STD_VER > 17
+static_assert(requires { typename cuda::std::ranges::equal_to::is_transparent; });
+#else
+template <class T, class = void>
+inline constexpr bool is_transparent = false;
+template <class T>
+inline constexpr bool is_transparent<T, cuda::std::void_t<typename T::is_transparent>> = true;
+static_assert(is_transparent<cuda::std::ranges::equal_to>);
+#endif
+
+__host__ __device__ constexpr bool test() {
+  auto fn = cuda::std::ranges::equal_to();
+
+  assert(fn(MoveOnly(42), MoveOnly(42)));
+
+  ForwardingTestObject a{};
+  ForwardingTestObject b{};
+  assert(!fn(a, b));
+  assert(fn(cuda::std::move(a), cuda::std::move(b)));
+
+  assert(!fn(1, 2));
+  assert(!fn(2, 1));
+  assert(fn(2, 2));
+
+  assert(!fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for equal_to<int*> and equal_to<void>.
+  do_pointer_comparison_test(cuda::std::ranges::equal_to());
+
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/greater.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/greater.pass.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// <cuda/std/functional>
+
+// ranges::greater
+
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotTotallyOrdered {
+  __host__ __device__ friend bool operator<(const NotTotallyOrdered&, const NotTotallyOrdered&);
+};
+
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::greater, NotTotallyOrdered, NotTotallyOrdered>);
+#if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17 // MSVC considers implict conversions in C++17
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::greater, int, MoveOnly>);
+#endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17
+static_assert(cuda::std::is_invocable_v<cuda::std::ranges::greater, explicit_operators, explicit_operators>);
+
+#if TEST_STD_VER > 17
+static_assert(requires { typename cuda::std::ranges::greater::is_transparent; });
+#else
+template <class T, class = void>
+inline constexpr bool is_transparent = false;
+template <class T>
+inline constexpr bool is_transparent<T, cuda::std::void_t<typename T::is_transparent>> = true;
+static_assert(is_transparent<cuda::std::ranges::greater>);
+#endif
+
+__host__ __device__ constexpr bool test() {
+  auto fn = cuda::std::ranges::greater();
+
+  assert(fn(MoveOnly(42), MoveOnly(41)));
+
+  ForwardingTestObject a{};
+  ForwardingTestObject b{};
+  assert(!fn(a, b));
+  assert(fn(cuda::std::move(a), cuda::std::move(b)));
+
+  assert(!fn(2, 2));
+  assert(!fn(1, 2));
+  assert(fn(2, 1));
+
+  assert(fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for greater<int*> and greater<void>.
+  do_pointer_comparison_test(cuda::std::ranges::greater());
+
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/greater_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/greater_equal.pass.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// <cuda/std/functional>
+
+// ranges::greater_equal
+
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotTotallyOrdered {
+  __host__ __device__ friend bool operator<(const NotTotallyOrdered&, const NotTotallyOrdered&);
+};
+
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::greater_equal, NotTotallyOrdered, NotTotallyOrdered>);
+#if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17 // MSVC considers implict conversions in C++17
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::greater_equal, int, MoveOnly>);
+#endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17
+static_assert( cuda::std::is_invocable_v<cuda::std::ranges::greater_equal, explicit_operators, explicit_operators>);
+
+#if TEST_STD_VER > 17
+static_assert(requires { typename cuda::std::ranges::greater_equal::is_transparent; });
+#else
+template <class T, class = void>
+inline constexpr bool is_transparent = false;
+template <class T>
+inline constexpr bool is_transparent<T, cuda::std::void_t<typename T::is_transparent>> = true;
+static_assert(is_transparent<cuda::std::ranges::greater_equal>);
+#endif
+
+__host__ __device__ constexpr bool test() {
+  auto fn = cuda::std::ranges::greater_equal();
+
+  assert(fn(MoveOnly(42), MoveOnly(42)));
+
+  ForwardingTestObject a{};
+  ForwardingTestObject b{};
+  assert(fn(a, b));
+  assert(!fn(cuda::std::move(a), cuda::std::move(b)));
+
+  assert(fn(2, 2));
+  assert(fn(2, 1));
+  assert(!fn(1, 2));
+
+  assert(fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for greater_equal<int*> and greater_equal<void>.
+  do_pointer_comparison_test(cuda::std::ranges::greater_equal());
+
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/less.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/less.pass.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// <cuda/std/functional>
+
+// ranges::less
+
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotTotallyOrdered {
+  __host__ __device__ friend bool operator<(const NotTotallyOrdered&, const NotTotallyOrdered&);
+};
+
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::less, NotTotallyOrdered, NotTotallyOrdered>);
+#if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17 // MSVC considers implict conversions in C++17
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::less, int, MoveOnly>);
+#endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17
+static_assert(cuda::std::is_invocable_v<cuda::std::ranges::less, explicit_operators, explicit_operators>);
+
+#if TEST_STD_VER > 17
+static_assert(requires { typename cuda::std::ranges::less::is_transparent; });
+#else
+template <class T, class = void>
+inline constexpr bool is_transparent = false;
+template <class T>
+inline constexpr bool is_transparent<T, cuda::std::void_t<typename T::is_transparent>> = true;
+static_assert(is_transparent<cuda::std::ranges::less>);
+#endif
+
+__host__ __device__ constexpr bool test() {
+  auto fn = cuda::std::ranges::less();
+
+  assert(fn(MoveOnly(41), MoveOnly(42)));
+
+  ForwardingTestObject a{};
+  ForwardingTestObject b{};
+  assert(!fn(a, b));
+  assert(fn(cuda::std::move(a), cuda::std::move(b)));
+
+  assert(fn(1, 2));
+  assert(!fn(2, 2));
+  assert(!fn(2, 1));
+
+  assert(!fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for less<int*> and less<void>.
+  do_pointer_comparison_test(cuda::std::ranges::less());
+
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/less_equal.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/less_equal.pass.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// <cuda/std/functional>
+
+// ranges::less_equal
+
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotTotallyOrdered {
+  __host__ __device__ friend bool operator<(const NotTotallyOrdered&, const NotTotallyOrdered&);
+};
+
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::less_equal, NotTotallyOrdered, NotTotallyOrdered>);
+#if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17 // MSVC considers implict conversions in C++17
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::less_equal, int, MoveOnly>);
+#endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17
+static_assert(cuda::std::is_invocable_v<cuda::std::ranges::less_equal, explicit_operators, explicit_operators>);
+
+#if TEST_STD_VER > 17
+static_assert(requires { typename cuda::std::ranges::less_equal::is_transparent; });
+#else
+template <class T, class = void>
+inline constexpr bool is_transparent = false;
+template <class T>
+inline constexpr bool is_transparent<T, cuda::std::void_t<typename T::is_transparent>> = true;
+static_assert(is_transparent<cuda::std::ranges::less_equal>);
+#endif
+
+__host__ __device__ constexpr bool test() {
+  auto fn = cuda::std::ranges::less_equal();
+
+  assert(fn(MoveOnly(41), MoveOnly(42)));
+
+  // These are the opposite of other tests.
+  ForwardingTestObject a{};
+  ForwardingTestObject b{};
+  assert(fn(a, b));
+  assert(!fn(cuda::std::move(a), cuda::std::move(b)));
+
+  assert(fn(1, 2));
+  assert(fn(2, 2));
+  assert(!fn(2, 1));
+
+  assert(!fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for less_equal<int*> and less_equal<void>.
+  do_pointer_comparison_test(cuda::std::ranges::less_equal());
+
+  return 0;
+}

--- a/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/not_equal_to.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/function.objects/range.cmp/not_equal_to.pass.cpp
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// <cuda/std/functional>
+
+// ranges::not_equal_to
+
+#include <cuda/std/functional>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotEqualityComparable {
+  __host__ __device__ friend bool operator==(const NotEqualityComparable&, const NotEqualityComparable&);
+  __host__ __device__ friend bool operator!=(const NotEqualityComparable&, const NotEqualityComparable&) = delete;
+};
+
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::not_equal_to, NotEqualityComparable, NotEqualityComparable>);
+#if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17 // MSVC considers implict conversions in C++17
+static_assert(!cuda::std::is_invocable_v<cuda::std::ranges::not_equal_to, int, MoveOnly>);
+#endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 17
+static_assert(cuda::std::is_invocable_v<cuda::std::ranges::not_equal_to, explicit_operators, explicit_operators>);
+
+#if TEST_STD_VER > 17
+static_assert(requires { typename cuda::std::ranges::not_equal_to::is_transparent; });
+#else
+template <class T, class = void>
+inline constexpr bool is_transparent = false;
+template <class T>
+inline constexpr bool is_transparent<T, cuda::std::void_t<typename T::is_transparent>> = true;
+static_assert(is_transparent<cuda::std::ranges::not_equal_to>);
+#endif
+
+struct PtrAndNotEqOperator {
+  __host__ __device__ constexpr operator void*() const { return nullptr; }
+  // We *don't* want operator!= to be picked here.
+  __host__ __device__ friend constexpr bool operator!=(PtrAndNotEqOperator, PtrAndNotEqOperator) { return true; }
+};
+
+__host__ __device__ constexpr bool test() {
+  auto fn = cuda::std::ranges::not_equal_to();
+
+  assert(fn(MoveOnly(41), MoveOnly(42)));
+
+  // These are the opposite of other tests.
+  ForwardingTestObject a{};
+  ForwardingTestObject b{};
+  assert(fn(a, b));
+  assert(!fn(cuda::std::move(a), cuda::std::move(b)));
+
+  assert(fn(1, 2));
+  assert(!fn(2, 2));
+  assert(fn(2, 1));
+
+  assert(fn(2, 1L));
+
+  // Make sure that "ranges::equal_to(x, y) == !ranges::not_equal_to(x, y)", even here.
+  assert(!fn(PtrAndNotEqOperator(), PtrAndNotEqOperator()));
+  assert(cuda::std::ranges::equal_to()(PtrAndNotEqOperator(), PtrAndNotEqOperator()));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for not_equal_to<int*> and not_equal_to<void>.
+  do_pointer_comparison_test(cuda::std::ranges::not_equal_to());
+
+  return 0;
+}

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
@@ -66,6 +66,7 @@ set(files
   __functional/perfect_forward.h
   __functional/pointer_to_binary_function.h
   __functional/pointer_to_unary_function.h
+  __functional/ranges_operations.h
   __functional/reference_wrapper.h
   __functional/unary_function.h
   __functional/unary_negate.h

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/ranges_operations.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/ranges_operations.h
@@ -1,0 +1,107 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___FUNCTIONAL_RANGES_OPERATIONS_H
+#define _LIBCUDACXX___FUNCTIONAL_RANGES_OPERATIONS_H
+
+#ifndef __cuda_std__
+#include <__config>
+#endif //__cuda_std__
+
+#include "../__concepts/equality_comparable.h"
+#include "../__concepts/totally_ordered.h"
+#include "../__utility/forward.h"
+
+#if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+#if _LIBCUDACXX_STD_VER > 14
+
+_LIBCUDACXX_BEGIN_NAMESPACE_RANGES
+_LIBCUDACXX_BEGIN_NAMESPACE_RANGES_ABI
+
+struct equal_to {
+  _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
+    (requires equality_comparable_with<_Tp, _Up>)
+  _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
+  constexpr bool operator()(_Tp &&__t, _Up &&__u) const
+      noexcept(noexcept(bool(_CUDA_VSTD::forward<_Tp>(__t) == _CUDA_VSTD::forward<_Up>(__u)))) {
+    return _CUDA_VSTD::forward<_Tp>(__t) == _CUDA_VSTD::forward<_Up>(__u);
+  }
+
+  using is_transparent = void;
+};
+
+struct not_equal_to {
+  _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
+    (requires equality_comparable_with<_Tp, _Up>)
+  _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
+  constexpr bool operator()(_Tp &&__t, _Up &&__u) const
+      noexcept(noexcept(bool(!(_CUDA_VSTD::forward<_Tp>(__t) == _CUDA_VSTD::forward<_Up>(__u))))) {
+    return !(_CUDA_VSTD::forward<_Tp>(__t) == _CUDA_VSTD::forward<_Up>(__u));
+  }
+
+  using is_transparent = void;
+};
+
+struct less {
+  _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
+    (requires totally_ordered_with<_Tp, _Up>)
+  _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
+  constexpr bool operator()(_Tp &&__t, _Up &&__u) const
+      noexcept(noexcept(bool(_CUDA_VSTD::forward<_Tp>(__t) < _CUDA_VSTD::forward<_Up>(__u)))) {
+    return _CUDA_VSTD::forward<_Tp>(__t) < _CUDA_VSTD::forward<_Up>(__u);
+  }
+
+  using is_transparent = void;
+};
+
+struct less_equal {
+  _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
+    (requires totally_ordered_with<_Tp, _Up>)
+  _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
+  constexpr bool operator()(_Tp &&__t, _Up &&__u) const
+      noexcept(noexcept(bool(!(_CUDA_VSTD::forward<_Up>(__u) < _CUDA_VSTD::forward<_Tp>(__t))))) {
+    return !(_CUDA_VSTD::forward<_Up>(__u) < _CUDA_VSTD::forward<_Tp>(__t));
+  }
+
+  using is_transparent = void;
+};
+
+struct greater {
+  _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
+    (requires totally_ordered_with<_Tp, _Up>)
+  _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
+  constexpr bool operator()(_Tp &&__t, _Up &&__u) const
+      noexcept(noexcept(bool(_CUDA_VSTD::forward<_Up>(__u) < _CUDA_VSTD::forward<_Tp>(__t)))) {
+    return _CUDA_VSTD::forward<_Up>(__u) < _CUDA_VSTD::forward<_Tp>(__t);
+  }
+
+  using is_transparent = void;
+};
+
+struct greater_equal {
+  _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
+    (requires totally_ordered_with<_Tp, _Up>)
+  _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
+  constexpr bool operator()(_Tp &&__t, _Up &&__u) const
+      noexcept(noexcept(bool(!(_CUDA_VSTD::forward<_Tp>(__t) < _CUDA_VSTD::forward<_Up>(__u))))) {
+    return !(_CUDA_VSTD::forward<_Tp>(__t) < _CUDA_VSTD::forward<_Up>(__u));
+  }
+
+  using is_transparent = void;
+};
+_LIBCUDACXX_END_NAMESPACE_RANGES_ABI
+_LIBCUDACXX_END_NAMESPACE_RANGES
+
+#endif // _LIBCUDACXX_STD_VER > 14
+
+
+#endif // _LIBCUDACXX___FUNCTIONAL_RANGES_OPERATIONS_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/functional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/functional
@@ -528,6 +528,7 @@ POLICY:  For non-variadic implementations, the number of arguments is limited
 #include "__functional/perfect_forward.h"
 #include "__functional/pointer_to_binary_function.h"
 #include "__functional/pointer_to_unary_function.h"
+#include "__functional/ranges_operations.h"
 #include "__functional/reference_wrapper.h"
 #include "__functional/unary_function.h"
 #include "__functional/unary_negate.h"

--- a/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/equal_to.pass.cpp
+++ b/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/equal_to.pass.cpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <functional>
+
+// ranges::equal_to
+
+#include <cassert>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotEqualityComparable {
+  friend bool operator==(const NotEqualityComparable&, const NotEqualityComparable&);
+  friend bool operator!=(const NotEqualityComparable&, const NotEqualityComparable&) = delete;
+};
+
+static_assert(!std::is_invocable_v<std::ranges::equal_to, NotEqualityComparable, NotEqualityComparable>);
+static_assert(!std::is_invocable_v<std::ranges::equal_to, int, MoveOnly>);
+static_assert(std::is_invocable_v<std::ranges::equal_to, explicit_operators, explicit_operators>);
+
+static_assert(requires { typename std::ranges::equal_to::is_transparent; });
+
+constexpr bool test() {
+  auto fn = std::ranges::equal_to();
+
+  assert(fn(MoveOnly(42), MoveOnly(42)));
+
+  ForwardingTestObject a;
+  ForwardingTestObject b;
+  assert(!fn(a, b));
+  assert(fn(std::move(a), std::move(b)));
+
+  assert(!fn(1, 2));
+  assert(!fn(2, 1));
+  assert(fn(2, 2));
+
+  assert(!fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for equal_to<int*> and equal_to<void>.
+  do_pointer_comparison_test(std::ranges::equal_to());
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/greater.pass.cpp
+++ b/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/greater.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <functional>
+
+// ranges::greater
+
+#include <cassert>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotTotallyOrdered {
+  friend bool operator<(const NotTotallyOrdered&, const NotTotallyOrdered&);
+};
+
+static_assert(!std::is_invocable_v<std::ranges::greater, NotTotallyOrdered, NotTotallyOrdered>);
+static_assert(!std::is_invocable_v<std::ranges::greater, int, MoveOnly>);
+static_assert(std::is_invocable_v<std::ranges::greater, explicit_operators, explicit_operators>);
+
+static_assert(requires { typename std::ranges::greater::is_transparent; });
+
+constexpr bool test() {
+  auto fn = std::ranges::greater();
+
+  assert(fn(MoveOnly(42), MoveOnly(41)));
+
+  ForwardingTestObject a;
+  ForwardingTestObject b;
+  assert(!fn(a, b));
+  assert(fn(std::move(a), std::move(b)));
+
+  assert(!fn(2, 2));
+  assert(!fn(1, 2));
+  assert(fn(2, 1));
+
+  assert(fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for greater<int*> and greater<void>.
+  do_pointer_comparison_test(std::ranges::greater());
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/greater_equal.pass.cpp
+++ b/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/greater_equal.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <functional>
+
+// ranges::greater_equal
+
+#include <cassert>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotTotallyOrdered {
+  friend bool operator<(const NotTotallyOrdered&, const NotTotallyOrdered&);
+};
+
+static_assert(!std::is_invocable_v<std::ranges::greater_equal, NotTotallyOrdered, NotTotallyOrdered>);
+static_assert(!std::is_invocable_v<std::ranges::greater_equal, int, MoveOnly>);
+static_assert(std::is_invocable_v<std::ranges::greater_equal, explicit_operators, explicit_operators>);
+
+static_assert(requires { typename std::ranges::greater_equal::is_transparent; });
+
+constexpr bool test() {
+  auto fn = std::ranges::greater_equal();
+
+  assert(fn(MoveOnly(42), MoveOnly(42)));
+
+  ForwardingTestObject a;
+  ForwardingTestObject b;
+  assert(fn(a, b));
+  assert(!fn(std::move(a), std::move(b)));
+
+  assert(fn(2, 2));
+  assert(fn(2, 1));
+  assert(!fn(1, 2));
+
+  assert(fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for greater_equal<int*> and greater_equal<void>.
+  do_pointer_comparison_test(std::ranges::greater_equal());
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/less.pass.cpp
+++ b/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/less.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <functional>
+
+// ranges::less
+
+#include <cassert>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotTotallyOrdered {
+  friend bool operator<(const NotTotallyOrdered&, const NotTotallyOrdered&);
+};
+
+static_assert(!std::is_invocable_v<std::ranges::less, NotTotallyOrdered, NotTotallyOrdered>);
+static_assert(!std::is_invocable_v<std::ranges::less, int, MoveOnly>);
+static_assert(std::is_invocable_v<std::ranges::less, explicit_operators, explicit_operators>);
+
+static_assert(requires { typename std::ranges::less::is_transparent; });
+
+constexpr bool test() {
+  auto fn = std::ranges::less();
+
+  assert(fn(MoveOnly(41), MoveOnly(42)));
+
+  ForwardingTestObject a;
+  ForwardingTestObject b;
+  assert(!fn(a, b));
+  assert(fn(std::move(a), std::move(b)));
+
+  assert(fn(1, 2));
+  assert(!fn(2, 2));
+  assert(!fn(2, 1));
+
+  assert(!fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for less<int*> and less<void>.
+  do_pointer_comparison_test(std::ranges::less());
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/less_equal.pass.cpp
+++ b/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/less_equal.pass.cpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <functional>
+
+// ranges::less_equal
+
+#include <cassert>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotTotallyOrdered {
+  friend bool operator<(const NotTotallyOrdered&, const NotTotallyOrdered&);
+};
+
+static_assert(!std::is_invocable_v<std::ranges::less_equal, NotTotallyOrdered, NotTotallyOrdered>);
+static_assert(!std::is_invocable_v<std::ranges::less_equal, int, MoveOnly>);
+static_assert(std::is_invocable_v<std::ranges::less_equal, explicit_operators, explicit_operators>);
+
+static_assert(requires { typename std::ranges::less_equal::is_transparent; });
+
+constexpr bool test() {
+  auto fn = std::ranges::less_equal();
+
+  assert(fn(MoveOnly(41), MoveOnly(42)));
+
+  // These are the opposite of other tests.
+  ForwardingTestObject a;
+  ForwardingTestObject b;
+  assert(fn(a, b));
+  assert(!fn(std::move(a), std::move(b)));
+
+  assert(fn(1, 2));
+  assert(fn(2, 2));
+  assert(!fn(2, 1));
+
+  assert(!fn(2, 1L));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for less_equal<int*> and less_equal<void>.
+  do_pointer_comparison_test(std::ranges::less_equal());
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/not_equal_to.pass.cpp
+++ b/libcudacxx/libcxx/test/std/utilities/function.objects/range.cmp/not_equal_to.pass.cpp
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <functional>
+
+// ranges::not_equal_to
+
+#include <cassert>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include "test_macros.h"
+#include "compare_types.h"
+#include "MoveOnly.h"
+#include "pointer_comparison_test_helper.h"
+
+struct NotEqualityComparable {
+  friend bool operator==(const NotEqualityComparable&, const NotEqualityComparable&);
+  friend bool operator!=(const NotEqualityComparable&, const NotEqualityComparable&) = delete;
+};
+
+static_assert(!std::is_invocable_v<std::ranges::equal_to, NotEqualityComparable, NotEqualityComparable>);
+static_assert(!std::is_invocable_v<std::ranges::equal_to, int, MoveOnly>);
+static_assert(std::is_invocable_v<std::ranges::equal_to, explicit_operators, explicit_operators>);
+
+static_assert(requires { typename std::ranges::not_equal_to::is_transparent; });
+
+struct PtrAndNotEqOperator {
+  constexpr operator void*() const { return nullptr; }
+  // We *don't* want operator!= to be picked here.
+  friend constexpr bool operator!=(PtrAndNotEqOperator, PtrAndNotEqOperator) { return true; }
+};
+
+constexpr bool test() {
+  auto fn = std::ranges::not_equal_to();
+
+  assert(fn(MoveOnly(41), MoveOnly(42)));
+
+  // These are the opposite of other tests.
+  ForwardingTestObject a;
+  ForwardingTestObject b;
+  assert(fn(a, b));
+  assert(!fn(std::move(a), std::move(b)));
+
+  assert(fn(1, 2));
+  assert(!fn(2, 2));
+  assert(fn(2, 1));
+
+  assert(fn(2, 1L));
+
+  // Make sure that "ranges::equal_to(x, y) == !ranges::not_equal_to(x, y)", even here.
+  assert(!fn(PtrAndNotEqOperator(), PtrAndNotEqOperator()));
+  assert(std::ranges::equal_to()(PtrAndNotEqOperator(), PtrAndNotEqOperator()));
+
+  return true;
+}
+
+int main(int, char**) {
+
+  test();
+  static_assert(test());
+
+  // test total ordering of int* for not_equal_to<int*> and not_equal_to<void>.
+  do_pointer_comparison_test(std::ranges::not_equal_to());
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/support/compare_types.h
+++ b/libcudacxx/libcxx/test/support/compare_types.h
@@ -1,0 +1,532 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_SUPPORT_COMPARE_TYPES_H
+#define TEST_SUPPORT_COMPARE_TYPES_H
+
+#include <compare>
+#include <concepts>
+#include <type_traits>
+
+// `noexcept` specifiers deliberately imperfect since not all programmers bother to put the
+// specifiers on their overloads.
+
+struct equality_comparable_with_ec1;
+struct no_neq;
+
+struct cxx20_member_eq {
+  bool operator==(cxx20_member_eq const&) const = default;
+};
+
+struct cxx20_friend_eq {
+  friend bool operator==(cxx20_friend_eq const&, cxx20_friend_eq const&) = default;
+};
+
+struct member_three_way_comparable {
+  auto operator<=>(member_three_way_comparable const&) const = default;
+};
+
+struct friend_three_way_comparable {
+  friend auto operator<=>(friend_three_way_comparable const&, friend_three_way_comparable const&) = default;
+};
+
+struct explicit_operators {
+  friend bool operator==(explicit_operators, explicit_operators) noexcept;
+  friend bool operator!=(explicit_operators, explicit_operators) noexcept;
+  friend bool operator<(explicit_operators, explicit_operators) noexcept;
+  friend bool operator>(explicit_operators, explicit_operators) noexcept;
+  friend bool operator<=(explicit_operators, explicit_operators) noexcept;
+  friend bool operator>=(explicit_operators, explicit_operators) noexcept;
+
+  friend bool operator==(explicit_operators const&, equality_comparable_with_ec1 const&) noexcept;
+  friend bool operator==(equality_comparable_with_ec1 const&, explicit_operators const&) noexcept;
+  friend bool operator!=(explicit_operators const&, equality_comparable_with_ec1 const&) noexcept;
+  friend bool operator!=(equality_comparable_with_ec1 const&, explicit_operators const&) noexcept;
+};
+
+struct different_return_types {
+  bool operator==(different_return_types) const noexcept;
+  char operator!=(different_return_types) const noexcept;
+  short operator<(different_return_types) const noexcept;
+  int operator>(different_return_types) const noexcept;
+  long operator<=(different_return_types) const noexcept;
+  long long operator>=(different_return_types) const noexcept;
+
+  friend signed char operator==(explicit_operators, different_return_types);
+  friend unsigned char operator==(different_return_types, explicit_operators);
+  friend float operator!=(explicit_operators, different_return_types);
+  friend double operator!=(different_return_types, explicit_operators);
+
+  operator explicit_operators() const;
+};
+
+struct boolean {
+  operator bool() const noexcept;
+};
+
+struct one_member_one_friend {
+  friend boolean operator==(one_member_one_friend, one_member_one_friend) noexcept;
+  boolean operator!=(one_member_one_friend) const noexcept;
+
+  operator explicit_operators() const noexcept;
+  operator different_return_types() const noexcept;
+};
+
+struct equality_comparable_with_ec1 {
+  bool operator==(equality_comparable_with_ec1) const noexcept;
+  bool operator!=(equality_comparable_with_ec1) const noexcept;
+  operator explicit_operators() const noexcept;
+};
+
+struct no_eq {
+  friend bool operator==(no_eq, no_eq) = delete;
+  friend bool operator!=(no_eq, no_eq) noexcept;
+  friend bool operator<(no_eq, no_eq) noexcept;
+  friend bool operator>(no_eq, no_eq) noexcept;
+  friend bool operator>=(no_eq, no_eq) noexcept;
+  friend bool operator<=(no_eq, no_eq) noexcept;
+};
+
+struct no_neq {
+  friend bool operator==(no_neq, no_neq) noexcept;
+  friend bool operator!=(no_neq, no_neq) = delete;
+  friend bool operator<(no_eq, no_eq) noexcept;
+  friend bool operator>(no_eq, no_eq) noexcept;
+  friend bool operator>=(no_eq, no_eq) noexcept;
+  friend bool operator<=(no_eq, no_eq) noexcept;
+};
+
+struct no_lt {
+  friend bool operator==(no_lt, no_lt) noexcept;
+  friend bool operator!=(no_lt, no_lt) noexcept;
+  friend bool operator<(no_lt, no_lt) = delete;
+  friend bool operator>(no_lt, no_lt) noexcept;
+  friend bool operator>=(no_lt, no_lt) noexcept;
+  friend bool operator<=(no_lt, no_lt) noexcept;
+};
+
+struct no_gt {
+  friend bool operator==(no_gt, no_gt) noexcept;
+  friend bool operator!=(no_gt, no_gt) noexcept;
+  friend bool operator<(no_gt, no_gt) noexcept;
+  friend bool operator>(no_gt, no_gt) = delete;
+  friend bool operator>=(no_gt, no_gt) noexcept;
+  friend bool operator<=(no_gt, no_gt) noexcept;
+};
+
+struct no_le {
+  friend bool operator==(no_le, no_le) noexcept;
+  friend bool operator!=(no_le, no_le) noexcept;
+  friend bool operator<(no_le, no_le) noexcept;
+  friend bool operator>(no_le, no_le) noexcept;
+  friend bool operator>=(no_le, no_le) = delete;
+  friend bool operator<=(no_le, no_le) noexcept;
+};
+
+struct no_ge {
+  friend bool operator==(no_ge, no_ge) noexcept;
+  friend bool operator!=(no_ge, no_ge) noexcept;
+  friend bool operator<(no_ge, no_ge) noexcept;
+  friend bool operator>(no_ge, no_ge) noexcept;
+  friend bool operator>=(no_ge, no_ge) noexcept;
+  friend bool operator<=(no_ge, no_ge) = delete;
+};
+
+struct wrong_return_type_eq {
+  void operator==(wrong_return_type_eq) const noexcept;
+  bool operator!=(wrong_return_type_eq) const noexcept;
+  bool operator<(wrong_return_type_eq) const noexcept;
+  bool operator>(wrong_return_type_eq) const noexcept;
+  bool operator>=(wrong_return_type_eq) const noexcept;
+  bool operator<=(wrong_return_type_eq) const noexcept;
+};
+
+struct wrong_return_type_ne {
+  bool operator==(wrong_return_type_ne) const noexcept;
+  void operator!=(wrong_return_type_ne) const noexcept;
+  bool operator<(wrong_return_type_ne) const noexcept;
+  bool operator>(wrong_return_type_ne) const noexcept;
+  bool operator>=(wrong_return_type_ne) const noexcept;
+  bool operator<=(wrong_return_type_ne) const noexcept;
+};
+
+struct wrong_return_type_lt {
+  bool operator==(wrong_return_type_lt) const noexcept;
+  bool operator!=(wrong_return_type_lt) const noexcept;
+  void operator<(wrong_return_type_lt) const noexcept;
+  bool operator>(wrong_return_type_lt) const noexcept;
+  bool operator>=(wrong_return_type_lt) const noexcept;
+  bool operator<=(wrong_return_type_lt) const noexcept;
+};
+
+struct wrong_return_type_gt {
+  bool operator==(wrong_return_type_gt) const noexcept;
+  bool operator!=(wrong_return_type_gt) const noexcept;
+  bool operator<(wrong_return_type_gt) const noexcept;
+  void operator>(wrong_return_type_gt) const noexcept;
+  bool operator>=(wrong_return_type_gt) const noexcept;
+  bool operator<=(wrong_return_type_gt) const noexcept;
+};
+
+struct wrong_return_type_le {
+  bool operator==(wrong_return_type_le) const noexcept;
+  bool operator!=(wrong_return_type_le) const noexcept;
+  bool operator<(wrong_return_type_le) const noexcept;
+  bool operator>(wrong_return_type_le) const noexcept;
+  void operator>=(wrong_return_type_le) const noexcept;
+  bool operator<=(wrong_return_type_le) const noexcept;
+};
+
+struct wrong_return_type_ge {
+  bool operator==(wrong_return_type_ge) const noexcept;
+  bool operator!=(wrong_return_type_ge) const noexcept;
+  bool operator<(wrong_return_type_ge) const noexcept;
+  bool operator>(wrong_return_type_ge) const noexcept;
+  bool operator>=(wrong_return_type_ge) const noexcept;
+  void operator<=(wrong_return_type_ge) const noexcept;
+};
+
+struct wrong_return_type {
+  void operator==(wrong_return_type) const noexcept;
+  void operator!=(wrong_return_type) const noexcept;
+  void operator<(wrong_return_type) const noexcept;
+  void operator>(wrong_return_type) const noexcept;
+  void operator>=(wrong_return_type) const noexcept;
+  void operator<=(wrong_return_type_ge) const noexcept;
+};
+
+struct cxx20_member_eq_operator_with_deleted_ne {
+  bool operator==(cxx20_member_eq_operator_with_deleted_ne const&) const = default;
+  bool operator!=(cxx20_member_eq_operator_with_deleted_ne const&) const = delete;
+};
+
+struct cxx20_friend_eq_operator_with_deleted_ne {
+  friend bool operator==(cxx20_friend_eq_operator_with_deleted_ne const&,
+                         cxx20_friend_eq_operator_with_deleted_ne const&) = default;
+  friend bool operator!=(cxx20_friend_eq_operator_with_deleted_ne const&,
+                         cxx20_friend_eq_operator_with_deleted_ne const&) = delete;
+};
+
+struct member_three_way_comparable_with_deleted_eq {
+  auto operator<=>(member_three_way_comparable_with_deleted_eq const&) const = default;
+  bool operator==(member_three_way_comparable_with_deleted_eq const&) const = delete;
+};
+
+struct member_three_way_comparable_with_deleted_ne {
+  auto operator<=>(member_three_way_comparable_with_deleted_ne const&) const = default;
+  bool operator!=(member_three_way_comparable_with_deleted_ne const&) const = delete;
+};
+
+struct friend_three_way_comparable_with_deleted_eq {
+  friend auto operator<=>(friend_three_way_comparable_with_deleted_eq const&,
+                          friend_three_way_comparable_with_deleted_eq const&) = default;
+  friend bool operator==(friend_three_way_comparable_with_deleted_eq const&,
+                         friend_three_way_comparable_with_deleted_eq const&) = delete;
+};
+
+struct friend_three_way_comparable_with_deleted_ne {
+  friend auto operator<=>(friend_three_way_comparable_with_deleted_ne const&,
+                          friend_three_way_comparable_with_deleted_ne const&) = default;
+  friend bool operator!=(friend_three_way_comparable_with_deleted_ne const&,
+                         friend_three_way_comparable_with_deleted_ne const&) = delete;
+};
+
+struct one_way_eq {
+  bool operator==(one_way_eq const&) const = default;
+  friend bool operator==(one_way_eq, explicit_operators);
+  friend bool operator==(explicit_operators, one_way_eq) = delete;
+
+  operator explicit_operators() const;
+};
+
+struct one_way_ne {
+  bool operator==(one_way_ne const&) const = default;
+  friend bool operator==(one_way_ne, explicit_operators);
+  friend bool operator!=(one_way_ne, explicit_operators) = delete;
+
+  operator explicit_operators() const;
+};
+static_assert(requires(explicit_operators const x, one_way_ne const y) { x != y; });
+
+struct explicit_bool {
+  explicit operator bool() const noexcept;
+};
+
+struct totally_ordered_with_others {
+  auto operator<=>(totally_ordered_with_others const&) const = default;
+};
+
+struct no_lt_not_totally_ordered_with {
+  bool operator==(no_lt_not_totally_ordered_with const&) const = default;
+  auto operator<=>(no_lt_not_totally_ordered_with const&) const = default;
+  operator totally_ordered_with_others() const noexcept;
+
+  bool operator==(totally_ordered_with_others const&) const;
+  auto operator<=>(totally_ordered_with_others const&) const;
+  auto operator<(totally_ordered_with_others const&) const;
+};
+
+struct no_gt_not_totally_ordered_with {
+  bool operator==(no_gt_not_totally_ordered_with const&) const = default;
+  auto operator<=>(no_gt_not_totally_ordered_with const&) const = default;
+  operator totally_ordered_with_others() const noexcept;
+
+  bool operator==(totally_ordered_with_others const&) const;
+  auto operator<=>(totally_ordered_with_others const&) const;
+  auto operator>(totally_ordered_with_others const&) const;
+};
+
+struct no_le_not_totally_ordered_with {
+  bool operator==(no_le_not_totally_ordered_with const&) const = default;
+  auto operator<=>(no_le_not_totally_ordered_with const&) const = default;
+  operator totally_ordered_with_others() const noexcept;
+
+  bool operator==(totally_ordered_with_others const&) const;
+  auto operator<=>(totally_ordered_with_others const&) const;
+  auto operator<=(totally_ordered_with_others const&) const;
+};
+
+struct no_ge_not_totally_ordered_with {
+  bool operator==(no_ge_not_totally_ordered_with const&) const = default;
+  auto operator<=>(no_ge_not_totally_ordered_with const&) const = default;
+  operator totally_ordered_with_others() const noexcept;
+
+  bool operator==(totally_ordered_with_others const&) const;
+  auto operator<=>(totally_ordered_with_others const&) const;
+  auto operator>=(totally_ordered_with_others const&) const;
+};
+
+struct partial_ordering_totally_ordered_with {
+  auto operator<=>(partial_ordering_totally_ordered_with const&) const noexcept = default;
+  std::partial_ordering operator<=>(totally_ordered_with_others const&) const noexcept;
+
+  operator totally_ordered_with_others() const;
+};
+
+struct weak_ordering_totally_ordered_with {
+  auto operator<=>(weak_ordering_totally_ordered_with const&) const noexcept = default;
+  std::weak_ordering operator<=>(totally_ordered_with_others const&) const noexcept;
+
+  operator totally_ordered_with_others() const;
+};
+
+struct strong_ordering_totally_ordered_with {
+  auto operator<=>(strong_ordering_totally_ordered_with const&) const noexcept = default;
+  std::strong_ordering operator<=>(totally_ordered_with_others const&) const noexcept;
+
+  operator totally_ordered_with_others() const;
+};
+
+struct eq_returns_explicit_bool {
+  friend explicit_bool operator==(eq_returns_explicit_bool, eq_returns_explicit_bool);
+  friend bool operator!=(eq_returns_explicit_bool, eq_returns_explicit_bool);
+  friend bool operator<(eq_returns_explicit_bool, eq_returns_explicit_bool);
+  friend bool operator>(eq_returns_explicit_bool, eq_returns_explicit_bool);
+  friend bool operator<=(eq_returns_explicit_bool, eq_returns_explicit_bool);
+  friend bool operator>=(eq_returns_explicit_bool, eq_returns_explicit_bool);
+
+  operator totally_ordered_with_others() const;
+
+  friend explicit_bool operator==(eq_returns_explicit_bool, totally_ordered_with_others);
+  friend explicit_bool operator==(totally_ordered_with_others, eq_returns_explicit_bool);
+  friend bool operator!=(eq_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator!=(totally_ordered_with_others, eq_returns_explicit_bool);
+  friend bool operator<(eq_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<(totally_ordered_with_others, eq_returns_explicit_bool);
+  friend bool operator>(eq_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>(totally_ordered_with_others, eq_returns_explicit_bool);
+  friend bool operator<=(eq_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<=(totally_ordered_with_others, eq_returns_explicit_bool);
+  friend bool operator>=(eq_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>=(totally_ordered_with_others, eq_returns_explicit_bool);
+};
+
+struct ne_returns_explicit_bool {
+  friend bool operator==(ne_returns_explicit_bool, ne_returns_explicit_bool);
+  friend explicit_bool operator!=(ne_returns_explicit_bool, ne_returns_explicit_bool);
+  friend bool operator<(ne_returns_explicit_bool, ne_returns_explicit_bool);
+  friend bool operator>(ne_returns_explicit_bool, ne_returns_explicit_bool);
+  friend bool operator<=(ne_returns_explicit_bool, ne_returns_explicit_bool);
+  friend bool operator>=(ne_returns_explicit_bool, ne_returns_explicit_bool);
+
+  operator totally_ordered_with_others() const;
+
+  friend bool operator==(ne_returns_explicit_bool, totally_ordered_with_others);
+  friend explicit_bool operator!=(ne_returns_explicit_bool, totally_ordered_with_others);
+  friend explicit_bool operator!=(totally_ordered_with_others, ne_returns_explicit_bool);
+  friend bool operator<(ne_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<(totally_ordered_with_others, ne_returns_explicit_bool);
+  friend bool operator>(ne_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>(totally_ordered_with_others, ne_returns_explicit_bool);
+  friend bool operator<=(ne_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<=(totally_ordered_with_others, ne_returns_explicit_bool);
+  friend bool operator>=(ne_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>=(totally_ordered_with_others, ne_returns_explicit_bool);
+};
+
+struct lt_returns_explicit_bool {
+  friend bool operator==(lt_returns_explicit_bool, lt_returns_explicit_bool);
+  friend bool operator!=(lt_returns_explicit_bool, lt_returns_explicit_bool);
+  friend explicit_bool operator<(lt_returns_explicit_bool, lt_returns_explicit_bool);
+  friend bool operator>(lt_returns_explicit_bool, lt_returns_explicit_bool);
+  friend bool operator<=(lt_returns_explicit_bool, lt_returns_explicit_bool);
+  friend bool operator>=(lt_returns_explicit_bool, lt_returns_explicit_bool);
+
+  operator totally_ordered_with_others() const;
+
+  friend bool operator==(lt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator!=(lt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator!=(totally_ordered_with_others, lt_returns_explicit_bool);
+  friend explicit_bool operator<(lt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<(totally_ordered_with_others, lt_returns_explicit_bool);
+  friend bool operator>(lt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>(totally_ordered_with_others, lt_returns_explicit_bool);
+  friend bool operator<=(lt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<=(totally_ordered_with_others, lt_returns_explicit_bool);
+  friend bool operator>=(lt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>=(totally_ordered_with_others, lt_returns_explicit_bool);
+};
+
+struct gt_returns_explicit_bool {
+  friend bool operator==(gt_returns_explicit_bool, gt_returns_explicit_bool);
+  friend bool operator!=(gt_returns_explicit_bool, gt_returns_explicit_bool);
+  friend bool operator<(gt_returns_explicit_bool, gt_returns_explicit_bool);
+  friend explicit_bool operator>(gt_returns_explicit_bool, gt_returns_explicit_bool);
+  friend bool operator<=(gt_returns_explicit_bool, gt_returns_explicit_bool);
+  friend bool operator>=(gt_returns_explicit_bool, gt_returns_explicit_bool);
+
+  operator totally_ordered_with_others() const;
+
+  friend bool operator==(gt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator!=(gt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator!=(totally_ordered_with_others, gt_returns_explicit_bool);
+  friend bool operator<(gt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<(totally_ordered_with_others, gt_returns_explicit_bool);
+  friend explicit_bool operator>(gt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>(totally_ordered_with_others, gt_returns_explicit_bool);
+  friend bool operator<=(gt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<=(totally_ordered_with_others, gt_returns_explicit_bool);
+  friend bool operator>=(gt_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>=(totally_ordered_with_others, gt_returns_explicit_bool);
+};
+
+struct le_returns_explicit_bool {
+  friend bool operator==(le_returns_explicit_bool, le_returns_explicit_bool);
+  friend bool operator!=(le_returns_explicit_bool, le_returns_explicit_bool);
+  friend bool operator<(le_returns_explicit_bool, le_returns_explicit_bool);
+  friend bool operator>(le_returns_explicit_bool, le_returns_explicit_bool);
+  friend explicit_bool operator<=(le_returns_explicit_bool, le_returns_explicit_bool);
+  friend bool operator>=(le_returns_explicit_bool, le_returns_explicit_bool);
+
+  operator totally_ordered_with_others() const;
+
+  friend bool operator==(le_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator!=(le_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator!=(totally_ordered_with_others, le_returns_explicit_bool);
+  friend bool operator<(le_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<(totally_ordered_with_others, le_returns_explicit_bool);
+  friend bool operator>(le_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>(totally_ordered_with_others, le_returns_explicit_bool);
+  friend bool operator<=(le_returns_explicit_bool, totally_ordered_with_others);
+  friend explicit_bool operator<=(totally_ordered_with_others, le_returns_explicit_bool);
+  friend bool operator>=(le_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>=(totally_ordered_with_others, le_returns_explicit_bool);
+};
+
+struct ge_returns_explicit_bool {
+  friend bool operator==(ge_returns_explicit_bool, ge_returns_explicit_bool);
+  friend bool operator!=(ge_returns_explicit_bool, ge_returns_explicit_bool);
+  friend bool operator<(ge_returns_explicit_bool, ge_returns_explicit_bool);
+  friend bool operator>(ge_returns_explicit_bool, ge_returns_explicit_bool);
+  friend bool operator<=(ge_returns_explicit_bool, ge_returns_explicit_bool);
+  friend explicit_bool operator>=(ge_returns_explicit_bool, ge_returns_explicit_bool);
+
+  operator totally_ordered_with_others() const;
+
+  friend bool operator==(ge_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator!=(ge_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator!=(totally_ordered_with_others, ge_returns_explicit_bool);
+  friend bool operator<(ge_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<(totally_ordered_with_others, ge_returns_explicit_bool);
+  friend bool operator>(ge_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator>(totally_ordered_with_others, ge_returns_explicit_bool);
+  friend bool operator<=(ge_returns_explicit_bool, totally_ordered_with_others);
+  friend bool operator<=(totally_ordered_with_others, ge_returns_explicit_bool);
+  friend bool operator>=(ge_returns_explicit_bool, totally_ordered_with_others);
+  friend explicit_bool operator>=(totally_ordered_with_others, ge_returns_explicit_bool);
+};
+
+struct returns_true_type {
+  friend std::true_type operator==(returns_true_type, returns_true_type);
+  friend std::true_type operator!=(returns_true_type, returns_true_type);
+  friend std::true_type operator<(returns_true_type, returns_true_type);
+  friend std::true_type operator>(returns_true_type, returns_true_type);
+  friend std::true_type operator<=(returns_true_type, returns_true_type);
+  friend std::true_type operator>=(returns_true_type, returns_true_type);
+
+  operator totally_ordered_with_others() const;
+
+  friend std::true_type operator==(returns_true_type, totally_ordered_with_others);
+  friend std::true_type operator==(totally_ordered_with_others, returns_true_type);
+  friend std::true_type operator!=(returns_true_type, totally_ordered_with_others);
+  friend std::true_type operator!=(totally_ordered_with_others, returns_true_type);
+  friend std::true_type operator<(returns_true_type, totally_ordered_with_others);
+  friend std::true_type operator<(totally_ordered_with_others, returns_true_type);
+  friend std::true_type operator>(returns_true_type, totally_ordered_with_others);
+  friend std::true_type operator>(totally_ordered_with_others, returns_true_type);
+  friend std::true_type operator<=(returns_true_type, totally_ordered_with_others);
+  friend std::true_type operator<=(totally_ordered_with_others, returns_true_type);
+  friend std::true_type operator>=(returns_true_type, totally_ordered_with_others);
+  friend std::true_type operator>=(totally_ordered_with_others, returns_true_type);
+};
+
+struct returns_int_ptr {
+  friend int* operator==(returns_int_ptr, returns_int_ptr);
+  friend int* operator!=(returns_int_ptr, returns_int_ptr);
+  friend int* operator<(returns_int_ptr, returns_int_ptr);
+  friend int* operator>(returns_int_ptr, returns_int_ptr);
+  friend int* operator<=(returns_int_ptr, returns_int_ptr);
+  friend int* operator>=(returns_int_ptr, returns_int_ptr);
+
+  operator totally_ordered_with_others() const;
+
+  friend int* operator==(returns_int_ptr, totally_ordered_with_others);
+  friend int* operator==(totally_ordered_with_others, returns_int_ptr);
+  friend int* operator!=(returns_int_ptr, totally_ordered_with_others);
+  friend int* operator!=(totally_ordered_with_others, returns_int_ptr);
+  friend int* operator<(returns_int_ptr, totally_ordered_with_others);
+  friend int* operator<(totally_ordered_with_others, returns_int_ptr);
+  friend int* operator>(returns_int_ptr, totally_ordered_with_others);
+  friend int* operator>(totally_ordered_with_others, returns_int_ptr);
+  friend int* operator<=(returns_int_ptr, totally_ordered_with_others);
+  friend int* operator<=(totally_ordered_with_others, returns_int_ptr);
+  friend int* operator>=(returns_int_ptr, totally_ordered_with_others);
+  friend int* operator>=(totally_ordered_with_others, returns_int_ptr);
+};
+
+struct ForwardingTestObject {
+  constexpr bool operator<(ForwardingTestObject&&) && { return true; }
+  constexpr bool operator<(const ForwardingTestObject&) const& { return false; }
+
+  constexpr bool operator==(ForwardingTestObject&&) && { return true; }
+  constexpr bool operator==(const ForwardingTestObject&) const& { return false; }
+
+  constexpr bool operator!=(ForwardingTestObject&&) && { return true; }
+  constexpr bool operator!=(const ForwardingTestObject&) const& { return false; }
+
+  constexpr bool operator<=(ForwardingTestObject&&) && { return true; }
+  constexpr bool operator<=(const ForwardingTestObject&) const& { return false; }
+
+  constexpr bool operator>(ForwardingTestObject&&) && { return true; }
+  constexpr bool operator>(const ForwardingTestObject&) const& { return false; }
+
+  constexpr bool operator>=(ForwardingTestObject&&) && { return true; }
+  constexpr bool operator>=(const ForwardingTestObject&) const& { return false; }
+};
+
+#endif // TEST_SUPPORT_COMPARE_TYPES_H


### PR DESCRIPTION
This implements the various comparison objects that come with `std::ranges`

Fixes #463