### PR TITLE
Fix deprecated status

### DIFF
--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -646,7 +646,7 @@ CUB_RUNTIME_FUNCTION cudaError_t call_cub_segmented_sort_api(
   const int* offset_begin_it                  = d_begin_offsets;
   thrust::device_ptr<const int> offset_end_it = thrust::device_pointer_cast(d_end_offsets);
 
-  cudaError_t status = cudaErrorNotYetImplemented;
+  cudaError_t status = cudaErrorInvalidValue;
 
   if (stable_sort)
   {


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/1691

<!-- Provide a standalone description of changes in this PR. -->

cudaErrorNotYetImplemented is deprecated: nvbug 4626945. This PR removes `cudaErrorNotYetImplemented` from CUB tests. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
