### PR TITLE
Replace typedef by alias declarations in CUB

### DIFF
--- a/cub/README.md
+++ b/cub/README.md
@@ -34,9 +34,9 @@ __global__ void BlockSortKernel(int *d_in, int *d_out)
 
      // Specialize BlockRadixSort, BlockLoad, and BlockStore for 128 threads
      // owning 16 integer items each
-     typedef BlockRadixSort<int, 128, 16>                     BlockRadixSort;
-     typedef BlockLoad<int, 128, 16, BLOCK_LOAD_TRANSPOSE>   BlockLoad;
-     typedef BlockStore<int, 128, 16, BLOCK_STORE_TRANSPOSE> BlockStore;
+     using BlockRadixSort = BlockRadixSort<int, 128, 16>;
+     using BlockLoad = BlockLoad<int, 128, 16, BLOCK_LOAD_TRANSPOSE>;
+     using BlockStore = BlockStore<int, 128, 16, BLOCK_STORE_TRANSPOSE>;
 
      // Allocate shared memory
      __shared__ union {

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -230,19 +230,19 @@ struct AgentHistogram
                                SampleIteratorT>;
 
   /// Pixel input iterator type (for applying cache modifier)
-  typedef CacheModifiedInputIterator<LOAD_MODIFIER, PixelT, OffsetT> WrappedPixelIteratorT;
+  using WrappedPixelIteratorT = CacheModifiedInputIterator<LOAD_MODIFIER, PixelT, OffsetT>;
 
   /// Qaud input iterator type (for applying cache modifier)
-  typedef CacheModifiedInputIterator<LOAD_MODIFIER, VecT, OffsetT> WrappedVecsIteratorT;
+  using WrappedVecsIteratorT = CacheModifiedInputIterator<LOAD_MODIFIER, VecT, OffsetT>;
 
   /// Parameterized BlockLoad type for samples
-  typedef BlockLoad<SampleT, BLOCK_THREADS, SAMPLES_PER_THREAD, AgentHistogramPolicyT::LOAD_ALGORITHM> BlockLoadSampleT;
+  using BlockLoadSampleT = BlockLoad<SampleT, BLOCK_THREADS, SAMPLES_PER_THREAD, AgentHistogramPolicyT::LOAD_ALGORITHM>;
 
   /// Parameterized BlockLoad type for pixels
-  typedef BlockLoad<PixelT, BLOCK_THREADS, PIXELS_PER_THREAD, AgentHistogramPolicyT::LOAD_ALGORITHM> BlockLoadPixelT;
+  using BlockLoadPixelT = BlockLoad<PixelT, BLOCK_THREADS, PIXELS_PER_THREAD, AgentHistogramPolicyT::LOAD_ALGORITHM>;
 
   /// Parameterized BlockLoad type for vecs
-  typedef BlockLoad<VecT, BLOCK_THREADS, VECS_PER_THREAD, AgentHistogramPolicyT::LOAD_ALGORITHM> BlockLoadVecT;
+  using BlockLoadVecT = BlockLoad<VecT, BLOCK_THREADS, VECS_PER_THREAD, AgentHistogramPolicyT::LOAD_ALGORITHM>;
 
   /// Shared memory type required by this thread block
   struct _TempStorage
@@ -505,7 +505,7 @@ struct AgentHistogram
     SampleT (&samples)[PIXELS_PER_THREAD][NUM_CHANNELS],
     Int2Type<_NUM_ACTIVE_CHANNELS> num_active_channels)
   {
-    typedef PixelT AliasedPixels[PIXELS_PER_THREAD];
+    using AliasedPixels = PixelT[PIXELS_PER_THREAD];
 
     WrappedPixelIteratorT d_wrapped_pixels((PixelT*) (d_native_samples + block_offset));
 
@@ -520,7 +520,7 @@ struct AgentHistogram
     SampleT (&samples)[PIXELS_PER_THREAD][NUM_CHANNELS],
     Int2Type<1> num_active_channels)
   {
-    typedef VecT AliasedVecs[VECS_PER_THREAD];
+    using AliasedVecs = VecT[VECS_PER_THREAD];
 
     WrappedVecsIteratorT d_wrapped_vecs((VecT*) (d_native_samples + block_offset));
 
@@ -547,7 +547,7 @@ struct AgentHistogram
     Int2Type<true> is_full_tile,
     Int2Type<false> is_aligned)
   {
-    typedef SampleT AliasedSamples[SAMPLES_PER_THREAD];
+    using AliasedSamples = SampleT[SAMPLES_PER_THREAD];
 
     // Load using sample iterator
     BlockLoadSampleT(temp_storage.aliasable.sample_load)
@@ -562,7 +562,7 @@ struct AgentHistogram
     Int2Type<false> is_full_tile,
     Int2Type<true> is_aligned)
   {
-    typedef PixelT AliasedPixels[PIXELS_PER_THREAD];
+    using AliasedPixels = PixelT[PIXELS_PER_THREAD];
 
     WrappedPixelIteratorT d_wrapped_pixels((PixelT*) (d_native_samples + block_offset));
 
@@ -581,7 +581,7 @@ struct AgentHistogram
     Int2Type<false> is_full_tile,
     Int2Type<false> is_aligned)
   {
-    typedef SampleT AliasedSamples[SAMPLES_PER_THREAD];
+    using AliasedSamples = SampleT[SAMPLES_PER_THREAD];
 
     BlockLoadSampleT(temp_storage.aliasable.sample_load)
       .Load(d_wrapped_samples + block_offset, reinterpret_cast<AliasedSamples&>(samples), valid_samples);

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -202,7 +202,7 @@ struct AgentRadixSortDownsweep
   using BlockLoadValuesT = BlockLoad<ValueT, BLOCK_THREADS, ITEMS_PER_THREAD, LOAD_ALGORITHM>;
 
   // Value exchange array type
-  typedef ValueT ValueExchangeT[TILE_ITEMS];
+  using ValueExchangeT = ValueT[TILE_ITEMS];
 
   /**
    * Shared memory storage layout

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -102,9 +102,9 @@ struct AgentRadixSortHistogram
   using bit_ordered_type       = typename traits::bit_ordered_type;
   using bit_ordered_conversion = typename traits::bit_ordered_conversion_policy;
 
-  typedef RadixSortTwiddle<IS_DESCENDING, KeyT> Twiddle;
-  typedef std::uint32_t ShmemCounterT;
-  typedef ShmemCounterT ShmemAtomicCounterT;
+  using Twiddle             = RadixSortTwiddle<IS_DESCENDING, KeyT>;
+  using ShmemCounterT       = std::uint32_t;
+  using ShmemAtomicCounterT = ShmemCounterT;
 
   using fundamental_digit_extractor_t = ShiftDigitExtractor<KeyT>;
   using digit_extractor_t = typename traits::template digit_extractor_t<fundamental_digit_extractor_t, DecomposerT>;

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -131,7 +131,7 @@ struct AgentRadixSortOnesweep
   using fundamental_digit_extractor_t = ShiftDigitExtractor<KeyT>;
   using digit_extractor_t = typename traits::template digit_extractor_t<fundamental_digit_extractor_t, DecomposerT>;
 
-  typedef PortionOffsetT AtomicOffsetT;
+  using AtomicOffsetT = PortionOffsetT;
 
   static constexpr RadixRankAlgorithm RANK_ALGORITHM = AgentRadixSortOnesweepPolicy::RANK_ALGORITHM;
   static constexpr BlockScanAlgorithm SCAN_ALGORITHM = AgentRadixSortOnesweepPolicy::SCAN_ALGORITHM;
@@ -140,7 +140,7 @@ struct AgentRadixSortOnesweep
       ? AgentRadixSortOnesweepPolicy::STORE_ALGORITHM
       : RADIX_SORT_STORE_DIRECT;
 
-  typedef RadixSortTwiddle<IS_DESCENDING, KeyT> Twiddle;
+  using Twiddle = RadixSortTwiddle<IS_DESCENDING, KeyT>;
 
   static_assert(RANK_ALGORITHM == RADIX_RANK_MATCH || RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ANY
                   || RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR,
@@ -229,14 +229,8 @@ struct AgentRadixSortOnesweep
 
   struct CountsCallback
   {
-    typedef AgentRadixSortOnesweep<AgentRadixSortOnesweepPolicy,
-                                   IS_DESCENDING,
-                                   KeyT,
-                                   ValueT,
-                                   OffsetT,
-                                   PortionOffsetT,
-                                   DecomposerT>
-      AgentT;
+    using AgentT =
+      AgentRadixSortOnesweep<AgentRadixSortOnesweepPolicy, IS_DESCENDING, KeyT, ValueT, OffsetT, PortionOffsetT, DecomposerT>;
     AgentT& agent;
     int (&bins)[BINS_PER_THREAD];
     bit_ordered_type (&keys)[ITEMS_PER_THREAD];

--- a/cub/cub/agent/agent_radix_sort_upsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_upsweep.cuh
@@ -125,10 +125,10 @@ struct AgentRadixSortUpsweep
   using bit_ordered_conversion = typename traits::bit_ordered_conversion_policy;
 
   // Integer type for digit counters (to be packed into words of PackedCounters)
-  typedef unsigned char DigitCounter;
+  using DigitCounter = unsigned char;
 
   // Integer type for packing DigitCounters into columns of shared memory banks
-  typedef unsigned int PackedCounter;
+  using PackedCounter = unsigned int;
 
   static constexpr CacheLoadModifier LOAD_MODIFIER = AgentRadixSortUpsweepPolicy::LOAD_MODIFIER;
 
@@ -167,7 +167,7 @@ struct AgentRadixSortUpsweep
   };
 
   // Input iterator wrapper type (for applying cache modifier)s
-  typedef CacheModifiedInputIterator<LOAD_MODIFIER, bit_ordered_type, OffsetT> KeysItr;
+  using KeysItr = CacheModifiedInputIterator<LOAD_MODIFIER, bit_ordered_type, OffsetT>;
 
   // Digit extractor type
   using fundamental_digit_extractor_t = BFEDigitExtractor<KeyT>;

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -269,8 +269,8 @@ struct AgentReduceByKey
     TilePrefixCallbackOp<OffsetValuePairT, ReduceBySegmentOpT, ScanTileStateT, 0, DelayConstructorT>;
 
   // Key and value exchange types
-  typedef KeyOutputT KeyExchangeT[TILE_ITEMS + 1];
-  typedef AccumT ValueExchangeT[TILE_ITEMS + 1];
+  using KeyExchangeT   = KeyOutputT[TILE_ITEMS + 1];
+  using ValueExchangeT = AccumT[TILE_ITEMS + 1];
 
   // Shared memory type for this thread block
   union _TempStorage

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -262,7 +262,7 @@ struct AgentRle
   using WarpExchangeOffsets = WarpExchange<OffsetT, ITEMS_PER_THREAD>;
   using WarpExchangeLengths = WarpExchange<LengthT, ITEMS_PER_THREAD>;
 
-  typedef LengthOffsetPair WarpAggregates[WARPS];
+  using WarpAggregates = LengthOffsetPair[WARPS];
 
   // Shared memory type for this thread block
   struct _TempStorage

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -172,21 +172,21 @@ struct AgentScan
   };
 
   // Parameterized BlockLoad type
-  typedef BlockLoad<AccumT,
-                    AgentScanPolicyT::BLOCK_THREADS,
-                    AgentScanPolicyT::ITEMS_PER_THREAD,
-                    AgentScanPolicyT::LOAD_ALGORITHM>
-    BlockLoadT;
+  using BlockLoadT =
+    BlockLoad<AccumT,
+              AgentScanPolicyT::BLOCK_THREADS,
+              AgentScanPolicyT::ITEMS_PER_THREAD,
+              AgentScanPolicyT::LOAD_ALGORITHM>;
 
   // Parameterized BlockStore type
-  typedef BlockStore<AccumT,
-                     AgentScanPolicyT::BLOCK_THREADS,
-                     AgentScanPolicyT::ITEMS_PER_THREAD,
-                     AgentScanPolicyT::STORE_ALGORITHM>
-    BlockStoreT;
+  using BlockStoreT =
+    BlockStore<AccumT,
+               AgentScanPolicyT::BLOCK_THREADS,
+               AgentScanPolicyT::ITEMS_PER_THREAD,
+               AgentScanPolicyT::STORE_ALGORITHM>;
 
   // Parameterized BlockScan type
-  typedef BlockScan<AccumT, AgentScanPolicyT::BLOCK_THREADS, AgentScanPolicyT::SCAN_ALGORITHM> BlockScanT;
+  using BlockScanT = BlockScan<AccumT, AgentScanPolicyT::BLOCK_THREADS, AgentScanPolicyT::SCAN_ALGORITHM>;
 
   // Callback type for obtaining tile prefix during block scan
   using DelayConstructorT     = typename AgentScanPolicyT::detail::delay_constructor_t;
@@ -194,7 +194,7 @@ struct AgentScan
 
   // Stateful BlockScan prefix callback type for managing a running total while
   // scanning consecutive tiles
-  typedef BlockScanRunningPrefixOp<AccumT, ScanOpT> RunningPrefixCallbackOp;
+  using RunningPrefixCallbackOp = BlockScanRunningPrefixOp<AccumT, ScanOpT>;
 
   // Shared memory type for this thread block
   union _TempStorage

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -248,7 +248,7 @@ struct AgentSelectIf
   using TilePrefixCallbackOpT = TilePrefixCallbackOp<OffsetT, cub::Sum, ScanTileStateT, 0, DelayConstructorT>;
 
   // Item exchange type
-  typedef InputT ItemExchangeT[TILE_ITEMS];
+  using ItemExchangeT = InputT[TILE_ITEMS];
 
   // Shared memory type for this thread block
   union _TempStorage

--- a/cub/cub/agent/agent_spmv_orig.cuh
+++ b/cub/cub/agent/agent_spmv_orig.cuh
@@ -224,40 +224,40 @@ struct AgentSpmv
   };
 
   /// 2D merge path coordinate type
-  typedef typename CubVector<OffsetT, 2>::Type CoordinateT;
+  using CoordinateT = typename CubVector<OffsetT, 2>::Type;
 
   /// Input iterator wrapper types (for applying cache modifiers)
 
-  typedef CacheModifiedInputIterator<AgentSpmvPolicyT::ROW_OFFSETS_SEARCH_LOAD_MODIFIER, OffsetT, OffsetT>
-    RowOffsetsSearchIteratorT;
+  using RowOffsetsSearchIteratorT =
+    CacheModifiedInputIterator<AgentSpmvPolicyT::ROW_OFFSETS_SEARCH_LOAD_MODIFIER, OffsetT, OffsetT>;
 
-  typedef CacheModifiedInputIterator<AgentSpmvPolicyT::ROW_OFFSETS_LOAD_MODIFIER, OffsetT, OffsetT> RowOffsetsIteratorT;
+  using RowOffsetsIteratorT = CacheModifiedInputIterator<AgentSpmvPolicyT::ROW_OFFSETS_LOAD_MODIFIER, OffsetT, OffsetT>;
 
-  typedef CacheModifiedInputIterator<AgentSpmvPolicyT::COLUMN_INDICES_LOAD_MODIFIER, OffsetT, OffsetT>
-    ColumnIndicesIteratorT;
+  using ColumnIndicesIteratorT =
+    CacheModifiedInputIterator<AgentSpmvPolicyT::COLUMN_INDICES_LOAD_MODIFIER, OffsetT, OffsetT>;
 
-  typedef CacheModifiedInputIterator<AgentSpmvPolicyT::VALUES_LOAD_MODIFIER, ValueT, OffsetT> ValueIteratorT;
+  using ValueIteratorT = CacheModifiedInputIterator<AgentSpmvPolicyT::VALUES_LOAD_MODIFIER, ValueT, OffsetT>;
 
-  typedef CacheModifiedInputIterator<AgentSpmvPolicyT::VECTOR_VALUES_LOAD_MODIFIER, ValueT, OffsetT>
-    VectorValueIteratorT;
+  using VectorValueIteratorT =
+    CacheModifiedInputIterator<AgentSpmvPolicyT::VECTOR_VALUES_LOAD_MODIFIER, ValueT, OffsetT>;
 
   // Tuple type for scanning (pairs accumulated segment-value with segment-index)
-  typedef KeyValuePair<OffsetT, ValueT> KeyValuePairT;
+  using KeyValuePairT = KeyValuePair<OffsetT, ValueT>;
 
   // Reduce-value-by-segment scan operator
-  typedef ReduceByKeyOp<cub::Sum> ReduceBySegmentOpT;
+  using ReduceBySegmentOpT = ReduceByKeyOp<cub::Sum>;
 
   // BlockReduce specialization
-  typedef BlockReduce<ValueT, BLOCK_THREADS, BLOCK_REDUCE_WARP_REDUCTIONS> BlockReduceT;
+  using BlockReduceT = BlockReduce<ValueT, BLOCK_THREADS, BLOCK_REDUCE_WARP_REDUCTIONS>;
 
   // BlockScan specialization
-  typedef BlockScan<KeyValuePairT, BLOCK_THREADS, AgentSpmvPolicyT::SCAN_ALGORITHM> BlockScanT;
+  using BlockScanT = BlockScan<KeyValuePairT, BLOCK_THREADS, AgentSpmvPolicyT::SCAN_ALGORITHM>;
 
   // BlockScan specialization
-  typedef BlockScan<ValueT, BLOCK_THREADS, AgentSpmvPolicyT::SCAN_ALGORITHM> BlockPrefixSumT;
+  using BlockPrefixSumT = BlockScan<ValueT, BLOCK_THREADS, AgentSpmvPolicyT::SCAN_ALGORITHM>;
 
   // BlockExchange specialization
-  typedef BlockExchange<ValueT, BLOCK_THREADS, ITEMS_PER_THREAD> BlockExchangeT;
+  using BlockExchangeT = BlockExchange<ValueT, BLOCK_THREADS, ITEMS_PER_THREAD>;
 
   /// Merge item type (either a non-zero value or a row-end offset)
   union MergeItem

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -861,7 +861,7 @@ struct ReduceByKeyScanTileState;
 template <typename ValueT, typename KeyT>
 struct ReduceByKeyScanTileState<ValueT, KeyT, false> : ScanTileState<KeyValuePair<KeyT, ValueT>>
 {
-  typedef ScanTileState<KeyValuePair<KeyT, ValueT>> SuperClass;
+  using SuperClass = ScanTileState<KeyValuePair<KeyT, ValueT>>;
 
   /// Constructor
   _CCCL_HOST_DEVICE _CCCL_FORCEINLINE ReduceByKeyScanTileState()
@@ -1082,7 +1082,7 @@ template <typename T,
 struct TilePrefixCallbackOp
 {
   // Parameterized warp reduce
-  typedef WarpReduce<T, CUB_PTX_WARP_THREADS> WarpReduceT;
+  using WarpReduceT = WarpReduce<T, (1 << (5))>;
 
   // Temporary storage type
   struct _TempStorage
@@ -1098,7 +1098,7 @@ struct TilePrefixCallbackOp
   {};
 
   // Type of status word
-  typedef typename ScanTileStateT::StatusWord StatusWord;
+  using StatusWord = typename ScanTileStateT::StatusWord;
 
   // Fields
   _TempStorage& temp_storage; ///< Reference to a warp-reduction instance

--- a/cub/cub/block/block_discontinuity.cuh
+++ b/cub/cub/block/block_discontinuity.cuh
@@ -84,7 +84,7 @@ CUB_NAMESPACE_BEGIN
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
-//!        typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
+//!        using BlockDiscontinuity = cub::BlockDiscontinuity<int, 128>;
 //!
 //!        // Allocate shared memory for BlockDiscontinuity
 //!        __shared__ typename BlockDiscontinuity::TempStorage temp_storage;
@@ -377,7 +377,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
+  //!        using BlockDiscontinuity = cub::BlockDiscontinuity<int, 128>;
   //!
   //!        // Allocate shared memory for BlockDiscontinuity
   //!        __shared__ typename BlockDiscontinuity::TempStorage temp_storage;
@@ -450,7 +450,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
+  //!        using BlockDiscontinuity = cub::BlockDiscontinuity<int, 128>;
   //!
   //!        // Allocate shared memory for BlockDiscontinuity
   //!        __shared__ typename BlockDiscontinuity::TempStorage temp_storage;
@@ -539,7 +539,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
+  //!        using BlockDiscontinuity = cub::BlockDiscontinuity<int, 128>;
   //!
   //!        // Allocate shared memory for BlockDiscontinuity
   //!        __shared__ typename BlockDiscontinuity::TempStorage temp_storage;
@@ -627,7 +627,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
+  //!        using BlockDiscontinuity = cub::BlockDiscontinuity<int, 128>;
   //!
   //!        // Allocate shared memory for BlockDiscontinuity
   //!        __shared__ typename BlockDiscontinuity::TempStorage temp_storage;
@@ -732,7 +732,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
+  //!        using BlockDiscontinuity = cub::BlockDiscontinuity<int, 128>;
   //!
   //!        // Allocate shared memory for BlockDiscontinuity
   //!        __shared__ typename BlockDiscontinuity::TempStorage temp_storage;
@@ -850,7 +850,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
+  //!        using BlockDiscontinuity = cub::BlockDiscontinuity<int, 128>;
   //!
   //!        // Allocate shared memory for BlockDiscontinuity
   //!        __shared__ typename BlockDiscontinuity::TempStorage temp_storage;
@@ -979,7 +979,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
+  //!        using BlockDiscontinuity = cub::BlockDiscontinuity<int, 128>;
   //!
   //!        // Allocate shared memory for BlockDiscontinuity
   //!        __shared__ typename BlockDiscontinuity::TempStorage temp_storage;
@@ -1108,7 +1108,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
+  //!        using BlockDiscontinuity = cub::BlockDiscontinuity<int, 128>;
   //!
   //!        // Allocate shared memory for BlockDiscontinuity
   //!        __shared__ typename BlockDiscontinuity::TempStorage temp_storage;

--- a/cub/cub/block/block_exchange.cuh
+++ b/cub/cub/block/block_exchange.cuh
@@ -86,7 +86,7 @@ CUB_NAMESPACE_BEGIN
 //!    __global__ void ExampleKernel(int *d_data, ...)
 //!    {
 //!        // Specialize BlockExchange for a 1D block of 128 threads owning 4 integer items each
-//!        typedef cub::BlockExchange<int, 128, 4> BlockExchange;
+//!        using BlockExchange = cub::BlockExchange<int, 128, 4>;
 //!
 //!        // Allocate shared memory for BlockExchange
 //!        __shared__ typename BlockExchange::TempStorage temp_storage;
@@ -887,7 +887,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, ...)
   //!    {
   //!        // Specialize BlockExchange for a 1D block of 128 threads owning 4 integer items each
-  //!        typedef cub::BlockExchange<int, 128, 4> BlockExchange;
+  //!        using BlockExchange = cub::BlockExchange<int, 128, 4>;
   //!
   //!        // Allocate shared memory for BlockExchange
   //!        __shared__ typename BlockExchange::TempStorage temp_storage;
@@ -935,7 +935,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, ...)
   //!    {
   //!        // Specialize BlockExchange for a 1D block of 128 threads owning 4 integer items each
-  //!        typedef cub::BlockExchange<int, 128, 4> BlockExchange;
+  //!        using BlockExchange = cub::BlockExchange<int, 128, 4>;
   //!
   //!        // Allocate shared memory for BlockExchange
   //!        __shared__ typename BlockExchange::TempStorage temp_storage;
@@ -989,7 +989,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, ...)
   //!    {
   //!        // Specialize BlockExchange for a 1D block of 128 threads owning 4 integer items each
-  //!        typedef cub::BlockExchange<int, 128, 4> BlockExchange;
+  //!        using BlockExchange = cub::BlockExchange<int, 128, 4>;
   //!
   //!        // Allocate shared memory for BlockExchange
   //!        __shared__ typename BlockExchange::TempStorage temp_storage;
@@ -1041,7 +1041,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, ...)
   //!    {
   //!        // Specialize BlockExchange for a 1D block of 128 threads owning 4 integer items each
-  //!        typedef cub::BlockExchange<int, 128, 4> BlockExchange;
+  //!        using BlockExchange = cub::BlockExchange<int, 128, 4>;
   //!
   //!        // Allocate shared memory for BlockExchange
   //!        __shared__ typename BlockExchange::TempStorage temp_storage;

--- a/cub/cub/block/block_histogram.cuh
+++ b/cub/cub/block/block_histogram.cuh
@@ -123,8 +123,8 @@ enum BlockHistogramAlgorithm
 //!
 //!    __global__ void ExampleKernel(...)
 //!    {
-//!        // Specialize a 256-bin BlockHistogram type for a 1D block of 128 threads having 4 character
-//!    samples each typedef cub::BlockHistogram<unsigned char, 128, 4, 256> BlockHistogram;
+//!        // Specialize a 256-bin BlockHistogram type for a 1D block of 128 threads having 4 character samples each
+//!        using BlockHistogram = cub::BlockHistogram<unsigned char, 128, 4, 256>;
 //!
 //!        // Allocate shared memory for BlockHistogram
 //!        __shared__ typename BlockHistogram::TempStorage temp_storage;
@@ -204,7 +204,7 @@ private:
                                BlockHistogramAtomic<BINS>>;
 
   /// Shared memory storage layout type for BlockHistogram
-  typedef typename InternalBlockHistogram::TempStorage _TempStorage;
+  using _TempStorage = typename InternalBlockHistogram::TempStorage;
 
   /// Shared storage reference
   _TempStorage& temp_storage;
@@ -265,7 +265,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!      // Specialize a 256-bin BlockHistogram type for a 1D block of 128 threads having 4 character samples each
-  //!      typedef cub::BlockHistogram<unsigned char, 128, 4, 256> BlockHistogram;
+  //!      using BlockHistogram = cub::BlockHistogram<unsigned char, 128, 4, 256>;
   //!
   //!      // Allocate shared memory for BlockHistogram
   //!      __shared__ typename BlockHistogram::TempStorage temp_storage;
@@ -324,9 +324,8 @@ public:
   //!
   //!    __global__ void ExampleKernel(...)
   //!    {
-  //!        // Specialize a 256-bin BlockHistogram type for a 1D block of 128 threads having 4
-  //!        // character samples each typedef cub::BlockHistogram<unsigned char, 128, 4, 256>
-  //!        // BlockHistogram;
+  //!        // Specialize a 256-bin BlockHistogram type for a 1D block of 128 threads having 4 character samples each
+  //!        using BlockHistogram = cub::BlockHistogram<unsigned char, 128, 4, 256>;
   //!
   //!        // Allocate shared memory for BlockHistogram
   //!        __shared__ typename BlockHistogram::TempStorage temp_storage;
@@ -383,9 +382,8 @@ public:
   //!
   //!    __global__ void ExampleKernel(...)
   //!    {
-  //!        // Specialize a 256-bin BlockHistogram type for a 1D block of 128 threads having 4
-  //!        // character samples each typedef cub::BlockHistogram<unsigned char, 128, 4, 256>
-  //!        // BlockHistogram;
+  //!        // Specialize a 256-bin BlockHistogram type for a 1D block of 128 threads having 4 character samples each
+  //!        using BlockHistogram = cub::BlockHistogram<unsigned char, 128, 4, 256>;
   //!
   //!        // Allocate shared memory for BlockHistogram
   //!        __shared__ typename BlockHistogram::TempStorage temp_storage;

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -192,7 +192,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void
 InternalLoadDirectBlockedVectorized(int linear_tid, T* block_ptr, T (&items)[ITEMS_PER_THREAD])
 {
   // Biggest memory access word that T is a whole multiple of
-  typedef typename UnitWord<T>::DeviceWord DeviceWord;
+  using DeviceWord = typename UnitWord<T>::DeviceWord;
 
   enum
   {
@@ -206,7 +206,7 @@ InternalLoadDirectBlockedVectorized(int linear_tid, T* block_ptr, T (&items)[ITE
   };
 
   // Vector type
-  typedef typename CubVector<DeviceWord, VECTOR_SIZE>::Type Vector;
+  using Vector = typename CubVector<DeviceWord, VECTOR_SIZE>::Type;
 
   // Vector items
   Vector vec_items[VECTORS_PER_THREAD];
@@ -754,7 +754,7 @@ enum BlockLoadAlgorithm
 //!    __global__ void ExampleKernel(int *d_data, ...)
 //!    {
 //!        // Specialize BlockLoad for a 1D block of 128 threads owning 4 integer items each
-//!        typedef cub::BlockLoad<int, 128, 4, BLOCK_LOAD_WARP_TRANSPOSE> BlockLoad;
+//!        using BlockLoad = cub::BlockLoad<int, 128, 4, BLOCK_LOAD_WARP_TRANSPOSE>;
 //!
 //!        // Allocate shared memory for BlockLoad
 //!        __shared__ typename BlockLoad::TempStorage temp_storage;
@@ -829,7 +829,7 @@ private:
   struct LoadInternal<BLOCK_LOAD_DIRECT, DUMMY>
   {
     /// Shared memory storage layout type
-    typedef NullType TempStorage;
+    using TempStorage = NullType;
 
     /// Linear thread-id
     int linear_tid;
@@ -904,7 +904,7 @@ private:
   struct LoadInternal<BLOCK_LOAD_STRIPED, DUMMY>
   {
     /// Shared memory storage layout type
-    typedef NullType TempStorage;
+    using TempStorage = NullType;
 
     /// Linear thread-id
     int linear_tid;
@@ -979,7 +979,7 @@ private:
   struct LoadInternal<BLOCK_LOAD_VECTORIZE, DUMMY>
   {
     /// Shared memory storage layout type
-    typedef NullType TempStorage;
+    using TempStorage = NullType;
 
     /// Linear thread-id
     int linear_tid;
@@ -1104,7 +1104,7 @@ private:
   struct LoadInternal<BLOCK_LOAD_TRANSPOSE, DUMMY>
   {
     // BlockExchange utility type for keys
-    typedef BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
+    using BlockExchange = BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
     /// Shared memory storage layout type
     struct _TempStorage : BlockExchange::TempStorage
@@ -1202,7 +1202,7 @@ private:
     static_assert(int(BLOCK_THREADS) % int(WARP_THREADS) == 0, "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
     // BlockExchange utility type for keys
-    typedef BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
+    using BlockExchange = BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
     /// Shared memory storage layout type
     struct _TempStorage : BlockExchange::TempStorage
@@ -1300,7 +1300,7 @@ private:
     static_assert(int(BLOCK_THREADS) % int(WARP_THREADS) == 0, "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
     // BlockExchange utility type for keys
-    typedef BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, true, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
+    using BlockExchange = BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, true, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
     /// Shared memory storage layout type
     struct _TempStorage : BlockExchange::TempStorage
@@ -1384,10 +1384,10 @@ private:
   };
 
   /// Internal load implementation to use
-  typedef LoadInternal<ALGORITHM, 0> InternalLoad;
+  using InternalLoad = LoadInternal<ALGORITHM, 0>;
 
   /// Shared memory storage layout type
-  typedef typename InternalLoad::TempStorage _TempStorage;
+  using _TempStorage = typename InternalLoad::TempStorage;
 
   /// Internal storage allocator
   _CCCL_DEVICE _CCCL_FORCEINLINE _TempStorage& PrivateStorage()
@@ -1456,7 +1456,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, ...)
   //!    {
   //!        // Specialize BlockLoad for a 1D block of 128 threads owning 4 integer items each
-  //!        typedef cub::BlockLoad<int, 128, 4, BLOCK_LOAD_WARP_TRANSPOSE> BlockLoad;
+  //!        using BlockLoad = cub::BlockLoad<int, 128, 4, BLOCK_LOAD_WARP_TRANSPOSE>;
   //!
   //!        // Allocate shared memory for BlockLoad
   //!        __shared__ typename BlockLoad::TempStorage temp_storage;
@@ -1505,7 +1505,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int valid_items, ...)
   //!    {
   //!        // Specialize BlockLoad for a 1D block of 128 threads owning 4 integer items each
-  //!        typedef cub::BlockLoad<int, 128, 4, BLOCK_LOAD_WARP_TRANSPOSE> BlockLoad;
+  //!        using BlockLoad = cub::BlockLoad<int, 128, 4, BLOCK_LOAD_WARP_TRANSPOSE>;
   //!
   //!        // Allocate shared memory for BlockLoad
   //!        __shared__ typename BlockLoad::TempStorage temp_storage;
@@ -1558,7 +1558,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int valid_items, ...)
   //!    {
   //!        // Specialize BlockLoad for a 1D block of 128 threads owning 4 integer items each
-  //!        typedef cub::BlockLoad<int, 128, 4, BLOCK_LOAD_WARP_TRANSPOSE> BlockLoad;
+  //!        using BlockLoad = cub::BlockLoad<int, 128, 4, BLOCK_LOAD_WARP_TRANSPOSE>;
   //!
   //!        // Allocate shared memory for BlockLoad
   //!        __shared__ typename BlockLoad::TempStorage temp_storage;

--- a/cub/cub/block/block_merge_sort.cuh
+++ b/cub/cub/block/block_merge_sort.cuh
@@ -703,7 +703,7 @@ private:
  * __global__ void ExampleKernel(...)
  * {
  *     // Specialize BlockMergeSort for a 1D block of 128 threads owning 4 integer items each
- *     typedef cub::BlockMergeSort<int, 128, 4> BlockMergeSort;
+ *     using BlockMergeSort = cub::BlockMergeSort<int, 128, 4>;
  *
  *     // Allocate shared memory for BlockMergeSort
  *     __shared__ typename BlockMergeSort::TempStorage temp_storage_shuffle;

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -260,7 +260,7 @@ public:
 
 private:
   /// BlockScan type
-  typedef BlockScan<PackedCounter, BLOCK_DIM_X, INNER_SCAN_ALGORITHM, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockScan;
+  using BlockScan = BlockScan<PackedCounter, BLOCK_DIM_X, INNER_SCAN_ALGORITHM, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
   struct __align__(16) _TempStorage
@@ -563,8 +563,8 @@ template <int BLOCK_DIM_X,
 class BlockRadixRankMatch
 {
 private:
-  typedef int32_t RankT;
-  typedef int32_t DigitCounterT;
+  using RankT         = int32_t;
+  using DigitCounterT = int32_t;
 
   enum
   {
@@ -594,7 +594,7 @@ public:
 
 private:
   /// BlockScan type
-  typedef BlockScan<DigitCounterT, BLOCK_THREADS, INNER_SCAN_ALGORITHM, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockScanT;
+  using BlockScanT = BlockScan<DigitCounterT, BLOCK_THREADS, INNER_SCAN_ALGORITHM, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
   struct __align__(16) _TempStorage
@@ -915,7 +915,7 @@ struct BlockRadixRankMatchEarlyCounts
   };
 
   // types
-  typedef cub::BlockScan<int, BLOCK_THREADS, INNER_SCAN_ALGORITHM> BlockScan;
+  using BlockScan = cub::BlockScan<int, BLOCK_THREADS, INNER_SCAN_ALGORITHM>;
 
   struct TempStorage
   {
@@ -1167,7 +1167,7 @@ struct BlockRadixRankMatchEarlyCounts
            DigitExtractorT digit_extractor,
            int (&exclusive_digit_prefix)[BINS_PER_THREAD])
   {
-    typedef BlockRadixRankEmptyCallback<BINS_PER_THREAD> CountsCallback;
+    using CountsCallback = BlockRadixRankEmptyCallback<BINS_PER_THREAD>;
     BlockRadixRankMatchInternal<UnsignedBits, KEYS_PER_THREAD, DigitExtractorT, CountsCallback> internal(
       temp_storage, digit_extractor, CountsCallback());
     internal.RankKeys(keys, ranks, exclusive_digit_prefix);

--- a/cub/cub/block/block_radix_sort.cuh
+++ b/cub/cub/block/block_radix_sort.cuh
@@ -152,7 +152,7 @@ CUB_NAMESPACE_BEGIN
 //!     __global__ void ExampleKernel(...)
 //!     {
 //!         // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer items each
-//!         typedef cub::BlockRadixSort<int, 128, 4> BlockRadixSort;
+//!         using BlockRadixSort = cub::BlockRadixSort<int, 128, 4>;
 //!
 //!         // Allocate shared memory for BlockRadixSort
 //!         __shared__ typename BlockRadixSort::TempStorage temp_storage;
@@ -250,35 +250,35 @@ private:
   using bit_ordered_conversion = typename traits::bit_ordered_conversion_policy;
 
   /// Ascending BlockRadixRank utility type
-  typedef BlockRadixRank<BLOCK_DIM_X,
-                         RADIX_BITS,
-                         false,
-                         MEMOIZE_OUTER_SCAN,
-                         INNER_SCAN_ALGORITHM,
-                         SMEM_CONFIG,
-                         BLOCK_DIM_Y,
-                         BLOCK_DIM_Z>
-    AscendingBlockRadixRank;
+  using AscendingBlockRadixRank =
+    BlockRadixRank<BLOCK_DIM_X,
+                   RADIX_BITS,
+                   false,
+                   MEMOIZE_OUTER_SCAN,
+                   INNER_SCAN_ALGORITHM,
+                   SMEM_CONFIG,
+                   BLOCK_DIM_Y,
+                   BLOCK_DIM_Z>;
 
   /// Descending BlockRadixRank utility type
-  typedef BlockRadixRank<BLOCK_DIM_X,
-                         RADIX_BITS,
-                         true,
-                         MEMOIZE_OUTER_SCAN,
-                         INNER_SCAN_ALGORITHM,
-                         SMEM_CONFIG,
-                         BLOCK_DIM_Y,
-                         BLOCK_DIM_Z>
-    DescendingBlockRadixRank;
+  using DescendingBlockRadixRank =
+    BlockRadixRank<BLOCK_DIM_X,
+                   RADIX_BITS,
+                   true,
+                   MEMOIZE_OUTER_SCAN,
+                   INNER_SCAN_ALGORITHM,
+                   SMEM_CONFIG,
+                   BLOCK_DIM_Y,
+                   BLOCK_DIM_Z>;
 
   /// Digit extractor type
   using fundamental_digit_extractor_t = BFEDigitExtractor<KeyT>;
 
   /// BlockExchange utility type for keys
-  typedef BlockExchange<KeyT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchangeKeys;
+  using BlockExchangeKeys = BlockExchange<KeyT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
   /// BlockExchange utility type for values
-  typedef BlockExchange<ValueT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchangeValues;
+  using BlockExchangeValues = BlockExchange<ValueT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
   /// Shared memory storage layout type
@@ -582,7 +582,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer keys each
-  //!        typedef cub::BlockRadixSort<int, 128, 4> BlockRadixSort;
+  //!        using BlockRadixSort = cub::BlockRadixSort<int, 128, 4>;
   //!
   //!        // Allocate shared memory for BlockRadixSort
   //!        __shared__ typename BlockRadixSort::TempStorage temp_storage;
@@ -766,7 +766,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer keys and values each
-  //!        typedef cub::BlockRadixSort<int, 128, 4, int> BlockRadixSort;
+  //!        using BlockRadixSort = cub::BlockRadixSort<int, 128, 4, int>;
   //!
   //!        // Allocate shared memory for BlockRadixSort
   //!        __shared__ typename BlockRadixSort::TempStorage temp_storage;
@@ -971,7 +971,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer keys each
-  //!        typedef cub::BlockRadixSort<int, 128, 4> BlockRadixSort;
+  //!        using BlockRadixSort = cub::BlockRadixSort<int, 128, 4>;
   //!
   //!        // Allocate shared memory for BlockRadixSort
   //!        __shared__ typename BlockRadixSort::TempStorage temp_storage;
@@ -1164,8 +1164,8 @@ public:
   //!
   //!    __global__ void ExampleKernel(...)
   //!    {
-  //!        // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer keys and
-  //!    values each typedef cub::BlockRadixSort<int, 128, 4, int> BlockRadixSort;
+  //!        // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer keys and values each
+  //!        using BlockRadixSort = cub::BlockRadixSort<int, 128, 4, int>;
   //!
   //!        // Allocate shared memory for BlockRadixSort
   //!        __shared__ typename BlockRadixSort::TempStorage temp_storage;
@@ -1379,7 +1379,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer keys each
-  //!        typedef cub::BlockRadixSort<int, 128, 4> BlockRadixSort;
+  //!        using BlockRadixSort = cub::BlockRadixSort<int, 128, 4>;
   //!
   //!        // Allocate shared memory for BlockRadixSort
   //!        __shared__ typename BlockRadixSort::TempStorage temp_storage;
@@ -1575,7 +1575,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer keys and values each
-  //!        typedef cub::BlockRadixSort<int, 128, 4, int> BlockRadixSort;
+  //!        using BlockRadixSort = cub::BlockRadixSort<int, 128, 4, int>;
   //!
   //!        // Allocate shared memory for BlockRadixSort
   //!        __shared__ typename BlockRadixSort::TempStorage temp_storage;
@@ -1777,7 +1777,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer keys each
-  //!        typedef cub::BlockRadixSort<int, 128, 4> BlockRadixSort;
+  //!        using BlockRadixSort = cub::BlockRadixSort<int, 128, 4>;
   //!
   //!        // Allocate shared memory for BlockRadixSort
   //!        __shared__ typename BlockRadixSort::TempStorage temp_storage;
@@ -1973,7 +1973,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockRadixSort for a 1D block of 128 threads owning 4 integer keys and values each
-  //!        typedef cub::BlockRadixSort<int, 128, 4, int> BlockRadixSort;
+  //!        using BlockRadixSort = cub::BlockRadixSort<int, 128, 4, int>;
   //!
   //!        // Allocate shared memory for BlockRadixSort
   //!        __shared__ typename BlockRadixSort::TempStorage temp_storage;

--- a/cub/cub/block/block_reduce.cuh
+++ b/cub/cub/block/block_reduce.cuh
@@ -193,7 +193,7 @@ enum BlockReduceAlgorithm
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
-//!        typedef cub::BlockReduce<int, 128> BlockReduce;
+//!        using BlockReduce = cub::BlockReduce<int, 128>;
 //!
 //!        // Allocate shared memory for BlockReduce
 //!        __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -247,9 +247,9 @@ private:
     BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
   };
 
-  typedef BlockReduceWarpReductions<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z> WarpReductions;
-  typedef BlockReduceRakingCommutativeOnly<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z> RakingCommutativeOnly;
-  typedef BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z> Raking;
+  using WarpReductions        = BlockReduceWarpReductions<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>;
+  using RakingCommutativeOnly = BlockReduceRakingCommutativeOnly<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>;
+  using Raking                = BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
   /// Internal specialization type
   using InternalBlockReduce =
@@ -260,7 +260,7 @@ private:
                                                           Raking>>; // BlockReduceRaking
 
   /// Shared memory storage layout type for BlockReduce
-  typedef typename InternalBlockReduce::TempStorage _TempStorage;
+  using _TempStorage = typename InternalBlockReduce::TempStorage;
 
   /// Internal storage allocator
   _CCCL_DEVICE _CCCL_FORCEINLINE _TempStorage& PrivateStorage()
@@ -325,7 +325,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockReduce<int, 128> BlockReduce;
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
   //!
   //!        // Allocate shared memory for BlockReduce
   //!        __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -375,7 +375,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockReduce<int, 128> BlockReduce;
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
   //!
   //!        // Allocate shared memory for BlockReduce
   //!        __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -429,7 +429,7 @@ public:
   //!    __global__ void ExampleKernel(int num_valid, ...)
   //!    {
   //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockReduce<int, 128> BlockReduce;
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
   //!
   //!        // Allocate shared memory for BlockReduce
   //!        __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -493,7 +493,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockReduce<int, 128> BlockReduce;
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
   //!
   //!        // Allocate shared memory for BlockReduce
   //!        __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -536,7 +536,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockReduce<int, 128> BlockReduce;
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
   //!
   //!        // Allocate shared memory for BlockReduce
   //!        __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -584,7 +584,7 @@ public:
   //!    __global__ void ExampleKernel(int num_valid, ...)
   //!    {
   //!        // Specialize BlockReduce for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockReduce<int, 128> BlockReduce;
+  //!        using BlockReduce = cub::BlockReduce<int, 128>;
   //!
   //!        // Allocate shared memory for BlockReduce
   //!        __shared__ typename BlockReduce::TempStorage temp_storage;

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -175,7 +175,7 @@ enum BlockScanAlgorithm
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-//!        typedef cub::BlockScan<int, 128> BlockScan;
+//!        using BlockScan = cub::BlockScan<int, 128>;
 //!
 //!        // Allocate shared memory for BlockScan
 //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -247,15 +247,15 @@ private:
       ? BLOCK_SCAN_RAKING
       : ALGORITHM;
 
-  typedef BlockScanWarpScans<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z> WarpScans;
-  typedef BlockScanRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, (SAFE_ALGORITHM == BLOCK_SCAN_RAKING_MEMOIZE)>
-    Raking;
+  using WarpScans = BlockScanWarpScans<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>;
+  using Raking =
+    BlockScanRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, (SAFE_ALGORITHM == BLOCK_SCAN_RAKING_MEMOIZE)>;
 
   /// Define the delegate type for the desired algorithm
   using InternalBlockScan = cub::detail::conditional_t<SAFE_ALGORITHM == BLOCK_SCAN_WARP_SCANS, WarpScans, Raking>;
 
   /// Shared memory storage layout type for BlockScan
-  typedef typename InternalBlockScan::TempStorage _TempStorage;
+  using _TempStorage = typename InternalBlockScan::TempStorage;
 
   /// Shared storage reference
   _TempStorage& temp_storage;
@@ -321,7 +321,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -373,7 +373,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -457,7 +457,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int num_items, ...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -534,7 +534,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -594,7 +594,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -691,9 +691,9 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int num_items, ...)
   //!    {
   //!        // Specialize BlockLoad, BlockStore, and BlockScan for a 1D block of 128 threads, 4 ints per thread
-  //!        typedef cub::BlockLoad<int*, 128, 4, BLOCK_LOAD_TRANSPOSE>   BlockLoad;
-  //!        typedef cub::BlockStore<int, 128, 4, BLOCK_STORE_TRANSPOSE>  BlockStore;
-  //!        typedef cub::BlockScan<int, 128>                             BlockScan;
+  //!        using BlockLoad  = cub::BlockLoad<int*, 128, 4, BLOCK_LOAD_TRANSPOSE>;
+  //!        using BlockStore = cub::BlockStore<int, 128, 4, BLOCK_STORE_TRANSPOSE>;
+  //!        using BlockScan  = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate aliased shared memory for BlockLoad, BlockStore, and BlockScan
   //!        __shared__ union {
@@ -780,7 +780,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -841,7 +841,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -936,7 +936,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int num_items, ...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -1019,7 +1019,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -1096,7 +1096,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -1205,9 +1205,9 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int num_items, ...)
   //!    {
   //!        // Specialize BlockLoad, BlockStore, and BlockScan for a 1D block of 128 threads, 4 ints per thread
-  //!        typedef cub::BlockLoad<int*, 128, 4, BLOCK_LOAD_TRANSPOSE>   BlockLoad;
-  //!        typedef cub::BlockStore<int, 128, 4, BLOCK_STORE_TRANSPOSE>  BlockStore;
-  //!        typedef cub::BlockScan<int, 128>                             BlockScan;
+  //!        using BlockLoad = cub::BlockLoad<int*, 128, 4, BLOCK_LOAD_TRANSPOSE>  ;
+  //!        using BlockStore = cub::BlockStore<int, 128, 4, BLOCK_STORE_TRANSPOSE> ;
+  //!        using BlockScan = cub::BlockScan<int, 128>                            ;
   //!
   //!        // Allocate aliased shared memory for BlockLoad, BlockStore, and BlockScan
   //!        __shared__ union {
@@ -1465,7 +1465,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -1513,7 +1513,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -1596,7 +1596,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int num_items, ...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -1671,7 +1671,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -1741,7 +1741,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -1852,9 +1852,9 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int num_items, ...)
   //!    {
   //!        // Specialize BlockLoad, BlockStore, and BlockScan for a 1D block of 128 threads, 4 ints per thread
-  //!        typedef cub::BlockLoad<int*, 128, 4, BLOCK_LOAD_TRANSPOSE>   BlockLoad;
-  //!        typedef cub::BlockStore<int, 128, 4, BLOCK_STORE_TRANSPOSE>  BlockStore;
-  //!        typedef cub::BlockScan<int, 128>                             BlockScan;
+  //!        using BlockLoad = cub::BlockLoad<int*, 128, 4, BLOCK_LOAD_TRANSPOSE>  ;
+  //!        using BlockStore = cub::BlockStore<int, 128, 4, BLOCK_STORE_TRANSPOSE> ;
+  //!        using BlockScan = cub::BlockScan<int, 128>                            ;
   //!
   //!        // Allocate aliased shared memory for BlockLoad, BlockStore, and BlockScan
   //!        __shared__ union {
@@ -1955,7 +1955,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -2012,7 +2012,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -2104,7 +2104,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int num_items, ...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -2188,7 +2188,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -2322,7 +2322,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize BlockScan for a 1D block of 128 threads of type int
-  //!        typedef cub::BlockScan<int, 128> BlockScan;
+  //!        using BlockScan = cub::BlockScan<int, 128>;
   //!
   //!        // Allocate shared memory for BlockScan
   //!        __shared__ typename BlockScan::TempStorage temp_storage;
@@ -2494,9 +2494,9 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int num_items, ...)
   //!    {
   //!        // Specialize BlockLoad, BlockStore, and BlockScan for a 1D block of 128 threads, 4 ints per thread
-  //!        typedef cub::BlockLoad<int*, 128, 4, BLOCK_LOAD_TRANSPOSE>   BlockLoad;
-  //!        typedef cub::BlockStore<int, 128, 4, BLOCK_STORE_TRANSPOSE>  BlockStore;
-  //!        typedef cub::BlockScan<int, 128>                             BlockScan;
+  //!        using BlockLoad = cub::BlockLoad<int*, 128, 4, BLOCK_LOAD_TRANSPOSE>  ;
+  //!        using BlockStore = cub::BlockStore<int, 128, 4, BLOCK_STORE_TRANSPOSE> ;
+  //!        using BlockScan = cub::BlockScan<int, 128>                            ;
   //!
   //!        // Allocate aliased shared memory for BlockLoad, BlockStore, and BlockScan
   //!        __shared__ union {

--- a/cub/cub/block/block_shuffle.cuh
+++ b/cub/cub/block/block_shuffle.cuh
@@ -88,7 +88,7 @@ private:
   };
 
   /// Shared memory storage layout type (last element from each thread's input)
-  typedef T _TempStorage[BLOCK_THREADS];
+  using _TempStorage = T[BLOCK_THREADS];
 
 public:
   /// \smemstorage{BlockShuffle}

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -184,7 +184,7 @@ StoreDirectBlockedVectorized(int linear_tid, T* block_ptr, T (&items)[ITEMS_PER_
   };
 
   // Vector type
-  typedef typename CubVector<T, VEC_SIZE>::Type Vector;
+  using Vector = typename CubVector<T, VEC_SIZE>::Type;
 
   // Alias global pointer
   Vector* block_ptr_vectors = reinterpret_cast<Vector*>(const_cast<T*>(block_ptr));
@@ -595,7 +595,7 @@ enum BlockStoreAlgorithm
 //!    __global__ void ExampleKernel(int *d_data, ...)
 //!    {
 //!        // Specialize BlockStore for a 1D block of 128 threads owning 4 integer items each
-//!        typedef cub::BlockStore<int, 128, 4, BLOCK_STORE_WARP_TRANSPOSE> BlockStore;
+//!        using BlockStore = cub::BlockStore<int, 128, 4, BLOCK_STORE_WARP_TRANSPOSE>;
 //!
 //!        // Allocate shared memory for BlockStore
 //!        __shared__ typename BlockStore::TempStorage temp_storage;
@@ -664,7 +664,7 @@ private:
   struct StoreInternal<BLOCK_STORE_DIRECT, DUMMY>
   {
     /// Shared memory storage layout type
-    typedef NullType TempStorage;
+    using TempStorage = NullType;
 
     /// Linear thread-id
     int linear_tid;
@@ -715,7 +715,7 @@ private:
   struct StoreInternal<BLOCK_STORE_STRIPED, DUMMY>
   {
     /// Shared memory storage layout type
-    typedef NullType TempStorage;
+    using TempStorage = NullType;
 
     /// Linear thread-id
     int linear_tid;
@@ -766,7 +766,7 @@ private:
   struct StoreInternal<BLOCK_STORE_VECTORIZE, DUMMY>
   {
     /// Shared memory storage layout type
-    typedef NullType TempStorage;
+    using TempStorage = NullType;
 
     /// Linear thread-id
     int linear_tid;
@@ -833,7 +833,7 @@ private:
   struct StoreInternal<BLOCK_STORE_TRANSPOSE, DUMMY>
   {
     // BlockExchange utility type for keys
-    typedef BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
+    using BlockExchange = BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
     /// Shared memory storage layout type
     struct _TempStorage : BlockExchange::TempStorage
@@ -916,7 +916,7 @@ private:
     static_assert(int(BLOCK_THREADS) % int(WARP_THREADS) == 0, "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
     // BlockExchange utility type for keys
-    typedef BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
+    using BlockExchange = BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
     /// Shared memory storage layout type
     struct _TempStorage : BlockExchange::TempStorage
@@ -999,7 +999,7 @@ private:
     static_assert(int(BLOCK_THREADS) % int(WARP_THREADS) == 0, "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
     // BlockExchange utility type for keys
-    typedef BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, true, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
+    using BlockExchange = BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, true, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
     /// Shared memory storage layout type
     struct _TempStorage : BlockExchange::TempStorage
@@ -1068,10 +1068,10 @@ private:
   };
 
   /// Internal load implementation to use
-  typedef StoreInternal<ALGORITHM, 0> InternalStore;
+  using InternalStore = StoreInternal<ALGORITHM, 0>;
 
   /// Shared memory storage layout type
-  typedef typename InternalStore::TempStorage _TempStorage;
+  using _TempStorage = typename InternalStore::TempStorage;
 
   /// Internal storage allocator
   _CCCL_DEVICE _CCCL_FORCEINLINE _TempStorage& PrivateStorage()
@@ -1139,7 +1139,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, ...)
   //!    {
   //!        // Specialize BlockStore for a 1D block of 128 threads owning 4 integer items each
-  //!        typedef cub::BlockStore<int, 128, 4, BLOCK_STORE_WARP_TRANSPOSE> BlockStore;
+  //!        using BlockStore = cub::BlockStore<int, 128, 4, BLOCK_STORE_WARP_TRANSPOSE>;
   //!
   //!        // Allocate shared memory for BlockStore
   //!        __shared__ typename BlockStore::TempStorage temp_storage;
@@ -1191,7 +1191,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int valid_items, ...)
   //!    {
   //!        // Specialize BlockStore for a 1D block of 128 threads owning 4 integer items each
-  //!        typedef cub::BlockStore<int, 128, 4, BLOCK_STORE_WARP_TRANSPOSE> BlockStore;
+  //!        using BlockStore = cub::BlockStore<int, 128, 4, BLOCK_STORE_WARP_TRANSPOSE>;
   //!
   //!        // Allocate shared memory for BlockStore
   //!        __shared__ typename BlockStore::TempStorage temp_storage;

--- a/cub/cub/block/specializations/block_histogram_sort.cuh
+++ b/cub/cub/block/specializations/block_histogram_sort.cuh
@@ -92,20 +92,20 @@ struct BlockHistogramSort
   };
 
   // Parameterize BlockRadixSort type for our thread block
-  typedef BlockRadixSort<T,
-                         BLOCK_DIM_X,
-                         ITEMS_PER_THREAD,
-                         NullType,
-                         4,
-                         true,
-                         BLOCK_SCAN_WARP_SCANS,
-                         cudaSharedMemBankSizeFourByte,
-                         BLOCK_DIM_Y,
-                         BLOCK_DIM_Z>
-    BlockRadixSortT;
+  using BlockRadixSortT =
+    BlockRadixSort<T,
+                   BLOCK_DIM_X,
+                   ITEMS_PER_THREAD,
+                   NullType,
+                   4,
+                   true,
+                   BLOCK_SCAN_WARP_SCANS,
+                   cudaSharedMemBankSizeFourByte,
+                   BLOCK_DIM_Y,
+                   BLOCK_DIM_Z>;
 
   // Parameterize BlockDiscontinuity type for our thread block
-  typedef BlockDiscontinuity<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockDiscontinuityT;
+  using BlockDiscontinuityT = BlockDiscontinuity<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
   /// Shared memory
   union _TempStorage

--- a/cub/cub/block/specializations/block_reduce_raking.cuh
+++ b/cub/cub/block/specializations/block_reduce_raking.cuh
@@ -91,10 +91,10 @@ struct BlockReduceRaking
   };
 
   /// Layout type for padded thread block raking grid
-  typedef BlockRakingLayout<T, BLOCK_THREADS> BlockRakingLayout;
+  using BlockRakingLayout = BlockRakingLayout<T, BLOCK_THREADS>;
 
   ///  WarpReduce utility type
-  typedef typename WarpReduce<T, BlockRakingLayout::RAKING_THREADS>::InternalWarpReduce WarpReduce;
+  using WarpReduce = typename WarpReduce<T, BlockRakingLayout::RAKING_THREADS>::InternalWarpReduce;
 
   /// Constants
   enum

--- a/cub/cub/block/specializations/block_reduce_raking_commutative_only.cuh
+++ b/cub/cub/block/specializations/block_reduce_raking_commutative_only.cuh
@@ -83,7 +83,7 @@ struct BlockReduceRakingCommutativeOnly
 
   // The fall-back implementation to use when BLOCK_THREADS is not a multiple of the warp size or not all threads have
   // valid values
-  typedef BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z> FallBack;
+  using FallBack = BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>;
 
   /// Constants
   enum
@@ -105,10 +105,10 @@ struct BlockReduceRakingCommutativeOnly
   };
 
   ///  WarpReduce utility type
-  typedef WarpReduce<T, RAKING_THREADS> WarpReduce;
+  using WarpReduce = WarpReduce<T, RAKING_THREADS>;
 
   /// Layout type for padded thread block raking grid
-  typedef BlockRakingLayout<T, SHARING_THREADS> BlockRakingLayout;
+  using BlockRakingLayout = BlockRakingLayout<T, SHARING_THREADS>;
 
   /// Shared memory storage layout type
   union _TempStorage

--- a/cub/cub/block/specializations/block_reduce_warp_reductions.cuh
+++ b/cub/cub/block/specializations/block_reduce_warp_reductions.cuh
@@ -91,7 +91,7 @@ struct BlockReduceWarpReductions
   };
 
   ///  WarpReduce utility type
-  typedef typename WarpReduce<T, LOGICAL_WARP_SIZE>::InternalWarpReduce WarpReduce;
+  using WarpReduce = typename WarpReduce<T, LOGICAL_WARP_SIZE>::InternalWarpReduce;
 
   /// Shared memory storage layout type
   struct _TempStorage

--- a/cub/cub/block/specializations/block_scan_raking.cuh
+++ b/cub/cub/block/specializations/block_scan_raking.cuh
@@ -91,7 +91,7 @@ struct BlockScanRaking
   };
 
   /// Layout type for padded thread block raking grid
-  typedef BlockRakingLayout<T, BLOCK_THREADS> BlockRakingLayout;
+  using BlockRakingLayout = BlockRakingLayout<T, BLOCK_THREADS>;
 
   /// Constants
   enum
@@ -107,7 +107,7 @@ struct BlockScanRaking
   };
 
   ///  WarpScan utility type
-  typedef WarpScan<T, RAKING_THREADS> WarpScan;
+  using WarpScan = WarpScan<T, RAKING_THREADS>;
 
   /// Shared memory storage layout type
   struct _TempStorage

--- a/cub/cub/block/specializations/block_scan_warp_scans.cuh
+++ b/cub/cub/block/specializations/block_scan_warp_scans.cuh
@@ -86,10 +86,10 @@ struct BlockScanWarpScans
   };
 
   ///  WarpScan utility type
-  typedef WarpScan<T, WARP_THREADS> WarpScanT;
+  using WarpScanT = WarpScan<T, WARP_THREADS>;
 
   ///  WarpScan utility type
-  typedef WarpScan<T, WARPS> WarpAggregateScan;
+  using WarpAggregateScan = WarpScan<T, WARPS>;
 
   /// Shared memory storage layout type
 

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -1160,7 +1160,7 @@ struct DeviceReduce
     // Selection op (not used)
 
     // Default == operator
-    typedef Equality EqualityOp;
+    using EqualityOp = Equality;
 
     return DispatchReduceByKey<
       KeysInputIteratorT,

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -933,10 +933,10 @@ public:
       }
 
       // Use the search transform op for converting samples to privatized bins
-      typedef SearchTransform<const LevelT*> PrivatizedDecodeOpT;
+      using PrivatizedDecodeOpT = SearchTransform<const LevelT*>;
 
       // Use the pass-thru transform op for converting privatized bins to output bins
-      typedef PassThruTransform OutputDecodeOpT;
+      using OutputDecodeOpT = PassThruTransform;
 
       PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS]{};
       OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS]{};
@@ -1135,10 +1135,10 @@ public:
       }
 
       // Use the pass-thru transform op for converting samples to privatized bins
-      typedef PassThruTransform PrivatizedDecodeOpT;
+      using PrivatizedDecodeOpT = PassThruTransform;
 
       // Use the search transform op for converting privatized bins to output bins
-      typedef SearchTransform<const LevelT*> OutputDecodeOpT;
+      using OutputDecodeOpT = SearchTransform<const LevelT*>;
 
       int num_privatized_levels[NUM_ACTIVE_CHANNELS];
       PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS]{};
@@ -1301,10 +1301,10 @@ public:
       }
 
       // Use the scale transform op for converting samples to privatized bins
-      typedef ScaleTransform PrivatizedDecodeOpT;
+      using PrivatizedDecodeOpT = ScaleTransform;
 
       // Use the pass-thru transform op for converting privatized bins to output bins
-      typedef PassThruTransform OutputDecodeOpT;
+      using OutputDecodeOpT = PassThruTransform;
 
       PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS]{};
       OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS]{};
@@ -1520,10 +1520,10 @@ public:
       }
 
       // Use the pass-thru transform op for converting samples to privatized bins
-      typedef PassThruTransform PrivatizedDecodeOpT;
+      using PrivatizedDecodeOpT = PassThruTransform;
 
       // Use the scale transform op for converting privatized bins to output bins
-      typedef ScaleTransform OutputDecodeOpT;
+      using OutputDecodeOpT = ScaleTransform;
 
       int num_privatized_levels[NUM_ACTIVE_CHANNELS];
       PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS]{};

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -147,7 +147,7 @@ __launch_bounds__(int((ALT_DIGIT_BITS) ? int(ChainedPolicyT::ActivePolicy::AltUp
   };
 
   // Parameterize AgentRadixSortUpsweep type for the current configuration
-  typedef AgentRadixSortUpsweep<ActiveUpsweepPolicyT, KeyT, OffsetT, DecomposerT> AgentRadixSortUpsweepT;
+  using AgentRadixSortUpsweepT = AgentRadixSortUpsweep<ActiveUpsweepPolicyT, KeyT, OffsetT, DecomposerT>;
 
   // Shared memory storage
   __shared__ typename AgentRadixSortUpsweepT::TempStorage temp_storage;
@@ -187,8 +187,8 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanPolicy::BLOCK_THREADS), 
   CUB_DETAIL_KERNEL_ATTRIBUTES void RadixSortScanBinsKernel(OffsetT* d_spine, int num_counts)
 {
   // Parameterize the AgentScan type for the current configuration
-  typedef AgentScan<typename ChainedPolicyT::ActivePolicy::ScanPolicy, OffsetT*, OffsetT*, cub::Sum, OffsetT, OffsetT, OffsetT>
-    AgentScanT;
+  using AgentScanT =
+    AgentScan<typename ChainedPolicyT::ActivePolicy::ScanPolicy, OffsetT*, OffsetT*, cub::Sum, OffsetT, OffsetT, OffsetT>;
 
   // Shared memory storage
   __shared__ typename AgentScanT::TempStorage temp_storage;
@@ -300,8 +300,8 @@ __launch_bounds__(int((ALT_DIGIT_BITS) ? int(ChainedPolicyT::ActivePolicy::AltDo
   };
 
   // Parameterize AgentRadixSortDownsweep type for the current configuration
-  typedef AgentRadixSortDownsweep<ActiveDownsweepPolicyT, IS_DESCENDING, KeyT, ValueT, OffsetT, DecomposerT>
-    AgentRadixSortDownsweepT;
+  using AgentRadixSortDownsweepT =
+    AgentRadixSortDownsweep<ActiveDownsweepPolicyT, IS_DESCENDING, KeyT, ValueT, OffsetT, DecomposerT>;
 
   // Shared memory storage
   __shared__ typename AgentRadixSortDownsweepT::TempStorage temp_storage;
@@ -381,22 +381,22 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::SingleTilePolicy::BLOCK_THRE
   };
 
   // BlockRadixSort type
-  typedef BlockRadixSort<KeyT,
-                         BLOCK_THREADS,
-                         ITEMS_PER_THREAD,
-                         ValueT,
-                         ChainedPolicyT::ActivePolicy::SingleTilePolicy::RADIX_BITS,
-                         (ChainedPolicyT::ActivePolicy::SingleTilePolicy::RANK_ALGORITHM == RADIX_RANK_MEMOIZE),
-                         ChainedPolicyT::ActivePolicy::SingleTilePolicy::SCAN_ALGORITHM>
-    BlockRadixSortT;
+  using BlockRadixSortT =
+    BlockRadixSort<KeyT,
+                   BLOCK_THREADS,
+                   ITEMS_PER_THREAD,
+                   ValueT,
+                   ChainedPolicyT::ActivePolicy::SingleTilePolicy::RADIX_BITS,
+                   (ChainedPolicyT::ActivePolicy::SingleTilePolicy::RANK_ALGORITHM == RADIX_RANK_MEMOIZE),
+                   ChainedPolicyT::ActivePolicy::SingleTilePolicy::SCAN_ALGORITHM>;
 
   // BlockLoad type (keys)
-  typedef BlockLoad<KeyT, BLOCK_THREADS, ITEMS_PER_THREAD, ChainedPolicyT::ActivePolicy::SingleTilePolicy::LOAD_ALGORITHM>
-    BlockLoadKeys;
+  using BlockLoadKeys =
+    BlockLoad<KeyT, BLOCK_THREADS, ITEMS_PER_THREAD, ChainedPolicyT::ActivePolicy::SingleTilePolicy::LOAD_ALGORITHM>;
 
   // BlockLoad type (values)
-  typedef BlockLoad<ValueT, BLOCK_THREADS, ITEMS_PER_THREAD, ChainedPolicyT::ActivePolicy::SingleTilePolicy::LOAD_ALGORITHM>
-    BlockLoadValues;
+  using BlockLoadValues =
+    BlockLoad<ValueT, BLOCK_THREADS, ITEMS_PER_THREAD, ChainedPolicyT::ActivePolicy::SingleTilePolicy::LOAD_ALGORITHM>;
 
   // Unsigned word for key bits
   using traits           = detail::radix::traits_t<KeyT>;
@@ -720,8 +720,8 @@ CUB_DETAIL_KERNEL_ATTRIBUTES
 __launch_bounds__(ChainedPolicyT::ActivePolicy::HistogramPolicy::BLOCK_THREADS) void DeviceRadixSortHistogramKernel(
   OffsetT* d_bins_out, const KeyT* d_keys_in, OffsetT num_items, int start_bit, int end_bit, DecomposerT decomposer = {})
 {
-  typedef typename ChainedPolicyT::ActivePolicy::HistogramPolicy HistogramPolicyT;
-  typedef AgentRadixSortHistogram<HistogramPolicyT, IS_DESCENDING, KeyT, OffsetT, DecomposerT> AgentT;
+  using HistogramPolicyT = typename ChainedPolicyT::ActivePolicy::HistogramPolicy;
+  using AgentT           = AgentRadixSortHistogram<HistogramPolicyT, IS_DESCENDING, KeyT, OffsetT, DecomposerT>;
   __shared__ typename AgentT::TempStorage temp_storage;
   AgentT agent(temp_storage, d_bins_out, d_keys_in, num_items, start_bit, end_bit, decomposer);
   agent.Process();
@@ -750,9 +750,9 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void __launch_bounds__(ChainedPolicyT::ActivePolicy
     int num_bits,
     DecomposerT decomposer = {})
 {
-  typedef typename ChainedPolicyT::ActivePolicy::OnesweepPolicy OnesweepPolicyT;
-  typedef AgentRadixSortOnesweep<OnesweepPolicyT, IS_DESCENDING, KeyT, ValueT, OffsetT, PortionOffsetT, DecomposerT>
-    AgentT;
+  using OnesweepPolicyT = typename ChainedPolicyT::ActivePolicy::OnesweepPolicy;
+  using AgentT =
+    AgentRadixSortOnesweep<OnesweepPolicyT, IS_DESCENDING, KeyT, ValueT, OffsetT, PortionOffsetT, DecomposerT>;
   __shared__ typename AgentT::TempStorage s;
 
   AgentT agent(
@@ -778,12 +778,12 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void __launch_bounds__(ChainedPolicyT::ActivePolicy
 template <typename ChainedPolicyT, typename OffsetT>
 CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(OffsetT* d_bins)
 {
-  typedef typename ChainedPolicyT::ActivePolicy::ExclusiveSumPolicy ExclusiveSumPolicyT;
+  using ExclusiveSumPolicyT     = typename ChainedPolicyT::ActivePolicy::ExclusiveSumPolicy;
   constexpr int RADIX_BITS      = ExclusiveSumPolicyT::RADIX_BITS;
   constexpr int RADIX_DIGITS    = 1 << RADIX_BITS;
   constexpr int BLOCK_THREADS   = ExclusiveSumPolicyT::BLOCK_THREADS;
   constexpr int BINS_PER_THREAD = (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS;
-  typedef cub::BlockScan<OffsetT, BLOCK_THREADS> BlockScan;
+  using BlockScan               = cub::BlockScan<OffsetT, BLOCK_THREADS>;
   __shared__ typename BlockScan::TempStorage temp_storage;
 
   // load the bins
@@ -910,13 +910,13 @@ struct DeviceRadixSortPolicy
     };
 
     // Histogram policy
-    typedef AgentRadixSortHistogramPolicy<256, 8, 1, KeyT, ONESWEEP_RADIX_BITS> HistogramPolicy;
+    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 1, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    typedef AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS> ExclusiveSumPolicy;
+    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    typedef AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
       256,
       21,
       DominantT,
@@ -924,15 +924,14 @@ struct DeviceRadixSortPolicy
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_WARP_SCANS,
       RADIX_SORT_STORE_DIRECT,
-      ONESWEEP_RADIX_BITS>
-      OnesweepPolicy;
+      ONESWEEP_RADIX_BITS>;
 
     // Scan policy
-    typedef AgentScanPolicy<1024, 4, OffsetT, BLOCK_LOAD_VECTORIZE, LOAD_DEFAULT, BLOCK_STORE_VECTORIZE, BLOCK_SCAN_WARP_SCANS>
-      ScanPolicy;
+    using ScanPolicy =
+      AgentScanPolicy<1024, 4, OffsetT, BLOCK_LOAD_VECTORIZE, LOAD_DEFAULT, BLOCK_STORE_VECTORIZE, BLOCK_SCAN_WARP_SCANS>;
 
     // Keys-only downsweep policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicyKeys = AgentRadixSortDownsweepPolicy<
       128,
       9,
       DominantT,
@@ -940,9 +939,8 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MATCH,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS>
-      DownsweepPolicyKeys;
-    typedef AgentRadixSortDownsweepPolicy<
+      PRIMARY_RADIX_BITS>;
+    using AltDownsweepPolicyKeys = AgentRadixSortDownsweepPolicy<
       64,
       18,
       DominantT,
@@ -950,12 +948,11 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS - 1>
-      AltDownsweepPolicyKeys;
+      PRIMARY_RADIX_BITS - 1>;
 
     // Key-value pairs downsweep policies
-    typedef DownsweepPolicyKeys DownsweepPolicyPairs;
-    typedef AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicyPairs    = DownsweepPolicyKeys;
+    using AltDownsweepPolicyPairs = AgentRadixSortDownsweepPolicy<
       128,
       15,
       DominantT,
@@ -963,8 +960,7 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS - 1>
-      AltDownsweepPolicyPairs;
+      PRIMARY_RADIX_BITS - 1>;
 
     // Downsweep policies
     using DownsweepPolicy = cub::detail::conditional_t<KEYS_ONLY, DownsweepPolicyKeys, DownsweepPolicyPairs>;
@@ -996,13 +992,13 @@ struct DeviceRadixSortPolicy
     };
 
     // Histogram policy
-    typedef AgentRadixSortHistogramPolicy<256, 8, 1, KeyT, ONESWEEP_RADIX_BITS> HistogramPolicy;
+    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 1, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    typedef AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS> ExclusiveSumPolicy;
+    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    typedef AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
       256,
       21,
       DominantT,
@@ -1010,21 +1006,20 @@ struct DeviceRadixSortPolicy
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_WARP_SCANS,
       RADIX_SORT_STORE_DIRECT,
-      ONESWEEP_RADIX_BITS>
-      OnesweepPolicy;
+      ONESWEEP_RADIX_BITS>;
 
     // ScanPolicy
-    typedef AgentScanPolicy<512,
-                            23,
-                            OffsetT,
-                            BLOCK_LOAD_WARP_TRANSPOSE,
-                            LOAD_DEFAULT,
-                            BLOCK_STORE_WARP_TRANSPOSE,
-                            BLOCK_SCAN_RAKING_MEMOIZE>
-      ScanPolicy;
+    using ScanPolicy =
+      AgentScanPolicy<512,
+                      23,
+                      OffsetT,
+                      BLOCK_LOAD_WARP_TRANSPOSE,
+                      LOAD_DEFAULT,
+                      BLOCK_STORE_WARP_TRANSPOSE,
+                      BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
       160,
       39,
       DominantT,
@@ -1032,9 +1027,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_BASIC,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS>
-      DownsweepPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      PRIMARY_RADIX_BITS>;
+    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
       256,
       16,
       DominantT,
@@ -1042,15 +1036,14 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      PRIMARY_RADIX_BITS - 1>
-      AltDownsweepPolicy;
+      PRIMARY_RADIX_BITS - 1>;
 
     // Upsweep policies
-    typedef DownsweepPolicy UpsweepPolicy;
-    typedef AltDownsweepPolicy AltUpsweepPolicy;
+    using UpsweepPolicy    = DownsweepPolicy;
+    using AltUpsweepPolicy = AltDownsweepPolicy;
 
     // Single-tile policy
-    typedef AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
       256,
       19,
       DominantT,
@@ -1058,11 +1051,10 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SINGLE_TILE_RADIX_BITS>
-      SingleTilePolicy;
+      SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
       192,
       31,
       DominantT,
@@ -1070,9 +1062,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS>
-      SegmentedPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      SEGMENTED_RADIX_BITS>;
+    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
       256,
       11,
       DominantT,
@@ -1080,8 +1071,7 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS - 1>
-      AltSegmentedPolicy;
+      SEGMENTED_RADIX_BITS - 1>;
   };
 
   /// SM60 (GP100)
@@ -1098,13 +1088,13 @@ struct DeviceRadixSortPolicy
     };
 
     // Histogram policy
-    typedef AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS> HistogramPolicy;
+    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    typedef AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS> ExclusiveSumPolicy;
+    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    typedef AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
       256,
       OFFSET_64BIT ? 29 : 30,
       DominantT,
@@ -1112,21 +1102,20 @@ struct DeviceRadixSortPolicy
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_WARP_SCANS,
       RADIX_SORT_STORE_DIRECT,
-      ONESWEEP_RADIX_BITS>
-      OnesweepPolicy;
+      ONESWEEP_RADIX_BITS>;
 
     // ScanPolicy
-    typedef AgentScanPolicy<512,
-                            23,
-                            OffsetT,
-                            BLOCK_LOAD_WARP_TRANSPOSE,
-                            LOAD_DEFAULT,
-                            BLOCK_STORE_WARP_TRANSPOSE,
-                            BLOCK_SCAN_RAKING_MEMOIZE>
-      ScanPolicy;
+    using ScanPolicy =
+      AgentScanPolicy<512,
+                      23,
+                      OffsetT,
+                      BLOCK_LOAD_WARP_TRANSPOSE,
+                      LOAD_DEFAULT,
+                      BLOCK_STORE_WARP_TRANSPOSE,
+                      BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
       256,
       25,
       DominantT,
@@ -1134,9 +1123,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MATCH,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS>
-      DownsweepPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      PRIMARY_RADIX_BITS>;
+    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
       192,
       OFFSET_64BIT ? 32 : 39,
       DominantT,
@@ -1144,15 +1132,14 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS - 1>
-      AltDownsweepPolicy;
+      PRIMARY_RADIX_BITS - 1>;
 
     // Upsweep policies
-    typedef DownsweepPolicy UpsweepPolicy;
-    typedef AltDownsweepPolicy AltUpsweepPolicy;
+    using UpsweepPolicy    = DownsweepPolicy;
+    using AltUpsweepPolicy = AltDownsweepPolicy;
 
     // Single-tile policy
-    typedef AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
       256,
       19,
       DominantT,
@@ -1160,11 +1147,10 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SINGLE_TILE_RADIX_BITS>
-      SingleTilePolicy;
+      SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
       192,
       39,
       DominantT,
@@ -1172,9 +1158,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS>
-      SegmentedPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      SEGMENTED_RADIX_BITS>;
+    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
       384,
       11,
       DominantT,
@@ -1182,8 +1167,7 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS - 1>
-      AltSegmentedPolicy;
+      SEGMENTED_RADIX_BITS - 1>;
   };
 
   /// SM61 (GP104)
@@ -1199,13 +1183,13 @@ struct DeviceRadixSortPolicy
     };
 
     // Histogram policy
-    typedef AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS> HistogramPolicy;
+    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    typedef AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS> ExclusiveSumPolicy;
+    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    typedef AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
       256,
       30,
       DominantT,
@@ -1213,21 +1197,20 @@ struct DeviceRadixSortPolicy
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_WARP_SCANS,
       RADIX_SORT_STORE_DIRECT,
-      ONESWEEP_RADIX_BITS>
-      OnesweepPolicy;
+      ONESWEEP_RADIX_BITS>;
 
     // ScanPolicy
-    typedef AgentScanPolicy<512,
-                            23,
-                            OffsetT,
-                            BLOCK_LOAD_WARP_TRANSPOSE,
-                            LOAD_DEFAULT,
-                            BLOCK_STORE_WARP_TRANSPOSE,
-                            BLOCK_SCAN_RAKING_MEMOIZE>
-      ScanPolicy;
+    using ScanPolicy =
+      AgentScanPolicy<512,
+                      23,
+                      OffsetT,
+                      BLOCK_LOAD_WARP_TRANSPOSE,
+                      LOAD_DEFAULT,
+                      BLOCK_STORE_WARP_TRANSPOSE,
+                      BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
       384,
       31,
       DominantT,
@@ -1235,9 +1218,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MATCH,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      PRIMARY_RADIX_BITS>
-      DownsweepPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      PRIMARY_RADIX_BITS>;
+    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
       256,
       35,
       DominantT,
@@ -1245,15 +1227,14 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      PRIMARY_RADIX_BITS - 1>
-      AltDownsweepPolicy;
+      PRIMARY_RADIX_BITS - 1>;
 
     // Upsweep policies
-    typedef AgentRadixSortUpsweepPolicy<128, 16, DominantT, LOAD_LDG, PRIMARY_RADIX_BITS> UpsweepPolicy;
-    typedef AgentRadixSortUpsweepPolicy<128, 16, DominantT, LOAD_LDG, PRIMARY_RADIX_BITS - 1> AltUpsweepPolicy;
+    using UpsweepPolicy    = AgentRadixSortUpsweepPolicy<128, 16, DominantT, LOAD_LDG, PRIMARY_RADIX_BITS>;
+    using AltUpsweepPolicy = AgentRadixSortUpsweepPolicy<128, 16, DominantT, LOAD_LDG, PRIMARY_RADIX_BITS - 1>;
 
     // Single-tile policy
-    typedef AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
       256,
       19,
       DominantT,
@@ -1261,11 +1242,10 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SINGLE_TILE_RADIX_BITS>
-      SingleTilePolicy;
+      SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
       192,
       39,
       DominantT,
@@ -1273,9 +1253,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS>
-      SegmentedPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      SEGMENTED_RADIX_BITS>;
+    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
       384,
       11,
       DominantT,
@@ -1283,8 +1262,7 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS - 1>
-      AltSegmentedPolicy;
+      SEGMENTED_RADIX_BITS - 1>;
   };
 
   /// SM62 (Tegra, less RF)
@@ -1299,13 +1277,13 @@ struct DeviceRadixSortPolicy
     };
 
     // Histogram policy
-    typedef AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS> HistogramPolicy;
+    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    typedef AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS> ExclusiveSumPolicy;
+    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    typedef AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
       256,
       30,
       DominantT,
@@ -1313,21 +1291,20 @@ struct DeviceRadixSortPolicy
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_WARP_SCANS,
       RADIX_SORT_STORE_DIRECT,
-      ONESWEEP_RADIX_BITS>
-      OnesweepPolicy;
+      ONESWEEP_RADIX_BITS>;
 
     // ScanPolicy
-    typedef AgentScanPolicy<512,
-                            23,
-                            OffsetT,
-                            BLOCK_LOAD_WARP_TRANSPOSE,
-                            LOAD_DEFAULT,
-                            BLOCK_STORE_WARP_TRANSPOSE,
-                            BLOCK_SCAN_RAKING_MEMOIZE>
-      ScanPolicy;
+    using ScanPolicy =
+      AgentScanPolicy<512,
+                      23,
+                      OffsetT,
+                      BLOCK_LOAD_WARP_TRANSPOSE,
+                      LOAD_DEFAULT,
+                      BLOCK_STORE_WARP_TRANSPOSE,
+                      BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
       256,
       16,
       DominantT,
@@ -1335,9 +1312,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      PRIMARY_RADIX_BITS>
-      DownsweepPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      PRIMARY_RADIX_BITS>;
+    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
       256,
       16,
       DominantT,
@@ -1345,15 +1321,14 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_RAKING_MEMOIZE,
-      ALT_RADIX_BITS>
-      AltDownsweepPolicy;
+      ALT_RADIX_BITS>;
 
     // Upsweep policies
-    typedef DownsweepPolicy UpsweepPolicy;
-    typedef AltDownsweepPolicy AltUpsweepPolicy;
+    using UpsweepPolicy    = DownsweepPolicy;
+    using AltUpsweepPolicy = AltDownsweepPolicy;
 
     // Single-tile policy
-    typedef AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
       256,
       19,
       DominantT,
@@ -1361,12 +1336,11 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS>
-      SingleTilePolicy;
+      PRIMARY_RADIX_BITS>;
 
     // Segmented policies
-    typedef DownsweepPolicy SegmentedPolicy;
-    typedef AltDownsweepPolicy AltSegmentedPolicy;
+    using SegmentedPolicy    = DownsweepPolicy;
+    using AltSegmentedPolicy = AltDownsweepPolicy;
   };
 
   /// SM70 (GV100)
@@ -1383,13 +1357,13 @@ struct DeviceRadixSortPolicy
     };
 
     // Histogram policy
-    typedef AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS> HistogramPolicy;
+    using HistogramPolicy = AgentRadixSortHistogramPolicy<256, 8, 8, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    typedef AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS> ExclusiveSumPolicy;
+    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    typedef AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
       256,
       sizeof(KeyT) == 4 && sizeof(ValueT) == 4 ? 46 : 23,
       DominantT,
@@ -1397,21 +1371,20 @@ struct DeviceRadixSortPolicy
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_WARP_SCANS,
       RADIX_SORT_STORE_DIRECT,
-      ONESWEEP_RADIX_BITS>
-      OnesweepPolicy;
+      ONESWEEP_RADIX_BITS>;
 
     // ScanPolicy
-    typedef AgentScanPolicy<512,
-                            23,
-                            OffsetT,
-                            BLOCK_LOAD_WARP_TRANSPOSE,
-                            LOAD_DEFAULT,
-                            BLOCK_STORE_WARP_TRANSPOSE,
-                            BLOCK_SCAN_RAKING_MEMOIZE>
-      ScanPolicy;
+    using ScanPolicy =
+      AgentScanPolicy<512,
+                      23,
+                      OffsetT,
+                      BLOCK_LOAD_WARP_TRANSPOSE,
+                      LOAD_DEFAULT,
+                      BLOCK_STORE_WARP_TRANSPOSE,
+                      BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
       512,
       23,
       DominantT,
@@ -1419,9 +1392,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MATCH,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS>
-      DownsweepPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      PRIMARY_RADIX_BITS>;
+    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
       (sizeof(KeyT) > 1) ? 256 : 128,
       OFFSET_64BIT ? 46 : 47,
       DominantT,
@@ -1429,16 +1401,15 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS - 1>
-      AltDownsweepPolicy;
+      PRIMARY_RADIX_BITS - 1>;
 
     // Upsweep policies
-    typedef AgentRadixSortUpsweepPolicy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS> UpsweepPolicy;
-    typedef AgentRadixSortUpsweepPolicy<256, OFFSET_64BIT ? 46 : 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>
-      AltUpsweepPolicy;
+    using UpsweepPolicy = AgentRadixSortUpsweepPolicy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS>;
+    using AltUpsweepPolicy =
+      AgentRadixSortUpsweepPolicy<256, OFFSET_64BIT ? 46 : 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>;
 
     // Single-tile policy
-    typedef AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
       256,
       19,
       DominantT,
@@ -1446,11 +1417,10 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SINGLE_TILE_RADIX_BITS>
-      SingleTilePolicy;
+      SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
       192,
       39,
       DominantT,
@@ -1458,9 +1428,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS>
-      SegmentedPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      SEGMENTED_RADIX_BITS>;
+    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
       384,
       11,
       DominantT,
@@ -1468,8 +1437,7 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS - 1>
-      AltSegmentedPolicy;
+      SEGMENTED_RADIX_BITS - 1>;
   };
 
   /// SM80
@@ -1486,13 +1454,13 @@ struct DeviceRadixSortPolicy
     };
 
     // Histogram policy
-    typedef AgentRadixSortHistogramPolicy<128, 16, 1, KeyT, ONESWEEP_RADIX_BITS> HistogramPolicy;
+    using HistogramPolicy = AgentRadixSortHistogramPolicy<128, 16, 1, KeyT, ONESWEEP_RADIX_BITS>;
 
     // Exclusive sum policy
-    typedef AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS> ExclusiveSumPolicy;
+    using ExclusiveSumPolicy = AgentRadixSortExclusiveSumPolicy<256, ONESWEEP_RADIX_BITS>;
 
     // Onesweep policy
-    typedef AgentRadixSortOnesweepPolicy<
+    using OnesweepPolicy = AgentRadixSortOnesweepPolicy<
       384,
       OFFSET_64BIT && sizeof(KeyT) == 4 && !KEYS_ONLY ? 17 : 21,
       DominantT,
@@ -1500,21 +1468,20 @@ struct DeviceRadixSortPolicy
       RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
       BLOCK_SCAN_RAKING_MEMOIZE,
       RADIX_SORT_STORE_DIRECT,
-      ONESWEEP_RADIX_BITS>
-      OnesweepPolicy;
+      ONESWEEP_RADIX_BITS>;
 
     // ScanPolicy
-    typedef AgentScanPolicy<512,
-                            23,
-                            OffsetT,
-                            BLOCK_LOAD_WARP_TRANSPOSE,
-                            LOAD_DEFAULT,
-                            BLOCK_STORE_WARP_TRANSPOSE,
-                            BLOCK_SCAN_RAKING_MEMOIZE>
-      ScanPolicy;
+    using ScanPolicy =
+      AgentScanPolicy<512,
+                      23,
+                      OffsetT,
+                      BLOCK_LOAD_WARP_TRANSPOSE,
+                      LOAD_DEFAULT,
+                      BLOCK_STORE_WARP_TRANSPOSE,
+                      BLOCK_SCAN_RAKING_MEMOIZE>;
 
     // Downsweep policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using DownsweepPolicy = AgentRadixSortDownsweepPolicy<
       512,
       23,
       DominantT,
@@ -1522,9 +1489,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MATCH,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS>
-      DownsweepPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      PRIMARY_RADIX_BITS>;
+    using AltDownsweepPolicy = AgentRadixSortDownsweepPolicy<
       (sizeof(KeyT) > 1) ? 256 : 128,
       47,
       DominantT,
@@ -1532,15 +1498,14 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      PRIMARY_RADIX_BITS - 1>
-      AltDownsweepPolicy;
+      PRIMARY_RADIX_BITS - 1>;
 
     // Upsweep policies
-    typedef AgentRadixSortUpsweepPolicy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS> UpsweepPolicy;
-    typedef AgentRadixSortUpsweepPolicy<256, 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1> AltUpsweepPolicy;
+    using UpsweepPolicy    = AgentRadixSortUpsweepPolicy<256, 23, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS>;
+    using AltUpsweepPolicy = AgentRadixSortUpsweepPolicy<256, 47, DominantT, LOAD_DEFAULT, PRIMARY_RADIX_BITS - 1>;
 
     // Single-tile policy
-    typedef AgentRadixSortDownsweepPolicy<
+    using SingleTilePolicy = AgentRadixSortDownsweepPolicy<
       256,
       19,
       DominantT,
@@ -1548,11 +1513,10 @@ struct DeviceRadixSortPolicy
       LOAD_LDG,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SINGLE_TILE_RADIX_BITS>
-      SingleTilePolicy;
+      SINGLE_TILE_RADIX_BITS>;
 
     // Segmented policies
-    typedef AgentRadixSortDownsweepPolicy<
+    using SegmentedPolicy = AgentRadixSortDownsweepPolicy<
       192,
       39,
       DominantT,
@@ -1560,9 +1524,8 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS>
-      SegmentedPolicy;
-    typedef AgentRadixSortDownsweepPolicy<
+      SEGMENTED_RADIX_BITS>;
+    using AltSegmentedPolicy = AgentRadixSortDownsweepPolicy<
       384,
       11,
       DominantT,
@@ -1570,8 +1533,7 @@ struct DeviceRadixSortPolicy
       LOAD_DEFAULT,
       RADIX_RANK_MEMOIZE,
       BLOCK_SCAN_WARP_SCANS,
-      SEGMENTED_RADIX_BITS - 1>
-      AltSegmentedPolicy;
+      SEGMENTED_RADIX_BITS - 1>;
   };
 
   /// SM90
@@ -2113,10 +2075,10 @@ struct DispatchRadixSort : SelectedPolicy
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t InvokeOnesweep()
   {
-    typedef typename DispatchRadixSort::MaxPolicy MaxPolicyT;
+    using MaxPolicyT = typename DispatchRadixSort::MaxPolicy;
     // PortionOffsetT is used for offsets within a portion, and must be signed.
-    typedef int PortionOffsetT;
-    typedef PortionOffsetT AtomicOffsetT;
+    using PortionOffsetT = int;
+    using AtomicOffsetT  = PortionOffsetT;
 
     // compute temporary storage size
     constexpr int RADIX_BITS                = ActivePolicyT::ONESWEEP_RADIX_BITS;
@@ -2545,7 +2507,7 @@ struct DispatchRadixSort : SelectedPolicy
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t InvokeManyTiles(Int2Type<false>)
   {
     // Invoke upsweep-downsweep
-    typedef typename DispatchRadixSort::MaxPolicy MaxPolicyT;
+    using MaxPolicyT = typename DispatchRadixSort::MaxPolicy;
     return InvokePasses<ActivePolicyT>(
       DeviceRadixSortUpsweepKernel<MaxPolicyT, false, IS_DESCENDING, KeyT, OffsetT, DecomposerT>,
       DeviceRadixSortUpsweepKernel<MaxPolicyT, true, IS_DESCENDING, KeyT, OffsetT, DecomposerT>,
@@ -2619,8 +2581,8 @@ struct DispatchRadixSort : SelectedPolicy
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke()
   {
-    typedef typename DispatchRadixSort::MaxPolicy MaxPolicyT;
-    typedef typename ActivePolicyT::SingleTilePolicy SingleTilePolicyT;
+    using MaxPolicyT        = typename DispatchRadixSort::MaxPolicy;
+    using SingleTilePolicyT = typename ActivePolicyT::SingleTilePolicy;
 
     // Return if empty problem, or if no bits to sort and double-buffering is used
     if (num_items == 0 || (begin_bit == end_bit && is_overwrite_okay))
@@ -2710,7 +2672,7 @@ struct DispatchRadixSort : SelectedPolicy
     cudaStream_t stream,
     DecomposerT decomposer = {})
   {
-    typedef typename DispatchRadixSort::MaxPolicy MaxPolicyT;
+    using MaxPolicyT = typename DispatchRadixSort::MaxPolicy;
 
     cudaError_t error;
     do
@@ -3164,7 +3126,7 @@ struct DispatchSegmentedRadixSort : SelectedPolicy
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke()
   {
-    typedef typename DispatchSegmentedRadixSort::MaxPolicy MaxPolicyT;
+    using MaxPolicyT = typename DispatchSegmentedRadixSort::MaxPolicy;
 
     // Return if empty problem, or if no bits to sort and double-buffering is used
     if (num_items == 0 || num_segments == 0 || (begin_bit == end_bit && is_overwrite_okay))
@@ -3266,7 +3228,7 @@ struct DispatchSegmentedRadixSort : SelectedPolicy
     bool is_overwrite_okay,
     cudaStream_t stream)
   {
-    typedef typename DispatchSegmentedRadixSort::MaxPolicy MaxPolicyT;
+    using MaxPolicyT = typename DispatchSegmentedRadixSort::MaxPolicy;
 
     cudaError_t error;
     do

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -862,8 +862,8 @@ struct DispatchReduce : SelectedPolicy
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke()
   {
-    typedef typename ActivePolicyT::SingleTilePolicy SingleTilePolicyT;
-    typedef typename DispatchReduce::MaxPolicy MaxPolicyT;
+    using SingleTilePolicyT = typename ActivePolicyT::SingleTilePolicy;
+    using MaxPolicyT        = typename DispatchReduce::MaxPolicy;
 
     // Force kernel code-generation in all compiler passes
     if (num_items <= (SingleTilePolicyT::BLOCK_THREADS * SingleTilePolicyT::ITEMS_PER_THREAD))
@@ -940,7 +940,7 @@ struct DispatchReduce : SelectedPolicy
     cudaStream_t stream,
     TransformOpT transform_op = {})
   {
-    typedef typename DispatchReduce::MaxPolicy MaxPolicyT;
+    using MaxPolicyT = typename DispatchReduce::MaxPolicy;
 
     cudaError error = cudaSuccess;
     do
@@ -1260,7 +1260,7 @@ struct DispatchSegmentedReduce : SelectedPolicy
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke()
   {
-    typedef typename DispatchSegmentedReduce::MaxPolicy MaxPolicyT;
+    using MaxPolicyT = typename DispatchSegmentedReduce::MaxPolicy;
 
     // Force kernel code-generation in all compiler passes
     return InvokePasses<ActivePolicyT>(
@@ -1335,7 +1335,7 @@ struct DispatchSegmentedReduce : SelectedPolicy
     InitT init,
     cudaStream_t stream)
   {
-    typedef typename DispatchSegmentedReduce::MaxPolicy MaxPolicyT;
+    using MaxPolicyT = typename DispatchSegmentedReduce::MaxPolicy;
 
     if (num_segments <= 0)
     {

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -183,10 +183,10 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanPolicyT::BLOCK_THREADS))
     OffsetT num_items)
 {
   using RealInitValueT = typename InitValueT::value_type;
-  typedef typename ChainedPolicyT::ActivePolicy::ScanPolicyT ScanPolicyT;
+  using ScanPolicyT    = typename ChainedPolicyT::ActivePolicy::ScanPolicyT;
 
   // Thread block type for scanning input tiles
-  typedef AgentScan<ScanPolicyT, InputIteratorT, OutputIteratorT, ScanOpT, RealInitValueT, OffsetT, AccumT> AgentScanT;
+  using AgentScanT = AgentScan<ScanPolicyT, InputIteratorT, OutputIteratorT, ScanOpT, RealInitValueT, OffsetT, AccumT>;
 
   // Shared memory for AgentScan
   __shared__ typename AgentScanT::TempStorage temp_storage;
@@ -350,8 +350,8 @@ struct DispatchScan : SelectedPolicy
   template <typename ActivePolicyT, typename InitKernel, typename ScanKernel>
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t Invoke(InitKernel init_kernel, ScanKernel scan_kernel)
   {
-    typedef typename ActivePolicyT::ScanPolicyT Policy;
-    typedef typename cub::ScanTileState<AccumT> ScanTileStateT;
+    using Policy         = typename ActivePolicyT::ScanPolicyT;
+    using ScanTileStateT = typename cub::ScanTileState<AccumT>;
 
     // `LOAD_LDG` makes in-place execution UB and doesn't lead to better
     // performance.
@@ -498,8 +498,8 @@ struct DispatchScan : SelectedPolicy
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION _CCCL_HOST _CCCL_FORCEINLINE cudaError_t Invoke()
   {
-    typedef typename DispatchScan::MaxPolicy MaxPolicyT;
-    typedef typename cub::ScanTileState<AccumT> ScanTileStateT;
+    using MaxPolicyT     = typename DispatchScan::MaxPolicy;
+    using ScanTileStateT = typename cub::ScanTileState<AccumT>;
     // Ensure kernels are instantiated.
     return Invoke<ActivePolicyT>(
       DeviceScanInitKernel<ScanTileStateT>,
@@ -547,7 +547,7 @@ struct DispatchScan : SelectedPolicy
     OffsetT num_items,
     cudaStream_t stream)
   {
-    typedef typename DispatchScan::MaxPolicy MaxPolicyT;
+    using MaxPolicyT = typename DispatchScan::MaxPolicy;
 
     cudaError_t error;
     do

--- a/cub/cub/device/dispatch/dispatch_spmv_orig.cuh
+++ b/cub/cub/device/dispatch/dispatch_spmv_orig.cuh
@@ -87,8 +87,8 @@ CUB_NAMESPACE_BEGIN
 template <typename AgentSpmvPolicyT, typename ValueT, typename OffsetT>
 CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceSpmv1ColKernel(SpmvParams<ValueT, OffsetT> spmv_params)
 {
-  typedef CacheModifiedInputIterator<AgentSpmvPolicyT::VECTOR_VALUES_LOAD_MODIFIER, ValueT, OffsetT>
-    VectorValueIteratorT;
+  using VectorValueIteratorT =
+    CacheModifiedInputIterator<AgentSpmvPolicyT::VECTOR_VALUES_LOAD_MODIFIER, ValueT, OffsetT>;
 
   VectorValueIteratorT wrapped_vector_x(spmv_params.d_vector_x);
 
@@ -144,8 +144,8 @@ DeviceSpmvSearchKernel(int num_merge_tiles, CoordinateT* d_tile_coordinates, Spm
     TILE_ITEMS       = BLOCK_THREADS * ITEMS_PER_THREAD,
   };
 
-  typedef CacheModifiedInputIterator<SpmvPolicyT::ROW_OFFSETS_SEARCH_LOAD_MODIFIER, OffsetT, OffsetT>
-    RowOffsetsSearchIteratorT;
+  using RowOffsetsSearchIteratorT =
+    CacheModifiedInputIterator<SpmvPolicyT::ROW_OFFSETS_SEARCH_LOAD_MODIFIER, OffsetT, OffsetT>;
 
   // Find the starting coordinate for all tiles (plus the end coordinate of the last one)
   int tile_idx = (blockIdx.x * blockDim.x) + threadIdx.x;
@@ -227,7 +227,7 @@ __launch_bounds__(int(SpmvPolicyT::BLOCK_THREADS)) CUB_DETAIL_KERNEL_ATTRIBUTES 
   int num_segment_fixup_tiles)
 {
   // Spmv agent type specialization
-  typedef AgentSpmv<SpmvPolicyT, ValueT, OffsetT, HAS_ALPHA, HAS_BETA> AgentSpmvT;
+  using AgentSpmvT = AgentSpmv<SpmvPolicyT, ValueT, OffsetT, HAS_ALPHA, HAS_BETA>;
 
   // Shared memory for AgentSpmv
   __shared__ typename AgentSpmvT::TempStorage temp_storage;
@@ -313,13 +313,13 @@ __launch_bounds__(int(AgentSegmentFixupPolicyT::BLOCK_THREADS))
     ScanTileStateT tile_state)
 {
   // Thread block type for reducing tiles of value segments
-  typedef AgentSegmentFixup<AgentSegmentFixupPolicyT,
-                            PairsInputIteratorT,
-                            AggregatesOutputIteratorT,
-                            cub::Equality,
-                            cub::Sum,
-                            OffsetT>
-    AgentSegmentFixupT;
+  using AgentSegmentFixupT =
+    AgentSegmentFixup<AgentSegmentFixupPolicyT,
+                      PairsInputIteratorT,
+                      AggregatesOutputIteratorT,
+                      cub::Equality,
+                      cub::Sum,
+                      OffsetT>;
 
   // Shared memory for AgentSegmentFixup
   __shared__ typename AgentSegmentFixupT::TempStorage temp_storage;
@@ -356,16 +356,16 @@ struct DispatchSpmv
   };
 
   // SpmvParams bundle type
-  typedef SpmvParams<ValueT, OffsetT> SpmvParamsT;
+  using SpmvParamsT = SpmvParams<ValueT, OffsetT>;
 
   // 2D merge path coordinate type
-  typedef typename CubVector<OffsetT, 2>::Type CoordinateT;
+  using CoordinateT = typename CubVector<OffsetT, 2>::Type;
 
   // Tile status descriptor interface type
-  typedef ReduceByKeyScanTileState<ValueT, OffsetT> ScanTileStateT;
+  using ScanTileStateT = ReduceByKeyScanTileState<ValueT, OffsetT>;
 
   // Tuple type for scanning (pairs accumulated segment-value with segment-index)
-  typedef KeyValuePair<OffsetT, ValueT> KeyValuePairT;
+  using KeyValuePairT = KeyValuePair<OffsetT, ValueT>;
 
   //---------------------------------------------------------------------
   // Tuning policies
@@ -374,70 +374,70 @@ struct DispatchSpmv
   /// SM35
   struct Policy350
   {
-    typedef AgentSpmvPolicy<(sizeof(ValueT) > 4) ? 96 : 128,
-                            (sizeof(ValueT) > 4) ? 4 : 7,
-                            LOAD_LDG,
-                            LOAD_CA,
-                            LOAD_LDG,
-                            LOAD_LDG,
-                            LOAD_LDG,
-                            (sizeof(ValueT) > 4) ? true : false,
-                            BLOCK_SCAN_WARP_SCANS>
-      SpmvPolicyT;
+    using SpmvPolicyT =
+      AgentSpmvPolicy<(sizeof(ValueT) > 4) ? 96 : 128,
+                      (sizeof(ValueT) > 4) ? 4 : 7,
+                      LOAD_LDG,
+                      LOAD_CA,
+                      LOAD_LDG,
+                      LOAD_LDG,
+                      LOAD_LDG,
+                      (sizeof(ValueT) > 4) ? true : false,
+                      BLOCK_SCAN_WARP_SCANS>;
 
-    typedef AgentSegmentFixupPolicy<128, 3, BLOCK_LOAD_VECTORIZE, LOAD_LDG, BLOCK_SCAN_WARP_SCANS> SegmentFixupPolicyT;
+    using SegmentFixupPolicyT = AgentSegmentFixupPolicy<128, 3, BLOCK_LOAD_VECTORIZE, LOAD_LDG, BLOCK_SCAN_WARP_SCANS>;
   };
 
   /// SM37
   struct Policy370
   {
-    typedef AgentSpmvPolicy<(sizeof(ValueT) > 4) ? 128 : 128,
-                            (sizeof(ValueT) > 4) ? 9 : 14,
-                            LOAD_LDG,
-                            LOAD_CA,
-                            LOAD_LDG,
-                            LOAD_LDG,
-                            LOAD_LDG,
-                            false,
-                            BLOCK_SCAN_WARP_SCANS>
-      SpmvPolicyT;
+    using SpmvPolicyT =
+      AgentSpmvPolicy<(sizeof(ValueT) > 4) ? 128 : 128,
+                      (sizeof(ValueT) > 4) ? 9 : 14,
+                      LOAD_LDG,
+                      LOAD_CA,
+                      LOAD_LDG,
+                      LOAD_LDG,
+                      LOAD_LDG,
+                      false,
+                      BLOCK_SCAN_WARP_SCANS>;
 
-    typedef AgentSegmentFixupPolicy<128, 3, BLOCK_LOAD_VECTORIZE, LOAD_LDG, BLOCK_SCAN_WARP_SCANS> SegmentFixupPolicyT;
+    using SegmentFixupPolicyT = AgentSegmentFixupPolicy<128, 3, BLOCK_LOAD_VECTORIZE, LOAD_LDG, BLOCK_SCAN_WARP_SCANS>;
   };
 
   /// SM50
   struct Policy500
   {
-    typedef AgentSpmvPolicy<(sizeof(ValueT) > 4) ? 64 : 128,
-                            (sizeof(ValueT) > 4) ? 6 : 7,
-                            LOAD_LDG,
-                            LOAD_DEFAULT,
-                            (sizeof(ValueT) > 4) ? LOAD_LDG : LOAD_DEFAULT,
-                            (sizeof(ValueT) > 4) ? LOAD_LDG : LOAD_DEFAULT,
-                            LOAD_LDG,
-                            (sizeof(ValueT) > 4) ? true : false,
-                            (sizeof(ValueT) > 4) ? BLOCK_SCAN_WARP_SCANS : BLOCK_SCAN_RAKING_MEMOIZE>
-      SpmvPolicyT;
+    using SpmvPolicyT =
+      AgentSpmvPolicy<(sizeof(ValueT) > 4) ? 64 : 128,
+                      (sizeof(ValueT) > 4) ? 6 : 7,
+                      LOAD_LDG,
+                      LOAD_DEFAULT,
+                      (sizeof(ValueT) > 4) ? LOAD_LDG : LOAD_DEFAULT,
+                      (sizeof(ValueT) > 4) ? LOAD_LDG : LOAD_DEFAULT,
+                      LOAD_LDG,
+                      (sizeof(ValueT) > 4) ? true : false,
+                      (sizeof(ValueT) > 4) ? BLOCK_SCAN_WARP_SCANS : BLOCK_SCAN_RAKING_MEMOIZE>;
 
-    typedef AgentSegmentFixupPolicy<128, 3, BLOCK_LOAD_VECTORIZE, LOAD_LDG, BLOCK_SCAN_RAKING_MEMOIZE>
-      SegmentFixupPolicyT;
+    using SegmentFixupPolicyT =
+      AgentSegmentFixupPolicy<128, 3, BLOCK_LOAD_VECTORIZE, LOAD_LDG, BLOCK_SCAN_RAKING_MEMOIZE>;
   };
 
   /// SM60
   struct Policy600
   {
-    typedef AgentSpmvPolicy<(sizeof(ValueT) > 4) ? 64 : 128,
-                            (sizeof(ValueT) > 4) ? 5 : 7,
-                            LOAD_DEFAULT,
-                            LOAD_DEFAULT,
-                            LOAD_DEFAULT,
-                            LOAD_DEFAULT,
-                            LOAD_DEFAULT,
-                            false,
-                            BLOCK_SCAN_WARP_SCANS>
-      SpmvPolicyT;
+    using SpmvPolicyT =
+      AgentSpmvPolicy<(sizeof(ValueT) > 4) ? 64 : 128,
+                      (sizeof(ValueT) > 4) ? 5 : 7,
+                      LOAD_DEFAULT,
+                      LOAD_DEFAULT,
+                      LOAD_DEFAULT,
+                      LOAD_DEFAULT,
+                      LOAD_DEFAULT,
+                      false,
+                      BLOCK_SCAN_WARP_SCANS>;
 
-    typedef AgentSegmentFixupPolicy<128, 3, BLOCK_LOAD_DIRECT, LOAD_LDG, BLOCK_SCAN_WARP_SCANS> SegmentFixupPolicyT;
+    using SegmentFixupPolicyT = AgentSegmentFixupPolicy<128, 3, BLOCK_LOAD_DIRECT, LOAD_LDG, BLOCK_SCAN_WARP_SCANS>;
   };
 
   //---------------------------------------------------------------------
@@ -445,16 +445,16 @@ struct DispatchSpmv
   //---------------------------------------------------------------------
 
 #if (CUB_PTX_ARCH >= 600)
-  typedef Policy600 PtxPolicy;
+  using PtxPolicy = Policy600;
 
 #elif (CUB_PTX_ARCH >= 500)
-  typedef Policy500 PtxPolicy;
+  using PtxPolicy = Policy500;
 
 #elif (CUB_PTX_ARCH >= 370)
-  typedef Policy370 PtxPolicy;
+  using PtxPolicy = Policy370;
 
 #else
-  typedef Policy350 PtxPolicy;
+  using PtxPolicy = Policy350;
 
 #endif
 

--- a/cub/cub/grid/grid_barrier.cuh
+++ b/cub/cub/grid/grid_barrier.cuh
@@ -54,7 +54,7 @@ CUB_NAMESPACE_BEGIN
 class GridBarrier
 {
 protected:
-  typedef unsigned int SyncFlag;
+  using SyncFlag = unsigned int;
 
   // Counters in global device memory
   SyncFlag* d_sync;

--- a/cub/cub/iterator/arg_index_input_iterator.cuh
+++ b/cub/cub/iterator/arg_index_input_iterator.cuh
@@ -87,7 +87,7 @@ CUB_NAMESPACE_BEGIN
  * cub::ArgIndexInputIterator<double*> itr(d_in);
  *
  * // Within device code:
- * typedef typename cub::ArgIndexInputIterator<double*>::value_type Tuple;
+ * using Tuple = typename cub::ArgIndexInputIterator<double*>::value_type;
  * Tuple item_offset_pair.key = *itr;
  * printf("%f @ %d\n",
  *   item_offset_pair.value,
@@ -119,32 +119,32 @@ public:
   // Required iterator traits
 
   /// My own type
-  typedef ArgIndexInputIterator self_type;
+  using self_type = ArgIndexInputIterator;
 
   /// Type to express the result of subtracting one iterator from another
-  typedef OffsetT difference_type;
+  using difference_type = OffsetT;
 
   /// The type of the element the iterator can point to
-  typedef KeyValuePair<difference_type, OutputValueT> value_type;
+  using value_type = KeyValuePair<difference_type, OutputValueT>;
 
   /// The type of a pointer to an element the iterator can point to
-  typedef value_type* pointer;
+  using pointer = value_type*;
 
   /// The type of a reference to an element the iterator can point to
-  typedef value_type reference;
+  using reference = value_type;
 
 #if (THRUST_VERSION >= 100700)
   // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
 
   /// The iterator category
-  typedef typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
+  using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::any_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
-    reference>::type iterator_category;
+    reference>::type;
 #else
   /// The iterator category
-  typedef std::random_access_iterator_tag iterator_category;
+  using iterator_category = std::random_access_iterator_tag;
 #endif // THRUST_VERSION
 
 private:

--- a/cub/cub/iterator/cache_modified_input_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_input_iterator.cuh
@@ -112,19 +112,19 @@ public:
   // Required iterator traits
 
   /// My own type
-  typedef CacheModifiedInputIterator self_type;
+  using self_type = CacheModifiedInputIterator;
 
   /// Type to express the result of subtracting one iterator from another
-  typedef OffsetT difference_type;
+  using difference_type = OffsetT;
 
   /// The type of the element the iterator can point to
-  typedef ValueType value_type;
+  using value_type = ValueType;
 
   /// The type of a pointer to an element the iterator can point to
-  typedef ValueType* pointer;
+  using pointer = ValueType*;
 
   /// The type of a reference to an element the iterator can point to
-  typedef ValueType reference;
+  using reference = ValueType;
 
 #if !defined(_CCCL_COMPILER_NVRTC)
 #  if (THRUST_VERSION >= 100700)

--- a/cub/cub/iterator/cache_modified_output_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_output_iterator.cuh
@@ -129,32 +129,32 @@ public:
   // Required iterator traits
 
   /// My own type
-  typedef CacheModifiedOutputIterator self_type;
+  using self_type = CacheModifiedOutputIterator;
 
   /// Type to express the result of subtracting one iterator from another
-  typedef OffsetT difference_type;
+  using difference_type = OffsetT;
 
   /// The type of the element the iterator can point to
-  typedef void value_type;
+  using value_type = void;
 
   /// The type of a pointer to an element the iterator can point to
-  typedef void pointer;
+  using pointer = void;
 
   /// The type of a reference to an element the iterator can point to
-  typedef Reference reference;
+  using reference = Reference;
 
 #if (THRUST_VERSION >= 100700)
   // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
 
   /// The iterator category
-  typedef typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
+  using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::device_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
-    reference>::type iterator_category;
+    reference>::type;
 #else
   /// The iterator category
-  typedef std::random_access_iterator_tag iterator_category;
+  using iterator_category = std::random_access_iterator_tag;
 #endif // THRUST_VERSION
 
 private:

--- a/cub/cub/iterator/constant_input_iterator.cuh
+++ b/cub/cub/iterator/constant_input_iterator.cuh
@@ -97,32 +97,32 @@ public:
   // Required iterator traits
 
   /// My own type
-  typedef ConstantInputIterator self_type;
+  using self_type = ConstantInputIterator;
 
   /// Type to express the result of subtracting one iterator from another
-  typedef OffsetT difference_type;
+  using difference_type = OffsetT;
 
   /// The type of the element the iterator can point to
-  typedef ValueType value_type;
+  using value_type = ValueType;
 
   /// The type of a pointer to an element the iterator can point to
-  typedef ValueType* pointer;
+  using pointer = ValueType*;
 
   /// The type of a reference to an element the iterator can point to
-  typedef ValueType reference;
+  using reference = ValueType;
 
 #if (THRUST_VERSION >= 100700)
   // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
 
   /// The iterator category
-  typedef typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
+  using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::any_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
-    reference>::type iterator_category;
+    reference>::type;
 #else
   /// The iterator category
-  typedef std::random_access_iterator_tag iterator_category;
+  using iterator_category = std::random_access_iterator_tag;
 #endif // THRUST_VERSION
 
 private:

--- a/cub/cub/iterator/counting_input_iterator.cuh
+++ b/cub/cub/iterator/counting_input_iterator.cuh
@@ -102,19 +102,19 @@ public:
   // Required iterator traits
 
   /// My own type
-  typedef CountingInputIterator self_type;
+  using self_type = CountingInputIterator;
 
   /// Type to express the result of subtracting one iterator from another
-  typedef OffsetT difference_type;
+  using difference_type = OffsetT;
 
   /// The type of the element the iterator can point to
-  typedef ValueType value_type;
+  using value_type = ValueType;
 
   /// The type of a pointer to an element the iterator can point to
-  typedef ValueType* pointer;
+  using pointer = ValueType*;
 
   /// The type of a reference to an element the iterator can point to
-  typedef ValueType reference;
+  using reference = ValueType;
 
 #if !defined(_CCCL_COMPILER_NVRTC)
 #  if (THRUST_VERSION >= 100700)

--- a/cub/cub/iterator/discard_output_iterator.cuh
+++ b/cub/cub/iterator/discard_output_iterator.cuh
@@ -64,32 +64,32 @@ public:
   // Required iterator traits
 
   /// My own type
-  typedef DiscardOutputIterator self_type;
+  using self_type = DiscardOutputIterator;
 
   /// Type to express the result of subtracting one iterator from another
-  typedef OffsetT difference_type;
+  using difference_type = OffsetT;
 
   /// The type of the element the iterator can point to
-  typedef void value_type;
+  using value_type = void;
 
   /// The type of a pointer to an element the iterator can point to
-  typedef void pointer;
+  using pointer = void;
 
   /// The type of a reference to an element the iterator can point to
-  typedef void reference;
+  using reference = void;
 
 #if (THRUST_VERSION >= 100700)
   // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
 
   /// The iterator category
-  typedef typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
+  using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::any_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
-    reference>::type iterator_category;
+    reference>::type;
 #else
   /// The iterator category
-  typedef std::random_access_iterator_tag iterator_category;
+  using iterator_category = std::random_access_iterator_tag;
 #endif // THRUST_VERSION
 
 private:

--- a/cub/cub/iterator/tex_obj_input_iterator.cuh
+++ b/cub/cub/iterator/tex_obj_input_iterator.cuh
@@ -114,37 +114,37 @@ public:
   // Required iterator traits
 
   /// My own type
-  typedef TexObjInputIterator self_type;
+  using self_type = TexObjInputIterator;
 
   /// Type to express the result of subtracting one iterator from another
-  typedef OffsetT difference_type;
+  using difference_type = OffsetT;
 
   /// The type of the element the iterator can point to
-  typedef T value_type;
+  using value_type = T;
 
   /// The type of a pointer to an element the iterator can point to
-  typedef T* pointer;
+  using pointer = T*;
 
   /// The type of a reference to an element the iterator can point to
-  typedef T reference;
+  using reference = T;
 
 #if (THRUST_VERSION >= 100700)
   // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
 
   /// The iterator category
-  typedef typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
+  using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::device_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
-    reference>::type iterator_category;
+    reference>::type;
 #else
   /// The iterator category
-  typedef std::random_access_iterator_tag iterator_category;
+  using iterator_category = std::random_access_iterator_tag;
 #endif // THRUST_VERSION
 
 private:
   // Largest texture word we can use in device
-  typedef typename UnitWord<T>::TextureWord TextureWord;
+  using TextureWord = typename UnitWord<T>::TextureWord;
 
   // Number of texture words per T
   enum

--- a/cub/cub/iterator/transform_input_iterator.cuh
+++ b/cub/cub/iterator/transform_input_iterator.cuh
@@ -120,32 +120,32 @@ public:
   // Required iterator traits
 
   /// My own type
-  typedef TransformInputIterator self_type;
+  using self_type = TransformInputIterator;
 
   /// Type to express the result of subtracting one iterator from another
-  typedef OffsetT difference_type;
+  using difference_type = OffsetT;
 
   /// The type of the element the iterator can point to
-  typedef ValueType value_type;
+  using value_type = ValueType;
 
   /// The type of a pointer to an element the iterator can point to
-  typedef ValueType* pointer;
+  using pointer = ValueType*;
 
   /// The type of a reference to an element the iterator can point to
-  typedef ValueType reference;
+  using reference = ValueType;
 
 #if (THRUST_VERSION >= 100700)
   // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
 
   /// The iterator category
-  typedef typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
+  using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::any_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
-    reference>::type iterator_category;
+    reference>::type;
 #else
   /// The iterator category
-  typedef std::random_access_iterator_tag iterator_category;
+  using iterator_category = std::random_access_iterator_tag;
 #endif // THRUST_VERSION
 
 private:

--- a/cub/cub/thread/thread_load.cuh
+++ b/cub/cub/thread/thread_load.cuh
@@ -342,7 +342,7 @@ template <typename T>
 _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadLoadVolatilePointer(T* ptr, Int2Type<false> /*is_primitive*/)
 {
   // Word type for memcopying
-  typedef typename UnitWord<T>::VolatileWord VolatileWord;
+  using VolatileWord = typename UnitWord<T>::VolatileWord;
 
   constexpr int VOLATILE_MULTIPLE = sizeof(T) / sizeof(VolatileWord);
 
@@ -368,7 +368,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadLoad(T* ptr, Int2Type<LOAD_VOLATILE> /*mo
 template <typename T, int MODIFIER>
 _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadLoad(T const* ptr, Int2Type<MODIFIER> /*modifier*/, Int2Type<true> /*is_pointer*/)
 {
-  typedef typename UnitWord<T>::DeviceWord DeviceWord;
+  using DeviceWord = typename UnitWord<T>::DeviceWord;
 
   constexpr int DEVICE_MULTIPLE = sizeof(T) / sizeof(DeviceWord);
 

--- a/cub/cub/thread/thread_store.cuh
+++ b/cub/cub/thread/thread_store.cuh
@@ -291,8 +291,8 @@ template <typename T>
 _CCCL_DEVICE _CCCL_FORCEINLINE void ThreadStoreVolatilePtr(T* ptr, T val, Int2Type<false> /*is_primitive*/)
 {
   // Create a temporary using shuffle-words, then store using volatile-words
-  typedef typename UnitWord<T>::VolatileWord VolatileWord;
-  typedef typename UnitWord<T>::ShuffleWord ShuffleWord;
+  using VolatileWord = typename UnitWord<T>::VolatileWord;
+  using ShuffleWord  = typename UnitWord<T>::ShuffleWord;
 
   constexpr int VOLATILE_MULTIPLE = sizeof(T) / sizeof(VolatileWord);
   constexpr int SHUFFLE_MULTIPLE  = sizeof(T) / sizeof(ShuffleWord);
@@ -326,8 +326,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void
 ThreadStore(T* ptr, T val, Int2Type<MODIFIER> /*modifier*/, Int2Type<true> /*is_pointer*/)
 {
   // Create a temporary using shuffle-words, then store using device-words
-  typedef typename UnitWord<T>::DeviceWord DeviceWord;
-  typedef typename UnitWord<T>::ShuffleWord ShuffleWord;
+  using DeviceWord  = typename UnitWord<T>::DeviceWord;
+  using ShuffleWord = typename UnitWord<T>::ShuffleWord;
 
   constexpr int DEVICE_MULTIPLE  = sizeof(T) / sizeof(DeviceWord);
   constexpr int SHUFFLE_MULTIPLE = sizeof(T) / sizeof(ShuffleWord);

--- a/cub/cub/util_allocator.cuh
+++ b/cub/cub/util_allocator.cuh
@@ -191,7 +191,7 @@ struct CachingDeviceAllocator
   };
 
   /// BlockDescriptor comparator function interface
-  typedef bool (*Compare)(const BlockDescriptor&, const BlockDescriptor&);
+  using Compare = bool (*)(const BlockDescriptor&, const BlockDescriptor&);
 
   class TotalBytes
   {
@@ -205,13 +205,13 @@ struct CachingDeviceAllocator
   };
 
   /// Set type for cached blocks (ordered by size)
-  typedef std::multiset<BlockDescriptor, Compare> CachedBlocks;
+  using CachedBlocks = std::multiset<BlockDescriptor, Compare>;
 
   /// Set type for live blocks (ordered by ptr)
-  typedef std::multiset<BlockDescriptor, Compare> BusyBlocks;
+  using BusyBlocks = std::multiset<BlockDescriptor, Compare>;
 
   /// Map type of device ordinals to the number of cached bytes cached by each device
-  typedef std::map<int, TotalBytes> GpuCachedBytes;
+  using GpuCachedBytes = std::map<int, TotalBytes>;
 
   //---------------------------------------------------------------------
   // Utility functions

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -319,7 +319,7 @@ CUB_RUNTIME_FUNCTION inline cudaError_t PtxVersionUncached(int& ptx_version)
 {
   // Instantiate `EmptyKernel<void>` in both host and device code to ensure
   // it can be called.
-  typedef void (*EmptyKernelPtr)();
+  using EmptyKernelPtr        = void (*)();
   EmptyKernelPtr empty_kernel = EmptyKernel<void>;
 
   // This is necessary for unused variable warnings in host compilers. The
@@ -693,7 +693,7 @@ template <int PTX_VERSION, typename PolicyT>
 struct ChainedPolicy<PTX_VERSION, PolicyT, PolicyT>
 {
   /// The policy for the active compiler pass
-  typedef PolicyT ActivePolicy;
+  using ActivePolicy = PolicyT;
 
   /// Specializes and dispatches op in accordance to the first policy in the chain of adequate PTX version
   template <typename FunctorT>

--- a/cub/cub/util_ptx.cuh
+++ b/cub/cub/util_ptx.cuh
@@ -527,7 +527,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleUp(T input, int src_offset, int first_th
     SHFL_C = (32 - LOGICAL_WARP_THREADS) << 8
   };
 
-  typedef typename UnitWord<T>::ShuffleWord ShuffleWord;
+  using ShuffleWord = typename UnitWord<T>::ShuffleWord;
 
   constexpr int WORDS = (sizeof(T) + sizeof(ShuffleWord) - 1) / sizeof(ShuffleWord);
 
@@ -608,7 +608,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleDown(T input, int src_offset, int last_t
     SHFL_C = (32 - LOGICAL_WARP_THREADS) << 8
   };
 
-  typedef typename UnitWord<T>::ShuffleWord ShuffleWord;
+  using ShuffleWord = typename UnitWord<T>::ShuffleWord;
 
   constexpr int WORDS = (sizeof(T) + sizeof(ShuffleWord) - 1) / sizeof(ShuffleWord);
 
@@ -688,7 +688,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleIndex(T input, int src_lane, unsigned in
     SHFL_C = ((32 - LOGICAL_WARP_THREADS) << 8) | (LOGICAL_WARP_THREADS - 1)
   };
 
-  typedef typename UnitWord<T>::ShuffleWord ShuffleWord;
+  using ShuffleWord = typename UnitWord<T>::ShuffleWord;
 
   constexpr int WORDS = (sizeof(T) + sizeof(ShuffleWord) - 1) / sizeof(ShuffleWord);
 

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -339,22 +339,23 @@ struct AlignBytes
   };
 
   /// The "truly aligned" type
-  typedef T Type;
+  using Type = T;
 };
 
 // Specializations where host C++ compilers (e.g., 32-bit Windows) may disagree
 // with device C++ compilers (EDG) on types passed as template parameters through
 // kernel functions
 
-#  define __CUB_ALIGN_BYTES(t, b)  \
-    template <>                    \
-    struct AlignBytes<t>           \
-    {                              \
-      enum                         \
-      {                            \
-        ALIGN_BYTES = b            \
-      };                           \
-      typedef __align__(b) t Type; \
+#  define __CUB_ALIGN_BYTES(t, b)                                                                  \
+    template <>                                                                                    \
+    struct AlignBytes<t>                                                                           \
+    {                                                                                              \
+      enum                                                                                         \
+      {                                                                                            \
+        ALIGN_BYTES = b                                                                            \
+      };                                                                                           \
+      typedef __align__(b) t Type;                                                                 \
+      /* TODO(bgruber): rewriting the above to using Type __align__(b) = t; does not compile :S */ \
     };
 
 __CUB_ALIGN_BYTES(short4, 8)
@@ -436,30 +437,30 @@ struct UnitWord
 template <>
 struct UnitWord<float2>
 {
-  typedef int ShuffleWord;
-  typedef unsigned long long VolatileWord;
-  typedef unsigned long long DeviceWord;
-  typedef float2 TextureWord;
+  using ShuffleWord  = int;
+  using VolatileWord = unsigned long long;
+  using DeviceWord   = unsigned long long;
+  using TextureWord  = float2;
 };
 
 // float4 specialization workaround (for SM10-SM13)
 template <>
 struct UnitWord<float4>
 {
-  typedef int ShuffleWord;
-  typedef unsigned long long VolatileWord;
-  typedef ulonglong2 DeviceWord;
-  typedef float4 TextureWord;
+  using ShuffleWord  = int;
+  using VolatileWord = unsigned long long;
+  using DeviceWord   = ulonglong2;
+  using TextureWord  = float4;
 };
 
 // char2 specialization workaround (for SM10-SM13)
 template <>
 struct UnitWord<char2>
 {
-  typedef unsigned short ShuffleWord;
-  typedef unsigned short VolatileWord;
-  typedef unsigned short DeviceWord;
-  typedef unsigned short TextureWord;
+  using ShuffleWord  = unsigned short;
+  using VolatileWord = unsigned short;
+  using DeviceWord   = unsigned short;
+  using TextureWord  = unsigned short;
 };
 
 // clang-format off
@@ -473,7 +474,7 @@ template <typename T> struct UnitWord<const volatile T> : UnitWord<T> {};
  ******************************************************************************/
 
 /**
- * \brief Exposes a member typedef \p Type that names the corresponding CUDA vector type if one exists.  Otherwise \p
+ * \brief Exposes a member alias \p Type that names the corresponding CUDA vector type if one exists.  Otherwise \p
  * Type refers to the CubVector structure itself, which will wrap the corresponding \p x, \p y, etc. vector fields.
  */
 template <typename T, int vec_elements>
@@ -496,8 +497,8 @@ struct CubVector<T, 1>
 {
   T x;
 
-  typedef T BaseType;
-  typedef CubVector<T, 1> Type;
+  using BaseType = T;
+  using Type     = CubVector<T, 1>;
 };
 
 /**
@@ -509,8 +510,8 @@ struct CubVector<T, 2>
   T x;
   T y;
 
-  typedef T BaseType;
-  typedef CubVector<T, 2> Type;
+  using BaseType = T;
+  using Type     = CubVector<T, 2>;
 };
 
 /**
@@ -523,8 +524,8 @@ struct CubVector<T, 3>
   T y;
   T z;
 
-  typedef T BaseType;
-  typedef CubVector<T, 3> Type;
+  using BaseType = T;
+  using Type     = CubVector<T, 3>;
 };
 
 /**
@@ -538,8 +539,8 @@ struct CubVector<T, 4>
   T z;
   T w;
 
-  typedef T BaseType;
-  typedef CubVector<T, 4> Type;
+  using BaseType = T;
+  using Type     = CubVector<T, 4>;
 };
 
 /**
@@ -550,8 +551,8 @@ struct CubVector<T, 4>
     template <>                                                                             \
     struct CubVector<base_type, 1> : short_type##1                                          \
     {                                                                                       \
-      typedef base_type BaseType;                                                           \
-      typedef short_type##1 Type;                                                           \
+      using BaseType = base_type;                                                           \
+      using Type     = short_type##1;                                                       \
       _CCCL_HOST_DEVICE _CCCL_FORCEINLINE CubVector operator+(const CubVector& other) const \
       {                                                                                     \
         CubVector retval;                                                                   \
@@ -569,8 +570,8 @@ struct CubVector<T, 4>
     template <>                                                                             \
     struct CubVector<base_type, 2> : short_type##2                                          \
     {                                                                                       \
-      typedef base_type BaseType;                                                           \
-      typedef short_type##2 Type;                                                           \
+      using BaseType = base_type;                                                           \
+      using Type     = short_type##2;                                                       \
       _CCCL_HOST_DEVICE _CCCL_FORCEINLINE CubVector operator+(const CubVector& other) const \
       {                                                                                     \
         CubVector retval;                                                                   \
@@ -590,8 +591,8 @@ struct CubVector<T, 4>
     template <>                                                                             \
     struct CubVector<base_type, 3> : short_type##3                                          \
     {                                                                                       \
-      typedef base_type BaseType;                                                           \
-      typedef short_type##3 Type;                                                           \
+      using BaseType = base_type;                                                           \
+      using Type     = short_type##3;                                                       \
       _CCCL_HOST_DEVICE _CCCL_FORCEINLINE CubVector operator+(const CubVector& other) const \
       {                                                                                     \
         CubVector retval;                                                                   \
@@ -613,8 +614,8 @@ struct CubVector<T, 4>
     template <>                                                                             \
     struct CubVector<base_type, 4> : short_type##4                                          \
     {                                                                                       \
-      typedef base_type BaseType;                                                           \
-      typedef short_type##4 Type;                                                           \
+      using BaseType = base_type;                                                           \
+      using Type     = short_type##4;                                                       \
       _CCCL_HOST_DEVICE _CCCL_FORCEINLINE CubVector operator+(const CubVector& other) const \
       {                                                                                     \
         CubVector retval;                                                                   \
@@ -667,7 +668,7 @@ template <typename T>
 struct Uninitialized
 {
   /// Biggest memory-access word that T is a whole multiple of and is not larger than the alignment of T
-  typedef typename UnitWord<T>::DeviceWord DeviceWord;
+  using DeviceWord = typename UnitWord<T>::DeviceWord;
 
   static constexpr ::cuda::std::size_t DATA_SIZE = sizeof(T);
   static constexpr ::cuda::std::size_t WORD_SIZE = sizeof(DeviceWord);
@@ -696,8 +697,8 @@ template <typename _Key,
           >
 struct KeyValuePair
 {
-  typedef _Key Key; ///< Key data type
-  typedef _Value Value; ///< Value data type
+  using Key   = _Key; ///< Key data type
+  using Value = _Value; ///< Value data type
 
   Key key; ///< Item key
   Value value; ///< Item value
@@ -736,10 +737,10 @@ struct KeyValuePair
 template <typename K, typename V>
 struct KeyValuePair<K, V, true, false>
 {
-  typedef K Key;
-  typedef V Value;
+  using Key   = K;
+  using Value = V;
 
-  typedef char Pad[AlignBytes<V>::ALIGN_BYTES - AlignBytes<K>::ALIGN_BYTES];
+  using Pad = char[AlignBytes<V>::ALIGN_BYTES - AlignBytes<K>::ALIGN_BYTES];
 
   Value value; // Value has larger would-be alignment and goes first
   Key key;
@@ -765,10 +766,10 @@ struct KeyValuePair<K, V, true, false>
 template <typename K, typename V>
 struct KeyValuePair<K, V, false, true>
 {
-  typedef K Key;
-  typedef V Value;
+  using Key   = K;
+  using Value = V;
 
-  typedef char Pad[AlignBytes<K>::ALIGN_BYTES - AlignBytes<V>::ALIGN_BYTES];
+  using Pad = char[AlignBytes<K>::ALIGN_BYTES - AlignBytes<V>::ALIGN_BYTES];
 
   Key key; // Key has larger would-be alignment and goes first
   Value value;
@@ -974,7 +975,7 @@ struct BaseTraits
 template <typename _UnsignedBits, typename T>
 struct BaseTraits<UNSIGNED_INTEGER, true, false, _UnsignedBits, T>
 {
-  typedef _UnsignedBits UnsignedBits;
+  using UnsignedBits = _UnsignedBits;
 
   static constexpr Category CATEGORY       = UNSIGNED_INTEGER;
   static constexpr UnsignedBits LOWEST_KEY = UnsignedBits(0);
@@ -1019,7 +1020,7 @@ struct BaseTraits<UNSIGNED_INTEGER, true, false, _UnsignedBits, T>
 template <typename _UnsignedBits, typename T>
 struct BaseTraits<SIGNED_INTEGER, true, false, _UnsignedBits, T>
 {
-  typedef _UnsignedBits UnsignedBits;
+  using UnsignedBits = _UnsignedBits;
 
   static constexpr Category CATEGORY       = SIGNED_INTEGER;
   static constexpr UnsignedBits HIGH_BIT   = UnsignedBits(1) << ((sizeof(UnsignedBits) * 8) - 1);
@@ -1171,7 +1172,7 @@ struct FpLimits<__nv_fp8_e5m2>
 template <typename _UnsignedBits, typename T>
 struct BaseTraits<FLOATING_POINT, true, false, _UnsignedBits, T>
 {
-  typedef _UnsignedBits UnsignedBits;
+  using UnsignedBits = _UnsignedBits;
 
   static constexpr Category CATEGORY       = FLOATING_POINT;
   static constexpr UnsignedBits HIGH_BIT   = UnsignedBits(1) << ((sizeof(UnsignedBits) * 8) - 1);

--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -134,7 +134,7 @@ struct WarpReduceShfl
   };
 
   /// Shared memory storage layout type
-  typedef NullType TempStorage;
+  using TempStorage = NullType;
 
   //---------------------------------------------------------------------
   // Thread fields

--- a/cub/cub/warp/specializations/warp_reduce_smem.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_smem.cuh
@@ -95,7 +95,7 @@ struct WarpReduceSmem
   };
 
   /// Shared memory flag type
-  typedef unsigned char SmemFlag;
+  using SmemFlag = unsigned char;
 
   /// Shared memory storage layout type (1.5 warps-worth of elements for each warp)
   struct _TempStorage

--- a/cub/cub/warp/specializations/warp_scan_smem.cuh
+++ b/cub/cub/warp/specializations/warp_scan_smem.cuh
@@ -90,7 +90,7 @@ struct WarpScanSmem
   using CellT = T;
 
   /// Shared memory storage layout type (1.5 warps-worth of elements for each warp)
-  typedef CellT _TempStorage[WARP_SMEM_ELEMENTS];
+  using _TempStorage = CellT[WARP_SMEM_ELEMENTS];
 
   // Alias wrapper allowing storage to be unioned
   struct TempStorage : Uninitialized<_TempStorage>

--- a/cub/cub/warp/warp_reduce.cuh
+++ b/cub/cub/warp/warp_reduce.cuh
@@ -93,7 +93,7 @@ CUB_NAMESPACE_BEGIN
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        // Specialize WarpReduce for type int
-//!        typedef cub::WarpReduce<int> WarpReduce;
+//!        using WarpReduce = cub::WarpReduce<int>;
 //!
 //!        // Allocate WarpReduce shared memory for 4 warps
 //!        __shared__ typename WarpReduce::TempStorage temp_storage[4];
@@ -120,7 +120,7 @@ CUB_NAMESPACE_BEGIN
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        // Specialize WarpReduce for type int
-//!        typedef cub::WarpReduce<int> WarpReduce;
+//!        using WarpReduce = cub::WarpReduce<int>;
 //!
 //!        // Allocate WarpReduce shared memory for one warp
 //!        __shared__ typename WarpReduce::TempStorage temp_storage;
@@ -233,7 +233,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpReduce for type int
-  //!        typedef cub::WarpReduce<int> WarpReduce;
+  //!        using WarpReduce = cub::WarpReduce<int>;
   //!
   //!        // Allocate WarpReduce shared memory for 4 warps
   //!        __shared__ typename WarpReduce::TempStorage temp_storage[4];
@@ -279,7 +279,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int valid_items)
   //!    {
   //!        // Specialize WarpReduce for type int
-  //!        typedef cub::WarpReduce<int> WarpReduce;
+  //!        using WarpReduce = cub::WarpReduce<int>;
   //!
   //!        // Allocate WarpReduce shared memory for one warp
   //!        __shared__ typename WarpReduce::TempStorage temp_storage;
@@ -330,7 +330,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpReduce for type int
-  //!        typedef cub::WarpReduce<int> WarpReduce;
+  //!        using WarpReduce = cub::WarpReduce<int>;
   //!
   //!        // Allocate WarpReduce shared memory for one warp
   //!        __shared__ typename WarpReduce::TempStorage temp_storage;
@@ -384,7 +384,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpReduce for type int
-  //!        typedef cub::WarpReduce<int> WarpReduce;
+  //!        using WarpReduce = cub::WarpReduce<int>;
   //!
   //!        // Allocate WarpReduce shared memory for one warp
   //!        __shared__ typename WarpReduce::TempStorage temp_storage;
@@ -443,7 +443,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpReduce for type int
-  //!        typedef cub::WarpReduce<int> WarpReduce;
+  //!        using WarpReduce = cub::WarpReduce<int>;
   //!
   //!        // Allocate WarpReduce shared memory for 4 warps
   //!        __shared__ typename WarpReduce::TempStorage temp_storage[4];
@@ -501,7 +501,7 @@ public:
   //!    __global__ void ExampleKernel(int *d_data, int valid_items)
   //!    {
   //!        // Specialize WarpReduce for type int
-  //!        typedef cub::WarpReduce<int> WarpReduce;
+  //!        using WarpReduce = cub::WarpReduce<int>;
   //!
   //!        // Allocate WarpReduce shared memory for one warp
   //!        __shared__ typename WarpReduce::TempStorage temp_storage;
@@ -561,7 +561,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpReduce for type int
-  //!        typedef cub::WarpReduce<int> WarpReduce;
+  //!        using WarpReduce = cub::WarpReduce<int>;
   //!
   //!        // Allocate WarpReduce shared memory for one warp
   //!        __shared__ typename WarpReduce::TempStorage temp_storage;
@@ -620,7 +620,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpReduce for type int
-  //!        typedef cub::WarpReduce<int> WarpReduce;
+  //!        using WarpReduce = cub::WarpReduce<int>;
   //!
   //!        // Allocate WarpReduce shared memory for one warp
   //!        __shared__ typename WarpReduce::TempStorage temp_storage;

--- a/cub/cub/warp/warp_scan.cuh
+++ b/cub/cub/warp/warp_scan.cuh
@@ -99,7 +99,7 @@ CUB_NAMESPACE_BEGIN
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        // Specialize WarpScan for type int
-//!        typedef cub::WarpScan<int> WarpScan;
+//!        using WarpScan = cub::WarpScan<int>;
 //!
 //!        // Allocate WarpScan shared memory for 4 warps
 //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -125,7 +125,7 @@ CUB_NAMESPACE_BEGIN
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        // Specialize WarpScan for type int
-//!        typedef cub::WarpScan<int> WarpScan;
+//!        using WarpScan = cub::WarpScan<int>;
 //!
 //!        // Allocate WarpScan shared memory for one warp
 //!        __shared__ typename WarpScan::TempStorage temp_storage;
@@ -235,7 +235,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -281,7 +281,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -339,7 +339,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -388,7 +388,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -447,7 +447,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -554,7 +554,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -681,7 +681,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -742,7 +742,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -810,7 +810,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -880,7 +880,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -960,7 +960,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -1028,7 +1028,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
@@ -1104,7 +1104,7 @@ public:
   //!    __global__ void ExampleKernel(...)
   //!    {
   //!        // Specialize WarpScan for type int
-  //!        typedef cub::WarpScan<int> WarpScan;
+  //!        using WarpScan = cub::WarpScan<int>;
   //!
   //!        // Allocate WarpScan shared memory for 4 warps
   //!        __shared__ typename WarpScan::TempStorage temp_storage[4];

--- a/cub/examples/block/example_block_radix_sort.cu
+++ b/cub/examples/block/example_block_radix_sort.cu
@@ -50,7 +50,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 /// Verbose output
@@ -87,10 +87,10 @@ __launch_bounds__(BLOCK_THREADS) __global__
 
   // Specialize BlockLoad type for our thread block (uses warp-striped loads for coalescing, then transposes in shared
   // memory to a blocked arrangement)
-  typedef BlockLoad<Key, BLOCK_THREADS, ITEMS_PER_THREAD, BLOCK_LOAD_WARP_TRANSPOSE> BlockLoadT;
+  using BlockLoadT = BlockLoad<Key, BLOCK_THREADS, ITEMS_PER_THREAD, BLOCK_LOAD_WARP_TRANSPOSE>;
 
   // Specialize BlockRadixSort type for our thread block
-  typedef BlockRadixSort<Key, BLOCK_THREADS, ITEMS_PER_THREAD> BlockRadixSortT;
+  using BlockRadixSortT = BlockRadixSort<Key, BLOCK_THREADS, ITEMS_PER_THREAD>;
 
   // Shared memory
   __shared__ union TempStorage

--- a/cub/examples/block/example_block_reduce.cu
+++ b/cub/examples/block/example_block_reduce.cu
@@ -49,7 +49,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 /// Verbose output
@@ -76,7 +76,7 @@ __global__ void BlockReduceKernel(int* d_in, // Tile of input
                                   clock_t* d_elapsed) // Elapsed cycle count of block reduction
 {
   // Specialize BlockReduce type for our thread block
-  typedef BlockReduce<int, BLOCK_THREADS, ALGORITHM> BlockReduceT;
+  using BlockReduceT = BlockReduce<int, BLOCK_THREADS, ALGORITHM>;
 
   // Shared memory
   __shared__ typename BlockReduceT::TempStorage temp_storage;

--- a/cub/examples/block/example_block_reduce_dyn_smem.cu
+++ b/cub/examples/block/example_block_reduce_dyn_smem.cu
@@ -52,7 +52,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 /// Verbose output

--- a/cub/examples/block/example_block_scan.cu
+++ b/cub/examples/block/example_block_scan.cu
@@ -49,7 +49,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 /// Verbose output
@@ -77,14 +77,14 @@ __global__ void BlockPrefixSumKernel(int* d_in, // Tile of input
 {
   // Specialize BlockLoad type for our thread block (uses warp-striped loads for coalescing, then transposes in shared
   // memory to a blocked arrangement)
-  typedef BlockLoad<int, BLOCK_THREADS, ITEMS_PER_THREAD, BLOCK_LOAD_WARP_TRANSPOSE> BlockLoadT;
+  using BlockLoadT = BlockLoad<int, BLOCK_THREADS, ITEMS_PER_THREAD, BLOCK_LOAD_WARP_TRANSPOSE>;
 
   // Specialize BlockStore type for our thread block (uses warp-striped loads for coalescing, then transposes in shared
   // memory to a blocked arrangement)
-  typedef BlockStore<int, BLOCK_THREADS, ITEMS_PER_THREAD, BLOCK_STORE_WARP_TRANSPOSE> BlockStoreT;
+  using BlockStoreT = BlockStore<int, BLOCK_THREADS, ITEMS_PER_THREAD, BLOCK_STORE_WARP_TRANSPOSE>;
 
   // Specialize BlockScan type for our thread block
-  typedef BlockScan<int, BLOCK_THREADS, ALGORITHM> BlockScanT;
+  using BlockScanT = BlockScan<int, BLOCK_THREADS, ALGORITHM>;
 
   // Shared memory
   __shared__ union TempStorage

--- a/cub/examples/device/example_device_partition_flagged.cu
+++ b/cub/examples/device/example_device_partition_flagged.cu
@@ -49,7 +49,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console

--- a/cub/examples/device/example_device_partition_if.cu
+++ b/cub/examples/device/example_device_partition_if.cu
@@ -49,7 +49,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console

--- a/cub/examples/device/example_device_radix_sort.cu
+++ b/cub/examples/device/example_device_radix_sort.cu
@@ -50,7 +50,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console

--- a/cub/examples/device/example_device_reduce.cu
+++ b/cub/examples/device/example_device_reduce.cu
@@ -48,7 +48,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console

--- a/cub/examples/device/example_device_scan.cu
+++ b/cub/examples/device/example_device_scan.cu
@@ -48,7 +48,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console

--- a/cub/examples/device/example_device_select_flagged.cu
+++ b/cub/examples/device/example_device_select_flagged.cu
@@ -49,7 +49,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console

--- a/cub/examples/device/example_device_select_if.cu
+++ b/cub/examples/device/example_device_select_if.cu
@@ -49,7 +49,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console

--- a/cub/examples/device/example_device_select_unique.cu
+++ b/cub/examples/device/example_device_select_unique.cu
@@ -49,7 +49,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console

--- a/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
+++ b/cub/examples/device/example_device_sort_find_non_trivial_runs.cu
@@ -51,7 +51,7 @@
 using namespace cub;
 
 //---------------------------------------------------------------------
-// Globals, constants and typedefs
+// Globals, constants and aliases
 //---------------------------------------------------------------------
 
 bool g_verbose = false; // Whether to display input/output to console
@@ -186,8 +186,8 @@ int Solve(Key* h_keys, Value* h_values, int num_items, int* h_offsets_reference,
  */
 int main(int argc, char** argv)
 {
-  typedef unsigned int Key;
-  typedef int Value;
+  using Key   = unsigned int;
+  using Value = int;
 
   int timing_iterations = 0;
   int num_items         = 40;

--- a/cub/test/c2h/checked_allocator.cuh
+++ b/cub/test/c2h/checked_allocator.cuh
@@ -109,7 +109,7 @@ public:
   template <typename U>
   struct rebind
   {
-    typedef checked_cuda_allocator<U> other;
+    using other = checked_cuda_allocator<U>;
   };
 
   _CCCL_HOST_DEVICE checked_cuda_allocator() {}

--- a/docs/cub/developer_overview.rst
+++ b/docs/cub/developer_overview.rst
@@ -247,7 +247,7 @@ so the actual ``_TempStorage`` type is defined as:
 
 .. code-block:: c++
 
-    typedef typename InternalWarpReduce::TempStorage _TempStorage;
+    using _TempStorage = typename InternalWarpReduce::TempStorage;
 
 and algorithm implementation look like:
 

--- a/docs/cub/index.rst
+++ b/docs/cub/index.rst
@@ -97,12 +97,12 @@ integer keys:
     __global__ void BlockSortKernel(int *d_in, int *d_out)
     {
         // Specialize BlockLoad, BlockStore, and BlockRadixSort collective types
-        typedef cub::BlockLoad<
-          int, BLOCK_THREADS, ITEMS_PER_THREAD, cub::BLOCK_LOAD_TRANSPOSE> BlockLoadT;
-        typedef cub::BlockStore<
-          int, BLOCK_THREADS, ITEMS_PER_THREAD, cub::BLOCK_STORE_TRANSPOSE> BlockStoreT;
-        typedef cub::BlockRadixSort<
-          int, BLOCK_THREADS, ITEMS_PER_THREAD> BlockRadixSortT;
+        using BlockLoadT = cub::BlockLoad<
+          int, BLOCK_THREADS, ITEMS_PER_THREAD, cub::BLOCK_LOAD_TRANSPOSE>;
+        using BlockStoreT = cub::BlockStore<
+          int, BLOCK_THREADS, ITEMS_PER_THREAD, cub::BLOCK_STORE_TRANSPOSE>;
+        using BlockRadixSortT = cub::BlockRadixSort<
+          int, BLOCK_THREADS, ITEMS_PER_THREAD>;
 
         // Allocate type-safe, repurposable shared memory for collectives
         __shared__ union {
@@ -281,7 +281,7 @@ fragment performing a collective prefix sum across the threads of a thread block
     __global__ void SomeKernelFoo(...)
     {
         // Specialize BlockScan for 128 threads on integer types
-      typedef cub::BlockScan<int, 128> BlockScan;
+      using BlockScan = cub::BlockScan<int, 128>;
 
       // Allocate shared memory for BlockScan
       __shared__ typename BlockScan::TempStorage scan_storage;


### PR DESCRIPTION
This PR replaces (almost) all occurences of `typedef` by alias declarations  in CUB.

This was done using a combination of:
* clang-tidy modernize-use-using
* regex replace: "typedef ([\w<>,:\s*&+:\[\]\.]+)\s+([\w_]+);" by "using $2 = $1;"
* manual search and edits

Fixes a part of: #1747