### PR TITLE
Fix availability of `is_constant_evaluated` on old MSVC

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -522,7 +522,7 @@ extern "C++" {
 
 #if __check_builtin(builtin_is_constant_evaluated)           \
  || (defined(_LIBCUDACXX_COMPILER_GCC)  && _GNUC_VER >= 900) \
- || (defined(_LIBCUDACXX_COMPILER_MSVC) && _MSC_VER  > 1924)
+ || (defined(_LIBCUDACXX_COMPILER_MSVC) && _MSC_VER  > 1924 && !defined(_LIBCUDACXX_CUDACC_BELOW_11_3))
 #define _LIBCUDACXX_IS_CONSTANT_EVALUATED(...) __builtin_is_constant_evaluated(__VA_ARGS__)
 #endif // __check_builtin(builtin_is_constant_evaluated)
 


### PR DESCRIPTION
@ptheywood found that there is an unfortunate incompatability of MSVC2019 which does support `__builtin_is_constant_evaluated` from 19.24 onwards and old nvcc below 11.3 which does not.

Fix this by hardening the condition we use to detect availability

Fixes #1179

