### PR TITLE
Add verbose flag to ninja build.

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -101,7 +101,7 @@ function configure(){
 function build(){
     local BUILD_NAME=$1
     source "./sccache_stats.sh" start
-    cmake --build $BUILD_DIR --parallel $PARALLEL_LEVEL -- -v
+    cmake --build $BUILD_DIR --parallel $PARALLEL_LEVEL -v
     echo "${BUILD_NAME} build complete"
     source "./sccache_stats.sh" end
 }

--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -101,7 +101,7 @@ function configure(){
 function build(){
     local BUILD_NAME=$1
     source "./sccache_stats.sh" start
-    cmake --build $BUILD_DIR --parallel $PARALLEL_LEVEL
+    cmake --build $BUILD_DIR --parallel $PARALLEL_LEVEL -- -v
     echo "${BUILD_NAME} build complete"
     source "./sccache_stats.sh" end
 }

--- a/ci/windows/build_common.psm1
+++ b/ci/windows/build_common.psm1
@@ -85,7 +85,7 @@ function build {
 
     sccache_stats('Start')
 
-    cmake --build $script:BUILD_DIR --parallel $script:PARALLEL_LEVEL -- -v
+    cmake --build $script:BUILD_DIR --parallel $script:PARALLEL_LEVEL -v
     $test_result = $LastExitCode
 
     sccache_stats('Stop')

--- a/ci/windows/build_common.psm1
+++ b/ci/windows/build_common.psm1
@@ -85,7 +85,7 @@ function build {
 
     sccache_stats('Start')
 
-    cmake --build $script:BUILD_DIR --parallel $script:PARALLEL_LEVEL
+    cmake --build $script:BUILD_DIR --parallel $script:PARALLEL_LEVEL -- -v
     $test_result = $LastExitCode
 
     sccache_stats('Stop')


### PR DESCRIPTION
## Description

Adds the `-v` option to the ninja build to enable the verbose compiler invocation for every object file.

This is useful for ensuring the correct arguments are passed to the compiler. 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
