### PR TITLE
PTX: Add `cuda::ptx::get_sreg`

### DIFF
--- a/libcudacxx/docs/ptx.md
+++ b/libcudacxx/docs/ptx.md
@@ -1157,3 +1157,283 @@ __device__ static inline bool mbarrier_try_wait_parity(
 [`pmevent`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#miscellaneous-instructions-pmevent
 [`trap`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#miscellaneous-instructions-trap
 [`setmaxnreg`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#miscellaneous-instructions-setmaxnreg
+
+## [10. Special registers](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers)
+
+| Register                       | PTX ISA | SM Version | Available in libcu++    |
+|--------------------------------|---------|------------|-------------------------|
+| [`tid`]                        | 20      | All        | CTK-FUTURE, CCCL v2.4.0 |
+| [`ntid`]                       | 20      | All        | CTK-FUTURE, CCCL v2.4.0 |
+| [`laneid`]                     | 13      | All        | CTK-FUTURE, CCCL v2.4.0 |
+| [`warpid`]                     | 13      | All        | CTK-FUTURE, CCCL v2.4.0 |
+| [`nwarpid`]                    | 20      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`ctaid`]                      | 20      | All        | CTK-FUTURE, CCCL v2.4.0 |
+| [`nctaid`]                     | 20      | All        | CTK-FUTURE, CCCL v2.4.0 |
+| [`smid`]                       | 13      | All        | CTK-FUTURE, CCCL v2.4.0 |
+| [`nsmid`]                      | 20      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`gridid`]                     | 30      | 30         | CTK-FUTURE, CCCL v2.4.0 |
+| [`is_explicit_cluster`]        | 78      | 90         | CTK-FUTURE, CCCL v2.4.0 |
+| [`clusterid`]                  | 78      | 90         | CTK-FUTURE, CCCL v2.4.0 |
+| [`nclusterid`]                 | 78      | 90         | CTK-FUTURE, CCCL v2.4.0 |
+| [`cluster_ctaid`]              | 78      | 90         | CTK-FUTURE, CCCL v2.4.0 |
+| [`cluster_nctaid`]             | 78      | 90         | CTK-FUTURE, CCCL v2.4.0 |
+| [`cluster_ctarank`]            | 78      | 90         | CTK-FUTURE, CCCL v2.4.0 |
+| [`cluster_nctarank`]           | 78      | 90         | CTK-FUTURE, CCCL v2.4.0 |
+| [`lanemask_eq`]                | 20      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`lanemask_le`]                | 20      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`lanemask_lt`]                | 20      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`lanemask_ge`]                | 20      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`lanemask_gt`]                | 20      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`clock`]                      | 10      | All        | CTK-FUTURE, CCCL v2.4.0 |
+| [`clock_hi`]                   | 50      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`clock64`]                    | 20      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`pm0`]                        |         |            | No                      |
+| [`pm0_64`]                     |         |            | No                      |
+| [`envreg`]                     |         |            | No                      |
+| [`globaltimer`]                | 31      | 30         | CTK-FUTURE, CCCL v2.4.0 |
+| [`globaltimer_lo`]             | 31      | 30         | CTK-FUTURE, CCCL v2.4.0 |
+| [`globaltimer_hi`]             | 31      | 30         | CTK-FUTURE, CCCL v2.4.0 |
+| [`reserved_smem_offset_begin`] |         |            | No                      |
+| [`reserved_smem_offset_end`]   |         |            | No                      |
+| [`reserved_smem_offset_cap`]   |         |            | No                      |
+| [`reserved_smem_offset_2`]     |         |            | No                      |
+| [`total_smem_size`]            | 41      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`aggr_smem_size`]             | 81      | 90         | CTK-FUTURE, CCCL v2.4.0 |
+| [`dynamic_smem_size`]          | 41      | 20         | CTK-FUTURE, CCCL v2.4.0 |
+| [`current_graph_exec`]         | 80      | 50         | CTK-FUTURE, CCCL v2.4.0 |
+
+[`tid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-tid
+[`ntid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-ntid
+[`laneid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-laneid
+[`warpid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-warpid
+[`nwarpid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-nwarpid
+[`ctaid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-ctaid
+[`nctaid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-nctaid
+[`smid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-smid
+[`nsmid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-nsmid
+[`gridid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-gridid
+[`is_explicit_cluster`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-is-explicit-cluster
+[`clusterid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-clusterid
+[`nclusterid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-nclusterid
+[`cluster_ctaid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-cluster-ctaid
+[`cluster_nctaid`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-cluster-nctaid
+[`cluster_ctarank`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-cluster-ctarank
+[`cluster_nctarank`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-cluster-nctarank
+[`lanemask_eq`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-lanemask-eq
+[`lanemask_le`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-lanemask-le
+[`lanemask_lt`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-lanemask-lt
+[`lanemask_ge`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-lanemask-ge
+[`lanemask_gt`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-lanemask-gt
+[`clock`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-clock-clock-hi
+[`clock_hi`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-clock-clock-hi
+[`clock64`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-clock64
+[`pm0`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-pm0-pm7
+[`pm0_64`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-pm0-64-pm7-64
+[`envreg`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-envreg-32
+[`globaltimer`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-globaltimer-globaltimer-lo-globaltimer-hi
+[`globaltimer_lo`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-globaltimer-globaltimer-lo-globaltimer-hi
+[`globaltimer_hi`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-globaltimer-globaltimer-lo-globaltimer-hi
+[`reserved_smem_offset_begin`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-reserved-smem-offset-begin-reserved-smem-offset-end-reserved-smem-offset-cap-reserved-smem-offset-2
+[`reserved_smem_offset_end`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-reserved-smem-offset-begin-reserved-smem-offset-end-reserved-smem-offset-cap-reserved-smem-offset-2
+[`reserved_smem_offset_cap`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-reserved-smem-offset-begin-reserved-smem-offset-end-reserved-smem-offset-cap-reserved-smem-offset-2
+[`reserved_smem_offset_2`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-reserved-smem-offset-begin-reserved-smem-offset-end-reserved-smem-offset-cap-reserved-smem-offset-2
+[`total_smem_size`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-total-smem-size
+[`aggr_smem_size`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-aggr-smem-size
+[`dynamic_smem_size`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-dynamic-smem-size
+[`current_graph_exec`]: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-current-graph-exec
+
+
+**get_sreg**:
+```cuda
+// mov.u32 out, %%tid.x; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_tid_x();
+
+// mov.u32 out, %%tid.y; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_tid_y();
+
+// mov.u32 out, %%tid.z; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_tid_z();
+
+// mov.u32 out, %%ntid.x; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ntid_x();
+
+// mov.u32 out, %%ntid.y; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ntid_y();
+
+// mov.u32 out, %%ntid.z; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ntid_z();
+
+// mov.u32 out, %%laneid; // PTX ISA 13
+template <typename=void>
+__device__ static inline uint32_t get_sreg_laneid();
+
+// mov.u32 out, %%warpid; // PTX ISA 13
+template <typename=void>
+__device__ static inline uint32_t get_sreg_warpid();
+
+// mov.u32 out, %%nwarpid; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nwarpid();
+
+// mov.u32 out, %%ctaid.x; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ctaid_x();
+
+// mov.u32 out, %%ctaid.y; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ctaid_y();
+
+// mov.u32 out, %%ctaid.z; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ctaid_z();
+
+// mov.u32 out, %%nctaid.x; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nctaid_x();
+
+// mov.u32 out, %%nctaid.y; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nctaid_y();
+
+// mov.u32 out, %%nctaid.z; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nctaid_z();
+
+// mov.u32 out, %%smid; // PTX ISA 13
+template <typename=void>
+__device__ static inline uint32_t get_sreg_smid();
+
+// mov.u32 out, %%nsmid; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nsmid();
+
+// mov.u64 out, %%gridid; // PTX ISA 30
+template <typename=void>
+__device__ static inline uint64_t get_sreg_gridid();
+
+// mov.pred out, %%is_explicit_cluster; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline bool get_sreg_is_explicit_cluster();
+
+// mov.u32 out, %%clusterid.x; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clusterid_x();
+
+// mov.u32 out, %%clusterid.y; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clusterid_y();
+
+// mov.u32 out, %%clusterid.z; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clusterid_z();
+
+// mov.u32 out, %%nclusterid.x; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nclusterid_x();
+
+// mov.u32 out, %%nclusterid.y; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nclusterid_y();
+
+// mov.u32 out, %%nclusterid.z; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nclusterid_z();
+
+// mov.u32 out, %%cluster_ctaid.x; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_ctaid_x();
+
+// mov.u32 out, %%cluster_ctaid.y; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_ctaid_y();
+
+// mov.u32 out, %%cluster_ctaid.z; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_ctaid_z();
+
+// mov.u32 out, %%cluster_nctaid.x; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_nctaid_x();
+
+// mov.u32 out, %%cluster_nctaid.y; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_nctaid_y();
+
+// mov.u32 out, %%cluster_nctaid.z; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_nctaid_z();
+
+// mov.u32 out, %%cluster_ctarank; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_ctarank();
+
+// mov.u32 out, %%cluster_nctarank; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_nctarank();
+
+// mov.u32 out, %%lanemask_eq; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_eq();
+
+// mov.u32 out, %%lanemask_le; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_le();
+
+// mov.u32 out, %%lanemask_lt; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_lt();
+
+// mov.u32 out, %%lanemask_ge; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_ge();
+
+// mov.u32 out, %%lanemask_gt; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_gt();
+
+// mov.u32 out, %%clock; // PTX ISA 10
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clock();
+
+// mov.u32 out, %%clock_hi; // PTX ISA 50, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clock_hi();
+
+// mov.u64 out, %%clock64; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint64_t get_sreg_clock64();
+
+// mov.u64 out, %%globaltimer; // PTX ISA 31, SM_35
+template <typename=void>
+__device__ static inline uint64_t get_sreg_globaltimer();
+
+// mov.u32 out, %%globaltimer_lo; // PTX ISA 31, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_globaltimer_lo();
+
+// mov.u32 out, %%globaltimer_hi; // PTX ISA 31, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_globaltimer_hi();
+
+// mov.u32 out, %%total_smem_size; // PTX ISA 41, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_total_smem_size();
+
+// mov.u32 out, %%aggr_smem_size; // PTX ISA 81, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_aggr_smem_size();
+
+// mov.u32 out, %%dynamic_smem_size; // PTX ISA 41, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_dynamic_smem_size();
+
+// mov.u64 out, %%current_graph_exec; // PTX ISA 80, SM_50
+template <typename=void>
+__device__ static inline uint64_t get_sreg_current_graph_exec();
+```

--- a/libcudacxx/docs/ptx.md
+++ b/libcudacxx/docs/ptx.md
@@ -1245,195 +1245,195 @@ __device__ static inline bool mbarrier_try_wait_parity(
 
 **get_sreg**:
 ```cuda
-// mov.u32 out, %%tid.x; // PTX ISA 20
+// mov.u32 sreg_value, %%tid.x; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_tid_x();
 
-// mov.u32 out, %%tid.y; // PTX ISA 20
+// mov.u32 sreg_value, %%tid.y; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_tid_y();
 
-// mov.u32 out, %%tid.z; // PTX ISA 20
+// mov.u32 sreg_value, %%tid.z; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_tid_z();
 
-// mov.u32 out, %%ntid.x; // PTX ISA 20
+// mov.u32 sreg_value, %%ntid.x; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ntid_x();
 
-// mov.u32 out, %%ntid.y; // PTX ISA 20
+// mov.u32 sreg_value, %%ntid.y; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ntid_y();
 
-// mov.u32 out, %%ntid.z; // PTX ISA 20
+// mov.u32 sreg_value, %%ntid.z; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ntid_z();
 
-// mov.u32 out, %%laneid; // PTX ISA 13
+// mov.u32 sreg_value, %%laneid; // PTX ISA 13
 template <typename=void>
 __device__ static inline uint32_t get_sreg_laneid();
 
-// mov.u32 out, %%warpid; // PTX ISA 13
+// mov.u32 sreg_value, %%warpid; // PTX ISA 13
 template <typename=void>
 __device__ static inline uint32_t get_sreg_warpid();
 
-// mov.u32 out, %%nwarpid; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%nwarpid; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nwarpid();
 
-// mov.u32 out, %%ctaid.x; // PTX ISA 20
+// mov.u32 sreg_value, %%ctaid.x; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ctaid_x();
 
-// mov.u32 out, %%ctaid.y; // PTX ISA 20
+// mov.u32 sreg_value, %%ctaid.y; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ctaid_y();
 
-// mov.u32 out, %%ctaid.z; // PTX ISA 20
+// mov.u32 sreg_value, %%ctaid.z; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ctaid_z();
 
-// mov.u32 out, %%nctaid.x; // PTX ISA 20
+// mov.u32 sreg_value, %%nctaid.x; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nctaid_x();
 
-// mov.u32 out, %%nctaid.y; // PTX ISA 20
+// mov.u32 sreg_value, %%nctaid.y; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nctaid_y();
 
-// mov.u32 out, %%nctaid.z; // PTX ISA 20
+// mov.u32 sreg_value, %%nctaid.z; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nctaid_z();
 
-// mov.u32 out, %%smid; // PTX ISA 13
+// mov.u32 sreg_value, %%smid; // PTX ISA 13
 template <typename=void>
 __device__ static inline uint32_t get_sreg_smid();
 
-// mov.u32 out, %%nsmid; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%nsmid; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nsmid();
 
-// mov.u64 out, %%gridid; // PTX ISA 30
+// mov.u64 sreg_value, %%gridid; // PTX ISA 30
 template <typename=void>
 __device__ static inline uint64_t get_sreg_gridid();
 
-// mov.pred out, %%is_explicit_cluster; // PTX ISA 78, SM_90
+// mov.pred sreg_value, %%is_explicit_cluster; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline bool get_sreg_is_explicit_cluster();
 
-// mov.u32 out, %%clusterid.x; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%clusterid.x; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clusterid_x();
 
-// mov.u32 out, %%clusterid.y; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%clusterid.y; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clusterid_y();
 
-// mov.u32 out, %%clusterid.z; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%clusterid.z; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clusterid_z();
 
-// mov.u32 out, %%nclusterid.x; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%nclusterid.x; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nclusterid_x();
 
-// mov.u32 out, %%nclusterid.y; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%nclusterid.y; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nclusterid_y();
 
-// mov.u32 out, %%nclusterid.z; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%nclusterid.z; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nclusterid_z();
 
-// mov.u32 out, %%cluster_ctaid.x; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_ctaid.x; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_ctaid_x();
 
-// mov.u32 out, %%cluster_ctaid.y; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_ctaid.y; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_ctaid_y();
 
-// mov.u32 out, %%cluster_ctaid.z; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_ctaid.z; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_ctaid_z();
 
-// mov.u32 out, %%cluster_nctaid.x; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_nctaid.x; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_nctaid_x();
 
-// mov.u32 out, %%cluster_nctaid.y; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_nctaid.y; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_nctaid_y();
 
-// mov.u32 out, %%cluster_nctaid.z; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_nctaid.z; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_nctaid_z();
 
-// mov.u32 out, %%cluster_ctarank; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_ctarank; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_ctarank();
 
-// mov.u32 out, %%cluster_nctarank; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_nctarank; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_nctarank();
 
-// mov.u32 out, %%lanemask_eq; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_eq; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_eq();
 
-// mov.u32 out, %%lanemask_le; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_le; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_le();
 
-// mov.u32 out, %%lanemask_lt; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_lt; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_lt();
 
-// mov.u32 out, %%lanemask_ge; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_ge; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_ge();
 
-// mov.u32 out, %%lanemask_gt; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_gt; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_gt();
 
-// mov.u32 out, %%clock; // PTX ISA 10
+// mov.u32 sreg_value, %%clock; // PTX ISA 10
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clock();
 
-// mov.u32 out, %%clock_hi; // PTX ISA 50, SM_35
+// mov.u32 sreg_value, %%clock_hi; // PTX ISA 50, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clock_hi();
 
-// mov.u64 out, %%clock64; // PTX ISA 20, SM_35
+// mov.u64 sreg_value, %%clock64; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint64_t get_sreg_clock64();
 
-// mov.u64 out, %%globaltimer; // PTX ISA 31, SM_35
+// mov.u64 sreg_value, %%globaltimer; // PTX ISA 31, SM_35
 template <typename=void>
 __device__ static inline uint64_t get_sreg_globaltimer();
 
-// mov.u32 out, %%globaltimer_lo; // PTX ISA 31, SM_35
+// mov.u32 sreg_value, %%globaltimer_lo; // PTX ISA 31, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_globaltimer_lo();
 
-// mov.u32 out, %%globaltimer_hi; // PTX ISA 31, SM_35
+// mov.u32 sreg_value, %%globaltimer_hi; // PTX ISA 31, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_globaltimer_hi();
 
-// mov.u32 out, %%total_smem_size; // PTX ISA 41, SM_35
+// mov.u32 sreg_value, %%total_smem_size; // PTX ISA 41, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_total_smem_size();
 
-// mov.u32 out, %%aggr_smem_size; // PTX ISA 81, SM_90
+// mov.u32 sreg_value, %%aggr_smem_size; // PTX ISA 81, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_aggr_smem_size();
 
-// mov.u32 out, %%dynamic_smem_size; // PTX ISA 41, SM_35
+// mov.u32 sreg_value, %%dynamic_smem_size; // PTX ISA 41, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_dynamic_smem_size();
 
-// mov.u64 out, %%current_graph_exec; // PTX ISA 80, SM_50
+// mov.u64 sreg_value, %%current_graph_exec; // PTX ISA 80, SM_50
 template <typename=void>
 __device__ static inline uint64_t get_sreg_current_graph_exec();
 ```

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx.h
@@ -1778,6 +1778,1185 @@ _LIBCUDACXX_DEVICE static inline void red_async(
 
 // 10. Special Registers
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers
+/*
+// mov.u32 out, %%tid.x; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_tid_x();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_tid_x()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%tid.x;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%tid.y; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_tid_y();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_tid_y()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%tid.y;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%tid.z; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_tid_z();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_tid_z()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%tid.z;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%ntid.x; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ntid_x();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ntid_x()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm volatile (
+    "mov.u32 %0, %%ntid.x;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%ntid.y; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ntid_y();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ntid_y()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm volatile (
+    "mov.u32 %0, %%ntid.y;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%ntid.z; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ntid_z();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ntid_z()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm volatile (
+    "mov.u32 %0, %%ntid.z;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%laneid; // PTX ISA 13
+template <typename=void>
+__device__ static inline uint32_t get_sreg_laneid();
+*/
+#if __cccl_ptx_isa >= 130
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_laneid()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%laneid;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 130
+
+/*
+// mov.u32 out, %%warpid; // PTX ISA 13
+template <typename=void>
+__device__ static inline uint32_t get_sreg_warpid();
+*/
+#if __cccl_ptx_isa >= 130
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_warpid()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm volatile (
+    "mov.u32 %0, %%warpid;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 130
+
+/*
+// mov.u32 out, %%nwarpid; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nwarpid();
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_nwarpid_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nwarpid()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm volatile (
+      "mov.u32 %0, %%nwarpid;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_nwarpid_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%ctaid.x; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ctaid_x();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ctaid_x()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%ctaid.x;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%ctaid.y; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ctaid_y();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ctaid_y()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%ctaid.y;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%ctaid.z; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_ctaid_z();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ctaid_z()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%ctaid.z;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%nctaid.x; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nctaid_x();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nctaid_x()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%nctaid.x;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%nctaid.y; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nctaid_y();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nctaid_y()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%nctaid.y;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%nctaid.z; // PTX ISA 20
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nctaid_z();
+*/
+#if __cccl_ptx_isa >= 200
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nctaid_z()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%nctaid.z;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%smid; // PTX ISA 13
+template <typename=void>
+__device__ static inline uint32_t get_sreg_smid();
+*/
+#if __cccl_ptx_isa >= 130
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_smid()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm (
+    "mov.u32 %0, %%smid;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 130
+
+/*
+// mov.u32 out, %%nsmid; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nsmid();
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_nsmid_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nsmid()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm volatile (
+      "mov.u32 %0, %%nsmid;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_nsmid_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u64 out, %%gridid; // PTX ISA 30
+template <typename=void>
+__device__ static inline uint64_t get_sreg_gridid();
+*/
+#if __cccl_ptx_isa >= 300
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_gridid()
+{
+  _CUDA_VSTD::uint64_t __out;
+  asm (
+    "mov.u64 %0, %%gridid;"
+    : "=l"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 300
+
+/*
+// mov.pred out, %%is_explicit_cluster; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline bool get_sreg_is_explicit_cluster();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_is_explicit_cluster_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline bool get_sreg_is_explicit_cluster()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "{\n\t .reg .pred P_OUT; \n\t"
+      "mov.pred P_OUT, %%is_explicit_cluster;\n\t"
+      "selp.b32 %0, 1, 0, P_OUT; \n"
+      "}"
+      : "=r"(__out)
+      :
+      :
+    );
+    return static_cast<bool>(__out);
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_is_explicit_cluster_is_not_supported_before_SM_90__();
+    return false;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%clusterid.x; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clusterid_x();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_clusterid_x_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clusterid_x()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%clusterid.x;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_clusterid_x_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%clusterid.y; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clusterid_y();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_clusterid_y_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clusterid_y()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%clusterid.y;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_clusterid_y_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%clusterid.z; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clusterid_z();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_clusterid_z_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clusterid_z()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%clusterid.z;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_clusterid_z_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%nclusterid.x; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nclusterid_x();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_nclusterid_x_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nclusterid_x()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%nclusterid.x;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_nclusterid_x_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%nclusterid.y; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nclusterid_y();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_nclusterid_y_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nclusterid_y()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%nclusterid.y;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_nclusterid_y_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%nclusterid.z; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_nclusterid_z();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_nclusterid_z_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nclusterid_z()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%nclusterid.z;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_nclusterid_z_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%cluster_ctaid.x; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_ctaid_x();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_cluster_ctaid_x_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctaid_x()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%cluster_ctaid.x;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_cluster_ctaid_x_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%cluster_ctaid.y; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_ctaid_y();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_cluster_ctaid_y_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctaid_y()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%cluster_ctaid.y;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_cluster_ctaid_y_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%cluster_ctaid.z; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_ctaid_z();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_cluster_ctaid_z_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctaid_z()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%cluster_ctaid.z;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_cluster_ctaid_z_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%cluster_nctaid.x; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_nctaid_x();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_cluster_nctaid_x_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctaid_x()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%cluster_nctaid.x;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_cluster_nctaid_x_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%cluster_nctaid.y; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_nctaid_y();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_cluster_nctaid_y_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctaid_y()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%cluster_nctaid.y;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_cluster_nctaid_y_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%cluster_nctaid.z; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_nctaid_z();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_cluster_nctaid_z_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctaid_z()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%cluster_nctaid.z;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_cluster_nctaid_z_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%cluster_ctarank; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_ctarank();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_cluster_ctarank_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctarank()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%cluster_ctarank;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_cluster_ctarank_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%cluster_nctarank; // PTX ISA 78, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_cluster_nctarank();
+*/
+#if __cccl_ptx_isa >= 780
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_cluster_nctarank_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctarank()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%cluster_nctarank;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_cluster_nctarank_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 780
+
+/*
+// mov.u32 out, %%lanemask_eq; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_eq();
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_lanemask_eq_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_eq()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%lanemask_eq;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_lanemask_eq_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%lanemask_le; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_le();
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_lanemask_le_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_le()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%lanemask_le;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_lanemask_le_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%lanemask_lt; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_lt();
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_lanemask_lt_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_lt()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%lanemask_lt;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_lanemask_lt_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%lanemask_ge; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_ge();
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_lanemask_ge_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_ge()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%lanemask_ge;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_lanemask_ge_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%lanemask_gt; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_lanemask_gt();
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_lanemask_gt_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_gt()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%lanemask_gt;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_lanemask_gt_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u32 out, %%clock; // PTX ISA 10
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clock();
+*/
+#if __cccl_ptx_isa >= 100
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clock()
+{
+  _CUDA_VSTD::uint32_t __out;
+  asm volatile (
+    "mov.u32 %0, %%clock;"
+    : "=r"(__out)
+    :
+    :
+  );
+  return __out;
+}
+#endif // __cccl_ptx_isa >= 100
+
+/*
+// mov.u32 out, %%clock_hi; // PTX ISA 50, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_clock_hi();
+*/
+#if __cccl_ptx_isa >= 500
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_clock_hi_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clock_hi()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm volatile (
+      "mov.u32 %0, %%clock_hi;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_clock_hi_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 500
+
+/*
+// mov.u64 out, %%clock64; // PTX ISA 20, SM_35
+template <typename=void>
+__device__ static inline uint64_t get_sreg_clock64();
+*/
+#if __cccl_ptx_isa >= 200
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_clock64_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_clock64()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint64_t __out;
+    asm volatile (
+      "mov.u64 %0, %%clock64;"
+      : "=l"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_clock64_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 200
+
+/*
+// mov.u64 out, %%globaltimer; // PTX ISA 31, SM_35
+template <typename=void>
+__device__ static inline uint64_t get_sreg_globaltimer();
+*/
+#if __cccl_ptx_isa >= 310
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_globaltimer_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_globaltimer()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint64_t __out;
+    asm volatile (
+      "mov.u64 %0, %%globaltimer;"
+      : "=l"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_globaltimer_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 310
+
+/*
+// mov.u32 out, %%globaltimer_lo; // PTX ISA 31, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_globaltimer_lo();
+*/
+#if __cccl_ptx_isa >= 310
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_globaltimer_lo_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_globaltimer_lo()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm volatile (
+      "mov.u32 %0, %%globaltimer_lo;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_globaltimer_lo_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 310
+
+/*
+// mov.u32 out, %%globaltimer_hi; // PTX ISA 31, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_globaltimer_hi();
+*/
+#if __cccl_ptx_isa >= 310
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_globaltimer_hi_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_globaltimer_hi()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm volatile (
+      "mov.u32 %0, %%globaltimer_hi;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_globaltimer_hi_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 310
+
+/*
+// mov.u32 out, %%total_smem_size; // PTX ISA 41, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_total_smem_size();
+*/
+#if __cccl_ptx_isa >= 410
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_total_smem_size_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_total_smem_size()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%total_smem_size;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_total_smem_size_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 410
+
+/*
+// mov.u32 out, %%aggr_smem_size; // PTX ISA 81, SM_90
+template <typename=void>
+__device__ static inline uint32_t get_sreg_aggr_smem_size();
+*/
+#if __cccl_ptx_isa >= 810
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_aggr_smem_size_is_not_supported_before_SM_90__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_aggr_smem_size()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%aggr_smem_size;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_aggr_smem_size_is_not_supported_before_SM_90__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 810
+
+/*
+// mov.u32 out, %%dynamic_smem_size; // PTX ISA 41, SM_35
+template <typename=void>
+__device__ static inline uint32_t get_sreg_dynamic_smem_size();
+*/
+#if __cccl_ptx_isa >= 410
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_dynamic_smem_size_is_not_supported_before_SM_35__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_dynamic_smem_size()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
+    _CUDA_VSTD::uint32_t __out;
+    asm (
+      "mov.u32 %0, %%dynamic_smem_size;"
+      : "=r"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_dynamic_smem_size_is_not_supported_before_SM_35__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 410
+
+/*
+// mov.u64 out, %%current_graph_exec; // PTX ISA 80, SM_50
+template <typename=void>
+__device__ static inline uint64_t get_sreg_current_graph_exec();
+*/
+#if __cccl_ptx_isa >= 800
+extern "C" _LIBCUDACXX_DEVICE void __cuda_ptx_get_sreg_current_graph_exec_is_not_supported_before_SM_50__();
+template <typename=void>
+_LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_current_graph_exec()
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_50,(
+    _CUDA_VSTD::uint64_t __out;
+    asm (
+      "mov.u64 %0, %%current_graph_exec;"
+      : "=l"(__out)
+      :
+      :
+    );
+    return __out;
+  ),(
+    // Unsupported architectures will have a linker error with a semi-decent error message
+    __cuda_ptx_get_sreg_current_graph_exec_is_not_supported_before_SM_50__();
+    return 0;
+  ));
+}
+#endif // __cccl_ptx_isa >= 800
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_PTX
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/ptx.h
@@ -1779,7 +1779,7 @@ _LIBCUDACXX_DEVICE static inline void red_async(
 // 10. Special Registers
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers
 /*
-// mov.u32 out, %%tid.x; // PTX ISA 20
+// mov.u32 sreg_value, %%tid.x; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_tid_x();
 */
@@ -1787,19 +1787,19 @@ __device__ static inline uint32_t get_sreg_tid_x();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_tid_x()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%tid.x;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%tid.y; // PTX ISA 20
+// mov.u32 sreg_value, %%tid.y; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_tid_y();
 */
@@ -1807,19 +1807,19 @@ __device__ static inline uint32_t get_sreg_tid_y();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_tid_y()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%tid.y;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%tid.z; // PTX ISA 20
+// mov.u32 sreg_value, %%tid.z; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_tid_z();
 */
@@ -1827,19 +1827,19 @@ __device__ static inline uint32_t get_sreg_tid_z();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_tid_z()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%tid.z;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%ntid.x; // PTX ISA 20
+// mov.u32 sreg_value, %%ntid.x; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ntid_x();
 */
@@ -1847,19 +1847,19 @@ __device__ static inline uint32_t get_sreg_ntid_x();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ntid_x()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm volatile (
     "mov.u32 %0, %%ntid.x;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%ntid.y; // PTX ISA 20
+// mov.u32 sreg_value, %%ntid.y; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ntid_y();
 */
@@ -1867,19 +1867,19 @@ __device__ static inline uint32_t get_sreg_ntid_y();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ntid_y()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm volatile (
     "mov.u32 %0, %%ntid.y;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%ntid.z; // PTX ISA 20
+// mov.u32 sreg_value, %%ntid.z; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ntid_z();
 */
@@ -1887,19 +1887,19 @@ __device__ static inline uint32_t get_sreg_ntid_z();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ntid_z()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm volatile (
     "mov.u32 %0, %%ntid.z;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%laneid; // PTX ISA 13
+// mov.u32 sreg_value, %%laneid; // PTX ISA 13
 template <typename=void>
 __device__ static inline uint32_t get_sreg_laneid();
 */
@@ -1907,19 +1907,19 @@ __device__ static inline uint32_t get_sreg_laneid();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_laneid()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%laneid;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 130
 
 /*
-// mov.u32 out, %%warpid; // PTX ISA 13
+// mov.u32 sreg_value, %%warpid; // PTX ISA 13
 template <typename=void>
 __device__ static inline uint32_t get_sreg_warpid();
 */
@@ -1927,19 +1927,19 @@ __device__ static inline uint32_t get_sreg_warpid();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_warpid()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm volatile (
     "mov.u32 %0, %%warpid;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 130
 
 /*
-// mov.u32 out, %%nwarpid; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%nwarpid; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nwarpid();
 */
@@ -1949,14 +1949,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nwarpid()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm volatile (
       "mov.u32 %0, %%nwarpid;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_nwarpid_is_not_supported_before_SM_35__();
@@ -1966,7 +1966,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nwarpid()
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%ctaid.x; // PTX ISA 20
+// mov.u32 sreg_value, %%ctaid.x; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ctaid_x();
 */
@@ -1974,19 +1974,19 @@ __device__ static inline uint32_t get_sreg_ctaid_x();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ctaid_x()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%ctaid.x;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%ctaid.y; // PTX ISA 20
+// mov.u32 sreg_value, %%ctaid.y; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ctaid_y();
 */
@@ -1994,19 +1994,19 @@ __device__ static inline uint32_t get_sreg_ctaid_y();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ctaid_y()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%ctaid.y;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%ctaid.z; // PTX ISA 20
+// mov.u32 sreg_value, %%ctaid.z; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_ctaid_z();
 */
@@ -2014,19 +2014,19 @@ __device__ static inline uint32_t get_sreg_ctaid_z();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_ctaid_z()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%ctaid.z;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%nctaid.x; // PTX ISA 20
+// mov.u32 sreg_value, %%nctaid.x; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nctaid_x();
 */
@@ -2034,19 +2034,19 @@ __device__ static inline uint32_t get_sreg_nctaid_x();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nctaid_x()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%nctaid.x;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%nctaid.y; // PTX ISA 20
+// mov.u32 sreg_value, %%nctaid.y; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nctaid_y();
 */
@@ -2054,19 +2054,19 @@ __device__ static inline uint32_t get_sreg_nctaid_y();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nctaid_y()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%nctaid.y;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%nctaid.z; // PTX ISA 20
+// mov.u32 sreg_value, %%nctaid.z; // PTX ISA 20
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nctaid_z();
 */
@@ -2074,19 +2074,19 @@ __device__ static inline uint32_t get_sreg_nctaid_z();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nctaid_z()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%nctaid.z;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%smid; // PTX ISA 13
+// mov.u32 sreg_value, %%smid; // PTX ISA 13
 template <typename=void>
 __device__ static inline uint32_t get_sreg_smid();
 */
@@ -2094,19 +2094,19 @@ __device__ static inline uint32_t get_sreg_smid();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_smid()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm (
     "mov.u32 %0, %%smid;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 130
 
 /*
-// mov.u32 out, %%nsmid; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%nsmid; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nsmid();
 */
@@ -2116,14 +2116,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nsmid()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm volatile (
       "mov.u32 %0, %%nsmid;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_nsmid_is_not_supported_before_SM_35__();
@@ -2133,7 +2133,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nsmid()
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u64 out, %%gridid; // PTX ISA 30
+// mov.u64 sreg_value, %%gridid; // PTX ISA 30
 template <typename=void>
 __device__ static inline uint64_t get_sreg_gridid();
 */
@@ -2141,19 +2141,19 @@ __device__ static inline uint64_t get_sreg_gridid();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_gridid()
 {
-  _CUDA_VSTD::uint64_t __out;
+  _CUDA_VSTD::uint64_t __sreg_value;
   asm (
     "mov.u64 %0, %%gridid;"
-    : "=l"(__out)
+    : "=l"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 300
 
 /*
-// mov.pred out, %%is_explicit_cluster; // PTX ISA 78, SM_90
+// mov.pred sreg_value, %%is_explicit_cluster; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline bool get_sreg_is_explicit_cluster();
 */
@@ -2163,17 +2163,17 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline bool get_sreg_is_explicit_cluster()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "{\n\t .reg .pred P_OUT; \n\t"
       "mov.pred P_OUT, %%is_explicit_cluster;\n\t"
       "selp.b32 %0, 1, 0, P_OUT; \n"
       "}"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return static_cast<bool>(__out);
+    return static_cast<bool>(__sreg_value);
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_is_explicit_cluster_is_not_supported_before_SM_90__();
@@ -2183,7 +2183,7 @@ _LIBCUDACXX_DEVICE static inline bool get_sreg_is_explicit_cluster()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%clusterid.x; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%clusterid.x; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clusterid_x();
 */
@@ -2193,14 +2193,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clusterid_x()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%clusterid.x;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_clusterid_x_is_not_supported_before_SM_90__();
@@ -2210,7 +2210,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clusterid_x()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%clusterid.y; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%clusterid.y; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clusterid_y();
 */
@@ -2220,14 +2220,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clusterid_y()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%clusterid.y;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_clusterid_y_is_not_supported_before_SM_90__();
@@ -2237,7 +2237,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clusterid_y()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%clusterid.z; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%clusterid.z; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clusterid_z();
 */
@@ -2247,14 +2247,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clusterid_z()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%clusterid.z;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_clusterid_z_is_not_supported_before_SM_90__();
@@ -2264,7 +2264,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clusterid_z()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%nclusterid.x; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%nclusterid.x; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nclusterid_x();
 */
@@ -2274,14 +2274,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nclusterid_x()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%nclusterid.x;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_nclusterid_x_is_not_supported_before_SM_90__();
@@ -2291,7 +2291,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nclusterid_x()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%nclusterid.y; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%nclusterid.y; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nclusterid_y();
 */
@@ -2301,14 +2301,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nclusterid_y()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%nclusterid.y;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_nclusterid_y_is_not_supported_before_SM_90__();
@@ -2318,7 +2318,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nclusterid_y()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%nclusterid.z; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%nclusterid.z; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_nclusterid_z();
 */
@@ -2328,14 +2328,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nclusterid_z()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%nclusterid.z;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_nclusterid_z_is_not_supported_before_SM_90__();
@@ -2345,7 +2345,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_nclusterid_z()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%cluster_ctaid.x; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_ctaid.x; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_ctaid_x();
 */
@@ -2355,14 +2355,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctaid_x()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%cluster_ctaid.x;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_cluster_ctaid_x_is_not_supported_before_SM_90__();
@@ -2372,7 +2372,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctaid_x()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%cluster_ctaid.y; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_ctaid.y; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_ctaid_y();
 */
@@ -2382,14 +2382,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctaid_y()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%cluster_ctaid.y;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_cluster_ctaid_y_is_not_supported_before_SM_90__();
@@ -2399,7 +2399,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctaid_y()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%cluster_ctaid.z; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_ctaid.z; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_ctaid_z();
 */
@@ -2409,14 +2409,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctaid_z()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%cluster_ctaid.z;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_cluster_ctaid_z_is_not_supported_before_SM_90__();
@@ -2426,7 +2426,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctaid_z()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%cluster_nctaid.x; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_nctaid.x; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_nctaid_x();
 */
@@ -2436,14 +2436,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctaid_x()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%cluster_nctaid.x;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_cluster_nctaid_x_is_not_supported_before_SM_90__();
@@ -2453,7 +2453,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctaid_x(
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%cluster_nctaid.y; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_nctaid.y; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_nctaid_y();
 */
@@ -2463,14 +2463,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctaid_y()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%cluster_nctaid.y;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_cluster_nctaid_y_is_not_supported_before_SM_90__();
@@ -2480,7 +2480,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctaid_y(
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%cluster_nctaid.z; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_nctaid.z; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_nctaid_z();
 */
@@ -2490,14 +2490,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctaid_z()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%cluster_nctaid.z;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_cluster_nctaid_z_is_not_supported_before_SM_90__();
@@ -2507,7 +2507,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctaid_z(
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%cluster_ctarank; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_ctarank; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_ctarank();
 */
@@ -2517,14 +2517,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctarank()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%cluster_ctarank;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_cluster_ctarank_is_not_supported_before_SM_90__();
@@ -2534,7 +2534,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_ctarank()
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%cluster_nctarank; // PTX ISA 78, SM_90
+// mov.u32 sreg_value, %%cluster_nctarank; // PTX ISA 78, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_cluster_nctarank();
 */
@@ -2544,14 +2544,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctarank()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%cluster_nctarank;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_cluster_nctarank_is_not_supported_before_SM_90__();
@@ -2561,7 +2561,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_cluster_nctarank(
 #endif // __cccl_ptx_isa >= 780
 
 /*
-// mov.u32 out, %%lanemask_eq; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_eq; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_eq();
 */
@@ -2571,14 +2571,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_eq()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%lanemask_eq;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_lanemask_eq_is_not_supported_before_SM_35__();
@@ -2588,7 +2588,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_eq()
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%lanemask_le; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_le; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_le();
 */
@@ -2598,14 +2598,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_le()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%lanemask_le;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_lanemask_le_is_not_supported_before_SM_35__();
@@ -2615,7 +2615,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_le()
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%lanemask_lt; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_lt; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_lt();
 */
@@ -2625,14 +2625,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_lt()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%lanemask_lt;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_lanemask_lt_is_not_supported_before_SM_35__();
@@ -2642,7 +2642,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_lt()
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%lanemask_ge; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_ge; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_ge();
 */
@@ -2652,14 +2652,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_ge()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%lanemask_ge;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_lanemask_ge_is_not_supported_before_SM_35__();
@@ -2669,7 +2669,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_ge()
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%lanemask_gt; // PTX ISA 20, SM_35
+// mov.u32 sreg_value, %%lanemask_gt; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_lanemask_gt();
 */
@@ -2679,14 +2679,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_gt()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%lanemask_gt;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_lanemask_gt_is_not_supported_before_SM_35__();
@@ -2696,7 +2696,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_lanemask_gt()
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u32 out, %%clock; // PTX ISA 10
+// mov.u32 sreg_value, %%clock; // PTX ISA 10
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clock();
 */
@@ -2704,19 +2704,19 @@ __device__ static inline uint32_t get_sreg_clock();
 template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clock()
 {
-  _CUDA_VSTD::uint32_t __out;
+  _CUDA_VSTD::uint32_t __sreg_value;
   asm volatile (
     "mov.u32 %0, %%clock;"
-    : "=r"(__out)
+    : "=r"(__sreg_value)
     :
     :
   );
-  return __out;
+  return __sreg_value;
 }
 #endif // __cccl_ptx_isa >= 100
 
 /*
-// mov.u32 out, %%clock_hi; // PTX ISA 50, SM_35
+// mov.u32 sreg_value, %%clock_hi; // PTX ISA 50, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_clock_hi();
 */
@@ -2726,14 +2726,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clock_hi()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm volatile (
       "mov.u32 %0, %%clock_hi;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_clock_hi_is_not_supported_before_SM_35__();
@@ -2743,7 +2743,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_clock_hi()
 #endif // __cccl_ptx_isa >= 500
 
 /*
-// mov.u64 out, %%clock64; // PTX ISA 20, SM_35
+// mov.u64 sreg_value, %%clock64; // PTX ISA 20, SM_35
 template <typename=void>
 __device__ static inline uint64_t get_sreg_clock64();
 */
@@ -2753,14 +2753,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_clock64()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint64_t __out;
+    _CUDA_VSTD::uint64_t __sreg_value;
     asm volatile (
       "mov.u64 %0, %%clock64;"
-      : "=l"(__out)
+      : "=l"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_clock64_is_not_supported_before_SM_35__();
@@ -2770,7 +2770,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_clock64()
 #endif // __cccl_ptx_isa >= 200
 
 /*
-// mov.u64 out, %%globaltimer; // PTX ISA 31, SM_35
+// mov.u64 sreg_value, %%globaltimer; // PTX ISA 31, SM_35
 template <typename=void>
 __device__ static inline uint64_t get_sreg_globaltimer();
 */
@@ -2780,14 +2780,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_globaltimer()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint64_t __out;
+    _CUDA_VSTD::uint64_t __sreg_value;
     asm volatile (
       "mov.u64 %0, %%globaltimer;"
-      : "=l"(__out)
+      : "=l"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_globaltimer_is_not_supported_before_SM_35__();
@@ -2797,7 +2797,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_globaltimer()
 #endif // __cccl_ptx_isa >= 310
 
 /*
-// mov.u32 out, %%globaltimer_lo; // PTX ISA 31, SM_35
+// mov.u32 sreg_value, %%globaltimer_lo; // PTX ISA 31, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_globaltimer_lo();
 */
@@ -2807,14 +2807,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_globaltimer_lo()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm volatile (
       "mov.u32 %0, %%globaltimer_lo;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_globaltimer_lo_is_not_supported_before_SM_35__();
@@ -2824,7 +2824,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_globaltimer_lo()
 #endif // __cccl_ptx_isa >= 310
 
 /*
-// mov.u32 out, %%globaltimer_hi; // PTX ISA 31, SM_35
+// mov.u32 sreg_value, %%globaltimer_hi; // PTX ISA 31, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_globaltimer_hi();
 */
@@ -2834,14 +2834,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_globaltimer_hi()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm volatile (
       "mov.u32 %0, %%globaltimer_hi;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_globaltimer_hi_is_not_supported_before_SM_35__();
@@ -2851,7 +2851,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_globaltimer_hi()
 #endif // __cccl_ptx_isa >= 310
 
 /*
-// mov.u32 out, %%total_smem_size; // PTX ISA 41, SM_35
+// mov.u32 sreg_value, %%total_smem_size; // PTX ISA 41, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_total_smem_size();
 */
@@ -2861,14 +2861,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_total_smem_size()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%total_smem_size;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_total_smem_size_is_not_supported_before_SM_35__();
@@ -2878,7 +2878,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_total_smem_size()
 #endif // __cccl_ptx_isa >= 410
 
 /*
-// mov.u32 out, %%aggr_smem_size; // PTX ISA 81, SM_90
+// mov.u32 sreg_value, %%aggr_smem_size; // PTX ISA 81, SM_90
 template <typename=void>
 __device__ static inline uint32_t get_sreg_aggr_smem_size();
 */
@@ -2888,14 +2888,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_aggr_smem_size()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%aggr_smem_size;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_aggr_smem_size_is_not_supported_before_SM_90__();
@@ -2905,7 +2905,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_aggr_smem_size()
 #endif // __cccl_ptx_isa >= 810
 
 /*
-// mov.u32 out, %%dynamic_smem_size; // PTX ISA 41, SM_35
+// mov.u32 sreg_value, %%dynamic_smem_size; // PTX ISA 41, SM_35
 template <typename=void>
 __device__ static inline uint32_t get_sreg_dynamic_smem_size();
 */
@@ -2915,14 +2915,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_dynamic_smem_size()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_35,(
-    _CUDA_VSTD::uint32_t __out;
+    _CUDA_VSTD::uint32_t __sreg_value;
     asm (
       "mov.u32 %0, %%dynamic_smem_size;"
-      : "=r"(__out)
+      : "=r"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_dynamic_smem_size_is_not_supported_before_SM_35__();
@@ -2932,7 +2932,7 @@ _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint32_t get_sreg_dynamic_smem_size
 #endif // __cccl_ptx_isa >= 410
 
 /*
-// mov.u64 out, %%current_graph_exec; // PTX ISA 80, SM_50
+// mov.u64 sreg_value, %%current_graph_exec; // PTX ISA 80, SM_50
 template <typename=void>
 __device__ static inline uint64_t get_sreg_current_graph_exec();
 */
@@ -2942,14 +2942,14 @@ template <typename=void>
 _LIBCUDACXX_DEVICE static inline _CUDA_VSTD::uint64_t get_sreg_current_graph_exec()
 {
   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_50,(
-    _CUDA_VSTD::uint64_t __out;
+    _CUDA_VSTD::uint64_t __sreg_value;
     asm (
       "mov.u64 %0, %%current_graph_exec;"
-      : "=l"(__out)
+      : "=l"(__sreg_value)
       :
       :
     );
-    return __out;
+    return __sreg_value;
   ),(
     // Unsupported architectures will have a linker error with a semi-decent error message
     __cuda_ptx_get_sreg_current_graph_exec_is_not_supported_before_SM_50__();

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.get_sreg.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.get_sreg.compile.pass.cpp
@@ -33,303 +33,303 @@
 
 __global__ void test_get_sreg(void ** fn_ptr) {
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%tid.x;
+  // mov.u32 sreg_value, %%tid.x;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_tid_x));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%tid.y;
+  // mov.u32 sreg_value, %%tid.y;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_tid_y));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%tid.z;
+  // mov.u32 sreg_value, %%tid.z;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_tid_z));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%ntid.x;
+  // mov.u32 sreg_value, %%ntid.x;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ntid_x));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%ntid.y;
+  // mov.u32 sreg_value, %%ntid.y;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ntid_y));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%ntid.z;
+  // mov.u32 sreg_value, %%ntid.z;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ntid_z));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 130
-  // mov.u32 out, %%laneid;
+  // mov.u32 sreg_value, %%laneid;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_laneid));
 #endif // __cccl_ptx_isa >= 130
 
 #if __cccl_ptx_isa >= 130
-  // mov.u32 out, %%warpid;
+  // mov.u32 sreg_value, %%warpid;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_warpid));
 #endif // __cccl_ptx_isa >= 130
 
 #if __cccl_ptx_isa >= 200
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%nwarpid;
+    // mov.u32 sreg_value, %%nwarpid;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nwarpid));
   ));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%ctaid.x;
+  // mov.u32 sreg_value, %%ctaid.x;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ctaid_x));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%ctaid.y;
+  // mov.u32 sreg_value, %%ctaid.y;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ctaid_y));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%ctaid.z;
+  // mov.u32 sreg_value, %%ctaid.z;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ctaid_z));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%nctaid.x;
+  // mov.u32 sreg_value, %%nctaid.x;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nctaid_x));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%nctaid.y;
+  // mov.u32 sreg_value, %%nctaid.y;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nctaid_y));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
-  // mov.u32 out, %%nctaid.z;
+  // mov.u32 sreg_value, %%nctaid.z;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nctaid_z));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 130
-  // mov.u32 out, %%smid;
+  // mov.u32 sreg_value, %%smid;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_smid));
 #endif // __cccl_ptx_isa >= 130
 
 #if __cccl_ptx_isa >= 200
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%nsmid;
+    // mov.u32 sreg_value, %%nsmid;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nsmid));
   ));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 300
-  // mov.u64 out, %%gridid;
+  // mov.u64 sreg_value, %%gridid;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint64_t (*)()>(cuda::ptx::get_sreg_gridid));
 #endif // __cccl_ptx_isa >= 300
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.pred out, %%is_explicit_cluster;
+    // mov.pred sreg_value, %%is_explicit_cluster;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<bool (*)()>(cuda::ptx::get_sreg_is_explicit_cluster));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%clusterid.x;
+    // mov.u32 sreg_value, %%clusterid.x;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clusterid_x));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%clusterid.y;
+    // mov.u32 sreg_value, %%clusterid.y;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clusterid_y));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%clusterid.z;
+    // mov.u32 sreg_value, %%clusterid.z;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clusterid_z));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%nclusterid.x;
+    // mov.u32 sreg_value, %%nclusterid.x;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nclusterid_x));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%nclusterid.y;
+    // mov.u32 sreg_value, %%nclusterid.y;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nclusterid_y));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%nclusterid.z;
+    // mov.u32 sreg_value, %%nclusterid.z;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nclusterid_z));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%cluster_ctaid.x;
+    // mov.u32 sreg_value, %%cluster_ctaid.x;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_ctaid_x));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%cluster_ctaid.y;
+    // mov.u32 sreg_value, %%cluster_ctaid.y;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_ctaid_y));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%cluster_ctaid.z;
+    // mov.u32 sreg_value, %%cluster_ctaid.z;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_ctaid_z));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%cluster_nctaid.x;
+    // mov.u32 sreg_value, %%cluster_nctaid.x;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_nctaid_x));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%cluster_nctaid.y;
+    // mov.u32 sreg_value, %%cluster_nctaid.y;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_nctaid_y));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%cluster_nctaid.z;
+    // mov.u32 sreg_value, %%cluster_nctaid.z;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_nctaid_z));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%cluster_ctarank;
+    // mov.u32 sreg_value, %%cluster_ctarank;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_ctarank));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 780
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%cluster_nctarank;
+    // mov.u32 sreg_value, %%cluster_nctarank;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_nctarank));
   ));
 #endif // __cccl_ptx_isa >= 780
 
 #if __cccl_ptx_isa >= 200
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%lanemask_eq;
+    // mov.u32 sreg_value, %%lanemask_eq;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_eq));
   ));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%lanemask_le;
+    // mov.u32 sreg_value, %%lanemask_le;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_le));
   ));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%lanemask_lt;
+    // mov.u32 sreg_value, %%lanemask_lt;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_lt));
   ));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%lanemask_ge;
+    // mov.u32 sreg_value, %%lanemask_ge;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_ge));
   ));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 200
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%lanemask_gt;
+    // mov.u32 sreg_value, %%lanemask_gt;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_gt));
   ));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 100
-  // mov.u32 out, %%clock;
+  // mov.u32 sreg_value, %%clock;
   *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clock));
 #endif // __cccl_ptx_isa >= 100
 
 #if __cccl_ptx_isa >= 500
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%clock_hi;
+    // mov.u32 sreg_value, %%clock_hi;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clock_hi));
   ));
 #endif // __cccl_ptx_isa >= 500
 
 #if __cccl_ptx_isa >= 200
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u64 out, %%clock64;
+    // mov.u64 sreg_value, %%clock64;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint64_t (*)()>(cuda::ptx::get_sreg_clock64));
   ));
 #endif // __cccl_ptx_isa >= 200
 
 #if __cccl_ptx_isa >= 310
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u64 out, %%globaltimer;
+    // mov.u64 sreg_value, %%globaltimer;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint64_t (*)()>(cuda::ptx::get_sreg_globaltimer));
   ));
 #endif // __cccl_ptx_isa >= 310
 
 #if __cccl_ptx_isa >= 310
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%globaltimer_lo;
+    // mov.u32 sreg_value, %%globaltimer_lo;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_globaltimer_lo));
   ));
 #endif // __cccl_ptx_isa >= 310
 
 #if __cccl_ptx_isa >= 310
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%globaltimer_hi;
+    // mov.u32 sreg_value, %%globaltimer_hi;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_globaltimer_hi));
   ));
 #endif // __cccl_ptx_isa >= 310
 
 #if __cccl_ptx_isa >= 410
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%total_smem_size;
+    // mov.u32 sreg_value, %%total_smem_size;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_total_smem_size));
   ));
 #endif // __cccl_ptx_isa >= 410
 
 #if __cccl_ptx_isa >= 810
   NV_IF_TARGET(NV_PROVIDES_SM_90, (
-    // mov.u32 out, %%aggr_smem_size;
+    // mov.u32 sreg_value, %%aggr_smem_size;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_aggr_smem_size));
   ));
 #endif // __cccl_ptx_isa >= 810
 
 #if __cccl_ptx_isa >= 410
   NV_IF_TARGET(NV_PROVIDES_SM_35, (
-    // mov.u32 out, %%dynamic_smem_size;
+    // mov.u32 sreg_value, %%dynamic_smem_size;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_dynamic_smem_size));
   ));
 #endif // __cccl_ptx_isa >= 410
 
 #if __cccl_ptx_isa >= 800
   NV_IF_TARGET(NV_PROVIDES_SM_50, (
-    // mov.u64 out, %%current_graph_exec;
+    // mov.u64 sreg_value, %%current_graph_exec;
     *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint64_t (*)()>(cuda::ptx::get_sreg_current_graph_exec));
   ));
 #endif // __cccl_ptx_isa >= 800

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.get_sreg.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.get_sreg.compile.pass.cpp
@@ -1,0 +1,341 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+// UNSUPPORTED: libcpp-has-no-threads
+
+// <cuda/ptx>
+
+#include <cuda/ptx>
+#include <cuda/std/utility>
+
+/*
+ * We use a special strategy to force the generation of the PTX. This is mainly
+ * a fight against dead-code-elimination in the NVVM layer.
+ *
+ * The reason we need this strategy is because certain older versions of ptxas
+ * segfault when a non-sensical sequence of PTX is generated. So instead, we try
+ * to force the instantiation and compilation to PTX of all the overloads of the
+ * PTX wrapping functions.
+ *
+ * We do this by writing a function pointer of each overload to the kernel
+ * parameter `fn_ptr`.
+ *
+ * Because `fn_ptr` is possibly visible outside this translation unit, the
+ * compiler must compile all the functions which are stored.
+ *
+ */
+
+__global__ void test_get_sreg(void ** fn_ptr) {
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%tid.x;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_tid_x));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%tid.y;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_tid_y));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%tid.z;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_tid_z));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%ntid.x;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ntid_x));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%ntid.y;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ntid_y));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%ntid.z;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ntid_z));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 130
+  // mov.u32 out, %%laneid;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_laneid));
+#endif // __cccl_ptx_isa >= 130
+
+#if __cccl_ptx_isa >= 130
+  // mov.u32 out, %%warpid;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_warpid));
+#endif // __cccl_ptx_isa >= 130
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%nwarpid;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nwarpid));
+  ));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%ctaid.x;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ctaid_x));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%ctaid.y;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ctaid_y));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%ctaid.z;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_ctaid_z));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%nctaid.x;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nctaid_x));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%nctaid.y;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nctaid_y));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  // mov.u32 out, %%nctaid.z;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nctaid_z));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 130
+  // mov.u32 out, %%smid;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_smid));
+#endif // __cccl_ptx_isa >= 130
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%nsmid;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nsmid));
+  ));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 300
+  // mov.u64 out, %%gridid;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint64_t (*)()>(cuda::ptx::get_sreg_gridid));
+#endif // __cccl_ptx_isa >= 300
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.pred out, %%is_explicit_cluster;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<bool (*)()>(cuda::ptx::get_sreg_is_explicit_cluster));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%clusterid.x;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clusterid_x));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%clusterid.y;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clusterid_y));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%clusterid.z;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clusterid_z));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%nclusterid.x;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nclusterid_x));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%nclusterid.y;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nclusterid_y));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%nclusterid.z;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_nclusterid_z));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%cluster_ctaid.x;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_ctaid_x));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%cluster_ctaid.y;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_ctaid_y));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%cluster_ctaid.z;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_ctaid_z));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%cluster_nctaid.x;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_nctaid_x));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%cluster_nctaid.y;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_nctaid_y));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%cluster_nctaid.z;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_nctaid_z));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%cluster_ctarank;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_ctarank));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 780
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%cluster_nctarank;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_cluster_nctarank));
+  ));
+#endif // __cccl_ptx_isa >= 780
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%lanemask_eq;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_eq));
+  ));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%lanemask_le;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_le));
+  ));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%lanemask_lt;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_lt));
+  ));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%lanemask_ge;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_ge));
+  ));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%lanemask_gt;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_lanemask_gt));
+  ));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 100
+  // mov.u32 out, %%clock;
+  *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clock));
+#endif // __cccl_ptx_isa >= 100
+
+#if __cccl_ptx_isa >= 500
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%clock_hi;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_clock_hi));
+  ));
+#endif // __cccl_ptx_isa >= 500
+
+#if __cccl_ptx_isa >= 200
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u64 out, %%clock64;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint64_t (*)()>(cuda::ptx::get_sreg_clock64));
+  ));
+#endif // __cccl_ptx_isa >= 200
+
+#if __cccl_ptx_isa >= 310
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u64 out, %%globaltimer;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint64_t (*)()>(cuda::ptx::get_sreg_globaltimer));
+  ));
+#endif // __cccl_ptx_isa >= 310
+
+#if __cccl_ptx_isa >= 310
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%globaltimer_lo;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_globaltimer_lo));
+  ));
+#endif // __cccl_ptx_isa >= 310
+
+#if __cccl_ptx_isa >= 310
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%globaltimer_hi;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_globaltimer_hi));
+  ));
+#endif // __cccl_ptx_isa >= 310
+
+#if __cccl_ptx_isa >= 410
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%total_smem_size;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_total_smem_size));
+  ));
+#endif // __cccl_ptx_isa >= 410
+
+#if __cccl_ptx_isa >= 810
+  NV_IF_TARGET(NV_PROVIDES_SM_90, (
+    // mov.u32 out, %%aggr_smem_size;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_aggr_smem_size));
+  ));
+#endif // __cccl_ptx_isa >= 810
+
+#if __cccl_ptx_isa >= 410
+  NV_IF_TARGET(NV_PROVIDES_SM_35, (
+    // mov.u32 out, %%dynamic_smem_size;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint32_t (*)()>(cuda::ptx::get_sreg_dynamic_smem_size));
+  ));
+#endif // __cccl_ptx_isa >= 410
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(NV_PROVIDES_SM_50, (
+    // mov.u64 out, %%current_graph_exec;
+    *fn_ptr++ = reinterpret_cast<void*>(static_cast<uint64_t (*)()>(cuda::ptx::get_sreg_current_graph_exec));
+  ));
+#endif // __cccl_ptx_isa >= 800
+}
+
+int main(int, char**)
+{
+    return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.get_sreg.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.get_sreg.compile.pass.cpp
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: libcpp-has-no-threads
+// UNSUPPORTED: clang && !nvcc
 
 // <cuda/ptx>
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #1350 

Adds the ability to query the PTX special registers.

Noting the Hopper-specific ones:
[10.12. Special Registers: %clusterid](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-clusterid)		
[10.13. Special Registers: %nclusterid](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-nclusterid)		
[10.14. Special Registers: %cluster_ctaid](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-cluster-ctaid)		
[10.15. Special Registers: %cluster_nctaid](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-cluster-nctaid)		
[10.16. Special Registers: %cluster_ctarank](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-cluster-ctarank)		
[10.17. Special Registers: %cluster_nctarank](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-cluster-nctarank)		
[10.31. Special Registers: %aggr_smem_size](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-aggr-smem-size)		

Other requested additions include `lanemask_{lt,gt,ge,le}`, as requested by @canonizer. These functions are also used in CUB `cccl/cub/cub/util_ptx.h`. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
