### PR TITLE
Return demangled name in `c2h::type_name`

### DIFF
--- a/cub/test/c2h/utility.cuh
+++ b/cub/test/c2h/utility.cuh
@@ -27,9 +27,13 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <typeinfo>
+#ifdef __GNUC__
+#  include <cxxabi.h>
+#endif // __GNUC__
 
 namespace c2h
 {
@@ -47,10 +51,25 @@ __host__ __device__ To bit_cast(const From& in)
   return out;
 }
 
+// TODO(bgruber): duplicated version of thrust/testing/unittest/system.h
+inline std::string demangle(const char* name)
+{
+#if __GNUC__ && !_NVHPC_CUDA
+  int status     = 0;
+  char* realname = abi::__cxa_demangle(name, 0, 0, &status);
+  std::string result(realname);
+  std::free(realname);
+  return result;
+#else // __GNUC__ && !_NVHPC_CUDA
+  return name;
+#endif // __GNUC__ && !_NVHPC_CUDA
+}
+
+// TODO(bgruber): duplicated version of thrust/testing/unittest/util.h
 template <typename T>
 std::string type_name()
 {
-  return typeid(T).name();
+  return demangle(typeid(T).name());
 }
 
 } // namespace c2h

--- a/thrust/testing/unittest/system.h
+++ b/thrust/testing/unittest/system.h
@@ -11,22 +11,16 @@
 
 namespace unittest
 {
-
-#if __GNUC__ && !_NVHPC_CUDA
 inline std::string demangle(const char* name)
 {
+#if __GNUC__ && !_NVHPC_CUDA
   int status     = 0;
   char* realname = abi::__cxa_demangle(name, 0, 0, &status);
   std::string result(realname);
   std::free(realname);
-
   return result;
-}
 #else
-inline std::string demangle(const char* name)
-{
   return name;
-}
 #endif
-
+}
 } // namespace unittest


### PR DESCRIPTION
Thrust has a nice testing API to produce a demangled type name: `thrust::type_name<T>()`. The Catch2 helper in CUB's test is less capable. This PR improves CUB's version to be equivalent to thrust.

Ideally, CUB could use the thrust implementation, or vice-versa. Is there space for shared testing infrastructure?