### PR TITLE
Implement `cuda::mr::cuda_async_memory_resource`

### DIFF
--- a/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
@@ -86,7 +86,7 @@ private:
   //! @brief Causes the buffer to be treated as a span when passed to cudax::launch.
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   _CCCL_NODISCARD_FRIEND _CUDA_VSTD::span<_Tp>
-  __cudax_launch_transform(stream_ref, uninitialized_buffer& __self) noexcept
+  __cudax_launch_transform(::cuda::stream_ref, uninitialized_buffer& __self) noexcept
   {
     static_assert(_CUDA_VSTD::_One_of<_CUDA_VMR::device_accessible, _Properties...>,
                   "The buffer must be device accessible to be passed to `launch`");
@@ -96,7 +96,7 @@ private:
   //! @brief Causes the buffer to be treated as a span when passed to cudax::launch
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   _CCCL_NODISCARD_FRIEND _CUDA_VSTD::span<const _Tp>
-  __cudax_launch_transform(stream_ref, const uninitialized_buffer& __self) noexcept
+  __cudax_launch_transform(::cuda::stream_ref, const uninitialized_buffer& __self) noexcept
   {
     static_assert(_CUDA_VSTD::_One_of<_CUDA_VMR::device_accessible, _Properties...>,
                   "The buffer must be device accessible to be passed to `launch`");

--- a/cudax/include/cuda/experimental/__memory_resource/async_memory_pool.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/async_memory_pool.cuh
@@ -1,0 +1,306 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__MEMORY_RESOURCE_CUDA_MEMORY_POOL
+#define _CUDAX__MEMORY_RESOURCE_CUDA_MEMORY_POOL
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// cudaMallocAsync was introduced in CTK 11.2
+#if !defined(_CCCL_COMPILER_MSVC_2017) && !defined(_CCCL_CUDACC_BELOW_11_2)
+
+#  if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#    include <cuda_runtime.h>
+#    include <cuda_runtime_api.h>
+#  endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+
+#  include <cuda/__memory_resource/get_property.h>
+#  include <cuda/__memory_resource/properties.h>
+#  include <cuda/__memory_resource/resource_ref.h>
+#  include <cuda/std/__cuda/api_wrapper.h>
+#  include <cuda/std/__new_>
+#  include <cuda/stream_ref>
+
+#  include <cuda/experimental/__stream/stream.cuh>
+
+#  if _CCCL_STD_VER >= 2014
+
+//! @file
+//! The \c async_memory_pool class provides a wrapper around a `cudaMempool_t`.
+namespace cuda::experimental::mr
+{
+
+//! @brief  Checks whether the current device supports \c cudaMallocAsync.
+//! @param __device_id The id of the device for which to query support.
+//! @throws cuda_error if \c cudaDeviceGetAttribute failed.
+//! @returns true if \c cudaDevAttrMemoryPoolsSupported is not zero.
+inline void __device_supports_stream_ordered_allocations(const int __device_id)
+{
+  int __pool_is_supported = 0;
+  _CCCL_TRY_CUDA_API(
+    ::cudaDeviceGetAttribute,
+    "Failed to call cudaDeviceGetAttribute",
+    &__pool_is_supported,
+    ::cudaDevAttrMemoryPoolsSupported,
+    __device_id);
+  if (__pool_is_supported == 0)
+  {
+    ::cuda::__throw_cuda_error(::cudaErrorNotSupported, "cudaMallocAsync is not supported on the given device");
+  }
+}
+
+//! @brief Internal redefinition of ``cudaMemAllocationHandleType``.
+//! @note We need to define our own enum here because the earliest CUDA runtime version that supports asynchronous
+//! memory pools (CUDA 11.2) did not support these flags. See the <a
+//! href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html">cudaMemAllocationHandleType</a> docs.
+enum class cudaMemAllocationHandleType
+{
+  cudaMemHandleTypeNone                = 0x0, ///< Does not allow any export mechanism.
+  cudaMemHandleTypePosixFileDescriptor = 0x1, ///< Allows a file descriptor to be used for exporting.
+  cudaMemHandleTypeWin32               = 0x2, ///< Allows a Win32 NT handle to be used for exporting. (HANDLE)
+  cudaMemHandleTypeWin32Kmt            = 0x4, ///< Allows a Win32 KMT handle to be used for exporting. (D3DKMT_HANDLE)
+  cudaMemHandleTypeFabric = 0x8, ///< Allows a fabric handle to be used for exporting. (cudaMemFabricHandle_t)
+};
+
+//! @brief \c async_memory_pool_properties is a wrapper around properties passed to \c async_memory_pool to create a
+//! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">cudaMemPool_t</a>.
+struct async_memory_pool_properties
+{
+  size_t initial_pool_size                           = 0;
+  size_t release_threshold                           = 0;
+  cudaMemAllocationHandleType allocation_handle_type = cudaMemAllocationHandleType::cudaMemHandleTypeNone;
+};
+
+//! @brief \c async_memory_pool is an owning wrapper around a
+//! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">cudaMemPool_t</a>.
+//!
+//! It handles creation and destruction of the underlying pool utilizing the provided \c async_memory_pool_properties.
+class async_memory_pool
+{
+private:
+  ::cudaMemPool_t __pool_handle_ = nullptr;
+
+  //! @brief Check whether the specified `cudaMemAllocationHandleType` is supported on the present
+  //! CUDA driver/runtime version.
+  //! @note This query was introduced in CUDA 11.3 so on CUDA 11.2 this function will only return
+  //! true for `cudaMemHandleTypeNone`.
+  //! @param __device_id The id of the device to check for support.
+  //! @param __handle_type An IPC export handle type to check for support.
+  //! @return true if the handle type is supported by cudaDevAttrMemoryPoolSupportedHandleTypes.
+  static void __cuda_supports_export_handle_type(const int __device_id, cudaMemAllocationHandleType __handle_type)
+  {
+    int __supported_handles = static_cast<int>(cudaMemAllocationHandleType::cudaMemHandleTypeNone);
+#    if !defined(_CCCL_CUDACC_BELOW_11_3)
+    if (__handle_type != cudaMemAllocationHandleType::cudaMemHandleTypeNone)
+    {
+      const ::cudaError_t __status =
+        ::cudaDeviceGetAttribute(&__supported_handles, ::cudaDevAttrMemoryPoolSupportedHandleTypes, __device_id);
+      // export handle is not supported at all
+      switch (__status)
+      {
+        case ::cudaSuccess:
+          break;
+        case ::cudaErrorInvalidValue:
+          ::cudaGetLastError(); // Clear CUDA error state
+          ::cuda::__throw_cuda_error(
+            ::cudaErrorNotSupported, "Requested IPC memory handle type not supported on given device");
+        default:
+          ::cudaGetLastError(); // Clear CUDA error state
+          ::cuda::__throw_cuda_error(__status, "Failed to call cudaDeviceGetAttribute");
+      }
+    }
+#    endif //_CCCL_CUDACC_BELOW_11_3
+    if ((static_cast<int>(__handle_type) & __supported_handles) != static_cast<int>(__handle_type))
+    {
+      ::cuda::__throw_cuda_error(
+        ::cudaErrorNotSupported, "Requested IPC memory handle type not supported on given device");
+    }
+  }
+
+  //! @brief  Creates the CUDA memory pool from the passed in arguments.
+  //! @throws cuda_error If the creation of the CUDA memory pool failed.
+  //! @returns The created CUDA memory pool.
+  _CCCL_NODISCARD static cudaMemPool_t
+  __create_cuda_mempool(const int __device_id, async_memory_pool_properties __properties) noexcept
+  {
+    ::cuda::experimental::mr::__device_supports_stream_ordered_allocations(__device_id);
+    async_memory_pool::__cuda_supports_export_handle_type(__device_id, __properties.allocation_handle_type);
+
+    ::cudaMemPoolProps __pool_properties{};
+    __pool_properties.allocType     = ::cudaMemAllocationTypePinned;
+    __pool_properties.handleTypes   = ::cudaMemAllocationHandleType(__properties.allocation_handle_type);
+    __pool_properties.location.type = ::cudaMemLocationTypeDevice;
+    __pool_properties.location.id   = __device_id;
+    ::cudaMemPool_t __cuda_pool_handle{};
+    _CCCL_TRY_CUDA_API(::cudaMemPoolCreate, "Failed to call cudaMemPoolCreate", &__cuda_pool_handle, &__pool_properties);
+
+    // CUDA drivers before 11.5 have known incompatibilities with the async allocator.
+    // We'll disable `cudaMemPoolReuseAllowOpportunistic` if cuda driver < 11.5.
+    // See https://github.com/NVIDIA/spark-rapids/issues/4710.
+    int __driver_version = 0;
+    _CCCL_TRY_CUDA_API(::cudaDriverGetVersion, "Failed to call cudaDriverGetVersion", &__driver_version);
+
+    constexpr int __min_async_version = 11050;
+    if (__driver_version < __min_async_version)
+    {
+      int __disable_reuse = 0;
+      _CCCL_TRY_CUDA_API(
+        ::cudaMemPoolSetAttribute,
+        "Failed to call cudaMemPoolSetAttribute with cudaMemPoolReuseAllowOpportunistic",
+        __cuda_pool_handle,
+        ::cudaMemPoolReuseAllowOpportunistic,
+        &__disable_reuse);
+    }
+
+    _CCCL_TRY_CUDA_API(
+      ::cudaMemPoolSetAttribute,
+      "Failed to call cudaMemPoolSetAttribute with cudaMemPoolAttrReleaseThreshold",
+      __cuda_pool_handle,
+      ::cudaMemPoolAttrReleaseThreshold,
+      &__properties.release_threshold);
+
+    // allocate the requested initial size to prime the pool.
+    // We need to use a new stream so we do not wait on other work
+    if (__properties.initial_pool_size != 0)
+    {
+      ::cuda::experimental::stream __temp_stream{__device_id};
+      void* __ptr{nullptr};
+      _CCCL_TRY_CUDA_API(
+        ::cudaMallocAsync,
+        "async_memory_pool failed to allocate the initial pool size",
+        &__ptr,
+        __properties.initial_pool_size,
+        __temp_stream.get());
+
+      _CCCL_ASSERT_CUDA_API(
+        ::cudaFreeAsync, "async_memory_pool failed to free the initial pool allocation", __ptr, __temp_stream.get());
+    }
+    return __cuda_pool_handle;
+  }
+
+  struct __from_handle_t
+  {};
+
+  //! @brief Constructs a \c async_memory_pool from a handle taking ownership of the pool
+  //! @param __handle The handle to the existing pool
+  explicit async_memory_pool(__from_handle_t, ::cudaMemPool_t __handle) noexcept
+      : __pool_handle_(__handle)
+  {}
+
+public:
+  //! @brief Constructs a \c async_memory_pool with the optionally specified initial pool size and release threshold.
+  //! If the pool size grows beyond the release threshold, unused memory held by the pool will be released at the next
+  //! synchronization event.
+  //! @throws cuda_error if the CUDA version does not support ``cudaMallocAsync``.
+  //! @param __device_id The device id of the device the stream pool is constructed on.
+  //! @param __pool_properties Optional, additional properties of the pool to be created.
+  explicit async_memory_pool(const ::cuda::experimental::device_ref __device_id,
+                             async_memory_pool_properties __properties = {})
+      : __pool_handle_(__create_cuda_mempool(__device_id.get(), __properties))
+  {}
+
+  //! @brief Disables construction from a plain `cudaMemPool_t`. We want to ensure clean ownership semantics.
+  async_memory_pool(::cudaMemPool_t) = delete;
+
+  async_memory_pool(async_memory_pool const&)            = delete;
+  async_memory_pool(async_memory_pool&&)                 = delete;
+  async_memory_pool& operator=(async_memory_pool const&) = delete;
+  async_memory_pool& operator=(async_memory_pool&&)      = delete;
+
+  //! @brief Destroys the \c async_memory_pool by releasing the internal ``cudaMemPool_t``.
+  ~async_memory_pool() noexcept
+  {
+    _CCCL_ASSERT_CUDA_API(::cudaMemPoolDestroy, "~async_memory_pool() failed to destroy pool", __pool_handle_);
+  }
+
+  //! @brief Equality comparison with another \c async_memory_pool.
+  //! @returns true if the stored ``cudaMemPool_t`` are equal.
+  _CCCL_NODISCARD constexpr bool operator==(async_memory_pool const& __rhs) const noexcept
+  {
+    return __pool_handle_ == __rhs.__pool_handle_;
+  }
+
+#    if _CCCL_STD_VER <= 2017
+  //! @brief Inequality comparison with another \c async_memory_pool.
+  //! @returns true if the stored ``cudaMemPool_t`` are not equal.
+  _CCCL_NODISCARD constexpr bool operator!=(async_memory_pool const& __rhs) const noexcept
+  {
+    return __pool_handle_ != __rhs.__pool_handle_;
+  }
+#    endif // _CCCL_STD_VER <= 2017
+
+  //! @brief Equality comparison with a \c cudaMemPool_t.
+  //! @param __rhs A \c cudaMemPool_t.
+  //! @returns true if the stored ``cudaMemPool_t`` is equal to \p __rhs.
+  _CCCL_NODISCARD_FRIEND constexpr bool operator==(async_memory_pool const& __lhs, ::cudaMemPool_t __rhs) noexcept
+  {
+    return __lhs.__pool_handle_ == __rhs;
+  }
+
+#    if _CCCL_STD_VER <= 2017
+  //! @copydoc async_memory_pool::operator==(async_memory_pool const&, ::cudaMemPool_t)
+  _CCCL_NODISCARD_FRIEND constexpr bool operator==(::cudaMemPool_t __lhs, async_memory_pool const& __rhs) noexcept
+  {
+    return __rhs.__pool_handle_ == __lhs;
+  }
+
+  //! @copydoc async_memory_pool::operator==(async_memory_pool const&, ::cudaMemPool_t)
+  _CCCL_NODISCARD_FRIEND constexpr bool operator!=(async_memory_pool const& __lhs, ::cudaMemPool_t __rhs) noexcept
+  {
+    return __lhs.__pool_handle_ != __rhs;
+  }
+
+  //! @copydoc async_memory_pool::operator==(async_memory_pool const&, ::cudaMemPool_t)
+  _CCCL_NODISCARD_FRIEND constexpr bool operator!=(::cudaMemPool_t __lhs, async_memory_pool const& __rhs) noexcept
+  {
+    return __rhs.__pool_handle_ != __lhs;
+  }
+#    endif // _CCCL_STD_VER <= 2017
+
+  //! @brief Returns the underlying handle to the CUDA memory pool.
+  _CCCL_NODISCARD constexpr cudaMemPool_t get() const noexcept
+  {
+    return __pool_handle_;
+  }
+
+  //! @brief Construct an `async_memory_pool` object from a native `cudaMemPool_t` handle.
+  //!
+  //! @param __handle The native handle
+  //!
+  //! @return The constructed `async_memory_pool` object
+  //!
+  //! @note The constructed `async_memory_pool` object takes ownership of the native handle.
+  _CCCL_NODISCARD static async_memory_pool from_native_handle(::cudaMemPool_t __handle) noexcept
+  {
+    return async_memory_pool(__from_handle_t{}, __handle);
+  }
+
+  // Disallow construction from an `int`, e.g., `0`.
+  static async_memory_pool from_native_handle(int) = delete;
+
+  // Disallow construction from `nullptr`.
+  static async_memory_pool from_native_handle(_CUDA_VSTD::nullptr_t) = delete;
+};
+
+} // namespace cuda::experimental::mr
+
+#  endif // _CCCL_STD_VER >= 2014
+
+#endif // !_CCCL_COMPILER_MSVC_2017 && !_CCCL_CUDACC_BELOW_11_2
+
+#endif // _CUDAX__MEMORY_RESOURCE_CUDA_MEMORY_POOL

--- a/cudax/include/cuda/experimental/__memory_resource/async_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/async_memory_resource.cuh
@@ -1,0 +1,318 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__MEMORY_RESOURCE_CUDA_ASYNC_MEMORY_RESOURCE
+#define _CUDAX__MEMORY_RESOURCE_CUDA_ASYNC_MEMORY_RESOURCE
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// cudaMallocAsync was introduced in CTK 11.2
+#if !defined(_CCCL_COMPILER_MSVC_2017) && !defined(_CCCL_CUDACC_BELOW_11_2)
+
+#  if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#    include <cuda_runtime.h>
+#    include <cuda_runtime_api.h>
+#  endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+
+#  include <cuda/__memory_resource/get_property.h>
+#  include <cuda/__memory_resource/properties.h>
+#  include <cuda/__memory_resource/resource_ref.h>
+#  include <cuda/std/__concepts/__concept_macros.h>
+#  include <cuda/std/__cuda/api_wrapper.h>
+#  include <cuda/std/__new_>
+#  include <cuda/std/cstddef>
+#  include <cuda/stream_ref>
+
+#  include <cuda/experimental/__device/device_ref.cuh>
+#  include <cuda/experimental/__memory_resource/async_memory_pool.cuh>
+#  include <cuda/experimental/__stream/stream.cuh>
+
+#  if _CCCL_STD_VER >= 2014
+
+namespace cuda::experimental::mr
+{
+
+//! @brief global stream to synchronize in the synchronous interface of \c async_memory_resource
+inline ::cuda::stream_ref __async_memory_resource_sync_stream()
+{
+  static ::cuda::experimental::stream __stream{};
+  return __stream;
+}
+
+//! @rst
+//! .. _cudax-memory-resource-async:
+//!
+//! Stream ordered memory resource
+//! ------------------------------
+//!
+//! ``async_memory_resource`` uses `cudaMallocFromPoolAsync / cudaFreeAsync
+//! <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html>`__ for allocation/deallocation. A
+//! ``async_memory_resource`` is a thin wrapper around a \c cudaMemPool_t.
+//!
+//! .. warning::
+//!
+//!    ``async_memory_resource`` does not own the pool and it is the responsibility of the user to ensure that the
+//!    lifetime of the pool exceeds the lifetime of the ``async_memory_resource``.
+//!
+//! @endrst
+class async_memory_resource
+{
+private:
+  ::cudaMemPool_t __pool_;
+
+  //! @brief Checks whether the passed in alignment is valid.
+  //! @param __alignment the alignment to check.
+  //! @returns true if \p __alignment is valid.
+  _CCCL_NODISCARD static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
+  {
+    return __alignment <= _CUDA_VMR::default_cuda_malloc_alignment
+        && (_CUDA_VMR::default_cuda_malloc_alignment % __alignment == 0);
+  }
+
+  //! @brief  Returns the default ``cudaMemPool_t`` from the specified device.
+  //! @throws cuda_error if retrieving the default ``cudaMemPool_t`` fails.
+  //! @returns The default memory pool of the specified device.
+  _CCCL_NODISCARD static ::cudaMemPool_t __get_default_mem_pool(const int __device_id)
+  {
+    ::cuda::experimental::mr::__device_supports_stream_ordered_allocations(__device_id);
+
+    ::cudaMemPool_t __pool;
+    _CCCL_TRY_CUDA_API(
+      ::cudaDeviceGetDefaultMemPool, "Failed to call cudaDeviceGetDefaultMemPool", &__pool, __device_id);
+    return __pool;
+  }
+
+public:
+  //! @brief Default constructs the async_memory_resource using the default \c cudaMemPool_t of the default device.
+  //! @throws cuda_error if retrieving the default \c cudaMemPool_t fails.
+  async_memory_resource()
+      : __pool_(__get_default_mem_pool(0))
+  {}
+
+  //! @brief Constructs a async_memory_resource using the default \c cudaMemPool_t of a given device.
+  //! @throws cuda_error if retrieving the default \c cudaMemPool_t fails.
+  explicit async_memory_resource(::cuda::experimental::device_ref __device)
+      : __pool_(__get_default_mem_pool(__device.get()))
+  {}
+
+  async_memory_resource(int)                   = delete;
+  async_memory_resource(_CUDA_VSTD::nullptr_t) = delete;
+
+  //! @brief  Constructs the async_memory_resource from a \c cudaMemPool_t.
+  //! @param __pool The \c cudaMemPool_t used to allocate memory.
+  explicit async_memory_resource(::cudaMemPool_t __pool) noexcept
+      : __pool_(__pool)
+  {}
+
+  //! @brief  Constructs the async_memory_resource from a \c async_memory_pool by calling get().
+  //! @param __pool The \c async_memory_pool used to allocate memory.
+  explicit async_memory_resource(async_memory_pool& __pool) noexcept
+      : __pool_(__pool.get())
+  {}
+
+  //! @brief Allocate device memory of size at least \p __bytes via cudaMallocFromPoolAsync.
+  //! @param __bytes The size in bytes of the allocation.
+  //! @param __alignment The requested alignment of the allocation.
+  //! @throws std::invalid_argument In case of invalid alignment.
+  //! @throws cuda::cuda_error If an error code was return by the CUDA API call.
+  //! @returns Pointer to the newly allocated memory.
+  _CCCL_NODISCARD void* allocate(const size_t __bytes,
+                                 const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment)
+  {
+    if (!__is_valid_alignment(__alignment))
+    {
+      _CUDA_VSTD_NOVERSION::__throw_invalid_argument(
+        "Invalid alignment passed to "
+        "async_memory_resource::allocate_async.");
+    }
+
+    void* __ptr{nullptr};
+    _CCCL_TRY_CUDA_API(
+      ::cudaMallocFromPoolAsync,
+      "async_memory_resource::allocate failed to allocate with cudaMallocFromPoolAsync",
+      &__ptr,
+      __bytes,
+      __pool_,
+      __async_memory_resource_sync_stream().get());
+    __async_memory_resource_sync_stream().wait();
+    return __ptr;
+  }
+
+  //! @brief Deallocate memory pointed to by \p __ptr.
+  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`.
+  //! @param __bytes  The number of bytes that was passed to the `allocate` call that returned \p __ptr.
+  //! @param __alignment The alignment that was passed to the `allocate` call that returned \p __ptr.
+  //! @note The pointer passed to `deallocate` must not be in use in a stream. It is the users responsibility to
+  //! properly synchronize all relevant streams before calling `deallocate`.
+  void deallocate(void* __ptr, const size_t, const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment)
+  {
+    _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),
+                       "Invalid alignment passed to async_memory_resource::deallocate.");
+    _CCCL_ASSERT_CUDA_API(
+      ::cudaFreeAsync, "async_memory_resource::deallocate failed", __ptr, __async_memory_resource_sync_stream().get());
+    __async_memory_resource_sync_stream().wait();
+    (void) __alignment;
+  }
+
+  //! @brief Allocate device memory of size at least \p __bytes via `cudaMallocFromPoolAsync`.
+  //! @param __bytes The size in bytes of the allocation.
+  //! @param __alignment The requested alignment of the allocation.
+  //! @param __stream Stream on which to perform allocation.
+  //! @throws std::invalid_argument In case of invalid alignment.
+  //! @throws cuda::cuda_error If an error code was return by the cuda api call.
+  //! @returns Pointer to the newly allocated memory.
+  _CCCL_NODISCARD void* allocate_async(const size_t __bytes, const size_t __alignment, const ::cuda::stream_ref __stream)
+  {
+    if (!__is_valid_alignment(__alignment))
+    {
+      _CUDA_VSTD_NOVERSION::__throw_invalid_argument(
+        "Invalid alignment passed to "
+        "async_memory_resource::allocate_async.");
+    }
+
+    return allocate_async(__bytes, __stream);
+  }
+
+  //! @brief Allocate device memory of size at least \p __bytes via cudaMallocFromPoolAsync.
+  //! @param __bytes The size in bytes of the allocation.
+  //! @param __stream Stream on which to perform allocation.
+  //! @throws cuda::cuda_error If an error code was return by the cuda api call.
+  //! @returns Pointer to the newly allocated memory.
+  _CCCL_NODISCARD void* allocate_async(const size_t __bytes, const ::cuda::stream_ref __stream)
+  {
+    void* __ptr{nullptr};
+    _CCCL_TRY_CUDA_API(
+      ::cudaMallocFromPoolAsync,
+      "async_memory_resource::allocate_async failed to allocate with cudaMallocFromPoolAsync",
+      &__ptr,
+      __bytes,
+      __pool_,
+      __stream.get());
+    return __ptr;
+  }
+
+  //! @brief Deallocate memory pointed to by \p __ptr.
+  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate_async`
+  //! @param __bytes The number of bytes that was passed to the `allocate_async` call that returned \p __ptr.
+  //! @param __alignment The alignment that was passed to the `allocate_async` call that returned \p __ptr.
+  //! @param __stream A stream that has a stream ordering relationship with the stream used in the
+  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate_async</a> call
+  //! that returned \p __ptr.
+  void deallocate_async(void* __ptr, const size_t __bytes, const size_t __alignment, const ::cuda::stream_ref __stream)
+  {
+    // We need to ensure that the provided alignment matches the minimal provided alignment
+    _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),
+                       "Invalid alignment passed to async_memory_resource::deallocate.");
+    deallocate_async(__ptr, __bytes, __stream);
+    (void) __alignment;
+  }
+
+  //! @brief Deallocate memory pointed to by \p __ptr.
+  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate_async`.
+  //! @param __bytes The number of bytes that was passed to the `allocate_async` call that returned \p __ptr.
+  //! @param __stream A stream that has a stream ordering relationship with the stream used in the
+  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate_async</a> call
+  //! that returned \p __ptr.
+  void deallocate_async(void* __ptr, size_t, const ::cuda::stream_ref __stream)
+  {
+    _CCCL_ASSERT_CUDA_API(::cudaFreeAsync, "async_memory_resource::deallocate_async failed", __ptr, __stream.get());
+  }
+
+  //! @brief Equality comparison with another async_memory_resource.
+  //! @returns true if underlying \c cudaMemPool_t are equal.
+  _CCCL_NODISCARD constexpr bool operator==(async_memory_resource const& __rhs) const noexcept
+  {
+    return __pool_ == __rhs.__pool_;
+  }
+#    if _CCCL_STD_VER <= 2017
+
+  //! @brief Inequality comparison with another \c async_memory_resource.
+  //! @returns true if underlying \c cudaMemPool_t are inequal.
+  _CCCL_NODISCARD constexpr bool operator!=(async_memory_resource const& __rhs) const noexcept
+  {
+    return __pool_ != __rhs.__pool_;
+  }
+#    endif // _CCCL_STD_VER <= 2017
+
+#    if _CCCL_STD_VER >= 2020
+  //! @brief Equality comparison between a \c async_memory_resource and another resource.
+  //! @param __rhs The resource to compare to.
+  //! @returns If the underlying types are equality comparable, returns the result of equality comparison of both
+  //! resources. Otherwise, returns false.
+  _LIBCUDACXX_TEMPLATE(class _Resource)
+  _LIBCUDACXX_REQUIRES((_CUDA_VMR::__different_resource<async_memory_resource, _Resource>) )
+  _CCCL_NODISCARD bool operator==(_Resource const& __rhs) const noexcept
+  {
+    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource*>(this)}
+        == _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+  }
+#    else // ^^^ C++20 ^^^ / vvv C++17
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator==(async_memory_resource const& __lhs, _Resource const& __rhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>)
+  {
+    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource&>(__lhs)}
+        == _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __rhs, async_memory_resource const& __lhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>)
+  {
+    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource&>(__lhs)}
+        == _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator!=(async_memory_resource const& __lhs, _Resource const& __rhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>)
+  {
+    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource&>(__lhs)}
+        != _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __rhs, async_memory_resource const& __lhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>)
+  {
+    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource&>(__lhs)}
+        != _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+  }
+#    endif // _CCCL_STD_VER <= 2017
+
+  //! @brief Returns the underlying handle to the CUDA memory pool.
+  _CCCL_NODISCARD constexpr cudaMemPool_t get() const noexcept
+  {
+    return __pool_;
+  }
+
+#    ifndef DOXYGEN_SHOULD_SKIP_THIS // Doxygen cannot handle the friend function
+  //! @brief Enables the \c device_accessible property for \c async_memory_resource.
+  //! @relates async_memory_resource
+  friend constexpr void get_property(async_memory_resource const&, _CUDA_VMR::device_accessible) noexcept {}
+#    endif // DOXYGEN_SHOULD_SKIP_THIS
+};
+static_assert(_CUDA_VMR::resource_with<async_memory_resource, _CUDA_VMR::device_accessible>, "");
+
+} // namespace cuda::experimental::mr
+
+#  endif // _CCCL_STD_VER >= 2014
+
+#endif // !_CCCL_COMPILER_MSVC_2017 && !_CCCL_CUDACC_BELOW_11_2
+
+#endif //_CUDAX__MEMORY_RESOURCE_CUDA_ASYNC_MEMORY_RESOURCE

--- a/cudax/include/cuda/experimental/__memory_resource/async_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/async_memory_resource.cuh
@@ -157,7 +157,7 @@ public:
   //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`.
   //! @param __bytes  The number of bytes that was passed to the `allocate` call that returned \p __ptr.
   //! @param __alignment The alignment that was passed to the `allocate` call that returned \p __ptr.
-  //! @note The pointer passed to `deallocate` must not be in use in a stream. It is the users responsibility to
+  //! @note The pointer passed to `deallocate` must not be in use in a stream. It is the caller's responsibility to
   //! properly synchronize all relevant streams before calling `deallocate`.
   void deallocate(void* __ptr, const size_t, const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment)
   {
@@ -213,6 +213,8 @@ public:
   //! @param __stream A stream that has a stream ordering relationship with the stream used in the
   //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate_async</a> call
   //! that returned \p __ptr.
+  //! @note The pointer passed to `deallocate_async` must not be in use in a stream other than \p __stream.
+  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate_async`.
   void deallocate_async(void* __ptr, const size_t __bytes, const size_t __alignment, const ::cuda::stream_ref __stream)
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
@@ -228,6 +230,8 @@ public:
   //! @param __stream A stream that has a stream ordering relationship with the stream used in the
   //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate_async</a> call
   //! that returned \p __ptr.
+  //! @note The pointer passed to `deallocate_async` must not be in use in a stream other than \p __stream.
+  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate_async`.
   void deallocate_async(void* __ptr, size_t, const ::cuda::stream_ref __stream)
   {
     _CCCL_ASSERT_CUDA_API(::cudaFreeAsync, "async_memory_resource::deallocate_async failed", __ptr, __stream.get());

--- a/cudax/include/cuda/experimental/memory_resource.cuh
+++ b/cudax/include/cuda/experimental/memory_resource.cuh
@@ -13,5 +13,6 @@
 
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
 #include <cuda/experimental/__memory_resource/async_memory_pool.cuh>
+#include <cuda/experimental/__memory_resource/async_memory_resource.cuh>
 
 #endif // __CUDAX_MEMORY_RESOURCE___

--- a/cudax/include/cuda/experimental/memory_resource.cuh
+++ b/cudax/include/cuda/experimental/memory_resource.cuh
@@ -12,5 +12,6 @@
 #define __CUDAX_MEMORY_RESOURCE___
 
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
+#include <cuda/experimental/__memory_resource/async_memory_pool.cuh>
 
 #endif // __CUDAX_MEMORY_RESOURCE___

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -93,6 +93,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   cudax_add_catch2_test(test_target memory_resource ${cn_target}
     memory_resource/any_resource.cu
     memory_resource/async_memory_pool.cu
+    memory_resource/async_memory_resource.cu
   )
 
   cudax_add_catch2_test(test_target async_tests ${cn_target}

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -92,6 +92,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
 
   cudax_add_catch2_test(test_target memory_resource ${cn_target}
     memory_resource/any_resource.cu
+    memory_resource/async_memory_pool.cu
   )
 
   cudax_add_catch2_test(test_target async_tests ${cn_target}

--- a/cudax/test/memory_resource/async_memory_pool.cu
+++ b/cudax/test/memory_resource/async_memory_pool.cu
@@ -1,0 +1,211 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+#include <cuda/stream_ref>
+
+#include <cuda/experimental/memory_resource.cuh>
+
+#include <catch2/catch.hpp>
+
+namespace cudax = cuda::experimental;
+using pool      = cudax::mr::async_memory_pool;
+static_assert(!cuda::std::is_trivial<pool>::value, "");
+static_assert(!cuda::std::is_trivially_default_constructible<pool>::value, "");
+static_assert(!cuda::std::is_default_constructible<pool>::value, "");
+static_assert(!cuda::std::is_copy_constructible<pool>::value, "");
+static_assert(!cuda::std::is_move_constructible<pool>::value, "");
+static_assert(!cuda::std::is_copy_assignable<pool>::value, "");
+static_assert(!cuda::std::is_move_assignable<pool>::value, "");
+static_assert(!cuda::std::is_trivially_destructible<pool>::value, "");
+static_assert(!cuda::std::is_empty<pool>::value, "");
+
+static bool ensure_release_threshold(::cudaMemPool_t pool, const size_t expected_threshold)
+{
+  size_t release_threshold = expected_threshold + 1337; // use something different than the expected threshold
+  _CCCL_TRY_CUDA_API(
+    ::cudaMemPoolGetAttribute,
+    "Failed to call cudaMemPoolGetAttribute",
+    pool,
+    ::cudaMemPoolAttrReleaseThreshold,
+    &release_threshold);
+  return release_threshold == expected_threshold;
+}
+
+static bool ensure_disable_reuse(::cudaMemPool_t pool, const int driver_version)
+{
+  int disable_reuse = 0;
+  _CCCL_TRY_CUDA_API(
+    ::cudaMemPoolGetAttribute,
+    "Failed to call cudaMemPoolGetAttribute",
+    pool,
+    ::cudaMemPoolReuseAllowOpportunistic,
+    &disable_reuse);
+
+  constexpr int min_async_version = 11050;
+  return driver_version < min_async_version ? disable_reuse == 0 : disable_reuse != 0;
+}
+
+static bool ensure_export_handle(::cudaMemPool_t pool, const ::cudaMemAllocationHandleType allocation_handle)
+{
+  size_t handle              = 0;
+  const ::cudaError_t status = ::cudaMemPoolExportToShareableHandle(&handle, pool, allocation_handle, 0);
+  ::cudaGetLastError(); // Clear CUDA error state
+
+  // If no export was defined we need to querry cudaErrorInvalidValue
+  return allocation_handle == ::cudaMemHandleTypeNone ? status == ::cudaErrorInvalidValue : status == ::cudaSuccess;
+}
+
+TEST_CASE("async_memory_pool construction", "[memory_resource]")
+{
+  int current_device{};
+  {
+    _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to query current device with with cudaGetDevice.", &current_device);
+  }
+
+  int driver_version = 0;
+  {
+    _CCCL_TRY_CUDA_API(::cudaDriverGetVersion, "Failed to call cudaDriverGetVersion", &driver_version);
+  }
+
+  ::cudaMemPool_t current_default_pool{};
+  {
+    _CCCL_TRY_CUDA_API(::cudaDeviceGetDefaultMemPool,
+                       "Failed to call cudaDeviceGetDefaultMemPool",
+                       &current_default_pool,
+                       current_device);
+  }
+
+  using memory_pool = cudax::mr::async_memory_pool;
+  SECTION("Construct from device id")
+  {
+    cudax::mr::async_memory_pool from_device{current_device};
+
+    ::cudaMemPool_t get = from_device.get();
+    CHECK(get != current_default_pool);
+
+    // Ensure we use the right release threshold
+    CHECK(ensure_release_threshold(get, 0));
+
+    // Ensure that we disable reuse with unsupported drivers
+    CHECK(ensure_disable_reuse(get, driver_version));
+
+    // Ensure that we disable export
+    CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
+  }
+
+  SECTION("Construct with empty properties")
+  {
+    cudax::mr::async_memory_pool_properties props{};
+    memory_pool from_defaulted_properties{current_device, props};
+
+    ::cudaMemPool_t get = from_defaulted_properties.get();
+    CHECK(get != current_default_pool);
+
+    // Ensure we use the right release threshold
+    CHECK(ensure_release_threshold(get, 0));
+
+    // Ensure that we disable reuse with unsupported drivers
+    CHECK(ensure_disable_reuse(get, driver_version));
+
+    // Ensure that we disable export
+    CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
+  }
+
+  SECTION("Construct with initial pool size")
+  {
+    cudax::mr::async_memory_pool_properties props = {42, 20};
+    memory_pool with_threshold{current_device, props};
+
+    ::cudaMemPool_t get = with_threshold.get();
+    CHECK(get != current_default_pool);
+
+    // Ensure we use the right release threshold
+    CHECK(ensure_release_threshold(get, props.release_threshold));
+
+    // Ensure that we disable reuse with unsupported drivers
+    CHECK(ensure_disable_reuse(get, driver_version));
+
+    // Ensure that we disable export
+    CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
+  }
+
+  // Allocation handles are only supported after 11.2
+#if !defined(_CCCL_CUDACC_BELOW_11_2)
+  SECTION("Construct with allocation handle")
+  {
+    cudax::mr::async_memory_pool_properties props = {
+      42, 20, cudax::mr::cudaMemAllocationHandleType::cudaMemHandleTypePosixFileDescriptor};
+    memory_pool with_allocation_handle{current_device, props};
+
+    ::cudaMemPool_t get = with_allocation_handle.get();
+    CHECK(get != current_default_pool);
+
+    // Ensure we use the right release threshold
+    CHECK(ensure_release_threshold(get, props.release_threshold));
+
+    // Ensure that we disable reuse with unsupported drivers
+    CHECK(ensure_disable_reuse(get, driver_version));
+
+    // Ensure that we disable export
+    CHECK(ensure_export_handle(get, static_cast<cudaMemAllocationHandleType>(props.allocation_handle_type)));
+  }
+#endif // !_CCCL_CUDACC_BELOW_11_2
+
+  SECTION("Take ownership of native handle")
+  {
+    ::cudaMemPoolProps pool_properties{};
+    pool_properties.allocType     = ::cudaMemAllocationTypePinned;
+    pool_properties.handleTypes   = ::cudaMemAllocationHandleType(cudaMemAllocationHandleType::cudaMemHandleTypeNone);
+    pool_properties.location.type = ::cudaMemLocationTypeDevice;
+    pool_properties.location.id   = current_device;
+    ::cudaMemPool_t new_pool{};
+    _CCCL_TRY_CUDA_API(::cudaMemPoolCreate, "Failed to call cudaMemPoolCreate", &new_pool, &pool_properties);
+
+    cudax::mr::async_memory_pool from_handle = cudax::mr::async_memory_pool::from_native_handle(new_pool);
+    CHECK(from_handle.get() == new_pool);
+  }
+}
+
+TEST_CASE("async_memory_pool comparison", "[memory_resource]")
+{
+  int current_device{};
+  {
+    _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to querry current device with with cudaGetDevice.", &current_device);
+  }
+
+  int driver_version = 0;
+  {
+    _CCCL_TRY_CUDA_API(::cudaDriverGetVersion, "Failed to call cudaDriverGetVersion", &driver_version);
+  }
+
+  ::cudaMemPool_t current_default_pool{};
+  {
+    _CCCL_TRY_CUDA_API(::cudaDeviceGetDefaultMemPool,
+                       "Failed to call cudaDeviceGetDefaultMemPool",
+                       &current_default_pool,
+                       current_device);
+  }
+
+  cudax::mr::async_memory_pool first{current_device};
+  { // comparison against a plain async_memory_pool
+    cudax::mr::async_memory_pool second{current_device};
+    CHECK(first == first);
+    CHECK(first != second);
+  }
+
+  { // comparison against a cudaMemPool_t
+    CHECK(first == first.get());
+    CHECK(first.get() == first);
+    CHECK(first != current_default_pool);
+    CHECK(current_default_pool != first);
+  }
+}

--- a/cudax/test/memory_resource/async_memory_resource.cu
+++ b/cudax/test/memory_resource/async_memory_resource.cu
@@ -1,0 +1,490 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+#include <cuda/stream_ref>
+
+#include <cuda/experimental/memory_resource.cuh>
+
+#include <stdexcept>
+
+#include <catch2/catch.hpp>
+
+namespace cudax = cuda::experimental;
+
+static_assert(!cuda::std::is_trivial<cudax::mr::async_memory_resource>::value, "");
+static_assert(!cuda::std::is_trivially_default_constructible<cudax::mr::async_memory_resource>::value, "");
+static_assert(cuda::std::is_default_constructible<cudax::mr::async_memory_resource>::value, "");
+static_assert(cuda::std::is_copy_constructible<cudax::mr::async_memory_resource>::value, "");
+static_assert(cuda::std::is_move_constructible<cudax::mr::async_memory_resource>::value, "");
+static_assert(cuda::std::is_copy_assignable<cudax::mr::async_memory_resource>::value, "");
+static_assert(cuda::std::is_move_assignable<cudax::mr::async_memory_resource>::value, "");
+static_assert(cuda::std::is_trivially_destructible<cudax::mr::async_memory_resource>::value, "");
+static_assert(!cuda::std::is_empty<cudax::mr::async_memory_resource>::value, "");
+
+static bool ensure_release_threshold(::cudaMemPool_t pool, const size_t expected_threshold)
+{
+  size_t release_threshold = expected_threshold + 1337; // use something different than the expected threshold
+  _CCCL_TRY_CUDA_API(
+    ::cudaMemPoolGetAttribute,
+    "Failed to call cudaMemPoolGetAttribute",
+    pool,
+    ::cudaMemPoolAttrReleaseThreshold,
+    &release_threshold);
+  return release_threshold == expected_threshold;
+}
+
+static bool ensure_disable_reuse(::cudaMemPool_t pool, const int driver_version)
+{
+  int disable_reuse = 0;
+  _CCCL_TRY_CUDA_API(
+    ::cudaMemPoolGetAttribute,
+    "Failed to call cudaMemPoolGetAttribute",
+    pool,
+    ::cudaMemPoolReuseAllowOpportunistic,
+    &disable_reuse);
+
+  constexpr int min_async_version = 11050;
+  return driver_version < min_async_version ? disable_reuse == 0 : disable_reuse != 0;
+}
+
+static bool ensure_export_handle(::cudaMemPool_t pool, const ::cudaMemAllocationHandleType allocation_handle)
+{
+  size_t handle              = 0;
+  const ::cudaError_t status = ::cudaMemPoolExportToShareableHandle(&handle, pool, allocation_handle, 0);
+  ::cudaGetLastError(); // Clear CUDA error state
+
+  // If no export was defined we need to query cudaErrorInvalidValue
+  return allocation_handle == ::cudaMemHandleTypeNone ? status == ::cudaErrorInvalidValue : status == ::cudaSuccess;
+}
+
+TEST_CASE("async_memory_resource construction", "[memory_resource]")
+{
+  int current_device{};
+  {
+    _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to query current device with cudaGetDevice.", &current_device);
+  }
+
+  int driver_version = 0;
+  {
+    _CCCL_TRY_CUDA_API(::cudaDriverGetVersion, "Failed to call cudaDriverGetVersion", &driver_version);
+  }
+
+  ::cudaMemPool_t current_default_pool{};
+  {
+    _CCCL_TRY_CUDA_API(::cudaDeviceGetDefaultMemPool,
+                       "Failed to call cudaDeviceGetDefaultMemPool",
+                       &current_default_pool,
+                       current_device);
+  }
+
+  using async_resource = cuda::experimental::mr::async_memory_resource;
+  SECTION("Default construction")
+  {
+    {
+      async_resource default_constructed{};
+      CHECK(default_constructed.get() == current_default_pool);
+    }
+
+    // Ensure that the pool was not destroyed by allocating something
+    void* ptr{nullptr};
+    _CCCL_TRY_CUDA_API(
+      ::cudaMallocAsync,
+      "Failed to allocate with pool passed to cuda::experimental::mr::async_memory_resource",
+      &ptr,
+      42,
+      current_default_pool,
+      ::cudaStream_t{0});
+    CHECK(ptr != nullptr);
+
+    _CCCL_ASSERT_CUDA_API(
+      ::cudaFreeAsync,
+      "Failed to deallocate with pool passed to cuda::experimental::mr::async_memory_resource",
+      ptr,
+      ::cudaStream_t{0});
+  }
+
+  SECTION("Construct from mempool handle")
+  {
+    ::cudaMemPoolProps pool_properties{};
+    pool_properties.allocType     = ::cudaMemAllocationTypePinned;
+    pool_properties.handleTypes   = ::cudaMemAllocationHandleType(0);
+    pool_properties.location.type = ::cudaMemLocationTypeDevice;
+    pool_properties.location.id   = current_device;
+    cudaMemPool_t cuda_pool_handle{};
+    _CCCL_TRY_CUDA_API(::cudaMemPoolCreate, "Failed to call cudaMemPoolCreate", &cuda_pool_handle, &pool_properties);
+
+    {
+      async_resource from_cudaMemPool{cuda_pool_handle};
+      CHECK(from_cudaMemPool.get() == cuda_pool_handle);
+      CHECK(from_cudaMemPool.get() != current_default_pool);
+    }
+
+    // Ensure that the pool was not destroyed by allocating something
+    void* ptr{nullptr};
+    _CCCL_TRY_CUDA_API(
+      ::cudaMallocAsync,
+      "Failed to allocate with pool passed to cuda::experimental::mr::async_memory_resource",
+      &ptr,
+      42,
+      current_default_pool,
+      ::cudaStream_t{0});
+    CHECK(ptr != nullptr);
+
+    _CCCL_ASSERT_CUDA_API(
+      ::cudaFreeAsync,
+      "Failed to deallocate with pool passed to cuda::experimental::mr::async_memory_resource",
+      ptr,
+      ::cudaStream_t{0});
+  }
+
+  SECTION("Construct with initial pool size")
+  {
+    cuda::experimental::mr::async_memory_pool_properties props = {
+      42,
+    };
+    cuda::experimental::mr::async_memory_pool pool{current_device, props};
+    async_resource from_initial_pool_size{pool};
+
+    ::cudaMemPool_t get = from_initial_pool_size.get();
+    CHECK(get != current_default_pool);
+
+    // Ensure we use the right release threshold
+    CHECK(ensure_release_threshold(get, 0));
+
+    // Ensure that we disable reuse with unsupported drivers
+    CHECK(ensure_disable_reuse(get, driver_version));
+
+    // Ensure that we disable export
+    CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
+  }
+
+  SECTION("Construct with release threshold")
+  {
+    cuda::experimental::mr::async_memory_pool_properties props = {
+      42,
+      20,
+    };
+    cuda::experimental::mr::async_memory_pool pool{current_device, props};
+    async_resource with_threshold{pool};
+
+    ::cudaMemPool_t get = with_threshold.get();
+    CHECK(get != current_default_pool);
+
+    // Ensure we use the right release threshold
+    CHECK(ensure_release_threshold(get, props.release_threshold));
+
+    // Ensure that we disable reuse with unsupported drivers
+    CHECK(ensure_disable_reuse(get, driver_version));
+
+    // Ensure that we disable export
+    CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
+  }
+
+  // Allocation handles are only supported after 11.2
+#if !defined(_CCCL_CUDACC_BELOW_11_2)
+  SECTION("Construct with allocation handle")
+  {
+    cuda::experimental::mr::async_memory_pool_properties props = {
+      42,
+      20,
+      cuda::experimental::mr::cudaMemAllocationHandleType::cudaMemHandleTypePosixFileDescriptor,
+    };
+    cuda::experimental::mr::async_memory_pool pool{current_device, props};
+    async_resource with_allocation_handle{pool};
+
+    ::cudaMemPool_t get = with_allocation_handle.get();
+    CHECK(get != current_default_pool);
+
+    // Ensure we use the right release threshold
+    CHECK(ensure_release_threshold(get, props.release_threshold));
+
+    // Ensure that we disable reuse with unsupported drivers
+    CHECK(ensure_disable_reuse(get, driver_version));
+
+    // Ensure that we disable export
+    CHECK(ensure_export_handle(get, static_cast<cudaMemAllocationHandleType>(props.allocation_handle_type)));
+  }
+#endif // !_CCCL_CUDACC_BELOW_11_2
+}
+
+static void ensure_device_ptr(void* ptr)
+{
+  CHECK(ptr != nullptr);
+  cudaPointerAttributes attributes;
+  cudaError_t status = cudaPointerGetAttributes(&attributes, ptr);
+  CHECK(status == cudaSuccess);
+  CHECK(attributes.type == cudaMemoryTypeDevice);
+}
+
+TEST_CASE("async_memory_resource allocation", "[memory_resource]")
+{
+  cuda::experimental::mr::async_memory_resource res{};
+
+  { // allocate / deallocate
+    auto* ptr = res.allocate(42);
+    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
+    ensure_device_ptr(ptr);
+
+    res.deallocate(ptr, 42);
+  }
+
+  { // allocate / deallocate with alignment
+    auto* ptr = res.allocate(42, 4);
+    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
+    ensure_device_ptr(ptr);
+
+    res.deallocate(ptr, 42, 4);
+  }
+
+  { // allocate_async / deallocate_async
+    cudaStream_t raw_stream;
+    cudaStreamCreate(&raw_stream);
+    cuda::stream_ref stream{raw_stream};
+
+    auto* ptr = res.allocate_async(42, stream);
+    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
+
+    stream.wait();
+    ensure_device_ptr(ptr);
+
+    res.deallocate_async(ptr, 42, stream);
+    cudaStreamDestroy(raw_stream);
+  }
+
+  { // allocate_async / deallocate_async with alignment
+    cudaStream_t raw_stream;
+    cudaStreamCreate(&raw_stream);
+    cuda::stream_ref stream{raw_stream};
+
+    auto* ptr = res.allocate_async(42, 4, stream);
+    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
+
+    stream.wait();
+    ensure_device_ptr(ptr);
+
+    res.deallocate_async(ptr, 42, 4, stream);
+    cudaStreamDestroy(raw_stream);
+  }
+
+#ifndef _LIBCUDACXX_NO_EXCEPTIONS
+  { // allocate with too small alignment
+    while (true)
+    {
+      try
+      {
+        auto* ptr = res.allocate(5, 42);
+        (void) ptr;
+      }
+      catch (std::invalid_argument&)
+      {
+        break;
+      }
+      CHECK(false);
+    }
+  }
+
+  { // allocate with non matching alignment
+    while (true)
+    {
+      try
+      {
+        auto* ptr = res.allocate(5, 1337);
+        (void) ptr;
+      }
+      catch (std::invalid_argument&)
+      {
+        break;
+      }
+      CHECK(false);
+    }
+  }
+  { // allocate_async with too small alignment
+    while (true)
+    {
+      cudaStream_t raw_stream;
+      cudaStreamCreate(&raw_stream);
+      try
+      {
+        auto* ptr = res.allocate_async(5, 42, raw_stream);
+        (void) ptr;
+      }
+      catch (std::invalid_argument&)
+      {
+        cudaStreamDestroy(raw_stream);
+        break;
+      }
+      CHECK(false);
+    }
+  }
+
+  { // allocate_async with non matching alignment
+    while (true)
+    {
+      cudaStream_t raw_stream;
+      cudaStreamCreate(&raw_stream);
+      try
+      {
+        auto* ptr = res.allocate_async(5, 1337, raw_stream);
+        (void) ptr;
+      }
+      catch (std::invalid_argument&)
+      {
+        cudaStreamDestroy(raw_stream);
+        break;
+      }
+      CHECK(false);
+    }
+  }
+#endif // _LIBCUDACXX_NO_EXCEPTIONS
+}
+
+enum class AccessibilityType
+{
+  Device,
+  Host,
+};
+
+template <AccessibilityType Accessibilty>
+struct resource
+{
+  void* allocate(size_t, size_t)
+  {
+    return nullptr;
+  }
+  void deallocate(void*, size_t, size_t) {}
+
+  bool operator==(const resource&) const
+  {
+    return true;
+  }
+  bool operator!=(const resource& other) const
+  {
+    return false;
+  }
+
+  template <AccessibilityType Accessibilty2                                         = Accessibilty,
+            cuda::std::enable_if_t<Accessibilty2 == AccessibilityType::Device, int> = 0>
+  friend void get_property(const resource&, cuda::mr::device_accessible) noexcept
+  {}
+};
+static_assert(cuda::mr::resource<resource<AccessibilityType::Host>>, "");
+static_assert(!cuda::mr::resource_with<resource<AccessibilityType::Host>, cuda::mr::device_accessible>, "");
+static_assert(cuda::mr::resource<resource<AccessibilityType::Device>>, "");
+static_assert(cuda::mr::resource_with<resource<AccessibilityType::Device>, cuda::mr::device_accessible>, "");
+
+template <AccessibilityType Accessibilty>
+struct async_resource : public resource<Accessibilty>
+{
+  void* allocate_async(size_t, size_t, cuda::stream_ref)
+  {
+    return nullptr;
+  }
+  void deallocate_async(void*, size_t, size_t, cuda::stream_ref) {}
+};
+static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
+static_assert(!cuda::mr::async_resource_with<async_resource<AccessibilityType::Host>, cuda::mr::device_accessible>, "");
+static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
+static_assert(cuda::mr::async_resource_with<async_resource<AccessibilityType::Device>, cuda::mr::device_accessible>,
+              "");
+
+TEST_CASE("async_memory_resource comparison", "[memory_resource]")
+{
+  int current_device{};
+  {
+    _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to query current device with cudaGetDevice.", &current_device);
+  }
+
+  cuda::experimental::mr::async_memory_resource first{};
+  { // comparison against a plain async_memory_resource
+    cuda::experimental::mr::async_memory_resource second{};
+    CHECK(first == second);
+    CHECK(!(first != second));
+  }
+
+  { // comparison against a plain async_memory_resource with a different pool
+    cudaMemPool_t cuda_pool_handle{};
+    {
+      ::cudaMemPoolProps pool_properties{};
+      pool_properties.allocType     = ::cudaMemAllocationTypePinned;
+      pool_properties.handleTypes   = ::cudaMemAllocationHandleType(0);
+      pool_properties.location.type = ::cudaMemLocationTypeDevice;
+      pool_properties.location.id   = current_device;
+      _CCCL_TRY_CUDA_API(::cudaMemPoolCreate, "Failed to call cudaMemPoolCreate", &cuda_pool_handle, &pool_properties);
+    }
+    cuda::experimental::mr::async_memory_resource second{cuda_pool_handle};
+    CHECK(first != second);
+    CHECK(!(first == second));
+  }
+
+  { // comparison against a async_memory_resource wrapped inside a resource_ref<device_accessible>
+    cuda::experimental::mr::async_memory_resource second{};
+    cuda::mr::resource_ref<cuda::mr::device_accessible> second_ref{second};
+    CHECK(first == second_ref);
+    CHECK(!(first != second_ref));
+    CHECK(second_ref == first);
+    CHECK(!(second_ref != first));
+  }
+
+  { // comparison against a async_memory_resource wrapped inside a resource_ref<>
+    cuda::experimental::mr::async_memory_resource second{};
+    CHECK(first == cuda::mr::resource_ref<>{second});
+    CHECK(!(first != cuda::mr::resource_ref<>{second}));
+    CHECK(cuda::mr::resource_ref<>{second} == first);
+    CHECK(!(cuda::mr::resource_ref<>{second} != first));
+  }
+
+  { // comparison against a async_memory_resource wrapped inside a async_resource_ref
+    cuda::experimental::mr::async_memory_resource second{};
+    cuda::mr::async_resource_ref<cuda::mr::device_accessible> second_ref{second};
+
+    CHECK(first == second_ref);
+    CHECK(!(first != second_ref));
+    CHECK(second_ref == first);
+    CHECK(!(second_ref != first));
+  }
+
+  { // comparison against a async_memory_resource wrapped inside a async_resource_ref<>
+    cuda::experimental::mr::async_memory_resource second{};
+    CHECK(first == cuda::mr::async_resource_ref<>{second});
+    CHECK(!(first != cuda::mr::async_resource_ref<>{second}));
+    CHECK(cuda::mr::async_resource_ref<>{second} == first);
+    CHECK(!(cuda::mr::async_resource_ref<>{second} != first));
+  }
+
+  { // comparison against a different resource through resource_ref
+    resource<AccessibilityType::Host> host_resource{};
+    resource<AccessibilityType::Device> device_resource{};
+    CHECK(!(first == host_resource));
+    CHECK(first != host_resource);
+    CHECK(!(first == device_resource));
+    CHECK(first != device_resource);
+
+    CHECK(!(host_resource == first));
+    CHECK(host_resource != first);
+    CHECK(!(device_resource == first));
+    CHECK(device_resource != first);
+  }
+
+  { // comparison against a different resource through resource_ref
+    async_resource<AccessibilityType::Host> host_async_resource{};
+    async_resource<AccessibilityType::Device> device_async_resource{};
+    CHECK(!(first == host_async_resource));
+    CHECK(first != host_async_resource);
+    CHECK(!(first == device_async_resource));
+    CHECK(first != device_async_resource);
+
+    CHECK(!(host_async_resource == first));
+    CHECK(host_async_resource != first);
+    CHECK(!(device_async_resource == first));
+    CHECK(device_async_resource != first);
+  }
+}

--- a/docs/cudax/index.rst
+++ b/docs/cudax/index.rst
@@ -16,7 +16,8 @@ However, any feature within this library has important use cases and we encourag
 
 Specifically, ``cudax`` provides:
    - :ref:`uninitialized storage <cudax-containers-uninitialized-buffer>`
-   - :ref:`an ownning type erased memory resource <cudax-memory-resource-async-any-resource>`
+   - :ref:`an owning type erased memory resource <cudax-memory-resource-async-any-resource>`
+   - :ref:`stream-ordered memory resources <cudax-memory-resource-async>`
    - dimensions description functionality
 
 Stability Guarantees

--- a/docs/cudax/memory_resource.rst
+++ b/docs/cudax/memory_resource.rst
@@ -11,6 +11,7 @@ Memory Resources
    ${repo_docs_api_path}/enum*async__memory__pool*
    ${repo_docs_api_path}/struct*async__memory__pool__properties*
    ${repo_docs_api_path}/class*async__memory__pool*
+   ${repo_docs_api_path}/class*async__memory__resource*
 
 The ``<cuda/experimental/memory_resource.cuh>`` header provides:
    -  :ref:`any_resource <cudax-memory-resource-any-resource>` and

--- a/docs/cudax/memory_resource.rst
+++ b/docs/cudax/memory_resource.rst
@@ -8,9 +8,20 @@ Memory Resources
    :maxdepth: 3
 
    ${repo_docs_api_path}/*any__resource*
+   ${repo_docs_api_path}/enum*async__memory__pool*
+   ${repo_docs_api_path}/struct*async__memory__pool__properties*
+   ${repo_docs_api_path}/class*async__memory__pool*
 
 The ``<cuda/experimental/memory_resource.cuh>`` header provides:
    -  :ref:`any_resource <cudax-memory-resource-any-resource>` and
       :ref:`async_any_resource <cudax-memory-resource-async-any-resource>` type erased memory resources similar to
       ``std::any``. In contrast to :ref:`resource_ref <libcudacxx-extended-api-memory-resources-resource-ref>` they
       own the contained resource.
+   -  :ref:`async_memory_resource <cudax-memory-resource-async>` A standard C++ interface for *heterogeneous*,
+      *stream-ordered* memory allocation tailored to the needs of CUDA C++ developers. This design builds off of the
+      success of the `RAPIDS Memory Manager (RMM) <https://github.com/rapidsai/rmm>`__ project and evolves the design
+      based on lessons learned.
+
+``<cuda/experimental/memory_resource.cuh>`` is not intended to replace RMM, but instead moves the definition of the
+memory allocation interface to a more centralized home in CCCL. RMM will remain as a collection of implementations of
+the ``cuda::mr`` interfaces.


### PR DESCRIPTION
This implements two facilities for allocating stream order device accessible memory.

The first commit adds `cuda_memory_pool`, a wrapper around `::cudaMemPool_t` that takes care of initialization of the buffer and its destruction.

The second commit adds `cuda_async_memory_resource`, is a leightweight async_resource. It utilizes either a self-owned `cuda_memory_pool` that is properly destroyed when it goes out of scope, or wraps a user provided `::cudaMemPool_t`.

This allows interoperability between different libraries by retaining an existing pool

Fixes #1514
