### PR TITLE
 Add Gonzalo/Allard to trustees

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -2,3 +2,6 @@
 # https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/
 
 enabled: true
+additional_trustees:
+- ahendriksen
+- gonzalobg


### PR DESCRIPTION
## Description
Adds @gonzalobg and @ahendriksen to list of trusted users so CI will start automatically for their PRs. 


