### PR TITLE
Update to devcontainers 24.04

### DIFF
--- a/.devcontainer/cuda11.1-gcc6/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc6/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc6-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc6-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda11.1-gcc7/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc7-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc7-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda11.1-gcc8/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc8-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc8-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda11.1-gcc9/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc9-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc9-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda11.1-llvm9/devcontainer.json
+++ b/.devcontainer/cuda11.1-llvm9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-llvm9-cuda11.1-ubuntu18.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-llvm9-cuda11.1-ubuntu18.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.3-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc10-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc10-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.3-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc11-cuda12.3-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc11-cuda12.3-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.3-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc12-cuda12.3-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc12-cuda12.3-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.3-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc7-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc7-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.3-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc8-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc8-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.3-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc9-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc9-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-llvm10/devcontainer.json
+++ b/.devcontainer/cuda12.3-llvm10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-llvm10-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-llvm10-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-llvm11/devcontainer.json
+++ b/.devcontainer/cuda12.3-llvm11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-llvm11-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-llvm11-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-llvm12/devcontainer.json
+++ b/.devcontainer/cuda12.3-llvm12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-llvm12-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-llvm12-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-llvm13/devcontainer.json
+++ b/.devcontainer/cuda12.3-llvm13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-llvm13-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-llvm13-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.3-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-llvm14-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-llvm14-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.3-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-llvm15-cuda12.3-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-llvm15-cuda12.3-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.3-llvm16/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-llvm16-cuda12.3-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-llvm16-cuda12.3-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-llvm9/devcontainer.json
+++ b/.devcontainer/cuda12.3-llvm9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-llvm9-cuda12.3-ubuntu20.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-llvm9-cuda12.3-ubuntu20.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/cuda12.3-oneapi2023.2.0/devcontainer.json
+++ b/.devcontainer/cuda12.3-oneapi2023.2.0/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-oneapi2023.2.0-cuda12.3-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-oneapi2023.2.0-cuda12.3-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.02-cpp-gcc12-cuda12.3-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.04-cpp-gcc12-cuda12.3-ubuntu22.04",
   "hostRequirements": {
     "gpu": true
   },

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,7 +8,7 @@ gpus:
   - 'v100'
 
 # The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers
-devcontainer_version: '24.02'
+devcontainer_version: '24.04'
 
 # gcc compiler configurations
 gcc6: &gcc6 { name: 'gcc', version: '6', exe: 'g++' }


### PR DESCRIPTION
## Description

We need to update to get the latest sccache version that avoids a bug: https://github.com/rapidsai/devcontainers/pull/228/ 
