### PR TITLE
Functional requirements API

### DIFF
--- a/cub/cub/block/radix_rank_sort_operations.cuh
+++ b/cub/cub/block/radix_rank_sort_operations.cuh
@@ -43,6 +43,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cub/detail/meta.cuh>
 #include <cub/detail/type_traits.cuh>
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
@@ -149,21 +150,6 @@ struct ShiftDigitExtractor : BaseDigitExtractor<KeyT>
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 namespace detail
 {
-
-template <bool... Bs>
-struct logic_helper_t;
-
-template <bool>
-struct true_t
-{
-  static constexpr bool value = true;
-};
-
-template <bool... Bs>
-using all_t = //
-  ::cuda::std::is_same< //
-    logic_helper_t<Bs...>, //
-    logic_helper_t<true_t<Bs>::value...>>;
 
 struct identity_decomposer_t
 {

--- a/cub/cub/detail/meta.cuh
+++ b/cub/cub/detail/meta.cuh
@@ -1,0 +1,112 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/type_traits>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+
+template <class... >
+using void_t = void;
+
+template <bool... Bs>
+struct logic_helper_t;
+
+template <bool>
+struct false_t
+{
+  static constexpr bool value = false;
+};
+
+template <bool>
+struct true_t
+{
+  static constexpr bool value = true;
+};
+
+template <bool... Bs>
+using all_t = ::cuda::std::is_same<logic_helper_t<Bs...>, logic_helper_t<true_t<Bs>::value...>>;
+
+template <bool... Bs>
+using none_t = ::cuda::std::is_same<logic_helper_t<Bs...>, logic_helper_t<false_t<Bs>::value...>>;
+
+// True if `T` and `U` are ordered with `operator<`
+template <class T, class U, class = void>
+struct ordered : ::cuda::std::false_type
+{};
+
+template <class T, class U>
+struct ordered<T,
+               U,
+               void_t<decltype(::cuda::std::declval<T>() < ::cuda::std::declval<U>()
+                               && ::cuda::std::declval<U>() < ::cuda::std::declval<T>())>> : ::cuda::std::true_type
+{};
+
+// True if `T` and `U` can be compared at compile time with `operator<`
+template <class T, class U, class = void>
+struct statically_ordered : ::cuda::std::false_type
+{};
+
+template <class T, class U>
+struct statically_ordered<T, U, typename ::cuda::std::enable_if<true_t<T{} < U{} || U{} < T{}>::value>::type>
+    : ::cuda::std::true_type
+{};
+
+// True if `T{} < U{}` is true and can be computed at compile time
+template <class T, class U, class = void>
+struct statically_less : ::cuda::std::false_type
+{};
+
+template <class T, class U>
+struct statically_less<T, U, typename ::cuda::std::enable_if<T{} < U{}>::type> : ::cuda::std::true_type
+{};
+
+// True if `!(T{} < U{}) && !(T{} < T{})` and the expression can be computed at compile time
+template <class T, class U>
+struct statically_equal
+    : ::cuda::std::integral_constant<
+        bool,
+        statically_ordered<T, U>::value && !statically_less<T, U>::value && !statically_less<U, T>::value>
+{};
+
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/cub/detail/requirements.cuh
+++ b/cub/cub/detail/requirements.cuh
@@ -1,0 +1,200 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/detail/meta.cuh>
+
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+
+namespace requirements 
+{
+
+// The `operator<(T, T)` must exist
+template <class T>
+struct requirement : ordered<T, T>
+{};
+
+// True if all `Ts...` satisfy `requirement`
+template <class... Ts>
+struct list_of_requirements : all_t<requirement<Ts>::value...>
+{};
+
+template <class... Ts>
+struct list_of_requirements_from_unique_categories_impl : ::cuda::std::true_type
+{};
+
+template <class T, class... Ts>
+struct list_of_requirements_from_unique_categories_impl<T, Ts...>
+    : ::cuda::std::integral_constant<
+        bool,
+        none_t<ordered<T, Ts>::value...>::value && list_of_requirements_from_unique_categories_impl<Ts...>::value>
+{};
+
+// True if `Ts...` is a list of requirements, and i-th type in `Ts...` is not ordered with j-th type for all i != j
+template <class... Ts>
+struct list_of_requirements_from_unique_categories
+    : ::cuda::std::integral_constant<
+        bool,
+        list_of_requirements<Ts...>::value && list_of_requirements_from_unique_categories_impl<Ts...>::value>
+{};
+
+template <class CategoryRepresentativeT, class... Ts>
+struct first_categorial_match_rev_id : ::cuda::std::integral_constant<::cuda::std::size_t, sizeof...(Ts)>
+{};
+
+template <class CategoryRepresentativeT>
+struct first_categorial_match_rev_id<CategoryRepresentativeT> : ::cuda::std::integral_constant<::cuda::std::size_t, 0>
+{};
+
+template <class CategoryRepresentativeT, class H, class... Ts>
+struct first_categorial_match_rev_id<CategoryRepresentativeT, H, Ts...>
+    : ::cuda::std::integral_constant<::cuda::std::size_t,
+                                     ordered<CategoryRepresentativeT, H>::value
+                                       ? sizeof...(Ts) + 1
+                                       : first_categorial_match_rev_id<CategoryRepresentativeT, Ts...>::value>
+{};
+
+// Index of the first type in `Ts...` that `CategoryRepresentativeT` is ordered with
+// If no such type exists, returns `sizeof...(Ts)` (end)
+template <class CategoryRepresentativeT, class... Ts>
+struct first_categorial_match_id
+    : ::cuda::std::integral_constant<::cuda::std::size_t,
+                                     sizeof...(Ts) - first_categorial_match_rev_id<CategoryRepresentativeT, Ts...>::value>
+{};
+
+template <class CategoryRepresentativeT, ::cuda::std::size_t FirstMatchId, std::size_t E, class... Ts>
+struct first_categorial_match_impl
+{
+  using type = typename ::cuda::std::tuple_element<FirstMatchId, ::cuda::std::tuple<Ts...>>::type;
+};
+
+template <class CategoryRepresentativeT, std::size_t E>
+struct first_categorial_match_impl<CategoryRepresentativeT, E, E>
+{};
+
+template <class CategoryRepresentativeT, class... Ts>
+using first_categorial_match =
+  typename first_categorial_match_impl<CategoryRepresentativeT,
+                                       first_categorial_match_id<CategoryRepresentativeT, Ts...>::value,
+                                       sizeof...(Ts),
+                                       Ts...>::type;
+
+template <class GuaranteesT, class RequirementsT>
+struct requirements_categorically_match_guarantees : ::cuda::std::true_type
+{};
+
+template <class RequirementT, class... RequirementsTs, class... GuaranteesTs>
+struct requirements_categorically_match_guarantees<::cuda::std::tuple<GuaranteesTs...>,
+                                                   ::cuda::std::tuple<RequirementT, RequirementsTs...>>
+    : ::cuda::std::integral_constant<
+        bool,
+        !list_of_requirements_from_unique_categories<RequirementT, GuaranteesTs...>::value
+          && requirements_categorically_match_guarantees<::cuda::std::tuple<GuaranteesTs...>,
+                                                         ::cuda::std::tuple<RequirementsTs...>>::value>
+{};
+
+template <
+  class CategoryRepresentativeT,
+  class... Ts,
+  typename ::cuda::std::enable_if<first_categorial_match_id<CategoryRepresentativeT, Ts...>::value != sizeof...(Ts),
+                                  int>::type = 0>
+first_categorial_match<CategoryRepresentativeT, Ts...> match(const ::cuda::std::tuple<Ts...>& tpl)
+{
+  return ::cuda::std::get<first_categorial_match_id<CategoryRepresentativeT, Ts...>::value>(tpl);
+}
+
+template <class CategoryRepresentativeT,
+          class... GuaranteesTs,
+          class... RequirementsTs,
+          typename ::cuda::std::enable_if<
+            first_categorial_match_id<CategoryRepresentativeT, RequirementsTs...>::value != sizeof...(RequirementsTs),
+            int>::type = 0>
+first_categorial_match<CategoryRepresentativeT, RequirementsTs...>
+masked_value(const ::cuda::std::tuple<GuaranteesTs...>&, const ::cuda::std::tuple<RequirementsTs...>& requirements)
+{
+  return ::cuda::std::get<first_categorial_match_id<CategoryRepresentativeT, RequirementsTs...>::value>(requirements);
+}
+
+template <class CategoryRepresentativeT,
+          class... GuaranteesTs,
+          class... RequirementsTs,
+          typename ::cuda::std::enable_if<
+            first_categorial_match_id<CategoryRepresentativeT, RequirementsTs...>::value == sizeof...(RequirementsTs),
+            int>::type = 0>
+first_categorial_match<CategoryRepresentativeT, GuaranteesTs...>
+masked_value(const ::cuda::std::tuple<GuaranteesTs...>& guarantees, const ::cuda::std::tuple<RequirementsTs...>&)
+{
+  return ::cuda::std::get<first_categorial_match_id<CategoryRepresentativeT, GuaranteesTs...>::value>(guarantees);
+}
+
+template <class... GuaranteesTs, class... RequirementsTs>
+auto mask(const ::cuda::std::tuple<GuaranteesTs...>& guarantees,
+          const ::cuda::std::tuple<RequirementsTs...>& requirements)
+  -> decltype(::cuda::std::make_tuple(masked_value<GuaranteesTs>(guarantees, requirements)...))
+{
+  static_assert(list_of_requirements_from_unique_categories<GuaranteesTs...>::value,
+                "Guarantees must be from unique categories");
+  static_assert(list_of_requirements_from_unique_categories<RequirementsTs...>::value,
+                "Requirements must be from unique categories");
+  static_assert(requirements_categorically_match_guarantees<::cuda::std::tuple<GuaranteesTs...>,
+                                                            ::cuda::std::tuple<RequirementsTs...>>::value,
+                "Requested requirements are not supported by this algorithm");
+  // static_assert(!contains_unknown_requirements<std::tuple<Ss...>, std::tuple<GuaranteesTs...>>::value,
+  //               "Unknown requirements");
+  return ::cuda::std::make_tuple(masked_value<GuaranteesTs>(guarantees, requirements)...);
+}
+
+} // namespace requirements
+
+} // namespace detail
+
+template <class... RequirementsTs>
+::cuda::std::tuple<RequirementsTs...> require(RequirementsTs... requirements)
+{
+  static_assert(detail::requirements::list_of_requirements_from_unique_categories<RequirementsTs...>::value,
+                "Requirements must be unique");
+  return ::cuda::std::make_tuple(requirements...);
+}
+
+CUB_NAMESPACE_END

--- a/cub/cub/guarantees.cuh
+++ b/cub/cub/guarantees.cuh
@@ -1,0 +1,102 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cub/config.cuh>
+#include "cub/detail/meta.cuh"
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/detail/requirements.cuh>
+
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+
+namespace guarantees
+{
+
+template <class... GuaranteesTs>
+using guarantees_t = ::cuda::std::tuple<GuaranteesTs...>;
+
+enum class determinism_t
+{
+  not_guaranteed,
+  run_to_run
+};
+
+template <determinism_t Guarantee>
+struct determinism_holder_t
+{
+  static constexpr determinism_t value = Guarantee;
+};
+
+template <determinism_t L, determinism_t R>
+_CCCL_HOST_DEVICE constexpr bool operator<(determinism_holder_t<L>, determinism_holder_t<R>)
+{
+  return L < R;
+}
+
+using run_to_run_deterministic_t   = determinism_holder_t<determinism_t::run_to_run>;
+using determinism_not_guaranteed_t = determinism_holder_t<determinism_t::not_guaranteed>;
+
+template <class GuaranteesT, class RequirementsT>
+struct statically_satisfy : ::cuda::std::false_type
+{};
+
+template <class... GuaranteesTs, class... RequirementsTs>
+struct statically_satisfy<::cuda::std::tuple<GuaranteesTs...>, ::cuda::std::tuple<RequirementsTs...>>
+    : ::cuda::std::integral_constant<bool,
+                                     all_t<statically_less<RequirementsTs, GuaranteesTs>::value
+                                           || statically_equal<RequirementsTs, GuaranteesTs>::value
+                                           || !statically_ordered<GuaranteesTs, RequirementsTs>::value...>::value>
+{};
+
+} // namespace guarantees
+
+} // namespace detail
+
+inline namespace guarantees
+{
+
+_CCCL_GLOBAL_CONSTANT detail::guarantees::run_to_run_deterministic_t run_to_run_determinism{};
+_CCCL_GLOBAL_CONSTANT detail::guarantees::determinism_not_guaranteed_t nondeterminism{};
+
+} // namespace guarantees
+
+CUB_NAMESPACE_END

--- a/cub/test/catch2_test_guarantees.cu
+++ b/cub/test/catch2_test_guarantees.cu
@@ -1,0 +1,314 @@
+/******************************************************************************
+ * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <cub/guarantees.cuh>
+
+#include <limits>
+
+#include <c2h/catch2_test_helper.h>
+
+TEST_CASE("Determinism guarantees are ordered", "[guarantees]")
+{
+  auto strong = cub::require(cub::run_to_run_determinism);
+  auto weak   = cub::require(cub::nondeterminism);
+
+  REQUIRE(!(strong < strong));
+  REQUIRE(!(weak < weak));
+  REQUIRE((weak < strong));
+  REQUIRE(!(strong < weak));
+  STATIC_REQUIRE(cub::nondeterminism < cub::run_to_run_determinism);
+  STATIC_REQUIRE(!(cub::run_to_run_determinism < cub::nondeterminism));
+}
+
+namespace detail
+{
+struct max_memory_footprint_t
+{
+  ::cuda::std::size_t bytes{::cuda::std::numeric_limits<::cuda::std::size_t>::max()};
+
+  max_memory_footprint_t() = default;
+  explicit max_memory_footprint_t(::cuda::std::size_t bytes)
+      : bytes{bytes}
+  {}
+
+  friend inline bool operator<(max_memory_footprint_t lhs, max_memory_footprint_t rhs)
+  {
+    return lhs.bytes > rhs.bytes;
+  }
+};
+
+struct max_memory_footprint_fn_t
+{
+  max_memory_footprint_t operator()(std::size_t bytes) const
+  {
+    return max_memory_footprint_t{bytes};
+  }
+};
+
+} // namespace detail
+
+enum class reduce_backend_detector_t
+{
+  run_to_run_deterministic__small_buffer,
+  non_deterministic__small_buffer,
+  run_to_run_deterministic__large_buffer,
+  non_deterministic__large_buffer
+};
+
+class reduce
+{
+  // Example of exhaustive dispatch
+  template <class IteratorT>
+  static reduce_backend_detector_t
+  sum(IteratorT,
+      IteratorT,
+      cub::detail::guarantees::run_to_run_deterministic_t,
+      detail::max_memory_footprint_t max_footprint)
+  {
+    if (max_footprint.bytes == ::cuda::std::numeric_limits<std::size_t>::max())
+    {
+      return reduce_backend_detector_t::run_to_run_deterministic__large_buffer;
+    }
+    return reduce_backend_detector_t::run_to_run_deterministic__small_buffer;
+  }
+
+  template <class IteratorT>
+  static reduce_backend_detector_t
+  sum(IteratorT,
+      IteratorT,
+      cub::detail::guarantees::determinism_not_guaranteed_t,
+      detail::max_memory_footprint_t max_footprint)
+  {
+    if (max_footprint.bytes == ::cuda::std::numeric_limits<std::size_t>::max())
+    {
+      return reduce_backend_detector_t::non_deterministic__large_buffer;
+    }
+    return reduce_backend_detector_t::non_deterministic__small_buffer;
+  }
+
+public:
+  static constexpr detail::max_memory_footprint_fn_t max_memory_footprint{};
+
+  // User-visible default guarantees
+  using default_guarantees_t =
+    cub::detail::guarantees::guarantees_t<cub::detail::guarantees::determinism_not_guaranteed_t,
+                                          detail::max_memory_footprint_t>;
+
+  template <class IteratorT, class RequirementsT = default_guarantees_t>
+  static reduce_backend_detector_t
+  sum(IteratorT begin, IteratorT end, RequirementsT requirements = default_guarantees_t())
+  {
+    auto guarantees    = cub::detail::requirements::mask(default_guarantees_t(), requirements);
+    auto max_footprint = cub::detail::requirements::match<detail::max_memory_footprint_t>(guarantees);
+    auto determinism = cub::detail::requirements::match<cub::detail::guarantees::run_to_run_deterministic_t>(guarantees);
+    return reduce::sum(begin, end, determinism, max_footprint);
+  }
+};
+
+TEST_CASE("Max memory footprint is ordered", "[guarantees]")
+{
+  detail::max_memory_footprint_t();
+  auto small = reduce::max_memory_footprint(1);
+  auto big   = reduce::max_memory_footprint(2);
+
+  REQUIRE(!(small < small));
+  REQUIRE(!(big < big));
+
+  // smaller buffer size requirement is more strict
+  REQUIRE((big < small));
+  REQUIRE(!(small < big));
+}
+
+TEST_CASE("Tag dispatch works", "[guarantees]")
+{
+  int data[] = {1, 2, 3, 4, 5};
+
+  {
+    reduce_backend_detector_t backend = reduce::sum(cuda::std::begin(data), cuda::std::end(data));
+    REQUIRE((backend == reduce_backend_detector_t::non_deterministic__large_buffer));
+  }
+
+  {
+    reduce_backend_detector_t backend =
+      reduce::sum(cuda::std::begin(data), cuda::std::end(data), cub::require(cub::run_to_run_determinism));
+    REQUIRE((backend == reduce_backend_detector_t::run_to_run_deterministic__large_buffer));
+  }
+
+  {
+    reduce_backend_detector_t backend =
+      reduce::sum(cuda::std::begin(data), cuda::std::end(data), cub::require(reduce::max_memory_footprint(1)));
+    REQUIRE((backend == reduce_backend_detector_t::non_deterministic__small_buffer));
+  }
+
+  {
+    reduce_backend_detector_t backend = reduce::sum(
+      cuda::std::begin(data),
+      cuda::std::end(data),
+      cub::require(cub::run_to_run_determinism, reduce::max_memory_footprint(1)));
+    REQUIRE((backend == reduce_backend_detector_t::run_to_run_deterministic__small_buffer));
+  }
+
+  {
+    reduce_backend_detector_t backend = reduce::sum(
+      cuda::std::begin(data), cuda::std::end(data), cub::require(cub::nondeterminism, reduce::max_memory_footprint(1)));
+    REQUIRE((backend == reduce_backend_detector_t::non_deterministic__small_buffer));
+  }
+}
+
+namespace detail
+{
+
+template <class T>
+struct preserve_partials_in_t
+{
+  T* d_ptr{};
+
+  preserve_partials_in_t() = default;
+  explicit preserve_partials_in_t(T* d_ptr)
+      : d_ptr{d_ptr}
+  {}
+};
+
+struct discard_partials_t
+{};
+
+constexpr bool operator<(discard_partials_t, discard_partials_t)
+{
+  return false;
+}
+
+template <class T>
+constexpr bool operator<(discard_partials_t, preserve_partials_in_t<T>)
+{
+  return true;
+}
+
+template <class T>
+constexpr bool operator<(preserve_partials_in_t<T>, discard_partials_t)
+{
+  return false;
+}
+
+template <class T, class U>
+constexpr bool operator<(preserve_partials_in_t<T>, preserve_partials_in_t<U>)
+{
+  return false;
+}
+
+} // namespace detail
+
+enum class scan_backend_detector_t
+{
+  weak,
+  strong
+};
+
+class scan
+{
+  // Two impplementations of scan:
+  // 1. run-to-run deterministic, work efficient, preserving partials, and
+  // 2. non-deterministic and memory efficient
+
+  using weak_guarantees_t = cub::detail::guarantees::guarantees_t<cub::detail::guarantees::determinism_not_guaranteed_t,
+                                                                  detail::discard_partials_t>;
+
+  using strong_guarantees_t = cub::detail::guarantees::guarantees_t<cub::detail::guarantees::run_to_run_deterministic_t,
+                                                                    detail::preserve_partials_in_t<void>>;
+
+  using default_guarantees_t = weak_guarantees_t;
+
+  template <class IteratorT, class RequirementsT>
+  static typename ::cuda::std::enable_if<
+    cub::detail::guarantees::statically_satisfy<weak_guarantees_t, RequirementsT>::value,
+    scan_backend_detector_t>::type
+  sum_impl(IteratorT, IteratorT, RequirementsT)
+  {
+    return scan_backend_detector_t::weak;
+  }
+
+  template <class IteratorT, class RequirementsT>
+  static typename ::cuda::std::enable_if<
+    !cub::detail::guarantees::statically_satisfy<weak_guarantees_t, RequirementsT>::value
+      && cub::detail::guarantees::statically_satisfy<strong_guarantees_t, RequirementsT>::value,
+    scan_backend_detector_t>::type
+  sum_impl(IteratorT, IteratorT, RequirementsT)
+  {
+    return scan_backend_detector_t::strong;
+  }
+
+public:
+  template <class T>
+  static detail::preserve_partials_in_t<T> preserve_partials_in(T* d_ptr)
+  {
+    return detail::preserve_partials_in_t<T>{d_ptr};
+  }
+
+  template <class IteratorT, class RequirementsT = default_guarantees_t>
+  scan_backend_detector_t sum(IteratorT begin, IteratorT end, RequirementsT requirements = default_guarantees_t())
+  {
+    return sum_impl(begin, end, cub::detail::requirements::mask(default_guarantees_t(), requirements));
+  }
+};
+
+TEST_CASE("Subsumption works", "[guarantees]")
+{
+  int data[] = {1, 2, 3, 4, 5};
+  int partials[] = {1, 3, 6, 10, 15};
+
+  {
+    scan_backend_detector_t backend = scan().sum(cuda::std::begin(data), cuda::std::end(data));
+    REQUIRE((backend == scan_backend_detector_t::weak));
+  }
+
+  {
+    scan_backend_detector_t backend =
+      scan().sum(cuda::std::begin(data), cuda::std::end(data), cub::require(cub::run_to_run_determinism));
+    REQUIRE((backend == scan_backend_detector_t::strong));
+  }
+
+  {
+    scan_backend_detector_t backend =
+      scan().sum(cuda::std::begin(data), cuda::std::end(data), cub::require(scan::preserve_partials_in(partials)));
+    REQUIRE((backend == scan_backend_detector_t::strong));
+  }
+
+  {
+    scan_backend_detector_t backend = scan().sum(
+      cuda::std::begin(data),
+      cuda::std::end(data),
+      cub::require(cub::run_to_run_determinism, scan::preserve_partials_in(partials)));
+    REQUIRE((backend == scan_backend_detector_t::strong));
+  }
+
+  {
+    scan_backend_detector_t backend = scan().sum(
+      cuda::std::begin(data),
+      cuda::std::end(data),
+      cub::require(cub::nondeterminism, scan::preserve_partials_in(partials)));
+    REQUIRE((backend == scan_backend_detector_t::strong));
+  }
+}

--- a/cub/test/catch2_test_meta.cu
+++ b/cub/test/catch2_test_meta.cu
@@ -1,0 +1,98 @@
+/******************************************************************************
+ * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <c2h/catch2_test_helper.h>
+
+#include <cub/detail/meta.cuh>
+
+TEST_CASE("all_t works", "[meta][utils]")
+{
+  STATIC_REQUIRE(cub::detail::all_t<false, true, true>::value == false);
+  STATIC_REQUIRE(cub::detail::all_t<true, false, true>::value == false);
+  STATIC_REQUIRE(cub::detail::all_t<true, true, false>::value == false);
+  STATIC_REQUIRE(cub::detail::all_t<true, true, true>::value == true);
+  STATIC_REQUIRE(cub::detail::all_t<true, true>::value == true);
+  STATIC_REQUIRE(cub::detail::all_t<true>::value == true);
+  STATIC_REQUIRE(cub::detail::all_t<>::value == true);
+}
+
+TEST_CASE("none_t works", "[meta][utils]")
+{
+  STATIC_REQUIRE(cub::detail::none_t<false, true, true>::value == false);
+  STATIC_REQUIRE(cub::detail::none_t<true, false, true>::value == false);
+  STATIC_REQUIRE(cub::detail::none_t<true, true, false>::value == false);
+  STATIC_REQUIRE(cub::detail::none_t<true, true, true>::value == false);
+  STATIC_REQUIRE(cub::detail::none_t<false, false>::value == true);
+  STATIC_REQUIRE(cub::detail::none_t<false>::value == true);
+  STATIC_REQUIRE(cub::detail::none_t<>::value == true);
+}
+
+struct A{};
+struct B{};
+struct C{};
+struct D{};
+
+template <class T>
+bool operator<(A, T) { return false; }
+constexpr bool operator<(B, A) { return true; }
+constexpr bool operator<(A, C) { return false; }
+
+constexpr bool operator<(A, D) { return false; }
+constexpr bool operator<(D, A) { return false; }
+
+TEST_CASE("ordered works", "[meta][utils]")
+{
+  STATIC_REQUIRE(cub::detail::ordered<A, B>::value == true);
+  STATIC_REQUIRE(cub::detail::ordered<B, A>::value == true);
+  STATIC_REQUIRE(cub::detail::ordered<A, C>::value == false);
+  STATIC_REQUIRE(cub::detail::ordered<B, C>::value == false);
+}
+
+TEST_CASE("staticly_ordered works", "[meta][utils]")
+{
+  STATIC_REQUIRE(cub::detail::statically_ordered<A, B>::value == false);
+  STATIC_REQUIRE(cub::detail::statically_ordered<B, A>::value == true);
+  STATIC_REQUIRE(cub::detail::statically_ordered<A, C>::value == false);
+  STATIC_REQUIRE(cub::detail::statically_ordered<B, C>::value == false);
+}
+
+TEST_CASE("staticly_less works", "[meta][utils]")
+{
+  STATIC_REQUIRE(cub::detail::statically_less<A, B>::value == false);
+  STATIC_REQUIRE(cub::detail::statically_less<B, A>::value == true);
+  STATIC_REQUIRE(cub::detail::statically_less<A, C>::value == false);
+  STATIC_REQUIRE(cub::detail::statically_less<B, C>::value == false);
+}
+
+TEST_CASE("staticly_equal works", "[meta][utils]")
+{
+  STATIC_REQUIRE(cub::detail::statically_equal<A, A>::value == false);
+  STATIC_REQUIRE(cub::detail::statically_equal<A, D>::value == true);
+  STATIC_REQUIRE(cub::detail::statically_equal<D, A>::value == true);
+  STATIC_REQUIRE(cub::detail::statically_equal<A, C>::value == false);
+  STATIC_REQUIRE(cub::detail::statically_equal<B, C>::value == false);
+}

--- a/cub/test/catch2_test_requirements.cu
+++ b/cub/test/catch2_test_requirements.cu
@@ -1,0 +1,189 @@
+/******************************************************************************
+ * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <c2h/catch2_test_helper.h>
+
+#include <cub/detail/requirements.cuh>
+
+struct A{ int v; };
+struct B{};
+struct C{};
+struct D{};
+
+template <class T>
+bool operator<(A, T) { return false; }
+constexpr bool operator<(B, A) { return true; }
+
+template <class T>
+constexpr bool operator<(C, T) { return false; }
+
+constexpr bool operator<(D, D) { return false; }
+
+TEST_CASE("requirement works", "[requirements][meta]")
+{
+  STATIC_REQUIRE(cub::detail::requirements::requirement<A>::value == true);
+  STATIC_REQUIRE(cub::detail::requirements::requirement<B>::value == false);
+}
+
+TEST_CASE("list_of_requirement works", "[requirements][meta]")
+{
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements<A>::value == true);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements<B>::value == false);
+
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements<A, A, A>::value == true);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements<B, A, A>::value == false);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements<A, B, A>::value == false);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements<A, A, B>::value == false);
+}
+
+TEST_CASE("list_of_requirements_from_unique_categories works", "[requirements][meta]")
+{
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<>::value == true);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<A>::value == true);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<C>::value == true);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<A, C>::value == false);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<A, D>::value == true);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<D, C>::value == true);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<D, D>::value == false);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<A, D, C>::value == false);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<A, C, D>::value == false);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<C, A, D>::value == false);
+  STATIC_REQUIRE(cub::detail::requirements::list_of_requirements_from_unique_categories<C, D, A>::value == false);
+}
+
+TEST_CASE("first_categorial_match_id works", "[requirements][meta]")
+{
+  STATIC_REQUIRE(cub::detail::requirements::first_categorial_match_id<A>::value == 0);
+  STATIC_REQUIRE(cub::detail::requirements::first_categorial_match_id<A, A>::value == 0);
+  STATIC_REQUIRE(cub::detail::requirements::first_categorial_match_id<A, C>::value == 0);
+  STATIC_REQUIRE(cub::detail::requirements::first_categorial_match_id<A, C, D>::value == 0);
+  STATIC_REQUIRE(cub::detail::requirements::first_categorial_match_id<A, D, C>::value == 1);
+}
+
+TEST_CASE("first_categorial_match works", "[requirements][meta]")
+{
+  STATIC_REQUIRE(std::is_same<cub::detail::requirements::first_categorial_match<A, A>, A>::value);
+  STATIC_REQUIRE(std::is_same<cub::detail::requirements::first_categorial_match<A, D, C>, C>::value);
+  STATIC_REQUIRE(std::is_same<cub::detail::requirements::first_categorial_match<A, D, A>, A>::value);
+  STATIC_REQUIRE(std::is_same<cub::detail::requirements::first_categorial_match<A, A, D>, A>::value);
+  STATIC_REQUIRE(std::is_same<cub::detail::requirements::first_categorial_match<A, C, D>, C>::value);
+}
+
+TEST_CASE("requirements_categorically_match_guarantees works", "[requirements][meta]")
+{
+  STATIC_REQUIRE(
+    cub::detail::requirements::requirements_categorically_match_guarantees<::cuda::std::tuple<A>,
+                                                                           ::cuda::std::tuple<A>>::value);
+  STATIC_REQUIRE(
+    cub::detail::requirements::requirements_categorically_match_guarantees<::cuda::std::tuple<A, D>,
+                                                                           ::cuda::std::tuple<A>>::value);
+  STATIC_REQUIRE(
+    cub::detail::requirements::requirements_categorically_match_guarantees<::cuda::std::tuple<A, D>,
+                                                                           ::cuda::std::tuple<D>>::value);
+  STATIC_REQUIRE(
+    cub::detail::requirements::requirements_categorically_match_guarantees<::cuda::std::tuple<A, D>,
+                                                                           ::cuda::std::tuple<A, D>>::value);
+  STATIC_REQUIRE(
+    cub::detail::requirements::requirements_categorically_match_guarantees<::cuda::std::tuple<A, D>,
+                                                                           ::cuda::std::tuple<A, D>>::value);
+  STATIC_REQUIRE(
+    cub::detail::requirements::requirements_categorically_match_guarantees<::cuda::std::tuple<A, D>,
+                                                                           ::cuda::std::tuple<C>>::value);
+  STATIC_REQUIRE(
+    !cub::detail::requirements::requirements_categorically_match_guarantees<::cuda::std::tuple<D>,
+                                                                            ::cuda::std::tuple<C>>::value);
+}
+
+TEST_CASE("get works", "[requirements][meta]")
+{
+  A a1{1};
+  A a2{2};
+
+  REQUIRE(cub::detail::requirements::match<C>(::cuda::std::make_tuple(a1)).v == a1.v);
+  REQUIRE(cub::detail::requirements::match<C>(::cuda::std::make_tuple(a2)).v == a2.v);
+  REQUIRE(cub::detail::requirements::match<C>(::cuda::std::make_tuple(D{}, a2)).v == a2.v);
+  REQUIRE(cub::detail::requirements::match<C>(::cuda::std::make_tuple(a2, D{})).v == a2.v);
+}
+
+TEST_CASE("mask works", "[requirements][meta]")
+{
+  A a1{1};
+  A a2{2};
+
+  {
+    auto defaults = ::cuda::std::make_tuple(a1);
+    auto requirements = ::cuda::std::make_tuple();
+    auto guarantees = cub::detail::requirements::mask(defaults, requirements);
+
+    REQUIRE(::cuda::std::get<0>(guarantees).v == 1);
+  }
+
+  {
+    auto defaults = ::cuda::std::make_tuple(a1);
+    auto requirements = ::cuda::std::make_tuple(a2);
+    auto guarantees = cub::detail::requirements::mask(defaults, requirements);
+
+    REQUIRE(::cuda::std::get<0>(guarantees).v == 2);
+  }
+
+  {
+    auto defaults = ::cuda::std::make_tuple(a1, D{});
+    auto requirements = ::cuda::std::make_tuple(a2);
+    auto guarantees = cub::detail::requirements::mask(defaults, requirements);
+
+    REQUIRE(::cuda::std::get<0>(guarantees).v == 2);
+  }
+
+  {
+    auto defaults = ::cuda::std::make_tuple(D{}, a1);
+    auto requirements = ::cuda::std::make_tuple(a2);
+    auto guarantees = cub::detail::requirements::mask(defaults, requirements);
+
+    REQUIRE(::cuda::std::get<1>(guarantees).v == 2);
+  }
+}
+
+TEST_CASE("require works", "[requirements][meta]")
+{
+  A a1{1};
+  A a2{2};
+  D d{};
+
+  {
+    auto guarantees = cub::require(a1);
+
+    REQUIRE(::cuda::std::get<0>(guarantees).v == a1.v);
+    REQUIRE(::cuda::std::tuple_size<decltype(guarantees)>::value == 1);
+  }
+
+  {
+    auto guarantees = cub::require(a2, d);
+
+    REQUIRE(::cuda::std::get<0>(guarantees).v == a2.v);
+    REQUIRE(::cuda::std::tuple_size<decltype(guarantees)>::value == 2);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/1187

<!-- Provide a standalone description of changes in this PR. -->

This is a prerequisite PR for deterministic scan. This PR provides an implementation and a design alternative for functional requirements API. Some of the functional requirements to the design below:

## Design Requirements
### Generic
The requirements API should not be limited to determinism guarantees. There are use cases where clients couldn't use scan because it's not work efficient (invokes operator more times than needed). Alternatively, one could imagine a functional requirement on the maximal temporary storage size. The design of functional requirements API should allow alternative functional requirements going forward. 

### Algorithm Specific
There might be algorithm-specific functional guarantees. For instance, in the for-each one could relax the requirement of not being able to copy elements or alternatively, the user can explicitly require that the function object is invoked on the original value. Alternatively, we scan might provide a guarantee on storing partial aggregates. 

### Library-Wide Requirements
Opposite to the previous requirement, we should provide library-wide requirements. It won't be a great experience if every algorithm provide it's own version of determinism requirements. This can get inconsistent quickly. Apart from that, when we start working on determinism API exposure in Thrust, it'll be mush easier to attach "run-to-run deterministic" tag to execution policy as opposed to attaching such a tag to each algorithm.

### Type Safe
If given functional requirement can't be satisfied, the most sound approach would be to fail at compile time. If we introduce the functional requirement API for some algorithm, but then forget to handle, say, determinism requirements, it'll be a critical issue on the users end. I incline towards emitting a compile-time error if we see function requirement that's not known to a given algorithm.

### Visible Defaults
The default deterministic API "parameter" should be defined on the algorithm basis. Apart from different algorithms exposing different guarantees (scan vs reduce), this would provide some visibility into algorithm behavior without looking deep into the implementation.

### Runtime
The API should allow passing runtime parameters. Say you have N free bytes in memory and you request a given algorithm (reduce by key) to fit into this memory. This is a functional requirement which requires runtime parameter. 

## Design Alternative

Details on the design are given in the developer overview section of CUB docs. I'll briefly highlight user-facing API here. The terminology is the following. Algorithms provide guarantees, whereas users have requirements. Examples of the requirements API:

```cpp
// default guarantees (see below)
reduce::sum(begin, end);

// run-to-run determinism is enforced
reduce::sum(begin, end, cub::require(cub::run_to_run_determinism));

// default determinism guarantees, memory footprint limit
reduce::sum(begin, end, cub::require(cub::max_memory_footprint(128_KB)));

// default determinism guarantees, memory footprint limit
reduce::sum(begin, end, cub::require(cub::max_memory_footprint(128_KB)));

// run-to-run deterministic with memory footprint limit
reduce::sum(begin, end, cub::require(cub::run_to_run_determinism,
                                     cub::max_memory_footprint(128_KB)));
```

The requirements belong to requirement categories. For instance, `cub::run_to_run_determinism` shares category with `cub::nondeterminism`. Only one requirement per category is allowed in the requirements list.

The requirements API allows:

- stateful requirements
- providing requirements in any order
- not instantiating unrelated kernels
- failing at compile time if requirements can’t be satisfied

The requirements API doesn’t allow:

- multiple requirements from the same category in the requirements list
- providing requirements from the category that is not supported by the algorithm

Users do not see passed this API. As far as users are concerned, we reserve the right to change default guarantees at any time. If there are functional requirements that are critical for users, those should be specified specifically.

All guarantees are ordered within the category. We reserve the right to select the implementation with stronger guarantees compared to what user requested. The remaining part of this section is only related to CUB developers.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
