### PR TITLE
Fix errors when find_package(CCCL) is called twice.

### DIFF
--- a/lib/cmake/cccl/cccl-config.cmake
+++ b/lib/cmake/cccl/cccl-config.cmake
@@ -71,7 +71,7 @@ foreach(component IN LISTS components)
         "${cccl_cmake_dir}/.."                            # Install layout
     )
 
-    if (TARGET Thrust::Thrust AND NOT CCCL::Thrust)
+    if (TARGET Thrust::Thrust AND NOT TARGET CCCL::Thrust)
       # By default, configure a CCCL::Thrust target with host=cpp device=cuda
       option(CCCL_ENABLE_DEFAULT_THRUST_TARGET
         "Create a CCCL::Thrust target using CCCL_THRUST_[HOST|DEVICE]_SYSTEM."

--- a/test/cmake/test_export/CMakeLists.txt
+++ b/test/cmake/test_export/CMakeLists.txt
@@ -66,6 +66,8 @@ function(do_find_package pkg_name pkg_prefix)
   if (NOT ${pkg_name}_FOUND)
     message(FATAL_ERROR "Failed: find_package(${pkg_name} ${arg_str})")
   endif()
+  # Re-execute find_package to ensure that repeated calls don't break:
+  find_package(${pkg_name} ${arg_list})
 endfunction()
 
 # Run find package with the requested configuration:


### PR DESCRIPTION
Fixes #1156.

## Description

When calling `find_package(CCCL)` a second time, a missing `TARGET` keyword in a CMake conditional caused the `CCCL::Thrust` target to be added twice.

This corrects the issue and extends our cmake package tests to call `find_package` twice.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [X] New or existing tests cover these changes.
