### PR TITLE
Ensure that {cr}begin works with types that pull in namespace std via ADL

### DIFF
--- a/cub/test/catch2_test_helper.h
+++ b/cub/test/catch2_test_helper.h
@@ -190,6 +190,32 @@ auto BitwiseEqualsRange(const Range& range) -> CustomEqualsRangeMatcher<Range, b
     REQUIRE_THAT(vec_ref, detail::NaNEqualsRange(vec_out)); \
   }
 
+#include <cuda/std/tuple>
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+template <size_t N, typename... T>
+__enable_if_t<(N == sizeof...(T))> print_elem(::std::ostream&, const tuple<T...>&)
+{}
+
+template <size_t N, typename... T>
+__enable_if_t<(N < sizeof...(T))> print_elem(::std::ostream& os, const tuple<T...>& tup)
+{
+  _CCCL_IF_CONSTEXPR (N != 0)
+  {
+    os << ", ";
+  }
+  os << _CUDA_VSTD::get<N>(tup);
+  _CUDA_VSTD::print_elem<N + 1>(os, tup);
+}
+
+template <typename... T>
+::std::ostream& operator<<(::std::ostream& os, const tuple<T...>& tup)
+{
+  os << "[";
+  _CUDA_VSTD::print_elem<0>(os, tup);
+  return os << "]";
+}
+_LIBCUDACXX_END_NAMESPACE_STD
+
 #include <c2h/custom_type.cuh>
 #include <c2h/generators.cuh>
 

--- a/libcudacxx/include/cuda/__cccl_config
+++ b/libcudacxx/include/cuda/__cccl_config
@@ -17,6 +17,7 @@
 #include <cuda/std/__cccl/dialect.h>
 #include <cuda/std/__cccl/execution_space.h>
 #include <cuda/std/__cccl/ptx_isa.h>
+#include <cuda/std/__cccl/sequence_access.h>
 #include <cuda/std/__cccl/system_header.h>
 #include <cuda/std/__cccl/version.h>
 #include <cuda/std/__cccl/visibility.h>

--- a/libcudacxx/include/cuda/std/__cccl/sequence_access.h
+++ b/libcudacxx/include/cuda/std/__cccl/sequence_access.h
@@ -22,69 +22,67 @@
 #  pragma system_header
 #endif // no system header
 
-// We need to define hidden _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITYs for {cr,r,}{begin,end} of our
-// containers as we will otherwise encounter ambigouities
-#define _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(_ClassName, _ConstIter)                                                 \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY iterator begin(_ClassName& __sequence) noexcept(          \
-    noexcept(__sequence.begin()))                                                                                \
-  {                                                                                                              \
-    return __sequence.begin();                                                                                   \
-  }                                                                                                              \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter begin(const _ClassName& __sequence) noexcept(  \
-    noexcept(__sequence.begin()))                                                                                \
-  {                                                                                                              \
-    return __sequence.begin();                                                                                   \
-  }                                                                                                              \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY iterator end(_ClassName& __sequence) noexcept(            \
-    noexcept(__sequence.end()))                                                                                  \
-  {                                                                                                              \
-    return __sequence.end();                                                                                     \
-  }                                                                                                              \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter end(const _ClassName& __sequence) noexcept(    \
-    noexcept(__sequence.end()))                                                                                  \
-  {                                                                                                              \
-    return __sequence.end();                                                                                     \
-  }                                                                                                              \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter cbegin(const _ClassName& __sequence) noexcept( \
-    noexcept(__sequence.begin()))                                                                                \
-  {                                                                                                              \
-    return __sequence.begin();                                                                                   \
-  }                                                                                                              \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter cend(const _ClassName& __sequence) noexcept(   \
-    noexcept(__sequence.end()))                                                                                  \
-  {                                                                                                              \
-    return __sequence.end();                                                                                     \
+// We need to define hidden friends for {cr,r,}{begin,end} of our containers as we will otherwise encounter ambigouities
+#define _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(_ClassName, _ConstIter)                                                     \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE iterator begin(_ClassName& __sequence) noexcept(                          \
+    noexcept(__sequence.begin()))                                                                                    \
+  {                                                                                                                  \
+    return __sequence.begin();                                                                                       \
+  }                                                                                                                  \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE _ConstIter begin(const _ClassName& __sequence) noexcept(                  \
+    noexcept(__sequence.begin()))                                                                                    \
+  {                                                                                                                  \
+    return __sequence.begin();                                                                                       \
+  }                                                                                                                  \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE iterator end(_ClassName& __sequence) noexcept(noexcept(__sequence.end())) \
+  {                                                                                                                  \
+    return __sequence.end();                                                                                         \
+  }                                                                                                                  \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE _ConstIter end(const _ClassName& __sequence) noexcept(                    \
+    noexcept(__sequence.end()))                                                                                      \
+  {                                                                                                                  \
+    return __sequence.end();                                                                                         \
+  }                                                                                                                  \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE _ConstIter cbegin(const _ClassName& __sequence) noexcept(                 \
+    noexcept(__sequence.begin()))                                                                                    \
+  {                                                                                                                  \
+    return __sequence.begin();                                                                                       \
+  }                                                                                                                  \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE _ConstIter cend(const _ClassName& __sequence) noexcept(                   \
+    noexcept(__sequence.end()))                                                                                      \
+  {                                                                                                                  \
+    return __sequence.end();                                                                                         \
   }
-#define _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(_ClassName, _ConstIter)                                          \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY reverse_iterator rbegin(_ClassName& __sequence) noexcept(  \
-    noexcept(__sequence.rbegin()))                                                                                \
-  {                                                                                                               \
-    return __sequence.rbegin();                                                                                   \
-  }                                                                                                               \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter rbegin(const _ClassName& __sequence) noexcept(  \
-    noexcept(__sequence.rbegin()))                                                                                \
-  {                                                                                                               \
-    return __sequence.rbegin();                                                                                   \
-  }                                                                                                               \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY reverse_iterator rend(_ClassName& __sequence) noexcept(    \
-    noexcept(__sequence.rend()))                                                                                  \
-  {                                                                                                               \
-    return __sequence.rend();                                                                                     \
-  }                                                                                                               \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter rend(const _ClassName& __sequence) noexcept(    \
-    noexcept(__sequence.rend()))                                                                                  \
-  {                                                                                                               \
-    return __sequence.rend();                                                                                     \
-  }                                                                                                               \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter crbegin(const _ClassName& __sequence) noexcept( \
-    noexcept(__sequence.rbegin()))                                                                                \
-  {                                                                                                               \
-    return __sequence.rbegin();                                                                                   \
-  }                                                                                                               \
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter crend(const _ClassName& __sequence) noexcept(   \
-    noexcept(__sequence.rend()))                                                                                  \
-  {                                                                                                               \
-    return __sequence.rend();                                                                                     \
+#define _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(_ClassName, _ConstRevIter)                              \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE reverse_iterator rbegin(_ClassName& __sequence) noexcept(     \
+    noexcept(__sequence.rbegin()))                                                                       \
+  {                                                                                                      \
+    return __sequence.rbegin();                                                                          \
+  }                                                                                                      \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE _ConstRevIter rbegin(const _ClassName& __sequence) noexcept(  \
+    noexcept(__sequence.rbegin()))                                                                       \
+  {                                                                                                      \
+    return __sequence.rbegin();                                                                          \
+  }                                                                                                      \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE reverse_iterator rend(_ClassName& __sequence) noexcept(       \
+    noexcept(__sequence.rend()))                                                                         \
+  {                                                                                                      \
+    return __sequence.rend();                                                                            \
+  }                                                                                                      \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE _ConstRevIter rend(const _ClassName& __sequence) noexcept(    \
+    noexcept(__sequence.rend()))                                                                         \
+  {                                                                                                      \
+    return __sequence.rend();                                                                            \
+  }                                                                                                      \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE _ConstRevIter crbegin(const _ClassName& __sequence) noexcept( \
+    noexcept(__sequence.rbegin()))                                                                       \
+  {                                                                                                      \
+    return __sequence.rbegin();                                                                          \
+  }                                                                                                      \
+  _CCCL_NODISCARD_FRIEND _CCCL_HOST_DEVICE _ConstRevIter crend(const _ClassName& __sequence) noexcept(   \
+    noexcept(__sequence.rend()))                                                                         \
+  {                                                                                                      \
+    return __sequence.rend();                                                                            \
   }
 
 #endif // __CCCL_SEQUENCE_ACCESS_H

--- a/libcudacxx/include/cuda/std/__cccl/sequence_access.h
+++ b/libcudacxx/include/cuda/std/__cccl/sequence_access.h
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CCCL_SEQUENCE_ACCESS_H
+#define __CCCL_SEQUENCE_ACCESS_H
+
+#include <cuda/std/__cccl/compiler.h>
+#include <cuda/std/__cccl/system_header.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// We need to define hidden _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITYs for {cr,r,}{begin,end} of our
+// containers as we will otherwise encounter ambigouities
+#define _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(_ClassName, _ConstIter)                                                 \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY iterator begin(_ClassName& __sequence) noexcept(          \
+    noexcept(__sequence.begin()))                                                                                \
+  {                                                                                                              \
+    return __sequence.begin();                                                                                   \
+  }                                                                                                              \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter begin(const _ClassName& __sequence) noexcept(  \
+    noexcept(__sequence.begin()))                                                                                \
+  {                                                                                                              \
+    return __sequence.begin();                                                                                   \
+  }                                                                                                              \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY iterator end(_ClassName& __sequence) noexcept(            \
+    noexcept(__sequence.end()))                                                                                  \
+  {                                                                                                              \
+    return __sequence.end();                                                                                     \
+  }                                                                                                              \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter end(const _ClassName& __sequence) noexcept(    \
+    noexcept(__sequence.end()))                                                                                  \
+  {                                                                                                              \
+    return __sequence.end();                                                                                     \
+  }                                                                                                              \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter cbegin(const _ClassName& __sequence) noexcept( \
+    noexcept(__sequence.begin()))                                                                                \
+  {                                                                                                              \
+    return __sequence.begin();                                                                                   \
+  }                                                                                                              \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter cend(const _ClassName& __sequence) noexcept(   \
+    noexcept(__sequence.end()))                                                                                  \
+  {                                                                                                              \
+    return __sequence.end();                                                                                     \
+  }
+#define _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(_ClassName, _ConstIter)                                          \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY reverse_iterator rbegin(_ClassName& __sequence) noexcept(  \
+    noexcept(__sequence.rbegin()))                                                                                \
+  {                                                                                                               \
+    return __sequence.rbegin();                                                                                   \
+  }                                                                                                               \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter rbegin(const _ClassName& __sequence) noexcept(  \
+    noexcept(__sequence.rbegin()))                                                                                \
+  {                                                                                                               \
+    return __sequence.rbegin();                                                                                   \
+  }                                                                                                               \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY reverse_iterator rend(_ClassName& __sequence) noexcept(    \
+    noexcept(__sequence.rend()))                                                                                  \
+  {                                                                                                               \
+    return __sequence.rend();                                                                                     \
+  }                                                                                                               \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter rend(const _ClassName& __sequence) noexcept(    \
+    noexcept(__sequence.rend()))                                                                                  \
+  {                                                                                                               \
+    return __sequence.rend();                                                                                     \
+  }                                                                                                               \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter crbegin(const _ClassName& __sequence) noexcept( \
+    noexcept(__sequence.rbegin()))                                                                                \
+  {                                                                                                               \
+    return __sequence.rbegin();                                                                                   \
+  }                                                                                                               \
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY _ConstIter crend(const _ClassName& __sequence) noexcept(   \
+    noexcept(__sequence.rend()))                                                                                  \
+  {                                                                                                               \
+    return __sequence.rend();                                                                                     \
+  }
+
+#endif // __CCCL_SEQUENCE_ACCESS_H

--- a/libcudacxx/include/cuda/std/__cuda/barrier.h
+++ b/libcudacxx/include/cuda/std/__cuda/barrier.h
@@ -245,6 +245,7 @@ public:
 private:
   _LIBCUDACXX_INLINE_VISIBILITY inline bool __test_wait_sm_80(arrival_token __token) const
   {
+    (void) __token;
     int32_t __ready = 0;
     NV_DISPATCH_TARGET(
       NV_PROVIDES_SM_80,

--- a/libcudacxx/include/cuda/std/__iterator/access.h
+++ b/libcudacxx/include/cuda/std/__iterator/access.h
@@ -25,57 +25,107 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-template <class _Tp, size_t _Np>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 _Tp* begin(_Tp (&__array)[_Np])
+namespace __begin
 {
-  return __array;
-}
-
-template <class _Tp, size_t _Np>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 _Tp* end(_Tp (&__array)[_Np])
+struct __fn
 {
-  return __array + _Np;
-}
+  template <class _Tp, size_t _Np>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 _Tp* operator()(_Tp (&__array)[_Np]) const noexcept
+  {
+    return __array;
+  }
 
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto begin(_Cp& __c) -> decltype(__c.begin())
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(_Cp& __c) const noexcept(noexcept(__c.begin()))
+    -> decltype(__c.begin())
+  {
+    return __c.begin();
+  }
+
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(const _Cp& __c) const
+    noexcept(noexcept(__c.begin())) -> decltype(__c.begin())
+  {
+    return __c.begin();
+  }
+};
+} // namespace __begin
+
+inline namespace __cpo
 {
-  return __c.begin();
-}
+_LIBCUDACXX_CPO_ACCESSIBILITY auto begin = __begin::__fn{};
+} // namespace __cpo
 
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto begin(const _Cp& __c) -> decltype(__c.begin())
+namespace __end
 {
-  return __c.begin();
-}
-
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto end(_Cp& __c) -> decltype(__c.end())
+struct __fn
 {
-  return __c.end();
-}
+  template <class _Tp, size_t _Np>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 _Tp* operator()(_Tp (&__array)[_Np]) const noexcept
+  {
+    return __array + _Np;
+  }
 
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto end(const _Cp& __c) -> decltype(__c.end())
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(_Cp& __c) const noexcept(noexcept(__c.end()))
+    -> decltype(__c.end())
+  {
+    return __c.end();
+  }
+
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(const _Cp& __c) const
+    noexcept(noexcept(__c.end())) -> decltype(__c.end())
+  {
+    return __c.end();
+  }
+};
+} // namespace __end
+
+inline namespace __cpo
 {
-  return __c.end();
-}
+_LIBCUDACXX_CPO_ACCESSIBILITY auto end = __end::__fn{};
+} // namespace __cpo
 
-#if _CCCL_STD_VER > 2011
+#if _CCCL_STD_VER >= 2014
 
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto cbegin(const _Cp& __c) -> decltype(_CUDA_VSTD::begin(__c))
+namespace __cbegin
 {
-  return _CUDA_VSTD::begin(__c);
-}
-
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto cend(const _Cp& __c) -> decltype(_CUDA_VSTD::end(__c))
+struct __fn
 {
-  return _CUDA_VSTD::end(__c);
-}
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(const _Cp& __c) const
+    noexcept(noexcept(_CUDA_VSTD::begin(__c))) -> decltype(_CUDA_VSTD::begin(__c))
+  {
+    return _CUDA_VSTD::begin(__c);
+  }
+};
+} // namespace __cbegin
 
-#endif
+inline namespace __cpo
+{
+_LIBCUDACXX_CPO_ACCESSIBILITY auto cbegin = __cbegin::__fn{};
+} // namespace __cpo
+
+namespace __cend
+{
+struct __fn
+{
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(const _Cp& __c) const
+    noexcept(noexcept(_CUDA_VSTD::end(__c))) -> decltype(_CUDA_VSTD::end(__c))
+  {
+    return _CUDA_VSTD::end(__c);
+  }
+};
+} // namespace __cend
+
+inline namespace __cpo
+{
+_LIBCUDACXX_CPO_ACCESSIBILITY auto cend = __cend::__fn{};
+} // namespace __cpo
+
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/reverse_access.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_access.h
@@ -27,69 +27,123 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011
+#if _CCCL_STD_VER >= 2014
 
-template <class _Tp, size_t _Np>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 reverse_iterator<_Tp*> rbegin(_Tp (&__array)[_Np])
+namespace __rbegin
 {
-  return reverse_iterator<_Tp*>(__array + _Np);
-}
-
-template <class _Tp, size_t _Np>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 reverse_iterator<_Tp*> rend(_Tp (&__array)[_Np])
+struct __fn
 {
-  return reverse_iterator<_Tp*>(__array);
-}
+  template <class _Tp, size_t _Np>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 reverse_iterator<_Tp*>
+  operator()(_Tp (&__array)[_Np]) const noexcept
+  {
+    return reverse_iterator<_Tp*>(__array + _Np);
+  }
 
-template <class _Ep>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 reverse_iterator<const _Ep*> rbegin(initializer_list<_Ep> __il)
+  template <class _Ep>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 reverse_iterator<const _Ep*>
+  operator()(initializer_list<_Ep> __il) const noexcept
+  {
+    return reverse_iterator<const _Ep*>(__il.end());
+  }
+
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(_Cp& __c) const noexcept(noexcept(__c.rbegin()))
+    -> decltype(__c.rbegin())
+  {
+    return __c.rbegin();
+  }
+
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(const _Cp& __c) const
+    noexcept(noexcept(__c.rbegin())) -> decltype(__c.rbegin())
+  {
+    return __c.rbegin();
+  }
+};
+} // namespace __rbegin
+
+inline namespace __cpo
 {
-  return reverse_iterator<const _Ep*>(__il.end());
-}
+_LIBCUDACXX_CPO_ACCESSIBILITY auto rbegin = __rbegin::__fn{};
+} // namespace __cpo
 
-template <class _Ep>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 reverse_iterator<const _Ep*> rend(initializer_list<_Ep> __il)
+namespace __rend
 {
-  return reverse_iterator<const _Ep*>(__il.begin());
-}
-
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 auto rbegin(_Cp& __c) -> decltype(__c.rbegin())
+struct __fn
 {
-  return __c.rbegin();
-}
+  template <class _Tp, size_t _Np>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 reverse_iterator<_Tp*>
+  operator()(_Tp (&__array)[_Np]) const noexcept
+  {
+    return reverse_iterator<_Tp*>(__array);
+  }
 
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 auto rbegin(const _Cp& __c) -> decltype(__c.rbegin())
+  template <class _Ep>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 reverse_iterator<const _Ep*>
+  operator()(initializer_list<_Ep> __il) const noexcept
+  {
+    return reverse_iterator<const _Ep*>(__il.begin());
+  }
+
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(_Cp& __c) const noexcept(noexcept(__c.rend()))
+    -> decltype(__c.rend())
+  {
+    return __c.rend();
+  }
+
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(const _Cp& __c) const
+    noexcept(noexcept(__c.rend())) -> decltype(__c.rend())
+  {
+    return __c.rend();
+  }
+};
+} // namespace __rend
+
+inline namespace __cpo
 {
-  return __c.rbegin();
-}
+_LIBCUDACXX_CPO_ACCESSIBILITY auto rend = __rend::__fn{};
+} // namespace __cpo
 
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 auto rend(_Cp& __c) -> decltype(__c.rend())
+namespace __crbegin
 {
-  return __c.rend();
-}
-
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 auto rend(const _Cp& __c) -> decltype(__c.rend())
+struct __fn
 {
-  return __c.rend();
-}
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(const _Cp& __c) const
+    noexcept(noexcept(_CUDA_VSTD::rbegin(__c))) -> decltype(_CUDA_VSTD::rbegin(__c))
+  {
+    return _CUDA_VSTD::rbegin(__c);
+  }
+};
+} // namespace __crbegin
 
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 auto crbegin(const _Cp& __c) -> decltype(_CUDA_VSTD::rbegin(__c))
+inline namespace __cpo
 {
-  return _CUDA_VSTD::rbegin(__c);
-}
+_LIBCUDACXX_CPO_ACCESSIBILITY auto crbegin = __crbegin::__fn{};
+} // namespace __cpo
 
-template <class _Cp>
-_LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX17 auto crend(const _Cp& __c) -> decltype(_CUDA_VSTD::rend(__c))
+namespace __crend
 {
-  return _CUDA_VSTD::rend(__c);
-}
+struct __fn
+{
+  template <class _Cp>
+  _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 auto operator()(const _Cp& __c) const
+    noexcept(noexcept(_CUDA_VSTD::rend(__c))) -> decltype(_CUDA_VSTD::rend(__c))
+  {
+    return _CUDA_VSTD::rend(__c);
+  }
+};
+} // namespace __crend
 
-#endif // _CCCL_STD_VER > 2011
+inline namespace __cpo
+{
+_LIBCUDACXX_CPO_ACCESSIBILITY auto crend = __crend::__fn{};
+} // namespace __cpo
+
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -316,7 +316,7 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _It = _Iter)
   _LIBCUDACXX_REQUIRES(copyable<_It>)
-  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr _It begin() const
+  _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr _It begin() const
   {
     return __begin_;
   }
@@ -328,7 +328,7 @@ public:
     return _CUDA_VSTD::move(__begin_);
   }
 
-  _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr _Sent end() const
+  _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr _Sent end() const
   {
     return __end_;
   }

--- a/libcudacxx/include/cuda/std/__ranges/view_interface.h
+++ b/libcudacxx/include/cuda/std/__ranges/view_interface.h
@@ -178,42 +178,6 @@ public:
   {
     return _CUDA_VRANGES::begin(__derived())[__index];
   }
-
-  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::begin(_CUDA_VSTD::declval<_D2&>()))>
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr _Ret begin(_Derived& __range)
-  {
-    return _CUDA_VRANGES::begin(__range);
-  }
-
-  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::begin(_CUDA_VSTD::declval<const _D2&>()))>
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr _Ret begin(const _Derived& __range)
-  {
-    return _CUDA_VRANGES::begin(__range);
-  }
-
-  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::cbegin(_CUDA_VSTD::declval<const _D2&>()))>
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr auto cbegin(const _Derived& __range)
-  {
-    return _CUDA_VRANGES::cbegin(__range);
-  }
-
-  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::end(_CUDA_VSTD::declval<_D2&>()))>
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr auto end(_Derived& __range)
-  {
-    return _CUDA_VRANGES::end(__range);
-  }
-
-  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::end(_CUDA_VSTD::declval<const _D2&>()))>
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr auto end(const _Derived& __range)
-  {
-    return _CUDA_VRANGES::end(__range);
-  }
-
-  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::cend(_CUDA_VSTD::declval<const _D2&>()))>
-  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr auto cend(const _Derived& __range)
-  {
-    return _CUDA_VRANGES::cend(__range);
-  }
 };
 
 _LIBCUDACXX_END_NAMESPACE_RANGES_ABI

--- a/libcudacxx/include/cuda/std/__ranges/view_interface.h
+++ b/libcudacxx/include/cuda/std/__ranges/view_interface.h
@@ -33,6 +33,7 @@
 #include <cuda/std/__type_traits/is_class.h>
 #include <cuda/std/__type_traits/is_reference.h>
 #include <cuda/std/__type_traits/remove_cv.h>
+#include <cuda/std/__utility/declval.h>
 #include <cuda/std/detail/libcxx/include/__assert>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
@@ -176,6 +177,42 @@ public:
   operator[](range_difference_t<_RARange> __index) const
   {
     return _CUDA_VRANGES::begin(__derived())[__index];
+  }
+
+  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::begin(_CUDA_VSTD::declval<_D2&>()))>
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr _Ret begin(_Derived& __range)
+  {
+    return _CUDA_VRANGES::begin(__range);
+  }
+
+  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::begin(_CUDA_VSTD::declval<const _D2&>()))>
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr _Ret begin(const _Derived& __range)
+  {
+    return _CUDA_VRANGES::begin(__range);
+  }
+
+  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::cbegin(_CUDA_VSTD::declval<const _D2&>()))>
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr auto cbegin(const _Derived& __range)
+  {
+    return _CUDA_VRANGES::cbegin(__range);
+  }
+
+  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::end(_CUDA_VSTD::declval<_D2&>()))>
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr auto end(_Derived& __range)
+  {
+    return _CUDA_VRANGES::end(__range);
+  }
+
+  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::end(_CUDA_VSTD::declval<const _D2&>()))>
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr auto end(const _Derived& __range)
+  {
+    return _CUDA_VRANGES::end(__range);
+  }
+
+  template <class _D2 = _Derived, class _Ret = decltype(_CUDA_VRANGES::cend(_CUDA_VSTD::declval<const _D2&>()))>
+  _CCCL_NODISCARD_FRIEND _LIBCUDACXX_INLINE_VISIBILITY constexpr auto cend(const _Derived& __range)
+  {
+    return _CUDA_VRANGES::cend(__range);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__utility/swap.h
+++ b/libcudacxx/include/cuda/std/__utility/swap.h
@@ -41,8 +41,9 @@ inline _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 __swap_result_t<_Tp> 
 }
 
 template <class _Tp, size_t _Np>
-inline _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 __enable_if_t<__is_swappable<_Tp>::value>
-swap(_Tp (&__a)[_Np], _Tp (&__b)[_Np]) noexcept(__is_nothrow_swappable<_Tp>::value)
+inline _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14
+  __enable_if_t<__detect_adl_swap::__has_no_adl_swap_array<_Tp, _Np>::value && __is_swappable<_Tp>::value>
+  swap(_Tp (&__a)[_Np], _Tp (&__b)[_Np]) noexcept(__is_nothrow_swappable<_Tp>::value)
 {
   for (size_t __i = 0; __i != _Np; ++__i)
   {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/array
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/array
@@ -323,9 +323,6 @@ struct _LIBCUDACXX_TEMPLATE_VIS array
   {
     return __elems_;
   }
-
-  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(array, const_iterator);
-  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(array, const_reverse_iterator);
 };
 
 template <class _Tp>
@@ -501,9 +498,6 @@ struct _LIBCUDACXX_TEMPLATE_VIS array<_Tp, 0>
     return *data();
   }
   _CCCL_DIAG_POP
-
-  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(array, const_iterator);
-  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(array, const_reverse_iterator);
 };
 
 #if _CCCL_STD_VER >= 2017

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/array
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/array
@@ -323,6 +323,9 @@ struct _LIBCUDACXX_TEMPLATE_VIS array
   {
     return __elems_;
   }
+
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(array, const_iterator);
+  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(array, const_reverse_iterator);
 };
 
 template <class _Tp>
@@ -498,6 +501,9 @@ struct _LIBCUDACXX_TEMPLATE_VIS array<_Tp, 0>
     return *data();
   }
   _CCCL_DIAG_POP
+
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(array, const_iterator);
+  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(array, const_reverse_iterator);
 };
 
 #if _CCCL_STD_VER >= 2017

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/span
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/span
@@ -502,6 +502,9 @@ public:
     return span<byte, _Extent * sizeof(element_type)>{reinterpret_cast<byte*>(data()), size_bytes()};
   }
 
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(span, iterator);
+  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(span, reverse_iterator);
+
 private:
   pointer __data_;
 };
@@ -728,6 +731,9 @@ public:
   {
     return {reinterpret_cast<byte*>(data()), size_bytes()};
   }
+
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(span, iterator);
+  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(span, reverse_iterator);
 
 private:
   pointer __data_;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/span
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/span
@@ -502,9 +502,6 @@ public:
     return span<byte, _Extent * sizeof(element_type)>{reinterpret_cast<byte*>(data()), size_bytes()};
   }
 
-  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(span, iterator);
-  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(span, reverse_iterator);
-
 private:
   pointer __data_;
 };
@@ -731,9 +728,6 @@ public:
   {
     return {reinterpret_cast<byte*>(data()), size_bytes()};
   }
-
-  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(span, iterator);
-  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(span, reverse_iterator);
 
 private:
   pointer __data_;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -484,7 +484,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
   _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl& operator=(_Tuple&& __t) noexcept(
     (__all<_CCCL_TRAIT(is_nothrow_assignable, _Tp&, __tuple_elem_at<_Tuple, _Indx>)...>::value))
   {
-    __swallow(__tuple_leaf<_Indx, _Tp>::operator=(
+    _CUDA_VSTD::__swallow(__tuple_leaf<_Indx, _Tp>::operator=(
       _CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(_CUDA_VSTD::get<_Indx>(__t)))...);
     return *this;
   }
@@ -495,14 +495,15 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
   _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl&
   operator=(const __tuple_impl& __t) noexcept((__all<_CCCL_TRAIT(is_nothrow_copy_assignable, _Tp)...>::value))
   {
-    __swallow(__tuple_leaf<_Indx, _Tp>::operator=(static_cast<const __tuple_leaf<_Indx, _Tp>&>(__t).get())...);
+    _CUDA_VSTD::__swallow(
+      __tuple_leaf<_Indx, _Tp>::operator=(static_cast<const __tuple_leaf<_Indx, _Tp>&>(__t).get())...);
     return *this;
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY __tuple_impl&
   operator=(__tuple_impl&& __t) noexcept((__all<_CCCL_TRAIT(is_nothrow_move_assignable, _Tp)...>::value))
   {
-    __swallow(__tuple_leaf<_Indx, _Tp>::operator=(
+    _CUDA_VSTD::__swallow(__tuple_leaf<_Indx, _Tp>::operator=(
       _CUDA_VSTD::forward<_Tp>(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t).get()))...);
     return *this;
   }
@@ -510,7 +511,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
   _LIBCUDACXX_INLINE_VISIBILITY void
   swap(__tuple_impl& __t) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
   {
-    __swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t))...);
+    _CUDA_VSTD::__swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t))...);
   }
 };
 

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.range/begin-end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.range/begin-end.pass.cpp
@@ -43,6 +43,11 @@
 
 #include "test_macros.h"
 
+#if !defined(TEST_COMPILER_NVRTC)
+#  include <iterator>
+#  include <utility>
+#endif // !TEST_COMPILER_NVRTC
+
 // cuda::std::array is explicitly allowed to be initialized with A a = { init-list };.
 // Disable the missing braces warning for this reason.
 #include "disable_missing_braces_warning.h"
@@ -54,7 +59,7 @@ __host__ __device__ void test_const_container(const C& c, typename C::value_type
   assert(*cuda::std::begin(c) == val);
   assert(cuda::std::begin(c) != c.end());
   assert(cuda::std::end(c) == c.end());
-#if TEST_STD_VER > 2011
+#if TEST_STD_VER >= 2014
   assert(cuda::std::cbegin(c) == c.cbegin());
   assert(cuda::std::cbegin(c) != c.cend());
   assert(cuda::std::cend(c) == c.cend());
@@ -64,7 +69,7 @@ __host__ __device__ void test_const_container(const C& c, typename C::value_type
   assert(cuda::std::crbegin(c) == c.crbegin());
   assert(cuda::std::crbegin(c) != c.crend());
   assert(cuda::std::crend(c) == c.crend());
-#endif
+#endif // TEST_STD_VER >= 2014
 }
 
 template <typename T>
@@ -74,19 +79,11 @@ __host__ __device__ void test_const_container(const cuda::std::initializer_list<
   assert(*cuda::std::begin(c) == val);
   assert(cuda::std::begin(c) != c.end());
   assert(cuda::std::end(c) == c.end());
-#if TEST_STD_VER > 2011
-//  initializer_list doesn't have cbegin/cend/rbegin/rend
-//  but cuda::std::cbegin(),etc work (b/c they're general fn templates)
-//     assert ( cuda::std::cbegin(c)  == c.cbegin());
-//     assert ( cuda::std::cbegin(c)  != c.cend());
-//     assert ( cuda::std::cend(c)    == c.cend());
-//     assert ( cuda::std::rbegin(c)  == c.rbegin());
-//     assert ( cuda::std::rbegin(c)  != c.rend());
-//     assert ( cuda::std::rend(c)    == c.rend());
-//     assert ( cuda::std::crbegin(c) == c.crbegin());
-//     assert ( cuda::std::crbegin(c) != c.crend());
-//     assert ( cuda::std::crend(c)   == c.crend());
-#endif
+#if TEST_STD_VER >= 2014
+  assert(cuda::std::cbegin(c) != cuda::std::cend(c));
+  assert(cuda::std::rbegin(c) != cuda::std::rend(c));
+  assert(cuda::std::crbegin(c) != cuda::std::crend(c));
+#endif // TEST_STD_VER >= 2014
 }
 
 template <typename C>
@@ -96,7 +93,7 @@ __host__ __device__ void test_container(C& c, typename C::value_type val)
   assert(*cuda::std::begin(c) == val);
   assert(cuda::std::begin(c) != c.end());
   assert(cuda::std::end(c) == c.end());
-#if TEST_STD_VER > 2011
+#if TEST_STD_VER >= 2014
   assert(cuda::std::cbegin(c) == c.cbegin());
   assert(cuda::std::cbegin(c) != c.cend());
   assert(cuda::std::cend(c) == c.cend());
@@ -106,7 +103,7 @@ __host__ __device__ void test_container(C& c, typename C::value_type val)
   assert(cuda::std::crbegin(c) == c.crbegin());
   assert(cuda::std::crbegin(c) != c.crend());
   assert(cuda::std::crend(c) == c.crend());
-#endif
+#endif // TEST_STD_VER >= 2014
 }
 
 template <typename T>
@@ -116,18 +113,11 @@ __host__ __device__ void test_container(cuda::std::initializer_list<T>& c, T val
   assert(*cuda::std::begin(c) == val);
   assert(cuda::std::begin(c) != c.end());
   assert(cuda::std::end(c) == c.end());
-#if TEST_STD_VER > 2011
-//  initializer_list doesn't have cbegin/cend/rbegin/rend
-//     assert ( cuda::std::cbegin(c)  == c.cbegin());
-//     assert ( cuda::std::cbegin(c)  != c.cend());
-//     assert ( cuda::std::cend(c)    == c.cend());
-//     assert ( cuda::std::rbegin(c)  == c.rbegin());
-//     assert ( cuda::std::rbegin(c)  != c.rend());
-//     assert ( cuda::std::rend(c)    == c.rend());
-//     assert ( cuda::std::crbegin(c) == c.crbegin());
-//     assert ( cuda::std::crbegin(c) != c.crend());
-//     assert ( cuda::std::crend(c)   == c.crend());
-#endif
+#if TEST_STD_VER >= 2014
+  assert(cuda::std::cbegin(c) != cuda::std::cend(c));
+  assert(cuda::std::rbegin(c) != cuda::std::rend(c));
+  assert(cuda::std::crbegin(c) != cuda::std::crend(c));
+#endif // TEST_STD_VER >= 2014
 }
 
 template <typename T, size_t Sz>
@@ -137,12 +127,12 @@ __host__ __device__ void test_const_array(const T (&array)[Sz])
   assert(*cuda::std::begin(array) == array[0]);
   assert(cuda::std::begin(array) != cuda::std::end(array));
   assert(cuda::std::end(array) == array + Sz);
-#if TEST_STD_VER > 2011
+#if TEST_STD_VER >= 2014
   assert(cuda::std::cbegin(array) == array);
   assert(*cuda::std::cbegin(array) == array[0]);
   assert(cuda::std::cbegin(array) != cuda::std::cend(array));
   assert(cuda::std::cend(array) == array + Sz);
-#endif
+#endif // TEST_STD_VER >= 2014
 }
 
 STATIC_TEST_GLOBAL_VAR TEST_CONSTEXPR_GLOBAL int global_array[]{1, 2, 3};
@@ -151,6 +141,52 @@ STATIC_TEST_GLOBAL_VAR TEST_CONSTEXPR_GLOBAL int global_array[]{1, 2, 3};
 STATIC_TEST_GLOBAL_VAR TEST_CONSTEXPR_GLOBAL int global_const_array[] = {0, 1, 2, 3, 4};
 #  endif // nvcc > 11.2
 #endif // TEST_STD_VER > 2014
+
+__host__ __device__ void test_ambiguous_std()
+{
+#if !defined(TEST_COMPILER_NVRTC)
+  // clang-format off
+  NV_IF_TARGET(NV_IS_HOST, (
+    {
+      cuda::std::array<::std::pair<int, int>, 10> c = {};
+      assert(begin(c) == c.begin());
+      assert(begin(c) != c.end());
+      assert(end(c) == c.end());
+    }
+
+    {
+      cuda::std::initializer_list<::std::pair<int, int>> init = {{1, 2}};
+      assert(begin(init) == init.begin());
+      assert(begin(init) != init.end());
+      assert(end(init) == init.end());
+    }
+  ))
+#if TEST_STD_VER >= 2014
+  NV_IF_TARGET(NV_IS_HOST, (
+    {
+      cuda::std::array<::std::pair<int, int>, 10> c = {};
+      assert(cbegin(c) == c.cbegin());
+      assert(cbegin(c) != c.cend());
+      assert(cend(c) == c.cend());
+      assert(rbegin(c) == c.rbegin());
+      assert(rbegin(c) != c.rend());
+      assert(rend(c) == c.rend());
+      assert(crbegin(c) == c.crbegin());
+      assert(crbegin(c) != c.crend());
+      assert(crend(c) == c.crend());
+    }
+
+    {
+      cuda::std::initializer_list<::std::pair<int, int>> init = {{1, 2}};
+      assert(cbegin(init) != cend(init));
+      assert(rbegin(init) != rend(init));
+      assert(crbegin(init) != crend(init));
+    }
+  ))
+#endif // TEST_STD_VER >= 2014
+  // clang-format on
+#endif // !TEST_COMPILER_NVRTC
+}
 
 int main(int, char**)
 {
@@ -185,13 +221,13 @@ int main(int, char**)
   test_const_container(il, 4);
 
   test_const_array(global_array);
-#if TEST_STD_VER > 2011
+#if TEST_STD_VER >= 2014
   constexpr const int* b = cuda::std::cbegin(global_array);
   constexpr const int* e = cuda::std::cend(global_array);
   static_assert(e - b == 3, "");
-#endif
+#endif // TEST_STD_VER >= 2014
 
-#if TEST_STD_VER > 2014
+#if TEST_STD_VER >= 2017
   {
     typedef cuda::std::array<int, 5> C;
     constexpr const C local_const_array{0, 1, 2, 3, 4};
@@ -228,7 +264,9 @@ int main(int, char**)
     static_assert(*cuda::std::crbegin(global_const_array) == 4, "");
   }
 #  endif // nvcc > 11.2
-#endif // TEST_STD_VER > 2014
+#endif // TEST_STD_VER >= 2017
+
+  test_ambiguous_std();
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_swappable.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_swappable.pass.cpp
@@ -62,6 +62,7 @@ struct DeletedSwap
 
 } // namespace MyNS
 
+#if 0 // We cannot test this because we need to avoid defining ambiguous overloads
 namespace MyNS2
 {
 
@@ -73,6 +74,7 @@ __host__ __device__ void swap(T&, T&)
 {}
 
 } // end namespace MyNS2
+#endif // Not implementable
 
 int main(int, char**)
 {
@@ -96,10 +98,12 @@ int main(int, char**)
     // test that a deleted swap is correctly handled.
     static_assert(!cuda::std::is_swappable<DeletedSwap>::value, "");
   }
+#if 0 // We cannot test this because we need to avoid defining ambiguous overloads
   {
     // test that a swap with ambiguous overloads is handled correctly.
     static_assert(!cuda::std::is_swappable<MyNS2::AmbiguousSwap>::value, "");
   }
+#endif // Not implementable
   {
     // test for presence of is_swappable_v
     static_assert(cuda::std::is_swappable_v<int>, "");

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap.pass.cpp
@@ -1,0 +1,168 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <utility>
+
+// template<class T>
+//   requires MoveAssignable<T> && MoveConstructible<T>
+//   void
+//   swap(T& a, T& b);
+
+#include <cuda/std/__memory_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+#if !defined(TEST_COMPILER_NVRTC)
+#  include <utility>
+#endif // !TEST_COMPILER_NVRTC
+
+struct CopyOnly
+{
+  __host__ __device__ CopyOnly() {}
+  __host__ __device__ CopyOnly(CopyOnly const&) noexcept {}
+  __host__ __device__ CopyOnly& operator=(CopyOnly const&)
+  {
+    return *this;
+  }
+};
+
+struct MoveOnly
+{
+  __host__ __device__ MoveOnly() {}
+  __host__ __device__ MoveOnly(MoveOnly&&) {}
+  __host__ __device__ MoveOnly& operator=(MoveOnly&&) noexcept
+  {
+    return *this;
+  }
+};
+
+struct NoexceptMoveOnly
+{
+  __host__ __device__ NoexceptMoveOnly() {}
+  __host__ __device__ NoexceptMoveOnly(NoexceptMoveOnly&&) noexcept {}
+  __host__ __device__ NoexceptMoveOnly& operator=(NoexceptMoveOnly&&) noexcept
+  {
+    return *this;
+  }
+};
+
+struct NotMoveConstructible
+{
+  __host__ __device__ NotMoveConstructible& operator=(NotMoveConstructible&&)
+  {
+    return *this;
+  }
+
+private:
+  __host__ __device__ NotMoveConstructible(NotMoveConstructible&&);
+};
+
+struct NotMoveAssignable
+{
+  __host__ __device__ NotMoveAssignable(NotMoveAssignable&&);
+
+private:
+  __host__ __device__ NotMoveAssignable& operator=(NotMoveAssignable&&);
+};
+
+template <class Tp>
+__host__ __device__ auto can_swap_test(int)
+  -> decltype(cuda::std::swap(cuda::std::declval<Tp>(), cuda::std::declval<Tp>()));
+
+template <class Tp>
+__host__ __device__ auto can_swap_test(...) -> cuda::std::false_type;
+
+template <class Tp>
+__host__ __device__ constexpr bool can_swap()
+{
+  return cuda::std::is_same<decltype(can_swap_test<Tp>(0)), void>::value;
+}
+
+#if TEST_STD_VER >= 2014
+__host__ __device__ constexpr bool test_swap_constexpr()
+{
+  int i = 1;
+  int j = 2;
+  cuda::std::swap(i, j);
+  return i == 2 && j == 1;
+}
+#endif // TEST_STD_VER >= 2014
+
+template <class T>
+struct swap_with_friend
+{
+  __host__ __device__ friend void swap(swap_with_friend&, swap_with_friend&) {}
+};
+
+__host__ __device__ void test_ambiguous_std()
+{
+#if !defined(TEST_COMPILER_NVRTC)
+  // clang-format off
+  NV_IF_TARGET(NV_IS_HOST, (
+    {
+      cuda::std::pair<::std::pair<int, int>, int> i = {};
+      cuda::std::pair<::std::pair<int, int>, int> j = {};
+      swap(i,j);
+    }
+    { // Ensure that we do not SFINAE swap out if there is a free function as that will take precedent
+      swap_with_friend<::std::pair<int, int>> with_friend;
+      cuda::std::swap(with_friend, with_friend);
+    }
+  ))
+  // clang-format on
+#  if TEST_STD_VER >= 2014
+  static_assert(cuda::std::is_swappable<cuda::std::pair<::std::pair<int, int>, int>>::value, "");
+  static_assert(cuda::std::is_swappable<swap_with_friend<::std::pair<int, int>>>::value, "");
+#  endif // TEST_STD_VER >= 2014
+#endif // !TEST_COMPILER_NVRTC
+}
+
+int main(int, char**)
+{
+  {
+    int i = 1;
+    int j = 2;
+    cuda::std::swap(i, j);
+    assert(i == 2);
+    assert(j == 1);
+  }
+  {
+    cuda::std::unique_ptr<int> i(new int(1));
+    cuda::std::unique_ptr<int> j(new int(2));
+    cuda::std::swap(i, j);
+    assert(*i == 2);
+    assert(*j == 1);
+  }
+  {
+    // test that the swap
+    static_assert(can_swap<CopyOnly&>(), "");
+    static_assert(can_swap<MoveOnly&>(), "");
+    static_assert(can_swap<NoexceptMoveOnly&>(), "");
+
+    static_assert(!can_swap<NotMoveConstructible&>(), "");
+    static_assert(!can_swap<NotMoveAssignable&>(), "");
+
+    CopyOnly c;
+    MoveOnly m;
+    NoexceptMoveOnly nm;
+    static_assert(!noexcept(cuda::std::swap(c, c)), "");
+    static_assert(!noexcept(cuda::std::swap(m, m)), "");
+    static_assert(noexcept(cuda::std::swap(nm, nm)), "");
+  }
+
+#if TEST_STD_VER >= 2014
+  static_assert(test_swap_constexpr(), "");
+#endif // TEST_STD_VER >= 2014
+
+  test_ambiguous_std();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap_array.pass.cpp
@@ -1,0 +1,150 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <utility>
+
+// template<ValueType T, size_t N>
+//   requires Swappable<T>
+//   void
+//   swap(T (&a)[N], T (&b)[N]);
+
+#include <cuda/std/__algorithm_>
+#include <cuda/std/__memory_>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+#if !defined(TEST_COMPILER_NVRTC)
+#  include <utility>
+#endif // !TEST_COMPILER_NVRTC
+
+struct CopyOnly
+{
+  __host__ __device__ CopyOnly() {}
+  __host__ __device__ CopyOnly(CopyOnly const&) noexcept {}
+  __host__ __device__ CopyOnly& operator=(CopyOnly const&)
+  {
+    return *this;
+  }
+};
+
+struct NoexceptMoveOnly
+{
+  __host__ __device__ NoexceptMoveOnly() {}
+  __host__ __device__ NoexceptMoveOnly(NoexceptMoveOnly&&) noexcept {}
+  __host__ __device__ NoexceptMoveOnly& operator=(NoexceptMoveOnly&&) noexcept
+  {
+    return *this;
+  }
+};
+
+struct NotMoveConstructible
+{
+  __host__ __device__ NotMoveConstructible() {}
+  __host__ __device__ NotMoveConstructible& operator=(NotMoveConstructible&&)
+  {
+    return *this;
+  }
+
+private:
+  __host__ __device__ NotMoveConstructible(NotMoveConstructible&&);
+};
+
+template <class Tp>
+__host__ __device__ auto can_swap_test(int)
+  -> decltype(cuda::std::swap(cuda::std::declval<Tp>(), cuda::std::declval<Tp>()));
+
+template <class Tp>
+__host__ __device__ auto can_swap_test(...) -> cuda::std::false_type;
+
+template <class Tp>
+__host__ __device__ constexpr bool can_swap()
+{
+  return cuda::std::is_same<decltype(can_swap_test<Tp>(0)), void>::value;
+}
+
+#if TEST_STD_VER >= 2014
+__host__ __device__ constexpr bool test_swap_constexpr()
+{
+  int i[3] = {1, 2, 3};
+  int j[3] = {4, 5, 6};
+  cuda::std::swap(i, j);
+  return i[0] == 4 && i[1] == 5 && i[2] == 6 && j[0] == 1 && j[1] == 2 && j[2] == 3;
+}
+#endif // TEST_STD_VER >= 2014
+
+__host__ __device__ void test_ambiguous_std()
+{
+#if !defined(TEST_COMPILER_NVRTC)
+  // clang-format off
+  NV_IF_TARGET(NV_IS_HOST, (
+    cuda::std::pair<::std::pair<int, int>, int> i[3] = {};
+    cuda::std::pair<::std::pair<int, int>, int> j[3] = {};
+    swap(i,j);
+  ))
+  // clang-format on
+#endif // !TEST_COMPILER_NVRTC
+}
+
+int main(int, char**)
+{
+  {
+    int i[3] = {1, 2, 3};
+    int j[3] = {4, 5, 6};
+    cuda::std::swap(i, j);
+    assert(i[0] == 4);
+    assert(i[1] == 5);
+    assert(i[2] == 6);
+    assert(j[0] == 1);
+    assert(j[1] == 2);
+    assert(j[2] == 3);
+  }
+  {
+    cuda::std::unique_ptr<int> i[3];
+    for (int k = 0; k < 3; ++k)
+    {
+      i[k].reset(new int(k + 1));
+    }
+    cuda::std::unique_ptr<int> j[3];
+    for (int k = 0; k < 3; ++k)
+    {
+      j[k].reset(new int(k + 4));
+    }
+    cuda::std::swap(i, j);
+    assert(*i[0] == 4);
+    assert(*i[1] == 5);
+    assert(*i[2] == 6);
+    assert(*j[0] == 1);
+    assert(*j[1] == 2);
+    assert(*j[2] == 3);
+  }
+  {
+    using CA = CopyOnly[42];
+    using MA = NoexceptMoveOnly[42];
+    using NA = NotMoveConstructible[42];
+    static_assert(can_swap<CA&>(), "");
+    static_assert(can_swap<MA&>(), "");
+    static_assert(!can_swap<NA&>(), "");
+
+    CA ca;
+    MA ma;
+    static_assert(!noexcept(cuda::std::swap(ca, ca)), "");
+    static_assert(noexcept(cuda::std::swap(ma, ma)), "");
+  }
+
+#if TEST_STD_VER >= 2014
+  static_assert(test_swap_constexpr(), "");
+#endif // TEST_STD_VER >= 2014
+
+  test_ambiguous_std();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.swap/swap_array.pass.cpp
@@ -83,7 +83,7 @@ __host__ __device__ constexpr bool test_swap_constexpr()
 
 __host__ __device__ void test_ambiguous_std()
 {
-#if !defined(TEST_COMPILER_NVRTC)
+#if !defined(TEST_COMPILER_NVRTC) && !defined(TEST_COMPILER_MSVC_2017)
   // clang-format off
   NV_IF_TARGET(NV_IS_HOST, (
     cuda::std::pair<::std::pair<int, int>, int> i[3] = {};
@@ -91,7 +91,7 @@ __host__ __device__ void test_ambiguous_std()
     swap(i,j);
   ))
   // clang-format on
-#endif // !TEST_COMPILER_NVRTC
+#endif // !TEST_COMPILER_NVRTC && !TEST_COMPILER_MSVC_2017
 }
 
 int main(int, char**)

--- a/thrust/thrust/detail/contiguous_storage.h
+++ b/thrust/thrust/detail/contiguous_storage.h
@@ -140,6 +140,8 @@ public:
   // on move assignment
   _CCCL_HOST_DEVICE contiguous_storage& operator=(contiguous_storage&& other);
 
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(contiguous_storage, const_iterator);
+
 private:
   // XXX we could inherit from this to take advantage of empty base class optimization
   allocator_type m_allocator;

--- a/thrust/thrust/detail/range/head_flags.h
+++ b/thrust/thrust/detail/range/head_flags.h
@@ -122,6 +122,8 @@ public:
     return *(begin() + i);
   }
 
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(head_flags_with_init, iterator);
+
 private:
   iterator m_begin, m_end;
 };
@@ -201,6 +203,8 @@ public:
   {
     return *(begin() + i);
   }
+
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(head_flags, iterator);
 
 private:
   iterator m_begin, m_end;

--- a/thrust/thrust/detail/range/tail_flags.h
+++ b/thrust/thrust/detail/range/tail_flags.h
@@ -107,6 +107,8 @@ public:
     return *(begin() + i);
   }
 
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(tail_flags, iterator);
+
 private:
   iterator m_begin, m_end;
 };

--- a/thrust/thrust/detail/trivial_sequence.h
+++ b/thrust/thrust/detail/trivial_sequence.h
@@ -65,9 +65,19 @@ struct _trivial_sequence<Iterator, DerivedPolicy, thrust::detail::true_type>
     return first;
   }
 
+  _CCCL_HOST_DEVICE friend iterator_type begin(_trivial_sequence& sequence)
+  {
+    return sequence.first;
+  }
+
   _CCCL_HOST_DEVICE iterator_type end()
   {
     return last;
+  }
+
+  _CCCL_HOST_DEVICE friend iterator_type end(_trivial_sequence& sequence)
+  {
+    return sequence.last;
   }
 };
 
@@ -89,9 +99,19 @@ struct _trivial_sequence<Iterator, DerivedPolicy, thrust::detail::false_type>
     return buffer.begin();
   }
 
+  _CCCL_HOST_DEVICE friend iterator_type begin(_trivial_sequence& sequence)
+  {
+    return sequence.begin();
+  }
+
   _CCCL_HOST_DEVICE iterator_type end()
   {
     return buffer.end();
+  }
+
+  _CCCL_HOST_DEVICE friend iterator_type end(_trivial_sequence& sequence)
+  {
+    return sequence.end();
   }
 };
 

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -472,6 +472,9 @@ public:
    */
   allocator_type get_allocator() const;
 
+  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(vector_base, const_iterator);
+  _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(vector_base, const_reverse_iterator);
+
 protected:
   // Our storage
   storage_type m_storage;


### PR DESCRIPTION
Those types must be host only so we can safely SFINAE away our own free functions that would be ambiguous

Fixes #1679