### PR TITLE
Use only explicit NVTX3 V1 API in CUB

### DIFF
--- a/cub/test/test_nvtx_in_usercode.cu
+++ b/cub/test/test_nvtx_in_usercode.cu
@@ -2,21 +2,15 @@
 
 #include <thrust/iterator/counting_iterator.h>
 
-#include <nvtx3/nvtx3.hpp> // user-side include of NVTX, retrieved elsewhere
+#include <cuda/std/functional>
 
-struct Op
-{
-  _CCCL_HOST_DEVICE void operator()(int i) const
-  {
-    printf("%d\n", i);
-  }
-};
+#include <nvtx3/nvtx3.hpp> // user-side include of NVTX, retrieved elsewhere
 
 int main()
 {
-  nvtx3::scoped_range range("user-range"); // user-side use of NVTX
+  nvtx3::scoped_range range("user-range"); // user-side use of unversioned NVTX API
 
   thrust::counting_iterator<int> it{0};
-  cub::DeviceFor::ForEach(it, it + 16, Op{}); // internal use of NVTX
+  cub::DeviceFor::ForEach(it, it + 16, ::cuda::std::negate<int>{}); // internal use of NVTX
   cudaDeviceSynchronize();
 }

--- a/cub/test/test_nvtx_in_usercode_explicit.cu
+++ b/cub/test/test_nvtx_in_usercode_explicit.cu
@@ -1,0 +1,17 @@
+#define NVTX3_CPP_REQUIRE_EXPLICIT_VERSION
+#include <cub/device/device_for.cuh> // internal include of NVTX
+
+#include <thrust/iterator/counting_iterator.h>
+
+#include <cuda/std/functional>
+
+#include <nvtx3/nvtx3.hpp> // user-side include of NVTX, retrieved elsewhere
+
+int main()
+{
+  nvtx3::v1::scoped_range range("user-range"); // user-side use of explicit NVTX API
+
+  thrust::counting_iterator<int> it{0};
+  cub::DeviceFor::ForEach(it, it + 16, ::cuda::std::negate<int>{}); // internal use of NVTX
+  cudaDeviceSynchronize();
+}

--- a/cub/test/test_nvtx_standalone.cu
+++ b/cub/test/test_nvtx_standalone.cu
@@ -10,19 +10,13 @@
 
 #include <thrust/iterator/counting_iterator.h>
 
-struct Op
-{
-  _CCCL_HOST_DEVICE void operator()(int i) const
-  {
-    printf("%d\n", i);
-  }
-};
+#include <cuda/std/functional>
 
 int main()
 {
   CUB_DETAIL_NVTX_RANGE_SCOPE("main");
 
   thrust::counting_iterator<int> it{0};
-  cub::DeviceFor::ForEach(it, it + 16, Op{});
+  cub::DeviceFor::ForEach(it, it + 16, ::cuda::std::negate<int>{});
   cudaDeviceSynchronize();
 }


### PR DESCRIPTION
This PR lets the CUB headers detect the available NVTX3 API C++ wrapper version and then only provide NVTX range functionality if V1 is detected. Furthermore, CUB programs against the explicit API version, which is available independent of whether the user uses NVTX3 in explicit or implicit API flavor.

This PR is an evolution of: #1688

Fixes: #1750