### PR TITLE
Fix block reduce alignment

### DIFF
--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -1370,6 +1370,25 @@ template <> struct NumericTraits<bool> :                BaseTraits<UNSIGNED_INTE
 template <typename T>
 struct Traits : NumericTraits<typename ::cuda::std::remove_cv<T>::type> {};
 
+namespace detail 
+{
+
+template <::cuda::std::size_t Alignment, class... T> 
+struct max_alignment_t;
+
+template <::cuda::std::size_t Alignment> 
+struct max_alignment_t<Alignment> 
+{
+  constexpr static ::cuda::std::size_t value = Alignment;
+};
+
+template <::cuda::std::size_t Alignment, class Head, class... Tail>
+struct max_alignment_t<Alignment, Head, Tail...> 
+{
+  constexpr static ::cuda::std::size_t value = max_alignment_t<(cub::max)(Alignment, alignof(Head)), Tail...>::value;
+};
+
+} // namespace detail
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 

--- a/cub/test/catch2_test_util_type.cu
+++ b/cub/test/catch2_test_util_type.cu
@@ -66,3 +66,17 @@ CUB_TEST("Tests non_void_value_t", "[util][type]")
     ::cuda::std::is_same<int, //
                          cub::detail::non_void_value_t<non_void_fancy_it, fallback_t>>::value);
 }
+
+namespace {
+struct alignas(32) test32_t {};
+} // namespace
+
+CUB_TEST("Maximal alignment is computed correctly", "[util][type]")
+{
+  STATIC_REQUIRE(cub::detail::max_alignment_t<8>::value == 8);
+  STATIC_REQUIRE(cub::detail::max_alignment_t<1, int>::value == alignof(int));
+  STATIC_REQUIRE(cub::detail::max_alignment_t<1, int, double>::value == alignof(double));
+  STATIC_REQUIRE(cub::detail::max_alignment_t<1, int, double>::value == alignof(double));
+  STATIC_REQUIRE(cub::detail::max_alignment_t<1, int, double, test32_t>::value == 32);
+  STATIC_REQUIRE(cub::detail::max_alignment_t<128, int, double, test32_t>::value == 128);
+}


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/1229

<!-- Provide a standalone description of changes in this PR. -->
Vectorized loads of temporary storage in block reduce, lead to unaligned access. This PR marks temporary storage for block reduce as `struct alignas(detail::max_alignment_t<16, T, WarpReduceStorage>::value) _TempStorage`. This and reordering of member variables in temporary storage, ensures that warp aggregate loads can be vectorized. 

Note that other parts of CUB rely on `__align__(16)`. This is potentially problematic for custom types with explicitly specified alignment. I'll create a separate issue for unifying the approach later. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
