### PR TITLE
Address potential oob in cub when passing in an invalid device counter

### DIFF
--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -443,7 +443,7 @@ public:
   template <typename Invocable>
   _CCCL_HOST DevicePayload operator()(Invocable&& f, int device)
   {
-    if (device >= DeviceCount())
+    if (device >= DeviceCount() || device < 0)
     {
       return DevicePayload{0, cudaErrorInvalidDevice};
     }


### PR DESCRIPTION
Fixes nvbug4605535
