### PR TITLE
Fixes discard_memory compilation failure for pre-Volta

### DIFF
--- a/libcudacxx/docs/extended_api/memory_access_properties/discard_memory.md
+++ b/libcudacxx/docs/extended_api/memory_access_properties/discard_memory.md
@@ -23,7 +23,7 @@ Does **not** generate any HW store operations.
 This kernel needs a scratch pad that does not fit in shared memory, so it uses an allocation in global memory instead:
 
 ```cuda
-#include <cuda/annotated_ptr>
+#include <cuda/discard_memory>
 __device__ int compute(int* scratch, size_t N);
 
 __global__ void kernel(int const* in, int* out, int* scratch, size_t N) {

--- a/libcudacxx/include/cuda/annotated_ptr
+++ b/libcudacxx/include/cuda/annotated_ptr
@@ -56,6 +56,7 @@
 
 #include <cuda/std/cstdint>
 #include <cuda/barrier>
+#include <cuda/discard_memory>
 
 #include "std/detail/__access_property"
 
@@ -167,25 +168,6 @@ void apply_access_property(const volatile void* __ptr, const _Shape __shape, acc
     //Apply to all 128 bytes aligned cache lines inclusive of __p
     for (std::size_t __i = 0; __i < __end; __i += _LINE_SIZE) {
       asm volatile ("prefetch.global.L2::evict_normal [%0];" ::"l"(__p + (__i * _LINE_SIZE)) :);
-    }
-  ))
-}
-
-inline
-_LIBCUDACXX_HOST_DEVICE
-void discard_memory(volatile void* __ptr, std::size_t __nbytes) noexcept {
-  NV_IF_TARGET(NV_PROVIDES_SM_80,(
-    if (!__isGlobal((void*)__ptr)) return;
-
-    char* __p = reinterpret_cast<char*>(const_cast<void*>(__ptr));
-    static constexpr std::size_t _LINE_SIZE = 128;
-    std::size_t __start = (reinterpret_cast<std::uintptr_t>(__p) % _LINE_SIZE) ? 1 : 0;
-    std::size_t __end = (reinterpret_cast<std::uintptr_t>(__p + __nbytes) % _LINE_SIZE) ? __nbytes - _LINE_SIZE : __nbytes;
-    __end /= _LINE_SIZE;
-
-    //Trim the first block and last block if they're not 128 bytes aligned
-    for (std::size_t __i = __start; __i < __end; __i += _LINE_SIZE) {
-      asm volatile ("discard.global.L2 [%0], 128;" ::"l"(__p + (__i * _LINE_SIZE)) :);
     }
   ))
 }

--- a/libcudacxx/include/cuda/discard_memory
+++ b/libcudacxx/include/cuda/discard_memory
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * NVIDIA SOFTWARE LICENSE
+ *
+ * This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs your use of the NVIDIA/CUDA C++ Library software and materials provided hereunder (“SOFTWARE”).
+ *
+ * This license can be accepted only by an adult of legal age of majority in the country in which the SOFTWARE is used. If you are under the legal age of majority, you must ask your parent or legal guardian to consent to this license. By taking delivery of the SOFTWARE, you affirm that you have reached the legal age of majority, you accept the terms of this license, and you take legal and financial responsibility for the actions of your permitted users.
+ *
+ * You agree to use the SOFTWARE only for purposes that are permitted by (a) this license, and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions.
+ *
+ * 1. LICENSE. Subject to the terms of this license, NVIDIA grants you a non-exclusive limited license to: (a) install and use the SOFTWARE, and (b) distribute the SOFTWARE subject to the distribution requirements described in this license. NVIDIA reserves all rights, title and interest in and to the SOFTWARE not expressly granted to you under this license.
+ *
+ * 2. DISTRIBUTION REQUIREMENTS. These are the distribution requirements for you to exercise the distribution grant:
+ * a.      The terms under which you distribute the SOFTWARE must be consistent with the terms of this license, including (without limitation) terms relating to the license grant and license restrictions and protection of NVIDIA’s intellectual property rights.
+ * b.      You agree to notify NVIDIA in writing of any known or suspected distribution or use of the SOFTWARE not in compliance with the requirements of this license, and to enforce the terms of your agreements with respect to distributed SOFTWARE.
+ *
+ * 3. LIMITATIONS. Your license to use the SOFTWARE is restricted as follows:
+ * a.      The SOFTWARE is licensed for you to develop applications only for use in systems with NVIDIA GPUs.
+ * b.      You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary notices from any portion of the SOFTWARE or copies of the SOFTWARE.
+ * c.      You may not modify or create derivative works of any portion of the SOFTWARE.
+ * d.      You may not bypass, disable, or circumvent any technical measure, encryption, security, digital rights management or authentication mechanism in the SOFTWARE.
+ * e.      You may not use the SOFTWARE in any manner that would cause it to become subject to an open source software license. As examples, licenses that require as a condition of use, modification, and/or distribution that the SOFTWARE be (i) disclosed or distributed in source code form; (ii) licensed for the purpose of making derivative works; or (iii) redistributable at no charge.
+ * f.      Unless you have an agreement with NVIDIA for this purpose, you may not use the SOFTWARE with any system or application where the use or failure of the system or application can reasonably be expected to threaten or result in personal injury, death, or catastrophic loss. Examples include use in avionics, navigation, military, medical, life support or other life critical applications. NVIDIA does not design, test or manufacture the SOFTWARE for these critical uses and NVIDIA shall not be liable to you or any third party, in whole or in part, for any claims or damages arising from such uses.
+ * g.      You agree to defend, indemnify and hold harmless NVIDIA and its affiliates, and their respective employees, contractors, agents, officers and directors, from and against any and all claims, damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses (including but not limited to attorney’s fees and costs incident to establishing the right of indemnification) arising out of or related to use of the SOFTWARE outside of the scope of this Agreement, or not in compliance with its terms.
+ *
+ * 4. PRE-RELEASE. SOFTWARE versions identified as alpha, beta, preview, early access or otherwise as pre-release may not be fully functional, may contain errors or design flaws, and may have reduced or different security, privacy, availability, and reliability standards relative to commercial versions of NVIDIA software and materials. You may use a pre-release SOFTWARE version at your own risk, understanding that these versions are not intended for use in production or business-critical systems.
+ *
+ * 5. OWNERSHIP. The SOFTWARE and the related intellectual property rights therein are and will remain the sole and exclusive property of NVIDIA or its licensors. The SOFTWARE is copyrighted and protected by the laws of the United States and other countries, and international treaty provisions. NVIDIA may make changes to the SOFTWARE, at any time without notice, but is not obligated to support or update the SOFTWARE.
+ *
+ * 6. COMPONENTS UNDER OTHER LICENSES. The SOFTWARE may include NVIDIA or third-party components with separate legal notices or terms as may be described in proprietary notices accompanying the SOFTWARE. If and to the extent there is a conflict between the terms in this license and the license terms associated with a component, the license terms associated with the components control only to the extent necessary to resolve the conflict.
+ *
+ * 7. FEEDBACK. You may, but don’t have to, provide to NVIDIA any Feedback. “Feedback” means any suggestions, bug fixes, enhancements, modifications, feature requests or other feedback regarding the SOFTWARE. For any Feedback that you voluntarily provide, you hereby grant NVIDIA and its affiliates a perpetual, non-exclusive, worldwide, irrevocable license to use, reproduce, modify, license, sublicense (through multiple tiers of sublicensees), and distribute (through multiple tiers of distributors) the Feedback without the payment of any royalties or fees to you. NVIDIA will use Feedback at its choice.
+ *
+ * 8. NO WARRANTIES. THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY EXPRESS OR IMPLIED WARRANTY OF ANY KIND INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. NVIDIA DOES NOT WARRANT THAT THE SOFTWARE WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ALL ERRORS WILL BE CORRECTED.
+ *
+ * 9. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND ITS AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR ANY LOST PROFITS, PROJECT DELAYS, LOSS OF USE, LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR THE USE OR PERFORMANCE OF THE SOFTWARE, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON BREACH OF CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF ACTION OR THEORY OF LIABILITY, EVEN IF NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD REASONABLY HAVE FORESEEN, THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL CUMULATIVE LIABILITY UNDER OR ARISING OUT OF THIS LICENSE EXCEED US$10.00. THE NATURE OF THE LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE OR EXTEND THIS LIMIT.
+ *
+ * 10. TERMINATION. Your rights under this license will terminate automatically without notice from NVIDIA if you fail to comply with any term and condition of this license or if you commence or participate in any legal proceeding against NVIDIA with respect to the SOFTWARE. NVIDIA may terminate this license with advance written notice to you if NVIDIA decides to no longer provide the SOFTWARE in a country or, in NVIDIA’s sole discretion, the continued use of it is no longer commercially viable. Upon any termination of this license, you agree to promptly discontinue use of the SOFTWARE and destroy all copies in your possession or control. Your prior distributions in accordance with this license are not affected by the termination of this license. All provisions of this license will survive termination, except for the license granted to you.
+ *
+ * 11. APPLICABLE LAW. This license will be governed in all respects by the laws of the United States and of the State of Delaware as those laws are applied to contracts entered into and performed entirely within Delaware by Delaware residents, without regard to the conflicts of laws principles. The United Nations Convention on Contracts for the International Sale of Goods is specifically disclaimed. You agree to all terms of this Agreement in the English language. The state or federal courts residing in Santa Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of this license. Notwithstanding this, you agree that NVIDIA shall still be allowed to apply for injunctive remedies or an equivalent type of urgent legal relief in any jurisdiction.
+ *
+ * 12. NO ASSIGNMENT. This license and your rights and obligations thereunder may not be assigned by you by any means or operation of law without NVIDIA’s permission. Any attempted assignment not approved by NVIDIA in writing shall be void and of no effect.
+ *
+ * 13. EXPORT. The SOFTWARE is subject to United States export laws and regulations. You agree that you will not ship, transfer or export the SOFTWARE into any country, or use the SOFTWARE in any manner, prohibited by the United States Bureau of Industry and Security or economic sanctions regulations administered by the U.S. Department of Treasury’s Office of Foreign Assets Control (OFAC), or any applicable export laws, restrictions or regulations. These laws include restrictions on destinations, end users and end use. By accepting this license, you confirm that you are not a resident or citizen of any country currently embargoed by the U.S. and that you are not otherwise prohibited from receiving the SOFTWARE.
+ *
+ * 14. GOVERNMENT USE. The SOFTWARE has been developed entirely at private expense and is “commercial items” consisting of “commercial computer software” and “commercial computer software documentation” provided with RESTRICTED RIGHTS. Use, duplication or disclosure by the U.S. Government or a U.S. Government subcontractor is subject to the restrictions in this license pursuant to DFARS 227.7202-3(a) or as set forth in subparagraphs (b)(1) and (2) of the Commercial Computer Software - Restricted Rights clause at FAR 52.227-19, as applicable. Contractor/manufacturer is NVIDIA, 2788 San Tomas Expressway, Santa Clara, CA 95051.
+ *
+ * 15. ENTIRE AGREEMENT. This license is the final, complete and exclusive agreement between the parties relating to the subject matter of this license and supersedes all prior or contemporaneous understandings and agreements relating to this subject matter, whether oral or written. If any court of competent jurisdiction determines that any provision of this license is illegal, invalid or unenforceable, the remaining provisions will remain in full force and effect. This license may only be modified in a writing signed by an authorized representative of each party.
+ *
+ * (v. August 20, 2021)
+ */
+
+#ifndef _CUDA_DISCARD_MEMORY
+#  define _CUDA_DISCARD_MEMORY
+
+#include "std/detail/__config"
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+inline _LIBCUDACXX_HOST_DEVICE void discard_memory(volatile void* __ptr, std::size_t __nbytes) noexcept
+{
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (if (!__isGlobal((void*) __ptr)) return;
+
+     char* __p                               = reinterpret_cast<char*>(const_cast<void*>(__ptr));
+     static constexpr std::size_t _LINE_SIZE = 128;
+     std::size_t __start                     = (reinterpret_cast<std::uintptr_t>(__p) % _LINE_SIZE) ? 1 : 0;
+     std::size_t __end =
+       (reinterpret_cast<std::uintptr_t>(__p + __nbytes) % _LINE_SIZE) ? __nbytes - _LINE_SIZE : __nbytes;
+     __end /= _LINE_SIZE;
+
+     // Trim the first block and last block if they're not 128 bytes aligned
+     for (std::size_t __i = __start; __i < __end; __i += _LINE_SIZE) {
+       asm volatile("discard.global.L2 [%0], 128;" ::"l"(__p + (__i * _LINE_SIZE)) :);
+     }),
+    ((void) (__ptr); (void) (__nbytes);))
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif
+

--- a/libcudacxx/include/cuda/discard_memory
+++ b/libcudacxx/include/cuda/discard_memory
@@ -3,57 +3,136 @@
  *
  * NVIDIA SOFTWARE LICENSE
  *
- * This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs your use of the NVIDIA/CUDA C++ Library software and materials provided hereunder (“SOFTWARE”).
+ * This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs your use of the
+ * NVIDIA/CUDA C++ Library software and materials provided hereunder (“SOFTWARE”).
  *
- * This license can be accepted only by an adult of legal age of majority in the country in which the SOFTWARE is used. If you are under the legal age of majority, you must ask your parent or legal guardian to consent to this license. By taking delivery of the SOFTWARE, you affirm that you have reached the legal age of majority, you accept the terms of this license, and you take legal and financial responsibility for the actions of your permitted users.
+ * This license can be accepted only by an adult of legal age of majority in the country in which the SOFTWARE is used.
+ * If you are under the legal age of majority, you must ask your parent or legal guardian to consent to this license. By
+ * taking delivery of the SOFTWARE, you affirm that you have reached the legal age of majority, you accept the terms of
+ * this license, and you take legal and financial responsibility for the actions of your permitted users.
  *
- * You agree to use the SOFTWARE only for purposes that are permitted by (a) this license, and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions.
+ * You agree to use the SOFTWARE only for purposes that are permitted by (a) this license, and (b) any applicable law,
+ * regulation or generally accepted practices or guidelines in the relevant jurisdictions.
  *
- * 1. LICENSE. Subject to the terms of this license, NVIDIA grants you a non-exclusive limited license to: (a) install and use the SOFTWARE, and (b) distribute the SOFTWARE subject to the distribution requirements described in this license. NVIDIA reserves all rights, title and interest in and to the SOFTWARE not expressly granted to you under this license.
+ * 1. LICENSE. Subject to the terms of this license, NVIDIA grants you a non-exclusive limited license to: (a) install
+ * and use the SOFTWARE, and (b) distribute the SOFTWARE subject to the distribution requirements described in this
+ * license. NVIDIA reserves all rights, title and interest in and to the SOFTWARE not expressly granted to you under
+ * this license.
  *
  * 2. DISTRIBUTION REQUIREMENTS. These are the distribution requirements for you to exercise the distribution grant:
- * a.      The terms under which you distribute the SOFTWARE must be consistent with the terms of this license, including (without limitation) terms relating to the license grant and license restrictions and protection of NVIDIA’s intellectual property rights.
- * b.      You agree to notify NVIDIA in writing of any known or suspected distribution or use of the SOFTWARE not in compliance with the requirements of this license, and to enforce the terms of your agreements with respect to distributed SOFTWARE.
+ * a.      The terms under which you distribute the SOFTWARE must be consistent with the terms of this license,
+ * including (without limitation) terms relating to the license grant and license restrictions and protection of
+ * NVIDIA’s intellectual property rights. b.      You agree to notify NVIDIA in writing of any known or suspected
+ * distribution or use of the SOFTWARE not in compliance with the requirements of this license, and to enforce the terms
+ * of your agreements with respect to distributed SOFTWARE.
  *
  * 3. LIMITATIONS. Your license to use the SOFTWARE is restricted as follows:
  * a.      The SOFTWARE is licensed for you to develop applications only for use in systems with NVIDIA GPUs.
- * b.      You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary notices from any portion of the SOFTWARE or copies of the SOFTWARE.
- * c.      You may not modify or create derivative works of any portion of the SOFTWARE.
- * d.      You may not bypass, disable, or circumvent any technical measure, encryption, security, digital rights management or authentication mechanism in the SOFTWARE.
- * e.      You may not use the SOFTWARE in any manner that would cause it to become subject to an open source software license. As examples, licenses that require as a condition of use, modification, and/or distribution that the SOFTWARE be (i) disclosed or distributed in source code form; (ii) licensed for the purpose of making derivative works; or (iii) redistributable at no charge.
- * f.      Unless you have an agreement with NVIDIA for this purpose, you may not use the SOFTWARE with any system or application where the use or failure of the system or application can reasonably be expected to threaten or result in personal injury, death, or catastrophic loss. Examples include use in avionics, navigation, military, medical, life support or other life critical applications. NVIDIA does not design, test or manufacture the SOFTWARE for these critical uses and NVIDIA shall not be liable to you or any third party, in whole or in part, for any claims or damages arising from such uses.
- * g.      You agree to defend, indemnify and hold harmless NVIDIA and its affiliates, and their respective employees, contractors, agents, officers and directors, from and against any and all claims, damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses (including but not limited to attorney’s fees and costs incident to establishing the right of indemnification) arising out of or related to use of the SOFTWARE outside of the scope of this Agreement, or not in compliance with its terms.
+ * b.      You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary notices from
+ * any portion of the SOFTWARE or copies of the SOFTWARE. c.      You may not modify or create derivative works of any
+ * portion of the SOFTWARE. d.      You may not bypass, disable, or circumvent any technical measure, encryption,
+ * security, digital rights management or authentication mechanism in the SOFTWARE. e.      You may not use the SOFTWARE
+ * in any manner that would cause it to become subject to an open source software license. As examples, licenses that
+ * require as a condition of use, modification, and/or distribution that the SOFTWARE be (i) disclosed or distributed in
+ * source code form; (ii) licensed for the purpose of making derivative works; or (iii) redistributable at no charge. f.
+ * Unless you have an agreement with NVIDIA for this purpose, you may not use the SOFTWARE with any system or
+ * application where the use or failure of the system or application can reasonably be expected to threaten or result in
+ * personal injury, death, or catastrophic loss. Examples include use in avionics, navigation, military, medical, life
+ * support or other life critical applications. NVIDIA does not design, test or manufacture the SOFTWARE for these
+ * critical uses and NVIDIA shall not be liable to you or any third party, in whole or in part, for any claims or
+ * damages arising from such uses. g.      You agree to defend, indemnify and hold harmless NVIDIA and its affiliates,
+ * and their respective employees, contractors, agents, officers and directors, from and against any and all claims,
+ * damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses (including but not limited
+ * to attorney’s fees and costs incident to establishing the right of indemnification) arising out of or related to use
+ * of the SOFTWARE outside of the scope of this Agreement, or not in compliance with its terms.
  *
- * 4. PRE-RELEASE. SOFTWARE versions identified as alpha, beta, preview, early access or otherwise as pre-release may not be fully functional, may contain errors or design flaws, and may have reduced or different security, privacy, availability, and reliability standards relative to commercial versions of NVIDIA software and materials. You may use a pre-release SOFTWARE version at your own risk, understanding that these versions are not intended for use in production or business-critical systems.
+ * 4. PRE-RELEASE. SOFTWARE versions identified as alpha, beta, preview, early access or otherwise as pre-release may
+ * not be fully functional, may contain errors or design flaws, and may have reduced or different security, privacy,
+ * availability, and reliability standards relative to commercial versions of NVIDIA software and materials. You may use
+ * a pre-release SOFTWARE version at your own risk, understanding that these versions are not intended for use in
+ * production or business-critical systems.
  *
- * 5. OWNERSHIP. The SOFTWARE and the related intellectual property rights therein are and will remain the sole and exclusive property of NVIDIA or its licensors. The SOFTWARE is copyrighted and protected by the laws of the United States and other countries, and international treaty provisions. NVIDIA may make changes to the SOFTWARE, at any time without notice, but is not obligated to support or update the SOFTWARE.
+ * 5. OWNERSHIP. The SOFTWARE and the related intellectual property rights therein are and will remain the sole and
+ * exclusive property of NVIDIA or its licensors. The SOFTWARE is copyrighted and protected by the laws of the United
+ * States and other countries, and international treaty provisions. NVIDIA may make changes to the SOFTWARE, at any time
+ * without notice, but is not obligated to support or update the SOFTWARE.
  *
- * 6. COMPONENTS UNDER OTHER LICENSES. The SOFTWARE may include NVIDIA or third-party components with separate legal notices or terms as may be described in proprietary notices accompanying the SOFTWARE. If and to the extent there is a conflict between the terms in this license and the license terms associated with a component, the license terms associated with the components control only to the extent necessary to resolve the conflict.
+ * 6. COMPONENTS UNDER OTHER LICENSES. The SOFTWARE may include NVIDIA or third-party components with separate legal
+ * notices or terms as may be described in proprietary notices accompanying the SOFTWARE. If and to the extent there is
+ * a conflict between the terms in this license and the license terms associated with a component, the license terms
+ * associated with the components control only to the extent necessary to resolve the conflict.
  *
- * 7. FEEDBACK. You may, but don’t have to, provide to NVIDIA any Feedback. “Feedback” means any suggestions, bug fixes, enhancements, modifications, feature requests or other feedback regarding the SOFTWARE. For any Feedback that you voluntarily provide, you hereby grant NVIDIA and its affiliates a perpetual, non-exclusive, worldwide, irrevocable license to use, reproduce, modify, license, sublicense (through multiple tiers of sublicensees), and distribute (through multiple tiers of distributors) the Feedback without the payment of any royalties or fees to you. NVIDIA will use Feedback at its choice.
+ * 7. FEEDBACK. You may, but don’t have to, provide to NVIDIA any Feedback. “Feedback” means any suggestions, bug fixes,
+ * enhancements, modifications, feature requests or other feedback regarding the SOFTWARE. For any Feedback that you
+ * voluntarily provide, you hereby grant NVIDIA and its affiliates a perpetual, non-exclusive, worldwide, irrevocable
+ * license to use, reproduce, modify, license, sublicense (through multiple tiers of sublicensees), and distribute
+ * (through multiple tiers of distributors) the Feedback without the payment of any royalties or fees to you. NVIDIA
+ * will use Feedback at its choice.
  *
- * 8. NO WARRANTIES. THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY EXPRESS OR IMPLIED WARRANTY OF ANY KIND INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. NVIDIA DOES NOT WARRANT THAT THE SOFTWARE WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ALL ERRORS WILL BE CORRECTED.
+ * 8. NO WARRANTIES. THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY EXPRESS OR IMPLIED WARRANTY OF ANY KIND INCLUDING, BUT
+ * NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. NVIDIA DOES NOT
+ * WARRANT THAT THE SOFTWARE WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED OR
+ * ERROR-FREE, OR THAT ALL ERRORS WILL BE CORRECTED.
  *
- * 9. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND ITS AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR ANY LOST PROFITS, PROJECT DELAYS, LOSS OF USE, LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR THE USE OR PERFORMANCE OF THE SOFTWARE, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON BREACH OF CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF ACTION OR THEORY OF LIABILITY, EVEN IF NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD REASONABLY HAVE FORESEEN, THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL CUMULATIVE LIABILITY UNDER OR ARISING OUT OF THIS LICENSE EXCEED US$10.00. THE NATURE OF THE LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE OR EXTEND THIS LIMIT.
+ * 9. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND ITS AFFILIATES SHALL NOT BE LIABLE
+ * FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR ANY LOST PROFITS, PROJECT DELAYS, LOSS OF USE,
+ * LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH
+ * THIS LICENSE OR THE USE OR PERFORMANCE OF THE SOFTWARE, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON
+ * BREACH OF CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF ACTION
+ * OR THEORY OF LIABILITY, EVEN IF NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD REASONABLY HAVE FORESEEN, THE
+ * POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL CUMULATIVE LIABILITY UNDER OR ARISING
+ * OUT OF THIS LICENSE EXCEED US$10.00. THE NATURE OF THE LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE
+ * OR EXTEND THIS LIMIT.
  *
- * 10. TERMINATION. Your rights under this license will terminate automatically without notice from NVIDIA if you fail to comply with any term and condition of this license or if you commence or participate in any legal proceeding against NVIDIA with respect to the SOFTWARE. NVIDIA may terminate this license with advance written notice to you if NVIDIA decides to no longer provide the SOFTWARE in a country or, in NVIDIA’s sole discretion, the continued use of it is no longer commercially viable. Upon any termination of this license, you agree to promptly discontinue use of the SOFTWARE and destroy all copies in your possession or control. Your prior distributions in accordance with this license are not affected by the termination of this license. All provisions of this license will survive termination, except for the license granted to you.
+ * 10. TERMINATION. Your rights under this license will terminate automatically without notice from NVIDIA if you fail
+ * to comply with any term and condition of this license or if you commence or participate in any legal proceeding
+ * against NVIDIA with respect to the SOFTWARE. NVIDIA may terminate this license with advance written notice to you if
+ * NVIDIA decides to no longer provide the SOFTWARE in a country or, in NVIDIA’s sole discretion, the continued use of
+ * it is no longer commercially viable. Upon any termination of this license, you agree to promptly discontinue use of
+ * the SOFTWARE and destroy all copies in your possession or control. Your prior distributions in accordance with this
+ * license are not affected by the termination of this license. All provisions of this license will survive termination,
+ * except for the license granted to you.
  *
- * 11. APPLICABLE LAW. This license will be governed in all respects by the laws of the United States and of the State of Delaware as those laws are applied to contracts entered into and performed entirely within Delaware by Delaware residents, without regard to the conflicts of laws principles. The United Nations Convention on Contracts for the International Sale of Goods is specifically disclaimed. You agree to all terms of this Agreement in the English language. The state or federal courts residing in Santa Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of this license. Notwithstanding this, you agree that NVIDIA shall still be allowed to apply for injunctive remedies or an equivalent type of urgent legal relief in any jurisdiction.
+ * 11. APPLICABLE LAW. This license will be governed in all respects by the laws of the United States and of the State
+ * of Delaware as those laws are applied to contracts entered into and performed entirely within Delaware by Delaware
+ * residents, without regard to the conflicts of laws principles. The United Nations Convention on Contracts for the
+ * International Sale of Goods is specifically disclaimed. You agree to all terms of this Agreement in the English
+ * language. The state or federal courts residing in Santa Clara County, California shall have exclusive jurisdiction
+ * over any dispute or claim arising out of this license. Notwithstanding this, you agree that NVIDIA shall still be
+ * allowed to apply for injunctive remedies or an equivalent type of urgent legal relief in any jurisdiction.
  *
- * 12. NO ASSIGNMENT. This license and your rights and obligations thereunder may not be assigned by you by any means or operation of law without NVIDIA’s permission. Any attempted assignment not approved by NVIDIA in writing shall be void and of no effect.
+ * 12. NO ASSIGNMENT. This license and your rights and obligations thereunder may not be assigned by you by any means or
+ * operation of law without NVIDIA’s permission. Any attempted assignment not approved by NVIDIA in writing shall be
+ * void and of no effect.
  *
- * 13. EXPORT. The SOFTWARE is subject to United States export laws and regulations. You agree that you will not ship, transfer or export the SOFTWARE into any country, or use the SOFTWARE in any manner, prohibited by the United States Bureau of Industry and Security or economic sanctions regulations administered by the U.S. Department of Treasury’s Office of Foreign Assets Control (OFAC), or any applicable export laws, restrictions or regulations. These laws include restrictions on destinations, end users and end use. By accepting this license, you confirm that you are not a resident or citizen of any country currently embargoed by the U.S. and that you are not otherwise prohibited from receiving the SOFTWARE.
+ * 13. EXPORT. The SOFTWARE is subject to United States export laws and regulations. You agree that you will not ship,
+ * transfer or export the SOFTWARE into any country, or use the SOFTWARE in any manner, prohibited by the United States
+ * Bureau of Industry and Security or economic sanctions regulations administered by the U.S. Department of Treasury’s
+ * Office of Foreign Assets Control (OFAC), or any applicable export laws, restrictions or regulations. These laws
+ * include restrictions on destinations, end users and end use. By accepting this license, you confirm that you are not
+ * a resident or citizen of any country currently embargoed by the U.S. and that you are not otherwise prohibited from
+ * receiving the SOFTWARE.
  *
- * 14. GOVERNMENT USE. The SOFTWARE has been developed entirely at private expense and is “commercial items” consisting of “commercial computer software” and “commercial computer software documentation” provided with RESTRICTED RIGHTS. Use, duplication or disclosure by the U.S. Government or a U.S. Government subcontractor is subject to the restrictions in this license pursuant to DFARS 227.7202-3(a) or as set forth in subparagraphs (b)(1) and (2) of the Commercial Computer Software - Restricted Rights clause at FAR 52.227-19, as applicable. Contractor/manufacturer is NVIDIA, 2788 San Tomas Expressway, Santa Clara, CA 95051.
+ * 14. GOVERNMENT USE. The SOFTWARE has been developed entirely at private expense and is “commercial items” consisting
+ * of “commercial computer software” and “commercial computer software documentation” provided with RESTRICTED RIGHTS.
+ * Use, duplication or disclosure by the U.S. Government or a U.S. Government subcontractor is subject to the
+ * restrictions in this license pursuant to DFARS 227.7202-3(a) or as set forth in subparagraphs (b)(1) and (2) of the
+ * Commercial Computer Software - Restricted Rights clause at FAR 52.227-19, as applicable. Contractor/manufacturer is
+ * NVIDIA, 2788 San Tomas Expressway, Santa Clara, CA 95051.
  *
- * 15. ENTIRE AGREEMENT. This license is the final, complete and exclusive agreement between the parties relating to the subject matter of this license and supersedes all prior or contemporaneous understandings and agreements relating to this subject matter, whether oral or written. If any court of competent jurisdiction determines that any provision of this license is illegal, invalid or unenforceable, the remaining provisions will remain in full force and effect. This license may only be modified in a writing signed by an authorized representative of each party.
+ * 15. ENTIRE AGREEMENT. This license is the final, complete and exclusive agreement between the parties relating to the
+ * subject matter of this license and supersedes all prior or contemporaneous understandings and agreements relating to
+ * this subject matter, whether oral or written. If any court of competent jurisdiction determines that any provision of
+ * this license is illegal, invalid or unenforceable, the remaining provisions will remain in full force and effect.
+ * This license may only be modified in a writing signed by an authorized representative of each party.
  *
  * (v. August 20, 2021)
  */
 
 #ifndef _CUDA_DISCARD_MEMORY
-#  define _CUDA_DISCARD_MEMORY
+#define _CUDA_DISCARD_MEMORY
 
+#include <cuda/std/cstdint>
 #include "std/detail/__config"
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
@@ -65,15 +144,18 @@ inline _LIBCUDACXX_HOST_DEVICE void discard_memory(volatile void* __ptr, std::si
     (if (!__isGlobal((void*) __ptr)) return;
 
      char* __p                               = reinterpret_cast<char*>(const_cast<void*>(__ptr));
+     char* const __end_p                     = __p + __nbytes;
      static constexpr std::size_t _LINE_SIZE = 128;
-     std::size_t __start                     = (reinterpret_cast<std::uintptr_t>(__p) % _LINE_SIZE) ? 1 : 0;
-     std::size_t __end =
-       (reinterpret_cast<std::uintptr_t>(__p + __nbytes) % _LINE_SIZE) ? __nbytes - _LINE_SIZE : __nbytes;
-     __end /= _LINE_SIZE;
 
      // Trim the first block and last block if they're not 128 bytes aligned
-     for (std::size_t __i = __start; __i < __end; __i += _LINE_SIZE) {
-       asm volatile("discard.global.L2 [%0], 128;" ::"l"(__p + (__i * _LINE_SIZE)) :);
+     std::size_t __misalignment = reinterpret_cast<std::uintptr_t>(__p) % _LINE_SIZE;
+     char* __start_aligned      = __misalignment == 0 ? __p : __p + (_LINE_SIZE - __misalignment);
+     char* const __end_aligned  = __end_p - (reinterpret_cast<std::uintptr_t>(__end_p) % _LINE_SIZE);
+
+     while (__start_aligned < __end_aligned) {
+       printf("-> [%p, %p)\n", __start_aligned, __start_aligned + 128);
+       asm volatile("discard.global.L2 [%0], 128;" ::"l"(__start_aligned) :);
+       __start_aligned += _LINE_SIZE;
      }),
     ((void) (__ptr); (void) (__nbytes);))
 }
@@ -81,4 +163,3 @@ inline _LIBCUDACXX_HOST_DEVICE void discard_memory(volatile void* __ptr, std::si
 _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #endif
-

--- a/libcudacxx/include/cuda/discard_memory
+++ b/libcudacxx/include/cuda/discard_memory
@@ -1,139 +1,18 @@
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- *
- * NVIDIA SOFTWARE LICENSE
- *
- * This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs your use of the
- * NVIDIA/CUDA C++ Library software and materials provided hereunder (“SOFTWARE”).
- *
- * This license can be accepted only by an adult of legal age of majority in the country in which the SOFTWARE is used.
- * If you are under the legal age of majority, you must ask your parent or legal guardian to consent to this license. By
- * taking delivery of the SOFTWARE, you affirm that you have reached the legal age of majority, you accept the terms of
- * this license, and you take legal and financial responsibility for the actions of your permitted users.
- *
- * You agree to use the SOFTWARE only for purposes that are permitted by (a) this license, and (b) any applicable law,
- * regulation or generally accepted practices or guidelines in the relevant jurisdictions.
- *
- * 1. LICENSE. Subject to the terms of this license, NVIDIA grants you a non-exclusive limited license to: (a) install
- * and use the SOFTWARE, and (b) distribute the SOFTWARE subject to the distribution requirements described in this
- * license. NVIDIA reserves all rights, title and interest in and to the SOFTWARE not expressly granted to you under
- * this license.
- *
- * 2. DISTRIBUTION REQUIREMENTS. These are the distribution requirements for you to exercise the distribution grant:
- * a.      The terms under which you distribute the SOFTWARE must be consistent with the terms of this license,
- * including (without limitation) terms relating to the license grant and license restrictions and protection of
- * NVIDIA’s intellectual property rights. b.      You agree to notify NVIDIA in writing of any known or suspected
- * distribution or use of the SOFTWARE not in compliance with the requirements of this license, and to enforce the terms
- * of your agreements with respect to distributed SOFTWARE.
- *
- * 3. LIMITATIONS. Your license to use the SOFTWARE is restricted as follows:
- * a.      The SOFTWARE is licensed for you to develop applications only for use in systems with NVIDIA GPUs.
- * b.      You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary notices from
- * any portion of the SOFTWARE or copies of the SOFTWARE. c.      You may not modify or create derivative works of any
- * portion of the SOFTWARE. d.      You may not bypass, disable, or circumvent any technical measure, encryption,
- * security, digital rights management or authentication mechanism in the SOFTWARE. e.      You may not use the SOFTWARE
- * in any manner that would cause it to become subject to an open source software license. As examples, licenses that
- * require as a condition of use, modification, and/or distribution that the SOFTWARE be (i) disclosed or distributed in
- * source code form; (ii) licensed for the purpose of making derivative works; or (iii) redistributable at no charge. f.
- * Unless you have an agreement with NVIDIA for this purpose, you may not use the SOFTWARE with any system or
- * application where the use or failure of the system or application can reasonably be expected to threaten or result in
- * personal injury, death, or catastrophic loss. Examples include use in avionics, navigation, military, medical, life
- * support or other life critical applications. NVIDIA does not design, test or manufacture the SOFTWARE for these
- * critical uses and NVIDIA shall not be liable to you or any third party, in whole or in part, for any claims or
- * damages arising from such uses. g.      You agree to defend, indemnify and hold harmless NVIDIA and its affiliates,
- * and their respective employees, contractors, agents, officers and directors, from and against any and all claims,
- * damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses (including but not limited
- * to attorney’s fees and costs incident to establishing the right of indemnification) arising out of or related to use
- * of the SOFTWARE outside of the scope of this Agreement, or not in compliance with its terms.
- *
- * 4. PRE-RELEASE. SOFTWARE versions identified as alpha, beta, preview, early access or otherwise as pre-release may
- * not be fully functional, may contain errors or design flaws, and may have reduced or different security, privacy,
- * availability, and reliability standards relative to commercial versions of NVIDIA software and materials. You may use
- * a pre-release SOFTWARE version at your own risk, understanding that these versions are not intended for use in
- * production or business-critical systems.
- *
- * 5. OWNERSHIP. The SOFTWARE and the related intellectual property rights therein are and will remain the sole and
- * exclusive property of NVIDIA or its licensors. The SOFTWARE is copyrighted and protected by the laws of the United
- * States and other countries, and international treaty provisions. NVIDIA may make changes to the SOFTWARE, at any time
- * without notice, but is not obligated to support or update the SOFTWARE.
- *
- * 6. COMPONENTS UNDER OTHER LICENSES. The SOFTWARE may include NVIDIA or third-party components with separate legal
- * notices or terms as may be described in proprietary notices accompanying the SOFTWARE. If and to the extent there is
- * a conflict between the terms in this license and the license terms associated with a component, the license terms
- * associated with the components control only to the extent necessary to resolve the conflict.
- *
- * 7. FEEDBACK. You may, but don’t have to, provide to NVIDIA any Feedback. “Feedback” means any suggestions, bug fixes,
- * enhancements, modifications, feature requests or other feedback regarding the SOFTWARE. For any Feedback that you
- * voluntarily provide, you hereby grant NVIDIA and its affiliates a perpetual, non-exclusive, worldwide, irrevocable
- * license to use, reproduce, modify, license, sublicense (through multiple tiers of sublicensees), and distribute
- * (through multiple tiers of distributors) the Feedback without the payment of any royalties or fees to you. NVIDIA
- * will use Feedback at its choice.
- *
- * 8. NO WARRANTIES. THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY EXPRESS OR IMPLIED WARRANTY OF ANY KIND INCLUDING, BUT
- * NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. NVIDIA DOES NOT
- * WARRANT THAT THE SOFTWARE WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED OR
- * ERROR-FREE, OR THAT ALL ERRORS WILL BE CORRECTED.
- *
- * 9. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND ITS AFFILIATES SHALL NOT BE LIABLE
- * FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR ANY LOST PROFITS, PROJECT DELAYS, LOSS OF USE,
- * LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH
- * THIS LICENSE OR THE USE OR PERFORMANCE OF THE SOFTWARE, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON
- * BREACH OF CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF ACTION
- * OR THEORY OF LIABILITY, EVEN IF NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD REASONABLY HAVE FORESEEN, THE
- * POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL CUMULATIVE LIABILITY UNDER OR ARISING
- * OUT OF THIS LICENSE EXCEED US$10.00. THE NATURE OF THE LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE
- * OR EXTEND THIS LIMIT.
- *
- * 10. TERMINATION. Your rights under this license will terminate automatically without notice from NVIDIA if you fail
- * to comply with any term and condition of this license or if you commence or participate in any legal proceeding
- * against NVIDIA with respect to the SOFTWARE. NVIDIA may terminate this license with advance written notice to you if
- * NVIDIA decides to no longer provide the SOFTWARE in a country or, in NVIDIA’s sole discretion, the continued use of
- * it is no longer commercially viable. Upon any termination of this license, you agree to promptly discontinue use of
- * the SOFTWARE and destroy all copies in your possession or control. Your prior distributions in accordance with this
- * license are not affected by the termination of this license. All provisions of this license will survive termination,
- * except for the license granted to you.
- *
- * 11. APPLICABLE LAW. This license will be governed in all respects by the laws of the United States and of the State
- * of Delaware as those laws are applied to contracts entered into and performed entirely within Delaware by Delaware
- * residents, without regard to the conflicts of laws principles. The United Nations Convention on Contracts for the
- * International Sale of Goods is specifically disclaimed. You agree to all terms of this Agreement in the English
- * language. The state or federal courts residing in Santa Clara County, California shall have exclusive jurisdiction
- * over any dispute or claim arising out of this license. Notwithstanding this, you agree that NVIDIA shall still be
- * allowed to apply for injunctive remedies or an equivalent type of urgent legal relief in any jurisdiction.
- *
- * 12. NO ASSIGNMENT. This license and your rights and obligations thereunder may not be assigned by you by any means or
- * operation of law without NVIDIA’s permission. Any attempted assignment not approved by NVIDIA in writing shall be
- * void and of no effect.
- *
- * 13. EXPORT. The SOFTWARE is subject to United States export laws and regulations. You agree that you will not ship,
- * transfer or export the SOFTWARE into any country, or use the SOFTWARE in any manner, prohibited by the United States
- * Bureau of Industry and Security or economic sanctions regulations administered by the U.S. Department of Treasury’s
- * Office of Foreign Assets Control (OFAC), or any applicable export laws, restrictions or regulations. These laws
- * include restrictions on destinations, end users and end use. By accepting this license, you confirm that you are not
- * a resident or citizen of any country currently embargoed by the U.S. and that you are not otherwise prohibited from
- * receiving the SOFTWARE.
- *
- * 14. GOVERNMENT USE. The SOFTWARE has been developed entirely at private expense and is “commercial items” consisting
- * of “commercial computer software” and “commercial computer software documentation” provided with RESTRICTED RIGHTS.
- * Use, duplication or disclosure by the U.S. Government or a U.S. Government subcontractor is subject to the
- * restrictions in this license pursuant to DFARS 227.7202-3(a) or as set forth in subparagraphs (b)(1) and (2) of the
- * Commercial Computer Software - Restricted Rights clause at FAR 52.227-19, as applicable. Contractor/manufacturer is
- * NVIDIA, 2788 San Tomas Expressway, Santa Clara, CA 95051.
- *
- * 15. ENTIRE AGREEMENT. This license is the final, complete and exclusive agreement between the parties relating to the
- * subject matter of this license and supersedes all prior or contemporaneous understandings and agreements relating to
- * this subject matter, whether oral or written. If any court of competent jurisdiction determines that any provision of
- * this license is illegal, invalid or unenforceable, the remaining provisions will remain in full force and effect.
- * This license may only be modified in a writing signed by an authorized representative of each party.
- *
- * (v. August 20, 2021)
- */
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef _CUDA_DISCARD_MEMORY
 #define _CUDA_DISCARD_MEMORY
 
 #include <cuda/std/cstdint>
-#include "std/detail/__config"
+#include <cuda/std/detail/__config>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/std/detail/__access_property
+++ b/libcudacxx/include/cuda/std/detail/__access_property
@@ -239,13 +239,13 @@ namespace __detail_ap {
                     __on::__l2_cop_on_t __hit_prop,
                     std::uint32_t __hit_ratio,
                     __off::__l2_cop_off_t __miss_prop) noexcept
-                        : __fraction(__hit_ratio),
+                        : __ap_reserved(0x0),
+                          __fraction(__hit_ratio),
                           __l2_cop_off(__miss_prop),
                           __l2_cop_on(__hit_prop),
                           __l2_descriptor_mode(_DESC_INTERLEAVED),
                           __l1_inv_dont_allocate(0x0),
                           __l2_sector_promote_256B(0x0),
-                          __ap_reserved(0x0),
                           __ap_reserved2(0x0) {}
 
       _LIBCUDACXX_HOST_DEVICE


### PR DESCRIPTION
## Description

Closes issue https://github.com/NVIDIA/cccl/issues/624 and unblocks PR https://github.com/NVIDIA/cccl/pull/619

<!-- Provide a standalone description of changes in this PR. -->
Including `<cuda/annotated_ptr>` includes `<cuda/barrier>`, which in turn includs `"std/barrier"`. `"std/barrier"` in turn has the following guard in place:
```
#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
#  error "CUDA synchronization primitives are only supported for sm_70 and up."
#endif
```
This prevents users from using functionality like `cuda::discard_memory` in `<cuda/annotated_ptr>` that does not rely on `barrier`.

This PR:
- moves `cuda::discard_memory` to its own header
- fixes aligned pointer computation in `cuda::discard_memory` and the loop for discarding memory
- fixes initialization order in `__access_property` that the compiler complained about

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.