### PR TITLE
Add the DeviceSelect::FlaggedIf algorithm

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -697,6 +697,123 @@ struct DeviceSelect
                                                          stream);
   }
 
+  template <typename InputIteratorT,
+            typename FlagIterator,
+            typename OutputIteratorT,
+            typename NumSelectedIteratorT,
+            typename SelectOp>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    FlagIterator d_flags,
+    OutputIteratorT d_out,
+    NumSelectedIteratorT d_num_selected_out,
+    int num_items,
+    SelectOp select_op,
+    cudaStream_t stream = 0)
+  {
+    using OffsetT    = int; // Signed integer type for global offsets
+    using EqualityOp = NullType; // Equality operator (not used)
+
+    return DispatchSelectIf<
+      InputIteratorT,
+      FlagIterator,
+      OutputIteratorT,
+      NumSelectedIteratorT,
+      SelectOp,
+      EqualityOp,
+      OffsetT,
+      false>::Dispatch(d_temp_storage,
+                       temp_storage_bytes,
+                       d_in,
+                       d_flags,
+                       d_out,
+                       d_num_selected_out,
+                       select_op,
+                       EqualityOp(),
+                       num_items,
+                       stream);
+  }
+
+  template <typename InputIteratorT,
+            typename FlagIterator,
+            typename OutputIteratorT,
+            typename NumSelectedIteratorT,
+            typename SelectOp>
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    FlagIterator d_flags,
+    OutputIteratorT d_out,
+    NumSelectedIteratorT d_num_selected_out,
+    int num_items,
+    SelectOp select_op,
+    cudaStream_t stream,
+    bool debug_synchronous)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return FlaggedIf<InputIteratorT, FlagIterator, OutputIteratorT, NumSelectedIteratorT, SelectOp>(
+      d_temp_storage, temp_storage_bytes, d_in, d_flags, d_out, d_num_selected_out, num_items, select_op, stream);
+  }
+
+  template <typename IteratorT, typename FlagIterator, typename NumSelectedIteratorT, typename SelectOp>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    IteratorT d_data,
+    FlagIterator d_flags,
+    NumSelectedIteratorT d_num_selected_out,
+    int num_items,
+    SelectOp select_op,
+    cudaStream_t stream = 0)
+  {
+    using OffsetT    = int; // Signed integer type for global offsets
+    using EqualityOp = NullType; // Equality operator (not used)
+
+    constexpr bool may_alias = true;
+
+    return DispatchSelectIf<
+      IteratorT,
+      FlagIterator,
+      IteratorT,
+      NumSelectedIteratorT,
+      SelectOp,
+      EqualityOp,
+      OffsetT,
+      false,
+      may_alias>::Dispatch(d_temp_storage,
+                           temp_storage_bytes,
+                           d_data, // in
+                           d_flags,
+                           d_data, // out
+                           d_num_selected_out,
+                           select_op,
+                           EqualityOp(),
+                           num_items,
+                           stream);
+  }
+
+  template <typename IteratorT, typename FlagIterator, typename NumSelectedIteratorT, typename SelectOp>
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    IteratorT d_data,
+    FlagIterator d_flags,
+    NumSelectedIteratorT d_num_selected_out,
+    int num_items,
+    SelectOp select_op,
+    cudaStream_t stream,
+    bool debug_synchronous)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return FlaggedIf<IteratorT, FlagIterator, NumSelectedIteratorT, SelectOp>(
+      d_temp_storage, temp_storage_bytes, d_data, d_flags, d_num_selected_out, num_items, select_op, stream);
+  }
+
   //! @rst
   //! Given an input sequence ``d_in`` having runs of consecutive equal-valued keys,
   //! only the first key from each run is selectively copied to ``d_out``.

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -830,43 +830,17 @@ struct DeviceSelect
   //!
   //! The code snippet below illustrates the compaction of items selected from an ``int`` device vector.
   //!
-  //! .. code-block:: c++
+  //! .. literalinclude:: ../../test/catch2_test_device_select_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-select-iseven
+  //!     :end-before: example-end segmented-select-iseven
   //!
-  //!    #include <cub/cub.cuh>  // or equivalently <cub/device/device_select.cuh>
-  //!
-  //!    struct is_even_t
-  //!    {
-  //!      __host__ __device__ bool operator()(int const& elem) const
-  //!      {
-  //!        return !(elem % 2);
-  //!      }
-  //!    };
-  //!
-  //!    // Declare, allocate, and initialize device-accessible pointers for input,
-  //!    // flags, and output
-  //!    int  num_items;              // e.g., 8
-  //!    int  *d_data;                // e.g., [0, 1, 2, 3, 4, 5, 6, 7]
-  //!    char *d_flags;               // e.g., [8, 6, 7, 5, 3, 0, 9, 3]
-  //!    int  *d_num_selected_out;    // e.g., [ ]
-  //!    ...
-  //!
-  //!    // Determine temporary device storage requirements
-  //!    void     *d_temp_storage = NULL;
-  //!    size_t   temp_storage_bytes = 0;
-  //!    cub::DeviceSelect::FlaggedIf(
-  //!      d_temp_storage, temp_storage_bytes,
-  //!      d_in, d_flags, d_num_selected_out, num_items, is_even);
-  //!
-  //!    // Allocate temporary storage
-  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
-  //!
-  //!    // Run selection
-  //!    cub::DeviceSelect::Flagged(
-  //!      d_temp_storage, temp_storage_bytes,
-  //!      d_in, d_flags, d_num_selected_out, num_items, is_even);
-  //!
-  //!    // d_data                <-- [0, 1, 5]
-  //!    // d_num_selected_out    <-- [3]
+  //! .. literalinclude:: ../../test/catch2_test_device_select_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-select-flaggedif-inplace
+  //!     :end-before: example-end segmented-select-flaggedif-inplace
   //!
   //! @endrst
   //!

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -697,6 +697,78 @@ struct DeviceSelect
                                                          stream);
   }
 
+//! @rst
+  //! Uses the ``select_op`` functor applied to ``d_flag`` to selectively copy the 
+  //! corresponding items from ``d_in`` into ``d_out``.
+  //! The total number of items selected is written to ``d_num_selected_out``.
+  //! 
+  //! - The type of ``d_flags`` must conform to the requirements of the input 
+  //!   argument of the unary predicate ``select_op``.
+  //! - The return value of ``select_op(d_flags)`` must be castable to ``bool``. 
+  //! - Copies of the selected items are compacted into ``d_out`` and maintain
+  //!   their original relative ordering.
+  //! - | The range ``[d_out, d_out + *d_num_selected_out)`` shall not overlap
+  //!   | ``[d_in, d_in + num_items)`` nor ``d_num_selected_out`` in any way.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the compaction of items selected from an ``int`` device vector.
+  //!
+  //! .. literalinclude:: ../../test/catch2_test_device_select_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-select-flaggedif
+  //!     :end-before: example-end segmented-select-flaggedif
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam FlagIterator
+  //!   **[inferred]** Random-access input iterator type for reading selection flags @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing selected items @iterator
+  //!
+  //! @tparam NumSelectedIteratorT
+  //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
+  //!
+  //! @tparam SelectOp
+  //!   **[inferred]** Selection operator type having member `bool operator()(const T &a)`
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[in] d_flags
+  //!   Pointer to the input sequence of selection flags
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output sequence of selected data items
+  //!
+  //! @param[out] d_num_selected_out
+  //!   Pointer to the output total number of items selected
+  //!   (i.e., length of `d_out`)
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_in`)
+  //!
+  //! @param[in] select_op
+  //!   Unary selection operator
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
   template <typename InputIteratorT,
             typename FlagIterator,
             typename OutputIteratorT,

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -702,9 +702,8 @@ struct DeviceSelect
   //! corresponding items from ``d_in`` into ``d_out``.
   //! The total number of items selected is written to ``d_num_selected_out``.
   //!
-  //! - The expression ``select_op(d_flags)`` must be convertible to ``bool`` for
-  //!   every argument ``flag``, where the type of ``flag`` corresponds to the
-  //!   value type of ``FlagIterator``.
+  //! - The expression ``select_op(flag)`` must be convertible to ``bool``,
+  //!   where the type of ``flag`` corresponds to the value type of ``FlagIterator``.
   //! - Copies of the selected items are compacted into ``d_out`` and maintain
   //!   their original relative ordering.
   //! - | The range ``[d_out, d_out + *d_num_selected_out)`` shall not overlap
@@ -819,9 +818,8 @@ struct DeviceSelect
   //! corresponding items in ``d_data``.
   //! The total number of items selected is written to ``d_num_selected_out``.
   //!
-  //! - The expression ``select_op(d_flags)`` must be convertible to ``bool`` for
-  //!   every argument ``flag``, where the type of ``flag`` corresponds to the
-  //!   value type of ``FlagIterator``.
+  //! - The expression ``select_op(flag)`` must be convertible to ``bool``,
+  //!   where the type of ``flag`` corresponds to the value type of ``FlagIterator``.
   //! - Copies of the selected items are compacted in-place and maintain their original relative ordering.
   //! - | The ``d_data`` may equal ``d_flags``. The range ``[d_data, d_data + num_items)`` shall not overlap
   //!   | ``[d_flags, d_flags + num_items)`` in any other way.

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -736,29 +736,6 @@ struct DeviceSelect
                        stream);
   }
 
-  template <typename InputIteratorT,
-            typename FlagIterator,
-            typename OutputIteratorT,
-            typename NumSelectedIteratorT,
-            typename SelectOp>
-  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
-    void* d_temp_storage,
-    size_t& temp_storage_bytes,
-    InputIteratorT d_in,
-    FlagIterator d_flags,
-    OutputIteratorT d_out,
-    NumSelectedIteratorT d_num_selected_out,
-    int num_items,
-    SelectOp select_op,
-    cudaStream_t stream,
-    bool debug_synchronous)
-  {
-    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
-
-    return FlaggedIf<InputIteratorT, FlagIterator, OutputIteratorT, NumSelectedIteratorT, SelectOp>(
-      d_temp_storage, temp_storage_bytes, d_in, d_flags, d_out, d_num_selected_out, num_items, select_op, stream);
-  }
-
   template <typename IteratorT, typename FlagIterator, typename NumSelectedIteratorT, typename SelectOp>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
     void* d_temp_storage,
@@ -794,24 +771,6 @@ struct DeviceSelect
                            EqualityOp(),
                            num_items,
                            stream);
-  }
-
-  template <typename IteratorT, typename FlagIterator, typename NumSelectedIteratorT, typename SelectOp>
-  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t FlaggedIf(
-    void* d_temp_storage,
-    size_t& temp_storage_bytes,
-    IteratorT d_data,
-    FlagIterator d_flags,
-    NumSelectedIteratorT d_num_selected_out,
-    int num_items,
-    SelectOp select_op,
-    cudaStream_t stream,
-    bool debug_synchronous)
-  {
-    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
-
-    return FlaggedIf<IteratorT, FlagIterator, NumSelectedIteratorT, SelectOp>(
-      d_temp_storage, temp_storage_bytes, d_data, d_flags, d_num_selected_out, num_items, select_op, stream);
   }
 
   //! @rst

--- a/cub/test/catch2_test_device_select_api.cu
+++ b/cub/test/catch2_test_device_select_api.cu
@@ -1,0 +1,89 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <cub/device/device_select.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/equal.h>
+
+#include <cstddef>
+
+#include "catch2_test_helper.h"
+
+struct is_even_t
+{
+  __host__ __device__ bool operator()(int const& elem) const
+  {
+    return !(elem % 2);
+  }
+};
+
+CUB_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][device]")
+{
+  // example-begin segmented-select-flaggedif
+  int num_items                   = 8;
+  thrust::device_vector<int> d_in = {0, 1, 2, 3, 4, 5, 6, 7};
+  //   auto d_offsets_it               = thrust::raw_pointer_cast(d_offsets.data());
+  thrust::device_vector<int> d_flags = {8, 6, 7, 5, 3, 0, 9, 3};
+  thrust::device_vector<int> d_out(num_items);
+  thrust::device_vector<int> d_num_selected_out(num_items);
+  is_even_t is_even{};
+
+  // Determine temporary device storage requirements
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  cub::DeviceSelect::FlaggedIf(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_flags.begin(),
+    d_out.begin(),
+    d_num_selected_out.data(),
+    num_items,
+    is_even);
+
+  // Allocate temporary storage
+  cudaMalloc(&d_temp_storage, temp_storage_bytes);
+
+  // Run selection
+  cub::DeviceSelect::FlaggedIf(
+    d_temp_storage,
+    temp_storage_bytes,
+    d_in.begin(),
+    d_flags.begin(),
+    d_out.begin(),
+    d_num_selected_out.data(),
+    num_items,
+    is_even);
+
+  thrust::device_vector<int> expected{0, 1, 5};
+  // example-end segmented-select-flaggedif
+
+  d_out.resize(d_num_selected_out[0]);
+  REQUIRE(d_out == expected);
+  REQUIRE(d_num_selected_out[0] == (int) expected.size());
+}

--- a/cub/test/catch2_test_device_select_api.cu
+++ b/cub/test/catch2_test_device_select_api.cu
@@ -37,9 +37,9 @@
 // example-begin segmented-select-iseven
 struct is_even_t
 {
-  __host__ __device__ bool operator()(int const& elem) const
+  __host__ __device__ bool operator()(int flag) const
   {
-    return !(elem % 2);
+    return !(flag % 2);
   }
 };
 // example-end segmented-select-iseven

--- a/cub/test/catch2_test_device_select_api.cu
+++ b/cub/test/catch2_test_device_select_api.cu
@@ -34,6 +34,7 @@
 
 #include "catch2_test_helper.h"
 
+// example-begin segmented-select-iseven
 struct is_even_t
 {
   __host__ __device__ bool operator()(int const& elem) const
@@ -41,13 +42,13 @@ struct is_even_t
     return !(elem % 2);
   }
 };
+// example-end segmented-select-iseven
 
 CUB_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][device]")
 {
   // example-begin segmented-select-flaggedif
-  int num_items                   = 8;
-  thrust::device_vector<int> d_in = {0, 1, 2, 3, 4, 5, 6, 7};
-  //   auto d_offsets_it               = thrust::raw_pointer_cast(d_offsets.data());
+  constexpr int num_items            = 8;
+  thrust::device_vector<int> d_in    = {0, 1, 2, 3, 4, 5, 6, 7};
   thrust::device_vector<int> d_flags = {8, 6, 7, 5, 3, 0, 9, 3};
   thrust::device_vector<int> d_out(num_items);
   thrust::device_vector<int> d_num_selected_out(num_items);
@@ -83,7 +84,7 @@ CUB_TEST("cub::DeviceSelect::FlaggedIf works with int data elements", "[select][
   thrust::device_vector<int> expected{0, 1, 5};
   // example-end segmented-select-flaggedif
 
+  REQUIRE(d_num_selected_out[0] == static_cast<int>(expected.size()));
   d_out.resize(d_num_selected_out[0]);
   REQUIRE(d_out == expected);
-  REQUIRE(d_num_selected_out[0] == (int) expected.size());
 }

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -197,7 +197,7 @@ CUB_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(CUB_SEED(1), flags);
   const c2h::host_vector<input_type> reference_out = get_reference(in, flags, is_even);
-  const int num_selected                           = reference_out.size();
+  const std::size_t num_selected                   = reference_out.size();
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -234,7 +234,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(CUB_SEED(1), flags);
   const c2h::host_vector<input_type> reference = get_reference(in, flags, is_even);
-  const int num_selected                       = reference.size();
+  const std::size_t num_selected               = reference.size();
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -263,7 +263,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with pointers", "[device][select_flagged
   c2h::gen(CUB_SEED(1), flags);
 
   const c2h::host_vector<input_type> reference = get_reference(in, flags, is_even);
-  const int num_selected                       = reference.size();
+  const std::size_t num_selected               = reference.size();
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -222,7 +222,7 @@ CUB_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
   REQUIRE(reference_out == out);
 }
 
-CUB_TEST("DeviceSelect::If works with iterators", "[device][select_if]", all_types, flag_types)
+CUB_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", all_types, flag_types)
 {
   using input_type = typename c2h::get<0, TestType>;
   using flag_type  = typename c2h::get<1, TestType>;
@@ -250,7 +250,7 @@ CUB_TEST("DeviceSelect::If works with iterators", "[device][select_if]", all_typ
   REQUIRE(reference == out);
 }
 
-CUB_TEST("DeviceSelect::Flagged works with pointers", "[device][select_flagged]", types, flag_types)
+CUB_TEST("DeviceSelect::FlaggedIf works with pointers", "[device][select_flagged]", types, flag_types)
 {
   using input_type = typename c2h::get<0, TestType>;
   using flag_type  = typename c2h::get<1, TestType>;

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -1,0 +1,95 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <cub/device/device_select.cuh>
+
+// #include "catch2_test_helper.h"
+#include "catch2_test_launch_helper.h"
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceSelect::FlaggedIf, select_flagged_if);
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+struct always_true_t
+{
+  template <typename T>
+  __device__ bool operator()(const T&) const
+  {
+    return true;
+  }
+};
+
+using all_types =
+  c2h::type_list<std::uint8_t,
+                 std::uint16_t,
+                 std::uint32_t,
+                 std::uint64_t,
+                 ulonglong2,
+                 ulonglong4,
+                 int,
+                 long2,
+                 c2h::custom_type_t<c2h::equal_comparable_t>>;
+
+using types = c2h::type_list<std::uint8_t, std::uint32_t, ulonglong4, c2h::custom_type_t<c2h::equal_comparable_t>>;
+
+CUB_TEST("DeviceSelect::FlaggedIf can run with empty input", "[device][select_flagged_if]", types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  constexpr int num_items = 0;
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::device_vector<int> flags(num_items);
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  select_flagged_if(in.begin(), flags.begin(), out.begin(), d_num_selected_out, num_items, always_true_t{});
+
+  REQUIRE(num_selected_out[0] == 0);
+}
+
+CUB_TEST("DeviceSelect::If handles all matched", "[device][select_flagged_if]", types)
+{
+  using type = typename c2h::get<0, TestType>;
+
+  const int num_items = GENERATE_COPY(take(2, random(1, 1000000)));
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::device_vector<int> flags(num_items);
+  c2h::gen(CUB_SEED(2), in);
+
+  // Needs to be device accessible
+  c2h::device_vector<int> num_selected_out(1, 0);
+  int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
+
+  select_flagged_if(in.begin(), flags.begin(), out.begin(), d_first_num_selected_out, num_items, always_true_t{});
+
+  REQUIRE(num_selected_out[0] == num_items);
+  REQUIRE(out == in);
+}

--- a/cub/test/catch2_test_device_select_flagged_if.cu
+++ b/cub/test/catch2_test_device_select_flagged_if.cu
@@ -28,7 +28,10 @@
 #include <cub/device/device_select.cuh>
 
 #include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
 #include <thrust/logical.h>
+
+#include <algorithm>
 
 #include "catch2_test_helper.h"
 #include "catch2_test_launch_helper.h"
@@ -197,7 +200,7 @@ CUB_TEST("DeviceSelect::FlaggedIf does not change input and is stable",
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(CUB_SEED(1), flags);
   const c2h::host_vector<input_type> reference_out = get_reference(in, flags, is_even);
-  const std::size_t num_selected                   = reference_out.size();
+  const int num_selected                           = static_cast<int>(reference_out.size());
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -234,7 +237,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with iterators", "[device][select_if]", 
   c2h::device_vector<flag_type> flags(num_items);
   c2h::gen(CUB_SEED(1), flags);
   const c2h::host_vector<input_type> reference = get_reference(in, flags, is_even);
-  const std::size_t num_selected               = reference.size();
+  const int num_selected                       = static_cast<int>(reference.size());
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);
@@ -263,7 +266,7 @@ CUB_TEST("DeviceSelect::FlaggedIf works with pointers", "[device][select_flagged
   c2h::gen(CUB_SEED(1), flags);
 
   const c2h::host_vector<input_type> reference = get_reference(in, flags, is_even);
-  const std::size_t num_selected               = reference.size();
+  const int num_selected                       = static_cast<int>(reference.size());
 
   // Needs to be device accessible
   c2h::device_vector<int> num_selected_out(1, 0);


### PR DESCRIPTION
## Description

This adds the `cub::DeviceSelect::FlaggedIf` algorithm which combines the predicate selection approach of `cub::DeviceSelect::If` and the flag approach of `cub::DeviceSelect::Flagged`.

This fixes #1409.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
