### PR TITLE
Drop removed clang-tidy option

### DIFF
--- a/cub/.clang-tidy
+++ b/cub/.clang-tidy
@@ -11,7 +11,6 @@ Checks:
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
  - key:             modernize-loop-convert.MaxCopySize


### PR DESCRIPTION
The `AnalyzeTemporaryDestructors` option was deprecated in clang-tidy 16 and removed in 18.

See also: https://reviews.llvm.org/D156303
