### PR TITLE
Fix GCC 13

### DIFF
--- a/cub/cub/util_allocator.cuh
+++ b/cub/cub/util_allocator.cuh
@@ -44,6 +44,7 @@
 #endif // no system header
 
 #include <cub/util_debug.cuh>
+#include <cub/util_deprecated.cuh>
 #include <cub/util_namespace.cuh>
 
 #include <map>
@@ -327,8 +328,7 @@ struct CachingDeviceAllocator
                            unsigned int min_bin    = 1,
                            unsigned int max_bin    = INVALID_BIN,
                            size_t max_cached_bytes = INVALID_SIZE,
-                           bool skip_cleanup       = false,
-                           bool debug              = false)
+                           bool skip_cleanup       = false)
         : bin_growth(bin_growth)
         , min_bin(min_bin)
         , max_bin(max_bin)
@@ -336,9 +336,43 @@ struct CachingDeviceAllocator
         , max_bin_bytes(IntPow(bin_growth, max_bin))
         , max_cached_bytes(max_cached_bytes)
         , skip_cleanup(skip_cleanup)
-        , debug(debug)
+        , debug(false)
         , cached_blocks(BlockDescriptor::SizeCompare)
         , live_blocks(BlockDescriptor::PtrCompare)
+    {}
+
+    /**
+     * @brief Constructor.
+     *
+     * @param bin_growth
+     *   Geometric growth factor for bin-sizes
+     *
+     * @param min_bin
+     *   Minimum bin (default is bin_growth ^ 1)
+     *
+     * @param max_bin
+     *   Maximum bin (default is no max bin)
+     *
+     * @param max_cached_bytes
+     *   Maximum aggregate cached bytes per device (default is no limit)
+     *
+     * @param skip_cleanup
+     *   Whether or not to skip a call to @p FreeAllCached() when the destructor is called (default
+     *   is to deallocate)
+     *
+     * @param debug
+     *   Whether or not to print (de)allocation events to stdout (default is no stderr output)
+     */
+    CUB_DEPRECATED_BECAUSE("CUB no longer accepts `debug` parameter. "
+                           "Define CUB_DEBUG_LOG instead, or silence this message with "
+                           "CUB_IGNORE_DEPRECATED_API.")
+    CachingDeviceAllocator(unsigned int bin_growth,
+                           unsigned int min_bin,
+                           unsigned int max_bin,
+                           size_t max_cached_bytes,
+                           bool skip_cleanup,
+                           bool /* debug */)
+        : CachingDeviceAllocator(bin_growth, min_bin, max_bin, max_cached_bytes, skip_cleanup)
     {}
 
 
@@ -383,7 +417,9 @@ struct CachingDeviceAllocator
         // Lock
         mutex.lock();
 
-        if (debug) _CubLog("Changing max_cached_bytes (%lld -> %lld)\n", (long long) this->max_cached_bytes, (long long) max_cached_bytes_);
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+        _CubLog("Changing max_cached_bytes (%lld -> %lld)\n", (long long) this->max_cached_bytes, (long long) max_cached_bytes_);
+#endif
 
         this->max_cached_bytes = max_cached_bytes_;
 
@@ -494,8 +530,10 @@ struct CachingDeviceAllocator
                     cached_bytes[device].free -= search_key.bytes;
                     cached_bytes[device].live += search_key.bytes;
 
-                    if (debug) _CubLog("\tDevice %d reused cached block at %p (%lld bytes) for stream %lld (previously associated with stream %lld).\n",
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+                    _CubLog("\tDevice %d reused cached block at %p (%lld bytes) for stream %lld (previously associated with stream %lld).\n",
                         device, search_key.d_ptr, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long)  block_itr->associated_stream);
+#endif
 
                     cached_blocks.erase(block_itr);
 
@@ -532,8 +570,10 @@ struct CachingDeviceAllocator
             if (error == cudaErrorMemoryAllocation)
             {
                 // The allocation attempt failed: free all cached blocks on device and retry
-                if (debug) _CubLog("\tDevice %d failed to allocate %lld bytes for stream %lld, retrying after freeing cached allocations",
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+                _CubLog("\tDevice %d failed to allocate %lld bytes for stream %lld, retrying after freeing cached allocations",
                       device, (long long) search_key.bytes, (long long) search_key.associated_stream);
+#endif
 
                 error = cudaSuccess;    // Reset the error we will return
                 cudaGetLastError();     // Reset CUDART's error
@@ -567,8 +607,10 @@ struct CachingDeviceAllocator
                     // Reduce balance and erase entry
                     cached_bytes[device].free -= block_itr->bytes;
 
-                    if (debug) _CubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+                    _CubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
                         device, (long long) block_itr->bytes, (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+#endif
 
                     block_itr = cached_blocks.erase(block_itr);
                 }
@@ -602,8 +644,10 @@ struct CachingDeviceAllocator
             cached_bytes[device].live += search_key.bytes;
             mutex.unlock();
 
-            if (debug) _CubLog("\tDevice %d allocated new device block at %p (%lld bytes associated with stream %lld).\n",
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+            _CubLog("\tDevice %d allocated new device block at %p (%lld bytes associated with stream %lld).\n",
                       device, search_key.d_ptr, (long long) search_key.bytes, (long long) search_key.associated_stream);
+#endif
 
             // Attempt to revert back to previous device if necessary
             if ((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != device))
@@ -619,8 +663,10 @@ struct CachingDeviceAllocator
         // Copy device pointer to output parameter
         *d_ptr = search_key.d_ptr;
 
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
         if (debug) _CubLog("\t\t%lld available blocks cached (%lld bytes), %lld live blocks outstanding(%lld bytes).\n",
             (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+#endif
 
         return error;
     }
@@ -696,9 +742,11 @@ struct CachingDeviceAllocator
                 cached_blocks.insert(search_key);
                 cached_bytes[device].free += search_key.bytes;
 
-                if (debug) _CubLog("\tDevice %d returned %lld bytes from associated stream %lld.\n\t\t %lld available blocks cached (%lld bytes), %lld live blocks outstanding. (%lld bytes)\n",
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+                _CubLog("\tDevice %d returned %lld bytes from associated stream %lld.\n\t\t %lld available blocks cached (%lld bytes), %lld live blocks outstanding. (%lld bytes)\n",
                     device, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long) cached_blocks.size(),
                     (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+#endif
             }
         }
 
@@ -746,8 +794,10 @@ struct CachingDeviceAllocator
                 return error;
             }
 
-            if (debug) _CubLog("\tDevice %d freed %lld bytes from associated stream %lld.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+            _CubLog("\tDevice %d freed %lld bytes from associated stream %lld.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
                 device, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+#endif
         }
 
         // Reset device
@@ -834,8 +884,10 @@ struct CachingDeviceAllocator
             cached_bytes[current_device].free -= block_bytes;
             cached_blocks.erase(begin);
 
-            if (debug) _CubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+            _CubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
                 current_device, (long long) block_bytes, (long long) cached_blocks.size(), (long long) cached_bytes[current_device].free, (long long) live_blocks.size(), (long long) cached_bytes[current_device].live);
+#endif
 
         }
 

--- a/cub/cub/util_debug.cuh
+++ b/cub/cub/util_debug.cuh
@@ -168,7 +168,7 @@
     #define CUB_STDERR
 #endif
 
-#ifdef CUB_STDERR
+#if defined(CUB_STDERR) || defined(CUB_DETAIL_DEBUG_ENABLE_LOG)
 #include <cstdio>
 #endif
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/1174

<!-- Provide a standalone description of changes in this PR. -->
Deprecates `debug` parameter of the `CachingDeviceAllocator` to harmonize logging approach across CUB facilities. Fixes GCC 13. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
