### PR TITLE
Test combined internal/user-side use of NVTX

### DIFF
--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -26,6 +26,15 @@ option(METAL_BUILD_EXAMPLES OFF)
 option(METAL_BUILD_TESTS OFF)
 CPMAddPackage("gh:brunocodutra/metal@2.1.4")
 
+CPMAddPackage(
+  NAME NVTX
+  GITHUB_REPOSITORY NVIDIA/NVTX
+  GIT_TAG release-v3
+  DOWNLOAD_ONLY
+  SYSTEM
+)
+include("${NVTX_SOURCE_DIR}/c/nvtxImportedTargets.cmake")
+
 find_package(CUDAToolkit)
 
 set(curand_default OFF)
@@ -279,6 +288,10 @@ function(cub_add_test target_name_var test_name test_src cub_target launcher_id)
     cub_clone_target_properties(${test_target} ${cub_target})
     target_include_directories(${test_target} PRIVATE "${CUB_SOURCE_DIR}/test")
     target_compile_definitions(${test_target} PRIVATE CUB_DETAIL_DEBUG_ENABLE_SYNC)
+
+    if ("${test_target}" MATCHES "nvtx_in_usercode")
+      target_link_libraries(${test_target} nvtx3-cpp)
+    endif()
 
     if (CUB_IN_THRUST)
       thrust_fix_clang_nvcc_build_for(${test_target})

--- a/cub/test/test_nvtx_in_usercode.cu
+++ b/cub/test/test_nvtx_in_usercode.cu
@@ -1,0 +1,22 @@
+#include <cub/device/device_for.cuh> // internal include of NVTX
+
+#include <thrust/iterator/counting_iterator.h>
+
+#include <nvtx3/nvtx3.hpp> // user-side include of NVTX, retrieved elsewhere
+
+struct Op
+{
+  _CCCL_HOST_DEVICE void operator()(int i) const
+  {
+    printf("%d\n", i);
+  }
+};
+
+int main()
+{
+  nvtx3::scoped_range range("user-range"); // user-side use of NVTX
+
+  thrust::counting_iterator<int> it{0};
+  cub::DeviceFor::ForEach(it, it + 16, Op{}); // internal use of NVTX
+  cudaDeviceSynchronize();
+}


### PR DESCRIPTION
This PR adds a test where the NVTX API is used internally by CUB via the vendored nvtx3.hpp, and a second time in the test's main file with headers cloned from the NVTX GitHub repository. The test verifies that CUB's use of NVTX does not break users using NVTX beside CUB.