### PR TITLE
[CI] Sink error when git repo is missing from build.

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -90,7 +90,7 @@ echo "GPU_ARCHS=$GPU_ARCHS"
 echo "PARALLEL_LEVEL=$PARALLEL_LEVEL"
 echo "BUILD_DIR=$BUILD_DIR"
 echo "Current commit is:"
-git log -1
+git log -1 || "Not a repository"
 echo "========================================"
 
 function configure(){


### PR DESCRIPTION
## Description

Makes the commit check in CI scripts a non-failure if the git repo doesn't exist.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
