### PR TITLE
Add missing #pragma once in some headers

### DIFF
--- a/cub/test/catch2_radix_sort_helper.cuh
+++ b/cub/test/catch2_radix_sort_helper.cuh
@@ -25,6 +25,8 @@
  *
  ******************************************************************************/
 
+#pragma once
+
 #include <cub/device/device_radix_sort.cuh>
 #include <cub/device/device_segmented_radix_sort.cuh>
 #include <cub/util_macro.cuh>

--- a/cub/test/fill_striped.cuh
+++ b/cub/test/fill_striped.cuh
@@ -25,6 +25,8 @@
  *
  ******************************************************************************/
 
+#pragma once
+
 #include <type_traits>
 
 template <typename T, typename = int>

--- a/cub/test/mersenne.h
+++ b/cub/test/mersenne.h
@@ -41,6 +41,8 @@
  email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
  */
 
+#pragma once
+
 #include <stdio.h>
 
 namespace mersenne


### PR DESCRIPTION
## Description

This PR adds a few missing `#pragma once` in some headers.

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] ~~The documentation is up to date with these changes.~~
