### PR TITLE
Add missing exit from `run-as-coder`

### DIFF
--- a/.github/workflows/run-as-coder.yml
+++ b/.github/workflows/run-as-coder.yml
@@ -64,5 +64,6 @@ jobs:
               echo "For additional information, see:"
               echo "   - DevContainer Documentation: https://github.com/NVIDIA/cccl/blob/main/.devcontainer/README.md"
               echo "   - Continuous Integration (CI) Overview: https://github.com/NVIDIA/cccl/blob/main/ci-overview.md"
+              exit $exit_code
             fi
 


### PR DESCRIPTION
## Description

The CI log improvements dropped exiting from the `run-as-coder` workflow when an error occurred in the provided command. This led to CI jobs reporting success when they actually failed. 

