### PR TITLE
PTX: Add `cuda::ptx::fence`

### DIFF
--- a/libcudacxx/docs/ptx.md
+++ b/libcudacxx/docs/ptx.md
@@ -502,7 +502,8 @@ int main() {
 | [`bar, barrier`]      | No                      |
 | [`bar.warp.sync`]     | No                      |
 | [`barrier.cluster`]   | No                      |
-| [`membar/fence`]      | No                      |
+| [`membar`]            | No                      |
+| [`fence`]             | CTK-FUTURE, CCCL v2.4.0 |
 | [`atom`]              | No                      |
 | [`red`]               | No                      |
 | [`red.async`]         | CTK-FUTURE, CCCL v2.3.0 |
@@ -517,7 +518,8 @@ int main() {
 [`bar, barrier`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-bar-barrier
 [`bar.warp.sync`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-bar-warp-sync
 [`barrier.cluster`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-barrier-cluster
-[`membar/fence`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-membar-fence
+[`membar`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-membar-fence
+[`fence`]: #fence
 [`atom`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-atom
 [`red`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-red
 [`red.async`]: #redasync
@@ -528,6 +530,82 @@ int main() {
 [`redux.sync`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-redux-sync
 [`griddepcontrol`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-griddepcontrol
 [`elect.sync`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-elect-sync
+
+#### `fence`
+
+- PTX ISA: [`fence`](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-membar-fence)
+
+**fence**:
+```cuda
+// fence{.sem}.scope; // 1. PTX ISA 60, SM_70
+// .sem       = { .sc, .acq_rel }
+// .scope     = { .cta, .gpu, .sys }
+template <cuda::ptx::dot_sem Sem, cuda::ptx::dot_scope Scope>
+__device__ static inline void fence(
+  cuda::ptx::sem_t<Sem> sem,
+  cuda::ptx::scope_t<Scope> scope);
+
+// fence{.sem}.scope; // 2. PTX ISA 78, SM_90
+// .sem       = { .sc, .acq_rel }
+// .scope     = { .cluster }
+template <cuda::ptx::dot_sem Sem>
+__device__ static inline void fence(
+  cuda::ptx::sem_t<Sem> sem,
+  cuda::ptx::scope_cluster_t);
+```
+
+**fence_mbarrier_init**:
+```cuda
+// fence.mbarrier_init.sem.scope; // 3. PTX ISA 80, SM_90
+// .sem       = { .release }
+// .scope     = { .cluster }
+template <typename=void>
+__device__ static inline void fence_mbarrier_init(
+  cuda::ptx::sem_release_t,
+  cuda::ptx::scope_cluster_t);
+```
+
+**fence_proxy_alias**:
+```cuda
+// fence.proxy.alias; // 4. PTX ISA 75, SM_70
+template <typename=void>
+__device__ static inline void fence_proxy_alias();
+```
+
+**fence_proxy_async**:
+```cuda
+// fence.proxy.async; // 5. PTX ISA 80, SM_90
+template <typename=void>
+__device__ static inline void fence_proxy_async();
+
+// fence.proxy.async{.space}; // 6. PTX ISA 80, SM_90
+// .space     = { .global, .shared::cluster, .shared::cta }
+template <cuda::ptx::dot_space Space>
+__device__ static inline void fence_proxy_async(
+  cuda::ptx::space_t<Space> space);
+```
+
+**fence_proxy_tensormap_generic**:
+```cuda
+// fence.proxy.tensormap::generic.release.scope; // 7. PTX ISA 83, SM_90
+// .sem       = { .release }
+// .scope     = { .cta, .cluster, .gpu, .sys }
+template <cuda::ptx::dot_scope Scope>
+__device__ static inline void fence_proxy_tensormap_generic(
+  cuda::ptx::sem_release_t,
+  cuda::ptx::scope_t<Scope> scope);
+
+// fence.proxy.tensormap::generic.sem.scope [addr], size; // 8. PTX ISA 83, SM_90
+// .sem       = { .acquire }
+// .scope     = { .cta, .cluster, .gpu, .sys }
+template <int N32, cuda::ptx::dot_scope Scope>
+__device__ static inline void fence_proxy_tensormap_generic(
+  cuda::ptx::sem_acquire_t,
+  cuda::ptx::scope_t<Scope> scope,
+  const void* addr,
+  cuda::ptx::n32_t<N32> size);
+```
+
 
 #### `red.async`
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx.h
@@ -423,7 +423,6 @@ _LIBCUDACXX_DEVICE static inline void st_async(
         : "memory"
       );
     }
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_st_async_is_not_supported_before_SM_90__();
@@ -472,7 +471,6 @@ _LIBCUDACXX_DEVICE static inline void st_async(
         : "memory"
       );
     }
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_st_async_is_not_supported_before_SM_90__();
@@ -510,7 +508,6 @@ _LIBCUDACXX_DEVICE static inline void st_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_st_async_is_not_supported_before_SM_90__();
@@ -740,7 +737,6 @@ _LIBCUDACXX_DEVICE static inline void fence(
         : "memory"
       );
     }
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_fence_is_not_supported_before_SM_70__();
@@ -783,7 +779,6 @@ _LIBCUDACXX_DEVICE static inline void fence(
         : "memory"
       );
     }
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_fence_is_not_supported_before_SM_90__();
@@ -816,7 +811,6 @@ _LIBCUDACXX_DEVICE static inline void fence_mbarrier_init(
       :
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_fence_mbarrier_init_is_not_supported_before_SM_90__();
@@ -841,7 +835,6 @@ _LIBCUDACXX_DEVICE static inline void fence_proxy_alias()
       :
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_fence_proxy_alias_is_not_supported_before_SM_70__();
@@ -866,7 +859,6 @@ _LIBCUDACXX_DEVICE static inline void fence_proxy_async()
       :
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_fence_proxy_async_is_not_supported_before_SM_90__();
@@ -912,7 +904,6 @@ _LIBCUDACXX_DEVICE static inline void fence_proxy_async(
         : "memory"
       );
     }
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_fence_proxy_async_is_not_supported_before_SM_90__();
@@ -968,7 +959,6 @@ _LIBCUDACXX_DEVICE static inline void fence_proxy_tensormap_generic(
         : "memory"
       );
     }
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_fence_proxy_tensormap_generic_is_not_supported_before_SM_90__();
@@ -1033,7 +1023,6 @@ _LIBCUDACXX_DEVICE static inline void fence_proxy_tensormap_generic(
         : "memory"
       );
     }
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_fence_proxy_tensormap_generic_is_not_supported_before_SM_90__();
@@ -1082,7 +1071,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1122,7 +1110,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1162,7 +1149,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1202,7 +1188,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1242,7 +1227,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1282,7 +1266,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1322,7 +1305,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1362,7 +1344,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1403,7 +1384,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1444,7 +1424,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1485,7 +1464,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1525,7 +1503,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();
@@ -1563,7 +1540,6 @@ _LIBCUDACXX_DEVICE static inline void red_async(
         "r"(__as_ptr_remote_dsmem(__remote_bar))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_red_async_is_not_supported_before_SM_90__();

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx.h
@@ -678,6 +678,369 @@ _LIBCUDACXX_DEVICE static inline void st_async(
 
 // 9.7.12.4. Parallel Synchronization and Communication Instructions: membar/fence
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-membar-fence
+/*
+// fence{.sem}.scope; // 1. PTX ISA 60, SM_70
+// .sem       = { .sc, .acq_rel }
+// .scope     = { .cta, .gpu, .sys }
+template <cuda::ptx::dot_sem Sem, cuda::ptx::dot_scope Scope>
+__device__ static inline void fence(
+  cuda::ptx::sem_t<Sem> sem,
+  cuda::ptx::scope_t<Scope> scope);
+*/
+#if __cccl_ptx_isa >= 600
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_fence_is_not_supported_before_SM_70__();
+template <dot_sem _Sem, dot_scope _Scope>
+_LIBCUDACXX_DEVICE static inline void fence(
+  sem_t<_Sem> __sem,
+  scope_t<_Scope> __scope)
+{
+  static_assert(__sem == sem_sc || __sem == sem_acq_rel, "");
+  static_assert(__scope == scope_cta || __scope == scope_gpu || __scope == scope_sys, "");
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,(
+    if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__sem == sem_sc && __scope == scope_cta) {
+      asm volatile (
+        "fence.sc.cta; // 1."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__sem == sem_sc && __scope == scope_gpu) {
+      asm volatile (
+        "fence.sc.gpu; // 1."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__sem == sem_sc && __scope == scope_sys) {
+      asm volatile (
+        "fence.sc.sys; // 1."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__sem == sem_acq_rel && __scope == scope_cta) {
+      asm volatile (
+        "fence.acq_rel.cta; // 1."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__sem == sem_acq_rel && __scope == scope_gpu) {
+      asm volatile (
+        "fence.acq_rel.gpu; // 1."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__sem == sem_acq_rel && __scope == scope_sys) {
+      asm volatile (
+        "fence.acq_rel.sys; // 1."
+        :
+        :
+        : "memory"
+      );
+    }
+
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_fence_is_not_supported_before_SM_70__();
+    return;
+  ));
+}
+#endif // __cccl_ptx_isa >= 600
+
+/*
+// fence{.sem}.scope; // 2. PTX ISA 78, SM_90
+// .sem       = { .sc, .acq_rel }
+// .scope     = { .cluster }
+template <cuda::ptx::dot_sem Sem>
+__device__ static inline void fence(
+  cuda::ptx::sem_t<Sem> sem,
+  cuda::ptx::scope_cluster_t);
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_fence_is_not_supported_before_SM_90__();
+template <dot_sem _Sem>
+_LIBCUDACXX_DEVICE static inline void fence(
+  sem_t<_Sem> __sem,
+  scope_cluster_t)
+{
+  static_assert(__sem == sem_sc || __sem == sem_acq_rel, "");
+  // __scope == scope_cluster (due to parameter type constraint)
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__sem == sem_sc) {
+      asm volatile (
+        "fence.sc.cluster; // 2."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__sem == sem_acq_rel) {
+      asm volatile (
+        "fence.acq_rel.cluster; // 2."
+        :
+        :
+        : "memory"
+      );
+    }
+
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_fence_is_not_supported_before_SM_90__();
+    return;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+/*
+// fence.mbarrier_init.sem.scope; // 3. PTX ISA 80, SM_90
+// .sem       = { .release }
+// .scope     = { .cluster }
+template <typename=void>
+__device__ static inline void fence_mbarrier_init(
+  cuda::ptx::sem_release_t,
+  cuda::ptx::scope_cluster_t);
+*/
+#if __cccl_ptx_isa >= 800
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_fence_mbarrier_init_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline void fence_mbarrier_init(
+  sem_release_t,
+  scope_cluster_t)
+{
+  // __sem == sem_release (due to parameter type constraint)
+  // __scope == scope_cluster (due to parameter type constraint)
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    asm volatile (
+      "fence.mbarrier_init.release.cluster; // 3."
+      :
+      :
+      : "memory"
+    );
+
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_fence_mbarrier_init_is_not_supported_before_SM_90__();
+    return;
+  ));
+}
+#endif // __cccl_ptx_isa >= 800
+/*
+// fence.proxy.alias; // 4. PTX ISA 75, SM_70
+template <typename=void>
+__device__ static inline void fence_proxy_alias();
+*/
+#if __cccl_ptx_isa >= 750
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_fence_proxy_alias_is_not_supported_before_SM_70__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline void fence_proxy_alias()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70,(
+    asm volatile (
+      "fence.proxy.alias; // 4."
+      :
+      :
+      : "memory"
+    );
+
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_fence_proxy_alias_is_not_supported_before_SM_70__();
+    return;
+  ));
+}
+#endif // __cccl_ptx_isa >= 750
+/*
+// fence.proxy.async; // 5. PTX ISA 80, SM_90
+template <typename=void>
+__device__ static inline void fence_proxy_async();
+*/
+#if __cccl_ptx_isa >= 800
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_fence_proxy_async_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline void fence_proxy_async()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    asm volatile (
+      "fence.proxy.async; // 5."
+      :
+      :
+      : "memory"
+    );
+
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_fence_proxy_async_is_not_supported_before_SM_90__();
+    return;
+  ));
+}
+#endif // __cccl_ptx_isa >= 800
+
+/*
+// fence.proxy.async{.space}; // 6. PTX ISA 80, SM_90
+// .space     = { .global, .shared::cluster, .shared::cta }
+template <cuda::ptx::dot_space Space>
+__device__ static inline void fence_proxy_async(
+  cuda::ptx::space_t<Space> space);
+*/
+#if __cccl_ptx_isa >= 800
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_fence_proxy_async_is_not_supported_before_SM_90__();
+template <dot_space _Space>
+_LIBCUDACXX_DEVICE static inline void fence_proxy_async(
+  space_t<_Space> __space)
+{
+  static_assert(__space == space_global || __space == space_cluster || __space == space_shared, "");
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__space == space_global) {
+      asm volatile (
+        "fence.proxy.async.global; // 6."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__space == space_cluster) {
+      asm volatile (
+        "fence.proxy.async.shared::cluster; // 6."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__space == space_shared) {
+      asm volatile (
+        "fence.proxy.async.shared::cta; // 6."
+        :
+        :
+        : "memory"
+      );
+    }
+
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_fence_proxy_async_is_not_supported_before_SM_90__();
+    return;
+  ));
+}
+#endif // __cccl_ptx_isa >= 800
+/*
+// fence.proxy.tensormap::generic.release.scope; // 7. PTX ISA 83, SM_90
+// .sem       = { .release }
+// .scope     = { .cta, .cluster, .gpu, .sys }
+template <cuda::ptx::dot_scope Scope>
+__device__ static inline void fence_proxy_tensormap_generic(
+  cuda::ptx::sem_release_t,
+  cuda::ptx::scope_t<Scope> scope);
+*/
+#if __cccl_ptx_isa >= 830
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_fence_proxy_tensormap_generic_is_not_supported_before_SM_90__();
+template <dot_scope _Scope>
+_LIBCUDACXX_DEVICE static inline void fence_proxy_tensormap_generic(
+  sem_release_t,
+  scope_t<_Scope> __scope)
+{
+  // __sem == sem_release (due to parameter type constraint)
+  static_assert(__scope == scope_cta || __scope == scope_cluster || __scope == scope_gpu || __scope == scope_sys, "");
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__scope == scope_cta) {
+      asm volatile (
+        "fence.proxy.tensormap::generic.release.cta; // 7."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__scope == scope_cluster) {
+      asm volatile (
+        "fence.proxy.tensormap::generic.release.cluster; // 7."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__scope == scope_gpu) {
+      asm volatile (
+        "fence.proxy.tensormap::generic.release.gpu; // 7."
+        :
+        :
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__scope == scope_sys) {
+      asm volatile (
+        "fence.proxy.tensormap::generic.release.sys; // 7."
+        :
+        :
+        : "memory"
+      );
+    }
+
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_fence_proxy_tensormap_generic_is_not_supported_before_SM_90__();
+    return;
+  ));
+}
+#endif // __cccl_ptx_isa >= 830
+
+/*
+// fence.proxy.tensormap::generic.sem.scope [addr], size; // 8. PTX ISA 83, SM_90
+// .sem       = { .acquire }
+// .scope     = { .cta, .cluster, .gpu, .sys }
+template <int N32, cuda::ptx::dot_scope Scope>
+__device__ static inline void fence_proxy_tensormap_generic(
+  cuda::ptx::sem_acquire_t,
+  cuda::ptx::scope_t<Scope> scope,
+  const void* addr,
+  cuda::ptx::n32_t<N32> size);
+*/
+#if __cccl_ptx_isa >= 830
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_fence_proxy_tensormap_generic_is_not_supported_before_SM_90__();
+template <int _N32, dot_scope _Scope>
+_LIBCUDACXX_DEVICE static inline void fence_proxy_tensormap_generic(
+  sem_acquire_t,
+  scope_t<_Scope> __scope,
+  const void* __addr,
+  n32_t<_N32> __size)
+{
+  // __sem == sem_acquire (due to parameter type constraint)
+  static_assert(__scope == scope_cta || __scope == scope_cluster || __scope == scope_gpu || __scope == scope_sys, "");
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__scope == scope_cta) {
+      asm volatile (
+        "fence.proxy.tensormap::generic.acquire.cta [%0], %1; // 8."
+        :
+        : "l"(__addr),
+          "n"(__size)
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__scope == scope_cluster) {
+      asm volatile (
+        "fence.proxy.tensormap::generic.acquire.cluster [%0], %1; // 8."
+        :
+        : "l"(__addr),
+          "n"(__size)
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__scope == scope_gpu) {
+      asm volatile (
+        "fence.proxy.tensormap::generic.acquire.gpu [%0], %1; // 8."
+        :
+        : "l"(__addr),
+          "n"(__size)
+        : "memory"
+      );
+    } else if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (__scope == scope_sys) {
+      asm volatile (
+        "fence.proxy.tensormap::generic.acquire.sys [%0], %1; // 8."
+        :
+        : "l"(__addr),
+          "n"(__size)
+        : "memory"
+      );
+    }
+
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_fence_proxy_tensormap_generic_is_not_supported_before_SM_90__();
+    return;
+  ));
+}
+#endif // __cccl_ptx_isa >= 830
 
 // 9.7.12.5. Parallel Synchronization and Communication Instructions: atom
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-atom

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx/parallel_synchronization_and_communication_instructions_mbarrier.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx/parallel_synchronization_and_communication_instructions_mbarrier.h
@@ -318,7 +318,6 @@ _LIBCUDACXX_DEVICE static inline void mbarrier_arrive(
       : "r"(__as_ptr_remote_dsmem(__addr))
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_mbarrier_arrive_is_not_supported_before_SM_90__();
@@ -361,7 +360,6 @@ _LIBCUDACXX_DEVICE static inline void mbarrier_arrive(
         "r"(__count)
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_mbarrier_arrive_is_not_supported_before_SM_90__();
@@ -490,7 +488,6 @@ _LIBCUDACXX_DEVICE static inline void mbarrier_arrive_expect_tx(
         "r"(__tx_count)
       : "memory"
     );
-
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_mbarrier_arrive_expect_tx_is_not_supported_before_SM_90__();

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.fence.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.fence.compile.pass.cpp
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: libcpp-has-no-threads
+
+// <cuda/ptx>
+
+#include <cuda/ptx>
+#include <cuda/std/utility>
+
+/*
+ * We use a special strategy to force the generation of the PTX. This is mainly
+ * a fight against dead-code-elimination in the NVVM layer.
+ *
+ * The reason we need this strategy is because certain older versions of ptxas
+ * segfault when a non-sensical sequence of PTX is generated. So instead, we try
+ * to force the instantiation and compilation to PTX of all the overloads of the
+ * PTX wrapping functions.
+ *
+ * We do this by writing a function pointer of each overload to the kernel
+ * parameter `fn_ptr`.
+ *
+ * Because `fn_ptr` is possibly visible outside this translation unit, the
+ * compiler must compile all the functions which are stored.
+ *
+ */
+
+__global__ void test_fence(void ** fn_ptr) {
+#if __cccl_ptx_isa >= 600
+  NV_IF_TARGET(NV_PROVIDES_SM_70, (
+    // fence.sc.cta; // 1.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_sc_t, cuda::ptx::scope_cta_t)>(cuda::ptx::fence));
+    // fence.sc.gpu; // 1.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_sc_t, cuda::ptx::scope_gpu_t)>(cuda::ptx::fence));
+    // fence.sc.sys; // 1.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_sc_t, cuda::ptx::scope_sys_t)>(cuda::ptx::fence));
+    // fence.acq_rel.cta; // 1.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_acq_rel_t, cuda::ptx::scope_cta_t)>(cuda::ptx::fence));
+    // fence.acq_rel.gpu; // 1.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_acq_rel_t, cuda::ptx::scope_gpu_t)>(cuda::ptx::fence));
+    // fence.acq_rel.sys; // 1.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_acq_rel_t, cuda::ptx::scope_sys_t)>(cuda::ptx::fence));
+  ));
+#endif // __cccl_ptx_isa >= 600
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // fence.sc.cluster; // 2.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_sc_t, cuda::ptx::scope_cluster_t)>(cuda::ptx::fence));
+    // fence.acq_rel.cluster; // 2.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_acq_rel_t, cuda::ptx::scope_cluster_t)>(cuda::ptx::fence));
+  ));
+#endif // __cccl_ptx_isa >= 780
+}
+
+__global__ void test_fence_mbarrier_init(void ** fn_ptr) {
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // fence.mbarrier_init.release.cluster; // 3.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_release_t, cuda::ptx::scope_cluster_t)>(cuda::ptx::fence_mbarrier_init));
+  ));
+#endif // __cccl_ptx_isa >= 800
+}
+
+__global__ void test_fence_proxy_alias(void ** fn_ptr) {
+#if __cccl_ptx_isa >= 750
+  NV_IF_TARGET(NV_PROVIDES_SM_70, (
+    // fence.proxy.alias; // 4.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::fence_proxy_alias));
+  ));
+#endif // __cccl_ptx_isa >= 750
+}
+
+__global__ void test_fence_proxy_async(void ** fn_ptr) {
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // fence.proxy.async; // 5.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::fence_proxy_async));
+  ));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // fence.proxy.async.global; // 6.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t)>(cuda::ptx::fence_proxy_async));
+    // fence.proxy.async.shared::cluster; // 6.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_cluster_t)>(cuda::ptx::fence_proxy_async));
+    // fence.proxy.async.shared::cta; // 6.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t)>(cuda::ptx::fence_proxy_async));
+  ));
+#endif // __cccl_ptx_isa >= 800
+}
+
+__global__ void test_fence_proxy_tensormap_generic(void ** fn_ptr) {
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // fence.proxy.tensormap::generic.release.cta; // 7.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_release_t, cuda::ptx::scope_cta_t)>(cuda::ptx::fence_proxy_tensormap_generic));
+    // fence.proxy.tensormap::generic.release.cluster; // 7.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_release_t, cuda::ptx::scope_cluster_t)>(cuda::ptx::fence_proxy_tensormap_generic));
+    // fence.proxy.tensormap::generic.release.gpu; // 7.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_release_t, cuda::ptx::scope_gpu_t)>(cuda::ptx::fence_proxy_tensormap_generic));
+    // fence.proxy.tensormap::generic.release.sys; // 7.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_release_t, cuda::ptx::scope_sys_t)>(cuda::ptx::fence_proxy_tensormap_generic));
+  ));
+#endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // fence.proxy.tensormap::generic.acquire.cta [addr], size; // 8.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_acquire_t, cuda::ptx::scope_cta_t, const void* , cuda::ptx::n32_t<128>)>(cuda::ptx::fence_proxy_tensormap_generic));
+    // fence.proxy.tensormap::generic.acquire.cluster [addr], size; // 8.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_acquire_t, cuda::ptx::scope_cluster_t, const void* , cuda::ptx::n32_t<128>)>(cuda::ptx::fence_proxy_tensormap_generic));
+    // fence.proxy.tensormap::generic.acquire.gpu [addr], size; // 8.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_acquire_t, cuda::ptx::scope_gpu_t, const void* , cuda::ptx::n32_t<128>)>(cuda::ptx::fence_proxy_tensormap_generic));
+    // fence.proxy.tensormap::generic.acquire.sys [addr], size; // 8.
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::sem_acquire_t, cuda::ptx::scope_sys_t, const void* , cuda::ptx::n32_t<128>)>(cuda::ptx::fence_proxy_tensormap_generic));
+  ));
+#endif // __cccl_ptx_isa >= 830
+}
+
+int main(int, char**)
+{
+    return 0;
+}


### PR DESCRIPTION
## Description

Closes #1339 

Adds `cuda::ptx::fence`. This wraps the PTX fence instructions.
Follow up to #1336.

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
