### PR TITLE
Fixx test issues against gcc-6

### DIFF
--- a/libcudacxx/test/libcudacxx/std/containers/sequences/array/array.creation/to_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/array/array.creation/to_array.pass.cpp
@@ -9,7 +9,7 @@
 
 // <cuda/std/array>
 // UNSUPPORTED: c++03, c++11
-// UNSUPPORTED: gcc-7, gcc-8
+// UNSUPPORTED: gcc-6, gcc-7, gcc-8
 // UNSUPPORTED: nvcc-11.1
 
 // template <typename T, size_t Size>

--- a/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/reverse.iterators/reverse.iter.elem/arrow.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/reverse.iterators/reverse.iter.elem/arrow.pass.cpp
@@ -110,14 +110,16 @@ int main(int, char**)
   }
 #endif // defined(_LIBCUDACXX_HAS_LIST)
 
-#if TEST_STD_VER > 2011 && defined(_LIBCUDACXX_ADDRESSOF)
+#if TEST_STD_VER > 2011 && !defined(TEST_COMPILER_NVRTC) &&                    \
+    !defined(TEST_COMPILER_CUDACC_BELOW_11_3) &&                               \
+    defined(_LIBCUDACXX_ADDRESSOF)
   {
     typedef cuda::std::reverse_iterator<const C *> RI;
     constexpr RI it1 = cuda::std::make_reverse_iterator(gC + 1);
 
     static_assert(it1->get() == gC[0].get(), "");
   }
-#endif // TEST_STD_VER > 2011 && _LIBCUDACXX_ADDRESSOF
+#endif // TEST_STD_VER > 2011 && !TEST_COMPILER_NVRTC && !TEST_COMPILER_CUDACC_BELOW_11_3 && _LIBCUDACXX_ADDRESSOF
   {
     unused(gC);
   }

--- a/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/reverse.iterators/reverse.iter.elem/arrow.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/predef.iterators/reverse.iterators/reverse.iter.elem/arrow.pass.cpp
@@ -110,14 +110,14 @@ int main(int, char**)
   }
 #endif // defined(_LIBCUDACXX_HAS_LIST)
 
-#if TEST_STD_VER > 2011 && !defined(TEST_COMPILER_NVRTC) && !defined(TEST_COMPILER_CUDACC_BELOW_11_3)
+#if TEST_STD_VER > 2011 && defined(_LIBCUDACXX_ADDRESSOF)
   {
     typedef cuda::std::reverse_iterator<const C *> RI;
     constexpr RI it1 = cuda::std::make_reverse_iterator(gC + 1);
 
     static_assert(it1->get() == gC[0].get(), "");
   }
-#endif
+#endif // TEST_STD_VER > 2011 && _LIBCUDACXX_ADDRESSOF
   {
     unused(gC);
   }

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp
@@ -25,7 +25,9 @@
 
 int main(int, char**)
 {
+#if !defined(TEST_COMPILER_GCC) || __GNUC__ >= 7
   static_assert(!cuda::std::is_assignable<cuda::std::variant<int, int>, int>::value, "");
+#endif // !gcc-6
   static_assert(!cuda::std::is_assignable<cuda::std::variant<long, long long>, int>::value, "");
   static_assert(cuda::std::is_assignable<cuda::std::variant<char>, int>::value == VariantAllowsNarrowingConversions, "");
 

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp
@@ -203,8 +203,10 @@ struct Baz {};
 __host__ __device__
 void test_construction_with_repeated_types() {
   using V = cuda::std::variant<int, Bar, Baz, int, Baz, int, int>;
+#if !defined(TEST_COMPILER_GCC) || __GNUC__ >= 7
   static_assert(!cuda::std::is_constructible<V, int>::value, "");
   static_assert(!cuda::std::is_constructible<V, Baz>::value, "");
+#endif // !gcc-6
   // OK, the selected type appears only once and so it shouldn't
   // be affected by the duplicate types.
   static_assert(cuda::std::is_constructible<V, Bar>::value, "");

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp
@@ -24,7 +24,9 @@
 
 int main(int, char**)
 {
+#if !defined(TEST_COMPILER_GCC) || __GNUC__ >= 7
   static_assert(!cuda::std::is_constructible<cuda::std::variant<int, int>, int>::value, "");
+#endif // !gcc-6
   static_assert(!cuda::std::is_constructible<cuda::std::variant<long, long long>, int>::value, "");
   static_assert(cuda::std::is_constructible<cuda::std::variant<char>, int>::value == VariantAllowsNarrowingConversions, "");
 

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_argument_forwarding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_argument_forwarding.pass.cpp
@@ -9,6 +9,7 @@
 // UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
+// UNSUPPORTED: gcc-6
 
 // <cuda/std/variant>
 // template <class R, class Visitor, class... Variants>

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.visit_return/visit_call_operator_forwarding.pass.cpp
@@ -9,6 +9,7 @@
 // UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: clang-7, clang-8
+// UNSUPPORTED: gcc-6
 
 // <cuda/std/variant>
 // template <class R, class Visitor, class... Variants>


### PR DESCRIPTION
We will hopefully drop gcc-6 support soon so just disable the failing asserts and be dnoe with it.

Fixes nvbug4544955
