### PR TITLE
Reduce thrust benchmarks noise

### DIFF
--- a/thrust/benchmarks/bench/adjacent_difference/basic.cu
+++ b/thrust/benchmarks/bench/adjacent_difference/basic.cu
@@ -43,8 +43,11 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::adjacent_difference(input.cbegin(), input.cend(), output.begin());
+  caching_allocator_t alloc;
+  thrust::adjacent_difference(policy(alloc), input.cbegin(), input.cend(), output.begin());
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    thrust::adjacent_difference(policy(alloc, launch), input.cbegin(), input.cend(), output.begin());
   });
 }
 

--- a/thrust/benchmarks/bench/reduce/basic.cu
+++ b/thrust/benchmarks/bench/reduce/basic.cu
@@ -42,8 +42,11 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(1);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    do_not_optimize(thrust::reduce(in.begin(), in.end()));
+  caching_allocator_t alloc;
+  do_not_optimize(thrust::reduce(policy(alloc), in.begin(), in.end()));
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch & launch) {
+    do_not_optimize(thrust::reduce(policy(alloc, launch), in.begin(), in.end()));
   });
 }
 

--- a/thrust/benchmarks/bench/reduce/by_key.cu
+++ b/thrust/benchmarks/bench/reduce/by_key.cu
@@ -57,13 +57,16 @@ static void basic(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
   state.add_global_memory_writes<KeyT>(unique_keys);
   state.add_global_memory_writes<ValueT>(unique_keys);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::reduce_by_key(in_keys.begin(),
-                          in_keys.end(),
-                          in_vals.begin(),
-                          out_keys.begin(),
-                          out_vals.begin());
-  });
+  caching_allocator_t alloc;
+  thrust::reduce_by_key(policy(alloc), in_keys.begin(), in_keys.end(),
+                        in_vals.begin(), out_keys.begin(), out_vals.begin());
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::reduce_by_key(policy(alloc, launch), in_keys.begin(),
+                                     in_keys.end(), in_vals.begin(),
+                                     out_keys.begin(), out_vals.begin());
+             });
 }
 
 using key_types = nvbench::type_list<int8_t,

--- a/thrust/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/thrust/benchmarks/bench/scan/exclusive/by_key.cu
@@ -45,9 +45,16 @@ static void scan(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
   state.add_global_memory_reads<ValueT>(elements);
   state.add_global_memory_writes<ValueT>(elements);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::exclusive_scan_by_key(keys.cbegin(), keys.cend(), in_vals.cbegin(), out_vals.begin());
-  });
+  caching_allocator_t alloc;
+  thrust::exclusive_scan_by_key(policy(alloc), keys.cbegin(), keys.cend(),
+                                in_vals.cbegin(), out_vals.begin());
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::exclusive_scan_by_key(
+                   policy(alloc, launch), keys.cbegin(), keys.cend(),
+                   in_vals.cbegin(), out_vals.begin());
+             });
 }
 
 using key_types = all_types;

--- a/thrust/benchmarks/bench/scan/exclusive/max.cu
+++ b/thrust/benchmarks/bench/scan/exclusive/max.cu
@@ -43,9 +43,15 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::exclusive_scan(input.cbegin(), input.cend(), output.begin(), T{}, max_t{});
-  });
+  caching_allocator_t alloc;
+  thrust::exclusive_scan(policy(alloc), input.cbegin(), input.cend(), output.begin(), T{}, max_t{});
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::exclusive_scan(policy(alloc, launch), input.cbegin(),
+                                      input.cend(), output.begin(), T{},
+                                      max_t{});
+             });
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(all_types))

--- a/thrust/benchmarks/bench/scan/exclusive/sum.cu
+++ b/thrust/benchmarks/bench/scan/exclusive/sum.cu
@@ -43,9 +43,14 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::exclusive_scan(input.cbegin(), input.cend(), output.begin());
-  });
+  caching_allocator_t alloc;
+  thrust::exclusive_scan(policy(alloc), input.cbegin(), input.cend(), output.begin());
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::exclusive_scan(policy(alloc, launch), input.cbegin(),
+                                      input.cend(), output.begin());
+             });
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(all_types))

--- a/thrust/benchmarks/bench/scan/inclusive/by_key.cu
+++ b/thrust/benchmarks/bench/scan/inclusive/by_key.cu
@@ -45,9 +45,16 @@ static void scan(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
   state.add_global_memory_reads<ValueT>(elements);
   state.add_global_memory_writes<ValueT>(elements);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::inclusive_scan_by_key(keys.cbegin(), keys.cend(), in_vals.cbegin(), out_vals.begin());
-  });
+  caching_allocator_t alloc;
+  thrust::inclusive_scan_by_key(policy(alloc), keys.cbegin(), keys.cend(),
+                                in_vals.cbegin(), out_vals.begin());
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::inclusive_scan_by_key(
+                   policy(alloc, launch), keys.cbegin(), keys.cend(),
+                   in_vals.cbegin(), out_vals.begin());
+             });
 }
 
 using key_types = all_types;

--- a/thrust/benchmarks/bench/scan/inclusive/max.cu
+++ b/thrust/benchmarks/bench/scan/inclusive/max.cu
@@ -43,9 +43,14 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::inclusive_scan(input.cbegin(), input.cend(), output.begin(), max_t{});
-  });
+  caching_allocator_t alloc;
+  thrust::inclusive_scan(policy(alloc), input.cbegin(), input.cend(), output.begin(), max_t{});
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::inclusive_scan(policy(alloc, launch), input.cbegin(),
+                                      input.cend(), output.begin(), max_t{});
+             });
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(all_types))

--- a/thrust/benchmarks/bench/scan/inclusive/sum.cu
+++ b/thrust/benchmarks/bench/scan/inclusive/sum.cu
@@ -43,9 +43,14 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::inclusive_scan(input.cbegin(), input.cend(), output.begin());
-  });
+  caching_allocator_t alloc;
+  thrust::inclusive_scan(policy(alloc), input.cbegin(), input.cend(), output.begin());
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::inclusive_scan(policy(alloc, launch), input.cbegin(),
+                                      input.cend(), output.begin());
+             });
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(all_types))

--- a/thrust/benchmarks/bench/set_operations/base.cuh
+++ b/thrust/benchmarks/bench/set_operations/base.cuh
@@ -50,24 +50,22 @@ static void basic(nvbench::state &state, nvbench::type_list<T>, OpT op)
   thrust::sort(input.begin(), input.begin() + elements_in_A);
   thrust::sort(input.begin() + elements_in_A, input.end());
 
-  const std::size_t elements_in_AB = thrust::distance(output.begin(),
-                                                      op(input.cbegin(),
-                                                         input.cbegin() + elements_in_A,
-                                                         input.cbegin() + elements_in_A,
-                                                         input.cend(),
-                                                         output.begin()));
+  caching_allocator_t alloc;
+  const std::size_t elements_in_AB = thrust::distance(
+      output.begin(),
+      op(policy(alloc), input.cbegin(), input.cbegin() + elements_in_A,
+         input.cbegin() + elements_in_A, input.cend(), output.begin()));
 
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements_in_AB);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    op(input.cbegin(),
-       input.cbegin() + elements_in_A,
-       input.cbegin() + elements_in_A,
-       input.cend(),
-       output.begin());
-  });
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               op(policy(alloc, launch), input.cbegin(),
+                  input.cbegin() + elements_in_A,
+                  input.cbegin() + elements_in_A, input.cend(), output.begin());
+             });
 }
 
 using types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t>;

--- a/thrust/benchmarks/bench/set_operations/by_key.cuh
+++ b/thrust/benchmarks/bench/set_operations/by_key.cuh
@@ -53,14 +53,11 @@ static void basic(nvbench::state &state, nvbench::type_list<KeyT, ValueT>, OpT o
   thrust::sort(in_keys.begin(), in_keys.begin() + elements_in_A);
   thrust::sort(in_keys.begin() + elements_in_A, in_keys.end());
 
-  auto result_ends = op(in_keys.cbegin(),
-                        in_keys.cbegin() + elements_in_A,
-                        in_keys.cbegin() + elements_in_A,
-                        in_keys.cend(),
-                        in_vals.cbegin(),
-                        in_vals.cbegin() + elements_in_A,
-                        out_keys.begin(),
-                        out_vals.begin());
+  caching_allocator_t alloc;
+  auto result_ends =
+      op(policy(alloc), in_keys.cbegin(), in_keys.cbegin() + elements_in_A,
+         in_keys.cbegin() + elements_in_A, in_keys.cend(), in_vals.cbegin(),
+         in_vals.cbegin() + elements_in_A, out_keys.begin(), out_vals.begin());
 
   const std::size_t elements_in_AB = thrust::distance(out_keys.begin(), result_ends.first);
 
@@ -70,16 +67,14 @@ static void basic(nvbench::state &state, nvbench::type_list<KeyT, ValueT>, OpT o
   state.add_global_memory_reads<ValueT>(OpT::read_all_values ? elements : elements_in_A); 
   state.add_global_memory_writes<ValueT>(elements_in_AB);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    op(in_keys.cbegin(),
-       in_keys.cbegin() + elements_in_A,
-       in_keys.cbegin() + elements_in_A,
-       in_keys.cend(),
-       in_vals.cbegin(),
-       in_vals.cbegin() + elements_in_A,
-       out_keys.begin(),
-       out_vals.begin());
-  });
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               op(policy(alloc, launch), in_keys.cbegin(),
+                  in_keys.cbegin() + elements_in_A,
+                  in_keys.cbegin() + elements_in_A, in_keys.cend(),
+                  in_vals.cbegin(), in_vals.cbegin() + elements_in_A,
+                  out_keys.begin(), out_vals.begin());
+             });
 }
 
 using key_types   = nvbench::type_list<int8_t, int16_t, int32_t, int64_t>;

--- a/thrust/benchmarks/bench/set_operations/difference.cu
+++ b/thrust/benchmarks/bench/set_operations/difference.cu
@@ -29,16 +29,18 @@
 
 struct op_t
 {
-  template <typename InputIterator1,
-            typename InputIterator2,
-            typename OutputIterator>
-  __host__ OutputIterator operator()(InputIterator1 first1,
+  template <class PolicyT,
+            class InputIterator1,
+            class InputIterator2,
+            class OutputIterator>
+  __host__ OutputIterator operator()(const PolicyT& policy,
+                                     InputIterator1 first1,
                                      InputIterator1 last1,
                                      InputIterator2 first2,
                                      InputIterator2 last2,
                                      OutputIterator result) const
   {
-    return thrust::set_difference(first1, last1, first2, last2, result);
+    return thrust::set_difference(policy, first1, last1, first2, last2, result);
   }
 };
 

--- a/thrust/benchmarks/bench/set_operations/difference_by_key.cu
+++ b/thrust/benchmarks/bench/set_operations/difference_by_key.cu
@@ -31,14 +31,16 @@ struct op_t
 {
   static constexpr bool read_all_values = true;
 
-  template <class InputIterator1,
+  template <class PolicyT,
+            class InputIterator1,
             class InputIterator2,
             class InputIterator3,
             class InputIterator4,
             class OutputIterator1,
             class OutputIterator2>
   __host__ thrust::pair<OutputIterator1, OutputIterator2>
-  operator()(InputIterator1 keys_first1,
+  operator()(const PolicyT& policy,
+             InputIterator1 keys_first1,
              InputIterator1 keys_last1,
              InputIterator2 keys_first2,
              InputIterator2 keys_last2,
@@ -47,7 +49,8 @@ struct op_t
              OutputIterator1 keys_result,
              OutputIterator2 values_result) const
   {
-    return thrust::set_difference_by_key(keys_first1,
+    return thrust::set_difference_by_key(policy,
+                                         keys_first1,
                                          keys_last1,
                                          keys_first2,
                                          keys_last2,

--- a/thrust/benchmarks/bench/set_operations/intersection.cu
+++ b/thrust/benchmarks/bench/set_operations/intersection.cu
@@ -29,16 +29,18 @@
 
 struct op_t
 {
-  template <typename InputIterator1,
-            typename InputIterator2,
-            typename OutputIterator>
-  __host__ OutputIterator operator()(InputIterator1 first1,
+  template <class PolicyT,
+            class InputIterator1,
+            class InputIterator2,
+            class OutputIterator>
+  __host__ OutputIterator operator()(const PolicyT& policy,
+                                     InputIterator1 first1,
                                      InputIterator1 last1,
                                      InputIterator2 first2,
                                      InputIterator2 last2,
                                      OutputIterator result) const
   {
-    return thrust::set_intersection(first1, last1, first2, last2, result);
+    return thrust::set_intersection(policy, first1, last1, first2, last2, result);
   }
 };
 

--- a/thrust/benchmarks/bench/set_operations/intersection_by_key.cu
+++ b/thrust/benchmarks/bench/set_operations/intersection_by_key.cu
@@ -31,14 +31,16 @@ struct op_t
 {
   static constexpr bool read_all_values = false;
   
-  template <class InputIterator1,
+  template <class PolicyT,
+            class InputIterator1,
             class InputIterator2,
             class InputIterator3,
             class InputIterator4,
             class OutputIterator1,
             class OutputIterator2>
   __host__ thrust::pair<OutputIterator1, OutputIterator2>
-  operator()(InputIterator1 keys_first1,
+  operator()(const PolicyT& policy,
+             InputIterator1 keys_first1,
              InputIterator1 keys_last1,
              InputIterator2 keys_first2,
              InputIterator2 keys_last2,
@@ -47,7 +49,8 @@ struct op_t
              OutputIterator1 keys_result,
              OutputIterator2 values_result) const
   {
-    return thrust::set_intersection_by_key(keys_first1,
+    return thrust::set_intersection_by_key(policy,
+                                           keys_first1,
                                            keys_last1,
                                            keys_first2,
                                            keys_last2,

--- a/thrust/benchmarks/bench/set_operations/symmetric_difference.cu
+++ b/thrust/benchmarks/bench/set_operations/symmetric_difference.cu
@@ -29,16 +29,18 @@
 
 struct op_t
 {
-  template <typename InputIterator1,
-            typename InputIterator2,
-            typename OutputIterator>
-  __host__ OutputIterator operator()(InputIterator1 first1,
+  template <class PolicyT,
+            class InputIterator1,
+            class InputIterator2,
+            class OutputIterator>
+  __host__ OutputIterator operator()(const PolicyT& policy,
+                                     InputIterator1 first1,
                                      InputIterator1 last1,
                                      InputIterator2 first2,
                                      InputIterator2 last2,
                                      OutputIterator result) const
   {
-    return thrust::set_symmetric_difference(first1, last1, first2, last2, result);
+    return thrust::set_symmetric_difference(policy, first1, last1, first2, last2, result);
   }
 };
 

--- a/thrust/benchmarks/bench/set_operations/symmetric_difference_by_key.cu
+++ b/thrust/benchmarks/bench/set_operations/symmetric_difference_by_key.cu
@@ -31,14 +31,16 @@ struct op_t
 {
   static constexpr bool read_all_values = true;
 
-  template <class InputIterator1,
+  template <class PolicyT,
+            class InputIterator1,
             class InputIterator2,
             class InputIterator3,
             class InputIterator4,
             class OutputIterator1,
             class OutputIterator2>
   __host__ thrust::pair<OutputIterator1, OutputIterator2>
-  operator()(InputIterator1 keys_first1,
+  operator()(const PolicyT& policy,
+             InputIterator1 keys_first1,
              InputIterator1 keys_last1,
              InputIterator2 keys_first2,
              InputIterator2 keys_last2,
@@ -47,7 +49,8 @@ struct op_t
              OutputIterator1 keys_result,
              OutputIterator2 values_result) const
   {
-    return thrust::set_symmetric_difference_by_key(keys_first1,
+    return thrust::set_symmetric_difference_by_key(policy,
+                                                   keys_first1,
                                                    keys_last1,
                                                    keys_first2,
                                                    keys_last2,

--- a/thrust/benchmarks/bench/set_operations/union.cu
+++ b/thrust/benchmarks/bench/set_operations/union.cu
@@ -29,16 +29,18 @@
 
 struct op_t
 {
-  template <typename InputIterator1,
-            typename InputIterator2,
-            typename OutputIterator>
-  __host__ OutputIterator operator()(InputIterator1 first1,
+  template <class PolicyT,
+            class InputIterator1,
+            class InputIterator2,
+            class OutputIterator>
+  __host__ OutputIterator operator()(const PolicyT& policy,
+                                     InputIterator1 first1,
                                      InputIterator1 last1,
                                      InputIterator2 first2,
                                      InputIterator2 last2,
                                      OutputIterator result) const
   {
-    return thrust::set_union(first1, last1, first2, last2, result);
+    return thrust::set_union(policy, first1, last1, first2, last2, result);
   }
 };
 

--- a/thrust/benchmarks/bench/set_operations/union_by_key.cu
+++ b/thrust/benchmarks/bench/set_operations/union_by_key.cu
@@ -31,14 +31,16 @@ struct op_t
 {
   static constexpr bool read_all_values = true;
 
-  template <class InputIterator1,
+  template <class PolicyT,
+            class InputIterator1,
             class InputIterator2,
             class InputIterator3,
             class InputIterator4,
             class OutputIterator1,
             class OutputIterator2>
   __host__ thrust::pair<OutputIterator1, OutputIterator2>
-  operator()(InputIterator1 keys_first1,
+  operator()(const PolicyT& policy,
+             InputIterator1 keys_first1,
              InputIterator1 keys_last1,
              InputIterator2 keys_first2,
              InputIterator2 keys_last2,
@@ -47,7 +49,8 @@ struct op_t
              OutputIterator1 keys_result,
              OutputIterator2 values_result) const
   {
-    return thrust::set_union_by_key(keys_first1,
+    return thrust::set_union_by_key(policy,
+                                    keys_first1,
                                     keys_last1,
                                     keys_first2,
                                     keys_last2,

--- a/thrust/benchmarks/bench/shuffle/basic.cu
+++ b/thrust/benchmarks/bench/shuffle/basic.cu
@@ -44,8 +44,11 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_writes<T>(elements);
 
   auto do_engine = [&](auto &&engine_constructor) {
-    state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-      thrust::shuffle(data.begin(), data.end(), engine_constructor());
+    caching_allocator_t alloc;
+    thrust::shuffle(policy(alloc), data.begin(), data.end(), engine_constructor());
+
+    state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & launch) {
+      thrust::shuffle(policy(alloc, launch), data.begin(), data.end(), engine_constructor());
     });
   };
 

--- a/thrust/benchmarks/bench/sort/keys.cu
+++ b/thrust/benchmarks/bench/sort/keys.cu
@@ -45,11 +45,14 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
+  caching_allocator_t alloc;
+  thrust::sort(policy(alloc), vec.begin(), vec.end());
+
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
-             [&](nvbench::launch &/* launch */, auto &timer) {
+             [&](nvbench::launch &launch, auto &timer) {
                vec = input;
                timer.start();
-               thrust::sort(vec.begin(), vec.end());
+               thrust::sort(policy(alloc, launch), vec.begin(), vec.end());
                timer.stop();
              });
 }

--- a/thrust/benchmarks/bench/sort/keys_custom.cu
+++ b/thrust/benchmarks/bench/sort/keys_custom.cu
@@ -45,11 +45,14 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(elements);
 
+  caching_allocator_t alloc;
+  thrust::sort(policy(alloc), vec.begin(), vec.end(), less_t{});
+
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
-             [&](nvbench::launch & /* launch */, auto &timer) {
+             [&](nvbench::launch & launch, auto &timer) {
                vec = input;
                timer.start();
-               thrust::sort(vec.begin(), vec.end(), less_t{});
+               thrust::sort(policy(alloc, launch), vec.begin(), vec.end(), less_t{});
                timer.stop();
              });
 }

--- a/thrust/benchmarks/bench/sort/pairs_custom.cu
+++ b/thrust/benchmarks/bench/sort/pairs_custom.cu
@@ -49,12 +49,15 @@ static void basic(nvbench::state &state, nvbench::type_list<KeyT, ValueT>)
   state.add_global_memory_writes<KeyT>(elements);
   state.add_global_memory_writes<ValueT>(elements);
 
+  caching_allocator_t alloc;
+  thrust::sort_by_key(policy(alloc), keys.begin(), keys.end(), vals.begin(), less_t{});
+
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
-             [&](nvbench::launch & /* launch */, auto &timer) {
+             [&](nvbench::launch & launch, auto &timer) {
                keys = in_keys;
                vals = in_vals;
                timer.start();
-               thrust::sort_by_key(keys.begin(), keys.end(), vals.begin(), less_t{});
+               thrust::sort_by_key(policy(alloc, launch), keys.begin(), keys.end(), vals.begin(), less_t{});
                timer.stop();
              });
 }

--- a/thrust/benchmarks/bench/unique/basic.cu
+++ b/thrust/benchmarks/bench/unique/basic.cu
@@ -43,17 +43,20 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
     generate.uniform.key_segments(elements, min_segment_size, max_segment_size);
   thrust::device_vector<T> output(elements);
 
-  const std::size_t unique_items =
-    thrust::distance(output.begin(),
-                     thrust::unique_copy(input.cbegin(), input.cend(), output.begin()));
+  caching_allocator_t alloc;
+  const std::size_t unique_items = thrust::distance(
+      output.begin(), thrust::unique_copy(policy(alloc), input.cbegin(),
+                                          input.cend(), output.begin()));
 
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<T>(unique_items);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::unique_copy(input.cbegin(), input.cend(), output.begin());
-  });
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::unique_copy(policy(alloc, launch), input.cbegin(),
+                                   input.cend(), output.begin());
+             });
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))

--- a/thrust/benchmarks/bench/vectorized_search/base.cu
+++ b/thrust/benchmarks/bench/vectorized_search/base.cu
@@ -46,13 +46,20 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
 
   state.add_element_count(needles);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::binary_search(data.begin(),
-                          data.begin() + elements,
-                          data.begin() + elements,
-                          data.end(),
-                          result.begin());
-  });
+  caching_allocator_t alloc;
+  thrust::binary_search(policy(alloc),
+                        data.begin(),
+                        data.begin() + elements,
+                        data.begin() + elements,
+                        data.end(),
+                        result.begin());
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::binary_search(
+                   policy(alloc, launch), data.begin(), data.begin() + elements,
+                   data.begin() + elements, data.end(), result.begin());
+             });
 }
 
 using types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t>;

--- a/thrust/benchmarks/bench/vectorized_search/lower_bound.cu
+++ b/thrust/benchmarks/bench/vectorized_search/lower_bound.cu
@@ -46,13 +46,20 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
 
   state.add_element_count(needles);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::lower_bound(data.begin(),
-                        data.begin() + elements,
-                        data.begin() + elements,
-                        data.end(),
-                        result.begin());
-  });
+  caching_allocator_t alloc;
+  thrust::lower_bound(policy(alloc),
+                      data.begin(),
+                      data.begin() + elements,
+                      data.begin() + elements,
+                      data.end(),
+                      result.begin());
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::lower_bound(
+                   policy(alloc, launch), data.begin(), data.begin() + elements,
+                   data.begin() + elements, data.end(), result.begin());
+             });
 }
 
 using types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t>;

--- a/thrust/benchmarks/bench/vectorized_search/upper_bound.cu
+++ b/thrust/benchmarks/bench/vectorized_search/upper_bound.cu
@@ -46,13 +46,16 @@ static void basic(nvbench::state &state, nvbench::type_list<T>)
 
   state.add_element_count(needles);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch & /* launch */) {
-    thrust::upper_bound(data.begin(),
-                        data.begin() + elements,
-                        data.begin() + elements,
-                        data.end(),
-                        result.begin());
-  });
+  caching_allocator_t alloc;
+  thrust::upper_bound(policy(alloc), data.begin(), data.begin() + elements,
+                      data.begin() + elements, data.end(), result.begin());
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               thrust::upper_bound(
+                   policy(alloc, launch), data.begin(), data.begin() + elements,
+                   data.begin() + elements, data.end(), result.begin());
+             });
 }
 
 using types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t>;

--- a/thrust/cmake/ThrustBuildCompilerTargets.cmake
+++ b/thrust/cmake/ThrustBuildCompilerTargets.cmake
@@ -26,9 +26,6 @@ function(thrust_build_compiler_targets)
 
   thrust_update_system_found_flags()
 
-  # Ensure that we build our tests without treating ourself as system header
-  list(APPEND cxx_compile_definitions "_CCCL_NO_SYSTEM_HEADER")
-
   if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     append_option_if_available("/W4" cxx_compile_options)
 

--- a/thrust/testing/CMakeLists.txt
+++ b/thrust/testing/CMakeLists.txt
@@ -79,6 +79,9 @@ function(thrust_add_test target_name_var test_name test_src thrust_target)
     target_compile_definitions(${test_target} PRIVATE THRUST_TEST_DEVICE_SIDE)
   endif()
 
+  # Ensure that we build our tests without treating ourself as system header
+  target_compile_definitions(${test_target} PRIVATE "_CCCL_NO_SYSTEM_HEADER")
+
   thrust_fix_clang_nvcc_build_for(${test_target})
 
   # Add to the active configuration's meta target


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/1202

<!-- Provide a standalone description of changes in this PR. -->
This PR introduces caching allocator policy into thrust benchmarks. This significantly reduces noise and runtime for thrust benchmarks. Apart from that, excluding memory allocation reduces number of modes in the elapsed time distributions. 

![caching_allocator](https://github.com/NVIDIA/cccl/assets/9890394/251f403d-34e0-4233-b6f0-dd003a71d29e)

This is important for our performance CI.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
