### PR TITLE
Fix config when only non-CDPv1 arches are enabled.

### DIFF
--- a/cub/cmake/CubCudaConfig.cmake
+++ b/cub/cmake/CubCudaConfig.cmake
@@ -33,8 +33,15 @@ endif()
 
 option(CUB_FORCE_RDC "Enable separable compilation on all targets that support it." OFF)
 
+list(LENGTH CUB_CUDA_ARCHITECTURES_RDC rdc_arch_count)
+if (rdc_arch_count EQUAL 0)
+  message(NOTICE "Disabling CUB CDPv1 targets as no enabled architectures support it.")
+  set(CUB_ENABLE_RDC_TESTS OFF CACHE BOOL "" FORCE)
+  set(CUB_FORCE_RDC OFF CACHE BOOL "" FORCE)
+endif()
+
 #
-# Clang CUDA options 
+# Clang CUDA options
 #
 if ("Clang" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-unknown-cuda-version -Xclang=-fcuda-allow-variadic-functions")

--- a/thrust/cmake/ThrustCudaConfig.cmake
+++ b/thrust/cmake/ThrustCudaConfig.cmake
@@ -26,10 +26,16 @@ message(STATUS "THRUST_CUDA_ARCHITECTURES_RDC: ${THRUST_CUDA_ARCHITECTURES_RDC}"
 option(THRUST_ENABLE_RDC_TESTS "Enable tests that require separable compilation." ON)
 option(THRUST_FORCE_RDC "Enable separable compilation on all targets that support it." OFF)
 
+list(LENGTH THRUST_CUDA_ARCHITECTURES_RDC rdc_arch_count)
+if (rdc_arch_count EQUAL 0)
+  message(NOTICE "Disabling THRUST CDPv1 targets as no enabled architectures support it.")
+  set(THRUST_ENABLE_RDC_TESTS OFF CACHE BOOL "" FORCE)
+  set(THRUST_FORCE_RDC OFF CACHE BOOL "" FORCE)
+endif()
+
 #
 # Clang CUDA options
 #
 if ("Clang" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-unknown-cuda-version -Xclang=-fcuda-allow-variadic-functions")
 endif ()
-


### PR DESCRIPTION
Allows things like `ci/build_cub.sh -arch 90` to work as-expected.

Fixes #219,

## Description

Adds logic to skip adding RDC targets when the RDC arch list is empty.