### PR TITLE
Fix invalid `_CCCL_CUDACC` definition for clang cuda

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -56,7 +56,14 @@
 #  define _CCCL_CUDA_COMPILER
 #endif // cuda compiler available
 
-#if defined(__CUDACC__) || defined(_CCCL_CUDA_COMPILER_NVHPC)
+// clang-cuda does not define __CUDACC_VER_MAJOR__ and friends
+#if defined(_CCCL_CUDA_COMPILER_CLANG)
+#  define _CCCL_CUDACC
+#  define _CCCL_CUDACC_VER_MAJOR CUDA_VERSION / 1000
+#  define _CCCL_CUDACC_VER_MINOR (CUDA_VERSION % 1000) / 10
+#  define _CCCL_CUDACC_VER_BUILD 0
+#  define _CCCL_CUDACC_VER       CUDA_VERSION * 100
+#elif defined(_CCCL_CUDA_COMPILER)
 #  define _CCCL_CUDACC
 #  define _CCCL_CUDACC_VER_MAJOR __CUDACC_VER_MAJOR__
 #  define _CCCL_CUDACC_VER_MINOR __CUDACC_VER_MINOR__

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -1892,11 +1892,13 @@ extern "C" _LIBCUDACXX_FUNC_VIS void __sanitizer_annotate_contiguous_container(
 // We need `is_constant_evaluated` for clang and gcc. MSVC also needs extensive rework
 #if !defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED)
 #define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
-#elif defined(__CUDACC_RTC__)
+#elif defined(_CCCL_COMPILER_NVRTC)
 #define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
-#elif defined(_MSC_VER)
+#elif defined(_CCCL_COMPILER_MSVC)
 #define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
 #elif defined(_CCCL_CUDACC_BELOW_11_8)
+#define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
+#elif defined(_CCCL_CUDA_COMPILER_CLANG)
 #define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
 #endif
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -310,7 +310,7 @@ long double    truncl(long double x);
 #  pragma system_header
 #endif // no system header
 
-#if !defined(__CUDACC_RTC__) || !defined(__cuda_std__)
+#if !defined(_CCCL_COMPILER_NVRTC) || !defined(__cuda_std__)
 #include <math.h>
 #endif
 
@@ -685,7 +685,7 @@ __constexpr_isfinite(_A1 __lcpp_x) noexcept
     return isfinite(__lcpp_x);
 }
 
-#if defined(_MSC_VER) || defined(__CUDACC_RTC__) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#if defined(_CCCL_COMPILER_MSVC) || defined(_CCCL_COMPILER_NVRTC)
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _A1 __constexpr_copysign(_A1 __x, _A1 __y) noexcept
@@ -717,9 +717,9 @@ _CCCL_CONSTEXPR_CXX14 __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_
     static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
     return __builtin_copysign((__result_type)__x, (__result_type)__y);
 }
-#endif // !_MSC_VER
+#endif // !_CCCL_COMPILER_MSVC
 
-#if defined(_MSC_VER) || defined(__CUDACC_RTC__) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#if defined(_CCCL_COMPILER_MSVC) || defined(_CCCL_COMPILER_NVRTC)
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _A1 __constexpr_fabs(_A1 __x) noexcept
@@ -747,9 +747,9 @@ inline _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY
 _CCCL_CONSTEXPR_CXX14 double __constexpr_fabs(_Tp __x) noexcept {
     return __builtin_fabs(static_cast<double>(__x));
 }
-#endif // !_MSC_VER
+#endif // !_CCCL_COMPILER_MSVC
 
-#if defined(_MSC_VER) || defined(__CUDACC_RTC__) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#if defined(_CCCL_COMPILER_MSVC) || defined(_CCCL_COMPILER_NVRTC)
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _A1 __constexpr_fmax(_A1 __x, _A1 __y) noexcept
@@ -806,9 +806,9 @@ __constexpr_fmax(_Tp __x, _Up __y) noexcept {
   using __result_type = __promote_t<_Tp, _Up>;
   return _CUDA_VSTD::__constexpr_fmax(static_cast<__result_type>(__x), static_cast<__result_type>(__y));
 }
-#endif // !_MSC_VER
+#endif // !_CCCL_COMPILER_MSVC
 
-#if defined(_MSC_VER) || defined(__CUDACC_RTC__) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#if defined(_CCCL_COMPILER_MSVC) || defined(_CCCL_COMPILER_NVRTC) || defined(_CCCL_CUDA_COMPILER_CLANG)
 template <class _A1>
 _LIBCUDACXX_INLINE_VISIBILITY
 _A1 __constexpr_logb(_A1 __x)
@@ -845,7 +845,7 @@ _CCCL_CONSTEXPR_CXX14_COMPLEX _Tp __constexpr_logb(_Tp __x) {
 }
 #endif // !_MSVC
 
-#if defined(_MSC_VER) || defined(__CUDACC_RTC__) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#if defined(_CCCL_COMPILER_MSVC) || defined(_CCCL_COMPILER_NVRTC) || defined(_CCCL_CUDA_COMPILER_CLANG)
 template <class _Tp>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _Tp __constexpr_scalbn(_Tp __x, int __i) {
@@ -913,7 +913,7 @@ _CCCL_CONSTEXPR_CXX14_COMPLEX _Tp __constexpr_scalbn(_Tp __x, int __exp) {
 #endif // defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED)
   return __builtin_scalbn(__x, __exp);
 }
-#endif // !_MSC_VER
+#endif // !_CCCL_COMPILER_MSVC
 
 #if _CCCL_STD_VER > 2017
 template <typename _Fp>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/binder_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/binder_typedefs.compile.pass.cpp
@@ -17,7 +17,9 @@
 
 // check that binder typedefs exit
 
-// #include <cuda/std/functional>
+#define _LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS
+
+#include <cuda/std/functional>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/default.allocator/allocator_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/default.allocator/allocator_types.pass.cpp
@@ -33,6 +33,8 @@
 
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS
 
+#define _LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS
+
 #include <cuda/std/__memory_>
 #include <cuda/std/cstddef>
 #include <cuda/std/type_traits>

--- a/libcudacxx/test/libcudacxx/std/utilities/memory/default.allocator/allocator_types.void.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/default.allocator/allocator_types.void.compile.pass.cpp
@@ -27,6 +27,8 @@
 
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS
 
+#define _LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS
+
 #include <cuda/std/__memory_>
 #include <cuda/std/type_traits>
 


### PR DESCRIPTION
clang-cuda does not implement the `__CUDACC_VER_MAJOR__` macros

Consequently the currently the _CCCL_CUDACC_VER was 0 which made clang-cuda fail all our `_CCCL_CUDACC_BELOW_MEOW` checks.

We can fix this by synthesizing the information from `CUDA_VERSION`