### PR TITLE
Add safety guards against conflicting library versions

### DIFF
--- a/cub/cub/version.cuh
+++ b/cub/cub/version.cuh
@@ -87,3 +87,5 @@
 static_assert(CUB_MAJOR_VERSION == CCCL_MAJOR_VERSION,"");
 static_assert(CUB_MINOR_VERSION == CCCL_MINOR_VERSION,"");
 static_assert(CUB_SUBMINOR_VERSION == CCCL_PATCH_VERSION,"");
+
+static_assert(CUB_VERSION == (CCCL_VERSION / 10), "Conflicting CUB and libcu++ versions detected. Check include paths.");

--- a/thrust/thrust/version.h
+++ b/thrust/thrust/version.h
@@ -91,3 +91,6 @@
 static_assert(THRUST_MAJOR_VERSION == CCCL_MAJOR_VERSION, "");
 static_assert(THRUST_MINOR_VERSION == CCCL_MINOR_VERSION, "");
 static_assert(THRUST_SUBMINOR_VERSION == CCCL_PATCH_VERSION, "");
+
+static_assert(THRUST_VERSION == (CCCL_VERSION / 10),
+              "Conflicting Thrust and libcu++ versions detected. Check include paths.");


### PR DESCRIPTION
Using different versions of our libraries is a common issue that leads to frequent bug preports.

We are adding some checks to all headers that hopefully catch most of those situations