### PR TITLE
Make thrust::sort use radix sort with more comparators

### DIFF
--- a/thrust/testing/cuda/sort.cu
+++ b/thrust/testing/cuda/sort.cu
@@ -138,3 +138,22 @@ void TestComparisonSortCudaStreams()
   cudaStreamDestroy(s);
 }
 DECLARE_UNITTEST(TestComparisonSortCudaStreams);
+
+template <typename T>
+struct TestRadixSortDispatch
+{
+  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, thrust::less<T>>::value, "");
+  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, thrust::greater<T>>::value, "");
+  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::less<T>>::value, "");
+  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::greater<T>>::value, "");
+
+  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, thrust::less<>>::value, "");
+  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, thrust::greater<>>::value, "");
+  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::less<>>::value, "");
+  static_assert(thrust::cuda_cub::__smart_sort::can_use_primitive_sort<T, ::cuda::std::greater<>>::value, "");
+
+  void operator()() const {}
+};
+// TODO(bgruber): use a single test case with a concatenated key list and a cartesion product with the comparators
+SimpleUnitTest<TestRadixSortDispatch, IntegralTypes> TestRadixSortDispatchIntegralInstance;
+SimpleUnitTest<TestRadixSortDispatch, FloatingPointTypes> TestRadixSortDispatchFPInstance;


### PR DESCRIPTION
The implementation of `thrust::sort` checks whether the supplied comparator is `thrust::less<Key>` or `thrust::greater<Key>` to choose whether to use radix sort or merge sort. However, we have more comparison operators available: `::cuda::std::less/greater` and all transparent comparators (`Key` is `void`). This PR lets the additional comparators also use radix sort.

The PR to make the thrust comparators aliases to the libcudacxx one's will not fix this immediately, since thrust will stay with its own types for a deprecation iteration of CCCL: #1872
