### PR TITLE
[BACKPORT] Symbol visibility is now invariant in regards to `__cuda_std__` definition (#1832)

### DIFF
--- a/libcudacxx/include/cuda/std/__functional/bind.h
+++ b/libcudacxx/include/cuda/std/__functional/bind.h
@@ -76,16 +76,16 @@ struct __ph
 {};
 
 #  if defined(_LIBCUDACXX_BUILDING_LIBRARY)
-_LIBCUDACXX_FUNC_VIS extern const __ph<1> _1;
-_LIBCUDACXX_FUNC_VIS extern const __ph<2> _2;
-_LIBCUDACXX_FUNC_VIS extern const __ph<3> _3;
-_LIBCUDACXX_FUNC_VIS extern const __ph<4> _4;
-_LIBCUDACXX_FUNC_VIS extern const __ph<5> _5;
-_LIBCUDACXX_FUNC_VIS extern const __ph<6> _6;
-_LIBCUDACXX_FUNC_VIS extern const __ph<7> _7;
-_LIBCUDACXX_FUNC_VIS extern const __ph<8> _8;
-_LIBCUDACXX_FUNC_VIS extern const __ph<9> _9;
-_LIBCUDACXX_FUNC_VIS extern const __ph<10> _10;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<1> _1;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<2> _2;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<3> _3;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<4> _4;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<5> _5;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<6> _6;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<7> _7;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<8> _8;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<9> _9;
+_LIBCUDACXX_INLINE_VISIBILITY extern const __ph<10> _10;
 #  else
 /* _LIBCUDACXX_INLINE_VAR */ constexpr __ph<1> _1{};
 /* _LIBCUDACXX_INLINE_VAR */ constexpr __ph<2> _2{};

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -1049,8 +1049,6 @@ typedef __char32_t char32_t;
 #      define _LIBCUDACXX_EXPORTED_FROM_ABI __declspec(dllimport)
 #    endif
 
-#    define _LIBCUDACXX_TYPE_VIS      _LIBCUDACXX_DLL_VIS
-#    define _LIBCUDACXX_FUNC_VIS      _LIBCUDACXX_DLL_VIS
 #    define _LIBCUDACXX_EXCEPTION_ABI _LIBCUDACXX_DLL_VIS
 #    define _LIBCUDACXX_HIDDEN
 #    define _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
@@ -1073,14 +1071,6 @@ typedef __char32_t char32_t;
 #      define _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS inline _LIBCUDACXX_HIDDEN
 #    else
 #      define _LIBCUDACXX_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
-#    endif
-#  endif
-
-#  ifndef _LIBCUDACXX_FUNC_VIS
-#    if !defined(_LIBCUDACXX_DISABLE_VISIBILITY_ANNOTATIONS)
-#      define _LIBCUDACXX_FUNC_VIS _CCCL_VISIBILITY_DEFAULT
-#    else
-#      define _LIBCUDACXX_FUNC_VIS
 #    endif
 #  endif
 
@@ -1113,8 +1103,8 @@ typedef __char32_t char32_t;
 #  endif
 
 #  ifndef _LIBCUDACXX_OVERRIDABLE_FUNC_VIS
-#    define _LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_FUNC_VIS
-#  endif
+#    define _LIBCUDACXX_OVERRIDABLE_FUNC_VIS _LIBCUDACXX_INLINE_VISIBILITY
+#  endif // _LIBCUDACXX_OVERRIDABLE_FUNC_VIS
 
 #  ifndef _LIBCUDACXX_EXCEPTION_ABI
 #    if !defined(_LIBCUDACXX_DISABLE_VISIBILITY_ANNOTATIONS)
@@ -1440,21 +1430,13 @@ typedef unsigned int char32_t;
 #  endif
 
 #  ifndef _LIBCUDACXX_HAS_NO_ASAN
-extern "C" _LIBCUDACXX_FUNC_VIS void
+extern "C" _LIBCUDACXX_INLINE_VISIBILITY void
 __sanitizer_annotate_contiguous_container(const void*, const void*, const void*, const void*);
 #  endif
 
 #  ifndef _LIBCUDACXX_WEAK
 #    define _LIBCUDACXX_WEAK __attribute__((__weak__))
 #  endif
-
-// Redefine some macros for internal use
-#  if defined(__cuda_std__)
-#    undef _LIBCUDACXX_FUNC_VIS
-#    define _LIBCUDACXX_FUNC_VIS _LIBCUDACXX_INLINE_VISIBILITY
-#    undef _LIBCUDACXX_TYPE_VIS
-#    define _LIBCUDACXX_TYPE_VIS
-#  endif // __cuda_std__
 
 // Thread API
 #  ifndef _LIBCUDACXX_HAS_THREAD_API_EXTERNAL

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__debug
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__debug
@@ -205,11 +205,11 @@ private:
   _LIBCUDACXX_HIDDEN __i_node* __insert_iterator(void* __i);
   _LIBCUDACXX_HIDDEN __i_node* __find_iterator(const void* __i) const;
 
-  friend _LIBCUDACXX_FUNC_VIS __libcpp_db* __get_db();
+  friend _LIBCUDACXX_INLINE_VISIBILITY __libcpp_db* __get_db();
 };
 
-_LIBCUDACXX_FUNC_VIS __libcpp_db* __get_db();
-_LIBCUDACXX_FUNC_VIS const __libcpp_db* __get_const_db();
+_LIBCUDACXX_INLINE_VISIBILITY __libcpp_db* __get_db();
+_LIBCUDACXX_INLINE_VISIBILITY const __libcpp_db* __get_const_db();
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__threading_support
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__threading_support
@@ -56,7 +56,7 @@ _CCCL_PUSH_MACROS
 #  endif
 
 #  if defined(_LIBCUDACXX_HAS_THREAD_LIBRARY_EXTERNAL) || defined(_LIBCUDACXX_BUILDING_THREAD_LIBRARY_EXTERNAL)
-#    define _LIBCUDACXX_THREAD_ABI_VISIBILITY _LIBCUDACXX_FUNC_VIS
+#    define _LIBCUDACXX_THREAD_ABI_VISIBILITY _LIBCUDACXX_INLINE_VISIBILITY
 #  else
 #    define _LIBCUDACXX_THREAD_ABI_VISIBILITY inline _LIBCUDACXX_INLINE_VISIBILITY
 #  endif
@@ -687,8 +687,7 @@ struct alignas(64) __libcpp_contention_t
 #    endif
 };
 
-_LIBCUDACXX_FUNC_VIS
-__libcpp_contention_t* __libcpp_contention_state(void const volatile* p) noexcept;
+_LIBCUDACXX_INLINE_VISIBILITY __libcpp_contention_t* __libcpp_contention_state(void const volatile* p) noexcept;
 
 #  endif // _LIBCUDACXX_HAS_NO_THREAD_CONTENTION_TABLE
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
@@ -1986,55 +1986,60 @@ inline _LIBCUDACXX_INLINE_VISIBILITY void sort(__wrap_iter<_Tp*> __first, __wrap
   _CUDA_VSTD::sort<_Tp*, _Comp_ref>(__first.base(), __last.base(), __comp);
 }
 
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, char*>(char*, char*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, wchar_t*>(wchar_t*, wchar_t*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, signed*>(signed*, signed*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, char*>(char*, char*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, wchar_t*>(wchar_t*, wchar_t*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, signed*>(signed*, signed*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS void __sort<__less&, unsigned char*>(unsigned char*, unsigned char*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, short*>(short*, short*, __less&))
+  _LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, unsigned char*>(unsigned char*, unsigned char*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, short*>(short*, short*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS void __sort<__less&, unsigned short*>(unsigned short*, unsigned short*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, int*>(int*, int*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, unsigned*>(unsigned*, unsigned*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, long*>(long*, long*, __less&))
+  _LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, unsigned short*>(unsigned short*, unsigned short*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, int*>(int*, int*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, unsigned*>(unsigned*, unsigned*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, long*>(long*, long*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS void __sort<__less&, unsigned long*>(unsigned long*, unsigned long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, long long*>(long long*, long long*, __less&))
+  _LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, unsigned long*>(unsigned long*, unsigned long*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS void __sort<__less&, unsigned long long*>(unsigned long long*, unsigned long long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, float*>(float*, float*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, double*>(double*, double*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS void __sort<__less&, long double*>(long double*, long double*, __less&))
+  _LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, long long*>(long long*, long long*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, unsigned long long*>(
+  unsigned long long*, unsigned long long*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, float*>(float*, float*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, double*>(double*, double*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(
+  _LIBCUDACXX_INLINE_VISIBILITY void __sort<__less&, long double*>(long double*, long double*, __less&))
 
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, char*>(char*, char*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, wchar_t*>(wchar_t*, wchar_t*, __less&))
+  _LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, char*>(char*, char*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, signed char*>(signed char*, signed char*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, unsigned char*>(
+  _LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, wchar_t*>(wchar_t*, wchar_t*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, signed char*>(
+  signed char*, signed char*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, unsigned char*>(
   unsigned char*, unsigned char*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, short*>(short*, short*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, unsigned short*>(
+  _LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, short*>(short*, short*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, unsigned short*>(
   unsigned short*, unsigned short*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, int*>(int*, int*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, unsigned*>(unsigned*, unsigned*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, long*>(long*, long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, unsigned long*>(
+  _LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, int*>(int*, int*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(
+  _LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, unsigned*>(unsigned*, unsigned*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(
+  _LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, long*>(long*, long*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, unsigned long*>(
   unsigned long*, unsigned long*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, long long*>(long long*, long long*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, unsigned long long*>(
+  _LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, long long*>(long long*, long long*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, unsigned long long*>(
   unsigned long long*, unsigned long long*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, float*>(float*, float*, __less&))
+  _LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, float*>(float*, float*, __less&))
 _LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, double*>(double*, double*, __less&))
-_LIBCUDACXX_EXTERN_TEMPLATE(
-  _LIBCUDACXX_FUNC_VIS bool __insertion_sort_incomplete<__less&, long double*>(long double*, long double*, __less&))
+  _LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, double*>(double*, double*, __less&))
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY bool __insertion_sort_incomplete<__less&, long double*>(
+  long double*, long double*, __less&))
 
-_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_FUNC_VIS unsigned __sort5<__less&, long double*>(
+_LIBCUDACXX_EXTERN_TEMPLATE(_LIBCUDACXX_INLINE_VISIBILITY unsigned __sort5<__less&, long double*>(
   long double*, long double*, long double*, long double*, long double*, __less&))
 
 // inplace_merge

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -3720,7 +3720,7 @@ struct _FilesystemClock
 
   _LIBCUDACXX_EXPORTED_FROM_ABI static _CCCL_CONSTEXPR_CXX14 const bool is_steady = false;
 
-  _LIBCUDACXX_AVAILABILITY_FILESYSTEM _LIBCUDACXX_FUNC_VIS static time_point now() noexcept;
+  _LIBCUDACXX_AVAILABILITY_FILESYSTEM _LIBCUDACXX_INLINE_VISIBILITY static time_point now() noexcept;
 
   _LIBCUDACXX_INLINE_VISIBILITY static time_t to_time_t(const time_point& __t) noexcept
   {


### PR DESCRIPTION
* Explicitly ensure all chrono types have default visibility

Now that steady_clock and system_clock have default visibility, dependent types such as sys_time also have default
visibility as was requested by the usage of `_LIBCUDACXX_INLINE_VISIBILITY`.
