### PR TITLE
Replace deprecated `_VSTD` macro with `std`

### DIFF
--- a/thrust/thrust/type_traits/is_contiguous_iterator.h
+++ b/thrust/thrust/type_traits/is_contiguous_iterator.h
@@ -147,7 +147,11 @@ struct is_libcxx_wrap_iter : false_type {};
 #if defined(_LIBCPP_VERSION)
 template <typename Iterator>
 struct is_libcxx_wrap_iter<
+#  if _LIBCPP_VERSION < 14000
+  _VSTD::__wrap_iter<Iterator>
+#  else
   std::__wrap_iter<Iterator>
+#  endif
 > : true_type {};
 #endif
 

--- a/thrust/thrust/type_traits/is_contiguous_iterator.h
+++ b/thrust/thrust/type_traits/is_contiguous_iterator.h
@@ -147,7 +147,7 @@ struct is_libcxx_wrap_iter : false_type {};
 #if defined(_LIBCPP_VERSION)
 template <typename Iterator>
 struct is_libcxx_wrap_iter<
-  _VSTD::__wrap_iter<Iterator>
+  std::__wrap_iter<Iterator>
 > : true_type {};
 #endif
 


### PR DESCRIPTION
## Description

The `_VSTD` macro in libc++ has been unnecessary since LLVM 14.0, and is now removed from trunk, which will eventually be released as LLVM 19.0. Anyone using libc++ 14.0 or greater can just use `std` instead. As LLVM 14.0 was released mid-2022, which is relatively recent, we can check the specific `_LIBCPP_VERSION` value to provide backwards compatibility, as prior to 14.0 it had a different value.

Timeline of LLVM changes:
- LLVM 13.0 config with the old definition, which includes an inline namespace: https://github.com/llvm/llvm-project/blob/release/13.x/libcxx/include/__config
- Change to make it just `std`: https://github.com/llvm/llvm-project/commit/453620f55ea38186cdf165b1ca2deb6c6b226132
- LLVM 14.0 config with the new definition: https://github.com/llvm/llvm-project/blob/release/14.x/libcxx/include/__config
- Removal from trunk: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
