### PR TITLE
Change numerical behavior of `complex::acosh` for certain edge cases

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -1486,9 +1486,18 @@ asinh(const complex<_Tp>& __x)
             return __x;
         return complex<_Tp>(__x.real(), __x.real());
     }
-    if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+    if (_CUDA_VSTD::__constexpr_isinf(__x.imag())) {
         return complex<_Tp>(copysign(__x.imag(), __x.real()), copysign(__pi/_Tp(2), __x.imag()));
+    }
+    if (__x.real() == 0 && __x.imag() == 0) {
+        return __x;
+    }
     complex<_Tp> __z = _CUDA_VSTD::log(__x + _CUDA_VSTD::sqrt(_CUDA_VSTD::__sqr(__x) + _Tp(1)));
+    if (!_CUDA_VSTD::__constexpr_isfinite(__z.real())) {
+        __z = _CUDA_VSTD::log(__x + _CUDA_VSTD::sqrt(complex<_Tp>(__x.real(), __x.imag() - _Tp(1)))
+                                  * _CUDA_VSTD::sqrt(complex<_Tp>(__x.real(), __x.imag() + _Tp(1))));
+        return complex<_Tp>(__z.real(), copysign(__z.imag(), __x.imag()));
+    }
     return complex<_Tp>(copysign(__z.real(), __x.real()), copysign(__z.imag(), __x.imag()));
 }
 
@@ -1520,10 +1529,11 @@ acosh(const complex<_Tp>& __x)
             return complex<_Tp>(_CUDA_VSTD::abs(__x.imag()), __x.real());
         return complex<_Tp>(__x.real(), __x.real());
     }
-    if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+    if (_CUDA_VSTD::__constexpr_isinf(__x.imag())) {
         return complex<_Tp>(_CUDA_VSTD::abs(__x.imag()), copysign(__pi/_Tp(2), __x.imag()));
-    complex<_Tp> __z = _CUDA_VSTD::log(__x + _CUDA_VSTD::sqrt(_CUDA_VSTD::__sqr(__x) - _Tp(1)));
-    return complex<_Tp>(copysign(__z.real(), _Tp(0)), copysign(__z.imag(), __x.imag()));
+    }
+    return _Tp(2.0) * _CUDA_VSTD::log(_CUDA_VSTD::sqrt(_Tp(0.5) * (__x + _Tp(1.0)))
+                                    + _CUDA_VSTD::sqrt(_Tp(0.5) * (__x - _Tp(1.0))));
 }
 
 // atanh

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/acosh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/acosh.pass.cpp
@@ -137,8 +137,24 @@ __host__ __device__ void test_edges()
         }
         else
         {
-            assert(!cuda::std::signbit(r.real()));
+            assert(!cuda::std::signbit(r.real()) || (cuda::std::cosh(r.real()) == 1));
             assert(cuda::std::signbit(r.imag()) == cuda::std::signbit(testcases[i].imag()));
+        }
+
+        const auto acosh_conj = cuda::std::acosh(cuda::std::conj(testcases[i]));
+        const auto conj_acosh = cuda::std::conj(cuda::std::acosh(testcases[i]));
+        if (acosh_conj != conj_acosh) {
+            if (cuda::std::isnan(acosh_conj.real())) {
+                assert(cuda::std::isnan(conj_acosh.real()));
+            } else if (cuda::std::isinf(acosh_conj.real())) {
+                assert(cuda::std::isinf(conj_acosh.real()));
+            } else if (cuda::std::isnan(acosh_conj.imag())) {
+                assert(cuda::std::isnan(conj_acosh.imag()));
+            } else if (cuda::std::isinf(acosh_conj.imag())) {
+                assert(cuda::std::isinf(conj_acosh.imag()));
+            } else {
+                assert(false);
+            }
         }
     }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/asinh.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/asinh.pass.cpp
@@ -117,6 +117,39 @@ __host__ __device__ void test_edges()
             assert(cuda::std::signbit(r.real()) == cuda::std::signbit(testcases[i].real()));
             assert(cuda::std::signbit(r.imag()) == cuda::std::signbit(testcases[i].imag()));
         }
+
+        const auto asinh_conj = cuda::std::asinh(cuda::std::conj(testcases[i]));
+        const auto conj_asinh = cuda::std::conj(cuda::std::asinh(testcases[i]));
+        if (asinh_conj != conj_asinh) {
+            if (cuda::std::isnan(asinh_conj.real())) {
+                assert(cuda::std::isnan(conj_asinh.real()));
+            } else if (cuda::std::isinf(asinh_conj.real())) {
+                assert(cuda::std::isinf(conj_asinh.real()));
+            } else if (cuda::std::isnan(asinh_conj.imag())) {
+                assert(cuda::std::isnan(conj_asinh.imag()));
+            } else if (cuda::std::isinf(asinh_conj.imag())) {
+                assert(cuda::std::isinf(conj_asinh.imag()));
+            } else {
+                assert(false);
+            }
+        }
+
+        const auto neg_asinh = -cuda::std::asinh(testcases[i]);
+        const auto asinh_neg = cuda::std::asinh(-testcases[i]);
+        if (neg_asinh != asinh_neg) {
+            if (cuda::std::isnan(neg_asinh.real())) {
+                assert(cuda::std::isnan(asinh_neg.real()));
+            } else if (cuda::std::isinf(neg_asinh.real())) {
+                assert(cuda::std::isinf(asinh_neg.real()));
+            } else if (cuda::std::isnan(neg_asinh.imag())) {
+                assert(cuda::std::isnan(asinh_neg.imag()));
+            } else if (cuda::std::isinf(neg_asinh.imag())) {
+                assert(cuda::std::isinf(asinh_neg.imag()));
+            } else {
+                assert(cuda::std::abs((neg_asinh.real()-asinh_neg.real())) < 1.e-3);
+                assert(cuda::std::abs((neg_asinh.imag()-asinh_neg.imag())) < 1.e-3);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
We want to preserve behavior from thrust::complex, which also happens to be consistent with the behavior of libstdc++

The change is that we are now using Kahans formula to calculate acosh. This greatly simplifies the implementation too which is nice

See https://se.mathworks.com/company/newsletters/articles/trigonometry-is-a-complex-subject.html

Fixes nvbug4445377