### PR TITLE
[BACKPORT] Fix issues with ambiguous calls to `addressof` in `thrust::optional`

### DIFF
--- a/thrust/thrust/optional.h
+++ b/thrust/thrust/optional.h
@@ -1621,11 +1621,11 @@ public:
         using thrust::swap;
         swap(**this, *rhs);
       } else {
-        new (addressof(rhs.m_value)) T(std::move(this->m_value));
+        new (thrust::addressof(rhs.m_value)) T(std::move(this->m_value));
         this->m_value.T::~T();
       }
     } else if (rhs.has_value()) {
-      new (addressof(this->m_value)) T(std::move(rhs.m_value));
+      new (thrust::addressof(this->m_value)) T(std::move(rhs.m_value));
       rhs.m_value.T::~T();
     }
   }
@@ -1637,7 +1637,7 @@ public:
   __thrust_exec_check_disable__
   __host__ __device__
   constexpr const T *operator->() const {
-    return addressof(this->m_value);
+    return thrust::addressof(this->m_value);
   }
 
   /// \group pointer
@@ -1645,7 +1645,7 @@ public:
   __thrust_exec_check_disable__
   __host__ __device__
   THRUST_OPTIONAL_CPP11_CONSTEXPR T *operator->() {
-    return addressof(this->m_value);
+    return thrust::addressof(this->m_value);
   }
 
   /// \return the stored value
@@ -2691,7 +2691,7 @@ public:
             detail::enable_if_t<!detail::is_optional<detail::decay_t<U>>::value>
                 * = nullptr>
   __host__ __device__
-  constexpr optional(U &&u) : m_value(addressof(u)) {
+  constexpr optional(U &&u) : m_value(thrust::addressof(u)) {
     static_assert(std::is_lvalue_reference<U>::value, "U must be an lvalue");
   }
 
@@ -2733,7 +2733,7 @@ public:
   __host__ __device__
   optional &operator=(U &&u) {
     static_assert(std::is_lvalue_reference<U>::value, "U must be an lvalue");
-    m_value = addressof(u);
+    m_value = thrust::addressof(u);
     return *this;
   }
 
@@ -2745,7 +2745,7 @@ public:
   template <class U>
   __host__ __device__
   optional &operator=(const optional<U> &rhs) {
-    m_value = addressof(rhs.value());
+    m_value = thrust::addressof(rhs.value());
     return *this;
   }
 


### PR DESCRIPTION
This is breaking rmm transition
