### PR TITLE
Ensure `cuda::std::nullopt` is visible in device code

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -254,7 +254,7 @@ struct nullopt_t
     _LIBCUDACXX_INLINE_VISIBILITY constexpr explicit nullopt_t(__secret_tag, __secret_tag) noexcept {}
 };
 
-_LIBCUDACXX_INLINE_VAR constexpr nullopt_t nullopt{nullopt_t::__secret_tag{}, nullopt_t::__secret_tag{}};
+_LIBCUDACXX_CPO_ACCESSIBILITY nullopt_t nullopt{nullopt_t::__secret_tag{}, nullopt_t::__secret_tag{}};
 
 struct __optional_construct_from_invoke_tag {};
 

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
@@ -71,7 +71,7 @@ test()
 }
 
 __global__ void test_global_visibility() {
-    cuda::std::nullopt meow;
+    cuda::std::optional<int> meow = cuda::std::nullopt;
     (void)meow;
 }
 

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
@@ -72,7 +72,7 @@ test()
 
 __global__ void test_global_visibility() {
     cuda::std::optional<int> meow = cuda::std::nullopt;
-    (void)meow;
+    unused(meow);
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
@@ -70,6 +70,11 @@ test()
     };
 }
 
+__global__ void test_global_visibility() {
+    cuda::std::nullopt meow;
+    (void)meow;
+}
+
 int main(int, char**)
 {
     test_constexpr<optional<int>>();


### PR DESCRIPTION
## Description
Ensure `cuda::std::nullopt` is visible in device code.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes #1597

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
