### PR TITLE
Add an efficient unstable thread sort, use it in unstable block/device merge/segmented sorts, and improve tests

### DIFF
--- a/cub/benchmarks/bench/merge_sort/keys.cu
+++ b/cub/benchmarks/bench/merge_sort/keys.cu
@@ -78,14 +78,15 @@ struct policy_hub_t
 template <typename T, typename OffsetT>
 void keys(nvbench::state &state, nvbench::type_list<T, OffsetT>)
 {
-  using key_t            = T;
-  using value_t          = cub::NullType;
-  using key_input_it_t   = key_t *;
-  using value_input_it_t = value_t *;
-  using key_it_t         = key_t *;
-  using value_it_t       = value_t *;
-  using offset_t         = OffsetT;
-  using compare_op_t     = less_t;
+  using key_t              = T;
+  using value_t            = cub::NullType;
+  using key_input_it_t     = key_t *;
+  using value_input_it_t   = value_t *;
+  using key_it_t           = key_t *;
+  using value_it_t         = value_t *;
+  using offset_t           = OffsetT;
+  using compare_op_t       = less_t;
+  constexpr bool is_stable = true;
 
 #if !TUNE_BASE
   using policy_t   = policy_hub_t<key_t>;
@@ -95,10 +96,11 @@ void keys(nvbench::state &state, nvbench::type_list<T, OffsetT>)
                                             value_it_t,
                                             offset_t,
                                             compare_op_t,
+                                            is_stable,
                                             policy_t>;
 #else // TUNE_BASE
   using dispatch_t = cub::
-    DispatchMergeSort<key_input_it_t, value_input_it_t, key_it_t, value_it_t, offset_t, compare_op_t>;
+    DispatchMergeSort<key_input_it_t, value_input_it_t, key_it_t, value_it_t, offset_t, compare_op_t, is_stable>;
 #endif // TUNE_BASE
 
   // Retrieve axis parameters

--- a/cub/benchmarks/bench/merge_sort/pairs.cu
+++ b/cub/benchmarks/bench/merge_sort/pairs.cu
@@ -75,14 +75,15 @@ struct policy_hub_t
 template <typename KeyT, typename ValueT, typename OffsetT>
 void pairs(nvbench::state &state, nvbench::type_list<KeyT, ValueT, OffsetT>)
 {
-  using key_t            = KeyT;
-  using value_t          = ValueT;
-  using key_input_it_t   = key_t *;
-  using value_input_it_t = value_t *;
-  using key_it_t         = key_t *;
-  using value_it_t       = value_t *;
-  using offset_t         = OffsetT;
-  using compare_op_t     = less_t;
+  using key_t              = KeyT;
+  using value_t            = ValueT;
+  using key_input_it_t     = key_t *;
+  using value_input_it_t   = value_t *;
+  using key_it_t           = key_t *;
+  using value_it_t         = value_t *;
+  using offset_t           = OffsetT;
+  using compare_op_t       = less_t;
+  constexpr bool is_stable = true;
 
 #if !TUNE_BASE
   using policy_t   = policy_hub_t<key_t>;
@@ -92,10 +93,11 @@ void pairs(nvbench::state &state, nvbench::type_list<KeyT, ValueT, OffsetT>)
                                             value_it_t,
                                             offset_t,
                                             compare_op_t,
+                                            is_stable,
                                             policy_t>;
 #else // TUNE_BASE
   using dispatch_t = cub::
-    DispatchMergeSort<key_input_it_t, value_input_it_t, key_it_t, value_it_t, offset_t, compare_op_t>;
+    DispatchMergeSort<key_input_it_t, value_input_it_t, key_it_t, value_it_t, offset_t, compare_op_t, is_stable>;
 #endif // TUNE_BASE
 
   // Retrieve axis parameters

--- a/cub/benchmarks/bench/segmented_sort/keys.cu
+++ b/cub/benchmarks/bench/segmented_sort/keys.cu
@@ -156,6 +156,7 @@ void seg_sort(nvbench::state &state,
               bit_entropy entropy)
 {
   constexpr bool is_descending   = false;
+  constexpr bool is_stable       = true;
   constexpr bool is_overwrite_ok = false;
 
   using offset_t          = OffsetT;
@@ -168,6 +169,7 @@ void seg_sort(nvbench::state &state,
   using policy_t = device_seg_sort_policy_hub<key_t>;
   using dispatch_t = //
     cub::DispatchSegmentedSort<is_descending,
+                               is_stable,
                                key_t,
                                value_t,
                                offset_t,
@@ -177,6 +179,7 @@ void seg_sort(nvbench::state &state,
 #else
   using dispatch_t = //
     cub::DispatchSegmentedSort<is_descending,
+                               is_stable,
                                key_t,
                                value_t,
                                offset_t,

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -67,6 +67,7 @@ struct AgentMergeSortPolicy
 
 /// \brief This agent is responsible for the initial in-tile sorting.
 template <typename Policy,
+          bool IS_STABLE,
           typename KeyInputIteratorT,
           typename ValueInputIteratorT,
           typename KeyIteratorT,
@@ -212,12 +213,25 @@ struct AgentBlockSort
 
     if (IS_LAST_TILE)
     {
-      BlockMergeSortT(storage.block_merge)
-        .StableSort(keys_local, items_local, compare_op, num_remaining, keys_local[0]);
+      CUB_IF_CONSTEXPR(IS_STABLE) {
+        BlockMergeSortT(storage.block_merge)
+          .StableSort(keys_local, items_local, compare_op, num_remaining, keys_local[0]);
+      }
+      else
+      {
+        BlockMergeSortT(storage.block_merge)
+          .Sort(keys_local, items_local, compare_op, num_remaining, keys_local[0]);
+      }
     }
     else
     {
-      BlockMergeSortT(storage.block_merge).StableSort(keys_local, items_local, compare_op);
+      CUB_IF_CONSTEXPR(IS_STABLE) {
+        BlockMergeSortT(storage.block_merge).StableSort(keys_local, items_local, compare_op);
+      }
+      else
+      {
+        BlockMergeSortT(storage.block_merge).Sort(keys_local, items_local, compare_op);
+      }
     }
 
     CTA_SYNC();

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -213,11 +213,11 @@ struct AgentBlockSort
     if (IS_LAST_TILE)
     {
       BlockMergeSortT(storage.block_merge)
-        .Sort(keys_local, items_local, compare_op, num_remaining, keys_local[0]);
+        .StableSort(keys_local, items_local, compare_op, num_remaining, keys_local[0]);
     }
     else
     {
-      BlockMergeSortT(storage.block_merge).Sort(keys_local, items_local, compare_op);
+      BlockMergeSortT(storage.block_merge).StableSort(keys_local, items_local, compare_op);
     }
 
     CTA_SYNC();

--- a/cub/cub/agent/agent_sub_warp_merge_sort.cuh
+++ b/cub/cub/agent/agent_sub_warp_merge_sort.cuh
@@ -277,7 +277,7 @@ public:
         WARP_SYNC(warp_merge_sort.get_member_mask());
       }
 
-      warp_merge_sort.Sort(keys, values, BinaryOpT{}, segment_size, oob_default);
+      warp_merge_sort.StableSort(keys, values, BinaryOpT{}, segment_size, oob_default);
       WARP_SYNC(warp_merge_sort.get_member_mask());
 
       WarpStoreKeysT(storage.store_keys).Store(keys_output, keys, segment_size);

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -244,7 +244,8 @@ public:
    *
    * @tparam CompareOp
    *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
-   *   `CompareOp` is a model of [Strict Weak Ordering].
+   *   `CompareOp` is a model of [Strict Weak Ordering]. It is recommended to
+   *   use CUB's default operators such as `cub::Less` when suitable.
    *
    * @param[in,out] keys
    *   Keys to sort
@@ -280,7 +281,8 @@ public:
    *
    * @tparam CompareOp
    *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
-   *   `CompareOp` is a model of [Strict Weak Ordering].
+   *   `CompareOp` is a model of [Strict Weak Ordering]. It is recommended to
+   *   use CUB's default operators such as `cub::Less` when suitable.
    *
    * @param[in,out] keys
    *   Keys to sort
@@ -317,7 +319,8 @@ public:
    *
    * @tparam CompareOp
    *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
-   *   `CompareOp` is a model of [Strict Weak Ordering].
+   *   `CompareOp` is a model of [Strict Weak Ordering]. It is recommended to
+   *   use CUB's default operators such as `cub::Less` when suitable.
    *
    * @param[in,out] keys
    *   Keys to sort
@@ -356,7 +359,8 @@ public:
    *
    * @tparam CompareOp
    *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`
-   *   `CompareOp` is a model of [Strict Weak Ordering].
+   *   `CompareOp` is a model of [Strict Weak Ordering]. It is recommended to
+   *   use CUB's default operators such as `cub::Less` when suitable.
    *
    * @tparam IS_LAST_TILE
    *   True if `valid_items` isn't equal to the `ITEMS_PER_TILE`
@@ -518,7 +522,8 @@ public:
    *
    * @tparam CompareOp
    *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
-   *   `CompareOp` is a model of [Strict Weak Ordering].
+   *   `CompareOp` is a model of [Strict Weak Ordering]. It is recommended to
+   *   use CUB's default operators such as `cub::Less` when suitable.
    *
    * @param[in,out] keys
    *   Keys to sort
@@ -548,7 +553,8 @@ public:
    *
    * @tparam CompareOp
    *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
-   *   `CompareOp` is a model of [Strict Weak Ordering].
+   *   `CompareOp` is a model of [Strict Weak Ordering]. It is recommended to
+   *   use CUB's default operators such as `cub::Less` when suitable.
    *
    * @param[in,out] keys
    *   Keys to sort
@@ -589,7 +595,8 @@ public:
    *
    * @tparam CompareOp
    *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
-   *   `CompareOp` is a model of [Strict Weak Ordering].
+   *   `CompareOp` is a model of [Strict Weak Ordering]. It is recommended to
+   *   use CUB's default operators such as `cub::Less` when suitable.
    *
    * @param[in,out] keys
    *   Keys to sort
@@ -633,7 +640,8 @@ public:
    *
    * @tparam CompareOp
    *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
-   *   `CompareOp` is a model of [Strict Weak Ordering].
+   *   `CompareOp` is a model of [Strict Weak Ordering]. It is recommended to
+   *   use CUB's default operators such as `cub::Less` when suitable.
    *
    * @tparam IS_LAST_TILE
    *   True if `valid_items` isn't equal to the `ITEMS_PER_TILE`

--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -225,7 +225,8 @@ struct DeviceMergeSort
                                                  KeyIteratorT,
                                                  ValueIteratorT,
                                                  PromotedOffsetT,
-                                                 CompareOpT>;
+                                                 CompareOpT,
+                                                 false>;
 
     return DispatchMergeSortT::Dispatch(d_temp_storage,
                                         temp_storage_bytes,
@@ -400,7 +401,8 @@ struct DeviceMergeSort
                                                  KeyIteratorT,
                                                  ValueIteratorT,
                                                  PromotedOffsetT,
-                                                 CompareOpT>;
+                                                 CompareOpT,
+                                                 false>;
 
     return DispatchMergeSortT::Dispatch(d_temp_storage,
                                         temp_storage_bytes,
@@ -551,7 +553,8 @@ struct DeviceMergeSort
                                                  KeyIteratorT,
                                                  NullType *,
                                                  PromotedOffsetT,
-                                                 CompareOpT>;
+                                                 CompareOpT,
+                                                 false>;
 
     return DispatchMergeSortT::Dispatch(d_temp_storage,
                                         temp_storage_bytes,
@@ -703,7 +706,8 @@ struct DeviceMergeSort
                                                  KeyIteratorT,
                                                  NullType *,
                                                  PromotedOffsetT,
-                                                 CompareOpT>;
+                                                 CompareOpT,
+                                                 false>;
 
     return DispatchMergeSortT::Dispatch(d_temp_storage,
                                         temp_storage_bytes,
@@ -850,14 +854,23 @@ struct DeviceMergeSort
   {
     using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
-    return SortPairs<KeyIteratorT, ValueIteratorT, PromotedOffsetT, CompareOpT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys,
-      d_items,
-      num_items,
-      compare_op,
-      stream);
+    using DispatchMergeSortT = DispatchMergeSort<KeyIteratorT,
+                                                 ValueIteratorT,
+                                                 KeyIteratorT,
+                                                 ValueIteratorT,
+                                                 PromotedOffsetT,
+                                                 CompareOpT,
+                                                 true>;
+
+    return DispatchMergeSortT::Dispatch(d_temp_storage,
+                                        temp_storage_bytes,
+                                        d_keys,
+                                        d_items,
+                                        d_keys,
+                                        d_items,
+                                        num_items,
+                                        compare_op,
+                                        stream);
   }
 
   template <typename KeyIteratorT,
@@ -984,12 +997,23 @@ struct DeviceMergeSort
   {
     using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
-    return SortKeys<KeyIteratorT, PromotedOffsetT, CompareOpT>(d_temp_storage,
-                                                       temp_storage_bytes,
-                                                       d_keys,
-                                                       num_items,
-                                                       compare_op,
-                                                       stream);
+    using DispatchMergeSortT = DispatchMergeSort<KeyIteratorT,
+                                                 NullType *,
+                                                 KeyIteratorT,
+                                                 NullType *,
+                                                 PromotedOffsetT,
+                                                 CompareOpT,
+                                                 true>;
+
+    return DispatchMergeSortT::Dispatch(d_temp_storage,
+                                        temp_storage_bytes,
+                                        d_keys,
+                                        static_cast<NullType *>(nullptr),
+                                        d_keys,
+                                        static_cast<NullType *>(nullptr),
+                                        num_items,
+                                        compare_op,
+                                        stream);
   }
 
   template <typename KeyIteratorT,
@@ -1127,13 +1151,23 @@ struct DeviceMergeSort
   {
     using PromotedOffsetT = detail::promote_small_offset_t<OffsetT>; 
 
-    return SortKeysCopy<KeyInputIteratorT, KeyIteratorT, PromotedOffsetT, CompareOpT>(d_temp_storage,
-                                                                              temp_storage_bytes,
-                                                                              d_input_keys,
-                                                                              d_output_keys,
-                                                                              num_items,
-                                                                              compare_op,
-                                                                              stream);
+    using DispatchMergeSortT = DispatchMergeSort<KeyInputIteratorT,
+                                                 NullType *,
+                                                 KeyIteratorT,
+                                                 NullType *,
+                                                 PromotedOffsetT,
+                                                 CompareOpT,
+                                                 true>;
+
+    return DispatchMergeSortT::Dispatch(d_temp_storage,
+                                        temp_storage_bytes,
+                                        d_input_keys,
+                                        static_cast<NullType *>(nullptr),
+                                        d_output_keys,
+                                        static_cast<NullType *>(nullptr),
+                                        num_items,
+                                        compare_op,
+                                        stream);
   }
 };
 

--- a/cub/cub/device/device_segmented_sort.cuh
+++ b/cub/cub/device/device_segmented_sort.cuh
@@ -254,8 +254,10 @@ struct DeviceSegmentedSort
            cudaStream_t stream = 0)
   {
     constexpr bool is_descending = false;
+    constexpr bool is_stable = false;
     constexpr bool is_overwrite_okay = false;
     using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
                                             KeyT,
                                             cub::NullType,
                                             int,
@@ -429,8 +431,10 @@ struct DeviceSegmentedSort
                      cudaStream_t stream = 0)
   {
     constexpr bool is_descending = true;
+    constexpr bool is_stable = false;
     constexpr bool is_overwrite_okay = false;
     using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
                                             KeyT,
                                             cub::NullType,
                                             int,
@@ -615,9 +619,11 @@ struct DeviceSegmentedSort
            cudaStream_t stream = 0)
   {
     constexpr bool is_descending     = false;
+    constexpr bool is_stable         = false;
     constexpr bool is_overwrite_okay = true;
 
     using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
                                             KeyT,
                                             cub::NullType,
                                             int,
@@ -799,10 +805,12 @@ struct DeviceSegmentedSort
                      EndOffsetIteratorT d_end_offsets,
                      cudaStream_t stream = 0)
   {
-    constexpr bool is_descending = true;
+    constexpr bool is_descending     = true;
+    constexpr bool is_stable         = false;
     constexpr bool is_overwrite_okay = true;
 
     using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
                                             KeyT,
                                             cub::NullType,
                                             int,
@@ -976,16 +984,30 @@ struct DeviceSegmentedSort
                  EndOffsetIteratorT d_end_offsets,
                  cudaStream_t stream = 0)
   {
-    return SortKeys<KeyT, BeginOffsetIteratorT, EndOffsetIteratorT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys_in,
-      d_keys_out,
-      num_items,
-      num_segments,
-      d_begin_offsets,
-      d_end_offsets,
-      stream);
+    constexpr bool is_descending = false;
+    constexpr bool is_stable = true;
+    constexpr bool is_overwrite_okay = false;
+    using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
+                                            KeyT,
+                                            cub::NullType,
+                                            int,
+                                            BeginOffsetIteratorT,
+                                            EndOffsetIteratorT>;
+
+    DoubleBuffer<KeyT> d_keys(const_cast<KeyT *>(d_keys_in), d_keys_out);
+    DoubleBuffer<NullType> d_values;
+
+    return DispatchT::Dispatch(d_temp_storage,
+                               temp_storage_bytes,
+                               d_keys,
+                               d_values,
+                               num_items,
+                               num_segments,
+                               d_begin_offsets,
+                               d_end_offsets,
+                               is_overwrite_okay,
+                               stream);
   }
 
   template <typename KeyT,
@@ -1143,17 +1165,30 @@ struct DeviceSegmentedSort
                            EndOffsetIteratorT d_end_offsets,
                            cudaStream_t stream = 0)
   {
-    return SortKeysDescending<KeyT,
-                              BeginOffsetIteratorT,
-                              EndOffsetIteratorT>(d_temp_storage,
-                                                  temp_storage_bytes,
-                                                  d_keys_in,
-                                                  d_keys_out,
-                                                  num_items,
-                                                  num_segments,
-                                                  d_begin_offsets,
-                                                  d_end_offsets,
-                                                  stream);
+    constexpr bool is_descending = true;
+    constexpr bool is_stable = true;
+    constexpr bool is_overwrite_okay = false;
+    using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
+                                            KeyT,
+                                            cub::NullType,
+                                            int,
+                                            BeginOffsetIteratorT,
+                                            EndOffsetIteratorT>;
+
+    DoubleBuffer<KeyT> d_keys(const_cast<KeyT *>(d_keys_in), d_keys_out);
+    DoubleBuffer<NullType> d_values;
+
+    return DispatchT::Dispatch(d_temp_storage,
+                               temp_storage_bytes,
+                               d_keys,
+                               d_values,
+                               num_items,
+                               num_segments,
+                               d_begin_offsets,
+                               d_end_offsets,
+                               is_overwrite_okay,
+                               stream);
   }
 
   template <typename KeyT,
@@ -1322,15 +1357,30 @@ struct DeviceSegmentedSort
                  EndOffsetIteratorT d_end_offsets,
                  cudaStream_t stream = 0)
   {
-    return SortKeys<KeyT, BeginOffsetIteratorT, EndOffsetIteratorT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys,
-      num_items,
-      num_segments,
-      d_begin_offsets,
-      d_end_offsets,
-      stream);
+    constexpr bool is_descending     = false;
+    constexpr bool is_stable         = true;
+    constexpr bool is_overwrite_okay = true;
+
+    using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
+                                            KeyT,
+                                            cub::NullType,
+                                            int,
+                                            BeginOffsetIteratorT,
+                                            EndOffsetIteratorT>;
+
+    DoubleBuffer<NullType> d_values;
+
+    return DispatchT::Dispatch(d_temp_storage,
+                               temp_storage_bytes,
+                               d_keys,
+                               d_values,
+                               num_items,
+                               num_segments,
+                               d_begin_offsets,
+                               d_end_offsets,
+                               is_overwrite_okay,
+                               stream);
   }
 
   template <typename KeyT,
@@ -1495,16 +1545,30 @@ struct DeviceSegmentedSort
                            EndOffsetIteratorT d_end_offsets,
                            cudaStream_t stream = 0)
   {
-    return SortKeysDescending<KeyT,
-                              BeginOffsetIteratorT,
-                              EndOffsetIteratorT>(d_temp_storage,
-                                                  temp_storage_bytes,
-                                                  d_keys,
-                                                  num_items,
-                                                  num_segments,
-                                                  d_begin_offsets,
-                                                  d_end_offsets,
-                                                  stream);
+    constexpr bool is_descending     = true;
+    constexpr bool is_stable         = true;
+    constexpr bool is_overwrite_okay = true;
+
+    using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
+                                            KeyT,
+                                            cub::NullType,
+                                            int,
+                                            BeginOffsetIteratorT,
+                                            EndOffsetIteratorT>;
+
+    DoubleBuffer<NullType> d_values;
+
+    return DispatchT::Dispatch(d_temp_storage,
+                               temp_storage_bytes,
+                               d_keys,
+                               d_values,
+                               num_items,
+                               num_segments,
+                               d_begin_offsets,
+                               d_end_offsets,
+                               is_overwrite_okay,
+                               stream);
   }
 
   template <typename KeyT,
@@ -1686,9 +1750,11 @@ struct DeviceSegmentedSort
            EndOffsetIteratorT d_end_offsets,
            cudaStream_t stream = 0)
   {
-    constexpr bool is_descending = false;
+    constexpr bool is_descending     = false;
+    constexpr bool is_stable         = false;
     constexpr bool is_overwrite_okay = false;
     using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
                                             KeyT,
                                             ValueT,
                                             int,
@@ -1891,9 +1957,11 @@ struct DeviceSegmentedSort
                       EndOffsetIteratorT d_end_offsets,
                       cudaStream_t stream = 0)
   {
-    constexpr bool is_descending = true;
+    constexpr bool is_descending     = true;
+    constexpr bool is_stable         = false;
     constexpr bool is_overwrite_okay = false;
     using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
                                             KeyT,
                                             ValueT,
                                             int,
@@ -2105,9 +2173,11 @@ struct DeviceSegmentedSort
             EndOffsetIteratorT d_end_offsets,
             cudaStream_t stream = 0)
   {
-    constexpr bool is_descending = false;
+    constexpr bool is_descending     = false;
+    constexpr bool is_stable         = false;
     constexpr bool is_overwrite_okay = true;
     using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
                                             KeyT,
                                             ValueT,
                                             int,
@@ -2309,9 +2379,11 @@ struct DeviceSegmentedSort
                       EndOffsetIteratorT d_end_offsets,
                       cudaStream_t stream = 0)
   {
-    constexpr bool is_descending = true;
+    constexpr bool is_descending     = true;
+    constexpr bool is_stable         = false;
     constexpr bool is_overwrite_okay = true;
     using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
                                             KeyT,
                                             ValueT,
                                             int,
@@ -2509,20 +2581,30 @@ struct DeviceSegmentedSort
                   EndOffsetIteratorT d_end_offsets,
                   cudaStream_t stream = 0)
   {
-    return SortPairs<KeyT,
-                     ValueT,
-                     BeginOffsetIteratorT,
-                     EndOffsetIteratorT>(d_temp_storage,
-                                         temp_storage_bytes,
-                                         d_keys_in,
-                                         d_keys_out,
-                                         d_values_in,
-                                         d_values_out,
-                                         num_items,
-                                         num_segments,
-                                         d_begin_offsets,
-                                         d_end_offsets,
-                                         stream);
+    constexpr bool is_descending     = false;
+    constexpr bool is_stable         = true;
+    constexpr bool is_overwrite_okay = false;
+    using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
+                                            KeyT,
+                                            ValueT,
+                                            int,
+                                            BeginOffsetIteratorT,
+                                            EndOffsetIteratorT>;
+
+    DoubleBuffer<KeyT> d_keys(const_cast<KeyT *>(d_keys_in), d_keys_out);
+    DoubleBuffer<ValueT> d_values(const_cast<ValueT *>(d_values_in), d_values_out);
+
+    return DispatchT::Dispatch(d_temp_storage,
+                               temp_storage_bytes,
+                               d_keys,
+                               d_values,
+                               num_items,
+                               num_segments,
+                               d_begin_offsets,
+                               d_end_offsets,
+                               is_overwrite_okay,
+                               stream);
   }
 
   template <typename KeyT,
@@ -2706,20 +2788,30 @@ struct DeviceSegmentedSort
                             EndOffsetIteratorT d_end_offsets,
                             cudaStream_t stream = 0)
   {
-    return SortPairsDescending<KeyT,
-                               ValueT,
-                               BeginOffsetIteratorT,
-                               EndOffsetIteratorT>(d_temp_storage,
-                                                   temp_storage_bytes,
-                                                   d_keys_in,
-                                                   d_keys_out,
-                                                   d_values_in,
-                                                   d_values_out,
-                                                   num_items,
-                                                   num_segments,
-                                                   d_begin_offsets,
-                                                   d_end_offsets,
-                                                   stream);
+    constexpr bool is_descending     = true;
+    constexpr bool is_stable         = true;
+    constexpr bool is_overwrite_okay = false;
+    using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
+                                            KeyT,
+                                            ValueT,
+                                            int,
+                                            BeginOffsetIteratorT,
+                                            EndOffsetIteratorT>;
+
+    DoubleBuffer<KeyT> d_keys(const_cast<KeyT *>(d_keys_in), d_keys_out);
+    DoubleBuffer<ValueT> d_values(const_cast<ValueT *>(d_values_in), d_values_out);
+
+    return DispatchT::Dispatch(d_temp_storage,
+                               temp_storage_bytes,
+                               d_keys,
+                               d_values,
+                               num_items,
+                               num_segments,
+                               d_begin_offsets,
+                               d_end_offsets,
+                               is_overwrite_okay,
+                               stream);
   }
 
   template <typename KeyT,
@@ -2913,18 +3005,27 @@ struct DeviceSegmentedSort
                   EndOffsetIteratorT d_end_offsets,
                   cudaStream_t stream = 0)
   {
-    return SortPairs<KeyT,
-                     ValueT,
-                     BeginOffsetIteratorT,
-                     EndOffsetIteratorT>(d_temp_storage,
-                                         temp_storage_bytes,
-                                         d_keys,
-                                         d_values,
-                                         num_items,
-                                         num_segments,
-                                         d_begin_offsets,
-                                         d_end_offsets,
-                                         stream);
+    constexpr bool is_descending     = false;
+    constexpr bool is_stable         = true;
+    constexpr bool is_overwrite_okay = true;
+    using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
+                                            KeyT,
+                                            ValueT,
+                                            int,
+                                            BeginOffsetIteratorT,
+                                            EndOffsetIteratorT>;
+
+    return DispatchT::Dispatch(d_temp_storage,
+                               temp_storage_bytes,
+                               d_keys,
+                               d_values,
+                               num_items,
+                               num_segments,
+                               d_begin_offsets,
+                               d_end_offsets,
+                               is_overwrite_okay,
+                               stream);
   }
 
   template <typename KeyT,
@@ -3111,18 +3212,27 @@ struct DeviceSegmentedSort
                             EndOffsetIteratorT d_end_offsets,
                             cudaStream_t stream = 0)
   {
-    return SortPairsDescending<KeyT,
-                               ValueT,
-                               BeginOffsetIteratorT,
-                               EndOffsetIteratorT>(d_temp_storage,
-                                                   temp_storage_bytes,
-                                                   d_keys,
-                                                   d_values,
-                                                   num_items,
-                                                   num_segments,
-                                                   d_begin_offsets,
-                                                   d_end_offsets,
-                                                   stream);
+    constexpr bool is_descending     = true;
+    constexpr bool is_stable         = true;
+    constexpr bool is_overwrite_okay = true;
+    using DispatchT = DispatchSegmentedSort<is_descending,
+                                            is_stable,
+                                            KeyT,
+                                            ValueT,
+                                            int,
+                                            BeginOffsetIteratorT,
+                                            EndOffsetIteratorT>;
+
+    return DispatchT::Dispatch(d_temp_storage,
+                               temp_storage_bytes,
+                               d_keys,
+                               d_values,
+                               num_items,
+                               num_segments,
+                               d_begin_offsets,
+                               d_end_offsets,
+                               is_overwrite_okay,
+                               stream);
   }
 
   template <typename KeyT,

--- a/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
@@ -107,6 +107,7 @@ CUB_NAMESPACE_BEGIN
  *   considered empty.
  */
 template <bool IS_DESCENDING,
+          bool IS_STABLE,
           typename ChainedPolicyT,
           typename KeyT,
           typename ValueT,
@@ -149,7 +150,7 @@ __launch_bounds__(ChainedPolicyT::ActivePolicy::LargeSegmentPolicy::BLOCK_THREAD
   using WarpReduceT = cub::WarpReduce<KeyT>;
 
   using AgentWarpMergeSortT =
-    AgentSubWarpSort<IS_DESCENDING, MediumPolicyT, KeyT, ValueT, OffsetT>;
+    AgentSubWarpSort<IS_DESCENDING, IS_STABLE, MediumPolicyT, KeyT, ValueT, OffsetT>;
 
   __shared__ union
   {
@@ -302,6 +303,7 @@ __launch_bounds__(ChainedPolicyT::ActivePolicy::LargeSegmentPolicy::BLOCK_THREAD
  *   considered empty.
  */
 template <bool IS_DESCENDING,
+          bool IS_STABLE,
           typename ChainedPolicyT,
           typename KeyT,
           typename ValueT,
@@ -335,10 +337,10 @@ __launch_bounds__(ChainedPolicyT::ActivePolicy::SmallAndMediumSegmentedSortPolic
   constexpr int threads_per_small_segment = SmallPolicyT::WARP_THREADS;
 
   using MediumAgentWarpMergeSortT =
-    AgentSubWarpSort<IS_DESCENDING, MediumPolicyT, KeyT, ValueT, OffsetT>;
+    AgentSubWarpSort<IS_DESCENDING, IS_STABLE, MediumPolicyT, KeyT, ValueT, OffsetT>;
 
   using SmallAgentWarpMergeSortT =
-    AgentSubWarpSort<IS_DESCENDING, SmallPolicyT, KeyT, ValueT, OffsetT>;
+    AgentSubWarpSort<IS_DESCENDING, IS_STABLE, SmallPolicyT, KeyT, ValueT, OffsetT>;
 
   constexpr auto segments_per_medium_block =
     static_cast<unsigned int>(SmallAndMediumPolicyT::SEGMENTS_PER_MEDIUM_BLOCK);
@@ -1088,6 +1090,7 @@ struct DeviceSegmentedSortPolicy
 };
 
 template <bool IS_DESCENDING,
+          bool IS_STABLE,
           typename KeyT,
           typename ValueT,
           typename OffsetT,
@@ -1450,6 +1453,7 @@ struct DispatchSegmentedSort : SelectedPolicy
                                            EndOffsetIteratorT,
                                            OffsetT>,
             DeviceSegmentedSortKernelSmall<IS_DESCENDING,
+                                           IS_STABLE,
                                            MaxPolicyT,
                                            KeyT,
                                            ValueT,
@@ -1473,6 +1477,7 @@ struct DispatchSegmentedSort : SelectedPolicy
 
         error = SortWithoutPartitioning<LargeSegmentPolicyT>(
           DeviceSegmentedSortFallbackKernel<IS_DESCENDING,
+                                            IS_STABLE,
                                             MaxPolicyT,
                                             KeyT,
                                             ValueT,

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -81,6 +81,8 @@ struct InequalityWrapper
 #if _CCCL_STD_VER > 2011
 using Equality = ::cuda::std::equal_to<>;
 using Inequality = ::cuda::std::not_equal_to<>;
+using Less = ::cuda::std::less<>;
+using Greater = ::cuda::std::greater<>;
 using Sum = ::cuda::std::plus<>;
 using Difference = ::cuda::std::minus<>;
 using Division = ::cuda::std::divides<>;
@@ -104,6 +106,28 @@ struct Inequality
   _CCCL_HOST_DEVICE _CCCL_FORCEINLINE bool operator()(T &&t, U &&u) const
   {
     return ::cuda::std::forward<T>(t) != ::cuda::std::forward<U>(u);
+  }
+};
+
+/// @brief Default less functor
+struct Less
+{
+  /// Boolean less operator, returns `t < u`
+  template <typename T, typename U>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE bool operator()(T &&t, U &&u) const
+  {
+    return ::cuda::std::forward<T>(t) < ::cuda::std::forward<U>(u);
+  }
+};
+
+/// @brief Default greater functor
+struct Greater
+{
+  /// Boolean greater operator, returns `t > u`
+  template <typename T, typename U>
+  _CCCL_HOST_DEVICE _CCCL_FORCEINLINE bool operator()(T &&t, U &&u) const
+  {
+    return ::cuda::std::forward<T>(t) > ::cuda::std::forward<U>(u);
   }
 };
 

--- a/cub/cub/thread/thread_sort.cuh
+++ b/cub/cub/thread/thread_sort.cuh
@@ -46,6 +46,12 @@
 
 CUB_NAMESPACE_BEGIN
 
+template <typename IntT>
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr IntT NetworkDegree(IntT n, IntT m = IntT{1})
+{
+  return (m < n) ? NetworkDegree(n, m * 2) + 1 : 0;
+}
+
 template <typename T>
 _CCCL_DEVICE _CCCL_FORCEINLINE void Swap(T& lhs, T& rhs)
 {
@@ -116,7 +122,8 @@ SPECIALIZE_SORT_DESC(float)
  *   Value type. If `cub::NullType` is used as `ValueT`, only keys are sorted.
  *
  * @tparam CompareOp
- *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`
+ *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
+ *   `CompareOp` is a model of [Strict Weak Ordering].
  *
  * @tparam ITEMS_PER_THREAD
  *   The number of items per thread
@@ -130,6 +137,8 @@ SPECIALIZE_SORT_DESC(float)
  * @param[in] compare_op
  *   Comparison function object which returns true if the first argument is
  *   ordered before the second
+ *
+ * [Strict Weak Ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
  */
 template <typename KeyT, typename ValueT, typename CompareOp, int ITEMS_PER_THREAD>
 _CCCL_DEVICE _CCCL_FORCEINLINE void
@@ -144,6 +153,145 @@ StableOddEvenSort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_THRE
       CompareSwap(keys[j], keys[j + 1], items[j], items[j + 1], compare_op);
     } // inner loop
   } // outer loop
+}
+
+/**
+ * @brief Sorts data using Ian Parberry's pairwise sorting network
+ *
+ * The sorting method is not stable. Further details can be found in:
+ * Ian Parberry, "The Pairwise Sorting Network". Parallel Processing Letters,
+ * Vol. 2, No. 2,3, pp. 205-211, 1992.
+ * https://ianparberry.com/pubs/pairwise.pdf
+ *
+ * The complexity is O(N log^2(N)), as opposed to O(N^2) for the stable odd-even
+ * transposition sort. E.g. for N=16, pairwise is 2x faster; for N=64, 4x faster.
+ *
+ * This method generally outperforms Batcher's odd-even mergesort, especially
+ * for selection (top-k or median), as larger parts of the sorting network can be
+ * pruned by compiler optimizations.
+ *
+ * @tparam KeyT
+ *   Key type
+ *
+ * @tparam ValueT
+ *   Value type. If `cub::NullType` is used as `ValueT`, only keys are sorted.
+ *
+ * @tparam CompareOp
+ *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
+ *   `CompareOp` is a model of [Strict Weak Ordering].
+ *
+ * @tparam ITEMS_PER_THREAD
+ *   The number of items per thread
+ *
+ * @param[in,out] keys
+ *   Keys to sort
+ *
+ * @param[in,out] items
+ *   Values to sort
+ *
+ * @param[in] compare_op
+ *   Comparison function object which returns true if the first argument is
+ *   ordered before the second
+ *
+ * [Strict Weak Ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
+ */
+template <typename KeyT, typename ValueT, typename CompareOp, int ITEMS_PER_THREAD>
+_CCCL_DEVICE _CCCL_FORCEINLINE void
+PairwiseSort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_THREAD], CompareOp compare_op)
+{
+  constexpr int N = ITEMS_PER_THREAD;
+  constexpr int D = NetworkDegree(N);
+  constexpr int M = 1 << D; // Smallest power of two greater than N
+
+#pragma unroll
+  for (int i = 1; i < M; i *= 2)
+  {
+#pragma unroll
+    for (int j = 0; j < i; j++)
+    {
+#pragma unroll
+      for (int idx_lhs = j; idx_lhs < N - i; idx_lhs += 2 * i)
+      {
+        const int idx_rhs = idx_lhs + i;
+        CompareSwap(keys[idx_lhs], keys[idx_rhs], items[idx_lhs], items[idx_rhs], compare_op);
+      }
+    }
+  }
+
+#pragma unroll
+  for (int p = 0; p < D - 1; p++)
+  {
+    const int i = M >> (p + 2);
+    const int k = (1 << (p + 1)) - 1;
+#pragma unroll
+    for (int j = k; j > 0; j /= 2)
+    {
+      const int delta = i * j;
+#pragma unroll
+      for (int idx_lhs = 0; idx_lhs < N; idx_lhs++)
+      {
+        if ((idx_lhs / i) % 2 == 1)
+        {
+          int idx_rhs = idx_lhs + delta;
+          if (idx_rhs < N)
+          {
+            CompareSwap(keys[idx_lhs], keys[idx_rhs], items[idx_lhs], items[idx_rhs], compare_op);
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @brief Sorts data using a sorting network
+ *
+ * Wraps around stable and unstable methods. When stability is not required, setting IS_STABLE
+ * to false generally offers better performance.
+ *
+ * For all methods, it is valid to pad `keys` to the right with a key M such that there is no
+ * key K in `keys` that satisfies compare_op(M, K).
+ *
+ * @tparam KeyT
+ *   Key type
+ *
+ * @tparam ValueT
+ *   Value type. If `cub::NullType` is used as `ValueT`, only keys are sorted.
+ *
+ * @tparam CompareOp
+ *   functor type having member `bool operator()(KeyT lhs, KeyT rhs)`.
+ *   `CompareOp` is a model of [Strict Weak Ordering].
+ *
+ * @tparam ITEMS_PER_THREAD
+ *   The number of items per thread
+ *
+ * @tparam IS_STABLE
+ *   Whether to use a stable sorting method.
+ *
+ * @param[in,out] keys
+ *   Keys to sort
+ *
+ * @param[in,out] items
+ *   Values to sort
+ *
+ * @param[in] compare_op
+ *   Comparison function object which returns true if the first argument is
+ *   ordered before the second
+ *
+ * [Strict Weak Ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
+ */
+template <typename KeyT, typename ValueT, typename CompareOp, int ITEMS_PER_THREAD, bool IS_STABLE>
+_CCCL_DEVICE _CCCL_FORCEINLINE void
+ThreadNetworkSort(KeyT (&keys)[ITEMS_PER_THREAD], ValueT (&items)[ITEMS_PER_THREAD], CompareOp compare_op)
+{
+  CUB_IF_CONSTEXPR(IS_STABLE)
+  {
+    StableOddEvenSort(keys, items, compare_op);
+  }
+  else
+  {
+    PairwiseSort(keys, items, compare_op);
+  }
 }
 
 CUB_NAMESPACE_END

--- a/cub/test/c2h/generators.cu
+++ b/cub/test/c2h/generators.cu
@@ -144,6 +144,23 @@ struct random_to_item_t<T, cub::FLOATING_POINT>
   }
 };
 
+template <>
+struct random_to_item_t<bool, cub::Traits<bool>::CATEGORY>
+{
+  float m_min;
+  float m_max;
+
+  __host__ __device__ random_to_item_t(bool min, bool max)
+      : m_min(static_cast<float>(min))
+      , m_max(static_cast<float>(max))
+  {}
+
+  __device__ bool operator()(float random_value)
+  {
+    return random_value < 0.5f * (m_min + m_max);
+  }
+};
+
 template <typename T, int VecItem>
 struct random_to_vec_item_t;
 

--- a/cub/test/catch2_test_warp_merge_sort.cu
+++ b/cub/test/catch2_test_warp_merge_sort.cu
@@ -39,7 +39,7 @@
 struct CustomLess
 {
   template <typename T>
-  __device__ __host__ bool operator()(const T &lhs, const T &rhs)
+  __device__ __host__ inline bool operator()(const T &lhs, const T &rhs) const
   {
     return lhs < rhs;
   }
@@ -174,6 +174,7 @@ __global__ void warp_merge_sort_kernel(KeyT *keys_in,
 /**
  * @brief Delegate wrapper for WarpMergeSort::StableSort on keys-only
  */
+template <class CompareOp>
 struct warp_stable_sort_keys_t
 {
   template <typename T, int ITEMS_PER_THREAD, typename WarpSortT>
@@ -182,13 +183,14 @@ struct warp_stable_sort_keys_t
                              int /*valid_items*/,
                              T /*oob_default*/) const
   {
-    warp_sort.StableSort(thread_data, CustomLess{});
+    warp_sort.StableSort(thread_data, CompareOp{});
   }
 };
 
 /**
  * @brief Delegate wrapper for partial WarpMergeSort::StableSort keys-only
  */
+template <class CompareOp>
 struct warp_partial_stable_sort_keys_t
 {
   template <typename T, int ITEMS_PER_THREAD, typename WarpSortT>
@@ -197,13 +199,14 @@ struct warp_partial_stable_sort_keys_t
                              int valid_items,
                              T oob_default) const
   {
-    warp_sort.StableSort(thread_data, CustomLess{}, valid_items, oob_default);
+    warp_sort.StableSort(thread_data, CompareOp{}, valid_items, oob_default);
   }
 };
 
 /**
  * @brief Delegate wrapper for WarpMergeSort::Sort on keys-only
  */
+template <class CompareOp>
 struct warp_sort_keys_t
 {
   template <typename T, int ITEMS_PER_THREAD, typename WarpSortT>
@@ -212,13 +215,14 @@ struct warp_sort_keys_t
                              int /*valid_items*/,
                              T /*oob_default*/) const
   {
-    warp_sort.Sort(thread_data, CustomLess{});
+    warp_sort.Sort(thread_data, CompareOp{});
   }
 };
 
 /**
  * @brief Delegate wrapper for partial WarpMergeSort::StableSort keys-only
  */
+template <class CompareOp>
 struct warp_partial_sort_keys_t
 {
   template <typename T, int ITEMS_PER_THREAD, typename WarpSortT>
@@ -227,13 +231,14 @@ struct warp_partial_sort_keys_t
                              int valid_items,
                              T oob_default) const
   {
-    warp_sort.Sort(thread_data, CustomLess{}, valid_items, oob_default);
+    warp_sort.Sort(thread_data, CompareOp{}, valid_items, oob_default);
   }
 };
 
 /**
  * @brief Delegate wrapper for WarpMergeSort::StableSort on key-value pairs
  */
+template <class CompareOp>
 struct warp_stable_sort_pairs_t
 {
   template <typename KeyT, typename ValueT, int ITEMS_PER_THREAD, typename WarpSortT>
@@ -243,13 +248,14 @@ struct warp_stable_sort_pairs_t
                              int /*valid_items*/,
                              KeyT /*oob_default*/) const
   {
-    warp_sort.StableSort(keys, values, CustomLess{});
+    warp_sort.StableSort(keys, values, CompareOp{});
   }
 };
 
 /**
  * @brief Delegate wrapper for partial WarpMergeSort::StableSort key-value pairs
  */
+template <class CompareOp>
 struct warp_partial_stable_sort_pairs_t
 {
   template <typename KeyT, typename ValueT, int ITEMS_PER_THREAD, typename WarpSortT>
@@ -259,13 +265,14 @@ struct warp_partial_stable_sort_pairs_t
                              int valid_items,
                              KeyT oob_default) const
   {
-    warp_sort.StableSort(keys, values, CustomLess{}, valid_items, oob_default);
+    warp_sort.StableSort(keys, values, CompareOp{}, valid_items, oob_default);
   }
 };
 
 /**
  * @brief Delegate wrapper for WarpMergeSort::Sort on key-value pairs
  */
+template <class CompareOp>
 struct warp_sort_pairs_t
 {
   template <typename KeyT, typename ValueT, int ITEMS_PER_THREAD, typename WarpSortT>
@@ -275,13 +282,14 @@ struct warp_sort_pairs_t
                              int /*valid_items*/,
                              KeyT /*oob_default*/) const
   {
-    warp_sort.Sort(keys, values, CustomLess{});
+    warp_sort.Sort(keys, values, CompareOp{});
   }
 };
 
 /**
  * @brief Delegate wrapper for partial WarpMergeSort::StableSort key-value pairs
  */
+template <class CompareOp>
 struct warp_partial_sort_pairs_t
 {
   template <typename KeyT, typename ValueT, int ITEMS_PER_THREAD, typename WarpSortT>
@@ -291,7 +299,7 @@ struct warp_partial_sort_pairs_t
                              int valid_items,
                              KeyT oob_default) const
   {
-    warp_sort.Sort(keys, values, CustomLess{}, valid_items, oob_default);
+    warp_sort.Sort(keys, values, CompareOp{}, valid_items, oob_default);
   }
 };
 
@@ -356,17 +364,18 @@ void warp_merge_sort(c2h::device_vector<KeyT> &keys_in,
  * @brief Performs a stable sort on per-warp segments of data and assigns oob_default to items that
  * are out-of-bounds.
  */
-template <typename RandomItT, typename SegmentSizeItT, typename T>
-void compute_host_reference(RandomItT h_data,
-                            SegmentSizeItT segment_sizes,
-                            unsigned int num_segments,
-                            T oob_default,
-                            int logical_warp_items)
+template <typename RandomItT, typename SegmentSizeItT, typename T, typename CompareOp>
+void compute_stable_host_reference(RandomItT h_data,
+                                   SegmentSizeItT segment_sizes,
+                                   unsigned int num_segments,
+                                   T oob_default,
+                                   int logical_warp_items,
+                                   CompareOp compare_op)
 {
   for (unsigned int segment_id = 0; segment_id < num_segments; segment_id++)
   {
     unsigned int segment_size = segment_sizes[segment_id];
-    std::stable_sort(h_data, h_data + segment_size);
+    std::stable_sort(h_data, h_data + segment_size, compare_op);
     std::fill(h_data + segment_size, h_data + logical_warp_items, oob_default);
     h_data += logical_warp_items;
   }
@@ -420,8 +429,9 @@ CUB_TEST("Warp sort on keys-only works",
 {
   using params = params_t<TestType>;
   using type   = typename params::type;
+  using CompareOp = CustomLess;
   using warp_sort_delegate =
-    cub::detail::conditional_t<params::is_stable, warp_stable_sort_keys_t, warp_sort_keys_t>;
+    cub::detail::conditional_t<params::is_stable, warp_stable_sort_keys_t<CompareOp>, warp_sort_keys_t<CompareOp>>;
 
   // Prepare test data
   c2h::device_vector<type> d_in(params::tile_size);
@@ -438,16 +448,33 @@ CUB_TEST("Warp sort on keys-only works",
     oob_default,
     warp_sort_delegate{});
 
-  // Prepare verification data
-  c2h::host_vector<type> h_in_out = d_in;
-  compute_host_reference(h_in_out.begin(),
-                         segment_sizes,
-                         params::total_warps,
-                         oob_default,
-                         params::logical_warp_items);
+  if(params::is_stable) {
+    c2h::host_vector<type> h_in_out = d_in;
+    compute_stable_host_reference(h_in_out.begin(),
+                                  segment_sizes,
+                                  params::total_warps,
+                                  oob_default,
+                                  params::logical_warp_items,
+                                  CompareOp{});
 
-  // Verify results
-  REQUIRE(h_in_out == d_out);
+    REQUIRE(h_in_out == d_out);
+  } else {
+    c2h::host_vector<type> h_in = d_in;
+    c2h::host_vector<type> h_out = d_out;
+
+    for (unsigned int segment_id = 0; segment_id < params::total_warps; segment_id++) {
+      unsigned int segment_offset = params::logical_warp_items * segment_id;
+      unsigned int segment_size = params::logical_warp_items;
+
+      std::vector<type> h_in_segment(h_in.begin() + segment_offset,
+                                     h_in.begin() + segment_offset + segment_size);
+      std::vector<type> h_out_segment(h_out.begin() + segment_offset,
+                                      h_out.begin() + segment_offset + segment_size);
+
+      REQUIRE_THAT(h_out_segment, Catch::Matchers::UnorderedEquals(h_in_segment));
+      REQUIRE_SORTED(h_out_segment, CompareOp{});
+    }
+  }
 }
 
 CUB_TEST("Warp sort keys-only on partial warp-tile works",
@@ -459,8 +486,9 @@ CUB_TEST("Warp sort keys-only on partial warp-tile works",
 {
   using params             = params_t<TestType>;
   using type               = typename params::type;
+  using CompareOp = CustomLess;
   using warp_sort_delegate = cub::detail::
-    conditional_t<params::is_stable, warp_partial_stable_sort_keys_t, warp_partial_sort_keys_t>;
+    conditional_t<params::is_stable, warp_partial_stable_sort_keys_t<CompareOp>, warp_partial_sort_keys_t<CompareOp>>;
 
   // Prepare test data
   c2h::device_vector<type> d_in(params::tile_size);
@@ -478,17 +506,40 @@ CUB_TEST("Warp sort keys-only on partial warp-tile works",
     oob_default,
     warp_sort_delegate{});
 
-  // Prepare verification data
-  c2h::host_vector<type> h_in_out     = d_in;
   c2h::host_vector<int> segment_sizes = d_segment_sizes;
-  compute_host_reference(h_in_out.begin(),
-                         segment_sizes,
-                         params::total_warps,
-                         oob_default,
-                         params::logical_warp_items);
 
-  // Verify results
-  REQUIRE(h_in_out == d_out);
+  if(params::is_stable) {
+    c2h::host_vector<type> h_in_out = d_in;
+    compute_stable_host_reference(h_in_out.begin(),
+                          segment_sizes,
+                          params::total_warps,
+                          oob_default,
+                          params::logical_warp_items,
+                          CompareOp{});
+
+    REQUIRE(h_in_out == d_out);
+  } else {
+    c2h::host_vector<type> h_in = d_in;
+    c2h::host_vector<type> h_out = d_out;
+
+    for (unsigned int segment_id = 0; segment_id < params::total_warps; segment_id++) {
+      unsigned int segment_offset = params::logical_warp_items * segment_id;
+      unsigned int segment_size = segment_sizes[segment_id];
+
+      // Separate in-bounds and out-of-bounds parts
+      std::vector<type> h_in_ib(h_in.begin() + segment_offset,
+                                h_in.begin() + segment_offset + segment_size);
+      std::vector<type> h_out_ib(h_out.begin() + segment_offset,
+                                 h_out.begin() + segment_offset + segment_size);
+      std::vector<type> h_ref_oob(params::logical_warp_items - segment_size, oob_default);
+      std::vector<type> h_out_oob(h_out.begin() + segment_offset + segment_size,
+                                  h_out.begin() + segment_offset + params::logical_warp_items);
+
+      REQUIRE_THAT(h_out_ib, Catch::Matchers::UnorderedEquals(h_in_ib));
+      REQUIRE(h_out_oob == h_ref_oob);
+      REQUIRE_SORTED(h_out_ib, CompareOp{});
+    }
+  }
 }
 
 CUB_TEST("Warp sort on keys-value pairs works",
@@ -502,8 +553,9 @@ CUB_TEST("Warp sort on keys-value pairs works",
   using params     = params_t<TestType>;
   using key_type   = typename params::type;
   using value_type = typename c2h::get<4, TestType>;
+  using CompareOp = CustomLess;
   using warp_sort_delegate =
-    cub::detail::conditional_t<params::is_stable, warp_stable_sort_pairs_t, warp_sort_pairs_t>;
+    cub::detail::conditional_t<params::is_stable, warp_stable_sort_pairs_t<CompareOp>, warp_sort_pairs_t<CompareOp>>;
 
   // Prepare test data
   c2h::device_vector<key_type> d_keys_in(params::tile_size);
@@ -512,7 +564,8 @@ CUB_TEST("Warp sort on keys-value pairs works",
   c2h::device_vector<value_type> d_values_out(params::tile_size);
   auto segment_sizes     = thrust::make_constant_iterator(params::logical_warp_items);
   const auto oob_default = std::numeric_limits<key_type>::max();
-  c2h::gen(CUB_SEED(10), d_keys_in);
+  c2h::gen(CUB_SEED(3), d_keys_in);
+  c2h::gen(CUB_SEED(3), d_values_in);
 
   // Run test
   warp_merge_sort<params::items_per_thread, params::logical_warp_threads, params::total_warps>(
@@ -522,21 +575,52 @@ CUB_TEST("Warp sort on keys-value pairs works",
     d_values_out,
     segment_sizes,
     oob_default,
-    warp_stable_sort_pairs_t{});
+    warp_sort_delegate{});
 
-  // Prepare verification data
-  c2h::host_vector<key_type> h_keys_in_out     = d_keys_in;
-  c2h::host_vector<value_type> h_values_in_out = d_values_in;
-  auto cpu_kv_pairs = thrust::make_zip_iterator(h_keys_in_out.begin(), h_values_in_out.begin());
-  compute_host_reference(cpu_kv_pairs,
-                         segment_sizes,
-                         params::total_warps,
-                         thrust::make_tuple(oob_default, value_type{}),
-                         params::logical_warp_items);
+  if(params::is_stable) {
+    c2h::host_vector<key_type> h_keys_in_out     = d_keys_in;
+    c2h::host_vector<value_type> h_values_in_out = d_values_in;
+    auto cpu_kv_pairs = thrust::make_zip_iterator(h_keys_in_out.begin(), h_values_in_out.begin());
+    compute_stable_host_reference(cpu_kv_pairs,
+                                  segment_sizes,
+                                  params::total_warps,
+                                  thrust::make_tuple(oob_default, value_type{}),
+                                  params::logical_warp_items,
+                                  [](const thrust::tuple<key_type, value_type>& lhs, const thrust::tuple<key_type, value_type>& rhs) -> bool {
+                                    CompareOp compare_op;
+                                    return compare_op(thrust::get<0>(lhs), thrust::get<0>(rhs));
+                                  });
 
-  // Verify results
-  REQUIRE(h_keys_in_out == d_keys_out);
-  REQUIRE(h_values_in_out == d_values_out);
+    REQUIRE(h_keys_in_out == d_keys_out);
+    REQUIRE(h_values_in_out == d_values_out);
+  } else {
+    c2h::host_vector<key_type> h_keys_in      = d_keys_in;
+    c2h::host_vector<value_type> h_values_in  = d_values_in;
+    c2h::host_vector<key_type> h_keys_out     = d_keys_out;
+    c2h::host_vector<value_type> h_values_out = d_values_out;
+
+    for (unsigned int segment_id = 0; segment_id < params::total_warps; segment_id++) {
+      unsigned int segment_offset = params::logical_warp_items * segment_id;
+      unsigned int segment_size = params::logical_warp_items;
+
+      std::vector<std::pair<key_type, value_type>> h_pairs_in_segment(segment_size);
+      std::vector<std::pair<key_type, value_type>> h_pairs_out_segment(segment_size);
+      for(unsigned int item_id = 0; item_id < segment_size; item_id++) {
+        h_pairs_in_segment[item_id] = std::make_pair(h_keys_in[item_id + segment_offset],
+                                                     h_values_in[item_id + segment_offset]);
+        h_pairs_out_segment[item_id] = std::make_pair(h_keys_out[item_id + segment_offset],
+                                                      h_values_out[item_id + segment_offset]);
+      }
+
+      REQUIRE_THAT(h_pairs_out_segment, Catch::Matchers::UnorderedEquals(h_pairs_in_segment));
+      REQUIRE_SORTED(
+        h_pairs_out_segment,
+        [](const std::pair<key_type, value_type>& lhs, const std::pair<key_type, value_type>& rhs) -> bool {
+          CompareOp compare_op;
+          return compare_op(lhs.first, rhs.first);
+        });
+    }
+  }
 }
 
 CUB_TEST("Warp sort on key-value pairs of a partial warp-tile works",
@@ -550,8 +634,9 @@ CUB_TEST("Warp sort on key-value pairs of a partial warp-tile works",
   using params             = params_t<TestType>;
   using key_type           = typename params::type;
   using value_type         = typename c2h::get<4, TestType>;
+  using CompareOp = CustomLess;
   using warp_sort_delegate = cub::detail::
-    conditional_t<params::is_stable, warp_partial_stable_sort_pairs_t, warp_partial_sort_pairs_t>;
+    conditional_t<params::is_stable, warp_partial_stable_sort_pairs_t<CompareOp>, warp_partial_sort_pairs_t<CompareOp>>;
 
   // Prepare test data
   c2h::device_vector<key_type> d_keys_in(params::tile_size);
@@ -560,8 +645,9 @@ CUB_TEST("Warp sort on key-value pairs of a partial warp-tile works",
   c2h::device_vector<value_type> d_values_out(params::tile_size);
   c2h::device_vector<int> d_segment_sizes(params::total_warps);
   const auto oob_default = std::numeric_limits<key_type>::max();
-  c2h::gen(CUB_SEED(5), d_keys_in);
-  c2h::gen(CUB_SEED(5), d_segment_sizes, 0, params::logical_warp_items);
+  c2h::gen(CUB_SEED(3), d_keys_in);
+  c2h::gen(CUB_SEED(3), d_values_in);
+  c2h::gen(CUB_SEED(3), d_segment_sizes, 0, params::logical_warp_items);
 
   // Run test
   warp_merge_sort<params::items_per_thread, params::logical_warp_threads, params::total_warps>(
@@ -573,18 +659,59 @@ CUB_TEST("Warp sort on key-value pairs of a partial warp-tile works",
     oob_default,
     warp_sort_delegate{});
 
-  // Prepare verification data
-  c2h::host_vector<key_type> h_keys_in_out     = d_keys_in;
-  c2h::host_vector<value_type> h_values_in_out = d_values_in;
   c2h::host_vector<int> segment_sizes          = d_segment_sizes;
-  auto cpu_kv_pairs = thrust::make_zip_iterator(h_keys_in_out.begin(), h_values_in_out.begin());
-  compute_host_reference(cpu_kv_pairs,
-                         segment_sizes,
-                         params::total_warps,
-                         thrust::make_tuple(oob_default, value_type{}),
-                         params::logical_warp_items);
 
-  // Verify results
-  REQUIRE(h_keys_in_out == d_keys_out);
-  REQUIRE(h_values_in_out == d_values_out);
+  if(params::is_stable) {
+    c2h::host_vector<key_type> h_keys_in_out     = d_keys_in;
+    c2h::host_vector<value_type> h_values_in_out = d_values_in;
+    auto cpu_kv_pairs = thrust::make_zip_iterator(h_keys_in_out.begin(), h_values_in_out.begin());
+    compute_stable_host_reference(cpu_kv_pairs,
+                                  segment_sizes,
+                                  params::total_warps,
+                                  thrust::make_tuple(oob_default, value_type{}),
+                                  params::logical_warp_items,
+                                  [](const thrust::tuple<key_type, value_type>& lhs, const thrust::tuple<key_type, value_type>& rhs) -> bool {
+                                    CompareOp compare_op;
+                                    return compare_op(thrust::get<0>(lhs), thrust::get<0>(rhs));
+                                  });
+
+    REQUIRE(h_keys_in_out == d_keys_out);
+    REQUIRE(h_values_in_out == d_values_out);
+  } else {
+    c2h::host_vector<key_type> h_keys_in      = d_keys_in;
+    c2h::host_vector<value_type> h_values_in  = d_values_in;
+    c2h::host_vector<key_type> h_keys_out     = d_keys_out;
+    c2h::host_vector<value_type> h_values_out = d_values_out;
+
+    for (unsigned int segment_id = 0; segment_id < params::total_warps; segment_id++) {
+      unsigned int segment_offset = params::logical_warp_items * segment_id;
+      unsigned int segment_size = segment_sizes[segment_id];
+
+      std::vector<std::pair<key_type, value_type>> h_pairs_in_ib(segment_size);
+      std::vector<std::pair<key_type, value_type>> h_pairs_out_ib(segment_size);
+      for(unsigned int item_id = 0; item_id < segment_size; item_id++) {
+        h_pairs_in_ib[item_id] = std::make_pair(h_keys_in[item_id + segment_offset],
+                                                h_values_in[item_id + segment_offset]);
+        h_pairs_out_ib[item_id] = std::make_pair(h_keys_out[item_id + segment_offset],
+                                                 h_values_out[item_id + segment_offset]);
+      }
+      std::vector<std::pair<key_type, value_type>> h_pairs_ref_oob(
+        params::logical_warp_items - segment_size, std::make_pair(oob_default, value_type{}));
+      std::vector<std::pair<key_type, value_type>> h_pairs_out_oob(
+        params::logical_warp_items - segment_size);
+      for(unsigned int item_id = 0; item_id < params::logical_warp_items - segment_size; item_id++) {
+        h_pairs_out_oob[item_id] = std::make_pair(h_keys_out[item_id + segment_offset + segment_size],
+                                                  h_values_out[item_id + segment_offset + segment_size]);
+      }
+
+      REQUIRE_THAT(h_pairs_out_ib, Catch::Matchers::UnorderedEquals(h_pairs_in_ib));
+      REQUIRE(h_pairs_out_oob == h_pairs_ref_oob);
+      REQUIRE_SORTED(
+        h_pairs_out_ib,
+        [](const std::pair<key_type, value_type>& lhs, const std::pair<key_type, value_type>& rhs) -> bool {
+          CompareOp compare_op;
+          return compare_op(lhs.first, rhs.first);
+        });
+    }
+  }
 }

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -53,6 +53,7 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "c2h/extended_types.cuh"

--- a/cub/test/test_util_sort.h
+++ b/cub/test/test_util_sort.h
@@ -1,0 +1,111 @@
+/******************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <set>
+#include <utility>
+
+/**
+ * Check that an array is a permutation of another.
+ */
+template <typename KeyT>
+bool IsPermutationOf(const KeyT* h_keys0, const KeyT* h_keys1, size_t size)
+{
+  std::multiset<KeyT> key_set;
+
+  // Add elements of the first array to the multiset.
+  for (size_t i = 0; i < size; i++)
+  {
+    key_set.insert(h_keys0[i]);
+  }
+
+  // Remove elements of the second array from the multiset, return false
+  // if not found.
+  for (size_t i = 0; i < size; i++)
+  {
+    auto it = key_set.find(h_keys1[i]);
+    if (it == key_set.end())
+    {
+      return false;
+    }
+    key_set.erase(it);
+  }
+
+  return true;
+}
+
+/**
+ * Check that the key-value pairs from two arrays are a permutation of the
+ * key-value pairs from two other arrays.
+ */
+template <typename KeyT, typename ValueT>
+bool IsPermutationOf(
+  const KeyT* h_keys0, const KeyT* h_keys1, const ValueT* h_values0, const ValueT* h_values1, size_t size)
+{
+  std::multiset<std::pair<KeyT, ValueT>> key_set;
+
+  // Add pairs of the first array pair to the multiset.
+  for (size_t i = 0; i < size; i++)
+  {
+    key_set.insert(std::make_pair(h_keys0[i], h_values0[i]));
+  }
+
+  // Remove pairs of the second array pair from the multiset, return false
+  // if not found.
+  for (size_t i = 0; i < size; i++)
+  {
+    auto it = key_set.find(std::make_pair(h_keys1[i], h_values1[i]));
+    if (it == key_set.end())
+    {
+      return false;
+    }
+    key_set.erase(it);
+  }
+
+  return true;
+}
+
+/**
+ * Check that keys are sorted according to the given comparison operator.
+ */
+template <typename RandomItT, typename CompareOp>
+bool IsSorted(RandomItT data_begin, RandomItT data_end, const CompareOp& compare_op)
+{
+  if (data_begin == data_end)
+  {
+    return true;
+  }
+  for (auto it = data_begin; it + 1 != data_end; it++)
+  {
+    if (compare_op(*(it + 1), *it))
+    {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Description

closes #1551 

Changes:
 - Faster unstable thread sort using Parberry's pairwise method.
 - Faster unstable block merge sort using the unstable thread sort.
 - Faster unstable device segmented sort using the unstable warp/block merge sort.
 - Faster unstable device merge sort using the unstable block merge sort.
 - Introduce `cub:Less` and `cub::Greater` operators and provide specializations of compare-swap to improve fp32 key-only sorting performance using min/max instead of predicate.
 - Stable device merge sort and segmented sort were using unstable block merge sort APIs, now they're dispatching to the appropriate block-level APIs.

Testing improvements/bug fixes:
 - `test_thread_sort` was casting the values to KeyT.
 - `test_warp_merge_sort` was comparing sort-pairs-by-key to a lexicographic ref sort.
 - `test_warp_merge_sort` was comparing stable and unstable variants to a stable ref sort.
 - `test_warp_merge_sort` did not generate the values, they were all 0...
 - `test_block_merge_sort` was only testing stable APIs.
 - `test_block_merge_sort` was not testing inputs for which stability is relevant (drawing random int32_t keys has a very small chance of conflict).
 - `test_device_segmented_sort` tested the unstable sort against a stable reference sort.
 - Sort tests were only testing a trivial less operator, and thus not testing the genericity of the implementation.

Future work (in follow-up PRs):
 - Make device merge sort policy templated on `IS_STABLE`, and re-tune.
 - Make device segmented sort policy templated on `IS_STABLE`, and re-tune.
 - Look at the performance of the merging part in block merge sort (Batcher's odd-even mergesort was outperforming it in a quick micro-benchmark I did)

Misc notes:
 - I just found out about #1484, changes on the segmented sort tests will conflict.
 - I have hardcoded `is_stable = true` in the benchmarks but ideally, we'd want to benchmark both. What would be the best way to do that? (a) add a new set; (b) add a boolean axis; (c) a separate benchmark (quite redundant).

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
