### PR TITLE
[DOC]: Fix documentation links

### DIFF
--- a/libcudacxx/docs/extended_api/asynchronous_operations.md
+++ b/libcudacxx/docs/extended_api/asynchronous_operations.md
@@ -1,8 +1,9 @@
 ## Asynchronous Operations
 
 | [`cuda::memcpy_async`]           | Asynchronously copies one range to another. `(function template)` <br/><br/> 1.1.0 / CUDA 11.0 <br/> 1.2.0 / CUDA 11.1 (group & aligned overloads) |
-| [`cuda::device_memcpy_async_tx`] | Asynchronously copies one range to another with manual transaction accounting. `(function)`                                                        |
+| [`cuda::device::memcpy_async_tx`] | Asynchronously copies one range to another with manual transaction accounting. `(function)`                                                        |
 
 
 [`cuda::memcpy_async`]: {{ "extended_api/asynchronous_operations/memcpy_async.html" | relative_url }}
+[`cuda::device::memcpy_async_tx`]: {{ "extended_api/asynchronous_operations/memcpy_async_tx.html" | relative_url }}
 

--- a/libcudacxx/docs/extended_api/synchronization_primitives/barrier.md
+++ b/libcudacxx/docs/extended_api/synchronization_primitives/barrier.md
@@ -137,6 +137,7 @@ __global__ void example_kernel() {
 [`cuda::barrier::init`]: ./barrier/init.md
 [`cuda::device::barrier_native_handle`]: ./barrier/barrier_native_handle.md
 [`cuda::device::barrier_arrive_tx`]: ./barrier/barrier_arrive_tx.md
+[`cuda::device::barrier_expect_tx`]: ./barrier/barrier_expect_tx.md
 
 [`cuda::std::barrier`]: https://en.cppreference.com/w/cpp/thread/barrier
 

--- a/libcudacxx/docs/extended_api/synchronization_primitives/barrier/barrier_arrive_tx.md
+++ b/libcudacxx/docs/extended_api/synchronization_primitives/barrier/barrier_arrive_tx.md
@@ -51,9 +51,7 @@ below.
 ## Example
 
 Below example shows only `cuda::device::barrier_arrive_tx`. A more extensive
-example can be found in the
-[`cuda::device::memcpy_async_tx`](../../../asynchronous_operations/memcpy_async_tx.md)
-documentation.
+example can be found in the [`cuda::device::memcpy_async_tx`] documentation.
 
 ```cuda
 #include <cuda/barrier>
@@ -83,3 +81,4 @@ __global__ void example_kernel() {
 [Tracking asynchronous operations by the mbarrier object]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tracking-asynchronous-operations-by-the-mbarrier-object
 [thread.barrier.class paragraph 12]: https://eel.is/c++draft/thread.barrier.class#12
 
+[`cuda::device::memcpy_async_tx`]: ../../asynchronous_operations/memcpy_async_tx.md


### PR DESCRIPTION
## Description

Closes #1310.

Fixes several broken links in the documentation.



## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
