### PR TITLE
Revert to showing skipped jobs to WAR GHA bug.

### DIFF
--- a/.github/workflows/workflow-dispatch-job.yml
+++ b/.github/workflows/workflow-dispatch-job.yml
@@ -1,23 +1,5 @@
 name: "Workflow/Dispatch/Job"
 
-# Important note about depending on this workflow: The `result` will be a failure, even if successful.
-#
-# This reusable workflow dispatches to a number of internal jobs. Only one job will run,
-# and some may be in error states due to empty matrices (which are used instead of `if` to keep
-# skipped dispatch jobs out of the GHA UI). The `continue-on-error` flag should prevent these
-# errors from failing the workflow, but this does not work.
-#
-# Thus, the `result` of this workflow will always be a failure, even if the job itself is successful.
-#
-# Instead, the results from each job is uploaded as an artifact. See the workflow_results action for more details.
-# To depend on this job, you should use the `success` output instead:
-#
-# ```
-# dependent_job:
-#   needs: dispatch-job
-#   if: ${{ !cancelled() && needs.dispatch-job.outputs.success }}
-# ```
-
 defaults:
   run:
     shell: bash --noprofile --norc -euo pipefail {0}
@@ -34,7 +16,6 @@ on:
       command: {type: string, required: true}
       id: {type: string, required: true}
       env: {type: string, required: false}
-      dummy_matrix: {type: string, required: false, default: '[{"valid": true}]'}
 
 permissions:
   contents: read
@@ -42,15 +23,12 @@ permissions:
 jobs:
   linux:
     name: ${{inputs.name}}
-    continue-on-error: ${{ ! startsWith(inputs.runner, 'linux') }}
+    if: ${{ startsWith(inputs.runner, 'linux') }}
     outputs:
       success: ${{ steps.done.outputs.SUCCESS }}
     permissions:
       id-token: write
       contents: read
-    strategy:
-      matrix:
-        include: ${{ fromJSON(startsWith(inputs.runner, 'linux') && inputs.dummy_matrix || '[]') }}
     runs-on: ${{inputs.runner}}
     container:
       options: -u root
@@ -146,16 +124,12 @@ jobs:
 
   windows:
     name: ${{inputs.name}}
-    continue-on-error: ${{ ! startsWith(inputs.runner, 'windows') }}
+    if: ${{ startsWith(inputs.runner, 'windows') }}
     outputs:
       success: ${{ steps.done.outputs.SUCCESS }}
     permissions:
       id-token: write
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(startsWith(inputs.runner, 'windows') && inputs.dummy_matrix || '[]') }}
     runs-on: ${{inputs.runner}}
     env:
       SCCACHE_BUCKET: rapids-sccache-devs

--- a/.github/workflows/workflow-dispatch-two-stage.yml
+++ b/.github/workflows/workflow-dispatch-two-stage.yml
@@ -46,8 +46,6 @@ jobs:
     # This keeps the UI from getting cluttered.
     name: "c.${{ matrix.id }}"
     needs: producers
-    # dispatch-job's result is always false, check the outputs instead. See ci-dispatch-job.yml for more information.
-    if: ${{ !cancelled() && fromJson(needs.producers.outputs.success) }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/workflow-dispatch.yml
+++ b/.github/workflows/workflow-dispatch.yml
@@ -20,6 +20,7 @@ jobs:
     # Give the job a short and unique name, otherwise github will bloat the job name with the matrix values.
     # This keeps the UI from getting cluttered.
     name: "s.${{ matrix.id }}"
+    if: ${{ fromJSON(inputs.jobs)['standalone'] != null }}
     permissions:
       id-token: write
       contents: read
@@ -40,6 +41,7 @@ jobs:
     # Give the job a short and unique name, otherwise github will bloat the job name with the matrix values.
     # This keeps the UI from getting cluttered.
     name: "t.${{ matrix.id }}"
+    if: ${{ fromJSON(inputs.jobs)['two_stage'] != null }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Dispatching to an empty matrix is breaking GHA, causing workflows to never terminate and become uncancellable.
This addresses the issue by skipping jobs instead.
The UI will be cluttered, but this restores cancel+rerun functionality.