### PR TITLE
Fix usage of `result_of` in thrust

### DIFF
--- a/cub/cub/agent/agent_three_way_partition.cuh
+++ b/cub/cub/agent/agent_three_way_partition.cuh
@@ -93,7 +93,7 @@ struct accumulator_pack_base_t
 };
 
 template <class OffsetT>
-struct accumulator_pack_base_t<OffsetT, typename cuda::std::enable_if<sizeof(OffsetT) == 4>::type>
+struct accumulator_pack_base_t<OffsetT, typename ::cuda::std::enable_if<sizeof(OffsetT) == 4>::type>
 {
   using pack_t = std::uint64_t;
 

--- a/thrust/thrust/detail/type_traits.h
+++ b/thrust/thrust/detail/type_traits.h
@@ -673,20 +673,11 @@ template <typename T>
 struct is_empty : integral_constant<bool, sizeof(is_empty_helper_base) == sizeof(is_empty_helper<T>)>
 {};
 
-template <typename Invokable, typename... Args>
-using invoke_result_t =
-#if _CCCL_STD_VER < 2017
-  typename ::cuda::std::result_of<Invokable(Args...)>::type;
-#else // 2017+
-  ::cuda::std::invoke_result_t<Invokable, Args...>;
-#endif
+template <class F, class... Us>
+using invoke_result = ::cuda::std::__invoke_of<F, Us...>;
 
 template <class F, class... Us>
-struct invoke_result
-{
-  using type = invoke_result_t<F, Us...>;
-};
-
+using invoke_result_t = typename invoke_result<F, Us...>::type;
 } // namespace detail
 
 using detail::false_type;


### PR DESCRIPTION
result of has been deprecated and we should not use it when possible.

Rather than relying on it use `__invoke_of` everywhere

Also fix inproper qualification of `enalbe_if` in cub