### PR TITLE
Ensure the targets that Thrust creates are global.

### DIFF
--- a/lib/cmake/cccl/cccl-config.cmake
+++ b/lib/cmake/cccl/cccl-config.cmake
@@ -87,6 +87,7 @@ foreach(component IN LISTS components)
           DEVICE_OPTION_DOC
             "Device system for CCCL::Thrust target."
           ADVANCED
+          GLOBAL
         )
         target_link_libraries(CCCL::CCCL INTERFACE CCCL::Thrust)
       endif()

--- a/thrust/thrust/cmake/thrust-config.cmake
+++ b/thrust/thrust/cmake/thrust-config.cmake
@@ -35,6 +35,7 @@
 #   [HOST <default system>]          # Optionally change the default backend
 #   [DEVICE <default system>]        # Optionally change the default backend
 #   [ADVANCED]                       # Optionally mark options as advanced
+#   [GLOBAL]                         # Optionally mark the target as GLOBAL
 # )
 #
 # # Use a custom TBB, CUB, and/or OMP
@@ -107,6 +108,7 @@ set(THRUST_VERSION_COUNT ${${CMAKE_FIND_PACKAGE_NAME}_VERSION_COUNT} CACHE INTER
 function(thrust_create_target target_name)
   thrust_debug("Assembling target ${target_name}. Options: ${ARGN}" internal)
   set(options
+    GLOBAL
     ADVANCED
     FROM_OPTIONS
     IGNORE_CUB_VERSION_CHECK
@@ -180,7 +182,11 @@ function(thrust_create_target target_name)
   # We can just create an INTERFACE IMPORTED target here instead of going
   # through _thrust_declare_interface_alias as long as we aren't hanging any
   # Thrust/CUB include paths directly on ${target_name}.
-  add_library(${target_name} INTERFACE IMPORTED)
+  set(TCT_AS_GLOBAL )
+  if (TCT_GLOBAL)
+    set(TCT_AS_GLOBAL GLOBAL)
+  endif()
+  add_library(${target_name} INTERFACE IMPORTED ${TCT_AS_GLOBAL})
   target_link_libraries(${target_name}
     INTERFACE
     Thrust::${TCT_HOST}::Host


### PR DESCRIPTION
## Description
When using CCCL via `add_subdirectory` the CCCL::Thrust target isn't visible to consumers. This is due to the fact that it is non-global and therefore scoped to the CCCL source directory.

Extend `thrust_create_target` to have the `GLOBAL` option to allow CCCL to ensure the `CCCL::Thrust` target
is visible to consumers.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
