### PR TITLE
Allow filtering P0 benchmarks

### DIFF
--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -55,10 +55,13 @@ def parse_arguments():
 
 def run_benches(algnames, sub_space, seeker):
     for algname in algnames:
-        bench = BaseBench(algname)
-        ct_space = bench.ct_workload_space(sub_space)
-        rt_values = bench.rt_axes_values(sub_space)
-        seeker(algname, ct_space, rt_values)
+        try:
+            bench = BaseBench(algname)
+            ct_space = bench.ct_workload_space(sub_space)
+            rt_values = bench.rt_axes_values(sub_space)
+            seeker(algname, ct_space, rt_values)
+        except Exception as e:
+            print("#### ERROR exception occured while running {}: '{}'".format(algname, e))
 
 
 def filter_benchmarks_by_regex(benchmarks, R):

--- a/benchmarks/scripts/run.py
+++ b/benchmarks/scripts/run.py
@@ -34,11 +34,12 @@ class BaseRunner:
     self.estimator = cccl.bench.MedianCenterEstimator()
 
   def __call__(self, algname, ct_workload_space, rt_values):
+    failure_occured = False
     rt_values = filter_runtime_workloads_for_ci(rt_values)
 
     for ct_workload in ct_workload_space:
       bench = cccl.bench.BaseBench(algname)
-      if bench.build():
+      if bench.build(): # might throw
         results = bench.run(ct_workload, rt_values, self.estimator, False)
         for subbench in results:
           for point in results[subbench]:
@@ -49,8 +50,11 @@ class BaseRunner:
             if elapsed_time_looks_good(elapsed_time):
               print("&&&& PERF {} {} -sec".format(bench_name, elapsed_time))
       else:
-        print("&&&& FAILED bench")
-        sys.exit(-1)
+        failure_occured = True
+        print("&&&& FAILED {}".format(algname))
+    
+    if failure_occured:
+      sys.exit(1)
 
 
 def main():


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/1134

<!-- Provide a standalone description of changes in this PR. -->
This PR enables combination of -P0 and -R options when running CCCL benchmarks. 
It also changes run script so that it does not stop on exceptions. This is needed to collect all benchmarks failures in one launch. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
