### PR TITLE
Make `--cmake-options=""` always override others.

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -167,7 +167,7 @@ function configure_preset()
     local GROUP_NAME="🛠️  CMake Configure ${BUILD_NAME}"
 
     pushd .. > /dev/null
-    run_command "$GROUP_NAME" cmake --preset=$PRESET --log-level=VERBOSE "${GLOBAL_CMAKE_OPTIONS[@]}" $CMAKE_OPTIONS
+    run_command "$GROUP_NAME" cmake --preset=$PRESET --log-level=VERBOSE $CMAKE_OPTIONS "${GLOBAL_CMAKE_OPTIONS[@]}"
     status=$?
     popd > /dev/null
     return $status


### PR DESCRIPTION
This allows a user to override things like CUB's benchmarks when they aren't needed.