### PR TITLE
Abort testing on unsupported dialect flags

### DIFF
--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -708,7 +708,6 @@ class Configuration(object):
 
     def configure_default_compile_flags(self):
         nvcc_host_compiler = self.get_lit_conf('nvcc_host_compiler')
-        cxx_additional_flags = self.get_lit_conf('test_compiler_flags')
 
         if nvcc_host_compiler and self.cxx.type == 'nvcc':
             self.cxx.compile_flags += ['-ccbin={0}'.format(nvcc_host_compiler)]
@@ -767,8 +766,12 @@ class Configuration(object):
             if self.cxx.type == 'msvc':
                 stdflag = '/std:{0}'.format(std)
 
+            extraflags = []
+            if self.cxx.type == 'clang':
+                extraflags = ['-Wno-unknown-cuda-version']
+
             # Do a check with the user/config flag to ensure that the flag is supported.
-            if not self.cxx.hasCompileFlag([stdflag] + cxx_additional_flags.split(' ')):
+            if not self.cxx.hasCompileFlag([stdflag] + extraflags):
                 raise OSError("Configured compiler does not support flag {0}".format(stdflag))
 
             self.cxx.flags += [stdflag]

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -708,6 +708,8 @@ class Configuration(object):
 
     def configure_default_compile_flags(self):
         nvcc_host_compiler = self.get_lit_conf('nvcc_host_compiler')
+        cxx_additional_flags = self.get_lit_conf('test_compiler_flags')
+
         if nvcc_host_compiler and self.cxx.type == 'nvcc':
             self.cxx.compile_flags += ['-ccbin={0}'.format(nvcc_host_compiler)]
 
@@ -761,14 +763,15 @@ class Configuration(object):
 
         if std:
             # We found a dialect flag.
+            stdflag = '-std={0}'.format(std)
             if self.cxx.type == 'msvc':
-                self.cxx.compile_flags += ['/std:{0}'.format(std)]
-            else:
-                self.cxx.compile_flags += ['-std={0}'.format(std)]
+                stdflag = '/std:{0}'.format(std)
 
-            # Do a check with a user/config flag to ensure that the flag is supported.
-            if not self.cxx.hasCompileFlag(self.cxx.compile_flags):
-                raise OSError("Configured compiler does not support flag {0}".format(self.cxx.compile_flags))
+            # Do a check with the user/config flag to ensure that the flag is supported.
+            if not self.cxx.hasCompileFlag([stdflag] + cxx_additional_flags.split(' ')):
+                raise OSError("Configured compiler does not support flag {0}".format(stdflag))
+
+            self.cxx.flags += [stdflag]
 
         if not std:
             # There is no dialect flag. This happens with older MSVC.

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -765,6 +765,11 @@ class Configuration(object):
                 self.cxx.compile_flags += ['/std:{0}'.format(std)]
             else:
                 self.cxx.compile_flags += ['-std={0}'.format(std)]
+
+            # Do a check with a user/config flag to ensure that the flag is supported.
+            if not self.cxx.hasCompileFlag(self.cxx.compile_flags):
+                raise OSError("Configured compiler does not support flag {0}".format(self.cxx.compile_flags))
+
         if not std:
             # There is no dialect flag. This happens with older MSVC.
             if self.cxx.type == 'nvcc':


### PR DESCRIPTION
## Description

closes various nvbugs where testing should not occur.

example output:

```
PS C:\cccl> lit -a .\build\libcudacxx-cpp20\libcudacxx\test\libcudacxx\ -j1
lit: C:\cccl\libcudacxx\test\libcudacxx\lit.cfg:45: note: Using configuration variant: libcudacxx
....
  File "C:\cccl\libcudacxx\test\utils\libcudacxx\test\config.py", line 771, in configure_default_compile_flags
    raise OSError("Configured compiler does not support flag {0}".format(self.cxx.compile_flags))
OSError: Configured compiler does not support flag ['-std=c++20']
```

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
