### PR TITLE
[FEA]: Do not version vocabulary types in thrust

### DIFF
--- a/thrust/testing/unittest/testframework.h
+++ b/thrust/testing/unittest/testframework.h
@@ -229,7 +229,7 @@ private:
     }
 };
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 template <>
 struct numeric_limits<custom_numeric> : numeric_limits<int> {};
@@ -245,7 +245,7 @@ class integer_traits<custom_numeric>
 
 } // namespace detail
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END
 
 typedef unittest::type_list<char,
                             signed char,

--- a/thrust/thrust/complex.h
+++ b/thrust/thrust/complex.h
@@ -35,7 +35,7 @@
 #include <cuda/std/complex>
 #include <cuda/std/type_traits>
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 /*! \addtogroup numerics
  *  \{
@@ -604,7 +604,7 @@ template <typename T>
 struct is_complex<::std::complex<T>> : public thrust::true_type
 {};
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END
 
 /*! \} // complex_numbers
  */

--- a/thrust/thrust/detail/config/namespace.h
+++ b/thrust/thrust/detail/config/namespace.h
@@ -198,6 +198,27 @@
   } /* end namespace thrust */                                                 \
   THRUST_NS_POSTFIX
 
+/**
+ * \def THRUST_PLAIN_NAMESPACE_BEGIN
+ * This macro is used to open a `thrust::` namespace block, without the
+ * inline namespace requested by THRUST_DETAIL_ABI_NS_BEGIN.
+ * This macro is defined by Thrust and may not be overridden.
+ */
+#define THRUST_PLAIN_NAMESPACE_BEGIN \
+  THRUST_NS_PREFIX                   \
+  namespace thrust                   \
+  {
+
+/**
+ * \def THRUST_PLAIN_NAMESPACE_END
+ * This macro is used to close a `thrust::` namespace block, without the
+ * inline namespace requested by THRUST_DETAIL_ABI_NS_END.
+ * This macro is defined by Thrust and may not be overridden.
+ */
+#define THRUST_PLAIN_NAMESPACE_END   \
+  } /* end namespace thrust */       \
+  THRUST_NS_POSTFIX
+
 // The following is just here to add docs for the thrust namespace:
 
 THRUST_NS_PREFIX

--- a/thrust/thrust/detail/numeric_traits.h
+++ b/thrust/thrust/detail/numeric_traits.h
@@ -30,7 +30,7 @@
 
 //#include <stdint.h> // for intmax_t (not provided on MSVS 2005)
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 namespace detail
 {
@@ -134,4 +134,4 @@ numeric_distance(Number x, Number y)
 
 } // end detail
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -41,7 +41,7 @@
 #include <initializer_list>
 #include <vector>
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 namespace detail
 {
@@ -630,7 +630,7 @@ template<typename T1, typename Alloc1,
 bool operator!=(const std::vector<T1,Alloc1>&         lhs,
                 const detail::vector_base<T2,Alloc2>& rhs);
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END
 
 #include <thrust/detail/vector_base.inl>
 

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -38,7 +38,7 @@
 
 #include <stdexcept>
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 namespace detail
 {
@@ -1373,5 +1373,5 @@ bool operator!=(const std::vector<T1,Alloc1>&         lhs,
     return !(lhs == rhs);
 }
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END
 

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -38,7 +38,7 @@
 #include <vector>
 #include <utility>
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 /*! \addtogroup containers Containers
  *  \{
@@ -516,4 +516,4 @@ template<typename T, typename Alloc>
 /*! \} // containres
  */
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -38,7 +38,7 @@
 #include <vector>
 #include <utility>
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 /*! \addtogroup container_classes Container Classes
  *  \addtogroup host_containers Host Containers
@@ -539,4 +539,4 @@ template<typename T, typename Alloc>
 /*! \}
  */
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END

--- a/thrust/thrust/limits.h
+++ b/thrust/thrust/limits.h
@@ -20,9 +20,9 @@
 #include <thrust/detail/config.h>
 #include <thrust/detail/type_traits.h>
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 template <typename T>
 struct numeric_limits : std::numeric_limits<T> {};
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END

--- a/thrust/thrust/optional.h
+++ b/thrust/thrust/optional.h
@@ -92,7 +92,6 @@ THRUST_NAMESPACE_BEGIN
           : std::is_trivially_copy_constructible<T>{};
 #endif
   }
-THRUST_NAMESPACE_END
 #endif
 
 #define THRUST_OPTIONAL_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)                                     \
@@ -171,7 +170,7 @@ THRUST_NAMESPACE_END
 #define THRUST_OPTIONAL_CPP11_CONSTEXPR constexpr
 #endif
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 #ifndef THRUST_MONOSTATE_INPLACE_MUTEX
 #define THRUST_MONOSTATE_INPLACE_MUTEX
@@ -2864,7 +2863,7 @@ private:
   T *m_value;
 };
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END
 
 namespace std {
 // TODO SFINAE

--- a/thrust/thrust/pair.h
+++ b/thrust/thrust/pair.h
@@ -32,7 +32,7 @@
 
 #include <cuda/std/utility>
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 /*! \addtogroup utility
  *  \{
@@ -87,4 +87,4 @@ using ::cuda::std::make_pair;
 /*! \} // utility
  */
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END

--- a/thrust/thrust/tuple.h
+++ b/thrust/thrust/tuple.h
@@ -44,7 +44,7 @@
 
 #include <tuple>
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 
 // define null_type for backwards compatability
@@ -154,7 +154,7 @@ using ::cuda::std::tie;
 /*! \} // utility
  */
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 

--- a/thrust/thrust/universal_vector.h
+++ b/thrust/thrust/universal_vector.h
@@ -37,7 +37,7 @@
 #include __THRUST_DEVICE_SYSTEM_VECTOR_HEADER
 #undef __THRUST_DEVICE_SYSTEM_VECTOR_HEADER
 
-THRUST_NAMESPACE_BEGIN
+THRUST_PLAIN_NAMESPACE_BEGIN
 
 /*! \addtogroup containers Containers
  *  \{
@@ -60,4 +60,4 @@ using thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_vector;
 /*! \} // containers
  */
 
-THRUST_NAMESPACE_END
+THRUST_PLAIN_NAMESPACE_END


### PR DESCRIPTION
We have issues with the internal versioning of thrust types that may end up in a public API.

As we utilize cuda architectures for an internal namespace etc those types turn out to be different between host and device TUs.

Therefore, put types inte a plain unversioned namespace

Addresses #1262
