### PR TITLE
Make `cuda::stream_ref` universally available

### DIFF
--- a/libcudacxx/include/cuda/stream_ref
+++ b/libcudacxx/include/cuda/stream_ref
@@ -39,8 +39,6 @@ private:
 }  // cuda
 */
 
-#ifdef LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
-
 #include <cuda_runtime_api.h> // cuda_runtime_api needs to come first
 // clang-format on
 
@@ -185,7 +183,5 @@ public:
 _LIBCUDACXX_END_NAMESPACE_CUDA
 
 #include <cuda/std/detail/__pragma_pop>
-
-#endif // LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
 #endif //_CUDA_STREAM_REF


### PR DESCRIPTION
We had many users complain about the Guard and `stream_ref ` is simple enough so that we wont change its API dramatically
