### PR TITLE
Port `thrust::merge[_by_key]` to CUB

### DIFF
--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once
 

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -171,7 +171,12 @@ struct agent_t
 
     // if items are provided, merge them
     static constexpr bool have_items = !std::is_same<item_type, NullType>::value;
+#ifdef _CCCL_CUDACC_BELOW_11_8
+    if (have_items) // nvcc 11.1 cannot handle #pragma unroll inside if constexpr but 11.8 can.
+                    // nvcc versions between may work
+#else
     _CCCL_IF_CONSTEXPR (have_items)
+#endif
     {
       item_type items_loc[items_per_thread];
       gmem_to_reg<threads_per_block, IsFullTile>(

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/agent/agent_merge_sort.cuh>
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_merge_sort.cuh>
+#include <cub/block/block_store.cuh>
+#include <cub/util_namespace.cuh>
+#include <cub/util_type.cuh>
+
+#include <thrust/system/cuda/detail/core/util.h>
+
+#include <cuda/std/__cccl/dialect.h>
+
+CUB_NAMESPACE_BEGIN
+namespace detail
+{
+namespace merge
+{
+template <int ThreadsPerBlock,
+          int ItemsPerThread,
+          BlockLoadAlgorithm LoadAlgorithm,
+          CacheLoadModifier LoadCacheModifier,
+          BlockStoreAlgorithm StoreAlgorithm>
+struct agent_policy_t
+{
+  // do not change data member names, policy_wrapper_t depends on it
+  static constexpr int BLOCK_THREADS                   = ThreadsPerBlock;
+  static constexpr int ITEMS_PER_THREAD                = ItemsPerThread;
+  static constexpr int ITEMS_PER_TILE                  = BLOCK_THREADS * ITEMS_PER_THREAD;
+  static constexpr BlockLoadAlgorithm LOAD_ALGORITHM   = LoadAlgorithm;
+  static constexpr CacheLoadModifier LOAD_MODIFIER     = LoadCacheModifier;
+  static constexpr BlockStoreAlgorithm STORE_ALGORITHM = StoreAlgorithm;
+};
+
+// TODO(bgruber): can we unify this one with AgentMerge in agent_merge_sort.cuh?
+template <typename Policy,
+          typename KeysIt1,
+          typename ItemsIt1,
+          typename KeysIt2,
+          typename ItemsIt2,
+          typename KeysOutputIt,
+          typename ItemsOutputIt,
+          typename Offset,
+          typename CompareOp>
+struct agent_t
+{
+  using policy = Policy;
+
+  using key_type  = typename ::cuda::std::iterator_traits<KeysIt1>::value_type;
+  using item_type = typename ::cuda::std::iterator_traits<ItemsIt1>::value_type;
+
+  using keys_load_it1  = typename THRUST_NS_QUALIFIER::cuda_cub::core::LoadIterator<Policy, KeysIt1>::type;
+  using keys_load_it2  = typename THRUST_NS_QUALIFIER::cuda_cub::core::LoadIterator<Policy, KeysIt2>::type;
+  using items_load_it1 = typename THRUST_NS_QUALIFIER::cuda_cub::core::LoadIterator<Policy, ItemsIt1>::type;
+  using items_load_it2 = typename THRUST_NS_QUALIFIER::cuda_cub::core::LoadIterator<Policy, ItemsIt2>::type;
+
+  using block_load_keys1  = typename BlockLoadType<Policy, keys_load_it1>::type;
+  using block_load_keys2  = typename BlockLoadType<Policy, keys_load_it2>::type;
+  using block_load_items1 = typename BlockLoadType<Policy, items_load_it1>::type;
+  using block_load_items2 = typename BlockLoadType<Policy, items_load_it2>::type;
+
+  using block_store_keys  = typename BlockStoreType<Policy, KeysOutputIt, key_type>::type;
+  using block_store_items = typename BlockStoreType<Policy, ItemsOutputIt, item_type>::type;
+
+  union temp_storages
+  {
+    typename block_load_keys1::TempStorage load_keys1;
+    typename block_load_keys2::TempStorage load_keys2;
+    typename block_load_items1::TempStorage load_items1;
+    typename block_load_items2::TempStorage load_items2;
+    typename block_store_keys::TempStorage store_keys;
+    typename block_store_items::TempStorage store_items;
+
+    key_type keys_shared[Policy::ITEMS_PER_TILE + 1];
+    item_type items_shared[Policy::ITEMS_PER_TILE + 1];
+  };
+
+  struct TempStorage : Uninitialized<temp_storages>
+  {};
+
+  static constexpr int items_per_thread  = Policy::ITEMS_PER_THREAD;
+  static constexpr int threads_per_block = Policy::BLOCK_THREADS;
+  static constexpr Offset items_per_tile = Policy::ITEMS_PER_TILE;
+
+  // Per thread data
+  temp_storages& storage;
+  keys_load_it1 keys1_in;
+  items_load_it1 items1_in;
+  Offset keys1_count;
+  keys_load_it2 keys2_in;
+  items_load_it2 items2_in;
+  Offset keys2_count;
+  KeysOutputIt keys_out;
+  ItemsOutputIt items_out;
+  CompareOp compare_op;
+  Offset* merge_partitions;
+
+  template <bool IsFullTile>
+  _CCCL_DEVICE _CCCL_FORCEINLINE void consume_tile(Offset tile_idx, Offset tile_base, int num_remaining)
+  {
+    const Offset partition_beg = merge_partitions[tile_idx + 0];
+    const Offset partition_end = merge_partitions[tile_idx + 1];
+
+    const Offset diag0 = items_per_tile * tile_idx;
+    const Offset diag1 = (cub::min)(keys1_count + keys2_count, diag0 + items_per_tile);
+
+    // compute bounding box for keys1 & keys2
+    const Offset keys1_beg = partition_beg;
+    const Offset keys1_end = partition_end;
+    const Offset keys2_beg = diag0 - keys1_beg;
+    const Offset keys2_end = diag1 - keys1_end;
+
+    // number of keys per tile
+    const int num_keys1 = static_cast<int>(keys1_end - keys1_beg);
+    const int num_keys2 = static_cast<int>(keys2_end - keys2_beg);
+
+    key_type keys_loc[items_per_thread];
+    gmem_to_reg<threads_per_block, IsFullTile>(
+      keys_loc, keys1_in + keys1_beg, keys2_in + keys2_beg, num_keys1, num_keys2);
+    reg_to_shared<threads_per_block>(&storage.keys_shared[0], keys_loc);
+    CTA_SYNC();
+
+    // use binary search in shared memory to find merge path for each of thread.
+    // we can use int type here, because the number of items in shared memory is limited
+    const int diag0_loc = min<int>(num_keys1 + num_keys2, items_per_thread * threadIdx.x);
+
+    const int keys1_beg_loc =
+      MergePath(&storage.keys_shared[0], &storage.keys_shared[num_keys1], num_keys1, num_keys2, diag0_loc, compare_op);
+    const int keys1_end_loc = num_keys1;
+    const int keys2_beg_loc = diag0_loc - keys1_beg_loc;
+    const int keys2_end_loc = num_keys2;
+
+    const int num_keys1_loc = keys1_end_loc - keys1_beg_loc;
+    const int num_keys2_loc = keys2_end_loc - keys2_beg_loc;
+
+    // perform serial merge
+    int indices[items_per_thread];
+    cub::SerialMerge(
+      &storage.keys_shared[0],
+      keys1_beg_loc,
+      keys2_beg_loc + num_keys1,
+      num_keys1_loc,
+      num_keys2_loc,
+      keys_loc,
+      indices,
+      compare_op);
+    CTA_SYNC();
+
+    // write keys
+    if (IsFullTile)
+    {
+      block_store_keys{storage.store_keys}.Store(keys_out + tile_base, keys_loc);
+    }
+    else
+    {
+      block_store_keys{storage.store_keys}.Store(keys_out + tile_base, keys_loc, num_remaining);
+    }
+
+    // if items are provided, merge them
+    static constexpr bool have_items = !std::is_same<item_type, NullType>::value;
+    _CCCL_IF_CONSTEXPR (have_items)
+    {
+      item_type items_loc[items_per_thread];
+      gmem_to_reg<threads_per_block, IsFullTile>(
+        items_loc, items1_in + keys1_beg, items2_in + keys2_beg, num_keys1, num_keys2);
+      CTA_SYNC(); // TODO(bgruber): there is no sync when loading keys. bug or unnecessary?
+      reg_to_shared<threads_per_block>(&storage.items_shared[0], items_loc);
+      CTA_SYNC();
+
+      // gather items from shared mem
+#pragma unroll
+      for (int i = 0; i < items_per_thread; ++i)
+      {
+        items_loc[i] = storage.items_shared[indices[i]];
+      }
+      CTA_SYNC();
+
+      // write from reg to gmem
+      if (IsFullTile)
+      {
+        block_store_items{storage.store_items}.Store(items_out + tile_base, items_loc);
+      }
+      else
+      {
+        block_store_items{storage.store_items}.Store(items_out + tile_base, items_loc, num_remaining);
+      }
+    }
+  }
+
+  _CCCL_DEVICE _CCCL_FORCEINLINE void operator()()
+  {
+    // XXX with 8.5 chaging type to Offset (or long long) results in error!
+    // TODO(bgruber): is the above still true?
+    const int tile_idx     = static_cast<int>(blockIdx.x);
+    const Offset tile_base = tile_idx * items_per_tile;
+    // TODO(bgruber): random mixing of int and Offset
+    const int items_in_tile =
+      static_cast<int>(cub::min(static_cast<Offset>(items_per_tile), keys1_count + keys2_count - tile_base));
+    if (items_in_tile == items_per_tile)
+    {
+      consume_tile<true>(tile_idx, tile_base, items_per_tile); // full tile
+    }
+    else
+    {
+      consume_tile<false>(tile_idx, tile_base, items_in_tile); // partial tile
+    }
+  }
+};
+} // namespace merge
+} // namespace detail
+CUB_NAMESPACE_END

--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -181,7 +181,7 @@ struct agent_t
       item_type items_loc[items_per_thread];
       gmem_to_reg<threads_per_block, IsFullTile>(
         items_loc, items1_in + keys1_beg, items2_in + keys2_beg, num_keys1, num_keys2);
-      CTA_SYNC(); // TODO(bgruber): there is no sync when loading keys. bug or unnecessary?
+      CTA_SYNC(); // block_store_keys above uses shared memory, so make sure all threads are done before we write to it
       reg_to_shared<threads_per_block>(&storage.items_shared[0], items_loc);
       CTA_SYNC();
 

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -347,19 +347,18 @@ struct AgentPartition
 
       OffsetT partition_diag =
         ping
-          ? MergePath(
-              keys_ping + keys1_beg,
-              keys_ping + keys2_beg,
-              keys1_end - keys1_beg,
-              keys2_end - keys2_beg,
-              partition_at,
-              compare_op)
+          ? MergePath(keys_ping + keys1_beg,
+                      keys_ping + keys2_beg,
+                      keys1_end - keys1_beg,
+                      keys2_end - keys2_beg,
+                      partition_at,
+                      compare_op)
           : MergePath(keys_pong + keys1_beg,
-                         keys_pong + keys2_beg,
-                         keys1_end - keys1_beg,
-                         keys2_end - keys2_beg,
-                         partition_at,
-                         compare_op);
+                      keys_pong + keys2_beg,
+                      keys1_end - keys1_beg,
+                      keys2_end - keys2_beg,
+                      partition_at,
+                      compare_op);
 
       merge_partitions[partition_idx] = keys1_beg + partition_diag;
     }

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -383,17 +383,8 @@ gmem_to_reg(T (&output)[ITEMS_PER_THREAD], It1 input1, It2 input2, int count1, i
 #pragma unroll
     for (int item = 0; item < ITEMS_PER_THREAD; ++item)
     {
-      int idx = BLOCK_THREADS * item + threadIdx.x;
-      // FIXME(bgruber): the CUB version (1 LOC below) generates different SASS than the if/else from Thrust
-      // output[item] = (idx < count1) ? input1[idx] : input2[idx - count1];
-      if (idx < count1)
-      {
-        output[item] = input1[idx];
-      }
-      else
-      {
-        output[item] = input2[idx - count1];
-      }
+      int idx      = BLOCK_THREADS * item + threadIdx.x;
+      output[item] = (idx < count1) ? input1[idx] : input2[idx - count1];
     }
   }
   else
@@ -404,16 +395,7 @@ gmem_to_reg(T (&output)[ITEMS_PER_THREAD], It1 input1, It2 input2, int count1, i
       int idx = BLOCK_THREADS * item + threadIdx.x;
       if (idx < count1 + count2)
       {
-        // FIXME(bgruber): the CUB version (1 LOC below) generates different SASS than the if/else from Thrust
-        // output[item] = (idx < count1) ? input1[idx] : input2[idx - count1];
-        if (idx < count1)
-        {
-          output[item] = input1[idx];
-        }
-        else
-        {
-          output[item] = input2[idx - count1];
-        }
+        output[item] = (idx < count1) ? input1[idx] : input2[idx - count1];
       }
     }
   }

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -172,9 +172,9 @@ struct AgentBlockSort
   _CCCL_DEVICE _CCCL_FORCEINLINE void consume_tile(OffsetT tile_base, int num_remaining)
   {
     ValueT items_local[ITEMS_PER_THREAD];
-    if (!KEYS_ONLY)
+    _CCCL_IF_CONSTEXPR (!KEYS_ONLY)
     {
-      if (IS_LAST_TILE)
+      _CCCL_IF_CONSTEXPR (IS_LAST_TILE)
       {
         BlockLoadItems(storage.load_items)
           .Load(items_in + tile_base, items_local, num_remaining, *(items_in + tile_base));
@@ -188,7 +188,7 @@ struct AgentBlockSort
     }
 
     KeyT keys_local[ITEMS_PER_THREAD];
-    if (IS_LAST_TILE)
+    _CCCL_IF_CONSTEXPR (IS_LAST_TILE)
     {
       BlockLoadKeys(storage.load_keys).Load(keys_in + tile_base, keys_local, num_remaining, *(keys_in + tile_base));
     }
@@ -199,7 +199,7 @@ struct AgentBlockSort
 
     CTA_SYNC();
 
-    if (IS_LAST_TILE)
+    _CCCL_IF_CONSTEXPR (IS_LAST_TILE)
     {
       BlockMergeSortT(storage.block_merge).Sort(keys_local, items_local, compare_op, num_remaining, keys_local[0]);
     }
@@ -212,7 +212,7 @@ struct AgentBlockSort
 
     if (ping)
     {
-      if (IS_LAST_TILE)
+      _CCCL_IF_CONSTEXPR (IS_LAST_TILE)
       {
         BlockStoreKeysIt(storage.store_keys_it).Store(keys_out_it + tile_base, keys_local, num_remaining);
       }
@@ -221,11 +221,11 @@ struct AgentBlockSort
         BlockStoreKeysIt(storage.store_keys_it).Store(keys_out_it + tile_base, keys_local);
       }
 
-      if (!KEYS_ONLY)
+      _CCCL_IF_CONSTEXPR (!KEYS_ONLY)
       {
         CTA_SYNC();
 
-        if (IS_LAST_TILE)
+        _CCCL_IF_CONSTEXPR (IS_LAST_TILE)
         {
           BlockStoreItemsIt(storage.store_items_it).Store(items_out_it + tile_base, items_local, num_remaining);
         }
@@ -237,7 +237,7 @@ struct AgentBlockSort
     }
     else
     {
-      if (IS_LAST_TILE)
+      _CCCL_IF_CONSTEXPR (IS_LAST_TILE)
       {
         BlockStoreKeysRaw(storage.store_keys_raw).Store(keys_out_raw + tile_base, keys_local, num_remaining);
       }
@@ -246,11 +246,11 @@ struct AgentBlockSort
         BlockStoreKeysRaw(storage.store_keys_raw).Store(keys_out_raw + tile_base, keys_local);
       }
 
-      if (!KEYS_ONLY)
+      _CCCL_IF_CONSTEXPR (!KEYS_ONLY)
       {
         CTA_SYNC();
 
-        if (IS_LAST_TILE)
+        _CCCL_IF_CONSTEXPR (IS_LAST_TILE)
         {
           BlockStoreItemsRaw(storage.store_items_raw).Store(items_out_raw + tile_base, items_local, num_remaining);
         }
@@ -316,25 +316,25 @@ struct AgentPartition
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
-    OffsetT merged_tiles_number = target_merged_tiles_number / 2;
+    const OffsetT merged_tiles_number = target_merged_tiles_number / 2;
 
     // target_merged_tiles_number is a power of two.
-    OffsetT mask = target_merged_tiles_number - 1;
+    const OffsetT mask = target_merged_tiles_number - 1;
 
     // The first tile number in the tiles group being merged, equal to:
     // target_merged_tiles_number * (partition_idx / target_merged_tiles_number)
-    OffsetT list  = ~mask & partition_idx;
-    OffsetT start = items_per_tile * list;
-    OffsetT size  = items_per_tile * merged_tiles_number;
+    const OffsetT list  = ~mask & partition_idx;
+    const OffsetT start = items_per_tile * list;
+    const OffsetT size  = items_per_tile * merged_tiles_number;
 
     // Tile number within the tile group being merged, equal to:
     // partition_idx / target_merged_tiles_number
-    OffsetT local_tile_idx = mask & partition_idx;
+    const OffsetT local_tile_idx = mask & partition_idx;
 
-    OffsetT keys1_beg = (cub::min)(keys_count, start);
-    OffsetT keys1_end = (cub::min)(keys_count, detail::safe_add_bound_to_max(start, size));
-    OffsetT keys2_beg = keys1_end;
-    OffsetT keys2_end = (cub::min)(keys_count, detail::safe_add_bound_to_max(keys2_beg, size));
+    const OffsetT keys1_beg = (cub::min)(keys_count, start);
+    const OffsetT keys1_end = (cub::min)(keys_count, detail::safe_add_bound_to_max(start, size));
+    const OffsetT keys2_beg = keys1_end;
+    const OffsetT keys2_end = (cub::min)(keys_count, detail::safe_add_bound_to_max(keys2_beg, size));
 
     // The last partition (which is one-past-the-last-tile) is only to mark the end of keys1_end for the merge stage
     if (partition_idx + 1 == num_partitions)
@@ -343,29 +343,94 @@ struct AgentPartition
     }
     else
     {
-      OffsetT partition_at = (cub::min)(keys2_end - keys1_beg, items_per_tile * local_tile_idx);
+      const OffsetT partition_at = (cub::min)(keys2_end - keys1_beg, items_per_tile * local_tile_idx);
 
       OffsetT partition_diag =
         ping
-          ? MergePath<KeyT>(
+          ? MergePath(
               keys_ping + keys1_beg,
               keys_ping + keys2_beg,
               keys1_end - keys1_beg,
               keys2_end - keys2_beg,
               partition_at,
               compare_op)
-          : MergePath<KeyT>(
-              keys_pong + keys1_beg,
-              keys_pong + keys2_beg,
-              keys1_end - keys1_beg,
-              keys2_end - keys2_beg,
-              partition_at,
-              compare_op);
+          : MergePath(keys_pong + keys1_beg,
+                         keys_pong + keys2_beg,
+                         keys1_end - keys1_beg,
+                         keys2_end - keys2_beg,
+                         partition_at,
+                         compare_op);
 
       merge_partitions[partition_idx] = keys1_beg + partition_diag;
     }
   }
 };
+
+namespace detail
+{
+/**
+ * \brief Concatenates up to ITEMS_PER_THREAD elements from input{1,2} into output array
+ *
+ * Reads data in a coalesced fashion [BLOCK_THREADS * item + tid] and
+ * stores the result in output[item].
+ */
+template <int BLOCK_THREADS, bool IS_FULL_TILE, int ITEMS_PER_THREAD, class T, class It1, class It2>
+_CCCL_DEVICE _CCCL_FORCEINLINE void
+gmem_to_reg(T (&output)[ITEMS_PER_THREAD], It1 input1, It2 input2, int count1, int count2)
+{
+  _CCCL_IF_CONSTEXPR (IS_FULL_TILE)
+  {
+#pragma unroll
+    for (int item = 0; item < ITEMS_PER_THREAD; ++item)
+    {
+      int idx = BLOCK_THREADS * item + threadIdx.x;
+      // FIXME(bgruber): the CUB version (1 LOC below) generates different SASS than the if/else from Thrust
+      // output[item] = (idx < count1) ? input1[idx] : input2[idx - count1];
+      if (idx < count1)
+      {
+        output[item] = input1[idx];
+      }
+      else
+      {
+        output[item] = input2[idx - count1];
+      }
+    }
+  }
+  else
+  {
+#pragma unroll
+    for (int item = 0; item < ITEMS_PER_THREAD; ++item)
+    {
+      int idx = BLOCK_THREADS * item + threadIdx.x;
+      if (idx < count1 + count2)
+      {
+        // FIXME(bgruber): the CUB version (1 LOC below) generates different SASS than the if/else from Thrust
+        // output[item] = (idx < count1) ? input1[idx] : input2[idx - count1];
+        if (idx < count1)
+        {
+          output[item] = input1[idx];
+        }
+        else
+        {
+          output[item] = input2[idx - count1];
+        }
+      }
+    }
+  }
+}
+
+/// \brief Stores data in a coalesced fashion in[item] -> out[BLOCK_THREADS * item + tid]
+template <int BLOCK_THREADS, int ITEMS_PER_THREAD, class T, class It>
+_CCCL_DEVICE _CCCL_FORCEINLINE void reg_to_shared(It output, T (&input)[ITEMS_PER_THREAD])
+{
+#pragma unroll
+  for (int item = 0; item < ITEMS_PER_THREAD; ++item)
+  {
+    int idx     = BLOCK_THREADS * item + threadIdx.x;
+    output[idx] = input[item];
+  }
+}
+} // namespace detail
 
 /// \brief The agent is responsible for merging N consecutive sorted arrays into N/2 sorted arrays.
 template <typename Policy,
@@ -444,81 +509,36 @@ struct AgentMerge
   // Utility functions
   //---------------------------------------------------------------------
 
-  /**
-   * \brief Concatenates up to ITEMS_PER_THREAD elements from input{1,2} into output array
-   *
-   * Reads data in a coalesced fashion [BLOCK_THREADS * item + tid] and
-   * stores the result in output[item].
-   */
-  template <bool IS_FULL_TILE, class T, class It1, class It2>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  gmem_to_reg(T (&output)[ITEMS_PER_THREAD], It1 input1, It2 input2, int count1, int count2)
-  {
-    if (IS_FULL_TILE)
-    {
-#pragma unroll
-      for (int item = 0; item < ITEMS_PER_THREAD; ++item)
-      {
-        int idx      = BLOCK_THREADS * item + threadIdx.x;
-        output[item] = (idx < count1) ? input1[idx] : input2[idx - count1];
-      }
-    }
-    else
-    {
-#pragma unroll
-      for (int item = 0; item < ITEMS_PER_THREAD; ++item)
-      {
-        int idx = BLOCK_THREADS * item + threadIdx.x;
-        if (idx < count1 + count2)
-        {
-          output[item] = (idx < count1) ? input1[idx] : input2[idx - count1];
-        }
-      }
-    }
-  }
-
-  /// \brief Stores data in a coalesced fashion in[item] -> out[BLOCK_THREADS * item + tid]
-  template <class T, class It>
-  _CCCL_DEVICE _CCCL_FORCEINLINE void reg_to_shared(It output, T (&input)[ITEMS_PER_THREAD])
-  {
-#pragma unroll
-    for (int item = 0; item < ITEMS_PER_THREAD; ++item)
-    {
-      int idx     = BLOCK_THREADS * item + threadIdx.x;
-      output[idx] = input[item];
-    }
-  }
-
   template <bool IS_FULL_TILE>
   _CCCL_DEVICE _CCCL_FORCEINLINE void consume_tile(int tid, OffsetT tile_idx, OffsetT tile_base, int count)
   {
-    OffsetT partition_beg = merge_partitions[tile_idx + 0];
-    OffsetT partition_end = merge_partitions[tile_idx + 1];
+    const OffsetT partition_beg = merge_partitions[tile_idx + 0];
+    const OffsetT partition_end = merge_partitions[tile_idx + 1];
 
     // target_merged_tiles_number is a power of two.
-    OffsetT merged_tiles_number = target_merged_tiles_number / 2;
+    const OffsetT merged_tiles_number = target_merged_tiles_number / 2;
 
-    OffsetT mask = target_merged_tiles_number - 1;
+    const OffsetT mask = target_merged_tiles_number - 1;
 
     // The first tile number in the tiles group being merged, equal to:
     // target_merged_tiles_number * (tile_idx / target_merged_tiles_number)
-    OffsetT list  = ~mask & tile_idx;
-    OffsetT start = ITEMS_PER_TILE * list;
-    OffsetT size  = ITEMS_PER_TILE * merged_tiles_number;
+    const OffsetT list  = ~mask & tile_idx;
+    const OffsetT start = ITEMS_PER_TILE * list;
+    const OffsetT size  = ITEMS_PER_TILE * merged_tiles_number;
 
-    OffsetT diag = ITEMS_PER_TILE * tile_idx - start;
+    const OffsetT diag = ITEMS_PER_TILE * tile_idx - start;
 
-    OffsetT keys1_beg = partition_beg - start;
-    OffsetT keys1_end = partition_end - start;
+    const OffsetT keys1_beg = partition_beg - start;
+    OffsetT keys1_end       = partition_end - start;
 
-    OffsetT keys_end_dist_from_start = keys_count - start;
-    OffsetT max_keys2                = (keys_end_dist_from_start > size) ? (keys_end_dist_from_start - size) : 0;
+    const OffsetT keys_end_dist_from_start = keys_count - start;
+    const OffsetT max_keys2                = (keys_end_dist_from_start > size) ? (keys_end_dist_from_start - size) : 0;
 
     // We have the following invariants:
     // diag >= keys1_beg, because diag is the distance of the total merge path so far (keys1 + keys2)
     // diag+ITEMS_PER_TILE >= keys1_end, because diag+ITEMS_PER_TILE is the distance of the merge path for the next tile
     // and keys1_end is key1's component of that path
-    OffsetT keys2_beg = (cub::min)(max_keys2, diag - keys1_beg);
+    const OffsetT keys2_beg = (cub::min)(max_keys2, diag - keys1_beg);
     OffsetT keys2_end =
       (cub::min)(max_keys2, detail::safe_add_bound_to_max(diag, static_cast<OffsetT>(ITEMS_PER_TILE)) - keys1_end);
 
@@ -530,32 +550,31 @@ struct AgentMerge
     }
 
     // number of keys per tile
-    //
-    int num_keys1 = static_cast<int>(keys1_end - keys1_beg);
-    int num_keys2 = static_cast<int>(keys2_end - keys2_beg);
+    const int num_keys1 = static_cast<int>(keys1_end - keys1_beg);
+    const int num_keys2 = static_cast<int>(keys2_end - keys2_beg);
 
     // load keys1 & keys2
     KeyT keys_local[ITEMS_PER_THREAD];
     if (ping)
     {
-      gmem_to_reg<IS_FULL_TILE>(
+      detail::gmem_to_reg<BLOCK_THREADS, IS_FULL_TILE>(
         keys_local, keys_in_ping + start + keys1_beg, keys_in_ping + start + size + keys2_beg, num_keys1, num_keys2);
     }
     else
     {
-      gmem_to_reg<IS_FULL_TILE>(
+      detail::gmem_to_reg<BLOCK_THREADS, IS_FULL_TILE>(
         keys_local, keys_in_pong + start + keys1_beg, keys_in_pong + start + size + keys2_beg, num_keys1, num_keys2);
     }
-    reg_to_shared(&storage.keys_shared[0], keys_local);
+    detail::reg_to_shared<BLOCK_THREADS>(&storage.keys_shared[0], keys_local);
 
     // preload items into registers already
     //
     ValueT items_local[ITEMS_PER_THREAD];
-    if (!KEYS_ONLY)
+    _CCCL_IF_CONSTEXPR (!KEYS_ONLY)
     {
       if (ping)
       {
-        gmem_to_reg<IS_FULL_TILE>(
+        detail::gmem_to_reg<BLOCK_THREADS, IS_FULL_TILE>(
           items_local,
           items_in_ping + start + keys1_beg,
           items_in_ping + start + size + keys2_beg,
@@ -564,7 +583,7 @@ struct AgentMerge
       }
       else
       {
-        gmem_to_reg<IS_FULL_TILE>(
+        detail::gmem_to_reg<BLOCK_THREADS, IS_FULL_TILE>(
           items_local,
           items_in_pong + start + keys1_beg,
           items_in_pong + start + size + keys2_beg,
@@ -580,16 +599,16 @@ struct AgentMerge
     // we can use int type here, because the number of
     // items in shared memory is limited
     //
-    int diag0_local = (cub::min)(num_keys1 + num_keys2, ITEMS_PER_THREAD * tid);
+    const int diag0_local = (cub::min)(num_keys1 + num_keys2, ITEMS_PER_THREAD * tid);
 
-    int keys1_beg_local = MergePath<KeyT>(
+    const int keys1_beg_local = MergePath(
       &storage.keys_shared[0], &storage.keys_shared[num_keys1], num_keys1, num_keys2, diag0_local, compare_op);
-    int keys1_end_local = num_keys1;
-    int keys2_beg_local = diag0_local - keys1_beg_local;
-    int keys2_end_local = num_keys2;
+    const int keys1_end_local = num_keys1;
+    const int keys2_beg_local = diag0_local - keys1_beg_local;
+    const int keys2_end_local = num_keys2;
 
-    int num_keys1_local = keys1_end_local - keys1_beg_local;
-    int num_keys2_local = keys2_end_local - keys2_beg_local;
+    const int num_keys1_local = keys1_end_local - keys1_beg_local;
+    const int num_keys2_local = keys2_end_local - keys2_beg_local;
 
     // perform serial merge
     //
@@ -608,10 +627,9 @@ struct AgentMerge
     CTA_SYNC();
 
     // write keys
-    //
     if (ping)
     {
-      if (IS_FULL_TILE)
+      _CCCL_IF_CONSTEXPR (IS_FULL_TILE)
       {
         BlockStoreKeysPing(storage.store_keys_ping).Store(keys_out_ping + tile_base, keys_local);
       }
@@ -622,7 +640,7 @@ struct AgentMerge
     }
     else
     {
-      if (IS_FULL_TILE)
+      _CCCL_IF_CONSTEXPR (IS_FULL_TILE)
       {
         BlockStoreKeysPong(storage.store_keys_pong).Store(keys_out_pong + tile_base, keys_local);
       }
@@ -633,11 +651,11 @@ struct AgentMerge
     }
 
     // if items are provided, merge them
-    if (!KEYS_ONLY)
+    _CCCL_IF_CONSTEXPR (!KEYS_ONLY)
     {
       CTA_SYNC();
 
-      reg_to_shared(&storage.items_shared[0], items_local);
+      detail::reg_to_shared<BLOCK_THREADS>(&storage.items_shared[0], items_local);
 
       CTA_SYNC();
 
@@ -655,7 +673,7 @@ struct AgentMerge
       //
       if (ping)
       {
-        if (IS_FULL_TILE)
+        _CCCL_IF_CONSTEXPR (IS_FULL_TILE)
         {
           BlockStoreItemsPing(storage.store_items_ping).Store(items_out_ping + tile_base, items_local);
         }
@@ -666,7 +684,7 @@ struct AgentMerge
       }
       else
       {
-        if (IS_FULL_TILE)
+        _CCCL_IF_CONSTEXPR (IS_FULL_TILE)
         {
           BlockStoreItemsPong(storage.store_items_pong).Store(items_out_pong + tile_base, items_local);
         }
@@ -711,11 +729,12 @@ struct AgentMerge
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
-    int tile_idx      = static_cast<int>(blockIdx.x);
-    int num_tiles     = static_cast<int>(gridDim.x);
-    OffsetT tile_base = OffsetT(tile_idx) * ITEMS_PER_TILE;
-    int tid           = static_cast<int>(threadIdx.x);
-    int items_in_tile = static_cast<int>((cub::min)(static_cast<OffsetT>(ITEMS_PER_TILE), keys_count - tile_base));
+    const int tile_idx      = static_cast<int>(blockIdx.x);
+    const int num_tiles     = static_cast<int>(gridDim.x);
+    const OffsetT tile_base = OffsetT(tile_idx) * ITEMS_PER_TILE;
+    const int tid           = static_cast<int>(threadIdx.x);
+    const int items_in_tile =
+      static_cast<int>((cub::min)(static_cast<OffsetT>(ITEMS_PER_TILE), keys_count - tile_base));
 
     if (tile_idx < num_tiles - 1)
     {

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -634,7 +634,12 @@ struct AgentMerge
     }
 
     // if items are provided, merge them
+#ifdef _CCCL_CUDACC_BELOW_11_8
+    if (!KEYS_ONLY) // nvcc 11.1 cannot handle #pragma unroll inside if constexpr but 11.8 can.
+                    // nvcc versions between may work
+#else
     _CCCL_IF_CONSTEXPR (!KEYS_ONLY)
+#endif
     {
       CTA_SYNC();
 

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -408,8 +408,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void reg_to_shared(It output, T (&input)[ITEMS_PE
 #pragma unroll
   for (int item = 0; item < ITEMS_PER_THREAD; ++item)
   {
-    int idx     = BLOCK_THREADS * item + threadIdx.x;
-    output[idx] = input[item];
+    const int idx = BLOCK_THREADS * item + threadIdx.x;
+    output[idx]   = input[item];
   }
 }
 } // namespace detail
@@ -552,6 +552,7 @@ struct AgentMerge
     // preload items into registers already
     //
     ValueT items_local[ITEMS_PER_THREAD];
+    (void) items_local; // TODO(bgruber): replace by [[maybe_unused]] in C++17
     _CCCL_IF_CONSTEXPR (!KEYS_ONLY)
     {
       if (ping)

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -47,11 +47,12 @@
 
 CUB_NAMESPACE_BEGIN
 
-// Additional details of the Merge-Path Algorithm can be found in:
-// S. Odeh, O. Green, Z. Mwassi, O. Shmueli, Y. Birk, " Merge Path - Parallel
-// Merging Made Simple", Multithreaded Architectures and Applications (MTAAP)
-// Workshop, IEEE 26th International Parallel & Distributed Processing
-// Symposium (IPDPS), 2012
+// This implements the DiagonalIntersection algorithm from Merge-Path. Additional details can be found in:
+// * S. Odeh, O. Green, Z. Mwassi, O. Shmueli, Y. Birk, "Merge Path - Parallel Merging Made Simple", Multithreaded
+//   Architectures and Applications (MTAAP) Workshop, IEEE 26th International Parallel & Distributed Processing
+//   Symposium (IPDPS), 2012
+// * S. Odeh, O. Green, Y. Birk, "Merge Path - A Visually Intuitive Approach to Parallel Merging", 2014, URL:
+//   https://arxiv.org/abs/1406.2628
 template <typename KeyIt1, typename KeyIt2, typename OffsetT, typename BinaryPred>
 _CCCL_DEVICE _CCCL_FORCEINLINE OffsetT
 MergePath(KeyIt1 keys1, KeyIt2 keys2, OffsetT keys1_count, OffsetT keys2_count, OffsetT diag, BinaryPred binary_pred)
@@ -67,8 +68,7 @@ MergePath(KeyIt1 keys1, KeyIt2 keys2, OffsetT keys1_count, OffsetT keys2_count, 
     const OffsetT mid = cub::MidPoint<OffsetT>(keys1_begin, keys1_end);
     const key_t key1  = keys1[mid];
     const key_t key2  = keys2[diag - 1 - mid];
-    const bool pred   = binary_pred(key2, key1);
-    if (pred)
+    if (binary_pred(key2, key1))
     {
       keys1_end = mid;
     }

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -59,16 +59,12 @@ MergePath(KeyIt1 keys1, KeyIt2 keys2, OffsetT keys1_count, OffsetT keys2_count, 
   using key_t = typename ::cuda::std::iterator_traits<KeyIt1>::value_type;
   static_assert(::cuda::std::is_same<key_t, typename ::cuda::std::iterator_traits<KeyIt2>::value_type>::value, "");
 
-  // FIXME(bgruber): CUB uses different implementation here
-  // OffsetT keys1_begin = diag < keys2_count ? 0 : diag - keys2_count;
-  OffsetT keys1_begin = (cub::max)(0, diag - keys2_count);
+  OffsetT keys1_begin = diag < keys2_count ? 0 : diag - keys2_count;
   OffsetT keys1_end   = (cub::min)(diag, keys1_count);
 
   while (keys1_begin < keys1_end)
   {
-    // FIXME(bgruber): CUB uses different implementation here
-    // const OffsetT mid = cub::MidPoint<OffsetT>(keys1_begin, keys1_end);
-    const OffsetT mid = (keys1_begin + keys1_end) >> 1;
+    const OffsetT mid = cub::MidPoint<OffsetT>(keys1_begin, keys1_end);
     const key_t key1  = keys1[mid];
     const key_t key2  = keys2[diag - 1 - mid];
     const bool pred   = binary_pred(key2, key1);

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -59,12 +59,16 @@ MergePath(KeyIt1 keys1, KeyIt2 keys2, OffsetT keys1_count, OffsetT keys2_count, 
   using key_t = typename ::cuda::std::iterator_traits<KeyIt1>::value_type;
   static_assert(::cuda::std::is_same<key_t, typename ::cuda::std::iterator_traits<KeyIt2>::value_type>::value, "");
 
-  OffsetT keys1_begin = diag < keys2_count ? 0 : diag - keys2_count;
+  // FIXME(bgruber): CUB uses different implementation here
+  // OffsetT keys1_begin = diag < keys2_count ? 0 : diag - keys2_count;
+  OffsetT keys1_begin = (cub::max)(0, diag - keys2_count);
   OffsetT keys1_end   = (cub::min)(diag, keys1_count);
 
   while (keys1_begin < keys1_end)
   {
-    const OffsetT mid = cub::MidPoint<OffsetT>(keys1_begin, keys1_end);
+    // FIXME(bgruber): CUB uses different implementation here
+    // const OffsetT mid = cub::MidPoint<OffsetT>(keys1_begin, keys1_end);
+    const OffsetT mid = (keys1_begin + keys1_end) >> 1;
     const key_t key1  = keys1[mid];
     const key_t key2  = keys2[diag - 1 - mid];
     const bool pred   = binary_pred(key2, key1);

--- a/cub/cub/cub.cuh
+++ b/cub/cub/cub.cuh
@@ -64,6 +64,7 @@
 #include <cub/device/device_for.cuh>
 #include <cub/device/device_histogram.cuh>
 #include <cub/device/device_memcpy.cuh>
+#include <cub/device/device_merge.cuh>
 #include <cub/device/device_merge_sort.cuh>
 #include <cub/device/device_partition.cuh>
 #include <cub/device/device_radix_sort.cuh>

--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once
 

--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -143,7 +143,7 @@ struct DeviceMerge
   //! @param[in] values_in2 Iterator to the beginning of the values of the second sorted input sequence.
   //! @param[in] num_pairs2 Number of key-value pairs in the second input sequence.
   //! @param[out] keys_out Iterator to the beginning of the keys of the output sequence.
-  //! @param[in] values_out Iterator to the beginning of the values of the output sequence.
+  //! @param[out] values_out Iterator to the beginning of the values of the output sequence.
   //! @param[in] compare_op Comparison function object, returning true if the first argument is ordered before the
   //! second. Must establish a [strict weak ordering].
   //! @param[in] stream **[optional]** CUDA stream to launch kernels into. Default is stream<sub>0</sub>.

--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -142,7 +142,7 @@ struct DeviceMerge
   //! @param[in] keys_in2 Iterator to the beginning of the keys of the second sorted input sequence.
   //! @param[in] values_in2 Iterator to the beginning of the values of the second sorted input sequence.
   //! @param[in] num_pairs2 Number of key-value pairs in the second input sequence.
-  //! @param[in] keys_out Iterator to the beginning of the keys of the output sequence.
+  //! @param[out] keys_out Iterator to the beginning of the keys of the output sequence.
   //! @param[in] values_out Iterator to the beginning of the values of the output sequence.
   //! @param[in] compare_op Comparison function object, returning true if the first argument is ordered before the
   //! second. Must establish a [strict weak ordering].

--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -62,7 +62,7 @@ struct DeviceMerge
   //! @param[in] num_keys1 Number of keys in the first input sequence.
   //! @param[in] keys_in2 Iterator to the beginning of the second sorted input sequence.
   //! @param[in] num_keys2 Number of keys in the second input sequence.
-  //! @param[in] keys_out Iterator to the beginning of the output sequence.
+  //! @param[out] keys_out Iterator to the beginning of the output sequence.
   //! @param[in] compare_op Comparison function object, returning true if the first argument is ordered before the
   //! second. Must establish a [strict weak ordering].
   //! @param[in] stream **[optional]** CUDA stream to launch kernels into. Default is stream<sub>0</sub>.

--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/detail/nvtx.cuh>
+#include <cub/device/dispatch/dispatch_merge.cuh>
+#include <cub/util_namespace.cuh>
+
+#include <cuda/std/functional>
+
+CUB_NAMESPACE_BEGIN
+
+//! DeviceMerge provides device-wide, parallel operations for merging two sorted sequences of values (called keys) or
+//! key-value pairs in device-accessible memory. The sorting order is determined by a comparison functor (default:
+//! less-than), which has to establish a [strict weak ordering].
+//!
+//! [strict weak ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
+struct DeviceMerge
+{
+  //! @rst
+  //! Overview
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //! Merges two sorted sequences of values (called keys) into a sorted output sequence. Merging is unstable,
+  //! which means any two equivalent values (neither value is ordered before the other) may be written to the ouput
+  //! sequence in any order.
+  //!
+  //! A Simple Example
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //! The code snippet below illustrates the merging of two device vectors of `int` keys.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_merge_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin merge-keys
+  //!     :end-before: example-end merge-keys
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyIteratorIn1 **[deduced]** Random access iterator to the first sorted input sequence. Must have the same
+  //! value type as KeyIteratorIn2.
+  //! @tparam KeyIteratorIn2 **[deduced]** Random access iterator to the second sorted input sequence. Must have the
+  //! same value type as KeyIteratorIn1.
+  //! @tparam KeyIteratorOut **[deduced]** Random access iterator to the output sequence.
+  //! @tparam CompareOp **[deduced]** Binary predicate to compare the input iterator's value types. Must have a
+  //! signature equivalent to `bool operator()(Key lhs, Key rhs)` and establish a [strict weak ordering].
+  //!
+  //! @param[in] d_temp_storage Device-accessible allocation of temporary storage. When `nullptr`, the required
+  //! allocation size is written to `temp_storage_bytes` and no work is done.
+  //! @param[in,out] temp_storage_bytes Reference to size in bytes of `d_temp_storage` allocation.
+  //! @param[in] keys_in1 Iterator to the beginning of the first sorted input sequence.
+  //! @param[in] num_keys1 Number of keys in the first input sequence.
+  //! @param[in] keys_in2 Iterator to the beginning of the second sorted input sequence.
+  //! @param[in] num_keys2 Number of keys in the second input sequence.
+  //! @param[in] keys_out Iterator to the beginning of the output sequence.
+  //! @param[in] compare_op Comparison function object, returning true if the first argument is ordered before the
+  //! second. Must establish a [strict weak ordering].
+  //! @param[in] stream **[optional]** CUDA stream to launch kernels into. Default is stream<sub>0</sub>.
+  //!
+  //! [strict weak ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
+  template <typename KeyIteratorIn1,
+            typename KeyIteratorIn2,
+            typename KeyIteratorOut,
+            typename CompareOp = ::cuda::std::less<>>
+  CUB_RUNTIME_FUNCTION static cudaError_t MergeKeys(
+    void* d_temp_storage,
+    std::size_t& temp_storage_bytes,
+    KeyIteratorIn1 keys_in1,
+    int num_keys1,
+    KeyIteratorIn2 keys_in2,
+    int num_keys2,
+    KeyIteratorOut keys_out,
+    CompareOp compare_op = {},
+    cudaStream_t stream  = nullptr)
+  {
+    CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceMerge::MergeKeys");
+    return detail::merge::
+      dispatch_t<KeyIteratorIn1, NullType*, KeyIteratorIn2, NullType*, KeyIteratorOut, NullType*, int, CompareOp>::
+        dispatch(
+          d_temp_storage,
+          temp_storage_bytes,
+          keys_in1,
+          nullptr,
+          num_keys1,
+          keys_in2,
+          nullptr,
+          num_keys2,
+          keys_out,
+          nullptr,
+          compare_op,
+          stream);
+  }
+
+  //! @rst
+  //! Overview
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //! Merges two sorted sequences of key-value pairs into a sorted output sequence. Merging is unstable,
+  //! which means any two equivalent values (neither value is ordered before the other) may be written to the ouput
+  //! sequence in any order.
+  //!
+  //! A Simple Example
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //! The code snippet below illustrates the merging of two device vectors of `int` keys.
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_merge_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin merge-pairs
+  //!     :end-before: example-end merge-pairs
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyIteratorIn1 **[deduced]** Random access iterator to the keys of the first sorted input sequence. Must
+  //! have the same value type as KeyIteratorIn2.
+  //! @tparam ValueIteratorIn1 **[deduced]** Random access iterator to the values of the first sorted input sequence.
+  //! Must have the same value type as ValueIteratorIn2.
+  //! @tparam KeyIteratorIn2 **[deduced]** Random access iterator to the second sorted input sequence. Must have the
+  //! same value type as KeyIteratorIn1.
+  //! @tparam ValueIteratorIn2 **[deduced]** Random access iterator to the values of the second sorted input sequence.
+  //! Must have the same value type as ValueIteratorIn1.
+  //! @tparam KeyIteratorOut **[deduced]** Random access iterator to the keys of the output sequence.
+  //! @tparam ValueIteratorOut **[deduced]** Random access iterator to the values of the output sequence.
+  //! @tparam CompareOp **[deduced]** Binary predicate to compare the key input iterator's value types. Must have a
+  //! signature equivalent to `bool operator()(Key lhs, Key rhs)` and establish a [strict weak ordering].
+  //!
+  //! @param[in] d_temp_storage Device-accessible allocation of temporary storage. When `nullptr`, the required
+  //! allocation size is written to `temp_storage_bytes` and no work is done.
+  //! @param[in,out] temp_storage_bytes Reference to size in bytes of `d_temp_storage` allocation.
+  //! @param[in] keys_in1 Iterator to the beginning of the keys of the first sorted input sequence.
+  //! @param[in] values_in1 Iterator to the beginning of the values of the first sorted input sequence.
+  //! @param[in] num_pairs1 Number of key-value pairs in the first input sequence.
+  //! @param[in] keys_in2 Iterator to the beginning of the keys of the second sorted input sequence.
+  //! @param[in] values_in2 Iterator to the beginning of the values of the second sorted input sequence.
+  //! @param[in] num_pairs2 Number of key-value pairs in the second input sequence.
+  //! @param[in] keys_out Iterator to the beginning of the keys of the output sequence.
+  //! @param[in] values_out Iterator to the beginning of the values of the output sequence.
+  //! @param[in] compare_op Comparison function object, returning true if the first argument is ordered before the
+  //! second. Must establish a [strict weak ordering].
+  //! @param[in] stream **[optional]** CUDA stream to launch kernels into. Default is stream<sub>0</sub>.
+  //!
+  //! [strict weak ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
+  template <typename KeyIteratorIn1,
+            typename ValueIteratorIn1,
+            typename KeyIteratorIn2,
+            typename ValueIteratorIn2,
+            typename KeyIteratorOut,
+            typename ValueIteratorOut,
+            typename CompareOp = ::cuda::std::less<>>
+  CUB_RUNTIME_FUNCTION static cudaError_t MergePairs(
+    void* d_temp_storage,
+    std::size_t& temp_storage_bytes,
+    KeyIteratorIn1 keys_in1,
+    ValueIteratorIn1 values_in1,
+    int num_pairs1,
+    KeyIteratorIn2 keys_in2,
+    ValueIteratorIn2 values_in2,
+    int num_pairs2,
+    KeyIteratorOut keys_out,
+    ValueIteratorOut values_out,
+    CompareOp compare_op = {},
+    cudaStream_t stream  = nullptr)
+  {
+    CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceMerge::MergePairs");
+    return detail::merge::dispatch_t<
+      KeyIteratorIn1,
+      ValueIteratorIn1,
+      KeyIteratorIn2,
+      ValueIteratorIn2,
+      KeyIteratorOut,
+      ValueIteratorOut,
+      int,
+      CompareOp>::dispatch(d_temp_storage,
+                           temp_storage_bytes,
+                           keys_in1,
+                           values_in1,
+                           num_pairs1,
+                           keys_in2,
+                           values_in2,
+                           num_pairs2,
+                           keys_out,
+                           values_out,
+                           compare_op,
+                           stream);
+  }
+};
+
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once
 

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -1,0 +1,351 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/agent/agent_merge.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_type.cuh>
+#include <cub/util_vsmem.cuh>
+
+#include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
+
+CUB_NAMESPACE_BEGIN
+namespace detail
+{
+namespace merge
+{
+_LIBCUDACXX_INLINE_VAR constexpr int fallback_BLOCK_THREADS    = 64;
+_LIBCUDACXX_INLINE_VAR constexpr int fallback_ITEMS_PER_THREAD = 1;
+
+template <typename DefaultPolicy, class... Args>
+class choose_merge_agent
+{
+  using default_agent_t = agent_t<DefaultPolicy, Args...>;
+  using fallback_agent_t =
+    agent_t<policy_wrapper_t<DefaultPolicy, fallback_BLOCK_THREADS, fallback_ITEMS_PER_THREAD>, Args...>;
+
+  // Use fallback if merge agent exceeds maximum shared memory, but the fallback agent still fits
+  static constexpr bool use_fallback = sizeof(typename default_agent_t::TempStorage) > max_smem_per_block
+                                    && sizeof(typename fallback_agent_t::TempStorage) <= max_smem_per_block;
+
+public:
+  using type = ::cuda::std::__conditional_t<use_fallback, fallback_agent_t, default_agent_t>;
+};
+
+// Computes the merge path intersections at equally wide intervals. The approach is outlined in the paper:
+// Odeh et al, "Merge Path - Parallel Merging Made Simple" * doi : 10.1109 / IPDPSW .2012.202
+// The algorithm is the same as AgentPartition for merge sort, but that agent handles a lot more.
+template <typename MaxPolicy,
+          typename KeyIt1,
+          typename ValueIt1,
+          typename KeyIt2,
+          typename ValueIt2,
+          typename KeyIt3,
+          typename ValueIt3,
+          typename Offset,
+          typename CompareOp>
+CUB_DETAIL_KERNEL_ATTRIBUTES void device_partition_merge_path_kernel(
+  KeyIt1 keys1,
+  Offset keys1_count,
+  KeyIt2 keys2,
+  Offset keys2_count,
+  Offset num_partitions,
+  Offset* merge_partitions,
+  CompareOp compare_op)
+{
+  // items_per_tile must be the same of the merge kernel later, so we have to consider whether a fallback agent will be
+  // selected for the merge agent that changes the tile size
+  constexpr int items_per_tile =
+    choose_merge_agent<typename MaxPolicy::ActivePolicy::merge_policy,
+                       KeyIt1,
+                       ValueIt1,
+                       KeyIt2,
+                       ValueIt2,
+                       KeyIt3,
+                       ValueIt3,
+                       Offset,
+                       CompareOp>::type::policy::ITEMS_PER_TILE;
+  const Offset partition_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  if (partition_idx < num_partitions)
+  {
+    const Offset partition_at       = (cub::min)(partition_idx * items_per_tile, keys1_count + keys2_count);
+    merge_partitions[partition_idx] = cub::MergePath(keys1, keys2, keys1_count, keys2_count, partition_at, compare_op);
+  }
+}
+
+template <typename MaxPolicy,
+          typename KeyIt1,
+          typename ValueIt1,
+          typename KeyIt2,
+          typename ValueIt2,
+          typename KeyIt3,
+          typename ValueIt3,
+          typename Offset,
+          typename CompareOp>
+__launch_bounds__(
+  choose_merge_agent<typename MaxPolicy::ActivePolicy::merge_policy,
+                     KeyIt1,
+                     ValueIt1,
+                     KeyIt2,
+                     ValueIt2,
+                     KeyIt3,
+                     ValueIt3,
+                     Offset,
+                     CompareOp>::type::policy::BLOCK_THREADS)
+  CUB_DETAIL_KERNEL_ATTRIBUTES void device_merge_kernel(
+    KeyIt1 keys1,
+    ValueIt1 items1,
+    Offset num_keys1,
+    KeyIt2 keys2,
+    ValueIt2 items2,
+    Offset num_keys2,
+    KeyIt3 keys_result,
+    ValueIt3 items_result,
+    CompareOp compare_op,
+    Offset* merge_partitions,
+    vsmem_t global_temp_storage)
+{
+  using MergeAgent = typename choose_merge_agent<
+    typename MaxPolicy::ActivePolicy::merge_policy,
+    KeyIt1,
+    ValueIt1,
+    KeyIt2,
+    ValueIt2,
+    KeyIt3,
+    ValueIt3,
+    Offset,
+    CompareOp>::type;
+  using MergePolicy = typename MergeAgent::policy;
+
+  using THRUST_NS_QUALIFIER::cuda_cub::core::make_load_iterator;
+  using vsmem_helper_t = vsmem_helper_impl<MergeAgent>;
+  __shared__ typename vsmem_helper_t::static_temp_storage_t shared_temp_storage;
+  auto& temp_storage = vsmem_helper_t::get_temp_storage(shared_temp_storage, global_temp_storage);
+  MergeAgent{
+    temp_storage.Alias(),
+    make_load_iterator(MergePolicy{}, keys1),
+    make_load_iterator(MergePolicy{}, items1),
+    num_keys1,
+    make_load_iterator(MergePolicy{}, keys2),
+    make_load_iterator(MergePolicy{}, items2),
+    num_keys2,
+    keys_result,
+    items_result,
+    compare_op,
+    merge_partitions}();
+  vsmem_helper_t::discard_temp_storage(temp_storage);
+}
+
+template <typename KeyT, typename ValueT>
+struct device_merge_policy_hub
+{
+  static constexpr bool has_values = !::cuda::std::is_same<ValueT, NullType>::value;
+
+  // TODO(bgruber): is this correct?
+  using tune_type = char[has_values ? sizeof(KeyT) + sizeof(ValueT) : sizeof(KeyT)];
+
+  struct policy300 : ChainedPolicy<300, policy300, policy300>
+  {
+    using merge_policy =
+      agent_policy_t<128,
+                     Nominal4BItemsToItems<tune_type>(7),
+                     BLOCK_LOAD_WARP_TRANSPOSE,
+                     LOAD_DEFAULT,
+                     BLOCK_STORE_WARP_TRANSPOSE>;
+  };
+
+  struct policy350 : ChainedPolicy<350, policy350, policy300>
+  {
+    using merge_policy =
+      agent_policy_t<256,
+                     Nominal4BItemsToItems<tune_type>(11),
+                     BLOCK_LOAD_WARP_TRANSPOSE,
+                     LOAD_LDG,
+                     BLOCK_STORE_WARP_TRANSPOSE>;
+  };
+
+  struct policy520 : ChainedPolicy<520, policy520, policy350>
+  {
+    using merge_policy =
+      agent_policy_t<512,
+                     Nominal4BItemsToItems<tune_type>(13),
+                     BLOCK_LOAD_WARP_TRANSPOSE,
+                     LOAD_LDG,
+                     BLOCK_STORE_WARP_TRANSPOSE>;
+  };
+
+  struct policy600 : ChainedPolicy<600, policy600, policy520>
+  {
+    using merge_policy =
+      agent_policy_t<512,
+                     Nominal4BItemsToItems<tune_type>(15),
+                     BLOCK_LOAD_WARP_TRANSPOSE,
+                     LOAD_DEFAULT,
+                     BLOCK_STORE_WARP_TRANSPOSE>;
+  };
+
+  using max_policy = policy600;
+};
+
+template <typename KeyIt1,
+          typename ValueIt1,
+          typename KeyIt2,
+          typename ValueIt2,
+          typename KeyIt3,
+          typename ValueIt3,
+          typename Offset,
+          typename CompareOp,
+          typename PolicyHub = device_merge_policy_hub<value_t<KeyIt1>, value_t<ValueIt1>>>
+struct dispatch_t
+{
+  using key_t   = cub::detail::value_t<KeyIt1>;
+  using value_t = cub::detail::value_t<ValueIt1>;
+
+  // Cannot check output iterators, since they could be discard iterators, which do not have the right value_type
+  static_assert(::cuda::std::is_same<cub::detail::value_t<KeyIt2>, key_t>::value, "");
+  static_assert(::cuda::std::is_same<cub::detail::value_t<ValueIt2>, value_t>::value, "");
+  static_assert(::cuda::std::__invokable<CompareOp, key_t, key_t>::value,
+                "Comparison operator cannot compare two keys");
+  static_assert(
+    ::cuda::std::is_convertible<typename ::cuda::std::__invoke_of<CompareOp, key_t, key_t>::type, bool>::value,
+    "Comparison operator must be convertible to bool");
+
+  void* d_temp_storage;
+  std::size_t& temp_storage_bytes;
+  KeyIt1 d_keys1;
+  ValueIt1 d_values1;
+  Offset num_items1;
+  KeyIt2 d_keys2;
+  ValueIt2 d_values2;
+  Offset num_items2;
+  KeyIt3 d_keys_out;
+  ValueIt3 d_values_out;
+  CompareOp compare_op;
+  cudaStream_t stream;
+
+  template <typename ActivePolicy>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke()
+  {
+    using max_policy_t   = typename PolicyHub::max_policy;
+    using merge_policy_t = typename ActivePolicy::merge_policy;
+    using agent_t =
+      typename choose_merge_agent<merge_policy_t, KeyIt1, ValueIt1, KeyIt2, ValueIt2, KeyIt3, ValueIt3, Offset, CompareOp>::
+        type;
+
+    const auto num_tiles = cub::DivideAndRoundUp(num_items1 + num_items2, agent_t::policy::ITEMS_PER_TILE);
+    void* allocations[2] = {nullptr, nullptr};
+    {
+      const std::size_t merge_partitions_size      = (1 + num_tiles) * sizeof(Offset);
+      const std::size_t virtual_shared_memory_size = num_tiles * vsmem_helper_impl<agent_t>::vsmem_per_block;
+      const std::size_t allocation_sizes[2]        = {merge_partitions_size, virtual_shared_memory_size};
+      const auto error = CubDebug(AliasTemporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes));
+      if (cudaSuccess != error)
+      {
+        return error;
+      }
+    }
+
+    // Return if only temporary storage was requested or there is no work to be done
+    if (d_temp_storage == nullptr || num_tiles == 0)
+    {
+      return cudaSuccess;
+    }
+
+    auto merge_partitions = static_cast<Offset*>(allocations[0]);
+
+    // parition the merge path
+    {
+      const Offset num_partitions               = num_tiles + 1;
+      constexpr int threads_per_partition_block = 256; // TODO(bgruber): no policy?
+      const int partition_grid_size =
+        static_cast<int>(cub::DivideAndRoundUp(num_partitions, threads_per_partition_block));
+
+      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
+        partition_grid_size, threads_per_partition_block, 0, stream)
+        .doit(
+          device_partition_merge_path_kernel<
+            max_policy_t,
+            KeyIt1,
+            ValueIt1,
+            KeyIt2,
+            ValueIt2,
+            KeyIt3,
+            ValueIt3,
+            Offset,
+            CompareOp>,
+          d_keys1,
+          num_items1,
+          d_keys2,
+          num_items2,
+          num_partitions,
+          merge_partitions,
+          compare_op);
+      const auto error = CubDebug(DebugSyncStream(stream));
+      if (cudaSuccess != error)
+      {
+        return error;
+      }
+    }
+
+    // merge
+    if (num_tiles > 0)
+    {
+      auto vshmem_ptr = vsmem_t{allocations[1]};
+      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
+        static_cast<int>(num_tiles), static_cast<int>(agent_t::policy::BLOCK_THREADS), 0, stream)
+        .doit(
+          device_merge_kernel<max_policy_t, KeyIt1, ValueIt1, KeyIt2, ValueIt2, KeyIt3, ValueIt3, Offset, CompareOp>,
+          d_keys1,
+          d_values1,
+          num_items1,
+          d_keys2,
+          d_values2,
+          num_items2,
+          d_keys_out,
+          d_values_out,
+          compare_op,
+          merge_partitions,
+          vshmem_ptr);
+      const auto error = CubDebug(DebugSyncStream(stream));
+      if (cudaSuccess != error)
+      {
+        return error;
+      }
+    }
+
+    return cudaSuccess;
+  }
+
+  template <typename... Args>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(Args&&... args)
+  {
+    int ptx_version = 0;
+    auto error      = CubDebug(PtxVersion(ptx_version));
+    if (cudaSuccess != error)
+    {
+      return error;
+    }
+    dispatch_t dispatch{std::forward<Args>(args)...};
+    error = CubDebug(PolicyHub::max_policy::Invoke(ptx_version, dispatch));
+    if (cudaSuccess != error)
+    {
+      return error;
+    }
+
+    return cudaSuccess;
+  }
+};
+} // namespace merge
+} // namespace detail
+CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -510,19 +510,17 @@ struct DispatchMergeSort : SelectedPolicy
       constexpr auto tile_size = merge_sort_helper_t::policy_t::ITEMS_PER_TILE;
       const auto num_tiles     = cub::DivideAndRoundUp(num_items, tile_size);
 
-      const auto merge_partitions_size = static_cast<std::size_t>(1 + num_tiles) * sizeof(OffsetT);
-
-      const auto temporary_keys_storage_size = static_cast<std::size_t>(num_items * sizeof(KeyT));
-
+      const auto merge_partitions_size         = static_cast<std::size_t>(1 + num_tiles) * sizeof(OffsetT);
+      const auto temporary_keys_storage_size   = static_cast<std::size_t>(num_items * sizeof(KeyT));
       const auto temporary_values_storage_size = static_cast<std::size_t>(num_items * sizeof(ValueT)) * !KEYS_ONLY;
 
       /**
        * Merge sort supports large types, which can lead to excessive shared memory size requirements. In these cases,
        * merge sort allocates virtual shared memory that resides in global memory.
        */
-      std::size_t block_sort_smem_size       = num_tiles * BlockSortVSmemHelperT::vsmem_per_block;
-      std::size_t merge_smem_size            = num_tiles * MergeAgentVSmemHelperT::vsmem_per_block;
-      std::size_t virtual_shared_memory_size = (cub::max)(block_sort_smem_size, merge_smem_size);
+      const std::size_t block_sort_smem_size       = num_tiles * BlockSortVSmemHelperT::vsmem_per_block;
+      const std::size_t merge_smem_size            = num_tiles * MergeAgentVSmemHelperT::vsmem_per_block;
+      const std::size_t virtual_shared_memory_size = (cub::max)(block_sort_smem_size, merge_smem_size);
 
       void* allocations[4]            = {nullptr, nullptr, nullptr, nullptr};
       std::size_t allocation_sizes[4] = {
@@ -555,9 +553,9 @@ struct DispatchMergeSort : SelectedPolicy
        */
       bool ping = num_passes % 2 == 0;
 
-      auto merge_partitions = reinterpret_cast<OffsetT*>(allocations[0]);
-      auto keys_buffer      = reinterpret_cast<KeyT*>(allocations[1]);
-      auto items_buffer     = reinterpret_cast<ValueT*>(allocations[2]);
+      auto merge_partitions = static_cast<OffsetT*>(allocations[0]);
+      auto keys_buffer      = static_cast<KeyT*>(allocations[1]);
+      auto items_buffer     = static_cast<ValueT*>(allocations[2]);
 
       // Invoke DeviceMergeSortBlockSortKernel
       THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
@@ -617,7 +615,7 @@ struct DispatchMergeSort : SelectedPolicy
 
       for (int pass = 0; pass < num_passes; ++pass, ping = !ping)
       {
-        OffsetT target_merged_tiles_number = OffsetT(2) << pass;
+        const OffsetT target_merged_tiles_number = OffsetT(2) << pass;
 
         // Partition
         THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -704,9 +704,7 @@ struct DispatchMergeSort : SelectedPolicy
     {
       // Get PTX version
       int ptx_version = 0;
-
-      error = CubDebug(PtxVersion(ptx_version));
-
+      error           = CubDebug(PtxVersion(ptx_version));
       if (cudaSuccess != error)
       {
         break;

--- a/cub/cub/thread/thread_search.cuh
+++ b/cub/cub/thread/thread_search.cuh
@@ -97,6 +97,7 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE void MergePathSearch(
  * @param[in] val
  *   Search key
  */
+// TODO(bgruber): deprecate once ::cuda::std::lower_bound is made public
 template <typename InputIteratorT, typename OffsetT, typename T>
 _CCCL_DEVICE _CCCL_FORCEINLINE OffsetT LowerBound(InputIteratorT input, OffsetT num_items, T val)
 {
@@ -131,6 +132,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE OffsetT LowerBound(InputIteratorT input, OffsetT 
  * @param[in] val
  *   Search key
  */
+// TODO(bgruber): deprecate once ::cuda::std::upper_bound is made public
 template <typename InputIteratorT, typename OffsetT, typename T>
 _CCCL_DEVICE _CCCL_FORCEINLINE OffsetT UpperBound(InputIteratorT input, OffsetT num_items, T val)
 {

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -72,6 +72,7 @@ namespace detail
  * @brief Helper class template that allows overwriting the `BLOCK_THREAD` and `ITEMS_PER_THREAD`
  * configurations of a given policy.
  */
+// TODO(bgruber): this should be called something like "override_policy"
 template <typename PolicyT, int BLOCK_THREADS_, int ITEMS_PER_THREAD_ = PolicyT::ITEMS_PER_THREAD>
 struct policy_wrapper_t : PolicyT
 {

--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -80,6 +80,7 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT safe_add_bound_to_max(OffsetT lhs, O
 template <typename NumeratorT, typename DenominatorT>
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr NumeratorT DivideAndRoundUp(NumeratorT n, DenominatorT d)
 {
+  // TODO(bgruber): implement using ::cuda::ceil_div
   static_assert(
     cub::detail::is_integral_or_enum<NumeratorT>::value && cub::detail::is_integral_or_enum<DenominatorT>::value,
     "DivideAndRoundUp is only intended for integral types.");

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "insert_nested_NVTX_range_guard.h"
 // above header needs to be included first
@@ -114,7 +114,8 @@ DECLARE_LAUNCH_WRAPPER(detail::merge_pairs_custom_offset_type, merge_pairs_custo
 
 using types = c2h::type_list<std::uint8_t, std::int16_t, std::uint32_t, double>;
 
-using offset_types = c2h::type_list<std::int32_t, std::uint32_t, std::int64_t, std::uint64_t>;
+// gevtushenko: there is no code path in CUB and Thrust that leads to unsigned offsets, so let's safe some compile time
+using offset_types = c2h::type_list<std::int32_t, std::int64_t>;
 
 template <typename Key,
           typename Offset,

--- a/cub/test/catch2_test_device_merge.cu
+++ b/cub/test/catch2_test_device_merge.cu
@@ -1,0 +1,462 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "insert_nested_NVTX_range_guard.h"
+// above header needs to be included first
+
+#include <cub/device/device_merge.cuh>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/sort.h>
+
+#include <algorithm>
+
+#include "catch2_test_helper.h"
+#include "catch2_test_launch_helper.h"
+#include <test_util.h>
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceMerge::MergePairs, merge_pairs);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceMerge::MergeKeys, merge_keys);
+
+// TODO(bgruber): replace the following by the CUB device API directly, once we have figured out how to handle different
+// offset types
+namespace detail
+{
+template <typename KeyIteratorIn1,
+          typename KeyIteratorIn2,
+          typename KeyIteratorOut,
+          typename Offset,
+          typename CompareOp = ::cuda::std::less<>>
+CUB_RUNTIME_FUNCTION static cudaError_t merge_keys_custom_offset_type(
+  void* d_temp_storage,
+  std::size_t& temp_storage_bytes,
+  KeyIteratorIn1 keys_in1,
+  Offset num_keys1,
+  KeyIteratorIn2 keys_in2,
+  Offset num_keys2,
+  KeyIteratorOut keys_out,
+  CompareOp compare_op = {},
+  cudaStream_t stream  = 0)
+{
+  CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceMerge::MergeKeys");
+  return cub::detail::merge::dispatch_t<
+    KeyIteratorIn1,
+    cub::NullType*,
+    KeyIteratorIn2,
+    cub::NullType*,
+    KeyIteratorOut,
+    cub::NullType*,
+    Offset,
+    CompareOp>::dispatch(d_temp_storage,
+                         temp_storage_bytes,
+                         keys_in1,
+                         nullptr,
+                         num_keys1,
+                         keys_in2,
+                         nullptr,
+                         num_keys2,
+                         keys_out,
+                         nullptr,
+                         compare_op,
+                         stream);
+}
+
+template <typename KeyIteratorIn1,
+          typename ValueIteratorIn1,
+          typename KeyIteratorIn2,
+          typename ValueIteratorIn2,
+          typename KeyIteratorOut,
+          typename ValueIteratorOut,
+          typename Offset,
+          typename CompareOp = ::cuda::std::less<>>
+CUB_RUNTIME_FUNCTION static cudaError_t merge_pairs_custom_offset_type(
+  void* d_temp_storage,
+  std::size_t& temp_storage_bytes,
+  KeyIteratorIn1 keys_in1,
+  ValueIteratorIn1 values_in1,
+  Offset num_pairs1,
+  KeyIteratorIn2 keys_in2,
+  ValueIteratorIn2 values_in2,
+  Offset num_pairs2,
+  KeyIteratorOut keys_out,
+  ValueIteratorOut values_out,
+  CompareOp compare_op = {},
+  cudaStream_t stream  = 0)
+{
+  CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceMerge::MergePairs");
+  return cub::detail::merge::dispatch_t<
+    KeyIteratorIn1,
+    ValueIteratorIn1,
+    KeyIteratorIn2,
+    ValueIteratorIn2,
+    KeyIteratorOut,
+    ValueIteratorOut,
+    Offset,
+    CompareOp>::dispatch(d_temp_storage,
+                         temp_storage_bytes,
+                         keys_in1,
+                         values_in1,
+                         num_pairs1,
+                         keys_in2,
+                         values_in2,
+                         num_pairs2,
+                         keys_out,
+                         values_out,
+                         compare_op,
+                         stream);
+}
+} // namespace detail
+
+DECLARE_LAUNCH_WRAPPER(detail::merge_keys_custom_offset_type, merge_keys_custom_offset_type);
+DECLARE_LAUNCH_WRAPPER(detail::merge_pairs_custom_offset_type, merge_pairs_custom_offset_type);
+
+using types = c2h::type_list<std::uint8_t, std::int16_t, std::uint32_t, double>;
+
+using offset_types = c2h::type_list<std::int32_t, std::uint32_t, std::int64_t, std::uint64_t>;
+
+template <typename Key,
+          typename Offset,
+          typename CompareOp = ::cuda::std::less<Key>,
+          typename MergeKeys = decltype(::merge_keys)>
+void test_keys(Offset size1 = 3623, Offset size2 = 6346, CompareOp compare_op = {}, MergeKeys merge_keys = ::merge_keys)
+{
+  CAPTURE(c2h::type_name<Key>(), c2h::type_name<Offset>(), size1, size2);
+
+  c2h::device_vector<Key> keys1_d(size1);
+  c2h::device_vector<Key> keys2_d(size2);
+
+  c2h::gen(CUB_SEED(1), keys1_d);
+  c2h::gen(CUB_SEED(1), keys2_d);
+
+  thrust::sort(c2h::device_policy, keys1_d.begin(), keys1_d.end(), compare_op);
+  thrust::sort(c2h::device_policy, keys2_d.begin(), keys2_d.end(), compare_op);
+  // CAPTURE(keys1_d, keys2_d);
+
+  c2h::device_vector<Key> result_d(size1 + size2);
+  merge_keys(thrust::raw_pointer_cast(keys1_d.data()),
+             static_cast<Offset>(keys1_d.size()),
+             thrust::raw_pointer_cast(keys2_d.data()),
+             static_cast<Offset>(keys2_d.size()),
+             thrust::raw_pointer_cast(result_d.data()),
+             compare_op);
+
+  c2h::host_vector<Key> keys1_h = keys1_d;
+  c2h::host_vector<Key> keys2_h = keys2_d;
+  c2h::host_vector<Key> reference_h(size1 + size2);
+  std::merge(keys1_h.begin(), keys1_h.end(), keys2_h.begin(), keys2_h.end(), reference_h.begin(), compare_op);
+
+  // FIXME(bgruber): comparing std::vectors (slower than thrust vectors) but compiles a lot faster
+  CHECK((detail::to_vec(reference_h) == detail::to_vec(c2h::host_vector<Key>(result_d))));
+}
+
+CUB_TEST("DeviceMerge::MergeKeys key types", "[merge][device]", types)
+{
+  using key_t    = c2h::get<0, TestType>;
+  using offset_t = int;
+  test_keys<key_t, offset_t>();
+}
+
+using large_type_fallb = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<56>::type>;
+using large_type_vsmem = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t, c2h::huge_data<774>::type>;
+
+struct fallback_test_policy_hub
+{
+  struct max_policy : cub::ChainedPolicy<100, max_policy, max_policy>
+  {
+    using merge_policy = cub::detail::merge::
+      agent_policy_t<128, 7, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE>;
+  };
+};
+
+// TODO(bgruber): This test alone increases compile time from 1m16s to 8m43s. What's going on?
+CUB_TEST("DeviceMerge::MergeKeys large key types", "[merge][device]", c2h::type_list<large_type_vsmem, large_type_fallb>)
+{
+  using key_t    = c2h::get<0, TestType>;
+  using offset_t = int;
+
+  constexpr auto agent_sm = sizeof(key_t) * 128 * 7;
+  constexpr auto fallback_sm =
+    sizeof(key_t) * cub::detail::merge::fallback_BLOCK_THREADS * cub::detail::merge::fallback_ITEMS_PER_THREAD;
+  static_assert(agent_sm > cub::detail::max_smem_per_block,
+                "key_t is not big enough to exceed SM and trigger fallback policy");
+  static_assert(
+    ::cuda::std::is_same<key_t, large_type_fallb>::value == (fallback_sm <= cub::detail::max_smem_per_block),
+    "SM consumption by fallback policy should fit into max_smem_per_block");
+
+  test_keys<key_t, offset_t>(
+    3623,
+    6346,
+    ::cuda::std::less<key_t>{},
+    [](const key_t* k1, offset_t s1, const key_t* k2, offset_t s2, key_t* r, ::cuda::std::less<key_t> co) {
+      using dispatch_t = cub::detail::merge::dispatch_t<
+        const key_t*,
+        const cub::NullType*,
+        const key_t*,
+        const cub::NullType*,
+        key_t*,
+        cub::NullType*,
+        offset_t,
+        ::cuda::std::less<key_t>,
+        fallback_test_policy_hub>; // use a fixed policy for this test so the needed shared memory is deterministic
+
+      std::size_t temp_storage_bytes = 0;
+      dispatch_t::dispatch(
+        nullptr, temp_storage_bytes, k1, nullptr, s1, k2, nullptr, s2, r, nullptr, co, cudaStream_t{0});
+
+      c2h::device_vector<char> temp_storage(temp_storage_bytes);
+      dispatch_t::dispatch(
+        thrust::raw_pointer_cast(temp_storage.data()),
+        temp_storage_bytes,
+        k1,
+        nullptr,
+        s1,
+        k2,
+        nullptr,
+        s2,
+        r,
+        nullptr,
+        co,
+        cudaStream_t{0});
+    });
+}
+
+CUB_TEST("DeviceMerge::MergeKeys offset types", "[merge][device]", offset_types)
+{
+  using key_t    = int;
+  using offset_t = c2h::get<0, TestType>;
+  test_keys<key_t, offset_t>(3623, 6346, ::cuda::std::less<>{}, merge_keys_custom_offset_type);
+}
+
+CUB_TEST("DeviceMerge::MergeKeys input sizes", "[merge][device]")
+{
+  using key_t    = int;
+  using offset_t = int;
+  // TODO(bgruber): maybe less combinations
+  const auto size1 = offset_t{GENERATE(0, 1, 23, 123, 3234)};
+  const auto size2 = offset_t{GENERATE(0, 1, 52, 556, 56767)};
+  test_keys<key_t>(size1, size2);
+}
+
+// cannot put those in an anon namespace, or nvcc complains that the kernels have internal linkage
+using unordered_t = c2h::custom_type_t<c2h::equal_comparable_t>;
+struct order
+{
+  _CCCL_HOST_DEVICE auto operator()(const unordered_t& a, const unordered_t& b) const -> bool
+  {
+    return a.key < b.key;
+  }
+};
+
+CUB_TEST("DeviceMerge::MergeKeys no operator<", "[merge][device]")
+{
+  using key_t    = unordered_t;
+  using offset_t = int;
+  test_keys<key_t, offset_t, order>();
+}
+
+namespace
+{
+template <typename... Its>
+auto zip(Its... its) -> decltype(thrust::make_zip_iterator(its...))
+{
+  return thrust::make_zip_iterator(its...);
+}
+
+template <typename Value>
+struct key_to_value
+{
+  template <typename Key>
+  _CCCL_HOST_DEVICE auto operator()(const Key& k) const -> Value
+  {
+    Value v{};
+    convert(k, v, 0);
+    return v;
+  }
+
+  template <typename Key>
+  _CCCL_HOST_DEVICE static void convert(const Key& k, Value& v, ...)
+  {
+    v = static_cast<Value>(k);
+  }
+
+  template <template <typename> class... Policies>
+  _CCCL_HOST_DEVICE static void convert(const c2h::custom_type_t<Policies...>& k, Value& v, int)
+  {
+    v = static_cast<Value>(k.val);
+  }
+
+  template <typename Key, template <typename> class... Policies>
+  _CCCL_HOST_DEVICE static void convert(const Key& k, c2h::custom_type_t<Policies...>& v, int)
+  {
+    v     = {};
+    v.val = static_cast<decltype(v.val)>(k);
+  }
+};
+} // namespace
+
+template <typename Key,
+          typename Value,
+          typename Offset,
+          typename CompareOp  = ::cuda::std::less<Key>,
+          typename MergePairs = decltype(::merge_pairs)>
+void test_pairs(
+  Offset size1 = 200, Offset size2 = 625, CompareOp compare_op = {}, MergePairs merge_pairs = ::merge_pairs)
+{
+  CAPTURE(c2h::type_name<Key>(), c2h::type_name<Value>(), c2h::type_name<Offset>(), size1, size2);
+
+  // we start with random but sorted keys
+  c2h::device_vector<Key> keys1_d(size1);
+  c2h::device_vector<Key> keys2_d(size2);
+  c2h::gen(CUB_SEED(1), keys1_d);
+  c2h::gen(CUB_SEED(1), keys2_d);
+  thrust::sort(c2h::device_policy, keys1_d.begin(), keys1_d.end(), compare_op);
+  thrust::sort(c2h::device_policy, keys2_d.begin(), keys2_d.end(), compare_op);
+
+  // the values must be functionally dependent on the keys (equal key => equal value), since merge is unstable
+  c2h::device_vector<Value> values1_d(size1);
+  c2h::device_vector<Value> values2_d(size2);
+  thrust::transform(c2h::device_policy, keys1_d.begin(), keys1_d.end(), values1_d.begin(), key_to_value<Value>{});
+  thrust::transform(c2h::device_policy, keys2_d.begin(), keys2_d.end(), values2_d.begin(), key_to_value<Value>{});
+  //  CAPTURE(keys1_d, keys2_d, values1_d, values2_d);
+
+  // compute CUB result
+  c2h::device_vector<Key> result_keys_d(size1 + size2);
+  c2h::device_vector<Value> result_values_d(size1 + size2);
+  merge_pairs(
+    thrust::raw_pointer_cast(keys1_d.data()),
+    thrust::raw_pointer_cast(values1_d.data()),
+    static_cast<Offset>(keys1_d.size()),
+    thrust::raw_pointer_cast(keys2_d.data()),
+    thrust::raw_pointer_cast(values2_d.data()),
+    static_cast<Offset>(keys2_d.size()),
+    thrust::raw_pointer_cast(result_keys_d.data()),
+    thrust::raw_pointer_cast(result_values_d.data()),
+    compare_op);
+
+  // compute reference result
+  c2h::host_vector<Key> reference_keys_h(size1 + size2);
+  c2h::host_vector<Value> reference_values_h(size1 + size2);
+  {
+    c2h::host_vector<Key> keys1_h     = keys1_d;
+    c2h::host_vector<Value> values1_h = values1_d;
+    c2h::host_vector<Key> keys2_h     = keys2_d;
+    c2h::host_vector<Value> values2_h = values2_d;
+    using value_t                     = typename decltype(zip(keys1_h.begin(), values1_h.begin()))::value_type;
+    std::merge(zip(keys1_h.begin(), values1_h.begin()),
+               zip(keys1_h.end(), values1_h.end()),
+               zip(keys2_h.begin(), values2_h.begin()),
+               zip(keys2_h.end(), values2_h.end()),
+               zip(reference_keys_h.begin(), reference_values_h.begin()),
+               [&](const value_t& a, const value_t& b) {
+                 return compare_op(thrust::get<0>(a), thrust::get<0>(b));
+               });
+  }
+
+  // FIXME(bgruber): comparing std::vectors (slower than thrust vectors) but compiles a lot faster
+  CHECK((detail::to_vec(reference_keys_h) == detail::to_vec(c2h::host_vector<Key>(result_keys_d))));
+  CHECK((detail::to_vec(reference_values_h) == detail::to_vec(c2h::host_vector<Value>(result_values_d))));
+}
+
+CUB_TEST("DeviceMerge::MergePairs key types", "[merge][device]", types)
+{
+  using key_t    = c2h::get<0, TestType>;
+  using value_t  = int;
+  using offset_t = int;
+  test_pairs<key_t, value_t, offset_t>();
+}
+
+// TODO(bgruber): fine tune the type sizes again to hit the fallback and the vsmem policies
+// CUB_TEST("DeviceMerge::MergePairs large key types", "[merge][device]", large_types)
+// {
+//   using key_t    = c2h::get<0, TestType>;
+//   using value_t  = int;
+//   using offset_t = int;
+//   test_pairs<key_t, value_t, offset_t>();
+// }
+
+CUB_TEST("DeviceMerge::MergePairs value types", "[merge][device]", types)
+{
+  using key_t    = int;
+  using value_t  = c2h::get<0, TestType>;
+  using offset_t = int;
+  test_pairs<key_t, value_t, offset_t>();
+}
+
+CUB_TEST("DeviceMerge::MergePairs offset types", "[merge][device]", offset_types)
+{
+  using key_t    = int;
+  using value_t  = int;
+  using offset_t = c2h::get<0, TestType>;
+  test_pairs<key_t, value_t, offset_t>(3623, 6346, ::cuda::std::less<>{}, merge_pairs_custom_offset_type);
+}
+
+CUB_TEST("DeviceMerge::MergePairs input sizes", "[merge][device]")
+{
+  using key_t      = int;
+  using value_t    = int;
+  using offset_t   = int;
+  const auto size1 = offset_t{GENERATE(0, 1, 23, 123, 3234234)};
+  const auto size2 = offset_t{GENERATE(0, 1, 52, 556, 56767)};
+  test_pairs<key_t, value_t>(size1, size2);
+}
+
+// this test exceeds 4GiB of memory and the range of 32-bit integers
+CUB_TEST("DeviceMerge::MergePairs really large input", "[merge][device]")
+try
+{
+  using key_t     = char;
+  using value_t   = char;
+  const auto size = std::int64_t{1} << GENERATE(30, 31, 32, 33);
+  test_pairs<key_t, value_t>(size, size, ::cuda::std::less<>{}, merge_pairs_custom_offset_type);
+}
+catch (const std::bad_alloc&)
+{
+  // allocation failure is not a test failure, so we can run tests on smaller GPUs
+}
+
+CUB_TEST("DeviceMerge::MergePairs iterators", "[merge][device]")
+{
+  using key_t             = int;
+  using value_t           = int;
+  using offset_t          = int;
+  const offset_t size1    = 363;
+  const offset_t size2    = 634;
+  const auto values_start = 123456789;
+
+  auto key_it   = thrust::counting_iterator<key_t>{};
+  auto value_it = thrust::counting_iterator<key_t>{values_start};
+
+  // compute CUB result
+  c2h::device_vector<key_t> result_keys_d(size1 + size2);
+  c2h::device_vector<value_t> result_values_d(size1 + size2);
+  merge_pairs(
+    key_it,
+    value_it,
+    size1,
+    key_it,
+    value_it,
+    size2,
+    result_keys_d.begin(),
+    result_values_d.begin(),
+    ::cuda::std::less<key_t>{});
+
+  // check result
+  c2h::host_vector<key_t> result_keys_h     = result_keys_d;
+  c2h::host_vector<value_t> result_values_h = result_values_d;
+  const auto smaller_size                   = std::min(size1, size2);
+  for (offset_t i = 0; i < static_cast<offset_t>(result_keys_h.size()); i++)
+  {
+    if (i < 2 * smaller_size)
+    {
+      CHECK(result_keys_h[i + 0] == i / 2);
+      CHECK(result_values_h[i + 0] == values_start + i / 2);
+    }
+    else
+    {
+      CHECK(result_keys_h[i] == i - smaller_size);
+      CHECK(result_values_h[i] == values_start + i - smaller_size);
+    }
+  }
+}

--- a/cub/test/catch2_test_device_merge_api.cu
+++ b/cub/test/catch2_test_device_merge_api.cu
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "insert_nested_NVTX_range_guard.h"
 // above header needs to be included first
@@ -42,8 +42,9 @@ CUB_TEST("DeviceMerge::MergeKeys API example", "[merge][device]")
     static_cast<int>(keys2.size()),
     result.begin());
 
-  CHECK(result == thrust::host_vector<int>{0, 0, 2, 3, 3, 4, 5});
+  thrust::host_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
   // example-end merge-keys
+  CHECK(result == expected);
 }
 
 CUB_TEST("DeviceMerge::MergePairs API example", "[merge][device]")

--- a/cub/test/catch2_test_device_merge_api.cu
+++ b/cub/test/catch2_test_device_merge_api.cu
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "insert_nested_NVTX_range_guard.h"
+// above header needs to be included first
+
+#include <cub/device/device_merge.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include "catch2_test_helper.h"
+
+CUB_TEST("DeviceMerge::MergeKeys API example", "[merge][device]")
+{
+  // example-begin merge-keys
+  thrust::device_vector<int> keys1{0, 2, 5};
+  thrust::device_vector<int> keys2{0, 3, 3, 4};
+  thrust::device_vector<int> result(7);
+
+  // 1) Get temp storage size
+  std::size_t temp_storage_bytes = 0;
+  cub::DeviceMerge::MergeKeys(
+    nullptr,
+    temp_storage_bytes,
+    keys1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    static_cast<int>(keys2.size()),
+    result.begin());
+
+  // 2) Allocate temp storage
+  thrust::device_vector<char> temp_storage(temp_storage_bytes);
+
+  // 3) Perform merge operation
+  cub::DeviceMerge::MergeKeys(
+    thrust::raw_pointer_cast(temp_storage.data()),
+    temp_storage_bytes,
+    keys1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    static_cast<int>(keys2.size()),
+    result.begin());
+
+  CHECK(result == thrust::host_vector<int>{0, 0, 2, 3, 3, 4, 5});
+  // example-end merge-keys
+}
+
+CUB_TEST("DeviceMerge::MergePairs API example", "[merge][device]")
+{
+  // example-begin merge-pairs
+  thrust::device_vector<int> keys1{0, 2, 5};
+  thrust::device_vector<char> values1{'a', 'b', 'c'};
+  thrust::device_vector<int> keys2{0, 3, 3, 4};
+  thrust::device_vector<char> values2{'A', 'B', 'C', 'D'};
+  thrust::device_vector<int> result_keys(7);
+  thrust::device_vector<char> result_values(7);
+
+  // 1) Get temp storage size
+  std::size_t temp_storage_bytes = 0;
+  cub::DeviceMerge::MergePairs(
+    nullptr,
+    temp_storage_bytes,
+    keys1.begin(),
+    values1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    values2.begin(),
+    static_cast<int>(keys2.size()),
+    result_keys.begin(),
+    result_values.begin());
+
+  // 2) Allocate temp storage
+  thrust::device_vector<char> temp_storage(temp_storage_bytes);
+
+  // 3) Perform merge operation
+  cub::DeviceMerge::MergePairs(
+    thrust::raw_pointer_cast(temp_storage.data()),
+    temp_storage_bytes,
+    keys1.begin(),
+    values1.begin(),
+    static_cast<int>(keys1.size()),
+    keys2.begin(),
+    values2.begin(),
+    static_cast<int>(keys2.size()),
+    result_keys.begin(),
+    result_values.begin());
+
+  CHECK(result_keys == thrust::host_vector<int>{0, 0, 2, 3, 3, 4, 5});
+  CHECK(result_values == thrust::host_vector<char>{'a', 'A', 'b', 'B', 'C', 'D', 'c'});
+  // example-end merge-pairs
+}

--- a/cub/test/catch2_test_device_merge_api.cu
+++ b/cub/test/catch2_test_device_merge_api.cu
@@ -87,7 +87,9 @@ CUB_TEST("DeviceMerge::MergePairs API example", "[merge][device]")
     result_keys.begin(),
     result_values.begin());
 
-  CHECK(result_keys == thrust::host_vector<int>{0, 0, 2, 3, 3, 4, 5});
-  CHECK(result_values == thrust::host_vector<char>{'a', 'A', 'b', 'B', 'C', 'D', 'c'});
+  thrust::host_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  thrust::host_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
   // example-end merge-pairs
+  CHECK(result_keys == expected_keys);
+  CHECK(result_values == expected_values);
 }

--- a/docs/cub/device_wide.rst
+++ b/docs/cub/device_wide.rst
@@ -17,6 +17,7 @@ CUB device-level single-problem parallel algorithms:
 * :cpp:struct:`cub::DeviceFor <cub::DeviceFor>` provides device-wide, parallel operations for iterating over data residing within device-accessible memory
 * :cpp:class:`cub::DeviceHistogram <cub::DeviceHistogram>` constructs histograms from data samples residing within device-accessible memory
 * :cpp:struct:`cub::DevicePartition <cub::DevicePartition>` partitions data residing within device-accessible memory
+* :cpp:struct:`cub::DeviceMerge <cub::DeviceMerge>` merges two sorted sequences in device-accessible memory into a single one
 * :cpp:class:`cub::DeviceMergeSort <cub::DeviceMergeSort>` sorts items residing within device-accessible memory
 * :cpp:class:`cub::DeviceRadixSort <cub::DeviceRadixSort>` sorts items residing within device-accessible memory using radix sorting method
 * :cpp:struct:`cub::DeviceReduce <cub::DeviceReduce>` computes reduction of items residing within device-accessible memory

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -32,9 +32,8 @@
 #include <cstdint>
 
 /**
- * Dispatch between 32-bit and 64-bit index based versions of the same algorithm
- * implementation. This version assumes that callables for both branches consist
- * of the same tokens, and is intended to be used with Thrust-style dispatch
+ * Dispatch between 32-bit and 64-bit index based versions of the same algorithm implementation. This version assumes
+ * that callables for both branches consist of the same tokens, and is intended to be used with Thrust-style dispatch
  * interfaces, that always deduce the size type from the arguments.
  */
 #define THRUST_INDEX_TYPE_DISPATCH(status, call, count, arguments)         \
@@ -50,13 +49,11 @@
   }
 
 /**
- * Dispatch between 32-bit and 64-bit index based versions of the same algorithm
- * implementation. This version assumes that callables for both branches consist
- * of the same tokens, and is intended to be used with Thrust-style dispatch
+ * Dispatch between 32-bit and 64-bit index based versions of the same algorithm implementation. This version assumes
+ * that callables for both branches consist of the same tokens, and is intended to be used with Thrust-style dispatch
  * interfaces, that always deduce the size type from the arguments.
  *
- * This version of the macro supports providing two count variables, which is
- * necessary for set algorithms.
+ * This version of the macro supports providing two count variables, which is necessary for set algorithms.
  */
 #define THRUST_DOUBLE_INDEX_TYPE_DISPATCH(status, call, count1, count2, arguments) \
   if (count1 + count2 <= thrust::detail::integer_traits<std::int32_t>::const_max)  \
@@ -71,14 +68,13 @@
     auto THRUST_PP_CAT2(count2, _fixed) = static_cast<std::int64_t>(count2);       \
     status                              = call arguments;                          \
   }
+
 /**
- * Dispatch between 32-bit and 64-bit index based versions of the same algorithm
- * implementation. This version allows using different token sequences for callables
- * in both branches, and is intended to be used with CUB-style dispatch interfaces,
- * where the "simple" interface always forces the size to be `int` (making it harder
- * for us to use), but the complex interface that we end up using doesn't actually
- * provide a way to fully deduce the type from just the call, making the size type
- * appear in the token sequence of the callable.
+ * Dispatch between 32-bit and 64-bit index based versions of the same algorithm implementation. This version allows
+ * using different token sequences for callables in both branches, and is intended to be used with CUB-style dispatch
+ * interfaces, where the "simple" interface always forces the size to be `int` (making it harder for us to use), but the
+ * complex interface that we end up using doesn't actually provide a way to fully deduce the type from just the call,
+ * making the size type appear in the token sequence of the callable.
  *
  * See reduce_n_impl to see an example of how this is meant to be used.
  */
@@ -92,4 +88,19 @@
   {                                                                             \
     auto THRUST_PP_CAT2(count, _fixed) = static_cast<std::int64_t>(count);      \
     status                             = call_64 arguments;                     \
+  }
+
+/// Like \ref THRUST_INDEX_TYPE_DISPATCH2 but uses two counts.
+#define THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count1, count2, arguments) \
+  if (count1 + count2 <= thrust::detail::integer_traits<thrust::detail::int32_t>::const_max)    \
+  {                                                                                             \
+    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<thrust::detail::int32_t>(count1);         \
+    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<thrust::detail::int32_t>(count2);         \
+    status                              = call_32 arguments;                                    \
+  }                                                                                             \
+  else                                                                                          \
+  {                                                                                             \
+    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<thrust::detail::int64_t>(count1);         \
+    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<thrust::detail::int64_t>(count2);         \
+    status                              = call_64 arguments;                                    \
   }

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -92,15 +92,15 @@
 
 /// Like \ref THRUST_INDEX_TYPE_DISPATCH2 but uses two counts.
 #define THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count1, count2, arguments) \
-  if (count1 + count2 <= thrust::detail::integer_traits<thrust::detail::int32_t>::const_max)    \
+  if (count1 + count2 <= thrust::detail::integer_traits<std::int32_t>::const_max)               \
   {                                                                                             \
-    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<thrust::detail::int32_t>(count1);         \
-    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<thrust::detail::int32_t>(count2);         \
+    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<std::int32_t>(count1);                    \
+    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<std::int32_t>(count2);                    \
     status                              = call_32 arguments;                                    \
   }                                                                                             \
   else                                                                                          \
   {                                                                                             \
-    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<thrust::detail::int64_t>(count1);         \
-    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<thrust::detail::int64_t>(count2);         \
+    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<std::int64_t>(count1);                    \
+    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<std::int64_t>(count2);                    \
     status                              = call_64 arguments;                                    \
   }

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-j * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -38,20 +38,13 @@ j * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 
 #if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_NVCC
 
-#  include <cub/agent/agent_merge_sort.cuh>
-#  include <cub/util_macro.cuh>
+#  include <cub/device/device_merge.cuh>
 
-#  include <thrust/detail/mpl/math.h>
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/distance.h>
-#  include <thrust/extrema.h>
-#  include <thrust/merge.h>
+#  include <thrust/iterator/iterator_traits.h>
 #  include <thrust/pair.h>
-#  include <thrust/system/cuda/detail/cdp_dispatch.h>
-#  include <thrust/system/cuda/detail/core/agent_launcher.h>
-#  include <thrust/system/cuda/detail/core/util.h>
-#  include <thrust/system/cuda/detail/execution_policy.h>
-#  include <thrust/system/cuda/detail/par_to_seq.h>
+#  include <thrust/system/cuda/detail/dispatch.h>
 #  include <thrust/system/cuda/detail/util.h>
 
 #  include <cstdint>
@@ -59,613 +52,66 @@ j * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
-
-namespace __merge
+_CCCL_EXEC_CHECK_DISABLE
+template <class Derived, class KeysIt1, class KeysIt2, class ResultIt, class CompareOp = less<>>
+ResultIt _CCCL_HOST_DEVICE
+merge(execution_policy<Derived>& policy,
+      KeysIt1 keys1_begin,
+      KeysIt1 keys1_end,
+      KeysIt2 keys2_begin,
+      KeysIt2 keys2_end,
+      ResultIt result_begin,
+      CompareOp compare_op = {})
 {
-template <int _BLOCK_THREADS,
-          int _ITEMS_PER_THREAD                     = 1,
-          cub::BlockLoadAlgorithm _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
-          cub::CacheLoadModifier _LOAD_MODIFIER     = cub::LOAD_LDG,
-          cub::BlockStoreAlgorithm _STORE_ALGORITHM = cub::BLOCK_STORE_DIRECT>
-struct PtxPolicy
-{
-  enum
+  using size_type         = typename iterator_traits<KeysIt1>::difference_type;
+  const auto num_keys1    = static_cast<size_type>(distance(keys1_begin, keys1_end));
+  const auto num_keys2    = static_cast<size_type>(distance(keys2_begin, keys2_end));
+  const auto num_keys_out = num_keys1 + num_keys2;
+  if (num_keys_out == 0)
   {
-    BLOCK_THREADS    = _BLOCK_THREADS,
-    ITEMS_PER_THREAD = _ITEMS_PER_THREAD,
-    ITEMS_PER_TILE   = _BLOCK_THREADS * _ITEMS_PER_THREAD,
-  };
-
-  static const cub::BlockLoadAlgorithm LOAD_ALGORITHM   = _LOAD_ALGORITHM;
-  static const cub::CacheLoadModifier LOAD_MODIFIER     = _LOAD_MODIFIER;
-  static const cub::BlockStoreAlgorithm STORE_ALGORITHM = _STORE_ALGORITHM;
-}; // PtxPolicy
-
-// TODO(bgruber): similar to cub::AgentPartition
-template <class KeysIt1, class KeysIt2, class Size, class CompareOp>
-struct PartitionAgent
-{
-  template <class Arch>
-  struct PtxPlan : PtxPolicy<256>
-  {};
-
-  using ptx_plan = core::specialize_plan<PtxPlan>;
-
-  THRUST_AGENT_ENTRY(
-    KeysIt1 keys1,
-    KeysIt2 keys2,
-    Size keys1_count,
-    Size keys2_count,
-    Size num_partitions,
-    Size* merge_partitions,
-    CompareOp compare_op,
-    int items_per_tile,
-    char* /*shmem*/)
-  {
-    Size partition_idx = blockDim.x * blockIdx.x + threadIdx.x;
-    if (partition_idx < num_partitions)
-    {
-      Size partition_at   = (thrust::min)(partition_idx * items_per_tile, keys1_count + keys2_count);
-      Size partition_diag = cub::MergePath(keys1, keys2, keys1_count, keys2_count, partition_at, compare_op);
-      merge_partitions[partition_idx] = partition_diag;
-    }
-  }
-}; // struct PartitionAgent
-
-template <class Arch, class TSize>
-struct Tuning;
-
-namespace mpl = thrust::detail::mpl::math;
-
-template <int NOMINAL_4B_ITEMS_PER_THREAD, size_t INPUT_SIZE>
-struct items_per_thread
-{
-  static constexpr auto ITEMS_PER_THREAD = (cub::min)(
-    NOMINAL_4B_ITEMS_PER_THREAD, (cub::max)(1, static_cast<int>(NOMINAL_4B_ITEMS_PER_THREAD * 4 / INPUT_SIZE)));
-  static constexpr auto value = ITEMS_PER_THREAD % 2 == 1 ? ITEMS_PER_THREAD : ITEMS_PER_THREAD + 1;
-};
-
-template <class TSize>
-struct Tuning<sm30, TSize>
-{
-  enum
-  {
-    NOMINAL_4B_ITEMS_PER_THREAD = 7,
-    ITEMS_PER_THREAD            = items_per_thread<NOMINAL_4B_ITEMS_PER_THREAD, TSize::value>::value
-  };
-
-  using type =
-    PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE>;
-}; // Tuning sm300
-
-template <class TSize>
-struct Tuning<sm60, TSize> : Tuning<sm30, TSize>
-{
-  enum
-  {
-    NOMINAL_4B_ITEMS_PER_THREAD = 15,
-    ITEMS_PER_THREAD            = items_per_thread<NOMINAL_4B_ITEMS_PER_THREAD, TSize::value>::value
-  };
-
-  using type =
-    PtxPolicy<512, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE>;
-}; // Tuning sm52
-
-template <class TSize>
-struct Tuning<sm52, TSize> : Tuning<sm30, TSize>
-{
-  enum
-  {
-    NOMINAL_4B_ITEMS_PER_THREAD = 13,
-    ITEMS_PER_THREAD            = items_per_thread<NOMINAL_4B_ITEMS_PER_THREAD, TSize::value>::value
-  };
-
-  using type =
-    PtxPolicy<512, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_STORE_WARP_TRANSPOSE>;
-}; // Tuning sm52
-
-template <class TSize>
-struct Tuning<sm35, TSize> : Tuning<sm30, TSize>
-{
-  enum
-  {
-    NOMINAL_4B_ITEMS_PER_THREAD = 11,
-    ITEMS_PER_THREAD            = items_per_thread<NOMINAL_4B_ITEMS_PER_THREAD, TSize::value>::value
-  };
-
-  using type =
-    PtxPolicy<256, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_STORE_WARP_TRANSPOSE>;
-}; // Tuning sm350
-
-template <size_t VALUE>
-struct integer_constant : thrust::detail::integral_constant<size_t, VALUE>
-{};
-
-template <class KeysIt1,
-          class KeysIt2,
-          class ItemsIt1,
-          class ItemsIt2,
-          class Size,
-          class KeysOutputIt,
-          class ItemsOutputIt,
-          class CompareOp,
-          class MERGE_ITEMS>
-struct MergeAgent
-{
-  using key1_type  = typename iterator_traits<KeysIt1>::value_type;
-  using key2_type  = typename iterator_traits<KeysIt2>::value_type;
-  using item1_type = typename iterator_traits<ItemsIt1>::value_type;
-  using item2_type = typename iterator_traits<ItemsIt2>::value_type;
-
-  using key_type  = key1_type;
-  using item_type = item1_type;
-
-  using tuning_type =
-    ::cuda::std::__conditional_t<MERGE_ITEMS::value,
-                                 integer_constant<sizeof(key_type) + sizeof(item_type)>,
-                                 integer_constant<sizeof(key_type)>>;
-
-  template <class Arch>
-  struct PtxPlan : Tuning<Arch, tuning_type>::type
-  {
-    using tuning = Tuning<Arch, tuning_type>;
-
-    using KeysLoadIt1  = typename core::LoadIterator<PtxPlan, KeysIt1>::type;
-    using KeysLoadIt2  = typename core::LoadIterator<PtxPlan, KeysIt2>::type;
-    using ItemsLoadIt1 = typename core::LoadIterator<PtxPlan, ItemsIt1>::type;
-    using ItemsLoadIt2 = typename core::LoadIterator<PtxPlan, ItemsIt2>::type;
-
-    using BlockLoadKeys1  = typename core::BlockLoad<PtxPlan, KeysLoadIt1>::type;
-    using BlockLoadKeys2  = typename core::BlockLoad<PtxPlan, KeysLoadIt2>::type;
-    using BlockLoadItems1 = typename core::BlockLoad<PtxPlan, ItemsLoadIt1>::type;
-    using BlockLoadItems2 = typename core::BlockLoad<PtxPlan, ItemsLoadIt2>::type;
-
-    using BlockStoreKeys  = typename core::BlockStore<PtxPlan, KeysOutputIt, key_type>::type;
-    using BlockStoreItems = typename core::BlockStore<PtxPlan, ItemsOutputIt, item_type>::type;
-
-    // gather required temporary storage in a union
-    //
-    union TempStorage
-    {
-      typename BlockLoadKeys1::TempStorage load_keys1;
-      typename BlockLoadKeys2::TempStorage load_keys2;
-      typename BlockLoadItems1::TempStorage load_items1;
-      typename BlockLoadItems2::TempStorage load_items2;
-      typename BlockStoreKeys::TempStorage store_keys;
-      typename BlockStoreItems::TempStorage store_items;
-
-      core::uninitialized_array<item_type, PtxPlan::ITEMS_PER_TILE + 1> items_shared;
-      core::uninitialized_array<key_type, PtxPlan::ITEMS_PER_TILE + 1> keys_shared;
-    }; // union TempStorage
-  }; // struct PtxPlan
-
-  using ptx_plan = typename core::specialize_plan_msvc10_war<PtxPlan>::type::type;
-
-  using KeysLoadIt1     = typename ptx_plan::KeysLoadIt1;
-  using KeysLoadIt2     = typename ptx_plan::KeysLoadIt2;
-  using ItemsLoadIt1    = typename ptx_plan::ItemsLoadIt1;
-  using ItemsLoadIt2    = typename ptx_plan::ItemsLoadIt2;
-  using BlockLoadKeys1  = typename ptx_plan::BlockLoadKeys1;
-  using BlockLoadKeys2  = typename ptx_plan::BlockLoadKeys2;
-  using BlockLoadItems1 = typename ptx_plan::BlockLoadItems1;
-  using BlockLoadItems2 = typename ptx_plan::BlockLoadItems2;
-  using BlockStoreKeys  = typename ptx_plan::BlockStoreKeys;
-  using BlockStoreItems = typename ptx_plan::BlockStoreItems;
-  using TempStorage     = typename ptx_plan::TempStorage;
-
-  enum
-  {
-    ITEMS_PER_THREAD = ptx_plan::ITEMS_PER_THREAD,
-    BLOCK_THREADS    = ptx_plan::BLOCK_THREADS,
-    ITEMS_PER_TILE   = ptx_plan::ITEMS_PER_TILE
-  };
-
-  struct impl
-  {
-    //---------------------------------------------------------------------
-    // Per thread data
-    //---------------------------------------------------------------------
-
-    TempStorage& storage;
-    KeysLoadIt1 keys1_in;
-    KeysLoadIt2 keys2_in;
-    ItemsLoadIt1 items1_in;
-    ItemsLoadIt2 items2_in;
-    Size keys1_count;
-    Size keys2_count;
-    KeysOutputIt keys_out;
-    ItemsOutputIt items_out;
-    CompareOp compare_op;
-    Size* merge_partitions;
-
-    //---------------------------------------------------------------------
-    // Tile processing
-    //---------------------------------------------------------------------
-
-    template <bool IS_FULL_TILE>
-    void THRUST_DEVICE_FUNCTION consume_tile(Size tile_idx, Size tile_base, int num_remaining)
-    {
-      using core::sync_threadblock;
-      using core::uninitialized_array;
-
-      Size partition_beg = merge_partitions[tile_idx + 0];
-      Size partition_end = merge_partitions[tile_idx + 1];
-
-      Size diag0 = ITEMS_PER_TILE * tile_idx;
-      Size diag1 = (thrust::min)(keys1_count + keys2_count, diag0 + ITEMS_PER_TILE);
-
-      // compute bounding box for keys1 & keys2
-      //
-      Size keys1_beg = partition_beg;
-      Size keys1_end = partition_end;
-      Size keys2_beg = diag0 - keys1_beg;
-      Size keys2_end = diag1 - keys1_end;
-
-      // number of keys per tile
-      //
-      int num_keys1 = static_cast<int>(keys1_end - keys1_beg);
-      int num_keys2 = static_cast<int>(keys2_end - keys2_beg);
-
-      key_type keys_loc[ITEMS_PER_THREAD];
-      cub::detail::gmem_to_reg<BLOCK_THREADS, IS_FULL_TILE>(
-        keys_loc, keys1_in + keys1_beg, keys2_in + keys2_beg, num_keys1, num_keys2);
-      cub::detail::reg_to_shared<BLOCK_THREADS>(&storage.keys_shared[0], keys_loc);
-
-      sync_threadblock();
-
-      // use binary search in shared memory
-      // to find merge path for each of thread
-      // we can use int type here, because the number of
-      // items in shared memory is limited
-      //
-      int diag0_loc = min<int>(num_keys1 + num_keys2, ITEMS_PER_THREAD * threadIdx.x);
-
-      int keys1_beg_loc = cub::MergePath(
-        &storage.keys_shared[0], &storage.keys_shared[num_keys1], num_keys1, num_keys2, diag0_loc, compare_op);
-      int keys1_end_loc = num_keys1;
-      int keys2_beg_loc = diag0_loc - keys1_beg_loc;
-      int keys2_end_loc = num_keys2;
-
-      int num_keys1_loc = keys1_end_loc - keys1_beg_loc;
-      int num_keys2_loc = keys2_end_loc - keys2_beg_loc;
-
-      // perform serial merge
-      //
-      int indices[ITEMS_PER_THREAD];
-
-      cub::SerialMerge(
-        &storage.keys_shared[0],
-        keys1_beg_loc,
-        keys2_beg_loc + num_keys1,
-        num_keys1_loc,
-        num_keys2_loc,
-        keys_loc,
-        indices,
-        compare_op);
-
-      sync_threadblock();
-
-      // write keys
-      //
-      if (IS_FULL_TILE)
-      {
-        BlockStoreKeys(storage.store_keys).Store(keys_out + tile_base, keys_loc);
-      }
-      else
-      {
-        BlockStoreKeys(storage.store_keys).Store(keys_out + tile_base, keys_loc, num_remaining);
-      }
-
-      // if items are provided, merge them
-      if (MERGE_ITEMS::value)
-      {
-        item_type items_loc[ITEMS_PER_THREAD];
-        cub::detail::gmem_to_reg<BLOCK_THREADS, IS_FULL_TILE>(
-          items_loc, items1_in + keys1_beg, items2_in + keys2_beg, num_keys1, num_keys2);
-
-        sync_threadblock();
-
-        cub::detail::reg_to_shared<BLOCK_THREADS>(&storage.items_shared[0], items_loc);
-
-        sync_threadblock();
-
-        // gather items from shared mem
-        //
-#  pragma unroll
-        for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
-        {
-          items_loc[ITEM] = storage.items_shared[indices[ITEM]];
-        }
-
-        sync_threadblock();
-
-        // write form reg to gmem
-        //
-        if (IS_FULL_TILE)
-        {
-          BlockStoreItems(storage.store_items).Store(items_out + tile_base, items_loc);
-        }
-        else
-        {
-          BlockStoreItems(storage.store_items).Store(items_out + tile_base, items_loc, num_remaining);
-        }
-      }
-    }
-
-    //---------------------------------------------------------------------
-    // Constructor
-    //---------------------------------------------------------------------
-
-    THRUST_DEVICE_FUNCTION
-    impl(TempStorage& storage_,
-         KeysLoadIt1 keys1_in_,
-         KeysLoadIt2 keys2_in_,
-         ItemsLoadIt1 items1_in_,
-         ItemsLoadIt2 items2_in_,
-         Size keys1_count_,
-         Size keys2_count_,
-         KeysOutputIt keys_out_,
-         ItemsOutputIt items_out_,
-         CompareOp compare_op_,
-         Size* merge_partitions_)
-        : storage(storage_)
-        , keys1_in(keys1_in_)
-        , keys2_in(keys2_in_)
-        , items1_in(items1_in_)
-        , items2_in(items2_in_)
-        , keys1_count(keys1_count_)
-        , keys2_count(keys2_count_)
-        , keys_out(keys_out_)
-        , items_out(items_out_)
-        , compare_op(compare_op_)
-        , merge_partitions(merge_partitions_)
-    {
-      // XXX with 8.5 chaging type to Size (or long long) results in error!
-      int tile_idx      = blockIdx.x;
-      Size tile_base    = tile_idx * ITEMS_PER_TILE;
-      int items_in_tile = static_cast<int>(min<Size>(ITEMS_PER_TILE, keys1_count + keys2_count - tile_base));
-      if (items_in_tile == ITEMS_PER_TILE)
-      {
-        // full tile
-        consume_tile<true>(tile_idx, tile_base, ITEMS_PER_TILE);
-      }
-      else
-      {
-        // partial tile
-        consume_tile<false>(tile_idx, tile_base, items_in_tile);
-      }
-    }
-  }; // struct impl
-
-  //---------------------------------------------------------------------
-  // Agent entry point
-  //---------------------------------------------------------------------
-
-  THRUST_AGENT_ENTRY(
-    KeysIt1 keys1_in,
-    KeysIt2 keys2_in,
-    ItemsIt1 items1_in,
-    ItemsIt2 items2_in,
-    Size keys1_count,
-    Size keys2_count,
-    KeysOutputIt keys_out,
-    ItemsOutputIt items_out,
-    CompareOp compare_op,
-    Size* merge_partitions,
-    char* shmem)
-  {
-    TempStorage& storage = *reinterpret_cast<TempStorage*>(shmem);
-
-    impl(storage,
-         core::make_load_iterator(ptx_plan(), keys1_in),
-         core::make_load_iterator(ptx_plan(), keys2_in),
-         core::make_load_iterator(ptx_plan(), items1_in),
-         core::make_load_iterator(ptx_plan(), items2_in),
-         keys1_count,
-         keys2_count,
-         keys_out,
-         items_out,
-         compare_op,
-         merge_partitions);
-  }
-}; // struct MergeAgent;
-
-//---------------------------------------------------------------------
-// Two-step internal API
-//---------------------------------------------------------------------
-
-template <class MERGE_ITEMS,
-          class KeysIt1,
-          class KeysIt2,
-          class ItemsIt1,
-          class ItemsIt2,
-          class Size,
-          class KeysOutputIt,
-          class ItemsOutputIt,
-          class CompareOp>
-cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  KeysIt1 keys1,
-  KeysIt2 keys2,
-  ItemsIt1 items1,
-  ItemsIt2 items2,
-  Size num_keys1,
-  Size num_keys2,
-  KeysOutputIt keys_result,
-  ItemsOutputIt items_result,
-  CompareOp compare_op,
-  cudaStream_t stream)
-{
-  if (num_keys1 + num_keys2 == 0)
-  {
-    return cudaErrorNotSupported;
+    return result_begin;
   }
 
-  using core::AgentPlan;
-  using core::get_agent_plan;
-  using merge_agent = core::AgentLauncher<
-    MergeAgent<KeysIt1, KeysIt2, ItemsIt1, ItemsIt2, Size, KeysOutputIt, ItemsOutputIt, CompareOp, MERGE_ITEMS>>;
-
-  using partition_agent = core::AgentLauncher<PartitionAgent<KeysIt1, KeysIt2, Size, CompareOp>>;
-
-  cudaError_t status = cudaSuccess;
-
-  AgentPlan partition_plan = partition_agent::get_plan();
-  AgentPlan merge_plan     = merge_agent::get_plan(stream);
-
-  int tile_size  = merge_plan.items_per_tile;
-  Size num_tiles = (num_keys1 + num_keys2 + tile_size - 1) / tile_size;
-
-  size_t temp_storage1 = (1 + num_tiles) * sizeof(Size);
-  size_t temp_storage2 = core::vshmem_size(merge_plan.shared_memory_size, num_tiles);
-
-  void* allocations[2]       = {nullptr, nullptr};
-  size_t allocation_sizes[2] = {temp_storage1, temp_storage2};
-
-  status = core::alias_storage(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes);
-  CUDA_CUB_RET_IF_FAIL(status);
-
-  if (d_temp_storage == nullptr)
-  {
-    return status;
-  }
-
-  // partition data into work balanced tiles
-  Size* merge_partitions = (Size*) allocations[0];
-  char* vshmem_ptr       = temp_storage2 > 0 ? (char*) allocations[1] : nullptr;
-
-  {
-    Size num_partitions = num_tiles + 1;
-
-    partition_agent(partition_plan, num_partitions, stream, "partition agent")
-      .launch(
-        keys1, keys2, num_keys1, num_keys2, num_partitions, merge_partitions, compare_op, merge_plan.items_per_tile);
-    CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
-  }
-
-  merge_agent(merge_plan, num_keys1 + num_keys2, stream, vshmem_ptr, "merge agent")
-    .launch(keys1, keys2, items1, items2, num_keys1, num_keys2, keys_result, items_result, compare_op, merge_partitions);
-  CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
-
-  return status;
-}
-
-template <typename MERGE_ITEMS,
-          typename Derived,
-          typename KeysIt1,
-          typename KeysIt2,
-          typename ItemsIt1,
-          typename ItemsIt2,
-          typename KeysOutputIt,
-          typename ItemsOutputIt,
-          typename CompareOp>
-THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ItemsOutputIt> merge(
-  execution_policy<Derived>& policy,
-  KeysIt1 keys1_first,
-  KeysIt1 keys1_last,
-  KeysIt2 keys2_first,
-  KeysIt2 keys2_last,
-  ItemsIt1 items1_first,
-  ItemsIt2 items2_first,
-  KeysOutputIt keys_result,
-  ItemsOutputIt items_result,
-  CompareOp compare_op)
-{
-  using size_type = typename iterator_traits<KeysIt1>::difference_type;
-
-  size_type num_keys1 = static_cast<size_type>(thrust::distance(keys1_first, keys1_last));
-  size_type num_keys2 = static_cast<size_type>(thrust::distance(keys2_first, keys2_last));
-
-  size_type const count = num_keys1 + num_keys2;
-
-  if (count == 0)
-  {
-    return thrust::make_pair(keys_result, items_result);
-  }
-
-  size_t storage_size = 0;
-  cudaStream_t stream = cuda_cub::stream(policy);
-
+  const auto stream = cuda_cub::stream(policy);
   cudaError_t status;
-  status = doit_step<MERGE_ITEMS>(
-    nullptr,
-    storage_size,
-    keys1_first,
-    keys2_first,
-    items1_first,
-    items2_first,
+  size_t storage_size = 0;
+  THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
+    status,
+    cub::DeviceMerge::MergeKeys,
     num_keys1,
     num_keys2,
-    keys_result,
-    items_result,
-    compare_op,
-    stream);
-  cuda_cub::throw_on_error(status, "merge: failed on 1st step");
+    (nullptr,
+     storage_size,
+     keys1_begin,
+     num_keys1_fixed,
+     keys2_begin,
+     num_keys2_fixed,
+     result_begin,
+     compare_op,
+     stream));
+  throw_on_error(status, "merge: failed on 1st step");
 
-  // Allocate temporary storage.
-  thrust::detail::temporary_array<std::uint8_t, Derived> tmp(policy, storage_size);
-  void* ptr = static_cast<void*>(tmp.data().get());
-
-  status = doit_step<MERGE_ITEMS>(
-    ptr,
-    storage_size,
-    keys1_first,
-    keys2_first,
-    items1_first,
-    items2_first,
+  thrust::detail::temporary_array<char, Derived> temp_storage(policy, storage_size);
+  THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
+    status,
+    cub::DeviceMerge::MergeKeys,
     num_keys1,
     num_keys2,
-    keys_result,
-    items_result,
-    compare_op,
-    stream);
-  cuda_cub::throw_on_error(status, "merge: failed on 2nd step");
+    (temp_storage.data().get(),
+     storage_size,
+     keys1_begin,
+     num_keys1_fixed,
+     keys2_begin,
+     num_keys2_fixed,
+     result_begin,
+     compare_op,
+     stream));
+  throw_on_error(status, "merge: failed on 2nd step");
 
   status = cuda_cub::synchronize_optional(policy);
-  cuda_cub::throw_on_error(status, "merge: failed to synchronize");
+  throw_on_error(status, "merge: failed to synchronize");
 
-  return thrust::make_pair(keys_result + count, items_result + count);
-}
-} // namespace __merge
-
-//-------------------------
-// Thrust API entry points
-//-------------------------
-
-_CCCL_EXEC_CHECK_DISABLE
-template <class Derived, class KeysIt1, class KeysIt2, class ResultIt, class CompareOp>
-ResultIt _CCCL_HOST_DEVICE
-merge(execution_policy<Derived>& policy,
-      KeysIt1 keys1_first,
-      KeysIt1 keys1_last,
-      KeysIt2 keys2_first,
-      KeysIt2 keys2_last,
-      ResultIt result,
-      CompareOp compare_op)
-
-{
-  THRUST_CDP_DISPATCH(
-    (using keys_type = thrust::iterator_value_t<KeysIt1>; keys_type* null_ = nullptr;
-     auto tmp                                                              = __merge::merge<thrust::detail::false_type>(
-       policy, keys1_first, keys1_last, keys2_first, keys2_last, null_, null_, result, null_, compare_op);
-     result = tmp.first;),
-    (result = thrust::merge(
-       cvt_to_seq(derived_cast(policy)), keys1_first, keys1_last, keys2_first, keys2_last, result, compare_op);));
-  return result;
-}
-
-template <class Derived, class KeysIt1, class KeysIt2, class ResultIt>
-ResultIt _CCCL_HOST_DEVICE
-merge(execution_policy<Derived>& policy,
-      KeysIt1 keys1_first,
-      KeysIt1 keys1_last,
-      KeysIt2 keys2_first,
-      KeysIt2 keys2_last,
-      ResultIt result)
-{
-  using keys_type = typename thrust::iterator_value<KeysIt1>::type;
-  return cuda_cub::merge(policy, keys1_first, keys1_last, keys2_first, keys2_last, result, less<keys_type>());
+  return result_begin + num_keys_out;
 }
 
 _CCCL_EXEC_CHECK_DISABLE
@@ -676,72 +122,76 @@ template <class Derived,
           class ItemsIt2,
           class KeysOutputIt,
           class ItemsOutputIt,
-          class CompareOp>
+          class CompareOp = less<>>
 pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE merge_by_key(
   execution_policy<Derived>& policy,
-  KeysIt1 keys1_first,
-  KeysIt1 keys1_last,
-  KeysIt2 keys2_first,
-  KeysIt2 keys2_last,
-  ItemsIt1 items1_first,
-  ItemsIt2 items2_first,
-  KeysOutputIt keys_result,
-  ItemsOutputIt items_result,
-  CompareOp compare_op)
+  KeysIt1 keys1_begin,
+  KeysIt1 keys1_end,
+  KeysIt2 keys2_begin,
+  KeysIt2 keys2_end,
+  ItemsIt1 items1_begin,
+  ItemsIt2 items2_begin,
+  KeysOutputIt keys_out_begin,
+  ItemsOutputIt items_out_begin,
+  CompareOp compare_op = {})
 {
-  auto ret = thrust::make_pair(keys_result, items_result);
-  THRUST_CDP_DISPATCH(
-    (ret = __merge::merge<thrust::detail::true_type>(
-       policy,
-       keys1_first,
-       keys1_last,
-       keys2_first,
-       keys2_last,
-       items1_first,
-       items2_first,
-       keys_result,
-       items_result,
-       compare_op);),
-    (ret = thrust::merge_by_key(
-       cvt_to_seq(derived_cast(policy)),
-       keys1_first,
-       keys1_last,
-       keys2_first,
-       keys2_last,
-       items1_first,
-       items2_first,
-       keys_result,
-       items_result,
-       compare_op);));
-  return ret;
-}
+  using size_type = typename iterator_traits<KeysIt1>::difference_type;
 
-template <class Derived, class KeysIt1, class KeysIt2, class ItemsIt1, class ItemsIt2, class KeysOutputIt, class ItemsOutputIt>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE merge_by_key(
-  execution_policy<Derived>& policy,
-  KeysIt1 keys1_first,
-  KeysIt1 keys1_last,
-  KeysIt2 keys2_first,
-  KeysIt2 keys2_last,
-  ItemsIt1 items1_first,
-  ItemsIt2 items2_first,
-  KeysOutputIt keys_result,
-  ItemsOutputIt items_result)
-{
-  using keys_type = typename thrust::iterator_value<KeysIt1>::type;
-  return cuda_cub::merge_by_key(
-    policy,
-    keys1_first,
-    keys1_last,
-    keys2_first,
-    keys2_last,
-    items1_first,
-    items2_first,
-    keys_result,
-    items_result,
-    thrust::less<keys_type>());
-}
+  const auto num_keys1    = static_cast<size_type>(distance(keys1_begin, keys1_end));
+  const auto num_keys2    = static_cast<size_type>(distance(keys2_begin, keys2_end));
+  const auto num_keys_out = num_keys1 + num_keys2;
+  if (num_keys_out == 0)
+  {
+    return {keys_out_begin, items_out_begin};
+  }
 
+  const auto stream = cuda_cub::stream(policy);
+  cudaError_t status;
+  size_t storage_size = 0;
+  THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
+    status,
+    cub::DeviceMerge::MergePairs,
+    num_keys1,
+    num_keys2,
+    (nullptr,
+     storage_size,
+     keys1_begin,
+     items1_begin,
+     num_keys1_fixed,
+     keys2_begin,
+     items2_begin,
+     num_keys2_fixed,
+     keys_out_begin,
+     items_out_begin,
+     compare_op,
+     stream));
+  throw_on_error(status, "merge: failed on 1st step");
+
+  thrust::detail::temporary_array<char, Derived> temp_storage(policy, storage_size);
+  THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
+    status,
+    cub::DeviceMerge::MergePairs,
+    num_keys1,
+    num_keys2,
+    (temp_storage.data().get(),
+     storage_size,
+     keys1_begin,
+     items1_begin,
+     num_keys1_fixed,
+     keys2_begin,
+     items2_begin,
+     num_keys2_fixed,
+     keys_out_begin,
+     items_out_begin,
+     compare_op,
+     stream));
+  throw_on_error(status, "merge: failed on 2nd step");
+
+  status = cuda_cub::synchronize_optional(policy);
+  throw_on_error(status, "merge: failed to synchronize");
+
+  return {keys_out_begin + num_keys_out, items_out_begin + num_keys_out};
+}
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
 #endif

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -63,55 +63,84 @@ merge(execution_policy<Derived>& policy,
       ResultIt result_begin,
       CompareOp compare_op = {})
 {
-  using size_type         = typename iterator_traits<KeysIt1>::difference_type;
-  const auto num_keys1    = static_cast<size_type>(distance(keys1_begin, keys1_end));
-  const auto num_keys2    = static_cast<size_type>(distance(keys2_begin, keys2_end));
-  const auto num_keys_out = num_keys1 + num_keys2;
-  if (num_keys_out == 0)
-  {
-    return result_begin;
-  }
+  THRUST_CDP_DISPATCH(
+    (using size_type         = typename iterator_traits<KeysIt1>::difference_type;
+     const auto num_keys1    = static_cast<size_type>(distance(keys1_begin, keys1_end));
+     const auto num_keys2    = static_cast<size_type>(distance(keys2_begin, keys2_end));
+     const auto num_keys_out = num_keys1 + num_keys2;
+     if (num_keys_out == 0) { return result_begin; }
 
-  const auto stream = cuda_cub::stream(policy);
-  cudaError_t status;
-  size_t storage_size = 0;
-  THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
-    status,
-    cub::DeviceMerge::MergeKeys,
-    num_keys1,
-    num_keys2,
-    (nullptr,
-     storage_size,
-     keys1_begin,
-     num_keys1_fixed,
-     keys2_begin,
-     num_keys2_fixed,
-     result_begin,
-     compare_op,
-     stream));
-  throw_on_error(status, "merge: failed on 1st step");
+     using dispatch32_t = cub::detail::merge::dispatch_t<
+       KeysIt1,
+       cub::NullType*,
+       KeysIt2,
+       cub::NullType*,
+       ResultIt,
+       cub::NullType*,
+       thrust::detail::int32_t,
+       CompareOp>;
+     using dispatch64_t = cub::detail::merge::dispatch_t<
+       KeysIt1,
+       cub::NullType*,
+       KeysIt2,
+       cub::NullType*,
+       ResultIt,
+       cub::NullType*,
+       thrust::detail::int64_t,
+       CompareOp>;
 
-  thrust::detail::temporary_array<char, Derived> temp_storage(policy, storage_size);
-  THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
-    status,
-    cub::DeviceMerge::MergeKeys,
-    num_keys1,
-    num_keys2,
-    (temp_storage.data().get(),
-     storage_size,
-     keys1_begin,
-     num_keys1_fixed,
-     keys2_begin,
-     num_keys2_fixed,
-     result_begin,
-     compare_op,
-     stream));
-  throw_on_error(status, "merge: failed on 2nd step");
+     const auto stream = cuda_cub::stream(policy);
+     cudaError_t status;
+     size_t storage_size = 0;
+     THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(
+       status,
+       dispatch32_t::dispatch,
+       dispatch64_t::dispatch,
+       num_keys1,
+       num_keys2,
+       (nullptr,
+        storage_size,
+        keys1_begin,
+        nullptr,
+        num_keys1_fixed,
+        keys2_begin,
+        nullptr,
+        num_keys2_fixed,
+        result_begin,
+        nullptr,
+        compare_op,
+        stream));
+     throw_on_error(status, "merge: failed on 1st step");
 
-  status = cuda_cub::synchronize_optional(policy);
-  throw_on_error(status, "merge: failed to synchronize");
+     thrust::detail::temporary_array<char, Derived> temp_storage(policy, storage_size);
+     THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(
+       status,
+       dispatch32_t::dispatch,
+       dispatch64_t::dispatch,
+       num_keys1,
+       num_keys2,
+       (temp_storage.data().get(),
+        storage_size,
+        keys1_begin,
+        nullptr,
+        num_keys1_fixed,
+        keys2_begin,
+        nullptr,
+        num_keys2_fixed,
+        result_begin,
+        nullptr,
+        compare_op,
+        stream));
+     throw_on_error(status, "merge: failed on 2nd step");
 
-  return result_begin + num_keys_out;
+     status = cuda_cub::synchronize_optional(policy);
+     throw_on_error(status, "merge: failed to synchronize");
+
+     return result_begin + num_keys_out;),
+    (return thrust::merge(
+              cvt_to_seq(derived_cast(policy)), keys1_begin, keys1_end, keys2_begin, keys2_end, result_begin, compare_op);
+
+     ));
 }
 
 _CCCL_EXEC_CHECK_DISABLE
@@ -135,62 +164,80 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE merge_by_key(
   ItemsOutputIt items_out_begin,
   CompareOp compare_op = {})
 {
-  using size_type = typename iterator_traits<KeysIt1>::difference_type;
+  THRUST_CDP_DISPATCH(
+    (using size_type = typename iterator_traits<KeysIt1>::difference_type;
 
-  const auto num_keys1    = static_cast<size_type>(distance(keys1_begin, keys1_end));
-  const auto num_keys2    = static_cast<size_type>(distance(keys2_begin, keys2_end));
-  const auto num_keys_out = num_keys1 + num_keys2;
-  if (num_keys_out == 0)
-  {
-    return {keys_out_begin, items_out_begin};
-  }
+     const auto num_keys1    = static_cast<size_type>(distance(keys1_begin, keys1_end));
+     const auto num_keys2    = static_cast<size_type>(distance(keys2_begin, keys2_end));
+     const auto num_keys_out = num_keys1 + num_keys2;
+     if (num_keys_out == 0) {
+       return {keys_out_begin, items_out_begin};
+     }
 
-  const auto stream = cuda_cub::stream(policy);
-  cudaError_t status;
-  size_t storage_size = 0;
-  THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
-    status,
-    cub::DeviceMerge::MergePairs,
-    num_keys1,
-    num_keys2,
-    (nullptr,
-     storage_size,
-     keys1_begin,
-     items1_begin,
-     num_keys1_fixed,
-     keys2_begin,
-     items2_begin,
-     num_keys2_fixed,
-     keys_out_begin,
-     items_out_begin,
-     compare_op,
-     stream));
-  throw_on_error(status, "merge: failed on 1st step");
+     using dispatch32_t = cub::detail::merge::
+       dispatch_t<KeysIt1, ItemsIt1, KeysIt2, ItemsIt2, KeysOutputIt, ItemsOutputIt, thrust::detail::int32_t, CompareOp>;
+     using dispatch64_t = cub::detail::merge::
+       dispatch_t<KeysIt1, ItemsIt1, KeysIt2, ItemsIt2, KeysOutputIt, ItemsOutputIt, thrust::detail::int64_t, CompareOp>;
 
-  thrust::detail::temporary_array<char, Derived> temp_storage(policy, storage_size);
-  THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
-    status,
-    cub::DeviceMerge::MergePairs,
-    num_keys1,
-    num_keys2,
-    (temp_storage.data().get(),
-     storage_size,
-     keys1_begin,
-     items1_begin,
-     num_keys1_fixed,
-     keys2_begin,
-     items2_begin,
-     num_keys2_fixed,
-     keys_out_begin,
-     items_out_begin,
-     compare_op,
-     stream));
-  throw_on_error(status, "merge: failed on 2nd step");
+     const auto stream = cuda_cub::stream(policy);
+     cudaError_t status;
+     size_t storage_size = 0;
+     THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(
+       status,
+       dispatch32_t::dispatch,
+       dispatch64_t::dispatch,
+       num_keys1,
+       num_keys2,
+       (nullptr,
+        storage_size,
+        keys1_begin,
+        items1_begin,
+        num_keys1_fixed,
+        keys2_begin,
+        items2_begin,
+        num_keys2_fixed,
+        keys_out_begin,
+        items_out_begin,
+        compare_op,
+        stream));
+     throw_on_error(status, "merge: failed on 1st step");
 
-  status = cuda_cub::synchronize_optional(policy);
-  throw_on_error(status, "merge: failed to synchronize");
+     thrust::detail::temporary_array<char, Derived> temp_storage(policy, storage_size);
+     THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(
+       status,
+       dispatch32_t::dispatch,
+       dispatch64_t::dispatch,
+       num_keys1,
+       num_keys2,
+       (temp_storage.data().get(),
+        storage_size,
+        keys1_begin,
+        items1_begin,
+        num_keys1_fixed,
+        keys2_begin,
+        items2_begin,
+        num_keys2_fixed,
+        keys_out_begin,
+        items_out_begin,
+        compare_op,
+        stream));
+     throw_on_error(status, "merge: failed on 2nd step");
 
-  return {keys_out_begin + num_keys_out, items_out_begin + num_keys_out};
+     status = cuda_cub::synchronize_optional(policy);
+     throw_on_error(status, "merge: failed to synchronize");
+
+     return {keys_out_begin + num_keys_out, items_out_begin + num_keys_out};),
+    (return thrust::merge_by_key(
+              cvt_to_seq(derived_cast(policy)),
+              keys1_begin,
+              keys1_end,
+              keys2_begin,
+              keys2_end,
+              items1_begin,
+              items2_begin,
+              keys_out_begin,
+              items_out_begin,
+              compare_op);));
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -70,24 +70,10 @@ merge(execution_policy<Derived>& policy,
      const auto num_keys_out = num_keys1 + num_keys2;
      if (num_keys_out == 0) { return result_begin; }
 
-     using dispatch32_t = cub::detail::merge::dispatch_t<
-       KeysIt1,
-       cub::NullType*,
-       KeysIt2,
-       cub::NullType*,
-       ResultIt,
-       cub::NullType*,
-       thrust::detail::int32_t,
-       CompareOp>;
-     using dispatch64_t = cub::detail::merge::dispatch_t<
-       KeysIt1,
-       cub::NullType*,
-       KeysIt2,
-       cub::NullType*,
-       ResultIt,
-       cub::NullType*,
-       thrust::detail::int64_t,
-       CompareOp>;
+     using dispatch32_t = cub::detail::merge::
+       dispatch_t<KeysIt1, cub::NullType*, KeysIt2, cub::NullType*, ResultIt, cub::NullType*, std::int32_t, CompareOp>;
+     using dispatch64_t = cub::detail::merge::
+       dispatch_t<KeysIt1, cub::NullType*, KeysIt2, cub::NullType*, ResultIt, cub::NullType*, std::int64_t, CompareOp>;
 
      const auto stream = cuda_cub::stream(policy);
      cudaError_t status;
@@ -175,9 +161,9 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE merge_by_key(
      }
 
      using dispatch32_t = cub::detail::merge::
-       dispatch_t<KeysIt1, ItemsIt1, KeysIt2, ItemsIt2, KeysOutputIt, ItemsOutputIt, thrust::detail::int32_t, CompareOp>;
+       dispatch_t<KeysIt1, ItemsIt1, KeysIt2, ItemsIt2, KeysOutputIt, ItemsOutputIt, std::int32_t, CompareOp>;
      using dispatch64_t = cub::detail::merge::
-       dispatch_t<KeysIt1, ItemsIt1, KeysIt2, ItemsIt2, KeysOutputIt, ItemsOutputIt, thrust::detail::int64_t, CompareOp>;
+       dispatch_t<KeysIt1, ItemsIt1, KeysIt2, ItemsIt2, KeysOutputIt, ItemsOutputIt, std::int64_t, CompareOp>;
 
      const auto stream = cuda_cub::stream(policy);
      cudaError_t status;

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -156,9 +156,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE merge_by_key(
      const auto num_keys1    = static_cast<size_type>(distance(keys1_begin, keys1_end));
      const auto num_keys2    = static_cast<size_type>(distance(keys2_begin, keys2_end));
      const auto num_keys_out = num_keys1 + num_keys2;
-     if (num_keys_out == 0) {
-       return {keys_out_begin, items_out_begin};
-     }
+     if (num_keys_out == 0) { return {keys_out_begin, items_out_begin}; }
 
      using dispatch32_t = cub::detail::merge::
        dispatch_t<KeysIt1, ItemsIt1, KeysIt2, ItemsIt2, KeysOutputIt, ItemsOutputIt, std::int32_t, CompareOp>;


### PR DESCRIPTION
This PR ports the CUDA implementation of `thrust::merge[_by_key]` to CUB.

CUB already has an implementation of merge sort, also based on the merge path algorithm, so some infrastructure is taken from there, replacing the thrust implementation. However, whenever I was not sure what to pick, I preferred the thrust implementation and will attempt a unification in a separate PR after benchmarks are available. This especially concerns the agents.

The following new constructs are added:

* Public API entry points: `cub::DeviceMerge` with `MergeKeys` and `MergePairs`, including documentation.
* Internal dispatch layer: `cub::detail::DispatchMerge` with policy selection, fallback agent, vsmem implementation. Including a set of tuning policies taken over from the thrust implementation.
* Internal agent `cub::detail::AgentPartitionMergePath` implementing merge path partitioning.
* Internal agent `cub::detail::AgentMergeNoSort` implementing the device side merging. Very similar to merge sorts `AgentMerge` and I plan to unifying the implementations in a separate step.
* Extensive unit tests for the new CUB API.
* A few comments, drive-by fixes and refactorings.

A full tuning is probably necessary which will be conducted in a separate PR.

Compile-time of `thrust.test.merge`:
```
Before: 0m26.798s
After:  0m36.763s
```

<details>
<summary>Benchmark of `thrust.bench.merge` :</summary>

Running `nvbench_compare.py base.json branch.json`

```
## [0] NVIDIA H100 PCIe

|  T{ct}  |  Elements  |  Entropy  |  InputSizeRatio  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|-----------|------------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^16    |     1     |        25        |  21.842 us |       1.43% |  22.034 us |       5.27% |   0.192 us |   0.88% |   PASS   |
|   I8    |    2^20    |     1     |        25        |  27.602 us |       1.56% |  27.763 us |       2.02% |   0.161 us |   0.58% |   PASS   |
|   I8    |    2^24    |     1     |        25        |  66.583 us |       0.82% |  64.971 us |       0.88% |  -1.613 us |  -2.42% |   FAIL   |
|   I8    |    2^28    |     1     |        25        | 634.330 us |       0.31% | 613.761 us |       0.34% | -20.570 us |  -3.24% |   FAIL   |
|   I8    |    2^16    |   0.201   |        25        |  21.873 us |       1.78% |  22.052 us |       2.17% |   0.179 us |   0.82% |   PASS   |
|   I8    |    2^20    |   0.201   |        25        |  27.326 us |       3.29% |  27.322 us |       2.38% |  -0.004 us |  -0.02% |   PASS   |
|   I8    |    2^24    |   0.201   |        25        |  65.255 us |       0.64% |  63.658 us |       1.00% |  -1.597 us |  -2.45% |   FAIL   |
|   I8    |    2^28    |   0.201   |        25        | 630.302 us |       0.32% | 609.649 us |       0.36% | -20.653 us |  -3.28% |   FAIL   |
|   I8    |    2^16    |     1     |        50        |  22.411 us |       1.52% |  22.510 us |       3.64% |   0.099 us |   0.44% |   PASS   |
|   I8    |    2^20    |     1     |        50        |  28.515 us |       2.31% |  28.510 us |       1.29% |  -0.005 us |  -0.02% |   PASS   |
|   I8    |    2^24    |     1     |        50        |  67.800 us |       0.64% |  66.197 us |       0.66% |  -1.604 us |  -2.37% |   FAIL   |
|   I8    |    2^28    |     1     |        50        | 649.773 us |       0.46% | 629.247 us |       0.41% | -20.526 us |  -3.16% |   FAIL   |
|   I8    |    2^16    |   0.201   |        50        |  22.496 us |       2.60% |  22.547 us |       3.03% |   0.051 us |   0.23% |   PASS   |
|   I8    |    2^20    |   0.201   |        50        |  27.792 us |       1.56% |  27.946 us |       1.89% |   0.154 us |   0.56% |   PASS   |
|   I8    |    2^24    |   0.201   |        50        |  66.455 us |       0.60% |  64.921 us |       1.09% |  -1.534 us |  -2.31% |   FAIL   |
|   I8    |    2^28    |   0.201   |        50        | 637.270 us |       0.34% | 616.673 us |       0.38% | -20.597 us |  -3.23% |   FAIL   |
|   I8    |    2^16    |     1     |        75        |  22.178 us |       1.84% |  22.339 us |       2.51% |   0.161 us |   0.73% |   PASS   |
|   I8    |    2^20    |     1     |        75        |  28.112 us |       2.04% |  28.157 us |       1.54% |   0.045 us |   0.16% |   PASS   |
|   I8    |    2^24    |     1     |        75        |  66.745 us |       0.60% |  65.294 us |       1.18% |  -1.450 us |  -2.17% |   FAIL   |
|   I8    |    2^28    |     1     |        75        | 633.745 us |       0.31% | 612.842 us |       0.38% | -20.904 us |  -3.30% |   FAIL   |
|   I8    |    2^16    |   0.201   |        75        |  22.198 us |       2.97% |  22.337 us |       2.12% |   0.140 us |   0.63% |   PASS   |
|   I8    |    2^20    |   0.201   |        75        |  27.540 us |       2.01% |  27.694 us |       2.33% |   0.154 us |   0.56% |   PASS   |
|   I8    |    2^24    |   0.201   |        75        |  65.302 us |       0.94% |  64.032 us |       0.69% |  -1.270 us |  -1.94% |   FAIL   |
|   I8    |    2^28    |   0.201   |        75        | 626.013 us |       0.31% | 605.203 us |       0.35% | -20.810 us |  -3.32% |   FAIL   |
|   I16   |    2^16    |     1     |        25        |  23.348 us |       4.09% |  23.067 us |       1.57% |  -0.280 us |  -1.20% |   PASS   |
|   I16   |    2^20    |     1     |        25        |  30.352 us |       1.47% |  30.365 us |       1.18% |   0.013 us |   0.04% |   PASS   |
|   I16   |    2^24    |     1     |        25        |  82.447 us |       0.58% |  81.960 us |       0.47% |  -0.488 us |  -0.59% |   FAIL   |
|   I16   |    2^28    |     1     |        25        | 886.267 us |       0.25% | 879.144 us |       0.27% |  -7.123 us |  -0.80% |   FAIL   |
|   I16   |    2^16    |   0.201   |        25        |  23.129 us |       2.16% |  23.080 us |       1.97% |  -0.049 us |  -0.21% |   PASS   |
|   I16   |    2^20    |   0.201   |        25        |  30.261 us |       2.50% |  30.202 us |       1.33% |  -0.058 us |  -0.19% |   PASS   |
|   I16   |    2^24    |   0.201   |        25        |  75.287 us |       0.67% |  75.266 us |       0.66% |  -0.021 us |  -0.03% |   PASS   |
|   I16   |    2^28    |   0.201   |        25        | 748.692 us |       0.74% | 746.226 us |       0.78% |  -2.466 us |  -0.33% |   PASS   |
|   I16   |    2^16    |     1     |        50        |  23.782 us |       2.75% |  23.685 us |       2.17% |  -0.097 us |  -0.41% |   PASS   |
|   I16   |    2^20    |     1     |        50        |  30.969 us |       1.89% |  31.105 us |       1.34% |   0.137 us |   0.44% |   PASS   |
|   I16   |    2^24    |     1     |        50        |  84.724 us |       0.46% |  83.747 us |       0.93% |  -0.978 us |  -1.15% |   FAIL   |
|   I16   |    2^28    |     1     |        50        | 920.192 us |       0.19% | 901.230 us |       0.27% | -18.962 us |  -2.06% |   FAIL   |
|   I16   |    2^16    |   0.201   |        50        |  23.521 us |       3.51% |  23.697 us |       3.24% |   0.176 us |   0.75% |   PASS   |
|   I16   |    2^20    |   0.201   |        50        |  30.280 us |       1.76% |  30.764 us |       2.17% |   0.484 us |   1.60% |   PASS   |
|   I16   |    2^24    |   0.201   |        50        |  75.895 us |       0.59% |  76.160 us |       0.72% |   0.264 us |   0.35% |   PASS   |
|   I16   |    2^28    |   0.201   |        50        | 757.585 us |       0.77% | 755.773 us |       0.82% |  -1.812 us |  -0.24% |   PASS   |
|   I16   |    2^16    |     1     |        75        |  22.821 us |       2.00% |  23.086 us |       1.89% |   0.265 us |   1.16% |   PASS   |
|   I16   |    2^20    |     1     |        75        |  30.086 us |       1.32% |  30.490 us |       1.69% |   0.404 us |   1.34% |   FAIL   |
|   I16   |    2^24    |     1     |        75        |  82.047 us |       0.54% |  82.065 us |       0.57% |   0.018 us |   0.02% |   PASS   |
|   I16   |    2^28    |     1     |        75        | 886.565 us |       0.25% | 880.541 us |       0.28% |  -6.024 us |  -0.68% |   FAIL   |
|   I16   |    2^16    |   0.201   |        75        |  22.921 us |       1.86% |  23.136 us |       1.78% |   0.215 us |   0.94% |   PASS   |
|   I16   |    2^20    |   0.201   |        75        |  29.565 us |       1.29% |  30.108 us |       1.75% |   0.542 us |   1.83% |   FAIL   |
|   I16   |    2^24    |   0.201   |        75        |  75.021 us |       0.65% |  75.377 us |       0.79% |   0.355 us |   0.47% |   PASS   |
|   I16   |    2^28    |   0.201   |        75        | 744.530 us |       0.75% | 742.591 us |       0.80% |  -1.939 us |  -0.26% |   PASS   |
|   I32   |    2^16    |     1     |        25        |  23.432 us |       2.73% |  23.592 us |       2.23% |   0.159 us |   0.68% |   PASS   |
|   I32   |    2^20    |     1     |        25        |  31.594 us |       1.67% |  31.813 us |       1.21% |   0.219 us |   0.69% |   PASS   |
|   I32   |    2^24    |     1     |        25        | 103.510 us |       0.76% | 103.372 us |       0.64% |  -0.138 us |  -0.13% |   PASS   |
|   I32   |    2^28    |     1     |        25        |   1.263 ms |       0.18% |   1.262 ms |       0.14% |  -1.065 us |  -0.08% |   PASS   |
|   I32   |    2^16    |   0.201   |        25        |  24.005 us |       2.79% |  23.727 us |       3.65% |  -0.278 us |  -1.16% |   PASS   |
|   I32   |    2^20    |   0.201   |        25        |  31.509 us |       1.40% |  31.738 us |       1.17% |   0.229 us |   0.73% |   PASS   |
|   I32   |    2^24    |   0.201   |        25        | 103.135 us |       0.91% | 103.225 us |       0.77% |   0.090 us |   0.09% |   PASS   |
|   I32   |    2^28    |   0.201   |        25        |   1.244 ms |       0.12% |   1.245 ms |       0.12% |   1.002 us |   0.08% |   PASS   |
|   I32   |    2^16    |     1     |        50        |  24.019 us |       2.15% |  24.208 us |       2.70% |   0.189 us |   0.79% |   PASS   |
|   I32   |    2^20    |     1     |        50        |  32.874 us |       1.61% |  32.321 us |       1.25% |  -0.553 us |  -1.68% |   FAIL   |
|   I32   |    2^24    |     1     |        50        | 105.442 us |       0.78% | 104.331 us |       0.74% |  -1.111 us |  -1.05% |   FAIL   |
|   I32   |    2^28    |     1     |        50        |   1.280 ms |       0.19% |   1.279 ms |       0.16% |  -1.701 us |  -0.13% |   PASS   |
|   I32   |    2^16    |   0.201   |        50        |  25.211 us |       2.87% |  24.050 us |       2.10% |  -1.161 us |  -4.61% |   FAIL   |
|   I32   |    2^20    |   0.201   |        50        |  32.644 us |       2.14% |  32.125 us |       2.52% |  -0.519 us |  -1.59% |   PASS   |
|   I32   |    2^24    |   0.201   |        50        | 104.596 us |       0.73% | 104.011 us |       0.79% |  -0.586 us |  -0.56% |   PASS   |
|   I32   |    2^28    |   0.201   |        50        |   1.258 ms |       0.12% |   1.259 ms |       0.13% |   0.624 us |   0.05% |   PASS   |
|   I32   |    2^16    |     1     |        75        |  23.757 us |       2.02% |  23.200 us |       1.98% |  -0.557 us |  -2.34% |   FAIL   |
|   I32   |    2^20    |     1     |        75        |  32.017 us |       2.02% |  31.441 us |       1.17% |  -0.575 us |  -1.80% |   FAIL   |
|   I32   |    2^24    |     1     |        75        | 103.727 us |       0.80% | 102.959 us |       0.66% |  -0.768 us |  -0.74% |   FAIL   |
|   I32   |    2^28    |     1     |        75        |   1.264 ms |       0.20% |   1.261 ms |       0.14% |  -2.664 us |  -0.21% |   FAIL   |
|   I32   |    2^16    |   0.201   |        75        |  24.320 us |       2.78% |  23.597 us |       2.68% |  -0.723 us |  -2.97% |   FAIL   |
|   I32   |    2^20    |   0.201   |        75        |  32.081 us |       2.07% |  31.419 us |       1.12% |  -0.662 us |  -2.06% |   FAIL   |
|   I32   |    2^24    |   0.201   |        75        | 103.497 us |       0.77% | 102.911 us |       0.73% |  -0.585 us |  -0.57% |   PASS   |
|   I32   |    2^28    |   0.201   |        75        |   1.243 ms |       0.12% |   1.243 ms |       0.11% |   0.659 us |   0.05% |   PASS   |
|   I64   |    2^16    |     1     |        25        |  24.667 us |       2.80% |  24.259 us |       2.35% |  -0.408 us |  -1.66% |   PASS   |
|   I64   |    2^20    |     1     |        25        |  36.047 us |       1.21% |  35.505 us |       2.18% |  -0.543 us |  -1.51% |   FAIL   |
|   I64   |    2^24    |     1     |        25        | 179.325 us |       0.71% | 178.824 us |       0.63% |  -0.501 us |  -0.28% |   PASS   |
|   I64   |    2^28    |     1     |        25        |   2.508 ms |       0.10% |   2.507 ms |       0.07% |  -0.441 us |  -0.02% |   PASS   |
|   I64   |    2^16    |   0.201   |        25        |  25.525 us |       2.59% |  24.087 us |       2.99% |  -1.438 us |  -5.63% |   FAIL   |
|   I64   |    2^20    |   0.201   |        25        |  36.092 us |       1.31% |  35.179 us |       1.18% |  -0.913 us |  -2.53% |   FAIL   |
|   I64   |    2^24    |   0.201   |        25        | 178.690 us |       0.68% | 178.080 us |       0.68% |  -0.610 us |  -0.34% |   PASS   |
|   I64   |    2^28    |   0.201   |        25        |   2.474 ms |       0.06% |   2.474 ms |       0.06% |  -0.062 us |  -0.00% |   PASS   |
|   I64   |    2^16    |     1     |        50        |  25.163 us |       2.83% |  24.989 us |       2.70% |  -0.174 us |  -0.69% |   PASS   |
|   I64   |    2^20    |     1     |        50        |  37.091 us |       1.96% |  36.944 us |       1.84% |  -0.146 us |  -0.39% |   PASS   |
|   I64   |    2^24    |     1     |        50        | 181.273 us |       0.74% | 180.916 us |       0.71% |  -0.357 us |  -0.20% |   PASS   |
|   I64   |    2^28    |     1     |        50        |   2.548 ms |       0.12% |   2.546 ms |       0.08% |  -2.261 us |  -0.09% |   FAIL   |
|   I64   |    2^16    |   0.201   |        50        |  25.618 us |       3.17% |  25.167 us |       3.04% |  -0.450 us |  -1.76% |   PASS   |
|   I64   |    2^20    |   0.201   |        50        |  36.969 us |       1.10% |  36.682 us |       1.18% |  -0.287 us |  -0.78% |   PASS   |
|   I64   |    2^24    |   0.201   |        50        | 180.366 us |       0.73% | 180.155 us |       0.72% |  -0.211 us |  -0.12% |   PASS   |
|   I64   |    2^28    |   0.201   |        50        |   2.516 ms |       0.06% |   2.516 ms |       0.06% |   0.382 us |   0.02% |   PASS   |
|   I64   |    2^16    |     1     |        75        |  24.480 us |       2.20% |  24.336 us |       2.50% |  -0.144 us |  -0.59% |   PASS   |
|   I64   |    2^20    |     1     |        75        |  35.954 us |       1.26% |  35.794 us |       1.48% |  -0.160 us |  -0.45% |   PASS   |
|   I64   |    2^24    |     1     |        75        | 179.168 us |       0.70% | 178.804 us |       0.66% |  -0.365 us |  -0.20% |   PASS   |
|   I64   |    2^28    |     1     |        75        |   2.509 ms |       0.10% |   2.508 ms |       0.08% |  -1.246 us |  -0.05% |   PASS   |
|   I64   |    2^16    |   0.201   |        75        |  25.163 us |       3.20% |  24.693 us |       1.95% |  -0.469 us |  -1.87% |   PASS   |
|   I64   |    2^20    |   0.201   |        75        |  36.059 us |       1.94% |  35.744 us |       1.72% |  -0.314 us |  -0.87% |   PASS   |
|   I64   |    2^24    |   0.201   |        75        | 178.525 us |       0.65% | 178.218 us |       0.64% |  -0.307 us |  -0.17% |   PASS   |
|   I64   |    2^28    |   0.201   |        75        |   2.475 ms |       0.06% |   2.476 ms |       0.06% |   0.435 us |   0.02% |   PASS   |
|  I128   |    2^16    |     1     |        25        |  25.868 us |       1.83% |  25.704 us |       2.39% |  -0.164 us |  -0.63% |   PASS   |
|  I128   |    2^20    |     1     |        25        |  45.469 us |       1.38% |  45.148 us |       1.43% |  -0.321 us |  -0.71% |   PASS   |
|  I128   |    2^24    |     1     |        25        | 333.161 us |       0.32% | 333.008 us |       0.34% |  -0.154 us |  -0.05% |   PASS   |
|  I128   |    2^28    |     1     |        25        |   5.051 ms |       0.08% |   5.043 ms |       0.04% |  -8.013 us |  -0.16% |   FAIL   |
|  I128   |    2^16    |   0.201   |        25        |  26.753 us |       2.04% |  25.709 us |       1.69% |  -1.044 us |  -3.90% |   FAIL   |
|  I128   |    2^20    |   0.201   |        25        |  46.680 us |       1.72% |  46.337 us |       1.33% |  -0.342 us |  -0.73% |   PASS   |
|  I128   |    2^24    |   0.201   |        25        | 334.717 us |       2.16% | 334.350 us |       2.14% |  -0.368 us |  -0.11% |   PASS   |
|  I128   |    2^28    |   0.201   |        25        |   4.961 ms |       0.89% |   4.961 ms |       0.87% |  -0.137 us |  -0.00% |   PASS   |
|  I128   |    2^16    |     1     |        50        |  27.132 us |       2.11% |  26.928 us |       2.47% |  -0.204 us |  -0.75% |   PASS   |
|  I128   |    2^20    |     1     |        50        |  46.695 us |       1.25% |  46.189 us |       1.32% |  -0.506 us |  -1.08% |   PASS   |
|  I128   |    2^24    |     1     |        50        | 349.007 us |       1.83% | 348.394 us |       1.83% |  -0.614 us |  -0.18% |   PASS   |
|  I128   |    2^28    |     1     |        50        |   5.222 ms |       0.57% |   5.168 ms |       0.18% | -54.041 us |  -1.03% |   FAIL   |
|  I128   |    2^16    |   0.201   |        50        |  28.194 us |       3.60% |  27.417 us |       2.57% |  -0.778 us |  -2.76% |   FAIL   |
|  I128   |    2^20    |   0.201   |        50        |  47.612 us |       1.44% |  47.502 us |       1.90% |  -0.110 us |  -0.23% |   PASS   |
|  I128   |    2^24    |   0.201   |        50        | 342.038 us |       2.15% | 342.103 us |       2.17% |   0.065 us |   0.02% |   PASS   |
|  I128   |    2^28    |   0.201   |        50        |   5.072 ms |       0.74% |   5.072 ms |       0.88% |   0.732 us |   0.01% |   PASS   |
|  I128   |    2^16    |     1     |        75        |  26.335 us |       2.80% |  26.007 us |       1.66% |  -0.328 us |  -1.25% |   PASS   |
|  I128   |    2^20    |     1     |        75        |  45.377 us |       1.49% |  45.100 us |       1.43% |  -0.277 us |  -0.61% |   PASS   |
|  I128   |    2^24    |     1     |        75        | 339.315 us |       1.72% | 336.495 us |       1.85% |  -2.820 us |  -0.83% |   PASS   |
|  I128   |    2^28    |     1     |        75        |   5.067 ms |       0.10% |   5.052 ms |       0.10% | -14.962 us |  -0.30% |   FAIL   |
|  I128   |    2^16    |   0.201   |        75        |  27.758 us |       4.32% |  27.036 us |       1.78% |  -0.722 us |  -2.60% |   FAIL   |
|  I128   |    2^20    |   0.201   |        75        |  46.437 us |       1.21% |  46.439 us |       1.51% |   0.003 us |   0.01% |   PASS   |
|  I128   |    2^24    |   0.201   |        75        | 334.894 us |       2.10% | 334.996 us |       2.08% |   0.101 us |   0.03% |   PASS   |
|  I128   |    2^28    |   0.201   |        75        |   4.962 ms |       0.75% |   4.962 ms |       0.84% |  -0.037 us |  -0.00% |   PASS   |
|   F32   |    2^16    |     1     |        25        |  24.468 us |       2.21% |  23.690 us |       2.03% |  -0.778 us |  -3.18% |   FAIL   |
|   F32   |    2^20    |     1     |        25        |  31.909 us |       2.10% |  31.222 us |       1.67% |  -0.687 us |  -2.15% |   FAIL   |
|   F32   |    2^24    |     1     |        25        | 107.083 us |       1.02% | 104.880 us |       0.69% |  -2.203 us |  -2.06% |   FAIL   |
|   F32   |    2^28    |     1     |        25        |   1.294 ms |       1.44% |   1.272 ms |       2.79% | -21.351 us |  -1.65% |   FAIL   |
|   F32   |    2^16    |   0.201   |        25        |  28.905 us |       7.76% |  26.563 us |       6.99% |  -2.342 us |  -8.10% |   FAIL   |
|   F32   |    2^20    |   0.201   |        25        |  32.249 us |       1.66% |  31.679 us |       1.64% |  -0.570 us |  -1.77% |   FAIL   |
|   F32   |    2^24    |   0.201   |        25        | 103.881 us |       0.80% | 102.963 us |       0.68% |  -0.918 us |  -0.88% |   FAIL   |
|   F32   |    2^28    |   0.201   |        25        |   1.248 ms |       0.15% |   1.247 ms |       0.14% |  -1.469 us |  -0.12% |   PASS   |
|   F32   |    2^16    |     1     |        50        |  26.928 us |       1.97% |  24.492 us |       3.35% |  -2.436 us |  -9.04% |   FAIL   |
|   F32   |    2^20    |     1     |        50        |  33.311 us |       1.48% |  32.632 us |       1.30% |  -0.679 us |  -2.04% |   FAIL   |
|   F32   |    2^24    |     1     |        50        | 106.953 us |       1.16% | 104.617 us |       0.80% |  -2.336 us |  -2.18% |   FAIL   |
|   F32   |    2^28    |     1     |        50        |   1.293 ms |       0.23% |   1.285 ms |       0.16% |  -7.857 us |  -0.61% |   FAIL   |
|   F32   |    2^16    |   0.201   |        50        |  27.595 us |       7.31% |  25.489 us |       4.77% |  -2.106 us |  -7.63% |   FAIL   |
|   F32   |    2^20    |   0.201   |        50        |  32.840 us |       1.39% |  32.344 us |       1.98% |  -0.495 us |  -1.51% |   FAIL   |
|   F32   |    2^24    |   0.201   |        50        | 104.970 us |       0.91% | 104.079 us |       0.69% |  -0.891 us |  -0.85% |   FAIL   |
|   F32   |    2^28    |   0.201   |        50        |   1.263 ms |       0.15% |   1.261 ms |       0.15% |  -1.815 us |  -0.14% |   PASS   |
|   F32   |    2^16    |     1     |        75        |  25.405 us |       2.59% |  24.367 us |       2.35% |  -1.038 us |  -4.08% |   FAIL   |
|   F32   |    2^20    |     1     |        75        |  32.721 us |       2.47% |  32.151 us |       1.91% |  -0.570 us |  -1.74% |   PASS   |
|   F32   |    2^24    |     1     |        75        | 105.707 us |       1.15% | 104.060 us |       0.88% |  -1.647 us |  -1.56% |   FAIL   |
|   F32   |    2^28    |     1     |        75        |   1.303 ms |       1.39% |   1.270 ms |       0.15% | -32.851 us |  -2.52% |   FAIL   |
|   F32   |    2^16    |   0.201   |        75        |  26.951 us |       9.55% |  25.223 us |       5.42% |  -1.727 us |  -6.41% |   FAIL   |
|   F32   |    2^20    |   0.201   |        75        |  32.148 us |       1.67% |  31.612 us |       1.36% |  -0.535 us |  -1.66% |   FAIL   |
|   F32   |    2^24    |   0.201   |        75        | 104.034 us |       0.93% | 102.767 us |       0.67% |  -1.267 us |  -1.22% |   FAIL   |
|   F32   |    2^28    |   0.201   |        75        |   1.250 ms |       0.15% |   1.248 ms |       0.14% |  -1.766 us |  -0.14% |   PASS   |
|   F64   |    2^16    |     1     |        25        |  26.085 us |       2.88% |  24.945 us |       3.05% |  -1.140 us |  -4.37% |   FAIL   |
|   F64   |    2^20    |     1     |        25        |  36.421 us |       1.92% |  35.957 us |       1.28% |  -0.464 us |  -1.27% |   PASS   |
|   F64   |    2^24    |     1     |        25        | 181.732 us |       0.83% | 180.366 us |       0.75% |  -1.365 us |  -0.75% |   PASS   |
|   F64   |    2^28    |     1     |        25        |   2.559 ms |       1.11% |   2.520 ms |       0.14% | -38.735 us |  -1.51% |   FAIL   |
|   F64   |    2^16    |   0.201   |        25        |  28.710 us |      11.78% |  26.538 us |       6.57% |  -2.172 us |  -7.57% |   FAIL   |
|   F64   |    2^20    |   0.201   |        25        |  35.939 us |       1.46% |  35.834 us |       1.35% |  -0.106 us |  -0.29% |   PASS   |
|   F64   |    2^24    |   0.201   |        25        | 180.093 us |       0.76% | 179.075 us |       0.68% |  -1.017 us |  -0.56% |   PASS   |
|   F64   |    2^28    |   0.201   |        25        |   2.490 ms |       0.06% |   2.487 ms |       0.07% |  -3.278 us |  -0.13% |   FAIL   |
|   F64   |    2^16    |     1     |        50        |  26.299 us |       3.27% |  25.883 us |       2.51% |  -0.416 us |  -1.58% |   PASS   |
|   F64   |    2^20    |     1     |        50        |  37.501 us |       1.55% |  37.377 us |       1.36% |  -0.125 us |  -0.33% |   PASS   |
|   F64   |    2^24    |     1     |        50        | 184.810 us |       1.03% | 183.148 us |       0.87% |  -1.662 us |  -0.90% |   FAIL   |
|   F64   |    2^28    |     1     |        50        |   2.636 ms |       1.66% |   2.565 ms |       0.13% | -70.859 us |  -2.69% |   FAIL   |
|   F64   |    2^16    |   0.201   |        50        |  28.315 us |       9.15% |  27.161 us |       6.87% |  -1.154 us |  -4.08% |   PASS   |
|   F64   |    2^20    |   0.201   |        50        |  37.211 us |       1.41% |  36.963 us |       1.43% |  -0.249 us |  -0.67% |   PASS   |
|   F64   |    2^24    |   0.201   |        50        | 182.227 us |       0.80% | 181.027 us |       0.73% |  -1.200 us |  -0.66% |   PASS   |
|   F64   |    2^28    |   0.201   |        50        |   2.532 ms |       0.08% |   2.528 ms |       0.07% |  -4.706 us |  -0.19% |   FAIL   |
|   F64   |    2^16    |     1     |        75        |  26.496 us |       2.94% |  25.177 us |       2.75% |  -1.319 us |  -4.98% |   FAIL   |
|   F64   |    2^20    |     1     |        75        |  36.590 us |       1.36% |  36.486 us |       2.13% |  -0.104 us |  -0.29% |   PASS   |
|   F64   |    2^24    |     1     |        75        | 182.859 us |       1.08% | 181.260 us |       0.79% |  -1.599 us |  -0.87% |   FAIL   |
|   F64   |    2^28    |     1     |        75        |   2.620 ms |       3.19% |   2.525 ms |       0.21% | -95.083 us |  -3.63% |   FAIL   |
|   F64   |    2^16    |   0.201   |        75        |  29.545 us |      12.10% |  27.989 us |      10.39% |  -1.555 us |  -5.26% |   PASS   |
|   F64   |    2^20    |   0.201   |        75        |  36.625 us |       1.47% |  36.318 us |       1.25% |  -0.307 us |  -0.84% |   PASS   |
|   F64   |    2^24    |   0.201   |        75        | 180.201 us |       0.76% | 179.373 us |       0.66% |  -0.828 us |  -0.46% |   PASS   |
|   F64   |    2^28    |   0.201   |        75        |   2.492 ms |       0.07% |   2.487 ms |       0.06% |  -5.111 us |  -0.21% |   FAIL   |
```
</details>

Fixes: #1763

Please merge before:

- [x] #1824
- [x] #1849
- [x] #1850
- [x] #1851
- [x] #1951

TODO:

- [x] Check that `cub::DeviceMerge` correctly uses the fallback policy
- [x] Check that `cub::DeviceMerge` correctly uses virtual shared memory
- [x] Check `thrust::merge` compile-time before and after this PR
- [x] Since this PR changes the SASS, show a benchmark of thrust merge on H100.
