### PR TITLE
Drop new properties until we are certain about the design

### DIFF
--- a/libcudacxx/docs/extended_api/memory_resource/properties.md
+++ b/libcudacxx/docs/extended_api/memory_resource/properties.md
@@ -34,7 +34,6 @@ void function_that_dispatches_to_device(MemoryResource& resource);
 For now, libcu++ provides various commonly used properties:
 
 * `cuda::mr::device_accessible` and `cuda::mr::host_accessible` indicate whether memory allocated using a memory resource is accessible from host or device respectively.
-* `cuda::mr::managed_memory` indicates that the memory resource allocates CUDA unified memory which is both host and device accessible
 
 More properties may be added as the library and the hardware capabilities evolve. However, a user library is free to define custom properties.
 

--- a/libcudacxx/include/cuda/__memory_resource/cuda_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/cuda_managed_memory_resource.h
@@ -158,10 +158,6 @@ public:
 #    endif // _CCCL_STD_VER <= 2017
 
   /**
-   * @brief Enables the `managed_memory` property
-   */
-  friend constexpr void get_property(cuda_managed_memory_resource const&, managed_memory) noexcept {}
-  /**
    * @brief Enables the `device_accessible` property
    */
   friend constexpr void get_property(cuda_managed_memory_resource const&, device_accessible) noexcept {}
@@ -178,7 +174,6 @@ public:
     return __alignment <= default_cuda_malloc_alignment && (default_cuda_malloc_alignment % __alignment == 0);
   }
 };
-static_assert(resource_with<cuda_managed_memory_resource, managed_memory>, "");
 static_assert(resource_with<cuda_managed_memory_resource, device_accessible>, "");
 static_assert(resource_with<cuda_managed_memory_resource, host_accessible>, "");
 

--- a/libcudacxx/include/cuda/__memory_resource/cuda_pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/cuda_pinned_memory_resource.h
@@ -159,10 +159,6 @@ public:
 #    endif // _CCCL_STD_VER <= 2017
 
   /**
-   * @brief Enables the `pinned_memory` property
-   */
-  friend constexpr void get_property(cuda_pinned_memory_resource const&, pinned_memory) noexcept {}
-  /**
    * @brief Enables the `device_accessible` property
    */
   friend constexpr void get_property(cuda_pinned_memory_resource const&, device_accessible) noexcept {}
@@ -179,7 +175,6 @@ public:
     return __alignment <= default_cuda_malloc_host_alignment && (default_cuda_malloc_host_alignment % __alignment == 0);
   }
 };
-static_assert(resource_with<cuda_pinned_memory_resource, pinned_memory>, "");
 static_assert(resource_with<cuda_pinned_memory_resource, device_accessible>, "");
 static_assert(resource_with<cuda_pinned_memory_resource, host_accessible>, "");
 

--- a/libcudacxx/include/cuda/__memory_resource/properties.h
+++ b/libcudacxx/include/cuda/__memory_resource/properties.h
@@ -51,18 +51,6 @@ struct device_accessible
 struct host_accessible
 {};
 
-/**
- * @brief The \c managed_memory property signals that the allocated memory is managed
- */
-struct managed_memory
-{};
-
-/**
- * @brief The \c pinned_memory property signals that the allocated memory is not pageable.
- */
-struct pinned_memory
-{};
-
 _LIBCUDACXX_END_NAMESPACE_CUDA_MR
 
 #  endif // _CCCL_STD_VER >= 2014

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_managed_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_managed_memory_resource/equality.pass.cpp
@@ -40,16 +40,9 @@ struct resource
   {
     return false;
   }
-
-  template <AccessibilityType Accessibilty2                                         = Accessibilty,
-            cuda::std::enable_if_t<Accessibilty2 == AccessibilityType::Device, int> = 0>
-  friend void get_property(const resource&, cuda::mr::managed_memory) noexcept
-  {}
 };
 static_assert(cuda::mr::resource<resource<AccessibilityType::Host>>, "");
-static_assert(!cuda::mr::resource_with<resource<AccessibilityType::Host>, cuda::mr::managed_memory>, "");
 static_assert(cuda::mr::resource<resource<AccessibilityType::Device>>, "");
-static_assert(cuda::mr::resource_with<resource<AccessibilityType::Device>, cuda::mr::managed_memory>, "");
 
 template <AccessibilityType Accessibilty>
 struct async_resource : public resource<Accessibilty>
@@ -61,9 +54,7 @@ struct async_resource : public resource<Accessibilty>
   void deallocate_async(void*, size_t, size_t, cuda::stream_ref) {}
 };
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
-static_assert(!cuda::mr::async_resource_with<async_resource<AccessibilityType::Host>, cuda::mr::managed_memory>, "");
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
-static_assert(cuda::mr::async_resource_with<async_resource<AccessibilityType::Device>, cuda::mr::managed_memory>, "");
 
 void test()
 {
@@ -78,14 +69,6 @@ void test()
     cuda::mr::cuda_managed_memory_resource second{cudaMemAttachHost};
     assert(!(first == second));
     assert((first != second));
-  }
-
-  { // comparison against a cuda_managed_memory_resource wrapped inside a resource_ref<managed_memory>
-    cuda::mr::cuda_managed_memory_resource second{};
-    assert(first == cuda::mr::resource_ref<cuda::mr::managed_memory>{second});
-    assert(!(first != cuda::mr::resource_ref<cuda::mr::managed_memory>{second}));
-    assert(cuda::mr::resource_ref<cuda::mr::managed_memory>{second} == first);
-    assert(!(cuda::mr::resource_ref<cuda::mr::managed_memory>{second} != first));
   }
 
   { // comparison against a cuda_managed_memory_resource wrapped inside a resource_ref<>

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_pinned_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_pinned_memory_resource/equality.pass.cpp
@@ -40,16 +40,9 @@ struct resource
   {
     return false;
   }
-
-  template <AccessibilityType Accessibilty2                                         = Accessibilty,
-            cuda::std::enable_if_t<Accessibilty2 == AccessibilityType::Device, int> = 0>
-  friend void get_property(const resource&, cuda::mr::pinned_memory) noexcept
-  {}
 };
 static_assert(cuda::mr::resource<resource<AccessibilityType::Host>>, "");
-static_assert(!cuda::mr::resource_with<resource<AccessibilityType::Host>, cuda::mr::pinned_memory>, "");
 static_assert(cuda::mr::resource<resource<AccessibilityType::Device>>, "");
-static_assert(cuda::mr::resource_with<resource<AccessibilityType::Device>, cuda::mr::pinned_memory>, "");
 
 template <AccessibilityType Accessibilty>
 struct async_resource : public resource<Accessibilty>
@@ -61,9 +54,7 @@ struct async_resource : public resource<Accessibilty>
   void deallocate_async(void*, size_t, size_t, cuda::stream_ref) {}
 };
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
-static_assert(!cuda::mr::async_resource_with<async_resource<AccessibilityType::Host>, cuda::mr::pinned_memory>, "");
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
-static_assert(cuda::mr::async_resource_with<async_resource<AccessibilityType::Device>, cuda::mr::pinned_memory>, "");
 
 void test()
 {
@@ -78,15 +69,6 @@ void test()
     cuda::mr::cuda_pinned_memory_resource second{cudaHostAllocPortable};
     assert(!(first == second));
     assert((first != second));
-  }
-
-  { // comparison against a cuda_pinned_memory_resource wrapped inside a resource_ref<cuda::mr::pinned_memory>
-    cuda::mr::cuda_pinned_memory_resource second{};
-    cuda::mr::resource_ref<cuda::mr::pinned_memory> second_ref{second};
-    assert(first == second_ref);
-    assert(!(first != second_ref));
-    assert(second_ref == first);
-    assert(!(second_ref != first));
   }
 
   { // comparison against a cuda_pinned_memory_resource wrapped inside a resource_ref<>


### PR DESCRIPTION
Describing managed memory and pinned memory is not as trivial as creating two properties. 

Drop those until we are certain that we have the design right