### PR TITLE
Add constant initialization of managed variable to silence gcc warning

### DIFF
--- a/libcudacxx/.upstream-tests/test/heterogeneous/helpers.h
+++ b/libcudacxx/.upstream-tests/test/heterogeneous/helpers.h
@@ -344,18 +344,16 @@ struct manual_object
 
     union data
     {
-        __host__ __device__
-        data() {}
-
-        __host__ __device__
-        ~data() {}
-
+        __host__ __device__ constexpr data() noexcept : dummy() {};
+        char dummy = {};
         T object;
     } data;
+
+    constexpr manual_object() noexcept {}
 };
 
 template<typename T>
-__managed__ manual_object<T> managed_variable;
+__managed__ manual_object<T> managed_variable{};
 #endif
 
 template<typename T, std::size_t N, typename ...Args>


### PR DESCRIPTION
We have some bug reports about failing CI runs because of this.

So lets pull that fix out to unblock others.

See nvbug4273068