### PR TITLE
Group CUB docs

### DIFF
--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -192,12 +192,14 @@ private:
   // Whether or not there are values to be trucked along with keys
   static constexpr bool KEYS_ONLY = ::cuda::std::is_same<ValueT, NullType>::value;
 
+  #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
   /// Shared memory type required by this thread block
   union _TempStorage
   {
     KeyT keys_shared[ITEMS_PER_TILE + 1];
     ValueT items_shared[ITEMS_PER_TILE + 1];
   }; // union TempStorage
+  #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   /// Shared storage reference
   _TempStorage &temp_storage;

--- a/cub/cub/block/block_radix_sort.cuh
+++ b/cub/cub/block/block_radix_sort.cuh
@@ -284,6 +284,7 @@ private:
     /// BlockExchange utility type for values
     typedef BlockExchange<ValueT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchangeValues;
 
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
     /// Shared memory storage layout type
     union _TempStorage
     {
@@ -292,6 +293,7 @@ private:
         typename BlockExchangeKeys::TempStorage        exchange_keys;
         typename BlockExchangeValues::TempStorage      exchange_values;
     };
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 
     /******************************************************************************

--- a/cub/cub/block/block_run_length_decode.cuh
+++ b/cub/cub/block/block_run_length_decode.cuh
@@ -171,6 +171,7 @@ private:
   /// Type used to index into the block's runs
   using RunOffsetT = uint32_t;
 
+  #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
   /// Shared memory type required by this thread block
   union _TempStorage
   {
@@ -181,6 +182,7 @@ private:
       DecodedOffsetT run_offsets[BLOCK_RUNS];
     } runs;
   }; // union TempStorage
+  #endif // DOXYGEN_SHOULD_SKIP_THIS
 
   /// Internal storage allocator (used when the user does not provide pre-allocated shared memory)
   _CCCL_DEVICE _CCCL_FORCEINLINE _TempStorage &PrivateStorage()

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -1289,6 +1289,7 @@ public:
     //! @}  end member group
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 template <class Policy,
           class It,
           class T = cub::detail::value_t<It>>
@@ -1299,6 +1300,7 @@ struct BlockStoreType
                                Policy::ITEMS_PER_THREAD,
                                Policy::STORE_ALGORITHM>;
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 CUB_NAMESPACE_END
 

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -295,6 +295,7 @@ CUB_RUNTIME_FUNCTION inline int CurrentDevice()
     return device;
 }
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 /**
  * \brief RAII helper which saves the current device and switches to the
  *        specified device on construction and switches to the saved device on
@@ -319,6 +320,7 @@ public:
             CubDebug(cudaSetDevice(old_device));
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * \brief Returns the number of CUDA devices available or -1 if an error
@@ -377,6 +379,7 @@ CUB_RUNTIME_FUNCTION inline int DeviceCount()
     return result;
 }
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 /**
  * \brief Per-device cache for a CUDA attribute value; the attribute is queried
  *        and stored for each device upon construction.
@@ -485,6 +488,7 @@ public:
         return entry.payload;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * \brief Retrieves the PTX version that will be used on the current device (major * 100 + minor * 10).

--- a/cub/docs/block_wide.rst
+++ b/cub/docs/block_wide.rst
@@ -1,4 +1,6 @@
-Block-wide
+.. _block-module:
+
+Block-Wide "Collective" Primitives
 ==================================================
 
 .. toctree::
@@ -8,9 +10,17 @@ Block-wide
 
    ${repo_docs_api_path}/*Block*
 
-.. _block-module:
+CUB block-level algorithms are specialized for execution by threads in the same CUDA thread block:
 
-**Block-wide "collective" primitives**
-
-* Cooperative I/O, sort, scan, reduction, histogram, etc.  
-* Compatible with arbitrary thread block sizes and types 
+* :cpp:class:`cub::BlockAdjacentDifference <cub::BlockAdjacentDifference>` computes the difference between adjacent items partitioned across a CUDA thread block
+* :cpp:class:`cub::BlockDiscontinuity <cub::BlockDiscontinuity>` flags discontinuities within an ordered set of items partitioned across a CUDA thread block
+* :cpp:struct:`cub::BlockExchange <cub::BlockExchange>` rearranges data partitioned across a CUDA thread block
+* :cpp:class:`cub::BlockHistogram <cub::BlockHistogram>` constructs block-wide histograms from data samples partitioned across a CUDA thread block
+* :cpp:class:`cub::BlockLoad <cub::BlockLoad>` loads a linear segment of items from memory into a CUDA thread block
+* :cpp:class:`cub::BlockMergeSort <cub::BlockMergeSort>` sorts items partitioned across a CUDA thread block
+* :cpp:class:`cub::BlockRadixSort <cub::BlockRadixSort>` sorts items partitioned across a CUDA thread block using radix sorting method
+* :cpp:struct:`cub::BlockReduce <cub::BlockReduce>` computes reduction of items partitioned across a CUDA thread block
+* :cpp:class:`cub::BlockRunLengthDecode <cub::BlockRunLengthDecode>` decodes a run-length encoded sequence partitioned across a CUDA thread block
+* :cpp:struct:`cub::BlockScan <cub::BlockScan>` computes a prefix scan of items partitioned across a CUDA thread block
+* :cpp:struct:`cub::BlockShuffle <cub::BlockShuffle>` shifts items partitioned across a CUDA thread block
+* :cpp:class:`cub::BlockStore <cub::BlockStore>` stores items partitioned across a CUDA thread block to a linear segment of memory

--- a/cub/docs/block_wide.rst
+++ b/cub/docs/block_wide.rst
@@ -1,0 +1,16 @@
+Block-wide
+==================================================
+
+.. toctree::
+   :glob:
+   :hidden:
+   :maxdepth: 2
+
+   ${repo_docs_api_path}/*Block*
+
+.. _block-module:
+
+**Block-wide "collective" primitives**
+
+* Cooperative I/O, sort, scan, reduction, histogram, etc.  
+* Compatible with arbitrary thread block sizes and types 

--- a/cub/docs/device_wide.rst
+++ b/cub/docs/device_wide.rst
@@ -1,4 +1,6 @@
-Device-wide
+.. _device-module:
+
+Device-Wide Primitives
 ==================================================
 
 .. toctree::
@@ -6,11 +8,27 @@ Device-wide
    :hidden:
    :maxdepth: 2
 
-   ${repo_docs_api_path}/*Device*
+   ${repo_docs_api_path}/struct*Device*
 
-.. _device-module:
 
-**Device-wide primitives**
+CUB device-level single-problem parallel algorithms:
 
-* Parallel sort, prefix scan, reduction, histogram, etc.  
-* Compatible with CUDA dynamic parallelism
+* :cpp:class:`cub::DeviceAdjacentDifference <cub::DeviceAdjacentDifference>` computes the difference between adjacent elements residing within device-accessible memory
+* :cpp:struct:`cub::DeviceFor <cub::DeviceFor>` provides device-wide, parallel operations for iterating over data residing within device-accessible memory
+* :cpp:class:`cub::DeviceHistogram <cub::DeviceHistogram>` constructs histograms from data samples residing within device-accessible memory
+* :cpp:struct:`cub::DevicePartition <cub::DevicePartition>` partitions data residing within device-accessible memory
+* :cpp:class:`cub::DeviceMergeSort <cub::DeviceMergeSort>` sorts items residing within device-accessible memory
+* :cpp:class:`cub::DeviceRadixSort <cub::DeviceRadixSort>` sorts items residing within device-accessible memory using radix sorting method
+* :cpp:struct:`cub::DeviceReduce <cub::DeviceReduce>` computes reduction of items residing within device-accessible memory 
+* :cpp:class:`cub::DeviceRunLengthEncode <cub::DeviceRunLengthEncode>` demarcating "runs" of same-valued items withing a sequence residing within device-accessible memory
+* :cpp:struct:`cub::DeviceScan <cub::DeviceScan>` computes a prefix scan across a sequence of data items residing within device-accessible memory
+* :cpp:struct:`cub::DeviceSelect <cub::DeviceSelect>` compacts data residing within device-accessible memory
+
+
+CUB device-level segmented-problem (batched) parallel algorithms:
+
+* :cpp:struct:`cub::DeviceSegmentedSort <cub::DeviceSegmentedSort>` computes batched sort across non-overlapping sequences of data residing within device-accessible memory
+* :cpp:struct:`cub::DeviceSegmentedRadixSort <cub::DeviceSegmentedRadixSort>` computes batched radix sort across non-overlapping sequences of data residing within device-accessible memory
+* :cpp:struct:`cub::DeviceSegmentedReduce <cub::DeviceSegmentedReduce>` computes reductions across multiple sequences of data residing within device-accessible memory
+* :cpp:struct:`cub::DeviceCopy <cub::DeviceCopy>` provides device-wide, parallel operations for batched copying of data residing within device-accessible memory
+* :cpp:struct:`cub::DeviceMemcpy <cub::DeviceMemcpy>` provides device-wide, parallel operations for batched copying of data residing within device-accessible memory

--- a/cub/docs/device_wide.rst
+++ b/cub/docs/device_wide.rst
@@ -1,0 +1,16 @@
+Device-wide
+==================================================
+
+.. toctree::
+   :glob:
+   :hidden:
+   :maxdepth: 2
+
+   ${repo_docs_api_path}/*Device*
+
+.. _device-module:
+
+**Device-wide primitives**
+
+* Parallel sort, prefix scan, reduction, histogram, etc.  
+* Compatible with CUDA dynamic parallelism

--- a/cub/docs/index.rst
+++ b/cub/docs/index.rst
@@ -3,13 +3,14 @@ CUB
 
 .. toctree::
    :hidden:
-   :maxdepth: 2
+   :maxdepth: 3
 
-   ${repo_docs_api_path}/CUB_api
+   modules
    developer_overview
    test_overview
    tuning
    benchmarking
+   ${repo_docs_api_path}/CUB_api
 
 .. the line below can be used to use the README.md file as the index page
 .. .. mdinclude:: ../README.md
@@ -22,17 +23,17 @@ of the CUDA programming model:
 
 * **Parallel primitives**
 
-  * **Warp-wide "collective" primitives**
+  * :ref:`Warp-wide <warp-module>` "collective" primitives
 
     * Cooperative warp-wide prefix scan, reduction, etc.
     * Safely specialized for each underlying CUDA architecture
 
-  * **Block-wide "collective" primitives**
+  * :ref:`Block-wide <block-module>` "collective" primitives
 
     * Cooperative I/O, sort, scan, reduction, histogram, etc.  
     * Compatible with arbitrary thread block sizes and types 
 
-  * **Device-wide primitives**
+  * :ref:`Device-wide <device-module>` primitives
 
     * Parallel sort, prefix scan, reduction, histogram, etc.  
     * Compatible with CUDA dynamic parallelism

--- a/cub/docs/modules.rst
+++ b/cub/docs/modules.rst
@@ -1,0 +1,11 @@
+CUB Modules
+==================================================
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   warp_wide
+   block_wide
+   device_wide
+   

--- a/cub/docs/modules.rst
+++ b/cub/docs/modules.rst
@@ -9,3 +9,23 @@ CUB Modules
    block_wide
    device_wide
    
+
+CUB provides state-of-the-art, reusable software components for every layer 
+of the CUDA programming model:
+
+* **Parallel primitives**
+
+  * :ref:`Warp-wide <warp-module>` "collective" primitives
+
+    * Cooperative warp-wide prefix scan, reduction, etc.
+    * Safely specialized for each underlying CUDA architecture
+
+  * :ref:`Block-wide <block-module>` "collective" primitives
+
+    * Cooperative I/O, sort, scan, reduction, histogram, etc.  
+    * Compatible with arbitrary thread block sizes and types 
+
+  * :ref:`Device-wide <device-module>` primitives
+
+    * Parallel sort, prefix scan, reduction, histogram, etc.  
+    * Compatible with CUDA dynamic parallelism

--- a/cub/docs/warp_wide.rst
+++ b/cub/docs/warp_wide.rst
@@ -1,4 +1,6 @@
-Warp-wide
+.. _warp-module:
+
+Warp-Wide "Collective" Primitives
 ==================================================
 
 .. toctree::
@@ -8,9 +10,12 @@ Warp-wide
 
    ${repo_docs_api_path}/*Warp*
 
-.. _warp-module:
+CUB warp-level algorithms are specialized for execution by threads in the same CUDA warp. 
+These algorithms may only be invoked by ``1 <= n <= 32`` *consecutive* threads in the same warp:
 
-**Warp-wide "collective" primitives**
-
-* Cooperative warp-wide prefix scan, reduction, etc.
-* Safely specialized for each underlying CUDA architecture
+* :cpp:struct:`cub::WarpExchange <cub::WarpExchange>` rearranges data partitioned across a CUDA warp
+* :cpp:class:`cub::WarpLoad <cub::WarpLoad>` loads a linear segment of items from memory into a CUDA warp
+* :cpp:class:`cub::WarpMergeSort <cub::WarpMergeSort>` sorts items partitioned across a CUDA warp
+* :cpp:struct:`cub::WarpReduce <cub::WarpReduce>` computes reduction of items partitioned across a CUDA warp
+* :cpp:struct:`cub::WarpScan <cub::WarpScan>` computes a prefix scan of items partitioned across a CUDA warp
+* :cpp:class:`cub::WarpStore <cub::WarpStore>` stores items partitioned across a CUDA warp to a linear segment of memory

--- a/cub/docs/warp_wide.rst
+++ b/cub/docs/warp_wide.rst
@@ -1,0 +1,16 @@
+Warp-wide
+==================================================
+
+.. toctree::
+   :glob:
+   :hidden:
+   :maxdepth: 2
+
+   ${repo_docs_api_path}/*Warp*
+
+.. _warp-module:
+
+**Warp-wide "collective" primitives**
+
+* Cooperative warp-wide prefix scan, reduction, etc.
+* Safely specialized for each underlying CUDA architecture


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/1429

<!-- Provide a standalone description of changes in this PR. -->
This is the first take on returning modules to CUB docs. Main page now links to warp, block, and device-wide modules. Modules are also added to the tree. Rendered example is available at https://gevtushenko.github.io/cccl/cub.  

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
