### PR TITLE
Set finer-grain workflow permissions

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -14,9 +14,14 @@ on:
       container_image: {type: string, required: false}
       run_tests: {type: boolean, required: false, default: true}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{inputs.test_name}}
+    permissions:
+      id-token: write
     uses: ./.github/workflows/run-as-coder.yml
     with:
       name: Build ${{inputs.test_name}}
@@ -27,6 +32,8 @@ jobs:
 
   test:
     needs: build
+    permissions:
+      id-token: write
     if:  ${{ !cancelled() && ( needs.build.result == 'success' || needs.build.result == 'skipped' ) && inputs.run_tests}}
     name: Test ${{inputs.test_name}}
     uses: ./.github/workflows/run-as-coder.yml

--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   build:

--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   build:

--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -22,6 +22,7 @@ jobs:
     name: Build ${{inputs.test_name}}
     permissions:
       id-token: write
+      contents: read
     uses: ./.github/workflows/run-as-coder.yml
     with:
       name: Build ${{inputs.test_name}}
@@ -34,6 +35,7 @@ jobs:
     needs: build
     permissions:
       id-token: write
+      contents: read
     if:  ${{ !cancelled() && ( needs.build.result == 'success' || needs.build.result == 'skipped' ) && inputs.run_tests}}
     name: Test ${{inputs.test_name}}
     uses: ./.github/workflows/run-as-coder.yml

--- a/.github/workflows/dispatch-build-and-test.yml
+++ b/.github/workflows/dispatch-build-and-test.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   # Using a matrix to dispatch to the build-and-test reusable workflow for each build configuration

--- a/.github/workflows/dispatch-build-and-test.yml
+++ b/.github/workflows/dispatch-build-and-test.yml
@@ -19,6 +19,7 @@ jobs:
     name: build and test linux
     permissions:
       id-token: write
+      contents: read
     if: ${{ !inputs.is_windows }}
     uses: ./.github/workflows/build-and-test-linux.yml
     strategy:
@@ -37,6 +38,7 @@ jobs:
     name: build and test windows
     permissions:
       id-token: write
+      contents: read
     if: ${{ inputs.is_windows }}
     uses: ./.github/workflows/build-and-test-windows.yml
     strategy:

--- a/.github/workflows/dispatch-build-and-test.yml
+++ b/.github/workflows/dispatch-build-and-test.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   # Using a matrix to dispatch to the build-and-test reusable workflow for each build configuration

--- a/.github/workflows/dispatch-build-and-test.yml
+++ b/.github/workflows/dispatch-build-and-test.yml
@@ -8,12 +8,17 @@ on:
       devcontainer_version: {type: string, required: true}
       is_windows: {type: boolean, required: true}
 
+permissions:
+  contents: read
+
 jobs:
   # Using a matrix to dispatch to the build-and-test reusable workflow for each build configuration
   # ensures that the build/test steps can overlap across different configurations. For example,
   # the build step for CUDA 12.1 + gcc 9.3 can run at the same time as the test step for CUDA 11.0 + clang 11.
   build_and_test_linux:
     name: build and test linux
+    permissions:
+      id-token: write
     if: ${{ !inputs.is_windows }}
     uses: ./.github/workflows/build-and-test-linux.yml
     strategy:
@@ -30,6 +35,8 @@ jobs:
 
   build_and_test_windows:
     name: build and test windows
+    permissions:
+      id-token: write
     if: ${{ inputs.is_windows }}
     uses: ./.github/workflows/build-and-test-windows.yml
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   compute-matrix:
@@ -161,8 +162,6 @@ jobs:
 
   verify-devcontainers:
     name: Verify Dev Containers
-    permissions:
-      id-token: write
     uses: ./.github/workflows/verify-devcontainers.yml
 
   # This job is the final job that runs after all other jobs and is used for branch protection status checks.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -168,6 +168,9 @@ jobs:
 
   verify-devcontainers:
     name: Verify Dev Containers
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/verify-devcontainers.yml
 
   # This job is the final job that runs after all other jobs and is used for branch protection status checks.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,9 @@ concurrency:
   group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   compute-matrix:
     name: Compute matrix
@@ -53,6 +56,8 @@ jobs:
 
   nvrtc:
     name: NVRTC CUDA${{matrix.cuda}} C++${{matrix.std}}
+    permissions:
+      id-token: write
     needs: compute-matrix
     if: ${{ !contains(github.event.head_commit.message, 'skip-tests') }}
     uses: ./.github/workflows/run-as-coder.yml
@@ -69,6 +74,8 @@ jobs:
 
   thrust:
     name: Thrust CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
+    permissions:
+      id-token: write
     needs: compute-matrix
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
@@ -84,6 +91,8 @@ jobs:
 
   cub:
     name: CUB CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
+    permissions:
+      id-token: write
     needs: compute-matrix
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
@@ -99,6 +108,8 @@ jobs:
 
   libcudacxx:
     name: libcudacxx CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
+    permissions:
+      id-token: write
     needs: compute-matrix
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
@@ -114,6 +125,8 @@ jobs:
 
   clang-cuda:
     name: ${{matrix.lib}} ${{matrix.cpu}}/CTK${{matrix.cuda}}/clang-cuda
+    permissions:
+      id-token: write
     needs: compute-matrix
     strategy:
       fail-fast: false
@@ -129,6 +142,8 @@ jobs:
 
   cccl-infra:
     name: CCCL Infrastructure
+    permissions:
+      id-token: write
     needs: compute-matrix
     if: ${{ !contains(github.event.head_commit.message, 'skip-tests') }}
     strategy:
@@ -146,6 +161,8 @@ jobs:
 
   verify-devcontainers:
     name: Verify Dev Containers
+    permissions:
+      id-token: write
     uses: ./.github/workflows/verify-devcontainers.yml
 
   # This job is the final job that runs after all other jobs and is used for branch protection status checks.
@@ -154,7 +171,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     name: CI
-    if: ${{ always() }} # need to use always() instead of !cancelled() because skipped jobs count as success 
+    if: ${{ always() }} # need to use always() instead of !cancelled() because skipped jobs count as success
     needs:
       - clang-cuda
       - cub

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,6 +59,7 @@ jobs:
     name: NVRTC CUDA${{matrix.cuda}} C++${{matrix.std}}
     permissions:
       id-token: write
+      contents: read
     needs: compute-matrix
     if: ${{ !contains(github.event.head_commit.message, 'skip-tests') }}
     uses: ./.github/workflows/run-as-coder.yml
@@ -77,6 +78,7 @@ jobs:
     name: Thrust CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
     permissions:
       id-token: write
+      contents: read
     needs: compute-matrix
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
@@ -94,6 +96,7 @@ jobs:
     name: CUB CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
     permissions:
       id-token: write
+      contents: read
     needs: compute-matrix
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
@@ -111,6 +114,7 @@ jobs:
     name: libcudacxx CUDA${{ matrix.cuda_version }} ${{ matrix.compiler }}
     permissions:
       id-token: write
+      contents: read
     needs: compute-matrix
     uses: ./.github/workflows/dispatch-build-and-test.yml
     strategy:
@@ -128,6 +132,7 @@ jobs:
     name: ${{matrix.lib}} ${{matrix.cpu}}/CTK${{matrix.cuda}}/clang-cuda
     permissions:
       id-token: write
+      contents: read
     needs: compute-matrix
     strategy:
       fail-fast: false
@@ -145,6 +150,7 @@ jobs:
     name: CCCL Infrastructure
     permissions:
       id-token: write
+      contents: read
     needs: compute-matrix
     if: ${{ !contains(github.event.head_commit.message, 'skip-tests') }}
     strategy:

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   run-as-coder:

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -22,6 +22,7 @@ jobs:
     name: ${{inputs.name}}
     permissions:
       id-token: write
+      contents: read
     runs-on: ${{inputs.runner}}
     container:
       options: -u root

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -14,17 +14,20 @@ on:
       command: {type: string, required: true}
       env: { type: string, required: false, default: "" }
 
+permissions:
+  contents: read
+
 jobs:
   run-as-coder:
     name: ${{inputs.name}}
+    permissions:
+      id-token: write
     runs-on: ${{inputs.runner}}
     container:
       options: -u root
       image: ${{inputs.image}}
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    permissions:
-      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   run-as-coder:

--- a/.github/workflows/verify-devcontainers.yml
+++ b/.github/workflows/verify-devcontainers.yml
@@ -7,6 +7,9 @@ defaults:
   run:
     shell: bash -euo pipefail {0}
 
+permissions:
+  contents: read
+
 jobs:
   verify-make-devcontainers:
     name: Verify devcontainer files are up-to-date


### PR DESCRIPTION
## Description


closes https://github.com/NVIDIA/cccl/issues/919

In following with better security best practices, we don't want to rely on the default `GHA_TOKEN` permissions.

Instead, we want to set the least permissive permissions at the workflow level, and then set higher permissions at individual jobs that need them. 

Most jobs need `id-token: write` for https://github.com/aws-actions/configure-aws-credentials for sccache configuration. 
