### PR TITLE
Clean up `merge_by_key` and `merge_key_value` tests

### DIFF
--- a/thrust/testing/merge_key_value.cu
+++ b/thrust/testing/merge_key_value.cu
@@ -5,16 +5,32 @@
 
 #include <unittest/unittest.h>
 
-template <typename U>
+template <typename T, typename CompareOp, typename... Args>
+auto call_merge(Args&&... args) -> decltype(thrust::merge(std::forward<Args>(args)...))
+{
+  _CCCL_IF_CONSTEXPR (::cuda::std::is_void<CompareOp>::value)
+  {
+    return thrust::merge(std::forward<Args>(args)...);
+  }
+  else
+  {
+    // TODO(bgruber): remove next line in C++17 and pass CompareOp{} directly to stable_sort
+    using C = ::cuda::std::__conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
+    return thrust::merge(std::forward<Args>(args)..., C{});
+  }
+  _LIBCUDACXX_UNREACHABLE();
+}
+
+template <typename U, typename CompareOp = void>
 void TestMergeKeyValue(size_t n)
 {
-  typedef key_value<U, U> T;
+  using T = key_value<U, U>;
 
-  thrust::host_vector<U> h_keys_a   = unittest::random_integers<U>(n);
-  thrust::host_vector<U> h_values_a = unittest::random_integers<U>(n);
+  const auto h_keys_a   = unittest::random_integers<U>(n);
+  const auto h_values_a = unittest::random_integers<U>(n);
 
-  thrust::host_vector<U> h_keys_b   = unittest::random_integers<U>(n);
-  thrust::host_vector<U> h_values_b = unittest::random_integers<U>(n);
+  const auto h_keys_b   = unittest::random_integers<U>(n);
+  const auto h_values_b = unittest::random_integers<U>(n);
 
   thrust::host_vector<T> h_a(n), h_b(n);
   for (size_t i = 0; i < n; ++i)
@@ -23,60 +39,37 @@ void TestMergeKeyValue(size_t n)
     h_b[i] = T(h_keys_b[i], h_values_b[i]);
   }
 
-  thrust::stable_sort(h_a.begin(), h_a.end());
-  thrust::stable_sort(h_b.begin(), h_b.end());
+  _CCCL_IF_CONSTEXPR (::cuda::std::is_void<CompareOp>::value)
+  {
+    thrust::stable_sort(h_a.begin(), h_a.end());
+    thrust::stable_sort(h_b.begin(), h_b.end());
+  }
+  else
+  {
+    // TODO(bgruber): remove next line in C++17 and pass CompareOp{} directly to stable_sort
+    using C = ::cuda::std::__conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
+    thrust::stable_sort(h_a.begin(), h_a.end(), C{});
+    thrust::stable_sort(h_b.begin(), h_b.end(), C{});
+  }
 
-  thrust::device_vector<T> d_a = h_a;
-  thrust::device_vector<T> d_b = h_b;
+  const thrust::device_vector<T> d_a = h_a;
+  const thrust::device_vector<T> d_b = h_b;
 
   thrust::host_vector<T> h_result(h_a.size() + h_b.size());
   thrust::device_vector<T> d_result(d_a.size() + d_b.size());
 
-  typename thrust::host_vector<T>::iterator h_end;
-  typename thrust::device_vector<T>::iterator d_end;
-
-  h_end = thrust::merge(h_a.begin(), h_a.end(), h_b.begin(), h_b.end(), h_result.begin());
-
-  d_end = thrust::merge(d_a.begin(), d_a.end(), d_b.begin(), d_b.end(), d_result.begin());
+  const auto h_end = call_merge<T, CompareOp>(h_a.begin(), h_a.end(), h_b.begin(), h_b.end(), h_result.begin());
+  const auto d_end = call_merge<T, CompareOp>(d_a.begin(), d_a.end(), d_b.begin(), d_b.end(), d_result.begin());
 
   ASSERT_EQUAL_QUIET(h_result, d_result);
+  ASSERT_EQUAL(true, h_end == h_result.end());
+  ASSERT_EQUAL(true, d_end == d_result.end());
 }
 DECLARE_VARIABLE_UNITTEST(TestMergeKeyValue);
 
 template <typename U>
 void TestMergeKeyValueDescending(size_t n)
 {
-  typedef key_value<U, U> T;
-
-  thrust::host_vector<U> h_keys_a   = unittest::random_integers<U>(n);
-  thrust::host_vector<U> h_values_a = unittest::random_integers<U>(n);
-
-  thrust::host_vector<U> h_keys_b   = unittest::random_integers<U>(n);
-  thrust::host_vector<U> h_values_b = unittest::random_integers<U>(n);
-
-  thrust::host_vector<T> h_a(n), h_b(n);
-  for (size_t i = 0; i < n; ++i)
-  {
-    h_a[i] = T(h_keys_a[i], h_values_a[i]);
-    h_b[i] = T(h_keys_b[i], h_values_b[i]);
-  }
-
-  thrust::stable_sort(h_a.begin(), h_a.end(), thrust::greater<T>());
-  thrust::stable_sort(h_b.begin(), h_b.end(), thrust::greater<T>());
-
-  thrust::device_vector<T> d_a = h_a;
-  thrust::device_vector<T> d_b = h_b;
-
-  thrust::host_vector<T> h_result(h_a.size() + h_b.size());
-  thrust::device_vector<T> d_result(d_a.size() + d_b.size());
-
-  typename thrust::host_vector<T>::iterator h_end;
-  typename thrust::device_vector<T>::iterator d_end;
-
-  h_end = thrust::merge(h_a.begin(), h_a.end(), h_b.begin(), h_b.end(), h_result.begin(), thrust::greater<T>());
-
-  d_end = thrust::merge(d_a.begin(), d_a.end(), d_b.begin(), d_b.end(), d_result.begin(), thrust::greater<T>());
-
-  ASSERT_EQUAL_QUIET(h_result, d_result);
+  TestMergeKeyValue<U, thrust::greater<key_value<U, U>>>(n);
 }
 DECLARE_VARIABLE_UNITTEST(TestMergeKeyValueDescending);

--- a/thrust/testing/unittest/special_types.h
+++ b/thrust/testing/unittest/special_types.h
@@ -136,14 +136,12 @@ inline _CCCL_HOST_DEVICE void swap(user_swappable& x, user_swappable& y)
 class my_system : public THRUST_NS_QUALIFIER::device_execution_policy<my_system>
 {
 public:
-  my_system(int)
-      : correctly_dispatched(false)
-      , num_copies(0)
-  {}
+  my_system() = delete;
+
+  my_system(int) {}
 
   my_system(const my_system& other)
-      : correctly_dispatched(false)
-      , num_copies(other.num_copies + 1)
+      : num_copies(other.num_copies + 1)
   {}
 
   void validate_dispatch()
@@ -157,14 +155,11 @@ public:
   }
 
 private:
-  bool correctly_dispatched;
+  bool correctly_dispatched = false;
 
   // count the number of copies so that we can validate
   // that dispatch does not introduce any
-  unsigned int num_copies;
-
-  // disallow default construction
-  my_system();
+  unsigned int num_copies = 0;
 };
 
 struct my_tag : THRUST_NS_QUALIFIER::device_execution_policy<my_tag>


### PR DESCRIPTION
Spin-off from porting `thrust::merge` to CUB (#1817)