### PR TITLE
Fix thrust::optional<T&>::emplace()

### DIFF
--- a/thrust/testing/regression/gh_1706__thrust_optional_reference_emplace.cu
+++ b/thrust/testing/regression/gh_1706__thrust_optional_reference_emplace.cu
@@ -1,0 +1,40 @@
+#include <thrust/optional.h>
+
+#include <unittest/unittest.h>
+
+int main()
+{
+  {
+    int a = 10;
+
+    thrust::optional<int&> maybe(a);
+
+    int b = 20;
+    maybe.emplace(b);
+
+    ASSERT_EQUAL(maybe.value(), 20);
+    // Emplacing with b shouldn't change a
+    ASSERT_EQUAL(a, 10);
+
+    int c = 30;
+    maybe.emplace(c);
+
+    ASSERT_EQUAL(maybe.value(), 30);
+    ASSERT_EQUAL(b, 20);
+  }
+
+  {
+    thrust::optional<int&> maybe;
+
+    int b = 21;
+    maybe.emplace(b);
+
+    ASSERT_EQUAL(maybe.value(), 21);
+
+    int c = 31;
+    maybe.emplace(c);
+
+    ASSERT_EQUAL(maybe.value(), 31);
+    ASSERT_EQUAL(b, 21);
+  }
+}

--- a/thrust/thrust/optional.h
+++ b/thrust/thrust/optional.h
@@ -2773,13 +2773,11 @@ public:
   ///
   /// \group emplace
   _CCCL_EXEC_CHECK_DISABLE
-  template <class... Args>
-  _CCCL_HOST_DEVICE T& emplace(Args&&... args) noexcept
+  template <class U>
+  _CCCL_HOST_DEVICE T& emplace(U& u) noexcept
   {
-    static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");
-
-    *this = nullopt;
-    this->construct(std::forward<Args>(args)...);
+    m_value = thrust::addressof(u);
+    return *m_value;
   }
 
   /// Swaps this optional with the other.


### PR DESCRIPTION
## Description

closes https://github.com/NVIDIA/cccl/issues/1706

Where optional<T> inherits optional<T>::construct via a series of classes, optional<T&> does not. This means that optional<T&>::emplace() was broken and called into a member function that did not exist.

This replaces the functionality to make optional<T&>::emplace() change the stored reference to the new one. Note that it does _not_ emplace the referee, as this would lead to questionable behavior when the optional holds nullopt.

This was revealed by a change in LLVM, see
https://github.com/llvm/llvm-project/pull/90152 and https://github.com/ROCm/rocThrust/issues/404.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
