### PR TITLE
Update status check job to check status of precursor jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -154,7 +154,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     name: CI
-    if: ${{ !cancelled() }}
+    if: ${{ always() }} # need to use always() instead of !cancelled() because skipped jobs count as success 
     needs:
       - clang-cuda
       - cub

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -150,9 +150,11 @@ jobs:
 
   # This job is the final job that runs after all other jobs and is used for branch protection status checks.
   # See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks
+  # https://github.com/orgs/community/discussions/26822#discussioncomment-5122101
   ci:
     runs-on: ubuntu-latest
     name: CI
+    if: ${{ !cancelled() }}
     needs:
       - clang-cuda
       - cub
@@ -162,4 +164,11 @@ jobs:
       - cccl-infra
       - verify-devcontainers
     steps:
-      - run: echo "CI success"
+      - name: Check status of all precursor jobs
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}
+        run: exit 1


### PR DESCRIPTION
## Description

In our CI, we have a final job called `ci` that depends on all the prior jobs via `needs:`. This job is intended to be used as a status check such that a PR cannot be merged if this job has not been completed successfully. 

However, the status check job was not working as intended. Most importantly, if predecessor jobs were skipped, then the CI job would be skipped. Skipped jobs report as successful for the purpose of status checks:

![image](https://github.com/NVIDIA/cccl/assets/15221289/f8c5137c-ba0a-46e6-95aa-18aaf0e02d05)

This is not what we want. We want the status check job to always run, and exit if any of the predecessor jobs failed. 

This boils down to two things:
- Make the `ci` job always run by using `if ${{ always() }}` 
- Make the `ci` job explicitly check the status of precursor jobs. This uses a slick trick of using a wildcard in `needs.*.result` to avoid having to re-list all of the jobs. 
