### PR TITLE
Fix unused variable warning for `__can_use_complete_tx`

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/barrier.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/barrier.h
@@ -1101,6 +1101,7 @@ __completion_mechanism __dispatch_memcpy_async_global_to_shared(_Group const & _
 #if __cccl_ptx_isa >= 800
     NV_IF_TARGET(NV_PROVIDES_SM_90, (
         const bool __can_use_complete_tx = __allowed_completions & uint32_t(__completion_mechanism::__mbarrier_complete_tx);
+        _LIBCUDACXX_UNUSED_VAR(__can_use_complete_tx);
         _LIBCUDACXX_DEBUG_ASSERT(__can_use_complete_tx == (nullptr != __bar_handle), "Pass non-null bar_handle if and only if can_use_complete_tx.");
         if _LIBCUDACXX_CONSTEXPR_AFTER_CXX14 (_Align >= 16) {
             if (__can_use_complete_tx && __isShared(__bar_handle)) {


### PR DESCRIPTION
## Description

fixes nvbug/4541347
