### PR TITLE
Clarify Thrust/CUB ABI guarantees 

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,9 @@ For example, adding a new data member to a struct is an ABI Breaking Change as i
 In CCCL, the guarantees about ABI are as follows:
 
 - Symbols in the `thrust::` and `cub::` namespaces may break ABI at any time without warning.
-- The ABI of `cub::` symbols includes the CUDA architectures used for compilation. Therefore, a single `cub::` symbol may have a different ABI if compiled with different architectures.
+- The ABI of `thrust::` and `cub::` symbols includes the CUDA architectures used for compilation. Therefore, a single `cub::` symbol may have a different ABI if:
+    - compiled with different architectures
+    - compiled with nvcc vs host compiler only
 - Symbols in the `cuda::` namespace may also break ABI at any time. However, `cuda::` symbols embed an ABI version number that is incremented whenever an ABI break occurs. Multiple ABI versions may be supported concurrently, and therefore users have the option to revert to a prior ABI version. For more information, see [here](libcudacxx/docs/releases/versioning.md).
 
 **Who should care about ABI?**

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ In CCCL, the guarantees about ABI are as follows:
 - Symbols in the `thrust::` and `cub::` namespaces may break ABI at any time without warning.
 - The ABI of `thrust::` and `cub::` symbols includes the CUDA architectures used for compilation. Therefore, a single `cub::` symbol may have a different ABI if:
     - compiled with different architectures
-    - compiled with nvcc vs host compiler only
+    - compiled as a CUDA source file (`-x cu`) vs C++ source (`-x cpp`)
 - Symbols in the `cuda::` namespace may also break ABI at any time. However, `cuda::` symbols embed an ABI version number that is incremented whenever an ABI break occurs. Multiple ABI versions may be supported concurrently, and therefore users have the option to revert to a prior ABI version. For more information, see [here](libcudacxx/docs/releases/versioning.md).
 
 **Who should care about ABI?**

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ For example, adding a new data member to a struct is an ABI Breaking Change as i
 In CCCL, the guarantees about ABI are as follows:
 
 - Symbols in the `thrust::` and `cub::` namespaces may break ABI at any time without warning.
-- The ABI of `thrust::` and `cub::` symbols includes the CUDA architectures used for compilation. Therefore, a single `cub::` symbol may have a different ABI if:
+- The ABI of `thrust::` and `cub::` [symbols includes the CUDA architectures used for compilation](https://nvidia.github.io/cccl/cub/developer_overview.html#symbols-visibility). Therefore, a `thrust::` or `cub::` symbol may have a different ABI if:
     - compiled with different architectures
     - compiled as a CUDA source file (`-x cu`) vs C++ source (`-x cpp`)
 - Symbols in the `cuda::` namespace may also break ABI at any time. However, `cuda::` symbols embed an ABI version number that is incremented whenever an ABI break occurs. Multiple ABI versions may be supported concurrently, and therefore users have the option to revert to a prior ABI version. For more information, see [here](libcudacxx/docs/releases/versioning.md).


### PR DESCRIPTION
## Description

Adds `thrust::` to the docs about the archs included as an inline namespace, and further added additional detail about ABI incompatibility between host/device TUs. 
