### PR TITLE
Remove old f(void) function signatures

### DIFF
--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -85,7 +85,7 @@ struct policy_wrapper_t : PolicyT
  * \brief Empty kernel for querying PTX manifest metadata (e.g., version) for the current device
  */
 template <typename T>
-CUB_DETAIL_KERNEL_ATTRIBUTES void EmptyKernel(void)
+CUB_DETAIL_KERNEL_ATTRIBUTES void EmptyKernel()
 {}
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/cub/test/mersenne.h
+++ b/cub/test/mersenne.h
@@ -119,7 +119,7 @@ void init_by_array(unsigned int init_key[], int key_length)
 }
 
 /* generates a random number on [0,0xffffffff]-interval */
-unsigned int genrand_int32(void)
+unsigned int genrand_int32()
 {
   unsigned int y;
   static unsigned int mag01[2] = {0x0, MATRIX_A};

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
@@ -42,13 +42,13 @@ long               strtol  (const char* restrict nptr, char** restrict endptr, i
 long long          strtoll (const char* restrict nptr, char** restrict endptr, int base); // C99
 unsigned long      strtoul (const char* restrict nptr, char** restrict endptr, int base);
 unsigned long long strtoull(const char* restrict nptr, char** restrict endptr, int base); // C99
-int rand(void);
+int rand();
 void srand(unsigned int seed);
 void* calloc(size_t nmemb, size_t size);
 void free(void* ptr);
 void* malloc(size_t size);
 void* realloc(void* ptr, size_t size);
-void abort(void);
+void abort();
 int atexit(void (*func)(void));
 void exit(int status);
 void _Exit(int status);

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.cat/is_function.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.cat/is_function.pass.cpp
@@ -82,7 +82,7 @@ typedef void (*FunctionPtr)();
 
 int main(int, char**)
 {
-  test_is_function<void(void)>();
+  test_is_function<void()>();
   test_is_function<int(int)>();
   test_is_function<int(int, double)>();
   test_is_function<int(Abstract*)>();

--- a/thrust/examples/arbitrary_transformation.cu
+++ b/thrust/examples/arbitrary_transformation.cu
@@ -63,7 +63,7 @@ struct arbitrary_functor2
 };
 #endif // >= C++11
 
-int main(void)
+int main()
 {
   // allocate storage
   thrust::device_vector<float> A(5);

--- a/thrust/examples/basic_vector.cu
+++ b/thrust/examples/basic_vector.cu
@@ -3,7 +3,7 @@
 
 #include <iostream>
 
-int main(void)
+int main()
 {
   // H has storage for 4 integers
   thrust::host_vector<int> H(4);

--- a/thrust/examples/bounding_box.cu
+++ b/thrust/examples/bounding_box.cu
@@ -66,7 +66,7 @@ struct bbox_reduction : public thrust::binary_function<bbox, bbox, bbox>
   }
 };
 
-int main(void)
+int main()
 {
   const size_t N = 40;
   thrust::default_random_engine rng;

--- a/thrust/examples/bucket_sort2d.cu
+++ b/thrust/examples/bucket_sort2d.cu
@@ -13,7 +13,7 @@
 typedef thrust::tuple<float, float> vec2;
 
 // return a random vec2 in [0,1)^2
-vec2 make_random_vec2(void)
+vec2 make_random_vec2()
 {
   static thrust::default_random_engine rng;
   static thrust::uniform_real_distribution<float> u01(0.0f, 1.0f);
@@ -45,7 +45,7 @@ struct point_to_bucket_index : public thrust::unary_function<vec2, unsigned int>
   }
 };
 
-int main(void)
+int main()
 {
   const size_t N = 1000000;
 

--- a/thrust/examples/constant_iterator.cu
+++ b/thrust/examples/constant_iterator.cu
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <iterator>
 
-int main(void)
+int main()
 {
   thrust::device_vector<int> data(4);
   data[0] = 3;

--- a/thrust/examples/counting_iterator.cu
+++ b/thrust/examples/counting_iterator.cu
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <iterator>
 
-int main(void)
+int main()
 {
   // this example computes indices for all the nonzero values in a sequence
 

--- a/thrust/examples/cpp_integration/host.cpp
+++ b/thrust/examples/cpp_integration/host.cpp
@@ -10,7 +10,7 @@
 // defines the function prototype
 #include "device.h"
 
-int main(void)
+int main()
 {
   // generate 20 random numbers on the host
   thrust::host_vector<int> h_vec(20);

--- a/thrust/examples/cuda/unwrap_pointer.cu
+++ b/thrust/examples/cuda/unwrap_pointer.cu
@@ -5,7 +5,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
 
-int main(void)
+int main()
 {
   size_t N = 10;
 

--- a/thrust/examples/cuda/wrap_pointer.cu
+++ b/thrust/examples/cuda/wrap_pointer.cu
@@ -3,7 +3,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/fill.h>
 
-int main(void)
+int main()
 {
   size_t N = 10;
 

--- a/thrust/examples/device_ptr.cu
+++ b/thrust/examples/device_ptr.cu
@@ -7,7 +7,7 @@
 #include <cassert>
 #include <iostream>
 
-int main(void)
+int main()
 {
   // allocate memory buffer to store 10 integers on the device
   thrust::device_ptr<int> d_ptr = thrust::device_malloc<int>(10);

--- a/thrust/examples/discrete_voronoi.cu
+++ b/thrust/examples/discrete_voronoi.cu
@@ -207,7 +207,7 @@ void display_time(timer& t)
   std::cout << "  ( " << 1e3 * t.elapsed() << "ms )" << std::endl;
 }
 
-int main(void)
+int main()
 {
   int m = 2048; // number of rows
   int n = 2048; // number of columns

--- a/thrust/examples/dot_products_with_zip.cu
+++ b/thrust/examples/dot_products_with_zip.cu
@@ -38,7 +38,7 @@ thrust::host_vector<float> random_vector(const size_t N, unsigned int seed = thr
   return temp;
 }
 
-int main(void)
+int main()
 {
   // number of vectors
   const size_t N = 1000;

--- a/thrust/examples/expand.cu
+++ b/thrust/examples/expand.cu
@@ -60,7 +60,7 @@ void print(const std::string& s, const Vector& v)
   std::cout << std::endl;
 }
 
-int main(void)
+int main()
 {
   int counts[] = {3, 5, 2, 0, 1, 3, 4, 2, 4};
   int values[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};

--- a/thrust/examples/fill_copy_sequence.cu
+++ b/thrust/examples/fill_copy_sequence.cu
@@ -6,7 +6,7 @@
 
 #include <iostream>
 
-int main(void)
+int main()
 {
   // initialize all ten integers of a device_vector to 1
   thrust::device_vector<int> D(10, 1);

--- a/thrust/examples/histogram.cu
+++ b/thrust/examples/histogram.cu
@@ -139,7 +139,7 @@ void sparse_histogram(const Vector1& input, Vector2& histogram_values, Vector3& 
   print_vector("histogram counts", histogram_counts);
 }
 
-int main(void)
+int main()
 {
   thrust::default_random_engine rng;
   thrust::uniform_int_distribution<int> dist(0, 9);

--- a/thrust/examples/include/timer.h
+++ b/thrust/examples/include/timer.h
@@ -41,25 +41,25 @@ struct timer
   cudaEvent_t start;
   cudaEvent_t end;
 
-  timer(void)
+  timer()
   {
     cuda_safe_call(cudaEventCreate(&start));
     cuda_safe_call(cudaEventCreate(&end));
     restart();
   }
 
-  ~timer(void)
+  ~timer()
   {
     cuda_safe_call(cudaEventDestroy(start));
     cuda_safe_call(cudaEventDestroy(end));
   }
 
-  void restart(void)
+  void restart()
   {
     cuda_safe_call(cudaEventRecord(start, 0));
   }
 
-  double elapsed(void)
+  double elapsed()
   {
     cuda_safe_call(cudaEventRecord(end, 0));
     cuda_safe_call(cudaEventSynchronize(end));
@@ -69,7 +69,7 @@ struct timer
     return ms_elapsed / 1e3;
   }
 
-  double epsilon(void)
+  double epsilon()
   {
     return 0.5e-6;
   }
@@ -85,26 +85,26 @@ struct timer
   clock_t start;
   clock_t end;
 
-  timer(void)
+  timer()
   {
     restart();
   }
 
-  ~timer(void) {}
+  ~timer() {}
 
-  void restart(void)
+  void restart()
   {
     start = clock();
   }
 
-  double elapsed(void)
+  double elapsed()
   {
     end = clock();
 
     return static_cast<double>(end - start) / static_cast<double>(CLOCKS_PER_SEC);
   }
 
-  double epsilon(void)
+  double epsilon()
   {
     return 1.0 / static_cast<double>(CLOCKS_PER_SEC);
   }

--- a/thrust/examples/lambda.cu
+++ b/thrust/examples/lambda.cu
@@ -36,7 +36,7 @@ struct saxpy_functor : public thrust::binary_function<float, float, float>
   }
 };
 
-int main(void)
+int main()
 {
   // input data
   float a    = 2.0f;

--- a/thrust/examples/lexicographical_sort.cu
+++ b/thrust/examples/lexicographical_sort.cu
@@ -49,7 +49,7 @@ thrust::host_vector<int> random_vector(size_t N)
   return vec;
 }
 
-int main(void)
+int main()
 {
   size_t N = 20;
 

--- a/thrust/examples/max_abs_diff.cu
+++ b/thrust/examples/max_abs_diff.cu
@@ -17,7 +17,7 @@ struct abs_diff : public thrust::binary_function<T, T, T>
   }
 };
 
-int main(void)
+int main()
 {
   thrust::device_vector<float> d_a(4);
   thrust::device_vector<float> d_b(4);

--- a/thrust/examples/minmax.cu
+++ b/thrust/examples/minmax.cu
@@ -47,7 +47,7 @@ struct minmax_binary_op : public thrust::binary_function<minmax_pair<T>, minmax_
   }
 };
 
-int main(void)
+int main()
 {
   // input size
   size_t N = 10;

--- a/thrust/examples/mode.cu
+++ b/thrust/examples/mode.cu
@@ -17,7 +17,7 @@
 //
 // [1] http://en.wikipedia.org/wiki/Mode_(statistics)
 
-int main(void)
+int main()
 {
   const size_t N = 30;
   const size_t M = 10;

--- a/thrust/examples/monte_carlo.cu
+++ b/thrust/examples/monte_carlo.cu
@@ -60,7 +60,7 @@ struct estimate_pi : public thrust::unary_function<unsigned int, float>
   }
 };
 
-int main(void)
+int main()
 {
   // use 30K independent seeds
   int M = 30000;

--- a/thrust/examples/monte_carlo_disjoint_sequences.cu
+++ b/thrust/examples/monte_carlo_disjoint_sequences.cu
@@ -67,7 +67,7 @@ struct estimate_pi : public thrust::unary_function<unsigned int, float>
   }
 };
 
-int main(void)
+int main()
 {
   // use 30K subsequences of random numbers
   int M = 30000;

--- a/thrust/examples/norm.cu
+++ b/thrust/examples/norm.cu
@@ -27,7 +27,7 @@ struct square
   }
 };
 
-int main(void)
+int main()
 {
   // initialize host array
   float x[4] = {1.0, 2.0, 3.0, 4.0};

--- a/thrust/examples/padded_grid_reduction.cu
+++ b/thrust/examples/padded_grid_reduction.cu
@@ -72,7 +72,7 @@ struct reduce_tuple
   }
 };
 
-int main(void)
+int main()
 {
   int M = 10; // number of rows
   int n = 11; // number of columns excluding padding

--- a/thrust/examples/permutation_iterator.cu
+++ b/thrust/examples/permutation_iterator.cu
@@ -7,7 +7,7 @@
 // this example fuses a gather operation with a reduction for
 // greater efficiency than separate gather() and reduce() calls
 
-int main(void)
+int main()
 {
   // gather locations
   thrust::device_vector<int> map(4);

--- a/thrust/examples/raw_reference_cast.cu
+++ b/thrust/examples/raw_reference_cast.cu
@@ -75,7 +75,7 @@ void print(const std::string& name, const Vector& v)
   std::cout << "\n";
 }
 
-int main(void)
+int main()
 {
   typedef thrust::device_vector<int> Vector;
   typedef Vector::iterator Iterator;

--- a/thrust/examples/remove_points2d.cu
+++ b/thrust/examples/remove_points2d.cu
@@ -30,7 +30,7 @@ struct is_outside_circle
   }
 };
 
-int main(void)
+int main()
 {
   const size_t N = 20;
 

--- a/thrust/examples/repeated_range.cu
+++ b/thrust/examples/repeated_range.cu
@@ -49,12 +49,12 @@ public:
       , repeats(repeats)
   {}
 
-  iterator begin(void) const
+  iterator begin() const
   {
     return PermutationIterator(first, TransformIterator(CountingIterator(0), repeat_functor(repeats)));
   }
 
-  iterator end(void) const
+  iterator end() const
   {
     return begin() + repeats * (last - first);
   }
@@ -65,7 +65,7 @@ protected:
   difference_type repeats;
 };
 
-int main(void)
+int main()
 {
   thrust::device_vector<int> data(4);
   data[0] = 10;

--- a/thrust/examples/run_length_decoding.cu
+++ b/thrust/examples/run_length_decoding.cu
@@ -12,7 +12,7 @@
 //
 // [1] http://en.wikipedia.org/wiki/Run-length_encoding
 
-int main(void)
+int main()
 {
   // allocate storage for compressed input and run lengths
   thrust::device_vector<char> input(6);

--- a/thrust/examples/run_length_encoding.cu
+++ b/thrust/examples/run_length_encoding.cu
@@ -10,7 +10,7 @@
 //
 // [1] http://en.wikipedia.org/wiki/Run-length_encoding
 
-int main(void)
+int main()
 {
   // input data on the host
   const char data[] = "aaabbbbbcddeeeeeeeeeff";

--- a/thrust/examples/saxpy.cu
+++ b/thrust/examples/saxpy.cu
@@ -50,7 +50,7 @@ void saxpy_slow(float A, thrust::device_vector<float>& X, thrust::device_vector<
   thrust::transform(temp.begin(), temp.end(), Y.begin(), Y.begin(), thrust::plus<float>());
 }
 
-int main(void)
+int main()
 {
   // initialize host arrays
   float x[4] = {1.0, 1.0, 1.0, 1.0};

--- a/thrust/examples/scan_by_key.cu
+++ b/thrust/examples/scan_by_key.cu
@@ -25,7 +25,7 @@ void print(const Vector& v)
   std::cout << "\n";
 }
 
-int main(void)
+int main()
 {
   int keys[]   = {0, 0, 0, 1, 1, 2, 2, 2, 2, 3, 4, 4, 5, 5, 5}; // segments represented with keys
   int flags[]  = {1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0}; // segments represented with head flags

--- a/thrust/examples/set_operations.cu
+++ b/thrust/examples/set_operations.cu
@@ -133,7 +133,7 @@ void SetIntersectionSize(const Vector& A, const Vector& B)
   std::cout << "SetIntersectionSize(A,B) " << (C_end - C_begin) << std::endl;
 }
 
-int main(void)
+int main()
 {
   int a[] = {0, 2, 4, 5, 6, 8, 9};
   int b[] = {0, 1, 2, 3, 5, 7, 8};

--- a/thrust/examples/simple_moving_average.cu
+++ b/thrust/examples/simple_moving_average.cu
@@ -57,7 +57,7 @@ void simple_moving_average(const InputVector& data, size_t w, OutputVector& outp
   thrust::transform(temp.begin() + w, temp.end(), temp.begin(), output.begin(), minus_and_divide<T>(T(w)));
 }
 
-int main(void)
+int main()
 {
   // length of data series
   size_t n = 30;

--- a/thrust/examples/sort.cu
+++ b/thrust/examples/sort.cu
@@ -108,7 +108,7 @@ struct evens_before_odds
   }
 };
 
-int main(void)
+int main()
 {
   size_t N = 16;
 

--- a/thrust/examples/sorting_aos_vs_soa.cu
+++ b/thrust/examples/sorting_aos_vs_soa.cu
@@ -56,7 +56,7 @@ void initialize_keys(thrust::device_vector<MyStruct>& structures)
   structures = h_structures;
 }
 
-int main(void)
+int main()
 {
   size_t N = 2 * 1024 * 1024;
 

--- a/thrust/examples/sparse_vector.cu
+++ b/thrust/examples/sparse_vector.cu
@@ -83,7 +83,7 @@ void sum_sparse_vectors(
     thrust::plus<ValueType>());
 }
 
-int main(void)
+int main()
 {
   // initialize sparse vector A with 4 elements
   thrust::device_vector<int> A_index(4);

--- a/thrust/examples/stream_compaction.cu
+++ b/thrust/examples/stream_compaction.cu
@@ -28,7 +28,7 @@ void print_range(const std::string& name, Iterator first, Iterator last)
   std::cout << "\n";
 }
 
-int main(void)
+int main()
 {
   // input size
   size_t N = 10;

--- a/thrust/examples/strided_range.cu
+++ b/thrust/examples/strided_range.cu
@@ -49,12 +49,12 @@ public:
       , stride(stride)
   {}
 
-  iterator begin(void) const
+  iterator begin() const
   {
     return PermutationIterator(first, TransformIterator(CountingIterator(0), stride_functor(stride)));
   }
 
-  iterator end(void) const
+  iterator end() const
   {
     return begin() + ((last - first) + (stride - 1)) / stride;
   }
@@ -65,7 +65,7 @@ protected:
   difference_type stride;
 };
 
-int main(void)
+int main()
 {
   thrust::device_vector<int> data(8);
   data[0] = 10;

--- a/thrust/examples/sum.cu
+++ b/thrust/examples/sum.cu
@@ -5,14 +5,14 @@
 #include <thrust/random.h>
 #include <thrust/reduce.h>
 
-int my_rand(void)
+int my_rand()
 {
   static thrust::default_random_engine rng;
   static thrust::uniform_int_distribution<int> dist(0, 9999);
   return dist(rng);
 }
 
-int main(void)
+int main()
 {
   // generate random data on the host
   thrust::host_vector<int> h_vec(100);

--- a/thrust/examples/sum_rows.cu
+++ b/thrust/examples/sum_rows.cu
@@ -23,7 +23,7 @@ struct linear_index_to_row_index : public thrust::unary_function<T, T>
   }
 };
 
-int main(void)
+int main()
 {
   int R = 5; // number of rows
   int C = 8; // number of columns

--- a/thrust/examples/summary_statistics.cu
+++ b/thrust/examples/summary_statistics.cu
@@ -129,7 +129,7 @@ void print_range(const std::string& name, Iterator first, Iterator last)
   std::cout << "\n";
 }
 
-int main(void)
+int main()
 {
   typedef float T;
 

--- a/thrust/examples/summed_area_table.cu
+++ b/thrust/examples/summed_area_table.cu
@@ -87,7 +87,7 @@ void print(size_t m, size_t n, thrust::device_vector<T>& d_data)
   }
 }
 
-int main(void)
+int main()
 {
   size_t m = 3; // number of rows
   size_t n = 4; // number of columns

--- a/thrust/examples/tiled_range.cu
+++ b/thrust/examples/tiled_range.cu
@@ -49,12 +49,12 @@ public:
       , tiles(tiles)
   {}
 
-  iterator begin(void) const
+  iterator begin() const
   {
     return PermutationIterator(first, TransformIterator(CountingIterator(0), tile_functor(last - first)));
   }
 
-  iterator end(void) const
+  iterator end() const
   {
     return begin() + tiles * (last - first);
   }
@@ -65,7 +65,7 @@ protected:
   difference_type tiles;
 };
 
-int main(void)
+int main()
 {
   thrust::device_vector<int> data(4);
   data[0] = 10;

--- a/thrust/examples/transform_input_output_iterator.cu
+++ b/thrust/examples/transform_input_output_iterator.cu
@@ -66,7 +66,7 @@ struct ScaledIntegerToValue
   }
 };
 
-int main(void)
+int main()
 {
   const size_t size = 4;
   thrust::device_vector<int> A(size);

--- a/thrust/examples/transform_iterator.cu
+++ b/thrust/examples/transform_iterator.cu
@@ -55,7 +55,7 @@ void print_range(const std::string& name, Iterator first, Iterator last)
   std::cout << "\n";
 }
 
-int main(void)
+int main()
 {
   // clamp values to the range [1, 5]
   int lo = 1;

--- a/thrust/examples/transform_output_iterator.cu
+++ b/thrust/examples/transform_output_iterator.cu
@@ -16,7 +16,7 @@ struct Functor
   }
 };
 
-int main(void)
+int main()
 {
   float u[4] = {4, 3, 2, 1};
   float v[4] = {-1, 1, 1, -1};

--- a/thrust/examples/version.cu
+++ b/thrust/examples/version.cu
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-int main(void)
+int main()
 {
   int major    = THRUST_MAJOR_VERSION;
   int minor    = THRUST_MINOR_VERSION;

--- a/thrust/examples/weld_vertices.cu
+++ b/thrust/examples/weld_vertices.cu
@@ -36,7 +36,7 @@
 // define a 2d float vector
 typedef thrust::tuple<float, float> vec2;
 
-int main(void)
+int main()
 {
   // allocate memory for input mesh representation
   thrust::device_vector<vec2> input(9);

--- a/thrust/examples/word_count.cu
+++ b/thrust/examples/word_count.cu
@@ -52,7 +52,7 @@ int word_count(const thrust::device_vector<char>& input)
   return wc;
 }
 
-int main(void)
+int main()
 {
   // Paragraph from 'The Raven' by Edgar Allan Poe
   // http://en.wikipedia.org/wiki/The_Raven

--- a/thrust/testing/adjacent_difference.cu
+++ b/thrust/testing/adjacent_difference.cu
@@ -7,7 +7,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestAdjacentDifferenceSimple(void)
+void TestAdjacentDifferenceSimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/binary_search.cu
+++ b/thrust/testing/binary_search.cu
@@ -12,7 +12,7 @@ THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 //////////////////////
 
 template <class Vector>
-void TestScalarLowerBoundSimple(void)
+void TestScalarLowerBoundSimple()
 {
   Vector vec(5);
 
@@ -72,7 +72,7 @@ void TestScalarLowerBoundDispatchImplicit()
 DECLARE_UNITTEST(TestScalarLowerBoundDispatchImplicit);
 
 template <class Vector>
-void TestScalarUpperBoundSimple(void)
+void TestScalarUpperBoundSimple()
 {
   Vector vec(5);
 
@@ -132,7 +132,7 @@ void TestScalarUpperBoundDispatchImplicit()
 DECLARE_UNITTEST(TestScalarUpperBoundDispatchImplicit);
 
 template <class Vector>
-void TestScalarBinarySearchSimple(void)
+void TestScalarBinarySearchSimple()
 {
   Vector vec(5);
 
@@ -192,7 +192,7 @@ void TestScalarBinarySearchDispatchImplicit()
 DECLARE_UNITTEST(TestScalarBinarySearchDispatchImplicit);
 
 template <class Vector>
-void TestScalarEqualRangeSimple(void)
+void TestScalarEqualRangeSimple()
 {
   Vector vec(5);
 

--- a/thrust/testing/binary_search_descending.cu
+++ b/thrust/testing/binary_search_descending.cu
@@ -10,7 +10,7 @@
 //////////////////////
 
 template <class Vector>
-void TestScalarLowerBoundDescendingSimple(void)
+void TestScalarLowerBoundDescendingSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -36,7 +36,7 @@ void TestScalarLowerBoundDescendingSimple(void)
 DECLARE_VECTOR_UNITTEST(TestScalarLowerBoundDescendingSimple);
 
 template <class Vector>
-void TestScalarUpperBoundDescendingSimple(void)
+void TestScalarUpperBoundDescendingSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -62,7 +62,7 @@ void TestScalarUpperBoundDescendingSimple(void)
 DECLARE_VECTOR_UNITTEST(TestScalarUpperBoundDescendingSimple);
 
 template <class Vector>
-void TestScalarBinarySearchDescendingSimple(void)
+void TestScalarBinarySearchDescendingSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -88,7 +88,7 @@ void TestScalarBinarySearchDescendingSimple(void)
 DECLARE_VECTOR_UNITTEST(TestScalarBinarySearchDescendingSimple);
 
 template <class Vector>
-void TestScalarEqualRangeDescendingSimple(void)
+void TestScalarEqualRangeDescendingSimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/binary_search_vector.cu
+++ b/thrust/testing/binary_search_vector.cu
@@ -22,7 +22,7 @@ struct vector_like
 };
 
 template <class Vector>
-void TestVectorLowerBoundSimple(void)
+void TestVectorLowerBoundSimple()
 {
   Vector vec(5);
 
@@ -118,7 +118,7 @@ void TestVectorLowerBoundDispatchImplicit()
 DECLARE_UNITTEST(TestVectorLowerBoundDispatchImplicit);
 
 template <class Vector>
-void TestVectorUpperBoundSimple(void)
+void TestVectorUpperBoundSimple()
 {
   Vector vec(5);
 
@@ -212,7 +212,7 @@ void TestVectorUpperBoundDispatchImplicit()
 DECLARE_UNITTEST(TestVectorUpperBoundDispatchImplicit);
 
 template <class Vector>
-void TestVectorBinarySearchSimple(void)
+void TestVectorBinarySearchSimple()
 {
   Vector vec(5);
 

--- a/thrust/testing/binary_search_vector_descending.cu
+++ b/thrust/testing/binary_search_vector_descending.cu
@@ -21,7 +21,7 @@ struct vector_like
 };
 
 template <class Vector>
-void TestVectorLowerBoundDescendingSimple(void)
+void TestVectorLowerBoundDescendingSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -60,7 +60,7 @@ void TestVectorLowerBoundDescendingSimple(void)
 DECLARE_VECTOR_UNITTEST(TestVectorLowerBoundDescendingSimple);
 
 template <class Vector>
-void TestVectorUpperBoundDescendingSimple(void)
+void TestVectorUpperBoundDescendingSimple()
 {
   Vector vec(5);
 
@@ -98,7 +98,7 @@ void TestVectorUpperBoundDescendingSimple(void)
 DECLARE_VECTOR_UNITTEST(TestVectorUpperBoundDescendingSimple);
 
 template <class Vector>
-void TestVectorBinarySearchDescendingSimple(void)
+void TestVectorBinarySearchDescendingSimple()
 {
   Vector vec(5);
 

--- a/thrust/testing/constant_iterator.cu
+++ b/thrust/testing/constant_iterator.cu
@@ -7,7 +7,7 @@
 
 #include <unittest/unittest.h>
 
-void TestConstantIteratorConstructFromConvertibleSystem(void)
+void TestConstantIteratorConstructFromConvertibleSystem()
 {
   using namespace thrust;
 
@@ -21,7 +21,7 @@ void TestConstantIteratorConstructFromConvertibleSystem(void)
 }
 DECLARE_UNITTEST(TestConstantIteratorConstructFromConvertibleSystem);
 
-void TestConstantIteratorIncrement(void)
+void TestConstantIteratorIncrement()
 {
   using namespace thrust;
 
@@ -51,7 +51,7 @@ DECLARE_UNITTEST(TestConstantIteratorIncrement);
 static_assert(cuda::std::is_trivially_copy_constructible<thrust::constant_iterator<int>>::value, "");
 static_assert(cuda::std::is_trivially_copyable<thrust::constant_iterator<int>>::value, "");
 
-void TestConstantIteratorIncrementBig(void)
+void TestConstantIteratorIncrementBig()
 {
   long long int n = 10000000000ULL;
 
@@ -62,7 +62,7 @@ void TestConstantIteratorIncrementBig(void)
 }
 DECLARE_UNITTEST(TestConstantIteratorIncrementBig);
 
-void TestConstantIteratorComparison(void)
+void TestConstantIteratorComparison()
 {
   using namespace thrust;
 
@@ -90,7 +90,7 @@ void TestConstantIteratorComparison(void)
 }
 DECLARE_UNITTEST(TestConstantIteratorComparison);
 
-void TestMakeConstantIterator(void)
+void TestMakeConstantIterator()
 {
   using namespace thrust;
 
@@ -108,7 +108,7 @@ void TestMakeConstantIterator(void)
 DECLARE_UNITTEST(TestMakeConstantIterator);
 
 template <typename Vector>
-void TestConstantIteratorCopy(void)
+void TestConstantIteratorCopy()
 {
   using namespace thrust;
 
@@ -129,7 +129,7 @@ void TestConstantIteratorCopy(void)
 DECLARE_VECTOR_UNITTEST(TestConstantIteratorCopy);
 
 template <typename Vector>
-void TestConstantIteratorTransform(void)
+void TestConstantIteratorTransform()
 {
   using namespace thrust;
 
@@ -158,7 +158,7 @@ void TestConstantIteratorTransform(void)
 };
 DECLARE_VECTOR_UNITTEST(TestConstantIteratorTransform);
 
-void TestConstantIteratorReduce(void)
+void TestConstantIteratorReduce()
 {
   using namespace thrust;
 

--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -17,7 +17,7 @@
 
 #include <unittest/unittest.h>
 
-void TestCopyFromConstIterator(void)
+void TestCopyFromConstIterator()
 {
   typedef int T;
 
@@ -53,7 +53,7 @@ void TestCopyFromConstIterator(void)
 }
 DECLARE_UNITTEST(TestCopyFromConstIterator);
 
-void TestCopyToDiscardIterator(void)
+void TestCopyToDiscardIterator()
 {
   typedef int T;
 
@@ -73,7 +73,7 @@ void TestCopyToDiscardIterator(void)
 }
 DECLARE_UNITTEST(TestCopyToDiscardIterator);
 
-void TestCopyToDiscardIteratorZipped(void)
+void TestCopyToDiscardIteratorZipped()
 {
   typedef int T;
 
@@ -110,7 +110,7 @@ void TestCopyToDiscardIteratorZipped(void)
 DECLARE_UNITTEST(TestCopyToDiscardIteratorZipped);
 
 template <class Vector>
-void TestCopyMatchingTypes(void)
+void TestCopyMatchingTypes()
 {
   typedef typename Vector::value_type T;
 
@@ -144,7 +144,7 @@ void TestCopyMatchingTypes(void)
 DECLARE_VECTOR_UNITTEST(TestCopyMatchingTypes);
 
 template <class Vector>
-void TestCopyMixedTypes(void)
+void TestCopyMixedTypes()
 {
   Vector v(5);
   v[0] = 0;
@@ -176,7 +176,7 @@ void TestCopyMixedTypes(void)
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestCopyMixedTypes);
 
-void TestCopyVectorBool(void)
+void TestCopyVectorBool()
 {
   std::vector<bool> v(3);
   v[0] = true;
@@ -200,7 +200,7 @@ void TestCopyVectorBool(void)
 DECLARE_UNITTEST(TestCopyVectorBool);
 
 template <class Vector>
-void TestCopyListTo(void)
+void TestCopyListTo()
 {
   typedef typename Vector::value_type T;
 
@@ -271,7 +271,7 @@ struct mod_3
 };
 
 template <class Vector>
-void TestCopyIfSimple(void)
+void TestCopyIfSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -399,7 +399,7 @@ void TestCopyIfSequence(const size_t n)
 DECLARE_INTEGRAL_VARIABLE_UNITTEST(TestCopyIfSequence);
 
 template <class Vector>
-void TestCopyIfStencilSimple(void)
+void TestCopyIfStencilSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -550,7 +550,7 @@ void TestCopyIfNonTrivial()
 DECLARE_UNITTEST(TestCopyIfNonTrivial);
 
 template <typename Vector>
-void TestCopyCountingIterator(void)
+void TestCopyCountingIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -568,7 +568,7 @@ void TestCopyCountingIterator(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestCopyCountingIterator);
 
 template <typename Vector>
-void TestCopyZipIterator(void)
+void TestCopyZipIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -593,7 +593,7 @@ void TestCopyZipIterator(void)
 DECLARE_VECTOR_UNITTEST(TestCopyZipIterator);
 
 template <typename Vector>
-void TestCopyConstantIteratorToZipIterator(void)
+void TestCopyConstantIteratorToZipIterator()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/copy_n.cu
+++ b/thrust/testing/copy_n.cu
@@ -11,7 +11,7 @@
 
 #include <unittest/unittest.h>
 
-void TestCopyNFromConstIterator(void)
+void TestCopyNFromConstIterator()
 {
   typedef int T;
 
@@ -46,7 +46,7 @@ void TestCopyNFromConstIterator(void)
 }
 DECLARE_UNITTEST(TestCopyNFromConstIterator);
 
-void TestCopyNToDiscardIterator(void)
+void TestCopyNToDiscardIterator()
 {
   typedef int T;
 
@@ -69,7 +69,7 @@ void TestCopyNToDiscardIterator(void)
 DECLARE_UNITTEST(TestCopyNToDiscardIterator);
 
 template <class Vector>
-void TestCopyNMatchingTypes(void)
+void TestCopyNMatchingTypes()
 {
   typedef typename Vector::value_type T;
 
@@ -103,7 +103,7 @@ void TestCopyNMatchingTypes(void)
 DECLARE_VECTOR_UNITTEST(TestCopyNMatchingTypes);
 
 template <class Vector>
-void TestCopyNMixedTypes(void)
+void TestCopyNMixedTypes()
 {
   Vector v(5);
   v[0] = 0;
@@ -135,7 +135,7 @@ void TestCopyNMixedTypes(void)
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestCopyNMixedTypes);
 
-void TestCopyNVectorBool(void)
+void TestCopyNVectorBool()
 {
   std::vector<bool> v(3);
   v[0] = true;
@@ -159,7 +159,7 @@ void TestCopyNVectorBool(void)
 DECLARE_UNITTEST(TestCopyNVectorBool);
 
 template <class Vector>
-void TestCopyNListTo(void)
+void TestCopyNListTo()
 {
   typedef typename Vector::value_type T;
 
@@ -203,7 +203,7 @@ void TestCopyNListTo(void)
 DECLARE_VECTOR_UNITTEST(TestCopyNListTo);
 
 template <typename Vector>
-void TestCopyNCountingIterator(void)
+void TestCopyNCountingIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -221,7 +221,7 @@ void TestCopyNCountingIterator(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestCopyNCountingIterator);
 
 template <typename Vector>
-void TestCopyNZipIterator(void)
+void TestCopyNZipIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -248,7 +248,7 @@ void TestCopyNZipIterator(void)
 DECLARE_VECTOR_UNITTEST(TestCopyNZipIterator);
 
 template <typename Vector>
-void TestCopyNConstantIteratorToZipIterator(void)
+void TestCopyNConstantIteratorToZipIterator()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/count.cu
+++ b/thrust/testing/count.cu
@@ -4,7 +4,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestCountSimple(void)
+void TestCountSimple()
 {
   Vector data(5);
   data[0] = 1;
@@ -42,7 +42,7 @@ struct greater_than_five
 };
 
 template <class Vector>
-void TestCountIfSimple(void)
+void TestCountIfSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -71,7 +71,7 @@ void TestCountIf(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestCountIf);
 
 template <typename Vector>
-void TestCountFromConstIteratorSimple(void)
+void TestCountFromConstIteratorSimple()
 {
   Vector data(5);
   data[0] = 1;

--- a/thrust/testing/counting_iterator.cu
+++ b/thrust/testing/counting_iterator.cu
@@ -29,14 +29,14 @@ void test_iterator_traits()
 }
 
 template <typename T>
-void TestCountingDefaultConstructor(void)
+void TestCountingDefaultConstructor()
 {
   thrust::counting_iterator<T> iter0;
   ASSERT_EQUAL(*iter0, T{});
 }
 DECLARE_GENERIC_UNITTEST(TestCountingDefaultConstructor);
 
-void TestCountingIteratorCopyConstructor(void)
+void TestCountingIteratorCopyConstructor()
 {
   thrust::counting_iterator<int> iter0(100);
 
@@ -56,7 +56,7 @@ DECLARE_UNITTEST(TestCountingIteratorCopyConstructor);
 static_assert(cuda::std::is_trivially_copy_constructible<thrust::counting_iterator<int>>::value, "");
 static_assert(cuda::std::is_trivially_copyable<thrust::counting_iterator<int>>::value, "");
 
-void TestCountingIteratorIncrement(void)
+void TestCountingIteratorIncrement()
 {
   thrust::counting_iterator<int> iter(0);
 
@@ -81,7 +81,7 @@ void TestCountingIteratorIncrement(void)
 }
 DECLARE_UNITTEST(TestCountingIteratorIncrement);
 
-void TestCountingIteratorComparison(void)
+void TestCountingIteratorComparison()
 {
   thrust::counting_iterator<int> iter1(0);
   thrust::counting_iterator<int> iter2(0);
@@ -107,7 +107,7 @@ void TestCountingIteratorComparison(void)
 }
 DECLARE_UNITTEST(TestCountingIteratorComparison);
 
-void TestCountingIteratorFloatComparison(void)
+void TestCountingIteratorFloatComparison()
 {
   thrust::counting_iterator<float> iter1(0);
   thrust::counting_iterator<float> iter2(0);
@@ -171,7 +171,7 @@ void TestCountingIteratorFloatComparison(void)
 }
 DECLARE_UNITTEST(TestCountingIteratorFloatComparison);
 
-void TestCountingIteratorDistance(void)
+void TestCountingIteratorDistance()
 {
   thrust::counting_iterator<int> iter1(0);
   thrust::counting_iterator<int> iter2(5);
@@ -188,7 +188,7 @@ void TestCountingIteratorDistance(void)
 }
 DECLARE_UNITTEST(TestCountingIteratorDistance);
 
-void TestCountingIteratorUnsignedType(void)
+void TestCountingIteratorUnsignedType()
 {
   thrust::counting_iterator<unsigned int> iter0(0);
   thrust::counting_iterator<unsigned int> iter1(5);
@@ -201,7 +201,7 @@ void TestCountingIteratorUnsignedType(void)
 }
 DECLARE_UNITTEST(TestCountingIteratorUnsignedType);
 
-void TestCountingIteratorLowerBound(void)
+void TestCountingIteratorLowerBound()
 {
   size_t n       = 10000;
   const size_t M = 100;
@@ -230,7 +230,7 @@ void TestCountingIteratorLowerBound(void)
 }
 DECLARE_UNITTEST(TestCountingIteratorLowerBound);
 
-void TestCountingIteratorDifference(void)
+void TestCountingIteratorDifference()
 {
   typedef thrust::counting_iterator<thrust::detail::uint64_t> Iterator;
   typedef thrust::iterator_difference<Iterator>::type Difference;

--- a/thrust/testing/cstdint.cu
+++ b/thrust/testing/cstdint.cu
@@ -4,7 +4,7 @@
 
 #include <unittest/unittest.h>
 
-void TestStandardIntegerTypes(void)
+void TestStandardIntegerTypes()
 {
   ASSERT_EQUAL(sizeof(thrust::detail::int8_t), 1lu);
   ASSERT_EQUAL(sizeof(thrust::detail::int16_t), 2lu);

--- a/thrust/testing/cuda/gather.cu
+++ b/thrust/testing/cuda/gather.cu
@@ -184,7 +184,7 @@ void TestGatherIfDeviceDevice(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestGatherIfDeviceDevice);
 #endif
 
-void TestGatherIfCudaStreams(void)
+void TestGatherIfCudaStreams()
 {
   thrust::device_vector<int> flg(5); // predicate array
   thrust::device_vector<int> map(5); // gather indices

--- a/thrust/testing/cuda/generate.cu
+++ b/thrust/testing/cuda/generate.cu
@@ -8,7 +8,7 @@ struct return_value
 {
   T val;
 
-  return_value(void) {}
+  return_value() {}
   return_value(T v)
       : val(v)
   {}

--- a/thrust/testing/cuda/merge_sort.cu
+++ b/thrust/testing/cuda/merge_sort.cu
@@ -89,7 +89,7 @@ void InitializeSimpleStableKeySortTest(Vector& unsorted_keys, Vector& sorted_key
   sorted_keys[8] = 36;
 }
 
-void TestMergeSortKeySimple(void)
+void TestMergeSortKeySimple()
 {
 #if 0
     typedef thrust::device_vector<int> Vector;
@@ -110,7 +110,7 @@ void TestMergeSortKeySimple(void)
 }
 DECLARE_UNITTEST(TestMergeSortKeySimple);
 
-void TestMergeSortKeyValueSimple(void)
+void TestMergeSortKeyValueSimple()
 {
 #if 0
     typedef thrust::device_vector<int> Vector;
@@ -132,7 +132,7 @@ void TestMergeSortKeyValueSimple(void)
 }
 DECLARE_UNITTEST(TestMergeSortKeyValueSimple);
 
-void TestMergeSortStableKeySimple(void)
+void TestMergeSortStableKeySimple()
 {
 #if 0
     typedef thrust::device_vector<int> Vector;
@@ -153,7 +153,7 @@ void TestMergeSortStableKeySimple(void)
 }
 DECLARE_UNITTEST(TestMergeSortStableKeySimple);
 
-void TestMergeSortDescendingKey(void)
+void TestMergeSortDescendingKey()
 {
 #if 0
     const size_t n = 10027;
@@ -197,7 +197,7 @@ void TestMergeSortAscendingKeyValue(const size_t n)
 }
 DECLARE_VARIABLE_UNITTEST(TestMergeSortAscendingKeyValue);
 
-void TestMergeSortDescendingKeyValue(void)
+void TestMergeSortDescendingKeyValue()
 {
 #if 0
     const size_t n = 10027;

--- a/thrust/testing/cuda/scan.cu
+++ b/thrust/testing/cuda/scan.cu
@@ -258,7 +258,7 @@ struct const_ref_plus_mod3
   }
 };
 
-static void TestInclusiveScanWithConstAccumulator(void)
+static void TestInclusiveScanWithConstAccumulator()
 {
   // add numbers modulo 3 with external lookup table
   thrust::device_vector<int> data(7);

--- a/thrust/testing/decompose.cu
+++ b/thrust/testing/decompose.cu
@@ -4,7 +4,7 @@
 
 using thrust::system::detail::internal::uniform_decomposition;
 
-void TestUniformDecomposition(void)
+void TestUniformDecomposition()
 {
   {
     uniform_decomposition<int> ud(10, 10, 1);

--- a/thrust/testing/dereference.cu
+++ b/thrust/testing/dereference.cu
@@ -31,7 +31,7 @@ void simple_copy(Iterator1 first1, Iterator1 last1, Iterator2 first2)
 #endif
 }
 
-void TestDeviceDereferenceDeviceVectorIterator(void)
+void TestDeviceDereferenceDeviceVectorIterator()
 {
   thrust::device_vector<int> input = unittest::random_integers<int>(100);
   thrust::device_vector<int> output(input.size(), 0);
@@ -42,7 +42,7 @@ void TestDeviceDereferenceDeviceVectorIterator(void)
 }
 DECLARE_UNITTEST(TestDeviceDereferenceDeviceVectorIterator);
 
-void TestDeviceDereferenceDevicePtr(void)
+void TestDeviceDereferenceDevicePtr()
 {
   thrust::device_vector<int> input = unittest::random_integers<int>(100);
   thrust::device_vector<int> output(input.size(), 0);
@@ -57,7 +57,7 @@ void TestDeviceDereferenceDevicePtr(void)
 }
 DECLARE_UNITTEST(TestDeviceDereferenceDevicePtr);
 
-void TestDeviceDereferenceTransformIterator(void)
+void TestDeviceDereferenceTransformIterator()
 {
   thrust::device_vector<int> input = unittest::random_integers<int>(100);
   thrust::device_vector<int> output(input.size(), 0);
@@ -70,7 +70,7 @@ void TestDeviceDereferenceTransformIterator(void)
 }
 DECLARE_UNITTEST(TestDeviceDereferenceTransformIterator);
 
-void TestDeviceDereferenceCountingIterator(void)
+void TestDeviceDereferenceCountingIterator()
 {
   thrust::counting_iterator<int> first(1);
   thrust::counting_iterator<int> last(6);
@@ -87,7 +87,7 @@ void TestDeviceDereferenceCountingIterator(void)
 }
 DECLARE_UNITTEST(TestDeviceDereferenceCountingIterator);
 
-void TestDeviceDereferenceTransformedCountingIterator(void)
+void TestDeviceDereferenceTransformedCountingIterator()
 {
   thrust::counting_iterator<int> first(1);
   thrust::counting_iterator<int> last(6);

--- a/thrust/testing/device_delete.cu
+++ b/thrust/testing/device_delete.cu
@@ -8,11 +8,11 @@
 
 struct Foo
 {
-  __host__ __device__ Foo(void)
+  __host__ __device__ Foo()
       : set_me_upon_destruction{nullptr}
   {}
 
-  __host__ __device__ ~Foo(void)
+  __host__ __device__ ~Foo()
   {
     NV_IF_TARGET(NV_IS_DEVICE, (if (set_me_upon_destruction != nullptr) { *set_me_upon_destruction = true; }));
   }
@@ -21,7 +21,7 @@ struct Foo
 };
 
 #if !defined(__QNX__)
-void TestDeviceDeleteDestructorInvocation(void)
+void TestDeviceDeleteDestructorInvocation()
 {
   KNOWN_FAILURE;
   //

--- a/thrust/testing/device_ptr.cu
+++ b/thrust/testing/device_ptr.cu
@@ -3,7 +3,7 @@
 
 #include <unittest/unittest.h>
 
-void TestDevicePointerManipulation(void)
+void TestDevicePointerManipulation()
 {
   thrust::device_vector<int> data(5);
 
@@ -49,7 +49,7 @@ void TestDevicePointerManipulation(void)
 }
 DECLARE_UNITTEST(TestDevicePointerManipulation);
 
-void TestMakeDevicePointer(void)
+void TestMakeDevicePointer()
 {
   typedef int T;
 
@@ -66,7 +66,7 @@ void TestMakeDevicePointer(void)
 DECLARE_UNITTEST(TestMakeDevicePointer);
 
 template <typename Vector>
-void TestRawPointerCast(void)
+void TestRawPointerCast()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/device_reference.cu
+++ b/thrust/testing/device_reference.cu
@@ -3,7 +3,7 @@
 
 #include <unittest/unittest.h>
 
-void TestDeviceReferenceConstructorFromDeviceReference(void)
+void TestDeviceReferenceConstructorFromDeviceReference()
 {
   typedef int T;
 
@@ -28,7 +28,7 @@ void TestDeviceReferenceConstructorFromDeviceReference(void)
 }
 DECLARE_UNITTEST(TestDeviceReferenceConstructorFromDeviceReference);
 
-void TestDeviceReferenceConstructorFromDevicePointer(void)
+void TestDeviceReferenceConstructorFromDevicePointer()
 {
   typedef int T;
 
@@ -54,7 +54,7 @@ void TestDeviceReferenceConstructorFromDevicePointer(void)
 }
 DECLARE_UNITTEST(TestDeviceReferenceConstructorFromDevicePointer);
 
-void TestDeviceReferenceAssignmentFromDeviceReference(void)
+void TestDeviceReferenceAssignmentFromDeviceReference()
 {
   // test same types
   typedef int T0;
@@ -84,7 +84,7 @@ void TestDeviceReferenceAssignmentFromDeviceReference(void)
 }
 DECLARE_UNITTEST(TestDeviceReferenceAssignmentFromDeviceReference);
 
-void TestDeviceReferenceManipulation(void)
+void TestDeviceReferenceManipulation()
 {
   typedef int T1;
 
@@ -207,7 +207,7 @@ void TestDeviceReferenceManipulation(void)
 }
 DECLARE_UNITTEST(TestDeviceReferenceManipulation);
 
-void TestDeviceReferenceSwap(void)
+void TestDeviceReferenceSwap()
 {
   typedef int T;
 

--- a/thrust/testing/discard_iterator.cu
+++ b/thrust/testing/discard_iterator.cu
@@ -4,7 +4,7 @@
 
 #include <unittest/unittest.h>
 
-void TestDiscardIteratorIncrement(void)
+void TestDiscardIteratorIncrement()
 {
   thrust::discard_iterator<> lhs(0);
   thrust::discard_iterator<> rhs(0);
@@ -32,7 +32,7 @@ DECLARE_UNITTEST(TestDiscardIteratorIncrement);
 static_assert(cuda::std::is_trivially_copy_constructible<thrust::discard_iterator<>>::value, "");
 static_assert(cuda::std::is_trivially_copyable<thrust::discard_iterator<>>::value, "");
 
-void TestDiscardIteratorComparison(void)
+void TestDiscardIteratorComparison()
 {
   thrust::discard_iterator<> iter1(0);
   thrust::discard_iterator<> iter2(0);
@@ -58,7 +58,7 @@ void TestDiscardIteratorComparison(void)
 }
 DECLARE_UNITTEST(TestDiscardIteratorComparison);
 
-void TestMakeDiscardIterator(void)
+void TestMakeDiscardIterator()
 {
   thrust::discard_iterator<> iter0 = thrust::make_discard_iterator(13);
 
@@ -72,7 +72,7 @@ void TestMakeDiscardIterator(void)
 }
 DECLARE_UNITTEST(TestMakeDiscardIterator);
 
-void TestZippedDiscardIterator(void)
+void TestZippedDiscardIterator()
 {
   using namespace thrust;
 

--- a/thrust/testing/distance.cu
+++ b/thrust/testing/distance.cu
@@ -5,7 +5,7 @@
 // TODO expand this with other iterator types (forward, bidirectional, etc.)
 
 template <typename Vector>
-void TestDistance(void)
+void TestDistance()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/equal.cu
+++ b/thrust/testing/equal.cu
@@ -7,7 +7,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestEqualSimple(void)
+void TestEqualSimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/fill.cu
+++ b/thrust/testing/fill.cu
@@ -10,7 +10,7 @@
 THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 
 template <class Vector>
-void TestFillSimple(void)
+void TestFillSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -55,7 +55,7 @@ void TestFillSimple(void)
 }
 DECLARE_VECTOR_UNITTEST(TestFillSimple);
 
-void TestFillDiscardIterator(void)
+void TestFillDiscardIterator()
 {
   // there's no result to check because fill returns void
   thrust::fill(
@@ -67,7 +67,7 @@ void TestFillDiscardIterator(void)
 DECLARE_UNITTEST(TestFillDiscardIterator);
 
 template <class Vector>
-void TestFillMixedTypes(void)
+void TestFillMixedTypes()
 {
   Vector v(4);
 
@@ -121,7 +121,7 @@ void TestFill(size_t n)
 DECLARE_VARIABLE_UNITTEST(TestFill);
 
 template <class Vector>
-void TestFillNSimple(void)
+void TestFillNSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -170,7 +170,7 @@ void TestFillNSimple(void)
 }
 DECLARE_VECTOR_UNITTEST(TestFillNSimple);
 
-void TestFillNDiscardIterator(void)
+void TestFillNDiscardIterator()
 {
   thrust::discard_iterator<thrust::host_system_tag> h_result =
     thrust::fill_n(thrust::discard_iterator<thrust::host_system_tag>(), 10, 13);
@@ -186,7 +186,7 @@ void TestFillNDiscardIterator(void)
 DECLARE_UNITTEST(TestFillNDiscardIterator);
 
 template <class Vector>
-void TestFillNMixedTypes(void)
+void TestFillNMixedTypes()
 {
   Vector v(4);
 
@@ -246,7 +246,7 @@ void TestFillN(size_t n)
 DECLARE_VARIABLE_UNITTEST(TestFillN);
 
 template <typename Vector>
-void TestFillZipIterator(void)
+void TestFillZipIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -270,7 +270,7 @@ void TestFillZipIterator(void)
 };
 DECLARE_VECTOR_UNITTEST(TestFillZipIterator);
 
-void TestFillTuple(void)
+void TestFillTuple()
 {
   typedef int T;
   typedef thrust::tuple<T, T> Tuple;
@@ -290,7 +290,7 @@ struct TypeWithTrivialAssigment
   int x, y, z;
 };
 
-void TestFillWithTrivialAssignment(void)
+void TestFillWithTrivialAssignment()
 {
   typedef TypeWithTrivialAssigment T;
 
@@ -347,7 +347,7 @@ struct TypeWithNonTrivialAssigment
   }
 };
 
-void TestFillWithNonTrivialAssignment(void)
+void TestFillWithNonTrivialAssignment()
 {
   typedef TypeWithNonTrivialAssigment T;
 

--- a/thrust/testing/find.cu
+++ b/thrust/testing/find.cu
@@ -50,7 +50,7 @@ struct less_than_value_pred
 };
 
 template <class Vector>
-void TestFindSimple(void)
+void TestFindSimple()
 {
   Vector vec(5);
   vec[0] = 1;
@@ -104,7 +104,7 @@ void TestFindDispatchImplicit()
 DECLARE_UNITTEST(TestFindDispatchImplicit);
 
 template <class Vector>
-void TestFindIfSimple(void)
+void TestFindIfSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -160,7 +160,7 @@ void TestFindIfDispatchImplicit()
 DECLARE_UNITTEST(TestFindIfDispatchImplicit);
 
 template <class Vector>
-void TestFindIfNotSimple(void)
+void TestFindIfNotSimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/for_each.cu
+++ b/thrust/testing/for_each.cu
@@ -23,7 +23,7 @@ public:
 };
 
 template <class Vector>
-void TestForEachSimple(void)
+void TestForEachSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -88,7 +88,7 @@ void TestForEachDispatchImplicit()
 DECLARE_UNITTEST(TestForEachDispatchImplicit);
 
 template <class Vector>
-void TestForEachNSimple(void)
+void TestForEachNSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -152,7 +152,7 @@ void TestForEachNDispatchImplicit()
 }
 DECLARE_UNITTEST(TestForEachNDispatchImplicit);
 
-void TestForEachSimpleAnySystem(void)
+void TestForEachSimpleAnySystem()
 {
   thrust::device_vector<int> output(7, 0);
 
@@ -173,7 +173,7 @@ void TestForEachSimpleAnySystem(void)
 }
 DECLARE_UNITTEST(TestForEachSimpleAnySystem);
 
-void TestForEachNSimpleAnySystem(void)
+void TestForEachNSimpleAnySystem()
 {
   thrust::device_vector<int> output(7, 0);
 
@@ -273,7 +273,7 @@ struct SetFixedVectorToConstant
 };
 
 template <typename T, unsigned int N>
-void _TestForEachWithLargeTypes(void)
+void _TestForEachWithLargeTypes()
 {
   size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
 
@@ -294,7 +294,7 @@ void _TestForEachWithLargeTypes(void)
   ASSERT_EQUAL_QUIET(h_data, d_data);
 }
 
-void TestForEachWithLargeTypes(void)
+void TestForEachWithLargeTypes()
 {
   _TestForEachWithLargeTypes<int, 1>();
   _TestForEachWithLargeTypes<int, 2>();
@@ -314,7 +314,7 @@ void TestForEachWithLargeTypes(void)
 DECLARE_UNITTEST(TestForEachWithLargeTypes);
 
 template <typename T, unsigned int N>
-void _TestForEachNWithLargeTypes(void)
+void _TestForEachNWithLargeTypes()
 {
   size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
 
@@ -335,7 +335,7 @@ void _TestForEachNWithLargeTypes(void)
   ASSERT_EQUAL_QUIET(h_data, d_data);
 }
 
-void TestForEachNWithLargeTypes(void)
+void TestForEachNWithLargeTypes()
 {
   _TestForEachNWithLargeTypes<int, 1>();
   _TestForEachNWithLargeTypes<int, 2>();

--- a/thrust/testing/functional.cu
+++ b/thrust/testing/functional.cu
@@ -19,7 +19,7 @@ THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 const size_t NUM_SAMPLES = 10000;
 
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestUnaryFunctional(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestUnaryFunctional()
 {
   typedef typename InputVector::value_type InputType;
   typedef typename OutputVector::value_type OutputType;
@@ -37,7 +37,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestUnaryFunctional(void)
 }
 
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestBinaryFunctional(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestBinaryFunctional()
 {
   typedef typename InputVector::value_type InputType;
   typedef typename OutputVector::value_type OutputType;
@@ -108,12 +108,12 @@ Macro(vector_type, operator_name, unittest::uint64_t)
 
 // op(T) -> T
 #define DECLARE_UNARY_ARITHMETIC_FUNCTIONAL_UNITTEST(operator_name, OperatorName)                      \
-  void Test##OperatorName##FunctionalHost(void)                                                        \
+  void Test##OperatorName##FunctionalHost()                                                            \
   {                                                                                                    \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_UNARY_ARITHMETIC_FUNCTIONAL_TEST, host_vector, operator_name);   \
   }                                                                                                    \
   DECLARE_UNITTEST(Test##OperatorName##FunctionalHost);                                                \
-  void Test##OperatorName##FunctionalDevice(void)                                                      \
+  void Test##OperatorName##FunctionalDevice()                                                          \
   {                                                                                                    \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_UNARY_ARITHMETIC_FUNCTIONAL_TEST, device_vector, operator_name); \
   }                                                                                                    \
@@ -121,12 +121,12 @@ Macro(vector_type, operator_name, unittest::uint64_t)
 
 // op(T) -> bool
 #define DECLARE_UNARY_LOGICAL_FUNCTIONAL_UNITTEST(operator_name, OperatorName)                      \
-  void Test##OperatorName##FunctionalHost(void)                                                     \
+  void Test##OperatorName##FunctionalHost()                                                         \
   {                                                                                                 \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_UNARY_LOGICAL_FUNCTIONAL_TEST, host_vector, operator_name);   \
   }                                                                                                 \
   DECLARE_UNITTEST(Test##OperatorName##FunctionalHost);                                             \
-  void Test##OperatorName##FunctionalDevice(void)                                                   \
+  void Test##OperatorName##FunctionalDevice()                                                       \
   {                                                                                                 \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_UNARY_LOGICAL_FUNCTIONAL_TEST, device_vector, operator_name); \
   }                                                                                                 \
@@ -134,12 +134,12 @@ Macro(vector_type, operator_name, unittest::uint64_t)
 
 // op(T,T) -> T
 #define DECLARE_BINARY_ARITHMETIC_FUNCTIONAL_UNITTEST(operator_name, OperatorName)                      \
-  void Test##OperatorName##FunctionalHost(void)                                                         \
+  void Test##OperatorName##FunctionalHost()                                                             \
   {                                                                                                     \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_BINARY_ARITHMETIC_FUNCTIONAL_TEST, host_vector, operator_name);   \
   }                                                                                                     \
   DECLARE_UNITTEST(Test##OperatorName##FunctionalHost);                                                 \
-  void Test##OperatorName##FunctionalDevice(void)                                                       \
+  void Test##OperatorName##FunctionalDevice()                                                           \
   {                                                                                                     \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_BINARY_ARITHMETIC_FUNCTIONAL_TEST, device_vector, operator_name); \
   }                                                                                                     \
@@ -147,12 +147,12 @@ Macro(vector_type, operator_name, unittest::uint64_t)
 
 // op(T,T) -> T (for integer T only)
 #define DECLARE_BINARY_INTEGER_ARITHMETIC_FUNCTIONAL_UNITTEST(operator_name, OperatorName)                  \
-  void Test##OperatorName##FunctionalHost(void)                                                             \
+  void Test##OperatorName##FunctionalHost()                                                                 \
   {                                                                                                         \
     INSTANTIATE_INTEGER_TYPES(INSTANTIATE_BINARY_ARITHMETIC_FUNCTIONAL_TEST, host_vector, operator_name);   \
   }                                                                                                         \
   DECLARE_UNITTEST(Test##OperatorName##FunctionalHost);                                                     \
-  void Test##OperatorName##FunctionalDevice(void)                                                           \
+  void Test##OperatorName##FunctionalDevice()                                                               \
   {                                                                                                         \
     INSTANTIATE_INTEGER_TYPES(INSTANTIATE_BINARY_ARITHMETIC_FUNCTIONAL_TEST, device_vector, operator_name); \
   }                                                                                                         \
@@ -160,12 +160,12 @@ Macro(vector_type, operator_name, unittest::uint64_t)
 
 // op(T,T) -> bool
 #define DECLARE_BINARY_LOGICAL_FUNCTIONAL_UNITTEST(operator_name, OperatorName)                      \
-  void Test##OperatorName##FunctionalHost(void)                                                      \
+  void Test##OperatorName##FunctionalHost()                                                          \
   {                                                                                                  \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_BINARY_LOGICAL_FUNCTIONAL_TEST, host_vector, operator_name);   \
   }                                                                                                  \
   DECLARE_UNITTEST(Test##OperatorName##FunctionalHost);                                              \
-  void Test##OperatorName##FunctionalDevice(void)                                                    \
+  void Test##OperatorName##FunctionalDevice()                                                        \
   {                                                                                                  \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_BINARY_LOGICAL_FUNCTIONAL_TEST, device_vector, operator_name); \
   }                                                                                                  \
@@ -177,7 +177,7 @@ DECLARE_UNARY_LOGICAL_FUNCTIONAL_UNITTEST(logical_not, LogicalNot);
 
 // Ad-hoc testing for other functionals
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestIdentityFunctional(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestIdentityFunctional()
 {
   typedef typename Vector::value_type T;
 
@@ -196,7 +196,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestIdentityFunctional(void)
 DECLARE_VECTOR_UNITTEST(TestIdentityFunctional);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject1stFunctional(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject1stFunctional()
 {
   typedef typename Vector::value_type T;
 
@@ -220,7 +220,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject1stFunctional(void)
 DECLARE_VECTOR_UNITTEST(TestProject1stFunctional);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject2ndFunctional(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject2ndFunctional()
 {
   typedef typename Vector::value_type T;
 
@@ -244,7 +244,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject2ndFunctional(void)
 DECLARE_VECTOR_UNITTEST(TestProject2ndFunctional);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMaximumFunctional(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMaximumFunctional()
 {
   typedef typename Vector::value_type T;
 
@@ -271,7 +271,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMaximumFunctional(void)
 DECLARE_VECTOR_UNITTEST(TestMaximumFunctional);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMinimumFunctional(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMinimumFunctional()
 {
   typedef typename Vector::value_type T;
 
@@ -298,7 +298,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMinimumFunctional(void)
 DECLARE_VECTOR_UNITTEST(TestMinimumFunctional);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestNot1(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestNot1()
 {
   typedef typename Vector::value_type T;
 
@@ -331,7 +331,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestNot1);
       && _CCCL_STD_VER == 2011)
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestNot2(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestNot2()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/functional_arithmetic.cu
+++ b/thrust/testing/functional_arithmetic.cu
@@ -9,7 +9,7 @@
 const size_t NUM_SAMPLES = 10000;
 
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
-void TestBinaryFunctional(void)
+void TestBinaryFunctional()
 {
   typedef typename InputVector::value_type InputType;
   typedef typename OutputVector::value_type OutputType;
@@ -53,12 +53,12 @@ void TestBinaryFunctional(void)
                        std::operator_name<data_type>>();
 // op(T,T) -> T
 #define DECLARE_BINARY_ARITHMETIC_FUNCTIONAL_UNITTEST(operator_name, OperatorName)                      \
-  void Test##OperatorName##FunctionalHost(void)                                                         \
+  void Test##OperatorName##FunctionalHost()                                                             \
   {                                                                                                     \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_BINARY_ARITHMETIC_FUNCTIONAL_TEST, host_vector, operator_name);   \
   }                                                                                                     \
   DECLARE_UNITTEST(Test##OperatorName##FunctionalHost);                                                 \
-  void Test##OperatorName##FunctionalDevice(void)                                                       \
+  void Test##OperatorName##FunctionalDevice()                                                           \
   {                                                                                                     \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_BINARY_ARITHMETIC_FUNCTIONAL_TEST, device_vector, operator_name); \
   }                                                                                                     \
@@ -66,12 +66,12 @@ void TestBinaryFunctional(void)
 
 // op(T,T) -> T (for integer T only)
 #define DECLARE_BINARY_INTEGER_ARITHMETIC_FUNCTIONAL_UNITTEST(operator_name, OperatorName)                  \
-  void Test##OperatorName##FunctionalHost(void)                                                             \
+  void Test##OperatorName##FunctionalHost()                                                                 \
   {                                                                                                         \
     INSTANTIATE_INTEGER_TYPES(INSTANTIATE_BINARY_ARITHMETIC_FUNCTIONAL_TEST, host_vector, operator_name);   \
   }                                                                                                         \
   DECLARE_UNITTEST(Test##OperatorName##FunctionalHost);                                                     \
-  void Test##OperatorName##FunctionalDevice(void)                                                           \
+  void Test##OperatorName##FunctionalDevice()                                                               \
   {                                                                                                         \
     INSTANTIATE_INTEGER_TYPES(INSTANTIATE_BINARY_ARITHMETIC_FUNCTIONAL_TEST, device_vector, operator_name); \
   }                                                                                                         \

--- a/thrust/testing/functional_bitwise.cu
+++ b/thrust/testing/functional_bitwise.cu
@@ -42,7 +42,7 @@ struct bit_xor
 } // namespace ref
 
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
-void TestBinaryFunctional(void)
+void TestBinaryFunctional()
 {
   typedef typename InputVector::value_type InputType;
   typedef typename OutputVector::value_type OutputType;
@@ -93,12 +93,12 @@ Macro(vector_type, operator_name, unittest::uint64_t)
 
 // op(T,T) -> T (for bitwise op and integer T only)
 #define DECLARE_BINARY_BITWISE_FUNCTIONAL_UNITTEST(operator_name, OperatorName)                          \
-  void Test##OperatorName##FunctionalHost(void)                                                          \
+  void Test##OperatorName##FunctionalHost()                                                              \
   {                                                                                                      \
     INSTANTIATE_INTEGER_TYPES(INSTANTIATE_BINARY_BITWISE_FUNCTIONAL_TEST, host_vector, operator_name);   \
   }                                                                                                      \
   DECLARE_UNITTEST(Test##OperatorName##FunctionalHost);                                                  \
-  void Test##OperatorName##FunctionalDevice(void)                                                        \
+  void Test##OperatorName##FunctionalDevice()                                                            \
   {                                                                                                      \
     INSTANTIATE_INTEGER_TYPES(INSTANTIATE_BINARY_BITWISE_FUNCTIONAL_TEST, device_vector, operator_name); \
   }                                                                                                      \

--- a/thrust/testing/functional_logical.cu
+++ b/thrust/testing/functional_logical.cu
@@ -9,7 +9,7 @@
 const size_t NUM_SAMPLES = 10000;
 
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
-void TestBinaryFunctional(void)
+void TestBinaryFunctional()
 {
   typedef typename InputVector::value_type InputType;
   typedef typename OutputVector::value_type OutputType;
@@ -58,12 +58,12 @@ Macro(vector_type, operator_name, unittest::uint64_t)
 
 // op(T,T) -> bool
 #define DECLARE_BINARY_LOGICAL_FUNCTIONAL_UNITTEST(operator_name, OperatorName)                      \
-  void Test##OperatorName##FunctionalHost(void)                                                      \
+  void Test##OperatorName##FunctionalHost()                                                          \
   {                                                                                                  \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_BINARY_LOGICAL_FUNCTIONAL_TEST, host_vector, operator_name);   \
   }                                                                                                  \
   DECLARE_UNITTEST(Test##OperatorName##FunctionalHost);                                              \
-  void Test##OperatorName##FunctionalDevice(void)                                                    \
+  void Test##OperatorName##FunctionalDevice()                                                        \
   {                                                                                                  \
     INSTANTIATE_ALL_TYPES(INSTANTIATE_BINARY_LOGICAL_FUNCTIONAL_TEST, device_vector, operator_name); \
   }                                                                                                  \

--- a/thrust/testing/functional_placeholders_arithmetic.cu
+++ b/thrust/testing/functional_placeholders_arithmetic.cu
@@ -53,7 +53,7 @@ BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(Modulus, %, thrust::modulus, SmallIntegralTy
 
 #define UNARY_FUNCTIONAL_PLACEHOLDERS_TEST(name, reference_operator, functor)             \
   template <typename Vector>                                                              \
-  void TestFunctionalPlaceholders##name(void)                                             \
+  void TestFunctionalPlaceholders##name()                                                 \
   {                                                                                       \
     static const size_t num_samples = 10000;                                              \
     typedef typename Vector::value_type T;                                                \

--- a/thrust/testing/functional_placeholders_bitwise.cu
+++ b/thrust/testing/functional_placeholders_bitwise.cu
@@ -85,7 +85,7 @@ struct bit_negate_reference
 };
 
 template <typename Vector>
-void TestFunctionalPlaceholdersBitNegate(void)
+void TestFunctionalPlaceholdersBitNegate()
 {
   typedef typename Vector::value_type T;
   typedef typename rebind_vector<Vector, bool>::type bool_vector;

--- a/thrust/testing/functional_placeholders_compound_assignment.cu
+++ b/thrust/testing/functional_placeholders_compound_assignment.cu
@@ -144,12 +144,12 @@ BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(BitOrEqual, |=, bit_or_equal_reference, Smal
 BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(BitXorEqual, ^=, bit_xor_equal_reference, SmallIntegralTypes);
 
 // XXX ptxas produces an error
-void TestFunctionalPlaceholdersBitLshiftEqualDevice(void)
+void TestFunctionalPlaceholdersBitLshiftEqualDevice()
 {
   KNOWN_FAILURE;
 }
 // XXX KNOWN_FAILURE this until the above works
-void TestFunctionalPlaceholdersBitLshiftEqualHost(void)
+void TestFunctionalPlaceholdersBitLshiftEqualHost()
 {
   KNOWN_FAILURE;
 }
@@ -195,7 +195,7 @@ struct suffix_decrement_reference
 
 #define PREFIX_FUNCTIONAL_PLACEHOLDERS_TEST(name, reference_operator, functor)                                \
   template <typename Vector>                                                                                  \
-  void TestFunctionalPlaceholdersPrefix##name(void)                                                           \
+  void TestFunctionalPlaceholdersPrefix##name()                                                               \
   {                                                                                                           \
     const size_t num_samples = 10000;                                                                         \
     typedef typename Vector::value_type T;                                                                    \
@@ -219,7 +219,7 @@ PREFIX_FUNCTIONAL_PLACEHOLDERS_TEST(Decrement, --, prefix_decrement_reference);
 
 #define SUFFIX_FUNCTIONAL_PLACEHOLDERS_TEST(name, reference_operator, functor)                                \
   template <typename Vector>                                                                                  \
-  void TestFunctionalPlaceholdersSuffix##name(void)                                                           \
+  void TestFunctionalPlaceholdersSuffix##name()                                                               \
   {                                                                                                           \
     const size_t num_samples = 10000;                                                                         \
     typedef typename Vector::value_type T;                                                                    \

--- a/thrust/testing/functional_placeholders_logical.cu
+++ b/thrust/testing/functional_placeholders_logical.cu
@@ -31,7 +31,7 @@ struct rebind_vector<thrust::universal_vector<T, Allocator>, U>
 
 #define BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(name, reference_operator, functor)                        \
   template <typename Vector>                                                                          \
-  void TestFunctionalPlaceholders##name(void)                                                         \
+  void TestFunctionalPlaceholders##name()                                                             \
   {                                                                                                   \
     typedef typename Vector::value_type T;                                                            \
     typedef typename rebind_vector<Vector, bool>::type bool_vector;                                   \
@@ -53,7 +53,7 @@ BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(LogicalAnd, &&, thrust::logical_and);
 BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(LogicalOr, ||, thrust::logical_or);
 
 template <typename Vector>
-void TestFunctionalPlaceholdersLogicalNot(void)
+void TestFunctionalPlaceholdersLogicalNot()
 {
   typedef typename Vector::value_type T;
   typedef typename rebind_vector<Vector, bool>::type bool_vector;

--- a/thrust/testing/functional_placeholders_relational.cu
+++ b/thrust/testing/functional_placeholders_relational.cu
@@ -31,7 +31,7 @@ struct rebind_vector<thrust::universal_vector<T, Allocator>, U>
 
 #define BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(name, reference_operator, functor)                        \
   template <typename Vector>                                                                          \
-  void TestFunctionalPlaceholdersBinary##name(void)                                                   \
+  void TestFunctionalPlaceholdersBinary##name()                                                       \
   {                                                                                                   \
     typedef typename Vector::value_type T;                                                            \
     typedef typename rebind_vector<Vector, bool>::type bool_vector;                                   \

--- a/thrust/testing/gather.cu
+++ b/thrust/testing/gather.cu
@@ -12,7 +12,7 @@
 THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 
 template <class Vector>
-void TestGatherSimple(void)
+void TestGatherSimple()
 {
   Vector map(5); // gather indices
   Vector src(8); // source vector
@@ -135,7 +135,7 @@ void TestGatherToDiscardIterator(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestGatherToDiscardIterator);
 
 template <class Vector>
-void TestGatherIfSimple(void)
+void TestGatherIfSimple()
 {
   Vector flg(5); // predicate array
   Vector map(5); // gather indices
@@ -325,7 +325,7 @@ void TestGatherIfToDiscardIterator(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestGatherIfToDiscardIterator);
 
 template <typename Vector>
-void TestGatherCountingIterator(void)
+void TestGatherCountingIterator()
 {
   Vector source(10);
   thrust::sequence(source.begin(), source.end(), 0);

--- a/thrust/testing/generate.cu
+++ b/thrust/testing/generate.cu
@@ -11,7 +11,7 @@ struct return_value
 {
   T val;
 
-  return_value(void) {}
+  return_value() {}
   return_value(T v)
       : val(v)
   {}
@@ -23,7 +23,7 @@ struct return_value
 };
 
 template <class Vector>
-void TestGenerateSimple(void)
+void TestGenerateSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -109,7 +109,7 @@ void TestGenerateToDiscardIterator(const size_t)
 DECLARE_VARIABLE_UNITTEST(TestGenerateToDiscardIterator);
 
 template <class Vector>
-void TestGenerateNSimple(void)
+void TestGenerateNSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -184,7 +184,7 @@ void TestGenerateNToDiscardIterator(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestGenerateNToDiscardIterator);
 
 template <typename Vector>
-void TestGenerateZipIterator(void)
+void TestGenerateZipIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -204,7 +204,7 @@ void TestGenerateZipIterator(void)
 };
 DECLARE_VECTOR_UNITTEST(TestGenerateZipIterator);
 
-void TestGenerateTuple(void)
+void TestGenerateTuple()
 {
   typedef int T;
   typedef thrust::tuple<T, T> Tuple;

--- a/thrust/testing/inner_product.cu
+++ b/thrust/testing/inner_product.cu
@@ -8,7 +8,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestInnerProductSimple(void)
+void TestInnerProductSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -63,7 +63,7 @@ void TestInnerProductDispatchImplicit()
 DECLARE_UNITTEST(TestInnerProductDispatchImplicit);
 
 template <class Vector>
-void TestInnerProductWithOperator(void)
+void TestInnerProductWithOperator()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/is_partitioned.cu
+++ b/thrust/testing/is_partitioned.cu
@@ -14,7 +14,7 @@ struct is_even
 };
 
 template <typename Vector>
-void TestIsPartitionedSimple(void)
+void TestIsPartitionedSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -50,7 +50,7 @@ void TestIsPartitionedSimple(void)
 DECLARE_VECTOR_UNITTEST(TestIsPartitionedSimple);
 
 template <class Vector>
-void TestIsPartitioned(void)
+void TestIsPartitioned()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/is_sorted.cu
+++ b/thrust/testing/is_sorted.cu
@@ -4,7 +4,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestIsSortedSimple(void)
+void TestIsSortedSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -38,7 +38,7 @@ void TestIsSortedSimple(void)
 DECLARE_VECTOR_UNITTEST(TestIsSortedSimple);
 
 template <class Vector>
-void TestIsSortedRepeatedElements(void)
+void TestIsSortedRepeatedElements()
 {
   Vector v(10);
 
@@ -58,7 +58,7 @@ void TestIsSortedRepeatedElements(void)
 DECLARE_VECTOR_UNITTEST(TestIsSortedRepeatedElements);
 
 template <class Vector>
-void TestIsSorted(void)
+void TestIsSorted()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/is_sorted_until.cu
+++ b/thrust/testing/is_sorted_until.cu
@@ -4,7 +4,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestIsSortedUntilSimple(void)
+void TestIsSortedUntilSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;
@@ -61,7 +61,7 @@ void TestIsSortedUntilSimple(void)
 DECLARE_VECTOR_UNITTEST(TestIsSortedUntilSimple);
 
 template <typename Vector>
-void TestIsSortedUntilRepeatedElements(void)
+void TestIsSortedUntilRepeatedElements()
 {
   Vector v(10);
 
@@ -81,7 +81,7 @@ void TestIsSortedUntilRepeatedElements(void)
 DECLARE_VECTOR_UNITTEST(TestIsSortedUntilRepeatedElements);
 
 template <class Vector>
-void TestIsSortedUntil(void)
+void TestIsSortedUntil()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/logical.cu
+++ b/thrust/testing/logical.cu
@@ -5,7 +5,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestAllOf(void)
+void TestAllOf()
 {
   typedef typename Vector::value_type T;
 
@@ -60,7 +60,7 @@ void TestAllOfDispatchImplicit()
 DECLARE_UNITTEST(TestAllOfDispatchImplicit);
 
 template <class Vector>
-void TestAnyOf(void)
+void TestAnyOf()
 {
   typedef typename Vector::value_type T;
 
@@ -115,7 +115,7 @@ void TestAnyOfDispatchImplicit()
 DECLARE_UNITTEST(TestAnyOfDispatchImplicit);
 
 template <class Vector>
-void TestNoneOf(void)
+void TestNoneOf()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/max_element.cu
+++ b/thrust/testing/max_element.cu
@@ -6,7 +6,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestMaxElementSimple(void)
+void TestMaxElementSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -27,7 +27,7 @@ void TestMaxElementSimple(void)
 DECLARE_VECTOR_UNITTEST(TestMaxElementSimple);
 
 template <class Vector>
-void TestMaxElementWithTransform(void)
+void TestMaxElementWithTransform()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/merge.cu
+++ b/thrust/testing/merge.cu
@@ -9,7 +9,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestMergeSimple(void)
+void TestMergeSimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/merge_by_key.cu
+++ b/thrust/testing/merge_by_key.cu
@@ -8,7 +8,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestMergeByKeySimple(void)
+void TestMergeByKeySimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/metaprogamming.cu
+++ b/thrust/testing/metaprogamming.cu
@@ -2,7 +2,7 @@
 
 #include <unittest/unittest.h>
 
-void TestLog2(void)
+void TestLog2()
 {
   unsigned int result;
 

--- a/thrust/testing/min_element.cu
+++ b/thrust/testing/min_element.cu
@@ -4,7 +4,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestMinElementSimple(void)
+void TestMinElementSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -25,7 +25,7 @@ void TestMinElementSimple(void)
 DECLARE_VECTOR_UNITTEST(TestMinElementSimple);
 
 template <class Vector>
-void TestMinElementWithTransform(void)
+void TestMinElementWithTransform()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/minmax_element.cu
+++ b/thrust/testing/minmax_element.cu
@@ -4,7 +4,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestMinMaxElementSimple(void)
+void TestMinMaxElementSimple()
 {
   Vector data(6);
   data[0] = 3;
@@ -22,7 +22,7 @@ void TestMinMaxElementSimple(void)
 DECLARE_VECTOR_UNITTEST(TestMinMaxElementSimple);
 
 template <class Vector>
-void TestMinMaxElementWithTransform(void)
+void TestMinMaxElementWithTransform()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/mismatch.cu
+++ b/thrust/testing/mismatch.cu
@@ -4,7 +4,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestMismatchSimple(void)
+void TestMismatchSimple()
 {
   Vector a(4);
   Vector b(4);

--- a/thrust/testing/omp/nvcc_independence.cpp
+++ b/thrust/testing/omp/nvcc_independence.cpp
@@ -7,7 +7,7 @@
 
 #include <unittest/unittest.h>
 
-void TestNvccIndependenceTransform(void)
+void TestNvccIndependenceTransform()
 {
   typedef int T;
   const int n = 10;
@@ -25,7 +25,7 @@ void TestNvccIndependenceTransform(void)
 }
 DECLARE_UNITTEST(TestNvccIndependenceTransform);
 
-void TestNvccIndependenceReduce(void)
+void TestNvccIndependenceReduce()
 {
   typedef int T;
   const int n = 10;
@@ -42,7 +42,7 @@ void TestNvccIndependenceReduce(void)
 }
 DECLARE_UNITTEST(TestNvccIndependenceReduce);
 
-void TestNvccIndependenceExclusiveScan(void)
+void TestNvccIndependenceExclusiveScan()
 {
   typedef int T;
   const int n = 10;
@@ -59,7 +59,7 @@ void TestNvccIndependenceExclusiveScan(void)
 }
 DECLARE_UNITTEST(TestNvccIndependenceExclusiveScan);
 
-void TestNvccIndependenceSort(void)
+void TestNvccIndependenceSort()
 {
   typedef int T;
   const int n = 10;

--- a/thrust/testing/omp/reduce_intervals.cu
+++ b/thrust/testing/omp/reduce_intervals.cu
@@ -36,7 +36,7 @@ void reduce_intervals(InputIterator input, OutputIterator output, BinaryFunction
   }
 }
 
-void TestOmpReduceIntervalsSimple(void)
+void TestOmpReduceIntervalsSimple()
 {
   typedef int T;
   typedef thrust::device_vector<T> Vector;

--- a/thrust/testing/pair.cu
+++ b/thrust/testing/pair.cu
@@ -251,7 +251,7 @@ struct TestPairTupleSize
 };
 SimpleUnitTest<TestPairTupleSize, PairConstVolatileTypes> TestPairTupleSizeInstance;
 
-void TestPairTupleElement(void)
+void TestPairTupleElement()
 {
   using type0 = thrust::tuple_element<0, thrust::pair<int, float>>::type;
   using type1 = thrust::tuple_element<1, thrust::pair<int, float>>::type;
@@ -275,7 +275,7 @@ void TestPairTupleElement(void)
 };
 DECLARE_UNITTEST(TestPairTupleElement);
 
-void TestPairSwap(void)
+void TestPairSwap()
 {
   int x = 7;
   int y = 13;
@@ -311,7 +311,7 @@ void TestPairSwap(void)
 DECLARE_UNITTEST(TestPairSwap);
 
 #if _CCCL_STD_VER >= 2017
-void TestPairStructuredBindings(void)
+void TestPairStructuredBindings()
 {
   const int a = 42;
   const int b = 1337;

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -23,7 +23,7 @@ struct is_even
 typedef unittest::type_list<unittest::int8_t, unittest::int16_t, unittest::int32_t> PartitionTypes;
 
 template <typename Vector>
-void TestPartitionSimple(void)
+void TestPartitionSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;
@@ -61,7 +61,7 @@ void TestPartitionSimple(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionSimple);
 
 template <typename Vector>
-void TestPartitionStencilSimple(void)
+void TestPartitionStencilSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;
@@ -95,7 +95,7 @@ void TestPartitionStencilSimple(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionStencilSimple);
 
 template <typename Vector>
-void TestPartitionCopySimple(void)
+void TestPartitionCopySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -129,7 +129,7 @@ void TestPartitionCopySimple(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionCopySimple);
 
 template <typename Vector>
-void TestPartitionCopyStencilSimple(void)
+void TestPartitionCopyStencilSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -170,7 +170,7 @@ void TestPartitionCopyStencilSimple(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionCopyStencilSimple);
 
 template <typename Vector>
-void TestStablePartitionSimple(void)
+void TestStablePartitionSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;
@@ -197,7 +197,7 @@ void TestStablePartitionSimple(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestStablePartitionSimple);
 
 template <typename Vector>
-void TestStablePartitionStencilSimple(void)
+void TestStablePartitionStencilSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;
@@ -231,7 +231,7 @@ void TestStablePartitionStencilSimple(void)
 DECLARE_VECTOR_UNITTEST(TestStablePartitionStencilSimple);
 
 template <typename Vector>
-void TestStablePartitionCopySimple(void)
+void TestStablePartitionCopySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -265,7 +265,7 @@ void TestStablePartitionCopySimple(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestStablePartitionCopySimple);
 
 template <typename Vector>
-void TestStablePartitionCopyStencilSimple(void)
+void TestStablePartitionCopyStencilSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -935,7 +935,7 @@ struct is_ordered
 };
 
 template <typename Vector>
-void TestPartitionZipIterator(void)
+void TestPartitionZipIterator()
 {
   Vector data1(5);
   Vector data2(5);
@@ -981,7 +981,7 @@ void TestPartitionZipIterator(void)
 DECLARE_VECTOR_UNITTEST(TestPartitionZipIterator);
 
 template <typename Vector>
-void TestPartitionStencilZipIterator(void)
+void TestPartitionStencilZipIterator()
 {
   Vector data(5);
   data[0] = 1;
@@ -1026,7 +1026,7 @@ void TestPartitionStencilZipIterator(void)
 DECLARE_VECTOR_UNITTEST(TestPartitionStencilZipIterator);
 
 template <typename Vector>
-void TestStablePartitionZipIterator(void)
+void TestStablePartitionZipIterator()
 {
   Vector data1(5);
   Vector data2(5);
@@ -1072,7 +1072,7 @@ void TestStablePartitionZipIterator(void)
 DECLARE_VECTOR_UNITTEST(TestStablePartitionZipIterator);
 
 template <typename Vector>
-void TestStablePartitionStencilZipIterator(void)
+void TestStablePartitionStencilZipIterator()
 {
   Vector data(5);
   data[0] = 1;

--- a/thrust/testing/partition_point.cu
+++ b/thrust/testing/partition_point.cu
@@ -14,7 +14,7 @@ struct is_even
 };
 
 template <typename Vector>
-void TestPartitionPointSimple(void)
+void TestPartitionPointSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;
@@ -38,7 +38,7 @@ void TestPartitionPointSimple(void)
 DECLARE_VECTOR_UNITTEST(TestPartitionPointSimple);
 
 template <class Vector>
-void TestPartitionPoint(void)
+void TestPartitionPoint()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;

--- a/thrust/testing/permutation_iterator.cu
+++ b/thrust/testing/permutation_iterator.cu
@@ -9,7 +9,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestPermutationIteratorSimple(void)
+void TestPermutationIteratorSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;
@@ -59,7 +59,7 @@ static_assert(cuda::std::is_trivially_copy_constructible<thrust::permutation_ite
 static_assert(cuda::std::is_trivially_copyable<thrust::permutation_iterator<int*, int*>>::value, "");
 
 template <class Vector>
-void TestPermutationIteratorGather(void)
+void TestPermutationIteratorGather()
 {
   typedef typename Vector::iterator Iterator;
 
@@ -87,7 +87,7 @@ void TestPermutationIteratorGather(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorGather);
 
 template <class Vector>
-void TestPermutationIteratorScatter(void)
+void TestPermutationIteratorScatter()
 {
   typedef typename Vector::iterator Iterator;
 
@@ -120,7 +120,7 @@ void TestPermutationIteratorScatter(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorScatter);
 
 template <class Vector>
-void TestMakePermutationIterator(void)
+void TestMakePermutationIterator()
 {
   Vector source(8);
   Vector indices(4);
@@ -146,7 +146,7 @@ void TestMakePermutationIterator(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestMakePermutationIterator);
 
 template <typename Vector>
-void TestPermutationIteratorReduce(void)
+void TestPermutationIteratorReduce()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;
@@ -181,7 +181,7 @@ void TestPermutationIteratorReduce(void)
 };
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorReduce);
 
-void TestPermutationIteratorHostDeviceGather(void)
+void TestPermutationIteratorHostDeviceGather()
 {
   typedef int T;
   typedef thrust::host_vector<T> HostVector;
@@ -227,7 +227,7 @@ void TestPermutationIteratorHostDeviceGather(void)
 }
 DECLARE_UNITTEST(TestPermutationIteratorHostDeviceGather);
 
-void TestPermutationIteratorHostDeviceScatter(void)
+void TestPermutationIteratorHostDeviceScatter()
 {
   typedef int T;
   typedef thrust::host_vector<T> HostVector;
@@ -282,7 +282,7 @@ void TestPermutationIteratorHostDeviceScatter(void)
 DECLARE_UNITTEST(TestPermutationIteratorHostDeviceScatter);
 
 template <typename Vector>
-void TestPermutationIteratorWithCountingIterator(void)
+void TestPermutationIteratorWithCountingIterator()
 {
   using T      = typename Vector::value_type;
   using diff_t = typename thrust::counting_iterator<T>::difference_type;

--- a/thrust/testing/random.cu
+++ b/thrust/testing/random.cu
@@ -214,7 +214,7 @@ struct ValidateDistributionUnqual
 };
 
 template <typename Engine, thrust::detail::uint64_t value_10000>
-void TestEngineValidation(void)
+void TestEngineValidation()
 {
   // test host
   thrust::host_vector<bool> h(1);
@@ -230,7 +230,7 @@ void TestEngineValidation(void)
 }
 
 template <typename Engine>
-void TestEngineMax(void)
+void TestEngineMax()
 {
   // test host
   thrust::host_vector<bool> h(1);
@@ -246,7 +246,7 @@ void TestEngineMax(void)
 }
 
 template <typename Engine>
-void TestEngineMin(void)
+void TestEngineMin()
 {
   // test host
   thrust::host_vector<bool> h(1);
@@ -262,7 +262,7 @@ void TestEngineMin(void)
 }
 
 template <typename Engine>
-void TestEngineSaveRestore(void)
+void TestEngineSaveRestore()
 {
   // create a default engine
   Engine e0;
@@ -290,7 +290,7 @@ void TestEngineSaveRestore(void)
 }
 
 template <typename Engine>
-void TestEngineEqual(void)
+void TestEngineEqual()
 {
   ValidateEngineEqual<Engine> f;
 
@@ -308,7 +308,7 @@ void TestEngineEqual(void)
 }
 
 template <typename Engine>
-void TestEngineUnequal(void)
+void TestEngineUnequal()
 {
   ValidateEngineUnequal<Engine> f;
 
@@ -325,7 +325,7 @@ void TestEngineUnequal(void)
   ASSERT_EQUAL(true, d[0]);
 }
 
-void TestRanlux24BaseValidation(void)
+void TestRanlux24BaseValidation()
 {
   typedef thrust::random::ranlux24_base Engine;
 
@@ -333,7 +333,7 @@ void TestRanlux24BaseValidation(void)
 }
 DECLARE_UNITTEST(TestRanlux24BaseValidation);
 
-void TestRanlux24BaseMin(void)
+void TestRanlux24BaseMin()
 {
   typedef thrust::random::ranlux24_base Engine;
 
@@ -341,7 +341,7 @@ void TestRanlux24BaseMin(void)
 }
 DECLARE_UNITTEST(TestRanlux24BaseMin);
 
-void TestRanlux24BaseMax(void)
+void TestRanlux24BaseMax()
 {
   typedef thrust::random::ranlux24_base Engine;
 
@@ -349,7 +349,7 @@ void TestRanlux24BaseMax(void)
 }
 DECLARE_UNITTEST(TestRanlux24BaseMax);
 
-void TestRanlux24BaseSaveRestore(void)
+void TestRanlux24BaseSaveRestore()
 {
   typedef thrust::random::ranlux24_base Engine;
 
@@ -357,7 +357,7 @@ void TestRanlux24BaseSaveRestore(void)
 }
 DECLARE_UNITTEST(TestRanlux24BaseSaveRestore);
 
-void TestRanlux24BaseEqual(void)
+void TestRanlux24BaseEqual()
 {
   typedef thrust::random::ranlux24_base Engine;
 
@@ -365,7 +365,7 @@ void TestRanlux24BaseEqual(void)
 }
 DECLARE_UNITTEST(TestRanlux24BaseEqual);
 
-void TestRanlux24BaseUnequal(void)
+void TestRanlux24BaseUnequal()
 {
   typedef thrust::random::ranlux24_base Engine;
 
@@ -373,7 +373,7 @@ void TestRanlux24BaseUnequal(void)
 }
 DECLARE_UNITTEST(TestRanlux24BaseUnequal);
 
-void TestRanlux48BaseValidation(void)
+void TestRanlux48BaseValidation()
 {
   typedef thrust::random::ranlux48_base Engine;
 
@@ -381,7 +381,7 @@ void TestRanlux48BaseValidation(void)
 }
 DECLARE_UNITTEST(TestRanlux48BaseValidation);
 
-void TestRanlux48BaseMin(void)
+void TestRanlux48BaseMin()
 {
   typedef thrust::random::ranlux48_base Engine;
 
@@ -389,7 +389,7 @@ void TestRanlux48BaseMin(void)
 }
 DECLARE_UNITTEST(TestRanlux48BaseMin);
 
-void TestRanlux48BaseMax(void)
+void TestRanlux48BaseMax()
 {
   typedef thrust::random::ranlux48_base Engine;
 
@@ -397,7 +397,7 @@ void TestRanlux48BaseMax(void)
 }
 DECLARE_UNITTEST(TestRanlux48BaseMax);
 
-void TestRanlux48BaseSaveRestore(void)
+void TestRanlux48BaseSaveRestore()
 {
   typedef thrust::random::ranlux48_base Engine;
 
@@ -405,7 +405,7 @@ void TestRanlux48BaseSaveRestore(void)
 }
 DECLARE_UNITTEST(TestRanlux48BaseSaveRestore);
 
-void TestRanlux48BaseEqual(void)
+void TestRanlux48BaseEqual()
 {
   typedef thrust::random::ranlux48_base Engine;
 
@@ -414,14 +414,14 @@ void TestRanlux48BaseEqual(void)
 DECLARE_UNITTEST(TestRanlux48BaseEqual);
 
 #if defined(__INTEL_COMPILER) && 1800 >= __INTEL_COMPILER
-void TestRanlux48BaseUnequal(void)
+void TestRanlux48BaseUnequal()
 {
   // ICPC has a known failure with this test.
   // See nvbug 200414000.
   KNOWN_FAILURE;
 }
 #else
-void TestRanlux48BaseUnequal(void)
+void TestRanlux48BaseUnequal()
 {
   typedef thrust::random::ranlux48_base Engine;
 
@@ -430,7 +430,7 @@ void TestRanlux48BaseUnequal(void)
 #endif
 DECLARE_UNITTEST(TestRanlux48BaseUnequal);
 
-void TestMinstdRandValidation(void)
+void TestMinstdRandValidation()
 {
   typedef thrust::random::minstd_rand Engine;
 
@@ -438,7 +438,7 @@ void TestMinstdRandValidation(void)
 }
 DECLARE_UNITTEST(TestMinstdRandValidation);
 
-void TestMinstdRandMin(void)
+void TestMinstdRandMin()
 {
   typedef thrust::random::minstd_rand Engine;
 
@@ -446,7 +446,7 @@ void TestMinstdRandMin(void)
 }
 DECLARE_UNITTEST(TestMinstdRandMin);
 
-void TestMinstdRandMax(void)
+void TestMinstdRandMax()
 {
   typedef thrust::random::minstd_rand Engine;
 
@@ -454,7 +454,7 @@ void TestMinstdRandMax(void)
 }
 DECLARE_UNITTEST(TestMinstdRandMax);
 
-void TestMinstdRandSaveRestore(void)
+void TestMinstdRandSaveRestore()
 {
   typedef thrust::random::minstd_rand Engine;
 
@@ -462,7 +462,7 @@ void TestMinstdRandSaveRestore(void)
 }
 DECLARE_UNITTEST(TestMinstdRandSaveRestore);
 
-void TestMinstdRandEqual(void)
+void TestMinstdRandEqual()
 {
   typedef thrust::random::minstd_rand Engine;
 
@@ -470,7 +470,7 @@ void TestMinstdRandEqual(void)
 }
 DECLARE_UNITTEST(TestMinstdRandEqual);
 
-void TestMinstdRandUnequal(void)
+void TestMinstdRandUnequal()
 {
   typedef thrust::random::minstd_rand Engine;
 
@@ -478,7 +478,7 @@ void TestMinstdRandUnequal(void)
 }
 DECLARE_UNITTEST(TestMinstdRandUnequal);
 
-void TestMinstdRand0Validation(void)
+void TestMinstdRand0Validation()
 {
   typedef thrust::random::minstd_rand0 Engine;
 
@@ -486,7 +486,7 @@ void TestMinstdRand0Validation(void)
 }
 DECLARE_UNITTEST(TestMinstdRand0Validation);
 
-void TestMinstdRand0Min(void)
+void TestMinstdRand0Min()
 {
   typedef thrust::random::minstd_rand0 Engine;
 
@@ -494,7 +494,7 @@ void TestMinstdRand0Min(void)
 }
 DECLARE_UNITTEST(TestMinstdRand0Min);
 
-void TestMinstdRand0Max(void)
+void TestMinstdRand0Max()
 {
   typedef thrust::random::minstd_rand0 Engine;
 
@@ -502,7 +502,7 @@ void TestMinstdRand0Max(void)
 }
 DECLARE_UNITTEST(TestMinstdRand0Max);
 
-void TestMinstdRand0SaveRestore(void)
+void TestMinstdRand0SaveRestore()
 {
   typedef thrust::random::minstd_rand0 Engine;
 
@@ -510,7 +510,7 @@ void TestMinstdRand0SaveRestore(void)
 }
 DECLARE_UNITTEST(TestMinstdRand0SaveRestore);
 
-void TestMinstdRand0Equal(void)
+void TestMinstdRand0Equal()
 {
   typedef thrust::random::minstd_rand0 Engine;
 
@@ -518,7 +518,7 @@ void TestMinstdRand0Equal(void)
 }
 DECLARE_UNITTEST(TestMinstdRand0Equal);
 
-void TestMinstdRand0Unequal(void)
+void TestMinstdRand0Unequal()
 {
   typedef thrust::random::minstd_rand0 Engine;
 
@@ -526,7 +526,7 @@ void TestMinstdRand0Unequal(void)
 }
 DECLARE_UNITTEST(TestMinstdRand0Unequal);
 
-void TestTaus88Validation(void)
+void TestTaus88Validation()
 {
   typedef thrust::random::taus88 Engine;
 
@@ -534,7 +534,7 @@ void TestTaus88Validation(void)
 }
 DECLARE_UNITTEST(TestTaus88Validation);
 
-void TestTaus88Min(void)
+void TestTaus88Min()
 {
   typedef thrust::random::taus88 Engine;
 
@@ -542,7 +542,7 @@ void TestTaus88Min(void)
 }
 DECLARE_UNITTEST(TestTaus88Min);
 
-void TestTaus88Max(void)
+void TestTaus88Max()
 {
   typedef thrust::random::taus88 Engine;
 
@@ -550,7 +550,7 @@ void TestTaus88Max(void)
 }
 DECLARE_UNITTEST(TestTaus88Max);
 
-void TestTaus88SaveRestore(void)
+void TestTaus88SaveRestore()
 {
   typedef thrust::random::taus88 Engine;
 
@@ -558,7 +558,7 @@ void TestTaus88SaveRestore(void)
 }
 DECLARE_UNITTEST(TestTaus88SaveRestore);
 
-void TestTaus88Equal(void)
+void TestTaus88Equal()
 {
   typedef thrust::random::taus88 Engine;
 
@@ -566,7 +566,7 @@ void TestTaus88Equal(void)
 }
 DECLARE_UNITTEST(TestTaus88Equal);
 
-void TestTaus88Unequal(void)
+void TestTaus88Unequal()
 {
   typedef thrust::random::taus88 Engine;
 
@@ -574,7 +574,7 @@ void TestTaus88Unequal(void)
 }
 DECLARE_UNITTEST(TestTaus88Unequal);
 
-void TestRanlux24Validation(void)
+void TestRanlux24Validation()
 {
   typedef thrust::random::ranlux24 Engine;
 
@@ -582,7 +582,7 @@ void TestRanlux24Validation(void)
 }
 DECLARE_UNITTEST(TestRanlux24Validation);
 
-void TestRanlux24Min(void)
+void TestRanlux24Min()
 {
   typedef thrust::random::ranlux24 Engine;
 
@@ -590,7 +590,7 @@ void TestRanlux24Min(void)
 }
 DECLARE_UNITTEST(TestRanlux24Min);
 
-void TestRanlux24Max(void)
+void TestRanlux24Max()
 {
   typedef thrust::random::ranlux24 Engine;
 
@@ -598,7 +598,7 @@ void TestRanlux24Max(void)
 }
 DECLARE_UNITTEST(TestRanlux24Max);
 
-void TestRanlux24SaveRestore(void)
+void TestRanlux24SaveRestore()
 {
   typedef thrust::random::ranlux24 Engine;
 
@@ -606,7 +606,7 @@ void TestRanlux24SaveRestore(void)
 }
 DECLARE_UNITTEST(TestRanlux24SaveRestore);
 
-void TestRanlux24Equal(void)
+void TestRanlux24Equal()
 {
   typedef thrust::random::ranlux24 Engine;
 
@@ -614,7 +614,7 @@ void TestRanlux24Equal(void)
 }
 DECLARE_UNITTEST(TestRanlux24Equal);
 
-void TestRanlux24Unequal(void)
+void TestRanlux24Unequal()
 {
   typedef thrust::random::ranlux24 Engine;
 
@@ -622,7 +622,7 @@ void TestRanlux24Unequal(void)
 }
 DECLARE_UNITTEST(TestRanlux24Unequal);
 
-void TestRanlux48Validation(void)
+void TestRanlux48Validation()
 {
   typedef thrust::random::ranlux48 Engine;
 
@@ -630,7 +630,7 @@ void TestRanlux48Validation(void)
 }
 DECLARE_UNITTEST(TestRanlux48Validation);
 
-void TestRanlux48Min(void)
+void TestRanlux48Min()
 {
   typedef thrust::random::ranlux48 Engine;
 
@@ -638,7 +638,7 @@ void TestRanlux48Min(void)
 }
 DECLARE_UNITTEST(TestRanlux48Min);
 
-void TestRanlux48Max(void)
+void TestRanlux48Max()
 {
   typedef thrust::random::ranlux48 Engine;
 
@@ -646,7 +646,7 @@ void TestRanlux48Max(void)
 }
 DECLARE_UNITTEST(TestRanlux48Max);
 
-void TestRanlux48SaveRestore(void)
+void TestRanlux48SaveRestore()
 {
   typedef thrust::random::ranlux48 Engine;
 
@@ -654,7 +654,7 @@ void TestRanlux48SaveRestore(void)
 }
 DECLARE_UNITTEST(TestRanlux48SaveRestore);
 
-void TestRanlux48Equal(void)
+void TestRanlux48Equal()
 {
   typedef thrust::random::ranlux48 Engine;
 
@@ -662,7 +662,7 @@ void TestRanlux48Equal(void)
 }
 DECLARE_UNITTEST(TestRanlux48Equal);
 
-void TestRanlux48Unequal(void)
+void TestRanlux48Unequal()
 {
   typedef thrust::random::ranlux48 Engine;
 
@@ -672,7 +672,7 @@ DECLARE_UNITTEST(TestRanlux48Unequal);
 
 THRUST_DISABLE_MSVC_WARNING_BEGIN(4305) // truncation warning
 template <typename Distribution, typename Validator>
-void ValidateDistributionCharacteristic(void)
+void ValidateDistributionCharacteristic()
 {
   typedef typename Validator::random_engine Engine;
 
@@ -735,7 +735,7 @@ void ValidateDistributionCharacteristic(void)
 THRUST_DISABLE_MSVC_WARNING_END(4305)
 
 template <typename Distribution>
-void TestDistributionSaveRestore(void)
+void TestDistributionSaveRestore()
 {
   // create a default distribution
   Distribution d0(7, 13);
@@ -751,7 +751,7 @@ void TestDistributionSaveRestore(void)
   ASSERT_EQUAL(d0, d1);
 }
 
-void TestUniformIntDistributionMin(void)
+void TestUniformIntDistributionMin()
 {
   typedef thrust::random::uniform_int_distribution<int> int_dist;
   typedef thrust::random::uniform_int_distribution<unsigned int> uint_dist;
@@ -761,7 +761,7 @@ void TestUniformIntDistributionMin(void)
 }
 DECLARE_UNITTEST(TestUniformIntDistributionMin);
 
-void TestUniformIntDistributionMax(void)
+void TestUniformIntDistributionMax()
 {
   typedef thrust::random::uniform_int_distribution<int> int_dist;
   typedef thrust::random::uniform_int_distribution<unsigned int> uint_dist;
@@ -771,7 +771,7 @@ void TestUniformIntDistributionMax(void)
 }
 DECLARE_UNITTEST(TestUniformIntDistributionMax);
 
-void TestUniformIntDistributionSaveRestore(void)
+void TestUniformIntDistributionSaveRestore()
 {
   typedef thrust::random::uniform_int_distribution<int> int_dist;
   typedef thrust::random::uniform_int_distribution<unsigned int> uint_dist;
@@ -781,7 +781,7 @@ void TestUniformIntDistributionSaveRestore(void)
 }
 DECLARE_UNITTEST(TestUniformIntDistributionSaveRestore);
 
-void TestUniformRealDistributionMin(void)
+void TestUniformRealDistributionMin()
 {
   typedef thrust::random::uniform_real_distribution<float> float_dist;
   typedef thrust::random::uniform_real_distribution<double> double_dist;
@@ -791,7 +791,7 @@ void TestUniformRealDistributionMin(void)
 }
 DECLARE_UNITTEST(TestUniformRealDistributionMin);
 
-void TestUniformRealDistributionMax(void)
+void TestUniformRealDistributionMax()
 {
   typedef thrust::random::uniform_real_distribution<float> float_dist;
   typedef thrust::random::uniform_real_distribution<double> double_dist;
@@ -801,7 +801,7 @@ void TestUniformRealDistributionMax(void)
 }
 DECLARE_UNITTEST(TestUniformRealDistributionMax);
 
-void TestUniformRealDistributionSaveRestore(void)
+void TestUniformRealDistributionSaveRestore()
 {
   typedef thrust::random::uniform_real_distribution<float> float_dist;
   typedef thrust::random::uniform_real_distribution<double> double_dist;
@@ -811,7 +811,7 @@ void TestUniformRealDistributionSaveRestore(void)
 }
 DECLARE_UNITTEST(TestUniformRealDistributionSaveRestore);
 
-void TestNormalDistributionMin(void)
+void TestNormalDistributionMin()
 {
   typedef thrust::random::normal_distribution<float> float_dist;
   typedef thrust::random::normal_distribution<double> double_dist;
@@ -821,7 +821,7 @@ void TestNormalDistributionMin(void)
 }
 DECLARE_UNITTEST(TestNormalDistributionMin);
 
-void TestNormalDistributionMax(void)
+void TestNormalDistributionMax()
 {
   typedef thrust::random::normal_distribution<float> float_dist;
   typedef thrust::random::normal_distribution<double> double_dist;
@@ -831,7 +831,7 @@ void TestNormalDistributionMax(void)
 }
 DECLARE_UNITTEST(TestNormalDistributionMax);
 
-void TestNormalDistributionSaveRestore(void)
+void TestNormalDistributionSaveRestore()
 {
   typedef thrust::random::normal_distribution<float> float_dist;
   typedef thrust::random::normal_distribution<double> double_dist;

--- a/thrust/testing/reduce.cu
+++ b/thrust/testing/reduce.cu
@@ -26,7 +26,7 @@ struct is_equal_div_10_reduce
 };
 
 template <class Vector>
-void TestReduceSimple(void)
+void TestReduceSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -96,7 +96,7 @@ struct TestReduce
 VariableUnitTest<TestReduce, IntegralTypes> TestReduceInstance;
 
 template <class IntVector, class FloatVector>
-void TestReduceMixedTypes(void)
+void TestReduceMixedTypes()
 {
   // make sure we get types for default args and operators correct
   IntVector int_input(4);
@@ -117,12 +117,12 @@ void TestReduceMixedTypes(void)
   // int -> float should use using plus<float> operator by default
   ASSERT_EQUAL(thrust::reduce(int_input.begin(), int_input.end(), (float) 0.5), 10.5);
 }
-void TestReduceMixedTypesHost(void)
+void TestReduceMixedTypesHost()
 {
   TestReduceMixedTypes<thrust::host_vector<int>, thrust::host_vector<float>>();
 }
 DECLARE_UNITTEST(TestReduceMixedTypesHost);
-void TestReduceMixedTypesDevice(void)
+void TestReduceMixedTypesDevice()
 {
   TestReduceMixedTypes<thrust::device_vector<int>, thrust::device_vector<float>>();
 }
@@ -162,7 +162,7 @@ struct plus_mod3
 };
 
 template <typename Vector>
-void TestReduceWithIndirection(void)
+void TestReduceWithIndirection()
 {
   // add numbers modulo 3 with external lookup table
   typedef typename Vector::value_type T;

--- a/thrust/testing/reduce_by_key.cu
+++ b/thrust/testing/reduce_by_key.cu
@@ -45,7 +45,7 @@ void initialize_values(Vector& values)
 }
 
 template <typename Vector>
-void TestReduceByKeySimple(void)
+void TestReduceByKeySimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/reduce_large.cu
+++ b/thrust/testing/reduce_large.cu
@@ -3,7 +3,7 @@
 #include <unittest/unittest.h>
 
 template <typename T, unsigned int N>
-void _TestReduceWithLargeTypes(void)
+void _TestReduceWithLargeTypes()
 {
   size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
 
@@ -22,7 +22,7 @@ void _TestReduceWithLargeTypes(void)
   ASSERT_EQUAL_QUIET(h_result, d_result);
 }
 
-void TestReduceWithLargeTypes(void)
+void TestReduceWithLargeTypes()
 {
   _TestReduceWithLargeTypes<int, 4>();
   _TestReduceWithLargeTypes<int, 8>();

--- a/thrust/testing/remove.cu
+++ b/thrust/testing/remove.cu
@@ -28,7 +28,7 @@ struct is_true : thrust::unary_function<T, bool>
 };
 
 template <typename Vector>
-void TestRemoveSimple(void)
+void TestRemoveSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -85,7 +85,7 @@ void TestRemoveDispatchImplicit()
 DECLARE_UNITTEST(TestRemoveDispatchImplicit);
 
 template <typename Vector>
-void TestRemoveCopySimple(void)
+void TestRemoveCopySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -145,7 +145,7 @@ void TestRemoveCopyDispatchImplicit()
 DECLARE_UNITTEST(TestRemoveCopyDispatchImplicit);
 
 template <typename Vector>
-void TestRemoveIfSimple(void)
+void TestRemoveIfSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -202,7 +202,7 @@ void TestRemoveIfDispatchImplicit()
 DECLARE_UNITTEST(TestRemoveIfDispatchImplicit);
 
 template <typename Vector>
-void TestRemoveIfStencilSimple(void)
+void TestRemoveIfStencilSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -267,7 +267,7 @@ void TestRemoveIfStencilDispatchImplicit()
 DECLARE_UNITTEST(TestRemoveIfStencilDispatchImplicit);
 
 template <typename Vector>
-void TestRemoveCopyIfSimple(void)
+void TestRemoveCopyIfSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -327,7 +327,7 @@ void TestRemoveCopyIfDispatchImplicit()
 DECLARE_UNITTEST(TestRemoveCopyIfDispatchImplicit);
 
 template <typename Vector>
-void TestRemoveCopyIfStencilSimple(void)
+void TestRemoveCopyIfStencilSimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/replace.cu
+++ b/thrust/testing/replace.cu
@@ -13,7 +13,7 @@
 #endif
 
 template <class Vector>
-void TestReplaceSimple(void)
+void TestReplaceSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -88,7 +88,7 @@ void TestReplace(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestReplace);
 
 template <class Vector>
-void TestReplaceCopySimple(void)
+void TestReplaceCopySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -203,7 +203,7 @@ struct less_than_five
 };
 
 template <class Vector>
-void TestReplaceIfSimple(void)
+void TestReplaceIfSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -261,7 +261,7 @@ void TestReplaceIfDispatchImplicit()
 DECLARE_UNITTEST(TestReplaceIfDispatchImplicit);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceIfStencilSimple(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceIfStencilSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -356,7 +356,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceIfStencil(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestReplaceIfStencil);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfSimple(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -420,7 +420,7 @@ void TestReplaceCopyIfDispatchImplicit()
 DECLARE_UNITTEST(TestReplaceCopyIfDispatchImplicit);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfStencilSimple(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfStencilSimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/reverse.cu
+++ b/thrust/testing/reverse.cu
@@ -7,7 +7,7 @@
 typedef unittest::type_list<unittest::int8_t, unittest::int16_t, unittest::int32_t> ReverseTypes;
 
 template <typename Vector>
-void TestReverseSimple(void)
+void TestReverseSimple()
 {
   Vector data(5);
   data[0] = 1;
@@ -63,7 +63,7 @@ void TestReverseDispatchImplicit()
 DECLARE_UNITTEST(TestReverseDispatchImplicit);
 
 template <typename Vector>
-void TestReverseCopySimple(void)
+void TestReverseCopySimple()
 {
 #if defined(_CCCL_COMPILER_GCC) && THRUST_GCC_VERSION >= 80000 && THRUST_GCC_VERSION < 100000
 

--- a/thrust/testing/reverse_iterator.cu
+++ b/thrust/testing/reverse_iterator.cu
@@ -6,7 +6,7 @@
 
 #include <unittest/unittest.h>
 
-void TestReverseIteratorCopyConstructor(void)
+void TestReverseIteratorCopyConstructor()
 {
   thrust::host_vector<int> h_v(1, 13);
 
@@ -28,7 +28,7 @@ DECLARE_UNITTEST(TestReverseIteratorCopyConstructor);
 static_assert(cuda::std::is_trivially_copy_constructible<thrust::reverse_iterator<int*>>::value, "");
 static_assert(cuda::std::is_trivially_copyable<thrust::reverse_iterator<int*>>::value, "");
 
-void TestReverseIteratorIncrement(void)
+void TestReverseIteratorIncrement()
 {
   thrust::host_vector<int> h_v(4);
   thrust::sequence(h_v.begin(), h_v.end());
@@ -65,7 +65,7 @@ void TestReverseIteratorIncrement(void)
 DECLARE_UNITTEST(TestReverseIteratorIncrement);
 
 template <typename Vector>
-void TestReverseIteratorCopy(void)
+void TestReverseIteratorCopy()
 {
   Vector source(4);
   source[0] = 10;
@@ -85,7 +85,7 @@ void TestReverseIteratorCopy(void)
 }
 DECLARE_VECTOR_UNITTEST(TestReverseIteratorCopy);
 
-void TestReverseIteratorExclusiveScanSimple(void)
+void TestReverseIteratorExclusiveScanSimple()
 {
   typedef int T;
   const size_t n = 10;

--- a/thrust/testing/scan.cu
+++ b/thrust/testing/scan.cu
@@ -20,7 +20,7 @@ struct max_functor
 };
 
 template <class Vector>
-void TestScanSimple(void)
+void TestScanSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -211,7 +211,7 @@ void TestExclusiveScanDispatchImplicit()
 }
 DECLARE_UNITTEST(TestExclusiveScanDispatchImplicit);
 
-void TestInclusiveScan32(void)
+void TestInclusiveScan32()
 {
   typedef int T;
   size_t n = 32;
@@ -229,7 +229,7 @@ void TestInclusiveScan32(void)
 }
 DECLARE_UNITTEST(TestInclusiveScan32);
 
-void TestExclusiveScan32(void)
+void TestExclusiveScan32()
 {
   typedef int T;
   size_t n = 32;
@@ -249,7 +249,7 @@ void TestExclusiveScan32(void)
 DECLARE_UNITTEST(TestExclusiveScan32);
 
 template <class IntVector, class FloatVector>
-void TestScanMixedTypes(void)
+void TestScanMixedTypes()
 {
   // make sure we get types for default args and operators correct
   IntVector int_input(4);
@@ -310,12 +310,12 @@ void TestScanMixedTypes(void)
   ASSERT_EQUAL(float_output[2], 8.5f); // out: 8.0f  in: 3 accum: 11.5f
   ASSERT_EQUAL(float_output[3], 11.5f); // out: 11.f  in: 4 accum: 15.5f
 }
-void TestScanMixedTypesHost(void)
+void TestScanMixedTypesHost()
 {
   TestScanMixedTypes<thrust::host_vector<int>, thrust::host_vector<float>>();
 }
 DECLARE_UNITTEST(TestScanMixedTypesHost);
-void TestScanMixedTypesDevice(void)
+void TestScanMixedTypesDevice()
 {
   TestScanMixedTypes<thrust::device_vector<int>, thrust::device_vector<float>>();
 }
@@ -445,7 +445,7 @@ struct TestScanToDiscardIterator
 VariableUnitTest<TestScanToDiscardIterator, unittest::type_list<unittest::int8_t, unittest::int16_t, unittest::int32_t>>
   TestScanToDiscardIteratorInstance;
 
-void TestScanMixedTypes(void)
+void TestScanMixedTypes()
 {
   const unsigned int n = 113;
 
@@ -485,7 +485,7 @@ void TestScanMixedTypes(void)
 DECLARE_UNITTEST(TestScanMixedTypes);
 
 template <typename T, unsigned int N>
-void _TestScanWithLargeTypes(void)
+void _TestScanWithLargeTypes()
 {
   size_t n = (1024 * 1024) / sizeof(FixedVector<T, N>);
 
@@ -511,7 +511,7 @@ void _TestScanWithLargeTypes(void)
   ASSERT_EQUAL_QUIET(h_output, d_output);
 }
 
-void TestScanWithLargeTypes(void)
+void TestScanWithLargeTypes()
 {
   _TestScanWithLargeTypes<int, 1>();
 
@@ -540,7 +540,7 @@ struct plus_mod3
 };
 
 template <typename Vector>
-void TestInclusiveScanWithIndirection(void)
+void TestInclusiveScanWithIndirection()
 {
   // add numbers modulo 3 with external lookup table
   typedef typename Vector::value_type T;
@@ -590,7 +590,7 @@ struct const_ref_plus_mod3
 };
 
 template <typename Vector>
-void TestInclusiveScanWithConstAccumulator(void)
+void TestInclusiveScanWithConstAccumulator()
 {
   // add numbers modulo 3 with external lookup table
   typedef typename Vector::value_type T;

--- a/thrust/testing/scatter.cu
+++ b/thrust/testing/scatter.cu
@@ -10,7 +10,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestScatterSimple(void)
+void TestScatterSimple()
 {
   Vector map(5); // scatter indices
   Vector src(5); // source vector
@@ -123,7 +123,7 @@ void TestScatterToDiscardIterator(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestScatterToDiscardIterator);
 
 template <class Vector>
-void TestScatterIfSimple(void)
+void TestScatterIfSimple()
 {
   Vector flg(5); // predicate array
   Vector map(5); // scatter indices
@@ -262,7 +262,7 @@ void TestScatterIfToDiscardIterator(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestScatterIfToDiscardIterator);
 
 template <typename Vector>
-void TestScatterCountingIterator(void)
+void TestScatterCountingIterator()
 {
   Vector source(10);
   thrust::sequence(source.begin(), source.end(), 0);
@@ -296,7 +296,7 @@ void TestScatterCountingIterator(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestScatterCountingIterator);
 
 template <typename Vector>
-void TestScatterIfCountingIterator(void)
+void TestScatterIfCountingIterator()
 {
   Vector source(10);
   thrust::sequence(source.begin(), source.end(), 0);

--- a/thrust/testing/set_difference.cu
+++ b/thrust/testing/set_difference.cu
@@ -49,7 +49,7 @@ void TestSetDifferenceDispatchImplicit()
 DECLARE_UNITTEST(TestSetDifferenceDispatchImplicit);
 
 template <typename Vector>
-void TestSetDifferenceSimple(void)
+void TestSetDifferenceSimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/set_difference_by_key.cu
+++ b/thrust/testing/set_difference_by_key.cu
@@ -78,7 +78,7 @@ void TestSetDifferenceByKeyDispatchImplicit()
 DECLARE_UNITTEST(TestSetDifferenceByKeyDispatchImplicit);
 
 template <typename Vector>
-void TestSetDifferenceByKeySimple(void)
+void TestSetDifferenceByKeySimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/set_difference_by_key_descending.cu
+++ b/thrust/testing/set_difference_by_key_descending.cu
@@ -5,7 +5,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestSetDifferenceByKeyDescendingSimple(void)
+void TestSetDifferenceByKeyDescendingSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;

--- a/thrust/testing/set_difference_descending.cu
+++ b/thrust/testing/set_difference_descending.cu
@@ -5,7 +5,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestSetDifferenceDescendingSimple(void)
+void TestSetDifferenceDescendingSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;

--- a/thrust/testing/set_intersection.cu
+++ b/thrust/testing/set_intersection.cu
@@ -50,7 +50,7 @@ void TestSetIntersectionDispatchImplicit()
 DECLARE_UNITTEST(TestSetIntersectionDispatchImplicit);
 
 template <typename Vector>
-void TestSetIntersectionSimple(void)
+void TestSetIntersectionSimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/set_intersection_by_key.cu
+++ b/thrust/testing/set_intersection_by_key.cu
@@ -73,7 +73,7 @@ void TestSetIntersectionByKeyDispatchImplicit()
 DECLARE_UNITTEST(TestSetIntersectionByKeyDispatchImplicit);
 
 template <typename Vector>
-void TestSetIntersectionByKeySimple(void)
+void TestSetIntersectionByKeySimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/set_intersection_by_key_descending.cu
+++ b/thrust/testing/set_intersection_by_key_descending.cu
@@ -5,7 +5,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestSetIntersectionByKeyDescendingSimple(void)
+void TestSetIntersectionByKeyDescendingSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;

--- a/thrust/testing/set_intersection_descending.cu
+++ b/thrust/testing/set_intersection_descending.cu
@@ -5,7 +5,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestSetIntersectionDescendingSimple(void)
+void TestSetIntersectionDescendingSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;

--- a/thrust/testing/set_symmetric_difference.cu
+++ b/thrust/testing/set_symmetric_difference.cu
@@ -49,7 +49,7 @@ void TestSetSymmetricDifferenceDispatchImplicit()
 DECLARE_UNITTEST(TestSetSymmetricDifferenceDispatchImplicit);
 
 template <typename Vector>
-void TestSetSymmetricDifferenceSimple(void)
+void TestSetSymmetricDifferenceSimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/set_symmetric_difference_by_key.cu
@@ -78,7 +78,7 @@ void TestSetSymmetricDifferenceByKeyDispatchImplicit()
 DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyDispatchImplicit);
 
 template <typename Vector>
-void TestSetSymmetricDifferenceByKeySimple(void)
+void TestSetSymmetricDifferenceByKeySimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/set_symmetric_difference_by_key_descending.cu
+++ b/thrust/testing/set_symmetric_difference_by_key_descending.cu
@@ -5,7 +5,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestSetSymmetricDifferenceByKeyDescendingSimple(void)
+void TestSetSymmetricDifferenceByKeyDescendingSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;

--- a/thrust/testing/set_symmetric_difference_descending.cu
+++ b/thrust/testing/set_symmetric_difference_descending.cu
@@ -5,7 +5,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestSetSymmetricDifferenceDescendingSimple(void)
+void TestSetSymmetricDifferenceDescendingSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;

--- a/thrust/testing/set_union.cu
+++ b/thrust/testing/set_union.cu
@@ -49,7 +49,7 @@ void TestSetUnionDispatchImplicit()
 DECLARE_UNITTEST(TestSetUnionDispatchImplicit);
 
 template <typename Vector>
-void TestSetUnionSimple(void)
+void TestSetUnionSimple()
 {
   typedef typename Vector::iterator Iterator;
 
@@ -80,7 +80,7 @@ void TestSetUnionSimple(void)
 DECLARE_VECTOR_UNITTEST(TestSetUnionSimple);
 
 template <typename Vector>
-void TestSetUnionWithEquivalentElementsSimple(void)
+void TestSetUnionWithEquivalentElementsSimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/set_union_by_key.cu
+++ b/thrust/testing/set_union_by_key.cu
@@ -78,7 +78,7 @@ void TestSetUnionByKeyDispatchImplicit()
 DECLARE_UNITTEST(TestSetUnionByKeyDispatchImplicit);
 
 template <typename Vector>
-void TestSetUnionByKeySimple(void)
+void TestSetUnionByKeySimple()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/set_union_by_key_descending.cu
+++ b/thrust/testing/set_union_by_key_descending.cu
@@ -5,7 +5,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestSetUnionByKeyDescendingSimple(void)
+void TestSetUnionByKeyDescendingSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;

--- a/thrust/testing/set_union_descending.cu
+++ b/thrust/testing/set_union_descending.cu
@@ -5,7 +5,7 @@
 #include <unittest/unittest.h>
 
 template <typename Vector>
-void TestSetUnionDescendingSimple(void)
+void TestSetUnionDescendingSimple()
 {
   typedef typename Vector::value_type T;
   typedef typename Vector::iterator Iterator;

--- a/thrust/testing/sort.cu
+++ b/thrust/testing/sort.cu
@@ -60,7 +60,7 @@ void InitializeSimpleKeySortTest(Vector& unsorted_keys, Vector& sorted_keys)
 }
 
 template <class Vector>
-void TestSortSimple(void)
+void TestSortSimple()
 {
   Vector unsorted_keys;
   Vector sorted_keys;
@@ -86,7 +86,7 @@ void TestSortAscendingKey(const size_t n)
 }
 DECLARE_VARIABLE_UNITTEST(TestSortAscendingKey);
 
-void TestSortDescendingKey(void)
+void TestSortDescendingKey()
 {
   const size_t n = 10027;
 
@@ -100,7 +100,7 @@ void TestSortDescendingKey(void)
 }
 DECLARE_UNITTEST(TestSortDescendingKey);
 
-void TestSortBool(void)
+void TestSortBool()
 {
   const size_t n = 10027;
 
@@ -114,7 +114,7 @@ void TestSortBool(void)
 }
 DECLARE_UNITTEST(TestSortBool);
 
-void TestSortBoolDescending(void)
+void TestSortBoolDescending()
 {
   const size_t n = 10027;
 

--- a/thrust/testing/sort_by_key.cu
+++ b/thrust/testing/sort_by_key.cu
@@ -66,7 +66,7 @@ void InitializeSimpleKeyValueSortTest(
 }
 
 template <class Vector>
-void TestSortByKeySimple(void)
+void TestSortByKeySimple()
 {
   Vector unsorted_keys, unsorted_values;
   Vector sorted_keys, sorted_values;
@@ -114,7 +114,7 @@ void TestSortDescendingKeyValue(const size_t n)
 }
 DECLARE_VARIABLE_UNITTEST(TestSortDescendingKeyValue);
 
-void TestSortByKeyBool(void)
+void TestSortByKeyBool()
 {
   const size_t n = 10027;
 
@@ -132,7 +132,7 @@ void TestSortByKeyBool(void)
 }
 DECLARE_UNITTEST(TestSortByKeyBool);
 
-void TestSortByKeyBoolDescending(void)
+void TestSortByKeyBoolDescending()
 {
   const size_t n = 10027;
 

--- a/thrust/testing/sort_permutation_iterator.cu
+++ b/thrust/testing/sort_permutation_iterator.cu
@@ -40,12 +40,12 @@ public:
       , stride(stride)
   {}
 
-  iterator begin(void) const
+  iterator begin() const
   {
     return PermutationIterator(first, TransformIterator(CountingIterator(0), stride_functor(stride)));
   }
 
-  iterator end(void) const
+  iterator end() const
   {
     return begin() + ((last - first) + (stride - 1)) / stride;
   }
@@ -57,7 +57,7 @@ protected:
 };
 
 template <class Vector>
-void TestSortPermutationIterator(void)
+void TestSortPermutationIterator()
 {
   typedef typename Vector::iterator Iterator;
 
@@ -91,7 +91,7 @@ void TestSortPermutationIterator(void)
 DECLARE_VECTOR_UNITTEST(TestSortPermutationIterator);
 
 template <class Vector>
-void TestStableSortPermutationIterator(void)
+void TestStableSortPermutationIterator()
 {
   typedef typename Vector::iterator Iterator;
 
@@ -125,7 +125,7 @@ void TestStableSortPermutationIterator(void)
 DECLARE_VECTOR_UNITTEST(TestStableSortPermutationIterator);
 
 template <class Vector>
-void TestSortByKeyPermutationIterator(void)
+void TestSortByKeyPermutationIterator()
 {
   typedef typename Vector::iterator Iterator;
 
@@ -173,7 +173,7 @@ void TestSortByKeyPermutationIterator(void)
 DECLARE_VECTOR_UNITTEST(TestSortByKeyPermutationIterator);
 
 template <class Vector>
-void TestStableSortByKeyPermutationIterator(void)
+void TestStableSortByKeyPermutationIterator()
 {
   typedef typename Vector::iterator Iterator;
 

--- a/thrust/testing/stable_sort.cu
+++ b/thrust/testing/stable_sort.cu
@@ -73,7 +73,7 @@ void InitializeSimpleStableKeySortTest(Vector& unsorted_keys, Vector& sorted_key
 }
 
 template <class Vector>
-void TestStableSortSimple(void)
+void TestStableSortSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -137,7 +137,7 @@ struct comp_mod3
 };
 
 template <typename Vector>
-void TestStableSortWithIndirection(void)
+void TestStableSortWithIndirection()
 {
   // add numbers modulo 3 with external lookup table
   typedef typename Vector::value_type T;

--- a/thrust/testing/stable_sort_by_key.cu
+++ b/thrust/testing/stable_sort_by_key.cu
@@ -79,7 +79,7 @@ void InitializeSimpleStableKeyValueSortTest(
 }
 
 template <class Vector>
-void TestStableSortByKeySimple(void)
+void TestStableSortByKeySimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/stable_sort_by_key_large_keys.cu
+++ b/thrust/testing/stable_sort_by_key_large_keys.cu
@@ -4,7 +4,7 @@
 #include <unittest/unittest.h>
 
 template <unsigned int N>
-void _TestStableSortByKeyWithLargeKeys(void)
+void _TestStableSortByKeyWithLargeKeys()
 {
   size_t n = (128 * 1024) / sizeof(FixedVector<int, N>);
 
@@ -29,7 +29,7 @@ void _TestStableSortByKeyWithLargeKeys(void)
   ASSERT_EQUAL_QUIET(h_vals, d_vals);
 }
 
-void TestStableSortByKeyWithLargeKeys(void)
+void TestStableSortByKeyWithLargeKeys()
 {
   _TestStableSortByKeyWithLargeKeys<4>();
   _TestStableSortByKeyWithLargeKeys<8>();

--- a/thrust/testing/stable_sort_large.cu
+++ b/thrust/testing/stable_sort_large.cu
@@ -4,7 +4,7 @@
 #include <unittest/unittest.h>
 
 template <typename T, unsigned int N>
-void _TestStableSortWithLargeKeys(void)
+void _TestStableSortWithLargeKeys()
 {
   size_t n = (128 * 1024) / sizeof(FixedVector<T, N>);
 
@@ -24,7 +24,7 @@ void _TestStableSortWithLargeKeys(void)
   ASSERT_EQUAL_QUIET(h_keys, d_keys);
 }
 
-void TestStableSortWithLargeKeys(void)
+void TestStableSortWithLargeKeys()
 {
   _TestStableSortWithLargeKeys<int, 2>();
   _TestStableSortWithLargeKeys<int, 17>();

--- a/thrust/testing/swap_ranges.cu
+++ b/thrust/testing/swap_ranges.cu
@@ -42,7 +42,7 @@ void TestSwapRangesDispatchImplicit()
 DECLARE_UNITTEST(TestSwapRangesDispatchImplicit);
 
 template <class Vector>
-void TestSwapRangesSimple(void)
+void TestSwapRangesSimple()
 {
   Vector v1(5);
   v1[0] = 0;
@@ -96,7 +96,7 @@ void TestSwapRanges(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestSwapRanges);
 
 #if (THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_OMP)
-void TestSwapRangesForcedIterator(void)
+void TestSwapRangesForcedIterator()
 {
   thrust::device_vector<int> A(3, 0);
   thrust::device_vector<int> B(3, 1);
@@ -155,7 +155,7 @@ inline __host__ __device__ void swap(type_with_swap& a, type_with_swap& b)
   b.m_swapped = true;
 }
 
-void TestSwapRangesUserSwap(void)
+void TestSwapRangesUserSwap()
 {
   thrust::host_vector<type_with_swap> h_A(3, type_with_swap(0));
   thrust::host_vector<type_with_swap> h_B(3, type_with_swap(1));

--- a/thrust/testing/tabulate.cu
+++ b/thrust/testing/tabulate.cu
@@ -39,7 +39,7 @@ void TestTabulateDispatchImplicit()
 DECLARE_UNITTEST(TestTabulateDispatchImplicit);
 
 template <class Vector>
-void TestTabulateSimple(void)
+void TestTabulateSimple()
 {
   using namespace thrust::placeholders;
   typedef typename Vector::value_type T;

--- a/thrust/testing/transform.cu
+++ b/thrust/testing/transform.cu
@@ -17,7 +17,7 @@
 #endif
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformUnarySimple(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformUnarySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -77,7 +77,7 @@ void TestTransformUnaryDispatchImplicit()
 DECLARE_UNITTEST(TestTransformUnaryDispatchImplicit);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfUnaryNoStencilSimple(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfUnaryNoStencilSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -142,7 +142,7 @@ void TestTransformIfUnaryNoStencilDispatchImplicit()
 DECLARE_UNITTEST(TestTransformIfUnaryNoStencilDispatchImplicit);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfUnarySimple(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfUnarySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -214,7 +214,7 @@ void TestTransformIfUnaryDispatchImplicit()
 DECLARE_UNITTEST(TestTransformIfUnaryDispatchImplicit);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformBinarySimple(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformBinarySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -283,7 +283,7 @@ void TestTransformBinaryDispatchImplicit()
 DECLARE_UNITTEST(TestTransformBinaryDispatchImplicit);
 
 template <class Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfBinarySimple(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfBinarySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -763,7 +763,7 @@ struct plus_mod3
 };
 
 template <typename Vector>
-THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformWithIndirection(void)
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformWithIndirection()
 {
   // add numbers modulo 3 with external lookup table
   typedef typename Vector::value_type T;

--- a/thrust/testing/transform_input_output_iterator.cu
+++ b/thrust/testing/transform_input_output_iterator.cu
@@ -8,7 +8,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestTransformInputOutputIterator(void)
+void TestTransformInputOutputIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -52,7 +52,7 @@ void TestTransformInputOutputIterator(void)
 DECLARE_VECTOR_UNITTEST(TestTransformInputOutputIterator);
 
 template <class Vector>
-void TestMakeTransformInputOutputIterator(void)
+void TestMakeTransformInputOutputIterator()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/transform_iterator.cu
+++ b/thrust/testing/transform_iterator.cu
@@ -10,7 +10,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestTransformIterator(void)
+void TestTransformIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -36,7 +36,7 @@ void TestTransformIterator(void)
 DECLARE_VECTOR_UNITTEST(TestTransformIterator);
 
 template <class Vector>
-void TestMakeTransformIterator(void)
+void TestMakeTransformIterator()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/transform_output_iterator.cu
+++ b/thrust/testing/transform_output_iterator.cu
@@ -10,7 +10,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestTransformOutputIterator(void)
+void TestTransformOutputIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -39,7 +39,7 @@ void TestTransformOutputIterator(void)
 DECLARE_VECTOR_UNITTEST(TestTransformOutputIterator);
 
 template <class Vector>
-void TestMakeTransformOutputIterator(void)
+void TestMakeTransformOutputIterator()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/transform_reduce.cu
+++ b/thrust/testing/transform_reduce.cu
@@ -42,7 +42,7 @@ void TestTransformReduceDispatchImplicit()
 DECLARE_UNITTEST(TestTransformReduceDispatchImplicit);
 
 template <class Vector>
-void TestTransformReduceSimple(void)
+void TestTransformReduceSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -89,7 +89,7 @@ void TestTransformReduceFromConst(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestTransformReduceFromConst);
 
 template <class Vector>
-void TestTransformReduceCountingIterator(void)
+void TestTransformReduceCountingIterator()
 {
   typedef typename Vector::value_type T;
   typedef typename thrust::iterator_system<typename Vector::iterator>::type space;

--- a/thrust/testing/transform_scan.cu
+++ b/thrust/testing/transform_scan.cu
@@ -84,7 +84,7 @@ void TestTransformExclusiveScanDispatchImplicit()
 DECLARE_UNITTEST(TestTransformExclusiveScanDispatchImplicit);
 
 template <class Vector>
-void TestTransformScanSimple(void)
+void TestTransformScanSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -280,7 +280,7 @@ struct TestTransformScan
 VariableUnitTest<TestTransformScan, IntegralTypes> TestTransformScanInstance;
 
 template <class Vector>
-void TestTransformScanCountingIterator(void)
+void TestTransformScanCountingIterator()
 {
   typedef typename Vector::value_type T;
   typedef typename thrust::iterator_system<typename Vector::iterator>::type space;

--- a/thrust/testing/trivial_sequence.cu
+++ b/thrust/testing/trivial_sequence.cu
@@ -31,7 +31,7 @@ void test(Iterator first, Iterator last)
 }
 
 template <class Vector>
-void TestTrivialSequence(void)
+void TestTrivialSequence()
 {
   Vector A(5);
   A[0] = 0;

--- a/thrust/testing/tuple.cu
+++ b/thrust/testing/tuple.cu
@@ -458,7 +458,7 @@ struct TestTupleTie
 };
 SimpleUnitTest<TestTupleTie, NumericTypes> TestTupleTieInstance;
 
-void TestTupleSwap(void)
+void TestTupleSwap()
 {
   int a = 7;
   int b = 13;
@@ -498,7 +498,7 @@ void TestTupleSwap(void)
 DECLARE_UNITTEST(TestTupleSwap);
 
 #if _CCCL_STD_VER >= 2017
-void TestTupleStructuredBindings(void)
+void TestTupleStructuredBindings()
 {
   const int a = 0;
   const int b = 42;

--- a/thrust/testing/type_traits.cu
+++ b/thrust/testing/type_traits.cu
@@ -12,13 +12,13 @@
 struct non_pod
 {
   // non-pods can have constructors
-  non_pod(void) {}
+  non_pod() {}
 
   int x;
   int y;
 };
 
-void TestIsPlainOldData(void)
+void TestIsPlainOldData()
 {
   // primitive types
   ASSERT_EQUAL((bool) thrust::detail::is_pod<bool>::value, true);
@@ -64,7 +64,7 @@ void TestIsPlainOldData(void)
 }
 DECLARE_UNITTEST(TestIsPlainOldData);
 
-void TestIsContiguousIterator(void)
+void TestIsContiguousIterator()
 {
   typedef thrust::host_vector<int> HostVector;
   typedef thrust::device_vector<int> DeviceVector;
@@ -94,7 +94,7 @@ void TestIsContiguousIterator(void)
 }
 DECLARE_UNITTEST(TestIsContiguousIterator);
 
-void TestIsCommutative(void)
+void TestIsCommutative()
 {
   {
     typedef int T;

--- a/thrust/testing/uninitialized_copy.cu
+++ b/thrust/testing/uninitialized_copy.cu
@@ -77,7 +77,7 @@ void TestUninitializedCopyNDispatchImplicit()
 DECLARE_UNITTEST(TestUninitializedCopyNDispatchImplicit);
 
 template <class Vector>
-void TestUninitializedCopySimplePOD(void)
+void TestUninitializedCopySimplePOD()
 {
   Vector v1(5);
   v1[0] = 0;
@@ -98,7 +98,7 @@ void TestUninitializedCopySimplePOD(void)
 DECLARE_VECTOR_UNITTEST(TestUninitializedCopySimplePOD);
 
 template <typename Vector>
-void TestUninitializedCopyNSimplePOD(void)
+void TestUninitializedCopyNSimplePOD()
 {
   Vector v1(5);
   v1[0] = 0;
@@ -120,7 +120,7 @@ DECLARE_VECTOR_UNITTEST(TestUninitializedCopyNSimplePOD);
 
 struct CopyConstructTest
 {
-  __host__ __device__ CopyConstructTest(void)
+  __host__ __device__ CopyConstructTest()
       : copy_constructed_on_host(false)
       , copy_constructed_on_device(false)
   {}

--- a/thrust/testing/uninitialized_fill.cu
+++ b/thrust/testing/uninitialized_fill.cu
@@ -75,7 +75,7 @@ void TestUninitializedFillNDispatchImplicit()
 DECLARE_UNITTEST(TestUninitializedFillNDispatchImplicit);
 
 template <class Vector>
-void TestUninitializedFillPOD(void)
+void TestUninitializedFillPOD()
 {
   typedef typename Vector::value_type T;
 
@@ -130,7 +130,7 @@ DECLARE_VECTOR_UNITTEST(TestUninitializedFillPOD);
 
 struct CopyConstructTest
 {
-  __host__ __device__ CopyConstructTest(void)
+  __host__ __device__ CopyConstructTest()
       : copy_constructed_on_host(false)
       , copy_constructed_on_device(false)
   {}
@@ -185,7 +185,7 @@ struct TestUninitializedFillNonPOD
 DECLARE_UNITTEST(TestUninitializedFillNonPOD);
 
 template <class Vector>
-void TestUninitializedFillNPOD(void)
+void TestUninitializedFillNPOD()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/unique.cu
+++ b/thrust/testing/unique.cu
@@ -121,7 +121,7 @@ struct is_equal_div_10_unique
 };
 
 template <typename Vector>
-void TestUniqueSimple(void)
+void TestUniqueSimple()
 {
   typedef typename Vector::value_type T;
 
@@ -184,7 +184,7 @@ struct TestUnique
 VariableUnitTest<TestUnique, IntegralTypes> TestUniqueInstance;
 
 template <typename Vector>
-void TestUniqueCopySimple(void)
+void TestUniqueCopySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -280,7 +280,7 @@ struct TestUniqueCopyToDiscardIterator
 VariableUnitTest<TestUniqueCopyToDiscardIterator, IntegralTypes> TestUniqueCopyToDiscardIteratorInstance;
 
 template <typename Vector>
-void TestUniqueCountSimple(void)
+void TestUniqueCountSimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/unique_by_key.cu
+++ b/thrust/testing/unique_by_key.cu
@@ -147,7 +147,7 @@ void initialize_values(Vector& values)
 }
 
 template <typename Vector>
-void TestUniqueByKeySimple(void)
+void TestUniqueByKeySimple()
 {
   typedef typename Vector::value_type T;
 
@@ -195,7 +195,7 @@ void TestUniqueByKeySimple(void)
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestUniqueByKeySimple);
 
 template <typename Vector>
-void TestUniqueCopyByKeySimple(void)
+void TestUniqueCopyByKeySimple()
 {
   typedef typename Vector::value_type T;
 

--- a/thrust/testing/unittest/cuda/testframework.cu
+++ b/thrust/testing/unittest/cuda/testframework.cu
@@ -27,7 +27,7 @@ bool binary_exists_for_current_device()
   return cudaSuccess == error;
 }
 
-void list_devices(void)
+void list_devices()
 {
   int deviceCount;
   cudaGetDeviceCount(&deviceCount);

--- a/thrust/testing/unittest/special_types.h
+++ b/thrust/testing/unittest/special_types.h
@@ -70,7 +70,7 @@ struct key_value
   typedef Key key_type;
   typedef Value value_type;
 
-  __host__ __device__ key_value(void)
+  __host__ __device__ key_value()
       : key()
       , value()
   {}

--- a/thrust/testing/unittest/testframework.cu
+++ b/thrust/testing/unittest/testframework.cu
@@ -42,7 +42,7 @@ const size_t max_threshold     = (std::numeric_limits<size_t>::max)();
 
 std::vector<size_t> test_sizes;
 
-std::vector<size_t> get_test_sizes(void)
+std::vector<size_t> get_test_sizes()
 {
   return test_sizes;
 }
@@ -263,7 +263,7 @@ void report_results(std::vector<TestResult>& test_results, double elapsed_minute
   std::cout << "Time:  " << elapsed_minutes << " minutes" << std::endl;
 }
 
-void UnitTestDriver::list_tests(void)
+void UnitTestDriver::list_tests()
 {
   for (TestMap::iterator iter = test_map.begin(); iter != test_map.end(); iter++)
   {

--- a/thrust/testing/unittest/testframework.h
+++ b/thrust/testing/unittest/testframework.h
@@ -291,7 +291,7 @@ enum TestStatus
 typedef std::set<std::string> ArgumentSet;
 typedef std::map<std::string, std::string> ArgumentMap;
 
-std::vector<size_t> get_test_sizes(void);
+std::vector<size_t> get_test_sizes();
 void set_test_sizes(const std::string&);
 
 class UnitTest
@@ -331,7 +331,7 @@ public:
 
   void register_test(UnitTest* test);
   virtual bool run_tests(const ArgumentSet& args, const ArgumentMap& kwargs);
-  void list_tests(void);
+  void list_tests();
 
   static UnitTestDriver& s_driver();
 };
@@ -368,7 +368,7 @@ public:
 // Macro to create host and device versions of a
 // unit test for a bunch of data types
 #define DECLARE_VECTOR_UNITTEST(VTEST)                                                                                  \
-  void VTEST##Host(void)                                                                                                \
+  void VTEST##Host()                                                                                                    \
   {                                                                                                                     \
     VTEST<thrust::host_vector<signed char>>();                                                                          \
     VTEST<thrust::host_vector<short>>();                                                                                \
@@ -378,7 +378,7 @@ public:
     /* MR vectors */                                                                                                    \
     VTEST<thrust::host_vector<int, thrust::mr::stateless_resource_allocator<int, thrust::host_memory_resource>>>();     \
   }                                                                                                                     \
-  void VTEST##Device(void)                                                                                              \
+  void VTEST##Device()                                                                                                  \
   {                                                                                                                     \
     VTEST<thrust::device_vector<signed char>>();                                                                        \
     VTEST<thrust::device_vector<short>>();                                                                              \
@@ -388,7 +388,7 @@ public:
     /* MR vectors */                                                                                                    \
     VTEST<thrust::device_vector<int, thrust::mr::stateless_resource_allocator<int, thrust::device_memory_resource>>>(); \
   }                                                                                                                     \
-  void VTEST##Universal(void)                                                                                           \
+  void VTEST##Universal()                                                                                               \
   {                                                                                                                     \
     VTEST<thrust::universal_vector<int>>();                                                                             \
     VTEST<thrust::device_vector<                                                                                        \
@@ -401,19 +401,19 @@ public:
 
 // Same as above, but only for integral types
 #define DECLARE_INTEGRAL_VECTOR_UNITTEST(VTEST)                                                         \
-  void VTEST##Host(void)                                                                                \
+  void VTEST##Host()                                                                                    \
   {                                                                                                     \
     VTEST<thrust::host_vector<signed char>>();                                                          \
     VTEST<thrust::host_vector<short>>();                                                                \
     VTEST<thrust::host_vector<int>>();                                                                  \
   }                                                                                                     \
-  void VTEST##Device(void)                                                                              \
+  void VTEST##Device()                                                                                  \
   {                                                                                                     \
     VTEST<thrust::device_vector<signed char>>();                                                        \
     VTEST<thrust::device_vector<short>>();                                                              \
     VTEST<thrust::device_vector<int>>();                                                                \
   }                                                                                                     \
-  void VTEST##Universal(void)                                                                           \
+  void VTEST##Universal()                                                                               \
   {                                                                                                     \
     VTEST<thrust::universal_vector<int>>();                                                             \
     VTEST<thrust::device_vector<                                                                        \

--- a/thrust/testing/unittest/util.h
+++ b/thrust/testing/unittest/util.h
@@ -14,7 +14,7 @@ namespace unittest
 {
 
 template <typename T>
-std::string type_name(void)
+std::string type_name()
 {
   return demangle(typeid(T).name());
 } // end type_name()

--- a/thrust/testing/unittest_tester.cu
+++ b/thrust/testing/unittest_tester.cu
@@ -1,6 +1,6 @@
 #include <unittest/unittest.h>
 
-void TestAssertEqual(void)
+void TestAssertEqual()
 {
   ASSERT_EQUAL(0, 0);
   ASSERT_EQUAL(1, 1);
@@ -8,33 +8,33 @@ void TestAssertEqual(void)
 }
 DECLARE_UNITTEST(TestAssertEqual);
 
-void TestAssertLEqual(void)
+void TestAssertLEqual()
 {
   ASSERT_LEQUAL(0, 1);
   ASSERT_LEQUAL(0, 0);
 }
 DECLARE_UNITTEST(TestAssertLEqual);
 
-void TestAssertGEqual(void)
+void TestAssertGEqual()
 {
   ASSERT_GEQUAL(1, 0);
   ASSERT_GEQUAL(0, 0);
 }
 DECLARE_UNITTEST(TestAssertGEqual);
 
-void TestAssertLess(void)
+void TestAssertLess()
 {
   ASSERT_LESS(0, 1);
 }
 DECLARE_UNITTEST(TestAssertLess);
 
-void TestAssertGreater(void)
+void TestAssertGreater()
 {
   ASSERT_GREATER(1, 0);
 }
 DECLARE_UNITTEST(TestAssertGreater);
 
-void TestTypeName(void)
+void TestTypeName()
 {
   ASSERT_EQUAL(unittest::type_name<char>(), "char");
   ASSERT_EQUAL(unittest::type_name<signed char>(), "signed char");

--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -12,7 +12,7 @@
 #include <unittest/unittest.h>
 
 template <class Vector>
-void TestVectorZeroSize(void)
+void TestVectorZeroSize()
 {
   Vector v;
   ASSERT_EQUAL(v.size(), 0lu);
@@ -20,7 +20,7 @@ void TestVectorZeroSize(void)
 }
 DECLARE_VECTOR_UNITTEST(TestVectorZeroSize);
 
-void TestVectorBool(void)
+void TestVectorBool()
 {
   thrust::host_vector<bool> h(3);
   thrust::device_vector<bool> d(3);
@@ -43,7 +43,7 @@ void TestVectorBool(void)
 DECLARE_UNITTEST(TestVectorBool);
 
 template <class Vector>
-void TestVectorInitializerList(void)
+void TestVectorInitializerList()
 {
   Vector v{1, 2, 3};
   ASSERT_EQUAL(v.size(), 3lu);
@@ -68,7 +68,7 @@ void TestVectorInitializerList(void)
 DECLARE_VECTOR_UNITTEST(TestVectorInitializerList);
 
 template <class Vector>
-void TestVectorFrontBack(void)
+void TestVectorFrontBack()
 {
   typedef typename Vector::value_type T;
 
@@ -83,7 +83,7 @@ void TestVectorFrontBack(void)
 DECLARE_VECTOR_UNITTEST(TestVectorFrontBack);
 
 template <class Vector>
-void TestVectorData(void)
+void TestVectorData()
 {
   typedef typename Vector::pointer PointerT;
   typedef typename Vector::const_pointer PointerConstT;
@@ -112,7 +112,7 @@ void TestVectorData(void)
 DECLARE_VECTOR_UNITTEST(TestVectorData);
 
 template <class Vector>
-void TestVectorElementAssignment(void)
+void TestVectorElementAssignment()
 {
   Vector v(3);
 
@@ -142,7 +142,7 @@ void TestVectorElementAssignment(void)
 DECLARE_VECTOR_UNITTEST(TestVectorElementAssignment);
 
 template <class Vector>
-void TestVectorFromSTLVector(void)
+void TestVectorFromSTLVector()
 {
   typedef typename Vector::value_type T;
 
@@ -168,7 +168,7 @@ void TestVectorFromSTLVector(void)
 DECLARE_VECTOR_UNITTEST(TestVectorFromSTLVector);
 
 template <class Vector>
-void TestVectorFillAssign(void)
+void TestVectorFillAssign()
 {
   typedef typename Vector::value_type T;
 
@@ -183,7 +183,7 @@ void TestVectorFillAssign(void)
 DECLARE_VECTOR_UNITTEST(TestVectorFillAssign);
 
 template <class Vector>
-void TestVectorAssignFromSTLVector(void)
+void TestVectorAssignFromSTLVector()
 {
   typedef typename Vector::value_type T;
 
@@ -203,7 +203,7 @@ void TestVectorAssignFromSTLVector(void)
 DECLARE_VECTOR_UNITTEST(TestVectorAssignFromSTLVector);
 
 template <class Vector>
-void TestVectorFromBiDirectionalIterator(void)
+void TestVectorFromBiDirectionalIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -222,7 +222,7 @@ void TestVectorFromBiDirectionalIterator(void)
 DECLARE_VECTOR_UNITTEST(TestVectorFromBiDirectionalIterator);
 
 template <class Vector>
-void TestVectorAssignFromBiDirectionalIterator(void)
+void TestVectorAssignFromBiDirectionalIterator()
 {
   typedef typename Vector::value_type T;
 
@@ -242,7 +242,7 @@ void TestVectorAssignFromBiDirectionalIterator(void)
 DECLARE_VECTOR_UNITTEST(TestVectorAssignFromBiDirectionalIterator);
 
 template <class Vector>
-void TestVectorAssignFromHostVector(void)
+void TestVectorAssignFromHostVector()
 {
   typedef typename Vector::value_type T;
 
@@ -259,7 +259,7 @@ void TestVectorAssignFromHostVector(void)
 DECLARE_VECTOR_UNITTEST(TestVectorAssignFromHostVector);
 
 template <class Vector>
-void TestVectorToAndFromHostVector(void)
+void TestVectorToAndFromHostVector()
 {
   typedef typename Vector::value_type T;
 
@@ -300,7 +300,7 @@ void TestVectorToAndFromHostVector(void)
 DECLARE_VECTOR_UNITTEST(TestVectorToAndFromHostVector);
 
 template <class Vector>
-void TestVectorAssignFromDeviceVector(void)
+void TestVectorAssignFromDeviceVector()
 {
   typedef typename Vector::value_type T;
 
@@ -317,7 +317,7 @@ void TestVectorAssignFromDeviceVector(void)
 DECLARE_VECTOR_UNITTEST(TestVectorAssignFromDeviceVector);
 
 template <class Vector>
-void TestVectorToAndFromDeviceVector(void)
+void TestVectorToAndFromDeviceVector()
 {
   typedef typename Vector::value_type T;
 
@@ -358,7 +358,7 @@ void TestVectorToAndFromDeviceVector(void)
 DECLARE_VECTOR_UNITTEST(TestVectorToAndFromDeviceVector);
 
 template <class Vector>
-void TestVectorWithInitialValue(void)
+void TestVectorWithInitialValue()
 {
   typedef typename Vector::value_type T;
 
@@ -374,7 +374,7 @@ void TestVectorWithInitialValue(void)
 DECLARE_VECTOR_UNITTEST(TestVectorWithInitialValue);
 
 template <class Vector>
-void TestVectorSwap(void)
+void TestVectorSwap()
 {
   Vector v(3);
   v[0] = 0;
@@ -398,7 +398,7 @@ void TestVectorSwap(void)
 DECLARE_VECTOR_UNITTEST(TestVectorSwap);
 
 template <class Vector>
-void TestVectorErasePosition(void)
+void TestVectorErasePosition()
 {
   Vector v(5);
   v[0] = 0;
@@ -440,7 +440,7 @@ void TestVectorErasePosition(void)
 DECLARE_VECTOR_UNITTEST(TestVectorErasePosition);
 
 template <class Vector>
-void TestVectorEraseRange(void)
+void TestVectorEraseRange()
 {
   Vector v(6);
   v[0] = 0;
@@ -475,7 +475,7 @@ void TestVectorEraseRange(void)
 }
 DECLARE_VECTOR_UNITTEST(TestVectorEraseRange);
 
-void TestVectorEquality(void)
+void TestVectorEquality()
 {
   thrust::host_vector<int> h_a(3);
   thrust::host_vector<int> h_b(3);
@@ -597,7 +597,7 @@ void TestVectorEquality(void)
 }
 DECLARE_UNITTEST(TestVectorEquality);
 
-void TestVectorInequality(void)
+void TestVectorInequality()
 {
   thrust::host_vector<int> h_a(3);
   thrust::host_vector<int> h_b(3);
@@ -720,7 +720,7 @@ void TestVectorInequality(void)
 DECLARE_UNITTEST(TestVectorInequality);
 
 template <class Vector>
-void TestVectorResizing(void)
+void TestVectorResizing()
 {
   Vector v;
 
@@ -778,7 +778,7 @@ void TestVectorResizing(void)
 DECLARE_VECTOR_UNITTEST(TestVectorResizing);
 
 template <class Vector>
-void TestVectorReserving(void)
+void TestVectorReserving()
 {
   Vector v;
 
@@ -809,7 +809,7 @@ void TestVectorReserving(void)
 DECLARE_VECTOR_UNITTEST(TestVectorReserving)
 
 template <class Vector>
-void TestVectorUninitialisedCopy(void)
+void TestVectorUninitialisedCopy()
 {
   thrust::device_vector<int> v;
   std::vector<int> std_vector;
@@ -821,7 +821,7 @@ void TestVectorUninitialisedCopy(void)
 DECLARE_VECTOR_UNITTEST(TestVectorUninitialisedCopy);
 
 template <class Vector>
-void TestVectorShrinkToFit(void)
+void TestVectorShrinkToFit()
 {
   typedef typename Vector::value_type T;
 
@@ -863,7 +863,7 @@ struct LargeStruct
   }
 };
 
-void TestVectorContainingLargeType(void)
+void TestVectorContainingLargeType()
 {
   // Thrust issue #5
   // http://code.google.com/p/thrust/issues/detail?id=5
@@ -904,7 +904,7 @@ void TestVectorContainingLargeType(void)
 DECLARE_UNITTEST(TestVectorContainingLargeType);
 
 template <typename Vector>
-void TestVectorReversed(void)
+void TestVectorReversed()
 {
   Vector v(3);
   v[0] = 0;
@@ -928,7 +928,7 @@ void TestVectorReversed(void)
 DECLARE_VECTOR_UNITTEST(TestVectorReversed);
 
 template <class Vector>
-void TestVectorMove(void)
+void TestVectorMove()
 {
   // test move construction
   Vector v1(3);

--- a/thrust/testing/zip_iterator.cu
+++ b/thrust/testing/zip_iterator.cu
@@ -14,7 +14,7 @@ template <typename T>
 struct TestZipIteratorManipulation
 {
   template <typename Vector>
-  void test(void)
+  void test()
   {
     using namespace thrust;
 
@@ -268,7 +268,7 @@ struct TestZipIteratorSystem
 SimpleUnitTest<TestZipIteratorSystem, NumericTypes> TestZipIteratorSystemInstance;
 
 template <typename Vector>
-void TestZipIteratorCopy(void)
+void TestZipIteratorCopy()
 {
   using namespace thrust;
   using T = typename Vector::value_type;
@@ -352,7 +352,7 @@ struct TestZipIteratorTransform
 };
 VariableUnitTest<TestZipIteratorTransform, ThirtyTwoBitTypes> TestZipIteratorTransformInstance;
 
-void TestZipIteratorCopyAoSToSoA(void)
+void TestZipIteratorCopyAoSToSoA()
 {
   using namespace thrust;
 
@@ -399,7 +399,7 @@ void TestZipIteratorCopyAoSToSoA(void)
 };
 DECLARE_UNITTEST(TestZipIteratorCopyAoSToSoA);
 
-void TestZipIteratorCopySoAToAoS(void)
+void TestZipIteratorCopySoAToAoS()
 {
   using namespace thrust;
 

--- a/thrust/thrust/detail/allocator/allocator_traits.inl
+++ b/thrust/thrust/detail/allocator/allocator_traits.inl
@@ -247,7 +247,7 @@ class has_member_max_size
   typedef typename allocator_traits<Alloc>::size_type size_type;
 
 public:
-  typedef typename has_member_max_size_impl<Alloc, size_type(void)>::type type;
+  typedef typename has_member_max_size_impl<Alloc, size_type()>::type type;
   static const bool value = type::value;
 };
 

--- a/thrust/thrust/detail/temporary_array.h
+++ b/thrust/thrust/detail/temporary_array.h
@@ -108,11 +108,11 @@ public:
       , m_end(last)
   {}
 
-  iterator begin(void) const
+  iterator begin() const
   {
     return m_begin;
   }
-  iterator end(void) const
+  iterator end() const
   {
     return m_end;
   }

--- a/thrust/thrust/detail/type_traits/minimum_type.h
+++ b/thrust/thrust/detail/type_traits/minimum_type.h
@@ -82,7 +82,7 @@ struct primitive_minimum_type<T, T>
 struct any_conversion
 {
   template <typename T>
-  operator T(void);
+  operator T();
 };
 
 } // namespace minimum_type_detail

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -70,7 +70,7 @@ public:
 
   /*! This constructor creates an empty vector_base.
    */
-  vector_base(void);
+  vector_base();
 
   /*! This constructor creates an empty vector_base.
    *  \param alloc The allocator to use by this vector_base.
@@ -201,7 +201,7 @@ public:
 
   /*! The destructor erases the elements.
    */
-  ~vector_base(void);
+  ~vector_base();
 
   /*! \brief Resizes this vector_base to the specified number of elements.
    *  \param new_size Number of elements this vector_base should contain.
@@ -228,12 +228,12 @@ public:
 
   /*! Returns the number of elements in this vector_base.
    */
-  _CCCL_HOST_DEVICE size_type size(void) const;
+  _CCCL_HOST_DEVICE size_type size() const;
 
   /*! Returns the size() of the largest possible vector_base.
    *  \return The largest possible return value of size().
    */
-  _CCCL_HOST_DEVICE size_type max_size(void) const;
+  _CCCL_HOST_DEVICE size_type max_size() const;
 
   /*! \brief If n is less than or equal to capacity(), this call has no effect.
    *         Otherwise, this method is a request for allocation of additional memory. If
@@ -246,12 +246,12 @@ public:
   /*! Returns the number of elements which have been reserved in this
    *  vector_base.
    */
-  _CCCL_HOST_DEVICE size_type capacity(void) const;
+  _CCCL_HOST_DEVICE size_type capacity() const;
 
   /*! This method shrinks the capacity of this vector_base to exactly
    *  fit its elements.
    */
-  void shrink_to_fit(void);
+  void shrink_to_fit();
 
   /*! \brief Subscript access to the data contained in this vector_dev.
    *  \param n The index of the element for which data should be accessed.
@@ -277,119 +277,119 @@ public:
    *  this vector_base.
    *  \return mStart
    */
-  _CCCL_HOST_DEVICE iterator begin(void);
+  _CCCL_HOST_DEVICE iterator begin();
 
   /*! This method returns a const_iterator pointing to the beginning
    *  of this vector_base.
    *  \return mStart
    */
-  _CCCL_HOST_DEVICE const_iterator begin(void) const;
+  _CCCL_HOST_DEVICE const_iterator begin() const;
 
   /*! This method returns a const_iterator pointing to the beginning
    *  of this vector_base.
    *  \return mStart
    */
-  _CCCL_HOST_DEVICE const_iterator cbegin(void) const;
+  _CCCL_HOST_DEVICE const_iterator cbegin() const;
 
   /*! This method returns a reverse_iterator pointing to the beginning of
    *  this vector_base's reversed sequence.
    *  \return A reverse_iterator pointing to the beginning of this
    *          vector_base's reversed sequence.
    */
-  _CCCL_HOST_DEVICE reverse_iterator rbegin(void);
+  _CCCL_HOST_DEVICE reverse_iterator rbegin();
 
   /*! This method returns a const_reverse_iterator pointing to the beginning of
    *  this vector_base's reversed sequence.
    *  \return A const_reverse_iterator pointing to the beginning of this
    *          vector_base's reversed sequence.
    */
-  _CCCL_HOST_DEVICE const_reverse_iterator rbegin(void) const;
+  _CCCL_HOST_DEVICE const_reverse_iterator rbegin() const;
 
   /*! This method returns a const_reverse_iterator pointing to the beginning of
    *  this vector_base's reversed sequence.
    *  \return A const_reverse_iterator pointing to the beginning of this
    *          vector_base's reversed sequence.
    */
-  _CCCL_HOST_DEVICE const_reverse_iterator crbegin(void) const;
+  _CCCL_HOST_DEVICE const_reverse_iterator crbegin() const;
 
   /*! This method returns an iterator pointing to one element past the
    *  last of this vector_base.
    *  \return begin() + size().
    */
-  _CCCL_HOST_DEVICE iterator end(void);
+  _CCCL_HOST_DEVICE iterator end();
 
   /*! This method returns a const_iterator pointing to one element past the
    *  last of this vector_base.
    *  \return begin() + size().
    */
-  _CCCL_HOST_DEVICE const_iterator end(void) const;
+  _CCCL_HOST_DEVICE const_iterator end() const;
 
   /*! This method returns a const_iterator pointing to one element past the
    *  last of this vector_base.
    *  \return begin() + size().
    */
-  _CCCL_HOST_DEVICE const_iterator cend(void) const;
+  _CCCL_HOST_DEVICE const_iterator cend() const;
 
   /*! This method returns a reverse_iterator pointing to one element past the
    *  last of this vector_base's reversed sequence.
    *  \return rbegin() + size().
    */
-  _CCCL_HOST_DEVICE reverse_iterator rend(void);
+  _CCCL_HOST_DEVICE reverse_iterator rend();
 
   /*! This method returns a const_reverse_iterator pointing to one element past the
    *  last of this vector_base's reversed sequence.
    *  \return rbegin() + size().
    */
-  _CCCL_HOST_DEVICE const_reverse_iterator rend(void) const;
+  _CCCL_HOST_DEVICE const_reverse_iterator rend() const;
 
   /*! This method returns a const_reverse_iterator pointing to one element past the
    *  last of this vector_base's reversed sequence.
    *  \return rbegin() + size().
    */
-  _CCCL_HOST_DEVICE const_reverse_iterator crend(void) const;
+  _CCCL_HOST_DEVICE const_reverse_iterator crend() const;
 
   /*! This method returns a const_reference referring to the first element of this
    *  vector_base.
    *  \return The first element of this vector_base.
    */
-  _CCCL_HOST_DEVICE const_reference front(void) const;
+  _CCCL_HOST_DEVICE const_reference front() const;
 
   /*! This method returns a reference pointing to the first element of this
    *  vector_base.
    *  \return The first element of this vector_base.
    */
-  _CCCL_HOST_DEVICE reference front(void);
+  _CCCL_HOST_DEVICE reference front();
 
   /*! This method returns a const reference pointing to the last element of
    *  this vector_base.
    *  \return The last element of this vector_base.
    */
-  _CCCL_HOST_DEVICE const_reference back(void) const;
+  _CCCL_HOST_DEVICE const_reference back() const;
 
   /*! This method returns a reference referring to the last element of
    *  this vector_dev.
    *  \return The last element of this vector_base.
    */
-  _CCCL_HOST_DEVICE reference back(void);
+  _CCCL_HOST_DEVICE reference back();
 
   /*! This method returns a pointer to this vector_base's first element.
    *  \return A pointer to the first element of this vector_base.
    */
-  _CCCL_HOST_DEVICE pointer data(void);
+  _CCCL_HOST_DEVICE pointer data();
 
   /*! This method returns a const_pointer to this vector_base's first element.
    *  \return a const_pointer to the first element of this vector_base.
    */
-  _CCCL_HOST_DEVICE const_pointer data(void) const;
+  _CCCL_HOST_DEVICE const_pointer data() const;
 
   /*! This method resizes this vector_base to 0.
    */
-  void clear(void);
+  void clear();
 
   /*! This method returns true iff size() == 0.
    *  \return true if size() == 0; false, otherwise.
    */
-  _CCCL_HOST_DEVICE bool empty(void) const;
+  _CCCL_HOST_DEVICE bool empty() const;
 
   /*! This method appends the given element to the end of this vector_base.
    *  \param x The element to append.
@@ -399,7 +399,7 @@ public:
   /*! This method erases the last element of this vector_base, invalidating
    *  all iterators and references to it.
    */
-  void pop_back(void);
+  void pop_back();
 
   /*! This method swaps the contents of this vector_base with another vector_base.
    *  \param v The vector_base with which to swap.
@@ -470,7 +470,7 @@ public:
   /*! This method returns a copy of this vector's allocator.
    *  \return A copy of the alloctor used by this vector.
    */
-  allocator_type get_allocator(void) const;
+  allocator_type get_allocator() const;
 
 protected:
   // Our storage

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -44,7 +44,7 @@ namespace detail
 {
 
 template <typename T, typename Alloc>
-vector_base<T, Alloc>::vector_base(void)
+vector_base<T, Alloc>::vector_base()
     : m_storage()
     , m_size(0)
 {
@@ -326,13 +326,13 @@ void vector_base<T, Alloc>::resize(size_type new_size, const value_type& x)
 } // end vector_base::resize()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::size_type vector_base<T, Alloc>::size(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::size_type vector_base<T, Alloc>::size() const
 {
   return m_size;
 } // end vector_base::size()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::size_type vector_base<T, Alloc>::max_size(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::size_type vector_base<T, Alloc>::max_size() const
 {
   return m_storage.max_size();
 } // end vector_base::max_size()
@@ -378,13 +378,13 @@ void vector_base<T, Alloc>::reserve(size_type n)
 } // end vector_base::reserve()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::size_type vector_base<T, Alloc>::capacity(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::size_type vector_base<T, Alloc>::capacity() const
 {
   return m_storage.size();
 } // end vector_base::capacity()
 
 template <typename T, typename Alloc>
-void vector_base<T, Alloc>::shrink_to_fit(void)
+void vector_base<T, Alloc>::shrink_to_fit()
 {
   // use the swap trick
   vector_base(*this).swap(*this);
@@ -404,43 +404,43 @@ vector_base<T, Alloc>::operator[](const size_type n) const
 } // end vector_base::operator[]
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::iterator vector_base<T, Alloc>::begin(void)
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::iterator vector_base<T, Alloc>::begin()
 {
   return m_storage.begin();
 } // end vector_base::begin()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_iterator vector_base<T, Alloc>::begin(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_iterator vector_base<T, Alloc>::begin() const
 {
   return m_storage.begin();
 } // end vector_base::begin()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_iterator vector_base<T, Alloc>::cbegin(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_iterator vector_base<T, Alloc>::cbegin() const
 {
   return begin();
 } // end vector_base::cbegin()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::reverse_iterator vector_base<T, Alloc>::rbegin(void)
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::reverse_iterator vector_base<T, Alloc>::rbegin()
 {
   return reverse_iterator(end());
 } // end vector_base::rbegin()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reverse_iterator vector_base<T, Alloc>::rbegin(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reverse_iterator vector_base<T, Alloc>::rbegin() const
 {
   return const_reverse_iterator(end());
 } // end vector_base::rbegin()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reverse_iterator vector_base<T, Alloc>::crbegin(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reverse_iterator vector_base<T, Alloc>::crbegin() const
 {
   return rbegin();
 } // end vector_base::crbegin()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::iterator vector_base<T, Alloc>::end(void)
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::iterator vector_base<T, Alloc>::end()
 {
   iterator result = begin();
   thrust::advance(result, size());
@@ -448,7 +448,7 @@ _CCCL_HOST_DEVICE typename vector_base<T, Alloc>::iterator vector_base<T, Alloc>
 } // end vector_base::end()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_iterator vector_base<T, Alloc>::end(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_iterator vector_base<T, Alloc>::end() const
 {
   const_iterator result = begin();
   thrust::advance(result, size());
@@ -456,43 +456,43 @@ _CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_iterator vector_base<T, 
 } // end vector_base::end()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_iterator vector_base<T, Alloc>::cend(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_iterator vector_base<T, Alloc>::cend() const
 {
   return end();
 } // end vector_base::cend()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::reverse_iterator vector_base<T, Alloc>::rend(void)
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::reverse_iterator vector_base<T, Alloc>::rend()
 {
   return reverse_iterator(begin());
 } // end vector_base::rend()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reverse_iterator vector_base<T, Alloc>::rend(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reverse_iterator vector_base<T, Alloc>::rend() const
 {
   return const_reverse_iterator(begin());
 } // end vector_base::rend()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reverse_iterator vector_base<T, Alloc>::crend(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reverse_iterator vector_base<T, Alloc>::crend() const
 {
   return rend();
 } // end vector_base::crend()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reference vector_base<T, Alloc>::front(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reference vector_base<T, Alloc>::front() const
 {
   return *begin();
 } // end vector_base::front()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::reference vector_base<T, Alloc>::front(void)
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::reference vector_base<T, Alloc>::front()
 {
   return *begin();
 } // end vector_base::front()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reference vector_base<T, Alloc>::back(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reference vector_base<T, Alloc>::back() const
 {
   const_iterator ptr_to_back = end();
   --ptr_to_back;
@@ -500,7 +500,7 @@ _CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_reference vector_base<T,
 } // end vector_base::vector_base
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::reference vector_base<T, Alloc>::back(void)
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::reference vector_base<T, Alloc>::back()
 {
   iterator ptr_to_back = end();
   --ptr_to_back;
@@ -508,19 +508,19 @@ _CCCL_HOST_DEVICE typename vector_base<T, Alloc>::reference vector_base<T, Alloc
 } // end vector_base::vector_base
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::pointer vector_base<T, Alloc>::data(void)
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::pointer vector_base<T, Alloc>::data()
 {
   return pointer(&front());
 } // end vector_base::data()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_pointer vector_base<T, Alloc>::data(void) const
+_CCCL_HOST_DEVICE typename vector_base<T, Alloc>::const_pointer vector_base<T, Alloc>::data() const
 {
   return const_pointer(&front());
 } // end vector_base::data()
 
 template <typename T, typename Alloc>
-vector_base<T, Alloc>::~vector_base(void)
+vector_base<T, Alloc>::~vector_base()
 {
   // destroy every living thing
   if (!empty())
@@ -530,13 +530,13 @@ vector_base<T, Alloc>::~vector_base(void)
 } // end vector_base::~vector_base()
 
 template <typename T, typename Alloc>
-void vector_base<T, Alloc>::clear(void)
+void vector_base<T, Alloc>::clear()
 {
   erase(begin(), end());
 } // end vector_base::~vector_dev()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE bool vector_base<T, Alloc>::empty(void) const
+_CCCL_HOST_DEVICE bool vector_base<T, Alloc>::empty() const
 {
   return size() == 0;
 } // end vector_base::empty();
@@ -548,7 +548,7 @@ void vector_base<T, Alloc>::push_back(const value_type& x)
 } // end vector_base::push_back()
 
 template <typename T, typename Alloc>
-void vector_base<T, Alloc>::pop_back(void)
+void vector_base<T, Alloc>::pop_back()
 {
   iterator e           = end();
   iterator ptr_to_back = e;
@@ -608,7 +608,7 @@ void vector_base<T, Alloc>::assign(InputIterator first, InputIterator last)
 } // end vector_base::assign()
 
 template <typename T, typename Alloc>
-typename vector_base<T, Alloc>::allocator_type vector_base<T, Alloc>::get_allocator(void) const
+typename vector_base<T, Alloc>::allocator_type vector_base<T, Alloc>::get_allocator() const
 {
   return m_storage.get_allocator();
 } // end vector_base::get_allocator()

--- a/thrust/thrust/device_reference.h
+++ b/thrust/thrust/device_reference.h
@@ -52,7 +52,7 @@ THRUST_NAMESPACE_BEGIN
  *  \code
  *  #include <thrust/device_vector.h>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    thrust::device_vector<int> vec(1, 13);
  *
@@ -73,7 +73,7 @@ THRUST_NAMESPACE_BEGIN
  *  #include <thrust/device_vector.h>
  *  #include <iostream>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    thrust::device_vector<int> vec(1, 13);
  *
@@ -95,7 +95,7 @@ THRUST_NAMESPACE_BEGIN
  *  #include <thrust/device_vector.h>
  *  #include <iostream>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    thrust::device_vector<int> vec(1, 13);
  *
@@ -125,7 +125,7 @@ THRUST_NAMESPACE_BEGIN
  *    int x;
  *  };
  *
- *  int main(void)
+ *  int main()
  *  {
  *    thrust::device_vector<foo> foo_vec(1);
  *
@@ -147,7 +147,7 @@ THRUST_NAMESPACE_BEGIN
  *    int x;
  *  };
  *
- *  int main(void)
+ *  int main()
  *  {
  *    thrust::device_vector<foo> foo_vec(1);
  *
@@ -174,7 +174,7 @@ THRUST_NAMESPACE_BEGIN
  *  #include <stdio.h>
  *  #include <thrust/device_vector.h>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    thrust::device_vector<int> vec(1,13);
  *

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -71,7 +71,7 @@ public:
 
   /*! This constructor creates an empty \p device_vector.
    */
-  device_vector(void)
+  device_vector()
       : Parent()
   {}
 
@@ -86,7 +86,7 @@ public:
    */
   //  Define an empty destructor to explicitly specify
   //  its execution space qualifier, as a workaround for nvcc warning
-  ~device_vector(void) {}
+  ~device_vector() {}
 
   /*! This constructor creates a \p device_vector with the given
    *  size.
@@ -288,12 +288,12 @@ public:
 
     /*! Returns the number of elements in this vector.
      */
-    size_type size(void) const;
+    size_type size() const;
 
     /*! Returns the size() of the largest possible vector.
      *  \return The largest possible return value of size().
      */
-    size_type max_size(void) const;
+    size_type max_size() const;
 
     /*! \brief If n is less than or equal to capacity(), this call has no effect.
      *         Otherwise, this method is a request for allocation of additional memory. If
@@ -306,12 +306,12 @@ public:
     /*! Returns the number of elements which have been reserved in this
      *  vector.
      */
-    size_type capacity(void) const;
+    size_type capacity() const;
 
     /*! This method shrinks the capacity of this vector to exactly
      *  fit its elements.
      */
-    void shrink_to_fit(void);
+    void shrink_to_fit();
 
     /*! \brief Subscript access to the data contained in this vector_dev.
      *  \param n The index of the element for which data should be accessed.
@@ -337,119 +337,119 @@ public:
      *  this vector.
      *  \return mStart
      */
-    iterator begin(void);
+    iterator begin();
 
     /*! This method returns a const_iterator pointing to the beginning
      *  of this vector.
      *  \return mStart
      */
-    const_iterator begin(void) const;
+    const_iterator begin() const;
 
     /*! This method returns a const_iterator pointing to the beginning
      *  of this vector.
      *  \return mStart
      */
-    const_iterator cbegin(void) const;
+    const_iterator cbegin() const;
 
     /*! This method returns a reverse_iterator pointing to the beginning of
      *  this vector's reversed sequence.
      *  \return A reverse_iterator pointing to the beginning of this
      *          vector's reversed sequence.
      */
-    reverse_iterator rbegin(void);
+    reverse_iterator rbegin();
 
     /*! This method returns a const_reverse_iterator pointing to the beginning of
      *  this vector's reversed sequence.
      *  \return A const_reverse_iterator pointing to the beginning of this
      *          vector's reversed sequence.
      */
-    const_reverse_iterator rbegin(void) const;
+    const_reverse_iterator rbegin() const;
 
     /*! This method returns a const_reverse_iterator pointing to the beginning of
      *  this vector's reversed sequence.
      *  \return A const_reverse_iterator pointing to the beginning of this
      *          vector's reversed sequence.
      */
-    const_reverse_iterator crbegin(void) const;
+    const_reverse_iterator crbegin() const;
 
     /*! This method returns an iterator pointing to one element past the
      *  last of this vector.
      *  \return begin() + size().
      */
-    iterator end(void);
+    iterator end();
 
     /*! This method returns a const_iterator pointing to one element past the
      *  last of this vector.
      *  \return begin() + size().
      */
-    const_iterator end(void) const;
+    const_iterator end() const;
 
     /*! This method returns a const_iterator pointing to one element past the
      *  last of this vector.
      *  \return begin() + size().
      */
-    const_iterator cend(void) const;
+    const_iterator cend() const;
 
     /*! This method returns a reverse_iterator pointing to one element past the
      *  last of this vector's reversed sequence.
      *  \return rbegin() + size().
      */
-    reverse_iterator rend(void);
+    reverse_iterator rend();
 
     /*! This method returns a const_reverse_iterator pointing to one element past the
      *  last of this vector's reversed sequence.
      *  \return rbegin() + size().
      */
-    const_reverse_iterator rend(void) const;
+    const_reverse_iterator rend() const;
 
     /*! This method returns a const_reverse_iterator pointing to one element past the
      *  last of this vector's reversed sequence.
      *  \return rbegin() + size().
      */
-    const_reverse_iterator crend(void) const;
+    const_reverse_iterator crend() const;
 
     /*! This method returns a const_reference referring to the first element of this
      *  vector.
      *  \return The first element of this vector.
      */
-    const_reference front(void) const;
+    const_reference front() const;
 
     /*! This method returns a reference pointing to the first element of this
      *  vector.
      *  \return The first element of this vector.
      */
-    reference front(void);
+    reference front();
 
     /*! This method returns a const reference pointing to the last element of
      *  this vector.
      *  \return The last element of this vector.
      */
-    const_reference back(void) const;
+    const_reference back() const;
 
     /*! This method returns a reference referring to the last element of
      *  this vector_dev.
      *  \return The last element of this vector.
      */
-    reference back(void);
+    reference back();
 
     /*! This method returns a pointer to this vector's first element.
      *  \return A pointer to the first element of this vector.
      */
-    pointer data(void);
+    pointer data();
 
     /*! This method returns a const_pointer to this vector's first element.
      *  \return a const_pointer to the first element of this vector.
      */
-    const_pointer data(void) const;
+    const_pointer data() const;
 
     /*! This method resizes this vector to 0.
      */
-    void clear(void);
+    void clear();
 
     /*! This method returns true iff size() == 0.
      *  \return true if size() == 0; false, otherwise.
      */
-    bool empty(void) const;
+    bool empty() const;
 
     /*! This method appends the given element to the end of this vector.
      *  \param x The element to append.
@@ -459,7 +459,7 @@ public:
     /*! This method erases the last element of this vector, invalidating
      *  all iterators and references to it.
      */
-    void pop_back(void);
+    void pop_back();
 
     /*! This method swaps the contents of this device_vector with another vector.
      *  \param v The vector with which to swap.
@@ -528,7 +528,7 @@ public:
     /*! This method returns a copy of this vector's allocator.
      *  \return A copy of the alloctor used by this vector.
      */
-    allocator_type get_allocator(void) const;
+    allocator_type get_allocator() const;
 #endif // end doxygen-only members
 };
 

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -72,7 +72,7 @@ public:
 
   /*! This constructor creates an empty \p host_vector.
    */
-  _CCCL_HOST host_vector(void)
+  _CCCL_HOST host_vector()
       : Parent()
   {}
 
@@ -87,7 +87,7 @@ public:
    */
   //  Define an empty destructor to explicitly specify
   //  its execution space qualifier, as a workaround for nvcc warning
-  _CCCL_HOST ~host_vector(void) {}
+  _CCCL_HOST ~host_vector() {}
 
   /*! This constructor creates a \p host_vector with the given
    *  size.
@@ -290,12 +290,12 @@ public:
 
     /*! Returns the number of elements in this vector.
      */
-    size_type size(void) const;
+    size_type size() const;
 
     /*! Returns the size() of the largest possible vector.
      *  \return The largest possible return value of size().
      */
-    size_type max_size(void) const;
+    size_type max_size() const;
 
     /*! \brief If n is less than or equal to capacity(), this call has no effect.
      *         Otherwise, this method is a request for allocation of additional memory. If
@@ -308,12 +308,12 @@ public:
     /*! Returns the number of elements which have been reserved in this
      *  vector.
      */
-    size_type capacity(void) const;
+    size_type capacity() const;
 
     /*! This method shrinks the capacity of this vector to exactly
      *  fit its elements.
      */
-    void shrink_to_fit(void);
+    void shrink_to_fit();
 
     /*! \brief Subscript access to the data contained in this vector_dev.
      *  \param n The index of the element for which data should be accessed.
@@ -339,119 +339,119 @@ public:
      *  this vector.
      *  \return mStart
      */
-    iterator begin(void);
+    iterator begin();
 
     /*! This method returns a const_iterator pointing to the beginning
      *  of this vector.
      *  \return mStart
      */
-    const_iterator begin(void) const;
+    const_iterator begin() const;
 
     /*! This method returns a const_iterator pointing to the beginning
      *  of this vector.
      *  \return mStart
      */
-    const_iterator cbegin(void) const;
+    const_iterator cbegin() const;
 
     /*! This method returns a reverse_iterator pointing to the beginning of
      *  this vector's reversed sequence.
      *  \return A reverse_iterator pointing to the beginning of this
      *          vector's reversed sequence.
      */
-    reverse_iterator rbegin(void);
+    reverse_iterator rbegin();
 
     /*! This method returns a const_reverse_iterator pointing to the beginning of
      *  this vector's reversed sequence.
      *  \return A const_reverse_iterator pointing to the beginning of this
      *          vector's reversed sequence.
      */
-    const_reverse_iterator rbegin(void) const;
+    const_reverse_iterator rbegin() const;
 
     /*! This method returns a const_reverse_iterator pointing to the beginning of
      *  this vector's reversed sequence.
      *  \return A const_reverse_iterator pointing to the beginning of this
      *          vector's reversed sequence.
      */
-    const_reverse_iterator crbegin(void) const;
+    const_reverse_iterator crbegin() const;
 
     /*! This method returns an iterator pointing to one element past the
      *  last of this vector.
      *  \return begin() + size().
      */
-    iterator end(void);
+    iterator end();
 
     /*! This method returns a const_iterator pointing to one element past the
      *  last of this vector.
      *  \return begin() + size().
      */
-    const_iterator end(void) const;
+    const_iterator end() const;
 
     /*! This method returns a const_iterator pointing to one element past the
      *  last of this vector.
      *  \return begin() + size().
      */
-    const_iterator cend(void) const;
+    const_iterator cend() const;
 
     /*! This method returns a reverse_iterator pointing to one element past the
      *  last of this vector's reversed sequence.
      *  \return rbegin() + size().
      */
-    reverse_iterator rend(void);
+    reverse_iterator rend();
 
     /*! This method returns a const_reverse_iterator pointing to one element past the
      *  last of this vector's reversed sequence.
      *  \return rbegin() + size().
      */
-    const_reverse_iterator rend(void) const;
+    const_reverse_iterator rend() const;
 
     /*! This method returns a const_reverse_iterator pointing to one element past the
      *  last of this vector's reversed sequence.
      *  \return rbegin() + size().
      */
-    const_reverse_iterator crend(void) const;
+    const_reverse_iterator crend() const;
 
     /*! This method returns a const_reference referring to the first element of this
      *  vector.
      *  \return The first element of this vector.
      */
-    const_reference front(void) const;
+    const_reference front() const;
 
     /*! This method returns a reference pointing to the first element of this
      *  vector.
      *  \return The first element of this vector.
      */
-    reference front(void);
+    reference front();
 
     /*! This method returns a const reference pointing to the last element of
      *  this vector.
      *  \return The last element of this vector.
      */
-    const_reference back(void) const;
+    const_reference back() const;
 
     /*! This method returns a reference referring to the last element of
      *  this vector_dev.
      *  \return The last element of this vector.
      */
-    reference back(void);
+    reference back();
 
     /*! This method returns a pointer to this vector's first element.
      *  \return A pointer to the first element of this vector.
      */
-    pointer data(void);
+    pointer data();
 
     /*! This method returns a const_pointer to this vector's first element.
      *  \return a const_pointer to the first element of this vector.
      */
-    const_pointer data(void) const;
+    const_pointer data() const;
 
     /*! This method resizes this vector to 0.
      */
-    void clear(void);
+    void clear();
 
     /*! This method returns true iff size() == 0.
      *  \return true if size() == 0; false, otherwise.
      */
-    bool empty(void) const;
+    bool empty() const;
 
     /*! This method appends the given element to the end of this vector.
      *  \param x The element to append.
@@ -461,7 +461,7 @@ public:
     /*! This method erases the last element of this vector, invalidating
      *  all iterators and references to it.
      */
-    void pop_back(void);
+    void pop_back();
 
     /*! This method swaps the contents of this host_vector with another vector.
      *  \param v The vector with which to swap.
@@ -530,7 +530,7 @@ public:
     /*! This method returns a copy of this vector's allocator.
      *  \return A copy of the alloctor used by this vector.
      */
-    allocator_type get_allocator(void) const;
+    allocator_type get_allocator() const;
 #endif // end doxygen-only members
 };
 

--- a/thrust/thrust/random/detail/discard_block_engine.inl
+++ b/thrust/thrust/random/detail/discard_block_engine.inl
@@ -52,7 +52,7 @@ _CCCL_HOST_DEVICE discard_block_engine<Engine, p, r>::discard_block_engine(const
 {}
 
 template <typename Engine, size_t p, size_t r>
-_CCCL_HOST_DEVICE void discard_block_engine<Engine, p, r>::seed(void)
+_CCCL_HOST_DEVICE void discard_block_engine<Engine, p, r>::seed()
 {
   m_e.seed();
   m_n = 0;
@@ -94,7 +94,7 @@ _CCCL_HOST_DEVICE void discard_block_engine<Engine, p, r>::discard(unsigned long
 
 template <typename Engine, size_t p, size_t r>
 _CCCL_HOST_DEVICE const typename discard_block_engine<Engine, p, r>::base_type&
-discard_block_engine<Engine, p, r>::base(void) const
+discard_block_engine<Engine, p, r>::base() const
 {
   return m_e;
 }

--- a/thrust/thrust/random/detail/normal_distribution.inl
+++ b/thrust/thrust/random/detail/normal_distribution.inl
@@ -56,7 +56,7 @@ _CCCL_HOST_DEVICE normal_distribution<RealType>::normal_distribution(const param
 {} // end normal_distribution::normal_distribution()
 
 template <typename RealType>
-_CCCL_HOST_DEVICE void normal_distribution<RealType>::reset(void)
+_CCCL_HOST_DEVICE void normal_distribution<RealType>::reset()
 {
   super_t::reset();
 } // end normal_distribution::reset()
@@ -78,7 +78,7 @@ normal_distribution<RealType>::operator()(UniformRandomNumberGenerator& urng, co
 } // end normal_distribution::operator()()
 
 template <typename RealType>
-_CCCL_HOST_DEVICE typename normal_distribution<RealType>::param_type normal_distribution<RealType>::param(void) const
+_CCCL_HOST_DEVICE typename normal_distribution<RealType>::param_type normal_distribution<RealType>::param() const
 {
   return m_param;
 } // end normal_distribution::param()
@@ -91,14 +91,14 @@ _CCCL_HOST_DEVICE void normal_distribution<RealType>::param(const param_type& pa
 
 template <typename RealType>
 _CCCL_HOST_DEVICE typename normal_distribution<RealType>::result_type normal_distribution<RealType>::min
-THRUST_PREVENT_MACRO_SUBSTITUTION(void) const
+THRUST_PREVENT_MACRO_SUBSTITUTION() const
 {
   return -this->max THRUST_PREVENT_MACRO_SUBSTITUTION();
 } // end normal_distribution::min()
 
 template <typename RealType>
 _CCCL_HOST_DEVICE typename normal_distribution<RealType>::result_type normal_distribution<RealType>::max
-THRUST_PREVENT_MACRO_SUBSTITUTION(void) const
+THRUST_PREVENT_MACRO_SUBSTITUTION() const
 {
   // XXX this solution is pretty terrible
   // we can't use numeric_traits<RealType>::max because nvcc will
@@ -115,13 +115,13 @@ THRUST_PREVENT_MACRO_SUBSTITUTION(void) const
 } // end normal_distribution::max()
 
 template <typename RealType>
-_CCCL_HOST_DEVICE typename normal_distribution<RealType>::result_type normal_distribution<RealType>::mean(void) const
+_CCCL_HOST_DEVICE typename normal_distribution<RealType>::result_type normal_distribution<RealType>::mean() const
 {
   return m_param.first;
 } // end normal_distribution::mean()
 
 template <typename RealType>
-_CCCL_HOST_DEVICE typename normal_distribution<RealType>::result_type normal_distribution<RealType>::stddev(void) const
+_CCCL_HOST_DEVICE typename normal_distribution<RealType>::result_type normal_distribution<RealType>::stddev() const
 {
   return m_param.second;
 } // end normal_distribution::stddev()

--- a/thrust/thrust/random/detail/uniform_int_distribution.inl
+++ b/thrust/thrust/random/detail/uniform_int_distribution.inl
@@ -46,7 +46,7 @@ _CCCL_HOST_DEVICE uniform_int_distribution<IntType>::uniform_int_distribution(co
 {} // end uniform_int_distribution::uniform_int_distribution()
 
 template <typename IntType>
-_CCCL_HOST_DEVICE void uniform_int_distribution<IntType>::reset(void)
+_CCCL_HOST_DEVICE void uniform_int_distribution<IntType>::reset()
 {} // end uniform_int_distribution::reset()
 
 template <typename IntType>
@@ -79,22 +79,19 @@ uniform_int_distribution<IntType>::operator()(UniformRandomNumberGenerator& urng
 } // end uniform_int_distribution::operator()()
 
 template <typename IntType>
-_CCCL_HOST_DEVICE typename uniform_int_distribution<IntType>::result_type
-uniform_int_distribution<IntType>::a(void) const
+_CCCL_HOST_DEVICE typename uniform_int_distribution<IntType>::result_type uniform_int_distribution<IntType>::a() const
 {
   return m_param.first;
 } // end uniform_int_distribution<IntType>::a()
 
 template <typename IntType>
-_CCCL_HOST_DEVICE typename uniform_int_distribution<IntType>::result_type
-uniform_int_distribution<IntType>::b(void) const
+_CCCL_HOST_DEVICE typename uniform_int_distribution<IntType>::result_type uniform_int_distribution<IntType>::b() const
 {
   return m_param.second;
 } // end uniform_int_distribution::b()
 
 template <typename IntType>
-_CCCL_HOST_DEVICE typename uniform_int_distribution<IntType>::param_type
-uniform_int_distribution<IntType>::param(void) const
+_CCCL_HOST_DEVICE typename uniform_int_distribution<IntType>::param_type uniform_int_distribution<IntType>::param() const
 {
   return m_param;
 } // end uniform_int_distribution::param()
@@ -107,14 +104,14 @@ _CCCL_HOST_DEVICE void uniform_int_distribution<IntType>::param(const param_type
 
 template <typename IntType>
 _CCCL_HOST_DEVICE typename uniform_int_distribution<IntType>::result_type uniform_int_distribution<IntType>::min
-THRUST_PREVENT_MACRO_SUBSTITUTION(void) const
+THRUST_PREVENT_MACRO_SUBSTITUTION() const
 {
   return a();
 } // end uniform_int_distribution::min()
 
 template <typename IntType>
 _CCCL_HOST_DEVICE typename uniform_int_distribution<IntType>::result_type uniform_int_distribution<IntType>::max
-THRUST_PREVENT_MACRO_SUBSTITUTION(void) const
+THRUST_PREVENT_MACRO_SUBSTITUTION() const
 {
   return b();
 } // end uniform_int_distribution::max()

--- a/thrust/thrust/random/detail/uniform_real_distribution.inl
+++ b/thrust/thrust/random/detail/uniform_real_distribution.inl
@@ -44,7 +44,7 @@ _CCCL_HOST_DEVICE uniform_real_distribution<RealType>::uniform_real_distribution
 {} // end uniform_real_distribution::uniform_real_distribution()
 
 template <typename RealType>
-_CCCL_HOST_DEVICE void uniform_real_distribution<RealType>::reset(void)
+_CCCL_HOST_DEVICE void uniform_real_distribution<RealType>::reset()
 {} // end uniform_real_distribution::reset()
 
 template <typename RealType>
@@ -76,21 +76,21 @@ uniform_real_distribution<RealType>::operator()(UniformRandomNumberGenerator& ur
 
 template <typename RealType>
 _CCCL_HOST_DEVICE typename uniform_real_distribution<RealType>::result_type
-uniform_real_distribution<RealType>::a(void) const
+uniform_real_distribution<RealType>::a() const
 {
   return m_param.first;
 } // end uniform_real::a()
 
 template <typename RealType>
 _CCCL_HOST_DEVICE typename uniform_real_distribution<RealType>::result_type
-uniform_real_distribution<RealType>::b(void) const
+uniform_real_distribution<RealType>::b() const
 {
   return m_param.second;
 } // end uniform_real_distribution::b()
 
 template <typename RealType>
 _CCCL_HOST_DEVICE typename uniform_real_distribution<RealType>::param_type
-uniform_real_distribution<RealType>::param(void) const
+uniform_real_distribution<RealType>::param() const
 {
   return m_param;
   ;
@@ -104,14 +104,14 @@ _CCCL_HOST_DEVICE void uniform_real_distribution<RealType>::param(const param_ty
 
 template <typename RealType>
 _CCCL_HOST_DEVICE typename uniform_real_distribution<RealType>::result_type uniform_real_distribution<RealType>::min
-THRUST_PREVENT_MACRO_SUBSTITUTION(void) const
+THRUST_PREVENT_MACRO_SUBSTITUTION() const
 {
   return a();
 } // end uniform_real_distribution::min()
 
 template <typename RealType>
 _CCCL_HOST_DEVICE typename uniform_real_distribution<RealType>::result_type uniform_real_distribution<RealType>::max
-THRUST_PREVENT_MACRO_SUBSTITUTION(void) const
+THRUST_PREVENT_MACRO_SUBSTITUTION() const
 {
   return b();
 } // end uniform_real_distribution::max()

--- a/thrust/thrust/random/detail/xor_combine_engine.inl
+++ b/thrust/thrust/random/detail/xor_combine_engine.inl
@@ -35,7 +35,7 @@ namespace random
 {
 
 template <typename Engine1, size_t s1, typename Engine2, size_t s2>
-_CCCL_HOST_DEVICE xor_combine_engine<Engine1, s1, Engine2, s2>::xor_combine_engine(void)
+_CCCL_HOST_DEVICE xor_combine_engine<Engine1, s1, Engine2, s2>::xor_combine_engine()
     : m_b1()
     , m_b2()
 {} // end xor_combine_engine::xor_combine_engine()
@@ -54,7 +54,7 @@ _CCCL_HOST_DEVICE xor_combine_engine<Engine1, s1, Engine2, s2>::xor_combine_engi
 {} // end xor_combine_engine::xor_combine_engine()
 
 template <typename Engine1, size_t s1, typename Engine2, size_t s2>
-_CCCL_HOST_DEVICE void xor_combine_engine<Engine1, s1, Engine2, s2>::seed(void)
+_CCCL_HOST_DEVICE void xor_combine_engine<Engine1, s1, Engine2, s2>::seed()
 {
   m_b1.seed();
   m_b2.seed();
@@ -69,14 +69,14 @@ _CCCL_HOST_DEVICE void xor_combine_engine<Engine1, s1, Engine2, s2>::seed(result
 
 template <typename Engine1, size_t s1, typename Engine2, size_t s2>
 _CCCL_HOST_DEVICE const typename xor_combine_engine<Engine1, s1, Engine2, s2>::base1_type&
-xor_combine_engine<Engine1, s1, Engine2, s2>::base1(void) const
+xor_combine_engine<Engine1, s1, Engine2, s2>::base1() const
 {
   return m_b1;
 } // end xor_combine_engine::base1()
 
 template <typename Engine1, size_t s1, typename Engine2, size_t s2>
 _CCCL_HOST_DEVICE const typename xor_combine_engine<Engine1, s1, Engine2, s2>::base2_type&
-xor_combine_engine<Engine1, s1, Engine2, s2>::base2(void) const
+xor_combine_engine<Engine1, s1, Engine2, s2>::base2() const
 {
   return m_b2;
 } // end xor_combine_engine::base2()

--- a/thrust/thrust/random/discard_block_engine.h
+++ b/thrust/thrust/random/discard_block_engine.h
@@ -66,7 +66,7 @@ namespace random
  *  #include <thrust/random/discard_block_engine.h>
  *  #include <iostream>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    // create a discard_block_engine from minstd_rand, with a cycle length of 13
  *    // keep every first 10 values, and discard the next 3
@@ -137,7 +137,7 @@ public:
   /*! This method initializes the state of this \p discard_block_engine's adapted base engine
    *  by using its \p default_seed value.
    */
-  _CCCL_HOST_DEVICE void seed(void);
+  _CCCL_HOST_DEVICE void seed();
 
   /*! This method initializes the state of this \p discard_block_engine's adapted base engine
    *  by using the given seed.
@@ -168,7 +168,7 @@ public:
    *
    *  \return A const reference to the base engine this \p discard_block_engine adapts.
    */
-  _CCCL_HOST_DEVICE const base_type& base(void) const;
+  _CCCL_HOST_DEVICE const base_type& base() const;
 
   /*! \cond
    */

--- a/thrust/thrust/random/linear_congruential_engine.h
+++ b/thrust/thrust/random/linear_congruential_engine.h
@@ -65,7 +65,7 @@ namespace random
  *  #include <thrust/random/linear_congruential_engine.h>
  *  #include <iostream>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    // create a minstd_rand object, which is an instance of linear_congruential_engine
  *    thrust::minstd_rand rng1;

--- a/thrust/thrust/random/normal_distribution.h
+++ b/thrust/thrust/random/normal_distribution.h
@@ -58,7 +58,7 @@ namespace random
  *  #include <thrust/random/linear_congruential_engine.h>
  *  #include <thrust/random/normal_distribution.h>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    // create a minstd_rand object to act as our source of randomness
  *    thrust::minstd_rand rng;
@@ -125,7 +125,7 @@ public:
    *  \p normal_distribution do not depend on values produced by any random
    *  number generator prior to invoking this function.
    */
-  _CCCL_HOST_DEVICE void reset(void);
+  _CCCL_HOST_DEVICE void reset();
 
   // generating functions
 
@@ -155,14 +155,14 @@ public:
    *
    *  \return The mean (expected value) of this \p normal_distribution's output.
    */
-  _CCCL_HOST_DEVICE result_type mean(void) const;
+  _CCCL_HOST_DEVICE result_type mean() const;
 
   /*! This method returns the value of the parameter with which this \p normal_distribution
    *  was constructed.
    *
    *  \return The standard deviation of this \p uniform_real_distribution's output.
    */
-  _CCCL_HOST_DEVICE result_type stddev(void) const;
+  _CCCL_HOST_DEVICE result_type stddev() const;
 
   /*! This method returns a \p param_type object encapsulating the parameters with which this
    *  \p normal_distribution was constructed.
@@ -170,7 +170,7 @@ public:
    *  \return A \p param_type object encapsulating the parameters (i.e., the mean and standard deviation) of this \p
    * normal_distribution.
    */
-  _CCCL_HOST_DEVICE param_type param(void) const;
+  _CCCL_HOST_DEVICE param_type param() const;
 
   /*! This method changes the parameters of this \p normal_distribution using the values encapsulated
    *  in a given \p param_type object.
@@ -184,14 +184,14 @@ public:
    *
    *  \return The lower bound of this \p normal_distribution's half-open interval.
    */
-  _CCCL_HOST_DEVICE result_type min THRUST_PREVENT_MACRO_SUBSTITUTION(void) const;
+  _CCCL_HOST_DEVICE result_type min THRUST_PREVENT_MACRO_SUBSTITUTION() const;
 
   /*! This method returns the smallest number larger than largest floating point number this \p
    * uniform_real_distribution can potentially produce.
    *
    *  \return The upper bound of this \p normal_distribution's half-open interval.
    */
-  _CCCL_HOST_DEVICE result_type max THRUST_PREVENT_MACRO_SUBSTITUTION(void) const;
+  _CCCL_HOST_DEVICE result_type max THRUST_PREVENT_MACRO_SUBSTITUTION() const;
 
   /*! \cond
    */

--- a/thrust/thrust/random/uniform_int_distribution.h
+++ b/thrust/thrust/random/uniform_int_distribution.h
@@ -58,7 +58,7 @@ namespace random
  *  #include <thrust/random/linear_congruential_engine.h>
  *  #include <thrust/random/uniform_int_distribution.h>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    // create a minstd_rand object to act as our source of randomness
  *    thrust::minstd_rand rng;
@@ -128,7 +128,7 @@ public:
 
   /*! This does nothing.  It is included to conform to the requirements of the RandomDistribution concept.
    */
-  _CCCL_HOST_DEVICE void reset(void);
+  _CCCL_HOST_DEVICE void reset();
 
   // generating functions
 
@@ -158,21 +158,21 @@ public:
    *
    *  \return The lower bound of this \p uniform_int_distribution's range.
    */
-  _CCCL_HOST_DEVICE result_type a(void) const;
+  _CCCL_HOST_DEVICE result_type a() const;
 
   /*! This method returns the value of the parameter with which this \p uniform_int_distribution
    *  was constructed.
    *
    *  \return The upper bound of this \p uniform_int_distribution's range.
    */
-  _CCCL_HOST_DEVICE result_type b(void) const;
+  _CCCL_HOST_DEVICE result_type b() const;
 
   /*! This method returns a \p param_type object encapsulating the parameters with which this
    *  \p uniform_int_distribution was constructed.
    *
    *  \return A \p param_type object enapsulating the range of this \p uniform_int_distribution.
    */
-  _CCCL_HOST_DEVICE param_type param(void) const;
+  _CCCL_HOST_DEVICE param_type param() const;
 
   /*! This method changes the parameters of this \p uniform_int_distribution using the values encapsulated
    *  in a given \p param_type object.
@@ -185,13 +185,13 @@ public:
    *
    *  \return The lower bound of this \p uniform_int_distribution's range.
    */
-  _CCCL_HOST_DEVICE result_type min THRUST_PREVENT_MACRO_SUBSTITUTION(void) const;
+  _CCCL_HOST_DEVICE result_type min THRUST_PREVENT_MACRO_SUBSTITUTION() const;
 
   /*! This method returns the largest integer this \p uniform_int_distribution can potentially produce.
    *
    *  \return The upper bound of this \p uniform_int_distribution's range.
    */
-  _CCCL_HOST_DEVICE result_type max THRUST_PREVENT_MACRO_SUBSTITUTION(void) const;
+  _CCCL_HOST_DEVICE result_type max THRUST_PREVENT_MACRO_SUBSTITUTION() const;
 
   /*! \cond
    */

--- a/thrust/thrust/random/uniform_real_distribution.h
+++ b/thrust/thrust/random/uniform_real_distribution.h
@@ -56,7 +56,7 @@ namespace random
  *  #include <thrust/random/linear_congruential_engine.h>
  *  #include <thrust/random/uniform_real_distribution.h>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    // create a minstd_rand object to act as our source of randomness
  *    thrust::minstd_rand rng;
@@ -125,7 +125,7 @@ public:
 
   /*! This does nothing.  It is included to conform to the requirements of the RandomDistribution concept.
    */
-  _CCCL_HOST_DEVICE void reset(void);
+  _CCCL_HOST_DEVICE void reset();
 
   // generating functions
 
@@ -155,21 +155,21 @@ public:
    *
    *  \return The lower bound of this \p uniform_real_distribution's half-open interval.
    */
-  _CCCL_HOST_DEVICE result_type a(void) const;
+  _CCCL_HOST_DEVICE result_type a() const;
 
   /*! This method returns the value of the parameter with which this \p uniform_real_distribution
    *  was constructed.
    *
    *  \return The upper bound of this \p uniform_real_distribution's half-open interval.
    */
-  _CCCL_HOST_DEVICE result_type b(void) const;
+  _CCCL_HOST_DEVICE result_type b() const;
 
   /*! This method returns a \p param_type object encapsulating the parameters with which this
    *  \p uniform_real_distribution was constructed.
    *
    *  \return A \p param_type object enapsulating the half-open interval of this \p uniform_real_distribution.
    */
-  _CCCL_HOST_DEVICE param_type param(void) const;
+  _CCCL_HOST_DEVICE param_type param() const;
 
   /*! This method changes the parameters of this \p uniform_real_distribution using the values encapsulated
    *  in a given \p param_type object.
@@ -182,14 +182,14 @@ public:
    *
    *  \return The lower bound of this \p uniform_real_distribution's half-open interval.
    */
-  _CCCL_HOST_DEVICE result_type min THRUST_PREVENT_MACRO_SUBSTITUTION(void) const;
+  _CCCL_HOST_DEVICE result_type min THRUST_PREVENT_MACRO_SUBSTITUTION() const;
 
   /*! This method returns the smallest number larger than largest floating point number this \p
    * uniform_real_distribution can potentially produce.
    *
    *  \return The upper bound of this \p uniform_real_distribution's half-open interval.
    */
-  _CCCL_HOST_DEVICE result_type max THRUST_PREVENT_MACRO_SUBSTITUTION(void) const;
+  _CCCL_HOST_DEVICE result_type max THRUST_PREVENT_MACRO_SUBSTITUTION() const;
 
   /*! \cond
    */

--- a/thrust/thrust/random/xor_combine_engine.h
+++ b/thrust/thrust/random/xor_combine_engine.h
@@ -64,7 +64,7 @@ namespace random
  *  #include <thrust/random/xor_combine_engine.h>
  *  #include <iostream>
  *
- *  int main(void)
+ *  int main()
  *  {
  *    // create an xor_combine_engine from minstd_rand and minstd_rand0
  *    // use a shift of 0 for each
@@ -122,7 +122,7 @@ public:
   /*! This constructor constructs a new \p xor_combine_engine and constructs
    *  its adapted engines using their null constructors.
    */
-  _CCCL_HOST_DEVICE xor_combine_engine(void);
+  _CCCL_HOST_DEVICE xor_combine_engine();
 
   /*! This constructor constructs a new \p xor_combine_engine using
    *  given \p base1_type and \p base2_type engines to initialize its adapted base engines.
@@ -143,7 +143,7 @@ public:
   /*! This method initializes the state of this \p xor_combine_engine's adapted base engines
    *  by using their \p default_seed values.
    */
-  _CCCL_HOST_DEVICE void seed(void);
+  _CCCL_HOST_DEVICE void seed();
 
   /*! This method initializes the state of this \p xor_combine_engine's adapted base engines
    *  by using the given seed.
@@ -174,14 +174,14 @@ public:
    *
    *  \return A const reference to the first base engine this \p xor_combine_engine adapts.
    */
-  _CCCL_HOST_DEVICE const base1_type& base1(void) const;
+  _CCCL_HOST_DEVICE const base1_type& base1() const;
 
   /*! This member function returns a const reference to this \p xor_combine_engine's
    *  second adapted base engine.
    *
    *  \return A const reference to the second base engine this \p xor_combine_engine adapts.
    */
-  _CCCL_HOST_DEVICE const base2_type& base2(void) const;
+  _CCCL_HOST_DEVICE const base2_type& base2() const;
 
   /*! \cond
    */

--- a/thrust/thrust/system/cuda/detail/error.inl
+++ b/thrust/thrust/system/cuda/detail/error.inl
@@ -52,9 +52,9 @@ namespace detail
 class cuda_error_category : public error_category
 {
 public:
-  inline cuda_error_category(void) {}
+  inline cuda_error_category() {}
 
-  inline virtual const char* name(void) const
+  inline virtual const char* name() const
   {
     return "cuda";
   }
@@ -85,7 +85,7 @@ public:
 
 } // end namespace cuda_cub
 
-const error_category& cuda_category(void)
+const error_category& cuda_category()
 {
   static const thrust::system::cuda_cub::detail::cuda_error_category result;
   return result;

--- a/thrust/thrust/system/cuda/error.h
+++ b/thrust/thrust/system/cuda/error.h
@@ -135,7 +135,7 @@ enum errc_t
  *        shall return <tt>error_condition(ev,cuda_category())</tt>.
  *        Otherwise, the function shall return <tt>system_category.default_error_condition(ev)</tt>.
  */
-inline const error_category& cuda_category(void);
+inline const error_category& cuda_category();
 
 // XXX N3000 prefers is_error_code_enum<cuda::errc>
 

--- a/thrust/thrust/system/detail/bad_alloc.h
+++ b/thrust/thrust/system/detail/bad_alloc.h
@@ -48,9 +48,9 @@ public:
     m_what += w;
   } // end bad_alloc()
 
-  inline virtual ~bad_alloc(void) noexcept {};
+  inline virtual ~bad_alloc() noexcept {};
 
-  inline virtual const char* what(void) const noexcept
+  inline virtual const char* what() const noexcept
   {
     return m_what.c_str();
   } // end what()

--- a/thrust/thrust/system/detail/error_category.inl
+++ b/thrust/thrust/system/detail/error_category.inl
@@ -37,7 +37,7 @@ THRUST_NAMESPACE_BEGIN
 namespace system
 {
 
-error_category ::~error_category(void)
+error_category ::~error_category()
 {
   ;
 } // end error_category::~error_category()
@@ -79,9 +79,9 @@ namespace detail
 class generic_error_category : public error_category
 {
 public:
-  inline generic_error_category(void) {}
+  inline generic_error_category() {}
 
-  inline virtual const char* name(void) const
+  inline virtual const char* name() const
   {
     return "generic";
   }
@@ -102,9 +102,9 @@ public:
 class system_error_category : public error_category
 {
 public:
-  inline system_error_category(void) {}
+  inline system_error_category() {}
 
-  inline virtual const char* name(void) const
+  inline virtual const char* name() const
   {
     return "system";
   }
@@ -284,13 +284,13 @@ public:
 
 } // namespace detail
 
-const error_category& generic_category(void)
+const error_category& generic_category()
 {
   static const detail::generic_error_category result;
   return result;
 }
 
-const error_category& system_category(void)
+const error_category& system_category()
 {
   static const detail::system_error_category result;
   return result;

--- a/thrust/thrust/system/detail/error_code.inl
+++ b/thrust/thrust/system/detail/error_code.inl
@@ -33,7 +33,7 @@ THRUST_NAMESPACE_BEGIN
 namespace system
 {
 
-error_code ::error_code(void)
+error_code ::error_code()
     : m_val(0)
     , m_cat(&system_category())
 {
@@ -78,33 +78,33 @@ error_code ::operator=(ErrorCodeEnum e)
   return *this;
 } // end error_code::operator=()
 
-void error_code ::clear(void)
+void error_code ::clear()
 {
   m_val = 0;
   m_cat = &system_category();
 } // end error_code::clear()
 
-int error_code ::value(void) const
+int error_code ::value() const
 {
   return m_val;
 } // end error_code::value()
 
-const error_category& error_code ::category(void) const
+const error_category& error_code ::category() const
 {
   return *m_cat;
 } // end error_code::category()
 
-error_condition error_code ::default_error_condition(void) const
+error_condition error_code ::default_error_condition() const
 {
   return category().default_error_condition(value());
 } // end error_code::default_error_condition()
 
-std::string error_code ::message(void) const
+std::string error_code ::message() const
 {
   return category().message(value());
 } // end error_code::message()
 
-error_code ::operator bool(void) const
+error_code ::operator bool() const
 {
   return value() != 0;
 } // end error_code::operator bool ()

--- a/thrust/thrust/system/detail/error_condition.inl
+++ b/thrust/thrust/system/detail/error_condition.inl
@@ -34,7 +34,7 @@ THRUST_NAMESPACE_BEGIN
 namespace system
 {
 
-error_condition ::error_condition(void)
+error_condition ::error_condition()
     : m_val(0)
     , m_cat(&generic_category())
 {
@@ -80,28 +80,28 @@ error_condition ::operator=(ErrorConditionEnum e)
   return *this;
 } // end error_condition::operator=()
 
-void error_condition ::clear(void)
+void error_condition ::clear()
 {
   m_val = 0;
   m_cat = &generic_category();
 } // end error_condition::clear()
 
-int error_condition ::value(void) const
+int error_condition ::value() const
 {
   return m_val;
 } // end error_condition::value()
 
-const error_category& error_condition ::category(void) const
+const error_category& error_condition ::category() const
 {
   return *m_cat;
 } // end error_condition::category()
 
-std::string error_condition ::message(void) const
+std::string error_condition ::message() const
 {
   return category().message(value());
 } // end error_condition::message()
 
-error_condition ::operator bool(void) const
+error_condition ::operator bool() const
 {
   return value() != 0;
 } // end error_condition::operator bool ()

--- a/thrust/thrust/system/detail/internal/decompose.h
+++ b/thrust/thrust/system/detail/internal/decompose.h
@@ -45,17 +45,17 @@ public:
       , m_end(end)
   {}
 
-  _CCCL_HOST_DEVICE index_type begin(void) const
+  _CCCL_HOST_DEVICE index_type begin() const
   {
     return m_begin;
   }
 
-  _CCCL_HOST_DEVICE index_type end(void) const
+  _CCCL_HOST_DEVICE index_type end() const
   {
     return m_end;
   }
 
-  _CCCL_HOST_DEVICE index_type size(void) const
+  _CCCL_HOST_DEVICE index_type size() const
   {
     return m_end - m_begin;
   }
@@ -104,7 +104,7 @@ public:
     }
   }
 
-  _CCCL_HOST_DEVICE index_type size(void) const
+  _CCCL_HOST_DEVICE index_type size() const
   {
     return m_intervals;
   }

--- a/thrust/thrust/system/detail/system_error.inl
+++ b/thrust/thrust/system/detail/system_error.inl
@@ -73,12 +73,12 @@ system_error ::system_error(int ev, const error_category& ecat)
   ;
 } // end system_error::system_error()
 
-const error_code& system_error ::code(void) const noexcept
+const error_code& system_error ::code() const noexcept
 {
   return m_error_code;
 } // end system_error::code()
 
-const char* system_error ::what(void) const noexcept
+const char* system_error ::what() const noexcept
 {
   if (m_what.empty())
   {

--- a/thrust/thrust/system/error_code.h
+++ b/thrust/thrust/system/error_code.h
@@ -167,7 +167,7 @@ class error_category
 public:
   /*! Destructor does nothing.
    */
-  inline virtual ~error_category(void);
+  inline virtual ~error_category();
 
   // XXX enable upon c++0x
   // error_category(const error_category &) = delete;
@@ -175,7 +175,7 @@ public:
 
   /*! \return A string naming the error category.
    */
-  inline virtual const char* name(void) const = 0;
+  inline virtual const char* name() const = 0;
 
   /*! \return \p error_condition(ev, *this).
    */
@@ -214,7 +214,7 @@ public:
  *        shall behave as specified for the class \p error_category. The object's
  *        \p name virtual function shall return a pointer to the string <tt>"generic"</tt>.
  */
-inline const error_category& generic_category(void);
+inline const error_category& generic_category();
 
 /*! \return A reference to an object of a type derived from class \p error_category.
  *  \note The object's \p equivalent virtual functions shall behave as specified for
@@ -227,7 +227,7 @@ inline const error_category& generic_category(void);
  *        Otherwise, the function shall return <tt>error_condition(ev,system_category())</tt>.
  *        What constitutes correspondence for any given operating system is unspecified.
  */
-inline const error_category& system_category(void);
+inline const error_category& system_category();
 
 // [19.5.2] Class error_code
 
@@ -243,7 +243,7 @@ public:
   /*! Effects: Constructs an object of type \p error_code.
    *  \post <tt>value() == 0</tt> and <tt>category() == &system_category()</tt>.
    */
-  inline error_code(void);
+  inline error_code();
 
   /*! Effects: Constructs an object of type \p error_code.
    *  \post <tt>value() == val</tt> and <tt>category() == &cat</tt>.
@@ -281,32 +281,32 @@ public:
 
   /*! \post <tt>value() == 0</tt> and <tt>category() == system_category()</tt>.
    */
-  inline void clear(void);
+  inline void clear();
 
   // [19.5.2.4] observers:
 
   /*! \return An integral value of this \p error_code object.
    */
-  inline int value(void) const;
+  inline int value() const;
 
   /*! \return An \p error_category describing the category of this \p error_code object.
    */
-  inline const error_category& category(void) const;
+  inline const error_category& category() const;
 
   /*! \return <tt>category().default_error_condition()</tt>.
    */
-  inline error_condition default_error_condition(void) const;
+  inline error_condition default_error_condition() const;
 
   /*! \return <tt>category().message(value())</tt>.
    */
-  inline std::string message(void) const;
+  inline std::string message() const;
 
   // XXX replace the below upon c++0x
   // inline explicit operator bool (void) const;
 
   /*! \return <tt>value() != 0</tt>.
    */
-  inline operator bool(void) const;
+  inline operator bool() const;
 
   /*! \cond
    */
@@ -351,7 +351,7 @@ public:
    *  \post <tt>value() == 0</tt>.
    *  \post <tt>category() == generic_category()</tt>.
    */
-  inline error_condition(void);
+  inline error_condition();
 
   /*! Constructs an object of type \p error_condition.
    *  \post <tt>value() == val</tt>.
@@ -402,28 +402,28 @@ public:
    *  \post <tt>value == 0</tt>
    *  \post <tt>category() == generic_category()</tt>.
    */
-  inline void clear(void);
+  inline void clear();
 
   // [19.5.3.4] observers
 
   /*! \return The value encoded by this \p error_condition.
    */
-  inline int value(void) const;
+  inline int value() const;
 
   /*! \return A <tt>const</tt> reference to the \p error_category encoded by this \p error_condition.
    */
-  inline const error_category& category(void) const;
+  inline const error_category& category() const;
 
   /*! \return <tt>category().message(value())</tt>.
    */
-  inline std::string message(void) const;
+  inline std::string message() const;
 
   // XXX replace below with this upon c++0x
   // explicit operator bool (void) const;
 
   /*! \return <tt>value() != 0</tt>.
    */
-  inline operator bool(void) const;
+  inline operator bool() const;
 
   /*! \cond
    */

--- a/thrust/thrust/system/system_error.h
+++ b/thrust/thrust/system/system_error.h
@@ -65,13 +65,13 @@ namespace system
  *  #include <thrust/system.h>
  *  #include <thrust/sort.h>
  *
- *  void terminate_gracefully(void)
+ *  void terminate_gracefully()
  *  {
  *    // application-specific termination code here
  *    ...
  *  }
  *
- *  int main(void)
+ *  int main()
  *  {
  *    try
  *    {
@@ -146,19 +146,19 @@ public:
 
   /*! Destructor does not throw.
    */
-  inline virtual ~system_error(void) noexcept {};
+  inline virtual ~system_error() noexcept {};
 
   /*! Returns an object encoding the error.
    *  \return <tt>ec</tt> or <tt>error_code(ev, ecat)</tt>, from the
    *          constructor, as appropriate.
    */
-  inline const error_code& code(void) const noexcept;
+  inline const error_code& code() const noexcept;
 
   /*! Returns a human-readable string indicating the nature of the error.
    *  \return a string incorporating <tt>code().message()</tt> and the
    *          arguments supplied in the constructor.
    */
-  inline const char* what(void) const noexcept;
+  inline const char* what() const noexcept;
 
   /*! \cond
    */

--- a/thrust/thrust/system/tbb/detail/merge.inl
+++ b/thrust/thrust/system/tbb/detail/merge.inl
@@ -107,12 +107,12 @@ struct range
     result += thrust::distance(r.first1, mid1) + thrust::distance(r.first2, mid2);
   }
 
-  bool empty(void) const
+  bool empty() const
   {
     return (first1 == last1) && (first2 == last2);
   }
 
-  bool is_divisible(void) const
+  bool is_divisible() const
   {
     return static_cast<size_t>(thrust::distance(first1, last1) + thrust::distance(first2, last2)) > grain_size;
   }
@@ -216,12 +216,12 @@ struct range
     values_result += thrust::distance(r.keys_first1, mid1) + thrust::distance(r.keys_first2, mid2);
   }
 
-  bool empty(void) const
+  bool empty() const
   {
     return (keys_first1 == keys_last1) && (keys_first2 == keys_last2);
   }
 
-  bool is_divisible(void) const
+  bool is_divisible() const
   {
     return static_cast<size_t>(thrust::distance(keys_first1, keys_last1) + thrust::distance(keys_first2, keys_last2))
          > grain_size;


### PR DESCRIPTION
Function signatures of the form f(void) were necessary in C to express "no parameters", but this is the default for f() in C++ and thus no longer necessary.

Fixes: #1703