### PR TITLE
Work around thrust/memory.h circular include

### DIFF
--- a/thrust/thrust/system/detail/generic/memory.inl
+++ b/thrust/thrust/system/detail/generic/memory.inl
@@ -28,6 +28,7 @@
 
 #include <thrust/detail/static_assert.h>
 #include <thrust/detail/type_traits/pointer_traits.h>
+#include <thrust/detail/malloc_and_free_fwd.h>
 #include <thrust/system/detail/adl/malloc_and_free.h>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/detail/generic/memory.inl
+++ b/thrust/thrust/system/detail/generic/memory.inl
@@ -26,9 +26,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <thrust/detail/malloc_and_free_fwd.h>
 #include <thrust/detail/static_assert.h>
 #include <thrust/detail/type_traits/pointer_traits.h>
-#include <thrust/detail/malloc_and_free_fwd.h>
 #include <thrust/system/detail/adl/malloc_and_free.h>
 
 THRUST_NAMESPACE_BEGIN


### PR DESCRIPTION
Add `#include <thrust/detail/malloc_and_free_fwd.h>` to `thrust/thrust/system/detail/generic/memory.inl` to work around a circular include dependency that was resulting in errors about `thrust::malloc` not being defined.  The errors were seen with both G++ and NVC++ when using the OpenMP back end.

This fixes a regression that was introduced by pull request #1616 .

