### PR TITLE
Switch to NV runners for Windows.

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   prepare:
     name: Build ${{inputs.test_name}}
-    runs-on: windows-2022
+    runs-on: windows-amd64-cpu16
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Description

This switches our Windows jobs to NVIDIA hosted runners. These are faster, have more memory, and will, most importantly, not timeout when doing a full rebuild.