### PR TITLE
Improve code block CSS in libcu++ docs

### DIFF
--- a/libcudacxx/docs/_sass/color_schemes/nvidia.scss
+++ b/libcudacxx/docs/_sass/color_schemes/nvidia.scss
@@ -35,9 +35,11 @@ $search-background-color: $grey-dk-250;
 $table-background-color: $grey-dk-250;
 $feedback-color: darken($sidebar-color, 3%);
 
-div.highlighter-rouge,
-pre.highlight code
-{ background-color: #111 !important; }
+.highlighter-rouge div.highlight
+{ background: #1a1a1a; }
+
+.highlighter-rouge div.highlight pre
+{ background: #1a1a1a; }
 
 .highlight span.err { color: #ff0000; font-weight: bold; } /* Error */
 


### PR DESCRIPTION
## Description

closes #1481 

This PR improves the readability of code blocks in the libcu++ docs by:

- Removing a rule that sets the text background instead of the block background.
- Adding a rule for a darker background for code blocks.

Before:

![css_before](https://github.com/NVIDIA/cccl/assets/17441062/98b97b49-09d4-43a4-8b16-dee84efb0c82)

After:

![css_after_2](https://github.com/NVIDIA/cccl/assets/17441062/4ce78083-d33d-42a4-bc7c-77761085971d)

Notes:

- To override some defaults outside the project, I used a more specific selector.
- Local docs building is still broken, see #1309 
- I used the color `#1a1a1a` because I find that `#111111` is too high contrast. Most code editors use lower-contrast themes for better readability.