### PR TITLE
Silence some static asserts in ptx helpers

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx/ptx_helper_functions.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx/ptx_helper_functions.h
@@ -46,7 +46,9 @@ inline _LIBCUDACXX_DEVICE _CUDA_VSTD::uint64_t __as_ptr_gmem(const void* __ptr)
 template <typename _Tp>
 inline _LIBCUDACXX_DEVICE _CUDA_VSTD::uint32_t __as_b32(_Tp __val)
 {
+#if _CCCL_STD_VER >= 2017 && !defined(_LIBCUDACXX_HAS_NO_CXX14_CONSTEXPR)
   static_assert(sizeof(_Tp) == 4, "");
+#endif // _CCCL_STD_VER >= 2017  && !_LIBCUDACXX_HAS_NO_CXX14_CONSTEXPR
   // Consider using std::bitcast
   return *reinterpret_cast<_CUDA_VSTD::uint32_t*>(&__val);
 }
@@ -54,7 +56,9 @@ inline _LIBCUDACXX_DEVICE _CUDA_VSTD::uint32_t __as_b32(_Tp __val)
 template <typename _Tp>
 inline _LIBCUDACXX_DEVICE _CUDA_VSTD::uint64_t __as_b64(_Tp __val)
 {
+#if _CCCL_STD_VER >= 2017 && !defined(_LIBCUDACXX_HAS_NO_CXX14_CONSTEXPR)
   static_assert(sizeof(_Tp) == 8, "");
+#endif // _CCCL_STD_VER >= 2017 && !_LIBCUDACXX_HAS_NO_CXX14_CONSTEXPR
   // Consider using std::bitcast
   return *reinterpret_cast<_CUDA_VSTD::uint64_t*>(&__val);
 }


### PR DESCRIPTION
We only use if constexpr in C++17 so those functions are instantiated but never used, which is fine but the static assert triggers

Fixes nvbug4384352

We might want to backport this to 2.3.1