### PR TITLE
Fix argument name in windows CI

### DIFF
--- a/.github/workflows/dispatch-build-and-test.yml
+++ b/.github/workflows/dispatch-build-and-test.yml
@@ -38,5 +38,5 @@ jobs:
         include: ${{ fromJSON(inputs.per_cuda_compiler_matrix) }}
     with:
       test_name: ${{matrix.cpu}}/${{matrix.compiler.name}}${{matrix.compiler.version}}/C++${{matrix.std}}
-      build_script: "./ci/windows/build_${{ inputs.project_name }}.ps1 ${{matrix.std}}"
+      build_script: "./ci/windows/build_${{ inputs.project_name }}.ps1 -std ${{matrix.std}}"
       container_image: rapidsai/devcontainers:${{inputs.devcontainer_version}}-cuda${{matrix.cuda}}-${{matrix.compiler.name}}${{matrix.compiler.version}}-${{matrix.os}}

--- a/ci/windows/build_common.psm1
+++ b/ci/windows/build_common.psm1
@@ -1,7 +1,7 @@
 
 Param(
     [Parameter(Mandatory = $true)]
-    [Alias("cxx")]
+    [Alias("std")]
     [ValidateNotNullOrEmpty()]
     [ValidateSet(11, 14, 17, 20)]
     [int]$CXX_STANDARD = 17

--- a/ci/windows/build_cub.ps1
+++ b/ci/windows/build_cub.ps1
@@ -1,7 +1,7 @@
 
 Param(
     [Parameter(Mandatory = $true)]
-    [Alias("cxx")]
+    [Alias("std")]
     [ValidateNotNullOrEmpty()]
     [ValidateSet(11, 14, 17, 20)]
     [int]$CXX_STANDARD = 17

--- a/ci/windows/build_libcudacxx.ps1
+++ b/ci/windows/build_libcudacxx.ps1
@@ -1,7 +1,7 @@
 
 Param(
     [Parameter(Mandatory = $true)]
-    [Alias("cxx")]
+    [Alias("std")]
     [ValidateNotNullOrEmpty()]
     [ValidateSet(11, 14, 17, 20)]
     [int]$CXX_STANDARD = 17

--- a/ci/windows/build_thrust.ps1
+++ b/ci/windows/build_thrust.ps1
@@ -1,7 +1,7 @@
 
 Param(
     [Parameter(Mandatory = $true)]
-    [Alias("cxx")]
+    [Alias("std")]
     [ValidateNotNullOrEmpty()]
     [ValidateSet(11, 14, 17, 20)]
     [int]$CXX_STANDARD = 17


### PR DESCRIPTION
We are using `cxx` as the host compiler and `std` as the C++ version for linux tests.

However, on windows we use `cxx` for the standard version, which annoys me to no end.
