### PR TITLE
Make CUB test launch wrappers functor instances

### DIFF
--- a/cub/test/catch2_test_launch_helper.h
+++ b/cub/test/catch2_test_launch_helper.h
@@ -76,28 +76,34 @@
 #  error Test file should contain %PARAM% TEST_LAUNCH lid 0:1
 #endif
 
-#define DECLARE_INVOCABLE(API, WRAPPED_API_NAME, TMPL_HEAD_OPT, TMPL_ARGS_OPT)            \
-  TMPL_HEAD_OPT                                                                           \
-  struct WRAPPED_API_NAME##_invocable_t                                                   \
-  {                                                                                       \
-    template <class... Ts>                                                                \
-    CUB_RUNTIME_FUNCTION cudaError_t                                                      \
-    operator()(std::uint8_t* d_temp_storage, std::size_t& temp_storage_bytes, Ts... args) \
-    {                                                                                     \
-      return API TMPL_ARGS_OPT(d_temp_storage, temp_storage_bytes, args...);              \
-    }                                                                                     \
-  };
+#define DECLARE_INVOCABLE(API, WRAPPED_API_NAME, TMPL_HEAD_OPT, TMPL_ARGS_OPT)                  \
+  TMPL_HEAD_OPT                                                                                 \
+  struct WRAPPED_API_NAME##_invocable_t                                                         \
+  {                                                                                             \
+    template <class... Ts>                                                                      \
+    CUB_RUNTIME_FUNCTION cudaError_t                                                            \
+    operator()(std::uint8_t* d_temp_storage, std::size_t& temp_storage_bytes, Ts... args) const \
+    {                                                                                           \
+      return API TMPL_ARGS_OPT(d_temp_storage, temp_storage_bytes, args...);                    \
+    }                                                                                           \
+  }
+
+#define DECLARE_LAUNCH_WRAPPER(API, WRAPPED_API_NAME)                                                  \
+  DECLARE_INVOCABLE(API, WRAPPED_API_NAME, , );                                                        \
+  _LIBCUDACXX_INLINE_VAR constexpr struct WRAPPED_API_NAME##_t                                         \
+  {                                                                                                    \
+    template <class... As>                                                                             \
+    void operator()(As... args) const                                                                  \
+    {                                                                                                  \
+      launch(WRAPPED_API_NAME##_invocable_t{}, args...);                                               \
+    }                                                                                                  \
+  } WRAPPED_API_NAME; /* TODO(bgruber): mark with [[maybe_unused]] in C++17. Below is a workaround: */ \
+  static_assert(((void) WRAPPED_API_NAME, true), "")
 
 #define ESCAPE_LIST(...) __VA_ARGS__
 
-#define DECLARE_LAUNCH_WRAPPER(API, WRAPPED_API_NAME)  \
-  DECLARE_INVOCABLE(API, WRAPPED_API_NAME, , );        \
-  template <class... As>                               \
-  static void WRAPPED_API_NAME(As... args)             \
-  {                                                    \
-    launch(WRAPPED_API_NAME##_invocable_t{}, args...); \
-  }
-
+// TODO(bgruber): make the following macro also produce a global instance of a functor, but to pass the template
+// arguments, we need variable templates from C++14.
 #define DECLARE_TMPL_LAUNCH_WRAPPER(API, WRAPPED_API_NAME, TMPL_PARAMS, TMPL_ARGS)                         \
   DECLARE_INVOCABLE(API, WRAPPED_API_NAME, ESCAPE_LIST(template <TMPL_PARAMS>), ESCAPE_LIST(<TMPL_ARGS>)); \
   template <TMPL_PARAMS, class... As>                                                                      \


### PR DESCRIPTION
This allows them to be used in `decltype()` expressions and as default arguments for function parameters.