### PR TITLE
Improve thrust::equals

### DIFF
--- a/thrust/thrust/system/cuda/detail/equal.h
+++ b/thrust/thrust/system/cuda/detail/equal.h
@@ -37,9 +37,8 @@
 #endif // no system header
 
 #if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_NVCC
-#  include <thrust/system/cuda/config.h>
 
-#  include <thrust/system/cuda/detail/mismatch.h>
+#  include <thrust/logical.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
@@ -49,7 +48,10 @@ template <class Derived, class InputIt1, class InputIt2, class BinaryPred>
 bool _CCCL_HOST_DEVICE
 equal(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2, BinaryPred binary_pred)
 {
-  return cuda_cub::mismatch(policy, first1, last1, first2, binary_pred).first == last1;
+  const auto n                  = distance(first1, last1);
+  using transform_t             = transform_pair_of_input_iterators_t<bool, InputIt1, InputIt2, BinaryPred>;
+  transform_t transformed_first = transform_t(first1, first2, binary_pred);
+  return thrust::all_of(policy, transformed_first, transformed_first + n, identity{});
 }
 
 template <class Derived, class InputIt1, class InputIt2>

--- a/thrust/thrust/system/detail/generic/logical.h
+++ b/thrust/thrust/system/detail/generic/logical.h
@@ -25,10 +25,8 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/detail/internal_functional.h>
-#include <thrust/find.h>
+#include <thrust/count.h>
 #include <thrust/logical.h>
-#include <thrust/system/detail/generic/tag.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system
@@ -42,14 +40,16 @@ template <typename ExecutionPolicy, typename InputIterator, typename Predicate>
 _CCCL_HOST_DEVICE bool
 all_of(thrust::execution_policy<ExecutionPolicy>& exec, InputIterator first, InputIterator last, Predicate pred)
 {
-  return thrust::find_if(exec, first, last, thrust::not_fn(pred)) == last;
+  // TODO(bgruber): we could implement this even better using an early exit
+  return thrust::count_if(exec, first, last, thrust::not_fn(pred)) == 0;
 }
 
 template <typename ExecutionPolicy, typename InputIterator, typename Predicate>
 _CCCL_HOST_DEVICE bool
 any_of(thrust::execution_policy<ExecutionPolicy>& exec, InputIterator first, InputIterator last, Predicate pred)
 {
-  return thrust::find_if(exec, first, last, pred) != last;
+  // TODO(bgruber): we could implement this even better using an early exit
+  return thrust::count_if(exec, first, last, pred) > 0;
 }
 
 template <typename ExecutionPolicy, typename InputIterator, typename Predicate>


### PR DESCRIPTION
It's Friday and I am upset with the performance of comparing two thrust vectors. A good deal of unit tests is affected by this. This PR:

1. ~~Adds a benchmark for `thrust::equals`~~ Done in #1944 
2. Reimplements `thrust::equals` in terms of `thrust::all_of`
3. Reimplements `thrust::all_of` in terms of `thrust::count_if`, which according to #720 is >10x faster.
 
Results of the new `thrust::equals` benchmark from before and after applying 2. and 3.:

    ## [0] NVIDIA H100 PCIe

    |  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |          Diff |   %Diff |  Status  |
    |---------|------------|------------|-------------|------------|-------------|---------------|---------|----------|
    |   I8    |    2^16    | 101.896 us |       1.75% |  72.727 us |       1.98% |    -29.169 us | -28.63% |   FAIL   |
    |   I8    |    2^20    | 111.107 us |       1.16% |  76.573 us |       1.76% |    -34.534 us | -31.08% |   FAIL   |
    |   I8    |    2^24    | 936.143 us |       0.35% | 142.694 us |       0.63% |   -793.450 us | -84.76% |   FAIL   |
    |   I8    |    2^28    |  13.675 ms |       0.10% |   1.119 ms |       0.15% | -12555.718 us | -91.82% |   FAIL   |
    |   I16   |    2^16    | 101.747 us |       1.30% |  73.365 us |       1.66% |    -28.381 us | -27.89% |   FAIL   |
    |   I16   |    2^20    | 112.437 us |       1.13% |  80.526 us |       4.80% |    -31.910 us | -28.38% |   FAIL   |
    |   I16   |    2^24    | 946.016 us |       0.36% | 195.473 us |       0.66% |   -750.543 us | -79.34% |   FAIL   |
    |   I16   |    2^28    |  13.895 ms |       0.14% |   1.872 ms |       0.10% | -12022.463 us | -86.52% |   FAIL   |
    |   I32   |    2^16    | 102.312 us |       1.40% |  74.359 us |       1.89% |    -27.953 us | -27.32% |   FAIL   |
    |   I32   |    2^20    | 116.969 us |       0.99% |  86.583 us |       1.11% |    -30.386 us | -25.98% |   FAIL   |
    |   I32   |    2^24    | 990.614 us |       0.34% | 296.035 us |       0.46% |   -694.579 us | -70.12% |   FAIL   |
    |   I32   |    2^28    |  14.445 ms |       0.08% |   3.372 ms |       0.08% | -11073.339 us | -76.66% |   FAIL   |
    |   I64   |    2^16    | 103.238 us |       1.78% |  75.475 us |       2.38% |    -27.763 us | -26.89% |   FAIL   |
    |   I64   |    2^20    | 129.095 us |       1.17% |  98.486 us |       0.83% |    -30.610 us | -23.71% |   FAIL   |
    |   I64   |    2^24    |   1.095 ms |       0.28% | 503.365 us |       0.29% |   -591.867 us | -54.04% |   FAIL   |
    |   I64   |    2^28    |  16.248 ms |       0.07% |   6.610 ms |       0.06% |  -9637.774 us | -59.32% |   FAIL   |
    |  I128   |    2^16    | 106.196 us |       1.40% |  80.382 us |       2.34% |    -25.814 us | -24.31% |   FAIL   |
    |  I128   |    2^20    | 162.204 us |       0.73% | 130.275 us |       0.69% |    -31.929 us | -19.68% |   FAIL   |
    |  I128   |    2^24    |   1.327 ms |       0.23% | 913.127 us |       0.20% |   -413.895 us | -31.19% |   FAIL   |
    |  I128   |    2^28    |  19.532 ms |       0.10% |  13.122 ms |       0.05% |  -6410.285 us | -32.82% |   FAIL   |
    |   F32   |    2^16    | 104.041 us |       1.11% |  74.187 us |       1.53% |    -29.854 us | -28.69% |   FAIL   |
    |   F32   |    2^20    | 119.163 us |       1.04% |  86.922 us |       0.95% |    -32.241 us | -27.06% |   FAIL   |
    |   F32   |    2^24    |   1.002 ms |       0.44% | 307.830 us |       3.02% |   -693.705 us | -69.26% |   FAIL   |
    |   F32   |    2^28    |  14.671 ms |       0.12% |   3.373 ms |       0.13% | -11297.900 us | -77.01% |   FAIL   |
    |   F64   |    2^16    | 104.693 us |       1.49% |  75.549 us |       1.86% |    -29.144 us | -27.84% |   FAIL   |
    |   F64   |    2^20    | 130.312 us |       0.88% |  98.466 us |       1.44% |    -31.846 us | -24.44% |   FAIL   |
    |   F64   |    2^24    |   1.105 ms |       0.30% | 503.757 us |       0.28% |   -601.484 us | -54.42% |   FAIL   |
    |   F64   |    2^28    |  16.256 ms |       0.08% |   6.608 ms |       0.06% |  -9648.092 us | -59.35% |   FAIL   |
