### PR TITLE
[DOC]:  Move ptx.md out of extended API

### DIFF
--- a/libcudacxx/docs/contributing.md
+++ b/libcudacxx/docs/contributing.md
@@ -1,7 +1,7 @@
 ---
 has_children: true
 has_toc: true
-nav_order: 5
+nav_order: 6
 ---
 
 # Contributing

--- a/libcudacxx/docs/extended_api.md
+++ b/libcudacxx/docs/extended_api.md
@@ -23,8 +23,6 @@ nav_order: 3
 
 {% include_relative extended_api/memory_resource.md %}
 
-{% include_relative extended_api/ptx.md %}
-
 [Thread Scopes]: ./extended_api/memory_model.md#thread-scopes
 [Thread Groups]: ./extended_api/thread_groups.md
 

--- a/libcudacxx/docs/ptx.md
+++ b/libcudacxx/docs/ptx.md
@@ -1,3 +1,9 @@
+---
+has_children: true
+has_toc: false
+nav_order: 4
+---
+
 ## PTX instructions
 
 The `cuda::ptx` namespace contains functions that map one-to-one to

--- a/libcudacxx/docs/releases.md
+++ b/libcudacxx/docs/releases.md
@@ -1,7 +1,7 @@
 ---
 has_children: true
 has_toc: true
-nav_order: 4
+nav_order: 5
 ---
 
 # Releases


### PR DESCRIPTION


## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes #1307 

Previously, ptx.md was part of the extended API, but in the left hand side bar was listed as its own section. In addition, it was dumped in the Extended API overview page, which was not the intention.

Now, it has been moved out of the extended API, and moved to a separate spot in the left-hand side bar, below Extended API, and above Releases, and Contributing.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
