### PR TITLE
Let Catch2 report cudaError descriptions

### DIFF
--- a/cub/test/catch2_test_helper.h
+++ b/cub/test/catch2_test_helper.h
@@ -42,6 +42,7 @@ _CCCL_NV_DIAG_SUPPRESS(177) // catch2 may contain unused variableds
 #endif // nvcc-11
 
 #include <cuda/std/cmath>
+#include <cuda/std/utility>
 
 #include "catch2_main.cuh"
 #include "test_warning_suppression.cuh"
@@ -215,6 +216,15 @@ template <typename... T>
   return os << "]";
 }
 _LIBCUDACXX_END_NAMESPACE_STD
+
+template <>
+struct Catch::StringMaker<cudaError>
+{
+  static auto convert(cudaError e) -> std::string
+  {
+    return std::to_string(cuda::std::__to_underlying(e)) + " (" + cudaGetErrorString(e) + ")";
+  }
+};
 
 #include <c2h/custom_type.cuh>
 #include <c2h/generators.cuh>


### PR DESCRIPTION
This PR adds a Catch2 string maker to pretty-print `cudaError`s. A failed check that looked like:
```
/home/bgruber/dev/cccl/cub/test/catch2_test_launch_helper.h:196: FAILED:
  REQUIRE( cudaSuccess == error )
with expansion:
  0 == 9
```
will then look like:
```
/home/bgruber/dev/cccl/cub/test/catch2_test_launch_helper.h:196: FAILED:
  REQUIRE( cudaSuccess == error )
with expansion:
  0 (no error)
  ==
  9 (invalid configuration argument)
```