### PR TITLE
Install CUB headers with .hpp extension

### DIFF
--- a/cub/cmake/CubInstallRules.cmake
+++ b/cub/cmake/CubInstallRules.cmake
@@ -8,6 +8,7 @@ install(DIRECTORY "${CUB_SOURCE_DIR}/cub"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   FILES_MATCHING
     PATTERN "*.cuh"
+    PATTERN "*.hpp"
 )
 
 install(DIRECTORY "${CUB_SOURCE_DIR}/cub/cmake/"


### PR DESCRIPTION
This installs the vendored nvtx3.hpp, which was previously not installed with the rest of CUB.

Cherry-picked from https://github.com/miscco/cccl/pull/9. Thanks @trxcllnt!