### PR TITLE
Disallow float offset type in cub::segmented_reducde

### DIFF
--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -470,6 +470,12 @@ public:
   //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
   //!     :language: c++
   //!     :dedent:
+  //!     :start-after: example-begin segmented-reduce-custommin
+  //!     :end-before: example-end segmented-reduce-custommin
+  //!
+  //! .. literalinclude:: ../../test/catch2_test_device_segmented_reduce_api.cu
+  //!     :language: c++
+  //!     :dedent:
   //!     :start-after: example-begin segmented-reduce-min
   //!     :end-before: example-end segmented-reduce-min
   //!

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -1,0 +1,294 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <cub/device/device_segmented_reduce.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/equal.h>
+
+#include <climits>
+#include <cstddef>
+
+#include "catch2_test_helper.h"
+#include "thrust/detail/raw_pointer_cast.h"
+
+struct CustomMin
+{
+  template <typename T>
+  __device__ __forceinline__ T operator()(const T& a, const T& b) const
+  {
+    return (b < a) ? b : a;
+  }
+};
+
+struct is_equal
+{
+  __device__ bool operator()(cub::KeyValuePair<int, int> lhs, cub::KeyValuePair<int, int> rhs)
+  {
+    return !(lhs != rhs);
+  }
+};
+
+CUB_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[segmented_reduce][device]")
+{
+  // example-begin segmented-reduce-reduce
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  thrust::device_vector<int> d_out(3);
+  CustomMin min_op;
+  int initial_value{INT_MAX};
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::Reduce(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.begin(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1,
+    min_op,
+    initial_value);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::Reduce(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.data(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1,
+    min_op,
+    initial_value);
+
+  thrust::device_vector<int> expected{6, INT_MAX, 0};
+  // example-end segmented-reduce-reduce
+
+  REQUIRE(d_out == expected);
+}
+
+CUB_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segmented_reduce][device]")
+{
+  // example-begin segmented-reduce-sum
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  thrust::device_vector<int> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::Sum(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.begin(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::Sum(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.data(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<int> expected{21, 0, 17};
+  // example-end segmented-reduce-sum
+
+  REQUIRE(d_out == expected);
+}
+
+CUB_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segmented_reduce][device]")
+{
+  // example-begin segmented-reduce-min
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  thrust::device_vector<int> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::Min(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.begin(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::Min(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.data(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<int> expected{6, INT_MAX, 0};
+  // example-end segmented-reduce-min
+
+  REQUIRE(d_out == expected);
+}
+
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMin works with int data elements", "[segmented_reduce][device]")
+{
+  // example-begin segmented-reduce-argmin
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::ArgMin(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.begin(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::ArgMin(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.data(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{1, 6}, {1, INT_MAX}, {2, 0}};
+  // example-end segmented-reduce-argmin
+
+  REQUIRE(thrust::equal(d_out.begin(), d_out.end(), expected.begin(), is_equal()));
+}
+
+CUB_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segmented_reduce][device]")
+{
+  // example-begin segmented-reduce-max
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  thrust::device_vector<int> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::Max(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.begin(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::Max(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.data(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<int> expected{8, INT_MIN, 9};
+  // example-end segmented-reduce-max
+
+  REQUIRE(d_out == expected);
+}
+
+CUB_TEST("cub::DeviceSegmentedReduce::ArgMax works with int data elements", "[segmented_reduce][device]")
+{
+  // example-begin segmented-reduce-argmax
+  int num_segments                     = 3;
+  thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
+  thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSegmentedReduce::ArgMax(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.begin(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  // Run reduction
+  cub::DeviceSegmentedReduce::ArgMax(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_out.data(),
+    num_segments,
+    d_offsets.begin(),
+    d_offsets.begin() + 1);
+
+  thrust::device_vector<cub::KeyValuePair<int, int>> expected{{0, 8}, {1, INT_MIN}, {3, 9}};
+  // example-end segmented-reduce-argmax
+
+  REQUIRE(thrust::equal(d_out.begin(), d_out.end(), expected.begin(), is_equal()));
+}

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -85,7 +85,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[se
     d_temp_storage,
     temp_storage_bytes,
     d_in.begin(),
-    d_out.data(),
+    d_out.begin(),
     num_segments,
     d_offsets.begin(),
     d_offsets.begin() + 1,
@@ -126,7 +126,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segme
     d_temp_storage,
     temp_storage_bytes,
     d_in.begin(),
-    d_out.data(),
+    d_out.begin(),
     num_segments,
     d_offsets.begin(),
     d_offsets.begin() + 1);
@@ -165,7 +165,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segme
     d_temp_storage,
     temp_storage_bytes,
     d_in.begin(),
-    d_out.data(),
+    d_out.begin(),
     num_segments,
     d_offsets.begin(),
     d_offsets.begin() + 1);
@@ -204,7 +204,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin works with int data elements", "[se
     d_temp_storage,
     temp_storage_bytes,
     d_in.begin(),
-    d_out.data(),
+    d_out.begin(),
     num_segments,
     d_offsets.begin(),
     d_offsets.begin() + 1);
@@ -243,7 +243,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segme
     d_temp_storage,
     temp_storage_bytes,
     d_in.begin(),
-    d_out.data(),
+    d_out.begin(),
     num_segments,
     d_offsets.begin(),
     d_offsets.begin() + 1);
@@ -282,7 +282,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax works with int data elements", "[se
     d_temp_storage,
     temp_storage_bytes,
     d_in.begin(),
-    d_out.data(),
+    d_out.begin(),
     num_segments,
     d_offsets.begin(),
     d_offsets.begin() + 1);

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -58,6 +58,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[se
   // example-begin segmented-reduce-reduce
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<int> d_out(3);
   CustomMin min_op;
@@ -72,8 +73,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[se
     d_in.begin(),
     d_out.begin(),
     num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1,
+    d_offsets_it,
+    d_offsets_it + 1,
     min_op,
     initial_value);
 
@@ -87,8 +88,8 @@ CUB_TEST("cub::DeviceSegmentedReduce::Reduce works with int data elements", "[se
     d_in.begin(),
     d_out.begin(),
     num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1,
+    d_offsets_it,
+    d_offsets_it + 1,
     min_op,
     initial_value);
 
@@ -103,6 +104,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segme
   // example-begin segmented-reduce-sum
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<int> d_out(3);
 
@@ -110,26 +112,14 @@ CUB_TEST("cub::DeviceSegmentedReduce::Sum works with int data elements", "[segme
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
   cub::DeviceSegmentedReduce::Sum(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
   // Run reduction
   cub::DeviceSegmentedReduce::Sum(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<int> expected{21, 0, 17};
   // example-end segmented-reduce-sum
@@ -142,6 +132,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segme
   // example-begin segmented-reduce-min
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<int> d_out(3);
 
@@ -149,26 +140,14 @@ CUB_TEST("cub::DeviceSegmentedReduce::Min works with int data elements", "[segme
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
   cub::DeviceSegmentedReduce::Min(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
   // Run reduction
   cub::DeviceSegmentedReduce::Min(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<int> expected{6, INT_MAX, 0};
   // example-end segmented-reduce-min
@@ -181,6 +160,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin works with int data elements", "[se
   // example-begin segmented-reduce-argmin
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
 
@@ -188,26 +168,14 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMin works with int data elements", "[se
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
   cub::DeviceSegmentedReduce::ArgMin(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
   // Run reduction
   cub::DeviceSegmentedReduce::ArgMin(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<cub::KeyValuePair<int, int>> expected{{1, 6}, {1, INT_MAX}, {2, 0}};
   // example-end segmented-reduce-argmin
@@ -220,6 +188,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segme
   // example-begin segmented-reduce-max
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<int> d_out(3);
 
@@ -227,26 +196,14 @@ CUB_TEST("cub::DeviceSegmentedReduce::Max works with int data elements", "[segme
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
   cub::DeviceSegmentedReduce::Max(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
   // Run reduction
   cub::DeviceSegmentedReduce::Max(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<int> expected{8, INT_MIN, 9};
   // example-end segmented-reduce-max
@@ -259,6 +216,7 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax works with int data elements", "[se
   // example-begin segmented-reduce-argmax
   int num_segments                     = 3;
   thrust::device_vector<int> d_offsets = {0, 3, 3, 7};
+  auto d_offsets_it                    = thrust::raw_pointer_cast(d_offsets.data());
   thrust::device_vector<int> d_in{8, 6, 7, 5, 3, 0, 9};
   thrust::device_vector<cub::KeyValuePair<int, int>> d_out(3);
 
@@ -266,26 +224,14 @@ CUB_TEST("cub::DeviceSegmentedReduce::ArgMax works with int data elements", "[se
   void* d_temp_storage      = nullptr;
   size_t temp_storage_bytes = 0;
   cub::DeviceSegmentedReduce::ArgMax(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
 
   // Run reduction
   cub::DeviceSegmentedReduce::ArgMax(
-    d_temp_storage,
-    temp_storage_bytes,
-    d_in.begin(),
-    d_out.begin(),
-    num_segments,
-    d_offsets.begin(),
-    d_offsets.begin() + 1);
+    d_temp_storage, temp_storage_bytes, d_in.begin(), d_out.begin(), num_segments, d_offsets_it, d_offsets_it + 1);
 
   thrust::device_vector<cub::KeyValuePair<int, int>> expected{{0, 8}, {1, INT_MIN}, {3, 9}};
   // example-end segmented-reduce-argmax

--- a/cub/test/catch2_test_device_segmented_reduce_api.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_api.cu
@@ -36,6 +36,7 @@
 #include "catch2_test_helper.h"
 #include "thrust/detail/raw_pointer_cast.h"
 
+// example-begin segmented-reduce-custommin
 struct CustomMin
 {
   template <typename T>
@@ -44,6 +45,8 @@ struct CustomMin
     return (b < a) ? b : a;
   }
 };
+
+// example-end segmented-reduce-custommin
 
 struct is_equal
 {

--- a/cub/test/test_device_radix_sort_decomposer_fail.cu
+++ b/cub/test/test_device_radix_sort_decomposer_fail.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_radix_sort.cuh>
 
 struct custom_t

--- a/cub/test/test_device_radix_sort_decomposer_fail.cu
+++ b/cub/test/test_device_radix_sort_decomposer_fail.cu
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2011-2024, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/cub/test/test_device_segmented_reduce_offset_type_fail.cu
+++ b/cub/test/test_device_segmented_reduce_offset_type_fail.cu
@@ -1,3 +1,5 @@
+// %PARAM% TEST_ERR err 0:1:2:3:4:5
+
 #include <cub/device/device_segmented_reduce.cuh>
 
 int main()
@@ -9,22 +11,29 @@ int main()
   std::size_t temp_storage_bytes{};
   std::uint8_t* d_temp_storage{};
 
+#if TEST_ERR == 0
   // expected-error {{"Offset iterator type should be integral."}}
   cub::DeviceSegmentedReduce::Reduce(
     d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1, cub::Min(), 0);
 
+#elif TEST_ERR == 1
   // expected-error {{"Offset iterator type should be integral."}}
   cub::DeviceSegmentedReduce::Sum(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
 
+#elif TEST_ERR == 2
   // expected-error {{"Offset iterator type should be integral."}}
   cub::DeviceSegmentedReduce::Min(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
 
+#elif TEST_ERR == 3
   // expected-error {{"Offset iterator type should be integral."}}
   cub::DeviceSegmentedReduce::ArgMin(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
 
+#elif TEST_ERR == 4
   // expected-error {{"Offset iterator type should be integral."}}
   cub::DeviceSegmentedReduce::Max(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
 
+#elif TEST_ERR == 5
   // expected-error {{"Offset iterator type should be integral."}}
   cub::DeviceSegmentedReduce::ArgMax(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
+#endif
 }

--- a/cub/test/test_device_segmented_reduce_offset_type_fail.cu
+++ b/cub/test/test_device_segmented_reduce_offset_type_fail.cu
@@ -1,0 +1,30 @@
+#include <cub/device/device_segmented_reduce.cuh>
+
+int main()
+{
+  using offset_t = float; // error
+  // using offset_t = int; // ok
+  float *d_in{}, *d_out{};
+  offset_t* d_offsets{};
+  std::size_t temp_storage_bytes{};
+  std::uint8_t* d_temp_storage{};
+
+  // expected-error {{"Offset iterator type should be integral."}}
+  cub::DeviceSegmentedReduce::Reduce(
+    d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1, cub::Min(), 0);
+
+  // expected-error {{"Offset iterator type should be integral."}}
+  cub::DeviceSegmentedReduce::Sum(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
+
+  // expected-error {{"Offset iterator type should be integral."}}
+  cub::DeviceSegmentedReduce::Min(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
+
+  // expected-error {{"Offset iterator type should be integral."}}
+  cub::DeviceSegmentedReduce::ArgMin(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
+
+  // expected-error {{"Offset iterator type should be integral."}}
+  cub::DeviceSegmentedReduce::Max(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
+
+  // expected-error {{"Offset iterator type should be integral."}}
+  cub::DeviceSegmentedReduce::ArgMax(d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1);
+}

--- a/cub/test/test_device_segmented_reduce_offset_type_fail.cu
+++ b/cub/test/test_device_segmented_reduce_offset_type_fail.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 // %PARAM% TEST_ERR err 0:1:2:3:4:5
 
 #include <cub/device/device_segmented_reduce.cuh>

--- a/cub/test/test_device_segmented_reduce_offset_type_fail.cu
+++ b/cub/test/test_device_segmented_reduce_offset_type_fail.cu
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
## Description

Fixes #1221 for introducing tag_dispatching intermediate layer in cub::SegmentedReduce that improves error reporting and enforces that the offset type be integral.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] Add tests.
- [x] Export Doxygen examples in standalone test cases.
