### PR TITLE
Do not use VLAs in `cp_async_bulk_tensor_*` tests

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cccl/ptx_isa.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cccl/ptx_isa.h
@@ -98,7 +98,7 @@
 // When __CUDA_MINIMUM_ARCH__ is available, we only enable the feature when the
 // hardware supports it.
 #if (!defined(__CUDA_MINIMUM_ARCH__)) \
-  || (defined(__CUDA_MINIMUM_ARCH__) && 900 <= __CUDA_MINIMUM_ARCH__) && __cccl_isa_ptx >= 800
+  || (defined(__CUDA_MINIMUM_ARCH__) && 900 <= __CUDA_MINIMUM_ARCH__) && __cccl_ptx_isa >= 800
 #  define __cccl_lib_local_barrier_arrive_tx
 #  define __cccl_lib_experimental_ctk12_cp_async_exposure
 #endif

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/barrier.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/barrier.h
@@ -808,7 +808,7 @@ struct __memcpy_completion_impl {
                 // bulk group to be used with shared memory barriers.
                 _LIBCUDACXX_UNREACHABLE();
             case __completion_mechanism::__mbarrier_complete_tx:
-#if __cccl_isa_ptx >= 800
+#if __cccl_ptx_isa >= 800
                 // Pre-sm90, the mbarrier_complete_tx completion mechanism is not available.
                 NV_IF_TARGET(NV_PROVIDES_SM_90, (
                     // Only perform the expect_tx operation with the leader thread
@@ -818,7 +818,7 @@ struct __memcpy_completion_impl {
                 ),(
                     __cuda_ptx_mbarrier_complete_tx_is_not_supported_before_SM_90__();
                 ));
-#endif // __cccl_isa_ptx >= 800
+#endif // __cccl_ptx_isa >= 800
                 return async_contract_fulfillment::async;
             case __completion_mechanism::__sync:
                 // sync: In this case, we do not need to do anything. The user will have

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_1d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_1d.pass.cpp
@@ -43,6 +43,7 @@ __device__ constexpr cuda::std::array<uint32_t, 1> TEST_SMEM_COORDS[] = {
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
+constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -56,10 +57,9 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
-    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_1d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_1d.pass.cpp
@@ -17,6 +17,9 @@
 
 // <cuda/barrier>
 
+#include <cuda/barrier>
+#include <cuda/std/array>
+
 #include "cp_async_bulk_tensor_generic.h"
 
 // Define the size of contiguous tensor in global and shared memory.
@@ -26,21 +29,20 @@
 // offset.
 //
 // We have a separate variable for host and device because a constexpr
-// std::initializer_list cannot be shared between host and device as some of its
+// cuda::std::array cannot be shared between host and device as some of its
 // member functions take a const reference, which is unsupported by nvcc.
-           constexpr std::initializer_list<int> GMEM_DIMS    {256};
-__device__ constexpr std::initializer_list<int> GMEM_DIMS_DEV{256};
-           constexpr std::initializer_list<int> SMEM_DIMS    {32};
-__device__ constexpr std::initializer_list<int> SMEM_DIMS_DEV{32};
+           constexpr cuda::std::array<uint64_t, 1> GMEM_DIMS    {256};
+__device__ constexpr cuda::std::array<uint64_t, 1> GMEM_DIMS_DEV{256};
+           constexpr cuda::std::array<uint32_t, 1> SMEM_DIMS    {32};
+__device__ constexpr cuda::std::array<uint32_t, 1> SMEM_DIMS_DEV{32};
 
-__device__ constexpr std::initializer_list<int> TEST_SMEM_COORDS[] = {
+__device__ constexpr cuda::std::array<uint32_t, 1> TEST_SMEM_COORDS[] = {
     {0},
     {4},
     {8}
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
-constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -54,9 +56,10 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
+    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_2d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_2d.pass.cpp
@@ -44,6 +44,7 @@ __device__ constexpr cuda::std::array<uint32_t, 2> TEST_SMEM_COORDS[] = {
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
+constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -57,10 +58,9 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
-    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_2d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_2d.pass.cpp
@@ -17,6 +17,9 @@
 
 // <cuda/barrier>
 
+#include <cuda/barrier>
+#include <cuda/std/array>
+
 #include "cp_async_bulk_tensor_generic.h"
 
 // Define the size of contiguous tensor in global and shared memory.
@@ -26,14 +29,14 @@
 // offset.
 //
 // We have a separate variable for host and device because a constexpr
-// std::initializer_list cannot be shared between host and device as some of its
+// cuda::std::array cannot be shared between host and device as some of its
 // member functions take a const reference, which is unsupported by nvcc.
-           constexpr std::initializer_list<int> GMEM_DIMS    {8, 11};
-__device__ constexpr std::initializer_list<int> GMEM_DIMS_DEV{8, 11};
-           constexpr std::initializer_list<int> SMEM_DIMS    {4,  2};
-__device__ constexpr std::initializer_list<int> SMEM_DIMS_DEV{4,  2};
+           constexpr cuda::std::array<uint64_t, 2> GMEM_DIMS    {8, 11};
+__device__ constexpr cuda::std::array<uint64_t, 2> GMEM_DIMS_DEV{8, 11};
+           constexpr cuda::std::array<uint32_t, 2> SMEM_DIMS    {4,  2};
+__device__ constexpr cuda::std::array<uint32_t, 2> SMEM_DIMS_DEV{4,  2};
 
-__device__ constexpr std::initializer_list<int> TEST_SMEM_COORDS[] = {
+__device__ constexpr cuda::std::array<uint32_t, 2> TEST_SMEM_COORDS[] = {
     {0, 0},
     {4, 1},
     {4, 5},
@@ -41,7 +44,6 @@ __device__ constexpr std::initializer_list<int> TEST_SMEM_COORDS[] = {
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
-constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -55,9 +57,10 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
+    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_3d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_3d.pass.cpp
@@ -43,6 +43,7 @@ __device__ constexpr cuda::std::array<uint32_t, 3> TEST_SMEM_COORDS[] = {
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
+constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -56,10 +57,9 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
-    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_3d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_3d.pass.cpp
@@ -17,6 +17,9 @@
 
 // <cuda/barrier>
 
+#include <cuda/barrier>
+#include <cuda/std/array>
+
 #include "cp_async_bulk_tensor_generic.h"
 
 // Define the size of contiguous tensor in global and shared memory.
@@ -26,21 +29,20 @@
 // offset.
 //
 // We have a separate variable for host and device because a constexpr
-// std::initializer_list cannot be shared between host and device as some of its
+// cuda::std::array cannot be shared between host and device as some of its
 // member functions take a const reference, which is unsupported by nvcc.
-           constexpr std::initializer_list<int> GMEM_DIMS    {8, 11, 13};
-__device__ constexpr std::initializer_list<int> GMEM_DIMS_DEV{8, 11, 13};
-           constexpr std::initializer_list<int> SMEM_DIMS    {4,  2,  4};
-__device__ constexpr std::initializer_list<int> SMEM_DIMS_DEV{4,  2,  4};
+           constexpr cuda::std::array<uint64_t, 3> GMEM_DIMS    {8, 11, 13};
+__device__ constexpr cuda::std::array<uint64_t, 3> GMEM_DIMS_DEV{8, 11, 13};
+           constexpr cuda::std::array<uint32_t, 3> SMEM_DIMS    {4,  2,  4};
+__device__ constexpr cuda::std::array<uint32_t, 3> SMEM_DIMS_DEV{4,  2,  4};
 
-__device__ constexpr std::initializer_list<int> TEST_SMEM_COORDS[] = {
+__device__ constexpr cuda::std::array<uint32_t, 3> TEST_SMEM_COORDS[] = {
     {0, 0, 0},
     {4, 1, 3},
     {4, 5, 1}
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
-constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -54,9 +56,10 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
+    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_4d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_4d.pass.cpp
@@ -44,6 +44,7 @@ __device__ constexpr cuda::std::array<uint32_t, 4> TEST_SMEM_COORDS[] = {
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
+constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -57,10 +58,9 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
-    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_4d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_4d.pass.cpp
@@ -17,6 +17,9 @@
 
 // <cuda/barrier>
 
+#include <cuda/barrier>
+#include <cuda/std/array>
+
 #include "cp_async_bulk_tensor_generic.h"
 
 // Define the size of contiguous tensor in global and shared memory.
@@ -26,14 +29,14 @@
 // offset.
 //
 // We have a separate variable for host and device because a constexpr
-// std::initializer_list cannot be shared between host and device as some of its
+// cuda::std::array cannot be shared between host and device as some of its
 // member functions take a const reference, which is unsupported by nvcc.
-           constexpr std::initializer_list<int> GMEM_DIMS    {8, 11, 13, 3};
-__device__ constexpr std::initializer_list<int> GMEM_DIMS_DEV{8, 11, 13, 3};
-           constexpr std::initializer_list<int> SMEM_DIMS    {4,  2,  4, 1};
-__device__ constexpr std::initializer_list<int> SMEM_DIMS_DEV{4,  2,  4, 1};
+           constexpr cuda::std::array<uint64_t, 4> GMEM_DIMS    {8, 11, 13, 3};
+__device__ constexpr cuda::std::array<uint64_t, 4> GMEM_DIMS_DEV{8, 11, 13, 3};
+           constexpr cuda::std::array<uint32_t, 4> SMEM_DIMS    {4,  2,  4, 1};
+__device__ constexpr cuda::std::array<uint32_t, 4> SMEM_DIMS_DEV{4,  2,  4, 1};
 
-__device__ constexpr std::initializer_list<int> TEST_SMEM_COORDS[] = {
+__device__ constexpr cuda::std::array<uint32_t, 4> TEST_SMEM_COORDS[] = {
     {0, 0, 0, 0},
     {4, 1, 3, 0},
     {4, 8, 7, 2},
@@ -41,7 +44,6 @@ __device__ constexpr std::initializer_list<int> TEST_SMEM_COORDS[] = {
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
-constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -55,9 +57,10 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
+    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_5d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_5d.pass.cpp
@@ -43,6 +43,7 @@ __device__ constexpr cuda::std::array<uint32_t, 5> TEST_SMEM_COORDS[] = {
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
+constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -56,10 +57,9 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
-    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_5d.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_5d.pass.cpp
@@ -17,6 +17,9 @@
 
 // <cuda/barrier>
 
+#include <cuda/barrier>
+#include <cuda/std/array>
+
 #include "cp_async_bulk_tensor_generic.h"
 
 // Define the size of contiguous tensor in global and shared memory.
@@ -26,21 +29,20 @@
 // offset.
 //
 // We have a separate variable for host and device because a constexpr
-// std::initializer_list cannot be shared between host and device as some of its
+// cuda::std::array cannot be shared between host and device as some of its
 // member functions take a const reference, which is unsupported by nvcc.
-           constexpr std::initializer_list<int> GMEM_DIMS    {8, 11, 13, 3, 3};
-__device__ constexpr std::initializer_list<int> GMEM_DIMS_DEV{8, 11, 13, 3, 3};
-           constexpr std::initializer_list<int> SMEM_DIMS    {4,  2,  4, 1, 1};
-__device__ constexpr std::initializer_list<int> SMEM_DIMS_DEV{4,  2,  4, 1, 1};
+           constexpr cuda::std::array<uint64_t, 5> GMEM_DIMS    {8, 11, 13, 3, 3};
+__device__ constexpr cuda::std::array<uint64_t, 5> GMEM_DIMS_DEV{8, 11, 13, 3, 3};
+           constexpr cuda::std::array<uint32_t, 5> SMEM_DIMS    {4,  2,  4, 1, 1};
+__device__ constexpr cuda::std::array<uint32_t, 5> SMEM_DIMS_DEV{4,  2,  4, 1, 1};
 
-__device__ constexpr std::initializer_list<int> TEST_SMEM_COORDS[] = {
+__device__ constexpr cuda::std::array<uint32_t, 5> TEST_SMEM_COORDS[] = {
     {0, 0, 0, 0, 0},
     {4, 1, 3, 0, 1},
     {4, 5, 1, 1, 2}
 };
 
 constexpr size_t gmem_len = tensor_len(GMEM_DIMS);
-constexpr size_t smem_len = tensor_len(SMEM_DIMS);
 
 __device__ int gmem_tensor[gmem_len];
 
@@ -54,9 +56,10 @@ int main(int, char**)
         ),
         NV_IS_DEVICE, (
             for (auto smem_coord : TEST_SMEM_COORDS) {
-                test<smem_len>(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
+                test(smem_coord, SMEM_DIMS_DEV, GMEM_DIMS_DEV, gmem_tensor, gmem_len);
             }
         )
     );
+    (void)SMEM_DIMS;
     return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_generic.h
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_generic.h
@@ -131,7 +131,7 @@ __constant__ fake_cutensormap global_fake_tensor_map;
  * 6. It checks that all the values in global are properly modified.
  */
 template <size_t smem_len, size_t num_dims>
-__device__ void test(cuda::std::array<uint32_t, smem_len> smem_coord,
+__device__ void test(cuda::std::array<uint32_t, num_dims> smem_coord,
                      cuda::std::array<uint32_t, num_dims> smem_dims,
                      cuda::std::array<uint64_t, num_dims> gmem_dims,
                      int* gmem_tensor,

--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_generic.h
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_tensor_generic.h
@@ -14,6 +14,7 @@
 #define TEST_CP_ASYNC_BULK_TENSOR_GENERIC_H_
 
 #include <cuda/barrier>
+#include <cuda/std/array>
 #include <cuda/std/utility>     // cuda::std::move
 #include "test_macros.h"        // TEST_NV_DIAG_SUPPRESS
 
@@ -37,24 +38,26 @@ namespace cde = cuda::device::experimental;
  */
 
 // Compute the total number of elements in a tensor
-constexpr __host__ __device__ int tensor_len(std::initializer_list<int> dims) {
-    int len = 1;
+template<class T, size_t num_dims>
+constexpr __host__ __device__ int tensor_len(cuda::std::array<T, num_dims> dims) {
+    T len = 1;
     for (int d : dims) {
         len *= d;
     }
-    return len;
+    return static_cast<int>(len);
 }
 
 // Function to convert:
 // a linear index into a shared memory tensor
 // into
 // a linear index into a global memory tensor.
+template<size_t num_dims>
 inline __device__
 int smem_lin_idx_to_gmem_lin_idx(
     int smem_lin_idx,
-    std::initializer_list<int> smem_coord,
-    std::initializer_list<int> smem_dims,
-    std::initializer_list<int> gmem_dims) {
+    cuda::std::array<uint32_t, num_dims> smem_coord,
+    cuda::std::array<uint32_t, num_dims> smem_dims,
+    cuda::std::array<uint64_t, num_dims> gmem_dims) {
     assert(smem_coord.size() == smem_dims.size());
     assert(smem_coord.size() == gmem_dims.size());
 
@@ -70,38 +73,36 @@ int smem_lin_idx_to_gmem_lin_idx(
     return gmem_lin_idx;
 }
 
+template<size_t num_dims>
 __device__ inline void cp_tensor_global_to_shared(
     CUtensorMap* tensor_map,
-    std::initializer_list<int> indices,
+    cuda::std::array<uint32_t, num_dims> indices,
     void *smem,
     barrier &bar) {
 
-    const int* idxs = indices.begin();
-
     switch (indices.size()) {
-        case 1: cde::cp_async_bulk_tensor_1d_global_to_shared(smem, tensor_map, idxs[0], bar); break;
-        case 2: cde::cp_async_bulk_tensor_2d_global_to_shared(smem, tensor_map, idxs[0], idxs[1], bar); break;
-        case 3: cde::cp_async_bulk_tensor_3d_global_to_shared(smem, tensor_map, idxs[0], idxs[1], idxs[2], bar); break;
-        case 4: cde::cp_async_bulk_tensor_4d_global_to_shared(smem, tensor_map, idxs[0], idxs[1], idxs[2], idxs[3], bar); break;
-        case 5: cde::cp_async_bulk_tensor_5d_global_to_shared(smem, tensor_map, idxs[0], idxs[1], idxs[2], idxs[3], idxs[4], bar); break;
+        case 1: cde::cp_async_bulk_tensor_1d_global_to_shared(smem, tensor_map, indices[0], bar); break;
+        case 2: cde::cp_async_bulk_tensor_2d_global_to_shared(smem, tensor_map, indices[0], indices[1], bar); break;
+        case 3: cde::cp_async_bulk_tensor_3d_global_to_shared(smem, tensor_map, indices[0], indices[1], indices[2], bar); break;
+        case 4: cde::cp_async_bulk_tensor_4d_global_to_shared(smem, tensor_map, indices[0], indices[1], indices[2], indices[3], bar); break;
+        case 5: cde::cp_async_bulk_tensor_5d_global_to_shared(smem, tensor_map, indices[0], indices[1], indices[2], indices[3], indices[4], bar); break;
         default:
             assert(false && "Wrong number of dimensions.");
     }
 }
 
+template<size_t num_dims>
 __device__ inline void cp_tensor_shared_to_global(
     CUtensorMap* tensor_map,
-    std::initializer_list<int> indices,
+    cuda::std::array<uint32_t, num_dims> indices,
     void *smem) {
 
-    const int* idxs = indices.begin();
-
     switch (indices.size()) {
-        case 1: cde::cp_async_bulk_tensor_1d_shared_to_global(tensor_map, idxs[0], smem); break;
-        case 2: cde::cp_async_bulk_tensor_2d_shared_to_global(tensor_map, idxs[0], idxs[1], smem); break;
-        case 3: cde::cp_async_bulk_tensor_3d_shared_to_global(tensor_map, idxs[0], idxs[1], idxs[2], smem); break;
-        case 4: cde::cp_async_bulk_tensor_4d_shared_to_global(tensor_map, idxs[0], idxs[1], idxs[2], idxs[3], smem); break;
-        case 5: cde::cp_async_bulk_tensor_5d_shared_to_global(tensor_map, idxs[0], idxs[1], idxs[2], idxs[3], idxs[4], smem); break;
+        case 1: cde::cp_async_bulk_tensor_1d_shared_to_global(tensor_map, indices[0], smem); break;
+        case 2: cde::cp_async_bulk_tensor_2d_shared_to_global(tensor_map, indices[0], indices[1], smem); break;
+        case 3: cde::cp_async_bulk_tensor_3d_shared_to_global(tensor_map, indices[0], indices[1], indices[2], smem); break;
+        case 4: cde::cp_async_bulk_tensor_4d_shared_to_global(tensor_map, indices[0], indices[1], indices[2], indices[3], smem); break;
+        case 5: cde::cp_async_bulk_tensor_5d_shared_to_global(tensor_map, indices[0], indices[1], indices[2], indices[3], indices[4], smem); break;
         default:
             assert(false && "Wrong number of dimensions.");
     }
@@ -129,10 +130,10 @@ __constant__ fake_cutensormap global_fake_tensor_map;
  * 5. It writes the tile back to global memory
  * 6. It checks that all the values in global are properly modified.
  */
-template <int smem_len>
-__device__ void test(std::initializer_list<int> smem_coord,
-                     std::initializer_list<int> smem_dims,
-                     std::initializer_list<int> gmem_dims,
+template <size_t smem_len, size_t num_dims>
+__device__ void test(cuda::std::array<uint32_t, smem_len> smem_coord,
+                     cuda::std::array<uint32_t, num_dims> smem_dims,
+                     cuda::std::array<uint64_t, num_dims> gmem_dims,
                      int* gmem_tensor,
                      int gmem_len)
 {
@@ -208,33 +209,24 @@ PFN_cuTensorMapEncodeTiled get_cuTensorMapEncodeTiled() {
 #endif
 
 #ifndef TEST_COMPILER_NVRTC
-template <typename T>
-CUtensorMap map_encode(T *tensor_ptr, std::initializer_list<int> gmem_dims, std::initializer_list<int> smem_dims) {
+template <typename T, size_t num_dims>
+CUtensorMap map_encode(T *tensor_ptr, const cuda::std::array<uint64_t, num_dims>& gmem_dims, const cuda::std::array<uint32_t, num_dims>& smem_dims) {
     // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html
     CUtensorMap tensor_map{};
-    assert(gmem_dims.size() == smem_dims.size());
-    // rank is the number of dimensions of the array.
-    int rank = gmem_dims.size();
-    uint64_t size[rank];
-    for (int i  = 0; i < rank; ++i) {
-        size[i] = gmem_dims.begin()[i];
-    }
+
     // The stride is the number of bytes to traverse from the first element of one row to the next.
     // It must be a multiple of 16.
-    uint64_t stride[rank - 1];
-    int base_stride = sizeof(T);
-    for (int i = 0; i < rank - 1; ++i) {
-        base_stride *= gmem_dims.begin()[i];
+    uint64_t stride[num_dims - 1];
+    uint64_t base_stride = sizeof(T);
+    for (size_t i = 0; i < num_dims - 1; ++i) {
+        base_stride *= gmem_dims[i];
         stride[i] = base_stride;
     }
-    // The box_size is the size of the shared memory buffer that is used as the
-    // destination of a TMA transfer. Casting from int -> uint32_t.
-    const uint32_t *box_size = reinterpret_cast<const uint32_t *>(smem_dims.begin());
 
     // The distance between elements in units of sizeof(element). A stride of 2
     // can be used to load only the real component of a complex-valued tensor, for instance.
-    uint32_t elem_stride[rank]; // = {1, .., 1};
-    for (int i = 0; i < rank; ++i) {
+    uint32_t elem_stride[num_dims]; // = {1, .., 1};
+    for (size_t i = 0; i < num_dims; ++i) {
         elem_stride[i] = 1;
     }
 
@@ -245,11 +237,11 @@ CUtensorMap map_encode(T *tensor_ptr, std::initializer_list<int> gmem_dims, std:
     CUresult res = cuTensorMapEncodeTiled(
         &tensor_map,  // CUtensorMap *tensorMap,
         CUtensorMapDataType::CU_TENSOR_MAP_DATA_TYPE_INT32,
-        rank,                       // cuuint32_t tensorRank,
+        num_dims,                   // cuuint32_t tensorRank,
         tensor_ptr,                 // void *globalAddress,
-        size,                       // const cuuint64_t *globalDim,
+        gmem_dims.data(),           // const cuuint64_t *globalDim,
         stride,                     // const cuuint64_t *globalStrides,
-        box_size,                   // const cuuint32_t *boxDim,
+        smem_dims.data(),           // const cuuint32_t *boxDim,
         elem_stride,                // const cuuint32_t *elementStrides,
         CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
         CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_NONE,
@@ -261,8 +253,8 @@ CUtensorMap map_encode(T *tensor_ptr, std::initializer_list<int> gmem_dims, std:
     return tensor_map;
 }
 
-template <typename T>
-void init_tensor_map(const T& gmem_tensor_symbol, std::initializer_list<int> gmem_dims, std::initializer_list<int> smem_dims) {
+template <typename T, size_t num_dims>
+void init_tensor_map(const T& gmem_tensor_symbol, const cuda::std::array<uint64_t, num_dims>& gmem_dims, const cuda::std::array<uint32_t, num_dims>& smem_dims) {
     // Get pointer to gmem_tensor to create tensor map.
     int * tensor_ptr = nullptr;
     auto code = cudaGetSymbolAddress((void**)&tensor_ptr, gmem_tensor_symbol);


### PR DESCRIPTION
VLAs are a compiler extension and are correctly errored out by some compilers. As we always know the exact size of the array anyway just swtich to a `cuda::std::array`
