### PR TITLE
Make template parameters consistent in thrust::complex operators

### DIFF
--- a/thrust/thrust/complex.h
+++ b/thrust/thrust/complex.h
@@ -259,7 +259,7 @@ operator+(const complex<T0> &x, const T1 &y);
  */
 template <typename T0, typename T1>
 __host__ __device__ typename detail::disable_if<
-  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T1>>>::value,
+  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T0>>>::value,
   complex<typename detail::promoted_numerical_type<T0, T1>::type>>::type
 operator+(const T0 &x, const complex<T1> &y);
 
@@ -309,7 +309,7 @@ operator-(const complex<T0> &x, const T1 &y);
  */
 template <typename T0, typename T1>
 __host__ __device__ typename detail::disable_if<
-  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T1>>>::value,
+  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T0>>>::value,
   complex<typename detail::promoted_numerical_type<T0, T1>::type>>::type
 operator-(const T0 &x, const complex<T1> &y);
 

--- a/thrust/thrust/detail/complex.inl
+++ b/thrust/thrust/detail/complex.inl
@@ -120,7 +120,7 @@ operator+(const complex<T0> &x, const T1 &y)
 
 template <typename T0, typename T1>
 __host__ __device__ typename detail::disable_if<
-  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T1>>>::value,
+  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T0>>>::value,
   complex<typename detail::promoted_numerical_type<T0, T1>::type>>::type
 operator+(const T0 &x, const complex<T1> &y)
 {
@@ -152,7 +152,7 @@ operator-(const complex<T0> &x, const T1 &y)
 
 template <typename T0, typename T1>
 __host__ __device__ typename detail::disable_if<
-  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T1>>>::value,
+  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T0>>>::value,
   complex<typename detail::promoted_numerical_type<T0, T1>::type>>::type
 operator-(const T0 &x, const complex<T1> &y)
 {
@@ -186,7 +186,7 @@ operator*(const complex<T0> &x, const T1 &y)
 
 template <typename T0, typename T1>
 __host__ __device__ typename detail::disable_if<
-  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T1>>>::value,
+  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T0>>>::value,
   complex<typename detail::promoted_numerical_type<T0, T1>::type>>::type
 operator*(const T0 &x, const complex<T1> &y)
 {
@@ -221,7 +221,7 @@ operator/(const complex<T0> &x, const T1 &y)
 
 template <typename T0, typename T1>
 __host__ __device__ typename detail::disable_if<
-  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T1>>>::value,
+  detail::or_<detail::is_same<T0, T1>, detail::not_<detail::is_arithmetic<T0>>>::value,
   complex<typename detail::promoted_numerical_type<T0, T1>::type>>::type
 operator/(const T0 &x, const complex<T1> &y)
 {


### PR DESCRIPTION
Uses the right template parameter in `thrust::complex` operators w.r.t to the arguments consistently. 
Replaces T1 with T0 in `is_arithmetic<T1>`.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/554

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
