### PR TITLE
Use relative includes for our public headers

### DIFF
--- a/libcudacxx/include/cuda/annotated_ptr
+++ b/libcudacxx/include/cuda/annotated_ptr
@@ -54,10 +54,19 @@
 #ifndef _CUDA_ANNOTATED_PTR
 #define _CUDA_ANNOTATED_PTR
 
-#include <cuda/std/cstdint>
-#include <cuda/barrier>
-#include <cuda/discard_memory>
+#include "__cccl_config"
 
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include "barrier"
+#include "discard_memory"
+#include "std/cstdint"
 #include "std/detail/__access_property"
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/barrier
+++ b/libcudacxx/include/cuda/barrier
@@ -11,6 +11,16 @@
 #ifndef _CUDA_BARRIER
 #define _CUDA_BARRIER
 
+#include "__cccl_config"
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
 #include "std/barrier"
 
 // Forward-declare CUtensorMap for use in cp_async_bulk_tensor_* PTX wrapping

--- a/libcudacxx/include/cuda/discard_memory
+++ b/libcudacxx/include/cuda/discard_memory
@@ -11,9 +11,18 @@
 #ifndef _CUDA_DISCARD_MEMORY
 #define _CUDA_DISCARD_MEMORY
 
-#include <cuda/std/cstdint>
-#include <cuda/std/detail/__config>
-#include <cuda/std/detail/libcxx/include/__cuda/ptx.h>
+#include "__cccl_config"
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include "std/cstdint"
+#include "ptx"
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/functional
+++ b/libcudacxx/include/cuda/functional
@@ -55,9 +55,19 @@
 #ifndef _CUDA_FUNCTIONAL_
 #define _CUDA_FUNCTIONAL_
 
-#include <cuda/std/type_traits>
-#include <cuda/std/functional>
-#include <cuda/std/utility>
+#include "__cccl_config"
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include "std/type_traits"
+#include "std/functional"
+#include "std/utility"
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 namespace __detail

--- a/libcudacxx/include/cuda/memory_resource
+++ b/libcudacxx/include/cuda/memory_resource
@@ -82,10 +82,9 @@ class resource_ref {
 
 #ifdef LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-// Needs to come first due to cuda_runtime_api
-#include <cuda/stream_ref>
+#include <cuda_runtime_api.h> // cuda_runtime_api needs to come first
 
-#include <cuda/__cccl_config>
+#include "__cccl_config"
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -95,8 +94,9 @@ class resource_ref {
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/concepts>
-#include <cuda/std/type_traits>
+#include "std/concepts"
+#include "std/type_traits"
+#include "stream_ref"
 
 #if _CCCL_STD_VER > 2011
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/pipeline
+++ b/libcudacxx/include/cuda/pipeline
@@ -53,6 +53,16 @@
 #ifndef _CUDA_PIPELINE
 #define _CUDA_PIPELINE
 
+#include "__cccl_config"
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
 #include "barrier"
 #include "atomic"
 #include "std/chrono"

--- a/libcudacxx/include/cuda/std/detail/__config
+++ b/libcudacxx/include/cuda/std/detail/__config
@@ -11,7 +11,7 @@
 #ifndef __cuda_std__
 #define __cuda_std__
 
-#include <cuda/std/detail/libcxx/include/__cccl/version.h>
+#include "libcxx/include/__cccl/version.h"
 
 #define _LIBCUDACXX_CUDA_API_VERSION CCCL_VERSION
 #define _LIBCUDACXX_CUDA_API_VERSION_MAJOR CCCL_MAJOR_VERSION

--- a/libcudacxx/include/cuda/std/ranges
+++ b/libcudacxx/include/cuda/std/ranges
@@ -10,11 +10,6 @@
 #ifndef _CUDA_RANGES
 #define _CUDA_RANGES
 
-#include "concepts"
-#include "initializer_list"
-#include "iterator"
-#include "type_traits"
-
 #include "detail/__config"
 
 #include "detail/__pragma_push"

--- a/libcudacxx/include/cuda/stream_ref
+++ b/libcudacxx/include/cuda/stream_ref
@@ -42,7 +42,7 @@ private:
 #include <cuda_runtime_api.h> // cuda_runtime_api needs to come first
 // clang-format on
 
-#include <cuda/__cccl_config>
+#include "__cccl_config"
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -52,8 +52,8 @@ private:
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/array>
-#include <cuda/std/type_traits>
+#include "std/array"
+#include "std/type_traits"
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 


### PR DESCRIPTION
This ensures we are picking up the right headers and not ones from other include paths.

Also we should ensure that we are properly treated as system headers when we actually have code in the header
