### PR TITLE
Increase timeout for the libcu++ test runs

### DIFF
--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -134,6 +134,6 @@ add_test(NAME libcudacxx.test.lit COMMAND
 )
 
 set_tests_properties(libcudacxx.test.lit PROPERTIES
-  TIMEOUT 3600
+  TIMEOUT 4800
   RUN_SERIAL TRUE
 )


### PR DESCRIPTION
We are getting dangerously close to the timeout, with some CI [runs failing already with the last few tests remaining](https://github.com/NVIDIA/cccl/actions/runs/8983919400/job/24684480984?pr=1685)

Given that we have massively increased the number of tests longer test run time is to be expected.
