### PR TITLE
Replace `cub::ArrayWrapper` by `cuda::std::array` and deprecate it

### DIFF
--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -58,6 +58,10 @@
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
+#include <cuda/functional>
+#include <cuda/std/__algorithm/copy.h>
+#include <cuda/std/__algorithm/transform.h>
+#include <cuda/std/array>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
@@ -97,8 +101,8 @@ CUB_NAMESPACE_BEGIN
  */
 template <int NUM_ACTIVE_CHANNELS, typename CounterT, typename OffsetT>
 CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceHistogramInitKernel(
-  ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper,
-  ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper,
+  ::cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper,
+  ::cuda::std::array<CounterT*, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper,
   GridQueue<int> tile_queue)
 {
   if ((threadIdx.x == 0) && (blockIdx.x == 0))
@@ -111,9 +115,9 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceHistogramInitKernel(
 #pragma unroll
   for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
   {
-    if (output_bin < num_output_bins_wrapper.array[CHANNEL])
+    if (output_bin < num_output_bins_wrapper[CHANNEL])
     {
-      d_output_histograms_wrapper.array[CHANNEL][output_bin] = 0;
+      d_output_histograms_wrapper[CHANNEL][output_bin] = 0;
     }
   }
 }
@@ -203,12 +207,12 @@ template <typename ChainedPolicyT,
 __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentHistogramPolicyT::BLOCK_THREADS))
   CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceHistogramSweepKernel(
     SampleIteratorT d_samples,
-    ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper,
-    ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_privatized_bins_wrapper,
-    ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper,
-    ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS> d_privatized_histograms_wrapper,
-    ArrayWrapper<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op_wrapper,
-    ArrayWrapper<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op_wrapper,
+    ::cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper,
+    ::cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_privatized_bins_wrapper,
+    ::cuda::std::array<CounterT*, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper,
+    ::cuda::std::array<CounterT*, NUM_ACTIVE_CHANNELS> d_privatized_histograms_wrapper,
+    ::cuda::std::array<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op_wrapper,
+    ::cuda::std::array<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op_wrapper,
     OffsetT num_row_pixels,
     OffsetT num_rows,
     OffsetT row_stride_samples,
@@ -234,12 +238,12 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentHistogramPolicyT::BLOCK
   AgentHistogramT agent(
     temp_storage,
     d_samples,
-    num_output_bins_wrapper.array,
-    num_privatized_bins_wrapper.array,
-    d_output_histograms_wrapper.array,
-    d_privatized_histograms_wrapper.array,
-    output_decode_op_wrapper.array,
-    privatized_decode_op_wrapper.array);
+    num_output_bins_wrapper.__elems_,
+    num_privatized_bins_wrapper.__elems_,
+    d_output_histograms_wrapper.__elems_,
+    d_privatized_histograms_wrapper.__elems_,
+    output_decode_op_wrapper.__elems_,
+    privatized_decode_op_wrapper.__elems_);
 
   // Initialize counters
   agent.InitBinCounters();
@@ -397,54 +401,33 @@ struct dispatch_histogram
       // Construct the grid queue descriptor
       GridQueue<int> tile_queue(allocations[NUM_ALLOCATIONS - 1]);
 
-      // Setup array wrapper for histogram channel output (because we can't pass static arrays
-      // as kernel parameters)
-      ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper;
-      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-      {
-        d_output_histograms_wrapper.array[CHANNEL] = d_output_histograms[CHANNEL];
-      }
+      // Wrap arrays so we can pass them by-value to the kernel
+      ::cuda::std::array<CounterT*, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper;
+      ::cuda::std::array<CounterT*, NUM_ACTIVE_CHANNELS> d_privatized_histograms_wrapper;
+      ::cuda::std::array<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op_wrapper;
+      ::cuda::std::array<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op_wrapper;
+      ::cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_privatized_bins_wrapper;
+      ::cuda::std::array<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper;
 
-      // Setup array wrapper for privatized per-block histogram channel output (because we
-      // can't pass static arrays as kernel parameters)
-      ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS> d_privatized_histograms_wrapper;
-      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-      {
-        d_privatized_histograms_wrapper.array[CHANNEL] = (CounterT*) allocations[CHANNEL];
-      }
+      auto* typedAllocations = reinterpret_cast<CounterT**>(allocations);
+      ::cuda::std::copy(
+        d_output_histograms, d_output_histograms + NUM_ACTIVE_CHANNELS, d_output_histograms_wrapper.begin());
+      ::cuda::std::copy(
+        typedAllocations, typedAllocations + NUM_ACTIVE_CHANNELS, d_privatized_histograms_wrapper.begin());
+      ::cuda::std::copy(
+        privatized_decode_op, privatized_decode_op + NUM_ACTIVE_CHANNELS, privatized_decode_op_wrapper.begin());
+      ::cuda::std::copy(output_decode_op, output_decode_op + NUM_ACTIVE_CHANNELS, output_decode_op_wrapper.begin());
 
-      // Setup array wrapper for sweep bin transforms (because we can't pass static arrays as
-      // kernel parameters)
-      ArrayWrapper<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op_wrapper;
-      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-      {
-        privatized_decode_op_wrapper.array[CHANNEL] = privatized_decode_op[CHANNEL];
-      }
-
-      // Setup array wrapper for aggregation bin transforms (because we can't pass static
-      // arrays as kernel parameters)
-      ArrayWrapper<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op_wrapper;
-      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-      {
-        output_decode_op_wrapper.array[CHANNEL] = output_decode_op[CHANNEL];
-      }
-
-      // Setup array wrapper for num privatized bins (because we can't pass static arrays as
-      // kernel parameters)
-      ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_privatized_bins_wrapper;
-      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-      {
-        num_privatized_bins_wrapper.array[CHANNEL] = num_privatized_levels[CHANNEL] - 1;
-      }
-
-      // Setup array wrapper for num output bins (because we can't pass static arrays as
-      // kernel parameters)
-      ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper;
-      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-      {
-        num_output_bins_wrapper.array[CHANNEL] = num_output_levels[CHANNEL] - 1;
-      }
-
+      auto minus_one = cuda::proclaim_return_type<int>([](int levels) {
+        return levels - 1;
+      });
+      ::cuda::std::transform(
+        num_privatized_levels,
+        num_privatized_levels + NUM_ACTIVE_CHANNELS,
+        num_privatized_bins_wrapper.begin(),
+        minus_one);
+      ::cuda::std::transform(
+        num_output_levels, num_output_levels + NUM_ACTIVE_CHANNELS, num_output_bins_wrapper.begin(), minus_one);
       int histogram_init_block_threads = 256;
 
       int histogram_init_grid_dims =

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -870,9 +870,10 @@ struct KeyValuePair<K, V, false, true>
 
 /**
  * \brief A wrapper for passing simple static arrays as kernel parameters
+ * deprecated [Since 2.5.0] The `cub::ArrayWrapper` is deprecated. Use `cuda::std::array` instead.
  */
 template <typename T, int COUNT>
-struct ArrayWrapper
+struct CUB_DEPRECATED_BECAUSE("Use cuda::std::array instead.") ArrayWrapper
 {
   /// Statically-sized array of type \p T
   T array[COUNT];


### PR DESCRIPTION
The type `cub::ArrayWrapper` is only used by CUB's histogram algorithms and can be replaced by `cuda::std::array`, which offers a superset of the functionality.

- [x] Check generated SASS is the same

The generated SASS is identical before and after this PR, except for the mangling of function names.