### PR TITLE
Print helpful error message in test scripts when no GPU is found 

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -240,6 +240,13 @@ print_environment_details() {
   end_group "⚙️ Environment Details"
 }
 
+fail_if_no_gpu() {
+    if ! nvidia-smi &> /dev/null; then
+        echo "Error: No NVIDIA GPU detected. Please ensure you have an NVIDIA GPU installed and the drivers are properly configured." >&2
+        exit 1
+    fi
+}
+
 function configure_preset()
 {
     local BUILD_NAME=$1

--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -306,7 +306,7 @@ function test_preset()
     local PRESET=$2
     local GROUP_NAME="🚀  Test ${BUILD_NAME}"
 
-    fail_if_no_gpu()
+    fail_if_no_gpu
 
     pushd .. > /dev/null
     run_command "$GROUP_NAME" ctest --preset=$PRESET

--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -306,6 +306,8 @@ function test_preset()
     local PRESET=$2
     local GROUP_NAME="🚀  Test ${BUILD_NAME}"
 
+    fail_if_no_gpu()
+
     pushd .. > /dev/null
     run_command "$GROUP_NAME" ctest --preset=$PRESET
     status=$?


### PR DESCRIPTION
## Description

Adds a check to the `test_*` scripts provide a more helpful error message if no GPU is present. 
