### PR TITLE
Reduce benchmarking time

### DIFF
--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -635,6 +635,14 @@ class Bench:
                 cmd.append("--min-samples")
                 cmd.append("70")
 
+            # Unlike noise, minimal benchmarking time is not directly related to variance.
+            # Default minimal time is 0.5 seconds. For CI we want to reduce it to 0.1 seconds, 
+            # becuse we have limited time budget. Having smaller minimal time doesn't affect 
+            # stability of sample distribution median in a deterministic way. For small problem sizes, 
+            # 0.1s leads to smaller variation than 0.5s. For other workloads, 0.5 leads to smaller variance. 
+            cmd.append("--min-time")
+            cmd.append("0.1")
+
             # NVBench is currently broken for multiple GPUs, use `CUDA_VISIBLE_DEVICES`
             cmd.append("-d")
             cmd.append("0")

--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -49,10 +49,12 @@ def parse_arguments():
         '--list-benches', action=argparse.BooleanOptionalAction, help="Show available benchmarks.")
     parser.add_argument('--num-shards', type=int, default=1, help='Split benchmarks into M pieces and only run one')
     parser.add_argument('--run-shard', type=int, default=0, help='Run shard N / M of benchmarks')
+    parser.add_argument('-P0', action=argparse.BooleanOptionalAction, help="Run P0 benchmarks (overwrites -R)")
     return parser.parse_args()
 
 
 def run_benches(algnames, sub_space, seeker):
+    print(algnames)
     for algname in algnames:
         bench = BaseBench(algname)
         ct_space = bench.ct_workload_space(sub_space)
@@ -63,14 +65,18 @@ def run_benches(algnames, sub_space, seeker):
 def filter_benchmarks(benchmarks, args):
     if args.run_shard >= args.num_shards:
         raise ValueError('run-shard must be less than num-shards')
+    
+    R = args.R
+    if args.P0:
+        # TODO Exclude 'segmented'
+        R = '.*(scan|reduce|select|sort).*'
 
-    pattern = re.compile(args.R)
+    pattern = re.compile(R)
     algnames = list(filter(lambda x: pattern.match(x), benchmarks.keys()))
     algnames.sort()
 
     if args.num_shards > 1:
         algnames = np.array_split(algnames, args.num_shards)[args.run_shard].tolist()
-        print(algnames)
         return algnames
     
     return algnames

--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -67,8 +67,7 @@ def filter_benchmarks(benchmarks, args):
     
     R = args.R
     if args.P0:
-        # TODO Exclude 'segmented'
-        R = '.*(scan|reduce|select|sort).*'
+        R = '^(?!.*segmented).*(scan|reduce|select|sort).*'
 
     pattern = re.compile(R)
     algnames = list(filter(lambda x: pattern.match(x), benchmarks.keys()))

--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -54,7 +54,6 @@ def parse_arguments():
 
 
 def run_benches(algnames, sub_space, seeker):
-    print(algnames)
     for algname in algnames:
         bench = BaseBench(algname)
         ct_space = bench.ct_workload_space(sub_space)

--- a/benchmarks/scripts/run.py
+++ b/benchmarks/scripts/run.py
@@ -23,7 +23,7 @@ def problem_size_looks_large_enough(elements):
 def filter_runtime_workloads_for_ci(rt_values):
   for subbench in rt_values:
     for axis in rt_values[subbench]:
-      if axis == 'Elements{io}[pow2]':
+      if axis.startswith('Elements') and axis.endswith('[pow2]'):
         rt_values[subbench][axis] = list(filter(problem_size_looks_large_enough, rt_values[subbench][axis]))
 
   return rt_values

--- a/benchmarks/scripts/run.py
+++ b/benchmarks/scripts/run.py
@@ -6,11 +6,27 @@ import math
 import cccl.bench
 
 
-def elapsed_time_look_good(x):
+def elapsed_time_looks_good(x):
   if isinstance(x, float):
     if math.isfinite(x):
       return True
   return False
+
+
+def problem_size_looks_large_enough(elements):
+  # Small problem sizes do not utilize entire GPU.
+  # Benchmarking small problem sizes in environments where we do not control
+  # distributions comparison, e.g. CI, is not useful because of stability issues.
+  return elements.isdigit() and int(elements) > 20
+
+
+def filter_runtime_workloads_for_ci(rt_values):
+  for subbench in rt_values:
+    for axis in rt_values[subbench]:
+      if axis == 'Elements{io}[pow2]':
+        rt_values[subbench][axis] = list(filter(problem_size_looks_large_enough, rt_values[subbench][axis]))
+
+  return rt_values
 
 
 class BaseRunner:
@@ -18,6 +34,8 @@ class BaseRunner:
     self.estimator = cccl.bench.MedianCenterEstimator()
 
   def __call__(self, algname, ct_workload_space, rt_values):
+    rt_values = filter_runtime_workloads_for_ci(rt_values)
+
     for ct_workload in ct_workload_space:
       bench = cccl.bench.BaseBench(algname)
       if bench.build():
@@ -28,7 +46,7 @@ class BaseRunner:
             bench_name = bench_name.replace(' ', '___')
             bench_name = "".join(c if c.isalnum() else "_" for c in bench_name)
             elapsed_time = results[subbench][point]
-            if elapsed_time_look_good(elapsed_time):
+            if elapsed_time_looks_good(elapsed_time):
               print("&&&& PERF {} {} -sec".format(bench_name, elapsed_time))
       else:
         print("&&&& FAILED bench")

--- a/cub/benchmarks/bench/adjacent_difference/subtract_left.cu
+++ b/cub/benchmarks/bench/adjacent_difference/subtract_left.cu
@@ -100,7 +100,7 @@ void left(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
   std::uint8_t* d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(d_temp_storage,
                          temp_storage_bytes,
                          d_in,

--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -249,7 +249,7 @@ void copy(nvbench::state &state,
   thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(d_temp_storage,
                          temp_storage_bytes,
                          d_input_buffers,

--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -275,8 +275,8 @@ void uniform(nvbench::state &state, nvbench::type_list<T, OffsetT> tl)
        elements,
        min_buffer_size,
        max_buffer_size,
-       state.get_int64("RandomizeInput"),
-       state.get_int64("RandomizeOutput"));
+       state.get_int64("Randomize"),
+       state.get_int64("Randomize"));
 }
 
 template <class T, class OffsetT>
@@ -309,8 +309,7 @@ NVBENCH_BENCH_TYPES(uniform, NVBENCH_TYPE_AXES(types, u_offset_types))
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(25, 29, 2))
   .add_int64_axis("MinBufferSizeRatio", {1, 99})
   .add_int64_axis("MaxBufferSize", {8, 64, 256, 1024, 64 * 1024})
-  .add_int64_axis("RandomizeInput", {0, 1})
-  .add_int64_axis("RandomizeOutput", {0, 1});
+  .add_int64_axis("Randomize", {0, 1});
 
 NVBENCH_BENCH_TYPES(large, NVBENCH_TYPE_AXES(types, u_offset_types))
   .set_name("large")

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -110,7 +110,7 @@ static void even(nvbench::state &state, nvbench::type_list<SampleT, CounterT, Of
   thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(tmp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::DispatchEven(d_temp_storage,
                              temp_storage_bytes,
                              d_input,

--- a/cub/benchmarks/bench/histogram/even.cu
+++ b/cub/benchmarks/bench/histogram/even.cu
@@ -139,5 +139,5 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, bin_types, some_offset
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "BinT{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_int64_axis("Bins", {32, 64, 128, 2048, 2097152})
-  .add_string_axis("Entropy", {"0.201", "0.544", "1.000"});
+  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -150,5 +150,5 @@ NVBENCH_BENCH_TYPES(even, NVBENCH_TYPE_AXES(sample_types, bin_types, some_offset
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "BinT{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_int64_axis("Bins", {32, 64, 128, 2048, 2097152})
-  .add_string_axis("Entropy", {"0.201", "0.544", "1.000"});
+  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/multi/even.cu
+++ b/cub/benchmarks/bench/histogram/multi/even.cu
@@ -121,7 +121,7 @@ static void even(nvbench::state &state, nvbench::type_list<SampleT, CounterT, Of
   thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(tmp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::DispatchEven(d_temp_storage,
                              temp_storage_bytes,
                              d_input,

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -129,7 +129,7 @@ static void range(nvbench::state &state, nvbench::type_list<SampleT, CounterT, O
   thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(tmp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::DispatchRange(d_temp_storage,
                               temp_storage_bytes,
                               d_input,

--- a/cub/benchmarks/bench/histogram/multi/range.cu
+++ b/cub/benchmarks/bench/histogram/multi/range.cu
@@ -157,5 +157,5 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, bin_types, some_offse
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "BinT{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_int64_axis("Bins", {32, 64, 128, 2048, 2097152})
-  .add_string_axis("Entropy", {"0.201", "0.544", "1.000"});
+  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -116,7 +116,7 @@ static void range(nvbench::state &state, nvbench::type_list<SampleT, CounterT, O
   thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(tmp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::DispatchRange(d_temp_storage,
                               temp_storage_bytes,
                               d_input,

--- a/cub/benchmarks/bench/histogram/range.cu
+++ b/cub/benchmarks/bench/histogram/range.cu
@@ -144,5 +144,5 @@ NVBENCH_BENCH_TYPES(range, NVBENCH_TYPE_AXES(sample_types, bin_types, some_offse
   .set_name("base")
   .set_type_axes_names({"SampleT{ct}", "BinT{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_int64_axis("Bins", {32, 64, 128, 2048, 2097152})
-  .add_string_axis("Entropy", {"0.201", "0.544", "1.000"});
+  .add_int64_axis("Bins", {32, 128, 2048, 2097152})
+  .add_string_axis("Entropy", {"0.201", "1.000"});

--- a/cub/benchmarks/bench/merge_sort/keys.cu
+++ b/cub/benchmarks/bench/merge_sort/keys.cu
@@ -131,7 +131,7 @@ void keys(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(temp_storage,
                          temp_size,
                          d_buffer_1,

--- a/cub/benchmarks/bench/merge_sort/pairs.cu
+++ b/cub/benchmarks/bench/merge_sort/pairs.cu
@@ -134,7 +134,7 @@ void pairs(nvbench::state &state, nvbench::type_list<KeyT, ValueT, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(temp_storage,
                          temp_size,
                          d_keys_buffer_1,

--- a/cub/benchmarks/bench/partition/flagged.cu
+++ b/cub/benchmarks/bench/partition/flagged.cu
@@ -148,7 +148,7 @@ void flagged(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(temp_storage,
                          temp_size,
                          d_in,

--- a/cub/benchmarks/bench/partition/if.cu
+++ b/cub/benchmarks/bench/partition/if.cu
@@ -170,7 +170,7 @@ void partition(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(temp_storage,
                          temp_size,
                          d_in,

--- a/cub/benchmarks/bench/partition/three_way.cu
+++ b/cub/benchmarks/bench/partition/three_way.cu
@@ -146,7 +146,7 @@ void partition(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(temp_storage,
                          temp_size,
                          d_in,

--- a/cub/benchmarks/bench/radix_sort/keys.cu
+++ b/cub/benchmarks/bench/radix_sort/keys.cu
@@ -222,4 +222,4 @@ NVBENCH_BENCH_TYPES(radix_sort_keys, NVBENCH_TYPE_AXES(fundamental_types, offset
   .set_name("base")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});

--- a/cub/benchmarks/bench/radix_sort/keys.cu
+++ b/cub/benchmarks/bench/radix_sort/keys.cu
@@ -182,7 +182,7 @@ void radix_sort_keys(std::integral_constant<bool, true>,
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     cub::DoubleBuffer<key_t> keys     = d_keys;
     cub::DoubleBuffer<value_t> values = d_values;
 

--- a/cub/benchmarks/bench/radix_sort/pairs.cu
+++ b/cub/benchmarks/bench/radix_sort/pairs.cu
@@ -186,7 +186,7 @@ void radix_sort_values(std::integral_constant<bool, true>,
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     cub::DoubleBuffer<key_t> keys     = d_keys;
     cub::DoubleBuffer<value_t> values = d_values;
 

--- a/cub/benchmarks/bench/radix_sort/pairs.cu
+++ b/cub/benchmarks/bench/radix_sort/pairs.cu
@@ -224,7 +224,7 @@ void radix_sort_values(nvbench::state &state, nvbench::type_list<KeyT, ValueT, O
 #ifdef TUNE_KeyT
 using key_types = nvbench::type_list<TUNE_KeyT>;
 #else // !defined(TUNE_KeyT) 
-using key_types = fundamental_types;
+using key_types = integral_types;
 #endif // TUNE_KeyT
 
 #ifdef TUNE_ValueT
@@ -245,4 +245,4 @@ NVBENCH_BENCH_TYPES(radix_sort_values, NVBENCH_TYPE_AXES(key_types, value_types,
   .set_name("base")
   .set_type_axes_names({"KeyT{ct}", "ValueT{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.201"});

--- a/cub/benchmarks/bench/radix_sort/pairs.cu
+++ b/cub/benchmarks/bench/radix_sort/pairs.cu
@@ -245,4 +245,4 @@ NVBENCH_BENCH_TYPES(radix_sort_values, NVBENCH_TYPE_AXES(key_types, value_types,
   .set_name("base")
   .set_type_axes_names({"KeyT{ct}", "ValueT{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});

--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -103,7 +103,7 @@ void reduce(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(temp_storage,
                          temp_size,
                          d_in,

--- a/cub/benchmarks/bench/reduce/by_key.cu
+++ b/cub/benchmarks/bench/reduce/by_key.cu
@@ -158,7 +158,7 @@ static void reduce(nvbench::state &state, nvbench::type_list<KeyT, ValueT, Offse
   state.add_global_memory_writes<KeyT>(num_runs);
   state.add_global_memory_writes<OffsetT>(1);
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(d_temp_storage,
                          temp_storage_bytes,
                          d_in_keys,

--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -158,7 +158,7 @@ static void rle(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_writes<OffsetT>(num_runs);
   state.add_global_memory_writes<OffsetT>(1);
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(d_temp_storage,
                          temp_storage_bytes,
                          d_in_keys,

--- a/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
+++ b/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
@@ -145,7 +145,7 @@ static void rle(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_writes<OffsetT>(num_runs);
   state.add_global_memory_writes<OffsetT>(1);
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(d_temp_storage,
                          temp_storage_bytes,
                          d_in_keys,

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -121,7 +121,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> tmp(tmp_size);
   nvbench::uint8_t *d_tmp = thrust::raw_pointer_cast(tmp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(thrust::raw_pointer_cast(tmp.data()),
                          tmp_size,
                          d_input,

--- a/cub/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/cub/benchmarks/bench/scan/exclusive/by_key.cu
@@ -134,7 +134,7 @@ static void scan(nvbench::state &state, nvbench::type_list<KeyT, ValueT, OffsetT
   thrust::device_vector<nvbench::uint8_t> tmp(tmp_size);
   nvbench::uint8_t *d_tmp = thrust::raw_pointer_cast(tmp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(d_tmp,
                          tmp_size,
                          d_keys,

--- a/cub/benchmarks/bench/segmented_sort/keys.cu
+++ b/cub/benchmarks/bench/segmented_sort/keys.cu
@@ -255,7 +255,7 @@ NVBENCH_BENCH_TYPES(power_law, NVBENCH_TYPE_AXES(fundamental_types, some_offset_
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(22, 30, 4))
   .add_int64_power_of_two_axis("Segments{io}", nvbench::range(12, 20, 4))
-  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.201"});
 
 
 template <class T, typename OffsetT>

--- a/cub/benchmarks/bench/segmented_sort/keys.cu
+++ b/cub/benchmarks/bench/segmented_sort/keys.cu
@@ -220,7 +220,7 @@ void seg_sort(nvbench::state &state,
   thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
     cub::DoubleBuffer<key_t> keys     = d_keys;
     cub::DoubleBuffer<value_t> values = d_values;
 

--- a/cub/benchmarks/bench/select/flagged.cu
+++ b/cub/benchmarks/bench/select/flagged.cu
@@ -152,7 +152,7 @@ void select(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(temp_storage,
                          temp_size,
                          d_in,

--- a/cub/benchmarks/bench/select/if.cu
+++ b/cub/benchmarks/bench/select/if.cu
@@ -174,7 +174,7 @@ void select(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto *temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(temp_storage,
                          temp_size,
                          d_in,

--- a/cub/benchmarks/bench/select/unique_by_key.cu
+++ b/cub/benchmarks/bench/select/unique_by_key.cu
@@ -150,7 +150,7 @@ static void select(nvbench::state &state, nvbench::type_list<KeyT, ValueT, Offse
   state.add_global_memory_writes<KeyT>(num_runs);
   state.add_global_memory_writes<OffsetT>(1);
 
-  state.exec([&](nvbench::launch &launch) {
+  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
     dispatch_t::Dispatch(d_temp_storage,
                          temp_storage_bytes,
                          d_in_keys,

--- a/cub/benchmarks/nvbench_helper/CMakeLists.txt
+++ b/cub/benchmarks/nvbench_helper/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Fetch nvbench
-CPMAddPackage("gh:NVIDIA/nvbench#39b2770b62ce1f4e0ebeb9af60d7c6de624633a5")
+CPMAddPackage("gh:NVIDIA/nvbench#main")
 
 add_library(nvbench_helper OBJECT nvbench_helper/nvbench_helper.cuh
                                   nvbench_helper/nvbench_helper.cu)

--- a/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -53,29 +53,34 @@ using offset_types = nvbench::type_list<int32_t, int64_t>;
 #endif
 
 #ifdef TUNE_T
+using integral_types    = nvbench::type_list<TUNE_T>;
 using fundamental_types = nvbench::type_list<TUNE_T>;
-using all_types = nvbench::type_list<TUNE_T>;
+using all_types         = nvbench::type_list<TUNE_T>;
 #else
-using fundamental_types = nvbench::type_list<int8_t,
-                                             int16_t,
-                                             int32_t,
-                                             int64_t,
-#if NVBENCH_HELPER_HAS_I128
-                                             int128_t,
-#endif
-                                             float,
-                                             double>;
-                                             
-using all_types = nvbench::type_list<int8_t,
-                                     int16_t,
-                                     int32_t,
-                                     int64_t,
-#if NVBENCH_HELPER_HAS_I128
-                                     int128_t,
-#endif
-                                     float,
-                                     double,
-                                     complex>;
+using integral_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t>;
+
+using fundamental_types =
+  nvbench::type_list<int8_t,
+                     int16_t,
+                     int32_t,
+                     int64_t,
+#  if NVBENCH_HELPER_HAS_I128
+                     int128_t,
+#  endif
+                     float,
+                     double>;
+
+using all_types =
+  nvbench::type_list<int8_t,
+                     int16_t,
+                     int32_t,
+                     int64_t,
+#  if NVBENCH_HELPER_HAS_I128
+                     int128_t,
+#  endif
+                     float,
+                     double,
+                     complex>;
 #endif
 
 template <class T>

--- a/cub/docs/tuning.rst
+++ b/cub/docs/tuning.rst
@@ -121,7 +121,7 @@ Finally, we can run the algorithm:
 
 .. code:: c++
 
-    state.exec([&](nvbench::launch &launch) {
+    state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
       dispatch_t::Dispatch(temp_storage,
                            temp_size,
                            d_in,

--- a/thrust/benchmarks/bench/adjacent_difference/basic.cu
+++ b/thrust/benchmarks/bench/adjacent_difference/basic.cu
@@ -43,7 +43,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::adjacent_difference(input.cbegin(), input.cend(), output.begin());
   });
 }

--- a/thrust/benchmarks/bench/adjacent_difference/custom.cu
+++ b/thrust/benchmarks/bench/adjacent_difference/custom.cu
@@ -60,7 +60,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::adjacent_difference(input.cbegin(), input.cend(), output.begin(), custom_op<T>{42});
   });
 }

--- a/thrust/benchmarks/bench/adjacent_difference/in_place.cu
+++ b/thrust/benchmarks/bench/adjacent_difference/in_place.cu
@@ -42,7 +42,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::adjacent_difference(vec.begin(), vec.end(), vec.begin());
   });
 }

--- a/thrust/benchmarks/bench/copy/basic.cu
+++ b/thrust/benchmarks/bench/copy/basic.cu
@@ -45,7 +45,7 @@ static void basic(nvbench::state &state,
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::copy(input.cbegin(),
                  input.cend(),
                  output.begin());

--- a/thrust/benchmarks/bench/copy/if.cu
+++ b/thrust/benchmarks/bench/copy/if.cu
@@ -74,7 +74,7 @@ static void basic(nvbench::state &state,
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(selected_elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::copy_if(input.cbegin(), input.cend(), output.begin(), select_op);
   });
 }

--- a/thrust/benchmarks/bench/fill/basic.cu
+++ b/thrust/benchmarks/bench/fill/basic.cu
@@ -41,7 +41,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_element_count(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::fill(output.begin(), output.end(), T{42});
   });
 }

--- a/thrust/benchmarks/bench/inner_product/basic.cu
+++ b/thrust/benchmarks/bench/inner_product/basic.cu
@@ -44,7 +44,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements * 2);
   state.add_global_memory_writes<T>(1);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::inner_product(lhs.begin(), lhs.end(), rhs.begin(), T{0});
   });
 }

--- a/thrust/benchmarks/bench/merge/basic.cu
+++ b/thrust/benchmarks/bench/merge/basic.cu
@@ -50,7 +50,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::merge(in.cbegin(),
                   in.cbegin() + elements_in_lhs,
                   in.cbegin() + elements_in_lhs,

--- a/thrust/benchmarks/bench/partition/basic.cu
+++ b/thrust/benchmarks/bench/partition/basic.cu
@@ -72,7 +72,7 @@ static void basic(nvbench::state &state,
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::partition_copy(input.cbegin(),
                            input.cend(),
                            output.begin(),

--- a/thrust/benchmarks/bench/reduce/basic.cu
+++ b/thrust/benchmarks/bench/reduce/basic.cu
@@ -42,7 +42,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(1);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     do_not_optimize(thrust::reduce(in.begin(), in.end()));
   });
 }

--- a/thrust/benchmarks/bench/reduce/by_key.cu
+++ b/thrust/benchmarks/bench/reduce/by_key.cu
@@ -57,7 +57,7 @@ static void basic(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
   state.add_global_memory_writes<KeyT>(unique_keys);
   state.add_global_memory_writes<ValueT>(unique_keys);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::reduce_by_key(in_keys.begin(),
                           in_keys.end(),
                           in_vals.begin(),

--- a/thrust/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/thrust/benchmarks/bench/scan/exclusive/by_key.cu
@@ -45,7 +45,7 @@ static void scan(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
   state.add_global_memory_reads<ValueT>(elements);
   state.add_global_memory_writes<ValueT>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::exclusive_scan_by_key(keys.cbegin(), keys.cend(), in_vals.cbegin(), out_vals.begin());
   });
 }

--- a/thrust/benchmarks/bench/scan/exclusive/max.cu
+++ b/thrust/benchmarks/bench/scan/exclusive/max.cu
@@ -43,7 +43,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::exclusive_scan(input.cbegin(), input.cend(), output.begin(), T{}, max_t{});
   });
 }

--- a/thrust/benchmarks/bench/scan/exclusive/sum.cu
+++ b/thrust/benchmarks/bench/scan/exclusive/sum.cu
@@ -43,7 +43,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::exclusive_scan(input.cbegin(), input.cend(), output.begin());
   });
 }

--- a/thrust/benchmarks/bench/scan/inclusive/by_key.cu
+++ b/thrust/benchmarks/bench/scan/inclusive/by_key.cu
@@ -45,7 +45,7 @@ static void scan(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
   state.add_global_memory_reads<ValueT>(elements);
   state.add_global_memory_writes<ValueT>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::inclusive_scan_by_key(keys.cbegin(), keys.cend(), in_vals.cbegin(), out_vals.begin());
   });
 }

--- a/thrust/benchmarks/bench/scan/inclusive/max.cu
+++ b/thrust/benchmarks/bench/scan/inclusive/max.cu
@@ -43,7 +43,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::inclusive_scan(input.cbegin(), input.cend(), output.begin(), max_t{});
   });
 }

--- a/thrust/benchmarks/bench/scan/inclusive/sum.cu
+++ b/thrust/benchmarks/bench/scan/inclusive/sum.cu
@@ -43,7 +43,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::inclusive_scan(input.cbegin(), input.cend(), output.begin());
   });
 }

--- a/thrust/benchmarks/bench/set_operations/base.cuh
+++ b/thrust/benchmarks/bench/set_operations/base.cuh
@@ -61,7 +61,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>, OpT op)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements_in_AB);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     op(input.cbegin(),
        input.cbegin() + elements_in_A,
        input.cbegin() + elements_in_A,

--- a/thrust/benchmarks/bench/set_operations/by_key.cuh
+++ b/thrust/benchmarks/bench/set_operations/by_key.cuh
@@ -70,7 +70,7 @@ static void basic(nvbench::state &state, nvbench::type_list<KeyT, ValueT>, OpT o
   state.add_global_memory_reads<ValueT>(OpT::read_all_values ? elements : elements_in_A); 
   state.add_global_memory_writes<ValueT>(elements_in_AB);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     op(in_keys.cbegin(),
        in_keys.cbegin() + elements_in_A,
        in_keys.cbegin() + elements_in_A,

--- a/thrust/benchmarks/bench/shuffle/basic.cu
+++ b/thrust/benchmarks/bench/shuffle/basic.cu
@@ -44,7 +44,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_writes<T>(elements);
 
   auto do_engine = [&](auto &&engine_constructor) {
-    state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+    state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
       thrust::shuffle(data.begin(), data.end(), engine_constructor());
     });
   };

--- a/thrust/benchmarks/bench/sort/keys.cu
+++ b/thrust/benchmarks/bench/sort/keys.cu
@@ -58,4 +58,4 @@ NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
   .set_name("base")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.201"});

--- a/thrust/benchmarks/bench/sort/keys.cu
+++ b/thrust/benchmarks/bench/sort/keys.cu
@@ -58,4 +58,4 @@ NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
   .set_name("base")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});

--- a/thrust/benchmarks/bench/sort/keys_custom.cu
+++ b/thrust/benchmarks/bench/sort/keys_custom.cu
@@ -58,4 +58,4 @@ NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
   .set_name("base")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.201"});

--- a/thrust/benchmarks/bench/sort/keys_custom.cu
+++ b/thrust/benchmarks/bench/sort/keys_custom.cu
@@ -58,4 +58,4 @@ NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
   .set_name("base")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});

--- a/thrust/benchmarks/bench/sort/pairs.cu
+++ b/thrust/benchmarks/bench/sort/pairs.cu
@@ -74,4 +74,4 @@ NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(key_types, value_types))
   .set_name("base")
   .set_type_axes_names({"KeyT{ct}", "ValueT{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});

--- a/thrust/benchmarks/bench/sort/pairs.cu
+++ b/thrust/benchmarks/bench/sort/pairs.cu
@@ -59,19 +59,11 @@ static void basic(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
              });
 }
 
-using key_types   = fundamental_types;
-using value_types = nvbench::type_list<int8_t,
-                                       int16_t,
-                                       int32_t,
-                                       int64_t
-#if NVBENCH_HELPER_HAS_I128
-                                       ,
-                                       int128_t
-#endif
-                                       >;
+using key_types   = integral_types;
+using value_types = integral_types;
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(key_types, value_types))
   .set_name("base")
   .set_type_axes_names({"KeyT{ct}", "ValueT{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.201"});

--- a/thrust/benchmarks/bench/sort/pairs_custom.cu
+++ b/thrust/benchmarks/bench/sort/pairs_custom.cu
@@ -74,4 +74,4 @@ NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(key_types, value_types))
   .set_name("base")
   .set_type_axes_names({"KeyT{ct}", "ValueT{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});

--- a/thrust/benchmarks/bench/sort/pairs_custom.cu
+++ b/thrust/benchmarks/bench/sort/pairs_custom.cu
@@ -59,19 +59,11 @@ static void basic(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
              });
 }
 
-using key_types   = fundamental_types;
-using value_types = nvbench::type_list<int8_t,
-                                       int16_t,
-                                       int32_t,
-                                       int64_t
-#if NVBENCH_HELPER_HAS_I128
-                                       ,
-                                       int128_t
-#endif
-                                       >;
+using key_types   = integral_types;
+using value_types = integral_types;
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(key_types, value_types))
   .set_name("base")
   .set_type_axes_names({"KeyT{ct}", "ValueT{ct}"})
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});
+  .add_string_axis("Entropy", {"1.000", "0.201"});

--- a/thrust/benchmarks/bench/unique/basic.cu
+++ b/thrust/benchmarks/bench/unique/basic.cu
@@ -51,7 +51,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(unique_items);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::unique_copy(input.cbegin(), input.cend(), output.begin());
   });
 }

--- a/thrust/benchmarks/bench/unique/by_key.cu
+++ b/thrust/benchmarks/bench/unique/by_key.cu
@@ -56,7 +56,7 @@ static void basic(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
   state.add_global_memory_reads<ValueT>(elements);
   state.add_global_memory_writes<ValueT>(unique_elements);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::unique_by_key_copy(in_keys.cbegin(),
                                in_keys.cend(),
                                in_vals.cbegin(),

--- a/thrust/benchmarks/bench/vectorized_search/base.cu
+++ b/thrust/benchmarks/bench/vectorized_search/base.cu
@@ -46,7 +46,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
 
   state.add_element_count(needles);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::binary_search(data.begin(),
                           data.begin() + elements,
                           data.begin() + elements,

--- a/thrust/benchmarks/bench/vectorized_search/lower_bound.cu
+++ b/thrust/benchmarks/bench/vectorized_search/lower_bound.cu
@@ -46,7 +46,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
 
   state.add_element_count(needles);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::lower_bound(data.begin(),
                         data.begin() + elements,
                         data.begin() + elements,

--- a/thrust/benchmarks/bench/vectorized_search/upper_bound.cu
+++ b/thrust/benchmarks/bench/vectorized_search/upper_bound.cu
@@ -46,7 +46,7 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
 
   state.add_element_count(needles);
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
     thrust::upper_bound(data.begin(),
                         data.begin() + elements,
                         data.begin() + elements,


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/656

<!-- Provide a standalone description of changes in this PR. -->
This PR reduces minimal benchmarking time. Preliminary experiments show that it doesn't affect median stability in a deterministic way. Apart from that, this PR opts-out of NVBench batch measurements, since infrastructure do not rely on them. This PR also updates workloads for some benchmarks to be less conservative. 

The CI script now has new API:
- `-P0` - only runs:
   - cub.bench.merge_sort.keys
   - cub.bench.merge_sort.pairs
   - cub.bench.radix_sort.keys
   - cub.bench.radix_sort.pairs
   - cub.bench.reduce.by_key
   - cub.bench.reduce.max
   - cub.bench.reduce.sum
   - cub.bench.scan.exclusive.by_key
   - cub.bench.scan.exclusive.max
   - cub.bench.scan.exclusive.sum
   - cub.bench.select.flagged
   - cub.bench.select.if
   - cub.bench.select.unique_by_key
   - thrust.bench.reduce.basic
   - thrust.bench.reduce.by_key
   - thrust.bench.scan.exclusive.by_key
   - thrust.bench.scan.exclusive.max
   - thrust.bench.scan.exclusive.sum
   - thrust.bench.scan.inclusive.by_key
   - thrust.bench.scan.inclusive.max
   - thrust.bench.scan.inclusive.sum
   - thrust.bench.sort.keys
   - thrust.bench.sort.keys_custom
   - thrust.bench.sort.pairs
   - thrust.bench.sort.pairs_custom
- `--num-shards M --run-shard N` - splits all benchmarks in to M shards and runs N-th shard. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
