### PR TITLE
fix missing __device__ hint in WarpMergeSort Documentation

### DIFF
--- a/cub/cub/warp/warp_merge_sort.cuh
+++ b/cub/cub/warp/warp_merge_sort.cuh
@@ -69,7 +69,7 @@ CUB_NAMESPACE_BEGIN
 //!    struct CustomLess
 //!    {
 //!      template <typename DataType>
-//!      __device__ __host__ bool operator()(const DataType &lhs, const DataType &rhs)
+//!      __device__ bool operator()(const DataType &lhs, const DataType &rhs)
 //!      {
 //!        return lhs < rhs;
 //!      }

--- a/cub/cub/warp/warp_merge_sort.cuh
+++ b/cub/cub/warp/warp_merge_sort.cuh
@@ -69,7 +69,7 @@ CUB_NAMESPACE_BEGIN
 //!    struct CustomLess
 //!    {
 //!      template <typename DataType>
-//!      __host__ bool operator()(const DataType &lhs, const DataType &rhs)
+//!      __device__ __host__ bool operator()(const DataType &lhs, const DataType &rhs)
 //!      {
 //!        return lhs < rhs;
 //!      }


### PR DESCRIPTION
## Description

Fix missing `__device__` in WarpMergeSort documentation

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
