### PR TITLE
Report times for libcudacxx tests in CI 

### DIFF
--- a/libcudacxx/.upstream-tests/test/CMakeLists.txt
+++ b/libcudacxx/.upstream-tests/test/CMakeLists.txt
@@ -126,7 +126,7 @@ if (NOT LIBCUDACXX_TEST_WITH_NVRTC)
   add_custom_target(libcudacxx.test.lit.precompile
     "${CMAKE_COMMAND}" -E env
       "LIBCUDACXX_SITE_CONFIG=${lit_site_cfg_path}"
-    "${libcudacxx_LIT}" -vv --no-progress-bar
+    "${libcudacxx_LIT}" -vv --no-progress-bar --time-tests
       "-Dexecutor=\"NoopExecutor()\"" # Don't run the compiled tests.
       "${libcudacxx_SOURCE_DIR}/.upstream-tests/test"
   )
@@ -140,7 +140,7 @@ set(libcudacxx_LIT_PARALLEL_LEVEL 8 CACHE STRING
 add_test(NAME libcudacxx.test.lit COMMAND
   "${CMAKE_COMMAND}" -E env
     "LIBCUDACXX_SITE_CONFIG=${lit_site_cfg_path}"
-  "${libcudacxx_LIT}" -vv --no-progress-bar
+  "${libcudacxx_LIT}" -vv --no-progress-bar --time-tests
     -j "${libcudacxx_LIT_PARALLEL_LEVEL}"
     "${libcudacxx_SOURCE_DIR}/.upstream-tests/test"
 )


### PR DESCRIPTION
## Description

Adds `--time-tests` to report test times for libcudacxx tests. This is useful for tracking and debugging prolonged CI test time issues. 
