### PR TITLE
[skip-tests] Disable rdc tests for windows.

### DIFF
--- a/ci/windows/build_cub.ps1
+++ b/ci/windows/build_cub.ps1
@@ -17,7 +17,7 @@ Remove-Module -Name build_common
 Import-Module $PSScriptRoot/build_common.psm1 -ArgumentList $CXX_STANDARD
 
 $PRESET = "cub-cpp$CXX_STANDARD"
-$CMAKE_OPTIONS = ""
+$CMAKE_OPTIONS = "-DCUB_ENABLE_RDC_TESTS=OFF"
 
 if ($CL_VERSION -lt [version]"19.20") {
     $CMAKE_OPTIONS += "-DCUB_IGNORE_DEPRECATED_COMPILER=ON "


### PR DESCRIPTION
closes https://github.com/NVIDIA/cccl/issues/614

Those are currently flaky. We can skip GPU execution as we do not do that on windows anyways
