### PR TITLE
Allow ninja_summary to fail

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -203,7 +203,7 @@ function build_preset() {
               will have a weighted time that is the same or similar to its elapsed time. A
               compile that runs in parallel with 999 other compiles will have a weighted time
               that is tiny."
-        ./ninja_summary.py -C ${BUILD_DIR}/${PRESET}
+        ./ninja_summary.py -C ${BUILD_DIR}/${PRESET} || echo "Warning: ninja_summary.py failed to execute properly."
         end_group
     else
       echo $minimal_sccache_stats


### PR DESCRIPTION
Something happened that's causing the `ninja_summary.py` script to fail. Likely an upgraded `ninja` version in the devcontainers.

https://github.com/NVIDIA/cccl/actions/runs/8725128219/job/23937641343#step:8:3913

Updated the invocation to allow it to fail to unblock CI. 