### PR TITLE
Disable `fast-math` for ICC

### DIFF
--- a/libcudacxx/libcxx/CMakeLists.txt
+++ b/libcudacxx/libcxx/CMakeLists.txt
@@ -612,7 +612,7 @@ function(cxx_add_warning_flags target)
       -Wno-literal-suffix
       -Wno-c++14-compat
       -Wno-noexcept-type)
-  elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
+  elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
     target_add_compile_flags_if_supported(${target} PRIVATE
       -fno-fast-math)
   endif()

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -50,7 +50,7 @@ if (MSVC)
 endif()
 
 # Intel OneAPI compiler has fast math enabled by default which breaks almost all floating point tests
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
   set(LIBCUDACXX_TEST_COMPILER_FLAGS
     "${LIBCUDACXX_TEST_COMPILER_FLAGS} \
     --compiler-options=-fno-fast-math")


### PR DESCRIPTION
We test exact floating point behavior, this can lead to flakyness in the libcu++ test suite. We previously only disabled it for the new llvm based compiler, but we also got internal bug reports about invalid floating point operations on classic ICC

addresses nvbug3120750