### PR TITLE
Qualify call to distance in thrust::async_reduce

### DIFF
--- a/thrust/thrust/system/cuda/detail/async/reduce.h
+++ b/thrust/thrust/system/cuda/detail/async/reduce.h
@@ -141,7 +141,7 @@ namespace cuda_cub
 // ADL entry point.
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename T, typename BinaryOp>
 auto async_reduce(execution_policy<DerivedPolicy>& policy, ForwardIt first, Sentinel last, T init, BinaryOp op)
-  THRUST_RETURNS(thrust::system::cuda::detail::async_reduce_n(policy, first, distance(first, last), init, op))
+  THRUST_RETURNS(thrust::system::cuda::detail::async_reduce_n(policy, first, thrust::distance(first, last), init, op))
 
 } // namespace cuda_cub
 
@@ -222,7 +222,7 @@ template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typenam
 auto async_reduce_into(
   execution_policy<DerivedPolicy>& policy, ForwardIt first, Sentinel last, OutputIt output, T init, BinaryOp op)
   THRUST_RETURNS(
-    thrust::system::cuda::detail::async_reduce_into_n(policy, first, distance(first, last), output, init, op))
+    thrust::system::cuda::detail::async_reduce_into_n(policy, first, thrust::distance(first, last), output, init, op))
 
 } // namespace cuda_cub
 

--- a/thrust/thrust/system/cuda/detail/future.inl
+++ b/thrust/thrust/system/cuda/detail/future.inl
@@ -37,6 +37,8 @@
 #  include <thrust/type_traits/integer_sequence.h>
 #  include <thrust/type_traits/remove_cvref.h>
 
+#  include <cuda/std/__memory/unique_ptr.h>
+
 #  include <type_traits>
 
 THRUST_NAMESPACE_BEGIN
@@ -669,7 +671,7 @@ public:
   _CCCL_HOST explicit unique_eager_event(unique_eager_future<U>&& other)
       // NOTE: We upcast to `unique_ptr<async_signal>` here.
       : device_(other.where())
-      , async_signal_(std::move(other.async_signal_))
+      , async_signal_(other.async_signal_.release())
   {}
 
   _CCCL_HOST
@@ -758,11 +760,11 @@ struct unique_eager_future final
 
 private:
   int device_ = 0;
-  std::unique_ptr<detail::async_value<value_type>> async_signal_;
+  ::cuda::std::unique_ptr<detail::async_value<value_type>> async_signal_;
 
   _CCCL_HOST explicit unique_eager_future(int device_id, std::unique_ptr<detail::async_value<value_type>> async_signal)
       : device_(device_id)
-      , async_signal_(std::move(async_signal))
+      , async_signal_(async_signal.release())
   {}
 
 public:


### PR DESCRIPTION
If the arguments to the unqualified call to distance contain entities from the thrust and cuda::std namespaces at the same time, the distance functions from both namespaces are available and cause an ambiguity. This PR resolves the situation by qualifying the call.

Fixes: #1886