### PR TITLE
Minimize template instantiations in CUB thread_load

### DIFF
--- a/cub/cub/block/specializations/block_scan_warp_scans.cuh
+++ b/cub/cub/block/specializations/block_scan_warp_scans.cuh
@@ -204,6 +204,7 @@ struct BlockScanWarpScans
     block_aggregate = temp_storage.warp_aggregates[0];
 
     // Use template unrolling (since the PTX backend can't handle unrolling it for SM1x)
+    // TODO(bgruber): does that still hold today? This is creating a lot of template instantiations
     ApplyWarpAggregates(warp_prefix, scan_op, block_aggregate, Int2Type<1>());
     /*
             #pragma unroll

--- a/cub/cub/thread/thread_load.cuh
+++ b/cub/cub/thread/thread_load.cuh
@@ -113,10 +113,12 @@ _CCCL_DEVICE _CCCL_FORCEINLINE cub::detail::value_t<InputIteratorT> ThreadLoad(I
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 
 /// Helper structure for templated load iteration (inductive case)
+/// \deprecated [Since 2.6.0] Use UnrolledThreadLoad() or UnrolledCopy() instead.
 template <int COUNT, int MAX>
 struct IterateThreadLoad
 {
   template <CacheLoadModifier MODIFIER, typename T>
+  CUB_DEPRECATED_BECAUSE("Use UnrolledThreadLoad() instead")
   static _CCCL_DEVICE _CCCL_FORCEINLINE void Load(T const* ptr, T* vals)
   {
     vals[COUNT] = ThreadLoad<MODIFIER>(ptr + COUNT);
@@ -124,6 +126,7 @@ struct IterateThreadLoad
   }
 
   template <typename InputIteratorT, typename T>
+  CUB_DEPRECATED_BECAUSE("Use UnrolledCopy() instead")
   static _CCCL_DEVICE _CCCL_FORCEINLINE void Dereference(InputIteratorT itr, T* vals)
   {
     vals[COUNT] = itr[COUNT];
@@ -143,6 +146,39 @@ struct IterateThreadLoad<MAX, MAX>
   static _CCCL_DEVICE _CCCL_FORCEINLINE void Dereference(InputIteratorT /*itr*/, T* /*vals*/)
   {}
 };
+
+namespace detail
+{
+template <CacheLoadModifier MODIFIER, typename T, int... Is>
+_CCCL_DEVICE _CCCL_FORCEINLINE void
+UnrolledThreadLoadImpl(T const* src, T* dst, ::cuda::std::integer_sequence<int, Is...>)
+{
+  // TODO(bgruber): replace by fold over comma in C++17
+  int dummy[] = {(dst[Is] = ThreadLoad<MODIFIER>(src + Is), 0)...};
+  (void) dummy;
+}
+
+template <typename RandomAccessIterator, typename T, int... Is>
+_CCCL_DEVICE _CCCL_FORCEINLINE void
+UnrolledCopyImpl(RandomAccessIterator src, T* dst, ::cuda::std::integer_sequence<int, Is...>)
+{
+  // TODO(bgruber): replace by fold over comma in C++17
+  int dummy[] = {(dst[Is] = src[Is], 0)...};
+  (void) dummy;
+}
+} // namespace detail
+
+template <int Count, CacheLoadModifier MODIFIER, typename T>
+_CCCL_DEVICE _CCCL_FORCEINLINE void UnrolledThreadLoad(T const* src, T* dst)
+{
+  detail::UnrolledThreadLoadImpl<MODIFIER>(src, dst, ::cuda::std::make_integer_sequence<int, Count>{});
+}
+
+template <int Count, typename RandomAccessIterator, typename T>
+_CCCL_DEVICE _CCCL_FORCEINLINE void UnrolledCopy(RandomAccessIterator src, T* dst)
+{
+  detail::UnrolledCopyImpl(src, dst, ::cuda::std::make_integer_sequence<int, Count>{});
+}
 
 /**
  * Define a uint4 (16B) ThreadLoad specialization for the given Cache load modifier
@@ -312,7 +348,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadLoadVolatilePointer(T* ptr, Int2Type<fals
 
   T retval;
   VolatileWord* words = reinterpret_cast<VolatileWord*>(&retval);
-  IterateThreadLoad<0, VOLATILE_MULTIPLE>::Dereference(reinterpret_cast<volatile VolatileWord*>(ptr), words);
+  UnrolledCopy<VOLATILE_MULTIPLE>(reinterpret_cast<volatile VolatileWord*>(ptr), words);
   return retval;
 }
 
@@ -337,8 +373,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadLoad(T const* ptr, Int2Type<MODIFIER> /*m
   constexpr int DEVICE_MULTIPLE = sizeof(T) / sizeof(DeviceWord);
 
   DeviceWord words[DEVICE_MULTIPLE];
-
-  IterateThreadLoad<0, DEVICE_MULTIPLE>::template Load<CacheLoadModifier(MODIFIER)>(
+  UnrolledThreadLoad<DEVICE_MULTIPLE, CacheLoadModifier(MODIFIER)>(
     reinterpret_cast<DeviceWord*>(const_cast<T*>(ptr)), words);
 
   return *reinterpret_cast<T*>(words);


### PR DESCRIPTION
During compile-time optimization for #1817, I noticed a few places causing a spike of template instantiations (measured using clang's `-ftime-trace`), adding unnecessary compile-time. This PR fixes one of them and adds a comment to a second occurence.

In all cases, a for loop with `#pragma unroll` would probably compile the fastest though. A comment suggested this did not work for SM1x, which seems fairly old though :) With this PR I also hope to trigger a small discussion on how to do such unrolling nowadays.

It seems I need integer sequences for this to work properly

- [x] so let's make them available in C++11: #1859