### PR TITLE
Ensure that we play nicely with std::iterators

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__iterator/iterator_traits.h
@@ -42,7 +42,11 @@
 #include "../cstddef"
 
 #if !defined(_CCCL_COMPILER_NVRTC) && defined(__cuda_std__)
+#if defined(_CCCL_COMPILER_MSVC)
+#  include <xutility> // for ::std::input_iterator_tag
+#else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
 #  include <iterator> // for ::std::input_iterator_tag
+#endif // !_CCCL_COMPILER_MSVC
 
 #  if _CCCL_STD_VER >= 2020
 template <class _Tp, class = void>

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/iterator.pass.cpp
@@ -24,6 +24,10 @@
 
 #include "test_macros.h"
 
+#if defined(TEST_COMPILER_MSVC)
+#pragma warning(disable: 4324) // structure was padded due to alignment specifier
+#endif // TEST_COMPILER_MSVC
+
 #if !defined(TEST_COMPILER_NVRTC)
 #define THRUST_IGNORE_DEPRECATED_CPP_DIALECT
 #include <thrust/iterator/counting_iterator.h>


### PR DESCRIPTION
We were defining our own set of iterator categories

That meant that an interator that is a `std::random_access_iterator` would not be a `cuda::std::random_access_iterator`

To ensure that we are playing nicely with iterators that use `std::` iterator categories just pull in the standard ones.

Fixes [BUG]: cuda::std::iterator_traits does not expose proper member types in old C++ dialects #1509