### PR TITLE
Enable testing for the other half of the heterogeneous managed memory tests on MSVC.

### DIFF
--- a/libcudacxx/test/libcudacxx/heterogeneous/helpers.h
+++ b/libcudacxx/test/libcudacxx/heterogeneous/helpers.h
@@ -447,7 +447,7 @@ void validate_device_dynamic(tester_list<Testers...> testers, Args... args)
   permute_tests(test_harness, initial_launcher_list{});
 }
 
-#if __cplusplus >= 201402L
+#if _CCCL_STD_VER >= 2014
 template <typename T>
 struct manual_object
 {
@@ -549,7 +549,7 @@ void validate_managed(tester_list<Testers...>, Args... args)
   validate_in_managed_memory_helper(device_constructor, device_destructor, host_init_device_check);
   validate_in_managed_memory_helper(device_constructor, device_destructor, device_init_host_check);
 
-#if __cplusplus >= 201402L && !defined(__clang__)
+#if _CCCL_STD_VER >= 2014 && !defined(__clang__)
   // The managed variable template part of this test is disabled under clang, pending nvbug 2790305 being fixed.
 
   auto host_variable_constructor = [args...]() -> T* {

--- a/libcudacxx/test/libcudacxx/heterogeneous/helpers.h
+++ b/libcudacxx/test/libcudacxx/heterogeneous/helpers.h
@@ -492,8 +492,7 @@ __managed__ manual_object<T> managed_variable{};
 #endif
 
 template <typename Creator, typename Destroyer, typename Validator, std::size_t N>
-void validate_in_managed_memory_helper(
-  const Creator& creator, const Destroyer& destroyer, Validator (&performers)[N])
+void validate_in_managed_memory_helper(const Creator& creator, const Destroyer& destroyer, Validator (&performers)[N])
 {
   auto object = creator();
 
@@ -570,22 +569,14 @@ void validate_managed(tester_list<Testers...>, Args... args)
     managed_variable<T>.device_destroy();
   };
 
-  validate_in_managed_memory_helper(
-    host_variable_constructor, host_variable_destructor, host_init_device_check);
-  validate_in_managed_memory_helper(
-    host_variable_constructor, host_variable_destructor, device_init_host_check);
-  validate_in_managed_memory_helper(
-    host_variable_constructor, device_variable_destructor, host_init_device_check);
-  validate_in_managed_memory_helper(
-    host_variable_constructor, device_variable_destructor, device_init_host_check);
-  validate_in_managed_memory_helper(
-    device_variable_constructor, host_variable_destructor, host_init_device_check);
-  validate_in_managed_memory_helper(
-    device_variable_constructor, host_variable_destructor, device_init_host_check);
-  validate_in_managed_memory_helper(
-    device_variable_constructor, device_variable_destructor, host_init_device_check);
-  validate_in_managed_memory_helper(
-    device_variable_constructor, device_variable_destructor, device_init_host_check);
+  validate_in_managed_memory_helper(host_variable_constructor, host_variable_destructor, host_init_device_check);
+  validate_in_managed_memory_helper(host_variable_constructor, host_variable_destructor, device_init_host_check);
+  validate_in_managed_memory_helper(host_variable_constructor, device_variable_destructor, host_init_device_check);
+  validate_in_managed_memory_helper(host_variable_constructor, device_variable_destructor, device_init_host_check);
+  validate_in_managed_memory_helper(device_variable_constructor, host_variable_destructor, host_init_device_check);
+  validate_in_managed_memory_helper(device_variable_constructor, host_variable_destructor, device_init_host_check);
+  validate_in_managed_memory_helper(device_variable_constructor, device_variable_destructor, host_init_device_check);
+  validate_in_managed_memory_helper(device_variable_constructor, device_variable_destructor, device_init_host_check);
 #endif
 }
 

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -74,6 +74,10 @@ class LibcxxTestFormat(object):
                     yield lit.Test.Test(testSuite, path_in_suite + (filename,),
                                         localConfig)
 
+    def getTestsForPath(self, testSuite, path_in_suite,
+                            litConfig, localConfig):
+        yield lit.Test.Test(testSuite, path_in_suite, localConfig)
+
     def execute(self, test, lit_config):
         while True:
             try:


### PR DESCRIPTION
## Description

Makes the whole gamut of managed memory tests work on MSVC. Also simplifies the construction and launch stuff a bit.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
