### PR TITLE
Add matrix entry for 14.16+cuda_newest.

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -46,8 +46,8 @@ pull_request:
     - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'llvm', version: '15', exe: 'clang++'}, std: [11, 14, 17, 20], jobs: ['build']}
     - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'llvm', version: '16', exe: 'clang++'}, std: [11, 14, 17, 20], jobs: ['build', 'test']}
     - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'arm64', compiler: {name: 'llvm', version: '16', exe: 'clang++'}, std: [11, 14, 17, 20], jobs: ['build']}
-    - {cuda: *cuda_oldest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.16', exe: 'cl++'}, std: [14, 17],         jobs: ['build']}
-    - {cuda: *cuda_newest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.16', exe: 'cl++'}, std: [14, 17],         jobs: ['build']}
+    - {cuda: *cuda_oldest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.16', exe: 'cl++'}, std: [14],         jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.16', exe: 'cl++'}, std: [17],         jobs: ['build']}
     - {cuda: *cuda_newest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.29', exe: 'cl++'}, std: [14, 17],         jobs: ['build']}
     - {cuda: *cuda_newest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.36', exe: 'cl++'}, std: [14, 17, 20],     jobs: ['build']}
   nvrtc:

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -47,6 +47,7 @@ pull_request:
     - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'amd64', compiler: {name: 'llvm', version: '16', exe: 'clang++'}, std: [11, 14, 17, 20], jobs: ['build', 'test']}
     - {cuda: *cuda_newest, os: 'ubuntu22.04', cpu: 'arm64', compiler: {name: 'llvm', version: '16', exe: 'clang++'}, std: [11, 14, 17, 20], jobs: ['build']}
     - {cuda: *cuda_oldest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.16', exe: 'cl++'}, std: [14, 17],         jobs: ['build']}
+    - {cuda: *cuda_newest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.16', exe: 'cl++'}, std: [14, 17],         jobs: ['build']}
     - {cuda: *cuda_newest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.29', exe: 'cl++'}, std: [14, 17],         jobs: ['build']}
     - {cuda: *cuda_newest, os: 'windows2022', cpu: 'amd64', compiler: {name: 'cl',   version: '14.36', exe: 'cl++'}, std: [14, 17, 20],     jobs: ['build']}
   nvrtc:


### PR DESCRIPTION
## Description

Adds testing for VS2022 against the latest CUDA.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
