### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 ci:
     autofix_commit_msg: |
       [pre-commit.ci] auto code formatting
-    autofix_prs: true
+    autofix_prs: false
     autoupdate_branch: ''
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
     autoupdate_schedule: quarterly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,13 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
+ci:
+    autofix_commit_msg: |
+      [pre-commit.ci] auto code formatting
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: quarterly
+    skip: []
+    submodules: false
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
+    hooks:
+      - id: clang-format
+        types_or: [c, c++, cuda]
+        args: ["-fallback-style=none", "-style=file", "-i"]
+        exclude: |
+          (?x)^(
+            ^cub/.*|
+            ^libcudacxx/.*|
+            ^thrust/.*
+          )
+
+default_language_version:
+  python: python3

--- a/examples/example_project/example.cu
+++ b/examples/example_project/example.cu
@@ -13,65 +13,71 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 /*
 This is a simple example demonstrating the use of CCCL functionality from Thrust, CUB, and libcu++.
 
 The example computes the sum of an array of integers using a simple parallel reduction. Each thread block
-computes the sum of a subset of the array using cuB::BlockRecuce. The sum of each block is then reduced 
+computes the sum of a subset of the array using cuB::BlockRecuce. The sum of each block is then reduced
 to a single value using an atomic add via cuda::atomic_ref from libcu++. The result is stored in a device_vector
 from Thrust. The sum is then printed to the console.
 */
 
-#include <cstdio>
-#include <thrust/device_vector.h>
 #include <cub/block/block_reduce.cuh>
+
+#include <thrust/device_vector.h>
+
 #include <cuda/atomic>
+
+#include <cstdio>
 
 constexpr int block_size = 256;
 
 __global__ void sumKernel(int const* data, int* result, std::size_t N)
 {
-    using BlockReduce = cub::BlockReduce<int, block_size> ;
+  using BlockReduce = cub::BlockReduce<int, block_size>;
 
-    __shared__ typename BlockReduce::TempStorage temp_storage;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
 
-    int index = threadIdx.x + blockIdx.x * blockDim.x;
+  int index = threadIdx.x + blockIdx.x * blockDim.x;
 
-    int sum = 0;
-    if (index < N) {
-        sum += data[index];
-    }
+  int sum = 0;
+  if (index < N)
+  {
+    sum += data[index];
+  }
 
-    sum = BlockReduce(temp_storage).Sum(sum);
+  sum = BlockReduce(temp_storage).Sum(sum);
 
-    if (threadIdx.x == 0){
-        cuda::atomic_ref<int, cuda::thread_scope_device> atomic_result(*result);
-        atomic_result.fetch_add(sum, cuda::memory_order_relaxed);
-    }
+  if (threadIdx.x == 0)
+  {
+    cuda::atomic_ref<int, cuda::thread_scope_device> atomic_result(*result);
+    atomic_result.fetch_add(sum, cuda::memory_order_relaxed);
+  }
 }
 
 int main()
 {
-    std::size_t N = 1000;
-    thrust::device_vector<int> data(N, 1);
-    thrust::device_vector<int> result(1);
+  std::size_t N = 1000;
+  thrust::device_vector<int> data(N, 1);
+  thrust::device_vector<int> result(1);
 
-    int num_blocks = (N + block_size - 1) / block_size;
+  int num_blocks = (N + block_size - 1) / block_size;
 
-    sumKernel<<<num_blocks, block_size>>>(thrust::raw_pointer_cast(data.data()),
-                                          thrust::raw_pointer_cast(result.data()), N);
+  sumKernel<<<num_blocks, block_size>>>(
+    thrust::raw_pointer_cast(data.data()), thrust::raw_pointer_cast(result.data()), N);
 
-    auto err = cudaDeviceSynchronize();
-    if(err != cudaSuccess){
-        std::cout << "Error: " << cudaGetErrorString(err) << std::endl;
-        return -1;
-    }
+  auto err = cudaDeviceSynchronize();
+  if (err != cudaSuccess)
+  {
+    std::cout << "Error: " << cudaGetErrorString(err) << std::endl;
+    return -1;
+  }
 
-    std::cout << "Sum: " << result[0] << std::endl;
+  std::cout << "Sum: " << result[0] << std::endl;
 
-    assert(result[0] == N);
+  assert(result[0] == N);
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION
## Description

Closes #1588.

This PR adds a basic pre-commit configuration. For now, I have added only `clang-format` as a hook, and the configuration excludes the major components of the repository (cub, libcudacxx, thrust) because the diff would be extremely large. This PR is meant to be a starting point for further work on automated formatting.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
