### PR TITLE
Ensure that `cuda::aligned_size_t` is usable in a constexpr context

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/barrier.h
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__cuda/barrier.h
@@ -46,14 +46,18 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 template<thread_scope _Scope>
 class pipeline;
 
-template<_CUDA_VSTD::size_t _Alignment>
-struct aligned_size_t {
-    static constexpr _CUDA_VSTD::size_t align = _Alignment;
-    _CUDA_VSTD::size_t value;
-    _LIBCUDACXX_INLINE_VISIBILITY
-    explicit aligned_size_t(size_t __s) : value(__s) { }
-    _LIBCUDACXX_INLINE_VISIBILITY
-    operator size_t() const { return value; }
+template <_CUDA_VSTD::size_t _Alignment>
+struct aligned_size_t
+{
+  static constexpr _CUDA_VSTD::size_t align = _Alignment;
+  _CUDA_VSTD::size_t value;
+  _LIBCUDACXX_INLINE_VISIBILITY explicit constexpr aligned_size_t(size_t __s)
+      : value(__s)
+  {}
+  _LIBCUDACXX_INLINE_VISIBILITY constexpr operator size_t() const
+  {
+    return value;
+  }
 };
 
 // Type only used for logging purpose

--- a/libcudacxx/test/libcudacxx/cuda/barrier/aligned_size_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/aligned_size_t.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: libcpp-has-no-threads
+// UNSUPPORTED: pre-sm-70
+
+// <cuda/barrier>
+
+#include <cuda/barrier>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+__host__ __device__ TEST_CONSTEXPR_CXX14 bool test() {
+    using aligned_t = cuda::aligned_size_t<1>;
+    static_assert(!cuda::std::is_default_constructible<aligned_t>::value, "");
+    static_assert(aligned_t::align == 1, "");
+    {
+        const aligned_t aligned{42};
+        assert(aligned.value == 42);
+        assert(static_cast<cuda::std::size_t>(aligned) == 42);
+    }
+    return true;
+}
+
+// test C++11 differently
+static_assert(cuda::aligned_size_t<42>{1337}.value == 1337, "");
+
+int main(int, char**)
+{
+    test();
+#if TEST_STD_VER >= 2014
+    static_assert(test(), "");
+#endif // TEST_STD_VER >= 2014
+    return 0;
+}


### PR DESCRIPTION
Fixes [BUG]: `aligned_size_t` constructor and conversion operator are not constexpr #1563
