### PR TITLE
Do not replace the sccache binary for windows

### DIFF
--- a/ci/windows/build_common.psm1
+++ b/ci/windows/build_common.psm1
@@ -33,11 +33,6 @@ If(!(test-path -PathType container "../build")) {
 # The most recent build will always be symlinked to cccl/build/latest
 New-Item -ItemType Directory -Path "$BUILD_DIR" -Force
 
-# replace sccache binary to get it working with MSVC
-$script:path_to_sccache =(gcm sccache).Source
-Remove-Item $path_to_sccache -Force
-Invoke-WebRequest -Uri "https://github.com/robertmaynard/sccache/releases/download/nvcc_msvc_v1/sccache.exe" -OutFile $path_to_sccache
-
 # Prepare environment for CMake:
 $env:CMAKE_BUILD_PARALLEL_LEVEL = $PARALLEL_LEVEL
 $env:CTEST_PARALLEL_LEVEL = 1


### PR DESCRIPTION
Our changes have reached the latest upstream release so it should not be necessary anymore to download manually
