### PR TITLE
Massively improve test times in heterogeneous atomics tests

### DIFF
--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_cuda.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+#include <cuda/atomic>
+#include <cuda/std/cassert>
+
+#include "common.h"
+
+__host__ __device__ void validate_not_lock_free()
+{
+  cuda::atomic<big_not_lockfree_type> test;
+  assert(!test.is_lock_free());
+}
+
+void kernel_invoker()
+{
+  validate_pinned<cuda::atomic<signed char, cuda::thread_scope_system>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::atomic<signed short, cuda::thread_scope_system>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::atomic<signed int, cuda::thread_scope_system>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::atomic<signed long, cuda::thread_scope_system>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::atomic<signed long long, cuda::thread_scope_system>, arithmetic_atomic_testers>();
+
+  validate_pinned<cuda::atomic<unsigned char, cuda::thread_scope_system>, bitwise_atomic_testers>();
+  validate_pinned<cuda::atomic<unsigned short, cuda::thread_scope_system>, bitwise_atomic_testers>();
+  validate_pinned<cuda::atomic<unsigned int, cuda::thread_scope_system>, bitwise_atomic_testers>();
+  validate_pinned<cuda::atomic<unsigned long, cuda::thread_scope_system>, bitwise_atomic_testers>();
+  validate_pinned<cuda::atomic<unsigned long long, cuda::thread_scope_system>, bitwise_atomic_testers>();
+
+  validate_pinned<cuda::atomic<float>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::atomic<double>, arithmetic_atomic_testers>();
+
+  validate_pinned<cuda::atomic<big_not_lockfree_type, cuda::thread_scope_system>, basic_testers>();
+}
+
+int main(int arg, char** argv)
+{
+  validate_not_lock_free();
+
+  NV_IF_TARGET(NV_IS_HOST, (kernel_invoker();))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std.pass.cpp
@@ -14,7 +14,6 @@
 
 #include "common.h"
 
-
 __host__ __device__ void validate_not_lock_free()
 {
   cuda::std::atomic<big_not_lockfree_type> test;

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/atomic_std.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+#include <cuda/std/atomic>
+#include <cuda/std/cassert>
+
+#include "common.h"
+
+
+__host__ __device__ void validate_not_lock_free()
+{
+  cuda::std::atomic<big_not_lockfree_type> test;
+  assert(!test.is_lock_free());
+}
+
+void kernel_invoker()
+{
+  validate_pinned<cuda::std::atomic<signed char>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::std::atomic<signed short>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::std::atomic<signed int>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::std::atomic<signed long>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::std::atomic<signed long long>, arithmetic_atomic_testers>();
+
+  validate_pinned<cuda::std::atomic<unsigned char>, bitwise_atomic_testers>();
+  validate_pinned<cuda::std::atomic<unsigned short>, bitwise_atomic_testers>();
+  validate_pinned<cuda::std::atomic<unsigned int>, bitwise_atomic_testers>();
+  validate_pinned<cuda::std::atomic<unsigned long>, bitwise_atomic_testers>();
+  validate_pinned<cuda::std::atomic<unsigned long long>, bitwise_atomic_testers>();
+
+  validate_pinned<cuda::std::atomic<float>, arithmetic_atomic_testers>();
+  validate_pinned<cuda::std::atomic<double>, arithmetic_atomic_testers>();
+
+  validate_pinned<cuda::std::atomic<big_not_lockfree_type>, basic_testers>();
+}
+
+int main(int arg, char** argv)
+{
+  validate_not_lock_free();
+
+  NV_IF_TARGET(NV_IS_HOST, (kernel_invoker();))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/common.h
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/common.h
@@ -6,13 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: nvrtc, pre-sm-60
-// UNSUPPORTED: windows && pre-sm-70
-
 #include <cuda/std/atomic>
 #include <cuda/std/cassert>
 
-#include "helpers.h"
+#include "../helpers.h"
 
 template <int Operand>
 struct store_tester
@@ -186,55 +183,3 @@ public:
 private:
   int array[128];
 };
-
-__host__ __device__ void validate_not_lock_free()
-{
-  cuda::std::atomic<big_not_lockfree_type> test;
-  assert(!test.is_lock_free());
-}
-
-void kernel_invoker()
-{
-  validate_pinned<cuda::std::atomic<signed char>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::std::atomic<signed short>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::std::atomic<signed int>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::std::atomic<signed long>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::std::atomic<signed long long>, arithmetic_atomic_testers>();
-
-  validate_pinned<cuda::std::atomic<unsigned char>, bitwise_atomic_testers>();
-  validate_pinned<cuda::std::atomic<unsigned short>, bitwise_atomic_testers>();
-  validate_pinned<cuda::std::atomic<unsigned int>, bitwise_atomic_testers>();
-  validate_pinned<cuda::std::atomic<unsigned long>, bitwise_atomic_testers>();
-  validate_pinned<cuda::std::atomic<unsigned long long>, bitwise_atomic_testers>();
-
-  validate_pinned<cuda::std::atomic<float>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::std::atomic<double>, arithmetic_atomic_testers>();
-
-  validate_pinned<cuda::std::atomic<big_not_lockfree_type>, basic_testers>();
-
-  validate_pinned<cuda::atomic<signed char, cuda::thread_scope_system>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::atomic<signed short, cuda::thread_scope_system>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::atomic<signed int, cuda::thread_scope_system>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::atomic<signed long, cuda::thread_scope_system>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::atomic<signed long long, cuda::thread_scope_system>, arithmetic_atomic_testers>();
-
-  validate_pinned<cuda::atomic<unsigned char, cuda::thread_scope_system>, bitwise_atomic_testers>();
-  validate_pinned<cuda::atomic<unsigned short, cuda::thread_scope_system>, bitwise_atomic_testers>();
-  validate_pinned<cuda::atomic<unsigned int, cuda::thread_scope_system>, bitwise_atomic_testers>();
-  validate_pinned<cuda::atomic<unsigned long, cuda::thread_scope_system>, bitwise_atomic_testers>();
-  validate_pinned<cuda::atomic<unsigned long long, cuda::thread_scope_system>, bitwise_atomic_testers>();
-
-  validate_pinned<cuda::atomic<float>, arithmetic_atomic_testers>();
-  validate_pinned<cuda::atomic<double>, arithmetic_atomic_testers>();
-
-  validate_pinned<cuda::atomic<big_not_lockfree_type, cuda::thread_scope_system>, basic_testers>();
-}
-
-int main(int arg, char** argv)
-{
-  validate_not_lock_free();
-
-  NV_IF_TARGET(NV_IS_HOST, (kernel_invoker();))
-
-  return 0;
-}

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/flag.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/flag.pass.cpp
@@ -12,7 +12,7 @@
 #include <cuda/std/atomic>
 #include <cuda/std/cassert>
 
-#include "helpers.h"
+#include "../helpers.h"
 
 struct clear
 {

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_cuda.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_cuda.pass.cpp
@@ -191,6 +191,9 @@ void kernel_invoker()
   validate_pinned<unsigned int, bitwise_atomic_testers>();
   validate_pinned<unsigned long, bitwise_atomic_testers>();
   validate_pinned<unsigned long long, bitwise_atomic_testers>();
+
+  validate_pinned<float, arithmetic_atomic_testers>();
+  validate_pinned<double, arithmetic_atomic_testers>();
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_std.pass.cpp
@@ -9,10 +9,10 @@
 // UNSUPPORTED: nvrtc, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
 
-#include <cuda/atomic>
+#include <cuda/std/atomic>
 #include <cuda/std/cassert>
 
-#include "helpers.h"
+#include "../helpers.h"
 
 template <int Operand>
 struct store_tester
@@ -20,7 +20,7 @@ struct store_tester
   template <typename A>
   __host__ __device__ static void initialize(A& v)
   {
-    cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+    cuda::std::atomic_ref<A> a(v);
     using T = decltype(a.load());
     a.store(static_cast<T>(Operand));
   }
@@ -28,7 +28,7 @@ struct store_tester
   template <typename A>
   __host__ __device__ static void validate(A& v)
   {
-    cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+    cuda::std::atomic_ref<A> a(v);
     using T = decltype(a.load());
     assert(a.load() == static_cast<T>(Operand));
   }
@@ -40,7 +40,7 @@ struct exchange_tester
   template <typename A>
   __host__ __device__ static void initialize(A& v)
   {
-    cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+    cuda::std::atomic_ref<A> a(v);
     using T = decltype(a.load());
     assert(a.exchange(static_cast<T>(Operand)) == static_cast<T>(PreviousValue));
   }
@@ -48,7 +48,7 @@ struct exchange_tester
   template <typename A>
   __host__ __device__ static void validate(A& v)
   {
-    cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+    cuda::std::atomic_ref<A> a(v);
     using T = decltype(a.load());
     assert(a.load() == static_cast<T>(Operand));
   }
@@ -64,7 +64,7 @@ struct strong_cas_tester
   template <typename A>
   __host__ __device__ static void initialize(A& v)
   {
-    cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+    cuda::std::atomic_ref<A> a(v);
     using T    = decltype(a.load());
     T expected = static_cast<T>(Expected);
     assert(a.compare_exchange_strong(expected, static_cast<T>(Desired)) == ShouldSucceed);
@@ -74,7 +74,7 @@ struct strong_cas_tester
   template <typename A>
   __host__ __device__ static void validate(A& v)
   {
-    cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+    cuda::std::atomic_ref<A> a(v);
     using T = decltype(a.load());
     assert(a.load() == static_cast<T>(Result));
   }
@@ -90,7 +90,7 @@ struct weak_cas_tester
   template <typename A>
   __host__ __device__ static void initialize(A& v)
   {
-    cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+    cuda::std::atomic_ref<A> a(v);
     using T    = decltype(a.load());
     T expected = static_cast<T>(Expected);
     if (!ShouldSucceed)
@@ -108,7 +108,7 @@ struct weak_cas_tester
   template <typename A>
   __host__ __device__ static void validate(A& v)
   {
-    cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+    cuda::std::atomic_ref<A> a(v);
     using T = decltype(a.load());
     assert(a.load() == static_cast<T>(Result));
   }
@@ -121,7 +121,7 @@ struct weak_cas_tester
     template <typename A>                                            \
     __host__ __device__ static void initialize(A& v)                 \
     {                                                                \
-      cuda::atomic_ref<A, cuda::thread_scope_system> a(v);           \
+      cuda::std::atomic_ref<A> a(v);                                 \
       using T = decltype(a.load());                                  \
       assert(a.operation(Operand) == static_cast<T>(PreviousValue)); \
     }                                                                \
@@ -129,7 +129,7 @@ struct weak_cas_tester
     template <typename A>                                            \
     __host__ __device__ static void validate(A& v)                   \
     {                                                                \
-      cuda::atomic_ref<A, cuda::thread_scope_system> a(v);           \
+      cuda::std::atomic_ref<A> a(v);                                 \
       using T = decltype(a.load());                                  \
       assert(a.load() == static_cast<T>(ExpectedValue));             \
     }                                                                \
@@ -141,9 +141,6 @@ ATOMIC_TESTER(fetch_sub);
 ATOMIC_TESTER(fetch_and);
 ATOMIC_TESTER(fetch_or);
 ATOMIC_TESTER(fetch_xor);
-
-ATOMIC_TESTER(fetch_min);
-ATOMIC_TESTER(fetch_max);
 
 using basic_testers =
   tester_list<store_tester<0>,
@@ -158,12 +155,7 @@ using basic_testers =
               exchange_tester<-12, 17>>;
 
 using arithmetic_atomic_testers =
-  append<basic_testers,
-         fetch_add_tester<17, 13, 30>,
-         fetch_sub_tester<30, 21, 9>,
-         fetch_min_tester<9, 5, 5>,
-         fetch_max_tester<5, 9, 9>,
-         fetch_sub_tester<9, 17, -8>>;
+  append<basic_testers, fetch_add_tester<17, 13, 30>, fetch_sub_tester<30, 21, 9>, fetch_sub_tester<9, 17, -8>>;
 
 using bitwise_atomic_testers =
   append<arithmetic_atomic_testers,

--- a/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_std.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/atomic/reference_std.pass.cpp
@@ -184,21 +184,8 @@ void kernel_invoker()
   validate_pinned<unsigned long, bitwise_atomic_testers>();
   validate_pinned<unsigned long long, bitwise_atomic_testers>();
 
-#ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
-  validate_pinned<signed char, arithmetic_atomic_testers>();
-  validate_pinned<signed short, arithmetic_atomic_testers>();
-#endif
-  validate_pinned<signed int, arithmetic_atomic_testers>();
-  validate_pinned<signed long, arithmetic_atomic_testers>();
-  validate_pinned<signed long long, arithmetic_atomic_testers>();
-
-#ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
-  validate_pinned<unsigned char, bitwise_atomic_testers>();
-  validate_pinned<unsigned short, bitwise_atomic_testers>();
-#endif
-  validate_pinned<unsigned int, bitwise_atomic_testers>();
-  validate_pinned<unsigned long, bitwise_atomic_testers>();
-  validate_pinned<unsigned long long, bitwise_atomic_testers>();
+  validate_pinned<float, arithmetic_atomic_testers>();
+  validate_pinned<double, arithmetic_atomic_testers>();
 }
 
 int main(int arg, char** argv)

--- a/libcudacxx/test/libcudacxx/heterogeneous/helpers.h
+++ b/libcudacxx/test/libcudacxx/heterogeneous/helpers.h
@@ -399,10 +399,7 @@ using enable_if_permutations_remain = typename std::enable_if<Idx != 0, int>::ty
 template <size_t Idx>
 using enable_if_no_permutations_remain = typename std::enable_if<Idx == 0, int>::type;
 
-template <size_t Idx,
-          typename Fn,
-          typename Launchers,
-          enable_if_permutations_remain<Idx> = 0>
+template <size_t Idx, typename Fn, typename Launchers, enable_if_permutations_remain<Idx> = 0>
 void permute_tests(const Fn& fn, Launchers launchers)
 {
 #ifdef DEBUG_TESTERS
@@ -413,10 +410,7 @@ void permute_tests(const Fn& fn, Launchers launchers)
   permute_tests<Idx - 1>(fn, rotl<Launchers>{});
 }
 
-template <size_t Idx,
-          typename Fn,
-          typename Launchers,
-          enable_if_no_permutations_remain<Idx> = 0>
+template <size_t Idx, typename Fn, typename Launchers, enable_if_no_permutations_remain<Idx> = 0>
 void permute_tests(const Fn&, Launchers)
 {}
 


### PR DESCRIPTION
## Description

Speeds up testing atomics by splitting test units and simplifying some logic in the permutation tester.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
