### PR TITLE
Use `common_type` for complex `pow`

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/common_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/common_type.h
@@ -118,7 +118,7 @@ struct _LIBCUDACXX_TEMPLATE_VIS common_type<_Tp, _Up, _Vp, _Rest...>
     : __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...>>
 {};
 
-#if _CCCL_STD_VER > 2011
+#if _CCCL_STD_VER >= 2014
 template <class... _Tp>
 using common_type_t = typename common_type<_Tp...>::type;
 
@@ -127,7 +127,44 @@ _LIBCUDACXX_INLINE_VAR constexpr bool __has_common_type = false;
 
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VAR constexpr bool __has_common_type<_Tp, _Up, void_t<common_type_t<_Tp, _Up>>> = true;
-#endif
+#endif // _CCCL_STD_VER >= 2014
+
+#if defined(_LIBCUDACXX_HAS_NVFP16) && !defined(__CUDA_NO_HALF_CONVERSIONS__) && !defined(__CUDA_NO_HALF_OPERATORS__)
+template <>
+struct common_type<__half, __half>
+{
+  using type = __half;
+};
+template <class T>
+struct common_type<__half, T> : common_type<float, T>
+{};
+template <class T>
+struct common_type<T, __half> : common_type<T, float>
+{};
+#endif // _LIBCUDACXX_HAS_NVFP16 && !__CUDA_NO_HALF_CONVERSIONS__ && !__CUDA_NO_HALF_OPERATORS__
+
+#if defined(_LIBCUDACXX_HAS_NVBF16) && !defined(__CUDA_NO_BFLOAT16_CONVERSIONS__) \
+  && !defined(__CUDA_NO_BFLOAT16_OPERATORS__)
+template <>
+struct common_type<__nv_bfloat16, __nv_bfloat16>
+{
+  using type = __nv_bfloat16;
+};
+template <class T>
+struct common_type<__nv_bfloat16, T> : common_type<float, T>
+{};
+template <class T>
+struct common_type<T, __nv_bfloat16> : common_type<T, float>
+{};
+
+// __half and __nvbfloat16 have unordered conversion rank
+template <>
+struct common_type<__half, __nv_bfloat16>
+{};
+template <>
+struct common_type<__nv_bfloat16, __half>
+{};
+#endif // _LIBCUDACXX_HAS_NVBF16 && !__CUDA_NO_BFLOAT16_CONVERSIONS__ && !__CUDA_NO_BFLOAT16_OPERATORS__
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -603,7 +603,7 @@ inline _LIBCUDACXX_INLINE_VISIBILITY long double hypot(long double x, long doubl
 template <class _A1, class _A2, class _A3>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value && is_arithmetic<_A3>::value,
-              __promote<_A1, _A2, _A3>>
+              __promote_t<_A1, _A2, _A3>>
 hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) noexcept
 {
   using __result_type = __promote_t<_A1, _A2, _A3>;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -422,6 +422,14 @@ public:
   }
 };
 
+template <class>
+struct __is_complex : false_type
+{};
+
+template <class _Tp>
+struct __is_complex<complex<_Tp>> : true_type
+{};
+
 template <class _Tp, class _Up>
 _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14_COMPLEX complex<_Tp>&
 operator*=(complex<_Tp>& __lhs, const complex<_Up>& __rhs)
@@ -1109,25 +1117,24 @@ inline _LIBCUDACXX_INLINE_VISIBILITY complex<_Tp> pow(const complex<_Tp>& __x, c
 }
 
 template <class _Tp, class _Up>
-inline _LIBCUDACXX_INLINE_VISIBILITY complex<__promote_t<_Tp, _Up>> pow(const complex<_Tp>& __x, const complex<_Up>& __y)
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<__common_type_t<_Tp, _Up>>
+pow(const complex<_Tp>& __x, const complex<_Up>& __y)
 {
-  using __result_type = complex<__promote_t<_Tp, _Up>>;
+  using __result_type = complex<__common_type_t<_Tp, _Up>>;
   return _CUDA_VSTD::pow(__result_type(__x), __result_type(__y));
 }
 
-template <class _Tp, class _Up>
-inline _LIBCUDACXX_INLINE_VISIBILITY __enable_if_t<__is_complex_arithmetic<_Up>::value, complex<__promote_t<_Tp, _Up>>>
-pow(const complex<_Tp>& __x, const _Up& __y)
+template <class _Tp, class _Up, __enable_if_t<!__is_complex<_Up>::value, int> = 0>
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<__common_type_t<_Tp, _Up>> pow(const complex<_Tp>& __x, const _Up& __y)
 {
-  using __result_type = complex<__promote_t<_Tp, _Up>>;
+  using __result_type = complex<__common_type_t<_Tp, _Up>>;
   return _CUDA_VSTD::pow(__result_type(__x), __result_type(__y));
 }
 
-template <class _Tp, class _Up>
-inline _LIBCUDACXX_INLINE_VISIBILITY __enable_if_t<__is_complex_arithmetic<_Tp>::value, complex<__promote_t<_Tp, _Up>>>
-pow(const _Tp& __x, const complex<_Up>& __y)
+template <class _Tp, class _Up, __enable_if_t<!__is_complex<_Tp>::value, int> = 0>
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<__common_type_t<_Tp, _Up>> pow(const _Tp& __x, const complex<_Up>& __y)
 {
-  using __result_type = complex<__promote_t<_Tp, _Up>>;
+  using __result_type = complex<__common_type_t<_Tp, _Up>>;
   return _CUDA_VSTD::pow(__result_type(__x, 0), __result_type(__y));
 }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -1116,6 +1116,9 @@ inline _LIBCUDACXX_INLINE_VISIBILITY complex<_Tp> pow(const complex<_Tp>& __x, c
   return _CUDA_VSTD::exp(__y * _CUDA_VSTD::log(__x));
 }
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4244)
+
 template <class _Tp, class _Up>
 inline _LIBCUDACXX_INLINE_VISIBILITY complex<__common_type_t<_Tp, _Up>>
 pow(const complex<_Tp>& __x, const complex<_Up>& __y)
@@ -1137,6 +1140,8 @@ inline _LIBCUDACXX_INLINE_VISIBILITY complex<__common_type_t<_Tp, _Up>> pow(cons
   using __result_type = complex<__common_type_t<_Tp, _Up>>;
   return _CUDA_VSTD::pow(__result_type(__x, 0), __result_type(__y));
 }
+
+_CCCL_DIAG_POP
 
 // __sqr, computes pow(x, 2)
 

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_complex_scalar.pass.cpp
@@ -19,18 +19,19 @@
 #include "../cases.h"
 #include "test_macros.h"
 
-template <class T>
-__host__ __device__ void test(const cuda::std::complex<T>& a, const T& b, cuda::std::complex<T> x)
+template <class T, class U = T>
+__host__ __device__ void test(const cuda::std::complex<T>& a, const U& b, cuda::std::complex<T> x)
 {
+  static_assert(cuda::std::is_same<decltype(pow(a, b)), cuda::std::complex<T>>::value, "");
   cuda::std::complex<T> c = pow(a, b);
   is_about(real(c), real(x));
   is_about(imag(c), imag(x));
 }
 
-template <class T>
+template <class T, class U = T>
 __host__ __device__ void test()
 {
-  test(cuda::std::complex<T>(2, 3), T(2), cuda::std::complex<T>(-5, 12));
+  test(cuda::std::complex<T>(2, 3), U(2), cuda::std::complex<T>(-5, 12));
 }
 
 template <class T>
@@ -68,21 +69,23 @@ int main(int, char**)
 {
   test<float>();
   test<double>();
-// CUDA treats long double as double
-//  test<long double>();
+  // CUDA treats long double as double
+  //  test<long double>();
+
+  // Also test conversions
+  test<float, int>();
+  test<double, size_t>();
+
+  test_edges<double>();
+
 #ifdef _LIBCUDACXX_HAS_NVFP16
   test<__half>();
-#endif
+  test_edges<__half>();
+#endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
   test<__nv_bfloat16>();
-#endif
-  test_edges<double>();
-#ifdef _LIBCUDACXX_HAS_NVFP16
-  test_edges<__half>();
-#endif
-#ifdef _LIBCUDACXX_HAS_NVBF16
   test_edges<__nv_bfloat16>();
-#endif
+#endif // _LIBCUDACXX_HAS_NVBF16
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
@@ -19,18 +19,19 @@
 #include "../cases.h"
 #include "test_macros.h"
 
-template <class T>
-__host__ __device__ void test(const T& a, const cuda::std::complex<T>& b, cuda::std::complex<T> x)
+template <class T, class U = T>
+__host__ __device__ void test(const U& a, const cuda::std::complex<T>& b, cuda::std::complex<T> x)
 {
+  static_assert(cuda::std::is_same<decltype(pow(a, b)), cuda::std::complex<T>>::value, "");
   cuda::std::complex<T> c = pow(a, b);
   is_about(real(c), real(x));
   assert(cuda::std::abs(imag(c)) < T(1.e-6));
 }
 
-template <class T>
+template <class T, class U = T>
 __host__ __device__ void test()
 {
-  test(T(2), cuda::std::complex<T>(2), cuda::std::complex<T>(4));
+  test(U(2), cuda::std::complex<T>(2), cuda::std::complex<T>(4));
 }
 
 template <class T>
@@ -68,21 +69,23 @@ int main(int, char**)
 {
   test<float>();
   test<double>();
-// CUDA treats long double as double
-//  test<long double>();
+  // CUDA treats long double as double
+  //  test<long double>();
+
+  // Also test conversions
+  test<float, int>();
+  test<double, size_t>();
+
+  test_edges<double>();
+
 #ifdef _LIBCUDACXX_HAS_NVFP16
   test<__half>();
-#endif
+  test_edges<__half>();
+#endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
   test<__nv_bfloat16>();
-#endif
-  test_edges<double>();
-#ifdef _LIBCUDACXX_HAS_NVFP16
-  test_edges<__half>();
-#endif
-#ifdef _LIBCUDACXX_HAS_NVBF16
   test_edges<__nv_bfloat16>();
-#endif
+#endif // _LIBCUDACXX_HAS_NVBF16
 
   return 0;
 }


### PR DESCRIPTION
Previously we would rely on our internal `__promote` function.

However, that could have surprising results, e.g. `pow(complexy<float>, int)` would return `complex<double>`

With C++23, this situation got clarified and we should use `common_type` to determine the return type.
