### PR TITLE
Support FP8 in radix sort

### DIFF
--- a/cub/cmake/CubBuildCompilerTargets.cmake
+++ b/cub/cmake/CubBuildCompilerTargets.cmake
@@ -28,12 +28,6 @@ function(cub_build_compiler_targets)
     # Suppress overly-pedantic/unavoidable warnings brought in with /W4:
     # C4324: structure was padded due to alignment specifier
     append_option_if_available("/wd4324" cxx_compile_options)
-    # C4127: conditional expression is constant
-    # This can be fixed with `if constexpr` when available, but there's no way
-    # to silence these pre-C++17.
-    # TODO We should have per-dialect interface targets so we can leave these
-    # warnings enabled on C++17:
-    append_option_if_available("/wd4127" cxx_compile_options)
     # C4505: unreferenced local function has been removed
     # The CUDA `host_runtime.h` header emits this for
     # `__cudaUnregisterBinaryUtil`.

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -46,8 +46,10 @@ _CCCL_IMPLICIT_SYSTEM_HEADER
 #include <iterator>
 #include <limits>
 
+#include <cub/detail/cpp_compatibility.cuh>
 #include <cub/device/dispatch/dispatch_histogram.cuh>
 #include <cub/util_deprecated.cuh>
+
 
 CUB_NAMESPACE_BEGIN
 
@@ -819,29 +821,30 @@ struct DeviceHistogram
     using SampleT = cub::detail::value_t<SampleIteratorT>;
     Int2Type<sizeof(SampleT) == 1> is_byte_sample;
 
-    if ((sizeof(OffsetT) > sizeof(int)) &&
-        ((unsigned long long)(num_rows * row_stride_bytes) <
-         (unsigned long long)INT_MAX))
+    CUB_IF_CONSTEXPR(sizeof(OffsetT) > sizeof(int))
     {
-      // Down-convert OffsetT data type
-      return DispatchHistogram<NUM_CHANNELS,
-                               NUM_ACTIVE_CHANNELS,
-                               SampleIteratorT,
-                               CounterT,
-                               LevelT,
-                               int>::DispatchEven(d_temp_storage,
-                                                  temp_storage_bytes,
-                                                  d_samples,
-                                                  d_histogram,
-                                                  num_levels,
-                                                  lower_level,
-                                                  upper_level,
-                                                  (int)num_row_pixels,
-                                                  (int)num_rows,
-                                                  (int)(row_stride_bytes /
-                                                        sizeof(SampleT)),
-                                                  stream,
-                                                  is_byte_sample);
+      if ((unsigned long long)(num_rows * row_stride_bytes) < (unsigned long long)INT_MAX)
+      {
+        // Down-convert OffsetT data type
+        return DispatchHistogram<NUM_CHANNELS,
+                                NUM_ACTIVE_CHANNELS,
+                                SampleIteratorT,
+                                CounterT,
+                                LevelT,
+                                int>::DispatchEven(d_temp_storage,
+                                                    temp_storage_bytes,
+                                                    d_samples,
+                                                    d_histogram,
+                                                    num_levels,
+                                                    lower_level,
+                                                    upper_level,
+                                                    (int)num_row_pixels,
+                                                    (int)num_rows,
+                                                    (int)(row_stride_bytes /
+                                                          sizeof(SampleT)),
+                                                    stream,
+                                                    is_byte_sample);
+      }
     }
 
     return DispatchHistogram<NUM_CHANNELS,
@@ -1594,28 +1597,29 @@ struct DeviceHistogram
     using SampleT = cub::detail::value_t<SampleIteratorT>;
     Int2Type<sizeof(SampleT) == 1> is_byte_sample;
 
-    if ((sizeof(OffsetT) > sizeof(int)) &&
-        ((unsigned long long)(num_rows * row_stride_bytes) <
-         (unsigned long long)INT_MAX))
+    CUB_IF_CONSTEXPR(sizeof(OffsetT) > sizeof(int))
     {
-      // Down-convert OffsetT data type
-      return DispatchHistogram<NUM_CHANNELS,
-                               NUM_ACTIVE_CHANNELS,
-                               SampleIteratorT,
-                               CounterT,
-                               LevelT,
-                               int>::DispatchRange(d_temp_storage,
-                                                   temp_storage_bytes,
-                                                   d_samples,
-                                                   d_histogram,
-                                                   num_levels,
-                                                   d_levels,
-                                                   (int)num_row_pixels,
-                                                   (int)num_rows,
-                                                   (int)(row_stride_bytes /
-                                                         sizeof(SampleT)),
-                                                   stream,
-                                                   is_byte_sample);
+      if ((unsigned long long)(num_rows * row_stride_bytes) < (unsigned long long)INT_MAX)
+      {
+        // Down-convert OffsetT data type
+        return DispatchHistogram<NUM_CHANNELS,
+                                NUM_ACTIVE_CHANNELS,
+                                SampleIteratorT,
+                                CounterT,
+                                LevelT,
+                                int>::DispatchRange(d_temp_storage,
+                                                    temp_storage_bytes,
+                                                    d_samples,
+                                                    d_histogram,
+                                                    num_levels,
+                                                    d_levels,
+                                                    (int)num_row_pixels,
+                                                    (int)num_rows,
+                                                    (int)(row_stride_bytes /
+                                                          sizeof(SampleT)),
+                                                    stream,
+                                                    is_byte_sample);
+      }
     }
 
     return DispatchHistogram<NUM_CHANNELS,

--- a/cub/cub/util_ptx.cuh
+++ b/cub/cub/util_ptx.cuh
@@ -42,8 +42,9 @@
 _CCCL_IMPLICIT_SYSTEM_HEADER
 #endif // !_CCCL_COMPILER_NVHPC
 
-#include "util_debug.cuh"
-#include "util_type.cuh"
+#include <cub/detail/cpp_compatibility.cuh>
+#include <cub/util_debug.cuh>
+#include <cub/util_type.cuh>
 
 CUB_NAMESPACE_BEGIN
 
@@ -464,7 +465,7 @@ unsigned int WarpMask(unsigned int warp_id)
   unsigned int member_mask = 0xFFFFFFFFu >>
                              (CUB_WARP_THREADS(0) - LOGICAL_WARP_THREADS);
 
-  if (is_pow_of_two && !is_arch_warp)
+  CUB_IF_CONSTEXPR(is_pow_of_two && !is_arch_warp)
   {
     member_mask <<= warp_id * LOGICAL_WARP_THREADS;
   }

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -56,7 +56,14 @@ _CCCL_IMPLICIT_SYSTEM_HEADER
 #  include <cuda_bf16.h>
 // cuda_fp8.h transitively includes cuda_fp16.h, so we have to include the header under !CUB_DISABLE_BF16_SUPPORT
 #  if CUDA_VERSION >= 11080
+// cuda_fp8.h resets default for C4127, so we have to guard the inclusion
+#    if CUB_HOST_COMPILER == CUB_HOST_COMPILER_MSVC
+#      pragma warning(push)
+#    endif
 #    include <cuda_fp8.h>
+#    if CUB_HOST_COMPILER == CUB_HOST_COMPILER_MSVC
+#      pragma warning(pop)
+#    endif
 #  endif
 #endif
 

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -51,8 +51,13 @@ _CCCL_IMPLICIT_SYSTEM_HEADER
 #if !_NVHPC_CUDA
     #include <cuda_fp16.h>
 #endif
+
 #if !_NVHPC_CUDA && !defined(CUB_DISABLE_BF16_SUPPORT)
-    #include <cuda_bf16.h>
+#  include <cuda_bf16.h>
+// cuda_fp8.h transitively includes cuda_fp16.h, so we have to include the header under !CUB_DISABLE_BF16_SUPPORT
+#  if CUDA_VERSION >= 11080
+#    include <cuda_fp8.h>
+#  endif
 #endif
 
 #include <cub/detail/uninitialized_copy.cuh>
@@ -1160,6 +1165,37 @@ struct FpLimits<__nv_bfloat16>
 };
 #endif
 
+#if defined(__CUDA_FP8_TYPES_EXIST__)
+template <>
+struct FpLimits<__nv_fp8_e4m3>
+{
+    static __host__ __device__ __forceinline__ __nv_fp8_e4m3 Max() {
+        unsigned char max_word = 0x7EU;
+        return reinterpret_cast<__nv_fp8_e4m3&>(max_word);
+    }
+
+    static __host__ __device__ __forceinline__ __nv_fp8_e4m3 Lowest() {
+        unsigned char lowest_word = 0xFEU;
+        return reinterpret_cast<__nv_fp8_e4m3&>(lowest_word);
+    }
+};
+
+template <>
+struct FpLimits<__nv_fp8_e5m2>
+{
+    static __host__ __device__ __forceinline__ __nv_fp8_e5m2 Max() {
+        unsigned char max_word = 0x7BU;
+        return reinterpret_cast<__nv_fp8_e5m2&>(max_word);
+    }
+
+    static __host__ __device__ __forceinline__ __nv_fp8_e5m2 Lowest() {
+        unsigned char lowest_word = 0xFBU;
+        return reinterpret_cast<__nv_fp8_e5m2&>(lowest_word);
+    }
+};
+
+#endif
+
 /**
  * Basic type traits (fp primitive specialization)
  */
@@ -1303,6 +1339,12 @@ template <> struct NumericTraits<double> :              BaseTraits<FLOATING_POIN
 #endif
 #if !_NVHPC_CUDA && !defined(CUB_DISABLE_BF16_SUPPORT)
     template <> struct NumericTraits<__nv_bfloat16> :   BaseTraits<FLOATING_POINT, true, false, unsigned short, __nv_bfloat16> {};
+#endif
+
+
+#if defined(__CUDA_FP8_TYPES_EXIST__)
+    template <> struct NumericTraits<__nv_fp8_e4m3> :   BaseTraits<FLOATING_POINT, true, false, __nv_fp8_storage_t, __nv_fp8_e4m3> {};
+    template <> struct NumericTraits<__nv_fp8_e5m2> :   BaseTraits<FLOATING_POINT, true, false, __nv_fp8_storage_t, __nv_fp8_e5m2> {};
 #endif
 
 template <> struct NumericTraits<bool> :                BaseTraits<UNSIGNED_INTEGER, true, false, typename UnitWord<bool>::VolatileWord, bool> {};

--- a/cub/test/c2h/custom_type.cuh
+++ b/cub/test/c2h/custom_type.cuh
@@ -180,6 +180,14 @@ namespace std {
        return val;
      }
 
+     static c2h::custom_type_t<Policies...> min() 
+     {
+       c2h::custom_type_t<Policies...> val;
+       val.key = std::numeric_limits<std::size_t>::min();
+       val.val = std::numeric_limits<std::size_t>::min();
+       return val;
+     }
+
      static c2h::custom_type_t<Policies...> lowest() 
      {
        c2h::custom_type_t<Policies...> val;

--- a/cub/test/c2h/generators.cu
+++ b/cub/test/c2h/generators.cu
@@ -107,7 +107,7 @@ private:
   thrust::device_vector<float> m_distribution;
 };
 
-template <typename T>
+template <typename T, cub::Category = cub::Traits<T>::CATEGORY>
 struct random_to_item_t
 {
   float m_min;
@@ -121,6 +121,23 @@ struct random_to_item_t
   __device__ T operator()(float random_value)
   {
     return static_cast<T>((m_max - m_min) * random_value + m_min);
+  }
+};
+
+template <typename T>
+struct random_to_item_t<T, cub::FLOATING_POINT>
+{
+  float m_min;
+  float m_max;
+
+  __host__ __device__ random_to_item_t(T min, T max)
+      : m_min(static_cast<float>(min))
+      , m_max(static_cast<float>(max))
+  {}
+
+  __device__ T operator()(float random_value)
+  {
+    return static_cast<T>(m_max * random_value + m_min * (1.0f - random_value));
   }
 };
 
@@ -501,6 +518,10 @@ INSTANTIATE(std::int16_t);
 INSTANTIATE(std::int32_t);
 INSTANTIATE(std::int64_t);
 
+#if defined(__CUDA_FP8_TYPES_EXIST__)
+INSTANTIATE(__nv_fp8_e5m2);
+INSTANTIATE(__nv_fp8_e4m3);
+#endif // defined(__CUDA_FP8_TYPES_EXIST__)
 INSTANTIATE(float);
 INSTANTIATE(double);
 

--- a/cub/test/c2h/generators.cuh
+++ b/cub/test/c2h/generators.cuh
@@ -33,6 +33,45 @@
 
 #include <c2h/custom_type.cuh>
 
+#include <cub/util_type.cuh> // __CUDA_FP8_TYPES_EXIST__
+
+#if defined(__CUDA_FP8_TYPES_EXIST__)
+#  include <cuda_fp8.h>
+
+namespace std
+{
+template <>
+class numeric_limits<__nv_fp8_e4m3>
+{
+public:
+  static __nv_fp8_e4m3 max()
+  {
+    return cub::Traits<__nv_fp8_e4m3>::Max();
+  }
+
+  static __nv_fp8_e4m3 lowest()
+  {
+    return cub::Traits<__nv_fp8_e4m3>::Lowest();
+  }
+};
+
+template <>
+class numeric_limits<__nv_fp8_e5m2>
+{
+public:
+  static __nv_fp8_e5m2 max()
+  {
+    return cub::Traits<__nv_fp8_e5m2>::Max();
+  }
+
+  static __nv_fp8_e5m2 lowest()
+  {
+    return cub::Traits<__nv_fp8_e5m2>::Lowest();
+  }
+};
+} // namespace std
+#endif // defined(__CUDA_FP8_TYPES_EXIST__)
+
 namespace c2h
 {
 
@@ -112,7 +151,7 @@ void gen(seed_t seed,
 template <typename T>
 void gen(seed_t seed,
          thrust::device_vector<T> &data,
-         T min = std::numeric_limits<T>::min(),
+         T min = std::numeric_limits<T>::lowest(),
          T max = std::numeric_limits<T>::max());
 
 template <typename T>

--- a/cub/test/catch2_test_block_radix_sort.cuh
+++ b/cub/test/catch2_test_block_radix_sort.cuh
@@ -366,21 +366,62 @@ get_striped_keys(const thrust::host_vector<KeyT> &h_keys,
   thrust::host_vector<KeyT> h_striped_keys(h_keys);
   KeyT *h_striped_keys_data = thrust::raw_pointer_cast(h_striped_keys.data());
 
-  if ((begin_bit > 0) || (end_bit < static_cast<int>(sizeof(KeyT) * 8)))
-  {
-    const int num_bits = end_bit - begin_bit;
+  using traits_t                    = cub::Traits<KeyT>;
+  using bit_ordered_t               = typename traits_t::UnsignedBits;
+  const bit_ordered_t negative_zero = bit_ordered_t{1} << bit_ordered_t{sizeof(bit_ordered_t) * 8 - 1};
 
-    for (std::size_t i = 0; i < h_keys.size(); i++)
+  const int num_bits = end_bit - begin_bit;
+
+  for (std::size_t i = 0; i < h_keys.size(); i++)
+  {
+    bit_ordered_t key = reinterpret_cast<const bit_ordered_t&>(h_keys[i]);
+
+    if (traits_t::CATEGORY == cub::FLOATING_POINT && key == negative_zero)
+    {
+      key = 0;
+    }
+
+    key = traits_t::TwiddleIn(key);
+
+    if ((begin_bit > 0) || (end_bit < static_cast<int>(sizeof(KeyT) * 8)))
     {
       unsigned long long base = 0;
-      memcpy(&base, h_striped_keys_data + i, sizeof(KeyT));
+      memcpy(&base, &key, sizeof(bit_ordered_t));
       base &= ((1ULL << num_bits) - 1) << begin_bit;
-      memcpy(h_striped_keys_data + i, &base, sizeof(KeyT));
+      memcpy(&key, &base, sizeof(bit_ordered_t));
     }
-  }
+
+    // striped keys are used to compare bit ordered representation of keys, 
+    // so we do not twiddle-out the key here:
+    // key = traits_t::TwiddleOut(key);
+
+    memcpy(h_striped_keys_data + i, &key, sizeof(KeyT));
+}
 
   return h_striped_keys;
 }
+
+template <class T>
+struct indirect_binary_comparator_t
+{
+  const T* h_ptr{};
+  bool is_descending{};
+
+  indirect_binary_comparator_t(const T* h_ptr, bool is_descending)
+      : h_ptr(h_ptr)
+      , is_descending(is_descending)
+  {}
+
+  bool operator()(std::size_t a, std::size_t b)
+  {
+    if (is_descending)
+    {
+      return h_ptr[a] > h_ptr[b];
+    }
+
+    return h_ptr[a] < h_ptr[b];
+  }
+};
 
 template <class KeyT>
 thrust::host_vector<std::size_t>
@@ -395,16 +436,15 @@ get_permutation(const thrust::host_vector<KeyT> &h_keys,
   thrust::host_vector<std::size_t> h_permutation(h_keys.size());
   thrust::sequence(h_permutation.begin(), h_permutation.end());
 
+  using traits_t = cub::Traits<KeyT>;
+  using bit_ordered_t = typename traits_t::UnsignedBits;
+
+  auto bit_ordered_striped_keys =
+    reinterpret_cast<const bit_ordered_t*>(thrust::raw_pointer_cast(h_striped_keys.data()));
+
   std::stable_sort(h_permutation.begin(),
                    h_permutation.end(),
-                   [&](std::size_t a, std::size_t b) {
-                     if (is_descending)
-                     {
-                       return h_striped_keys[a] > h_striped_keys[b];
-                     }
-
-                     return h_striped_keys[a] < h_striped_keys[b];
-                   });
+                   indirect_binary_comparator_t<bit_ordered_t>{bit_ordered_striped_keys, is_descending});
 
   return h_permutation;
 }

--- a/cub/test/catch2_test_block_reduce.cu
+++ b/cub/test/catch2_test_block_reduce.cu
@@ -27,6 +27,7 @@
 
 #include <cub/block/block_reduce.cuh>
 
+#include <limits>
 #include <thrust/host_vector.h>
 
 #include <numeric>
@@ -175,7 +176,7 @@ CUB_TEST("Block reduce works with sum",
 
   thrust::device_vector<type> d_out(1);
   thrust::device_vector<type> d_in(params::tile_size);
-  c2h::gen(CUB_SEED(10), d_in);
+  c2h::gen(CUB_SEED(10), d_in, std::numeric_limits<type>::min());
 
   thrust::host_vector<type> h_in = d_in;
   thrust::host_vector<type> h_reference(1, std::accumulate(h_in.begin() + 1, h_in.end(), h_in[0], [](const type &lhs, const type &rhs) {
@@ -205,7 +206,7 @@ CUB_TEST("Block reduce works with sum in partial tiles",
 
   thrust::device_vector<type> d_out(1);
   thrust::device_vector<type> d_in(GENERATE_COPY(take(2, random(1, params::tile_size))));
-  c2h::gen(CUB_SEED(10), d_in);
+  c2h::gen(CUB_SEED(10), d_in, std::numeric_limits<type>::min());
 
   thrust::host_vector<type> h_in = d_in;
   std::vector<type> h_reference(1, std::accumulate(h_in.begin() + 1, h_in.end(), h_in[0], [](const type &lhs, const type &rhs) {
@@ -235,7 +236,7 @@ CUB_TEST("Block reduce works with custom op",
 
   thrust::device_vector<type> d_out(1);
   thrust::device_vector<type> d_in(params::tile_size);
-  c2h::gen(CUB_SEED(10), d_in);
+  c2h::gen(CUB_SEED(10), d_in, std::numeric_limits<type>::min());
 
   thrust::host_vector<type> h_in = d_in;
   thrust::host_vector<type> h_reference(
@@ -267,7 +268,7 @@ CUB_TEST("Block reduce works with custom op in partial tiles",
 
   thrust::device_vector<type> d_out(1);
   thrust::device_vector<type> d_in(GENERATE_COPY(take(2, random(1, params::tile_size))));
-  c2h::gen(CUB_SEED(10), d_in);
+  c2h::gen(CUB_SEED(10), d_in, std::numeric_limits<type>::min());
 
   thrust::host_vector<type> h_in = d_in;
   thrust::host_vector<type> h_reference(
@@ -305,7 +306,7 @@ CUB_TEST("Block reduce works with custom types",
 
   thrust::device_vector<type> d_out(1);
   thrust::device_vector<type> d_in(GENERATE_COPY(take(2, random(1, tile_size))));
-  c2h::gen(CUB_SEED(10), d_in);
+  c2h::gen(CUB_SEED(10), d_in, std::numeric_limits<type>::min());
 
   thrust::host_vector<type> h_in = d_in;
   thrust::host_vector<type> h_reference(1, std::accumulate(h_in.begin() + 1, h_in.end(), h_in[0], [](const type &lhs, const type &rhs) {
@@ -357,4 +358,3 @@ CUB_TEST("Block reduce works with vec types",
 
   REQUIRE(h_reference == d_out);
 }
-

--- a/cub/test/catch2_test_device_scan_by_key.cu
+++ b/cub/test/catch2_test_device_scan_by_key.cu
@@ -32,6 +32,7 @@
 #include <thrust/host_vector.h>
 
 #include <cstdint>
+#include <type_traits>
 
 #include "catch2_test_device_reduce.cuh"
 #include "catch2_test_device_scan.cuh"
@@ -121,7 +122,7 @@ CUB_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
 
   // Generate input data
   thrust::device_vector<value_t> in_values(num_items);
-  c2h::gen(CUB_SEED(2), in_values);
+  c2h::gen(CUB_SEED(2), in_values, std::numeric_limits<value_t>::min());
   auto d_values_it = thrust::raw_pointer_cast(in_values.data());
 
 // Skip DeviceScan::InclusiveSum and DeviceScan::ExclusiveSum tests for extended floating-point
@@ -352,7 +353,7 @@ CUB_TEST("Device scan works when memory for keys and results alias one another",
 
   // Generate input data
   thrust::device_vector<value_t> in_values(num_items);
-  c2h::gen(CUB_SEED(2), in_values);
+  c2h::gen(CUB_SEED(2), in_values, std::numeric_limits<value_t>::min());
   auto d_values_it = thrust::raw_pointer_cast(in_values.data());
 
   SECTION("inclusive sum")

--- a/cub/test/catch2_test_helper.h
+++ b/cub/test/catch2_test_helper.h
@@ -35,10 +35,11 @@
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
 
-#include "cub/util_compiler.cuh"
+#include <cub/util_compiler.cuh>
 #include "test_util_vec.h"
 
 #include "catch2_main.cuh"
+#include "test_warning_suppression.cuh"
 
 #ifndef VAR_IDX
 #define VAR_IDX 0
@@ -142,4 +143,3 @@ namespace detail
            random(std::numeric_limits<unsigned long long int>::min(),          \
                   std::numeric_limits<unsigned long long int>::max())))        \
   }
-

--- a/cub/test/catch2_test_warp_load.cu
+++ b/cub/test/catch2_test_warp_load.cu
@@ -175,7 +175,7 @@ thrust::device_vector<T> generate_input()
 
   thrust::device_vector<T> d_input(num_items);
 
-  if (LoadAlgorithm == cub::WarpLoadAlgorithm::WARP_LOAD_STRIPED)
+  CUB_IF_CONSTEXPR(LoadAlgorithm == cub::WarpLoadAlgorithm::WARP_LOAD_STRIPED)
   {
     thrust::host_vector<T> h_input(num_items);
 

--- a/cub/test/catch2_test_warp_scan.cu
+++ b/cub/test/catch2_test_warp_scan.cu
@@ -25,8 +25,10 @@
  *
  ******************************************************************************/
 
+#include <cub/detail/cpp_compatibility.cuh>
 #include <cub/util_macro.cuh>
 #include <cub/warp/warp_scan.cuh>
+
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
@@ -119,7 +121,7 @@ struct sum_op_t
   template <class WarpScanT, class T>
   __device__ void operator()(WarpScanT &scan, T &thread_data) const
   {
-    if (Mode == scan_mode::exclusive)
+    CUB_IF_CONSTEXPR(Mode == scan_mode::exclusive)
     {
       scan.ExclusiveSum(thread_data, thread_data);
     }
@@ -141,7 +143,7 @@ struct sum_aggregate_op_t
   {
     T warp_aggregate{};
 
-    if (Mode == scan_mode::exclusive)
+    CUB_IF_CONSTEXPR(Mode == scan_mode::exclusive)
     {
       scan.ExclusiveSum(thread_data, thread_data, warp_aggregate);
     }
@@ -165,7 +167,7 @@ struct min_op_t
   template <class T, class WarpScanT>
   __device__ void operator()(WarpScanT &scan, T &thread_data) const
   {
-    if (Mode == scan_mode::exclusive)
+    CUB_IF_CONSTEXPR(Mode == scan_mode::exclusive)
     {
       scan.ExclusiveScan(thread_data, thread_data, cub::Min{});
     }
@@ -187,7 +189,7 @@ struct min_aggregate_op_t
   {
     T warp_aggregate{};
 
-    if (Mode == scan_mode::exclusive)
+    CUB_IF_CONSTEXPR(Mode == scan_mode::exclusive)
     {
       scan.ExclusiveScan(thread_data, thread_data, cub::Min{}, warp_aggregate);
     }
@@ -466,7 +468,7 @@ CUB_TEST("Warp scan works with custom scan op", "[scan][warp]", types, logical_w
   // When comparing device output, the corresponding undefined data points need
   // to be fixed
 
-  if (params::mode == scan_mode::exclusive)
+  CUB_IF_CONSTEXPR(params::mode == scan_mode::exclusive)
   {
     for (size_t i = 0; i < h_out.size(); i += params::logical_warp_threads)
     {
@@ -515,7 +517,7 @@ CUB_TEST("Warp custom op scan returns valid warp aggregate",
   // When comparing device output, the corresponding undefined data points need
   // to be fixed
 
-  if (params::mode == scan_mode::exclusive)
+  CUB_IF_CONSTEXPR(params::mode == scan_mode::exclusive)
   {
     for (size_t i = 0; i < h_out.size(); i += params::logical_warp_threads)
     {

--- a/cub/test/test_device_batch_copy.cu
+++ b/cub/test/test_device_batch_copy.cu
@@ -25,8 +25,10 @@
  *
  ******************************************************************************/
 
+#include <cub/detail/cpp_compatibility.cuh>
 #include <cub/device/device_copy.cuh>
 #include <cub/util_ptx.cuh>
+
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
@@ -121,8 +123,10 @@ template <size_t n, typename... T>
 typename std::enable_if<n + 1 <= thrust::tuple_size<thrust::tuple<T...>>::value>::type
 print_tuple(std::ostream &os, const thrust::tuple<T...> &tup)
 {
-  if (n != 0)
+  CUB_IF_CONSTEXPR(n != 0)
+  {
     os << ", ";
+  }
   os << thrust::get<n>(tup);
   print_tuple<n + 1>(os, tup);
 }

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -58,6 +58,7 @@
 #include "c2h/extended_types.cuh"
 #include "mersenne.h"
 #include "test_util_vec.h"
+#include "test_warning_suppression.cuh"
 #include <nv/target>
 
 /******************************************************************************

--- a/cub/test/test_warning_suppression.cuh
+++ b/cub/test/test_warning_suppression.cuh
@@ -1,0 +1,40 @@
+/******************************************************************************
+* Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of the NVIDIA CORPORATION nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#pragma once
+
+#include <cub/util_compiler.cuh>
+#include <cub/util_cpp_dialect.cuh>
+
+// C4127: conditional expression is constant
+// This can be fixed with `if constexpr` when available, but there's no way to
+// silence these pre-C++17.
+#if CUB_HOST_COMPILER == CUB_HOST_COMPILER_MSVC
+#  if CUB_CPP_DIALECT < 2017
+#    pragma warning(disable:4127)
+#  endif
+#endif


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/617
closes https://github.com/NVIDIA/cccl/issues/590

<!-- Provide a standalone description of changes in this PR. -->
This PR:
1. introduces FP8 (`__nv_fp8_e4m3` and `__nv_fp8_e5m2`) support for CUB radix sort
2. fixes block radix sort tests to work correctly in the presence of negative FP values 
3. fixes default min / max generator values to be lowest / max
4. fixes c2h generator to correctly handle lowest / max value range

Some of the tests do not work correctly with the lowest / max FP range. These are mostly tests that accumulate values. When significant number of large values (1^38) is accumulated, we push floats to `inf` values, that complicates comparison. For now, I've reduced the value range for these tests to get them passing. We should think how to handle FP tests going forward.

The PR doesn't update CUB docs to guarantee fp8 support. I suggest the following order:

1. device radix sort test is ported to Catch2
2. device radix sort test covers fp8
3. documentation is updated to guarantee fp8 support

We should also document `__nv_bfloat16`. For some reason, only `__half` is documented right now. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
