### PR TITLE
Fix CUB/MSVC/RDC tests

### DIFF
--- a/cub/CMakeLists.txt
+++ b/cub/CMakeLists.txt
@@ -1,5 +1,6 @@
 # 3.15 is the minimum for including the project with add_subdirectory.
 # 3.21 is the minimum for the developer build.
+# 3.27.5 is the minimum for MSVC build with RDC=true.
 cmake_minimum_required(VERSION 3.15)
 
 # CXX is only needed for AppendOptionIfAvailable.

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -3,6 +3,7 @@ if(CMAKE_GENERATOR MATCHES "^Visual Studio")
     if("${CMAKE_VERSION}" VERSION_LESS 3.27.5)
       # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8794
       message(WARNING "CMake 3.27.5 or newer is required to enable RDC tests in Visual Studio.")
+      cmake_minimum_required(VERSION 3.27.5)
     endif()
   endif()
 endif()

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -1,3 +1,12 @@
+if(CMAKE_GENERATOR MATCHES "^Visual Studio")
+  if(CUB_ENABLE_RDC_TESTS)
+    if("${CMAKE_VERSION}" VERSION_LESS 3.27.5)
+      # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8794
+      message(WARNING "CMake 3.27.5 or newer is required to enable RDC tests in Visual Studio.")
+    endif()
+  endif()
+endif()
+
 if ("NVHPC" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
   # NVBugs 200770766
   set(CUB_SEPARATE_CATCH2 ON)
@@ -131,7 +140,7 @@ endfunction()
 # test_src: The source file that implements the test.
 # cub_target: The reference cub target with configuration information.
 #
-function(cub_add_test target_name_var test_name test_src cub_target)
+function(cub_add_test target_name_var test_name test_src cub_target cdp)
   cub_get_target_property(config_prefix ${cub_target} PREFIX)
 
   cub_is_catch2_test(is_catch2_test "${test_src}")
@@ -142,32 +151,20 @@ function(cub_add_test target_name_var test_name test_src cub_target)
 
   set(config_meta_target ${config_prefix}.tests)
 
-  if (is_catch2_test)
-    set(use_rdc_for_catch2_utils OFF)
-    if (CUB_ENABLE_RDC_TESTS OR CUB_FORCE_RDC)
-      set(use_rdc_for_catch2_utils ON)
-    endif()
+  if (${cdp})
+    set(cdp_val 1)
+  else()
+    set(cdp_val 0)
+  endif()
 
+  if (is_catch2_test)
     # Per config helper library:
-    set(config_c2h_target ${config_prefix}.test.catch2_helper)
+    set(config_c2h_target ${config_prefix}.test.catch2_helper.cdp_${cdp_val})
     if (NOT TARGET ${config_c2h_target})
       add_library(${config_c2h_target} STATIC c2h/generators.cu)
-      set_property(TARGET ${config_c2h_target}
-        PROPERTY POSITION_INDEPENDENT_CODE ON
-      )
-
-      if ("NVHPC" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
-        target_link_options(${config_c2h_target} PRIVATE "-cuda")
-        target_compile_options(${config_c2h_target} PRIVATE "-fPIC")
-      endif()
-
-      target_include_directories(${config_c2h_target}
-        PUBLIC "${CUB_SOURCE_DIR}/test"
-      )
-
+      target_include_directories(${config_c2h_target} PUBLIC "${CUB_SOURCE_DIR}/test")
       cub_clone_target_properties(${config_c2h_target} ${cub_target})
-      cub_configure_cuda_target(${config_c2h_target} RDC ${use_rdc_for_catch2_utils})
-
+      cub_configure_cuda_target(${config_c2h_target} RDC ${cdp_val})
       target_link_libraries(${config_c2h_target} PRIVATE ${cub_target})
       if (CUB_C2H_ENABLE_CURAND)
         target_link_libraries(${config_c2h_target} PRIVATE CUDA::curand)
@@ -189,18 +186,16 @@ function(cub_add_test target_name_var test_name test_src cub_target)
       add_test(NAME ${test_target} COMMAND "$<TARGET_FILE:${test_target}>")
     else() # Not CUB_SEPARATE_CATCH2
       # Per config catch2 runner
-      set(config_c2run_target ${config_prefix}.catch2_test)
+      set(config_c2run_target ${config_prefix}.catch2_test.cdp_${cdp_val})
       if (NOT TARGET ${config_c2run_target})
-        add_executable(${config_c2run_target} catch2_runner.cpp)
+        add_executable(${config_c2run_target} catch2_runner.cpp catch2_runner_helper.cu)
         target_link_libraries(${config_c2run_target} PRIVATE
           ${cub_target}
           ${config_c2h_target}
           Metal
-          Catch2::Catch2
-          CUDA::cudart
-        )
+          Catch2::Catch2)
         cub_clone_target_properties(${config_c2run_target} ${cub_target})
-        cub_configure_cuda_target(${config_c2run_target} RDC ${use_rdc_for_catch2_utils})
+        cub_configure_cuda_target(${config_c2run_target} RDC ${cdp_val})
         add_dependencies(${config_meta_target} ${config_c2run_target})
         target_include_directories(${config_c2run_target} PRIVATE
           "${CUB_SOURCE_DIR}/test"
@@ -219,7 +214,13 @@ function(cub_add_test target_name_var test_name test_src cub_target)
       endif() # per config catch2 runner
 
       add_library(${test_target} OBJECT "${test_src}")
-      target_link_libraries(${config_c2run_target} PRIVATE ${test_target})
+
+      if(CMAKE_GENERATOR MATCHES "^Visual Studio")
+        target_link_libraries(${config_c2run_target} PRIVATE $<TARGET_OBJECTS:${test_target}>)
+      else()
+        target_link_libraries(${config_c2run_target} PRIVATE ${test_target})
+      endif()
+      
     endif() # CUB_SEPARATE_CATCH2
 
     if (CUB_IN_THRUST)
@@ -312,7 +313,7 @@ foreach (test_src IN LISTS test_srcs)
 
     if (num_variants EQUAL 0)
       # Only one version of this test.
-      cub_add_test(test_target ${test_name} "${test_src}" ${cub_target})
+      cub_add_test(test_target ${test_name} "${test_src}" ${cub_target} ${CUB_FORCE_RDC})
       cub_configure_cuda_target(${test_target} RDC ${CUB_FORCE_RDC})
     else() # has variants:
       # Meta target to build all parametrizations of the current test for the
@@ -346,15 +347,6 @@ foreach (test_src IN LISTS test_srcs)
           continue()
         endif()
 
-        cub_add_test(test_target
-          ${test_name}.${label}
-          "${test_src}"
-          ${cub_target}
-        )
-        add_dependencies(${variant_meta_target} ${test_target})
-        add_dependencies(${cub_variant_meta_target} ${test_target})
-        target_compile_definitions(${test_target} PRIVATE ${defs})
-
         # Enable RDC if the test either:
         # 1. Explicitly requests it (cdp_1 label)
         # 2. Does not have an explicit CDP variant (no cdp_0 or cdp_1) but
@@ -363,10 +355,20 @@ foreach (test_src IN LISTS test_srcs)
         # Tests that explicitly request no cdp (cdp_0 label) should never enable
         # RDC.
         if (explicit_cdp)
-          cub_configure_cuda_target(${test_target} RDC ${enable_cdp})
+          set(cdp_val ${enable_cdp})
         else()
-          cub_configure_cuda_target(${test_target} RDC ${CUB_FORCE_RDC})
+          set(cdp_val ${CUB_FORCE_RDC})
         endif()
+
+        cub_add_test(test_target
+          ${test_name}.${label}
+          "${test_src}"
+          ${cub_target}
+          ${cdp_val})
+        cub_configure_cuda_target(${test_target} RDC ${cdp_val})
+        add_dependencies(${variant_meta_target} ${test_target})
+        add_dependencies(${cub_variant_meta_target} ${test_target})
+        target_compile_definitions(${test_target} PRIVATE ${defs})
       endforeach() # Variant
     endif() # Has variants
   endforeach() # CUB targets

--- a/cub/test/catch2_main.cuh
+++ b/cub/test/catch2_main.cuh
@@ -29,6 +29,11 @@
 
 #include <iostream>
 
+//! @file This file includes a custom Catch2 main function. When CMake is configured to build 
+//!       each test as a separate executable, this header is included into each test. On the other
+//!       hand, when all the tests are compiled into a single executable, this header is excluded
+//!       from the tests and included into catch2_runner.cpp
+
 #ifdef CUB_CONFIG_MAIN
 #define CATCH_CONFIG_RUNNER
 #endif

--- a/cub/test/catch2_runner.cpp
+++ b/cub/test/catch2_runner.cpp
@@ -26,4 +26,5 @@
 ******************************************************************************/
 
 #define CUB_CONFIG_MAIN
+#define CUB_EXCLUDE_CATCH2_HELPER_IMPL
 #include "catch2_main.cuh"

--- a/cub/test/catch2_runner.cpp
+++ b/cub/test/catch2_runner.cpp
@@ -25,6 +25,9 @@
 *
 ******************************************************************************/
 
+//! @file This file includes a custom Catch2 main function when CMake is configured to build 
+//!       all tests into a single executable.
+
 #define CUB_CONFIG_MAIN
 #define CUB_EXCLUDE_CATCH2_HELPER_IMPL
 #include "catch2_main.cuh"

--- a/cub/test/catch2_runner_helper.cu
+++ b/cub/test/catch2_runner_helper.cu
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+* Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -25,42 +25,4 @@
 *
 ******************************************************************************/
 
-#pragma once
-
-#include <iostream>
-
-#ifdef CUB_CONFIG_MAIN
-#define CATCH_CONFIG_RUNNER
-#endif
-
-#include <catch2/catch.hpp>
-
-#if defined(CUB_CONFIG_MAIN) 
-#include "catch2_runner_helper.h"
-
-#if !defined(CUB_EXCLUDE_CATCH2_HELPER_IMPL)
 #include "catch2_runner_helper.inl"
-#endif
-
-int main(int argc, char *argv[])
-{
-  Catch::Session session;
-
-  int device_id {};
-
-  // Build a new parser on top of Catch's
-  using namespace Catch::clara;
-  auto cli = session.cli()
-           | Opt(device_id, "device")["-d"]["--device"]("device id to use");
-  session.cli(cli);
-
-  int returnCode = session.applyCommandLine(argc, argv);
-  if(returnCode != 0)
-  {
-    return returnCode;
-  }
-
-  set_device(device_id);
-  return session.run(argc, argv);
-}
-#endif

--- a/cub/test/catch2_runner_helper.cu
+++ b/cub/test/catch2_runner_helper.cu
@@ -25,4 +25,9 @@
 *
 ******************************************************************************/
 
+//! @file This file includes CUDA-specific utilities for custom Catch2 main function when CMake is 
+//!       configured to build all tests into a single executable. In this case, we have to have
+//!       a CUDA target in the final Catch2 executable, otherwise CMake confuses linker options and 
+//!       MSVC/RDC build fails.
+
 #include "catch2_runner_helper.inl"

--- a/cub/test/catch2_runner_helper.h
+++ b/cub/test/catch2_runner_helper.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+* Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -27,40 +27,5 @@
 
 #pragma once
 
-#include <iostream>
-
-#ifdef CUB_CONFIG_MAIN
-#define CATCH_CONFIG_RUNNER
-#endif
-
-#include <catch2/catch.hpp>
-
-#if defined(CUB_CONFIG_MAIN) 
-#include "catch2_runner_helper.h"
-
-#if !defined(CUB_EXCLUDE_CATCH2_HELPER_IMPL)
-#include "catch2_runner_helper.inl"
-#endif
-
-int main(int argc, char *argv[])
-{
-  Catch::Session session;
-
-  int device_id {};
-
-  // Build a new parser on top of Catch's
-  using namespace Catch::clara;
-  auto cli = session.cli()
-           | Opt(device_id, "device")["-d"]["--device"]("device id to use");
-  session.cli(cli);
-
-  int returnCode = session.applyCommandLine(argc, argv);
-  if(returnCode != 0)
-  {
-    return returnCode;
-  }
-
-  set_device(device_id);
-  return session.run(argc, argv);
-}
-#endif
+int device_guard(int device_id);
+void set_device(int device_id);

--- a/cub/test/catch2_runner_helper.inl
+++ b/cub/test/catch2_runner_helper.inl
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+* Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -29,38 +29,25 @@
 
 #include <iostream>
 
-#ifdef CUB_CONFIG_MAIN
-#define CATCH_CONFIG_RUNNER
-#endif
-
-#include <catch2/catch.hpp>
-
-#if defined(CUB_CONFIG_MAIN) 
-#include "catch2_runner_helper.h"
-
-#if !defined(CUB_EXCLUDE_CATCH2_HELPER_IMPL)
-#include "catch2_runner_helper.inl"
-#endif
-
-int main(int argc, char *argv[])
+int device_guard(int device_id)
 {
-  Catch::Session session;
-
-  int device_id {};
-
-  // Build a new parser on top of Catch's
-  using namespace Catch::clara;
-  auto cli = session.cli()
-           | Opt(device_id, "device")["-d"]["--device"]("device id to use");
-  session.cli(cli);
-
-  int returnCode = session.applyCommandLine(argc, argv);
-  if(returnCode != 0)
+  int device_count {};
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess)
   {
-    return returnCode;
+    std::cerr << "Can't query devices number." << std::endl;
+    std::exit(-1);
   }
 
-  set_device(device_id);
-  return session.run(argc, argv);
+  if (device_id >= device_count || device_id < 0)
+  {
+    std::cerr << "Invalid device ID: " << device_id << std::endl;
+    std::exit(-1);
+  }
+
+  return device_id;
 }
-#endif
+
+void set_device(int device_id)
+{
+  cudaSetDevice(device_guard(device_id));
+}

--- a/cub/test/catch2_runner_helper.inl
+++ b/cub/test/catch2_runner_helper.inl
@@ -27,6 +27,11 @@
 
 #pragma once
 
+//! @file This file includes implementation of CUDA-specific utilities for custom Catch2 main 
+//!       When CMake is configured to include all the tests into a single executable, this file
+//!       is only included into catch2_runner_helper.cu. When CMake is configured to compile 
+//!       each test as a separate binary, this file is included into each test.
+
 #include <iostream>
 
 int device_guard(int device_id)

--- a/cub/test/catch2_test_debug.cu
+++ b/cub/test/catch2_test_debug.cu
@@ -32,6 +32,7 @@ TEST_CASE("CubDebug resets last error", "[debug][utils]")
   cub::EmptyKernel<int><<<0, 0>>>();
   cudaError error = cudaPeekAtLastError();
 
+  REQUIRE( error != cudaSuccess );
   REQUIRE( CubDebug(cudaSuccess) != cudaSuccess );
   REQUIRE( CubDebug(cudaSuccess) == cudaSuccess );
 }

--- a/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
@@ -39,7 +39,6 @@
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -39,7 +39,6 @@
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_partition_flagged.cu
+++ b/cub/test/catch2_test_device_partition_flagged.cu
@@ -37,7 +37,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_partition_if.cu
+++ b/cub/test/catch2_test_device_partition_if.cu
@@ -37,7 +37,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -39,7 +39,6 @@
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
 #include "c2h/extended_types.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_reduce_by_key.cu
+++ b/cub/test/catch2_test_device_reduce_by_key.cu
@@ -36,7 +36,6 @@
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
 #include "c2h/extended_types.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_reduce_by_key_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_iterators.cu
@@ -38,7 +38,6 @@
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_reduce_fp_inf.cu
+++ b/cub/test/catch2_test_device_reduce_fp_inf.cu
@@ -33,7 +33,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_iterators.cu
@@ -39,7 +39,6 @@
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_run_length_encode.cu
+++ b/cub/test/catch2_test_device_run_length_encode.cu
@@ -39,7 +39,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_run_length_encode_non_trivial_runs.cu
+++ b/cub/test/catch2_test_device_run_length_encode_non_trivial_runs.cu
@@ -40,7 +40,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_scan.cu
+++ b/cub/test/catch2_test_device_scan.cu
@@ -40,7 +40,6 @@
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
 #include "c2h/extended_types.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_scan_by_key.cu
+++ b/cub/test/catch2_test_device_scan_by_key.cu
@@ -40,7 +40,6 @@
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
 #include "c2h/extended_types.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_scan_by_key_iterators.cu
+++ b/cub/test/catch2_test_device_scan_by_key_iterators.cu
@@ -39,7 +39,6 @@
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
 #include "c2h/extended_types.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -41,7 +41,6 @@
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
 #include "c2h/extended_types.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -38,7 +38,6 @@
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
 #include "c2h/extended_types.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_segmented_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_iterators.cu
@@ -40,7 +40,6 @@
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
 #include "c2h/custom_type.cuh"
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_select_flagged.cu
+++ b/cub/test/catch2_test_device_select_flagged.cu
@@ -36,7 +36,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_select_if.cu
+++ b/cub/test/catch2_test_device_select_if.cu
@@ -38,7 +38,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -36,7 +36,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_select_unique_by_key.cu
+++ b/cub/test/catch2_test_device_select_unique_by_key.cu
@@ -37,7 +37,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 

--- a/cub/test/catch2_test_device_three_way_partition.cu
+++ b/cub/test/catch2_test_device_three_way_partition.cu
@@ -39,7 +39,6 @@
 
 // Has to go after all cub headers. Otherwise, this test won't catch unused
 // variables in cub kernels.
-#include "catch2/catch.hpp"
 #include "catch2_test_cdp_helper.h"
 #include "catch2_test_helper.h"
 #include "cub/util_type.cuh"


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/462

<!-- Provide a standalone description of changes in this PR. -->

There's a CMake [bug](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8794) affecting CUDA object libraries with RDC=true that was fixed in 3.27.5. This PR adds a warning when the visual studio generator is used with RDC=true build. Apart from that, there's another CMake bug related to object libraries that forces us to use `$<TARGET_OBJECTS:target>`. Unfortunately, this breaks ninja / make generators, so the WAR is only applied to the visual studio generator. Our Catch2 test mixes CUDA and CXX targets, because nvcc can't process Catch2 header. When CMake links object library with an executable produced by a single CXX target, we are back at linkage issues. To WAR this issue, this PR introduces a dummy CUDA target to the Catch2 runner. With this changes, I was able to successfully build RDC=true Catch2 tests on windows. 

Apart from that, Catch2 tests are now separated into `.cdp_0` and `.cdp_1` to ease tests development. While validating separate Catch2 compilation, I noticed that this mode was broken because of direct inclusion of Catch2 headers. This PR fixes thas as well.   

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
