### PR TITLE
Properly check whether a string is alphanumeric

### DIFF
--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -692,7 +692,7 @@ class Configuration(object):
 
                 # With Hopper there are new subarchitectures like 90a we need to handle those
                 subarchitecture = ''
-                if not isinstance(arch, int):
+                if not arch.isnumeric():
                     subarchitecture = arch[-1]
                     arch = arch[:-1]
                 arch = int(arch)


### PR DESCRIPTION
Somebody (me) did a snafu when adding SM90a support and it always truncated the architecture. 

Pyhon is hard