### PR TITLE
Fix code sample in README and docs

### DIFF
--- a/cub/README.md
+++ b/cub/README.md
@@ -35,8 +35,8 @@ __global__ void BlockSortKernel(int *d_in, int *d_out)
      // Specialize BlockRadixSort, BlockLoad, and BlockStore for 128 threads
      // owning 16 integer items each
      typedef BlockRadixSort<int, 128, 16>                     BlockRadixSort;
-     typedef BlockLoad<int, 128, 16, BLOCK_LOAD_TRANSPOSE>   BlockLoad;
-     typedef BlockStore<int, 128, 16, BLOCK_STORE_TRANSPOSE> BlockStore;
+     typedef BlockLoad<int, 128, 16, cub::BLOCK_LOAD_TRANSPOSE>   BlockLoad;
+     typedef BlockStore<int, 128, 16, cub::BLOCK_STORE_TRANSPOSE> BlockStore;
 
      // Allocate shared memory
      __shared__ union {

--- a/cub/README.md
+++ b/cub/README.md
@@ -35,8 +35,8 @@ __global__ void BlockSortKernel(int *d_in, int *d_out)
      // Specialize BlockRadixSort, BlockLoad, and BlockStore for 128 threads
      // owning 16 integer items each
      typedef BlockRadixSort<int, 128, 16>                     BlockRadixSort;
-     typedef BlockLoad<int, 128, 16, cub::BLOCK_LOAD_TRANSPOSE>   BlockLoad;
-     typedef BlockStore<int, 128, 16, cub::BLOCK_STORE_TRANSPOSE> BlockStore;
+     typedef BlockLoad<int, 128, 16, BLOCK_LOAD_TRANSPOSE>   BlockLoad;
+     typedef BlockStore<int, 128, 16, BLOCK_STORE_TRANSPOSE> BlockStore;
 
      // Allocate shared memory
      __shared__ union {

--- a/cub/docs/index.rst
+++ b/cub/docs/index.rst
@@ -96,9 +96,9 @@ integer keys:
     {
         // Specialize BlockLoad, BlockStore, and BlockRadixSort collective types
         typedef cub::BlockLoad<
-          int*, BLOCK_THREADS, ITEMS_PER_THREAD, BLOCK_LOAD_TRANSPOSE> BlockLoadT;
+          int, BLOCK_THREADS, ITEMS_PER_THREAD, cub::BLOCK_LOAD_TRANSPOSE> BlockLoadT;
         typedef cub::BlockStore<
-          int*, BLOCK_THREADS, ITEMS_PER_THREAD, BLOCK_STORE_TRANSPOSE> BlockStoreT;
+          int, BLOCK_THREADS, ITEMS_PER_THREAD, cub::BLOCK_STORE_TRANSPOSE> BlockStoreT;
         typedef cub::BlockRadixSort<
           int, BLOCK_THREADS, ITEMS_PER_THREAD> BlockRadixSortT;
 


### PR DESCRIPTION
Add missing namespace specifiers that were overlooked when https://github.com/NVIDIA/cccl/blob/29a24f49c26640e8d9e250ec20797698a6a92027/cub/examples/block/example_block_radix_sort.cu#L50 was removed.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #1651

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
