### PR TITLE
[CUB] Provide __half operators if user disabled them in CUDA headers.

### DIFF
--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -79,6 +79,113 @@
 
 CUB_NAMESPACE_BEGIN
 
+// Users may disable CUDA-provided __half operators, but CUB needs them.
+// See https://github.com/NVIDIA/cccl/discussions/1727 for the details.
+#if __CUDA_NO_HALF_OPERATORS__
+__host__ __device__ __forceinline__ __half operator+(const __half& lh, const __half& rh)
+{
+  return __hadd(lh, rh);
+}
+__host__ __device__ __forceinline__ __half operator-(const __half& lh, const __half& rh)
+{
+  return __hsub(lh, rh);
+}
+__host__ __device__ __forceinline__ __half operator*(const __half& lh, const __half& rh)
+{
+  return __hmul(lh, rh);
+}
+__host__ __device__ __forceinline__ __half operator/(const __half& lh, const __half& rh)
+{
+  return __hdiv(lh, rh);
+}
+__host__ __device__ __forceinline__ __half& operator+=(__half& lh, const __half& rh)
+{
+  lh = __hadd(lh, rh);
+  return lh;
+}
+__host__ __device__ __forceinline__ __half& operator-=(__half& lh, const __half& rh)
+{
+  lh = __hsub(lh, rh);
+  return lh;
+}
+__host__ __device__ __forceinline__ __half& operator*=(__half& lh, const __half& rh)
+{
+  lh = __hmul(lh, rh);
+  return lh;
+}
+__host__ __device__ __forceinline__ __half& operator/=(__half& lh, const __half& rh)
+{
+  lh = __hdiv(lh, rh);
+  return lh;
+}
+__host__ __device__ __forceinline__ __half& operator++(__half& h)
+{
+  __half_raw one;
+  one.x = 0x3C00U;
+  h += one;
+  return h;
+}
+__host__ __device__ __forceinline__ __half& operator--(__half& h)
+{
+  __half_raw one;
+  one.x = 0x3C00U;
+  h -= one;
+  return h;
+}
+__host__ __device__ __forceinline__ __half operator++(__half& h, const int ignored)
+{
+  static_cast<void>(ignored);
+
+  const __half ret = h;
+  __half_raw one;
+  one.x = 0x3C00U;
+  h += one;
+  return ret;
+}
+__host__ __device__ __forceinline__ __half operator--(__half& h, const int ignored)
+{
+  static_cast<void>(ignored);
+
+  const __half ret = h;
+  __half_raw one;
+  one.x = 0x3C00U;
+  h -= one;
+  return ret;
+}
+__host__ __device__ __forceinline__ __half operator+(const __half& h)
+{
+  return h;
+}
+__host__ __device__ __forceinline__ __half operator-(const __half& h)
+{
+  return __hneg(h);
+}
+__host__ __device__ __forceinline__ bool operator==(const __half& lh, const __half& rh)
+{
+  return __heq(lh, rh);
+}
+__host__ __device__ __forceinline__ bool operator!=(const __half& lh, const __half& rh)
+{
+  return __hneu(lh, rh);
+}
+__host__ __device__ __forceinline__ bool operator>(const __half& lh, const __half& rh)
+{
+  return __hgt(lh, rh);
+}
+__host__ __device__ __forceinline__ bool operator<(const __half& lh, const __half& rh)
+{
+  return __hlt(lh, rh);
+}
+__host__ __device__ __forceinline__ bool operator>=(const __half& lh, const __half& rh)
+{
+  return __hge(lh, rh);
+}
+__host__ __device__ __forceinline__ bool operator<=(const __half& lh, const __half& rh)
+{
+  return __hle(lh, rh);
+}
+#endif
+
 #ifndef CUB_IS_INT128_ENABLED
 #  if defined(__CUDACC_RTC__)
 #    if defined(__CUDACC_RTC_INT128__)


### PR DESCRIPTION
More details are here: https://github.com/NVIDIA/cccl/discussions/1727

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->
https://github.com/NVIDIA/cccl/issues/1766

<!-- Provide a standalone description of changes in this PR. -->
Provide operators for `__half`, if user disabled them in CUDA headers via `-D__CUDA_NO_HALF_OPERATORS__`

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
