### PR TITLE
Enable complex interop on MSVC

### DIFF
--- a/libcudacxx/.upstream-tests/test/cuda/complex_interop/complex.assign.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/complex_interop/complex.assign.pass.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: nvrtc
-// UNSUPPORTED: msvc
+
 #include <nv/target>
 
 #include <complex>

--- a/libcudacxx/.upstream-tests/test/cuda/complex_interop/complex.comp.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/complex_interop/complex.comp.pass.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: nvrtc
-// UNSUPPORTED: msvc
+
 #include <nv/target>
 
 #include <complex>

--- a/libcudacxx/.upstream-tests/test/cuda/complex_interop/complex.cons.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/complex_interop/complex.cons.pass.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: nvrtc
-// UNSUPPORTED: msvc
+
 #include <nv/target>
 
 #include <complex>

--- a/libcudacxx/.upstream-tests/test/cuda/complex_interop/complex.conv.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/complex_interop/complex.conv.pass.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: nvrtc
-// UNSUPPORTED: msvc
+
 #include <nv/target>
 
 #include <complex>

--- a/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.sortable/sortable.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/iterators/iterator.requirements/alg.req.sortable/sortable.compile.pass.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: msvc-19.16 && nvcc-11.1
 
 // template<class I, class R = ranges::less, class P = identity>
 //   concept sortable = see below;                            // since C++20

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -256,12 +256,12 @@ template<class T> complex<T> tanh (const complex<T>&);
 #endif // !_LIBCUDACXX_HAS_NO_LOCALIZATION && !_LIBCUDACXX_COMPILER_NVRTC
 
 // Compatability helpers for thrust to convert between `std::complex` and `cuda::std::complex`
-#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 #include <complex>
 
 #define _LIBCUDACXX_ACCESS_STD_COMPLEX_REAL(__c) reinterpret_cast<const _Up (&)[2]>(__c)[0]
 #define _LIBCUDACXX_ACCESS_STD_COMPLEX_IMAG(__c) reinterpret_cast<const _Up (&)[2]>(__c)[1]
-#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 
 #ifndef __cuda_std__
 #include <__pragma_push>
@@ -312,7 +312,7 @@ public:
     complex(const complex<_Xp>& __c)
         : __re_(__c.real()), __im_(__c.imag()) {}
 
-#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
     template <class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
     complex(const ::std::complex<_Up>& __other)
@@ -329,7 +329,7 @@ public:
 
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     operator ::std::complex<_Tp>() const { return { __re_, __im_ }; }
-#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 value_type real() const {return __re_;}
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 value_type imag() const {return __im_;}
@@ -414,7 +414,7 @@ public:
     explicit constexpr complex(const complex<long double>& __c);
 #endif // _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
 
-#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
     template <class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
     complex(const ::std::complex<_Up>& __other)
@@ -431,7 +431,7 @@ public:
 
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     operator ::std::complex<float>() const { return { __re_, __im_ }; }
-#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 
     _LIBCUDACXX_INLINE_VISIBILITY constexpr float real() const {return __re_;}
     _LIBCUDACXX_INLINE_VISIBILITY constexpr float imag() const {return __im_;}
@@ -512,7 +512,7 @@ public:
     explicit constexpr complex(const complex<long double>& __c);
 #endif //_LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
 
-#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
     template <class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
     complex(const ::std::complex<_Up>& __other)
@@ -529,7 +529,7 @@ public:
 
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     operator ::std::complex<double>() const { return { __re_, __im_ }; }
-#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 
     _LIBCUDACXX_INLINE_VISIBILITY constexpr double real() const {return __re_;}
     _LIBCUDACXX_INLINE_VISIBILITY constexpr double imag() const {return __im_;}
@@ -608,7 +608,7 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY
     constexpr complex(const complex<double>& __c);
 
-#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
     template <class _Up>
     _LIBCUDACXX_INLINE_VISIBILITY
     complex(const ::std::complex<_Up>& __other)
@@ -625,7 +625,7 @@ public:
 
     _LIBCUDACXX_HOST _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     operator ::std::complex<long double>() const { return { __re_, __im_ }; }
-#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 
     _LIBCUDACXX_INLINE_VISIBILITY constexpr long double real() const {return __re_;}
     _LIBCUDACXX_INLINE_VISIBILITY constexpr long double imag() const {return __im_;}
@@ -1051,7 +1051,7 @@ operator==(const _Tp& __x, const complex<_Tp>& __y)
     return __x == __y.real() && 0 == __y.imag();
 }
 
-#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 template <class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 bool
@@ -1067,7 +1067,7 @@ operator==(const ::std::complex<_Up>& __x, const complex<_Tp>& __y) {
     return __y.real() == _LIBCUDACXX_ACCESS_STD_COMPLEX_REAL(__x)
         && __y.imag() == _LIBCUDACXX_ACCESS_STD_COMPLEX_IMAG(__x);
 }
-#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 
 template<class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
@@ -1093,7 +1093,7 @@ operator!=(const _Tp& __x, const complex<_Tp>& __y)
     return !(__x == __y);
 }
 
-#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#if defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 template <class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
 bool
@@ -1107,7 +1107,7 @@ bool
 operator!=(const ::std::complex<_Up>& __x, const complex<_Tp>& __y) {
     return !(__x == __y);
 }
-#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC) && !defined(_LIBCUDACXX_COMPILER_MSVC)
+#endif // defined(__cuda_std__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
 
 // 26.3.7 values:
 


### PR DESCRIPTION
currently we did not enable the interoperability of `cuda::std::complex` with `std::complex` for MSVC

Fix this to enable it for `thrust::complex`
