### PR TITLE
Avoid ABI issues due to MSVC EBCO issues

### DIFF
--- a/libcudacxx/include/cuda/std/__expected/expected.h
+++ b/libcudacxx/include/cuda/std/__expected/expected.h
@@ -103,10 +103,7 @@ _LIBCUDACXX_INLINE_VAR constexpr bool __can_swap<void, _Err> =
 } // namespace __expected
 
 template <class _Tp, class _Err>
-class expected
-    : private __expected_move_assign<_Tp, _Err>
-    , private __expected_sfinae_ctor_base_t<_Tp, _Err>
-    , private __expected_sfinae_assign_base_t<_Tp, _Err>
+class expected : private __expected_move_assign<_Tp, _Err>
 {
   using __base = __expected_move_assign<_Tp, _Err>;
 
@@ -1212,10 +1209,7 @@ public:
 };
 
 template <class _Err>
-class expected<void, _Err>
-    : private __expected_move_assign<void, _Err>
-    , private __expected_void_sfinae_ctor_base_t<_Err>
-    , private __expected_void_sfinae_assign_base_t<_Err>
+class expected<void, _Err> : private __expected_move_assign<void, _Err>
 {
   using __base = __expected_move_assign<void, _Err>;
   static_assert(__unexpected::__valid_unexpected<_Err>,

--- a/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
@@ -147,6 +147,13 @@ struct _LIBCUDACXX_TYPE_VIS __check_tuple_constructor_fail
 
 #if _CCCL_STD_VER > 2011
 
+enum class __smf_availability
+{
+  __trivial,
+  __available,
+  __deleted,
+};
+
 template <bool _CanCopy>
 struct __sfinae_copy_base
 {};

--- a/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
@@ -147,67 +147,61 @@ struct _LIBCUDACXX_TYPE_VIS __check_tuple_constructor_fail
 
 #if _CCCL_STD_VER > 2011
 
-template <bool _CanCopy, bool _CanMove>
-struct __sfinae_ctor_base
+template <bool _CanCopy>
+struct __sfinae_copy_base
 {};
 template <>
-struct __sfinae_ctor_base<false, false>
+struct __sfinae_copy_base<false>
 {
-  __sfinae_ctor_base()                                     = default;
-  __sfinae_ctor_base(__sfinae_ctor_base const&)            = delete;
-  __sfinae_ctor_base(__sfinae_ctor_base&&)                 = delete;
-  __sfinae_ctor_base& operator=(__sfinae_ctor_base const&) = default;
-  __sfinae_ctor_base& operator=(__sfinae_ctor_base&&)      = default;
-};
-template <>
-struct __sfinae_ctor_base<true, false>
-{
-  __sfinae_ctor_base()                                     = default;
-  __sfinae_ctor_base(__sfinae_ctor_base const&)            = default;
-  __sfinae_ctor_base(__sfinae_ctor_base&&)                 = delete;
-  __sfinae_ctor_base& operator=(__sfinae_ctor_base const&) = default;
-  __sfinae_ctor_base& operator=(__sfinae_ctor_base&&)      = default;
-};
-template <>
-struct __sfinae_ctor_base<false, true>
-{
-  __sfinae_ctor_base()                                     = default;
-  __sfinae_ctor_base(__sfinae_ctor_base const&)            = delete;
-  __sfinae_ctor_base(__sfinae_ctor_base&&)                 = default;
-  __sfinae_ctor_base& operator=(__sfinae_ctor_base const&) = default;
-  __sfinae_ctor_base& operator=(__sfinae_ctor_base&&)      = default;
+  __sfinae_copy_base()                                     = default;
+  __sfinae_copy_base(__sfinae_copy_base const&)            = delete;
+  __sfinae_copy_base(__sfinae_copy_base&&)                 = default;
+  __sfinae_copy_base& operator=(__sfinae_copy_base const&) = default;
+  __sfinae_copy_base& operator=(__sfinae_copy_base&&)      = default;
 };
 
 template <bool _CanCopy, bool _CanMove>
-struct __sfinae_assign_base
+struct __sfinae_move_base : __sfinae_copy_base<_CanCopy>
 {};
-template <>
-struct __sfinae_assign_base<false, false>
+template <bool _CanCopy>
+struct __sfinae_move_base<_CanCopy, false> : __sfinae_copy_base<_CanCopy>
 {
-  __sfinae_assign_base()                                       = default;
-  __sfinae_assign_base(__sfinae_assign_base const&)            = default;
-  __sfinae_assign_base(__sfinae_assign_base&&)                 = default;
-  __sfinae_assign_base& operator=(__sfinae_assign_base const&) = delete;
-  __sfinae_assign_base& operator=(__sfinae_assign_base&&)      = delete;
+  __sfinae_move_base()                                     = default;
+  __sfinae_move_base(__sfinae_move_base const&)            = default;
+  __sfinae_move_base(__sfinae_move_base&&)                 = delete;
+  __sfinae_move_base& operator=(__sfinae_move_base const&) = default;
+  __sfinae_move_base& operator=(__sfinae_move_base&&)      = default;
 };
-template <>
-struct __sfinae_assign_base<true, false>
+
+template <bool _CanCopy, bool _CanMove, bool _CanCopyAssign>
+struct __sfinae_copy_assign_base : __sfinae_move_base<_CanCopy, _CanMove>
+{};
+template <bool _CanCopy, bool _CanMove>
+struct __sfinae_copy_assign_base<_CanCopy, _CanMove, false> : __sfinae_move_base<_CanCopy, _CanMove>
 {
-  __sfinae_assign_base()                                       = default;
-  __sfinae_assign_base(__sfinae_assign_base const&)            = default;
-  __sfinae_assign_base(__sfinae_assign_base&&)                 = default;
-  __sfinae_assign_base& operator=(__sfinae_assign_base const&) = default;
-  __sfinae_assign_base& operator=(__sfinae_assign_base&&)      = delete;
+  __sfinae_copy_assign_base()                                            = default;
+  __sfinae_copy_assign_base(__sfinae_copy_assign_base const&)            = default;
+  __sfinae_copy_assign_base(__sfinae_copy_assign_base&&)                 = default;
+  __sfinae_copy_assign_base& operator=(__sfinae_copy_assign_base const&) = delete;
+  __sfinae_copy_assign_base& operator=(__sfinae_copy_assign_base&&)      = default;
 };
-template <>
-struct __sfinae_assign_base<false, true>
+
+template <bool _CanCopy, bool _CanMove, bool _CanCopyAssign, bool _CanMoveAssign>
+struct __sfinae_move_assign_base : __sfinae_copy_assign_base<_CanCopy, _CanMove, _CanCopyAssign>
+{};
+template <bool _CanCopy, bool _CanMove, bool _CanCopyAssign>
+struct __sfinae_move_assign_base<_CanCopy, _CanMove, _CanCopyAssign, false>
+    : __sfinae_copy_assign_base<_CanCopy, _CanMove, _CanCopyAssign>
 {
-  __sfinae_assign_base()                                       = default;
-  __sfinae_assign_base(__sfinae_assign_base const&)            = default;
-  __sfinae_assign_base(__sfinae_assign_base&&)                 = default;
-  __sfinae_assign_base& operator=(__sfinae_assign_base const&) = delete;
-  __sfinae_assign_base& operator=(__sfinae_assign_base&&)      = default;
+  __sfinae_move_assign_base()                                            = default;
+  __sfinae_move_assign_base(__sfinae_move_assign_base const&)            = default;
+  __sfinae_move_assign_base(__sfinae_move_assign_base&&)                 = default;
+  __sfinae_move_assign_base& operator=(__sfinae_move_assign_base const&) = default;
+  __sfinae_move_assign_base& operator=(__sfinae_move_assign_base&&)      = delete;
 };
+
+template <bool _CanCopy, bool _CanMove, bool _CanCopyAssign, bool _CanMoveAssign>
+using __sfinae_base = __sfinae_move_assign_base<_CanCopy, _CanMove, _CanCopyAssign, _CanMoveAssign>;
 #endif // _CCCL_STD_VER > 2011
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -178,9 +178,14 @@ template<class T>
 #include <cuda/std/__functional/unary_function.h>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__memory/construct_at.h>
+#include <cuda/std/__new_>
 #include <cuda/std/__tuple_dir/sfinae_helpers.h>
 #include <cuda/std/__type_traits/conjunction.h>
 #include <cuda/std/__type_traits/disjunction.h>
+#include <cuda/std/__type_traits/is_copy_assignable.h>
+#include <cuda/std/__type_traits/is_copy_constructible.h>
+#include <cuda/std/__type_traits/is_move_assignable.h>
+#include <cuda/std/__type_traits/is_move_constructible.h>
 #include <cuda/std/__type_traits/is_object.h>
 #include <cuda/std/__type_traits/is_trivially_copy_assignable.h>
 #include <cuda/std/__type_traits/is_trivially_copy_constructible.h>
@@ -194,11 +199,10 @@ template<class T>
 #include <cuda/std/__utility/in_place.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/__utility/swap.h>
+#include <cuda/std/cstdlib>
 #include <cuda/std/detail/libcxx/include/__assert> // all public C++ headers provide the assertion handler
 #include <cuda/std/detail/libcxx/include/__availability>
 #include <cuda/std/detail/libcxx/include/__verbose_abort>
-#include <cuda/std/detail/libcxx/include/cstdlib>
-#include <cuda/std/detail/libcxx/include/new>
 #include <cuda/std/initializer_list>
 
 // standard-mandated includes
@@ -420,14 +424,21 @@ struct __optional_storage_base : __optional_destruct_base<_Tp>
   }
 };
 
-template <class _Tp, bool = is_trivially_copy_constructible<_Tp>::value>
+template <class _Tp>
+_LIBCUDACXX_INLINE_VAR constexpr __smf_availability __optional_can_copy_construct =
+  _CCCL_TRAIT(is_trivially_copy_constructible, _Tp) ? __smf_availability::__trivial
+  : _CCCL_TRAIT(is_copy_constructible, _Tp)
+    ? __smf_availability::__available
+    : __smf_availability::__deleted;
+
+template <class _Tp, __smf_availability = __optional_can_copy_construct<_Tp>>
 struct __optional_copy_base : __optional_storage_base<_Tp>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_copy_base, __optional_storage_base, _Tp);
 };
 
 template <class _Tp>
-struct __optional_copy_base<_Tp, false> : __optional_storage_base<_Tp>
+struct __optional_copy_base<_Tp, __smf_availability::__available> : __optional_storage_base<_Tp>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_copy_base, __optional_storage_base, _Tp);
 
@@ -445,14 +456,31 @@ struct __optional_copy_base<_Tp, false> : __optional_storage_base<_Tp>
   __optional_copy_base& operator=(__optional_copy_base&&)      = default;
 };
 
-template <class _Tp, bool = is_trivially_move_constructible<_Tp>::value>
+template <class _Tp>
+struct __optional_copy_base<_Tp, __smf_availability::__deleted> : __optional_storage_base<_Tp>
+{
+  _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_copy_base, __optional_storage_base, _Tp);
+  __optional_copy_base(const __optional_copy_base&)            = delete;
+  __optional_copy_base(__optional_copy_base&&)                 = default;
+  __optional_copy_base& operator=(const __optional_copy_base&) = default;
+  __optional_copy_base& operator=(__optional_copy_base&&)      = default;
+};
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VAR constexpr __smf_availability __optional_can_move_construct =
+  _CCCL_TRAIT(is_trivially_move_constructible, _Tp) ? __smf_availability::__trivial
+  : _CCCL_TRAIT(is_move_constructible, _Tp)
+    ? __smf_availability::__available
+    : __smf_availability::__deleted;
+
+template <class _Tp, __smf_availability = __optional_can_move_construct<_Tp>>
 struct __optional_move_base : __optional_copy_base<_Tp>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_move_base, __optional_copy_base, _Tp);
 };
 
 template <class _Tp>
-struct __optional_move_base<_Tp, false> : __optional_copy_base<_Tp>
+struct __optional_move_base<_Tp, __smf_availability::__available> : __optional_copy_base<_Tp>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_move_base, __optional_copy_base, _Tp);
 
@@ -468,16 +496,34 @@ struct __optional_move_base<_Tp, false> : __optional_copy_base<_Tp>
   __optional_move_base& operator=(__optional_move_base&&)      = default;
 };
 
-template <class _Tp,
-          bool = is_trivially_destructible<_Tp>::value && is_trivially_copy_constructible<_Tp>::value
-              && is_trivially_copy_assignable<_Tp>::value>
+template <class _Tp>
+struct __optional_move_base<_Tp, __smf_availability::__deleted> : __optional_copy_base<_Tp>
+{
+  _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_move_base, __optional_copy_base, _Tp);
+
+  __optional_move_base(const __optional_move_base&)            = default;
+  __optional_move_base(__optional_move_base&&)                 = delete;
+  __optional_move_base& operator=(const __optional_move_base&) = default;
+  __optional_move_base& operator=(__optional_move_base&&)      = default;
+};
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VAR constexpr __smf_availability __optional_can_copy_assign =
+  _CCCL_TRAIT(is_trivially_destructible, _Tp) && _CCCL_TRAIT(is_trivially_copy_constructible, _Tp)
+      && _CCCL_TRAIT(is_trivially_copy_assignable, _Tp)
+    ? __smf_availability::__trivial
+  : _CCCL_TRAIT(is_destructible, _Tp) && _CCCL_TRAIT(is_copy_constructible, _Tp) && _CCCL_TRAIT(is_copy_assignable, _Tp)
+    ? __smf_availability::__available
+    : __smf_availability::__deleted;
+
+template <class _Tp, __smf_availability = __optional_can_copy_assign<_Tp>>
 struct __optional_copy_assign_base : __optional_move_base<_Tp>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_copy_assign_base, __optional_move_base, _Tp);
 };
 
 template <class _Tp>
-struct __optional_copy_assign_base<_Tp, false> : __optional_move_base<_Tp>
+struct __optional_copy_assign_base<_Tp, __smf_availability::__available> : __optional_move_base<_Tp>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_copy_assign_base, __optional_move_base, _Tp);
 
@@ -494,16 +540,34 @@ struct __optional_copy_assign_base<_Tp, false> : __optional_move_base<_Tp>
   __optional_copy_assign_base& operator=(__optional_copy_assign_base&&) = default;
 };
 
-template <class _Tp,
-          bool = is_trivially_destructible<_Tp>::value && is_trivially_move_constructible<_Tp>::value
-              && is_trivially_move_assignable<_Tp>::value>
+template <class _Tp>
+struct __optional_copy_assign_base<_Tp, __smf_availability::__deleted> : __optional_move_base<_Tp>
+{
+  _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_copy_assign_base, __optional_move_base, _Tp);
+
+  __optional_copy_assign_base(const __optional_copy_assign_base&)            = default;
+  __optional_copy_assign_base(__optional_copy_assign_base&&)                 = default;
+  __optional_copy_assign_base& operator=(const __optional_copy_assign_base&) = delete;
+  __optional_copy_assign_base& operator=(__optional_copy_assign_base&&)      = default;
+};
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VAR constexpr __smf_availability __optional_can_move_assign =
+  _CCCL_TRAIT(is_trivially_destructible, _Tp) && _CCCL_TRAIT(is_trivially_move_constructible, _Tp)
+      && _CCCL_TRAIT(is_trivially_move_assignable, _Tp)
+    ? __smf_availability::__trivial
+  : _CCCL_TRAIT(is_destructible, _Tp) && _CCCL_TRAIT(is_move_constructible, _Tp) && _CCCL_TRAIT(is_move_assignable, _Tp)
+    ? __smf_availability::__available
+    : __smf_availability::__deleted;
+
+template <class _Tp, __smf_availability = __optional_can_move_assign<_Tp>>
 struct __optional_move_assign_base : __optional_copy_assign_base<_Tp>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_move_assign_base, __optional_copy_assign_base, _Tp);
 };
 
 template <class _Tp>
-struct __optional_move_assign_base<_Tp, false> : __optional_copy_assign_base<_Tp>
+struct __optional_move_assign_base<_Tp, __smf_availability::__available> : __optional_copy_assign_base<_Tp>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_move_assign_base, __optional_copy_assign_base, _Tp);
 
@@ -521,13 +585,15 @@ struct __optional_move_assign_base<_Tp, false> : __optional_copy_assign_base<_Tp
 };
 
 template <class _Tp>
-using __optional_sfinae_ctor_base_t =
-  __sfinae_ctor_base<is_copy_constructible<_Tp>::value, is_move_constructible<_Tp>::value>;
+struct __optional_move_assign_base<_Tp, __smf_availability::__deleted> : __optional_copy_assign_base<_Tp>
+{
+  _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__optional_move_assign_base, __optional_copy_assign_base, _Tp);
 
-template <class _Tp>
-using __optional_sfinae_assign_base_t =
-  __sfinae_assign_base<(is_copy_constructible<_Tp>::value && is_copy_assignable<_Tp>::value),
-                       (is_move_constructible<_Tp>::value && is_move_assignable<_Tp>::value)>;
+  __optional_move_assign_base(const __optional_move_assign_base& __opt)      = default;
+  __optional_move_assign_base(__optional_move_assign_base&&)                 = default;
+  __optional_move_assign_base& operator=(const __optional_move_assign_base&) = default;
+  __optional_move_assign_base& operator=(__optional_move_assign_base&&)      = delete;
+};
 
 template <class _Tp>
 class optional;
@@ -589,10 +655,7 @@ _LIBCUDACXX_INLINE_VAR constexpr bool __opt_is_assignable_from_opt =
   && !__opt_check_assignable_from_opt<_Tp, _Up>::value;
 
 template <class _Tp>
-class optional
-    : private __optional_move_assign_base<_Tp>
-    , private __optional_sfinae_ctor_base_t<_Tp>
-    , private __optional_sfinae_assign_base_t<_Tp>
+class optional : private __optional_move_assign_base<_Tp>
 {
   using __base = __optional_move_assign_base<_Tp>;
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/variant
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/variant
@@ -1506,9 +1506,9 @@ struct __variant_constraints
 
 template <class... _Types>
 class _LIBCUDACXX_TEMPLATE_VIS variant
-    : private __sfinae_ctor_base<__all<_CCCL_TRAIT(is_copy_constructible, _Types)...>::value,
-                                 __all<_CCCL_TRAIT(is_move_constructible, _Types)...>::value>
-    , private __sfinae_assign_base<
+    : private __sfinae_base<
+        __all<_CCCL_TRAIT(is_copy_constructible, _Types)...>::value,
+        __all<_CCCL_TRAIT(is_move_constructible, _Types)...>::value,
         __all<(_CCCL_TRAIT(is_copy_constructible, _Types) && _CCCL_TRAIT(is_copy_assignable, _Types))...>::value,
         __all<(_CCCL_TRAIT(is_move_constructible, _Types) && _CCCL_TRAIT(is_move_assignable, _Types))...>::value>
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/assign/assign.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.expected/assign/assign.copy.pass.cpp
@@ -87,6 +87,8 @@ static_assert(cuda::std::is_copy_assignable_v<cuda::std::expected<int, MoveMayTh
 
 #ifndef TEST_COMPILER_ICC
 // !is_nothrow_move_constructible_v<T> && !is_nothrow_move_constructible_v<E>
+static_assert(
+  cuda::std::__expected_can_copy_assign<MoveMayThrow, MoveMayThrow> == cuda::std::__smf_availability::__deleted, "");
 static_assert(!cuda::std::is_copy_assignable_v<cuda::std::expected<MoveMayThrow, MoveMayThrow>>, "");
 #endif // TEST_COMPILER_ICC
 

--- a/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/object_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expected/expected.void/object_size.pass.cpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11
+// <cuda/std/expected>
+
+#include <cuda/std/expected>
+
+#include "test_macros.h"
+
+using cuda::std::expected;
+
+int main(int, char**)
+{
+  static_assert(sizeof(expected<char, char>) == 2 * sizeof(char), "");
+  static_assert(sizeof(expected<short, short>) == 2 * sizeof(short), "");
+  static_assert(sizeof(expected<int, int>) == 2 * sizeof(int), "");
+  static_assert(sizeof(expected<long long, long long>) == 2 * sizeof(long long), "");
+
+  static_assert(sizeof(expected<long long, char>) == 2 * sizeof(long long), "");
+  static_assert(sizeof(expected<long long, short>) == 2 * sizeof(long long), "");
+  static_assert(sizeof(expected<long long, int>) == 2 * sizeof(long long), "");
+  static_assert(sizeof(expected<long long, long long>) == 2 * sizeof(long long), "");
+
+  static_assert(sizeof(expected<void, char>) == 2 * sizeof(char), "");
+  static_assert(sizeof(expected<void, short>) == 2 * sizeof(short), "");
+  static_assert(sizeof(expected<void, int>) == 2 * sizeof(int), "");
+  static_assert(sizeof(expected<void, long long>) == 2 * sizeof(long long), "");
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/object_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/object_size.pass.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11
+// <cuda/std/optional>
+
+#include <cuda/std/optional>
+
+#include "test_macros.h"
+
+using cuda::std::optional;
+
+int main(int, char**)
+{
+  static_assert(sizeof(optional<char>) == 2 * sizeof(char), "");
+  static_assert(sizeof(optional<short>) == 2 * sizeof(short), "");
+  static_assert(sizeof(optional<int>) == 2 * sizeof(int), "");
+  static_assert(sizeof(optional<long long>) == 2 * sizeof(long long), "");
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/object_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/object_size.pass.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11
+// UNSUPPORTED: msvc-19.16
+
+// <cuda/std/variant>
+
+#include <cuda/std/variant>
+
+#include "test_macros.h"
+
+using cuda::std::variant;
+
+int main(int, char**)
+{
+  static_assert(sizeof(variant<char>) == 2 * sizeof(char), "");
+  static_assert(sizeof(variant<short>) == 2 * sizeof(short), "");
+  static_assert(sizeof(variant<int>) == 2 * sizeof(int), "");
+  static_assert(sizeof(variant<long long>) == 2 * sizeof(long long), "");
+
+  static_assert(sizeof(variant<char, char>) == 2 * sizeof(char), "");
+  static_assert(sizeof(variant<char, short>) == 2 * sizeof(short), "");
+  static_assert(sizeof(variant<char, int>) == 2 * sizeof(int), "");
+  static_assert(sizeof(variant<char, long long>) == 2 * sizeof(long long), "");
+  return 0;
+}


### PR DESCRIPTION
MSVC allows empty base class optimization only for the last base class. So we cannot use multiple inheritance.

Otherwise, `expected`, `optional` or `variant` would have differing sizes between host nad device
