### PR TITLE
Merge prep jobs for verify-devcontainers CI.

### DIFF
--- a/.github/workflows/verify-devcontainers.yml
+++ b/.github/workflows/verify-devcontainers.yml
@@ -11,8 +11,10 @@ permissions:
   contents: read
 
 jobs:
-  verify-make-devcontainers:
+  get-devcontainer-list:
     name: Verify devcontainer files are up-to-date
+    outputs:
+      devcontainers: ${{ steps.get-list.outputs.devcontainers }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -36,16 +38,6 @@ jobs:
         else
           echo "::note::Dev Container files are up-to-date."
         fi
-
-  get-devcontainer-list:
-    needs: verify-make-devcontainers
-    name: Get list of devcontainer.json files
-    runs-on: ubuntu-latest
-    outputs:
-      devcontainers: ${{ steps.get-list.outputs.devcontainers }}
-    steps:
-    - name: Check out the code
-      uses: actions/checkout@v3
     - name: Get list of devcontainer.json paths and names
       id: get-list
       run: |


### PR DESCRIPTION
This eliminates a job launch by combining the "verify devcontainer files" and "get devcontainer list" jobs into one.