### PR TITLE
Project Automation - remove draft automation + reduce permissions

### DIFF
--- a/.github/workflows/project_automation_set_in_progress.yml
+++ b/.github/workflows/project_automation_set_in_progress.yml
@@ -45,8 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      issues: write
-      pull-requests: write
+      pull-requests: read
     
     steps:
       - name: Check if changes requested from a reviewer
@@ -57,17 +56,6 @@ jobs:
         run: |
           if [ ${{ github.event.review.state }} != 'changes_requested' ]; then
             echo "Changes not requested, exiting"
-            exit 0
-          
-          # If it is requesting changes, set PR to draft
-          # We use the default token here since we're granting write access to the PR
-          elif [ ${{ github.event.pull_request.draft }} == false ]; then
-            gh api graphql -f query='
-              mutation {
-                convertPullRequestToDraft(input: {pullRequestId: "${{ env.PR_GLOBAL_ID }}"}) {
-                  clientMutationId
-                }
-              }'
             exit 0
           fi
         continue-on-error: true


### PR DESCRIPTION
## Description

No issue here, apologies!

This PR removes the draft setting part of the in-progress project action and reduces permissions of the github_token to just read issues.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
