### PR TITLE
Add overload to set_difference_by_key

### DIFF
--- a/thrust/testing/set_difference_by_key.cu
+++ b/thrust/testing/set_difference_by_key.cu
@@ -120,6 +120,39 @@ void TestSetDifferenceByKeySimple(void)
 }
 DECLARE_VECTOR_UNITTEST(TestSetDifferenceByKeySimple);
 
+template<typename Vector>
+void TestSetDifferenceByKeyOverride(void)
+{
+  typedef typename Vector::iterator Iterator;
+
+  Vector a_key(4), b_key(5);
+  Vector a_val(4);
+
+  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4; a_key[3] = 5;
+  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0; a_val[3] = 0;
+
+  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4; b_key[4] = 6;
+
+  Vector ref_key(2), ref_val(2);
+  ref_key[0] = 2; ref_key[1] = 5;
+  ref_val[0] = 0; ref_val[1] = 0;
+
+  Vector result_key(2), result_val(2);
+
+  thrust::pair<Iterator,Iterator> end =
+    thrust::set_difference_by_key(a_key.begin(), a_key.end(),
+                                  b_key.begin(), b_key.end(),
+                                  a_val.begin(),
+                                  result_key.begin(),
+                                  result_val.begin());
+
+  ASSERT_EQUAL_QUIET(result_key.end(), end.first);
+  ASSERT_EQUAL_QUIET(result_val.end(), end.second);
+  ASSERT_EQUAL(ref_key, result_key);
+  ASSERT_EQUAL(ref_val, result_val);
+}
+DECLARE_VECTOR_UNITTEST(TestSetDifferenceByKeyOverride);
+
 
 template<typename T>
 void TestSetDifferenceByKey(const size_t n)

--- a/thrust/thrust/detail/set_operations.inl
+++ b/thrust/thrust/detail/set_operations.inl
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <thrust/detail/config.h>
+#include "thrust/iterator/constant_iterator.h"
+#include "thrust/iterator/detail/iterator_traits.inl"
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -499,6 +501,44 @@ template<typename InputIterator1,
   typedef typename thrust::iterator_system<InputIterator4>::type  System4;
   typedef typename thrust::iterator_system<OutputIterator1>::type System5;
   typedef typename thrust::iterator_system<OutputIterator2>::type System6;
+
+  System1 system1;
+  System2 system2;
+  System3 system3;
+  System4 system4;
+  System5 system5;
+  System6 system6;
+
+  return thrust::set_difference_by_key(select_system(system1,system2,system3,system4,system5,system6), keys_first1, keys_last1, keys_first2, keys_last2, values_first1, values_first2, keys_result, values_result);
+} // end set_difference_by_key()
+
+template<typename InputIterator1,
+         typename InputIterator2,
+         typename InputIterator3,
+         typename OutputIterator1,
+         typename OutputIterator2>
+  thrust::pair<OutputIterator1,OutputIterator2>
+    set_difference_by_key(InputIterator1 keys_first1,
+                          InputIterator1 keys_last1,
+                          InputIterator2 keys_first2,
+                          InputIterator2 keys_last2,
+                          InputIterator3 values_first1,
+                          OutputIterator1 keys_result,
+                          OutputIterator2 values_result)
+{
+  using thrust::system::detail::generic::select_system;
+  typedef typename thrust::iterator_value<InputIterator3>::type value_type1;
+  typedef thrust::constant_iterator<value_type1>                constant_iterator;
+  // fabricate a values_first2 by repeating a default-constructed value_type1
+  // XXX assumes value_type1 is default-constructible
+  constant_iterator values_first2 = thrust::make_constant_iterator(value_type1());
+
+  typedef typename thrust::iterator_system<InputIterator1>::type    System1;
+  typedef typename thrust::iterator_system<InputIterator2>::type    System2;
+  typedef typename thrust::iterator_system<InputIterator3>::type    System3;
+  typedef typename thrust::iterator_system<constant_iterator>::type System4;
+  typedef typename thrust::iterator_system<OutputIterator1>::type  System5;
+  typedef typename thrust::iterator_system<OutputIterator2>::type  System6;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/set_operations.h
+++ b/thrust/thrust/set_operations.h
@@ -1520,6 +1520,96 @@ template<typename InputIterator1,
  *  corresponding value element is copied from the corresponding values input range (beginning at
  *  \p values_first1 or \p values_first2) to the values output range.
  *
+ *  This version of \p set_difference_by_key compares key elements using \c operator<.
+ *
+ *  \param keys_first1 The beginning of the first input range of keys.
+ *  \param keys_last1 The end of the first input range of keys.
+ *  \param keys_first2 The beginning of the second input range of keys.
+ *  \param keys_last2 The end of the second input range of keys.
+ *  \param values_first1 The beginning of the first input range of values.
+ *  \param keys_result The beginning of the output range of keys.
+ *  \param values_result The beginning of the output range of values.
+ *  \return A \p pair \c p such that <tt>p.first</tt> is the end of the output range of keys,
+ *          and such that <tt>p.second</tt> is the end of the output range of values.
+ *
+ *  \tparam InputIterator1 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input Iterator</a>,
+ *          \p InputIterator1 and \p InputIterator2 have the same \c value_type,
+ *          \p InputIterator1's \c value_type is a model of <a href="https://en.cppreference.com/w/cpp/named_req/LessThanComparable">LessThan Comparable</a>,
+ *          the ordering on \p InputIterator1's \c value_type is a strict weak ordering, as defined in the <a href="https://en.cppreference.com/w/cpp/named_req/LessThanComparable">LessThan Comparable</a> requirements,
+ *          and \p InputIterator1's \c value_type is convertable to a type in \p OutputIterator's set of \c value_types.
+ *  \tparam InputIterator2 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input Iterator</a>,
+ *          \p InputIterator2 and \p InputIterator1 have the same \c value_type,
+ *          \p InputIterator2's \c value_type is a model of <a href="https://en.cppreference.com/w/cpp/named_req/LessThanComparable">LessThan Comparable</a>,
+ *          the ordering on \p InputIterator2's \c value_type is a strict weak ordering, as defined in the <a href="https://en.cppreference.com/w/cpp/named_req/LessThanComparable">LessThan Comparable</a> requirements,
+ *          and \p InputIterator2's \c value_type is convertable to a type in \p OutputIterator's set of \c value_types.
+ *  \tparam InputIterator3 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input Iterator</a>,
+ *          and \p InputIterator3's \c value_type is convertible to a type in \p OutputIterator2's set of \c value_types.
+ *  \tparam OutputIterator1 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output Iterator</a>.
+ *  \tparam OutputIterator2 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output Iterator</a>.
+ *
+ *  \pre The ranges <tt>[keys_first1, keys_last1)</tt> and <tt>[keys_first2, keys_last2)</tt> shall be sorted with respect to <tt>operator<</tt>.
+ *  \pre The resulting ranges shall not overlap with any input range.
+ *
+ *  The following code snippet demonstrates how to use \p set_difference_by_key to compute the
+ *  set difference of two sets of integers sorted in ascending order with their values.
+ *
+ *  \code
+ *  #include <thrust/set_operations.h>
+ *  ...
+ *  int A_keys[6] = {0, 1, 3, 4, 5, 6, 9};
+ *  int A_vals[6] = {0, 0, 0, 0, 0, 0, 0};
+ *
+ *  int B_keys[5] = {1, 3, 5, 7, 9};
+ *
+ *  int keys_result[3];
+ *  int vals_result[3];
+ *
+ *  thrust::pair<int*,int*> end = thrust::set_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5, A_vals, keys_result, vals_result);
+ *  // keys_result is now {0, 4, 6}
+ *  // vals_result is now {0, 0, 0}
+ *  \endcode
+ *
+ *  \see \p set_union_by_key
+ *  \see \p set_intersection_by_key
+ *  \see \p set_symmetric_difference_by_key
+ *  \see \p sort_by_key
+ *  \see \p is_sorted
+ */
+template<typename InputIterator1,
+         typename InputIterator2,
+         typename InputIterator3,
+         typename OutputIterator1,
+         typename OutputIterator2>
+  thrust::pair<OutputIterator1,OutputIterator2>
+    set_difference_by_key(InputIterator1                             keys_first1,
+                          InputIterator1                             keys_last1,
+                          InputIterator2                             keys_first2,
+                          InputIterator2                             keys_last2,
+                          InputIterator3                             values_first1,
+                          OutputIterator1                            keys_result,
+                          OutputIterator2                            values_result);
+
+
+/*! \p set_difference_by_key performs a key-value difference operation from set theory.
+ *  \p set_difference_by_key constructs a sorted range that is the difference of the sorted
+ *  ranges <tt>[keys_first1, keys_last1)</tt> and <tt>[keys_first2, keys_last2)</tt>. Associated
+ *  with each element from the input and output key ranges is a value element. The associated input
+ *  value ranges need not be sorted.
+ *
+ *  In the simplest case, \p set_difference_by_key performs the "difference" operation from set
+ *  theory: the keys output range contains a copy of every element that is contained in
+ *  <tt>[keys_first1, keys_last1)</tt> and not contained in <tt>[keys_first2, keys_last2)</tt>.
+ *  The general case is more complicated, because the input ranges may contain duplicate elements.
+ *  The generalization is that if <tt>[keys_first1, keys_last1)</tt> contains \c m elements
+ *  that are equivalent to each other and if <tt>[keys_first2, keys_last2)</tt> contains \c n
+ *  elements that are equivalent to them, the last <tt>max(m-n,0)</tt> elements from
+ *  <tt>[keys_first1, keys_last1)</tt> range shall be copied to the output range.
+ *
+ *  Each time a key element is copied from <tt>[keys_first1, keys_last1)</tt> or
+ *  <tt>[keys_first2, keys_last2)</tt> is copied to the keys output range, the
+ *  corresponding value element is copied from the corresponding values input range (beginning at
+ *  \p values_first1 or \p values_first2) to the values output range.
+ *
  *  This version of \p set_difference_by_key compares key elements using a function object \p comp.
  *
  *  The algorithm's execution is parallelized as determined by \p exec.


### PR DESCRIPTION
## Description
Hello!
Unsure if this is a correct interpretation and solution to the issue below.
I would appreciate feedback!

closes [https://github.com/NVIDIA/cccl/issues/785]

Added overload for set_difference_by_key(....) that uses thrust::constant_iterator for values_first2.
I'm not sure if this should be extended to also exist for other version, for example the one with a custom comparator.

## Checklist
I tried to add a simple test case to test my change, not user if this is the correct way to go about it. The documentation for how tests should be written for thrust is not as extensive as the one for CUB.
In regards to documentation, I have not changed anything. Because I'm unsure about what to do.
