### PR TITLE
Disable PR workflow triggering on pushes to main.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,6 @@ defaults:
 on:
   push:
     branches:
-      - main
       - "pull-request/[0-9]+"
 
 # Only runs one instance of this workflow at a time for a given PR and cancels any in-progress runs when a new one starts.


### PR DESCRIPTION
## Description
This PR disables the primary CI workflow triggering on pushes to the `main` branch. 

This is a vestigial artifact of when we were first setting up these workflows. It is no longer relevant and just unnecessarily consumes CI resources. 
