### PR TITLE
BACKPORT: Fix `_LIBCUDACXX_UNREACHABLE` for old MSVC (#1114)

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
@@ -113,8 +113,12 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 #  define _LIBCUDACXX_UNREACHABLE() __builtin_unreachable()
 #endif // CUDACC above 11.4
 #else // ^^^ __CUDA_ARCH__ ^^^ / vvv !__CUDA_ARCH__ vvv
-#if defined(_LIBCUDACXX_COMPILER_MSVC)
-#  define _LIBCUDACXX_UNREACHABLE() __assume(false)
+#if defined(_LIBCUDACXX_COMPILER_MSVC_2017)
+template<class = void>
+_LIBCUDACXX_INLINE_VISIBILITY __declspec(noreturn) void __unreachable_fallback() { __assume(0); }
+#  define _LIBCUDACXX_UNREACHABLE() __unreachable_fallback()
+#elif defined(_LIBCUDACXX_COMPILER_MSVC)
+#  define _LIBCUDACXX_UNREACHABLE() __assume(0)
 #elif defined(_LIBCUDACXX_COMPILER_GCC) || __has_builtin(__builtin_unreachable)
 #  define _LIBCUDACXX_UNREACHABLE() __builtin_unreachable()
 #else // Other compilers


### PR DESCRIPTION
This backports #1114