### PR TITLE
Fix truncation of constant value

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/limits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/limits
@@ -197,12 +197,18 @@ protected:
     static constexpr float_round_style round_style = round_toward_zero;
 };
 
+#if defined(_LIBCUDACXX_COMPILER_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable : 4309)
+#endif // _LIBCUDACXX_COMPILER_MSVC
 template <class _Tp, int __digits, bool _IsSigned>
 struct __libcpp_compute_min
 {
-    using _uTp = typename _CUDA_VSTD::make_unsigned<_Tp>::type;
-    static constexpr _Tp value = static_cast<_Tp>(static_cast<_uTp>(_uTp(1u) << __digits));
+    static constexpr _Tp value = static_cast<_Tp>(_Tp(1) << __digits);
 };
+#if defined(_LIBCUDACXX_COMPILER_MSVC)
+#  pragma warning(pop)
+#endif // _LIBCUDACXX_COMPILER_MSVC
 
 template <class _Tp, int __digits>
 struct __libcpp_compute_min<_Tp, __digits, false>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/limits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/limits
@@ -200,7 +200,8 @@ protected:
 template <class _Tp, int __digits, bool _IsSigned>
 struct __libcpp_compute_min
 {
-    static constexpr _Tp value = static_cast<_Tp>(_Tp(1) << __digits);
+    using _uTp = typename _CUDA_VSTD::make_unsigned<_Tp>::type;
+    static constexpr _Tp value = static_cast<_Tp>(static_cast<_uTp>(_uTp(1u) << __digits));
 };
 
 template <class _Tp, int __digits>


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/1096

<!-- Provide a standalone description of changes in this PR. -->
This PR fixes constant truncation warning in numeric traits. Changes make sure that we perform bit manipulations on unsigned version of integral types before casting back to signed ones. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
