### PR TITLE
Expose thrust's contiguous iterator unwrap helpers

### DIFF
--- a/thrust/testing/is_contiguous_iterator.cu
+++ b/thrust/testing/is_contiguous_iterator.cu
@@ -89,8 +89,8 @@ struct expect_passthrough
 template <typename IteratorT, typename PointerT, typename expected_unwrapped_type /* = expect_[pointer|passthrough] */>
 struct check_unwrapped_iterator
 {
-  using unwrapped_t = typename std::remove_reference<decltype(thrust::detail::try_unwrap_contiguous_iterator(
-    std::declval<IteratorT>()))>::type;
+  using unwrapped_t = ::cuda::std::__libcpp_remove_reference_t<decltype(thrust::try_unwrap_contiguous_iterator(
+    cuda::std::declval<IteratorT>()))>;
 
   static constexpr bool value =
     std::is_same<expected_unwrapped_type, expect_pointer>::value

--- a/thrust/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/thrust/system/cuda/detail/adjacent_difference.h
@@ -151,8 +151,8 @@ adjacent_difference(execution_policy<Derived>& policy, InputIt first, InputIt la
   std::size_t storage_size = 0;
   cudaStream_t stream      = cuda_cub::stream(policy);
 
-  using UnwrapInputIt  = thrust::detail::try_unwrap_contiguous_iterator_return_t<InputIt>;
-  using UnwrapOutputIt = thrust::detail::try_unwrap_contiguous_iterator_return_t<OutputIt>;
+  using UnwrapInputIt  = thrust::try_unwrap_contiguous_iterator_t<InputIt>;
+  using UnwrapOutputIt = thrust::try_unwrap_contiguous_iterator_t<OutputIt>;
 
   using InputValueT  = thrust::iterator_value_t<UnwrapInputIt>;
   using OutputValueT = thrust::iterator_value_t<UnwrapOutputIt>;
@@ -160,8 +160,8 @@ adjacent_difference(execution_policy<Derived>& policy, InputIt first, InputIt la
   constexpr bool can_compare_iterators = std::is_pointer<UnwrapInputIt>::value && std::is_pointer<UnwrapOutputIt>::value
                                       && std::is_same<InputValueT, OutputValueT>::value;
 
-  auto first_unwrap  = thrust::detail::try_unwrap_contiguous_iterator(first);
-  auto result_unwrap = thrust::detail::try_unwrap_contiguous_iterator(result);
+  auto first_unwrap  = thrust::try_unwrap_contiguous_iterator(first);
+  auto result_unwrap = thrust::try_unwrap_contiguous_iterator(result);
 
   thrust::detail::integral_constant<bool, can_compare_iterators> comparable;
 

--- a/thrust/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/thrust/system/cuda/detail/scan_by_key.h
@@ -85,14 +85,14 @@ _CCCL_HOST_DEVICE ValuesOutIt inclusive_scan_by_key_n(
   }
 
   // Convert to raw pointers if possible:
-  using KeysInUnwrapIt    = thrust::detail::try_unwrap_contiguous_iterator_return_t<KeysInIt>;
-  using ValuesInUnwrapIt  = thrust::detail::try_unwrap_contiguous_iterator_return_t<ValuesInIt>;
-  using ValuesOutUnwrapIt = thrust::detail::try_unwrap_contiguous_iterator_return_t<ValuesOutIt>;
+  using KeysInUnwrapIt    = thrust::try_unwrap_contiguous_iterator_t<KeysInIt>;
+  using ValuesInUnwrapIt  = thrust::try_unwrap_contiguous_iterator_t<ValuesInIt>;
+  using ValuesOutUnwrapIt = thrust::try_unwrap_contiguous_iterator_t<ValuesOutIt>;
   using AccumT            = typename thrust::iterator_traits<ValuesInUnwrapIt>::value_type;
 
-  auto keys_unwrap   = thrust::detail::try_unwrap_contiguous_iterator(keys);
-  auto values_unwrap = thrust::detail::try_unwrap_contiguous_iterator(values);
-  auto result_unwrap = thrust::detail::try_unwrap_contiguous_iterator(result);
+  auto keys_unwrap   = thrust::try_unwrap_contiguous_iterator(keys);
+  auto values_unwrap = thrust::try_unwrap_contiguous_iterator(values);
+  auto result_unwrap = thrust::try_unwrap_contiguous_iterator(result);
 
   using Dispatch32 = cub::DispatchScanByKey<
     KeysInUnwrapIt,
@@ -195,13 +195,13 @@ _CCCL_HOST_DEVICE ValuesOutIt exclusive_scan_by_key_n(
   }
 
   // Convert to raw pointers if possible:
-  using KeysInUnwrapIt    = thrust::detail::try_unwrap_contiguous_iterator_return_t<KeysInIt>;
-  using ValuesInUnwrapIt  = thrust::detail::try_unwrap_contiguous_iterator_return_t<ValuesInIt>;
-  using ValuesOutUnwrapIt = thrust::detail::try_unwrap_contiguous_iterator_return_t<ValuesOutIt>;
+  using KeysInUnwrapIt    = thrust::try_unwrap_contiguous_iterator_t<KeysInIt>;
+  using ValuesInUnwrapIt  = thrust::try_unwrap_contiguous_iterator_t<ValuesInIt>;
+  using ValuesOutUnwrapIt = thrust::try_unwrap_contiguous_iterator_t<ValuesOutIt>;
 
-  auto keys_unwrap   = thrust::detail::try_unwrap_contiguous_iterator(keys);
-  auto values_unwrap = thrust::detail::try_unwrap_contiguous_iterator(values);
-  auto result_unwrap = thrust::detail::try_unwrap_contiguous_iterator(result);
+  auto keys_unwrap   = thrust::try_unwrap_contiguous_iterator(keys);
+  auto values_unwrap = thrust::try_unwrap_contiguous_iterator(values);
+  auto result_unwrap = thrust::try_unwrap_contiguous_iterator(result);
 
   using Dispatch32 = cub::DispatchScanByKey<
     KeysInUnwrapIt,


### PR DESCRIPTION
Lifts the following functions into the public API and renames them:

* contiguous_iterator_raw_pointer_t -> unwrap_contiguous_iterator_t
* contiguous_iterator_raw_pointer_cast -> unwrap_contiguous_iterator
* try_unwrap_contiguous_iterator_return_t -> try_unwrap_contiguous_iterator_t
* try_unwrap_contiguous_iterator

Fixes: #1711