### PR TITLE
Add support for sm_90a in <nv/target> API

### DIFF
--- a/libcudacxx/include/nv/detail/__target_macros
+++ b/libcudacxx/include/nv/detail/__target_macros
@@ -231,6 +231,10 @@
 #define NV_IS_EXACTLY_SM_89 __NV_IS_EXACTLY_SM_89
 #define NV_IS_EXACTLY_SM_90 __NV_IS_EXACTLY_SM_90
 
+// Disable SM_90a support on non-supporting compilers.
+// Will re-enable for nvcc below.
+#define NV_HAS_FEATURE_SM_90a NV_NO_TARGET
+
 #define NV_IS_HOST         __NV_IS_HOST
 #define NV_IS_DEVICE       __NV_IS_DEVICE
 
@@ -347,9 +351,9 @@
 #    define _NV_TARGET_BOOL___NV_IS_EXACTLY_SM_90 0
 #  endif
 
-// SM90a support
+// Re-enable sm_90a support in nvcc.
+#  undef NV_HAS_FEATURE_SM_90a
 #  define NV_HAS_FEATURE_SM_90a   __NV_HAS_FEATURE_SM_90a
-
 #  if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900) && defined(__CUDA_ARCH_FEAT_SM90_ALL))
 #    define _NV_TARGET_BOOL___NV_HAS_FEATURE_SM_90a 1
 #  else

--- a/libcudacxx/include/nv/detail/__target_macros
+++ b/libcudacxx/include/nv/detail/__target_macros
@@ -347,6 +347,15 @@
 #    define _NV_TARGET_BOOL___NV_IS_EXACTLY_SM_90 0
 #  endif
 
+// SM90a support
+#  define NV_HAS_FEATURE_SM_90a   __NV_HAS_FEATURE_SM_90a
+
+#  if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900) && defined(__CUDA_ARCH_FEAT_SM90_ALL))
+#    define _NV_TARGET_BOOL___NV_HAS_FEATURE_SM_90a 1
+#  else
+#    define _NV_TARGET_BOOL___NV_HAS_FEATURE_SM_90a 0
+#  endif
+
 #  if (_NV_TARGET_IS_HOST)
 #    define _NV_TARGET_BOOL___NV_IS_HOST   1
 #    define _NV_TARGET_BOOL___NV_IS_DEVICE 0


### PR DESCRIPTION
The new API be used as follows:

```
__global__ void kernel(int *out) {
    NV_DISPATCH_TARGET(
        NV_HAS_FEATURE_SM_90a, (
        *out = 901;
    ), NV_PROVIDES_SM_90, (
        *out = 900;
    ), NV_IS_DEVICE, (
        *out = 0;
    ));
}
```

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #1270


<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes. How to test?? I made [this godbolt example](https://godbolt.org/z/jjY356Mh6) to see that it works correctly.
- [ ] The documentation is up to date with these changes. See https://github.com/NVIDIA/cccl/issues/1306
