### PR TITLE
Add guard against half support

### DIFF
--- a/cub/cmake/CubHeaderTesting.cmake
+++ b/cub/cmake/CubHeaderTesting.cmake
@@ -46,5 +46,14 @@ set(header_definitions
   "CUB_WRAPPED_NAMESPACE=wrapped_cub")
 cub_add_header_test(base "${header_definitions}")
 
-list(APPEND header_definitions "CUB_DISABLE_BF16_SUPPORT")
+set(header_definitions
+  "THRUST_WRAPPED_NAMESPACE=wrapped_thrust"
+  "CUB_WRAPPED_NAMESPACE=wrapped_cub"
+  "CCCL_DISABLE_BF16_SUPPORT")
 cub_add_header_test(bf16 "${header_definitions}")
+
+set(header_definitions
+  "THRUST_WRAPPED_NAMESPACE=wrapped_thrust"
+  "CUB_WRAPPED_NAMESPACE=wrapped_cub"
+  "CCCL_DISABLE_FP16_SUPPORT")
+cub_add_header_test(half "${header_definitions}")

--- a/cub/cmake/header_test.in
+++ b/cub/cmake/header_test.in
@@ -56,8 +56,17 @@
 
 #include <cub/${header}>
 
-#if defined(CUB_DISABLE_BF16_SUPPORT)
+#if defined(CCCL_DISABLE_BF16_SUPPORT)
 #if defined(__CUDA_BF16_TYPES_EXIST__)
 #error CUB should not include cuda_bf16.h when BF16 support is disabled
-#endif
-#endif
+#endif // __CUDA_BF16_TYPES_EXIST__
+#endif // CCCL_DISABLE_BF16_SUPPORT
+
+#if defined(CCCL_DISABLE_FP16_SUPPORT)
+#if defined(__CUDA_FP16_TYPES_EXIST__)
+#error CUB should not include cuda_fp16.h when half support is disabled
+#endif // __CUDA_FP16_TYPES_EXIST__
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+#error CUB should not include cuda_bf16.h when half support is disabled
+#endif // __CUDA_BF16_TYPES_EXIST__
+#endif // CCCL_DISABLE_FP16_SUPPORT

--- a/cub/cub/thread/thread_search.cuh
+++ b/cub/cub/thread/thread_search.cuh
@@ -173,7 +173,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE OffsetT UpperBound(InputIteratorT input, OffsetT 
 
     bool lt;
     NV_IF_TARGET(NV_PROVIDES_SM_53,
-                 (lt = val < input[retval + half];),
+                 (lt = __hlt(val, input[retval + half]);),
                  (lt = __half2float(val) < __half2float(input[retval + half]);));
 
     if (lt)
@@ -189,6 +189,6 @@ _CCCL_DEVICE _CCCL_FORCEINLINE OffsetT UpperBound(InputIteratorT input, OffsetT 
 
   return retval;
 }
-#endif
+#endif // __CUDA_FP16_TYPES_EXIST__
 
 CUB_NAMESPACE_END

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -1419,7 +1419,7 @@ template <> struct NumericTraits<double> :              BaseTraits<FLOATING_POIN
 #if defined(__CUDA_FP8_TYPES_EXIST__)
     template <> struct NumericTraits<__nv_fp8_e4m3> :   BaseTraits<FLOATING_POINT, true, false, __nv_fp8_storage_t, __nv_fp8_e4m3> {};
     template <> struct NumericTraits<__nv_fp8_e5m2> :   BaseTraits<FLOATING_POINT, true, false, __nv_fp8_storage_t, __nv_fp8_e5m2> {};
-#endif
+#endif // __CUDA_FP8_TYPES_EXIST__
 
 template <> struct NumericTraits<bool> :                BaseTraits<UNSIGNED_INTEGER, true, false, typename UnitWord<bool>::VolatileWord, bool> {};
 // clang-format on

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -49,6 +49,15 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
+#if defined(_CCCL_HAS_NVBF16)
+#  if !defined(_CCCL_CUDACC_BELOW_11_8)
+// cuda_fp8.h resets default for C4127, so we have to guard the inclusion
+_CCCL_DIAG_PUSH
+#    include <cuda_fp8.h>
+_CCCL_DIAG_POP
+#  endif // !_CCCL_CUDACC_BELOW_11_8
+#endif // _CCCL_HAS_NV_BF16
+
 #if !defined(_CCCL_COMPILER_NVRTC)
 #  include <iterator>
 #else

--- a/cub/test/c2h/extended_types.cuh
+++ b/cub/test/c2h/extended_types.cuh
@@ -28,11 +28,11 @@
 #pragma once
 
 #ifndef TEST_HALF_T
-#  define TEST_HALF_T !_NVHPC_CUDA
+#  define TEST_HALF_T _CCCL_HAS_NVFP16
 #endif
 
 #ifndef TEST_BF_T
-#  define TEST_BF_T !_NVHPC_CUDA
+#  define TEST_BF_T _CCCL_HAS_NVBF16
 #endif
 
 #ifdef TEST_HALF_T

--- a/cub/test/c2h/extended_types.cuh
+++ b/cub/test/c2h/extended_types.cuh
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <cuda/__cccl_config>
+
 #ifndef TEST_HALF_T
 #  define TEST_HALF_T _CCCL_HAS_NVFP16
 #endif

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -51,9 +51,9 @@
 #include <catch2_test_launch_helper.h>
 #include <nv/target>
 
-#define TEST_HALF_T !_NVHPC_CUDA
+#define TEST_HALF_T _CCCL_HAS_NVFP16
 
-#define TEST_BF_T !_NVHPC_CUDA
+#define TEST_BF_T _CCCL_HAS_NVBF16
 
 #if TEST_HALF_T
 #  include <cuda_fp16.h>

--- a/cub/test/test_device_histogram.cu
+++ b/cub/test/test_device_histogram.cu
@@ -50,7 +50,7 @@
 
 #include "test_util.h"
 
-#define TEST_HALF_T !_NVHPC_CUDA
+#define TEST_HALF_T _CCCL_HAS_NVFP16
 
 #if TEST_HALF_T
 #  include <cuda_fp16.h>

--- a/libcudacxx/docs/standard_api/numerics_library/complex.md
+++ b/libcudacxx/docs/standard_api/numerics_library/complex.md
@@ -30,10 +30,9 @@ Definition of `LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_MULTIPLICATION` or `LIBCUDAC
 ### Support for half and bfloat16 (since libcu++ 2.4.0)
 
 Our implementation includes support for the `__half` type from `<cuda_fp16.h>`, when the CUDA toolkit version is at
-least 12.2. This is detected automatically when compiling through NVCC. If you are compiling a host-only translation
-unit directly with the host compiler, you must define the macro `LIBCUDACXX_ENABLE_HOST_NVFP16` prior to including any
-libcu++ headers, and you must ensure that the `<cuda_fp16.h>` header that's found by the compiler comes from a CUDA
-toolkit version 12.2 or higher.
+least 12.2, and when `CCCL_DISABLE_FP16_SUPPORT` is **not** defined.
+
+This is detected automatically when compiling through NVCC. If you are compiling a host-only translation unit directly with the host compiler, you must define the macro `LIBCUDACXX_ENABLE_HOST_NVFP16` prior to including any libcu++ headers, and you must ensure that the `<cuda_fp16.h>` header that's found by the compiler comes from a CUDA toolkit version 12.2 or higher.
 
 Our implementation includes support for the `__nv_bfloat16` type from `<cuda_bf16.h>`, when the conditions for the
-support of `__half` are fulfilled, and when `CUB_DISABLE_BF16_SUPPORT` is **not** defined.
+support of `__half` are fulfilled, and when `CCCL_DISABLE_BF16_SUPPORT` and `CCCL_DISABLE_FP16_SUPPORT` are **not** defined.

--- a/libcudacxx/include/cuda/__cccl_config
+++ b/libcudacxx/include/cuda/__cccl_config
@@ -16,6 +16,7 @@
 #include <cuda/std/__cccl/diagnostic.h>
 #include <cuda/std/__cccl/dialect.h>
 #include <cuda/std/__cccl/execution_space.h>
+#include <cuda/std/__cccl/extended_floating_point.h>
 #include <cuda/std/__cccl/ptx_isa.h>
 #include <cuda/std/__cccl/system_header.h>
 #include <cuda/std/__cccl/version.h>

--- a/libcudacxx/include/cuda/std/__cccl/extended_floating_point.h
+++ b/libcudacxx/include/cuda/std/__cccl/extended_floating_point.h
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CCCL_EXTENDED_FLOATING_POINT_H
+#define __CCCL_EXTENDED_FLOATING_POINT_H
+
+#include <cuda/std/__cccl/compiler.h>
+#include <cuda/std/__cccl/system_header.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cccl/diagnostic.h>
+
+#ifndef __has_include
+#  define __has_include(x) 0
+#endif // !__has_include
+
+#if !defined(_CCCL_HAS_NVFP16)
+#  if __has_include(<cuda_fp16.h>)                                              \
+    && (defined(_CCCL_CUDA_COMPILER) || defined(LIBCUDACXX_ENABLE_HOST_NVFP16)) \
+    && !defined(CCCL_DISABLE_FP16_SUPPORT)
+#    define _CCCL_HAS_NVFP16 1
+#  endif
+#endif // !_CCCL_HAS_NVFP16
+
+#if !defined(_CCCL_HAS_NVBF16)
+#  if __has_include(<cuda_bf16.h>)         \
+    && defined(_CCCL_HAS_NVFP16)           \
+    && !defined(_CCCL_CUDACC_BELOW_11_8)   \
+    && !defined(CCCL_DISABLE_BF16_SUPPORT) \
+    && !defined(CUB_DISABLE_BF16_SUPPORT)
+#    define _CCCL_HAS_NVBF16 1
+#  endif
+#endif // !_CCCL_HAS_NVBF16
+
+#if defined(_CCCL_HAS_NVFP16)
+#  include <cuda_fp16.h>
+#endif // _CCCL_HAS_NVFP16
+
+#if defined(_CCCL_HAS_NVBF16)
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-function")
+#  include <cuda_bf16.h>
+_CCCL_DIAG_POP
+#endif // _CCCL_HAS_NVFP16
+
+#endif // __CCCL_EXTENDED_FLOATING_POINT_H

--- a/libcudacxx/include/cuda/std/__cccl/extended_floating_point.h
+++ b/libcudacxx/include/cuda/std/__cccl/extended_floating_point.h
@@ -39,7 +39,6 @@
 #if !defined(_CCCL_HAS_NVBF16)
 #  if __has_include(<cuda_bf16.h>)         \
     && defined(_CCCL_HAS_NVFP16)           \
-    && !defined(_CCCL_CUDACC_BELOW_11_8)   \
     && !defined(CCCL_DISABLE_BF16_SUPPORT) \
     && !defined(CUB_DISABLE_BF16_SUPPORT)
 #    define _CCCL_HAS_NVBF16 1

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -179,19 +179,19 @@ public:
   // We can utilize vectorized operations for those operators
   _LIBCUDACXX_INLINE_VISIBILITY friend complex& operator+=(complex& __lhs, const complex& __rhs) noexcept
   {
-    __lhs.__repr_ += __rhs.__repr_;
+    __lhs.__repr_ = __hadd2(__lhs.__repr_, __rhs.__repr_);
     return __lhs;
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY friend complex& operator-=(complex& __lhs, const complex& __rhs) noexcept
   {
-    __lhs.__repr_ -= __rhs.__repr_;
+    __lhs.__repr_ = __hsub2(__lhs.__repr_, __rhs.__repr_);
     return __lhs;
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY friend bool operator==(const complex& __x, const complex& __y)
+  _LIBCUDACXX_INLINE_VISIBILITY friend bool operator==(const complex& __lhs, const complex& __rhs) noexcept
   {
-    return __x.__repr_ == __y.__repr_;
+    return __hbeq2(__lhs.__repr_, __rhs.__repr_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -176,19 +176,19 @@ public:
   // We can utilize vectorized operations for those operators
   _LIBCUDACXX_INLINE_VISIBILITY friend complex& operator+=(complex& __lhs, const complex& __rhs) noexcept
   {
-    __lhs.__repr_ += __rhs.__repr_;
+    __lhs.__repr_ = __hadd2(__lhs.__repr_, __rhs.__repr_);
     return __lhs;
   }
 
   _LIBCUDACXX_INLINE_VISIBILITY friend complex& operator-=(complex& __lhs, const complex& __rhs) noexcept
   {
-    __lhs.__repr_ -= __rhs.__repr_;
+    __lhs.__repr_ = __hsub2(__lhs.__repr_, __rhs.__repr_);
     return __lhs;
   }
 
-  _LIBCUDACXX_INLINE_VISIBILITY friend bool operator==(const complex& __x, const complex& __y)
+  _LIBCUDACXX_INLINE_VISIBILITY friend bool operator==(const complex& __lhs, const complex& __rhs) noexcept
   {
-    return __x.__repr_ == __y.__repr_;
+    return __hbeq2(__lhs.__repr_, __rhs.__repr_);
   }
 };
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -966,10 +966,11 @@ typedef __char32_t char32_t;
 #  endif // _LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 #  ifndef _LIBCUDACXX_HAS_NVFP16
-#    if __has_include(<cuda_fp16.h>)                                                           \
+#    if __has_include(<cuda_fp16.h>)                                                     \
       && (defined(_LIBCUDACXX_COMPILER_CLANG_CUDA) || !defined(_CCCL_CUDACC_BELOW_12_2)) \
-      && (!defined(_LIBCUDACXX_COMPILER_CLANG_CUDA) || CUDA_VERSION >= 12020)                  \
-      && (defined(_CCCL_CUDACC) || defined(LIBCUDACXX_ENABLE_HOST_NVFP16))
+      && (!defined(_LIBCUDACXX_COMPILER_CLANG_CUDA) || CUDA_VERSION >= 12020)            \
+      && (defined(_CCCL_CUDACC) || defined(LIBCUDACXX_ENABLE_HOST_NVFP16))               \
+      && !defined(CCCL_DISABLE_FP16_SUPPORT)
 #      define _LIBCUDACXX_HAS_NVFP16
 #    endif
 #  endif // !_LIBCUDACXX_HAS_NVFP16
@@ -977,7 +978,7 @@ typedef __char32_t char32_t;
 #  ifndef _LIBCUDACXX_HAS_NVBF16
 #    if __has_include(<cuda_bf16.h>)        \
       && defined(_LIBCUDACXX_HAS_NVFP16)    \
-      && !defined(CUB_DISABLE_BF16_SUPPORT)
+      && !defined(CCCL_DISABLE_BF16_SUPPORT)
 #      define _LIBCUDACXX_HAS_NVBF16
 #    endif
 #  endif // !_LIBCUDACXX_HAS_NVBF16

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -62,13 +62,6 @@
 #  define _LIBCUDACXX_COMPILER_CLANG_CUDA
 #endif
 
-#if defined(__CUDACC__) || defined(_CCCL_CUDA_COMPILER_NVHPC)
-// TODO: Determine if this is necessary, I don't know why we automatically include this in <config>
-#  if defined(__clang__) || defined(__FLT16_MANT_DIG__)
-#    include <cuda_fp16.h>
-#  endif
-#endif
-
 #ifdef __cplusplus
 
 // __config may be included in `extern "C"` contexts, switch back to include <nv/target>
@@ -965,20 +958,17 @@ typedef __char32_t char32_t;
 #    endif
 #  endif // _LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
+// libcu++ requires host device support for its tests. Until then restrict usage to at least 12.2
 #  ifndef _LIBCUDACXX_HAS_NVFP16
-#    if __has_include(<cuda_fp16.h>)                                                     \
-      && (defined(_LIBCUDACXX_COMPILER_CLANG_CUDA) || !defined(_CCCL_CUDACC_BELOW_12_2)) \
-      && (!defined(_LIBCUDACXX_COMPILER_CLANG_CUDA) || CUDA_VERSION >= 12020)            \
-      && (defined(_CCCL_CUDACC) || defined(LIBCUDACXX_ENABLE_HOST_NVFP16))               \
-      && !defined(CCCL_DISABLE_FP16_SUPPORT)
+#    if defined(_CCCL_HAS_NVFP16) && !defined(_CCCL_CUDACC_BELOW_12_2) \
+      && (defined(_CCCL_CUDA_COMPILER) || defined(LIBCUDACXX_ENABLE_HOST_NVFP16))
 #      define _LIBCUDACXX_HAS_NVFP16
 #    endif
 #  endif // !_LIBCUDACXX_HAS_NVFP16
 
+// libcu++ requires host device support for its tests. Until then restrict usage to at least 12.2
 #  ifndef _LIBCUDACXX_HAS_NVBF16
-#    if __has_include(<cuda_bf16.h>)        \
-      && defined(_LIBCUDACXX_HAS_NVFP16)    \
-      && !defined(CCCL_DISABLE_BF16_SUPPORT)
+#    if defined(_CCCL_HAS_NVBF16) && !defined(_CCCL_CUDACC_BELOW_12_2)
 #      define _LIBCUDACXX_HAS_NVBF16
 #    endif
 #  endif // !_LIBCUDACXX_HAS_NVBF16


### PR DESCRIPTION
This mirrors our current escape hatch against `__nv_bfloat16` to also allow the user to disable half support

Addresses: #1727