### PR TITLE
Script for Running CUB Benchmarks

### DIFF
--- a/cub/benchmarks/scripts/cub/bench/bench.py
+++ b/cub/benchmarks/scripts/cub/bench/bench.py
@@ -607,7 +607,7 @@ class Bench:
 
         return definitions
 
-    def do_run(self, ct_point, rt_values, timeout):
+    def do_run(self, ct_point, rt_values, timeout, is_search=True):
         logger = Logger()
 
         try:
@@ -625,13 +625,14 @@ class Bench:
             cmd.append('--jsonbin')
             cmd.append(result_path)
 
-            # Allow noise because we rely on min samples
-            cmd.append("--max-noise")
-            cmd.append("100")
+            if is_search:
+                # Allow noise because we rely on min samples
+                cmd.append("--max-noise")
+                cmd.append("100")
 
-            # Need at least 70 samples
-            cmd.append("--min-samples")
-            cmd.append("70")
+                # Need at least 70 samples
+                cmd.append("--min-samples")
+                cmd.append("70")
 
             # NVBench is currently broken for multiple GPUs, use `CUDA_VISIBLE_DEVICES`
             cmd.append("-d")
@@ -672,7 +673,7 @@ class Bench:
         
         return self.axes_values(sub_space, False)
 
-    def run(self, ct_workload_point, rt_values, estimator):
+    def run(self, ct_workload_point, rt_values, estimator, is_search=True):
         logger = Logger()
         bench_cache = BenchCache()
         runs_cache = RunsCache()
@@ -689,7 +690,7 @@ class Bench:
                 raise Exception("Base bench return code = " + code)
             timeout = elapsed * 50
 
-        result = self.do_run(ct_workload_point, rt_values, timeout)
+        result = self.do_run(ct_workload_point, rt_values, timeout, is_search)
         runs_cache.push_run(self, result.code, result.elapsed)
         return bench_cache.push_bench_centers(self, result, estimator)
     

--- a/cub/benchmarks/scripts/run.py
+++ b/cub/benchmarks/scripts/run.py
@@ -18,7 +18,6 @@ class BaseRunner:
     self.estimator = cub.bench.MedianCenterEstimator()
 
   def __call__(self, algname, ct_workload_space, rt_values):
-    print("&&&& RUNNING bench")
     for ct_workload in ct_workload_space:
       bench = cub.bench.BaseBench(algname)
       if bench.build():
@@ -34,12 +33,13 @@ class BaseRunner:
       else:
         print("&&&& FAILED bench")
         sys.exit(-1)
-    print("&&&& PASSED bench")
 
 
 def main():
+  print("&&&& RUNNING bench")
   os.environ["CUDA_MODULE_LOADING"] = "EAGER"
   cub.bench.search(BaseRunner())
+  print("&&&& PASSED bench")
 
 
 if __name__ == "__main__":

--- a/cub/benchmarks/scripts/run.py
+++ b/cub/benchmarks/scripts/run.py
@@ -26,6 +26,7 @@ class BaseRunner:
         for subbench in results:
           for point in results[subbench]:
             bench_name = "{}.{}-{}".format(bench.algorithm_name(), subbench, point)
+            bench_name = bench_name.replace(' ', '___')
             bench_name = "".join(c if c.isalnum() else "_" for c in bench_name)
             elapsed_time = results[subbench][point]
             if elapsed_time_look_good(elapsed_time):

--- a/cub/benchmarks/scripts/run.py
+++ b/cub/benchmarks/scripts/run.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import cub.bench
+
+
+class BaseRunner:
+  def __init__(self):
+    self.estimator = cub.bench.MedianCenterEstimator()
+
+  def __call__(self, algname, ct_workload_space, rt_values):
+    print("&&&& RUNNING bench")
+    for ct_workload in ct_workload_space:
+      bench = cub.bench.BaseBench(algname)
+      if bench.build():
+        results = bench.run(ct_workload, rt_values, self.estimator, False)
+        for subbench in results:
+          for point in results[subbench]:
+            bench_name = "{}.{}-{}".format(bench.algorithm_name(), subbench, point)
+            bench_name = "".join(c if c.isalnum() else "_" for c in bench_name)
+            print("&&&& PERF {} {} -sec".format(bench_name, results[subbench][point]))
+      else:
+        print("&&&& FAILED bench")
+        sys.exit(-1)
+    print("&&&& PASSED bench")
+
+
+def main():
+  os.environ["CUDA_MODULE_LOADING"] = "EAGER"
+  cub.bench.search(BaseRunner())
+
+
+if __name__ == "__main__":
+  main()

--- a/cub/benchmarks/scripts/run.py
+++ b/cub/benchmarks/scripts/run.py
@@ -2,7 +2,15 @@
 
 import os
 import sys
+import math
 import cub.bench
+
+
+def elapsed_time_look_good(x):
+  if isinstance(x, float):
+    if math.isfinite(x):
+      return True
+  return False
 
 
 class BaseRunner:
@@ -19,7 +27,9 @@ class BaseRunner:
           for point in results[subbench]:
             bench_name = "{}.{}-{}".format(bench.algorithm_name(), subbench, point)
             bench_name = "".join(c if c.isalnum() else "_" for c in bench_name)
-            print("&&&& PERF {} {} -sec".format(bench_name, results[subbench][point]))
+            elapsed_time = results[subbench][point]
+            if elapsed_time_look_good(elapsed_time):
+              print("&&&& PERF {} {} -sec".format(bench_name, elapsed_time))
       else:
         print("&&&& FAILED bench")
         sys.exit(-1)

--- a/cub/docs/benchmarking.rst
+++ b/cub/docs/benchmarking.rst
@@ -7,8 +7,7 @@ This file contains instrutions on how to run all CUB benchmarks using CUB tuning
 
     pip3 install --user fpzip pandas scipy
     git clone https://github.com/NVIDIA/cccl.git
-    mkdir build; cd build
-    cmake .. -DCCCL_ENABLE_THRUST=OFF\
+    cmake -B build -DCCCL_ENABLE_THRUST=OFF\
              -DCCCL_ENABLE_LIBCUDACXX=OFF\
              -DCCCL_ENABLE_CUB=ON\
              -DCUB_ENABLE_DIALECT_CPP11=OFF\
@@ -20,6 +19,7 @@ This file contains instrutions on how to run all CUB benchmarks using CUB tuning
              -DCUB_ENABLE_TUNING=YES\
              -DCMAKE_BUILD_TYPE=Release\
              -DCMAKE_CUDA_ARCHITECTURES="89;90"
+    cd build
     ../cub/benchmarks/scripts/run.py
 
 

--- a/cub/docs/benchmarking.rst
+++ b/cub/docs/benchmarking.rst
@@ -6,7 +6,7 @@ This file contains instrutions on how to run all CUB benchmarks using CUB tuning
 .. code-block:: bash
 
     pip3 install --user fpzip pandas scipy
-    git clone git@github.com:senior-zero/cccl.git
+    git clone https://github.com/NVIDIA/cccl.git
     mkdir build; cd build
     cmake .. -DCCCL_ENABLE_THRUST=OFF\
              -DCCCL_ENABLE_LIBCUDACXX=OFF\

--- a/cub/docs/benchmarking.rst
+++ b/cub/docs/benchmarking.rst
@@ -1,0 +1,53 @@
+Running CUB Benchmarks
+*************************************
+
+This file contains instrutions on how to run all CUB benchmarks using CUB tuning infrastructure.
+
+.. code-block:: bash
+
+    pip3 install --user fpzip pandas scipy
+    git clone git@github.com:senior-zero/cccl.git
+    mkdir build; cd build
+    cmake .. -DCCCL_ENABLE_THRUST=OFF\
+             -DCCCL_ENABLE_LIBCUDACXX=OFF\
+             -DCCCL_ENABLE_CUB=ON\
+             -DCUB_ENABLE_DIALECT_CPP11=OFF\
+             -DCUB_ENABLE_DIALECT_CPP14=OFF\
+             -DCUB_ENABLE_DIALECT_CPP17=ON\
+             -DCUB_ENABLE_DIALECT_CPP20=OFF\
+             -DCUB_ENABLE_RDC_TESTS=OFF\
+             -DCUB_ENABLE_BENCHMARKS=YES\
+             -DCUB_ENABLE_TUNING=YES\
+             -DCMAKE_BUILD_TYPE=Release\
+             -DCMAKE_CUDA_ARCHITECTURES="89;90"
+    ../cub/benchmarks/scripts/run.py
+
+
+Expected output for the command above is:
+
+
+.. code-block:: bash
+
+    ../cub/benchmarks/scripts/run.py
+    &&&& RUNNING bench
+    ctk:  12.2.140
+    cub:  812ba98d1
+    &&&& PERF cub_bench_adjacent_difference_subtract_left_base_T_ct__I32___OffsetT_ct__I32___Elements_io__pow2__16 4.095999884157209e-06 -sec
+    &&&& PERF cub_bench_adjacent_difference_subtract_left_base_T_ct__I32___OffsetT_ct__I32___Elements_io__pow2__20 1.2288000107218977e-05 -sec
+    &&&& PERF cub_bench_adjacent_difference_subtract_left_base_T_ct__I32___OffsetT_ct__I32___Elements_io__pow2__24 0.00016998399223666638 -sec
+    &&&& PERF cub_bench_adjacent_difference_subtract_left_base_T_ct__I32___OffsetT_ct__I32___Elements_io__pow2__28 0.002673664130270481 -sec
+    ...
+
+
+It's also possible to benchmark a subset of algorithms and workloads:
+
+.. code-block:: bash
+
+    ../cub/benchmarks/scripts/run.py -R '.*scan.exclusive.sum.*' -a 'Elements{io}[pow2]=[24,28]' -a 'T{ct}=I32'
+    &&&& RUNNING bench
+    ctk:  12.2.140
+    cub:  812ba98d1
+    &&&& PERF cub_bench_scan_exclusive_sum_base_T_ct__I32___OffsetT_ct__I32___Elements_io__pow2__24 0.00016899200272746384 -sec
+    &&&& PERF cub_bench_scan_exclusive_sum_base_T_ct__I32___OffsetT_ct__I32___Elements_io__pow2__28 0.002696000039577484 -sec
+    &&&& PASSED bench
+


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl_private/issues/151

<!-- Provide a standalone description of changes in this PR. -->
This PR adds a script for running all CUB benchmarks and reporting results in the format similar to the one used in `thrust/internal/scripts/eris_perf.py`. More details are provided in `cub/docs/benchmarking.rst`. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
