### PR TITLE
use clang-format in dev containers

### DIFF
--- a/.devcontainer/cuda11.1-gcc6/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc6/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc6-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc6-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda11.1-gcc6"

--- a/.devcontainer/cuda11.1-gcc6/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc6/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda11.1-gcc7/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc7-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc7-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda11.1-gcc7"

--- a/.devcontainer/cuda11.1-gcc7/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc7/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda11.1-gcc8/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc8-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc8-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda11.1-gcc8"

--- a/.devcontainer/cuda11.1-gcc8/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc8/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda11.1-gcc9/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc9-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc9-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda11.1-gcc9"

--- a/.devcontainer/cuda11.1-gcc9/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc9/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda11.1-llvm9/devcontainer.json
+++ b/.devcontainer/cuda11.1-llvm9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-llvm9-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-llvm9-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda11.1-llvm9"

--- a/.devcontainer/cuda11.1-llvm9/devcontainer.json
+++ b/.devcontainer/cuda11.1-llvm9/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc10-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc10-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-gcc10"

--- a/.devcontainer/cuda12.2-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc10/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc11/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc11-cuda12.2-ubuntu22.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc11-cuda12.2-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-gcc11"

--- a/.devcontainer/cuda12.2-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc12-cuda12.2-ubuntu22.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc12-cuda12.2-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-gcc12"

--- a/.devcontainer/cuda12.2-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc12/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc7-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc7-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-gcc7"

--- a/.devcontainer/cuda12.2-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc7/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc8-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc8-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-gcc8"

--- a/.devcontainer/cuda12.2-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc8/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-gcc9-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-gcc9-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-gcc9"

--- a/.devcontainer/cuda12.2-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.2-gcc9/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-llvm10/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-llvm10-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-llvm10-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-llvm10"

--- a/.devcontainer/cuda12.2-llvm10/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm10/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-llvm11/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-llvm11-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-llvm11-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-llvm11"

--- a/.devcontainer/cuda12.2-llvm11/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm11/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-llvm12/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm12/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-llvm12/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-llvm12-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-llvm12-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-llvm12"

--- a/.devcontainer/cuda12.2-llvm13/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-llvm13-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-llvm13-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-llvm13"

--- a/.devcontainer/cuda12.2-llvm13/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm13/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-llvm14-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-llvm14-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-llvm14"

--- a/.devcontainer/cuda12.2-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm14/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-llvm15-cuda12.2-ubuntu22.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-llvm15-cuda12.2-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-llvm15"

--- a/.devcontainer/cuda12.2-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm15/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm16/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-llvm16-cuda12.2-ubuntu22.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-llvm16-cuda12.2-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-llvm16"

--- a/.devcontainer/cuda12.2-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm16/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/cuda12.2-llvm9/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:23.10-cpp-llvm9-cuda12.2-ubuntu20.04",
+  "image": "rapidsai/devcontainers:23.12-cpp-llvm9-cuda12.2-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },
@@ -33,7 +33,10 @@
     "vscode": {
       "extensions": [
         "llvm-vs-code-extensions.vscode-clangd"
-      ]
+      ],
+      "settings": {
+        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+      }
     }
   },
   "name": "cuda12.2-llvm9"

--- a/.devcontainer/cuda12.2-llvm9/devcontainer.json
+++ b/.devcontainer/cuda12.2-llvm9/devcontainer.json
@@ -32,10 +32,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ],
       "settings": {
-        "clangFormat.executable.default": "/usr/local/bin/clang-format"
+        "editor.defaultFormatter": "xaver.clang-format",
+        "clang-format.executable": "/usr/local/bin/clang-format"
       }
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,8 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "llvm-vs-code-extensions.vscode-clangd"
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format"
       ]
     }
   },

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.construction.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.construction.pass.cpp
@@ -52,11 +52,11 @@ struct async_resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const async_resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const async_resource& res, Property) noexcept {
     return res._val;
   }

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.conversion.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.conversion.pass.cpp
@@ -57,11 +57,11 @@ struct resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const resource& res, Property) noexcept {
     return res._val;
   }

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.equality.fail.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.equality.fail.cpp
@@ -54,12 +54,12 @@ struct async_resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  (requires !cuda::property_with_value<Property> &&
+  _LIBCUDACXX_REQUIRES( !cuda::property_with_value<Property> &&
    _CUDA_VSTD::_One_of<Property, Properties...>) //
       friend void get_property(const async_resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  (requires cuda::property_with_value<Property>&&
+  _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property>&&
        _CUDA_VSTD::_One_of<Property, Properties...>) //
       friend typename Property::value_type
       get_property(const async_resource& res, Property) noexcept {

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.equality.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.equality.pass.cpp
@@ -54,11 +54,11 @@ struct async_resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const async_resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const async_resource& res, Property) noexcept {
     return res._val;
   }

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.inheritance.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.inheritance.pass.cpp
@@ -43,11 +43,11 @@ struct async_resource_base {
   bool operator!=(const async_resource_base& other) const { return false; }
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const async_resource_base&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const async_resource_base& res, Property) noexcept {
     return 42;
   }

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.properties.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.async_resource_ref/async_resource_ref.properties.pass.cpp
@@ -61,11 +61,11 @@ struct async_resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const async_resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const async_resource& res, Property) noexcept {
     return res._val;
   }
@@ -88,25 +88,25 @@ static_assert(
     (2 * sizeof(void*)), "");
 
 _LIBCUDACXX_TEMPLATE(class Property, class Ref)
-  (requires (!cuda::property_with_value<Property>)) //
+  _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>)) //
     int InvokeIfWithValue(const Ref& ref) {
   return -1;
 }
 
 _LIBCUDACXX_TEMPLATE(class Property, class Ref)
-  (requires cuda::property_with_value<Property>) //
+  _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property>) //
     typename Property::value_type InvokeIfWithValue(const Ref& ref) {
   return get_property(ref, Property{});
 }
 
 _LIBCUDACXX_TEMPLATE(class Property, class Ref)
-  (requires cuda::property_with_value<Property>) //
+  _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property>) //
     int InvokeIfWithoutValue(const Ref& ref) {
   return -1;
 }
 
 _LIBCUDACXX_TEMPLATE(class Property, class Ref)
-  (requires (!cuda::property_with_value<Property>)) //
+  _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>)) //
     int InvokeIfWithoutValue(const Ref& ref) {
   get_property(ref, Property{});
   return 1;

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.construction.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.construction.pass.cpp
@@ -42,11 +42,11 @@ struct resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const resource& res, Property) noexcept {
     return res._val;
   }

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.conversion.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.conversion.pass.cpp
@@ -57,11 +57,11 @@ struct resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const resource& res, Property) noexcept {
     return res._val;
   }

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.equality.fail.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.equality.fail.cpp
@@ -43,12 +43,12 @@ struct resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  (requires !cuda::property_with_value<Property> &&
+  _LIBCUDACXX_REQUIRES( !cuda::property_with_value<Property> &&
    _CUDA_VSTD::_One_of<Property, Properties...>) //
       friend void get_property(const resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  (requires cuda::property_with_value<Property>&&
+  _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property>&&
        _CUDA_VSTD::_One_of<Property, Properties...>) //
       friend typename Property::value_type
       get_property(const resource& res, Property) noexcept {

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.equality.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.equality.pass.cpp
@@ -43,11 +43,11 @@ struct resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const resource& res, Property) noexcept {
     return res._val;
   }

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.inheritance.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.inheritance.pass.cpp
@@ -38,11 +38,11 @@ struct resource_base {
   bool operator!=(const resource_base& other) const { return false; }
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const resource_base&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const resource_base& res, Property) noexcept {
     return 42;
   }

--- a/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.properties.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/cuda/memory_resource/memory_resource.resource_ref/resource_ref.properties.pass.cpp
@@ -52,11 +52,11 @@ struct resource {
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>) && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend void get_property(const resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-    (requires cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
+    _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property> && _CUDA_VSTD::_One_of<Property, Properties...>) //
   friend typename Property::value_type get_property(const resource& res, Property) noexcept {
     return res._val;
   }
@@ -77,25 +77,25 @@ static_assert(sizeof(cuda::mr::resource_ref<property_without_value<short>,
               (2 * sizeof(void*)), "");
 
 _LIBCUDACXX_TEMPLATE(class Property, class Ref)
-  (requires (!cuda::property_with_value<Property>)) //
+  _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>)) //
     int InvokeIfWithValue(const Ref& ref) {
   return -1;
 }
 
 _LIBCUDACXX_TEMPLATE(class Property, class Ref)
-  (requires cuda::property_with_value<Property>) //
+  _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property>) //
     typename Property::value_type InvokeIfWithValue(const Ref& ref) {
   return get_property(ref, Property{});
 }
 
 _LIBCUDACXX_TEMPLATE(class Property, class Ref)
-  (requires cuda::property_with_value<Property>) //
+  _LIBCUDACXX_REQUIRES( cuda::property_with_value<Property>) //
     int InvokeIfWithoutValue(const Ref& ref) {
   return -1;
 }
 
 _LIBCUDACXX_TEMPLATE(class Property, class Ref)
-  (requires (!cuda::property_with_value<Property>)) //
+  _LIBCUDACXX_REQUIRES( (!cuda::property_with_value<Property>)) //
     int InvokeIfWithoutValue(const Ref& ref) {
   get_property(ref, Property{});
   return 1;

--- a/libcudacxx/.upstream-tests/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.pass.cpp
@@ -43,7 +43,7 @@ __host__ __device__ constexpr bool models_totally_ordered() noexcept {
 #else
 
 _LIBCUDACXX_TEMPLATE(class T)
-  (requires cuda::std::totally_ordered<T>)
+  _LIBCUDACXX_REQUIRES( cuda::std::totally_ordered<T>)
 __host__ __device__ constexpr bool models_totally_ordered() noexcept {
   return true;
 }

--- a/libcudacxx/.upstream-tests/test/std/concepts/concepts.lang/concept.convertible/convertible_to.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/concepts/concepts.lang/concept.convertible/convertible_to.pass.cpp
@@ -56,7 +56,7 @@ __host__ __device__ void CheckIsConvertibleButNotConvertibleTo() {
 template <class T>
 #else
 _LIBCUDACXX_TEMPLATE(class T)
-  (requires (!(cuda::std::same_as<T, bool> || cuda::std::same_as<T, nullptr_t>)))
+  _LIBCUDACXX_REQUIRES( (!(cuda::std::same_as<T, bool> || cuda::std::same_as<T, nullptr_t>)))
 #endif
 __host__ __device__ constexpr void CommonlyNotConvertibleTo() {
   CheckNotConvertibleTo<T, void>();
@@ -71,7 +71,7 @@ __host__ __device__ constexpr void CommonlyNotConvertibleTo() {
 }
 
 _LIBCUDACXX_TEMPLATE(class T)
-  (requires cuda::std::same_as<T, bool>)
+  _LIBCUDACXX_REQUIRES( cuda::std::same_as<T, bool>)
 __host__ __device__ constexpr void CommonlyNotConvertibleTo() {
   CheckNotConvertibleTo<bool, void>();
   CheckNotConvertibleTo<bool, nullptr_t>();
@@ -84,7 +84,7 @@ __host__ __device__ constexpr void CommonlyNotConvertibleTo() {
 }
 
 _LIBCUDACXX_TEMPLATE(class T)
-  (requires cuda::std::same_as<T, nullptr_t>)
+  _LIBCUDACXX_REQUIRES( cuda::std::same_as<T, nullptr_t>)
 __host__ __device__ constexpr void CommonlyNotConvertibleTo() {
   CheckNotConvertibleTo<nullptr_t, void>();
   CheckConvertibleTo<nullptr_t, nullptr_t>();

--- a/libcudacxx/.upstream-tests/test/std/concepts/concepts.lang/concept.same/same_as.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/concepts/concepts.lang/concept.same/same_as.pass.cpp
@@ -163,12 +163,12 @@ __host__ __device__ void CheckNotSameAs() {
 #if TEST_STD_VER > 17
 // Checks subsumption works as intended
 _LIBCUDACXX_TEMPLATE(class T, class U)
-  (requires same_as<T, U>)
+  _LIBCUDACXX_REQUIRES( same_as<T, U>)
 __host__ __device__ void SubsumptionTest();
 
 // clang-format off
 _LIBCUDACXX_TEMPLATE(class T, class U)
-  (requires same_as<T, U> && true)
+  _LIBCUDACXX_REQUIRES( same_as<T, U> && true)
 __host__ __device__ int SubsumptionTest();
 // clang-format on
 

--- a/libcudacxx/.upstream-tests/test/std/concepts/concepts.lang/concept.swappable/swappable.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/concepts/concepts.lang/concept.swappable/swappable.pass.cpp
@@ -35,7 +35,7 @@ struct expected {
 // clang-format off
 // Checks [concept.swappable]/2.1
 _LIBCUDACXX_TEMPLATE(class T, class U)
-  (requires cuda::std::same_as<cuda::std::remove_cvref_t<T>, cuda::std::remove_cvref_t<U> > &&
+  _LIBCUDACXX_REQUIRES( cuda::std::same_as<cuda::std::remove_cvref_t<T>, cuda::std::remove_cvref_t<U> > &&
          swappable<cuda::std::remove_cvref_t<T> >) //
 __host__ __device__ constexpr bool check_swap_21(T&& x, U&& y) {
   expected<cuda::std::remove_cvref_t<T> > const e{y, x};
@@ -45,7 +45,7 @@ __host__ __device__ constexpr bool check_swap_21(T&& x, U&& y) {
 
 // Checks [concept.swappable]/2.2
 _LIBCUDACXX_TEMPLATE(class T, cuda::std::size_t N)
-  (requires swappable<T>)
+  _LIBCUDACXX_REQUIRES( swappable<T>)
 __host__ __device__ constexpr bool check_swap_22(T (&x)[N], T (&y)[N]) {
   expected<T[N]> e{};
   for (cuda::std::size_t i = 0; i < N; ++i) {
@@ -65,7 +65,7 @@ __host__ __device__ constexpr bool check_swap_22(T (&x)[N], T (&y)[N]) {
 
 // Checks [concept.swappable]/2.3
 _LIBCUDACXX_TEMPLATE(class T)
-  (requires swappable<T> && cuda::std::copy_constructible<cuda::std::remove_cvref_t<T> >)
+  _LIBCUDACXX_REQUIRES( swappable<T> && cuda::std::copy_constructible<cuda::std::remove_cvref_t<T> >)
 __host__ __device__ constexpr bool check_swap_23(T x, T y) {
   expected<cuda::std::remove_cvref_t<T> > const e{y, x};
   cuda::std::ranges::swap(x, y);

--- a/libcudacxx/.upstream-tests/test/std/concepts/concepts.lang/concept.swappable/swappable_with.compile.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/concepts/concepts.lang/concept.swappable/swappable_with.compile.pass.cpp
@@ -646,14 +646,14 @@ static_assert(!check_swappable_with<HasANonMovable, HasANonMovable>(), "");
 namespace LWG3175 {
 // Example taken directly from [concept.swappable]
 _LIBCUDACXX_TEMPLATE(class T, class U)
-  (requires swappable_with<T, U>)
+  _LIBCUDACXX_REQUIRES( swappable_with<T, U>)
 __host__ __device__
 constexpr void value_swap(T&& t, U&& u) {
   cuda::std::ranges::swap(cuda::std::forward<T>(t), cuda::std::forward<U>(u));
 }
 
 _LIBCUDACXX_TEMPLATE(class T)
-  (requires swappable<T>)
+  _LIBCUDACXX_REQUIRES( swappable<T>)
 __host__ __device__
 constexpr void lv_swap(T& t1, T& t2) {
   cuda::std::ranges::swap(t1, t2);

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.convert.copy.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.convert.copy.pass.cpp
@@ -69,7 +69,7 @@ static_assert(!canCstrFromExpected<int, NoCtorFromInt, int, int>, "");
 template <class T>
 struct CtorFrom {
   _LIBCUDACXX_TEMPLATE(class T2 = T)
-    (requires(!cuda::std::same_as<T2, int>))
+    _LIBCUDACXX_REQUIRES((!cuda::std::same_as<T2, int>))
   __host__ __device__ explicit CtorFrom(int);
   __host__ __device__ explicit CtorFrom(T);
 
@@ -95,7 +95,7 @@ static_assert(!canCstrFromExpected<CtorFrom<cuda::std::expected<int, int> const&
 template <class T>
 struct ConvertFrom {
   _LIBCUDACXX_TEMPLATE(class T2 = T)
-    (requires(!cuda::std::same_as<T2, int>))
+    _LIBCUDACXX_REQUIRES((!cuda::std::same_as<T2, int>))
   __host__ __device__ ConvertFrom(int);
   __host__ __device__ ConvertFrom(T);
 

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.convert.move.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.convert.move.pass.cpp
@@ -70,7 +70,7 @@ static_assert(!canCstrFromExpected<int, NoCtorFromInt, int, int>, "");
 template <class T>
 struct CtorFrom {
   _LIBCUDACXX_TEMPLATE(class T2 = T)
-    (requires(!cuda::std::same_as<T2, int>))
+    _LIBCUDACXX_REQUIRES((!cuda::std::same_as<T2, int>))
   __host__ __device__ explicit CtorFrom(int);
   __host__ __device__ explicit CtorFrom(T);
   template<class U>
@@ -95,7 +95,7 @@ static_assert(!canCstrFromExpected<CtorFrom<cuda::std::expected<int, int> const&
 template <class T>
 struct ConvertFrom {
   _LIBCUDACXX_TEMPLATE(class T2 = T)
-    (requires(!cuda::std::same_as<T2, int>))
+    _LIBCUDACXX_REQUIRES((!cuda::std::same_as<T2, int>))
   __host__ __device__ ConvertFrom(int);
   __host__ __device__ ConvertFrom(T);
   template<class U>

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.inplace_init_list.pass.cpp
@@ -70,7 +70,7 @@ struct Data {
   cuda::std::tuple<Ts...> tuple_;
 
   _LIBCUDACXX_TEMPLATE(class... Us)
-    (requires cuda::std::is_constructible<cuda::std::tuple<Ts...>, Us&&...>::value)
+    _LIBCUDACXX_REQUIRES( cuda::std::is_constructible<cuda::std::tuple<Ts...>, Us&&...>::value)
   __host__ __device__ constexpr Data(cuda::std::initializer_list<int> il, Us&&... us) : tuple_(cuda::std::forward<Us>(us)...) {
       auto ibegin = il.begin();
       for (cuda::std::size_t i = 0; ibegin != il.end(); ++ibegin, ++i) {

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.expected/ctor/ctor.unexpect_init_list.pass.cpp
@@ -71,7 +71,7 @@ struct Data {
   cuda::std::tuple<Ts...> tuple_;
 
   _LIBCUDACXX_TEMPLATE(class... Us)
-    (requires cuda::std::is_constructible<cuda::std::tuple<Ts...>, Us&&...>::value)
+    _LIBCUDACXX_REQUIRES( cuda::std::is_constructible<cuda::std::tuple<Ts...>, Us&&...>::value)
   __host__ __device__ constexpr Data(cuda::std::initializer_list<int> il, Us&&... us) : tuple_(cuda::std::forward<Us>(us)...) {
     auto ibegin = il.begin();
     for (cuda::std::size_t i = 0; ibegin != il.end(); ++ibegin, ++i) {

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/ctor/ctor.convert.copy.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/ctor/ctor.convert.copy.pass.cpp
@@ -57,7 +57,7 @@ static_assert(!canCstrFromExpected<void, NoCtorFromInt, void, int>, "");
 template <class T>
 struct CtorFrom {
   _LIBCUDACXX_TEMPLATE(class T2 = T)
-    (requires(!cuda::std::same_as<T2, int>))
+    _LIBCUDACXX_REQUIRES((!cuda::std::same_as<T2, int>))
   __host__ __device__ explicit CtorFrom(int);
   __host__ __device__ explicit CtorFrom(T);
   template<class U>

--- a/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/ctor/ctor.convert.move.pass.cpp
+++ b/libcudacxx/.upstream-tests/test/std/utilities/expected/expected.void/ctor/ctor.convert.move.pass.cpp
@@ -58,7 +58,7 @@ static_assert(!canCstrFromExpected<void, NoCtorFromInt, void, int>, "");
 template <class T>
 struct CtorFrom {
   _LIBCUDACXX_TEMPLATE(class T2 = T)
-    (requires(!cuda::std::same_as<T2, int>))
+    _LIBCUDACXX_REQUIRES((!cuda::std::same_as<T2, int>))
   __host__ __device__ explicit CtorFrom(int);
   __host__ __device__ explicit CtorFrom(T);
   template<class U>

--- a/libcudacxx/.upstream-tests/test/support/test_iterators.h
+++ b/libcudacxx/.upstream-tests/test/support/test_iterators.h
@@ -1016,17 +1016,17 @@ struct Proxy {
   __host__ __device__ constexpr const T&& getData() const&& { return static_cast<const T&&>(data); }
 
   _LIBCUDACXX_TEMPLATE(class U)
-    (requires cuda::std::constructible_from<T, U&&>)
+    _LIBCUDACXX_REQUIRES( cuda::std::constructible_from<T, U&&>)
   __host__ __device__ constexpr Proxy(U&& u) : data{cuda::std::forward<U>(u)} {}
 
   // This constructor covers conversion from cvref of Proxy<U>, including non-const/const versions of copy/move constructor
   _LIBCUDACXX_TEMPLATE(class Other)
-    (requires(IsProxy<cuda::std::decay_t<Other>> &&
+    _LIBCUDACXX_REQUIRES((IsProxy<cuda::std::decay_t<Other>> &&
               cuda::std::constructible_from<T, decltype(cuda::std::declval<Other>().getData())>))
   __host__ __device__ constexpr Proxy(Other&& other) : data{cuda::std::forward<Other>(other).getData()} {}
 
   _LIBCUDACXX_TEMPLATE(class Other)
-    (requires(IsProxy<cuda::std::decay_t<Other>> &&
+    _LIBCUDACXX_REQUIRES((IsProxy<cuda::std::decay_t<Other>> &&
               cuda::std::assignable_from<cuda::std::__add_lvalue_reference_t<T>, decltype(cuda::std::declval<Other>().getData())>))
   __host__ __device__ constexpr Proxy& operator=(Other&& other) {
     data = cuda::std::forward<Other>(other).getData();
@@ -1039,7 +1039,7 @@ TEST_NV_DIAG_SUPPRESS(1805) // MSVC complains that if we pass a pointer type, ad
 
   // const assignment required to make ProxyIterator model cuda::std::indirectly_writable
   _LIBCUDACXX_TEMPLATE(class Other)
-    (requires(IsProxy<cuda::std::decay_t<Other>> &&
+    _LIBCUDACXX_REQUIRES((IsProxy<cuda::std::decay_t<Other>> &&
               cuda::std::assignable_from<const cuda::std::__add_lvalue_reference_t<T>, decltype(cuda::std::declval<Other>().getData())>))
   __host__ __device__ constexpr const Proxy& operator=(Other&& other) const {
     data = cuda::std::forward<Other>(other).getData();
@@ -1063,7 +1063,7 @@ TEST_NV_DIAG_SUPPRESS(1805) // MSVC complains that if we pass a pointer type, ad
   = default;
 #else
  _LIBCUDACXX_TEMPLATE(class T2 = T)
-    (requires(cuda::std::equality_comparable<T2> && !cuda::std::is_reference_v<T2>))
+    _LIBCUDACXX_REQUIRES((cuda::std::equality_comparable<T2> && !cuda::std::is_reference_v<T2>))
   __host__ __device__ friend constexpr bool operator==(const Proxy& lhs, const Proxy& rhs) {
     return lhs.data == rhs.data;
   }
@@ -1072,7 +1072,7 @@ TEST_NV_DIAG_SUPPRESS(1805) // MSVC complains that if we pass a pointer type, ad
   // Helps compare e.g. `Proxy<int>` and `Proxy<int&>`. Note that the default equality comparison operator is deleted
   // when `T` is a reference type.
  _LIBCUDACXX_TEMPLATE(class U)
-    (requires(cuda::std::equality_comparable_with<cuda::std::decay_t<T>, cuda::std::decay_t<U>>))
+    _LIBCUDACXX_REQUIRES((cuda::std::equality_comparable_with<cuda::std::decay_t<T>, cuda::std::decay_t<U>>))
   __host__ __device__ friend constexpr bool operator==(const Proxy& lhs, const Proxy<U>& rhs) {
     return lhs.data == rhs.data;
   }
@@ -1154,7 +1154,7 @@ struct ProxyIterator : ProxyIteratorBase<Base> {
   __host__ __device__ constexpr ProxyIterator(Base base) : base_{cuda::std::move(base)} {}
 
   _LIBCUDACXX_TEMPLATE(class T)
-    (requires cuda::std::constructible_from<Base, T&&>)
+    _LIBCUDACXX_REQUIRES( cuda::std::constructible_from<Base, T&&>)
   __host__ __device__ constexpr ProxyIterator(T&& t) : base_{cuda::std::forward<T>(t)} {}
 
   __host__ __device__  friend constexpr decltype(auto) base(const ProxyIterator& p) { return base(p.base_); }
@@ -1185,14 +1185,14 @@ struct ProxyIterator : ProxyIteratorBase<Base> {
   __host__ __device__ constexpr void operator++(int) { ++*this; }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::equality_comparable<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::equality_comparable<B2>)
   __host__ __device__ friend constexpr bool operator==(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ == y.base_;
   }
 
   // to satisfy forward_iterator
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::forward_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::forward_iterator<B2>)
   __host__ __device__ constexpr ProxyIterator operator++(int) {
     auto tmp = *this;
     ++*this;
@@ -1201,14 +1201,14 @@ struct ProxyIterator : ProxyIteratorBase<Base> {
 
   // to satisfy bidirectional_iterator
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::bidirectional_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::bidirectional_iterator<B2>)
   __host__ __device__ constexpr ProxyIterator& operator--() {
     --base_;
     return *this;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::bidirectional_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::bidirectional_iterator<B2>)
   __host__ __device__ constexpr ProxyIterator operator--(int) {
     auto tmp = *this;
     --*this;
@@ -1217,77 +1217,77 @@ struct ProxyIterator : ProxyIteratorBase<Base> {
 
   // to satisfy random_access_iterator
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ constexpr ProxyIterator& operator+=(difference_type n) {
     base_ += n;
     return *this;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ constexpr ProxyIterator& operator-=(difference_type n) {
     base_ -= n;
     return *this;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ constexpr Proxy<cuda::std::iter_reference_t<Base>> operator[](difference_type n) const {
     return {base_[n]};
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ friend constexpr bool operator<(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ < y.base_;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ friend constexpr bool operator>(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ > y.base_;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ friend constexpr bool operator<=(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ <= y.base_;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ friend constexpr bool operator>=(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ >= y.base_;
   }
 
 #ifndef TEST_HAS_NO_SPACESHIP_OPERATOR
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2> && cuda::std::three_way_comparable<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2> && cuda::std::three_way_comparable<B2>)
   __host__ __device__ friend constexpr auto operator<=>(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ <=> y.base_;
   }
 #endif // TEST_HAS_NO_SPACESHIP_OPERATOR
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ friend constexpr ProxyIterator operator+(const ProxyIterator& x, difference_type n) {
     return ProxyIterator{x.base_ + n};
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ friend constexpr ProxyIterator operator+(difference_type n, const ProxyIterator& x) {
     return ProxyIterator{n + x.base_};
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ friend constexpr ProxyIterator operator-(const ProxyIterator& x, difference_type n) {
     return ProxyIterator{x.base_ - n};
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires cuda::std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( cuda::std::random_access_iterator<B2>)
   __host__ __device__ friend constexpr difference_type operator-(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ - y.base_;
   }
@@ -1305,7 +1305,7 @@ struct ProxySentinel {
   __host__ __device__ constexpr ProxySentinel(BaseSent base) : base_{cuda::std::move(base)} {}
 
   _LIBCUDACXX_TEMPLATE(class Base)
-    (requires cuda::std::equality_comparable_with<Base, BaseSent>)
+    _LIBCUDACXX_REQUIRES( cuda::std::equality_comparable_with<Base, BaseSent>)
   __host__ __device__ friend constexpr bool operator==(const ProxyIterator<Base>& p, const ProxySentinel& sent) {
     return p.base_ == sent.base_;
   }

--- a/libcudacxx/include/cuda/memory_resource
+++ b/libcudacxx/include/cuda/memory_resource
@@ -153,13 +153,13 @@ template <class _Derived, class _Upstream>
 struct __fn {
   _LIBCUDACXX_DISABLE_EXEC_CHECK
   _LIBCUDACXX_TEMPLATE(class _Property)
-    (requires (!property_with_value<_Property>) _LIBCUDACXX_AND has_property<_Upstream, _Property>)
+    _LIBCUDACXX_REQUIRES( (!property_with_value<_Property>) _LIBCUDACXX_AND has_property<_Upstream, _Property>)
   _LIBCUDACXX_INLINE_VISIBILITY friend constexpr void get_property(const _Derived&, _Property) noexcept {}
 
   // The indirection is needed, otherwise the compiler might believe that _Derived is an incomplete type
   _LIBCUDACXX_DISABLE_EXEC_CHECK
   _LIBCUDACXX_TEMPLATE(class _Property, class _Derived2 = _Derived)
-    (requires property_with_value<_Property> _LIBCUDACXX_AND has_property<_Upstream, _Property> _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( property_with_value<_Property> _LIBCUDACXX_AND has_property<_Upstream, _Property> _LIBCUDACXX_AND
               __has_upstream_resource<_Derived2, _Upstream>)
   _LIBCUDACXX_INLINE_VISIBILITY friend constexpr __property_value_t<_Property> get_property(
     const _Derived& __res, _Property __prop) {
@@ -178,12 +178,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__get_property)
 struct __fn {
   _LIBCUDACXX_DISABLE_EXEC_CHECK
   _LIBCUDACXX_TEMPLATE(class _Upstream, class _Property)
-    (requires (!property_with_value<_Property>) _LIBCUDACXX_AND has_property<_Upstream, _Property>)
+    _LIBCUDACXX_REQUIRES( (!property_with_value<_Property>) _LIBCUDACXX_AND has_property<_Upstream, _Property>)
   _LIBCUDACXX_INLINE_VISIBILITY constexpr void operator()(const _Upstream&, _Property) const noexcept {}
 
   _LIBCUDACXX_DISABLE_EXEC_CHECK
   _LIBCUDACXX_TEMPLATE(class _Upstream, class _Property)
-    (requires (property_with_value<_Property>) _LIBCUDACXX_AND has_property<_Upstream, _Property>)
+    _LIBCUDACXX_REQUIRES( (property_with_value<_Property>) _LIBCUDACXX_AND has_property<_Upstream, _Property>)
   _LIBCUDACXX_INLINE_VISIBILITY constexpr __property_value_t<_Property> operator()(
     const _Upstream& __res, _Property __prop) const {
     return get_property(__res, __prop);
@@ -330,7 +330,7 @@ struct _Resource_vtable_builder
     }
 
     _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type)
-      (requires(_Alloc_type == _AllocType::_Default)) //
+      _LIBCUDACXX_REQUIRES((_Alloc_type == _AllocType::_Default)) //
      static constexpr _Alloc_vtable _Create() noexcept
     {
       return {&_Resource_vtable_builder::_Alloc<_Resource>,
@@ -339,7 +339,7 @@ struct _Resource_vtable_builder
     }
 
     _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type)
-      (requires(_Alloc_type == _AllocType::_Async)) //
+      _LIBCUDACXX_REQUIRES((_Alloc_type == _AllocType::_Async)) //
      static constexpr _Async_alloc_vtable _Create() noexcept
     {
       return {&_Resource_vtable_builder::_Alloc<_Resource>,
@@ -513,7 +513,7 @@ private:
 public:
   // clang-format off
     _LIBCUDACXX_TEMPLATE(class _Resource)
-        (requires (!_Is_basic_resource_ref<_Resource>
+        _LIBCUDACXX_REQUIRES( (!_Is_basic_resource_ref<_Resource>
           && (((_Alloc_type == _AllocType::_Default) && resource_with<_Resource, _Properties...>) //
             ||((_Alloc_type == _AllocType::_Async) && async_resource_with<_Resource, _Properties...>)))) //
      basic_resource_ref(_Resource& __res) noexcept
@@ -522,7 +522,7 @@ public:
     {}
 
     _LIBCUDACXX_TEMPLATE(class _Resource)
-        (requires (!_Is_basic_resource_ref<_Resource>
+        _LIBCUDACXX_REQUIRES( (!_Is_basic_resource_ref<_Resource>
           && (((_Alloc_type == _AllocType::_Default) && resource_with<_Resource, _Properties...>) //
             ||((_Alloc_type == _AllocType::_Async) && async_resource_with<_Resource, _Properties...>)))) //
      basic_resource_ref(_Resource* __res) noexcept
@@ -532,10 +532,10 @@ public:
 
     #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
-      (requires (_CUDA_VSTD::_One_of<_Properties, _OtherProperties...> && ...))
+      _LIBCUDACXX_REQUIRES( (_CUDA_VSTD::_One_of<_Properties, _OtherProperties...> && ...))
     #else
     _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
-      (requires _CUDA_VSTD::conjunction_v<_CUDA_VSTD::bool_constant<
+      _LIBCUDACXX_REQUIRES( _CUDA_VSTD::conjunction_v<_CUDA_VSTD::bool_constant<
             _CUDA_VSTD::_One_of<_Properties, _OtherProperties...>>...>)
     #endif
      basic_resource_ref(
@@ -546,11 +546,11 @@ public:
 
     #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
-      (requires (_Alloc_type == _AllocType::_Default)
+      _LIBCUDACXX_REQUIRES( (_Alloc_type == _AllocType::_Default)
         && (_CUDA_VSTD::_One_of<_Properties, _OtherProperties...> && ...))
     #else
     _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
-      (requires (_Alloc_type == _AllocType::_Default)
+      _LIBCUDACXX_REQUIRES( (_Alloc_type == _AllocType::_Default)
         && _CUDA_VSTD::conjunction_v<_CUDA_VSTD::bool_constant<
             _CUDA_VSTD::_One_of<_Properties, _OtherProperties...>>...>)
     #endif
@@ -562,11 +562,11 @@ public:
 
     #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
-      (requires(sizeof...(_Properties) == sizeof...(_OtherProperties))
+      _LIBCUDACXX_REQUIRES((sizeof...(_Properties) == sizeof...(_OtherProperties))
             && (_CUDA_VSTD::_One_of<_Properties, _OtherProperties...> && ...))
     #else
     _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
-      (requires (sizeof...(_Properties) == sizeof...(_OtherProperties))
+      _LIBCUDACXX_REQUIRES( (sizeof...(_Properties) == sizeof...(_OtherProperties))
           && _CUDA_VSTD::conjunction_v<_CUDA_VSTD::bool_constant<
           _CUDA_VSTD::_One_of<_Properties, _OtherProperties...>>...>)
     #endif
@@ -578,11 +578,11 @@ public:
 
     #if _LIBCUDACXX_STD_VER > 14
     _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
-      (requires (sizeof...(_Properties) == sizeof...(_OtherProperties))
+      _LIBCUDACXX_REQUIRES( (sizeof...(_Properties) == sizeof...(_OtherProperties))
             && (_CUDA_VSTD::_One_of<_Properties, _OtherProperties...> && ...))
     #else
     _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
-      (requires (sizeof...(_Properties) == sizeof...(_OtherProperties))
+      _LIBCUDACXX_REQUIRES( (sizeof...(_Properties) == sizeof...(_OtherProperties))
           && _CUDA_VSTD::conjunction_v<_CUDA_VSTD::bool_constant<
           _CUDA_VSTD::_One_of<_Properties, _OtherProperties...>>...>)
     #endif
@@ -592,11 +592,11 @@ public:
     }
 
     _LIBCUDACXX_TEMPLATE(class _Property)
-        (requires (!property_with_value<_Property>) _LIBCUDACXX_AND  _CUDA_VSTD::_One_of<_Property, _Properties...>) //
+        _LIBCUDACXX_REQUIRES( (!property_with_value<_Property>) _LIBCUDACXX_AND  _CUDA_VSTD::_One_of<_Property, _Properties...>) //
      friend void get_property(const basic_resource_ref &, _Property) noexcept {}
 
     _LIBCUDACXX_TEMPLATE(class _Property)
-        (requires  property_with_value<_Property> _LIBCUDACXX_AND _CUDA_VSTD::_One_of<_Property, _Properties...>) //
+        _LIBCUDACXX_REQUIRES(  property_with_value<_Property> _LIBCUDACXX_AND _CUDA_VSTD::_One_of<_Property, _Properties...>) //
      friend __property_value_t<_Property> get_property(
         const basic_resource_ref &__res, _Property) noexcept {
         return __res._Property_vtable<_Property>::__property_fn(__res.__object);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/__concept_macros.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/__concept_macros.h
@@ -237,36 +237,28 @@
 // _LIBCUDACXX_TEMPLATE
 // Usage:
 //   _LIBCUDACXX_TEMPLATE(typename A, typename _Bp)
-//     (requires Concept1<A> _LIBCUDACXX_AND Concept2<_Bp>)
+//     _LIBCUDACXX_REQUIRES( Concept1<A> _LIBCUDACXX_AND Concept2<_Bp>)
 //   void foo(A a, _Bp b)
 //   {}
 #if (defined(__cpp_concepts) && _LIBCUDACXX_STD_VER >= 20)
-#define _LIBCUDACXX_TEMPLATE(...)                                              \
-  template <__VA_ARGS__> _LIBCUDACXX_PP_EXPAND /**/
-#define _LIBCUDACXX_AND &&                     /**/
-#define _LIBCUDACXX_TRAILING_REQUIRES(...)                                     \
-  -> __VA_ARGS__ _LIBCUDACXX_PP_EXPAND
+#define _LIBCUDACXX_TEMPLATE(...) template <__VA_ARGS__>
+#define _LIBCUDACXX_REQUIRES(...) requires __VA_ARGS__
+#define _LIBCUDACXX_AND &&
+#define _LIBCUDACXX_TRAILING_REQUIRES(...) -> __VA_ARGS__ requires _LIBCUDACXX_PP_EXPAND
 #else
-#define _LIBCUDACXX_TEMPLATE(...)                                              \
-  template <__VA_ARGS__ _LIBCUDACXX_TEMPLATE_SFINAE_AUX_ /**/
-#define _LIBCUDACXX_AND                                                        \
-  &&_LIBCUDACXX_true_, int > = 0, _Concept::_Enable_if_t < /**/
+#define _LIBCUDACXX_TEMPLATE(...) template <__VA_ARGS__
+#define _LIBCUDACXX_REQUIRES(...)                                              \
+  , bool _LIBCUDACXX_true_ = true,                                             \
+         _Concept::_Enable_if_t <__VA_ARGS__ &&                                \
+             _LIBCUDACXX_true_,                                                \
+         int > = 0 > /**/
+#define _LIBCUDACXX_AND \
+  && _LIBCUDACXX_true_, int > = 0, _Concept::_Enable_if_t <
+#define _LIBCUDACXX_TRAILING_REQUIRES_AUX_(...)                                \
+  , __VA_ARGS__>
 #define _LIBCUDACXX_TRAILING_REQUIRES(...)                                     \
   -> _Concept::_Requires_t<__VA_ARGS__ _LIBCUDACXX_TRAILING_REQUIRES_AUX_
 #endif
-
-#define _LIBCUDACXX_TEMPLATE_SFINAE(...)                                       \
-  template <__VA_ARGS__ _LIBCUDACXX_TEMPLATE_SFINAE_AUX_ /**/
-#define _LIBCUDACXX_TEMPLATE_SFINAE_AUX_(...)                                  \
-  , bool _LIBCUDACXX_true_ = true,                                             \
-         _Concept::_Enable_if_t <                                              \
-                 _LIBCUDACXX_PP_CAT(_LIBCUDACXX_TEMPLATE_SFINAE_AUX_3_,        \
-                                    __VA_ARGS__) &&                            \
-             _LIBCUDACXX_true_,                                                \
-         int > = 0 > /**/
-#define _LIBCUDACXX_TRAILING_REQUIRES_AUX_(...)                                \
-  , _LIBCUDACXX_PP_CAT(_LIBCUDACXX_TEMPLATE_SFINAE_AUX_3_, __VA_ARGS__)> /**/
-#define _LIBCUDACXX_TEMPLATE_SFINAE_AUX_3_requires
 
 namespace _Concept {
 template <bool> struct _Select {};

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/equality_comparable.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/equality_comparable.h
@@ -68,13 +68,14 @@ _LIBCUDACXX_CONCEPT _With_lvalue_reference = _LIBCUDACXX_FRAGMENT(__with_lvalue_
 template<class _Tp, class _Up>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __weakly_equality_comparable_with_,
-  requires(__make_const_lvalue_ref<_Tp> __t, __make_const_lvalue_ref<_Up> __u) //
-  (requires(_With_lvalue_reference<_Tp>),
-   requires(_With_lvalue_reference<_Up>),
-   requires(__boolean_testable<decltype(__t == __u)>),
-   requires(__boolean_testable<decltype(__t != __u)>),
-   requires(__boolean_testable<decltype(__u == __t)>),
-   requires(__boolean_testable<decltype(__u != __t)>)));
+  requires(__make_const_lvalue_ref<_Tp> __t, __make_const_lvalue_ref<_Up> __u)(
+    requires(_With_lvalue_reference<_Tp>),
+    requires(_With_lvalue_reference<_Up>),
+    requires(__boolean_testable<decltype(__t == __u)>),
+    requires(__boolean_testable<decltype(__t != __u)>),
+    requires(__boolean_testable<decltype(__u == __t)>),
+    requires(__boolean_testable<decltype(__u != __t)>)
+  ));
 
 template<class _Tp, class _Up>
 _LIBCUDACXX_CONCEPT __weakly_equality_comparable_with =

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/movable.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/movable.h
@@ -41,11 +41,12 @@ concept movable =
 template<class _Tp>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   _Movable_,
-  requires()
-  (requires(is_object_v<_Tp>),
-   requires(move_constructible<_Tp>),
-   requires(assignable_from<_Tp&, _Tp>),
-   requires(swappable<_Tp>)));
+  requires()(//
+    requires(is_object_v<_Tp>),
+    requires(move_constructible<_Tp>),
+    requires(assignable_from<_Tp&, _Tp>),
+    requires(swappable<_Tp>)
+  ));
 
 template<class _Tp>
 _LIBCUDACXX_CONCEPT movable = _LIBCUDACXX_FRAGMENT(_Movable_, _Tp);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/predicate.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/predicate.h
@@ -37,9 +37,10 @@ concept predicate =
 template<class _Fn, class... _Args>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   _Predicate_,
-  requires()
-  (requires(regular_invocable<_Fn, _Args...>),
-   requires(__boolean_testable<invoke_result_t<_Fn, _Args...>>)));
+  requires()(//
+    requires(regular_invocable<_Fn, _Args...>),
+    requires(__boolean_testable<invoke_result_t<_Fn, _Args...>>)
+  ));
 
 template<class _Fn, class... _Args>
 _LIBCUDACXX_CONCEPT predicate = _LIBCUDACXX_FRAGMENT(_Predicate_, _Fn, _Args...);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/swappable.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/swappable.h
@@ -116,7 +116,7 @@ _LIBCUDACXX_NV_DIAG_DEFAULT(2642)
     // 2.1   `S` is `(void)swap(E1, E2)`* if `E1` or `E2` has class or enumeration type and...
     // *The name `swap` is used here unqualified.
     _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
-      (requires __unqualified_swappable_with<_Tp, _Up>)
+      _LIBCUDACXX_REQUIRES( __unqualified_swappable_with<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr void operator()(_Tp&& __t, _Up&& __u) const
       noexcept(noexcept(swap(_CUDA_VSTD::forward<_Tp>(__t), _CUDA_VSTD::forward<_Up>(__u))))
     {
@@ -125,7 +125,7 @@ _LIBCUDACXX_NV_DIAG_DEFAULT(2642)
 
     // 2.2   Otherwise, if `E1` and `E2` are lvalues of array types with equal extent and...
     _LIBCUDACXX_TEMPLATE(class _Tp, class _Up, size_t _Size)
-      (requires __swappable_arrays<_Tp, _Up, _Size>)
+      _LIBCUDACXX_REQUIRES( __swappable_arrays<_Tp, _Up, _Size>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr void operator()(_Tp(& __t)[_Size], _Up(& __u)[_Size]) const
       noexcept(__noexcept_swappable_arrays<_Tp, _Up>)
     {
@@ -137,7 +137,7 @@ _LIBCUDACXX_NV_DIAG_DEFAULT(2642)
 
     // 2.3   Otherwise, if `E1` and `E2` are lvalues of the same type `T` that models...
     _LIBCUDACXX_TEMPLATE(class _Tp)
-      (requires __exchangeable<_Tp>)
+      _LIBCUDACXX_REQUIRES( __exchangeable<_Tp>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr void operator()(_Tp& __x, _Tp& __y) const
       noexcept(_LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Tp) && _LIBCUDACXX_TRAIT(is_nothrow_move_assignable, _Tp))
     {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/totally_ordered.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__concepts/totally_ordered.h
@@ -61,15 +61,16 @@ concept totally_ordered_with =
 template<class _Tp, class _Up>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __partially_ordered_with_,
-  requires(__make_const_lvalue_ref<_Tp> __t, __make_const_lvalue_ref<_Up> __u) //
-  (requires(__boolean_testable<decltype(__t <  __u)>),
-   requires(__boolean_testable<decltype(__t >  __u)>),
-   requires(__boolean_testable<decltype(__t <= __u)>),
-   requires(__boolean_testable<decltype(__t >= __u)>),
-   requires(__boolean_testable<decltype(__u <  __t)>),
-   requires(__boolean_testable<decltype(__u >  __t)>),
-   requires(__boolean_testable<decltype(__u <= __t)>),
-   requires(__boolean_testable<decltype(__u >= __t)>)));
+  requires(__make_const_lvalue_ref<_Tp> __t, __make_const_lvalue_ref<_Up> __u)(
+    requires(__boolean_testable<decltype(__t <  __u)>),
+    requires(__boolean_testable<decltype(__t >  __u)>),
+    requires(__boolean_testable<decltype(__t <= __u)>),
+    requires(__boolean_testable<decltype(__t >= __u)>),
+    requires(__boolean_testable<decltype(__u <  __t)>),
+    requires(__boolean_testable<decltype(__u >  __t)>),
+    requires(__boolean_testable<decltype(__u <= __t)>),
+    requires(__boolean_testable<decltype(__u >= __t)>)
+  ));
 
 template<class _Tp, class _Up>
 _LIBCUDACXX_CONCEPT __partially_ordered_with = _LIBCUDACXX_FRAGMENT(__partially_ordered_with_, _Tp, _Up);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__expected/expected.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__expected/expected.h
@@ -147,7 +147,7 @@ public:
 
   // [expected.object.ctor], constructors
   _LIBCUDACXX_TEMPLATE(class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_default_constructible, _Tp2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_default_constructible, _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   expected() noexcept(_LIBCUDACXX_TRAIT(is_nothrow_default_constructible, _Tp2))
     : __base(true)
@@ -179,7 +179,7 @@ private:
 
 public:
   _LIBCUDACXX_TEMPLATE(class _Up, class _OtherErr)
-    (requires __can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&>::value _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( __can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&>::value _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, const _Up&, _Tp) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, const _OtherErr&, _Err)
     )
@@ -197,7 +197,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Up, class _OtherErr)
-    (requires __can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&>::value _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( __can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&>::value _LIBCUDACXX_AND
               (!_LIBCUDACXX_TRAIT(is_convertible, const _Up&, _Tp) || !_LIBCUDACXX_TRAIT(is_convertible, const _OtherErr&, _Err))
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -214,7 +214,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Up, class _OtherErr)
-    (requires __can_convert<_Up, _OtherErr, _Up, _OtherErr>::value _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( __can_convert<_Up, _OtherErr, _Up, _OtherErr>::value _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, _Up, _Tp) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, _OtherErr, _Err)
     )
@@ -232,7 +232,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Up, class _OtherErr)
-    (requires __can_convert<_Up, _OtherErr, _Up, _OtherErr>::value _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( __can_convert<_Up, _OtherErr, _Up, _OtherErr>::value _LIBCUDACXX_AND
               (!_LIBCUDACXX_TRAIT(is_convertible, _Up, _Tp) || !_LIBCUDACXX_TRAIT(is_convertible, _OtherErr, _Err))
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -249,7 +249,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Up = _Tp)
-    (requires (!_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, in_place_t)) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, in_place_t)) _LIBCUDACXX_AND
               (!_LIBCUDACXX_TRAIT(is_same, expected, __remove_cvref_t<_Up>)) _LIBCUDACXX_AND
               (!__unexpected::__is_unexpected<__remove_cvref_t<_Up>>) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Up) _LIBCUDACXX_AND
@@ -261,7 +261,7 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class _Up = _Tp)
-    (requires (!_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, in_place_t)) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_same, __remove_cvref_t<_Up>, in_place_t)) _LIBCUDACXX_AND
               (!_LIBCUDACXX_TRAIT(is_same, expected, __remove_cvref_t<_Up>)) _LIBCUDACXX_AND
               (!__unexpected::__is_unexpected<__remove_cvref_t<_Up>>) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Up) _LIBCUDACXX_AND
@@ -273,7 +273,7 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, const _OtherErr&, _Err)
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
@@ -282,7 +282,7 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
               (!_LIBCUDACXX_TRAIT(is_convertible, const _OtherErr&, _Err))
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
@@ -291,7 +291,7 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, _OtherErr, _Err)
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
@@ -301,7 +301,7 @@ public:
 
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
               (!_LIBCUDACXX_TRAIT(is_convertible, _OtherErr, _Err))
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
@@ -310,14 +310,14 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Args...))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   explicit expected(in_place_t, _Args&&... __args) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp, _Args...)) // strengthened
     : __base(in_place, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _LIBCUDACXX_TEMPLATE(class _Up, class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Tp, initializer_list<_Up>&, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Tp, initializer_list<_Up>&, _Args...))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   explicit expected(in_place_t, initializer_list<_Up> __il, _Args&&... __args)
     noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp, initializer_list<_Up>&, _Args...)) // strengthened
@@ -325,14 +325,14 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, _Args...))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   explicit expected(unexpect_t, _Args&&... __args) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Err, _Args...))  // strengthened
     : __base(unexpect, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _LIBCUDACXX_TEMPLATE(class _Up, class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, initializer_list<_Up>&, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, initializer_list<_Up>&, _Args...))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   explicit expected(unexpect_t, initializer_list<_Up> __il, _Args&&... __args)
     noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Err, initializer_list<_Up>&, _Args...)) // strengthened
@@ -357,7 +357,7 @@ private:
 public:
   // [expected.object.assign], assignment
   _LIBCUDACXX_TEMPLATE(class _Up = _Tp)
-    (requires (!_LIBCUDACXX_TRAIT(is_same, expected, __remove_cvref_t<_Up>)) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_same, expected, __remove_cvref_t<_Up>)) _LIBCUDACXX_AND
               (!__unexpected::__is_unexpected<__remove_cvref_t<_Up>>) _LIBCUDACXX_AND
                _LIBCUDACXX_TRAIT(is_constructible, _Tp, _Up) _LIBCUDACXX_AND
                _LIBCUDACXX_TRAIT(is_assignable, _Tp&, _Up) _LIBCUDACXX_AND
@@ -388,7 +388,7 @@ private:
 
 public:
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires __can_assign_from_unexpected<const _OtherErr&>)
+    _LIBCUDACXX_REQUIRES( __can_assign_from_unexpected<const _OtherErr&>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   expected& operator=(const unexpected<_OtherErr>& __un) {
     if (this->__has_val_) {
@@ -401,7 +401,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires __can_assign_from_unexpected<_OtherErr>)
+    _LIBCUDACXX_REQUIRES( __can_assign_from_unexpected<_OtherErr>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   expected& operator=(unexpected<_OtherErr>&& __un) {
     if (this->__has_val_) {
@@ -414,7 +414,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp, _Args...))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   _Tp& emplace(_Args&&... __args) noexcept {
     if (this->__has_val_) {
@@ -427,7 +427,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Up, class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp, initializer_list<_Up>&, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp, initializer_list<_Up>&, _Args...))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   _Tp& emplace(initializer_list<_Up> __il, _Args&&... __args) noexcept {
     if (this->__has_val_) {
@@ -443,7 +443,7 @@ public:
 public:
   // [expected.object.swap], swap
   _LIBCUDACXX_TEMPLATE(class _Tp2 = _Tp, class _Err2 = _Err)
-    (requires __expected::__can_swap<_Tp2, _Err2>)
+    _LIBCUDACXX_REQUIRES( __expected::__can_swap<_Tp2, _Err2>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   void swap(expected<_Tp2, _Err>& __rhs)
     noexcept(_LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Tp2) &&
@@ -474,7 +474,7 @@ public:
                                                    _LIBCUDACXX_TRAIT(is_nothrow_swappable, _Tp2) &&
                                                    _LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Err2) &&
                                                    _LIBCUDACXX_TRAIT(is_nothrow_swappable, _Err2))
-    _LIBCUDACXX_TRAILING_REQUIRES(void)(requires __expected::__can_swap<_Tp2, _Err2>)
+    _LIBCUDACXX_TRAILING_REQUIRES(void)(__expected::__can_swap<_Tp2, _Err2>)
   {
     return __x.swap(__y); // some compiler warn about non void function without return
   }
@@ -587,7 +587,7 @@ public:
 
   // [expected.object.monadic]
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto and_then(_Fun&& __fun) & {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Tp&>>;
@@ -605,7 +605,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto and_then(_Fun&& __fun) const& {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Tp&>>;
@@ -623,7 +623,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_move_constructible, _Err2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_move_constructible, _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto and_then(_Fun&& __fun) && {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Tp>>;
@@ -641,7 +641,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto and_then(_Fun&& __fun) const&& {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Tp>>;
@@ -659,7 +659,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Tp2, _Tp2&))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Tp2, _Tp2&))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto or_else(_Fun&& __fun) & {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Err&>>;
@@ -677,7 +677,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_copy_constructible, _Tp2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_copy_constructible, _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto or_else(_Fun&& __fun) const& {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Err&>>;
@@ -695,7 +695,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_move_constructible, _Tp2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_move_constructible, _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto or_else(_Fun&& __fun) && {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Err>>;
@@ -713,7 +713,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Tp2, const _Tp2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Tp2, const _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto or_else(_Fun&& __fun) const&& {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Err>>;
@@ -731,7 +731,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) & {
@@ -748,7 +748,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) & {
@@ -770,7 +770,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) const& {
@@ -787,7 +787,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) const& {
@@ -809,7 +809,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_move_constructible, _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_move_constructible, _Err2) _LIBCUDACXX_AND
              _LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) && {
@@ -825,7 +825,7 @@ public:
     }
   }
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_move_constructible, _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_move_constructible, _Err2) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) && {
@@ -847,7 +847,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) const&& {
@@ -864,7 +864,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) const&& {
@@ -886,7 +886,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Tp2, _Tp2&))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Tp2, _Tp2&))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform_error(_Fun&& __fun) & {
     static_assert(invocable<_Fun, _Err&>,
@@ -907,7 +907,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_copy_constructible, _Tp2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_copy_constructible, _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform_error(_Fun&& __fun) const& {
     static_assert(invocable<_Fun, const _Err&>,
@@ -928,7 +928,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_move_constructible, _Tp2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_move_constructible, _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform_error(_Fun&& __fun) && {
     static_assert(invocable<_Fun, _Err>,
@@ -949,7 +949,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Tp2, const _Tp2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Tp2, const _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform_error(_Fun&& __fun) const&& {
     static_assert(invocable<_Fun, const _Err>,
@@ -991,7 +991,7 @@ public:
 #endif // _LIBCUDACXX_STD_VER < 20
 
   _LIBCUDACXX_TEMPLATE(class _T2, class _E2)
-    (requires (!_LIBCUDACXX_TRAIT(is_void, _T2)))
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_void, _T2)))
   friend _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   bool operator==(const expected& __x, const expected<_T2, _E2>& __y) {
     if (__x.__has_val_ != __y.has_value()) {
@@ -1007,7 +1007,7 @@ public:
 
 #if _LIBCUDACXX_STD_VER < 20
   _LIBCUDACXX_TEMPLATE(class _T2, class _E2)
-    (requires (!_LIBCUDACXX_TRAIT(is_void, _T2)))
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_void, _T2)))
   friend _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   bool operator!=(const expected& __x, const expected<_T2, _E2>& __y) {
     return !(__x == __y);
@@ -1015,26 +1015,26 @@ public:
 #endif // _LIBCUDACXX_STD_VER < 20
 
   _LIBCUDACXX_TEMPLATE(class _T2)
-    (requires (!__expected::__is_expected_nonvoid<_T2>))
+    _LIBCUDACXX_REQUIRES( (!__expected::__is_expected_nonvoid<_T2>))
   friend _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   bool operator==(const expected& __x, const _T2& __v) {
     return __x.__has_val_ && static_cast<bool>(__x.__union_.__val_ == __v);
   }
 #if _LIBCUDACXX_STD_VER < 20
   _LIBCUDACXX_TEMPLATE(class _T2)
-    (requires (!__expected::__is_expected_nonvoid<_T2>))
+    _LIBCUDACXX_REQUIRES( (!__expected::__is_expected_nonvoid<_T2>))
   friend _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   bool operator==(const _T2& __v, const expected& __x) {
     return __x.__has_val_ && static_cast<bool>(__x.__union_.__val_ == __v);
   }
   _LIBCUDACXX_TEMPLATE(class _T2)
-    (requires (!__expected::__is_expected_nonvoid<_T2>))
+    _LIBCUDACXX_REQUIRES( (!__expected::__is_expected_nonvoid<_T2>))
   friend _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   bool operator!=(const expected& __x, const _T2& __v) {
     return !__x.__has_val_ || static_cast<bool>(__x.__union_.__val_ != __v);
   }
   _LIBCUDACXX_TEMPLATE(class _T2)
-    (requires (!__expected::__is_expected_nonvoid<_T2>))
+    _LIBCUDACXX_REQUIRES( (!__expected::__is_expected_nonvoid<_T2>))
   friend _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   bool operator!=(const _T2& __v, const expected& __x) {
     return !__x.__has_val_ || static_cast<bool>(__x.__union_.__val_ != __v);
@@ -1104,7 +1104,7 @@ public:
   constexpr expected& operator=(expected&&) = default;
 
   _LIBCUDACXX_TEMPLATE(class _Up, class _OtherErr)
-    (requires __can_convert<_Up, _OtherErr, const _OtherErr&>::value _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( __can_convert<_Up, _OtherErr, const _OtherErr&>::value _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, const _OtherErr&, _Err)
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -1118,7 +1118,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Up, class _OtherErr)
-    (requires __can_convert<_Up, _OtherErr, const _OtherErr&>::value _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( __can_convert<_Up, _OtherErr, const _OtherErr&>::value _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_convertible, const _OtherErr&, _Err))
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -1132,7 +1132,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Up, class _OtherErr)
-    (requires __can_convert<_Up, _OtherErr, _OtherErr>::value _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( __can_convert<_Up, _OtherErr, _OtherErr>::value _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, _OtherErr, _Err)
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -1146,7 +1146,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Up, class _OtherErr)
-    (requires __can_convert<_Up, _OtherErr, _OtherErr>::value _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( __can_convert<_Up, _OtherErr, _OtherErr>::value _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_convertible, _OtherErr, _Err))
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -1160,7 +1160,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, const _OtherErr&, _Err)
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
@@ -1170,7 +1170,7 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_convertible, const _OtherErr&, _Err))
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
@@ -1180,7 +1180,7 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_convertible, _OtherErr, _Err))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   expected(unexpected<_OtherErr>&& __unex)
@@ -1189,7 +1189,7 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_convertible, _OtherErr, _Err))
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
@@ -1202,7 +1202,7 @@ public:
   explicit expected(in_place_t) noexcept : __base(true) {}
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, _Args...))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   explicit expected(unexpect_t, _Args&&... __args)
     noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Err, _Args...)) // strengthened
@@ -1210,7 +1210,7 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class _Up, class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, initializer_list<_Up>&, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, initializer_list<_Up>&, _Args...))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   explicit expected(unexpect_t, initializer_list<_Up> __il, _Args&&... __args)
     noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Err, initializer_list<_Up>, _Args...)) // strengthened
@@ -1230,7 +1230,7 @@ public:
   // [expected.void.dtor], destructor
   // [expected.void.assign], assignment
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, const _OtherErr&) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_assignable, _Err&, const _OtherErr&)
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -1248,7 +1248,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _OtherErr)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, _OtherErr) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_assignable, _Err&, _OtherErr)
     )
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -1276,7 +1276,7 @@ public:
 
   // [expected.void.swap], swap
   _LIBCUDACXX_TEMPLATE(class _Err2 = _Err)
-    (requires __expected::__can_swap<void, _Err2>)
+    _LIBCUDACXX_REQUIRES( __expected::__can_swap<void, _Err2>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   void swap(expected<void, _Err2>& __rhs) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Err2) &&
                                                    _LIBCUDACXX_TRAIT(is_nothrow_swappable, _Err2))
@@ -1299,7 +1299,7 @@ public:
   friend _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   auto swap(expected& __x, expected& __y) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Err2) &&
                                                    _LIBCUDACXX_TRAIT(is_nothrow_swappable, _Err2))
-    _LIBCUDACXX_TRAILING_REQUIRES(void)(requires __expected::__can_swap<void, _Err2>)
+    _LIBCUDACXX_TRAILING_REQUIRES(void)(__expected::__can_swap<void, _Err2>)
   {
     return __x.swap(__y); // some compiler warn about non void function without return
   }
@@ -1356,7 +1356,7 @@ public:
 
   // [expected.void.monadic]
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto and_then(_Fun&& __fun) & {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun>>;
@@ -1374,7 +1374,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto and_then(_Fun&& __fun) const& {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun>>;
@@ -1392,7 +1392,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_move_constructible, _Err2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_move_constructible, _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto and_then(_Fun&& __fun) && {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun>>;
@@ -1410,7 +1410,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto and_then(_Fun&& __fun) const&& {
     using _Res = __remove_cvref_t<invoke_result_t<_Fun>>;
@@ -1496,7 +1496,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) & {
@@ -1511,7 +1511,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, _Err2&) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) & {
@@ -1533,7 +1533,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) const& {
@@ -1548,7 +1548,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_copy_constructible, _Err2) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) const& {
@@ -1570,7 +1570,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_move_constructible, _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_move_constructible, _Err2) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) && {
@@ -1584,7 +1584,7 @@ public:
     }
   }
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_move_constructible, _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_move_constructible, _Err2) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) && {
@@ -1606,7 +1606,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2) _LIBCUDACXX_AND
               _LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) const&& {
@@ -1621,7 +1621,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err2, const _Err2) _LIBCUDACXX_AND
             (!_LIBCUDACXX_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   auto transform(_Fun&& __fun) const&& {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__expected/expected_base.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__expected/expected_base.h
@@ -70,12 +70,12 @@ union __expected_union_t {
   struct __empty_t {};
 
   _LIBCUDACXX_TEMPLATE(class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_default_constructible, _Tp2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_default_constructible, _Tp2))
   _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_union_t() noexcept(_LIBCUDACXX_TRAIT(is_nothrow_default_constructible, _Tp2)) : __val_() {}
 
   _LIBCUDACXX_TEMPLATE(class _Tp2 = _Tp)
-    (requires (!_LIBCUDACXX_TRAIT(is_default_constructible, _Tp2)))
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_default_constructible, _Tp2)))
   _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_union_t() noexcept : __empty_() {}
 
@@ -117,12 +117,12 @@ union __expected_union_t<_Tp, _Err, true> {
   struct __empty_t {};
 
   _LIBCUDACXX_TEMPLATE(class _Tp2 = _Tp)
-    (requires _LIBCUDACXX_TRAIT(is_default_constructible, _Tp2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_default_constructible, _Tp2))
   _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_union_t() noexcept(_LIBCUDACXX_TRAIT(is_nothrow_default_constructible, _Tp2)) : __val_() {}
 
   _LIBCUDACXX_TEMPLATE(class _Tp2 = _Tp)
-    (requires (!_LIBCUDACXX_TRAIT(is_default_constructible, _Tp2)))
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_default_constructible, _Tp2)))
   _LIBCUDACXX_INLINE_VISIBILITY constexpr
   __expected_union_t() noexcept : __empty_() {}
 
@@ -380,7 +380,7 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
 #endif // !_LIBCUDACXX_COMPILER_NVRTC || nvcc >= 11.3
 
   _LIBCUDACXX_TEMPLATE(class _T1, class _T2, class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_nothrow_constructible, _T1, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_nothrow_constructible, _T1, _Args...))
   static _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   void __reinit_expected(_T1& __newval, _T2& __oldval, _Args&&... __args) noexcept {
     _CUDA_VSTD::__destroy_at(_CUDA_VSTD::addressof(__oldval));
@@ -388,7 +388,7 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
   }
 
   _LIBCUDACXX_TEMPLATE(class _T1, class _T2, class... _Args)
-    (requires (!_LIBCUDACXX_TRAIT(is_nothrow_constructible, _T1, _Args...)) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_nothrow_constructible, _T1, _Args...)) _LIBCUDACXX_AND
                 _LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _T1)
     )
   static _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -399,7 +399,7 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
   }
 
   _LIBCUDACXX_TEMPLATE(class _T1, class _T2, class... _Args)
-    (requires (!_LIBCUDACXX_TRAIT(is_nothrow_constructible, _T1, _Args...)) _LIBCUDACXX_AND
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_nothrow_constructible, _T1, _Args...)) _LIBCUDACXX_AND
               (!_LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _T1))
     )
   static _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
@@ -416,7 +416,7 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
   }
 
   _LIBCUDACXX_TEMPLATE(class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Err2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Err2))
   static _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   void __swap_val_unex_impl(__expected_storage<_Tp, _Err2>& __with_val, __expected_storage& __with_err) {
     _Err __tmp(_CUDA_VSTD::move(__with_err.__union_.__unex_));
@@ -433,7 +433,7 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
   }
 
   _LIBCUDACXX_TEMPLATE(class _Err2 = _Err)
-    (requires (!_LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Err2)))
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Err2)))
   static _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
   void __swap_val_unex_impl(__expected_storage<_Tp, _Err2>& __with_val, __expected_storage& __with_err) {
     static_assert(_LIBCUDACXX_TRAIT(is_nothrow_move_constructible, _Tp),

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__expected/unexpected.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__expected/unexpected.h
@@ -73,7 +73,7 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI unexpected(unexpected&&)      = default;
 
   _LIBCUDACXX_TEMPLATE(class _Error = _Err)
-    (requires (!_LIBCUDACXX_TRAIT(is_same, remove_cvref_t<_Error>, unexpected) &&
+    _LIBCUDACXX_REQUIRES( (!_LIBCUDACXX_TRAIT(is_same, remove_cvref_t<_Error>, unexpected) &&
                !_LIBCUDACXX_TRAIT(is_same, remove_cvref_t<_Error>, in_place_t) &&
                _LIBCUDACXX_TRAIT(is_constructible, _Err, _Error)))
   _LIBCUDACXX_INLINE_VISIBILITY
@@ -81,13 +81,13 @@ public:
     : __unex_(_CUDA_VSTD::forward<_Error>(__error)) {}
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, _Args...))
   _LIBCUDACXX_INLINE_VISIBILITY
   constexpr explicit unexpected(in_place_t, _Args&&... __args) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Err, _Args...))
     : __unex_(_CUDA_VSTD::forward<_Args>(__args)...) {}
 
   _LIBCUDACXX_TEMPLATE(class _Up, class... _Args)
-    (requires _LIBCUDACXX_TRAIT(is_constructible, _Err, initializer_list<_Up>&, _Args...))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, _Err, initializer_list<_Up>&, _Args...))
   _LIBCUDACXX_INLINE_VISIBILITY
   constexpr explicit unexpected(in_place_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(
     _LIBCUDACXX_TRAIT(is_nothrow_constructible, _Err, initializer_list<_Up>&, _Args...))
@@ -126,7 +126,7 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Err2 = _Err)
-    (requires _LIBCUDACXX_TRAIT(is_swappable, _Err2))
+    _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_swappable, _Err2))
   friend _LIBCUDACXX_INLINE_VISIBILITY constexpr
   void swap(unexpected& __lhs, unexpected& __rhs) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_swappable, _Err2))
   {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/bind_front.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/bind_front.h
@@ -65,7 +65,7 @@ _LIBCUDACXX_CONCEPT __can_bind_front = is_constructible_v<decay_t<_Fn>, _Fn> &&
                                        (is_move_constructible_v<decay_t<_Args>> && ... );
 
 _LIBCUDACXX_TEMPLATE(class _Fn, class... _Args)
-  (requires __can_bind_front<_Fn, _Args...>)
+  _LIBCUDACXX_REQUIRES( __can_bind_front<_Fn, _Args...>)
 _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
 constexpr auto bind_front(_Fn&& __f, _Args&&... __args) noexcept(is_nothrow_constructible_v<tuple<decay_t<_Args>...>, _Args&&...>) {
     return __bind_front_t<decay_t<_Fn>, decay_t<_Args>...>(_CUDA_VSTD::forward<_Fn>(__f), _CUDA_VSTD::forward<_Args>(__args)...);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/not_fn.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/not_fn.h
@@ -47,7 +47,7 @@ struct __not_fn_t : __perfect_forward<__not_fn_op, _Fn> {
     constexpr __not_fn_t() noexcept = default;
 
     _LIBCUDACXX_TEMPLATE(class _OrigFn)
-        (requires _LIBCUDACXX_TRAIT(is_same, _Fn, __decay_t<_OrigFn>))
+        _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_same, _Fn, __decay_t<_OrigFn>))
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     __not_fn_t(_OrigFn&& __fn) noexcept(noexcept(__base(_CUDA_VSTD::declval<_OrigFn>())))
         : __base(_CUDA_VSTD::forward<_OrigFn>(__fn))

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/perfect_forward.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/perfect_forward.h
@@ -45,7 +45,7 @@ private:
 
 public:
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires is_constructible_v<tuple<_BoundArgs...>, _Args&&...>)
+    _LIBCUDACXX_REQUIRES( is_constructible_v<tuple<_BoundArgs...>, _Args&&...>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
   explicit constexpr __perfect_forward_impl(_Args&&... __bound_args)
     noexcept(is_nothrow_constructible_v<tuple<_BoundArgs...>, _Args&&...>)
@@ -58,47 +58,47 @@ public:
   __perfect_forward_impl& operator=(__perfect_forward_impl&&) = default;
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires is_invocable_v<_Op, _BoundArgs&..., _Args...>)
+    _LIBCUDACXX_REQUIRES( is_invocable_v<_Op, _BoundArgs&..., _Args...>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr auto operator()(_Args&&... __args) &
     noexcept(noexcept(_Op()(_CUDA_VSTD::get<_Idx>(__bound_args_)..., _CUDA_VSTD::forward<_Args>(__args)...)))
     -> decltype(      _Op()(_CUDA_VSTD::get<_Idx>(__bound_args_)..., _CUDA_VSTD::forward<_Args>(__args)...))
     { return          _Op()(_CUDA_VSTD::get<_Idx>(__bound_args_)..., _CUDA_VSTD::forward<_Args>(__args)...); }
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires (!is_invocable_v<_Op, _BoundArgs&..., _Args...>))
+    _LIBCUDACXX_REQUIRES( (!is_invocable_v<_Op, _BoundArgs&..., _Args...>))
   _LIBCUDACXX_INLINE_VISIBILITY auto operator()(_Args&&...) & = delete;
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires is_invocable_v<_Op, _BoundArgs const&..., _Args...>)
+    _LIBCUDACXX_REQUIRES( is_invocable_v<_Op, _BoundArgs const&..., _Args...>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr auto operator()(_Args&&... __args) const&
     noexcept(noexcept(_Op()(_CUDA_VSTD::get<_Idx>(__bound_args_)..., _CUDA_VSTD::forward<_Args>(__args)...)))
     -> decltype(      _Op()(_CUDA_VSTD::get<_Idx>(__bound_args_)..., _CUDA_VSTD::forward<_Args>(__args)...))
     { return          _Op()(_CUDA_VSTD::get<_Idx>(__bound_args_)..., _CUDA_VSTD::forward<_Args>(__args)...); }
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires (!is_invocable_v<_Op, _BoundArgs const&..., _Args...>))
+    _LIBCUDACXX_REQUIRES( (!is_invocable_v<_Op, _BoundArgs const&..., _Args...>))
   _LIBCUDACXX_INLINE_VISIBILITY auto operator()(_Args&&...) const& = delete;
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires is_invocable_v<_Op, _BoundArgs..., _Args...>)
+    _LIBCUDACXX_REQUIRES( is_invocable_v<_Op, _BoundArgs..., _Args...>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr auto operator()(_Args&&... __args) &&
     noexcept(noexcept(_Op()(_CUDA_VSTD::get<_Idx>(_CUDA_VSTD::move(__bound_args_))..., _CUDA_VSTD::forward<_Args>(__args)...)))
     -> decltype(      _Op()(_CUDA_VSTD::get<_Idx>(_CUDA_VSTD::move(__bound_args_))..., _CUDA_VSTD::forward<_Args>(__args)...))
     { return          _Op()(_CUDA_VSTD::get<_Idx>(_CUDA_VSTD::move(__bound_args_))..., _CUDA_VSTD::forward<_Args>(__args)...); }
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires (!is_invocable_v<_Op, _BoundArgs..., _Args...>))
+    _LIBCUDACXX_REQUIRES( (!is_invocable_v<_Op, _BoundArgs..., _Args...>))
   _LIBCUDACXX_INLINE_VISIBILITY auto operator()(_Args&&...) && = delete;
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires is_invocable_v<_Op, _BoundArgs const..., _Args...>)
+    _LIBCUDACXX_REQUIRES( is_invocable_v<_Op, _BoundArgs const..., _Args...>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr auto operator()(_Args&&... __args) const&&
     noexcept(noexcept(_Op()(_CUDA_VSTD::get<_Idx>(_CUDA_VSTD::move(__bound_args_))..., _CUDA_VSTD::forward<_Args>(__args)...)))
     -> decltype(      _Op()(_CUDA_VSTD::get<_Idx>(_CUDA_VSTD::move(__bound_args_))..., _CUDA_VSTD::forward<_Args>(__args)...))
     { return          _Op()(_CUDA_VSTD::get<_Idx>(_CUDA_VSTD::move(__bound_args_))..., _CUDA_VSTD::forward<_Args>(__args)...); }
 
   _LIBCUDACXX_TEMPLATE(class... _Args)
-    (requires (!is_invocable_v<_Op, _BoundArgs const..., _Args...>))
+    _LIBCUDACXX_REQUIRES( (!is_invocable_v<_Op, _BoundArgs const..., _Args...>))
   _LIBCUDACXX_INLINE_VISIBILITY auto operator()(_Args&&...) const&& = delete;
 };
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/ranges_operations.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__functional/ranges_operations.h
@@ -29,7 +29,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_RANGES_ABI
 
 struct equal_to {
   _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
-    (requires equality_comparable_with<_Tp, _Up>)
+    _LIBCUDACXX_REQUIRES( equality_comparable_with<_Tp, _Up>)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
   constexpr bool operator()(_Tp &&__t, _Up &&__u) const
       noexcept(noexcept(bool(_CUDA_VSTD::forward<_Tp>(__t) == _CUDA_VSTD::forward<_Up>(__u)))) {
@@ -41,7 +41,7 @@ struct equal_to {
 
 struct not_equal_to {
   _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
-    (requires equality_comparable_with<_Tp, _Up>)
+    _LIBCUDACXX_REQUIRES( equality_comparable_with<_Tp, _Up>)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
   constexpr bool operator()(_Tp &&__t, _Up &&__u) const
       noexcept(noexcept(bool(!(_CUDA_VSTD::forward<_Tp>(__t) == _CUDA_VSTD::forward<_Up>(__u))))) {
@@ -53,7 +53,7 @@ struct not_equal_to {
 
 struct less {
   _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
-    (requires totally_ordered_with<_Tp, _Up>)
+    _LIBCUDACXX_REQUIRES( totally_ordered_with<_Tp, _Up>)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
   constexpr bool operator()(_Tp &&__t, _Up &&__u) const
       noexcept(noexcept(bool(_CUDA_VSTD::forward<_Tp>(__t) < _CUDA_VSTD::forward<_Up>(__u)))) {
@@ -65,7 +65,7 @@ struct less {
 
 struct less_equal {
   _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
-    (requires totally_ordered_with<_Tp, _Up>)
+    _LIBCUDACXX_REQUIRES( totally_ordered_with<_Tp, _Up>)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
   constexpr bool operator()(_Tp &&__t, _Up &&__u) const
       noexcept(noexcept(bool(!(_CUDA_VSTD::forward<_Up>(__u) < _CUDA_VSTD::forward<_Tp>(__t))))) {
@@ -77,7 +77,7 @@ struct less_equal {
 
 struct greater {
   _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
-    (requires totally_ordered_with<_Tp, _Up>)
+    _LIBCUDACXX_REQUIRES( totally_ordered_with<_Tp, _Up>)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
   constexpr bool operator()(_Tp &&__t, _Up &&__u) const
       noexcept(noexcept(bool(_CUDA_VSTD::forward<_Up>(__u) < _CUDA_VSTD::forward<_Tp>(__t)))) {
@@ -89,7 +89,7 @@ struct greater {
 
 struct greater_equal {
   _LIBCUDACXX_TEMPLATE(class _Tp, class _Up)
-    (requires totally_ordered_with<_Tp, _Up>)
+    _LIBCUDACXX_REQUIRES( totally_ordered_with<_Tp, _Up>)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
   constexpr bool operator()(_Tp &&__t, _Up &&__u) const
       noexcept(noexcept(bool(!(_CUDA_VSTD::forward<_Tp>(__t) < _CUDA_VSTD::forward<_Up>(__u))))) {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iter_move.h
@@ -110,7 +110,7 @@ _LIBCUDACXX_CONCEPT __just_deref = _LIBCUDACXX_FRAGMENT(__just_deref_, _Tp);
 
 struct __fn {
   _LIBCUDACXX_TEMPLATE(class _Ip)
-    (requires __unqualified_iter_move<_Ip>)
+    _LIBCUDACXX_REQUIRES( __unqualified_iter_move<_Ip>)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY
     constexpr decltype(auto) operator()(_Ip&& __i) const
     noexcept(noexcept(iter_move(_CUDA_VSTD::forward<_Ip>(__i))))
@@ -119,14 +119,14 @@ struct __fn {
   }
 
   _LIBCUDACXX_TEMPLATE(class _Ip)
-    (requires __move_deref<_Ip>)
+    _LIBCUDACXX_REQUIRES( __move_deref<_Ip>)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY constexpr auto operator()(_Ip&& __i) const
     noexcept(noexcept(_CUDA_VSTD::move(*_CUDA_VSTD::forward<_Ip>(__i))))
     -> decltype(      _CUDA_VSTD::move(*_CUDA_VSTD::forward<_Ip>(__i)))
     { return          _CUDA_VSTD::move(*_CUDA_VSTD::forward<_Ip>(__i)); }
 
   _LIBCUDACXX_TEMPLATE(class _Ip)
-    (requires __just_deref<_Ip>)
+    _LIBCUDACXX_REQUIRES( __just_deref<_Ip>)
   _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_INLINE_VISIBILITY constexpr auto operator()(_Ip&& __i) const
     noexcept(noexcept(*_CUDA_VSTD::forward<_Ip>(__i)))
     -> decltype(      *_CUDA_VSTD::forward<_Ip>(__i))

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iter_swap.h
@@ -97,7 +97,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__iter_swap)
 
   struct __fn {
   _LIBCUDACXX_TEMPLATE(class _T1, class _T2)
-    (requires __unqualified_iter_swap<_T1, _T2>)
+    _LIBCUDACXX_REQUIRES( __unqualified_iter_swap<_T1, _T2>)
     _LIBCUDACXX_INLINE_VISIBILITY
     constexpr void operator()(_T1&& __x, _T2&& __y) const
       noexcept(noexcept(iter_swap(_CUDA_VSTD::forward<_T1>(__x), _CUDA_VSTD::forward<_T2>(__y))))
@@ -106,7 +106,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__iter_swap)
     }
 
   _LIBCUDACXX_TEMPLATE(class _T1, class _T2)
-    (requires __readable_swappable<_T1, _T2>)
+    _LIBCUDACXX_REQUIRES( __readable_swappable<_T1, _T2>)
     _LIBCUDACXX_INLINE_VISIBILITY
     constexpr void operator()(_T1&& __x, _T2&& __y) const
       noexcept(noexcept(_CUDA_VRANGES::swap(*_CUDA_VSTD::forward<_T1>(__x), *_CUDA_VSTD::forward<_T2>(__y))))
@@ -115,7 +115,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__iter_swap)
     }
 
   _LIBCUDACXX_TEMPLATE(class _T1, class _T2)
-    (requires __moveable_storable<_T2, _T1>)
+    _LIBCUDACXX_REQUIRES( __moveable_storable<_T2, _T1>)
     _LIBCUDACXX_INLINE_VISIBILITY
     constexpr void operator()(_T1&& __x, _T2&& __y) const
       noexcept(noexcept(iter_value_t<_T2>(_CUDA_VRANGES::iter_move(__y))) &&

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iterator_traits.h
@@ -429,11 +429,12 @@ namespace __iterator_traits_detail {
 template <class _Ip>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __cpp17_iterator_,
-  requires(_Ip __i) //
-  (requires(__can_reference<decltype(*__i)>),
-   requires(same_as<_Ip&, decltype(++__i)>),
-   requires(__can_reference<decltype(*__i++)>),
-   requires(copyable<_Ip>)));
+  requires(_Ip __i)(//
+    requires(__can_reference<decltype(*__i)>),
+    requires(same_as<_Ip&, decltype(++__i)>),
+    requires(__can_reference<decltype(*__i++)>),
+    requires(copyable<_Ip>)
+  ));
 
 template <class _Ip>
 _LIBCUDACXX_CONCEPT __cpp17_iterator = _LIBCUDACXX_FRAGMENT(__cpp17_iterator_, _Ip);
@@ -485,14 +486,15 @@ _LIBCUDACXX_CONCEPT __cpp17_bidirectional_iterator = _LIBCUDACXX_FRAGMENT(__cpp1
 template<class _Ip>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __cpp17_random_access_iterator_,
-  requires(_Ip __i, typename incrementable_traits<_Ip>::difference_type __n) //
-  (requires(same_as<_Ip&, decltype(__i += __n)>),
-   requires(same_as<_Ip&, decltype(__i -= __n)>),
-   requires(same_as<_Ip, decltype(__i +  __n)>),
-   requires(same_as<_Ip, decltype(__n +  __i)>),
-   requires(same_as<_Ip, decltype(__i -  __n)>),
-   requires(same_as<decltype(__n), decltype(__i -  __i)>),
-   requires(convertible_to<decltype(__i[__n]), iter_reference_t<_Ip>>)));
+  requires(_Ip __i, typename incrementable_traits<_Ip>::difference_type __n)( //
+    requires(same_as<_Ip&, decltype(__i += __n)>),
+    requires(same_as<_Ip&, decltype(__i -= __n)>),
+    requires(same_as<_Ip, decltype(__i +  __n)>),
+    requires(same_as<_Ip, decltype(__n +  __i)>),
+    requires(same_as<_Ip, decltype(__i -  __n)>),
+    requires(same_as<decltype(__n), decltype(__i -  __i)>),
+    requires(convertible_to<decltype(__i[__n]), iter_reference_t<_Ip>>)
+  ));
 
 template<class _Ip>
 _LIBCUDACXX_CONCEPT __cpp17_random_access_iterator =

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/move_sentinel.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/move_sentinel.h
@@ -42,12 +42,12 @@ public:
   explicit move_sentinel(_Sent __s) : __last_(_CUDA_VSTD::move(__s)) {}
 
   _LIBCUDACXX_TEMPLATE(class _S2)
-    (requires convertible_to<const _S2&, _Sent>)
+    _LIBCUDACXX_REQUIRES( convertible_to<const _S2&, _Sent>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   move_sentinel(const move_sentinel<_S2>& __s) : __last_(__s.base()) {}
 
   _LIBCUDACXX_TEMPLATE(class _S2)
-    (requires assignable_from<const _S2&, _Sent>)
+    _LIBCUDACXX_REQUIRES( assignable_from<const _S2&, _Sent>)
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr
   move_sentinel& operator=(const move_sentinel<_S2>& __s)
     { __last_ = __s.base(); return *this; }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/projected.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/projected.h
@@ -28,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if _LIBCUDACXX_STD_VER > 14
 
 _LIBCUDACXX_TEMPLATE(class _It, class _Proj)
-  (requires indirectly_readable<_It> _LIBCUDACXX_AND indirectly_regular_unary_invocable<_Proj, _It>)
+  _LIBCUDACXX_REQUIRES( indirectly_readable<_It> _LIBCUDACXX_AND indirectly_regular_unary_invocable<_Proj, _It>)
 struct projected {
   using value_type = remove_cvref_t<indirect_result_t<_Proj&, _It>>;
   _LIBCUDACXX_INLINE_VISIBILITY indirect_result_t<_Proj&, _It> operator*() const; // not defined

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/sortable.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/sortable.h
@@ -39,9 +39,10 @@ concept sortable =
 template <class _Iter, class _Comp, class _Proj>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __sortable_,
-  requires() //
-  (requires(permutable<_Iter>),
-   requires(indirect_strict_weak_order<_Comp, projected<_Iter, _Proj>>)));
+  requires()( //
+    requires(permutable<_Iter>),
+    requires(indirect_strict_weak_order<_Comp, projected<_Iter, _Proj>>)
+  ));
 
 template <class _Iter, class _Comp = _CUDA_VRANGES::less, class _Proj = identity>
 _LIBCUDACXX_CONCEPT sortable = _LIBCUDACXX_FRAGMENT(__sortable_, _Iter, _Comp, _Proj);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/unreachable_sentinel.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/unreachable_sentinel.h
@@ -29,39 +29,43 @@ _LIBCUDACXX_BEGIN_NAMESPACE_RANGES_ABI
 
 // MSVC requires an interesting workaround for a /permissive- bug
 // We cannot simply define unreachable_sentinel_t with it friendfunctions,
-// but we must derive from a base class in a different namespace so that they are
-// only ever found through ADL
+// but we must derive from a base class in a different namespace so that they
+// are only ever found through ADL
 
 struct unreachable_sentinel_t
 #ifdef _LIBCUDACXX_COMPILER_MSVC
-;
+    ;
 namespace __unreachable_sentinel_detail {
 struct __unreachable_base
 #endif // _LIBCUDACXX_COMPILER_MSVC
 {
   _LIBCUDACXX_TEMPLATE(class _Iter)
-    (requires weakly_incrementable<_Iter>)
-  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_NODISCARD_FRIEND constexpr bool operator==(const unreachable_sentinel_t&, const _Iter&) noexcept {
+  _LIBCUDACXX_REQUIRES(weakly_incrementable<_Iter>)
+  _LIBCUDACXX_HIDE_FROM_ABI
+      _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_NODISCARD_FRIEND constexpr bool
+      operator==(const unreachable_sentinel_t &, const _Iter &) noexcept {
     return false;
   }
 #if _LIBCUDACXX_STD_VER < 20
   _LIBCUDACXX_TEMPLATE(class _Iter)
-    (requires weakly_incrementable<_Iter>)
-  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_NODISCARD_FRIEND constexpr bool operator==(const _Iter&, const unreachable_sentinel_t&) noexcept {
+  _LIBCUDACXX_REQUIRES(weakly_incrementable<_Iter>)
+  _LIBCUDACXX_HIDE_FROM_ABI
+      _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_NODISCARD_FRIEND constexpr bool
+      operator==(const _Iter &, const unreachable_sentinel_t &) noexcept {
     return false;
   }
   _LIBCUDACXX_TEMPLATE(class _Iter)
-    (requires weakly_incrementable<_Iter>)
-  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_NODISCARD_FRIEND constexpr bool operator!=(const unreachable_sentinel_t&, const _Iter&) noexcept {
+  _LIBCUDACXX_REQUIRES(weakly_incrementable<_Iter>)
+  _LIBCUDACXX_HIDE_FROM_ABI
+      _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_NODISCARD_FRIEND constexpr bool
+      operator!=(const unreachable_sentinel_t &, const _Iter &) noexcept {
     return true;
   }
   _LIBCUDACXX_TEMPLATE(class _Iter)
-    (requires weakly_incrementable<_Iter>)
-  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
-  _LIBCUDACXX_NODISCARD_FRIEND constexpr bool operator!=(const _Iter&, const unreachable_sentinel_t&) noexcept {
+  _LIBCUDACXX_REQUIRES(weakly_incrementable<_Iter>)
+  _LIBCUDACXX_HIDE_FROM_ABI
+      _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_NODISCARD_FRIEND constexpr bool
+      operator!=(const _Iter &, const unreachable_sentinel_t &) noexcept {
     return true;
   }
 #endif // _LIBCUDACXX_STD_VER < 20
@@ -69,7 +73,8 @@ struct __unreachable_base
 
 #ifdef _LIBCUDACXX_COMPILER_MSVC
 } // namespace __unreachable_sentinel_detail
-struct unreachable_sentinel_t : __unreachable_sentinel_detail::__unreachable_base {};
+struct unreachable_sentinel_t
+    : __unreachable_sentinel_detail::__unreachable_base {};
 #endif // _LIBCUDACXX_COMPILER_MSVC
 
 _LIBCUDACXX_END_NAMESPACE_RANGES_ABI

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -745,32 +745,32 @@ public:
     _LIBCUDACXX_INLINE_VISIBILITY constexpr optional(nullopt_t) noexcept {}
 
     _LIBCUDACXX_TEMPLATE(class _In_place_t, class... _Args)
-      (requires _LIBCUDACXX_TRAIT(is_same, _In_place_t, in_place_t) _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_same, _In_place_t, in_place_t) _LIBCUDACXX_AND
                 _LIBCUDACXX_TRAIT(is_constructible, value_type, _Args...))
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     explicit optional(_In_place_t, _Args&&... __args)
         : __base(in_place, _CUDA_VSTD::forward<_Args>(__args)...) {}
 
     _LIBCUDACXX_TEMPLATE(class _Up, class... _Args)
-      (requires _LIBCUDACXX_TRAIT(is_constructible, value_type, initializer_list<_Up>&, _Args...))
+      _LIBCUDACXX_REQUIRES( _LIBCUDACXX_TRAIT(is_constructible, value_type, initializer_list<_Up>&, _Args...))
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     explicit optional(in_place_t, initializer_list<_Up> __il, _Args&&... __args)
         : __base(in_place, __il, _CUDA_VSTD::forward<_Args>(__args)...) {}
 
     _LIBCUDACXX_TEMPLATE(class _Up = value_type)
-      (requires __opt_is_constructible_from_U<_Tp, _Up> _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( __opt_is_constructible_from_U<_Tp, _Up> _LIBCUDACXX_AND
                 __opt_is_implictly_constructible<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional(_Up&& __v) : __base(in_place, _CUDA_VSTD::forward<_Up>(__v)) {}
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __opt_is_constructible_from_U<_Tp, _Up> _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( __opt_is_constructible_from_U<_Tp, _Up> _LIBCUDACXX_AND
                 __opt_is_explictly_constructible<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     explicit optional(_Up&& __v) : __base(in_place, _CUDA_VSTD::forward<_Up>(__v)) {}
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
                 __opt_is_implictly_constructible<_Tp, const _Up&>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional(const optional<_Up>& __v) {
@@ -778,7 +778,7 @@ public:
     }
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
                 __opt_is_explictly_constructible<_Tp, const _Up&>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     explicit optional(const optional<_Up>& __v) {
@@ -786,7 +786,7 @@ public:
     }
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
                 __opt_is_implictly_constructible<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional(optional<_Up>&& __v) {
@@ -794,7 +794,7 @@ public:
     }
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( __opt_is_constructible_from_opt<_Tp, _Up> _LIBCUDACXX_AND
                 __opt_is_explictly_constructible<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     explicit optional(optional<_Up>&& __v) {
@@ -820,7 +820,7 @@ public:
     constexpr optional& operator=(optional&&) = default;
 
     _LIBCUDACXX_TEMPLATE(class _Up = value_type)
-      (requires __opt_is_assignable_from_U<_Tp, _Up> _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( __opt_is_assignable_from_U<_Tp, _Up> _LIBCUDACXX_AND
                 __opt_is_assignable<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional& operator=(_Up&& __v) {
@@ -832,7 +832,7 @@ public:
     }
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __opt_is_assignable_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( __opt_is_assignable_from_opt<_Tp, _Up> _LIBCUDACXX_AND
                 __opt_is_assignable<_Tp, const _Up&>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional& operator=(const optional<_Up>& __v) {
@@ -841,7 +841,7 @@ public:
     }
 
     _LIBCUDACXX_TEMPLATE(class _Up)
-      (requires __opt_is_assignable_from_opt<_Tp, _Up> _LIBCUDACXX_AND
+      _LIBCUDACXX_REQUIRES( __opt_is_assignable_from_opt<_Tp, _Up> _LIBCUDACXX_AND
                 __opt_is_assignable<_Tp, _Up>)
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional& operator=(optional<_Up>&& __v) {
@@ -1118,7 +1118,7 @@ public:
     }
 
     _LIBCUDACXX_TEMPLATE(class _Func, class _Tp2 = _Tp)
-        (requires invocable<_Func> _LIBCUDACXX_AND _LIBCUDACXX_TRAIT(is_copy_constructible, _Tp2))
+        _LIBCUDACXX_REQUIRES( invocable<_Func> _LIBCUDACXX_AND _LIBCUDACXX_TRAIT(is_copy_constructible, _Tp2))
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional or_else(_Func&& __f) const& {
         static_assert(_LIBCUDACXX_TRAIT(is_same, remove_cvref_t<invoke_result_t<_Func>>, optional),
@@ -1131,7 +1131,7 @@ public:
     }
 
     _LIBCUDACXX_TEMPLATE(class _Func, class _Tp2 = _Tp)
-        (requires invocable<_Func> _LIBCUDACXX_AND _LIBCUDACXX_TRAIT(is_move_constructible, _Tp2))
+        _LIBCUDACXX_REQUIRES( invocable<_Func> _LIBCUDACXX_AND _LIBCUDACXX_TRAIT(is_move_constructible, _Tp2))
     _LIBCUDACXX_INLINE_VISIBILITY constexpr
     optional or_else(_Func&& __f) && {
         static_assert(_LIBCUDACXX_TRAIT(is_same, remove_cvref_t<invoke_result_t<_Func>>, optional),

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -30,9 +30,9 @@ public:
     template <class... U>
         explicit(see-below) tuple(tuple<U...>&&);  // constexpr in C++14
     template <class U1, class U2>
-        explicit(see-below) tuple(const pair<U1, U2>&); // iff sizeof...(T) == 2 // constexpr in C++14
-    template <class U1, class U2>
-        explicit(see-below) tuple(pair<U1, U2>&&); // iff sizeof...(T) == 2  // constexpr in C++14
+        explicit(see-below) tuple(const pair<U1, U2>&); // iff sizeof...(T) == 2
+// constexpr in C++14 template <class U1, class U2> explicit(see-below)
+tuple(pair<U1, U2>&&); // iff sizeof...(T) == 2  // constexpr in C++14
 
     // allocator-extended constructors
     template <class Alloc>
@@ -46,22 +46,19 @@ public:
     template <class Alloc>
         tuple(allocator_arg_t, const Alloc& a, tuple&&);
     template <class Alloc, class... U>
-        explicit(see-below) tuple(allocator_arg_t, const Alloc& a, const tuple<U...>&);
-    template <class Alloc, class... U>
-        explicit(see-below) tuple(allocator_arg_t, const Alloc& a, tuple<U...>&&);
-    template <class Alloc, class U1, class U2>
-        explicit(see-below) tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&);
-    template <class Alloc, class U1, class U2>
-        explicit(see-below) tuple(allocator_arg_t, const Alloc& a, pair<U1, U2>&&);
+        explicit(see-below) tuple(allocator_arg_t, const Alloc& a, const
+tuple<U...>&); template <class Alloc, class... U> explicit(see-below)
+tuple(allocator_arg_t, const Alloc& a, tuple<U...>&&); template <class Alloc,
+class U1, class U2> explicit(see-below) tuple(allocator_arg_t, const Alloc& a,
+const pair<U1, U2>&); template <class Alloc, class U1, class U2>
+        explicit(see-below) tuple(allocator_arg_t, const Alloc& a, pair<U1,
+U2>&&);
 
     tuple& operator=(const tuple&);
     tuple&
-        operator=(tuple&&) noexcept(AND(is_nothrow_move_assignable<T>::value ...));
-    template <class... U>
-        tuple& operator=(const tuple<U...>&);
-    template <class... U>
-        tuple& operator=(tuple<U...>&&);
-    template <class U1, class U2>
+        operator=(tuple&&) noexcept(AND(is_nothrow_move_assignable<T>::value
+...)); template <class... U> tuple& operator=(const tuple<U...>&); template
+<class... U> tuple& operator=(tuple<U...>&&); template <class U1, class U2>
         tuple& operator=(const pair<U1, U2>&); // iff sizeof...(T) == 2
     template <class U1, class U2>
         tuple& operator=(pair<U1, U2>&&); // iff sizeof...(T) == 2
@@ -70,22 +67,22 @@ public:
 };
 
 template <class ...T>
-tuple(T...) -> tuple<T...>;                                         // since C++17
-template <class T1, class T2>
-tuple(pair<T1, T2>) -> tuple<T1, T2>;                               // since C++17
-template <class Alloc, class ...T>
-tuple(allocator_arg_t, Alloc, T...) -> tuple<T...>;                 // since C++17
-template <class Alloc, class T1, class T2>
-tuple(allocator_arg_t, Alloc, pair<T1, T2>) -> tuple<T1, T2>;       // since C++17
-template <class Alloc, class ...T>
-tuple(allocator_arg_t, Alloc, tuple<T...>) -> tuple<T...>;          // since C++17
+tuple(T...) -> tuple<T...>;                                         // since
+C++17 template <class T1, class T2> tuple(pair<T1, T2>) -> tuple<T1, T2>; //
+since C++17 template <class Alloc, class ...T> tuple(allocator_arg_t, Alloc,
+T...) -> tuple<T...>;                 // since C++17 template <class Alloc,
+class T1, class T2> tuple(allocator_arg_t, Alloc, pair<T1, T2>) -> tuple<T1,
+T2>;       // since C++17 template <class Alloc, class ...T>
+tuple(allocator_arg_t, Alloc, tuple<T...>) -> tuple<T...>;          // since
+C++17
 
 inline constexpr unspecified ignore;
 
 template <class... T> tuple<V...>  make_tuple(T&&...); // constexpr in C++14
-template <class... T> tuple<ATypes...> forward_as_tuple(T&&...) noexcept; // constexpr in C++14
-template <class... T> tuple<T&...> tie(T&...) noexcept; // constexpr in C++14
-template <class... Tuples> tuple<CTypes...> tuple_cat(Tuples&&... tpls); // constexpr in C++14
+template <class... T> tuple<ATypes...> forward_as_tuple(T&&...) noexcept; //
+constexpr in C++14 template <class... T> tuple<T&...> tie(T&...) noexcept; //
+constexpr in C++14 template <class... Tuples> tuple<CTypes...>
+tuple_cat(Tuples&&... tpls); // constexpr in C++14
 
 // [tuple.apply], calling a function with a tuple of arguments:
 template <class F, class Tuple>
@@ -127,12 +124,15 @@ template <class T1, class... T>
     constexpr const T1&& get(const tuple<T...>&&) noexcept;   // C++14
 
 // 20.4.1.6, relational operators:
-template<class... T, class... U> bool operator==(const tuple<T...>&, const tuple<U...>&); // constexpr in C++14
-template<class... T, class... U> bool operator<(const tuple<T...>&, const tuple<U...>&);  // constexpr in C++14
-template<class... T, class... U> bool operator!=(const tuple<T...>&, const tuple<U...>&); // constexpr in C++14
-template<class... T, class... U> bool operator>(const tuple<T...>&, const tuple<U...>&);  // constexpr in C++14
-template<class... T, class... U> bool operator<=(const tuple<T...>&, const tuple<U...>&); // constexpr in C++14
-template<class... T, class... U> bool operator>=(const tuple<T...>&, const tuple<U...>&); // constexpr in C++14
+template<class... T, class... U> bool operator==(const tuple<T...>&, const
+tuple<U...>&); // constexpr in C++14 template<class... T, class... U> bool
+operator<(const tuple<T...>&, const tuple<U...>&);  // constexpr in C++14
+template<class... T, class... U> bool operator!=(const tuple<T...>&, const
+tuple<U...>&); // constexpr in C++14 template<class... T, class... U> bool
+operator>(const tuple<T...>&, const tuple<U...>&);  // constexpr in C++14
+template<class... T, class... U> bool operator<=(const tuple<T...>&, const
+tuple<U...>&); // constexpr in C++14 template<class... T, class... U> bool
+operator>=(const tuple<T...>&, const tuple<U...>&); // constexpr in C++14
 
 template <class... Types, class Alloc>
   struct uses_allocator<tuple<Types...>, Alloc>;
@@ -146,7 +146,7 @@ template <class... Types>
 */
 
 #ifndef __cuda_std__
-#  include <__config>
+#include <__config>
 #endif // __cuda_std__
 
 #include "__assert" // all public C++ headers provide the assertion handler
@@ -180,42 +180,40 @@ template <class... Types>
 
 // [tuple.syn]
 #ifndef _LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
-#  include "compare"
+#include "compare"
 #endif
 
 #ifndef __cuda_std__
-#  include <__pragma_push>
+#include <__pragma_push>
 #endif // __cuda_std__
 
 #if defined(_LIBCUDACXX_USE_PRAGMA_GCC_SYSTEM_HEADER)
-#  pragma GCC system_header
+#pragma GCC system_header
 #endif
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // __tuple_leaf
-struct __tuple_leaf_default_constructor_tag
-{};
+struct __tuple_leaf_default_constructor_tag {};
 
-template <size_t _Ip, class _Hp, bool = _LIBCUDACXX_TRAIT(is_empty, _Hp) && !__libcpp_is_final<_Hp>::value>
+template <size_t _Ip, class _Hp,
+          bool = _LIBCUDACXX_TRAIT(is_empty, _Hp) &&
+                 !__libcpp_is_final<_Hp>::value>
 class __tuple_leaf;
 
 template <size_t _Ip, class _Hp, bool _Ep>
 inline _LIBCUDACXX_INLINE_VISIBILITY void
-swap(__tuple_leaf<_Ip, _Hp, _Ep>& __x, __tuple_leaf<_Ip, _Hp, _Ep>& __y) noexcept(__is_nothrow_swappable<_Hp>::value)
-{
+swap(__tuple_leaf<_Ip, _Hp, _Ep> &__x,
+     __tuple_leaf<_Ip, _Hp, _Ep>
+         &__y) noexcept(__is_nothrow_swappable<_Hp>::value) {
   swap(__x.get(), __y.get());
 }
 
-template <size_t _Ip, class _Hp, bool>
-class __tuple_leaf
-{
+template <size_t _Ip, class _Hp, bool> class __tuple_leaf {
   _Hp __value_;
 
   template <class _Tp>
-  _LIBCUDACXX_INLINE_VISIBILITY static constexpr bool
-  __can_bind_reference()
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY static constexpr bool __can_bind_reference() {
 #if __has_keyword(__reference_binds_to_temporary)
     return !__reference_binds_to_temporary(_Hp, _Tp);
 #else
@@ -223,728 +221,778 @@ class __tuple_leaf
 #endif
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf& operator=(const __tuple_leaf&);
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf &operator=(const __tuple_leaf &);
 
 public:
   _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_leaf() noexcept(
       _LIBCUDACXX_TRAIT(is_nothrow_default_constructible, _Hp))
-      : __value_()
-  {
+      : __value_() {
     static_assert(
-        !_LIBCUDACXX_TRAIT(is_reference, _Hp), "Attempted to default construct a reference element in a tuple");
+        !_LIBCUDACXX_TRAIT(is_reference, _Hp),
+        "Attempted to default construct a reference element in a tuple");
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_leaf(__tuple_leaf_default_constructor_tag) noexcept(
-      _LIBCUDACXX_TRAIT(is_nothrow_default_constructible, _Hp))
-      : __value_()
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_leaf(
+      __tuple_leaf_default_constructor_tag) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_default_constructible,
+                                                                       _Hp))
+      : __value_() {
     static_assert(
-        !_LIBCUDACXX_TRAIT(is_reference, _Hp), "Attempted to default construct a reference element in a tuple");
-  }
-
-  template <class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  __tuple_leaf(integral_constant<int, 0>, const _Alloc&)
-      : __value_()
-  {
-    static_assert(
-        !_LIBCUDACXX_TRAIT(is_reference, _Hp), "Attempted to default construct a reference element in a tuple");
+        !_LIBCUDACXX_TRAIT(is_reference, _Hp),
+        "Attempted to default construct a reference element in a tuple");
   }
 
   template <class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  __tuple_leaf(integral_constant<int, 1>, const _Alloc& __a)
-      : __value_(allocator_arg_t(), __a)
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf(integral_constant<int, 0>,
+                                             const _Alloc &)
+      : __value_() {
     static_assert(
-        !_LIBCUDACXX_TRAIT(is_reference, _Hp), "Attempted to default construct a reference element in a tuple");
+        !_LIBCUDACXX_TRAIT(is_reference, _Hp),
+        "Attempted to default construct a reference element in a tuple");
   }
 
   template <class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  __tuple_leaf(integral_constant<int, 2>, const _Alloc& __a)
-      : __value_(__a)
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf(integral_constant<int, 1>,
+                                             const _Alloc &__a)
+      : __value_(allocator_arg_t(), __a) {
     static_assert(
-        !_LIBCUDACXX_TRAIT(is_reference, _Hp), "Attempted to default construct a reference element in a tuple");
+        !_LIBCUDACXX_TRAIT(is_reference, _Hp),
+        "Attempted to default construct a reference element in a tuple");
+  }
+
+  template <class _Alloc>
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf(integral_constant<int, 2>,
+                                             const _Alloc &__a)
+      : __value_(__a) {
+    static_assert(
+        !_LIBCUDACXX_TRAIT(is_reference, _Hp),
+        "Attempted to default construct a reference element in a tuple");
   }
 
   template <class _Tp>
-  using __can_forward = _And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp>>;
+  using __can_forward = _And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>,
+                             is_constructible<_Hp, _Tp>>;
 
   template <class _Tp, __enable_if_t<__can_forward<_Tp>::value, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit __tuple_leaf(_Tp&& __t) noexcept(
-      _LIBCUDACXX_TRAIT(is_nothrow_constructible, _Hp, _Tp))
-      : __value_(_CUDA_VSTD::forward<_Tp>(__t))
-  {
-    static_assert(__can_bind_reference<_Tp&&>(),
-        "Attempted construction of reference element binds to a "
-        "temporary whose lifetime has ended");
+  _LIBCUDACXX_INLINE_VISIBILITY
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit __tuple_leaf(
+          _Tp &&__t) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Hp,
+                                                _Tp))
+      : __value_(_CUDA_VSTD::forward<_Tp>(__t)) {
+    static_assert(__can_bind_reference<_Tp &&>(),
+                  "Attempted construction of reference element binds to a "
+                  "temporary whose lifetime has ended");
   }
 
   template <class _Tp, class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 0>, const _Alloc&, _Tp&& __t)
-      : __value_(_CUDA_VSTD::forward<_Tp>(__t))
-  {
-    static_assert(__can_bind_reference<_Tp&&>(),
-        "Attempted construction of reference element binds to a "
-        "temporary whose lifetime has ended");
+  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 0>,
+                                                      const _Alloc &, _Tp &&__t)
+      : __value_(_CUDA_VSTD::forward<_Tp>(__t)) {
+    static_assert(__can_bind_reference<_Tp &&>(),
+                  "Attempted construction of reference element binds to a "
+                  "temporary whose lifetime has ended");
   }
 
   template <class _Tp, class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 1>, const _Alloc& __a, _Tp&& __t)
-      : __value_(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tp>(__t))
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 1>,
+                                                      const _Alloc &__a,
+                                                      _Tp &&__t)
+      : __value_(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tp>(__t)) {
     static_assert(
-        !_LIBCUDACXX_TRAIT(is_reference, _Hp), "Attempted to uses-allocator construct a reference element in a tuple");
+        !_LIBCUDACXX_TRAIT(is_reference, _Hp),
+        "Attempted to uses-allocator construct a reference element in a tuple");
   }
 
   template <class _Tp, class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 2>, const _Alloc& __a, _Tp&& __t)
-      : __value_(_CUDA_VSTD::forward<_Tp>(__t), __a)
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 2>,
+                                                      const _Alloc &__a,
+                                                      _Tp &&__t)
+      : __value_(_CUDA_VSTD::forward<_Tp>(__t), __a) {
     static_assert(
-        !_LIBCUDACXX_TRAIT(is_reference, _Hp), "Attempted to uses-allocator construct a reference element in a tuple");
+        !_LIBCUDACXX_TRAIT(is_reference, _Hp),
+        "Attempted to uses-allocator construct a reference element in a tuple");
   }
 
-  __tuple_leaf(const __tuple_leaf& __t) = default;
-  __tuple_leaf(__tuple_leaf&& __t)      = default;
+  __tuple_leaf(const __tuple_leaf &__t) = default;
+  __tuple_leaf(__tuple_leaf &&__t) = default;
 
   template <class _Tp>
-  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf&
-  operator=(_Tp&& __t) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_assignable, _Hp&, _Tp))
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf &operator=(_Tp &&__t) noexcept(
+      _LIBCUDACXX_TRAIT(is_nothrow_assignable, _Hp &, _Tp)) {
     __value_ = _CUDA_VSTD::forward<_Tp>(__t);
     return *this;
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY int
-  swap(__tuple_leaf& __t) noexcept(__is_nothrow_swappable<__tuple_leaf>::value)
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY int swap(__tuple_leaf &__t) noexcept(
+      __is_nothrow_swappable<__tuple_leaf>::value) {
     _CUDA_VSTD::swap(*this, __t);
     return 0;
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _Hp&
-  get() noexcept
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _Hp &
+  get() noexcept {
     return __value_;
   }
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const _Hp&
-  get() const noexcept
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const _Hp &
+  get() const noexcept {
     return __value_;
   }
 };
 
 template <size_t _Ip, class _Hp>
-class __tuple_leaf<_Ip, _Hp, true> : private _Hp
-{
-  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf& operator=(const __tuple_leaf&);
+class __tuple_leaf<_Ip, _Hp, true> : private _Hp {
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf &operator=(const __tuple_leaf &);
 
 public:
-  _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_leaf() noexcept(is_nothrow_default_constructible<_Hp>::value) {}
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_leaf() noexcept(
+      is_nothrow_default_constructible<_Hp>::value) {}
 
-  _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_leaf(__tuple_leaf_default_constructor_tag) noexcept(
-      _LIBCUDACXX_TRAIT(is_nothrow_default_constructible, _Hp))
-      : _Hp()
-  {}
-
-  template <class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  __tuple_leaf(integral_constant<int, 0>, const _Alloc&)
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_leaf(
+      __tuple_leaf_default_constructor_tag) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_default_constructible,
+                                                                       _Hp))
+      : _Hp() {}
 
   template <class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  __tuple_leaf(integral_constant<int, 1>, const _Alloc& __a)
-      : _Hp(allocator_arg_t(), __a)
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf(integral_constant<int, 0>,
+                                             const _Alloc &) {}
 
   template <class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  __tuple_leaf(integral_constant<int, 2>, const _Alloc& __a)
-      : _Hp(__a)
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf(integral_constant<int, 1>,
+                                             const _Alloc &__a)
+      : _Hp(allocator_arg_t(), __a) {}
+
+  template <class _Alloc>
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf(integral_constant<int, 2>,
+                                             const _Alloc &__a)
+      : _Hp(__a) {}
 
   template <class _Tp>
-  using __can_forward = _And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp>>;
+  using __can_forward = _And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>,
+                             is_constructible<_Hp, _Tp>>;
 
   template <class _Tp, __enable_if_t<__can_forward<_Tp>::value, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit __tuple_leaf(_Tp&& __t) noexcept(
-      (is_nothrow_constructible<_Hp, _Tp>::value))
-      : _Hp(_CUDA_VSTD::forward<_Tp>(__t))
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit __tuple_leaf(
+          _Tp &&__t) noexcept((is_nothrow_constructible<_Hp, _Tp>::value))
+      : _Hp(_CUDA_VSTD::forward<_Tp>(__t)) {}
 
   template <class _Tp, class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 0>, const _Alloc&, _Tp&& __t)
-      : _Hp(_CUDA_VSTD::forward<_Tp>(__t))
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 0>,
+                                                      const _Alloc &, _Tp &&__t)
+      : _Hp(_CUDA_VSTD::forward<_Tp>(__t)) {}
 
   template <class _Tp, class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 1>, const _Alloc& __a, _Tp&& __t)
-      : _Hp(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tp>(__t))
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 1>,
+                                                      const _Alloc &__a,
+                                                      _Tp &&__t)
+      : _Hp(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tp>(__t)) {}
 
   template <class _Tp, class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 2>, const _Alloc& __a, _Tp&& __t)
-      : _Hp(_CUDA_VSTD::forward<_Tp>(__t), __a)
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_leaf(integral_constant<int, 2>,
+                                                      const _Alloc &__a,
+                                                      _Tp &&__t)
+      : _Hp(_CUDA_VSTD::forward<_Tp>(__t), __a) {}
 
-  __tuple_leaf(__tuple_leaf const&) = default;
-  __tuple_leaf(__tuple_leaf&&)      = default;
+  __tuple_leaf(__tuple_leaf const &) = default;
+  __tuple_leaf(__tuple_leaf &&) = default;
 
   template <class _Tp>
-  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf&
-  operator=(_Tp&& __t) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_assignable, _Hp&, _Tp))
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_leaf &operator=(_Tp &&__t) noexcept(
+      _LIBCUDACXX_TRAIT(is_nothrow_assignable, _Hp &, _Tp)) {
     _Hp::operator=(_CUDA_VSTD::forward<_Tp>(__t));
     return *this;
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY int
-  swap(__tuple_leaf& __t) noexcept(__is_nothrow_swappable<__tuple_leaf>::value)
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY int swap(__tuple_leaf &__t) noexcept(
+      __is_nothrow_swappable<__tuple_leaf>::value) {
     _CUDA_VSTD::swap(*this, __t);
     return 0;
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _Hp&
-  get() noexcept
-  {
-    return static_cast<_Hp&>(*this);
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _Hp &
+  get() noexcept {
+    return static_cast<_Hp &>(*this);
   }
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const _Hp&
-  get() const noexcept
-  {
-    return static_cast<const _Hp&>(*this);
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const _Hp &
+  get() const noexcept {
+    return static_cast<const _Hp &>(*this);
   }
 };
 
 template <class... _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY void
-__swallow(_Tp&&...) noexcept
-{}
+_LIBCUDACXX_INLINE_VISIBILITY void __swallow(_Tp &&...) noexcept {}
 
-template <class _Tp>
-struct __all_default_constructible;
+template <class _Tp> struct __all_default_constructible;
 
 template <class... _Tp>
-struct __all_default_constructible<__tuple_types<_Tp...>> : __all<_LIBCUDACXX_TRAIT(is_default_constructible, _Tp)...>
-{};
+struct __all_default_constructible<__tuple_types<_Tp...>>
+    : __all<_LIBCUDACXX_TRAIT(is_default_constructible, _Tp)...> {};
 
-struct __tuple_variadic_constructor_tag
-{};
+struct __tuple_variadic_constructor_tag {};
 
 // __tuple_impl
 
-template <class _Indx, class... _Tp>
-struct __tuple_impl;
+template <class _Indx, class... _Tp> struct __tuple_impl;
 
 template <size_t... _Indx, class... _Tp>
-struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...>
-    : public __tuple_leaf<_Indx, _Tp>...
-{
+struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES
+    __tuple_impl<__tuple_indices<_Indx...>, _Tp...>
+    : public __tuple_leaf<_Indx, _Tp>... {
   _LIBCUDACXX_INLINE_VISIBILITY constexpr __tuple_impl() noexcept(
-      __all<_LIBCUDACXX_TRAIT(is_nothrow_default_constructible, _Tp)...>::value)
-  {}
+      __all<_LIBCUDACXX_TRAIT(is_nothrow_default_constructible,
+                              _Tp)...>::value) {}
 
   // Handle non-allocator, full initialization
   // Old MSVC cannot handle the noexept specifier outside of template arguments
-  template <class... _Up, __enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0,
-      bool __all_nothrow_constructible = __all<_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp, _Up)...>::value>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit __tuple_impl(
-      __tuple_variadic_constructor_tag, _Up&&... __u) noexcept(__all_nothrow_constructible)
-      : __tuple_leaf<_Indx, _Tp>(_CUDA_VSTD::forward<_Up>(__u))...
-  {}
+  template <class... _Up,
+            __enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0,
+            bool __all_nothrow_constructible = __all<_LIBCUDACXX_TRAIT(
+                is_nothrow_constructible, _Tp, _Up)...>::value>
+  _LIBCUDACXX_INLINE_VISIBILITY
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit __tuple_impl(
+          __tuple_variadic_constructor_tag,
+          _Up &&...__u) noexcept(__all_nothrow_constructible)
+      : __tuple_leaf<_Indx, _Tp>(_CUDA_VSTD::forward<_Up>(__u))... {}
 
   // Handle non-allocator, partial default initialization
   // Recursively delegate until we have full rank
-  template <class... _Up, __enable_if_t<sizeof...(_Up) < sizeof...(_Tp), int> = 0>
+  template <class... _Up,
+            __enable_if_t<sizeof...(_Up) < sizeof...(_Tp), int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit __tuple_impl(
-      __tuple_variadic_constructor_tag __tag, _Up&&... __u) noexcept(noexcept(__tuple_impl(__tag,
-      _CUDA_VSTD::forward<_Up>(__u)..., __tuple_leaf_default_constructor_tag{})))
-      : __tuple_impl(__tag, _CUDA_VSTD::forward<_Up>(__u)..., __tuple_leaf_default_constructor_tag{})
-  {}
+      __tuple_variadic_constructor_tag __tag,
+      _Up &&...__u) noexcept(noexcept(__tuple_impl(__tag,
+                                                   _CUDA_VSTD::forward<_Up>(
+                                                       __u)...,
+                                                   __tuple_leaf_default_constructor_tag{})))
+      : __tuple_impl(__tag, _CUDA_VSTD::forward<_Up>(__u)...,
+                     __tuple_leaf_default_constructor_tag{}) {}
 
   // Handle allocator aware, full initialization
-  template <class _Alloc, class... _Up, __enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0>
+  template <class _Alloc, class... _Up,
+            __enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_impl(
-      allocator_arg_t, const _Alloc& __a, __tuple_variadic_constructor_tag, _Up&&... __u)
-      : __tuple_leaf<_Indx, _Tp>(__uses_alloc_ctor<_Tp, _Alloc, _Up>(), __a, _CUDA_VSTD::forward<_Up>(__u))...
-  {}
+      allocator_arg_t, const _Alloc &__a, __tuple_variadic_constructor_tag,
+      _Up &&...__u)
+      : __tuple_leaf<_Indx, _Tp>(__uses_alloc_ctor<_Tp, _Alloc, _Up>(), __a,
+                                 _CUDA_VSTD::forward<_Up>(__u))... {}
 
   // Handle allocator aware, full default initialization
   template <class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_impl(allocator_arg_t, const _Alloc& __a)
-      : __tuple_leaf<_Indx, _Tp>(__uses_alloc_ctor<_Tp, _Alloc>(), __a)...
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY explicit __tuple_impl(allocator_arg_t,
+                                                      const _Alloc &__a)
+      : __tuple_leaf<_Indx, _Tp>(__uses_alloc_ctor<_Tp, _Alloc>(), __a)... {}
 
   template <class _Tuple, size_t _Indx2>
-  using __tuple_elem_at = __tuple_element_t<_Indx2, __make_tuple_types_t<_Tuple>>;
+  using __tuple_elem_at =
+      __tuple_element_t<_Indx2, __make_tuple_types_t<_Tuple>>;
 
-  template <class _Tuple, __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value, int> = 0>
+  template <class _Tuple,
+            __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value,
+                          int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-  __tuple_impl(_Tuple&& __t) noexcept(
-      (__all<_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp, __tuple_elem_at<_Tuple, _Indx>)...>::value))
-      : __tuple_leaf<_Indx, _Tp>(_CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(_CUDA_VSTD::get<_Indx>(__t)))...
-  {}
+  __tuple_impl(_Tuple &&__t) noexcept(
+      (__all<_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp,
+                               __tuple_elem_at<_Tuple, _Indx>)...>::value))
+      : __tuple_leaf<_Indx, _Tp>(
+            _CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(
+                _CUDA_VSTD::get<_Indx>(__t)))... {}
 
-  template <class _Alloc, class _Tuple, __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  __tuple_impl(allocator_arg_t, const _Alloc& __a, _Tuple&& __t)
-      : __tuple_leaf<_Indx, _Tp>(__uses_alloc_ctor<_Tp, _Alloc, __tuple_elem_at<_Tuple, _Indx>>(), __a,
-          _CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(_CUDA_VSTD::get<_Indx>(__t)))...
-  {}
+  template <class _Alloc, class _Tuple,
+            __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value,
+                          int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl(allocator_arg_t, const _Alloc &__a,
+                                             _Tuple &&__t)
+      : __tuple_leaf<_Indx, _Tp>(
+            __uses_alloc_ctor<_Tp, _Alloc, __tuple_elem_at<_Tuple, _Indx>>(),
+            __a,
+            _CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(
+                _CUDA_VSTD::get<_Indx>(__t)))... {}
 
-  template < class _Tuple, __enable_if_t<__tuple_assignable<_Tuple, tuple<_Tp...>>::value, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl&
-  operator=(_Tuple&& __t) noexcept(
-      (__all<_LIBCUDACXX_TRAIT(is_nothrow_assignable, _Tp&, __tuple_elem_at<_Tuple, _Indx>)...>::value))
-  {
+  template <
+      class _Tuple,
+      __enable_if_t<__tuple_assignable<_Tuple, tuple<_Tp...>>::value, int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl &operator=(_Tuple &&__t) noexcept(
+      (__all<_LIBCUDACXX_TRAIT(is_nothrow_assignable, _Tp &,
+                               __tuple_elem_at<_Tuple, _Indx>)...>::value)) {
     __swallow(__tuple_leaf<_Indx, _Tp>::operator=(
-        _CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(_CUDA_VSTD::get<_Indx>(__t)))...);
+        _CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(
+            _CUDA_VSTD::get<_Indx>(__t)))...);
     return *this;
   }
 
-  __tuple_impl(const __tuple_impl&) = default;
-  __tuple_impl(__tuple_impl&&)      = default;
+  __tuple_impl(const __tuple_impl &) = default;
+  __tuple_impl(__tuple_impl &&) = default;
 
-  _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl&
-  operator=(const __tuple_impl& __t) noexcept((__all<_LIBCUDACXX_TRAIT(is_nothrow_copy_assignable, _Tp)...>::value))
-  {
-    __swallow(__tuple_leaf<_Indx, _Tp>::operator=(static_cast<const __tuple_leaf<_Indx, _Tp>&>(__t).get())...);
-    return *this;
-  }
-
-  _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl&
-  operator=(__tuple_impl&& __t) noexcept((__all<_LIBCUDACXX_TRAIT(is_nothrow_move_assignable, _Tp)...>::value))
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl &
+  operator=(const __tuple_impl &__t) noexcept(
+      (__all<_LIBCUDACXX_TRAIT(is_nothrow_copy_assignable, _Tp)...>::value)) {
     __swallow(__tuple_leaf<_Indx, _Tp>::operator=(
-        _CUDA_VSTD::forward<_Tp>(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t).get()))...);
+        static_cast<const __tuple_leaf<_Indx, _Tp> &>(__t).get())...);
     return *this;
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY void
-  swap(__tuple_impl& __t) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
-  {
-    __swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t))...);
+  _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl &
+  operator=(__tuple_impl &&__t) noexcept(
+      (__all<_LIBCUDACXX_TRAIT(is_nothrow_move_assignable, _Tp)...>::value)) {
+    __swallow(__tuple_leaf<_Indx, _Tp>::operator=(_CUDA_VSTD::forward<_Tp>(
+        static_cast<__tuple_leaf<_Indx, _Tp> &>(__t).get()))...);
+    return *this;
+  }
+
+  _LIBCUDACXX_INLINE_VISIBILITY void swap(__tuple_impl &__t) noexcept(
+      __all<__is_nothrow_swappable<_Tp>::value...>::value) {
+    __swallow(__tuple_leaf<_Indx, _Tp>::swap(
+        static_cast<__tuple_leaf<_Indx, _Tp> &>(__t))...);
   }
 };
 
-struct __invalid_tuple_constraints
-{
+struct __invalid_tuple_constraints {
   static constexpr bool __implicit_constructible = false;
   static constexpr bool __explicit_constructible = false;
-  static constexpr bool __nothrow_constructible  = false;
+  static constexpr bool __nothrow_constructible = false;
 };
 
-template <class... _Tp>
-struct __tuple_constraints
-{
+template <class... _Tp> struct __tuple_constraints {
   static constexpr bool __implicit_default_constructible =
       __all<__is_implicitly_default_constructible<_Tp>::value...>::value;
 
   static constexpr bool __explicit_default_constructible =
-      !__implicit_default_constructible && __all<_LIBCUDACXX_TRAIT(is_default_constructible, _Tp)...>::value;
+      !__implicit_default_constructible &&
+      __all<_LIBCUDACXX_TRAIT(is_default_constructible, _Tp)...>::value;
 
   static constexpr bool __nothrow_default_constructible =
       __all<_LIBCUDACXX_TRAIT(is_nothrow_default_constructible, _Tp)...>::value;
 
   static constexpr bool __implicit_variadic_copy_constructible =
-      __tuple_constructible<tuple<const _Tp&...>, tuple<_Tp...>>::value
-      && __tuple_convertible<tuple<const _Tp&...>, tuple<_Tp...>>::value;
+      __tuple_constructible<tuple<const _Tp &...>, tuple<_Tp...>>::value &&
+      __tuple_convertible<tuple<const _Tp &...>, tuple<_Tp...>>::value;
 
   static constexpr bool __explicit_variadic_copy_constructible =
-      __tuple_constructible<tuple<const _Tp&...>, tuple<_Tp...>>::value
-      && !__tuple_convertible<tuple<const _Tp&...>, tuple<_Tp...>>::value;
+      __tuple_constructible<tuple<const _Tp &...>, tuple<_Tp...>>::value &&
+      !__tuple_convertible<tuple<const _Tp &...>, tuple<_Tp...>>::value;
 
   static constexpr bool __nothrow_variadic_copy_constructible =
       __all<_LIBCUDACXX_TRAIT(is_nothrow_copy_constructible, _Tp)...>::value;
 
-  template <class... _Args>
-  struct _PackExpandsToThisTuple : false_type
-  {};
+  template <class... _Args> struct _PackExpandsToThisTuple : false_type {};
 
   template <class _Arg>
-  struct _PackExpandsToThisTuple<_Arg> : is_same<__remove_cvref_t<_Arg>, tuple<_Tp...>>
-  {};
+  struct _PackExpandsToThisTuple<_Arg>
+      : is_same<__remove_cvref_t<_Arg>, tuple<_Tp...>> {};
 
-  template <class... _Args>
-  struct __variadic_constraints
-  {
+  template <class... _Args> struct __variadic_constraints {
     static constexpr bool __implicit_constructible =
-        __tuple_constructible<tuple<_Args...>, tuple<_Tp...>>::value
-        && __tuple_convertible<tuple<_Args...>, tuple<_Tp...>>::value;
+        __tuple_constructible<tuple<_Args...>, tuple<_Tp...>>::value &&
+        __tuple_convertible<tuple<_Args...>, tuple<_Tp...>>::value;
 
     static constexpr bool __explicit_constructible =
-        __tuple_constructible<tuple<_Args...>, tuple<_Tp...>>::value
-        && !__tuple_convertible<tuple<_Args...>, tuple<_Tp...>>::value;
+        __tuple_constructible<tuple<_Args...>, tuple<_Tp...>>::value &&
+        !__tuple_convertible<tuple<_Args...>, tuple<_Tp...>>::value;
 
-    static constexpr bool __nothrow_constructible =
-        __all<_LIBCUDACXX_TRAIT(is_nothrow_constructible, _Tp, _Args)...>::value;
+    static constexpr bool __nothrow_constructible = __all<_LIBCUDACXX_TRAIT(
+        is_nothrow_constructible, _Tp, _Args)...>::value;
   };
 
-  template <class... _Args>
-  struct __variadic_constraints_less_rank
-  {
+  template <class... _Args> struct __variadic_constraints_less_rank {
     static constexpr bool __implicit_constructible =
-        __tuple_constructible< tuple<_Args...>, __make_tuple_types_t<tuple<_Tp...>, sizeof...(_Args)>>::value
-        && __tuple_convertible< tuple<_Args...>, __make_tuple_types_t<tuple<_Tp...>, sizeof...(_Args)>>::value
-        && __all_default_constructible<__make_tuple_types_t< tuple<_Tp...>, sizeof...(_Tp), sizeof...(_Args)>>::value;
+        __tuple_constructible<
+            tuple<_Args...>,
+            __make_tuple_types_t<tuple<_Tp...>, sizeof...(_Args)>>::value &&
+        __tuple_convertible<
+            tuple<_Args...>,
+            __make_tuple_types_t<tuple<_Tp...>, sizeof...(_Args)>>::value &&
+        __all_default_constructible<__make_tuple_types_t<
+            tuple<_Tp...>, sizeof...(_Tp), sizeof...(_Args)>>::value;
 
     static constexpr bool __explicit_constructible =
-        __tuple_constructible< tuple<_Args...>, __make_tuple_types_t<tuple<_Tp...>, sizeof...(_Args)>>::value
-        && !__tuple_convertible< tuple<_Args...>, __make_tuple_types_t<tuple<_Tp...>, sizeof...(_Args)>>::value
-        && __all_default_constructible<__make_tuple_types_t< tuple<_Tp...>, sizeof...(_Tp), sizeof...(_Args)>>::value;
+        __tuple_constructible<
+            tuple<_Args...>,
+            __make_tuple_types_t<tuple<_Tp...>, sizeof...(_Args)>>::value &&
+        !__tuple_convertible<
+            tuple<_Args...>,
+            __make_tuple_types_t<tuple<_Tp...>, sizeof...(_Args)>>::value &&
+        __all_default_constructible<__make_tuple_types_t<
+            tuple<_Tp...>, sizeof...(_Tp), sizeof...(_Args)>>::value;
   };
 
-  template <class _Tuple>
-  struct __valid_tuple_like_constraints
-  {
+  template <class _Tuple> struct __valid_tuple_like_constraints {
     static constexpr bool __implicit_constructible =
-        __tuple_constructible<_Tuple, tuple<_Tp...>>::value && __tuple_convertible<_Tuple, tuple<_Tp...>>::value;
+        __tuple_constructible<_Tuple, tuple<_Tp...>>::value &&
+        __tuple_convertible<_Tuple, tuple<_Tp...>>::value;
 
     static constexpr bool __explicit_constructible =
-        __tuple_constructible<_Tuple, tuple<_Tp...>>::value && !__tuple_convertible<_Tuple, tuple<_Tp...>>::value;
+        __tuple_constructible<_Tuple, tuple<_Tp...>>::value &&
+        !__tuple_convertible<_Tuple, tuple<_Tp...>>::value;
   };
 
-  template <class _Tuple>
-  struct __valid_tuple_like_constraints_rank_one
-  {
+  template <class _Tuple> struct __valid_tuple_like_constraints_rank_one {
     template <class _Tuple2>
     struct _PreferTupleLikeConstructorImpl
         : _Or<
               // Don't attempt the two checks below if the tuple we are given
               // has the same type as this tuple.
               _IsSame<__remove_cvref_t<_Tuple2>, tuple<_Tp...>>,
-              _Lazy<_And, _Not<is_constructible<_Tp..., _Tuple2>>, _Not<is_convertible<_Tuple2, _Tp...>>>>
-    {};
+              _Lazy<_And, _Not<is_constructible<_Tp..., _Tuple2>>,
+                    _Not<is_convertible<_Tuple2, _Tp...>>>> {};
 
     // This trait is used to disable the tuple-like constructor when
     // the UTypes... constructor should be selected instead.
     // See LWG issue #2549.
     template <class _Tuple2>
-    using _PreferTupleLikeConstructor = _PreferTupleLikeConstructorImpl<_Tuple2>;
+    using _PreferTupleLikeConstructor =
+        _PreferTupleLikeConstructorImpl<_Tuple2>;
 
     static constexpr bool __implicit_constructible =
-        __tuple_constructible<_Tuple, tuple<_Tp...>>::value && __tuple_convertible<_Tuple, tuple<_Tp...>>::value
-        && _PreferTupleLikeConstructor<_Tuple>::value;
+        __tuple_constructible<_Tuple, tuple<_Tp...>>::value &&
+        __tuple_convertible<_Tuple, tuple<_Tp...>>::value &&
+        _PreferTupleLikeConstructor<_Tuple>::value;
 
     static constexpr bool __explicit_constructible =
-        __tuple_constructible<_Tuple, tuple<_Tp...>>::value && !__tuple_convertible<_Tuple, tuple<_Tp...>>::value
-        && _PreferTupleLikeConstructor<_Tuple>::value;
+        __tuple_constructible<_Tuple, tuple<_Tp...>>::value &&
+        !__tuple_convertible<_Tuple, tuple<_Tp...>>::value &&
+        _PreferTupleLikeConstructor<_Tuple>::value;
   };
 
   template <class _Tuple>
   using __tuple_like_constraints =
-      _If<sizeof...(_Tp) == 1, __valid_tuple_like_constraints_rank_one<_Tuple>, __valid_tuple_like_constraints<_Tuple>>;
+      _If<sizeof...(_Tp) == 1, __valid_tuple_like_constraints_rank_one<_Tuple>,
+          __valid_tuple_like_constraints<_Tuple>>;
 };
 
-template <class... _Tp>
-class _LIBCUDACXX_TEMPLATE_VIS tuple
-{
+template <class... _Tp> class _LIBCUDACXX_TEMPLATE_VIS tuple {
   typedef __tuple_impl<__make_tuple_indices_t<sizeof...(_Tp)>, _Tp...> _BaseT;
 
   _BaseT __base_;
 
-  template <class... _Args>
-  struct _PackExpandsToThisTuple : false_type
-  {};
+  template <class... _Args> struct _PackExpandsToThisTuple : false_type {};
 
   template <class _Arg>
-  struct _PackExpandsToThisTuple<_Arg> : is_same<__remove_cvref_t<_Arg>, tuple>
-  {};
+  struct _PackExpandsToThisTuple<_Arg>
+      : is_same<__remove_cvref_t<_Arg>, tuple> {};
 
   template <size_t _Jp, class... _Up>
-  friend _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY __tuple_element_t<_Jp, tuple<_Up...>>& get(
-      tuple<_Up...>&) noexcept;
+  friend _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
+      _LIBCUDACXX_INLINE_VISIBILITY __tuple_element_t<_Jp, tuple<_Up...>> &
+      get(tuple<_Up...> &) noexcept;
   template <size_t _Jp, class... _Up>
-  friend _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY const __tuple_element_t<_Jp, tuple<_Up...>>&
-  get(const tuple<_Up...>&) noexcept;
+  friend _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY const
+      __tuple_element_t<_Jp, tuple<_Up...>> &
+      get(const tuple<_Up...> &) noexcept;
   template <size_t _Jp, class... _Up>
-  friend _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY __tuple_element_t<_Jp, tuple<_Up...>>&& get(
-      tuple<_Up...>&&) noexcept;
+  friend _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
+      _LIBCUDACXX_INLINE_VISIBILITY __tuple_element_t<_Jp, tuple<_Up...>> &&
+      get(tuple<_Up...> &&) noexcept;
   template <size_t _Jp, class... _Up>
-  friend _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY const __tuple_element_t<_Jp, tuple<_Up...>>&&
-  get(const tuple<_Up...>&&) noexcept;
+  friend _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY const
+      __tuple_element_t<_Jp, tuple<_Up...>> &&
+      get(const tuple<_Up...> &&) noexcept;
 
 public:
-  template < class _Constraints                                          = __tuple_constraints<_Tp...>,
+  template <
+      class _Constraints = __tuple_constraints<_Tp...>,
       __enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY constexpr tuple() noexcept(_Constraints::__nothrow_default_constructible)
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr tuple() noexcept(
+      _Constraints::__nothrow_default_constructible) {}
 
-  template < class _Constraints                                          = __tuple_constraints<_Tp...>,
+  template <
+      class _Constraints = __tuple_constraints<_Tp...>,
       __enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit constexpr tuple() noexcept(_Constraints::__nothrow_default_constructible)
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY explicit constexpr tuple() noexcept(
+      _Constraints::__nothrow_default_constructible) {}
 
-  tuple(tuple const&) = default;
-  tuple(tuple&&)      = default;
+  tuple(tuple const &) = default;
+  tuple(tuple &&) = default;
 
-  template <class _AllocArgT, class _Alloc, class _Constraints = __tuple_constraints<_Tp...>,
-      __enable_if_t<_LIBCUDACXX_TRAIT(is_same, allocator_arg_t, _AllocArgT), int> = 0,
-      __enable_if_t<_Constraints::__implicit_default_constructible, int>          = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  tuple(_AllocArgT, _Alloc const& __a) noexcept(_Constraints::__nothrow_default_constructible)
-      : __base_(allocator_arg_t(), __a)
-  {}
+  template <
+      class _AllocArgT, class _Alloc,
+      class _Constraints = __tuple_constraints<_Tp...>,
+      __enable_if_t<_LIBCUDACXX_TRAIT(is_same, allocator_arg_t, _AllocArgT),
+                    int> = 0,
+      __enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY tuple(_AllocArgT, _Alloc const &__a) noexcept(
+      _Constraints::__nothrow_default_constructible)
+      : __base_(allocator_arg_t(), __a) {}
 
-  template <class _AllocArgT, class _Alloc, class _Constraints = __tuple_constraints<_Tp...>,
-      __enable_if_t<_LIBCUDACXX_TRAIT(is_same, allocator_arg_t, _AllocArgT), int> = 0,
-      __enable_if_t<_Constraints::__explicit_default_constructible, int>          = 0>
-  explicit _LIBCUDACXX_INLINE_VISIBILITY
-  tuple(_AllocArgT, _Alloc const& __a) noexcept(_Constraints::__nothrow_default_constructible)
-      : __base_(allocator_arg_t(), __a)
-  {}
+  template <
+      class _AllocArgT, class _Alloc,
+      class _Constraints = __tuple_constraints<_Tp...>,
+      __enable_if_t<_LIBCUDACXX_TRAIT(is_same, allocator_arg_t, _AllocArgT),
+                    int> = 0,
+      __enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
+  explicit _LIBCUDACXX_INLINE_VISIBILITY tuple(
+      _AllocArgT,
+      _Alloc const &__a) noexcept(_Constraints::__nothrow_default_constructible)
+      : __base_(allocator_arg_t(), __a) {}
 
-  template <class _Constraints                                                 = __tuple_constraints<_Tp...>,
-      __enable_if_t<_Constraints::__implicit_variadic_copy_constructible, int> = 0>
+  template <class _Constraints = __tuple_constraints<_Tp...>,
+            __enable_if_t<_Constraints::__implicit_variadic_copy_constructible,
+                          int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-  tuple(const _Tp&... __t) noexcept(_Constraints::__nothrow_variadic_copy_constructible)
-      : __base_(__tuple_variadic_constructor_tag{}, __t...)
-  {}
-
-  template <class _Constraints                                                 = __tuple_constraints<_Tp...>,
-      __enable_if_t<_Constraints::__explicit_variadic_copy_constructible, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(const _Tp&... __t) noexcept(
+  tuple(const _Tp &...__t) noexcept(
       _Constraints::__nothrow_variadic_copy_constructible)
-      : __base_(__tuple_variadic_constructor_tag{}, __t...)
-  {}
+      : __base_(__tuple_variadic_constructor_tag{}, __t...) {}
 
-  template <class _Alloc, class _Constraints = __tuple_constraints<_Tp...>,
-      __enable_if_t<_Constraints::__implicit_variadic_copy_constructible, int> = 0>
+  template <class _Constraints = __tuple_constraints<_Tp...>,
+            __enable_if_t<_Constraints::__explicit_variadic_copy_constructible,
+                          int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY
-  tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
-      _Constraints::__nothrow_variadic_copy_constructible)
-      : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, __t...)
-  {}
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(
+          const _Tp &...__t) noexcept(_Constraints::
+                                          __nothrow_variadic_copy_constructible)
+      : __base_(__tuple_variadic_constructor_tag{}, __t...) {}
 
   template <class _Alloc, class _Constraints = __tuple_constraints<_Tp...>,
-      __enable_if_t<_Constraints::__explicit_variadic_copy_constructible, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
+            __enable_if_t<_Constraints::__implicit_variadic_copy_constructible,
+                          int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY
+  tuple(allocator_arg_t, const _Alloc &__a, const _Tp &...__t) noexcept(
       _Constraints::__nothrow_variadic_copy_constructible)
-      : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, __t...)
-  {}
+      : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{},
+                __t...) {}
+
+  template <class _Alloc, class _Constraints = __tuple_constraints<_Tp...>,
+            __enable_if_t<_Constraints::__explicit_variadic_copy_constructible,
+                          int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY explicit tuple(
+      allocator_arg_t, const _Alloc &__a,
+      const _Tp
+          &...__t) noexcept(_Constraints::__nothrow_variadic_copy_constructible)
+      : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{},
+                __t...) {}
 
 #if defined(_LIBCUDACXX_NO_TUPLE_NOEXCEPT)
-  template <class... _Vp>
-  using __base_noexcept_constructible = false_type;
+  template <class... _Vp> using __base_noexcept_constructible = false_type;
 #else
   template <class... _Vp>
-  using __base_noexcept_constructible = is_nothrow_constructible< _BaseT, _Vp... >;
+  using __base_noexcept_constructible =
+      is_nothrow_constructible<_BaseT, _Vp...>;
 #endif // defined(_LIBCUDACXX_NO_TUPLE_NOEXCEPT)
 
   template <class... _Up>
-  using __variadic_constraints = _If<!_PackExpandsToThisTuple<_Up...>::value && sizeof...(_Up) == sizeof...(_Tp),
-      typename __tuple_constraints<_Tp...>::template __variadic_constraints<_Up...>, __invalid_tuple_constraints>;
+  using __variadic_constraints =
+      _If<!_PackExpandsToThisTuple<_Up...>::value &&
+              sizeof...(_Up) == sizeof...(_Tp),
+          typename __tuple_constraints<_Tp...>::template __variadic_constraints<
+              _Up...>,
+          __invalid_tuple_constraints>;
 
   template <class... _Up, class _Constraints = __variadic_constraints<_Up...>,
-      __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-  tuple(_Up&&... __u) noexcept(_Constraints::__nothrow_constructible)
-      : __base_(__tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
-  {}
+  tuple(_Up &&...__u) noexcept(_Constraints::__nothrow_constructible)
+      : __base_(__tuple_variadic_constructor_tag{},
+                _CUDA_VSTD::forward<_Up>(__u)...) {}
 
   template <class... _Up, class _Constraints = __variadic_constraints<_Up...>,
-      __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(_Up&&... __u) noexcept(
-      _Constraints::__nothrow_constructible)
-      : __base_(__tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
-  {}
+            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(_Up &&...__u) noexcept(
+          _Constraints::__nothrow_constructible)
+      : __base_(__tuple_variadic_constructor_tag{},
+                _CUDA_VSTD::forward<_Up>(__u)...) {}
 
   template <class... _Up>
-  using __variadic_constraints_less_rank = _If<!_PackExpandsToThisTuple<_Up...>::value,
-      typename __tuple_constraints<_Tp...>::template __variadic_constraints_less_rank<_Up...>,
-      __invalid_tuple_constraints>;
+  using __variadic_constraints_less_rank =
+      _If<!_PackExpandsToThisTuple<_Up...>::value,
+          typename __tuple_constraints<
+              _Tp...>::template __variadic_constraints_less_rank<_Up...>,
+          __invalid_tuple_constraints>;
 
-  template <class... _Up, class _Constraints = __variadic_constraints_less_rank<_Up...>,
-      __enable_if_t<sizeof...(_Up) < sizeof...(_Tp), int>        = 0,
-      __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(_Up&&... __u) noexcept(
-      __base_noexcept_constructible<__tuple_variadic_constructor_tag, _Up...>::value)
-      : __base_(__tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
-  {}
-
-  template <class _Alloc, class... _Up, class _Constraints = __variadic_constraints<_Up...>,
-      __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  template <class... _Up,
+            class _Constraints = __variadic_constraints_less_rank<_Up...>,
+            __enable_if_t<sizeof...(_Up) < sizeof...(_Tp), int> = 0,
+            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY
-  tuple(allocator_arg_t, const _Alloc& __a, _Up&&... __u) noexcept(_Constraints::__nothrow_constructible)
-      : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
-  {}
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(_Up &&...__u) noexcept(
+          __base_noexcept_constructible<__tuple_variadic_constructor_tag,
+                                        _Up...>::value)
+      : __base_(__tuple_variadic_constructor_tag{},
+                _CUDA_VSTD::forward<_Up>(__u)...) {}
 
-  template <class _Alloc, class... _Up, class _Constraints = __variadic_constraints<_Up...>,
-      __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  template <class _Alloc, class... _Up,
+            class _Constraints = __variadic_constraints<_Up...>,
+            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY
-  explicit tuple(allocator_arg_t, const _Alloc& __a, _Up&&... __u) noexcept(
-      _Constraints::__nothrow_constructible)
-      : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
-  {}
+  tuple(allocator_arg_t, const _Alloc &__a,
+        _Up &&...__u) noexcept(_Constraints::__nothrow_constructible)
+      : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{},
+                _CUDA_VSTD::forward<_Up>(__u)...) {}
+
+  template <class _Alloc, class... _Up,
+            class _Constraints = __variadic_constraints<_Up...>,
+            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY explicit tuple(
+      allocator_arg_t, const _Alloc &__a,
+      _Up &&...__u) noexcept(_Constraints::__nothrow_constructible)
+      : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{},
+                _CUDA_VSTD::forward<_Up>(__u)...) {}
 
   template <class _Tuple>
-  using __tuple_like_constraints = _If<__tuple_like_with_size<_Tuple, sizeof...(_Tp)>::value,
-      typename __tuple_constraints< _Tp...>::template __tuple_like_constraints<_Tuple>, __invalid_tuple_constraints>;
+  using __tuple_like_constraints =
+      _If<__tuple_like_with_size<_Tuple, sizeof...(_Tp)>::value,
+          typename __tuple_constraints<
+              _Tp...>::template __tuple_like_constraints<_Tuple>,
+          __invalid_tuple_constraints>;
 
-  template < class _Tuple, class _Constraints = __tuple_like_constraints<_Tuple>,
-      __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int>         = 0,
-      __enable_if_t<!_LIBCUDACXX_TRAIT(is_lvalue_reference, _Tuple), int> = 0,
-      __enable_if_t<_Constraints::__implicit_constructible, int>          = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-  tuple(_Tuple&& __t) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _BaseT, _Tuple))
-      : __base_(_CUDA_VSTD::forward<_Tuple>(__t))
-  {}
-
-  template <class _Tuple, class _Constraints = __tuple_like_constraints<const _Tuple&>,
+  template <
+      class _Tuple, class _Constraints = __tuple_like_constraints<_Tuple>,
       __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
-      __enable_if_t<_Constraints::__implicit_constructible, int>  = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-  tuple(const _Tuple& __t) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _BaseT, const _Tuple&))
-      : __base_(__t)
-  {}
-
-  template < class _Tuple, class _Constraints = __tuple_like_constraints<_Tuple>,
-      __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int>         = 0,
       __enable_if_t<!_LIBCUDACXX_TRAIT(is_lvalue_reference, _Tuple), int> = 0,
-      __enable_if_t<_Constraints::__explicit_constructible, int>          = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(_Tuple&& __t) noexcept(
-      _LIBCUDACXX_TRAIT(is_nothrow_constructible, _BaseT, _Tuple))
-      : __base_(_CUDA_VSTD::forward<_Tuple>(__t))
-  {}
-
-  template <class _Tuple, class _Constraints = __tuple_like_constraints<const _Tuple&>,
-      __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
-      __enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(const _Tuple& __t) noexcept(
-      _LIBCUDACXX_TRAIT(is_nothrow_constructible, _BaseT, const _Tuple&))
-      : __base_(__t)
-  {}
-
-  template <class _Alloc, class _Tuple, class _Constraints = __tuple_like_constraints<_Tuple>,
       __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t)
-      : __base_(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tuple>(__t))
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
+  tuple(_Tuple &&__t) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible,
+                                                 _BaseT, _Tuple))
+      : __base_(_CUDA_VSTD::forward<_Tuple>(__t)) {}
 
-  template <class _Alloc, class _Tuple, class _Constraints = __tuple_like_constraints<_Tuple>,
+  template <class _Tuple,
+            class _Constraints = __tuple_like_constraints<const _Tuple &>,
+            __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
+            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
+  tuple(const _Tuple &__t) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible,
+                                                      _BaseT, const _Tuple &))
+      : __base_(__t) {}
+
+  template <
+      class _Tuple, class _Constraints = __tuple_like_constraints<_Tuple>,
+      __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
+      __enable_if_t<!_LIBCUDACXX_TRAIT(is_lvalue_reference, _Tuple), int> = 0,
       __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY
-  explicit tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t)
-      : __base_(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tuple>(__t))
-  {}
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(_Tuple &&__t) noexcept(
+          _LIBCUDACXX_TRAIT(is_nothrow_constructible, _BaseT, _Tuple))
+      : __base_(_CUDA_VSTD::forward<_Tuple>(__t)) {}
+
+  template <class _Tuple,
+            class _Constraints = __tuple_like_constraints<const _Tuple &>,
+            __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
+            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 explicit tuple(
+          const _Tuple
+              &__t) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_constructible, _BaseT,
+                                               const _Tuple &))
+      : __base_(__t) {}
+
+  template <class _Alloc, class _Tuple,
+            class _Constraints = __tuple_like_constraints<_Tuple>,
+            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY tuple(allocator_arg_t, const _Alloc &__a,
+                                      _Tuple &&__t)
+      : __base_(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tuple>(__t)) {}
+
+  template <class _Alloc, class _Tuple,
+            class _Constraints = __tuple_like_constraints<_Tuple>,
+            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY explicit tuple(allocator_arg_t,
+                                               const _Alloc &__a, _Tuple &&__t)
+      : __base_(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tuple>(__t)) {}
 
   using _CanCopyAssign = __all<_LIBCUDACXX_TRAIT(is_copy_assignable, _Tp)...>;
   using _CanMoveAssign = __all<_LIBCUDACXX_TRAIT(is_move_assignable, _Tp)...>;
 
-  _LIBCUDACXX_INLINE_VISIBILITY tuple&
-  operator=(__conditional_t<_CanCopyAssign::value, tuple, __nat> const& __t) noexcept(
-      (__all<_LIBCUDACXX_TRAIT(is_nothrow_copy_assignable, _Tp)...>::value))
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY tuple &operator=(
+      __conditional_t<_CanCopyAssign::value, tuple, __nat> const
+          &__t) noexcept((__all<_LIBCUDACXX_TRAIT(is_nothrow_copy_assignable,
+                                                  _Tp)...>::value)) {
     __base_.operator=(__t.__base_);
     return *this;
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY tuple&
-  operator=(__conditional_t<_CanMoveAssign::value, tuple, __nat>&& __t) noexcept(
-      (__all<_LIBCUDACXX_TRAIT(is_nothrow_move_assignable, _Tp)...>::value))
-  {
-    __base_.operator=(static_cast<_BaseT&&>(__t.__base_));
+  _LIBCUDACXX_INLINE_VISIBILITY tuple &operator=(
+      __conditional_t<_CanMoveAssign::value, tuple, __nat>
+          &&__t) noexcept((__all<_LIBCUDACXX_TRAIT(is_nothrow_move_assignable,
+                                                   _Tp)...>::value)) {
+    __base_.operator=(static_cast<_BaseT &&>(__t.__base_));
     return *this;
   }
 
-  template < class _Tuple, __enable_if_t<__tuple_assignable<_Tuple, tuple>::value, bool> = false>
-  _LIBCUDACXX_INLINE_VISIBILITY tuple&
-  operator=(_Tuple&& __t) noexcept(_LIBCUDACXX_TRAIT(is_nothrow_assignable, _BaseT&, _Tuple))
-  {
+  template <
+      class _Tuple,
+      __enable_if_t<__tuple_assignable<_Tuple, tuple>::value, bool> = false>
+  _LIBCUDACXX_INLINE_VISIBILITY tuple &operator=(_Tuple &&__t) noexcept(
+      _LIBCUDACXX_TRAIT(is_nothrow_assignable, _BaseT &, _Tuple)) {
     __base_.operator=(_CUDA_VSTD::forward<_Tuple>(__t));
     return *this;
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY void
-  swap(tuple& __t) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY void swap(tuple &__t) noexcept(
+      __all<__is_nothrow_swappable<_Tp>::value...>::value) {
     __base_.swap(__t.__base_);
   }
 };
 
-template <>
-class _LIBCUDACXX_TEMPLATE_VIS tuple<>
-{
+template <> class _LIBCUDACXX_TEMPLATE_VIS tuple<> {
 public:
   constexpr tuple() noexcept = default;
   template <class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  tuple(allocator_arg_t, const _Alloc&) noexcept
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY tuple(allocator_arg_t,
+                                      const _Alloc &) noexcept {}
   template <class _Alloc>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  tuple(allocator_arg_t, const _Alloc&, const tuple&) noexcept
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY tuple(allocator_arg_t, const _Alloc &,
+                                      const tuple &) noexcept {}
   template <class _Up>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  tuple(array<_Up, 0>) noexcept
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY tuple(array<_Up, 0>) noexcept {}
   template <class _Alloc, class _Up>
-  _LIBCUDACXX_INLINE_VISIBILITY
-  tuple(allocator_arg_t, const _Alloc&, array<_Up, 0>) noexcept
-  {}
-  _LIBCUDACXX_INLINE_VISIBILITY void
-  swap(tuple&) noexcept
-  {}
+  _LIBCUDACXX_INLINE_VISIBILITY tuple(allocator_arg_t, const _Alloc &,
+                                      array<_Up, 0>) noexcept {}
+  _LIBCUDACXX_INLINE_VISIBILITY void swap(tuple &) noexcept {}
 };
 
 #ifndef _LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES
-template <class... _Tp>
-_LIBCUDACXX_HOST_DEVICE tuple(_Tp...) -> tuple<_Tp...>;
+template <class... _Tp> _LIBCUDACXX_HOST_DEVICE tuple(_Tp...) -> tuple<_Tp...>;
 template <class _Tp1, class _Tp2>
 _LIBCUDACXX_HOST_DEVICE tuple(pair<_Tp1, _Tp2>) -> tuple<_Tp1, _Tp2>;
 template <class _Alloc, class... _Tp>
 _LIBCUDACXX_HOST_DEVICE tuple(allocator_arg_t, _Alloc, _Tp...) -> tuple<_Tp...>;
 template <class _Alloc, class _Tp1, class _Tp2>
-_LIBCUDACXX_HOST_DEVICE tuple(allocator_arg_t, _Alloc, pair<_Tp1, _Tp2>) -> tuple<_Tp1, _Tp2>;
+_LIBCUDACXX_HOST_DEVICE tuple(allocator_arg_t, _Alloc, pair<_Tp1, _Tp2>)
+    -> tuple<_Tp1, _Tp2>;
 template <class _Alloc, class... _Tp>
-_LIBCUDACXX_HOST_DEVICE tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>;
+_LIBCUDACXX_HOST_DEVICE tuple(allocator_arg_t, _Alloc, tuple<_Tp...>)
+    -> tuple<_Tp...>;
 #endif // _LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES
 
 template <class... _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY __enable_if_t<_And<__is_swappable<_Tp>...>::value, void>
-swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
-{
+inline _LIBCUDACXX_INLINE_VISIBILITY
+    __enable_if_t<_And<__is_swappable<_Tp>...>::value, void>
+    swap(tuple<_Tp...> &__t, tuple<_Tp...> &__u) noexcept(
+        __all<__is_nothrow_swappable<_Tp>::value...>::value) {
   __t.swap(__u);
 }
 
 // get
 template <size_t _Ip, class... _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __tuple_element_t<_Ip, tuple<_Tp...>>&
-get(tuple<_Tp...>& __t) noexcept
-{
+inline _LIBCUDACXX_INLINE_VISIBILITY
+    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __tuple_element_t<_Ip, tuple<_Tp...>> &
+    get(tuple<_Tp...> &__t) noexcept {
   typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_element_t<_Ip, tuple<_Tp...>> type;
-  return static_cast<__tuple_leaf<_Ip, type>&>(__t.__base_).get();
+  return static_cast<__tuple_leaf<_Ip, type> &>(__t.__base_).get();
 }
 
 template <size_t _Ip, class... _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const __tuple_element_t<_Ip, tuple<_Tp...>>&
-get(const tuple<_Tp...>& __t) noexcept
-{
+inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const
+    __tuple_element_t<_Ip, tuple<_Tp...>> &
+    get(const tuple<_Tp...> &__t) noexcept {
   typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_element_t<_Ip, tuple<_Tp...>> type;
-  return static_cast<const __tuple_leaf<_Ip, type>&>(__t.__base_).get();
+  return static_cast<const __tuple_leaf<_Ip, type> &>(__t.__base_).get();
 }
 
 template <size_t _Ip, class... _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __tuple_element_t<_Ip, tuple<_Tp...>>&&
-get(tuple<_Tp...>&& __t) noexcept
-{
+inline _LIBCUDACXX_INLINE_VISIBILITY
+    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __tuple_element_t<_Ip, tuple<_Tp...>> &&
+    get(tuple<_Tp...> &&__t) noexcept {
   typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_element_t<_Ip, tuple<_Tp...>> type;
-  return static_cast<type&&>(static_cast<__tuple_leaf<_Ip, type>&&>(__t.__base_).get());
+  return static_cast<type &&>(
+      static_cast<__tuple_leaf<_Ip, type> &&>(__t.__base_).get());
 }
 
 template <size_t _Ip, class... _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const __tuple_element_t<_Ip, tuple<_Tp...>>&&
-get(const tuple<_Tp...>&& __t) noexcept
-{
+inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const
+    __tuple_element_t<_Ip, tuple<_Tp...>> &&
+    get(const tuple<_Tp...> &&__t) noexcept {
   typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_element_t<_Ip, tuple<_Tp...>> type;
-  return static_cast<const type&&>(static_cast<const __tuple_leaf<_Ip, type>&&>(__t.__base_).get());
+  return static_cast<const type &&>(
+      static_cast<const __tuple_leaf<_Ip, type> &&>(__t.__base_).get());
 }
 
 #if _LIBCUDACXX_STD_VER > 11
@@ -955,65 +1003,61 @@ static constexpr size_t __not_found = ~size_t(0);
 static constexpr size_t __ambiguous = __not_found - 1;
 
 inline _LIBCUDACXX_INLINE_VISIBILITY constexpr size_t
-__find_idx_return(size_t __curr_i, size_t __res, bool __matches)
-{
+__find_idx_return(size_t __curr_i, size_t __res, bool __matches) {
   return !__matches ? __res : (__res == __not_found ? __curr_i : __ambiguous);
 }
 
 template <size_t _Nx>
 inline _LIBCUDACXX_INLINE_VISIBILITY constexpr size_t
-__find_idx(size_t __i, const bool (&__matches)[_Nx])
-{
-  return __i == _Nx ? __not_found : __find_idx_return(__i, __find_idx(__i + 1, __matches), __matches[__i]);
+__find_idx(size_t __i, const bool (&__matches)[_Nx]) {
+  return __i == _Nx ? __not_found
+                    : __find_idx_return(__i, __find_idx(__i + 1, __matches),
+                                        __matches[__i]);
 }
 
-template <class _T1, class... _Args>
-struct __find_exactly_one_checked
-{
-  static constexpr bool __matches[sizeof...(_Args)] = {is_same<_T1, _Args>::value...};
-  static constexpr size_t value                     = __find_detail::__find_idx(0, __matches);
+template <class _T1, class... _Args> struct __find_exactly_one_checked {
+  static constexpr bool __matches[sizeof...(_Args)] = {
+      is_same<_T1, _Args>::value...};
+  static constexpr size_t value = __find_detail::__find_idx(0, __matches);
   static_assert(value != __not_found, "type not found in type list");
-  static_assert(value != __ambiguous, "type occurs more than once in type list");
+  static_assert(value != __ambiguous,
+                "type occurs more than once in type list");
 };
 
-template <class _T1>
-struct __find_exactly_one_checked<_T1>
-{
+template <class _T1> struct __find_exactly_one_checked<_T1> {
   static_assert(!is_same<_T1, _T1>::value, "type not in empty type list");
 };
 
 } // namespace __find_detail
 
 template <typename _T1, typename... _Args>
-struct __find_exactly_one_t : public __find_detail::__find_exactly_one_checked<_T1, _Args...>
-{};
+struct __find_exactly_one_t
+    : public __find_detail::__find_exactly_one_checked<_T1, _Args...> {};
 
 template <class _T1, class... _Args>
-inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _T1&
-get(tuple<_Args...>& __tup) noexcept
-{
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _T1 &
+get(tuple<_Args...> &__tup) noexcept {
   return _CUDA_VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(__tup);
 }
 
 template <class _T1, class... _Args>
-inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _T1 const&
-get(tuple<_Args...> const& __tup) noexcept
-{
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _T1 const &
+get(tuple<_Args...> const &__tup) noexcept {
   return _CUDA_VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(__tup);
 }
 
 template <class _T1, class... _Args>
-inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _T1&&
-get(tuple<_Args...>&& __tup) noexcept
-{
-  return _CUDA_VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(_CUDA_VSTD::move(__tup));
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _T1 &&
+get(tuple<_Args...> &&__tup) noexcept {
+  return _CUDA_VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(
+      _CUDA_VSTD::move(__tup));
 }
 
 template <class _T1, class... _Args>
-inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _T1 const&&
-get(tuple<_Args...> const&& __tup) noexcept
-{
-  return _CUDA_VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(_CUDA_VSTD::move(__tup));
+inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _T1 const &&
+get(tuple<_Args...> const &&__tup) noexcept {
+  return _CUDA_VSTD::get<__find_exactly_one_t<_T1, _Args...>::value>(
+      _CUDA_VSTD::move(__tup));
 }
 
 #endif
@@ -1021,19 +1065,17 @@ get(tuple<_Args...> const&& __tup) noexcept
 // tie
 
 template <class... _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 tuple<_Tp&...>
-tie(_Tp&... __t) noexcept
-{
-  return tuple<_Tp&...>(__t...);
+inline _LIBCUDACXX_INLINE_VISIBILITY
+    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 tuple<_Tp &...>
+    tie(_Tp &...__t) noexcept {
+  return tuple<_Tp &...>(__t...);
 }
 
-template <class _Up>
-struct __ignore_t
-{
+template <class _Up> struct __ignore_t {
   template <class _Tp>
-  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const __ignore_t&
-  operator=(_Tp&&) const
-  {
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const
+      __ignore_t &
+      operator=(_Tp &&) const {
     return *this;
   }
 };
@@ -1047,63 +1089,55 @@ static
 } // namespace
 
 template <class... _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 tuple<typename __unwrap_ref_decay<_Tp>::type...>
-make_tuple(_Tp&&... __t)
-{
-  return tuple<typename __unwrap_ref_decay<_Tp>::type...>(_CUDA_VSTD::forward<_Tp>(__t)...);
+inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
+    tuple<typename __unwrap_ref_decay<_Tp>::type...>
+    make_tuple(_Tp &&...__t) {
+  return tuple<typename __unwrap_ref_decay<_Tp>::type...>(
+      _CUDA_VSTD::forward<_Tp>(__t)...);
 }
 
 template <class... _Tp>
-inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 tuple<_Tp&&...>
-forward_as_tuple(_Tp&&... __t) noexcept
-{
-  return tuple<_Tp&&...>(_CUDA_VSTD::forward<_Tp>(__t)...);
+inline _LIBCUDACXX_INLINE_VISIBILITY
+    _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 tuple<_Tp &&...>
+    forward_as_tuple(_Tp &&...__t) noexcept {
+  return tuple<_Tp &&...>(_CUDA_VSTD::forward<_Tp>(__t)...);
 }
 
-template <size_t _Ip>
-struct __tuple_equal
-{
+template <size_t _Ip> struct __tuple_equal {
   template <class _Tp, class _Up>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-  operator()(const _Tp& __x, const _Up& __y)
-  {
-    return __tuple_equal<_Ip - 1>()(__x, __y) && _CUDA_VSTD::get<_Ip - 1>(__x) == _CUDA_VSTD::get<_Ip - 1>(__y);
+  operator()(const _Tp &__x, const _Up &__y) {
+    return __tuple_equal<_Ip - 1>()(__x, __y) &&
+           _CUDA_VSTD::get<_Ip - 1>(__x) == _CUDA_VSTD::get<_Ip - 1>(__y);
   }
 };
 
-template <>
-struct __tuple_equal<0>
-{
+template <> struct __tuple_equal<0> {
   template <class _Tp, class _Up>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-  operator()(const _Tp&, const _Up&)
-  {
+  operator()(const _Tp &, const _Up &) {
     return true;
   }
 };
 
 template <class... _Tp, class... _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-operator==(const tuple<_Tp...>& __x, const tuple<_Up...>& __y)
-{
-  static_assert(sizeof...(_Tp) == sizeof...(_Up), "Can't compare tuples of different sizes");
+operator==(const tuple<_Tp...> &__x, const tuple<_Up...> &__y) {
+  static_assert(sizeof...(_Tp) == sizeof...(_Up),
+                "Can't compare tuples of different sizes");
   return __tuple_equal<sizeof...(_Tp)>()(__x, __y);
 }
 
 template <class... _Tp, class... _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-operator!=(const tuple<_Tp...>& __x, const tuple<_Up...>& __y)
-{
+operator!=(const tuple<_Tp...> &__x, const tuple<_Up...> &__y) {
   return !(__x == __y);
 }
 
-template <size_t _Ip>
-struct __tuple_less
-{
+template <size_t _Ip> struct __tuple_less {
   template <class _Tp, class _Up>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-  operator()(const _Tp& __x, const _Up& __y)
-  {
+  operator()(const _Tp &__x, const _Up &__y) {
     const size_t __idx = tuple_size<_Tp>::value - _Ip;
     if (_CUDA_VSTD::get<__idx>(__x) < _CUDA_VSTD::get<__idx>(__y)) {
       return true;
@@ -1115,93 +1149,83 @@ struct __tuple_less
   }
 };
 
-template <>
-struct __tuple_less<0>
-{
+template <> struct __tuple_less<0> {
   template <class _Tp, class _Up>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-  operator()(const _Tp&, const _Up&)
-  {
+  operator()(const _Tp &, const _Up &) {
     return false;
   }
 };
 
 template <class... _Tp, class... _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-operator<(const tuple<_Tp...>& __x, const tuple<_Up...>& __y)
-{
-  static_assert(sizeof...(_Tp) == sizeof...(_Up), "Can't compare tuples of different sizes");
+operator<(const tuple<_Tp...> &__x, const tuple<_Up...> &__y) {
+  static_assert(sizeof...(_Tp) == sizeof...(_Up),
+                "Can't compare tuples of different sizes");
   return __tuple_less<sizeof...(_Tp)>()(__x, __y);
 }
 
 template <class... _Tp, class... _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-operator>(const tuple<_Tp...>& __x, const tuple<_Up...>& __y)
-{
+operator>(const tuple<_Tp...> &__x, const tuple<_Up...> &__y) {
   return __y < __x;
 }
 
 template <class... _Tp, class... _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-operator>=(const tuple<_Tp...>& __x, const tuple<_Up...>& __y)
-{
+operator>=(const tuple<_Tp...> &__x, const tuple<_Up...> &__y) {
   return !(__x < __y);
 }
 
 template <class... _Tp, class... _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 bool
-operator<=(const tuple<_Tp...>& __x, const tuple<_Up...>& __y)
-{
+operator<=(const tuple<_Tp...> &__x, const tuple<_Up...> &__y) {
   return !(__y < __x);
 }
 
 // tuple_cat
 
-template <class _Tp, class _Up>
-struct __tuple_cat_type;
+template <class _Tp, class _Up> struct __tuple_cat_type;
 
 template <class... _Ttypes, class... _Utypes>
-struct __tuple_cat_type<tuple<_Ttypes...>, __tuple_types<_Utypes...>>
-{
+struct __tuple_cat_type<tuple<_Ttypes...>, __tuple_types<_Utypes...>> {
   typedef _LIBCUDACXX_NODEBUG_TYPE tuple<_Ttypes..., _Utypes...> type;
 };
 
 template <class _ResultTuple, bool _Is_Tuple0TupleLike, class... _Tuples>
-struct __tuple_cat_return_1
-{};
+struct __tuple_cat_return_1 {};
 
 template <class... _Types, class _Tuple0>
-struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0>
-{
-  typedef _LIBCUDACXX_NODEBUG_TYPE
-      typename __tuple_cat_type< tuple<_Types...>, __make_tuple_types_t<__remove_cvref_t<_Tuple0>>>::type type;
+struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0> {
+  typedef _LIBCUDACXX_NODEBUG_TYPE typename __tuple_cat_type<
+      tuple<_Types...>, __make_tuple_types_t<__remove_cvref_t<_Tuple0>>>::type
+      type;
 };
 
 template <class... _Types, class _Tuple0, class _Tuple1, class... _Tuples>
-struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0, _Tuple1, _Tuples...>
+struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0, _Tuple1,
+                            _Tuples...>
     : public __tuple_cat_return_1<
-          typename __tuple_cat_type< tuple<_Types...>, __make_tuple_types_t<__remove_cvref_t<_Tuple0>>>::type,
-          __tuple_like<__libcpp_remove_reference_t<_Tuple1>>::value, _Tuple1, _Tuples...>
-{};
+          typename __tuple_cat_type<
+              tuple<_Types...>,
+              __make_tuple_types_t<__remove_cvref_t<_Tuple0>>>::type,
+          __tuple_like<__libcpp_remove_reference_t<_Tuple1>>::value, _Tuple1,
+          _Tuples...> {};
 
-template <class... _Tuples>
-struct __tuple_cat_return;
+template <class... _Tuples> struct __tuple_cat_return;
 
 template <class _Tuple0, class... _Tuples>
 struct __tuple_cat_return<_Tuple0, _Tuples...>
-    : public __tuple_cat_return_1< tuple<>, __tuple_like<__libcpp_remove_reference_t<_Tuple0>>::value, _Tuple0,
-          _Tuples...>
-{};
+    : public __tuple_cat_return_1<
+          tuple<>, __tuple_like<__libcpp_remove_reference_t<_Tuple0>>::value,
+          _Tuple0, _Tuples...> {};
 
-template <>
-struct __tuple_cat_return<>
-{
+template <> struct __tuple_cat_return<> {
   typedef _LIBCUDACXX_NODEBUG_TYPE tuple<> type;
 };
 
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 tuple<>
-tuple_cat()
-{
+tuple_cat() {
   return tuple<>();
 }
 
@@ -1209,54 +1233,67 @@ template <class _Rp, class _Indices, class _Tuple0, class... _Tuples>
 struct __tuple_cat_return_ref_imp;
 
 template <class... _Types, size_t... _I0, class _Tuple0>
-struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>, _Tuple0>
-{
+struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>,
+                                  _Tuple0> {
   typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tuple0> _T0;
-  typedef tuple< _Types..., typename __apply_cv<_Tuple0, __tuple_element_t<_I0, _T0>>::type&&...> type;
+  typedef tuple<
+      _Types...,
+      typename __apply_cv<_Tuple0, __tuple_element_t<_I0, _T0>>::type &&...>
+      type;
 };
 
-template <class... _Types, size_t... _I0, class _Tuple0, class _Tuple1, class... _Tuples>
-struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>, _Tuple0, _Tuple1, _Tuples...>
+template <class... _Types, size_t... _I0, class _Tuple0, class _Tuple1,
+          class... _Tuples>
+struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>,
+                                  _Tuple0, _Tuple1, _Tuples...>
     : public __tuple_cat_return_ref_imp<
           tuple<_Types...,
-              typename __apply_cv< _Tuple0, __tuple_element_t<_I0, __libcpp_remove_reference_t< _Tuple0>>>::type&&...>,
-          __make_tuple_indices_t< tuple_size<__libcpp_remove_reference_t<_Tuple1>>::value>, _Tuple1, _Tuples...>
-{};
+                typename __apply_cv<
+                    _Tuple0, __tuple_element_t<_I0, __libcpp_remove_reference_t<
+                                                        _Tuple0>>>::type &&...>,
+          __make_tuple_indices_t<
+              tuple_size<__libcpp_remove_reference_t<_Tuple1>>::value>,
+          _Tuple1, _Tuples...> {};
 
 template <class _Tuple0, class... _Tuples>
 struct __tuple_cat_return_ref
-    : public __tuple_cat_return_ref_imp< tuple<>,
-          __make_tuple_indices_t< tuple_size<__libcpp_remove_reference_t<_Tuple0>>::value>, _Tuple0, _Tuples...>
-{};
+    : public __tuple_cat_return_ref_imp<
+          tuple<>,
+          __make_tuple_indices_t<
+              tuple_size<__libcpp_remove_reference_t<_Tuple0>>::value>,
+          _Tuple0, _Tuples...> {};
 
-template <class _Types, class _I0, class _J0>
-struct __tuple_cat;
+template <class _Types, class _I0, class _J0> struct __tuple_cat;
 
 template <class... _Types, size_t... _I0, size_t... _J0>
-struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J0...>>
-{
+struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>,
+                   __tuple_indices<_J0...>> {
   template <class _Tuple0>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-      typename __tuple_cat_return_ref<tuple<_Types...>&&, _Tuple0&&>::type
-      operator()(tuple<_Types...> __t, _Tuple0&& __t0)
-  {
-    (void) __t;
-    return _CUDA_VSTD::forward_as_tuple(_CUDA_VSTD::forward<_Types>(_CUDA_VSTD::get<_I0>(__t))...,
+      typename __tuple_cat_return_ref<tuple<_Types...> &&, _Tuple0 &&>::type
+      operator()(tuple<_Types...> __t, _Tuple0 &&__t0) {
+    (void)__t;
+    return _CUDA_VSTD::forward_as_tuple(
+        _CUDA_VSTD::forward<_Types>(_CUDA_VSTD::get<_I0>(__t))...,
         _CUDA_VSTD::get<_J0>(_CUDA_VSTD::forward<_Tuple0>(__t0))...);
   }
 
   template <class _Tuple0, class _Tuple1, class... _Tuples>
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-      typename __tuple_cat_return_ref<tuple<_Types...>&&, _Tuple0&&, _Tuple1&&, _Tuples&&...>::type
-      operator()(tuple<_Types...> __t, _Tuple0&& __t0, _Tuple1&& __t1, _Tuples&&... __tpls)
-  {
-    (void) __t;
+      typename __tuple_cat_return_ref<tuple<_Types...> &&, _Tuple0 &&,
+                                      _Tuple1 &&, _Tuples &&...>::type
+      operator()(tuple<_Types...> __t, _Tuple0 &&__t0, _Tuple1 &&__t1,
+                 _Tuples &&...__tpls) {
+    (void)__t;
     typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tuple0> _T0;
     typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tuple1> _T1;
-    return __tuple_cat< tuple<_Types..., typename __apply_cv< _Tuple0, __tuple_element_t<_J0, _T0>>::type&&...>,
+    return __tuple_cat<
+        tuple<_Types..., typename __apply_cv<
+                             _Tuple0, __tuple_element_t<_J0, _T0>>::type &&...>,
         __make_tuple_indices_t<sizeof...(_Types) + tuple_size<_T0>::value>,
         __make_tuple_indices_t<tuple_size<_T1>::value>>()(
-        _CUDA_VSTD::forward_as_tuple(_CUDA_VSTD::forward<_Types>(_CUDA_VSTD::get<_I0>(__t))...,
+        _CUDA_VSTD::forward_as_tuple(
+            _CUDA_VSTD::forward<_Types>(_CUDA_VSTD::get<_I0>(__t))...,
             _CUDA_VSTD::get<_J0>(_CUDA_VSTD::forward<_Tuple0>(__t0))...),
         _CUDA_VSTD::forward<_Tuple1>(__t1),
         _CUDA_VSTD::forward<_Tuples>(__tpls)...);
@@ -1266,61 +1303,68 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
 template <class _Tuple0, class... _Tuples>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
     typename __tuple_cat_return<_Tuple0, _Tuples...>::type
-    tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls)
-{
+    tuple_cat(_Tuple0 &&__t0, _Tuples &&...__tpls) {
   typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tuple0> _T0;
-  return __tuple_cat<tuple<>, __tuple_indices<>, __make_tuple_indices_t<tuple_size<_T0>::value>>()(
-      tuple<>(), _CUDA_VSTD::forward<_Tuple0>(__t0), _CUDA_VSTD::forward<_Tuples>(__tpls)...);
+  return __tuple_cat<tuple<>, __tuple_indices<>,
+                     __make_tuple_indices_t<tuple_size<_T0>::value>>()(
+      tuple<>(), _CUDA_VSTD::forward<_Tuple0>(__t0),
+      _CUDA_VSTD::forward<_Tuples>(__tpls)...);
 }
 
 template <class... _Tp, class _Alloc>
-struct _LIBCUDACXX_TEMPLATE_VIS uses_allocator<tuple<_Tp...>, _Alloc> : true_type
-{};
+struct _LIBCUDACXX_TEMPLATE_VIS uses_allocator<tuple<_Tp...>, _Alloc>
+    : true_type {};
 
 template <class _T1, class _T2>
 template <class... _Args1, class... _Args2, size_t... _I1, size_t... _I2>
 inline _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
-pair<_T1, _T2>::pair(piecewise_construct_t, tuple<_Args1...>& __first_args, tuple<_Args2...>& __second_args,
-    __tuple_indices<_I1...>, __tuple_indices<_I2...>)
-    : first(_CUDA_VSTD::forward<_Args1>(_CUDA_VSTD::get<_I1>(__first_args))...)
-    , second(_CUDA_VSTD::forward<_Args2>(_CUDA_VSTD::get<_I2>(__second_args))...)
-{}
+pair<_T1, _T2>::pair(piecewise_construct_t, tuple<_Args1...> &__first_args,
+                     tuple<_Args2...> &__second_args, __tuple_indices<_I1...>,
+                     __tuple_indices<_I2...>)
+    : first(_CUDA_VSTD::forward<_Args1>(_CUDA_VSTD::get<_I1>(__first_args))...),
+      second(
+          _CUDA_VSTD::forward<_Args2>(_CUDA_VSTD::get<_I2>(__second_args))...) {
+}
 
 #if _LIBCUDACXX_STD_VER > 14
-#  define _LIBCUDACXX_NOEXCEPT_RETURN(...) \
-    noexcept(noexcept(__VA_ARGS__))        \
-    {                                      \
-      return __VA_ARGS__;                  \
-    }
+#define _LIBCUDACXX_NOEXCEPT_RETURN(...)                                       \
+  noexcept(noexcept(__VA_ARGS__)) { return __VA_ARGS__; }
 
 template <class _Fn, class _Tuple, size_t... _Id>
 inline _LIBCUDACXX_INLINE_VISIBILITY constexpr decltype(auto)
-__apply_tuple_impl(_Fn&& __f, _Tuple&& __t, __tuple_indices<_Id...>) _LIBCUDACXX_NOEXCEPT_RETURN(
-    _CUDA_VSTD::__invoke(_CUDA_VSTD::forward<_Fn>(__f), _CUDA_VSTD::get<_Id>(_CUDA_VSTD::forward<_Tuple>(__t))...))
+__apply_tuple_impl(_Fn &&__f, _Tuple &&__t, __tuple_indices<_Id...>)
+    _LIBCUDACXX_NOEXCEPT_RETURN(_CUDA_VSTD::__invoke(
+        _CUDA_VSTD::forward<_Fn>(__f),
+        _CUDA_VSTD::get<_Id>(_CUDA_VSTD::forward<_Tuple>(__t))...))
 
-    template <class _Fn, class _Tuple>
-    inline _LIBCUDACXX_INLINE_VISIBILITY constexpr decltype(auto) apply(_Fn&& __f, _Tuple&& __t)
-        _LIBCUDACXX_NOEXCEPT_RETURN(_CUDA_VSTD::__apply_tuple_impl(_CUDA_VSTD::forward<_Fn>(__f),
-            _CUDA_VSTD::forward<_Tuple>(__t), __make_tuple_indices_t<tuple_size_v<remove_reference_t<_Tuple>>>{}))
+        template <class _Fn, class _Tuple>
+        inline _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr decltype(auto) apply(_Fn &&__f, _Tuple &&__t)
+        _LIBCUDACXX_NOEXCEPT_RETURN(_CUDA_VSTD::__apply_tuple_impl(
+            _CUDA_VSTD::forward<_Fn>(__f), _CUDA_VSTD::forward<_Tuple>(__t),
+            __make_tuple_indices_t<tuple_size_v<remove_reference_t<_Tuple>>>{}))
 
             template <class _Tp, class _Tuple, size_t... _Idx>
             inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _Tp
-    __make_from_tuple_impl(_Tuple&& __t, __tuple_indices<_Idx...>)
-        _LIBCUDACXX_NOEXCEPT_RETURN(_Tp(_CUDA_VSTD::get<_Idx>(_CUDA_VSTD::forward<_Tuple>(__t))...))
+    __make_from_tuple_impl(_Tuple &&__t, __tuple_indices<_Idx...>)
+        _LIBCUDACXX_NOEXCEPT_RETURN(
+            _Tp(_CUDA_VSTD::get<_Idx>(_CUDA_VSTD::forward<_Tuple>(__t))...))
 
             template <class _Tp, class _Tuple>
             inline _LIBCUDACXX_INLINE_VISIBILITY constexpr _Tp
-    make_from_tuple(_Tuple&& __t) _LIBCUDACXX_NOEXCEPT_RETURN(_CUDA_VSTD::__make_from_tuple_impl<_Tp>(
-        _CUDA_VSTD::forward<_Tuple>(__t), __make_tuple_indices_t<tuple_size_v<remove_reference_t<_Tuple>>>{}))
+    make_from_tuple(_Tuple &&__t)
+        _LIBCUDACXX_NOEXCEPT_RETURN(_CUDA_VSTD::__make_from_tuple_impl<_Tp>(
+            _CUDA_VSTD::forward<_Tuple>(__t),
+            __make_tuple_indices_t<tuple_size_v<remove_reference_t<_Tuple>>>{}))
 
-#  undef _LIBCUDACXX_NOEXCEPT_RETURN
+#undef _LIBCUDACXX_NOEXCEPT_RETURN
 
 #endif // _LIBCUDACXX_STD_VER > 14
 
-        _LIBCUDACXX_END_NAMESPACE_STD
+            _LIBCUDACXX_END_NAMESPACE_STD
 
 #ifndef __cuda_std__
-#  include <__pragma_pop>
+#include <__pragma_pop>
 #endif //__cuda_std__
 
 #endif // _LIBCUDACXX_TUPLE

--- a/libcudacxx/libcxx/test/support/test_iterators.h
+++ b/libcudacxx/libcxx/test/support/test_iterators.h
@@ -1019,17 +1019,17 @@ struct Proxy {
   constexpr const T&& getData() const&& { return static_cast<const T&&>(data); }
 
   _LIBCUDACXX_TEMPLATE(class U)
-    (requires std::constructible_from<T, U&&>)
+    _LIBCUDACXX_REQUIRES( std::constructible_from<T, U&&>)
   constexpr Proxy(U&& u) : data{std::forward<U>(u)} {}
 
   // This constructor covers conversion from cvref of Proxy<U>, including non-const/const versions of copy/move constructor
   _LIBCUDACXX_TEMPLATE(class Other)
-    (requires(IsProxy<std::decay_t<Other>> &&
+    _LIBCUDACXX_REQUIRES((IsProxy<std::decay_t<Other>> &&
               std::constructible_from<T, decltype(std::declval<Other>().getData())>))
   constexpr Proxy(Other&& other) : data{std::forward<Other>(other).getData()} {}
 
   _LIBCUDACXX_TEMPLATE(class Other)
-    (requires(IsProxy<std::decay_t<Other>> &&
+    _LIBCUDACXX_REQUIRES((IsProxy<std::decay_t<Other>> &&
               std::assignable_from<std::__add_lvalue_reference_t<T>, decltype(std::declval<Other>().getData())>))
   constexpr Proxy& operator=(Other&& other) {
     data = std::forward<Other>(other).getData();
@@ -1042,7 +1042,7 @@ TEST_NV_DIAG_SUPPRESS(1805) // MSVC complains that if we pass a pointer type, ad
 
   // const assignment required to make ProxyIterator model std::indirectly_writable
   _LIBCUDACXX_TEMPLATE(class Other)
-    (requires(IsProxy<std::decay_t<Other>> &&
+    _LIBCUDACXX_REQUIRES((IsProxy<std::decay_t<Other>> &&
               std::assignable_from<const std::__add_lvalue_reference_t<T>, decltype(std::declval<Other>().getData())>))
   constexpr const Proxy& operator=(Other&& other) const {
     data = std::forward<Other>(other).getData();
@@ -1070,7 +1070,7 @@ TEST_NV_DIAG_DEFAULT(1805)
   = default;
 #else
  _LIBCUDACXX_TEMPLATE(class T2 = T)
-    (requires(std::equality_comparable<T2> && !std::is_reference_v<T2>))
+    _LIBCUDACXX_REQUIRES((std::equality_comparable<T2> && !std::is_reference_v<T2>))
   friend constexpr bool operator==(const Proxy& lhs, const Proxy& rhs) {
     return lhs.data == rhs.data;
   }
@@ -1079,7 +1079,7 @@ TEST_NV_DIAG_DEFAULT(1805)
   // Helps compare e.g. `Proxy<int>` and `Proxy<int&>`. Note that the default equality comparison operator is deleted
   // when `T` is a reference type.
  _LIBCUDACXX_TEMPLATE(class U)
-    (requires(std::equality_comparable_with<std::decay_t<T>, std::decay_t<U>>))
+    _LIBCUDACXX_REQUIRES((std::equality_comparable_with<std::decay_t<T>, std::decay_t<U>>))
   friend constexpr bool operator==(const Proxy& lhs, const Proxy<U>& rhs) {
     return lhs.data == rhs.data;
   }
@@ -1159,7 +1159,7 @@ struct ProxyIterator : ProxyIteratorBase<Base> {
   constexpr ProxyIterator(Base base) : base_{std::move(base)} {}
 
   _LIBCUDACXX_TEMPLATE(class T)
-    (requires std::constructible_from<Base, T&&>)
+    _LIBCUDACXX_REQUIRES( std::constructible_from<Base, T&&>)
   constexpr ProxyIterator(T&& t) : base_{std::forward<T>(t)} {}
 
    friend constexpr decltype(auto) base(const ProxyIterator& p) { return base(p.base_); }
@@ -1183,14 +1183,14 @@ struct ProxyIterator : ProxyIteratorBase<Base> {
   constexpr void operator++(int) { ++*this; }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::equality_comparable<B2>)
+    _LIBCUDACXX_REQUIRES( std::equality_comparable<B2>)
   friend constexpr bool operator==(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ == y.base_;
   }
 
   // to satisfy forward_iterator
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::forward_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::forward_iterator<B2>)
   constexpr ProxyIterator operator++(int) {
     auto tmp = *this;
     ++*this;
@@ -1199,14 +1199,14 @@ struct ProxyIterator : ProxyIteratorBase<Base> {
 
   // to satisfy bidirectional_iterator
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::bidirectional_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::bidirectional_iterator<B2>)
   constexpr ProxyIterator& operator--() {
     --base_;
     return *this;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::bidirectional_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::bidirectional_iterator<B2>)
   constexpr ProxyIterator operator--(int) {
     auto tmp = *this;
     --*this;
@@ -1215,77 +1215,77 @@ struct ProxyIterator : ProxyIteratorBase<Base> {
 
   // to satisfy random_access_iterator
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   constexpr ProxyIterator& operator+=(difference_type n) {
     base_ += n;
     return *this;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   constexpr ProxyIterator& operator-=(difference_type n) {
     base_ -= n;
     return *this;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   constexpr Proxy<std::iter_reference_t<Base>> operator[](difference_type n) const {
     return {base_[n]};
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   friend constexpr bool operator<(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ < y.base_;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   friend constexpr bool operator>(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ > y.base_;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   friend constexpr bool operator<=(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ <= y.base_;
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   friend constexpr bool operator>=(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ >= y.base_;
   }
 
 #ifndef TEST_HAS_NO_SPACESHIP_OPERATOR
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2> && std::three_way_comparable<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2> && std::three_way_comparable<B2>)
   friend constexpr auto operator<=>(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ <=> y.base_;
   }
 #endif // TEST_HAS_NO_SPACESHIP_OPERATOR
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   friend constexpr ProxyIterator operator+(const ProxyIterator& x, difference_type n) {
     return ProxyIterator{x.base_ + n};
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   friend constexpr ProxyIterator operator+(difference_type n, const ProxyIterator& x) {
     return ProxyIterator{n + x.base_};
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   friend constexpr ProxyIterator operator-(const ProxyIterator& x, difference_type n) {
     return ProxyIterator{x.base_ - n};
   }
 
   _LIBCUDACXX_TEMPLATE(class B2 = Base)
-    (requires std::random_access_iterator<B2>)
+    _LIBCUDACXX_REQUIRES( std::random_access_iterator<B2>)
   friend constexpr difference_type operator-(const ProxyIterator& x, const ProxyIterator& y) {
     return x.base_ - y.base_;
   }
@@ -1303,7 +1303,7 @@ struct ProxySentinel {
   constexpr ProxySentinel(BaseSent base) : base_{std::move(base)} {}
 
   _LIBCUDACXX_TEMPLATE(class Base)
-    (requires std::equality_comparable_with<Base, BaseSent>)
+    _LIBCUDACXX_REQUIRES( std::equality_comparable_with<Base, BaseSent>)
   friend constexpr bool operator==(const ProxyIterator<Base>& p, const ProxySentinel& sent) {
     return p.base_ == sent.base_;
   }


### PR DESCRIPTION
Currently we did not install clang-format in our dev containers

This lead to bad user experience, so with the latest iteration of the dev containers we get clang-format-17

We use that fixed version to avoid any differences between the different clang-format versions

Also add a clang-format file for libcu++ and apply it throughout the codebase