### PR TITLE
Fix `_LIBCUDACXX_UNREACHABLE` for old MSVC

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/array
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/array
@@ -467,9 +467,6 @@ struct _LIBCUDACXX_TEMPLATE_VIS array<_Tp, 0>
   {
     _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::operator[] on a zero-sized array");
     _LIBCUDACXX_UNREACHABLE();
-#if defined(_LIBCUDACXX_COMPILER_MSVC_2017)
-    return *data();
-#endif  // _LIBCUDACXX_COMPILER_MSVC_2017
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const_reference
@@ -477,9 +474,6 @@ struct _LIBCUDACXX_TEMPLATE_VIS array<_Tp, 0>
   {
     _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::operator[] on a zero-sized array");
     _LIBCUDACXX_UNREACHABLE();
-#if defined(_LIBCUDACXX_COMPILER_MSVC_2017)
-    return *data();
-#endif  // _LIBCUDACXX_COMPILER_MSVC_2017
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 reference at(size_type)
@@ -498,43 +492,27 @@ struct _LIBCUDACXX_TEMPLATE_VIS array<_Tp, 0>
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 reference front() noexcept
   {
     _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::front() on a zero-sized array");
-#if defined(_LIBCUDACXX_COMPILER_MSVC)
-    return *data();
-#else // ^^^ _LIBCUDACXX_COMPILER_MSVC ^^^ / vvv !_LIBCUDACXX_COMPILER_MSVC vvv
     _LIBCUDACXX_UNREACHABLE();
-#endif  // !_LIBCUDACXX_COMPILER_MSVC
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const_reference
   front() const noexcept
   {
     _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::front() on a zero-sized array");
-#if defined(_LIBCUDACXX_COMPILER_MSVC)
-    return *data();
-#else // ^^^ _LIBCUDACXX_COMPILER_MSVC ^^^ / vvv !_LIBCUDACXX_COMPILER_MSVC vvv
     _LIBCUDACXX_UNREACHABLE();
-#endif  // !_LIBCUDACXX_COMPILER_MSVC
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 reference back() noexcept
   {
     _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::back() on a zero-sized array");
-#if defined(_LIBCUDACXX_COMPILER_MSVC)
-    return *data();
-#else // ^^^ _LIBCUDACXX_COMPILER_MSVC ^^^ / vvv !_LIBCUDACXX_COMPILER_MSVC vvv
     _LIBCUDACXX_UNREACHABLE();
-#endif  // !_LIBCUDACXX_COMPILER_MSVC
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 const_reference
   back() const noexcept
   {
     _LIBCUDACXX_ASSERT(false, "cannot call array<T, 0>::back() on a zero-sized array");
-#if defined(_LIBCUDACXX_COMPILER_MSVC)
-    return *data();
-#else // ^^^ _LIBCUDACXX_COMPILER_MSVC ^^^ / vvv !_LIBCUDACXX_COMPILER_MSVC vvv
     _LIBCUDACXX_UNREACHABLE();
-#endif  // !_LIBCUDACXX_COMPILER_MSVC
   }
 };
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
@@ -113,8 +113,12 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 #  define _LIBCUDACXX_UNREACHABLE() __builtin_unreachable()
 #endif // CUDACC above 11.4
 #else // ^^^ __CUDA_ARCH__ ^^^ / vvv !__CUDA_ARCH__ vvv
-#if defined(_LIBCUDACXX_COMPILER_MSVC)
-#  define _LIBCUDACXX_UNREACHABLE() __assume(false)
+#if defined(_LIBCUDACXX_COMPILER_MSVC_2017)
+template<class = void>
+_LIBCUDACXX_INLINE_VISIBILITY __declspec(noreturn) void __unreachable_fallback() { __assume(0); }
+#  define _LIBCUDACXX_UNREACHABLE() __unreachable_fallback()
+#elif defined(_LIBCUDACXX_COMPILER_MSVC)
+#  define _LIBCUDACXX_UNREACHABLE() __assume(0)
 #elif defined(_LIBCUDACXX_COMPILER_GCC) || __has_builtin(__builtin_unreachable)
 #  define _LIBCUDACXX_UNREACHABLE() __builtin_unreachable()
 #else // Other compilers


### PR DESCRIPTION
MSVC2017 / 2019 have issues properly determining that `__assume(0)` is indeed meant to mean unreachable code and complains about missing return statement sometimes.

We can work around this by wrapping it into a `__declspec(noreturn)` function :shrug:

Addresses nvbug4359466