### PR TITLE
Refactor `thrust::[stable_]partition[_copy]` to use `cub::DevicePartition`

### DIFF
--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -857,7 +857,7 @@ struct AgentSelectIf
         OffsetT num_tile_selections     = prefix_op.GetBlockAggregate();
         OffsetT num_selections          = prefix_op.GetInclusivePrefix();
         OffsetT num_selections_prefix   = prefix_op.GetExclusivePrefix();
-        OffsetT num_rejected_prefix     = (tile_idx * TILE_ITEMS) - num_selections_prefix;
+        OffsetT num_rejected_prefix     = tile_offset - num_selections_prefix;
 
         // Discount any out-of-bounds selections
         if (IS_LAST_TILE)

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -51,6 +51,7 @@
 #include <cub/block/block_store.cuh>
 #include <cub/grid/grid_queue.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
+#include <cub/util_type.cuh>
 
 #include <cuda/std/type_traits>
 
@@ -121,6 +122,19 @@ struct AgentSelectIfPolicy
  * Thread block abstractions
  ******************************************************************************/
 
+namespace detail
+{
+template <typename SelectedOutputItT, typename RejectedOutputItT>
+struct partition_distinct_output_t
+{
+  using selected_iterator_t = SelectedOutputItT;
+  using rejected_iterator_t = RejectedOutputItT;
+
+  selected_iterator_t selected_it;
+  rejected_iterator_t rejected_it;
+};
+} // namespace detail
+
 /**
  * @brief AgentSelectIf implements a stateful abstraction of CUDA thread blocks for participating in
  * device-wide selection
@@ -139,8 +153,8 @@ struct AgentSelectIfPolicy
  *   Random-access input iterator type for selections (NullType* if a selection functor or
  *   discontinuity flagging is to be used for selection)
  *
- * @tparam SelectedOutputIteratorT
- *   Random-access output iterator type for selection_flags items
+ * @tparam OutputIteratorWrapperT
+ *   Either a random-access iterator or an instance of the `partition_distinct_output_t` template.
  *
  * @tparam SelectOpT
  *   Selection operator type (NullType if selections or discontinuity flagging is to be used for
@@ -159,7 +173,7 @@ struct AgentSelectIfPolicy
 template <typename AgentSelectIfPolicyT,
           typename InputIteratorT,
           typename FlagsInputIteratorT,
-          typename SelectedOutputIteratorT,
+          typename OutputIteratorWrapperT,
           typename SelectOpT,
           typename EqualityOpT,
           typename OffsetT,
@@ -279,13 +293,13 @@ struct AgentSelectIf
     // Per-thread fields
     //---------------------------------------------------------------------
 
-    _TempStorage &temp_storage;                   ///< Reference to temp_storage
-    WrappedInputIteratorT d_in;                   ///< Input items
-    SelectedOutputIteratorT d_selected_out;       ///< Unique output items
-    WrappedFlagsInputIteratorT d_flags_in;        ///< Input selection flags (if applicable)
+    _TempStorage& temp_storage; ///< Reference to temp_storage
+    WrappedInputIteratorT d_in; ///< Input items
+    OutputIteratorWrapperT d_selected_out; ///< Unique output items
+    WrappedFlagsInputIteratorT d_flags_in; ///< Input selection flags (if applicable)
     InequalityWrapper<EqualityOpT> inequality_op; ///< T inequality operator
-    SelectOpT select_op;                          ///< Selection operator
-    OffsetT num_items;                            ///< Total number of input items
+    SelectOpT select_op; ///< Selection operator
+    OffsetT num_items; ///< Total number of input items
 
     //---------------------------------------------------------------------
     // Constructor
@@ -316,7 +330,7 @@ struct AgentSelectIf
     _CCCL_DEVICE _CCCL_FORCEINLINE AgentSelectIf(TempStorage &temp_storage,
                                              InputIteratorT d_in,
                                              FlagsInputIteratorT d_flags_in,
-                                             SelectedOutputIteratorT d_selected_out,
+                                             OutputIteratorWrapperT d_selected_out,
                                              SelectOpT select_op,
                                              EqualityOpT equality_op,
                                              OffsetT num_items)
@@ -477,10 +491,10 @@ struct AgentSelectIf
     //---------------------------------------------------------------------
 
     /**
-     * Scatter flagged items to output offsets (specialized for direct scattering)
+     * Scatter flagged items to output offsets (specialized for direct scattering).
      */
     template <bool IS_LAST_TILE, bool IS_FIRST_TILE>
-    _CCCL_DEVICE _CCCL_FORCEINLINE void ScatterDirect(
+    _CCCL_DEVICE _CCCL_FORCEINLINE void ScatterSelectedDirect(
         InputT  (&items)[ITEMS_PER_THREAD],
         OffsetT (&selection_flags)[ITEMS_PER_THREAD],
         OffsetT (&selection_indices)[ITEMS_PER_THREAD],
@@ -519,19 +533,17 @@ struct AgentSelectIf
      *   Marker type indicating whether to keep rejected items in the second partition
      */
     template <bool IS_LAST_TILE, bool IS_FIRST_TILE>
-    _CCCL_DEVICE _CCCL_FORCEINLINE void ScatterTwoPhase(InputT (&items)[ITEMS_PER_THREAD],
-                                                    OffsetT (&selection_flags)[ITEMS_PER_THREAD],
-                                                    OffsetT (&selection_indices)[ITEMS_PER_THREAD],
-                                                    int /*num_tile_items*/,
-                                                    int num_tile_selections,
-                                                    OffsetT num_selections_prefix,
-                                                    OffsetT /*num_rejected_prefix*/,
-                                                    Int2Type<false> /*is_keep_rejects*/)
+    _CCCL_DEVICE _CCCL_FORCEINLINE void ScatterSelectedTwoPhase(
+      InputT (&items)[ITEMS_PER_THREAD],
+      OffsetT (&selection_flags)[ITEMS_PER_THREAD],
+      OffsetT (&selection_indices)[ITEMS_PER_THREAD],
+      int num_tile_selections,
+      OffsetT num_selections_prefix)
     {
         CTA_SYNC();
 
-        // Compact and scatter items
-        #pragma unroll
+// Compact and scatter items
+#pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             int local_scatter_offset = selection_indices[ITEM] - num_selections_prefix;
@@ -550,7 +562,52 @@ struct AgentSelectIf
     }
 
     /**
-     * @brief Scatter flagged items to output offsets (specialized for two-phase scattering)
+     * @brief Scatter flagged items. Specialized for selection algorithm that simply discards rejected items
+     *
+     * @param num_tile_items
+     *   Number of valid items in this tile
+     *
+     * @param num_tile_selections
+     *   Number of selections in this tile
+     *
+     * @param num_selections_prefix
+     *   Total number of selections prior to this tile
+     *
+     * @param num_rejected_prefix
+     *   Total number of rejections prior to this tile
+     *
+     * @param num_selections
+     *   Total number of selections including this tile
+     */
+    template <bool IS_LAST_TILE, bool IS_FIRST_TILE>
+    _CCCL_DEVICE _CCCL_FORCEINLINE void Scatter(
+      InputT (&items)[ITEMS_PER_THREAD],
+      OffsetT (&selection_flags)[ITEMS_PER_THREAD],
+      OffsetT (&selection_indices)[ITEMS_PER_THREAD],
+      int num_tile_items,
+      int num_tile_selections,
+      OffsetT num_selections_prefix,
+      OffsetT num_rejected_prefix,
+      OffsetT num_selections,
+      Int2Type<false> /*is_keep_rejects*/)
+    {
+        // Do a two-phase scatter if two-phase is enabled and the average number of selection_flags items per thread is
+        // greater than one
+        if (TWO_PHASE_SCATTER && (num_tile_selections > BLOCK_THREADS))
+        {
+            ScatterSelectedTwoPhase<IS_LAST_TILE, IS_FIRST_TILE>(
+              items, selection_flags, selection_indices, num_tile_selections, num_selections_prefix);
+        }
+        else
+        {
+            ScatterSelectedDirect<IS_LAST_TILE, IS_FIRST_TILE>(
+              items, selection_flags, selection_indices, num_selections);
+        }
+    }
+
+    /**
+     * @brief Scatter flagged items. Specialized for partitioning algorithm that writes rejected items to a second
+     * partition.
      *
      * @param num_tile_items
      *   Number of valid items in this tile
@@ -568,13 +625,14 @@ struct AgentSelectIf
      *   Marker type indicating whether to keep rejected items in the second partition
      */
     template <bool IS_LAST_TILE, bool IS_FIRST_TILE>
-    _CCCL_DEVICE _CCCL_FORCEINLINE void ScatterTwoPhase(InputT (&items)[ITEMS_PER_THREAD],
+    _CCCL_DEVICE _CCCL_FORCEINLINE void Scatter(InputT (&items)[ITEMS_PER_THREAD],
                                                     OffsetT (&selection_flags)[ITEMS_PER_THREAD],
                                                     OffsetT (&selection_indices)[ITEMS_PER_THREAD],
                                                     int num_tile_items,
                                                     int num_tile_selections,
                                                     OffsetT num_selections_prefix,
                                                     OffsetT num_rejected_prefix,
+                                                    OffsetT num_selections,
                                                     Int2Type<true> /*is_keep_rejects*/)
     {
         CTA_SYNC();
@@ -595,76 +653,83 @@ struct AgentSelectIf
             temp_storage.raw_exchange.Alias()[local_scatter_offset] = items[ITEM];
         }
 
+        // Ensure all threads finished scattering to shared memory 
         CTA_SYNC();
 
         // Gather items from shared memory and scatter to global
+        ScatterPartitionsToGlobal<IS_LAST_TILE, IS_FIRST_TILE>(
+          num_tile_items, tile_num_rejections, num_selections_prefix, num_rejected_prefix, d_selected_out);
+    }
+
+    /**
+     * @brief Second phase of scattering partitioned items to global memory. Specialized for partitioning to two
+     * distinct partitions.
+     */
+    template <bool IS_LAST_TILE, bool IS_FIRST_TILE, typename SelectedItT, typename RejectedItT>
+    _CCCL_DEVICE _CCCL_FORCEINLINE void ScatterPartitionsToGlobal(
+      int num_tile_items,
+      int tile_num_rejections,
+      OffsetT num_selections_prefix,
+      OffsetT num_rejected_prefix,
+      detail::partition_distinct_output_t<SelectedItT, RejectedItT> partitioned_out_it_wrapper)
+    {
         #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
-            int item_idx            = (ITEM * BLOCK_THREADS) + threadIdx.x;
-            int rejection_idx       = item_idx;
-            int selection_idx       = item_idx - tile_num_rejections;
-            OffsetT scatter_offset  = (item_idx < tile_num_rejections) ?
-                                        num_items - num_rejected_prefix - rejection_idx - 1 :
-                                        num_selections_prefix + selection_idx;
+            int item_idx      = (ITEM * BLOCK_THREADS) + threadIdx.x;
+            int rejection_idx = item_idx;
+            int selection_idx = item_idx - tile_num_rejections;
+            OffsetT scatter_offset =
+              (item_idx < tile_num_rejections)
+                ? num_rejected_prefix + rejection_idx
+                : num_selections_prefix + selection_idx;
 
             InputT item = temp_storage.raw_exchange.Alias()[item_idx];
 
             if (!IS_LAST_TILE || (item_idx < num_tile_items))
             {
-                d_selected_out[scatter_offset] = item;
+                if (item_idx >= tile_num_rejections)
+                {
+                    partitioned_out_it_wrapper.selected_it[scatter_offset] = item;
+                }
+                else
+                {
+                    partitioned_out_it_wrapper.rejected_it[scatter_offset] = item;
+                }
             }
         }
     }
 
     /**
-     * @brief Scatter flagged items
-     *
-     * @param num_tile_items
-     *   Number of valid items in this tile
-     *
-     * @param num_tile_selections
-     *   Number of selections in this tile
-     *
-     * @param num_selections_prefix
-     *   Total number of selections prior to this tile
-     *
-     * @param num_rejected_prefix
-     *   Total number of rejections prior to this tile
-     *
-     * @param num_selections
-     *   Total number of selections including this tile
+     * @brief Second phase of scattering partitioned items to global memory. Specialized for partitioning to a single
+     * iterator, where selected items are written in order from the beginning of the itereator and rejected items are
+     * writtem from the iterators end backwards.
      */
-    template <bool IS_LAST_TILE, bool IS_FIRST_TILE>
-    _CCCL_DEVICE _CCCL_FORCEINLINE void Scatter(InputT (&items)[ITEMS_PER_THREAD],
-                                            OffsetT (&selection_flags)[ITEMS_PER_THREAD],
-                                            OffsetT (&selection_indices)[ITEMS_PER_THREAD],
-                                            int num_tile_items,
-                                            int num_tile_selections,
-                                            OffsetT num_selections_prefix,
-                                            OffsetT num_rejected_prefix,
-                                            OffsetT num_selections)
+    template <bool IS_LAST_TILE, bool IS_FIRST_TILE, typename PartitionedOutputItT>
+    _CCCL_DEVICE _CCCL_FORCEINLINE void ScatterPartitionsToGlobal(
+      int num_tile_items,
+      int tile_num_rejections,
+      OffsetT num_selections_prefix,
+      OffsetT num_rejected_prefix,
+      PartitionedOutputItT partitioned_out_it)
     {
-        // Do a two-phase scatter if (a) keeping both partitions or (b) two-phase is enabled and the average number of selection_flags items per thread is greater than one
-        if (KEEP_REJECTS || (TWO_PHASE_SCATTER && (num_tile_selections > BLOCK_THREADS)))
+        #pragma unroll
+        for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
-            ScatterTwoPhase<IS_LAST_TILE, IS_FIRST_TILE>(
-                items,
-                selection_flags,
-                selection_indices,
-                num_tile_items,
-                num_tile_selections,
-                num_selections_prefix,
-                num_rejected_prefix,
-                Int2Type<KEEP_REJECTS>());
-        }
-        else
-        {
-            ScatterDirect<IS_LAST_TILE, IS_FIRST_TILE>(
-                items,
-                selection_flags,
-                selection_indices,
-                num_selections);
+            int item_idx      = (ITEM * BLOCK_THREADS) + threadIdx.x;
+            int rejection_idx = item_idx;
+            int selection_idx = item_idx - tile_num_rejections;
+            OffsetT scatter_offset =
+              (item_idx < tile_num_rejections)
+                ? num_items - num_rejected_prefix - rejection_idx - 1
+                : num_selections_prefix + selection_idx;
+
+            InputT item = temp_storage.raw_exchange.Alias()[item_idx];
+
+            if (!IS_LAST_TILE || (item_idx < num_tile_items))
+            {
+                partitioned_out_it[scatter_offset] = item;
+            }
         }
     }
 
@@ -736,7 +801,8 @@ struct AgentSelectIf
             num_tile_selections,
             0,
             0,
-            num_tile_selections);
+            num_tile_selections,
+            cub::Int2Type<KEEP_REJECTS>{});
 
         return num_tile_selections;
     }
@@ -810,7 +876,8 @@ struct AgentSelectIf
             num_tile_selections,
             num_selections_prefix,
             num_rejected_prefix,
-            num_selections);
+            num_selections,
+            cub::Int2Type<KEEP_REJECTS>{});
 
         return num_selections;
     }

--- a/thrust/thrust/system/cuda/detail/copy_if.h
+++ b/thrust/thrust/system/cuda/detail/copy_if.h
@@ -226,7 +226,7 @@ THRUST_RUNTIME_FUNCTION OutputIt copy_if(
     dispatch64_t::dispatch,
     num_items,
     (policy, temp_storage, temp_storage_bytes, first, stencil, output, predicate, num_items_fixed, output_end));
-  cuda_cub::throw_on_error(status, "copy_if failed on 1st step");
+  cuda_cub::throw_on_error(status, "copy_if failed on 2nd step");
 
   return output_end;
 }

--- a/thrust/thrust/system/cuda/detail/partition.h
+++ b/thrust/thrust/system/cuda/detail/partition.h
@@ -171,7 +171,7 @@ THRUST_RUNTIME_FUNCTION std::size_t partition(
 {
   using size_type = typename iterator_traits<InputIt>::difference_type;
 
-  size_type num_items = static_cast<size_type>(thrust::distance(first, last));
+  size_type num_items = thrust::distance(first, last);
   std::size_t num_selected{};
   cudaError_t status        = cudaSuccess;
   size_t temp_storage_bytes = 0;
@@ -222,6 +222,10 @@ THRUST_RUNTIME_FUNCTION pair<SelectedOutIt, RejectedOutIt> stable_partition_copy
   RejectedOutIt rejected_result,
   Predicate predicate)
 {
+  if(thrust::distance(first, last) <= 0){
+    return thrust::make_pair(selected_result, rejected_result);
+  }
+
   using output_it_wrapper_t = cub::detail::partition_distinct_output_t<SelectedOutIt, RejectedOutIt>;
   std::size_t num_items    = static_cast<std::size_t>(thrust::distance(first, last));
   std::size_t num_selected = partition(
@@ -233,6 +237,10 @@ template <typename Derived, typename InputIt, typename StencilIt, typename Predi
 THRUST_RUNTIME_FUNCTION InputIt inplace_partition(
   execution_policy<Derived>& policy, InputIt first, InputIt last, StencilIt stencil, Predicate predicate)
 {
+  if(thrust::distance(first, last) <= 0){
+    return first;
+  }
+
   // Element type of the input iterator
   using value_t         = typename iterator_traits<InputIt>::value_type;
   std::size_t num_items = static_cast<std::size_t>(thrust::distance(first, last));

--- a/thrust/thrust/system/cuda/detail/partition.h
+++ b/thrust/thrust/system/cuda/detail/partition.h
@@ -38,1041 +38,349 @@
 
 #if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_NVCC
 
-#include <thrust/detail/cstdint.h>
-#include <thrust/detail/temporary_array.h>
-#include <thrust/distance.h>
-#include <thrust/pair.h>
-#include <thrust/partition.h>
-#include <thrust/system/cuda/config.h>
-#include <thrust/system/cuda/detail/cdp_dispatch.h>
-#include <thrust/system/cuda/detail/core/agent_launcher.h>
-#include <thrust/system/cuda/detail/find.h>
-#include <thrust/system/cuda/detail/reverse.h>
-#include <thrust/system/cuda/detail/uninitialized_copy.h>
-#include <thrust/system/cuda/detail/par_to_seq.h>
-#include <thrust/system/cuda/detail/util.h>
+#  include <cub/device/dispatch/dispatch_select_if.cuh>
+#  include <cub/util_device.cuh>
+#  include <cub/util_math.cuh>
 
-#include <cub/agent/single_pass_scan_operators.cuh> // cub::ScanTileState
-#include <cub/block/block_scan.cuh>
-#include <cub/device/device_partition.cuh>
-#include <cub/util_device.cuh>
-#include <cub/util_math.cuh>
+#  include <thrust/detail/cstdint.h>
+#  include <thrust/detail/temporary_array.h>
+#  include <thrust/distance.h>
+#  include <thrust/pair.h>
+#  include <thrust/partition.h>
+#  include <thrust/system/cuda/config.h>
+#  include <thrust/system/cuda/detail/cdp_dispatch.h>
+#  include <thrust/system/cuda/detail/find.h>
+#  include <thrust/system/cuda/detail/par_to_seq.h>
+#  include <thrust/system/cuda/detail/reverse.h>
+#  include <thrust/system/cuda/detail/uninitialized_copy.h>
+#  include <thrust/system/cuda/detail/util.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub {
 
-namespace __partition {
+namespace detail
+{
 
-  template <int                     _BLOCK_THREADS,
-            int                     _ITEMS_PER_THREAD = 1,
-            cub::BlockLoadAlgorithm _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
-            cub::CacheLoadModifier  _LOAD_MODIFIER    = cub::LOAD_LDG,
-            cub::BlockScanAlgorithm _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS>
-  struct PtxPolicy
+template <typename Derived, typename InputIt, typename StencilIt, typename OutputIt, typename Predicate, typename OffsetT>
+struct DispatchPartitionIf
+{
+  static cudaError_t THRUST_RUNTIME_FUNCTION dispatch(
+    execution_policy<Derived>& policy,
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIt first,
+    StencilIt stencil,
+    OutputIt output,
+    Predicate predicate,
+    OffsetT num_items,
+    std::size_t& num_selected)
   {
-    enum
+    using num_selected_out_it_t = OffsetT*;
+    using equality_op_t         = cub::NullType;
+
+    cudaError_t status  = cudaSuccess;
+    cudaStream_t stream = cuda_cub::stream(policy);
+
+    std::size_t allocation_sizes[2] = {0, sizeof(OffsetT)};
+    void* allocations[2]            = {nullptr, nullptr};
+
+    // Partitioning algorithm keeps "rejected" items
+    constexpr bool keep_rejects = true;
+    constexpr bool may_alias    = false;
+
+    // Query algorithm memory requirements
+    status = cub::DispatchSelectIf<
+      InputIt,
+      StencilIt,
+      OutputIt,
+      num_selected_out_it_t,
+      Predicate,
+      equality_op_t,
+      OffsetT,
+      keep_rejects,
+      may_alias>::Dispatch(nullptr,
+                           allocation_sizes[0],
+                           first,
+                           stencil,
+                           output,
+                           static_cast<num_selected_out_it_t>(nullptr),
+                           predicate,
+                           equality_op_t{},
+                           num_items,
+                           stream);
+    CUDA_CUB_RET_IF_FAIL(status);
+
+    status = cub::AliasTemporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes);
+    CUDA_CUB_RET_IF_FAIL(status);
+
+    // Return if we're only querying temporary storage requirements
+    if (d_temp_storage == nullptr)
     {
-      BLOCK_THREADS      = _BLOCK_THREADS,
-      ITEMS_PER_THREAD   = _ITEMS_PER_THREAD,
-      ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD
-    };
-    static const cub::BlockLoadAlgorithm LOAD_ALGORITHM = _LOAD_ALGORITHM;
-    static const cub::CacheLoadModifier  LOAD_MODIFIER  = _LOAD_MODIFIER;
-    static const cub::BlockScanAlgorithm SCAN_ALGORITHM = _SCAN_ALGORITHM;
-  };    // struct PtxPolicy
-
-  template<class, class>
-  struct Tuning;
-
-  template<class T>
-  struct Tuning<sm35, T>
-  {
-    const static int INPUT_SIZE = sizeof(T);
-
-    enum
-    {
-      NOMINAL_4B_ITEMS_PER_THREAD = 10,
-      ITEMS_PER_THREAD            = CUB_MIN(NOMINAL_4B_ITEMS_PER_THREAD, CUB_MAX(1, (NOMINAL_4B_ITEMS_PER_THREAD * 4 / sizeof(T)))),
-    };
-
-    typedef PtxPolicy<128,
-                      ITEMS_PER_THREAD,
-                      cub::BLOCK_LOAD_WARP_TRANSPOSE,
-                      cub::LOAD_LDG,
-                      cub::BLOCK_SCAN_WARP_SCANS>
-        type;
-  };    // Tuning<350>
-
-  template<class T>
-  struct Tuning<sm30, T>
-  {
-    const static int INPUT_SIZE = sizeof(T);
-
-    enum
-    {
-      NOMINAL_4B_ITEMS_PER_THREAD = 7,
-      ITEMS_PER_THREAD            = CUB_MIN(NOMINAL_4B_ITEMS_PER_THREAD, CUB_MAX(3, (NOMINAL_4B_ITEMS_PER_THREAD * 4 / sizeof(T)))),
-    };
-
-    typedef PtxPolicy<128,
-                      ITEMS_PER_THREAD,
-                      cub::BLOCK_LOAD_WARP_TRANSPOSE,
-                      cub::LOAD_DEFAULT,
-                      cub::BLOCK_SCAN_WARP_SCANS>
-        type;
-  };    // Tuning<300>
-
-  template<int T>
-  struct __tag{};
-
-
-  struct no_stencil_tag_    {};
-  struct single_output_tag_
-  {
-    template<class T>
-    THRUST_DEVICE_FUNCTION T const& operator=(T const& t) const { return t; }
-  };
-
-  typedef no_stencil_tag_* no_stencil_tag;
-  typedef single_output_tag_* single_output_tag;;
-
-  template <class ItemsIt,
-            class StencilIt,
-            class SelectedOutIt,
-            class RejectedOutIt,
-            class Predicate,
-            class Size,
-            class NumSelectedOutIt>
-  struct PartitionAgent
-  {
-    typedef typename iterator_traits<ItemsIt>::value_type   item_type;
-    typedef typename iterator_traits<StencilIt>::value_type stencil_type;
-
-
-    typedef cub::ScanTileState<Size> ScanTileState;
-
-    template <class Arch>
-    struct PtxPlan : Tuning<Arch, item_type>::type
-    {
-      typedef Tuning<Arch,item_type> tuning;
-
-      typedef typename core::LoadIterator<PtxPlan, ItemsIt>::type   ItemsLoadIt;
-      typedef typename core::LoadIterator<PtxPlan, StencilIt>::type StencilLoadIt;
-
-      typedef typename core::BlockLoad<PtxPlan, ItemsLoadIt>::type   BlockLoadItems;
-      typedef typename core::BlockLoad<PtxPlan, StencilLoadIt>::type BlockLoadStencil;
-
-      typedef cub::TilePrefixCallbackOp<Size,
-                                        cub::Sum,
-                                        ScanTileState,
-                                        Arch::ver>
-          TilePrefixCallback;
-      typedef cub::BlockScan<Size,
-                             PtxPlan::BLOCK_THREADS,
-                             PtxPlan::SCAN_ALGORITHM,
-                             1,
-                             1,
-                             Arch::ver>
-          BlockScan;
-
-
-      union TempStorage
-      {
-        struct ScanStorage
-        {
-          typename BlockScan::TempStorage          scan;
-          typename TilePrefixCallback::TempStorage prefix;
-        } scan_storage;
-
-        typename BlockLoadItems::TempStorage   load_items;
-        typename BlockLoadStencil::TempStorage load_stencil;
-
-        core::uninitialized_array<item_type, PtxPlan::ITEMS_PER_TILE> raw_exchange;
-      };    // union TempStorage
-    };    // struct PtxPlan
-    typedef typename core::specialize_plan_msvc10_war<PtxPlan>::type::type ptx_plan;
-
-    typedef typename ptx_plan::ItemsLoadIt        ItemsLoadIt;
-    typedef typename ptx_plan::StencilLoadIt      StencilLoadIt;
-    typedef typename ptx_plan::BlockLoadItems     BlockLoadItems;
-    typedef typename ptx_plan::BlockLoadStencil   BlockLoadStencil;
-    typedef typename ptx_plan::TilePrefixCallback TilePrefixCallback;
-    typedef typename ptx_plan::BlockScan          BlockScan;
-    typedef typename ptx_plan::TempStorage        TempStorage;
-
-    enum
-    {
-      SINGLE_OUTPUT    = thrust::detail::is_same<RejectedOutIt, single_output_tag>::value,
-      USE_STENCIL      = !thrust::detail::is_same<StencilIt, no_stencil_tag>::value,
-      BLOCK_THREADS    = ptx_plan::BLOCK_THREADS,
-      ITEMS_PER_THREAD = ptx_plan::ITEMS_PER_THREAD,
-      ITEMS_PER_TILE   = ptx_plan::ITEMS_PER_TILE
-    };
-
-
-    struct impl
-    {
-      //---------------------------------------------------------------------
-      // Per-thread fields
-      //---------------------------------------------------------------------
-
-      TempStorage &  temp_storage;
-      ScanTileState &tile_state;
-      ItemsLoadIt    items_glob;
-      StencilLoadIt  stencil_glob;
-      SelectedOutIt  selected_out_glob;
-      RejectedOutIt  rejected_out_glob;
-      Predicate      predicate;
-      Size           num_items;
-
-      //---------------------------------------------------------------------
-      // Utilities
-      //---------------------------------------------------------------------
-
-      template <bool IS_LAST_TILE>
-      THRUST_DEVICE_FUNCTION void
-      scatter(item_type (&items)[ITEMS_PER_THREAD],
-              Size (&selection_flags)[ITEMS_PER_THREAD],
-              Size (&selection_indices)[ITEMS_PER_THREAD],
-              int  num_tile_items,
-              int  num_tile_selections,
-              Size num_selections_prefix,
-              Size num_rejected_prefix,
-              Size /*num_selections*/)
-      {
-        int tile_num_rejections = num_tile_items - num_tile_selections;
-
-        // Scatter items to shared memory (rejections first)
-#pragma unroll
-        for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
-        {
-          int item_idx             = (threadIdx.x * ITEMS_PER_THREAD) + ITEM;
-          int local_selection_idx  = selection_indices[ITEM] - num_selections_prefix;
-          int local_rejection_idx  = item_idx - local_selection_idx;
-          int local_scatter_offset = (selection_flags[ITEM])
-                                         ? tile_num_rejections + local_selection_idx
-                                         : local_rejection_idx;
-
-          temp_storage.raw_exchange[local_scatter_offset] = items[ITEM];
-        }
-
-        core::sync_threadblock();
-
-        // Gather items from shared memory and scatter to global
-#pragma unroll
-        for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
-        {
-          int  item_idx       = (ITEM * BLOCK_THREADS) + threadIdx.x;
-          int  rejection_idx  = item_idx;
-          int  selection_idx  = item_idx - tile_num_rejections;
-          Size scatter_offset = (item_idx < tile_num_rejections)
-                                    ? num_items -
-                                          num_rejected_prefix - rejection_idx - 1
-                                    : num_selections_prefix + selection_idx;
-
-          item_type item = temp_storage.raw_exchange[item_idx];
-
-          if (!IS_LAST_TILE || (item_idx < num_tile_items))
-          {
-            if (SINGLE_OUTPUT || item_idx >= tile_num_rejections)
-            {
-              selected_out_glob[scatter_offset] = item;
-            }
-            else    // if !SINGLE_OUTPUT, scatter rejected items separately
-            {
-              rejected_out_glob[num_items - scatter_offset - 1] = item;
-            }
-          }
-        }
-      }    // func scatter
-
-      //------------------------------------------
-      // specialize predicate on different types
-      //------------------------------------------
-
-      enum ItemStencil
-      {
-        ITEM,
-        STENCIL
-      };
-
-      template <bool TAG, class T>
-      struct wrap_value
-      {
-        T const &              x;
-        THRUST_DEVICE_FUNCTION wrap_value(T const &x) : x(x) {}
-
-        THRUST_DEVICE_FUNCTION T const &operator()() const { return x; };
-      };    // struct wrap_type
-
-      //------- item
-
-      THRUST_DEVICE_FUNCTION bool
-      predicate_wrapper(wrap_value<ITEM, item_type> const &x,
-                        __tag<false /* USE_STENCIL */>)
-      {
-        return predicate(x());
-      }
-
-      THRUST_DEVICE_FUNCTION bool
-      predicate_wrapper(wrap_value<ITEM, item_type> const &,
-                        __tag<true>)
-      {
-        return false;
-      }
-
-      //-------- stencil
-
-      template <class T>
-      THRUST_DEVICE_FUNCTION bool
-      predicate_wrapper(wrap_value<STENCIL, T> const &x,
-                        __tag<true>)
-      {
-        return predicate(x());
-      }
-
-      THRUST_DEVICE_FUNCTION bool
-      predicate_wrapper(wrap_value<STENCIL, no_stencil_tag_> const &,
-                        __tag<true>)
-      {
-        return false;
-      }
-
-
-      THRUST_DEVICE_FUNCTION bool
-      predicate_wrapper(wrap_value<STENCIL, stencil_type> const &,
-                        __tag<false>)
-      {
-        return false;
-      }
-
-      template <bool IS_LAST_TILE, ItemStencil TYPE, class T>
-      THRUST_DEVICE_FUNCTION void
-      compute_selection_flags(int num_tile_items,
-                              T (&values)[ITEMS_PER_THREAD],
-                              Size (&selection_flags)[ITEMS_PER_THREAD])
-      {
-#pragma unroll
-        for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
-        {
-          // Out-of-bounds items are selection_flags
-          selection_flags[ITEM] = 1;
-
-          if (!IS_LAST_TILE ||
-              (Size(threadIdx.x * ITEMS_PER_THREAD) + ITEM < num_tile_items))
-          {
-            selection_flags[ITEM] =
-                predicate_wrapper(wrap_value<TYPE, T>(values[ITEM]),
-                                  __tag<USE_STENCIL>());
-          }
-        }
-      }
-
-      //---------------------------------------------------------------------
-      // Tile processing
-      //---------------------------------------------------------------------
-
-      template <bool IS_LAST_TILE, bool IS_FIRST_TILE>
-      Size THRUST_DEVICE_FUNCTION
-      consume_tile_impl(int  num_tile_items,
-                        int  tile_idx,
-                        Size tile_base)
-      {
-        item_type items_loc[ITEMS_PER_THREAD];
-        Size      selection_flags[ITEMS_PER_THREAD];
-        Size      selection_idx[ITEMS_PER_THREAD];
-
-        if (IS_LAST_TILE)
-        {
-          BlockLoadItems(temp_storage.load_items)
-              .Load(items_glob + tile_base, items_loc, num_tile_items);
-        }
-        else
-        {
-          BlockLoadItems(temp_storage.load_items)
-              .Load(items_glob + tile_base, items_loc);
-        }
-
-        core::sync_threadblock();
-
-        if (USE_STENCIL)
-        {
-          stencil_type stencil_loc[ITEMS_PER_THREAD];
-
-          if (IS_LAST_TILE)
-          {
-            BlockLoadStencil(temp_storage.load_stencil)
-                .Load(stencil_glob + tile_base, stencil_loc, num_tile_items);
-          }
-          else
-          {
-            BlockLoadStencil(temp_storage.load_stencil)
-                .Load(stencil_glob + tile_base, stencil_loc);
-          }
-
-          compute_selection_flags<IS_LAST_TILE, STENCIL>(num_tile_items,
-                                                         stencil_loc,
-                                                         selection_flags);
-        }
-        else /* Use predicate on items rather then stencil */
-        {
-          compute_selection_flags<IS_LAST_TILE, ITEM>(num_tile_items,
-                                                      items_loc,
-                                                      selection_flags);
-        }
-
-        core::sync_threadblock();
-
-        Size num_tile_selections   = 0;
-        Size num_selections        = 0;
-        Size num_selections_prefix = 0;
-        Size num_rejected_prefix   = 0;
-        if (IS_FIRST_TILE)
-        {
-          BlockScan(temp_storage.scan_storage.scan)
-              .ExclusiveSum(selection_flags,
-                            selection_idx,
-                            num_tile_selections);
-
-          if (threadIdx.x == 0)
-          {
-            // Update tile status if this is not the last tile
-            if (!IS_LAST_TILE)
-              tile_state.SetInclusive(0, num_tile_selections);
-          }
-
-          // Do not count any out-of-bounds selections
-          if (IS_LAST_TILE)
-          {
-            int num_discount = ITEMS_PER_TILE - num_tile_items;
-            num_tile_selections -= num_discount;
-          }
-          num_selections = num_tile_selections;
-        }
-        else
-        {
-          TilePrefixCallback prefix_cb(tile_state,
-                                       temp_storage.scan_storage.prefix,
-                                       cub::Sum(),
-                                       tile_idx);
-          BlockScan(temp_storage.scan_storage.scan)
-              .ExclusiveSum(selection_flags,
-                            selection_idx,
-                            prefix_cb);
-
-          num_selections        = prefix_cb.GetInclusivePrefix();
-          num_tile_selections   = prefix_cb.GetBlockAggregate();
-          num_selections_prefix = prefix_cb.GetExclusivePrefix();
-          num_rejected_prefix   = tile_base - num_selections_prefix;
-
-          if (IS_LAST_TILE)
-          {
-            int num_discount = ITEMS_PER_TILE - num_tile_items;
-            num_tile_selections -= num_discount;
-            num_selections -= num_discount;
-          }
-        }
-
-        core::sync_threadblock();
-
-        scatter<IS_LAST_TILE>(items_loc,
-                              selection_flags,
-                              selection_idx,
-                              num_tile_items,
-                              num_tile_selections,
-                              num_selections_prefix,
-                              num_rejected_prefix,
-                              num_selections);
-
-
-        return num_selections;
-      }
-
-
-      template <bool         IS_LAST_TILE>
-      THRUST_DEVICE_FUNCTION Size
-      consume_tile(int  num_tile_items,
-                   int  tile_idx,
-                   Size tile_base)
-      {
-        if (tile_idx == 0)
-        {
-          return consume_tile_impl<IS_LAST_TILE, true>(num_tile_items,
-                                                       tile_idx,
-                                                       tile_base);
-        }
-        else
-        {
-          return consume_tile_impl<IS_LAST_TILE, false>(num_tile_items,
-                                                        tile_idx,
-                                                        tile_base);
-        }
-      }
-
-      //---------------------------------------------------------------------
-      // Constructor
-      //---------------------------------------------------------------------
-
-      THRUST_DEVICE_FUNCTION
-      impl(TempStorage &    temp_storage_,
-           ScanTileState &  tile_state_,
-           ItemsLoadIt      items_glob_,
-           StencilLoadIt    stencil_glob_,
-           SelectedOutIt    selected_out_glob_,
-           RejectedOutIt    rejected_out_glob_,
-           Predicate        predicate_,
-           Size             num_items_,
-           int              num_tiles,
-           NumSelectedOutIt num_selected_out)
-          : temp_storage(temp_storage_),
-            tile_state(tile_state_),
-            items_glob(items_glob_),
-            stencil_glob(stencil_glob_),
-            selected_out_glob(selected_out_glob_),
-            rejected_out_glob(rejected_out_glob_),
-            predicate(predicate_),
-            num_items(num_items_)
-      {
-        int  tile_idx  = blockIdx.x;
-        Size tile_base = tile_idx * ITEMS_PER_TILE;
-
-        if (tile_idx < num_tiles - 1)
-        {
-          consume_tile<false>(ITEMS_PER_TILE,
-                              tile_idx,
-                              tile_base);
-        }
-        else
-        {
-          int  num_remaining  = static_cast<int>(num_items - tile_base);
-          Size num_selections = consume_tile<true>(num_remaining,
-                                                   tile_idx,
-                                                   tile_base);
-          if (threadIdx.x == 0)
-          {
-            *num_selected_out = num_selections;
-          }
-        }
-      }    //
-    };     //struct impl
-
-    //---------------------------------------------------------------------
-    // Agent entry point
-    //---------------------------------------------------------------------
-
-    THRUST_AGENT_ENTRY(ItemsIt          items,
-                       StencilIt        stencil,
-                       SelectedOutIt    selected_out,
-                       RejectedOutIt    rejected_out,
-                       Predicate        predicate,
-                       Size             num_items,
-                       NumSelectedOutIt num_selected_out,
-                       ScanTileState    tile_state,
-                       int              num_tiles,
-                       char *           shmem)
-    {
-      TempStorage &storage = *reinterpret_cast<TempStorage *>(shmem);
-
-      impl(storage,
-           tile_state,
-           core::make_load_iterator(ptx_plan(), items),
-           core::make_load_iterator(ptx_plan(), stencil),
-           selected_out,
-           rejected_out,
-           predicate,
-           num_items,
-           num_tiles,
-           num_selected_out);
-    }
-  };       // struct PartitionAgent
-
-  template <class ScanTileState,
-            class NumSelectedIt,
-            class Size>
-  struct InitAgent
-  {
-    template <class Arch>
-    struct PtxPlan : PtxPolicy<128> {};
-
-
-    typedef core::specialize_plan<PtxPlan> ptx_plan;
-
-    //---------------------------------------------------------------------
-    // Agent entry point
-    //---------------------------------------------------------------------
-
-    THRUST_AGENT_ENTRY(ScanTileState tile_state,
-                       Size          num_tiles,
-                       NumSelectedIt num_selected_out,
-                       char *        /*shmem*/)
-    {
-      tile_state.InitializeStatus(num_tiles);
-      if (blockIdx.x == 0 && threadIdx.x == 0)
-        *num_selected_out = 0;
+      return status;
     }
 
-  }; // struct InitAgent
-
-  template <class ItemsIt,
-            class StencilIt,
-            class SelectedOutIt,
-            class RejectedOutIt,
-            class Predicate,
-            class Size,
-            class NumSelectedOutIt>
-  static cudaError_t THRUST_RUNTIME_FUNCTION
-  doit_step(void *           d_temp_storage,
-            size_t &         temp_storage_bytes,
-            ItemsIt          items,
-            StencilIt        stencil,
-            SelectedOutIt    selected_out,
-            RejectedOutIt    rejected_out,
-            Predicate        predicate,
-            NumSelectedOutIt num_selected_out,
-            Size             num_items,
-            cudaStream_t     stream)
-  {
-    using core::AgentLauncher;
-    using core::AgentPlan;
-    using core::get_agent_plan;
-
-    typedef AgentLauncher<
-        PartitionAgent<ItemsIt,
-                       StencilIt,
-                       SelectedOutIt,
-                       RejectedOutIt,
-                       Predicate,
-                       Size,
-                       NumSelectedOutIt> >
-        partition_agent;
-
-    typedef typename partition_agent::ScanTileState ScanTileState;
-
-    typedef AgentLauncher<
-        InitAgent<ScanTileState, NumSelectedOutIt, Size> >
-        init_agent;
-
-
-    using core::get_plan;
-    typename get_plan<init_agent>::type      init_plan      = init_agent::get_plan();
-    typename get_plan<partition_agent>::type partition_plan = partition_agent::get_plan(stream);
-
-    int tile_size = partition_plan.items_per_tile;
-    size_t num_tiles = cub::DivideAndRoundUp(num_items, tile_size);
-
-    size_t vshmem_storage = core::vshmem_size(partition_plan.shared_memory_size,
-                                              num_tiles);
-
-    cudaError_t status = cudaSuccess;
+    // Return for empty problems
     if (num_items == 0)
-      return status;
-
-    size_t allocation_sizes[2] = {0, vshmem_storage};
-    status = ScanTileState::AllocationSize(static_cast<int>(num_tiles), allocation_sizes[0]);
-    CUDA_CUB_RET_IF_FAIL(status);
-
-
-    void* allocations[2] = {NULL, NULL};
-    status = cub::AliasTemporaries(d_temp_storage,
-                                                temp_storage_bytes,
-                                                allocations,
-                                                allocation_sizes);
-    CUDA_CUB_RET_IF_FAIL(status);
-
-    if (d_temp_storage == NULL)
     {
+      num_selected = 0;
       return status;
     }
 
-    ScanTileState tile_status;
-    status = tile_status.Init(static_cast<int>(num_tiles), allocations[0], allocation_sizes[0]);
+    // Memory allocation for the number of selected output items
+    OffsetT* d_num_selected_out = thrust::detail::aligned_reinterpret_cast<OffsetT*>(allocations[1]);
+
+    // Run algorithm
+    status = cub::DispatchSelectIf<
+      InputIt,
+      StencilIt,
+      OutputIt,
+      num_selected_out_it_t,
+      Predicate,
+      equality_op_t,
+      OffsetT,
+      keep_rejects,
+      may_alias>::Dispatch(allocations[0],
+                           allocation_sizes[0],
+                           first,
+                           stencil,
+                           output,
+                           d_num_selected_out,
+                           predicate,
+                           equality_op_t{},
+                           num_items,
+                           stream);
     CUDA_CUB_RET_IF_FAIL(status);
 
-    init_agent ia(init_plan, num_tiles, stream, "partition::init_agent");
-
-    char *vshmem_ptr = vshmem_storage > 0 ? (char *)allocations[1] : NULL;
-
-    partition_agent pa(partition_plan, num_items, stream, vshmem_ptr, "partition::partition_agent");
-
-    ia.launch(tile_status, num_tiles, num_selected_out);
-    CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
-
-    pa.launch(items,
-              stencil,
-              selected_out,
-              rejected_out,
-              predicate,
-              num_items,
-              num_selected_out,
-              tile_status,
-              num_tiles);
-    CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
-    return status;
-
-  }
-
-  template <typename Derived,
-            typename InputIt,
-            typename StencilIt,
-            typename SelectedOutIt,
-            typename RejectedOutIt,
-            typename Predicate>
-  THRUST_RUNTIME_FUNCTION
-  pair<SelectedOutIt, RejectedOutIt>
-  partition(execution_policy<Derived>& policy,
-            InputIt                    first,
-            InputIt                    last,
-            StencilIt                  stencil,
-            SelectedOutIt              selected_result,
-            RejectedOutIt              rejected_result,
-            Predicate                  predicate)
-  {
-    typedef typename iterator_traits<InputIt>::difference_type size_type;
-
-    size_type    num_items          = static_cast<size_type>(thrust::distance(first, last));
-    size_t       temp_storage_bytes = 0;
-    cudaStream_t stream             = cuda_cub::stream(policy);
-
-    cudaError_t status;
-    status = doit_step(NULL,
-                       temp_storage_bytes,
-                       first,
-                       stencil,
-                       selected_result,
-                       rejected_result,
-                       predicate,
-                       reinterpret_cast<size_type*>(NULL),
-                       num_items,
-                       stream);
-    cuda_cub::throw_on_error(status, "partition failed on 1st step");
-
-    size_t allocation_sizes[2] = {sizeof(size_type), temp_storage_bytes};
-    void * allocations[2]      = {NULL, NULL};
-
-    size_t storage_size = 0;
-
-    status = core::alias_storage(NULL,
-                                 storage_size,
-                                 allocations,
-                                 allocation_sizes);
-    cuda_cub::throw_on_error(status, "partition failed on 1st alias_storage");
-
-    // Allocate temporary storage.
-    thrust::detail::temporary_array<thrust::detail::uint8_t, Derived>
-      tmp(policy, storage_size);
-    void *ptr = static_cast<void*>(tmp.data().get());
-
-    status = core::alias_storage(ptr,
-                                 storage_size,
-                                 allocations,
-                                 allocation_sizes);
-    cuda_cub::throw_on_error(status, "partition failed on 2nd alias_storage");
-
-    size_type* d_num_selected_out
-      = thrust::detail::aligned_reinterpret_cast<size_type*>(allocations[0]);
-
-    status = doit_step(allocations[1],
-                       temp_storage_bytes,
-                       first,
-                       stencil,
-                       selected_result,
-                       rejected_result,
-                       predicate,
-                       d_num_selected_out,
-                       num_items,
-                       stream);
-    cuda_cub::throw_on_error(status, "partition failed on 2nd step");
-
+    // Get number of selected items
     status = cuda_cub::synchronize(policy);
-    cuda_cub::throw_on_error(status, "partition failed to synchronize");
+    CUDA_CUB_RET_IF_FAIL(status);
+    num_selected = static_cast<std::size_t>(get_value(policy, d_num_selected_out));
 
-    size_type num_selected = 0;
-    if (num_items > 0)
-    {
-      num_selected = get_value(policy, d_num_selected_out);
-    }
-
-    return thrust::make_pair(selected_result + num_selected,
-                             rejected_result + num_items - num_selected);
+    return status;
   }
+};
 
-  template <typename Derived,
-            typename Iterator,
-            typename StencilIt,
-            typename Predicate>
-  THRUST_RUNTIME_FUNCTION
-  Iterator partition_inplace(execution_policy<Derived>& policy,
-                             Iterator                   first,
-                             Iterator                   last,
-                             StencilIt                  stencil,
-                             Predicate                  predicate)
-  {
-    typedef typename iterator_traits<Iterator>::difference_type size_type;
-    typedef typename iterator_traits<Iterator>::value_type      value_type;
+template <typename Derived, typename InputIt, typename StencilIt, typename OutputIt, typename Predicate>
+THRUST_RUNTIME_FUNCTION std::size_t partition(
+  execution_policy<Derived>& policy,
+  InputIt first,
+  InputIt last,
+  StencilIt stencil,
+  OutputIt output,
+  Predicate predicate)
+{
+  using size_type = typename iterator_traits<InputIt>::difference_type;
 
-    size_type num_items = thrust::distance(first, last);
+  size_type num_items = static_cast<size_type>(thrust::distance(first, last));
+  std::size_t num_selected{};
+  cudaError_t status        = cudaSuccess;
+  size_t temp_storage_bytes = 0;
 
-    // Allocate temporary storage.
-    thrust::detail::temporary_array<value_type, Derived> tmp(policy, num_items);
+  // 32-bit offset-type dispatch
+  using dispatch32_t = DispatchPartitionIf<Derived, InputIt, StencilIt, OutputIt, Predicate, thrust::detail::int32_t>;
 
-    cuda_cub::uninitialized_copy(policy, first, last, tmp.begin());
+  // 64-bit offset-type dispatch
+  using dispatch64_t = DispatchPartitionIf<Derived, InputIt, StencilIt, OutputIt, Predicate, thrust::detail::int64_t>;
 
-    pair<Iterator, single_output_tag> result =
-        partition(policy,
-                  tmp.data().get(),
-                  tmp.data().get() + num_items,
-                  stencil,
-                  first,
-                  single_output_tag(),
-                  predicate);
+  // Query temporary storage requirements
+  THRUST_INDEX_TYPE_DISPATCH2(
+    status,
+    dispatch32_t::dispatch,
+    dispatch64_t::dispatch,
+    num_items,
+    (policy, nullptr, temp_storage_bytes, first, stencil, output, predicate, num_items_fixed, num_selected));
+  cuda_cub::throw_on_error(status, "partition failed on 1st step");
 
-    size_type num_selected = result.first - first;
+  // Allocate temporary storage.
+  thrust::detail::temporary_array<thrust::detail::uint8_t, Derived> tmp(policy, temp_storage_bytes);
+  void* temp_storage = static_cast<void*>(tmp.data().get());
 
-    return first + num_selected;
-  }
-}    // namespace __partition
+  // Run algorithm
+  THRUST_INDEX_TYPE_DISPATCH2(
+    status,
+    dispatch32_t::dispatch,
+    dispatch64_t::dispatch,
+    num_items,
+    (policy, temp_storage, temp_storage_bytes, first, stencil, output, predicate, num_items_fixed, num_selected));
+  cuda_cub::throw_on_error(status, "partition failed on 2nd step");
 
-///// copy
+  return num_selected;
+}
+
+template <typename Derived,
+          typename InputIt,
+          typename StencilIt,
+          typename SelectedOutIt,
+          typename RejectedOutIt,
+          typename Predicate>
+THRUST_RUNTIME_FUNCTION pair<SelectedOutIt, RejectedOutIt> stable_partition_copy(
+  execution_policy<Derived>& policy,
+  InputIt first,
+  InputIt last,
+  StencilIt stencil,
+  SelectedOutIt selected_result,
+  RejectedOutIt rejected_result,
+  Predicate predicate)
+{
+  using output_it_wrapper_t = cub::detail::partition_distinct_output_t<SelectedOutIt, RejectedOutIt>;
+  std::size_t num_items    = static_cast<std::size_t>(thrust::distance(first, last));
+  std::size_t num_selected = partition(
+    policy, first, last, stencil, output_it_wrapper_t{selected_result, rejected_result}, predicate);
+  return thrust::make_pair(selected_result + num_selected, rejected_result + num_items - num_selected);
+}
+
+template <typename Derived, typename InputIt, typename StencilIt, typename Predicate>
+THRUST_RUNTIME_FUNCTION InputIt inplace_partition(
+  execution_policy<Derived>& policy, InputIt first, InputIt last, StencilIt stencil, Predicate predicate)
+{
+  // Element type of the input iterator
+  using value_t         = typename iterator_traits<InputIt>::value_type;
+  std::size_t num_items = static_cast<std::size_t>(thrust::distance(first, last));
+
+  // Allocate temporary storage, which will serve as the input to the partition
+  thrust::detail::temporary_array<value_t, Derived> tmp(policy, num_items);
+  cuda_cub::uninitialized_copy(policy, first, last, tmp.begin());
+
+  // Partition input from temporary storage to the user-provided range [`first`, `last`)
+  std::size_t num_selected =
+    partition(policy, tmp.data().get(), tmp.data().get() + num_items, stencil, first, predicate);
+  return first + num_selected;
+}
+
+} // namespace detail
 
 //-------------------------
 // Thrust API entry points
 //-------------------------
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived,
-          class InputIt,
-          class StencilIt,
-          class SelectedOutIt,
-          class RejectedOutIt,
-          class Predicate>
-pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE
-partition_copy(execution_policy<Derived> &policy,
-               InputIt                    first,
-               InputIt                    last,
-               StencilIt                  stencil,
-               SelectedOutIt              selected_result,
-               RejectedOutIt              rejected_result,
-               Predicate                  predicate)
+template <class Derived, class InputIt, class StencilIt, class SelectedOutIt, class RejectedOutIt, class Predicate>
+pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
+  execution_policy<Derived>& policy,
+  InputIt first,
+  InputIt last,
+  StencilIt stencil,
+  SelectedOutIt selected_result,
+  RejectedOutIt rejected_result,
+  Predicate predicate)
 {
   auto ret = thrust::make_pair(selected_result, rejected_result);
   THRUST_CDP_DISPATCH(
-    (ret = __partition::partition(policy,
-                                  first,
-                                  last,
-                                  stencil,
-                                  selected_result,
-                                  rejected_result,
-                                  predicate);),
-    (ret = thrust::partition_copy(cvt_to_seq(derived_cast(policy)),
-                                  first,
-                                  last,
-                                  stencil,
-                                  selected_result,
-                                  rejected_result,
-                                  predicate);));
+    (ret = detail::stable_partition_copy(policy, first, last, stencil, selected_result, rejected_result, predicate);),
+    (ret = thrust::partition_copy(
+       cvt_to_seq(derived_cast(policy)), first, last, stencil, selected_result, rejected_result, predicate);));
   return ret;
 }
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived,
-          class InputIt,
-          class SelectedOutIt,
-          class RejectedOutIt,
-          class Predicate>
-pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE
-partition_copy(execution_policy<Derived> &policy,
-               InputIt                    first,
-               InputIt                    last,
-               SelectedOutIt              selected_result,
-               RejectedOutIt              rejected_result,
-               Predicate                  predicate)
+template <class Derived, class InputIt, class SelectedOutIt, class RejectedOutIt, class Predicate>
+pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
+  execution_policy<Derived>& policy,
+  InputIt first,
+  InputIt last,
+  SelectedOutIt selected_result,
+  RejectedOutIt rejected_result,
+  Predicate predicate)
 {
   auto ret = thrust::make_pair(selected_result, rejected_result);
   THRUST_CDP_DISPATCH(
-    (ret = __partition::partition(policy,
-                                  first,
-                                  last,
-                                  __partition::no_stencil_tag(),
-                                  selected_result,
-                                  rejected_result,
-                                  predicate);),
-    (ret = thrust::partition_copy(cvt_to_seq(derived_cast(policy)),
-                                  first,
-                                  last,
-                                  selected_result,
-                                  rejected_result,
-                                  predicate);));
+    (ret = detail::stable_partition_copy(
+       policy, first, last, static_cast<cub::NullType*>(nullptr), selected_result, rejected_result, predicate);),
+    (ret = thrust::partition_copy(
+       cvt_to_seq(derived_cast(policy)), first, last, selected_result, rejected_result, predicate);));
   return ret;
 }
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived,
-          class InputIt,
-          class SelectedOutIt,
-          class RejectedOutIt,
-          class Predicate>
-pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE
-stable_partition_copy(execution_policy<Derived> &policy,
-                      InputIt                    first,
-                      InputIt                    last,
-                      SelectedOutIt              selected_result,
-                      RejectedOutIt              rejected_result,
-                      Predicate                  predicate)
+template <class Derived, class InputIt, class StencilIt, class SelectedOutIt, class RejectedOutIt, class Predicate>
+pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE stable_partition_copy(
+  execution_policy<Derived>& policy,
+  InputIt first,
+  InputIt last,
+  StencilIt stencil,
+  SelectedOutIt selected_result,
+  RejectedOutIt rejected_result,
+  Predicate predicate)
 {
   auto ret = thrust::make_pair(selected_result, rejected_result);
   THRUST_CDP_DISPATCH(
-    (ret = __partition::partition(policy,
-                                  first,
-                                  last,
-                                  __partition::no_stencil_tag(),
-                                  selected_result,
-                                  rejected_result,
-                                  predicate);),
-    (ret = thrust::stable_partition_copy(cvt_to_seq(derived_cast(policy)),
-                                         first,
-                                         last,
-                                         selected_result,
-                                         rejected_result,
-                                         predicate);));
+    (ret = detail::stable_partition_copy(policy, first, last, stencil, selected_result, rejected_result, predicate);),
+    (ret = thrust::stable_partition_copy(
+       cvt_to_seq(derived_cast(policy)), first, last, stencil, selected_result, rejected_result, predicate);));
   return ret;
 }
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived,
-          class InputIt,
-          class StencilIt,
-          class SelectedOutIt,
-          class RejectedOutIt,
-          class Predicate>
-pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE
-stable_partition_copy(execution_policy<Derived> &policy,
-                      InputIt                    first,
-                      InputIt                    last,
-                      StencilIt                  stencil,
-                      SelectedOutIt              selected_result,
-                      RejectedOutIt              rejected_result,
-                      Predicate                  predicate)
+template <class Derived, class InputIt, class SelectedOutIt, class RejectedOutIt, class Predicate>
+pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE stable_partition_copy(
+  execution_policy<Derived>& policy,
+  InputIt first,
+  InputIt last,
+  SelectedOutIt selected_result,
+  RejectedOutIt rejected_result,
+  Predicate predicate)
 {
   auto ret = thrust::make_pair(selected_result, rejected_result);
   THRUST_CDP_DISPATCH(
-    (ret = __partition::partition(policy,
-                                  first,
-                                  last,
-                                  stencil,
-                                  selected_result,
-                                  rejected_result,
-                                  predicate);),
-    (ret = thrust::stable_partition_copy(cvt_to_seq(derived_cast(policy)),
-                                         first,
-                                         last,
-                                         stencil,
-                                         selected_result,
-                                         rejected_result,
-                                         predicate);));
+    (ret = detail::stable_partition_copy(
+       policy, first, last, static_cast<cub::NullType*>(nullptr), selected_result, rejected_result, predicate);),
+    (ret = thrust::stable_partition_copy(
+       cvt_to_seq(derived_cast(policy)), first, last, selected_result, rejected_result, predicate);));
   return ret;
 }
 
 /// inplace
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived,
-          class Iterator,
-          class StencilIt,
-          class Predicate>
+template <class Derived, class Iterator, class StencilIt, class Predicate>
 Iterator _CCCL_HOST_DEVICE
-partition(execution_policy<Derived> &policy,
-          Iterator                   first,
-          Iterator                   last,
-          StencilIt                  stencil,
-          Predicate                  predicate)
+partition(execution_policy<Derived>& policy, Iterator first, Iterator last, StencilIt stencil, Predicate predicate)
 {
-  THRUST_CDP_DISPATCH(
-    (last =
-       __partition::partition_inplace(policy, first, last, stencil, predicate);),
-    (last = thrust::partition(cvt_to_seq(derived_cast(policy)),
-                              first,
-                              last,
-                              stencil,
-                              predicate);));
+  THRUST_CDP_DISPATCH((last = detail::inplace_partition(policy, first, last, stencil, predicate);),
+                      (last = thrust::partition(cvt_to_seq(derived_cast(policy)), first, last, stencil, predicate);));
   return last;
 }
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived,
-          class Iterator,
-          class Predicate>
+template <class Derived, class Iterator, class Predicate>
 Iterator _CCCL_HOST_DEVICE
-partition(execution_policy<Derived> &policy,
-          Iterator                   first,
-          Iterator                   last,
-          Predicate                  predicate)
+partition(execution_policy<Derived>& policy, Iterator first, Iterator last, Predicate predicate)
 {
   THRUST_CDP_DISPATCH(
-    (last = __partition::partition_inplace(policy,
-                                           first,
-                                           last,
-                                           __partition::no_stencil_tag(),
-                                           predicate);),
-    (last = thrust::partition(cvt_to_seq(derived_cast(policy)),
-                              first,
-                              last,
-                              predicate);));
+    (last = detail::inplace_partition(policy, first, last, static_cast<cub::NullType*>(nullptr), predicate);),
+    (last = thrust::partition(cvt_to_seq(derived_cast(policy)), first, last, predicate);));
   return last;
 }
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived,
-          class Iterator,
-          class StencilIt,
-          class Predicate>
-Iterator _CCCL_HOST_DEVICE
-stable_partition(execution_policy<Derived> &policy,
-                 Iterator                   first,
-                 Iterator                   last,
-                 StencilIt                  stencil,
-                 Predicate                  predicate)
+template <class Derived, class Iterator, class StencilIt, class Predicate>
+Iterator _CCCL_HOST_DEVICE stable_partition(
+  execution_policy<Derived>& policy, Iterator first, Iterator last, StencilIt stencil, Predicate predicate)
 {
   auto ret = last;
   THRUST_CDP_DISPATCH(
-    (ret =
-       __partition::partition_inplace(policy, first, last, stencil, predicate);
+    (ret = detail::inplace_partition(policy, first, last, stencil, predicate);
 
      /* partition returns rejected values in reverse order
        so reverse the rejected elements to make it stable */
      cuda_cub::reverse(policy, ret, last);),
-    (ret = thrust::stable_partition(cvt_to_seq(derived_cast(policy)),
-                                    first,
-                                    last,
-                                    stencil,
-                                    predicate);));
+    (ret = thrust::stable_partition(cvt_to_seq(derived_cast(policy)), first, last, stencil, predicate);));
   return ret;
 }
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived,
-          class Iterator,
-          class Predicate>
+template <class Derived, class Iterator, class Predicate>
 Iterator _CCCL_HOST_DEVICE
-stable_partition(execution_policy<Derived> &policy,
-                 Iterator                   first,
-                 Iterator                   last,
-                 Predicate                  predicate)
+stable_partition(execution_policy<Derived>& policy, Iterator first, Iterator last, Predicate predicate)
 {
   auto ret = last;
   THRUST_CDP_DISPATCH(
-    (ret = __partition::partition_inplace(policy,
-                                          first,
-                                          last,
-                                          __partition::no_stencil_tag(),
-                                          predicate);
+    (ret = detail::inplace_partition(policy, first, last, static_cast<cub::NullType*>(nullptr), predicate);
 
      /* partition returns rejected values in reverse order
       so reverse the rejected elements to make it stable */
      cuda_cub::reverse(policy, ret, last);),
-    (ret = thrust::stable_partition(cvt_to_seq(derived_cast(policy)),
-                                    first,
-                                    last,
-                                    predicate);));
+    (ret = thrust::stable_partition(cvt_to_seq(derived_cast(policy)), first, last, predicate);));
   return ret;
 }
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes https://github.com/NVIDIA/cccl/issues/1397
Closes https://github.com/NVIDIA/cccl/issues/1383
<!-- Link issue here -->


<!-- Provide a standalone description of changes in this PR. -->
**Changes:**
- Adds option to take a two distinct output iterators in `AgentSelectIf`: (1) one for the selected items, (2) one for the rejected items in 
  - This is required to implement `thrust::[stable_]partition_copy` interfaces 
- Adds dynamic 32/64-bit offset type-dispatch to `thrust::[stable_]partition[_if]`
- Adds tests for large number of items for  `thrust::stable_partition_if`
- Fixes an offset computation when writing `rejected` items for 64-bit offset types


**Follow-On Tasks** 
The following tasks are left for follow-on PRs:
- Support large number of items in cub's `cub::DevicePartition` interfaces is left to https://github.com/NVIDIA/cccl/issues/1437
- Adding the interfaces that are exposed in thrust (i.e., "stencil_if", partitioning selected items to a different iterator than rejected items) is deferred to https://github.com/NVIDIA/cccl/issues/1436
<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
