### PR TITLE
Implement `ranges::{c}begin` and `ranges::{c}end`

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/CMakeLists.txt
@@ -186,6 +186,7 @@ set(files
   __mutex_base
   __node_handle
   __nullptr
+  __ranges/access.h
   __ranges/enable_borrowed_range.h
   __ranges/enable_view.h
   __split_buffer

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__ranges/access.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__ranges/access.h
@@ -1,0 +1,296 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+#ifndef _LIBCUDACXX___RANGES_ACCESS_H
+#define _LIBCUDACXX___RANGES_ACCESS_H
+
+#ifndef __cuda_std__
+#include <__config>
+#endif // __cuda_std__
+
+#include "../__concepts/class_or_enum.h"
+#include "../__iterator/concepts.h"
+#include "../__iterator/readable_traits.h"
+#include "../__ranges/enable_borrowed_range.h"
+#include "../__type_traits/is_array.h"
+#include "../__type_traits/is_reference.h"
+#include "../__type_traits/remove_cvref.h"
+#include "../__type_traits/remove_reference.h"
+#include "../__utility/auto_cast.h"
+#include "../__utility/declval.h"
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+_LIBCUDACXX_BEGIN_NAMESPACE_RANGES
+
+#if _CCCL_STD_VER > 2014
+
+  template <class _Tp>
+  _LIBCUDACXX_CONCEPT __can_borrow =
+    is_lvalue_reference_v<_Tp> || enable_borrowed_range<remove_cvref_t<_Tp>>;
+
+// [range.access.begin]
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CPO(__begin)
+  template<class _Tp>
+  void begin(_Tp&) = delete;
+  template<class _Tp>
+  void begin(const _Tp&) = delete;
+
+#if _CCCL_STD_VER > 2017
+  template <class _Tp>
+  concept __member_begin =
+    __can_borrow<_Tp> &&
+    __workaround_52970<_Tp> &&
+    requires(_Tp&& __t) {
+      { _LIBCUDACXX_AUTO_CAST(__t.begin()) } -> input_or_output_iterator;
+    };
+
+  template <class _Tp>
+  concept __unqualified_begin =
+    !__member_begin<_Tp> &&
+    __can_borrow<_Tp> &&
+    __class_or_enum<remove_cvref_t<_Tp>> &&
+    requires(_Tp && __t) {
+      { _LIBCUDACXX_AUTO_CAST(begin(__t)) } -> input_or_output_iterator;
+    };
+#else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+  template<class _Tp>
+  _LIBCUDACXX_CONCEPT_FRAGMENT(
+    __member_begin_,
+    requires(_Tp&& __t)(
+      requires(__can_borrow<_Tp>),
+      requires(__workaround_52970<_Tp>),
+      requires(input_or_output_iterator<decltype(_LIBCUDACXX_AUTO_CAST(__t.begin()))>)
+    ));
+
+  template<class _Tp>
+  _LIBCUDACXX_CONCEPT __member_begin = _LIBCUDACXX_FRAGMENT(__member_begin_, _Tp);
+
+  template<class _Tp>
+  _LIBCUDACXX_CONCEPT_FRAGMENT(
+    __unqualified_begin_,
+    requires(_Tp&& __t)(
+      requires(!__member_begin<_Tp>),
+      requires(__can_borrow<_Tp>),
+      requires(__class_or_enum<remove_cvref_t<_Tp>>),
+      requires(input_or_output_iterator<decltype(_LIBCUDACXX_AUTO_CAST(begin(__t)))>)
+    ));
+
+  template<class _Tp>
+  _LIBCUDACXX_CONCEPT __unqualified_begin = _LIBCUDACXX_FRAGMENT(__unqualified_begin_, _Tp);
+#endif // _CCCL_STD_VER < 2020
+
+  struct __fn {
+    // This has been made valid as a defect report for C++17 onwards, however gcc below 11.0 does not implement it
+#if (!defined(_LIBCUDACXX_COMPILER_GCC) || __GNUC__ >= 11)
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES((sizeof(_Tp) >= 0)) // Disallow incomplete element types.
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp (&__t)[]) const noexcept
+    {
+      return __t + 0;
+    }
+#endif // (!defined(__GNUC__) || __GNUC__ >= 11)
+
+    _LIBCUDACXX_TEMPLATE(class _Tp, size_t _Np)
+      _LIBCUDACXX_REQUIRES((sizeof(_Tp) >= 0)) // Disallow incomplete element types.
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp (&__t)[_Np]) const noexcept
+    {
+      return __t + 0;
+    }
+
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES(__member_begin<_Tp>)
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(__t.begin())))
+    {
+      return _LIBCUDACXX_AUTO_CAST(__t.begin());
+    }
+
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES(__unqualified_begin<_Tp>)
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(begin(__t))))
+    {
+      return _LIBCUDACXX_AUTO_CAST(begin(__t));
+    }
+
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES((!__member_begin<_Tp>) _LIBCUDACXX_AND
+                (!__unqualified_begin<_Tp>))
+    void operator()(_Tp&&) const = delete;
+  };
+_LIBCUDACXX_END_NAMESPACE_CPO
+
+inline namespace __cpo {
+  _LIBCUDACXX_CPO_ACCESSIBILITY auto begin = __begin::__fn{};
+} // namespace __cpo
+
+// [range.range]
+
+  template <class _Tp>
+  using iterator_t = decltype(_CUDA_VRANGES::begin(_CUDA_VSTD::declval<_Tp&>()));
+
+// [range.access.end]
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CPO(__end)
+  template<class _Tp>
+  void end(_Tp&) = delete;
+  template<class _Tp>
+  void end(const _Tp&) = delete;
+
+#if _CCCL_STD_VER > 2017
+  template <class _Tp>
+  concept __member_end =
+    __can_borrow<_Tp> &&
+    __workaround_52970<_Tp> &&
+    requires(_Tp&& __t) {
+      typename iterator_t<_Tp>;
+      { _LIBCUDACXX_AUTO_CAST(__t.end()) } -> sentinel_for<iterator_t<_Tp>>;
+    };
+
+  template <class _Tp>
+  concept __unqualified_end =
+    !__member_end<_Tp> &&
+    __can_borrow<_Tp> &&
+    __class_or_enum<remove_cvref_t<_Tp>> &&
+    requires(_Tp && __t) {
+      typename iterator_t<_Tp>;
+      { _LIBCUDACXX_AUTO_CAST(end(__t)) } -> sentinel_for<iterator_t<_Tp>>;
+    };
+#else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+template<class _Tp>
+  _LIBCUDACXX_CONCEPT_FRAGMENT(
+    __member_end_,
+    requires(_Tp&& __t)(
+      requires(__can_borrow<_Tp>),
+      requires(__workaround_52970<_Tp>),
+      typename(iterator_t<_Tp>),
+      requires(sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(__t.end())), iterator_t<_Tp>>)
+    ));
+
+  template<class _Tp>
+  _LIBCUDACXX_CONCEPT __member_end = _LIBCUDACXX_FRAGMENT(__member_end_, _Tp);
+
+  template<class _Tp>
+  _LIBCUDACXX_CONCEPT_FRAGMENT(
+    __unqualified_end_,
+    requires(_Tp&& __t)(
+      requires(!__member_end<_Tp>),
+      requires(__can_borrow<_Tp>),
+      requires(__class_or_enum<remove_cvref_t<_Tp>>),
+      typename(iterator_t<_Tp>),
+      requires(sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(end(__t))), iterator_t<_Tp>>)
+    ));
+
+  template<class _Tp>
+  _LIBCUDACXX_CONCEPT __unqualified_end = _LIBCUDACXX_FRAGMENT(__unqualified_end_, _Tp);
+#endif // _CCCL_STD_VER < 2020
+
+  struct __fn {
+    _LIBCUDACXX_TEMPLATE(class _Tp, size_t _Np)
+      _LIBCUDACXX_REQUIRES((sizeof(_Tp) >= 0)) // Disallow incomplete element types.
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp (&__t)[_Np]) const noexcept
+    {
+      return __t + _Np;
+    }
+
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES(__member_end<_Tp>)
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(__t.end())))
+    {
+      return _LIBCUDACXX_AUTO_CAST(__t.end());
+    }
+
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES(__unqualified_end<_Tp>)
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(end(__t))))
+    {
+      return _LIBCUDACXX_AUTO_CAST(end(__t));
+    }
+
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES((!__member_end<_Tp>) _LIBCUDACXX_AND
+                (!__unqualified_end<_Tp>))
+    void operator()(_Tp&&) const = delete;
+  };
+_LIBCUDACXX_END_NAMESPACE_CPO
+
+inline namespace __cpo {
+  _LIBCUDACXX_CPO_ACCESSIBILITY auto end = __end::__fn{};
+} // namespace __cpo
+
+// [range.access.cbegin]
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CPO(__cbegin)
+  struct __fn {
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES(is_lvalue_reference_v<_Tp&&>)
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(_CUDA_VRANGES::begin(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(      _CUDA_VRANGES::begin(static_cast<const remove_reference_t<_Tp>&>(__t)))
+      { return          _CUDA_VRANGES::begin(static_cast<const remove_reference_t<_Tp>&>(__t)); }
+
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES(is_rvalue_reference_v<_Tp&&>)
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(_CUDA_VRANGES::begin(static_cast<const _Tp&&>(__t))))
+      -> decltype(      _CUDA_VRANGES::begin(static_cast<const _Tp&&>(__t)))
+      { return          _CUDA_VRANGES::begin(static_cast<const _Tp&&>(__t)); }
+  };
+_LIBCUDACXX_END_NAMESPACE_CPO
+
+inline namespace __cpo {
+  _LIBCUDACXX_CPO_ACCESSIBILITY auto cbegin = __cbegin::__fn{};
+} // namespace __cpo
+
+// [range.access.cend]
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CPO(__cend)
+  struct __fn {
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES(is_lvalue_reference_v<_Tp&&>)
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(_CUDA_VRANGES::end(static_cast<const remove_reference_t<_Tp>&>(__t))))
+      -> decltype(      _CUDA_VRANGES::end(static_cast<const remove_reference_t<_Tp>&>(__t)))
+      { return          _CUDA_VRANGES::end(static_cast<const remove_reference_t<_Tp>&>(__t)); }
+
+    _LIBCUDACXX_TEMPLATE(class _Tp)
+      _LIBCUDACXX_REQUIRES(is_rvalue_reference_v<_Tp&&>)
+    _LIBCUDACXX_NODISCARD_ATTRIBUTE _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
+    constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(_CUDA_VRANGES::end(static_cast<const _Tp&&>(__t))))
+      -> decltype(      _CUDA_VRANGES::end(static_cast<const _Tp&&>(__t)))
+      { return          _CUDA_VRANGES::end(static_cast<const _Tp&&>(__t)); }
+  };
+_LIBCUDACXX_END_NAMESPACE_CPO
+
+inline namespace __cpo {
+  _LIBCUDACXX_CPO_ACCESSIBILITY auto cend = __cend::__fn{};
+} // namespace __cpo
+#endif // _CCCL_STD_VER > 2014
+
+_LIBCUDACXX_END_NAMESPACE_RANGES
+
+#endif // _LIBCUDACXX___RANGES_ACCESS_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/auto_cast.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__utility/auto_cast.h
@@ -25,6 +25,10 @@
 #  pragma system_header
 #endif // no system header
 
+#if _CCCL_STD_VER < 2020 && defined(_LIBCUDACXX_COMPILER_MSVC)
+#define _LIBCUDACXX_AUTO_CAST(expr) (_CUDA_VSTD::decay_t<decltype((expr))>)(expr)
+#else
 #define _LIBCUDACXX_AUTO_CAST(expr) static_cast<_CUDA_VSTD::decay_t<decltype((expr))>>(expr)
+#endif
 
 #endif // _LIBCUDACXX___UTILITY_AUTO_CAST_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/ranges
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/ranges
@@ -311,6 +311,7 @@ namespace std {
 #endif // __cuda_std__
 
 #include "__assert" // all public C++ headers provide the assertion handler
+#include "__ranges/access.h"
 #include "__ranges/enable_borrowed_range.h"
 #include "__ranges/enable_view.h"
 

--- a/libcudacxx/libcxx/test/std/ranges/range.access/begin.pass.cpp
+++ b/libcudacxx/libcxx/test/std/ranges/range.access/begin.pass.cpp
@@ -1,0 +1,347 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::begin
+// std::ranges::cbegin
+
+#include <ranges>
+
+#include <cassert>
+#include <utility>
+#include "test_macros.h"
+#include "test_iterators.h"
+
+using RangeBeginT = decltype(std::ranges::begin);
+using RangeCBeginT = decltype(std::ranges::cbegin);
+
+static int globalBuff[8];
+
+static_assert(!std::is_invocable_v<RangeBeginT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeBeginT, int (&)[10]>);
+static_assert(!std::is_invocable_v<RangeBeginT, int (&&)[]>);
+// This has been made valid as a defect report for C++17 onwards, however both clang and gcc below 11.0 does not implement it
+#if (!defined(TEST_COMPILER_GCC) || __GNUC__ >= 11)
+static_assert( std::is_invocable_v<RangeBeginT, int (&)[]>);
+#endif // (!defined(TEST_COMPILER_GCC) || __GNUC__ >= 11)
+static_assert(!std::is_invocable_v<RangeCBeginT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeCBeginT, int (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, int (&&)[]>);
+// This has been made valid as a defect report for C++17 onwards, however both clang and gcc below 11.0 does not implement it
+#if (!defined(TEST_COMPILER_GCC) || __GNUC__ >= 11)
+static_assert( std::is_invocable_v<RangeCBeginT, int (&)[]>);
+#endif // (!defined(TEST_COMPILER_GCC) || __GNUC__ >= 11)
+
+struct Incomplete;
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeBeginT, const Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, const Incomplete(&&)[]>);
+
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete(&&)[10]>);
+static_assert(!std::is_invocable_v<RangeBeginT, const Incomplete(&&)[10]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete(&&)[10]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, const Incomplete(&&)[10]>);
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeBeginT, Incomplete(&)[]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeBeginT, const Incomplete(&)[]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCBeginT, Incomplete(&)[]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCBeginT, const Incomplete(&)[]>);
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeBeginT, Incomplete(&)[10]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeBeginT, const Incomplete(&)[10]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCBeginT, Incomplete(&)[10]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCBeginT, const Incomplete(&)[10]>);
+
+struct BeginMember {
+  int x;
+  constexpr const int *begin() const { return &x; }
+};
+
+// Ensure that we can't call with rvalues with borrowing disabled.
+static_assert( std::is_invocable_v<RangeBeginT, BeginMember &>);
+static_assert(!std::is_invocable_v<RangeBeginT, BeginMember &&>);
+static_assert( std::is_invocable_v<RangeBeginT, BeginMember const&>);
+static_assert(!std::is_invocable_v<RangeBeginT, BeginMember const&&>);
+static_assert( std::is_invocable_v<RangeCBeginT, BeginMember &>);
+static_assert(!std::is_invocable_v<RangeCBeginT, BeginMember &&>);
+static_assert( std::is_invocable_v<RangeCBeginT, BeginMember const&>);
+static_assert(!std::is_invocable_v<RangeCBeginT, BeginMember const&&>);
+
+constexpr bool testReturnTypes() {
+  {
+    int *x[2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::begin(x)), int**);
+    ASSERT_SAME_TYPE(decltype(std::ranges::cbegin(x)), int* const*);
+  }
+  {
+    int x[2][2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::begin(x)), int(*)[2]);
+    ASSERT_SAME_TYPE(decltype(std::ranges::cbegin(x)), const int(*)[2]);
+  }
+  {
+    struct Different {
+      char*& begin();
+      short*& begin() const;
+    } x;
+    ASSERT_SAME_TYPE(decltype(std::ranges::begin(x)), char*);
+    ASSERT_SAME_TYPE(decltype(std::ranges::cbegin(x)), short*);
+  }
+  return true;
+}
+
+constexpr bool testArray() {
+  int a[2];
+  assert(std::ranges::begin(a) == a);
+  assert(std::ranges::cbegin(a) == a);
+
+  int b[2][2];
+  assert(std::ranges::begin(b) == b);
+  assert(std::ranges::cbegin(b) == b);
+
+  BeginMember c[2];
+  assert(std::ranges::begin(c) == c);
+  assert(std::ranges::cbegin(c) == c);
+
+  return true;
+}
+
+struct BeginMemberReturnsInt {
+  int begin() const;
+};
+static_assert(!std::is_invocable_v<RangeBeginT, BeginMemberReturnsInt const&>);
+
+struct BeginMemberReturnsVoidPtr {
+  const void *begin() const;
+};
+static_assert(!std::is_invocable_v<RangeBeginT, BeginMemberReturnsVoidPtr const&>);
+
+struct EmptyBeginMember {
+  struct iterator {};
+  iterator begin() const;
+};
+static_assert(!std::is_invocable_v<RangeBeginT, EmptyBeginMember const&>);
+
+struct PtrConvertibleBeginMember {
+  struct iterator { operator int*() const; };
+  iterator begin() const;
+};
+static_assert(!std::is_invocable_v<RangeBeginT, PtrConvertibleBeginMember const&>);
+
+struct NonConstBeginMember {
+  int x;
+  constexpr int *begin() { return &x; }
+};
+static_assert( std::is_invocable_v<RangeBeginT,  NonConstBeginMember &>);
+static_assert(!std::is_invocable_v<RangeBeginT,  NonConstBeginMember const&>);
+static_assert(!std::is_invocable_v<RangeCBeginT, NonConstBeginMember &>);
+static_assert(!std::is_invocable_v<RangeCBeginT, NonConstBeginMember const&>);
+
+struct EnabledBorrowingBeginMember {
+  constexpr int *begin() const { return &globalBuff[0]; }
+};
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<EnabledBorrowingBeginMember> = true;
+
+struct BeginMemberFunction {
+  int x;
+  constexpr const int *begin() const { return &x; }
+  friend int *begin(BeginMemberFunction const&);
+};
+
+struct EmptyPtrBeginMember {
+  struct Empty {};
+  Empty x;
+  constexpr const Empty *begin() const { return &x; }
+};
+
+constexpr bool testBeginMember() {
+  BeginMember a;
+  assert(std::ranges::begin(a) == &a.x);
+  assert(std::ranges::cbegin(a) == &a.x);
+  static_assert(!std::is_invocable_v<RangeBeginT, BeginMember&&>);
+  static_assert(!std::is_invocable_v<RangeCBeginT, BeginMember&&>);
+
+  NonConstBeginMember b;
+  assert(std::ranges::begin(b) == &b.x);
+  static_assert(!std::is_invocable_v<RangeCBeginT, NonConstBeginMember&>);
+
+  EnabledBorrowingBeginMember c;
+  assert(std::ranges::begin(c) == &globalBuff[0]);
+  assert(std::ranges::cbegin(c) == &globalBuff[0]);
+  assert(std::ranges::begin(std::move(c)) == &globalBuff[0]);
+  assert(std::ranges::cbegin(std::move(c)) == &globalBuff[0]);
+
+  BeginMemberFunction d;
+  assert(std::ranges::begin(d) == &d.x);
+  assert(std::ranges::cbegin(d) == &d.x);
+
+  EmptyPtrBeginMember e;
+  assert(std::ranges::begin(e) == &e.x);
+  assert(std::ranges::cbegin(e) == &e.x);
+
+  return true;
+}
+
+
+struct BeginFunction {
+  int x;
+  friend constexpr const int *begin(BeginFunction const& bf) { return &bf.x; }
+};
+static_assert( std::is_invocable_v<RangeBeginT,  BeginFunction const&>);
+static_assert(!std::is_invocable_v<RangeBeginT,  BeginFunction &&>);
+static_assert(!std::is_invocable_v<RangeBeginT,  BeginFunction &>);
+static_assert( std::is_invocable_v<RangeCBeginT, BeginFunction const&>);
+static_assert( std::is_invocable_v<RangeCBeginT, BeginFunction &>);
+
+struct BeginFunctionReturnsInt {
+  friend int begin(BeginFunctionReturnsInt const&);
+};
+static_assert(!std::is_invocable_v<RangeBeginT, BeginFunctionReturnsInt const&>);
+
+struct BeginFunctionReturnsVoidPtr {
+  friend void *begin(BeginFunctionReturnsVoidPtr const&);
+};
+static_assert(!std::is_invocable_v<RangeBeginT, BeginFunctionReturnsVoidPtr const&>);
+
+struct BeginFunctionReturnsPtrConvertible {
+  struct iterator { operator int*() const; };
+  friend iterator begin(BeginFunctionReturnsPtrConvertible const&);
+};
+static_assert(!std::is_invocable_v<RangeBeginT, BeginFunctionReturnsPtrConvertible const&>);
+
+struct BeginFunctionByValue {
+  friend constexpr int *begin(BeginFunctionByValue) { return &globalBuff[1]; }
+};
+static_assert(!std::is_invocable_v<RangeCBeginT, BeginFunctionByValue>);
+
+struct BeginFunctionEnabledBorrowing {
+  friend constexpr int *begin(BeginFunctionEnabledBorrowing) { return &globalBuff[2]; }
+};
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<BeginFunctionEnabledBorrowing> = true;
+
+struct BeginFunctionReturnsEmptyPtr {
+  struct Empty {};
+  Empty x;
+  friend constexpr const Empty *begin(BeginFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+};
+
+struct BeginFunctionWithDataMember {
+  int x;
+  int begin;
+  friend constexpr const int *begin(BeginFunctionWithDataMember const& bf) { return &bf.x; }
+};
+
+struct BeginFunctionWithPrivateBeginMember {
+  int y;
+  friend constexpr const int *begin(BeginFunctionWithPrivateBeginMember const& bf) { return &bf.y; }
+private:
+  const int *begin() const;
+};
+
+constexpr bool testBeginFunction() {
+  BeginFunction a{};
+  const BeginFunction aa{};
+  static_assert(!std::invocable<RangeBeginT, decltype((a))>);
+  assert(std::ranges::cbegin(a) == &a.x);
+  assert(std::ranges::begin(aa) == &aa.x);
+  assert(std::ranges::cbegin(aa) == &aa.x);
+
+  BeginFunctionByValue b{};
+  const BeginFunctionByValue bb{};
+  assert(std::ranges::begin(b) == &globalBuff[1]);
+  assert(std::ranges::cbegin(b) == &globalBuff[1]);
+  assert(std::ranges::begin(bb) == &globalBuff[1]);
+  assert(std::ranges::cbegin(bb) == &globalBuff[1]);
+
+  BeginFunctionEnabledBorrowing c{};
+  const BeginFunctionEnabledBorrowing cc{};
+  assert(std::ranges::begin(std::move(c)) == &globalBuff[2]);
+  assert(std::ranges::cbegin(std::move(c)) == &globalBuff[2]);
+  assert(std::ranges::begin(std::move(cc)) == &globalBuff[2]);
+  assert(std::ranges::cbegin(std::move(cc)) == &globalBuff[2]);
+
+  BeginFunctionReturnsEmptyPtr d{};
+  const BeginFunctionReturnsEmptyPtr dd{};
+  static_assert(!std::invocable<RangeBeginT, decltype((d))>);
+  assert(std::ranges::cbegin(d) == &d.x);
+  assert(std::ranges::begin(dd) == &dd.x);
+  assert(std::ranges::cbegin(dd) == &dd.x);
+
+  BeginFunctionWithDataMember e{};
+  const BeginFunctionWithDataMember ee{};
+  static_assert(!std::invocable<RangeBeginT, decltype((e))>);
+  assert(std::ranges::begin(ee) == &ee.x);
+  assert(std::ranges::cbegin(e) == &e.x);
+  assert(std::ranges::cbegin(ee) == &ee.x);
+
+  BeginFunctionWithPrivateBeginMember f{};
+  const BeginFunctionWithPrivateBeginMember ff{};
+  static_assert(!std::invocable<RangeBeginT, decltype((f))>);
+  assert(std::ranges::cbegin(f) == &f.y);
+  assert(std::ranges::begin(ff) == &ff.y);
+  assert(std::ranges::cbegin(ff) == &ff.y);
+
+  return true;
+}
+
+
+ASSERT_NOEXCEPT(std::ranges::begin(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(std::ranges::cbegin(std::declval<int (&)[10]>()));
+
+struct NoThrowMemberBegin {
+  ThrowingIterator<int> begin() const noexcept; // auto(t.begin()) doesn't throw
+} ntmb;
+static_assert(noexcept(std::ranges::begin(ntmb)));
+static_assert(noexcept(std::ranges::cbegin(ntmb)));
+
+struct NoThrowADLBegin {
+  friend ThrowingIterator<int> begin(NoThrowADLBegin&) noexcept;  // auto(begin(t)) doesn't throw
+  friend ThrowingIterator<int> begin(const NoThrowADLBegin&) noexcept;
+} ntab;
+static_assert(noexcept(std::ranges::begin(ntab)));
+static_assert(noexcept(std::ranges::cbegin(ntab)));
+
+struct NoThrowMemberBeginReturnsRef {
+  ThrowingIterator<int>& begin() const noexcept; // auto(t.begin()) may throw
+} ntmbrr;
+static_assert(!noexcept(std::ranges::begin(ntmbrr)));
+static_assert(!noexcept(std::ranges::cbegin(ntmbrr)));
+
+struct BeginReturnsArrayRef {
+    auto begin() const noexcept -> int(&)[10];
+} brar;
+static_assert(noexcept(std::ranges::begin(brar)));
+static_assert(noexcept(std::ranges::cbegin(brar)));
+
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(!std::is_invocable_v<RangeBeginT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeBeginT, Holder<Incomplete>*&>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*&>);
+
+int main(int, char**) {
+  static_assert(testReturnTypes());
+
+  testArray();
+  static_assert(testArray());
+
+  testBeginMember();
+  static_assert(testBeginMember());
+
+  testBeginFunction();
+  static_assert(testBeginFunction());
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/ranges/range.access/begin.sizezero.pass.cpp
+++ b/libcudacxx/libcxx/test/std/ranges/range.access/begin.sizezero.pass.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: msvc
+
+// std::ranges::begin
+// std::ranges::cbegin
+//   Test the fix for https://llvm.org/PR54100
+
+#include <ranges>
+#include <cassert>
+
+#include "test_macros.h"
+
+struct A {
+  int m[0];
+};
+static_assert(sizeof(A) == 0); // an extension supported by GCC and Clang
+
+int main(int, char**)
+{
+  A a[10];
+  std::same_as<A*> auto p = std::ranges::begin(a);
+  assert(p == a);
+  std::same_as<const A*> auto cp = std::ranges::cbegin(a);
+  assert(cp == a);
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/ranges/range.access/begin.verify.cpp
+++ b/libcudacxx/libcxx/test/std/ranges/range.access/begin.verify.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::begin
+
+#include <ranges>
+
+struct NonBorrowedRange {
+  int* begin() const;
+  int* end() const;
+};
+static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
+
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::begin` is ill-formed.
+void test() {
+  std::ranges::begin(NonBorrowedRange());
+  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (std::ranges::)?__begin::__fn'}}}}
+  // expected-error@-2  {{attempt to use a deleted function}}
+}

--- a/libcudacxx/libcxx/test/std/ranges/range.access/end.pass.cpp
+++ b/libcudacxx/libcxx/test/std/ranges/range.access/end.pass.cpp
@@ -1,0 +1,370 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::end
+// std::ranges::cend
+
+#include <ranges>
+
+#include <cassert>
+#include <utility>
+#include "test_macros.h"
+#include "test_iterators.h"
+
+using RangeEndT = decltype(std::ranges::end);
+using RangeCEndT = decltype(std::ranges::cend);
+
+static int globalBuff[8];
+
+static_assert(!std::is_invocable_v<RangeEndT, int (&&)[]>);
+static_assert(!std::is_invocable_v<RangeEndT, int (&)[]>);
+static_assert(!std::is_invocable_v<RangeEndT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeEndT, int (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCEndT, int (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCEndT, int (&)[]>);
+static_assert(!std::is_invocable_v<RangeCEndT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeCEndT, int (&)[10]>);
+
+struct Incomplete;
+static_assert(!std::is_invocable_v<RangeEndT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeEndT, Incomplete(&&)[42]>);
+static_assert(!std::is_invocable_v<RangeCEndT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeCEndT, Incomplete(&&)[42]>);
+
+struct EndMember {
+  int x;
+  const int *begin() const;
+  constexpr const int *end() const { return &x; }
+};
+
+// Ensure that we can't call with rvalues with borrowing disabled.
+static_assert( std::is_invocable_v<RangeEndT, EndMember &>);
+static_assert(!std::is_invocable_v<RangeEndT, EndMember &&>);
+static_assert( std::is_invocable_v<RangeEndT, EndMember const&>);
+static_assert(!std::is_invocable_v<RangeEndT, EndMember const&&>);
+static_assert( std::is_invocable_v<RangeCEndT, EndMember &>);
+static_assert(!std::is_invocable_v<RangeCEndT, EndMember &&>);
+static_assert( std::is_invocable_v<RangeCEndT, EndMember const&>);
+static_assert(!std::is_invocable_v<RangeCEndT, EndMember const&&>);
+
+constexpr bool testReturnTypes() {
+  {
+    int *x[2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::end(x)), int**);
+    ASSERT_SAME_TYPE(decltype(std::ranges::cend(x)), int* const*);
+  }
+  {
+    int x[2][2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::end(x)), int(*)[2]);
+    ASSERT_SAME_TYPE(decltype(std::ranges::cend(x)), const int(*)[2]);
+  }
+  {
+    struct Different {
+      char *begin();
+      sentinel_wrapper<char*>& end();
+      short *begin() const;
+      sentinel_wrapper<short*>& end() const;
+    } x;
+    ASSERT_SAME_TYPE(decltype(std::ranges::end(x)), sentinel_wrapper<char*>);
+    ASSERT_SAME_TYPE(decltype(std::ranges::cend(x)), sentinel_wrapper<short*>);
+  }
+  return true;
+}
+
+constexpr bool testArray() {
+  int a[2];
+  assert(std::ranges::end(a) == a + 2);
+  assert(std::ranges::cend(a) == a + 2);
+
+  int b[2][2];
+  assert(std::ranges::end(b) == b + 2);
+  assert(std::ranges::cend(b) == b + 2);
+
+  EndMember c[2];
+  assert(std::ranges::end(c) == c + 2);
+  assert(std::ranges::cend(c) == c + 2);
+
+  return true;
+}
+
+struct EndMemberReturnsInt {
+  int begin() const;
+  int end() const;
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndMemberReturnsInt const&>);
+
+struct EndMemberReturnsVoidPtr {
+  const void *begin() const;
+  const void *end() const;
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndMemberReturnsVoidPtr const&>);
+
+struct PtrConvertible {
+  operator int*() const;
+};
+struct PtrConvertibleEndMember {
+  PtrConvertible begin() const;
+  PtrConvertible end() const;
+};
+static_assert(!std::is_invocable_v<RangeEndT, PtrConvertibleEndMember const&>);
+
+struct NoBeginMember {
+  constexpr const int *end();
+};
+static_assert(!std::is_invocable_v<RangeEndT, NoBeginMember const&>);
+
+struct NonConstEndMember {
+  int x;
+  constexpr int *begin() { return nullptr; }
+  constexpr int *end() { return &x; }
+};
+static_assert( std::is_invocable_v<RangeEndT,  NonConstEndMember &>);
+static_assert(!std::is_invocable_v<RangeEndT,  NonConstEndMember const&>);
+static_assert(!std::is_invocable_v<RangeCEndT, NonConstEndMember &>);
+static_assert(!std::is_invocable_v<RangeCEndT, NonConstEndMember const&>);
+
+struct EnabledBorrowingEndMember {
+  constexpr int *begin() const { return nullptr; }
+  constexpr int *end() const { return &globalBuff[0]; }
+};
+
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<EnabledBorrowingEndMember> = true;
+
+struct EndMemberFunction {
+  int x;
+  constexpr const int *begin() const { return nullptr; }
+  constexpr const int *end() const { return &x; }
+  friend constexpr int *end(EndMemberFunction const&);
+};
+
+struct Empty { };
+struct EmptyEndMember {
+  Empty begin() const;
+  Empty end() const;
+};
+static_assert(!std::is_invocable_v<RangeEndT, EmptyEndMember const&>);
+
+struct EmptyPtrEndMember {
+  Empty x;
+  constexpr const Empty *begin() const { return nullptr; }
+  constexpr const Empty *end() const { return &x; }
+};
+
+constexpr bool testEndMember() {
+  EndMember a;
+  assert(std::ranges::end(a) == &a.x);
+  assert(std::ranges::cend(a) == &a.x);
+
+  NonConstEndMember b;
+  assert(std::ranges::end(b) == &b.x);
+  static_assert(!std::is_invocable_v<RangeCEndT, decltype((b))>);
+
+  EnabledBorrowingEndMember c;
+  assert(std::ranges::end(std::move(c)) == &globalBuff[0]);
+  assert(std::ranges::cend(std::move(c)) == &globalBuff[0]);
+
+  EndMemberFunction d;
+  assert(std::ranges::end(d) == &d.x);
+  assert(std::ranges::cend(d) == &d.x);
+
+  EmptyPtrEndMember e;
+  assert(std::ranges::end(e) == &e.x);
+  assert(std::ranges::cend(e) == &e.x);
+
+  return true;
+}
+
+struct EndFunction {
+  int x;
+  friend constexpr const int *begin(EndFunction const&) { return nullptr; }
+  friend constexpr const int *end(EndFunction const& bf) { return &bf.x; }
+};
+
+static_assert( std::is_invocable_v<RangeEndT, EndFunction const&>);
+static_assert(!std::is_invocable_v<RangeEndT, EndFunction &&>);
+
+static_assert( std::is_invocable_v<RangeEndT,  EndFunction const&>);
+static_assert(!std::is_invocable_v<RangeEndT,  EndFunction &&>);
+static_assert(!std::is_invocable_v<RangeEndT,  EndFunction &>);
+static_assert( std::is_invocable_v<RangeCEndT, EndFunction const&>);
+static_assert( std::is_invocable_v<RangeCEndT, EndFunction &>);
+
+struct EndFunctionReturnsInt {
+  friend constexpr int begin(EndFunctionReturnsInt const&);
+  friend constexpr int end(EndFunctionReturnsInt const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsInt const&>);
+
+struct EndFunctionReturnsVoidPtr {
+  friend constexpr void *begin(EndFunctionReturnsVoidPtr const&);
+  friend constexpr void *end(EndFunctionReturnsVoidPtr const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsVoidPtr const&>);
+
+struct EndFunctionReturnsEmpty {
+  friend constexpr Empty begin(EndFunctionReturnsEmpty const&);
+  friend constexpr Empty end(EndFunctionReturnsEmpty const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsEmpty const&>);
+
+struct EndFunctionReturnsPtrConvertible {
+  friend constexpr PtrConvertible begin(EndFunctionReturnsPtrConvertible const&);
+  friend constexpr PtrConvertible end(EndFunctionReturnsPtrConvertible const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsPtrConvertible const&>);
+
+struct NoBeginFunction {
+  friend constexpr const int *end(NoBeginFunction const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, NoBeginFunction const&>);
+
+struct EndFunctionByValue {
+  friend constexpr int *begin(EndFunctionByValue) { return nullptr; }
+  friend constexpr int *end(EndFunctionByValue) { return &globalBuff[1]; }
+};
+static_assert(!std::is_invocable_v<RangeCEndT, EndFunctionByValue>);
+
+struct EndFunctionEnabledBorrowing {
+  friend constexpr int *begin(EndFunctionEnabledBorrowing) { return nullptr; }
+  friend constexpr int *end(EndFunctionEnabledBorrowing) { return &globalBuff[2]; }
+};
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<EndFunctionEnabledBorrowing> = true;
+
+struct EndFunctionReturnsEmptyPtr {
+  Empty x;
+  friend constexpr const Empty *begin(EndFunctionReturnsEmptyPtr const&) { return nullptr; }
+  friend constexpr const Empty *end(EndFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+};
+
+struct EndFunctionWithDataMember {
+  int x;
+  int end;
+  friend constexpr const int *begin(EndFunctionWithDataMember const&) { return nullptr; }
+  friend constexpr const int *end(EndFunctionWithDataMember const& bf) { return &bf.x; }
+};
+
+struct EndFunctionWithPrivateEndMember {
+  int y;
+  friend constexpr const int *begin(EndFunctionWithPrivateEndMember const&) { return nullptr; }
+  friend constexpr const int *end(EndFunctionWithPrivateEndMember const& bf) { return &bf.y; }
+private:
+  const int *end() const;
+};
+
+struct BeginMemberEndFunction {
+  int x;
+  constexpr const int *begin() const { return nullptr; }
+  friend constexpr const int *end(BeginMemberEndFunction const& bf) { return &bf.x; }
+};
+
+constexpr bool testEndFunction() {
+  const EndFunction a{};
+  assert(std::ranges::end(a) == &a.x);
+  assert(std::ranges::cend(a) == &a.x);
+  EndFunction aa{};
+  static_assert(!std::is_invocable_v<RangeEndT, decltype((aa))>);
+  assert(std::ranges::cend(aa) == &aa.x);
+
+  EndFunctionByValue b;
+  assert(std::ranges::end(b) == &globalBuff[1]);
+  assert(std::ranges::cend(b) == &globalBuff[1]);
+
+  EndFunctionEnabledBorrowing c;
+  assert(std::ranges::end(std::move(c)) == &globalBuff[2]);
+  assert(std::ranges::cend(std::move(c)) == &globalBuff[2]);
+
+  const EndFunctionReturnsEmptyPtr d{};
+  assert(std::ranges::end(d) == &d.x);
+  assert(std::ranges::cend(d) == &d.x);
+  EndFunctionReturnsEmptyPtr dd{};
+  static_assert(!std::is_invocable_v<RangeEndT, decltype((dd))>);
+  assert(std::ranges::cend(dd) == &dd.x);
+
+  const EndFunctionWithDataMember e{};
+  assert(std::ranges::end(e) == &e.x);
+  assert(std::ranges::cend(e) == &e.x);
+  EndFunctionWithDataMember ee{};
+  static_assert(!std::is_invocable_v<RangeEndT, decltype((ee))>);
+  assert(std::ranges::cend(ee) == &ee.x);
+
+  const EndFunctionWithPrivateEndMember f{};
+  assert(std::ranges::end(f) == &f.y);
+  assert(std::ranges::cend(f) == &f.y);
+  EndFunctionWithPrivateEndMember ff{};
+  static_assert(!std::is_invocable_v<RangeEndT, decltype((ff))>);
+  assert(std::ranges::cend(ff) == &ff.y);
+
+  const BeginMemberEndFunction g{};
+  assert(std::ranges::end(g) == &g.x);
+  assert(std::ranges::cend(g) == &g.x);
+  BeginMemberEndFunction gg{};
+  static_assert(!std::is_invocable_v<RangeEndT, decltype((gg))>);
+  assert(std::ranges::cend(gg) == &gg.x);
+
+  return true;
+}
+
+
+ASSERT_NOEXCEPT(std::ranges::end(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(std::ranges::cend(std::declval<int (&)[10]>()));
+
+struct NoThrowMemberEnd {
+  ThrowingIterator<int> begin() const;
+  ThrowingIterator<int> end() const noexcept; // auto(t.end()) doesn't throw
+} ntme;
+static_assert(noexcept(std::ranges::end(ntme)));
+static_assert(noexcept(std::ranges::cend(ntme)));
+
+struct NoThrowADLEnd {
+  ThrowingIterator<int> begin() const;
+  friend ThrowingIterator<int> end(NoThrowADLEnd&) noexcept;  // auto(end(t)) doesn't throw
+  friend ThrowingIterator<int> end(const NoThrowADLEnd&) noexcept;
+} ntae;
+static_assert(noexcept(std::ranges::end(ntae)));
+static_assert(noexcept(std::ranges::cend(ntae)));
+
+struct NoThrowMemberEndReturnsRef {
+  ThrowingIterator<int> begin() const;
+  ThrowingIterator<int>& end() const noexcept; // auto(t.end()) may throw
+} ntmerr;
+static_assert(!noexcept(std::ranges::end(ntmerr)));
+static_assert(!noexcept(std::ranges::cend(ntmerr)));
+
+struct EndReturnsArrayRef {
+    auto begin() const noexcept -> int(&)[10];
+    auto end() const noexcept -> int(&)[10];
+} erar;
+static_assert(noexcept(std::ranges::end(erar)));
+static_assert(noexcept(std::ranges::cend(erar)));
+
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(!std::is_invocable_v<RangeEndT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeEndT, Holder<Incomplete>*&>);
+static_assert(!std::is_invocable_v<RangeCEndT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeCEndT, Holder<Incomplete>*&>);
+
+int main(int, char**) {
+  static_assert(testReturnTypes());
+
+  testArray();
+  static_assert(testArray());
+
+  testEndMember();
+  static_assert(testEndMember());
+
+  testEndFunction();
+  static_assert(testEndFunction());
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/ranges/range.access/end.sizezero.pass.cpp
+++ b/libcudacxx/libcxx/test/std/ranges/range.access/end.sizezero.pass.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: msvc
+
+// std::ranges::end
+// std::ranges::cend
+//   Test the fix for https://llvm.org/PR54100
+
+#include <ranges>
+#include <cassert>
+
+#include "test_macros.h"
+
+struct A {
+  int m[0];
+};
+static_assert(sizeof(A) == 0); // an extension supported by GCC and Clang
+
+int main(int, char**)
+{
+  A a[10];
+  std::same_as<A*> auto p = std::ranges::end(a);
+  assert(p == a + 10);
+  std::same_as<const A*> auto cp = std::ranges::cend(a);
+  assert(cp == a + 10);
+
+  return 0;
+}

--- a/libcudacxx/libcxx/test/std/ranges/range.access/end.verify.cpp
+++ b/libcudacxx/libcxx/test/std/ranges/range.access/end.verify.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::end
+
+#include <ranges>
+
+struct NonBorrowedRange {
+  int* begin() const;
+  int* end() const;
+};
+static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
+
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::end` is ill-formed.
+void test() {
+  std::ranges::end(NonBorrowedRange());
+  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (std::ranges::)?__end::__fn'}}}}
+  // expected-error@-2  {{attempt to use a deleted function}}
+}

--- a/libcudacxx/test/libcudacxx/std/ranges/range.access/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.access/begin.pass.cpp
@@ -1,0 +1,361 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// std::ranges::begin
+// std::ranges::cbegin
+
+#include <cuda/std/ranges>
+
+#include <cuda/std/cassert>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+#include "test_iterators.h"
+
+using RangeBeginT = decltype(cuda::std::ranges::begin);
+using RangeCBeginT = decltype(cuda::std::ranges::cbegin);
+
+STATIC_TEST_GLOBAL_VAR int globalBuff[8] = {};
+
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, int (&&)[10]>);
+static_assert( cuda::std::is_invocable_v<RangeBeginT, int (&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, int (&&)[]>);
+
+// This has been made valid as a defect report for C++17 onwards, however both clang and gcc below 11.0 does not implement it
+#if (!defined(__GNUC__) || __GNUC__ >= 11)
+static_assert( cuda::std::is_invocable_v<RangeBeginT, int (&)[]>);
+#endif
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, int (&&)[10]>);
+static_assert( cuda::std::is_invocable_v<RangeCBeginT, int (&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, int (&&)[]>);
+// This has been made valid as a defect report for C++17 onwards, however both clang and gcc below 11.0 does not implement it
+#if (!defined(__GNUC__) || __GNUC__ >= 11)
+static_assert( cuda::std::is_invocable_v<RangeCBeginT, int (&)[]>);
+#endif
+
+struct Incomplete;
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete(&&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete(&&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete(&&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete(&&)[]>);
+
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete(&&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete(&&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete(&&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete(&&)[10]>);
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete(&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete(&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete(&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete(&)[]>);
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete(&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete(&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete(&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete(&)[10]>);
+
+struct BeginMember {
+  int x;
+  __host__ __device__ constexpr const int *begin() const { return &x; }
+};
+
+// Ensure that we can't call with rvalues with borrowing disabled.
+static_assert( cuda::std::is_invocable_v<RangeBeginT, BeginMember &>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMember &&>);
+static_assert( cuda::std::is_invocable_v<RangeBeginT, BeginMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMember const&&>);
+static_assert( cuda::std::is_invocable_v<RangeCBeginT, BeginMember &>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginMember &&>);
+static_assert( cuda::std::is_invocable_v<RangeCBeginT, BeginMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginMember const&&>);
+
+struct Different {
+  __host__ __device__ char*& begin();
+  __host__ __device__ short*& begin() const;
+};
+__host__ __device__ constexpr bool testReturnTypes() {
+  {
+    int *x[2] = {};
+    unused(x);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::begin(x)), int**>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cbegin(x)), int* const*>);
+  }
+  {
+    int x[2][2] = {};
+    unused(x);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::begin(x)), int(*)[2]>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cbegin(x)), const int(*)[2]>);
+  }
+  {
+    Different x{};
+    unused(x);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::begin(x)), char*>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cbegin(x)), short*>);
+  }
+  return true;
+}
+
+__host__ __device__ constexpr bool testArray() {
+  int a[2] = {};
+  assert(cuda::std::ranges::begin(a) == a);
+  assert(cuda::std::ranges::cbegin(a) == a);
+
+  int b[2][2] = {};
+  assert(cuda::std::ranges::begin(b) == b);
+  assert(cuda::std::ranges::cbegin(b) == b);
+
+  BeginMember c[2] = {};
+  assert(cuda::std::ranges::begin(c) == c);
+  assert(cuda::std::ranges::cbegin(c) == c);
+
+  return true;
+}
+
+struct BeginMemberReturnsInt {
+  __host__ __device__ int begin() const;
+};
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMemberReturnsInt const&>);
+
+struct BeginMemberReturnsVoidPtr {
+  __host__ __device__ const void *begin() const;
+};
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMemberReturnsVoidPtr const&>);
+
+struct EmptyBeginMember {
+  struct iterator {};
+  __host__ __device__ iterator begin() const;
+};
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, EmptyBeginMember const&>);
+
+struct PtrConvertibleBeginMember {
+  struct iterator { __host__ __device__ operator int*() const; };
+  __host__ __device__ iterator begin() const;
+};
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, PtrConvertibleBeginMember const&>);
+
+struct NonConstBeginMember {
+  int x;
+  __host__ __device__ constexpr int *begin() { return &x; }
+};
+static_assert( cuda::std::is_invocable_v<RangeBeginT,  NonConstBeginMember &>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT,  NonConstBeginMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, NonConstBeginMember &>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, NonConstBeginMember const&>);
+
+struct EnabledBorrowingBeginMember {
+  __host__ __device__ constexpr const int *begin() const { return &globalBuff[0]; }
+};
+template<>
+inline constexpr bool cuda::std::ranges::enable_borrowed_range<EnabledBorrowingBeginMember> = true;
+
+struct BeginMemberFunction {
+  int x;
+  __host__ __device__ constexpr const int *begin() const { return &x; }
+  __host__ __device__ friend int *begin(BeginMemberFunction const&);
+};
+
+struct EmptyPtrBeginMember {
+  struct Empty {};
+  Empty x;
+  __host__ __device__ constexpr const Empty *begin() const { return &x; }
+};
+
+__host__ __device__ constexpr bool testBeginMember() {
+  BeginMember a{};
+  assert(cuda::std::ranges::begin(a) == &a.x);
+  assert(cuda::std::ranges::cbegin(a) == &a.x);
+  static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMember&&>);
+  static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginMember&&>);
+
+  NonConstBeginMember b{};
+  assert(cuda::std::ranges::begin(b) == &b.x);
+  static_assert(!cuda::std::is_invocable_v<RangeCBeginT, NonConstBeginMember&>);
+
+  EnabledBorrowingBeginMember c{};
+  assert(cuda::std::ranges::begin(c) == &globalBuff[0]);
+  assert(cuda::std::ranges::cbegin(c) == &globalBuff[0]);
+  assert(cuda::std::ranges::begin(cuda::std::move(c)) == &globalBuff[0]);
+  assert(cuda::std::ranges::cbegin(cuda::std::move(c)) == &globalBuff[0]);
+
+  BeginMemberFunction d{};
+  assert(cuda::std::ranges::begin(d) == &d.x);
+  assert(cuda::std::ranges::cbegin(d) == &d.x);
+
+  EmptyPtrBeginMember e{};
+  assert(cuda::std::ranges::begin(e) == &e.x);
+  assert(cuda::std::ranges::cbegin(e) == &e.x);
+
+  return true;
+}
+
+
+struct BeginFunction {
+  int x;
+  __host__ __device__ friend constexpr const int *begin(BeginFunction const& bf) { return &bf.x; }
+};
+static_assert( cuda::std::is_invocable_v<RangeBeginT,  BeginFunction const&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT,  BeginFunction &&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT,  BeginFunction &>);
+static_assert( cuda::std::is_invocable_v<RangeCBeginT, BeginFunction const&>);
+static_assert( cuda::std::is_invocable_v<RangeCBeginT, BeginFunction &>);
+
+struct BeginFunctionReturnsInt {
+  __host__ __device__ friend int begin(BeginFunctionReturnsInt const&);
+};
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunctionReturnsInt const&>);
+
+struct BeginFunctionReturnsVoidPtr {
+  __host__ __device__ friend void *begin(BeginFunctionReturnsVoidPtr const&);
+};
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunctionReturnsVoidPtr const&>);
+
+struct BeginFunctionReturnsPtrConvertible {
+  struct iterator { __host__ __device__ operator int*() const; };
+  __host__ __device__ friend iterator begin(BeginFunctionReturnsPtrConvertible const&);
+};
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunctionReturnsPtrConvertible const&>);
+
+struct BeginFunctionByValue {
+  __host__ __device__ friend constexpr const int *begin(BeginFunctionByValue) { return &globalBuff[1]; }
+};
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginFunctionByValue>);
+
+struct BeginFunctionEnabledBorrowing {
+  __host__ __device__ friend constexpr const int *begin(BeginFunctionEnabledBorrowing) { return &globalBuff[2]; }
+};
+template<>
+inline constexpr bool cuda::std::ranges::enable_borrowed_range<BeginFunctionEnabledBorrowing> = true;
+
+struct BeginFunctionReturnsEmptyPtr {
+  struct Empty {};
+  Empty x;
+  __host__ __device__ friend constexpr const Empty *begin(BeginFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+};
+
+struct BeginFunctionWithDataMember {
+  int x;
+  int begin;
+  __host__ __device__ friend constexpr const int *begin(BeginFunctionWithDataMember const& bf) { return &bf.x; }
+};
+
+struct BeginFunctionWithPrivateBeginMember {
+  int y;
+  __host__ __device__ friend constexpr const int *begin(BeginFunctionWithPrivateBeginMember const& bf) { return &bf.y; }
+private:
+  __host__ __device__ const int *begin() const;
+};
+
+__host__ __device__ constexpr bool testBeginFunction() {
+  BeginFunction a{};
+  const BeginFunction aa{};
+  static_assert(!cuda::std::invocable<RangeBeginT, decltype((a))>);
+  assert(cuda::std::ranges::cbegin(a) == &a.x);
+  assert(cuda::std::ranges::begin(aa) == &aa.x);
+  assert(cuda::std::ranges::cbegin(aa) == &aa.x);
+
+  BeginFunctionByValue b{};
+  const BeginFunctionByValue bb{};
+  assert(cuda::std::ranges::begin(b) == &globalBuff[1]);
+  assert(cuda::std::ranges::cbegin(b) == &globalBuff[1]);
+  assert(cuda::std::ranges::begin(bb) == &globalBuff[1]);
+  assert(cuda::std::ranges::cbegin(bb) == &globalBuff[1]);
+
+  BeginFunctionEnabledBorrowing c{};
+  const BeginFunctionEnabledBorrowing cc{};
+  assert(cuda::std::ranges::begin(cuda::std::move(c)) == &globalBuff[2]);
+  assert(cuda::std::ranges::cbegin(cuda::std::move(c)) == &globalBuff[2]);
+  assert(cuda::std::ranges::begin(cuda::std::move(cc)) == &globalBuff[2]);
+  assert(cuda::std::ranges::cbegin(cuda::std::move(cc)) == &globalBuff[2]);
+
+  BeginFunctionReturnsEmptyPtr d{};
+  const BeginFunctionReturnsEmptyPtr dd{};
+  static_assert(!cuda::std::invocable<RangeBeginT, decltype((d))>);
+  assert(cuda::std::ranges::cbegin(d) == &d.x);
+  assert(cuda::std::ranges::begin(dd) == &dd.x);
+  assert(cuda::std::ranges::cbegin(dd) == &dd.x);
+
+  BeginFunctionWithDataMember e{};
+  const BeginFunctionWithDataMember ee{};
+  static_assert(!cuda::std::invocable<RangeBeginT, decltype((e))>);
+  assert(cuda::std::ranges::begin(ee) == &ee.x);
+  assert(cuda::std::ranges::cbegin(e) == &e.x);
+  assert(cuda::std::ranges::cbegin(ee) == &ee.x);
+
+  BeginFunctionWithPrivateBeginMember f{};
+  const BeginFunctionWithPrivateBeginMember ff{};
+  static_assert(!cuda::std::invocable<RangeBeginT, decltype((f))>);
+  assert(cuda::std::ranges::cbegin(f) == &f.y);
+  assert(cuda::std::ranges::begin(ff) == &ff.y);
+  assert(cuda::std::ranges::cbegin(ff) == &ff.y);
+
+  return true;
+}
+ASSERT_NOEXCEPT(cuda::std::ranges::begin(cuda::std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(cuda::std::ranges::cbegin(cuda::std::declval<int (&)[10]>()));
+
+_LIBCUDACXX_CPO_ACCESSIBILITY struct NoThrowMemberBegin {
+  __host__ __device__ ThrowingIterator<int> begin() const noexcept; // auto(t.begin()) doesn't throw
+} ntmb;
+static_assert(noexcept(cuda::std::ranges::begin(ntmb)));
+static_assert(noexcept(cuda::std::ranges::cbegin(ntmb)));
+
+_LIBCUDACXX_CPO_ACCESSIBILITY struct NoThrowADLBegin {
+  __host__ __device__ friend ThrowingIterator<int> begin(NoThrowADLBegin&) noexcept;  // auto(begin(t)) doesn't throw
+  __host__ __device__ friend ThrowingIterator<int> begin(const NoThrowADLBegin&) noexcept;
+} ntab;
+static_assert(noexcept(cuda::std::ranges::begin(ntab)));
+static_assert(noexcept(cuda::std::ranges::cbegin(ntab)));
+
+_LIBCUDACXX_CPO_ACCESSIBILITY struct NoThrowMemberBeginReturnsRef {
+  __host__ __device__ ThrowingIterator<int>& begin() const noexcept; // auto(t.begin()) may throw
+} ntmbrr;
+static_assert(!noexcept(cuda::std::ranges::begin(ntmbrr)));
+static_assert(!noexcept(cuda::std::ranges::cbegin(ntmbrr)));
+
+_LIBCUDACXX_CPO_ACCESSIBILITY struct BeginReturnsArrayRef {
+  __host__ __device__ auto begin() const noexcept -> int(&)[10];
+} brar;
+static_assert(noexcept(cuda::std::ranges::begin(brar)));
+static_assert(noexcept(cuda::std::ranges::cbegin(brar)));
+
+#if TEST_STD_VER > 2017
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Holder<Incomplete>*>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Holder<Incomplete>*&>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*&>);
+#endif // TEST_STD_VER > 2017
+
+int main(int, char**) {
+  static_assert(testReturnTypes());
+
+  testArray();
+#ifndef TEST_COMPILER_CUDACC_BELOW_11_3
+  static_assert(testArray());
+#endif // TEST_COMPILER_CUDACC_BELOW_11_3
+
+  testBeginMember();
+  static_assert(testBeginMember());
+
+  testBeginFunction();
+  static_assert(testBeginFunction());
+
+  unused(ntmb);
+  unused(ntab);
+  unused(ntmbrr);
+  unused(brar);
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/ranges/range.access/begin.sizezero.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.access/begin.sizezero.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: msvc
+
+// cuda::std::ranges::begin
+// cuda::std::ranges::cbegin
+//   Test the fix for https://llvm.org/PR54100
+
+#include <cuda/std/ranges>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+#ifndef __CUDA_ARCH__
+struct A {
+  int m[0];
+};
+static_assert(sizeof(A) == 0); // an extension supported by GCC and Clang
+
+__device__ static A a[10];
+
+int main(int, char**)
+{
+  auto p = cuda::std::ranges::begin(a);
+  static_assert(cuda::std::same_as<A*, decltype(cuda::std::ranges::begin(a))>);
+  assert(p == a);
+  auto cp = cuda::std::ranges::cbegin(a);
+  static_assert(cuda::std::same_as<const A*, decltype(cuda::std::ranges::cbegin(a))>);
+  assert(cp == a);
+
+  return 0;
+}
+#else
+int main(int, char**) { return 0; }
+#endif

--- a/libcudacxx/test/libcudacxx/std/ranges/range.access/begin.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.access/begin.verify.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: nvrtc
+
+// cuda::std::ranges::begin
+
+#include <cuda/std/ranges>
+
+struct NonBorrowedRange {
+  __host__ __device__ int* begin() const;
+  __host__ __device__ int* end() const;
+};
+static_assert(!cuda::std::ranges::enable_borrowed_range<NonBorrowedRange>);
+
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::begin` is ill-formed.
+__host__ __device__ void test() {
+  cuda::std::ranges::begin(NonBorrowedRange());
+  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (cuda::std::ranges::)?__begin::__fn'}}}}
+  // expected-error@-2  {{attempt to use a deleted function}}
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/ranges/range.access/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.access/end.pass.cpp
@@ -1,0 +1,382 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// cuda::std::ranges::end
+// cuda::std::ranges::cend
+
+#include <cuda/std/ranges>
+
+#include <cuda/std/cassert>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+#include "test_iterators.h"
+
+using RangeEndT = decltype(cuda::std::ranges::end);
+using RangeCEndT = decltype(cuda::std::ranges::cend);
+
+STATIC_TEST_GLOBAL_VAR int globalBuff[8] = {};
+
+static_assert(!cuda::std::is_invocable_v<RangeEndT, int (&&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, int (&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, int (&&)[10]>);
+static_assert( cuda::std::is_invocable_v<RangeEndT, int (&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, int (&&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, int (&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, int (&&)[10]>);
+static_assert( cuda::std::is_invocable_v<RangeCEndT, int (&)[10]>);
+
+struct Incomplete;
+static_assert(!cuda::std::is_invocable_v<RangeEndT, Incomplete(&&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, Incomplete(&&)[42]>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, Incomplete(&&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, Incomplete(&&)[42]>);
+
+struct EndMember {
+  int x;
+  __host__ __device__ const int *begin() const;
+  __host__ __device__ constexpr const int *end() const { return &x; }
+};
+
+// Ensure that we can't call with rvalues with borrowing disabled.
+static_assert( cuda::std::is_invocable_v<RangeEndT, EndMember &>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMember &&>);
+static_assert( cuda::std::is_invocable_v<RangeEndT, EndMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMember const&&>);
+static_assert( cuda::std::is_invocable_v<RangeCEndT, EndMember &>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, EndMember &&>);
+static_assert( cuda::std::is_invocable_v<RangeCEndT, EndMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, EndMember const&&>);
+
+struct Different {
+  __host__ __device__ char *begin();
+  __host__ __device__ sentinel_wrapper<char*>& end();
+  __host__ __device__ short *begin() const;
+  __host__ __device__ sentinel_wrapper<short*>& end() const;
+};
+__host__ __device__ constexpr bool testReturnTypes() {
+  {
+    int *x[2] = {};
+    unused(x);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::end(x)), int**>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cend(x)), int* const*>);
+  }
+  {
+    int x[2][2] = {};
+    unused(x);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::end(x)), int(*)[2]>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cend(x)), const int(*)[2]>);
+  }
+  {
+    Different x{};
+    unused(x);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::end(x)), sentinel_wrapper<char*>>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cend(x)), sentinel_wrapper<short*>>);
+  }
+  return true;
+}
+
+__host__ __device__ constexpr bool testArray() {
+  int a[2] = {};
+  assert(cuda::std::ranges::end(a) == a + 2);
+  assert(cuda::std::ranges::cend(a) == a + 2);
+
+  int b[2][2] = {};
+  assert(cuda::std::ranges::end(b) == b + 2);
+  assert(cuda::std::ranges::cend(b) == b + 2);
+
+  EndMember c[2] = {};
+  assert(cuda::std::ranges::end(c) == c + 2);
+  assert(cuda::std::ranges::cend(c) == c + 2);
+
+  return true;
+}
+
+struct EndMemberReturnsInt {
+  __host__ __device__ int begin() const;
+  __host__ __device__ int end() const;
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMemberReturnsInt const&>);
+
+struct EndMemberReturnsVoidPtr {
+  __host__ __device__ const void *begin() const;
+  __host__ __device__ const void *end() const;
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMemberReturnsVoidPtr const&>);
+
+struct PtrConvertible {
+  __host__ __device__ operator int*() const;
+};
+struct PtrConvertibleEndMember {
+  __host__ __device__ PtrConvertible begin() const;
+  __host__ __device__ PtrConvertible end() const;
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, PtrConvertibleEndMember const&>);
+
+struct NoBeginMember {
+  __host__ __device__ constexpr const int *end();
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, NoBeginMember const&>);
+
+struct NonConstEndMember {
+  int x;
+  __host__ __device__ constexpr int *begin() { return nullptr; }
+  __host__ __device__ constexpr int *end() { return &x; }
+};
+static_assert( cuda::std::is_invocable_v<RangeEndT,  NonConstEndMember &>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT,  NonConstEndMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, NonConstEndMember &>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, NonConstEndMember const&>);
+
+struct EnabledBorrowingEndMember {
+  __host__ __device__ constexpr int *begin() const { return nullptr; }
+  __host__ __device__ constexpr int *end() const { return &globalBuff[0]; }
+};
+template<>
+inline constexpr bool cuda::std::ranges::enable_borrowed_range<EnabledBorrowingEndMember> = true;
+
+struct EndMemberFunction {
+  int x;
+  __host__ __device__ constexpr const int *begin() const { return nullptr; }
+  __host__ __device__ constexpr const int *end() const { return &x; }
+  __host__ __device__ friend constexpr int *end(EndMemberFunction const&);
+};
+
+struct Empty { };
+struct EmptyEndMember {
+  __host__ __device__ Empty begin() const;
+  __host__ __device__ Empty end() const;
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EmptyEndMember const&>);
+
+struct EmptyPtrEndMember {
+  Empty x;
+  __host__ __device__ constexpr const Empty *begin() const { return nullptr; }
+  __host__ __device__ constexpr const Empty *end() const { return &x; }
+};
+
+__host__ __device__ constexpr bool testEndMember() {
+  EndMember a{};
+  assert(cuda::std::ranges::end(a) == &a.x);
+  assert(cuda::std::ranges::cend(a) == &a.x);
+
+  NonConstEndMember b{};
+  assert(cuda::std::ranges::end(b) == &b.x);
+  static_assert(!cuda::std::is_invocable_v<RangeCEndT, decltype((b))>);
+
+  EnabledBorrowingEndMember c{};
+  assert(cuda::std::ranges::end(cuda::std::move(c)) == &globalBuff[0]);
+  assert(cuda::std::ranges::cend(cuda::std::move(c)) == &globalBuff[0]);
+
+  EndMemberFunction d{};
+  assert(cuda::std::ranges::end(d) == &d.x);
+  assert(cuda::std::ranges::cend(d) == &d.x);
+
+  EmptyPtrEndMember e{};
+  assert(cuda::std::ranges::end(e) == &e.x);
+  assert(cuda::std::ranges::cend(e) == &e.x);
+
+  return true;
+}
+
+struct EndFunction {
+  int x;
+  __host__ __device__ friend constexpr const int *begin(EndFunction const&) { return nullptr; }
+  __host__ __device__ friend constexpr const int *end(EndFunction const& bf) { return &bf.x; }
+};
+
+static_assert( cuda::std::is_invocable_v<RangeEndT, EndFunction const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunction &&>);
+
+static_assert( cuda::std::is_invocable_v<RangeEndT,  EndFunction const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT,  EndFunction &&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT,  EndFunction &>);
+static_assert( cuda::std::is_invocable_v<RangeCEndT, EndFunction const&>);
+static_assert( cuda::std::is_invocable_v<RangeCEndT, EndFunction &>);
+
+struct EndFunctionReturnsInt {
+  __host__ __device__ friend constexpr int begin(EndFunctionReturnsInt const&);
+  __host__ __device__ friend constexpr int end(EndFunctionReturnsInt const&);
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsInt const&>);
+
+struct EndFunctionReturnsVoidPtr {
+  __host__ __device__ friend constexpr void *begin(EndFunctionReturnsVoidPtr const&);
+  __host__ __device__ friend constexpr void *end(EndFunctionReturnsVoidPtr const&);
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsVoidPtr const&>);
+
+struct EndFunctionReturnsEmpty {
+  __host__ __device__ friend constexpr Empty begin(EndFunctionReturnsEmpty const&);
+  __host__ __device__ friend constexpr Empty end(EndFunctionReturnsEmpty const&);
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsEmpty const&>);
+
+struct EndFunctionReturnsPtrConvertible {
+  __host__ __device__ friend constexpr PtrConvertible begin(EndFunctionReturnsPtrConvertible const&);
+  __host__ __device__ friend constexpr PtrConvertible end(EndFunctionReturnsPtrConvertible const&);
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsPtrConvertible const&>);
+
+struct NoBeginFunction {
+  __host__ __device__ friend constexpr const int *end(NoBeginFunction const&);
+};
+static_assert(!cuda::std::is_invocable_v<RangeEndT, NoBeginFunction const&>);
+
+struct EndFunctionByValue {
+  __host__ __device__ friend constexpr int *begin(EndFunctionByValue) { return nullptr; }
+  __host__ __device__ friend constexpr int *end(EndFunctionByValue) { return &globalBuff[1]; }
+};
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, EndFunctionByValue>);
+
+struct EndFunctionEnabledBorrowing {
+  __host__ __device__ friend constexpr int *begin(EndFunctionEnabledBorrowing) { return nullptr; }
+  __host__ __device__ friend constexpr int *end(EndFunctionEnabledBorrowing) { return &globalBuff[2]; }
+};
+template<>
+inline constexpr bool cuda::std::ranges::enable_borrowed_range<EndFunctionEnabledBorrowing> = true;
+
+struct EndFunctionReturnsEmptyPtr {
+  Empty x;
+  __host__ __device__ friend constexpr const Empty *begin(EndFunctionReturnsEmptyPtr const&) { return nullptr; }
+  __host__ __device__ friend constexpr const Empty *end(EndFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+};
+
+struct EndFunctionWithDataMember {
+  int x;
+  int end;
+  __host__ __device__ friend constexpr const int *begin(EndFunctionWithDataMember const&) { return nullptr; }
+  __host__ __device__ friend constexpr const int *end(EndFunctionWithDataMember const& bf) { return &bf.x; }
+};
+
+struct EndFunctionWithPrivateEndMember {
+  int y;
+  __host__ __device__ friend constexpr const int *begin(EndFunctionWithPrivateEndMember const&) { return nullptr; }
+  __host__ __device__ friend constexpr const int *end(EndFunctionWithPrivateEndMember const& bf) { return &bf.y; }
+private:
+  __host__ __device__ const int *end() const;
+};
+
+struct BeginMemberEndFunction {
+  int x;
+  __host__ __device__ constexpr const int *begin() const { return nullptr; }
+  __host__ __device__ friend constexpr const int *end(BeginMemberEndFunction const& bf) { return &bf.x; }
+};
+
+__host__ __device__ constexpr bool testEndFunction() {
+  const EndFunction a{};
+  assert(cuda::std::ranges::end(a) == &a.x);
+  assert(cuda::std::ranges::cend(a) == &a.x);
+  EndFunction aa{};
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((aa))>);
+  assert(cuda::std::ranges::cend(aa) == &aa.x);
+
+  EndFunctionByValue b{};
+  assert(cuda::std::ranges::end(b) == &globalBuff[1]);
+  assert(cuda::std::ranges::cend(b) == &globalBuff[1]);
+
+  EndFunctionEnabledBorrowing c{};
+  assert(cuda::std::ranges::end(cuda::std::move(c)) == &globalBuff[2]);
+  assert(cuda::std::ranges::cend(cuda::std::move(c)) == &globalBuff[2]);
+
+  const EndFunctionReturnsEmptyPtr d{};
+  assert(cuda::std::ranges::end(d) == &d.x);
+  assert(cuda::std::ranges::cend(d) == &d.x);
+  EndFunctionReturnsEmptyPtr dd{};
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((dd))>);
+  assert(cuda::std::ranges::cend(dd) == &dd.x);
+
+  const EndFunctionWithDataMember e{};
+  assert(cuda::std::ranges::end(e) == &e.x);
+  assert(cuda::std::ranges::cend(e) == &e.x);
+  EndFunctionWithDataMember ee{};
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((ee))>);
+  assert(cuda::std::ranges::cend(ee) == &ee.x);
+
+  const EndFunctionWithPrivateEndMember f{};
+  assert(cuda::std::ranges::end(f) == &f.y);
+  assert(cuda::std::ranges::cend(f) == &f.y);
+  EndFunctionWithPrivateEndMember ff{};
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((ff))>);
+  assert(cuda::std::ranges::cend(ff) == &ff.y);
+
+  const BeginMemberEndFunction g{};
+  assert(cuda::std::ranges::end(g) == &g.x);
+  assert(cuda::std::ranges::cend(g) == &g.x);
+  BeginMemberEndFunction gg{};
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((gg))>);
+  assert(cuda::std::ranges::cend(gg) == &gg.x);
+
+  return true;
+}
+ASSERT_NOEXCEPT(cuda::std::ranges::end(cuda::std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(cuda::std::ranges::cend(cuda::std::declval<int (&)[10]>()));
+
+_LIBCUDACXX_CPO_ACCESSIBILITY struct NoThrowMemberEnd {
+  __host__ __device__ ThrowingIterator<int> begin() const;
+  __host__ __device__ ThrowingIterator<int> end() const noexcept; // auto(t.end()) doesn't throw
+} ntme;
+static_assert(noexcept(cuda::std::ranges::end(ntme)));
+static_assert(noexcept(cuda::std::ranges::cend(ntme)));
+
+_LIBCUDACXX_CPO_ACCESSIBILITY struct NoThrowADLEnd {
+  __host__ __device__ ThrowingIterator<int> begin() const;
+  __host__ __device__ friend ThrowingIterator<int> end(NoThrowADLEnd&) noexcept;  // auto(end(t)) doesn't throw
+  __host__ __device__ friend ThrowingIterator<int> end(const NoThrowADLEnd&) noexcept;
+} ntae;
+static_assert(noexcept(cuda::std::ranges::end(ntae)));
+static_assert(noexcept(cuda::std::ranges::cend(ntae)));
+
+_LIBCUDACXX_CPO_ACCESSIBILITY struct NoThrowMemberEndReturnsRef {
+  __host__ __device__ ThrowingIterator<int> begin() const;
+  __host__ __device__ ThrowingIterator<int>& end() const noexcept; // auto(t.end()) may throw
+} ntmerr;
+static_assert(!noexcept(cuda::std::ranges::end(ntmerr)));
+static_assert(!noexcept(cuda::std::ranges::cend(ntmerr)));
+
+_LIBCUDACXX_CPO_ACCESSIBILITY struct EndReturnsArrayRef {
+  __host__ __device__ auto begin() const noexcept -> int(&)[10];
+  __host__ __device__ auto end() const noexcept -> int(&)[10];
+} erar;
+static_assert(noexcept(cuda::std::ranges::end(erar)));
+static_assert(noexcept(cuda::std::ranges::cend(erar)));
+
+#if TEST_STD_VER > 2017
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(!cuda::std::is_invocable_v<RangeEndT, Holder<Incomplete>*>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, Holder<Incomplete>*&>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, Holder<Incomplete>*>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, Holder<Incomplete>*&>);
+#endif // TEST_STD_VER > 2017
+
+int main(int, char**) {
+  static_assert(testReturnTypes());
+
+  testArray();
+#ifndef TEST_COMPILER_CUDACC_BELOW_11_3
+  static_assert(testArray());
+#endif // TEST_COMPILER_CUDACC_BELOW_11_3
+
+  testEndMember();
+  static_assert(testEndMember());
+
+  testEndFunction();
+  static_assert(testEndFunction());
+
+  unused(ntme);
+  unused(ntae);
+  unused(ntmerr);
+  unused(erar);
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/ranges/range.access/end.sizezero.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.access/end.sizezero.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: msvc
+
+// cuda::std::ranges::end
+// cuda::std::ranges::cend
+//   Test the fix for https://llvm.org/PR54100
+
+#include <cuda/std/ranges>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+#ifndef __CUDA_ARCH__
+struct A {
+  int m[0];
+};
+static_assert(sizeof(A) == 0); // an extension supported by GCC and Clang
+
+__device__ static A a[10];
+
+int main(int, char**)
+{
+  auto p = cuda::std::ranges::end(a);
+  static_assert(cuda::std::same_as<A*, decltype(cuda::std::ranges::end(a))>);
+  assert(p == a + 10);
+  auto cp = cuda::std::ranges::cend(a);
+  static_assert(cuda::std::same_as<const A*, decltype(cuda::std::ranges::cend(a))>);
+  assert(cp == a + 10);
+
+  return 0;
+}
+#else
+int main(int, char**) { return 0; }
+#endif

--- a/libcudacxx/test/libcudacxx/std/ranges/range.access/end.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.access/end.verify.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: nvrtc
+
+// cuda::std::ranges::end
+
+#include <cuda/std/ranges>
+
+struct NonBorrowedRange {
+  __host__ __device__ int* begin() const;
+  __host__ __device__ int* end() const;
+};
+static_assert(!cuda::std::ranges::enable_borrowed_range<NonBorrowedRange>);
+
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::end` is ill-formed.
+__host__ __device__ void test() {
+  cuda::std::ranges::end(NonBorrowedRange());
+  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (cuda::std::ranges::)?__end::__fn'}}}}
+  // expected-error@-2  {{attempt to use a deleted function}}
+}
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
This implements the `{c}begin` and `{c}end` CPOs

Fixes #1255