### PR TITLE
Use c2h::vectors in all non-example CUB tests

### DIFF
--- a/cub/test/catch2_test_device_select_if_vsmem.cu
+++ b/cub/test/catch2_test_device_select_if_vsmem.cu
@@ -30,13 +30,11 @@
 
 #include <cub/device/device_select.cuh>
 
-#include <thrust/device_vector.h>
-#include <thrust/host_vector.h>
-
 #include <algorithm>
 
 #include "catch2_test_helper.h"
 #include "catch2_test_launch_helper.h"
+#include <c2h/vector.cuh>
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -76,11 +74,11 @@ CUB_TEST("DeviceSelect::If works for large types", "[select_if][vsmem][device]",
   less_than_t<type> le{in[num_items / 2]};
 
   // Run test
-  thrust::device_vector<int> num_selected_out(1, 0);
+  c2h::device_vector<int> num_selected_out(1, 0);
   select_if(in.begin(), out.begin(), num_selected_out.begin(), num_items, le);
 
   // Ensure that we create the same output as std
-  thrust::host_vector<type> reference = in;
+  c2h::host_vector<type> reference = in;
   std::stable_partition(reference.begin(), reference.end(), le);
 
   out.resize(num_selected_out[0]);

--- a/cub/test/test_device_spmv.cu
+++ b/cub/test/test_device_spmv.cu
@@ -31,7 +31,6 @@
 #include <cub/device/device_spmv.cuh>
 #include <cub/util_debug.cuh>
 
-#include <thrust/device_vector.h>
 #include <thrust/distance.h>
 #include <thrust/host_vector.h>
 #include <thrust/mismatch.h>
@@ -42,6 +41,7 @@
 #include <typeinfo>
 
 #include "test_util.h"
+#include <c2h/vector.cuh>
 
 bool g_verbose = false;
 
@@ -196,8 +196,7 @@ struct csr_matrix
 
 private:
   template <typename VecValueT>
-  using vector_t =
-    cub::detail::conditional_t<HostStorage, thrust::host_vector<VecValueT>, thrust::device_vector<VecValueT>>;
+  using vector_t = cub::detail::conditional_t<HostStorage, c2h::host_vector<VecValueT>, c2h::device_vector<VecValueT>>;
 
   vector_t<ValueT> m_values;
   vector_t<int> m_row_offsets;
@@ -236,9 +235,9 @@ struct fp_almost_equal_functor
 // Use fuzzy check for floating point values.
 template <typename ValueT>
 bool compare_results(
-  std::true_type /* is_fp */, const thrust::host_vector<ValueT>& h_vec1, const thrust::device_vector<ValueT>& d_vec2)
+  std::true_type /* is_fp */, const c2h::host_vector<ValueT>& h_vec1, const c2h::device_vector<ValueT>& d_vec2)
 {
-  thrust::device_vector<ValueT> d_vec1(h_vec1);
+  c2h::device_vector<ValueT> d_vec1(h_vec1);
   auto err = thrust::mismatch(d_vec1.cbegin(), d_vec1.cend(), d_vec2.cbegin(), fp_almost_equal_functor<ValueT>{});
   if (err.first == d_vec1.cend() || err.second == d_vec2.cend())
   {
@@ -246,7 +245,7 @@ bool compare_results(
   }
   else
   {
-    thrust::host_vector<ValueT> h_vec2(d_vec2);
+    c2h::host_vector<ValueT> h_vec2(d_vec2);
     const auto idx = thrust::distance(d_vec1.cbegin(), err.first);
     std::cerr << "Mismatch at position " << idx << ": " << print_cast(ValueT{h_vec1[idx]}) << " vs "
               << print_cast(ValueT{h_vec2[idx]}) << std::endl;
@@ -256,9 +255,9 @@ bool compare_results(
 
 template <typename ValueT>
 bool compare_results(
-  std::false_type /* is_fp */, const thrust::host_vector<ValueT>& h_vec1, const thrust::device_vector<ValueT>& d_vec2)
+  std::false_type /* is_fp */, const c2h::host_vector<ValueT>& h_vec1, const c2h::device_vector<ValueT>& d_vec2)
 {
-  thrust::device_vector<ValueT> d_vec1(h_vec1);
+  c2h::device_vector<ValueT> d_vec1(h_vec1);
   auto err = thrust::mismatch(d_vec1.cbegin(), d_vec1.cend(), d_vec2.cbegin());
   if (err.first == d_vec1.cend() || err.second == d_vec2.cend())
   {
@@ -266,7 +265,7 @@ bool compare_results(
   }
   else
   {
-    thrust::host_vector<ValueT> h_vec2(d_vec2);
+    c2h::host_vector<ValueT> h_vec2(d_vec2);
     const auto idx = thrust::distance(d_vec1.cbegin(), err.first);
     std::cerr << "Mismatch at position " << idx << ": " << print_cast(ValueT{h_vec1[idx]}) << " vs "
               << print_cast(ValueT{h_vec2[idx]}) << std::endl;
@@ -337,9 +336,9 @@ host_csr_matrix<ValueT> make_random_csr_matrix(int num_rows, int num_cols, float
 //==============================================================================
 // Fill a vector with random values.
 template <typename ValueT>
-thrust::host_vector<ValueT> make_random_vector(int len)
+c2h::host_vector<ValueT> make_random_vector(int len)
 {
-  thrust::host_vector<ValueT> vec(len);
+  c2h::host_vector<ValueT> vec(len);
   for (auto& val : vec)
   {
     if (std::is_floating_point<ValueT>::value)
@@ -359,7 +358,7 @@ thrust::host_vector<ValueT> make_random_vector(int len)
 // Serial y = Ax computation
 template <typename ValueT>
 void compute_reference_solution(
-  const host_csr_matrix<ValueT>& a, const thrust::host_vector<ValueT>& x, thrust::host_vector<ValueT>& y)
+  const host_csr_matrix<ValueT>& a, const c2h::host_vector<ValueT>& x, c2h::host_vector<ValueT>& y)
 {
   if (a.get_num_rows() == 0 || a.get_num_columns() == 0)
   {
@@ -387,9 +386,9 @@ void compute_reference_solution(
 // cub::DeviceSpmv::CsrMV y = Ax computation
 template <typename ValueT>
 void compute_cub_solution(
-  const device_csr_matrix<ValueT>& a, const thrust::device_vector<ValueT>& x, thrust::device_vector<ValueT>& y)
+  const device_csr_matrix<ValueT>& a, const c2h::device_vector<ValueT>& x, c2h::device_vector<ValueT>& y)
 {
-  thrust::device_vector<char> temp_storage;
+  c2h::device_vector<char> temp_storage;
   std::size_t temp_storage_bytes{};
   auto err = cub::DeviceSpmv::CsrMV(
     nullptr,
@@ -424,7 +423,7 @@ void compute_cub_solution(
 // Compute y = Ax twice, one reference and one cub::DeviceSpmv, and compare the
 // results.
 template <typename ValueT>
-void test_spmv(const host_csr_matrix<ValueT>& h_a, const thrust::host_vector<ValueT>& h_x)
+void test_spmv(const host_csr_matrix<ValueT>& h_a, const c2h::host_vector<ValueT>& h_x)
 {
   if (g_verbose)
   {
@@ -440,10 +439,10 @@ void test_spmv(const host_csr_matrix<ValueT>& h_a, const thrust::host_vector<Val
   }
 
   const device_csr_matrix<ValueT> d_a(h_a);
-  const thrust::device_vector<ValueT> d_x(h_x);
+  const c2h::device_vector<ValueT> d_x(h_x);
 
-  thrust::host_vector<ValueT> h_y(h_a.get_num_rows());
-  thrust::device_vector<ValueT> d_y(d_a.get_num_rows());
+  c2h::host_vector<ValueT> h_y(h_a.get_num_rows());
+  c2h::device_vector<ValueT> d_y(d_a.get_num_rows());
 
   compute_reference_solution(h_a, h_x, h_y);
   compute_cub_solution(d_a, d_x, d_y);
@@ -453,7 +452,7 @@ void test_spmv(const host_csr_matrix<ValueT>& h_a, const thrust::host_vector<Val
     std::cout << "reference output:\n  [";
     print_vector(std::cout, h_y);
     std::cout << "]\n";
-    thrust::host_vector<ValueT> tmp_y(d_y);
+    c2h::host_vector<ValueT> tmp_y(d_y);
     std::cout << "cub::DeviceSpmv output:\n  [";
     print_vector(std::cout, tmp_y);
     std::cout << "]" << std::endl;
@@ -497,7 +496,7 @@ void test_doc_example()
   h_a.append_value(8, 7, ValueT{1});
   h_a.finalize();
 
-  thrust::host_vector<ValueT> h_x(9, ValueT{1});
+  c2h::host_vector<ValueT> h_x(9, ValueT{1});
 
   test_spmv(h_a, h_x);
 }
@@ -510,8 +509,8 @@ void test_random(int rows, int cols, float target_fill_ratio)
   std::cout << "\n\ntest_random<" << typeid(ValueT).name() << ">(" << rows << ", " << cols << ", " << target_fill_ratio
             << ")" << std::endl;
 
-  host_csr_matrix<ValueT> h_a     = make_random_csr_matrix<ValueT>(rows, cols, target_fill_ratio);
-  thrust::host_vector<ValueT> h_x = make_random_vector<ValueT>(cols);
+  host_csr_matrix<ValueT> h_a  = make_random_csr_matrix<ValueT>(rows, cols, target_fill_ratio);
+  c2h::host_vector<ValueT> h_x = make_random_vector<ValueT>(cols);
 
   test_spmv(h_a, h_x);
 }


### PR DESCRIPTION
Two CUB tests, `catch2_test_device_select_if_vsmem.cu` and `test_device_spmv.cu`, where not yet using `c2h::[host|device]_vector`. This PR changes that.