### PR TITLE
CMake support absolute CMAKE_INSTALL_LIBDIR values

### DIFF
--- a/cub/cmake/CubInstallRules.cmake
+++ b/cub/cmake/CubInstallRules.cmake
@@ -16,7 +16,24 @@ install(DIRECTORY "${CUB_SOURCE_DIR}/cub/cmake/"
 )
 # Need to configure a file to store the infix specified in
 # CMAKE_INSTALL_INCLUDEDIR since it can be defined by the user
-set(install_location "${CMAKE_INSTALL_LIBDIR}/cmake/cub")
+set(_CCCL_RELATIVE_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+if(_CCCL_RELATIVE_LIBDIR MATCHES "^${CMAKE_INSTALL_PREFIX}")
+  # libdir is an abs string that starts with prefix
+  string(LENGTH "${CMAKE_INSTALL_PREFIX}" to_remove)
+  string(SUBSTRING "${_CCCL_RELATIVE_LIBDIR}" ${to_remove} -1 relative)
+  # remove any leading "/""
+  string(REGEX REPLACE "^/(.)" "\\1" _CCCL_RELATIVE_LIBDIR "${relative}")
+elseif(_CCCL_RELATIVE_LIBDIR MATCHES "^/")
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBDIR ('${CMAKE_INSTALL_LIBDIR}') must be a relative path or an absolute path under CMAKE_INSTALL_PREFIX ('${CMAKE_INSTALL_PREFIX}')")
+endif()
+set(install_location "${_CCCL_RELATIVE_LIBDIR}/cmake/cub")
+
+# Transform to a list of directories, replace each directory with "../"
+# and convert back to a string
+string(REGEX REPLACE "/" ";" from_install_prefix "${install_location}")
+list(TRANSFORM from_install_prefix REPLACE ".+" "../")
+list(JOIN from_install_prefix "" from_install_prefix)
+
 configure_file("${CUB_SOURCE_DIR}/cub/cmake/cub-header-search.cmake.in"
   "${CUB_BINARY_DIR}/cub/cmake/cub-header-search.cmake"
   @ONLY)

--- a/cub/cub/cmake/cub-header-search.cmake.in
+++ b/cub/cub/cmake/cub-header-search.cmake.in
@@ -2,13 +2,7 @@
 unset(_CUB_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
 
 # Find CMAKE_INSTALL_INCLUDEDIR=@CMAKE_INSTALL_INCLUDEDIR@ directory"
-set(from_install_prefix "@install_location@")
-
-# Transform to a list of directories, replace each directoy with "../"
-# and convert back to a string
-string(REGEX REPLACE "/" ";" from_install_prefix "${from_install_prefix}")
-list(TRANSFORM from_install_prefix REPLACE ".+" "../")
-list(JOIN from_install_prefix "" from_install_prefix)
+set(from_install_prefix "@from_install_prefix@")
 
 find_path(_CUB_VERSION_INCLUDE_DIR cub/version.cuh
   NO_CMAKE_FIND_ROOT_PATH # Don't allow CMake to re-root the search

--- a/libcudacxx/cmake/libcudacxxInstallRules.cmake
+++ b/libcudacxx/cmake/libcudacxxInstallRules.cmake
@@ -28,7 +28,18 @@ install(DIRECTORY "${libcudacxx_SOURCE_DIR}/lib/cmake/libcudacxx"
 # Need to configure a file to store CMAKE_INSTALL_INCLUDEDIR
 # since it can be defined by the user. This is common to work around collisions
 # with the CTK installed headers.
-set(install_location "${CMAKE_INSTALL_LIBDIR}/cmake/libcudacxx")
+set(_CCCL_RELATIVE_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+if(_CCCL_RELATIVE_LIBDIR MATCHES "^${CMAKE_INSTALL_PREFIX}")
+  # libdir is an abs string that starts with prefix
+  string(LENGTH "${CMAKE_INSTALL_PREFIX}" to_remove)
+  string(SUBSTRING "${_CCCL_RELATIVE_LIBDIR}" ${to_remove} -1 relative)
+  # remove any leading "/""
+  string(REGEX REPLACE "^/(.)" "\\1" _CCCL_RELATIVE_LIBDIR "${relative}")
+elseif(_CCCL_RELATIVE_LIBDIR MATCHES "^/")
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBDIR ('${CMAKE_INSTALL_LIBDIR}') must be a relative path or an absolute path under CMAKE_INSTALL_PREFIX ('${CMAKE_INSTALL_PREFIX}')")
+endif()
+set(install_location "${_CCCL_RELATIVE_LIBDIR}/cmake/libcudacxx")
+
 # Transform to a list of directories, replace each directory with "../"
 # and convert back to a string
 string(REGEX REPLACE "/" ";" from_install_prefix "${install_location}")

--- a/thrust/cmake/ThrustInstallRules.cmake
+++ b/thrust/cmake/ThrustInstallRules.cmake
@@ -15,9 +15,27 @@ install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust/cmake/"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/thrust"
   REGEX .*header-search.cmake.* EXCLUDE
 )
+
 # Need to configure a file to store the infix specified in
 # CMAKE_INSTALL_INCLUDEDIR since it can be defined by the user
-set(install_location "${CMAKE_INSTALL_LIBDIR}/cmake/thrust")
+set(_CCCL_RELATIVE_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+if(_CCCL_RELATIVE_LIBDIR MATCHES "^${CMAKE_INSTALL_PREFIX}")
+  # libdir is an abs string that starts with prefix
+  string(LENGTH "${CMAKE_INSTALL_PREFIX}" to_remove)
+  string(SUBSTRING "${_CCCL_RELATIVE_LIBDIR}" ${to_remove} -1 relative)
+  # remove any leading "/""
+  string(REGEX REPLACE "^/(.)" "\\1" _CCCL_RELATIVE_LIBDIR "${relative}")
+elseif(_CCCL_RELATIVE_LIBDIR MATCHES "^/")
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBDIR ('${CMAKE_INSTALL_LIBDIR}') must be a relative path or an absolute path under CMAKE_INSTALL_PREFIX ('${CMAKE_INSTALL_PREFIX}')")
+endif()
+set(install_location "${_CCCL_RELATIVE_LIBDIR}/cmake/thrust")
+
+# Transform to a list of directories, replace each directory with "../"
+# and convert back to a string
+string(REGEX REPLACE "/" ";" from_install_prefix "${install_location}")
+list(TRANSFORM from_install_prefix REPLACE ".+" "../")
+list(JOIN from_install_prefix "" from_install_prefix)
+
 configure_file("${Thrust_SOURCE_DIR}/thrust/cmake/thrust-header-search.cmake.in"
   "${Thrust_BINARY_DIR}/thrust/cmake/thrust-header-search.cmake"
   @ONLY)

--- a/thrust/thrust/cmake/thrust-header-search.cmake.in
+++ b/thrust/thrust/cmake/thrust-header-search.cmake.in
@@ -2,13 +2,7 @@
 unset(_THRUST_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
 
 # Find CMAKE_INSTALL_INCLUDEDIR=@CMAKE_INSTALL_INCLUDEDIR@ directory"
-set(from_install_prefix "@install_location@")
-
-# Transform to a list of directories, replace each directoy with "../"
-# and convert back to a string
-string(REGEX REPLACE "/" ";" from_install_prefix "${from_install_prefix}")
-list(TRANSFORM from_install_prefix REPLACE ".+" "../")
-list(JOIN from_install_prefix "" from_install_prefix)
+set(from_install_prefix "@from_install_prefix@")
 
 find_path(_THRUST_VERSION_INCLUDE_DIR thrust/version.h
   NO_CMAKE_FIND_ROOT_PATH # Don't allow CMake to re-root the search


### PR DESCRIPTION
## Description
Allows us to support absolute `CMAKE_INSTALL_LIBDIR` paths when they are rooted in `CMAKE_INSTALL_PREFIX`.

Fixes #1390

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
