### PR TITLE
Ensure that we can test libcu++ against architectures < 70

### DIFF
--- a/libcudacxx/test/public_headers/CMakeLists.txt
+++ b/libcudacxx/test/public_headers/CMakeLists.txt
@@ -47,6 +47,10 @@ function(libcudacxx_add_public_header_test header)
   # Ensure that if this is an atomic header, we only include the right architectures
   string(REGEX MATCH "atomic|barrier|latch|semaphore|annotated_ptr|pipeline" match "${header}")
   if(match)
+    # Ensure that we only compile the header when we have some architectures enabled
+    if ("${architectures_at_least_sm70}" STREQUAL "")
+      return()
+    endif()
     set_target_properties(headertest_${header_name} PROPERTIES CUDA_ARCHITECTURES "${architectures_at_least_sm70}")
   endif()
 

--- a/libcudacxx/test/public_headers/CMakeLists.txt
+++ b/libcudacxx/test/public_headers/CMakeLists.txt
@@ -48,7 +48,7 @@ function(libcudacxx_add_public_header_test header)
   string(REGEX MATCH "atomic|barrier|latch|semaphore|annotated_ptr|pipeline" match "${header}")
   if(match)
     # Ensure that we only compile the header when we have some architectures enabled
-    if ("${architectures_at_least_sm70}" STREQUAL "")
+    if (NOT architectures_at_least_sm70)
       return()
     endif()
     set_target_properties(headertest_${header_name} PROPERTIES CUDA_ARCHITECTURES "${architectures_at_least_sm70}")


### PR DESCRIPTION
In our header test suite we compile headers that require a certain architecture only against those architectures that actually satisfy the requirement.

We missed the case when no architecture satisfy the constraints and we should not test that header at all.

Fixes nvbug4541374

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
