### PR TITLE
Fixes integer overflows in index computation when indexes approach `numeric_limits<OffsetT>::max()`. Adds tests for large `num_items`.

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -12,6 +12,8 @@ CCCL uses [Development Containers](https://containers.dev/) to provide consisten
 ### Prerequisites
 - [Visual Studio Code](https://code.visualstudio.com/)
 - [Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+- [Docker](https://docs.docker.com/engine/install/) - This is only for completeness because it should already be implicitly installed by the Dev Containers extension
 
 ### Steps
 

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -355,9 +355,9 @@ struct AgentPartition
     OffsetT local_tile_idx = mask & partition_idx;
 
     OffsetT keys1_beg = (cub::min)(keys_count, start);
-    OffsetT keys1_end = (cub::min)(keys_count, detail::SafeAddBoundToMax(start, size));
+    OffsetT keys1_end = (cub::min)(keys_count, detail::safe_add_bound_to_max(start, size));
     OffsetT keys2_beg = keys1_end;
-    OffsetT keys2_end = (cub::min)(keys_count, detail::SafeAddBoundToMax(keys2_beg, size));
+    OffsetT keys2_end = (cub::min)(keys_count, detail::safe_add_bound_to_max(keys2_beg, size));
 
     // The last partition (which is one-past-the-last-tile) is only to mark the end of keys1_end for the merge stage
     if (partition_idx + 1 == num_partitions)
@@ -548,8 +548,9 @@ struct AgentMerge
     // diag >= keys1_beg, because diag is the distance of the total merge path so far (keys1 + keys2)
     // diag+ITEMS_PER_TILE >= keys1_end, because diag+ITEMS_PER_TILE is the distance of the merge path for the next tile
     // and keys1_end is key1's component of that path
-    OffsetT keys2_beg = (cub::min)(max_keys2, diag - keys1_beg);                              
-    OffsetT keys2_end = (cub::min)(max_keys2, detail::SafeAddBoundToMax(diag, static_cast<OffsetT>(ITEMS_PER_TILE)) - keys1_end);
+    OffsetT keys2_beg = (cub::min)(max_keys2, diag - keys1_beg);
+    OffsetT keys2_end =
+      (cub::min)(max_keys2, detail::safe_add_bound_to_max(diag, static_cast<OffsetT>(ITEMS_PER_TILE)) - keys1_end);
 
     // Check if it's the last tile in the tile group being merged
     if (mask == (mask & tile_idx))

--- a/cub/cub/detail/choose_offset.cuh
+++ b/cub/cub/detail/choose_offset.cuh
@@ -78,7 +78,7 @@ struct promote_small_offset
                 "NumItemsT must be an integral type, but not bool");
 
   // Unsigned integer type for global offsets.
-  using type = typename std::conditional<sizeof(NumItemsT) < 4, std::int32_t, NumItemsT>::type;
+  using type = typename ::cuda::std::conditional<sizeof(NumItemsT) < 4, std::int32_t, NumItemsT>::type;
 };
 
 /**

--- a/cub/cub/detail/choose_offset.cuh
+++ b/cub/cub/detail/choose_offset.cuh
@@ -66,6 +66,22 @@ struct ChooseOffsetT
 };
 
 /**
+ * PromoteSmallOffsetT checks NumItemsT, the type of the num_items parameter, and
+ * promotes any integral type smaller than 32 bits to a signed 32-bit integer type.
+ */
+template <typename NumItemsT>
+struct PromoteSmallOffsetT
+{
+  // NumItemsT must be an integral type (but not bool).
+  static_assert(std::is_integral<NumItemsT>::value
+                  && !std::is_same<typename std::remove_cv<NumItemsT>::type, bool>::value,
+                "NumItemsT must be an integral type, but not bool");
+
+  // Unsigned integer type for global offsets.
+  using Type = typename std::conditional<sizeof(NumItemsT) < 4, std::int32_t, NumItemsT>::type;
+};
+
+/**
  * common_iterator_value sets member type to the common_type of
  * value_type for all argument types. used to get OffsetT in
  * DeviceSegmentedReduce.

--- a/cub/cub/detail/choose_offset.cuh
+++ b/cub/cub/detail/choose_offset.cuh
@@ -66,20 +66,27 @@ struct ChooseOffsetT
 };
 
 /**
- * PromoteSmallOffsetT checks NumItemsT, the type of the num_items parameter, and
+ * promote_small_offset checks NumItemsT, the type of the num_items parameter, and
  * promotes any integral type smaller than 32 bits to a signed 32-bit integer type.
  */
 template <typename NumItemsT>
-struct PromoteSmallOffsetT
+struct promote_small_offset
 {
   // NumItemsT must be an integral type (but not bool).
-  static_assert(std::is_integral<NumItemsT>::value
-                  && !std::is_same<typename std::remove_cv<NumItemsT>::type, bool>::value,
+  static_assert(::cuda::std::is_integral<NumItemsT>::value
+                  && !::cuda::std::is_same<typename ::cuda::std::remove_cv<NumItemsT>::type, bool>::value,
                 "NumItemsT must be an integral type, but not bool");
 
   // Unsigned integer type for global offsets.
-  using Type = typename std::conditional<sizeof(NumItemsT) < 4, std::int32_t, NumItemsT>::type;
+  using type = typename std::conditional<sizeof(NumItemsT) < 4, std::int32_t, NumItemsT>::type;
 };
+
+/**
+ * promote_small_offset_t is an alias template that checks NumItemsT, the type of the num_items parameter, and
+ * promotes any integral type smaller than 32 bits to a signed 32-bit integer type.
+ */
+template <typename NumItemsT>
+using promote_small_offset_t = typename promote_small_offset<NumItemsT>::type;
 
 /**
  * common_iterator_value sets member type to the common_type of

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -218,7 +218,7 @@ struct DeviceMergeSort
             CompareOpT compare_op,
             cudaStream_t stream = 0)
   {
-    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+    using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
     using DispatchMergeSortT = DispatchMergeSort<KeyIteratorT,
                                                  ValueIteratorT,
@@ -393,7 +393,7 @@ struct DeviceMergeSort
                 CompareOpT compare_op,
                 cudaStream_t stream = 0)
   {
-    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+    using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
     using DispatchMergeSortT = DispatchMergeSort<KeyInputIteratorT,
                                                  ValueInputIteratorT,
@@ -544,7 +544,7 @@ struct DeviceMergeSort
            CompareOpT compare_op,
            cudaStream_t stream = 0)
   {
-    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+    using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
     using DispatchMergeSortT = DispatchMergeSort<KeyIteratorT,
                                                  NullType *,
@@ -696,7 +696,7 @@ struct DeviceMergeSort
                CompareOpT compare_op,
                cudaStream_t stream = 0)
   {
-    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+    using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
     using DispatchMergeSortT = DispatchMergeSort<KeyInputIteratorT,
                                                  NullType *,
@@ -848,7 +848,7 @@ struct DeviceMergeSort
                   CompareOpT compare_op,
                   cudaStream_t stream = 0)
   {
-    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+    using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
     return SortPairs<KeyIteratorT, ValueIteratorT, PromotedOffsetT, CompareOpT>(
       d_temp_storage,
@@ -982,7 +982,7 @@ struct DeviceMergeSort
                  CompareOpT compare_op,
                  cudaStream_t stream = 0)
   {
-    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+    using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
     return SortKeys<KeyIteratorT, PromotedOffsetT, CompareOpT>(d_temp_storage,
                                                        temp_storage_bytes,
@@ -1125,7 +1125,7 @@ struct DeviceMergeSort
                      CompareOpT compare_op,
                      cudaStream_t stream = 0)
   {
-    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+    using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
     return SortKeysCopy<KeyInputIteratorT, KeyIteratorT, PromotedOffsetT, CompareOpT>(d_temp_storage,
                                                                               temp_storage_bytes,

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -37,6 +37,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cub/detail/choose_offset.cuh>
 #include <cub/device/dispatch/dispatch_merge_sort.cuh>
 #include <cub/util_deprecated.cuh>
 #include <cub/util_namespace.cuh>
@@ -217,11 +218,13 @@ struct DeviceMergeSort
             CompareOpT compare_op,
             cudaStream_t stream = 0)
   {
+    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+
     using DispatchMergeSortT = DispatchMergeSort<KeyIteratorT,
                                                  ValueIteratorT,
                                                  KeyIteratorT,
                                                  ValueIteratorT,
-                                                 OffsetT,
+                                                 PromotedOffsetT,
                                                  CompareOpT>;
 
     return DispatchMergeSortT::Dispatch(d_temp_storage,
@@ -390,11 +393,13 @@ struct DeviceMergeSort
                 CompareOpT compare_op,
                 cudaStream_t stream = 0)
   {
+    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+
     using DispatchMergeSortT = DispatchMergeSort<KeyInputIteratorT,
                                                  ValueInputIteratorT,
                                                  KeyIteratorT,
                                                  ValueIteratorT,
-                                                 OffsetT,
+                                                 PromotedOffsetT,
                                                  CompareOpT>;
 
     return DispatchMergeSortT::Dispatch(d_temp_storage,
@@ -539,11 +544,13 @@ struct DeviceMergeSort
            CompareOpT compare_op,
            cudaStream_t stream = 0)
   {
+    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+
     using DispatchMergeSortT = DispatchMergeSort<KeyIteratorT,
                                                  NullType *,
                                                  KeyIteratorT,
                                                  NullType *,
-                                                 OffsetT,
+                                                 PromotedOffsetT,
                                                  CompareOpT>;
 
     return DispatchMergeSortT::Dispatch(d_temp_storage,
@@ -689,11 +696,13 @@ struct DeviceMergeSort
                CompareOpT compare_op,
                cudaStream_t stream = 0)
   {
+    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+
     using DispatchMergeSortT = DispatchMergeSort<KeyInputIteratorT,
                                                  NullType *,
                                                  KeyIteratorT,
                                                  NullType *,
-                                                 OffsetT,
+                                                 PromotedOffsetT,
                                                  CompareOpT>;
 
     return DispatchMergeSortT::Dispatch(d_temp_storage,
@@ -839,7 +848,9 @@ struct DeviceMergeSort
                   CompareOpT compare_op,
                   cudaStream_t stream = 0)
   {
-    return SortPairs<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
+    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+
+    return SortPairs<KeyIteratorT, ValueIteratorT, PromotedOffsetT, CompareOpT>(
       d_temp_storage,
       temp_storage_bytes,
       d_keys,
@@ -971,7 +982,9 @@ struct DeviceMergeSort
                  CompareOpT compare_op,
                  cudaStream_t stream = 0)
   {
-    return SortKeys<KeyIteratorT, OffsetT, CompareOpT>(d_temp_storage,
+    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+
+    return SortKeys<KeyIteratorT, PromotedOffsetT, CompareOpT>(d_temp_storage,
                                                        temp_storage_bytes,
                                                        d_keys,
                                                        num_items,
@@ -1112,7 +1125,9 @@ struct DeviceMergeSort
                      CompareOpT compare_op,
                      cudaStream_t stream = 0)
   {
-    return SortKeysCopy<KeyInputIteratorT, KeyIteratorT, OffsetT, CompareOpT>(d_temp_storage,
+    using PromotedOffsetT = typename detail::PromoteSmallOffsetT<OffsetT>::Type; 
+
+    return SortKeysCopy<KeyInputIteratorT, KeyIteratorT, PromotedOffsetT, CompareOpT>(d_temp_storage,
                                                                               temp_storage_bytes,
                                                                               d_input_keys,
                                                                               d_output_keys,

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -234,7 +234,8 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceMergeSortPartitionKernel(
       merge_partitions,
       compare_op,
       target_merged_tiles_number,
-      items_per_tile);
+      items_per_tile,
+      num_partitions);
 
     agent.Process();
   }

--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -64,7 +64,7 @@ using is_integral_or_enum =
 template <typename OffsetT>
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT safe_add_bound_to_max(OffsetT lhs, OffsetT rhs)
 {
-  static_assert(::cuda::std::is_integral_v<OffsetT>, "OffsetT must be an integral type");
+  static_assert(::cuda::std::is_integral<OffsetT>::value, "OffsetT must be an integral type");
   static_assert(sizeof(OffsetT) >= 4, "OffsetT must be at least 32 bits in size");
   auto const capped_operand_rhs = (cub::min)(rhs, ::cuda::std::numeric_limits<OffsetT>::max() - lhs);
   return lhs + capped_operand_rhs;

--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -62,8 +62,10 @@ using is_integral_or_enum =
  * where `(lhs + rhs)` would overflow.
  */
 template <typename OffsetT>
-_CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT SafeAddBoundToMax(OffsetT lhs, OffsetT rhs)
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT safe_add_bound_to_max(OffsetT lhs, OffsetT rhs)
 {
+  static_assert(::cuda::std::is_integral_v<OffsetT>, "OffsetT must be an integral type");
+  static_assert(sizeof(OffsetT) >= 4, "OffsetT must be at least 32 bits in size");
   auto const capped_operand_rhs = (cub::min)(rhs, ::cuda::std::numeric_limits<OffsetT>::max() - lhs);
   return lhs + capped_operand_rhs;
 }

--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -62,7 +62,7 @@ using is_integral_or_enum =
  * where `(lhs + rhs)` would overflow.
  */
 template <typename OffsetT>
-_CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr OffsetT SafeAddBoundToMax(OffsetT lhs, OffsetT rhs)
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT SafeAddBoundToMax(OffsetT lhs, OffsetT rhs)
 {
   auto const capped_operand_rhs = (cub::min)(rhs, ::cuda::std::numeric_limits<OffsetT>::max() - lhs);
   return lhs + capped_operand_rhs;

--- a/cub/test/catch2_large_array_sort_helper.cuh
+++ b/cub/test/catch2_large_array_sort_helper.cuh
@@ -51,7 +51,7 @@
 #include <c2h/vector.cuh>
 #include <catch2_test_helper.h>
 
-// #define DEBUG_TIMING
+#define DEBUG_TIMING
 
 #ifdef DEBUG_TIMING
 #  define TIME(expr) expr

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -74,7 +74,8 @@ struct type_tuple
   using key_t    = KeyT;
 };
 using offset_types =
-  c2h::type_list<type_tuple<std::int32_t>,
+  c2h::type_list<type_tuple<std::int16_t>,
+                 type_tuple<std::int32_t>,
                  type_tuple<std::int32_t, std::uint32_t>,
                  type_tuple<std::uint32_t>,
                  type_tuple<std::uint64_t>>;
@@ -409,6 +410,8 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[.][merge][
     std::min(static_cast<std::size_t>(::cuda::std::numeric_limits<offset_t>::max()) - 1,
              ::cuda::std::numeric_limits<std::uint32_t>::max() + static_cast<std::size_t>(2000000ULL));
   offset_t num_items = static_cast<offset_t>(num_items_ull);
+
+  std::cout << "num_items: " << num_items << "\n";
 
   SECTION("Random")
   {

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -399,7 +399,7 @@ CUB_TEST(
   REQUIRE(values_expected == values_in_out);
 }
 
-CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[.][merge][sort][device][extensive]", offset_types)
+CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[merge][sort][device]", offset_types)
 {
   using testing_types_tuple = c2h::get<0, TestType>;
   using key_t               = typename testing_types_tuple::key_t;

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -411,8 +411,6 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[.][merge][
              ::cuda::std::numeric_limits<std::uint32_t>::max() + static_cast<std::size_t>(2000000ULL));
   offset_t num_items = static_cast<offset_t>(num_items_ull);
 
-  std::cout << "num_items: " << num_items << "\n";
-
   SECTION("Random")
   {
     try

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -123,6 +123,11 @@ struct tuple_to_custom_op_t
   }
 };
 
+/**
+ * @brief In combination with a counting iterator, this function object generates a sequence that wraps around after
+ * reaching `UnsignedIntegralKeyT`'s maximum value. E.g., for a uint8_t this maps the sequence of indexes [0, ..., 254,
+ * 255, 256, 256] -> [0, ..., 254, 255, 0, 1]
+ */
 template <typename UnsignedIntegralKeyT>
 struct index_to_key_value_op
 {
@@ -138,6 +143,16 @@ struct index_to_key_value_op
   }
 };
 
+/**
+ * @brief In combination with a counting iterator, this function object helps generate the expected sorted order for a
+ * sequence generated with `index_to_key_value_op`. It respects how many remainder items there are following the last
+ * occurrence of `UnsignedIntegralKeyT`'s max value. E.g., when we use `num_total_items` of `260` with an `uint8_t`, the
+ * input sequence was:
+ * [0, ..., 254, 255, 256, 257, 258, 259] <= index
+ * [0, ..., 254, 255,   0,   1,   2,   3] <= input
+ * -----------------
+ * [0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 6, ..., 255] <= expected sorted order (note, [0, 3] occur twice)
+ */
 template <typename UnsignedIntegralKeyT>
 class index_to_expected_key_op
 {

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -415,6 +415,8 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[merge][sor
   {
     try
     {
+      TIME(c2h::cpu_timer timer);
+
       // Initialize random input data
       large_array_sort_helper<key_t> arrays;
       constexpr bool is_descending = false;
@@ -428,6 +430,8 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[merge][sor
 
       // Verify results
       arrays.verify_unstable_key_sort(num_items, is_descending, arrays.keys_in);
+
+      TIME(timer.print_elapsed_seconds_and_reset("Random merge sort"));
     }
     catch (std::bad_alloc& e)
     {
@@ -441,6 +445,7 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[merge][sor
   {
     try
     {
+      TIME(c2h::cpu_timer timer);
       c2h::device_vector<key_t> keys_in_out(num_items);
 
       // Pre-populated array with a constant value
@@ -455,6 +460,8 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[merge][sor
         thrust::make_counting_iterator(std::size_t{}), index_to_expected_key_op<key_t>(num_items));
       bool is_correct = thrust::equal(expected_result_it, expected_result_it + num_items, keys_in_out.begin());
       REQUIRE(is_correct == true);
+
+      TIME(timer.print_elapsed_seconds_and_reset("Pre-sorted merge sort"));
     }
     catch (std::bad_alloc& e)
     {
@@ -468,6 +475,7 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[merge][sor
   {
     try
     {
+      TIME(c2h::cpu_timer timer);
       c2h::device_vector<key_t> keys_in_out(num_items);
 
       auto counting_it   = thrust::make_counting_iterator(std::size_t{0});
@@ -483,6 +491,7 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[merge][sor
         thrust::make_counting_iterator(std::size_t{}), index_to_expected_key_op<key_t>(num_items));
       bool is_correct = thrust::equal(expected_result_it, expected_result_it + num_items, keys_in_out.cbegin());
       REQUIRE(is_correct == true);
+      TIME(timer.print_elapsed_seconds_and_reset("Reverse-sorted merge sort"));
     }
     catch (std::bad_alloc& e)
     {

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -407,7 +407,7 @@ CUB_TEST("DeviceMergeSort::StableSortPairs works for large inputs", "[.][merge][
              ::cuda::std::numeric_limits<std::uint32_t>::max() + static_cast<std::size_t>(2000000ULL));
   offset_t num_items = static_cast<offset_t>(num_items_ull);
 
-  thrust::device_vector<key_t> keys_in_out(num_items);
+  c2h::device_vector<key_t> keys_in_out(num_items);
 
   // TODO this will build on common functionality in https://github.com/NVIDIA/cccl/pull/1349
   // SECTION("Random")

--- a/cub/test/catch2_test_util_choose_offset.cu
+++ b/cub/test/catch2_test_util_choose_offset.cu
@@ -44,33 +44,33 @@ CUB_TEST("Tests ChooseOffsetT", "[util][type]")
     ::cuda::std::is_same<typename cub::detail::ChooseOffsetT<std::int64_t>::Type, unsigned long long>::value);
 }
 
-CUB_TEST("Tests PromoteSmallOffsetT", "[util][type]")
+CUB_TEST("Tests promote_small_offset", "[util][type]")
 {
   // Uses input type for types of at least 32 bits
   STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::int32_t>::Type, std::int32_t>::value);
+    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::int32_t>, std::int32_t>::value);
 
   // Uses input type for types of at least 32 bits
   STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::uint32_t>::Type, std::uint32_t>::value);
+    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::uint32_t>, std::uint32_t>::value);
 
   // Uses input type for types of at least 32 bits
   STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::uint64_t>::Type, std::uint64_t>::value);
+    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::uint64_t>, std::uint64_t>::value);
 
   // Uses input type for types of at least 32 bits
   STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::int64_t>::Type, std::int64_t>::value);
+    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::int64_t>, std::int64_t>::value);
 
   // Uses 32-bit type for type smaller than 32 bits
   STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::int8_t>::Type, std::int32_t>::value);
+    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::int8_t>, std::int32_t>::value);
 
   // Uses 32-bit type for type smaller than 32 bits
   STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::int16_t>::Type, std::int32_t>::value);
+    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::int16_t>, std::int32_t>::value);
 
   // Uses 32-bit type for type smaller than 32 bits
   STATIC_REQUIRE(
-    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::uint16_t>::Type, std::int32_t>::value);
+    ::cuda::std::is_same<typename cub::detail::promote_small_offset_t<std::uint16_t>, std::int32_t>::value);
 }

--- a/cub/test/catch2_test_util_choose_offset.cu
+++ b/cub/test/catch2_test_util_choose_offset.cu
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <cub/detail/choose_offset.cuh>
+
+#include <cuda/std/type_traits>
+
+#include "catch2_test_helper.h"
+
+CUB_TEST("Tests ChooseOffsetT", "[util][type]")
+{
+  // Uses unsigned 32-bit type for signed 32-bit type
+  STATIC_REQUIRE(::cuda::std::is_same<typename cub::detail::ChooseOffsetT<std::int32_t>::Type, std::uint32_t>::value);
+
+  // Uses unsigned 32-bit type for type smaller than 32 bits
+  STATIC_REQUIRE(::cuda::std::is_same<typename cub::detail::ChooseOffsetT<std::int8_t>::Type, std::uint32_t>::value);
+
+  // Uses unsigned 64-bit type for signed 64-bit type
+  STATIC_REQUIRE(
+    ::cuda::std::is_same<typename cub::detail::ChooseOffsetT<std::int64_t>::Type, unsigned long long>::value);
+}
+
+CUB_TEST("Tests PromoteSmallOffsetT", "[util][type]")
+{
+  // Uses input type for types of at least 32 bits
+  STATIC_REQUIRE(
+    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::int32_t>::Type, std::int32_t>::value);
+
+  // Uses input type for types of at least 32 bits
+  STATIC_REQUIRE(
+    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::uint32_t>::Type, std::uint32_t>::value);
+
+  // Uses input type for types of at least 32 bits
+  STATIC_REQUIRE(
+    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::uint64_t>::Type, std::uint64_t>::value);
+
+  // Uses input type for types of at least 32 bits
+  STATIC_REQUIRE(
+    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::int64_t>::Type, std::int64_t>::value);
+
+  // Uses 32-bit type for type smaller than 32 bits
+  STATIC_REQUIRE(
+    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::int8_t>::Type, std::int32_t>::value);
+
+  // Uses 32-bit type for type smaller than 32 bits
+  STATIC_REQUIRE(
+    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::int16_t>::Type, std::int32_t>::value);
+
+  // Uses 32-bit type for type smaller than 32 bits
+  STATIC_REQUIRE(
+    ::cuda::std::is_same<typename cub::detail::PromoteSmallOffsetT<std::uint16_t>::Type, std::int32_t>::value);
+}

--- a/cub/test/catch2_test_util_math.cu
+++ b/cub/test/catch2_test_util_math.cu
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <cub/util_math.cuh>
+
+#include <cuda/std/type_traits>
+
+#include "catch2_test_helper.h"
+
+CUB_TEST("Tests safe_add_bound_to_max", "[util][math]")
+{
+  REQUIRE(cub::detail::safe_add_bound_to_max(0U, ::cuda::std::numeric_limits<std::uint32_t>::max())
+          == ::cuda::std::numeric_limits<std::uint32_t>::max());
+  REQUIRE(cub::detail::safe_add_bound_to_max(::cuda::std::numeric_limits<std::uint32_t>::max(), 0U)
+          == ::cuda::std::numeric_limits<std::uint32_t>::max());
+
+  // We do not overflow
+  REQUIRE(cub::detail::safe_add_bound_to_max(std::int32_t{0}, ::cuda::std::numeric_limits<std::int32_t>::max())
+          == ::cuda::std::numeric_limits<std::int32_t>::max());
+  REQUIRE(cub::detail::safe_add_bound_to_max(::cuda::std::numeric_limits<std::int32_t>::max(), std::int32_t{0})
+          == ::cuda::std::numeric_limits<std::int32_t>::max());
+  REQUIRE(cub::detail::safe_add_bound_to_max(std::int32_t{1}, ::cuda::std::numeric_limits<std::int32_t>::max())
+          == ::cuda::std::numeric_limits<std::int32_t>::max());
+  REQUIRE(cub::detail::safe_add_bound_to_max(::cuda::std::numeric_limits<std::int32_t>::max(), std::int32_t{1})
+          == ::cuda::std::numeric_limits<std::int32_t>::max());
+  REQUIRE(cub::detail::safe_add_bound_to_max(
+            ::cuda::std::numeric_limits<std::int32_t>::max(), ::cuda::std::numeric_limits<std::int32_t>::max())
+          == ::cuda::std::numeric_limits<std::int32_t>::max());
+
+  // We do not overflow
+  REQUIRE(cub::detail::safe_add_bound_to_max(std::int64_t{0}, ::cuda::std::numeric_limits<std::int64_t>::max())
+          == ::cuda::std::numeric_limits<std::int64_t>::max());
+  REQUIRE(cub::detail::safe_add_bound_to_max(::cuda::std::numeric_limits<std::int64_t>::max(), std::int64_t{0LL})
+          == ::cuda::std::numeric_limits<std::int64_t>::max());
+  REQUIRE(cub::detail::safe_add_bound_to_max(std::int64_t{1LL}, ::cuda::std::numeric_limits<std::int64_t>::max())
+          == ::cuda::std::numeric_limits<std::int64_t>::max());
+  REQUIRE(cub::detail::safe_add_bound_to_max(::cuda::std::numeric_limits<std::int64_t>::max(), std::int64_t{1LL})
+          == ::cuda::std::numeric_limits<std::int64_t>::max());
+  REQUIRE(cub::detail::safe_add_bound_to_max(
+            ::cuda::std::numeric_limits<std::int64_t>::max(), ::cuda::std::numeric_limits<std::int64_t>::max())
+          == ::cuda::std::numeric_limits<std::int64_t>::max());
+
+  // We do not underflow for negative rhs (not, lhs must not be negative per documentation)
+  REQUIRE(cub::detail::safe_add_bound_to_max(0, -1) == -1);
+  REQUIRE(cub::detail::safe_add_bound_to_max(1, -1) == 0);
+}


### PR DESCRIPTION
*note: chained PR, targeting [NVIDIA:pull-request/1349](https://github.com/NVIDIA/cccl/tree/pull-request/1349) as base branch for easier diff/reviews* 

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes https://github.com/NVIDIA/cccl/issues/1334<!-- Link issue here -->

One item that is yet to be done is adding tests with random / shuffled inputs for large number of items. That is dependent on https://github.com/NVIDIA/cccl/pull/1349

I had tried various ways to prevent integer overflows, most of which were degrading performance for small types by as much as 20%. This fix keeps performance changes within noise.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
