### PR TITLE
Ensure that thrust fancy iterators are `trivially_copy_constructible` when possible

### DIFF
--- a/thrust/testing/constant_iterator.cu
+++ b/thrust/testing/constant_iterator.cu
@@ -4,6 +4,8 @@
 #include <thrust/transform.h>
 #include <thrust/reduce.h>
 
+#include <cuda/std/type_traits>
+
 void TestConstantIteratorConstructFromConvertibleSystem(void)
 {
   using namespace thrust;
@@ -30,21 +32,23 @@ void TestConstantIteratorIncrement(void)
     lhs++;
 
     ASSERT_EQUAL(1, lhs - rhs);
-    
+
     lhs++;
     lhs++;
-    
+
     ASSERT_EQUAL(3, lhs - rhs);
 
     lhs += 5;
-    
+
     ASSERT_EQUAL(8, lhs - rhs);
 
     lhs -= 10;
-    
+
     ASSERT_EQUAL(-2, lhs - rhs);
 }
 DECLARE_UNITTEST(TestConstantIteratorIncrement);
+static_assert(cuda::std::is_trivially_copy_constructible<thrust::constant_iterator<int>>::value, "");
+static_assert(cuda::std::is_trivially_copyable<thrust::constant_iterator<int>>::value, "");
 
 void TestConstantIteratorIncrementBig(void)
 {
@@ -68,15 +72,15 @@ void TestConstantIteratorComparison(void)
     ASSERT_EQUAL(true, iter1 == iter2);
 
     iter1++;
-    
+
     ASSERT_EQUAL(1, iter1 - iter2);
     ASSERT_EQUAL(false, iter1 == iter2);
-   
+
     iter2++;
 
     ASSERT_EQUAL(0, iter1 - iter2);
     ASSERT_EQUAL(true, iter1 == iter2);
-  
+
     iter1 += 100;
     iter2 += 100;
 
@@ -146,7 +150,7 @@ void TestConstantIteratorTransform(void)
   ASSERT_EQUAL(-7, result[1]);
   ASSERT_EQUAL(-7, result[2]);
   ASSERT_EQUAL(-7, result[3]);
-  
+
   thrust::transform(first1, last1, first2, result.begin(), thrust::plus<T>());
 
   ASSERT_EQUAL(10, result[0]);

--- a/thrust/testing/counting_iterator.cu
+++ b/thrust/testing/counting_iterator.cu
@@ -5,6 +5,7 @@
 #include <thrust/distance.h>
 #include <thrust/detail/cstdint.h>
 
+#include <cuda/std/type_traits>
 
 THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 
@@ -33,6 +34,8 @@ void TestCountingIteratorCopyConstructor(void)
     ASSERT_EQUAL(*iter0, *d_iter);
 }
 DECLARE_UNITTEST(TestCountingIteratorCopyConstructor);
+static_assert(cuda::std::is_trivially_copy_constructible<thrust::counting_iterator<int>>::value, "");
+static_assert(cuda::std::is_trivially_copyable<thrust::counting_iterator<int>>::value, "");
 
 
 void TestCountingIteratorIncrement(void)
@@ -44,18 +47,18 @@ void TestCountingIteratorIncrement(void)
     iter++;
 
     ASSERT_EQUAL(*iter, 1);
-    
+
     iter++;
     iter++;
-    
+
     ASSERT_EQUAL(*iter, 3);
 
     iter += 5;
-    
+
     ASSERT_EQUAL(*iter, 8);
 
     iter -= 10;
-    
+
     ASSERT_EQUAL(*iter, -2);
 }
 DECLARE_UNITTEST(TestCountingIteratorIncrement);
@@ -70,15 +73,15 @@ void TestCountingIteratorComparison(void)
     ASSERT_EQUAL(iter1 == iter2, true);
 
     iter1++;
-    
+
     ASSERT_EQUAL(iter1 - iter2, 1);
     ASSERT_EQUAL(iter1 == iter2, false);
-   
+
     iter2++;
 
     ASSERT_EQUAL(iter1 - iter2, 0);
     ASSERT_EQUAL(iter1 == iter2, true);
-  
+
     iter1 += 100;
     iter2 += 100;
 
@@ -99,19 +102,19 @@ void TestCountingIteratorFloatComparison(void)
     ASSERT_EQUAL(iter2 <  iter1, false);
 
     iter1++;
-    
+
     ASSERT_EQUAL(iter1 - iter2, 1);
     ASSERT_EQUAL(iter1 == iter2, false);
-    ASSERT_EQUAL(iter2 < iter1, true); 
-    ASSERT_EQUAL(iter1 < iter2, false); 
-   
+    ASSERT_EQUAL(iter2 < iter1, true);
+    ASSERT_EQUAL(iter1 < iter2, false);
+
     iter2++;
 
     ASSERT_EQUAL(iter1 - iter2, 0);
     ASSERT_EQUAL(iter1 == iter2, true);
     ASSERT_EQUAL(iter1 < iter2, false);
     ASSERT_EQUAL(iter2 < iter1, false);
-  
+
     iter1 += 100;
     iter2 += 100;
 
@@ -130,12 +133,12 @@ void TestCountingIteratorFloatComparison(void)
     ASSERT_EQUAL(iter4 < iter3, false);
 
     iter3++; // iter3 = 1.0, iter4 = 0.5
-    
+
     ASSERT_EQUAL(iter3 - iter4, 0);
     ASSERT_EQUAL(iter3 == iter4, true);
     ASSERT_EQUAL(iter3 < iter4, false);
     ASSERT_EQUAL(iter4 < iter3, false);
-   
+
     iter4++; // iter3 = 1.0, iter4 = 1.5
 
     ASSERT_EQUAL(iter3 - iter4, 0);
@@ -162,9 +165,9 @@ void TestCountingIteratorDistance(void)
     ASSERT_EQUAL(thrust::distance(iter1, iter2), 5);
 
     iter1++;
-    
+
     ASSERT_EQUAL(thrust::distance(iter1, iter2), 4);
-   
+
     iter2 += 100;
 
     ASSERT_EQUAL(thrust::distance(iter1, iter2), 104);

--- a/thrust/testing/discard_iterator.cu
+++ b/thrust/testing/discard_iterator.cu
@@ -1,6 +1,8 @@
 #include <unittest/unittest.h>
 #include <thrust/iterator/discard_iterator.h>
 
+#include <cuda/std/type_traits>
+
 void TestDiscardIteratorIncrement(void)
 {
   thrust::discard_iterator<> lhs(0);
@@ -11,21 +13,23 @@ void TestDiscardIteratorIncrement(void)
   lhs++;
 
   ASSERT_EQUAL(1, lhs - rhs);
-  
+
   lhs++;
   lhs++;
-  
+
   ASSERT_EQUAL(3, lhs - rhs);
 
   lhs += 5;
-  
+
   ASSERT_EQUAL(8, lhs - rhs);
 
   lhs -= 10;
-  
+
   ASSERT_EQUAL(-2, lhs - rhs);
 }
 DECLARE_UNITTEST(TestDiscardIteratorIncrement);
+static_assert(cuda::std::is_trivially_copy_constructible<thrust::discard_iterator<>>::value, "");
+static_assert(cuda::std::is_trivially_copyable<thrust::discard_iterator<>>::value, "");
 
 void TestDiscardIteratorComparison(void)
 {
@@ -36,15 +40,15 @@ void TestDiscardIteratorComparison(void)
   ASSERT_EQUAL(true, iter1 == iter2);
 
   iter1++;
-  
+
   ASSERT_EQUAL(1, iter1 - iter2);
   ASSERT_EQUAL(false, iter1 == iter2);
-  
+
   iter2++;
 
   ASSERT_EQUAL(0, iter1 - iter2);
   ASSERT_EQUAL(true, iter1 == iter2);
-  
+
   iter1 += 100;
   iter2 += 100;
 
@@ -82,7 +86,7 @@ void TestZippedDiscardIterator(void)
   {
     ;
   }
-  
+
   ASSERT_EQUAL(10, thrust::get<0>(z_iter1_first.get_iterator_tuple()) - thrust::make_discard_iterator());
 
   typedef tuple<int *, discard_iterator<> > IteratorTuple2;

--- a/thrust/testing/permutation_iterator.cu
+++ b/thrust/testing/permutation_iterator.cu
@@ -6,6 +6,8 @@
 #include <thrust/transform_reduce.h>
 #include <thrust/sequence.h>
 
+#include <cuda/std/type_traits>
+
 template <class Vector>
 void TestPermutationIteratorSimple(void)
 {
@@ -14,7 +16,7 @@ void TestPermutationIteratorSimple(void)
 
     Vector source(8);
     Vector indices(4);
-    
+
     // initialize input
     thrust::sequence(source.begin(), source.end(), 1);
 
@@ -22,7 +24,7 @@ void TestPermutationIteratorSimple(void)
     indices[1] = 0;
     indices[2] = 5;
     indices[3] = 7;
-   
+
     thrust::permutation_iterator<Iterator, Iterator> begin(source.begin(), indices.begin());
     thrust::permutation_iterator<Iterator, Iterator> end(source.begin(),   indices.end());
 
@@ -53,6 +55,8 @@ void TestPermutationIteratorSimple(void)
     ASSERT_EQUAL(source[7],  8);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorSimple);
+static_assert(cuda::std::is_trivially_copy_constructible<thrust::permutation_iterator<int*, int*>>::value, "");
+static_assert(cuda::std::is_trivially_copyable<thrust::permutation_iterator<int*, int*>>::value, "");
 
 template <class Vector>
 void TestPermutationIteratorGather(void)
@@ -62,7 +66,7 @@ void TestPermutationIteratorGather(void)
     Vector source(8);
     Vector indices(4);
     Vector output(4, 10);
-    
+
     // initialize input
     thrust::sequence(source.begin(), source.end(), 1);
 
@@ -70,7 +74,7 @@ void TestPermutationIteratorGather(void)
     indices[1] = 0;
     indices[2] = 5;
     indices[3] = 7;
-   
+
     thrust::permutation_iterator<Iterator, Iterator> p_source(source.begin(), indices.begin());
 
     thrust::copy(p_source, p_source + 4, output.begin());
@@ -90,7 +94,7 @@ void TestPermutationIteratorScatter(void)
     Vector source(4, 10);
     Vector indices(4);
     Vector output(8);
-    
+
     // initialize output
     thrust::sequence(output.begin(), output.end(), 1);
 
@@ -98,7 +102,7 @@ void TestPermutationIteratorScatter(void)
     indices[1] = 0;
     indices[2] = 5;
     indices[3] = 7;
-   
+
     // construct transform_iterator
     thrust::permutation_iterator<Iterator, Iterator> p_output(output.begin(), indices.begin());
 
@@ -121,7 +125,7 @@ void TestMakePermutationIterator(void)
     Vector source(8);
     Vector indices(4);
     Vector output(4, 10);
-    
+
     // initialize input
     thrust::sequence(source.begin(), source.end(), 1);
 
@@ -129,7 +133,7 @@ void TestMakePermutationIterator(void)
     indices[1] = 0;
     indices[2] = 5;
     indices[3] = 7;
-   
+
     thrust::copy(thrust::make_permutation_iterator(source.begin(), indices.begin()),
                  thrust::make_permutation_iterator(source.begin(), indices.begin()) + 4,
                  output.begin());
@@ -150,7 +154,7 @@ void TestPermutationIteratorReduce(void)
     Vector source(8);
     Vector indices(4);
     Vector output(4, 10);
-    
+
     // initialize input
     thrust::sequence(source.begin(), source.end(), 1);
 
@@ -158,7 +162,7 @@ void TestPermutationIteratorReduce(void)
     indices[1] = 0;
     indices[2] = 5;
     indices[3] = 7;
-   
+
     // construct transform_iterator
     thrust::permutation_iterator<Iterator, Iterator> iter(source.begin(), indices.begin());
 
@@ -166,7 +170,7 @@ void TestPermutationIteratorReduce(void)
                                thrust::make_permutation_iterator(source.begin(), indices.begin()) + 4);
 
     ASSERT_EQUAL(result1, 19);
-    
+
     T result2 = thrust::transform_reduce(thrust::make_permutation_iterator(source.begin(), indices.begin()),
                                          thrust::make_permutation_iterator(source.begin(), indices.begin()) + 4,
                                          thrust::negate<T>(),
@@ -187,7 +191,7 @@ void TestPermutationIteratorHostDeviceGather(void)
     HostVector h_source(8);
     HostVector h_indices(4);
     HostVector h_output(4, 10);
-    
+
     DeviceVector d_source(8);
     DeviceVector d_indices(4);
     DeviceVector d_output(4, 10);
@@ -200,7 +204,7 @@ void TestPermutationIteratorHostDeviceGather(void)
     h_indices[1] = d_indices[1] = 0;
     h_indices[2] = d_indices[2] = 5;
     h_indices[3] = d_indices[3] = 7;
-   
+
     thrust::permutation_iterator<HostIterator,   HostIterator>   p_h_source(h_source.begin(), h_indices.begin());
     thrust::permutation_iterator<DeviceIterator, DeviceIterator> p_d_source(d_source.begin(), d_indices.begin());
 
@@ -211,7 +215,7 @@ void TestPermutationIteratorHostDeviceGather(void)
     ASSERT_EQUAL(d_output[1], 1);
     ASSERT_EQUAL(d_output[2], 6);
     ASSERT_EQUAL(d_output[3], 8);
-    
+
     // gather device->host
     thrust::copy(p_d_source, p_d_source + 4, h_output.begin());
 
@@ -233,7 +237,7 @@ void TestPermutationIteratorHostDeviceScatter(void)
     HostVector h_source(4,10);
     HostVector h_indices(4);
     HostVector h_output(8);
-    
+
     DeviceVector d_source(4,10);
     DeviceVector d_indices(4);
     DeviceVector d_output(8);
@@ -246,7 +250,7 @@ void TestPermutationIteratorHostDeviceScatter(void)
     h_indices[1] = d_indices[1] = 0;
     h_indices[2] = d_indices[2] = 5;
     h_indices[3] = d_indices[3] = 7;
-   
+
     thrust::permutation_iterator<HostIterator,   HostIterator>   p_h_output(h_output.begin(), h_indices.begin());
     thrust::permutation_iterator<DeviceIterator, DeviceIterator> p_d_output(d_output.begin(), d_indices.begin());
 
@@ -261,7 +265,7 @@ void TestPermutationIteratorHostDeviceScatter(void)
     ASSERT_EQUAL(d_output[5], 10);
     ASSERT_EQUAL(d_output[6],  7);
     ASSERT_EQUAL(d_output[7], 10);
-    
+
     // scatter device->host
     thrust::copy(d_source.begin(), d_source.end(), p_h_output);
 
@@ -281,7 +285,7 @@ void TestPermutationIteratorWithCountingIterator(void)
 {
   using T = typename Vector::value_type;
   using diff_t = typename thrust::counting_iterator<T>::difference_type;
-  
+
   thrust::counting_iterator<T> input(0), index(0);
 
   // test copy()

--- a/thrust/testing/reverse_iterator.cu
+++ b/thrust/testing/reverse_iterator.cu
@@ -3,6 +3,8 @@
 #include <thrust/sequence.h>
 #include <thrust/scan.h>
 
+#include <cuda/std/type_traits>
+
 void TestReverseIteratorCopyConstructor(void)
 {
   thrust::host_vector<int> h_v(1,13);
@@ -23,6 +25,8 @@ void TestReverseIteratorCopyConstructor(void)
   ASSERT_EQUAL(*d_iter2, *d_iter3);
 }
 DECLARE_UNITTEST(TestReverseIteratorCopyConstructor);
+static_assert(cuda::std::is_trivially_copy_constructible<thrust::reverse_iterator<int*>>::value, "");
+static_assert(cuda::std::is_trivially_copyable<thrust::reverse_iterator<int*>>::value, "");
 
 void TestReverseIteratorIncrement(void)
 {
@@ -71,7 +75,7 @@ void TestReverseIteratorCopy(void)
   source[3] = 40;
 
   Vector destination(4,0);
-  
+
   thrust::copy(thrust::make_reverse_iterator(source.end()),
                thrust::make_reverse_iterator(source.begin()),
                destination.begin());

--- a/thrust/testing/zip_iterator.cu
+++ b/thrust/testing/zip_iterator.cu
@@ -5,6 +5,8 @@
 #include <thrust/copy.h>
 #include <thrust/transform.h>
 
+#include <cuda/std/type_traits>
+
 using namespace unittest;
 
 template<typename T>
@@ -90,6 +92,7 @@ template<typename T>
   }
 };
 SimpleUnitTest<TestZipIteratorManipulation, type_list<int> > TestZipIteratorManipulationInstance;
+static_assert(cuda::std::is_trivially_copy_constructible<thrust::zip_iterator<thrust::tuple<int*, int*>>>::value, "");
 
 template <typename T>
   struct TestZipIteratorReference
@@ -224,7 +227,7 @@ template <typename T>
 
     //ASSERT_EQUAL(true, (detail::is_convertible<zip_iterator_system_type3, thrust::experimental::space::any>::value) );
 
-    
+
 #if 0
     // test host/any
     typedef tuple<Iterator1, Iterator5>                IteratorTuple4;
@@ -346,8 +349,8 @@ struct TestZipIteratorTransform
                d_result.begin(),
                SumTwoTuple());
     ASSERT_EQUAL(h_result, d_result);
-    
-    
+
+
     // Tuples with 3 elements
     transform( make_zip_iterator(make_tuple(h_data0.begin(), h_data1.begin(), h_data2.begin())),
                make_zip_iterator(make_tuple(h_data0.end(),   h_data1.end(),   h_data2.end())),

--- a/thrust/thrust/detail/type_traits.h
+++ b/thrust/thrust/detail/type_traits.h
@@ -441,6 +441,8 @@ template<typename T1, typename T2, typename T = void>
     : enable_if< is_convertible<T1,T2>::value, T >
 {};
 
+template<typename T1, typename T2, typename T = void>
+using enable_if_convertible_t = typename enable_if_convertible<T1, T2, T>::type;
 
 template<typename T1, typename T2, typename T = void>
   struct disable_if_convertible
@@ -453,6 +455,8 @@ template<typename T1, typename T2, typename Result = void>
     : enable_if<is_different<T1,T2>::value, Result>
 {};
 
+template<typename T1, typename T2, typename Result = void>
+using enable_if_different_t = typename enable_if_different<T1, T2, Result>::type;
 
 template<typename T>
   struct is_numeric

--- a/thrust/thrust/detail/type_traits.h
+++ b/thrust/thrust/detail/type_traits.h
@@ -455,9 +455,6 @@ template<typename T1, typename T2, typename Result = void>
     : enable_if<is_different<T1,T2>::value, Result>
 {};
 
-template<typename T1, typename T2, typename Result = void>
-using enable_if_different_t = typename enable_if_different<T1, T2, Result>::type;
-
 template<typename T>
   struct is_numeric
     : and_<

--- a/thrust/thrust/iterator/constant_iterator.h
+++ b/thrust/thrust/iterator/constant_iterator.h
@@ -120,35 +120,25 @@ template<typename Value,
     /*! \endcond
      */
 
-    /*! Null constructor initializes this \p constant_iterator's constant using its
-     *  null constructor.
+    /*! Default constructor initializes this \p constant_iterator's constant using its default constructor
      */
-    _CCCL_HOST_DEVICE
-    constant_iterator()
-      : super_t(), m_value() {}
-
-    /*! Copy constructor copies the value of another \p constant_iterator into this
-     *  \p constant_iterator.
-     *
-     *  \p rhs The constant_iterator to copy.
-     */
-    _CCCL_HOST_DEVICE
-    constant_iterator(constant_iterator const &rhs)
-      : super_t(rhs.base()), m_value(rhs.m_value) {}
+    constant_iterator() = default;
 
     /*! Copy constructor copies the value of another \p constant_iterator with related
      *  System type.
      *
      *  \param rhs The \p constant_iterator to copy.
      */
-    template<typename OtherSystem>
-    _CCCL_HOST_DEVICE
-    constant_iterator(constant_iterator<Value,Incrementable,OtherSystem> const &rhs,
-                      typename thrust::detail::enable_if_convertible<
-                        typename thrust::iterator_system<constant_iterator<Value,Incrementable,OtherSystem> >::type,
-                        typename thrust::iterator_system<super_t>::type
-                      >::type * = 0)
-      : super_t(rhs.base()), m_value(rhs.value()) {}
+    template <class OtherSystem,
+              detail::enable_if_different_t<OtherSystem, System, int> = 0,
+              detail::enable_if_convertible_t<
+                typename thrust::iterator_system<constant_iterator<Value, Incrementable, OtherSystem>>::type,
+                typename thrust::iterator_system<super_t>::type,
+                int> = 0>
+    _CCCL_HOST_DEVICE constant_iterator(constant_iterator<Value, Incrementable, OtherSystem> const& rhs)
+        : super_t(rhs.base())
+        , m_value(rhs.value())
+    {}
 
     /*! This constructor receives a value to use as the constant value of this
      *  \p constant_iterator and an index specifying the location of this
@@ -203,7 +193,7 @@ template<typename Value,
     }
 
   private:
-    Value m_value;
+    Value m_value{};
 
     /*! \endcond
      */

--- a/thrust/thrust/iterator/constant_iterator.h
+++ b/thrust/thrust/iterator/constant_iterator.h
@@ -122,7 +122,14 @@ template<typename Value,
 
     /*! Default constructor initializes this \p constant_iterator's constant using its default constructor
      */
+#if defined(_CCCL_COMPILER_MSVC_2017)
+    _CCCL_HOST_DEVICE constant_iterator()
+        : super_t()
+        , m_value()
+    {}
+#else // ^^^ _CCCL_COMPILER_MSVC_2017 ^^^ / vvv !_CCCL_COMPILER_MSVC_2017 vvv
     constant_iterator() = default;
+#endif // !_CCCL_COMPILER_MSVC_2017
 
     /*! Copy constructor copies the value of another \p constant_iterator with related
      *  System type.

--- a/thrust/thrust/iterator/constant_iterator.h
+++ b/thrust/thrust/iterator/constant_iterator.h
@@ -130,7 +130,6 @@ template<typename Value,
      *  \param rhs The \p constant_iterator to copy.
      */
     template <class OtherSystem,
-              detail::enable_if_different_t<OtherSystem, System, int> = 0,
               detail::enable_if_convertible_t<
                 typename thrust::iterator_system<constant_iterator<Value, Incrementable, OtherSystem>>::type,
                 typename thrust::iterator_system<super_t>::type,

--- a/thrust/thrust/iterator/constant_iterator.h
+++ b/thrust/thrust/iterator/constant_iterator.h
@@ -122,14 +122,8 @@ template<typename Value,
 
     /*! Default constructor initializes this \p constant_iterator's constant using its default constructor
      */
-#if defined(_CCCL_COMPILER_MSVC_2017)
     _CCCL_HOST_DEVICE constant_iterator()
-        : super_t()
-        , m_value()
-    {}
-#else // ^^^ _CCCL_COMPILER_MSVC_2017 ^^^ / vvv !_CCCL_COMPILER_MSVC_2017 vvv
-    constant_iterator() = default;
-#endif // !_CCCL_COMPILER_MSVC_2017
+        : super_t(), m_value() {}
 
     /*! Copy constructor copies the value of another \p constant_iterator with related
      *  System type.
@@ -199,7 +193,7 @@ template<typename Value,
     }
 
   private:
-    Value m_value{};
+    Value m_value;
 
     /*! \endcond
      */

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -163,22 +163,23 @@ template<typename Incrementable,
      *
      *  \p rhs The \p counting_iterator to copy.
      */
-    _CCCL_HOST_DEVICE
-    counting_iterator(counting_iterator const &rhs):super_t(rhs.base()){}
+    counting_iterator(counting_iterator const&) = default;
 
     /*! Copy constructor copies the value of another counting_iterator
      *  with related System type.
      *
      *  \param rhs The \p counting_iterator to copy.
      */
-    template<typename OtherSystem>
-    _CCCL_HOST_DEVICE
-    counting_iterator(counting_iterator<Incrementable, OtherSystem, Traversal, Difference> const &rhs,
-                      typename thrust::detail::enable_if_convertible<
-                        typename thrust::iterator_system<counting_iterator<Incrementable,OtherSystem,Traversal,Difference> >::type,
-                        typename thrust::iterator_system<super_t>::type
-                      >::type * = 0)
-      : super_t(rhs.base()){}
+    template <
+      class OtherSystem,
+      detail::enable_if_different_t<OtherSystem, System, int> = 0,
+      detail::enable_if_convertible_t<
+        typename thrust::iterator_system<counting_iterator<Incrementable, OtherSystem, Traversal, Difference>>::type,
+        typename thrust::iterator_system<super_t>::type,
+        int> = 0>
+    _CCCL_HOST_DEVICE counting_iterator(counting_iterator<Incrementable, OtherSystem, Traversal, Difference> const& rhs)
+        : super_t(rhs.base())
+    {}
 
     /*! This \c explicit constructor copies the value of an \c Incrementable
      *  into a new \p counting_iterator's \c Incrementable counter.

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -182,10 +182,6 @@ template<typename Incrementable,
     _CCCL_HOST_DEVICE
     explicit counting_iterator(Incrementable x):super_t(x){}
 
-#if _CCCL_STD_VER >= 2011
-    counting_iterator & operator=(const counting_iterator &) = default;
-#endif
-
     /*! \cond
      */
   private:

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -172,7 +172,6 @@ template<typename Incrementable,
      */
     template <
       class OtherSystem,
-      detail::enable_if_different_t<OtherSystem, System, int> = 0,
       detail::enable_if_convertible_t<
         typename thrust::iterator_system<counting_iterator<Incrementable, OtherSystem, Traversal, Difference>>::type,
         typename thrust::iterator_system<super_t>::type,

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -158,13 +158,6 @@ template<typename Incrementable,
     _CCCL_HOST_DEVICE
     counting_iterator() : super_t(Incrementable{}) {}
 
-    /*! Copy constructor copies the value of another \p counting_iterator into a
-     *  new \p counting_iterator.
-     *
-     *  \p rhs The \p counting_iterator to copy.
-     */
-    counting_iterator(counting_iterator const&) = default;
-
     /*! Copy constructor copies the value of another counting_iterator
      *  with related System type.
      *

--- a/thrust/thrust/iterator/detail/reverse_iterator.inl
+++ b/thrust/thrust/iterator/detail/reverse_iterator.inl
@@ -46,33 +46,6 @@ template<typename Iterator>
 
 template<typename BidirectionalIterator>
   _CCCL_HOST_DEVICE
-  reverse_iterator<BidirectionalIterator>
-    ::reverse_iterator(BidirectionalIterator x)
-      :super_t(x)
-{
-} // end reverse_iterator::reverse_iterator()
-
-template<typename BidirectionalIterator>
-  template<typename OtherBidirectionalIterator>
-    _CCCL_HOST_DEVICE
-    reverse_iterator<BidirectionalIterator>
-      ::reverse_iterator(reverse_iterator<OtherBidirectionalIterator> const &r
-// XXX msvc screws this up
-#if THRUST_HOST_COMPILER != THRUST_HOST_COMPILER_MSVC
-                     , typename thrust::detail::enable_if<
-                         thrust::detail::is_convertible<
-                           OtherBidirectionalIterator,
-                           BidirectionalIterator
-                         >::value
-                       >::type *
-#endif // MSVC
-                     )
-        :super_t(r.base())
-{
-} // end reverse_iterator::reverse_iterator()
-
-template<typename BidirectionalIterator>
-  _CCCL_HOST_DEVICE
   typename reverse_iterator<BidirectionalIterator>::super_t::reference
     reverse_iterator<BidirectionalIterator>
       ::dereference() const

--- a/thrust/thrust/iterator/detail/zip_iterator.inl
+++ b/thrust/thrust/iterator/detail/zip_iterator.inl
@@ -35,33 +35,10 @@ THRUST_NAMESPACE_BEGIN
 template<typename IteratorTuple>
 _CCCL_HOST_DEVICE
   zip_iterator<IteratorTuple>
-    ::zip_iterator()
-{
-} // end zip_iterator::zip_iterator()
-
-
-template<typename IteratorTuple>
-_CCCL_HOST_DEVICE
-  zip_iterator<IteratorTuple>
     ::zip_iterator(IteratorTuple iterator_tuple)
       :m_iterator_tuple(iterator_tuple)
 {
 } // end zip_iterator::zip_iterator()
-
-
-template<typename IteratorTuple>
-  template<typename OtherIteratorTuple>
-  _CCCL_HOST_DEVICE
-    zip_iterator<IteratorTuple>
-      ::zip_iterator(const zip_iterator<OtherIteratorTuple> &other,
-                     typename thrust::detail::enable_if_convertible<
-                       OtherIteratorTuple,
-                       IteratorTuple
-                     >::type *)
-        :m_iterator_tuple(other.get_iterator_tuple())
-{
-} // end zip_iterator::zip_iterator()
-
 
 template<typename IteratorTuple>
 _CCCL_HOST_DEVICE

--- a/thrust/thrust/iterator/discard_iterator.h
+++ b/thrust/thrust/iterator/discard_iterator.h
@@ -115,18 +115,6 @@ template<typename System = use_default>
     /*! \endcond
      */
 
-    /*! Copy constructor copies from a source discard_iterator.
-     *
-     *  \p rhs The discard_iterator to copy.
-     */
-    _CCCL_HOST_DEVICE
-    discard_iterator(discard_iterator const &rhs)
-      : super_t(rhs.base()) {}
-
-#if _CCCL_STD_VER >= 2011
-    discard_iterator & operator=(const discard_iterator &) = default;
-#endif
-
     /*! This constructor receives an optional index specifying the position of this
      *  \p discard_iterator in a range.
      *

--- a/thrust/thrust/iterator/permutation_iterator.h
+++ b/thrust/thrust/iterator/permutation_iterator.h
@@ -161,8 +161,6 @@ template <typename ElementIterator,
      */
     template <typename OtherElementIterator,
               typename OtherIndexIterator,
-              detail::enable_if_different_t<OtherElementIterator, ElementIterator, int>   = 0,
-              detail::enable_if_different_t<OtherIndexIterator, IndexIterator, int>       = 0,
               detail::enable_if_convertible_t<OtherElementIterator, ElementIterator, int> = 0,
               detail::enable_if_convertible_t<OtherIndexIterator, IndexIterator, int>     = 0>
     _CCCL_HOST_DEVICE permutation_iterator(permutation_iterator<OtherElementIterator, OtherIndexIterator> const& rhs)

--- a/thrust/thrust/iterator/permutation_iterator.h
+++ b/thrust/thrust/iterator/permutation_iterator.h
@@ -159,18 +159,19 @@ template <typename ElementIterator,
     /*! Copy constructor accepts a related \p permutation_iterator.
      *  \param r A compatible \p permutation_iterator to copy from.
      */
-    template<typename OtherElementIterator, typename OtherIndexIterator>
-    _CCCL_HOST_DEVICE
-    permutation_iterator(permutation_iterator<OtherElementIterator,OtherIndexIterator> const &r
-    // XXX remove these guards when we have static_assert
-    , typename detail::enable_if_convertible<OtherElementIterator, ElementIterator>::type* = 0
-    , typename detail::enable_if_convertible<OtherIndexIterator, IndexIterator>::type* = 0
-    )
-      : super_t(r.base()), m_element_iterator(r.m_element_iterator)
+    template <typename OtherElementIterator,
+              typename OtherIndexIterator,
+              detail::enable_if_different_t<OtherElementIterator, ElementIterator, int>   = 0,
+              detail::enable_if_different_t<OtherIndexIterator, IndexIterator, int>       = 0,
+              detail::enable_if_convertible_t<OtherElementIterator, ElementIterator, int> = 0,
+              detail::enable_if_convertible_t<OtherIndexIterator, IndexIterator, int>     = 0>
+    _CCCL_HOST_DEVICE permutation_iterator(permutation_iterator<OtherElementIterator, OtherIndexIterator> const& rhs)
+        : super_t(rhs.base())
+        , m_element_iterator(rhs.m_element_iterator)
     {}
 
-  /*! \cond
-   */
+    /*! \cond
+     */
   private:
     // MSVC 2013 and 2015 incorrectly warning about returning a reference to
     // a local/temporary here.

--- a/thrust/thrust/iterator/reverse_iterator.h
+++ b/thrust/thrust/iterator/reverse_iterator.h
@@ -166,8 +166,7 @@ template<typename BidirectionalIterator>
   public:
     /*! Default constructor does nothing.
      */
-    _CCCL_HOST_DEVICE
-    reverse_iterator() {}
+    reverse_iterator() = default;
 
     /*! \p Constructor accepts a \c BidirectionalIterator pointing to a range
      *  for this \p reverse_iterator to reverse.
@@ -175,27 +174,21 @@ template<typename BidirectionalIterator>
      *  \param x A \c BidirectionalIterator pointing to a range to reverse.
      */
     _CCCL_HOST_DEVICE
-    explicit reverse_iterator(BidirectionalIterator x);
+    explicit reverse_iterator(BidirectionalIterator x)
+      : super_t(x)
+    {}
 
     /*! \p Copy constructor allows construction from a related compatible
      *  \p reverse_iterator.
      *
      *  \param r A \p reverse_iterator to copy from.
      */
-    template<typename OtherBidirectionalIterator>
-    _CCCL_HOST_DEVICE
-    reverse_iterator(reverse_iterator<OtherBidirectionalIterator> const &r
-// XXX msvc screws this up
-// XXX remove these guards when we have static_assert
-#if THRUST_HOST_COMPILER != THRUST_HOST_COMPILER_MSVC
-                     , typename thrust::detail::enable_if<
-                         thrust::detail::is_convertible<
-                           OtherBidirectionalIterator,
-                           BidirectionalIterator
-                         >::value
-                       >::type * = 0
-#endif // MSVC
-                     );
+    template <typename OtherBidirectionalIterator,
+              detail::enable_if_different_t<OtherBidirectionalIterator, BidirectionalIterator, int>   = 0,
+              detail::enable_if_convertible_t<OtherBidirectionalIterator, BidirectionalIterator, int> = 0>
+    _CCCL_HOST_DEVICE reverse_iterator(reverse_iterator<OtherBidirectionalIterator> const& rhs)
+        : super_t(rhs.base())
+    {}
 
   /*! \cond
    */

--- a/thrust/thrust/iterator/reverse_iterator.h
+++ b/thrust/thrust/iterator/reverse_iterator.h
@@ -166,7 +166,11 @@ template<typename BidirectionalIterator>
   public:
     /*! Default constructor does nothing.
      */
+#if defined(_CCCL_COMPILER_MSVC_2017)
+    _CCCL_HOST_DEVICE reverse_iterator() {}
+#else // ^^^ _CCCL_COMPILER_MSVC_2017 ^^^ / vvv !_CCCL_COMPILER_MSVC_2017 vvv
     reverse_iterator() = default;
+#endif // !_CCCL_COMPILER_MSVC_2017
 
     /*! \p Constructor accepts a \c BidirectionalIterator pointing to a range
      *  for this \p reverse_iterator to reverse.

--- a/thrust/thrust/iterator/reverse_iterator.h
+++ b/thrust/thrust/iterator/reverse_iterator.h
@@ -184,7 +184,6 @@ template<typename BidirectionalIterator>
      *  \param r A \p reverse_iterator to copy from.
      */
     template <typename OtherBidirectionalIterator,
-              detail::enable_if_different_t<OtherBidirectionalIterator, BidirectionalIterator, int>   = 0,
               detail::enable_if_convertible_t<OtherBidirectionalIterator, BidirectionalIterator, int> = 0>
     _CCCL_HOST_DEVICE reverse_iterator(reverse_iterator<OtherBidirectionalIterator> const& rhs)
         : super_t(rhs.base())

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -166,7 +166,6 @@ template <typename IteratorTuple>
      *  \param other The \p zip_iterator to copy.
      */
     template <typename OtherIteratorTuple,
-              detail::enable_if_different_t<OtherIteratorTuple, IteratorTuple, int>   = 0,
               detail::enable_if_convertible_t<OtherIteratorTuple, IteratorTuple, int> = 0>
     inline _CCCL_HOST_DEVICE zip_iterator(const zip_iterator<OtherIteratorTuple>& other)
         : m_iterator_tuple(other.get_iterator_tuple())

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -150,8 +150,7 @@ template <typename IteratorTuple>
   public:
     /*! Null constructor does nothing.
      */
-    inline _CCCL_HOST_DEVICE
-    zip_iterator();
+    zip_iterator() = default;
 
     /*! This constructor creates a new \p zip_iterator from a
      *  \p tuple of iterators.
@@ -166,13 +165,12 @@ template <typename IteratorTuple>
      *
      *  \param other The \p zip_iterator to copy.
      */
-    template<typename OtherIteratorTuple>
-    inline _CCCL_HOST_DEVICE
-    zip_iterator(const zip_iterator<OtherIteratorTuple> &other,
-                 typename thrust::detail::enable_if_convertible<
-                   OtherIteratorTuple,
-                   IteratorTuple
-                 >::type * = 0);
+    template <typename OtherIteratorTuple,
+              detail::enable_if_different_t<OtherIteratorTuple, IteratorTuple, int>   = 0,
+              detail::enable_if_convertible_t<OtherIteratorTuple, IteratorTuple, int> = 0>
+    inline _CCCL_HOST_DEVICE zip_iterator(const zip_iterator<OtherIteratorTuple>& other)
+        : m_iterator_tuple(other.get_iterator_tuple())
+    {}
 
     /*! This method returns a \c const reference to this \p zip_iterator's
      *  \p tuple of iterators.

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -148,9 +148,13 @@ template <typename IteratorTuple>
     : public detail::zip_iterator_base<IteratorTuple>::type
 {
   public:
-    /*! Null constructor does nothing.
+    /*! Default constructor does nothing.
      */
+#if defined(_CCCL_COMPILER_MSVC_2017)
+    inline _CCCL_HOST_DEVICE zip_iterator() {}
+#else // ^^^ _CCCL_COMPILER_MSVC_2017 ^^^ / vvv !_CCCL_COMPILER_MSVC_2017 vvv
     zip_iterator() = default;
+#endif // !_CCCL_COMPILER_MSVC_2017
 
     /*! This constructor creates a new \p zip_iterator from a
      *  \p tuple of iterators.


### PR DESCRIPTION
Our implementation provides user defined copy constructors, even if that is not necessary, as this was necessary prior to C++11.

Having dropped any support for older standard dialects, we can simply rely on defaulting or even better omitting those copy constructors.

This ensures that thrust fany iterators are trivially_copy_constructible when possible.

I did not rework transform_iterator, as that would require considerable effort due to potentially non copy assignable functors.

Addresses #1367