### PR TITLE
Replace typedef by alias declarations in Thrust

### DIFF
--- a/thrust/examples/bucket_sort2d.cu
+++ b/thrust/examples/bucket_sort2d.cu
@@ -12,7 +12,7 @@
 #include "include/host_device.h"
 
 // define a 2d float vector
-typedef thrust::tuple<float, float> vec2;
+using vec2 = thrust::tuple<float, float>;
 
 // return a random vec2 in [0,1)^2
 vec2 make_random_vec2()

--- a/thrust/examples/counting_iterator.cu
+++ b/thrust/examples/counting_iterator.cu
@@ -29,7 +29,7 @@ int main()
   thrust::counting_iterator<int> last = first + 8;
 
   // compute indices of nonzero elements
-  typedef thrust::device_vector<int>::iterator IndexIterator;
+  using IndexIterator = thrust::device_vector<int>::iterator;
 
   IndexIterator indices_end = thrust::copy_if(first, last, stencil.begin(), indices.begin(), thrust::identity<int>());
   // indices now contains [1,2,5,7]

--- a/thrust/examples/cuda/custom_temporary_allocation.cu
+++ b/thrust/examples/cuda/custom_temporary_allocation.cu
@@ -49,7 +49,7 @@ private:
 // A simple allocator for caching cudaMalloc allocations.
 struct cached_allocator
 {
-  typedef char value_type;
+  using value_type = char;
 
   cached_allocator() {}
 
@@ -120,8 +120,8 @@ struct cached_allocator
   }
 
 private:
-  typedef std::multimap<std::ptrdiff_t, char*> free_blocks_type;
-  typedef std::map<char*, std::ptrdiff_t> allocated_blocks_type;
+  using free_blocks_type      = std::multimap<std::ptrdiff_t, char*>;
+  using allocated_blocks_type = std::map<char*, std::ptrdiff_t>;
 
   free_blocks_type free_blocks;
   allocated_blocks_type allocated_blocks;

--- a/thrust/examples/cuda/global_device_vector.cu
+++ b/thrust/examples/cuda/global_device_vector.cu
@@ -19,9 +19,8 @@ extern "C" cudaError_t cudaFreeIgnoreShutdown(void* ptr)
   return err;
 }
 
-typedef thrust::system::cuda::detail::
-  cuda_memory_resource<cudaMalloc, cudaFreeIgnoreShutdown, thrust::cuda::pointer<void>>
-    device_ignore_shutdown_memory_resource;
+using device_ignore_shutdown_memory_resource =
+  thrust::system::cuda::detail::cuda_memory_resource<cudaMalloc, cudaFreeIgnoreShutdown, thrust::cuda::pointer<void>>;
 
 template <typename T>
 using device_ignore_shutdown_allocator =

--- a/thrust/examples/cuda/range_view.cu
+++ b/thrust/examples/cuda/range_view.cu
@@ -19,11 +19,11 @@ template <class Iterator>
 class range_view
 {
 public:
-  typedef Iterator iterator;
-  typedef typename thrust::iterator_traits<iterator>::value_type value_type;
-  typedef typename thrust::iterator_traits<iterator>::pointer pointer;
-  typedef typename thrust::iterator_traits<iterator>::difference_type difference_type;
-  typedef typename thrust::iterator_traits<iterator>::reference reference;
+  using iterator        = Iterator;
+  using value_type      = typename thrust::iterator_traits<iterator>::value_type;
+  using pointer         = typename thrust::iterator_traits<iterator>::pointer;
+  using difference_type = typename thrust::iterator_traits<iterator>::difference_type;
+  using reference       = typename thrust::iterator_traits<iterator>::reference;
 
 private:
   const iterator first;

--- a/thrust/examples/dot_products_with_zip.cu
+++ b/thrust/examples/dot_products_with_zip.cu
@@ -14,7 +14,7 @@
 // into a single virtual Float3 array.
 
 // We'll use a 3-tuple to store our 3d vector type
-typedef thrust::tuple<float, float, float> Float3;
+using Float3 = thrust::tuple<float, float, float>;
 
 // This functor implements the dot product between 3d vectors
 struct DotProduct : public thrust::binary_function<Float3, Float3, float>
@@ -74,9 +74,9 @@ int main()
 
   // METHOD #1
   // Defining a zip_iterator type can be a little cumbersome ...
-  typedef thrust::device_vector<float>::iterator FloatIterator;
-  typedef thrust::tuple<FloatIterator, FloatIterator, FloatIterator> FloatIteratorTuple;
-  typedef thrust::zip_iterator<FloatIteratorTuple> Float3Iterator;
+  using FloatIterator      = thrust::device_vector<float>::iterator;
+  using FloatIteratorTuple = thrust::tuple<FloatIterator, FloatIterator, FloatIterator>;
+  using Float3Iterator     = thrust::zip_iterator<FloatIteratorTuple>;
 
   // Now we'll create some zip_iterators for A and B
   Float3Iterator A_first = thrust::make_zip_iterator(thrust::make_tuple(A0.begin(), A1.begin(), A2.begin()));

--- a/thrust/examples/expand.cu
+++ b/thrust/examples/expand.cu
@@ -20,7 +20,7 @@
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator>
 OutputIterator expand(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, OutputIterator output)
 {
-  typedef typename thrust::iterator_difference<InputIterator1>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<InputIterator1>::type;
 
   difference_type input_size  = thrust::distance(first1, last1);
   difference_type output_size = thrust::reduce(first1, last1);
@@ -53,7 +53,7 @@ OutputIterator expand(InputIterator1 first1, InputIterator1 last1, InputIterator
 template <typename Vector>
 void print(const std::string& s, const Vector& v)
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   std::cout << s;
   thrust::copy(v.begin(), v.end(), std::ostream_iterator<T>(std::cout, " "));

--- a/thrust/examples/histogram.cu
+++ b/thrust/examples/histogram.cu
@@ -49,7 +49,7 @@
 template <typename Vector>
 void print_vector(const std::string& name, const Vector& v)
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
   std::cout << "  " << std::setw(20) << name << "  ";
   thrust::copy(v.begin(), v.end(), std::ostream_iterator<T>(std::cout, " "));
   std::cout << std::endl;
@@ -59,8 +59,8 @@ void print_vector(const std::string& name, const Vector& v)
 template <typename Vector1, typename Vector2>
 void dense_histogram(const Vector1& input, Vector2& histogram)
 {
-  typedef typename Vector1::value_type ValueType; // input value type
-  typedef typename Vector2::value_type IndexType; // histogram index type
+  using ValueType = typename Vector1::value_type; // input value type
+  using IndexType = typename Vector2::value_type; // histogram index type
 
   // copy input data (could be skipped if input is allowed to be modified)
   thrust::device_vector<ValueType> data(input);
@@ -98,8 +98,8 @@ void dense_histogram(const Vector1& input, Vector2& histogram)
 template <typename Vector1, typename Vector2, typename Vector3>
 void sparse_histogram(const Vector1& input, Vector2& histogram_values, Vector3& histogram_counts)
 {
-  typedef typename Vector1::value_type ValueType; // input value type
-  typedef typename Vector3::value_type IndexType; // histogram index type
+  using ValueType = typename Vector1::value_type; // input value type
+  using IndexType = typename Vector3::value_type; // histogram index type
 
   // copy input data (could be skipped if input is allowed to be modified)
   thrust::device_vector<ValueType> data(input);

--- a/thrust/examples/mr_basic.cu
+++ b/thrust/examples/mr_basic.cu
@@ -30,7 +30,7 @@ int main()
 
   {
     // no virtual calls will be issued
-    typedef thrust::mr::allocator<int, thrust::mr::new_delete_resource> Alloc;
+    using Alloc = thrust::mr::allocator<int, thrust::mr::new_delete_resource>;
     Alloc alloc(&memres);
 
     do_stuff_with_vector<thrust::host_vector<int, Alloc>>(alloc);
@@ -39,7 +39,7 @@ int main()
   {
     // virtual calls will be issued - wrapping in a polymorphic wrapper
     thrust::mr::polymorphic_adaptor_resource<void*> adaptor(&memres);
-    typedef thrust::mr::polymorphic_allocator<int, void*> Alloc;
+    using Alloc = thrust::mr::polymorphic_allocator<int, void*>;
     Alloc alloc(&adaptor);
 
     do_stuff_with_vector<thrust::host_vector<int, Alloc>>(alloc);
@@ -47,30 +47,29 @@ int main()
 
   {
     // use the global device_ptr-flavored device memory resource
-    typedef thrust::device_ptr_memory_resource<thrust::device_memory_resource> Resource;
+    using Resource = thrust::device_ptr_memory_resource<thrust::device_memory_resource>;
     thrust::mr::polymorphic_adaptor_resource<thrust::device_ptr<void>> adaptor(
       thrust::mr::get_global_resource<Resource>());
-    typedef thrust::mr::polymorphic_allocator<int, thrust::device_ptr<void>> Alloc;
+    using Alloc = thrust::mr::polymorphic_allocator<int, thrust::device_ptr<void>>;
     Alloc alloc(&adaptor);
 
     do_stuff_with_vector<thrust::device_vector<int, Alloc>>(alloc);
   }
 
-  typedef thrust::mr::unsynchronized_pool_resource<thrust::mr::new_delete_resource> Pool;
+  using Pool = thrust::mr::unsynchronized_pool_resource<thrust::mr::new_delete_resource>;
   Pool pool(&memres);
   {
-    typedef thrust::mr::allocator<int, Pool> Alloc;
+    using Alloc = thrust::mr::allocator<int, Pool>;
     Alloc alloc(&pool);
 
     do_stuff_with_vector<thrust::host_vector<int, Alloc>>(alloc);
   }
 
-  typedef thrust::mr::disjoint_unsynchronized_pool_resource<thrust::mr::new_delete_resource,
-                                                            thrust::mr::new_delete_resource>
-    DisjointPool;
+  using DisjointPool =
+    thrust::mr::disjoint_unsynchronized_pool_resource<thrust::mr::new_delete_resource, thrust::mr::new_delete_resource>;
   DisjointPool disjoint_pool(&memres, &memres);
   {
-    typedef thrust::mr::allocator<int, DisjointPool> Alloc;
+    using Alloc = thrust::mr::allocator<int, DisjointPool>;
     Alloc alloc(&disjoint_pool);
 
     do_stuff_with_vector<thrust::host_vector<int, Alloc>>(alloc);

--- a/thrust/examples/padded_grid_reduction.cu
+++ b/thrust/examples/padded_grid_reduction.cu
@@ -24,8 +24,8 @@ template <typename IndexType, typename ValueType>
 struct transform_tuple
     : public thrust::unary_function<thrust::tuple<IndexType, ValueType>, thrust::tuple<bool, ValueType, ValueType>>
 {
-  typedef typename thrust::tuple<IndexType, ValueType> InputTuple;
-  typedef typename thrust::tuple<bool, ValueType, ValueType> OutputTuple;
+  using InputTuple  = typename thrust::tuple<IndexType, ValueType>;
+  using OutputTuple = typename thrust::tuple<bool, ValueType, ValueType>;
 
   IndexType n, N;
 
@@ -49,7 +49,7 @@ struct reduce_tuple
                                      thrust::tuple<bool, ValueType, ValueType>,
                                      thrust::tuple<bool, ValueType, ValueType>>
 {
-  typedef typename thrust::tuple<bool, ValueType, ValueType> Tuple;
+  using Tuple = typename thrust::tuple<bool, ValueType, ValueType>;
 
   __host__ __device__ Tuple operator()(const Tuple& t0, const Tuple& t1) const
   {
@@ -108,7 +108,7 @@ int main()
   std::cout << "\n";
 
   // compute min & max over valid region of the 2d grid
-  typedef thrust::tuple<bool, float, float> result_type;
+  using result_type = thrust::tuple<bool, float, float>;
 
   result_type init(true, FLT_MAX, -FLT_MAX); // initial value
   transform_tuple<int, float> unary_op(n, N); // transformation operator

--- a/thrust/examples/raw_reference_cast.cu
+++ b/thrust/examples/raw_reference_cast.cu
@@ -70,7 +70,7 @@ struct copy_iterators
 template <typename Vector>
 void print(const std::string& name, const Vector& v)
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   std::cout << name << ": ";
   thrust::copy(v.begin(), v.end(), std::ostream_iterator<T>(std::cout, " "));
@@ -79,9 +79,9 @@ void print(const std::string& name, const Vector& v)
 
 int main()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
-  typedef thrust::device_system_tag System;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
+  using System   = thrust::device_system_tag;
 
   // allocate device memory
   Vector A(5);

--- a/thrust/examples/repeated_range.cu
+++ b/thrust/examples/repeated_range.cu
@@ -21,7 +21,7 @@ template <typename Iterator>
 class repeated_range
 {
 public:
-  typedef typename thrust::iterator_difference<Iterator>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<Iterator>::type;
 
   struct repeat_functor : public thrust::unary_function<difference_type, difference_type>
   {
@@ -37,12 +37,12 @@ public:
     }
   };
 
-  typedef typename thrust::counting_iterator<difference_type> CountingIterator;
-  typedef typename thrust::transform_iterator<repeat_functor, CountingIterator> TransformIterator;
-  typedef typename thrust::permutation_iterator<Iterator, TransformIterator> PermutationIterator;
+  using CountingIterator    = typename thrust::counting_iterator<difference_type>;
+  using TransformIterator   = typename thrust::transform_iterator<repeat_functor, CountingIterator>;
+  using PermutationIterator = typename thrust::permutation_iterator<Iterator, TransformIterator>;
 
   // type of the repeated_range iterator
-  typedef PermutationIterator iterator;
+  using iterator = PermutationIterator;
 
   // construct repeated_range for the range [first,last)
   repeated_range(Iterator first, Iterator last, difference_type repeats)
@@ -80,7 +80,7 @@ int main()
   thrust::copy(data.begin(), data.end(), std::ostream_iterator<int>(std::cout, " "));
   std::cout << std::endl;
 
-  typedef thrust::device_vector<int>::iterator Iterator;
+  using Iterator = thrust::device_vector<int>::iterator;
 
   // create repeated_range with elements repeated twice
   repeated_range<Iterator> twice(data.begin(), data.end(), 2);

--- a/thrust/examples/simple_moving_average.cu
+++ b/thrust/examples/simple_moving_average.cu
@@ -41,7 +41,7 @@ struct minus_and_divide : public thrust::binary_function<T, T, T>
 template <typename InputVector, typename OutputVector>
 void simple_moving_average(const InputVector& data, size_t w, OutputVector& output)
 {
-  typedef typename InputVector::value_type T;
+  using T = typename InputVector::value_type;
 
   if (data.size() < w)
   {

--- a/thrust/examples/sparse_vector.cu
+++ b/thrust/examples/sparse_vector.cu
@@ -33,8 +33,8 @@ void sum_sparse_vectors(
   IndexVector3& C_index,
   ValueVector3& C_value)
 {
-  typedef typename IndexVector3::value_type IndexType;
-  typedef typename ValueVector3::value_type ValueType;
+  using IndexType = typename IndexVector3::value_type;
+  using ValueType = typename ValueVector3::value_type;
 
   assert(A_index.size() == A_value.size());
   assert(B_index.size() == B_value.size());

--- a/thrust/examples/stream_compaction.cu
+++ b/thrust/examples/stream_compaction.cu
@@ -23,7 +23,7 @@ struct is_odd : public thrust::unary_function<T, bool>
 template <typename Iterator>
 void print_range(const std::string& name, Iterator first, Iterator last)
 {
-  typedef typename std::iterator_traits<Iterator>::value_type T;
+  using T = typename std::iterator_traits<Iterator>::value_type;
 
   std::cout << name << ": ";
   thrust::copy(first, last, std::ostream_iterator<T>(std::cout, " "));
@@ -36,8 +36,8 @@ int main()
   size_t N = 10;
 
   // define some types
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   // allocate storage for array
   Vector values(N);

--- a/thrust/examples/strided_range.cu
+++ b/thrust/examples/strided_range.cu
@@ -21,7 +21,7 @@ template <typename Iterator>
 class strided_range
 {
 public:
-  typedef typename thrust::iterator_difference<Iterator>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<Iterator>::type;
 
   struct stride_functor : public thrust::unary_function<difference_type, difference_type>
   {
@@ -37,12 +37,12 @@ public:
     }
   };
 
-  typedef typename thrust::counting_iterator<difference_type> CountingIterator;
-  typedef typename thrust::transform_iterator<stride_functor, CountingIterator> TransformIterator;
-  typedef typename thrust::permutation_iterator<Iterator, TransformIterator> PermutationIterator;
+  using CountingIterator    = typename thrust::counting_iterator<difference_type>;
+  using TransformIterator   = typename thrust::transform_iterator<stride_functor, CountingIterator>;
+  using PermutationIterator = typename thrust::permutation_iterator<Iterator, TransformIterator>;
 
   // type of the strided_range iterator
-  typedef PermutationIterator iterator;
+  using iterator = PermutationIterator;
 
   // construct strided_range for the range [first,last)
   strided_range(Iterator first, Iterator last, difference_type stride)
@@ -84,7 +84,7 @@ int main()
   thrust::copy(data.begin(), data.end(), std::ostream_iterator<int>(std::cout, " "));
   std::cout << std::endl;
 
-  typedef thrust::device_vector<int>::iterator Iterator;
+  using Iterator = thrust::device_vector<int>::iterator;
 
   // create strided_range with indices [0,2,4,6]
   strided_range<Iterator> evens(data.begin(), data.end(), 2);

--- a/thrust/examples/summary_statistics.cu
+++ b/thrust/examples/summary_statistics.cu
@@ -124,7 +124,7 @@ struct summary_stats_binary_op
 template <typename Iterator>
 void print_range(const std::string& name, Iterator first, Iterator last)
 {
-  typedef typename std::iterator_traits<Iterator>::value_type T;
+  using T = typename std::iterator_traits<Iterator>::value_type;
 
   std::cout << name << ": ";
   thrust::copy(first, last, std::ostream_iterator<T>(std::cout, " "));
@@ -133,7 +133,7 @@ void print_range(const std::string& name, Iterator first, Iterator last)
 
 int main()
 {
-  typedef float T;
+  using T = float;
 
   // initialize host array
   T h_x[] = {4, 7, 13, 16};

--- a/thrust/examples/tiled_range.cu
+++ b/thrust/examples/tiled_range.cu
@@ -21,7 +21,7 @@ template <typename Iterator>
 class tiled_range
 {
 public:
-  typedef typename thrust::iterator_difference<Iterator>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<Iterator>::type;
 
   struct tile_functor : public thrust::unary_function<difference_type, difference_type>
   {
@@ -37,12 +37,12 @@ public:
     }
   };
 
-  typedef typename thrust::counting_iterator<difference_type> CountingIterator;
-  typedef typename thrust::transform_iterator<tile_functor, CountingIterator> TransformIterator;
-  typedef typename thrust::permutation_iterator<Iterator, TransformIterator> PermutationIterator;
+  using CountingIterator    = typename thrust::counting_iterator<difference_type>;
+  using TransformIterator   = typename thrust::transform_iterator<tile_functor, CountingIterator>;
+  using PermutationIterator = typename thrust::permutation_iterator<Iterator, TransformIterator>;
 
   // type of the tiled_range iterator
-  typedef PermutationIterator iterator;
+  using iterator = PermutationIterator;
 
   // construct repeated_range for the range [first,last)
   tiled_range(Iterator first, Iterator last, difference_type tiles)
@@ -80,7 +80,7 @@ int main()
   thrust::copy(data.begin(), data.end(), std::ostream_iterator<int>(std::cout, " "));
   std::cout << std::endl;
 
-  typedef thrust::device_vector<int>::iterator Iterator;
+  using Iterator = thrust::device_vector<int>::iterator;
 
   // create tiled_range with two tiles
   tiled_range<Iterator> two(data.begin(), data.end(), 2);

--- a/thrust/examples/transform_iterator.cu
+++ b/thrust/examples/transform_iterator.cu
@@ -50,7 +50,7 @@ struct simple_negate : public thrust::unary_function<T, T>
 template <typename Iterator>
 void print_range(const std::string& name, Iterator first, Iterator last)
 {
-  typedef typename std::iterator_traits<Iterator>::value_type T;
+  using T = typename std::iterator_traits<Iterator>::value_type;
 
   std::cout << name << ": ";
   thrust::copy(first, last, std::ostream_iterator<T>(std::cout, " "));
@@ -64,8 +64,8 @@ int main()
   int hi = 5;
 
   // define some types
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator VectorIterator;
+  using Vector         = thrust::device_vector<int>;
+  using VectorIterator = Vector::iterator;
 
   // initialize values
   Vector values(8);
@@ -82,7 +82,7 @@ int main()
   print_range("values         ", values.begin(), values.end());
 
   // define some more types
-  typedef thrust::transform_iterator<clamp<int>, VectorIterator> ClampedVectorIterator;
+  using ClampedVectorIterator = thrust::transform_iterator<clamp<int>, VectorIterator>;
 
   // create a transform_iterator that applies clamp() to the values array
   ClampedVectorIterator cv_begin = thrust::make_transform_iterator(values.begin(), clamp<int>(lo, hi));
@@ -97,8 +97,8 @@ int main()
 
   ////
   // combine transform_iterator with other fancy iterators like counting_iterator
-  typedef thrust::counting_iterator<int> CountingIterator;
-  typedef thrust::transform_iterator<clamp<int>, CountingIterator> ClampedCountingIterator;
+  using CountingIterator        = thrust::counting_iterator<int>;
+  using ClampedCountingIterator = thrust::transform_iterator<clamp<int>, CountingIterator>;
 
   CountingIterator count_begin(0);
   CountingIterator count_end(10);
@@ -112,7 +112,7 @@ int main()
 
   ////
   // combine transform_iterator with another transform_iterator
-  typedef thrust::transform_iterator<thrust::negate<int>, ClampedCountingIterator> NegatedClampedCountingIterator;
+  using NegatedClampedCountingIterator = thrust::transform_iterator<thrust::negate<int>, ClampedCountingIterator>;
 
   NegatedClampedCountingIterator ncs_begin = thrust::make_transform_iterator(cs_begin, thrust::negate<int>());
   NegatedClampedCountingIterator ncs_end   = thrust::make_transform_iterator(cs_end, thrust::negate<int>());
@@ -121,7 +121,7 @@ int main()
 
   ////
   // when a functor does not define result_type, a third template argument must be provided
-  typedef thrust::transform_iterator<simple_negate<int>, VectorIterator, int> NegatedVectorIterator;
+  using NegatedVectorIterator = thrust::transform_iterator<simple_negate<int>, VectorIterator, int>;
 
   NegatedVectorIterator nv_begin(values.begin(), simple_negate<int>());
   NegatedVectorIterator nv_end(values.end(), simple_negate<int>());

--- a/thrust/examples/uninitialized_vector.cu
+++ b/thrust/examples/uninitialized_vector.cu
@@ -38,7 +38,7 @@ struct uninitialized_allocator : thrust::device_allocator<T>
   template <typename U>
   struct rebind
   {
-    typedef uninitialized_allocator<U> other;
+    using other = uninitialized_allocator<U>;
   };
 
   // note that construct is annotated as
@@ -51,7 +51,7 @@ struct uninitialized_allocator : thrust::device_allocator<T>
 
 // to make a device_vector which does not initialize its elements,
 // use uninitialized_allocator as the 2nd template parameter
-typedef thrust::device_vector<float, uninitialized_allocator<float>> uninitialized_vector;
+using uninitialized_vector = thrust::device_vector<float, uninitialized_allocator<float>>;
 
 int main()
 {

--- a/thrust/examples/weld_vertices.cu
+++ b/thrust/examples/weld_vertices.cu
@@ -34,7 +34,7 @@
  */
 
 // define a 2d float vector
-typedef thrust::tuple<float, float> vec2;
+using vec2 = thrust::tuple<float, float>;
 
 int main()
 {

--- a/thrust/testing/adjacent_difference.cu
+++ b/thrust/testing/adjacent_difference.cu
@@ -9,7 +9,7 @@
 template <class Vector>
 void TestAdjacentDifferenceSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector input(4);
   Vector output(4);

--- a/thrust/testing/advance.cu
+++ b/thrust/testing/advance.cu
@@ -8,8 +8,8 @@
 template <typename Vector>
 void TestAdvance()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector v(10);
   thrust::sequence(v.begin(), v.end());
@@ -33,8 +33,8 @@ DECLARE_VECTOR_UNITTEST(TestAdvance);
 template <typename Vector>
 void TestNext()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector v(10);
   thrust::sequence(v.begin(), v.end());
@@ -64,8 +64,8 @@ DECLARE_VECTOR_UNITTEST(TestNext);
 template <typename Vector>
 void TestPrev()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector v(10);
   thrust::sequence(v.begin(), v.end());

--- a/thrust/testing/alignment.cu
+++ b/thrust/testing/alignment.cu
@@ -125,7 +125,7 @@ DECLARE_UNITTEST(test_alignment_of);
 template <std::size_t Align>
 void test_aligned_type_instantiation()
 {
-  typedef typename thrust::detail::aligned_type<Align>::type type;
+  using type = typename thrust::detail::aligned_type<Align>::type;
   ASSERT_GEQUAL(sizeof(type), 1lu);
   ASSERT_EQUAL(alignof(type), Align);
   ASSERT_EQUAL(thrust::detail::alignment_of<type>::value, Align);

--- a/thrust/testing/allocator.cu
+++ b/thrust/testing/allocator.cu
@@ -112,7 +112,7 @@ struct my_allocator_with_custom_destroy
     return !(*this == other);
   }
 
-  typedef thrust::detail::true_type is_always_equal;
+  using is_always_equal = thrust::detail::true_type;
 
   // use composition rather than inheritance
   // to avoid inheriting std::allocator's member
@@ -142,12 +142,11 @@ DECLARE_VARIABLE_UNITTEST(TestAllocatorCustomDestroy);
 template <typename T>
 struct my_minimal_allocator
 {
-  typedef T value_type;
+  using value_type = T;
 
-  // XXX ideally, we shouldn't require
-  //     these two typedefs
-  typedef T& reference;
-  typedef const T& const_reference;
+  // XXX ideally, we shouldn't require these two aliases
+  using reference       = T&;
+  using const_reference = const T&;
 
   _CCCL_HOST my_minimal_allocator() {}
 

--- a/thrust/testing/allocator_aware_policies.cu
+++ b/thrust/testing/allocator_aware_policies.cu
@@ -32,12 +32,12 @@ struct test_memory_resource_t final : thrust::mr::memory_resource<>
 template <typename Policy, template <typename> class CRTPBase>
 struct policy_info
 {
-  typedef Policy policy;
+  using policy = Policy;
 
   template <template <typename, template <typename> class> class Template, typename Argument>
   struct apply_base_second
   {
-    typedef Template<Argument, CRTPBase> type;
+    using type = Template<Argument, CRTPBase>;
   };
 };
 
@@ -100,13 +100,13 @@ struct TestAllocatorAttachment
   }
 };
 
-typedef policy_info<thrust::detail::seq_t, thrust::system::detail::sequential::execution_policy> sequential_info;
-typedef policy_info<thrust::system::cpp::detail::par_t, thrust::system::cpp::detail::execution_policy> cpp_par_info;
-typedef policy_info<thrust::system::omp::detail::par_t, thrust::system::omp::detail::execution_policy> omp_par_info;
-typedef policy_info<thrust::system::tbb::detail::par_t, thrust::system::tbb::detail::execution_policy> tbb_par_info;
+using sequential_info = policy_info<thrust::detail::seq_t, thrust::system::detail::sequential::execution_policy>;
+using cpp_par_info    = policy_info<thrust::system::cpp::detail::par_t, thrust::system::cpp::detail::execution_policy>;
+using omp_par_info    = policy_info<thrust::system::omp::detail::par_t, thrust::system::omp::detail::execution_policy>;
+using tbb_par_info    = policy_info<thrust::system::tbb::detail::par_t, thrust::system::tbb::detail::execution_policy>;
 
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-typedef policy_info<thrust::system::cuda::detail::par_t, thrust::cuda_cub::execute_on_stream_base> cuda_par_info;
+using cuda_par_info = policy_info<thrust::system::cuda::detail::par_t, thrust::cuda_cub::execute_on_stream_base>;
 #endif
 
 SimpleUnitTest<TestAllocatorAttachment,

--- a/thrust/testing/binary_search_descending.cu
+++ b/thrust/testing/binary_search_descending.cu
@@ -12,7 +12,7 @@
 template <class Vector>
 void TestScalarLowerBoundDescendingSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector vec(5);
 
@@ -38,7 +38,7 @@ DECLARE_VECTOR_UNITTEST(TestScalarLowerBoundDescendingSimple);
 template <class Vector>
 void TestScalarUpperBoundDescendingSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector vec(5);
 
@@ -64,7 +64,7 @@ DECLARE_VECTOR_UNITTEST(TestScalarUpperBoundDescendingSimple);
 template <class Vector>
 void TestScalarBinarySearchDescendingSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector vec(5);
 
@@ -90,7 +90,7 @@ DECLARE_VECTOR_UNITTEST(TestScalarBinarySearchDescendingSimple);
 template <class Vector>
 void TestScalarEqualRangeDescendingSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector vec(5);
 

--- a/thrust/testing/binary_search_vector.cu
+++ b/thrust/testing/binary_search_vector.cu
@@ -15,10 +15,10 @@
 template <class ExampleVector, typename NewType>
 struct vector_like
 {
-  typedef typename ExampleVector::allocator_type alloc;
-  typedef typename thrust::detail::allocator_traits<alloc> alloc_traits;
-  typedef typename alloc_traits::template rebind_alloc<NewType> new_alloc;
-  typedef thrust::detail::vector_base<NewType, new_alloc> type;
+  using alloc        = typename ExampleVector::allocator_type;
+  using alloc_traits = typename thrust::detail::allocator_traits<alloc>;
+  using new_alloc    = typename alloc_traits::template rebind_alloc<NewType>;
+  using type         = thrust::detail::vector_base<NewType, new_alloc>;
 };
 
 template <class Vector>
@@ -35,8 +35,8 @@ void TestVectorLowerBoundSimple()
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
 
-  typedef typename Vector::difference_type int_type;
-  typedef typename vector_like<Vector, int_type>::type IntVector;
+  using int_type  = typename Vector::difference_type;
+  using IntVector = typename vector_like<Vector, int_type>::type;
 
   // test with integral output type
   IntVector integral_output(10);
@@ -59,7 +59,7 @@ void TestVectorLowerBoundSimple()
   ASSERT_EQUAL(integral_output[9], 5);
 
   //    // test with interator output type
-  //    typedef typename vector_like<Vector, typename Vector::iterator>::type IteratorVector;
+  //    using IteratorVector = typename vector_like<Vector, typename Vector::iterator>::type;
   //    IteratorVector iterator_output(10);
   //    thrust::lower_bound(vec.begin(), vec.end(), input.begin(), input.end(), iterator_output.begin());
   //
@@ -131,8 +131,8 @@ void TestVectorUpperBoundSimple()
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
 
-  typedef typename Vector::difference_type int_type;
-  typedef typename vector_like<Vector, int_type>::type IntVector;
+  using int_type  = typename Vector::difference_type;
+  using IntVector = typename vector_like<Vector, int_type>::type;
 
   // test with integral output type
   IntVector integral_output(10);
@@ -153,7 +153,7 @@ void TestVectorUpperBoundSimple()
   ASSERT_EQUAL(integral_output[9], 5);
 
   //    // test with interator output type
-  //    typedef typename vector_like<Vector, typename Vector::iterator>::type IteratorVector;
+  //    using IteratorVector = typename vector_like<Vector, typename Vector::iterator>::type;
   //    IteratorVector iterator_output(10);
   //    thrust::lower_bound(vec.begin(), vec.end(), input.begin(), input.end(), iterator_output.begin());
   //
@@ -225,9 +225,9 @@ void TestVectorBinarySearchSimple()
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
 
-  typedef typename vector_like<Vector, bool>::type BoolVector;
-  typedef typename Vector::difference_type int_type;
-  typedef typename vector_like<Vector, int_type>::type IntVector;
+  using BoolVector = typename vector_like<Vector, bool>::type;
+  using int_type   = typename Vector::difference_type;
+  using IntVector  = typename vector_like<Vector, int_type>::type;
 
   // test with boolean output type
   BoolVector bool_output(10);
@@ -321,7 +321,7 @@ struct TestVectorLowerBound
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(2 * n);
     thrust::device_vector<T> d_input = h_input;
 
-    typedef typename thrust::host_vector<T>::difference_type int_type;
+    using int_type = typename thrust::host_vector<T>::difference_type;
     thrust::host_vector<int_type> h_output(2 * n);
     thrust::device_vector<int_type> d_output(2 * n);
 
@@ -345,7 +345,7 @@ struct TestVectorUpperBound
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(2 * n);
     thrust::device_vector<T> d_input = h_input;
 
-    typedef typename thrust::host_vector<T>::difference_type int_type;
+    using int_type = typename thrust::host_vector<T>::difference_type;
     thrust::host_vector<int_type> h_output(2 * n);
     thrust::device_vector<int_type> d_output(2 * n);
 
@@ -369,7 +369,7 @@ struct TestVectorBinarySearch
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(2 * n);
     thrust::device_vector<T> d_input = h_input;
 
-    typedef typename thrust::host_vector<T>::difference_type int_type;
+    using int_type = typename thrust::host_vector<T>::difference_type;
     thrust::host_vector<int_type> h_output(2 * n);
     thrust::device_vector<int_type> d_output(2 * n);
 

--- a/thrust/testing/binary_search_vector_descending.cu
+++ b/thrust/testing/binary_search_vector_descending.cu
@@ -14,16 +14,16 @@
 template <class ExampleVector, typename NewType>
 struct vector_like
 {
-  typedef typename ExampleVector::allocator_type alloc;
-  typedef typename thrust::detail::allocator_traits<alloc> alloc_traits;
-  typedef typename alloc_traits::template rebind_alloc<NewType> new_alloc;
-  typedef thrust::detail::vector_base<NewType, new_alloc> type;
+  using alloc        = typename ExampleVector::allocator_type;
+  using alloc_traits = typename thrust::detail::allocator_traits<alloc>;
+  using new_alloc    = typename alloc_traits::template rebind_alloc<NewType>;
+  using type         = thrust::detail::vector_base<NewType, new_alloc>;
 };
 
 template <class Vector>
 void TestVectorLowerBoundDescendingSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector vec(5);
 
@@ -36,8 +36,8 @@ void TestVectorLowerBoundDescendingSimple()
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
 
-  typedef typename Vector::difference_type int_type;
-  typedef typename vector_like<Vector, int_type>::type IntVector;
+  using int_type  = typename Vector::difference_type;
+  using IntVector = typename vector_like<Vector, int_type>::type;
 
   // test with integral output type
   IntVector integral_output(10);
@@ -73,9 +73,9 @@ void TestVectorUpperBoundDescendingSimple()
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
 
-  typedef typename Vector::difference_type int_type;
-  typedef typename Vector::value_type T;
-  typedef typename vector_like<Vector, int_type>::type IntVector;
+  using int_type  = typename Vector::difference_type;
+  using T         = typename Vector::value_type;
+  using IntVector = typename vector_like<Vector, int_type>::type;
 
   // test with integral output type
   IntVector integral_output(10);
@@ -111,10 +111,10 @@ void TestVectorBinarySearchDescendingSimple()
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
 
-  typedef typename vector_like<Vector, bool>::type BoolVector;
-  typedef typename Vector::difference_type int_type;
-  typedef typename Vector::value_type T;
-  typedef typename vector_like<Vector, int_type>::type IntVector;
+  using BoolVector = typename vector_like<Vector, bool>::type;
+  using int_type   = typename Vector::difference_type;
+  using T          = typename Vector::value_type;
+  using IntVector  = typename vector_like<Vector, int_type>::type;
 
   // test with boolean output type
   BoolVector bool_output(10);
@@ -166,7 +166,7 @@ struct TestVectorLowerBoundDescending
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(2 * n);
     thrust::device_vector<T> d_input = h_input;
 
-    typedef typename thrust::host_vector<T>::difference_type int_type;
+    using int_type = typename thrust::host_vector<T>::difference_type;
     thrust::host_vector<int_type> h_output(2 * n);
     thrust::device_vector<int_type> d_output(2 * n);
 
@@ -192,7 +192,7 @@ struct TestVectorUpperBoundDescending
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(2 * n);
     thrust::device_vector<T> d_input = h_input;
 
-    typedef typename thrust::host_vector<T>::difference_type int_type;
+    using int_type = typename thrust::host_vector<T>::difference_type;
     thrust::host_vector<int_type> h_output(2 * n);
     thrust::device_vector<int_type> d_output(2 * n);
 
@@ -218,7 +218,7 @@ struct TestVectorBinarySearchDescending
     thrust::host_vector<T> h_input   = unittest::random_integers<T>(2 * n);
     thrust::device_vector<T> d_input = h_input;
 
-    typedef typename thrust::host_vector<T>::difference_type int_type;
+    using int_type = typename thrust::host_vector<T>::difference_type;
     thrust::host_vector<int_type> h_output(2 * n);
     thrust::device_vector<int_type> d_output(2 * n);
 

--- a/thrust/testing/caching_allocator.cu
+++ b/thrust/testing/caching_allocator.cu
@@ -7,8 +7,8 @@
 template <typename Allocator>
 void test_implementation(Allocator alloc)
 {
-  typedef typename thrust::detail::allocator_traits<Allocator> Traits;
-  typedef typename Allocator::pointer Ptr;
+  using Traits = typename thrust::detail::allocator_traits<Allocator>;
+  using Ptr    = typename Allocator::pointer;
 
   Ptr p = Traits::allocate(alloc, 123);
   Traits::deallocate(alloc, p, 123);

--- a/thrust/testing/complex_transform.cu
+++ b/thrust/testing/complex_transform.cu
@@ -204,7 +204,7 @@ struct TestComplexArithmeticTransform
 {
   void operator()(const size_t n)
   {
-    typedef thrust::complex<T> type;
+    using type                     = thrust::complex<T>;
     thrust::host_vector<type> h_p1 = random_complex_samples<T>(n);
     thrust::host_vector<type> h_p2 = random_complex_samples<T>(n);
     thrust::host_vector<type> h_result(n);
@@ -225,7 +225,7 @@ struct TestComplexPlaneTransform
 {
   void operator()(const size_t n)
   {
-    typedef thrust::complex<T> type;
+    using type                     = thrust::complex<T>;
     thrust::host_vector<type> h_p1 = random_complex_samples<T>(n);
     thrust::host_vector<type> h_result(n);
 
@@ -244,7 +244,7 @@ struct TestComplexPowerTransform
 {
   void operator()(const size_t n)
   {
-    typedef thrust::complex<T> type;
+    using type                     = thrust::complex<T>;
     thrust::host_vector<type> h_p1 = random_complex_samples<T>(n);
     thrust::host_vector<type> h_p2 = random_complex_samples<T>(n);
     thrust::host_vector<type> h_result(n);
@@ -271,7 +271,7 @@ struct TestComplexExponentialTransform
 {
   void operator()(const size_t n)
   {
-    typedef thrust::complex<T> type;
+    using type                     = thrust::complex<T>;
     thrust::host_vector<type> h_p1 = random_complex_samples<T>(n);
     thrust::host_vector<type> h_result(n);
 
@@ -298,7 +298,7 @@ struct TestComplexTrigonometricTransform
 {
   void operator()(const size_t n)
   {
-    typedef thrust::complex<T> type;
+    using type                     = thrust::complex<T>;
     thrust::host_vector<type> h_p1 = random_complex_samples<T>(n);
     thrust::host_vector<type> h_result(n);
 

--- a/thrust/testing/constant_iterator.cu
+++ b/thrust/testing/constant_iterator.cu
@@ -133,8 +133,8 @@ void TestConstantIteratorTransform()
 {
   using namespace thrust;
 
-  typedef typename Vector::value_type T;
-  typedef constant_iterator<T> ConstIter;
+  using T         = typename Vector::value_type;
+  using ConstIter = constant_iterator<T>;
 
   Vector result(4);
 
@@ -162,8 +162,8 @@ void TestConstantIteratorReduce()
 {
   using namespace thrust;
 
-  typedef int T;
-  typedef constant_iterator<T> ConstIter;
+  using T         = int;
+  using ConstIter = constant_iterator<T>;
 
   ConstIter first = make_constant_iterator<T>(7);
   ConstIter last  = first + 4;

--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -19,7 +19,7 @@
 
 void TestCopyFromConstIterator()
 {
-  typedef int T;
+  using T = int;
 
   std::vector<T> v(5);
   v[0] = 0;
@@ -55,7 +55,7 @@ DECLARE_UNITTEST(TestCopyFromConstIterator);
 
 void TestCopyToDiscardIterator()
 {
-  typedef int T;
+  using T = int;
 
   thrust::host_vector<T> h_input(5, 1);
   thrust::device_vector<T> d_input = h_input;
@@ -75,7 +75,7 @@ DECLARE_UNITTEST(TestCopyToDiscardIterator);
 
 void TestCopyToDiscardIteratorZipped()
 {
-  typedef int T;
+  using T = int;
 
   thrust::host_vector<T> h_input(5, 1);
   thrust::device_vector<T> d_input = h_input;
@@ -84,11 +84,11 @@ void TestCopyToDiscardIteratorZipped()
   thrust::device_vector<T> d_output(5);
   thrust::discard_iterator<> reference(5);
 
-  typedef thrust::tuple<thrust::discard_iterator<>, thrust::host_vector<T>::iterator> Tuple1;
-  typedef thrust::tuple<thrust::discard_iterator<>, thrust::device_vector<T>::iterator> Tuple2;
+  using Tuple1 = thrust::tuple<thrust::discard_iterator<>, thrust::host_vector<T>::iterator>;
+  using Tuple2 = thrust::tuple<thrust::discard_iterator<>, thrust::device_vector<T>::iterator>;
 
-  typedef thrust::zip_iterator<Tuple1> ZipIterator1;
-  typedef thrust::zip_iterator<Tuple2> ZipIterator2;
+  using ZipIterator1 = thrust::zip_iterator<Tuple1>;
+  using ZipIterator2 = thrust::zip_iterator<Tuple2>;
 
   // copy from host_vector
   ZipIterator1 h_result = thrust::copy(
@@ -112,7 +112,7 @@ DECLARE_UNITTEST(TestCopyToDiscardIteratorZipped);
 template <class Vector>
 void TestCopyMatchingTypes()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -202,7 +202,7 @@ DECLARE_UNITTEST(TestCopyVectorBool);
 template <class Vector>
 void TestCopyListTo()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   // copy from list to Vector
   std::list<T> l;
@@ -273,7 +273,7 @@ struct mod_3
 template <class Vector>
 void TestCopyIfSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -401,7 +401,7 @@ DECLARE_INTEGRAL_VARIABLE_UNITTEST(TestCopyIfSequence);
 template <class Vector>
 void TestCopyIfStencilSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -552,7 +552,7 @@ DECLARE_UNITTEST(TestCopyIfNonTrivial);
 template <typename Vector>
 void TestCopyCountingIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   thrust::counting_iterator<T> iter(1);
 
@@ -570,7 +570,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestCopyCountingIterator);
 template <typename Vector>
 void TestCopyZipIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v1(3);
   v1[0] = 1;
@@ -595,7 +595,7 @@ DECLARE_VECTOR_UNITTEST(TestCopyZipIterator);
 template <typename Vector>
 void TestCopyConstantIteratorToZipIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v1(3, T(0));
   Vector v2(3, T(0));
@@ -776,9 +776,9 @@ struct is_non_const_reference<only_set_when_expected_it> : thrust::true_type
 template <>
 struct iterator_traits<only_set_when_expected_it>
 {
-  typedef long long value_type;
-  typedef only_set_when_expected_it reference;
-  typedef thrust::random_access_device_iterator_tag iterator_category;
+  using value_type        = long long;
+  using reference         = only_set_when_expected_it;
+  using iterator_category = thrust::random_access_device_iterator_tag;
 };
 THRUST_NAMESPACE_END
 

--- a/thrust/testing/copy_n.cu
+++ b/thrust/testing/copy_n.cu
@@ -13,7 +13,7 @@
 
 void TestCopyNFromConstIterator()
 {
-  typedef int T;
+  using T = int;
 
   std::vector<T> v(5);
   v[0] = 0;
@@ -48,7 +48,7 @@ DECLARE_UNITTEST(TestCopyNFromConstIterator);
 
 void TestCopyNToDiscardIterator()
 {
-  typedef int T;
+  using T = int;
 
   thrust::host_vector<T> h_input(5, 1);
   thrust::device_vector<T> d_input = h_input;
@@ -71,7 +71,7 @@ DECLARE_UNITTEST(TestCopyNToDiscardIterator);
 template <class Vector>
 void TestCopyNMatchingTypes()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -161,7 +161,7 @@ DECLARE_UNITTEST(TestCopyNVectorBool);
 template <class Vector>
 void TestCopyNListTo()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   // copy from list to Vector
   std::list<T> l;
@@ -205,7 +205,7 @@ DECLARE_VECTOR_UNITTEST(TestCopyNListTo);
 template <typename Vector>
 void TestCopyNCountingIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   thrust::counting_iterator<T> iter(1);
 
@@ -223,7 +223,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestCopyNCountingIterator);
 template <typename Vector>
 void TestCopyNZipIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v1(4);
   v1[0] = 1;
@@ -250,7 +250,7 @@ DECLARE_VECTOR_UNITTEST(TestCopyNZipIterator);
 template <typename Vector>
 void TestCopyNConstantIteratorToZipIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v1(4, T(0));
   Vector v2(4, T(0));

--- a/thrust/testing/count.cu
+++ b/thrust/testing/count.cu
@@ -44,7 +44,7 @@ struct greater_than_five
 template <class Vector>
 void TestCountIfSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;

--- a/thrust/testing/counting_iterator.cu
+++ b/thrust/testing/counting_iterator.cu
@@ -14,7 +14,7 @@ THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 // ensure that we properly support thrust::counting_iterator from cuda::std
 void test_iterator_traits()
 {
-  typedef cuda::std::iterator_traits<thrust::counting_iterator<int>> It;
+  using It       = cuda::std::iterator_traits<thrust::counting_iterator<int>>;
   using category = thrust::detail::iterator_category_with_system_and_traversal<std::random_access_iterator_tag,
                                                                                thrust::any_system_tag,
                                                                                thrust::random_access_traversal_tag>;
@@ -232,8 +232,8 @@ DECLARE_UNITTEST(TestCountingIteratorLowerBound);
 
 void TestCountingIteratorDifference()
 {
-  typedef thrust::counting_iterator<thrust::detail::uint64_t> Iterator;
-  typedef thrust::iterator_difference<Iterator>::type Difference;
+  using Iterator   = thrust::counting_iterator<thrust::detail::uint64_t>;
+  using Difference = thrust::iterator_difference<Iterator>::type;
 
   Difference diff = std::numeric_limits<thrust::detail::uint32_t>::max() + 1;
 

--- a/thrust/testing/cuda/binary_search.cu
+++ b/thrust/testing/cuda/binary_search.cu
@@ -8,9 +8,9 @@
 
 void TestEqualRangeOnStream()
 { // Regression test for GH issue #921 (nvbug 2173437)
-  typedef typename thrust::device_vector<int> vector_t;
-  typedef typename vector_t::iterator iterator_t;
-  typedef thrust::pair<iterator_t, iterator_t> result_t;
+  using vector_t   = typename thrust::device_vector<int>;
+  using iterator_t = typename vector_t::iterator;
+  using result_t   = thrust::pair<iterator_t, iterator_t>;
 
   vector_t input(10);
   thrust::sequence(thrust::device, input.begin(), input.end(), 0);

--- a/thrust/testing/cuda/copy_if.cu
+++ b/thrust/testing/cuda/copy_if.cu
@@ -125,7 +125,7 @@ DECLARE_UNITTEST(TestCopyIfDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestCopyIfCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector data(5);
   data[0] = 1;
@@ -259,8 +259,8 @@ DECLARE_UNITTEST(TestCopyIfStencilDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestCopyIfStencilCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(5);
   data[0] = 1;

--- a/thrust/testing/cuda/find.cu
+++ b/thrust/testing/cuda/find.cu
@@ -65,7 +65,7 @@ void TestFindDevice(ExecutionPolicy exec)
 
   typename thrust::host_vector<int>::iterator h_iter;
 
-  typedef typename thrust::device_vector<int>::iterator iter_type;
+  using iter_type = typename thrust::device_vector<int>::iterator;
   thrust::device_vector<iter_type> d_result(1);
 
   h_iter = thrust::find(h_data.begin(), h_data.end(), int(0));
@@ -122,7 +122,7 @@ void TestFindIfDevice(ExecutionPolicy exec)
 
   typename thrust::host_vector<int>::iterator h_iter;
 
-  typedef typename thrust::device_vector<int>::iterator iter_type;
+  using iter_type = typename thrust::device_vector<int>::iterator;
   thrust::device_vector<iter_type> d_result(1);
 
   h_iter = thrust::find_if(h_data.begin(), h_data.end(), equal_to_value_pred<int>(0));
@@ -178,7 +178,7 @@ void TestFindIfNotDevice(ExecutionPolicy exec)
 
   typename thrust::host_vector<int>::iterator h_iter;
 
-  typedef typename thrust::device_vector<int>::iterator iter_type;
+  using iter_type = typename thrust::device_vector<int>::iterator;
   thrust::device_vector<iter_type> d_result(1);
 
   h_iter = thrust::find_if_not(h_data.begin(), h_data.end(), not_equal_to_value_pred<int>(0));

--- a/thrust/testing/cuda/is_sorted_until.cu
+++ b/thrust/testing/cuda/is_sorted_until.cu
@@ -17,7 +17,7 @@ void TestIsSortedUntilDevice(ExecutionPolicy exec)
 
   thrust::device_vector<int> v = unittest::random_integers<int>(n);
 
-  typedef typename thrust::device_vector<int>::iterator iter_type;
+  using iter_type = typename thrust::device_vector<int>::iterator;
 
   thrust::device_vector<iter_type> result(1);
 
@@ -58,10 +58,10 @@ DECLARE_UNITTEST(TestIsSortedUntilDeviceDevice);
 
 void TestIsSortedUntilCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
-  typedef Vector::value_type T;
-  typedef Vector::iterator Iterator;
+  using T        = Vector::value_type;
+  using Iterator = Vector::iterator;
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/logical.cu
+++ b/thrust/testing/cuda/logical.cu
@@ -14,7 +14,7 @@ __global__ void all_of_kernel(ExecutionPolicy exec, Iterator first, Iterator las
 template <typename ExecutionPolicy>
 void TestAllOfDevice(ExecutionPolicy exec)
 {
-  typedef int T;
+  using T = int;
   thrust::device_vector<T> v(3, 1);
   thrust::device_vector<bool> result(1);
 
@@ -84,8 +84,8 @@ DECLARE_UNITTEST(TestAllOfDeviceDevice);
 
 void TestAllOfCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector v(3, 1);
 
@@ -117,7 +117,7 @@ __global__ void any_of_kernel(ExecutionPolicy exec, Iterator first, Iterator las
 template <typename ExecutionPolicy>
 void TestAnyOfDevice(ExecutionPolicy exec)
 {
-  typedef int T;
+  using T = int;
 
   thrust::device_vector<T> v(3, 1);
   thrust::device_vector<bool> result(1);
@@ -188,8 +188,8 @@ DECLARE_UNITTEST(TestAnyOfDeviceDevice);
 
 void TestAnyOfCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector v(3, 1);
 
@@ -221,7 +221,7 @@ __global__ void none_of_kernel(ExecutionPolicy exec, Iterator first, Iterator la
 template <typename ExecutionPolicy>
 void TestNoneOfDevice(ExecutionPolicy exec)
 {
-  typedef int T;
+  using T = int;
 
   thrust::device_vector<T> v(3, 1);
   thrust::device_vector<bool> result(1);
@@ -292,8 +292,8 @@ DECLARE_UNITTEST(TestNoneOfDeviceDevice);
 
 void TestNoneOfCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector v(3, 1);
 

--- a/thrust/testing/cuda/max_element.cu
+++ b/thrust/testing/cuda/max_element.cu
@@ -24,7 +24,7 @@ void TestMaxElementDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_data   = unittest::random_samples<int>(n);
   thrust::device_vector<int> d_data = h_data;
 
-  typedef typename thrust::device_vector<int>::iterator iter_type;
+  using iter_type = typename thrust::device_vector<int>::iterator;
 
   thrust::device_vector<iter_type> d_result(1);
 
@@ -72,8 +72,8 @@ DECLARE_UNITTEST(TestMaxElementDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestMaxElementCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(6);
   data[0] = 3;
@@ -111,8 +111,8 @@ DECLARE_UNITTEST(TestMaxElementCudaStreamsNoSync);
 
 void TestMaxElementDevicePointer()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(6);
   data[0] = 3;

--- a/thrust/testing/cuda/memory.cu
+++ b/thrust/testing/cuda/memory.cu
@@ -49,8 +49,8 @@ void TestGetTemporaryBufferDeviceSeq()
 {
   const std::ptrdiff_t n = 9001;
 
-  typedef thrust::pointer<int, thrust::detail::seq_t> pointer;
-  typedef thrust::pair<pointer, std::ptrdiff_t> ptr_and_sz_type;
+  using pointer         = thrust::pointer<int, thrust::detail::seq_t>;
+  using ptr_and_sz_type = thrust::pair<pointer, std::ptrdiff_t>;
   thrust::device_vector<ptr_and_sz_type> d_result(1);
 
   get_temporary_buffer_kernel<<<1, 1>>>(n, d_result.begin());
@@ -99,7 +99,7 @@ void TestMallocDeviceSeq()
 {
   const std::ptrdiff_t n = 9001;
 
-  typedef thrust::pointer<int, thrust::detail::seq_t> pointer;
+  using pointer = thrust::pointer<int, thrust::detail::seq_t>;
   thrust::device_vector<pointer> d_result(1);
 
   malloc_kernel<<<1, 1>>>(n, d_result.begin());

--- a/thrust/testing/cuda/merge_by_key.cu
+++ b/thrust/testing/cuda/merge_by_key.cu
@@ -53,7 +53,7 @@ void TestMergeByKeyDevice(ExecutionPolicy exec)
 
   thrust::device_vector<int> result_key(7), result_val(7);
 
-  typedef typename thrust::device_vector<int>::iterator Iterator;
+  using Iterator = typename thrust::device_vector<int>::iterator;
 
   thrust::device_vector<thrust::pair<Iterator, Iterator>> result_ends(1);
 
@@ -94,8 +94,8 @@ DECLARE_UNITTEST(TestMergeByKeyDeviceDevice);
 
 void TestMergeByKeyCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   // clang-format off
   Vector a_key(3), a_val(3), b_key(4), b_val(4);

--- a/thrust/testing/cuda/merge_sort.cu
+++ b/thrust/testing/cuda/merge_sort.cu
@@ -92,8 +92,8 @@ void InitializeSimpleStableKeySortTest(Vector& unsorted_keys, Vector& sorted_key
 void TestMergeSortKeySimple()
 {
 #if 0
-    typedef thrust::device_vector<int> Vector;
-    typedef Vector::value_type T;
+    using Vector = thrust::device_vector<int>;
+    using T = Vector::value_type;
 
     Vector unsorted_keys;
     Vector   sorted_keys;
@@ -113,8 +113,8 @@ DECLARE_UNITTEST(TestMergeSortKeySimple);
 void TestMergeSortKeyValueSimple()
 {
 #if 0
-    typedef thrust::device_vector<int> Vector;
-    typedef Vector::value_type T;
+    using Vector = thrust::device_vector<int>;
+    using T = Vector::value_type;
 
     Vector unsorted_keys, unsorted_values;
     Vector   sorted_keys,   sorted_values;
@@ -135,8 +135,8 @@ DECLARE_UNITTEST(TestMergeSortKeyValueSimple);
 void TestMergeSortStableKeySimple()
 {
 #if 0
-    typedef thrust::device_vector<int> Vector;
-    typedef Vector::value_type T;
+    using Vector = thrust::device_vector<int>;
+    using T = Vector::value_type;
 
     Vector unsorted_keys;
     Vector   sorted_keys;
@@ -225,7 +225,7 @@ template <typename U>
 void TestMergeSortKeyValue(size_t n)
 {
 #if 0
-  typedef key_value<U,U> T;
+  using T = key_value<U,U>;
 
   thrust::host_vector<U> h_keys   = unittest::random_integers<U>(n);
   thrust::host_vector<U> h_values = unittest::random_integers<U>(n);

--- a/thrust/testing/cuda/min_element.cu
+++ b/thrust/testing/cuda/min_element.cu
@@ -24,7 +24,7 @@ void TestMinElementDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_data   = unittest::random_samples<int>(n);
   thrust::device_vector<int> d_data = h_data;
 
-  typedef typename thrust::device_vector<int>::iterator iter_type;
+  using iter_type = typename thrust::device_vector<int>::iterator;
 
   thrust::device_vector<iter_type> d_result(1);
 
@@ -65,8 +65,8 @@ DECLARE_UNITTEST(TestMinElementDeviceDevice);
 
 void TestMinElementCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(6);
   data[0] = 3;
@@ -92,8 +92,8 @@ DECLARE_UNITTEST(TestMinElementCudaStreams);
 
 void TestMinElementDevicePointer()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(6);
   data[0] = 3;

--- a/thrust/testing/cuda/minmax_element.cu
+++ b/thrust/testing/cuda/minmax_element.cu
@@ -29,8 +29,8 @@ void TestMinMaxElementDevice(ExecutionPolicy exec)
   typename thrust::device_vector<int>::iterator d_min;
   typename thrust::device_vector<int>::iterator d_max;
 
-  typedef thrust::pair<typename thrust::device_vector<int>::iterator, typename thrust::device_vector<int>::iterator>
-    pair_type;
+  using pair_type =
+    thrust::pair<typename thrust::device_vector<int>::iterator, typename thrust::device_vector<int>::iterator>;
 
   thrust::device_vector<pair_type> d_result(1);
 
@@ -83,7 +83,7 @@ DECLARE_UNITTEST(TestMinMaxElementDeviceDevice);
 
 void TestMinMaxElementCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector data(6);
   data[0] = 3;
@@ -107,8 +107,8 @@ DECLARE_UNITTEST(TestMinMaxElementCudaStreams);
 
 void TestMinMaxElementDevicePointer()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(6);
   data[0] = 3;

--- a/thrust/testing/cuda/mismatch.cu
+++ b/thrust/testing/cuda/mismatch.cu
@@ -17,8 +17,8 @@ void TestMismatchDevice(ExecutionPolicy exec)
   thrust::device_vector<int> a = {1, 2, 3, 4};
   thrust::device_vector<int> b = {1, 2, 4, 3};
 
-  typedef thrust::pair<typename thrust::device_vector<int>::iterator, typename thrust::device_vector<int>::iterator>
-    pair_type;
+  using pair_type =
+    thrust::pair<typename thrust::device_vector<int>::iterator, typename thrust::device_vector<int>::iterator>;
 
   thrust::device_vector<pair_type> d_result(1);
 
@@ -69,7 +69,7 @@ DECLARE_UNITTEST(TestMismatchDeviceDevice);
 
 void TestMismatchCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector a = {1, 2, 3, 4};
   Vector b = {1, 2, 4, 3};

--- a/thrust/testing/cuda/pair_sort.cu
+++ b/thrust/testing/cuda/pair_sort.cu
@@ -24,7 +24,7 @@ template <typename ExecutionPolicy>
 void TestPairStableSortDevice(ExecutionPolicy exec)
 {
   size_t n = 10000;
-  typedef thrust::pair<int, int> P;
+  using P  = thrust::pair<int, int>;
 
   thrust::host_vector<int> h_p1 = unittest::random_integers<int>(n);
   thrust::host_vector<int> h_p2 = unittest::random_integers<int>(n);

--- a/thrust/testing/cuda/pair_sort_by_key.cu
+++ b/thrust/testing/cuda/pair_sort_by_key.cu
@@ -27,7 +27,7 @@ template <typename ExecutionPolicy>
 void TestPairStableSortByKeyDevice(ExecutionPolicy exec)
 {
   size_t n = 10000;
-  typedef thrust::pair<int, int> P;
+  using P  = thrust::pair<int, int>;
 
   // host arrays
   thrust::host_vector<int> h_p1 = unittest::random_integers<int>(n);

--- a/thrust/testing/cuda/partition.cu
+++ b/thrust/testing/cuda/partition.cu
@@ -46,8 +46,8 @@ __global__ void partition_kernel(ExecutionPolicy exec, Iterator1 first, Iterator
 template <typename ExecutionPolicy>
 void TestPartitionDevice(ExecutionPolicy exec)
 {
-  typedef int T;
-  typedef typename thrust::device_vector<T>::iterator iterator;
+  using T        = int;
+  using iterator = typename thrust::device_vector<T>::iterator;
 
   thrust::device_vector<T> data(5);
   data[0] = 1;
@@ -101,8 +101,8 @@ __global__ void partition_kernel(
 template <typename ExecutionPolicy>
 void TestPartitionStencilDevice(ExecutionPolicy exec)
 {
-  typedef int T;
-  typedef typename thrust::device_vector<T>::iterator iterator;
+  using T        = int;
+  using iterator = typename thrust::device_vector<T>::iterator;
 
   thrust::device_vector<T> data(5);
   data[0] = 0;
@@ -174,8 +174,8 @@ __global__ void partition_copy_kernel(
 template <typename ExecutionPolicy>
 void TestPartitionCopyDevice(ExecutionPolicy exec)
 {
-  typedef int T;
-  typedef thrust::device_vector<T>::iterator iterator;
+  using T        = int;
+  using iterator = thrust::device_vector<T>::iterator;
 
   thrust::device_vector<T> data(5);
   data[0] = 1;
@@ -187,7 +187,7 @@ void TestPartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<int> true_results(2);
   thrust::device_vector<int> false_results(3);
 
-  typedef thrust::pair<iterator, iterator> pair_type;
+  using pair_type = thrust::pair<iterator, iterator>;
   thrust::device_vector<pair_type> iterators(1);
 
   partition_copy_kernel<<<1, 1>>>(
@@ -253,7 +253,7 @@ __global__ void partition_copy_kernel(
 template <typename ExecutionPolicy>
 void TestPartitionCopyStencilDevice(ExecutionPolicy exec)
 {
-  typedef int T;
+  using T = int;
 
   thrust::device_vector<int> data(5);
   data[0] = 0;
@@ -272,8 +272,8 @@ void TestPartitionCopyStencilDevice(ExecutionPolicy exec)
   thrust::device_vector<int> true_results(2);
   thrust::device_vector<int> false_results(3);
 
-  typedef typename thrust::device_vector<int>::iterator iterator;
-  typedef thrust::pair<iterator, iterator> pair_type;
+  using iterator  = typename thrust::device_vector<int>::iterator;
+  using pair_type = thrust::pair<iterator, iterator>;
   thrust::device_vector<pair_type> iterators(1);
 
   partition_copy_kernel<<<1, 1>>>(
@@ -333,8 +333,8 @@ stable_partition_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, P
 template <typename ExecutionPolicy>
 void TestStablePartitionDevice(ExecutionPolicy exec)
 {
-  typedef int T;
-  typedef typename thrust::device_vector<T>::iterator iterator;
+  using T        = int;
+  using iterator = typename thrust::device_vector<T>::iterator;
 
   thrust::device_vector<T> data(5);
   data[0] = 1;
@@ -388,8 +388,8 @@ __global__ void stable_partition_kernel(
 template <typename ExecutionPolicy>
 void TestStablePartitionStencilDevice(ExecutionPolicy exec)
 {
-  typedef int T;
-  typedef typename thrust::device_vector<T>::iterator iterator;
+  using T        = int;
+  using iterator = typename thrust::device_vector<T>::iterator;
 
   thrust::device_vector<T> data(5);
   data[0] = 0;
@@ -461,8 +461,8 @@ __global__ void stable_partition_copy_kernel(
 template <typename ExecutionPolicy>
 void TestStablePartitionCopyDevice(ExecutionPolicy exec)
 {
-  typedef int T;
-  typedef thrust::device_vector<T>::iterator iterator;
+  using T        = int;
+  using iterator = thrust::device_vector<T>::iterator;
 
   thrust::device_vector<T> data(5);
   data[0] = 1;
@@ -474,7 +474,7 @@ void TestStablePartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<int> true_results(2);
   thrust::device_vector<int> false_results(3);
 
-  typedef thrust::pair<iterator, iterator> pair_type;
+  using pair_type = thrust::pair<iterator, iterator>;
   thrust::device_vector<pair_type> iterators(1);
 
   stable_partition_copy_kernel<<<1, 1>>>(
@@ -540,7 +540,7 @@ __global__ void stable_partition_copy_kernel(
 template <typename ExecutionPolicy>
 void TestStablePartitionCopyStencilDevice(ExecutionPolicy exec)
 {
-  typedef int T;
+  using T = int;
 
   thrust::device_vector<int> data(5);
   data[0] = 0;
@@ -559,8 +559,8 @@ void TestStablePartitionCopyStencilDevice(ExecutionPolicy exec)
   thrust::device_vector<int> true_results(2);
   thrust::device_vector<int> false_results(3);
 
-  typedef typename thrust::device_vector<int>::iterator iterator;
-  typedef thrust::pair<iterator, iterator> pair_type;
+  using iterator  = typename thrust::device_vector<int>::iterator;
+  using pair_type = thrust::pair<iterator, iterator>;
   thrust::device_vector<pair_type> iterators(1);
 
   stable_partition_copy_kernel<<<1, 1>>>(
@@ -687,9 +687,9 @@ DECLARE_UNITTEST(TestPartitionIfWithLargeNumberOfItems);
 template <typename ExecutionPolicy>
 void TestPartitionCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using T        = Vector::value_type;
+  using Iterator = Vector::iterator;
 
   Vector data(5);
   data[0] = 1;

--- a/thrust/testing/cuda/partition_point.cu
+++ b/thrust/testing/cuda/partition_point.cu
@@ -26,7 +26,7 @@ void TestPartitionPointDevice(ExecutionPolicy exec)
 {
   size_t n                     = 1000;
   thrust::device_vector<int> v = unittest::random_integers<int>(n);
-  typedef typename thrust::device_vector<int>::iterator iterator;
+  using iterator               = typename thrust::device_vector<int>::iterator;
 
   iterator ref = thrust::stable_partition(v.begin(), v.end(), is_even<int>());
 
@@ -53,9 +53,9 @@ DECLARE_UNITTEST(TestPartitionPointDeviceDevice);
 
 void TestPartitionPointCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using T        = Vector::value_type;
+  using Iterator = Vector::iterator;
 
   Vector v(4);
   v[0] = 1;

--- a/thrust/testing/cuda/reduce.cu
+++ b/thrust/testing/cuda/reduce.cu
@@ -64,7 +64,7 @@ VariableUnitTest<TestReduceDeviceNoSync, IntegralTypes> TestReduceDeviceNoSyncIn
 template <typename ExecutionPolicy>
 void TestReduceCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector v(3);
   v[0] = 1;

--- a/thrust/testing/cuda/reduce_by_key.cu
+++ b/thrust/testing/cuda/reduce_by_key.cu
@@ -114,14 +114,13 @@ void initialize_values(Vector& values)
 template <typename ExecutionPolicy>
 void TestReduceByKeyDevice(ExecutionPolicy exec)
 {
-  typedef int T;
+  using T = int;
 
   thrust::device_vector<T> keys;
   thrust::device_vector<T> values;
 
-  typedef
-    typename thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator>
-      iterator_pair;
+  using iterator_pair =
+    typename thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator>;
 
   thrust::device_vector<iterator_pair> new_last_vec(1);
   iterator_pair new_last;
@@ -244,8 +243,8 @@ DECLARE_UNITTEST(TestReduceByKeyDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestReduceByKeyCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector keys;
   Vector values;

--- a/thrust/testing/cuda/remove.cu
+++ b/thrust/testing/cuda/remove.cu
@@ -82,7 +82,7 @@ void TestRemoveDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_data   = unittest::random_samples<int>(n);
   thrust::device_vector<int> d_data = h_data;
 
-  typedef typename thrust::device_vector<int>::iterator iterator;
+  using iterator = typename thrust::device_vector<int>::iterator;
   thrust::device_vector<iterator> d_result(1);
 
   size_t h_size = thrust::remove(h_data.begin(), h_data.end(), 0) - h_data.begin();
@@ -120,7 +120,7 @@ void TestRemoveIfDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_data   = unittest::random_samples<int>(n);
   thrust::device_vector<int> d_data = h_data;
 
-  typedef typename thrust::device_vector<int>::iterator iterator;
+  using iterator = typename thrust::device_vector<int>::iterator;
   thrust::device_vector<iterator> d_result(1);
 
   size_t h_size = thrust::remove_if(h_data.begin(), h_data.end(), is_true<int>()) - h_data.begin();
@@ -158,7 +158,7 @@ void TestRemoveIfStencilDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_data   = unittest::random_samples<int>(n);
   thrust::device_vector<int> d_data = h_data;
 
-  typedef typename thrust::device_vector<int>::iterator iterator;
+  using iterator = typename thrust::device_vector<int>::iterator;
   thrust::device_vector<iterator> d_result(1);
 
   thrust::host_vector<bool> h_stencil   = unittest::random_integers<bool>(n);
@@ -202,7 +202,7 @@ void TestRemoveCopyDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_result(n);
   thrust::device_vector<int> d_result(n);
 
-  typedef typename thrust::device_vector<int>::iterator iterator;
+  using iterator = typename thrust::device_vector<int>::iterator;
   thrust::device_vector<iterator> d_new_end(1);
 
   size_t h_size = thrust::remove_copy(h_data.begin(), h_data.end(), h_result.begin(), 0) - h_result.begin();
@@ -243,7 +243,7 @@ void TestRemoveCopyIfDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_result(n);
   thrust::device_vector<int> d_result(n);
 
-  typedef typename thrust::device_vector<int>::iterator iterator;
+  using iterator = typename thrust::device_vector<int>::iterator;
   thrust::device_vector<iterator> d_new_end(1);
 
   size_t h_size =
@@ -286,7 +286,7 @@ void TestRemoveCopyIfStencilDevice(ExecutionPolicy exec)
   thrust::host_vector<int> h_result(n);
   thrust::device_vector<int> d_result(n);
 
-  typedef typename thrust::device_vector<int>::iterator iterator;
+  using iterator = typename thrust::device_vector<int>::iterator;
   thrust::device_vector<iterator> d_new_end(1);
 
   thrust::host_vector<bool> h_stencil   = unittest::random_integers<bool>(n);
@@ -326,8 +326,8 @@ DECLARE_UNITTEST(TestRemoveCopyIfStencilDeviceDevice);
 
 void TestRemoveCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -353,8 +353,8 @@ DECLARE_UNITTEST(TestRemoveCudaStreams);
 
 void TestRemoveCopyCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -382,8 +382,8 @@ DECLARE_UNITTEST(TestRemoveCopyCudaStreams);
 
 void TestRemoveIfCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -409,8 +409,8 @@ DECLARE_UNITTEST(TestRemoveIfCudaStreams);
 
 void TestRemoveIfStencilCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -444,8 +444,8 @@ DECLARE_UNITTEST(TestRemoveIfStencilCudaStreams);
 
 void TestRemoveCopyIfCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -474,8 +474,8 @@ DECLARE_UNITTEST(TestRemoveCopyIfCudaStreams);
 
 void TestRemoveCopyIfStencilCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(5);
   data[0] = 1;

--- a/thrust/testing/cuda/replace.cu
+++ b/thrust/testing/cuda/replace.cu
@@ -261,8 +261,8 @@ DECLARE_UNITTEST(TestReplaceCopyIfStencilDeviceDevice);
 
 void TestReplaceCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(5);
   data[0] = 1;

--- a/thrust/testing/cuda/reverse.cu
+++ b/thrust/testing/cuda/reverse.cu
@@ -78,7 +78,7 @@ DECLARE_UNITTEST(TestReverseCopyDeviceDevice);
 
 void TestReverseCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
   Vector data(5);
   data[0] = 1;
   data[1] = 2;
@@ -108,7 +108,7 @@ DECLARE_UNITTEST(TestReverseCudaStreams);
 
 void TestReverseCopyCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
   Vector data(5);
   data[0] = 1;
   data[1] = 2;

--- a/thrust/testing/cuda/scan.cu
+++ b/thrust/testing/cuda/scan.cu
@@ -114,8 +114,8 @@ VariableUnitTest<TestScanDeviceDevice, IntegralTypes> TestScanDeviceDeviceInstan
 
 void TestScanCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector::iterator iter;
 

--- a/thrust/testing/cuda/scan_by_key.cu
+++ b/thrust/testing/cuda/scan_by_key.cu
@@ -131,9 +131,9 @@ DECLARE_UNITTEST(TestScanByKeyDeviceDevice);
 
 void TestInclusiveScanByKeyCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using T        = Vector::value_type;
+  using Iterator = Vector::iterator;
 
   Vector keys(7);
   Vector vals(7);
@@ -203,9 +203,9 @@ DECLARE_UNITTEST(TestInclusiveScanByKeyCudaStreams);
 
 void TestExclusiveScanByKeyCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using T        = Vector::value_type;
+  using Iterator = Vector::iterator;
 
   Vector keys(7);
   Vector vals(7);

--- a/thrust/testing/cuda/scatter.cu
+++ b/thrust/testing/cuda/scatter.cu
@@ -135,7 +135,7 @@ DECLARE_UNITTEST(TestScatterIfDeviceDevice);
 
 void TestScatterCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector map(5); // scatter indices
   Vector src(5); // source vector
@@ -169,7 +169,7 @@ DECLARE_UNITTEST(TestScatterCudaStreams);
 
 void TestScatterIfCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector flg(5); // predicate array
   Vector map(5); // scatter indices

--- a/thrust/testing/cuda/sequence.cu
+++ b/thrust/testing/cuda/sequence.cu
@@ -79,7 +79,7 @@ DECLARE_UNITTEST(TestSequenceDeviceDevice);
 
 void TestSequenceCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector v(5);
 

--- a/thrust/testing/cuda/set_difference.cu
+++ b/thrust/testing/cuda/set_difference.cu
@@ -20,8 +20,8 @@ __global__ void set_difference_kernel(
 template <typename ExecutionPolicy>
 void TestSetDifferenceDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = typename Vector::iterator;
 
   Vector a(4), b(5);
 
@@ -63,8 +63,8 @@ DECLARE_UNITTEST(TestSetDifferenceDeviceDevice);
 
 void TestSetDifferenceCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   Vector a(4), b(5);
 

--- a/thrust/testing/cuda/set_difference_by_key.cu
+++ b/thrust/testing/cuda/set_difference_by_key.cu
@@ -32,8 +32,8 @@ __global__ void set_difference_by_key_kernel(
 template <typename ExecutionPolicy>
 void TestSetDifferenceByKeyDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a_key(4), b_key(5);
@@ -52,7 +52,7 @@ void TestSetDifferenceByKeyDevice(ExecutionPolicy exec)
 
   Vector result_key(2), result_val(2);
 
-  typedef thrust::pair<Iterator, Iterator> iter_pair;
+  using iter_pair = thrust::pair<Iterator, Iterator>;
 
   thrust::device_vector<iter_pair> end_vec(1);
 
@@ -93,8 +93,8 @@ DECLARE_UNITTEST(TestSetDifferenceByKeyDeviceDevice);
 
 void TestSetDifferenceByKeyCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   // clang-format off
   Vector a_key(4), b_key(5);

--- a/thrust/testing/cuda/set_intersection.cu
+++ b/thrust/testing/cuda/set_intersection.cu
@@ -23,8 +23,8 @@ __global__ void set_intersection_kernel(
 template <typename ExecutionPolicy>
 void TestSetIntersectionDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   Vector a(3), b(4);
 
@@ -72,8 +72,8 @@ DECLARE_UNITTEST(TestSetIntersectionDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestSetIntersectionCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   Vector a(3), b(4);
 

--- a/thrust/testing/cuda/set_intersection_by_key.cu
+++ b/thrust/testing/cuda/set_intersection_by_key.cu
@@ -29,8 +29,8 @@ __global__ void set_intersection_by_key_kernel(
 template <typename ExecutionPolicy>
 void TestSetIntersectionByKeyDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a_key(3), b_key(4);
@@ -48,7 +48,7 @@ void TestSetIntersectionByKeyDevice(ExecutionPolicy exec)
 
   Vector result_key(2), result_val(2);
 
-  typedef thrust::pair<Iterator, Iterator> iter_pair;
+  using iter_pair = thrust::pair<Iterator, Iterator>;
   thrust::device_vector<iter_pair> end_vec(1);
 
   set_intersection_by_key_kernel<<<1, 1>>>(
@@ -94,8 +94,8 @@ DECLARE_UNITTEST(TestSetIntersectionByKeyDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestSetIntersectionByKeyCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   // clang-format off
   Vector a_key(3), b_key(4);

--- a/thrust/testing/cuda/set_symmetric_difference.cu
+++ b/thrust/testing/cuda/set_symmetric_difference.cu
@@ -20,8 +20,8 @@ __global__ void set_symmetric_difference_kernel(
 template <typename ExecutionPolicy>
 void TestSetSymmetricDifferenceDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a(4), b(5);
@@ -62,8 +62,8 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceDeviceDevice);
 
 void TestSetSymmetricDifferenceCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   // clang-format off
   Vector a(4), b(5);

--- a/thrust/testing/cuda/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/cuda/set_symmetric_difference_by_key.cu
@@ -31,8 +31,8 @@ __global__ void set_symmetric_difference_by_key_kernel(
 template <typename ExecutionPolicy>
 void TestSetSymmetricDifferenceByKeyDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a_key(4), b_key(5);
@@ -51,7 +51,7 @@ void TestSetSymmetricDifferenceByKeyDevice(ExecutionPolicy exec)
 
   Vector result_key(5), result_val(5);
 
-  typedef thrust::pair<Iterator, Iterator> iter_pair;
+  using iter_pair = thrust::pair<Iterator, Iterator>;
   thrust::device_vector<iter_pair> end_vec(1);
 
   set_symmetric_difference_by_key_kernel<<<1, 1>>>(
@@ -91,8 +91,8 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyDeviceDevice);
 
 void TestSetSymmetricDifferenceByKeyCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   // clang-format off
   Vector a_key(4), b_key(5);

--- a/thrust/testing/cuda/set_union.cu
+++ b/thrust/testing/cuda/set_union.cu
@@ -20,8 +20,8 @@ __global__ void set_union_kernel(
 template <typename ExecutionPolicy>
 void TestSetUnionDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a(3), b(4);
@@ -61,8 +61,8 @@ DECLARE_UNITTEST(TestSetUnionDeviceDevice);
 
 void TestSetUnionCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   // clang-format off
   Vector a(3), b(4);

--- a/thrust/testing/cuda/set_union_by_key.cu
+++ b/thrust/testing/cuda/set_union_by_key.cu
@@ -31,8 +31,8 @@ __global__ void set_union_by_key_kernel(
 template <typename ExecutionPolicy>
 void TestSetUnionByKeyDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a_key(3), b_key(4);
@@ -90,8 +90,8 @@ DECLARE_UNITTEST(TestSetUnionByKeyDeviceDevice);
 
 void TestSetUnionByKeyCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::iterator Iterator;
+  using Vector   = thrust::device_vector<int>;
+  using Iterator = Vector::iterator;
 
   Vector a_key(3), b_key(4);
   Vector a_val(3), b_val(4);

--- a/thrust/testing/cuda/swap_ranges.cu
+++ b/thrust/testing/cuda/swap_ranges.cu
@@ -13,7 +13,7 @@ __global__ void swap_ranges_kernel(ExecutionPolicy exec, Iterator1 first1, Itera
 template <typename ExecutionPolicy>
 void TestSwapRangesDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector v1(5);
   v1[0] = 0;
@@ -61,7 +61,7 @@ DECLARE_UNITTEST(TestSwapRangesDeviceDevice);
 
 void TestSwapRangesCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector v1(5);
   v1[0] = 0;

--- a/thrust/testing/cuda/tabulate.cu
+++ b/thrust/testing/cuda/tabulate.cu
@@ -14,9 +14,9 @@ __global__ void tabulate_kernel(ExecutionPolicy exec, Iterator first, Iterator l
 template <typename ExecutionPolicy>
 void TestTabulateDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
   using namespace thrust::placeholders;
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
 
@@ -73,8 +73,8 @@ DECLARE_UNITTEST(TestTabulateDeviceDevice);
 void TestTabulateCudaStreams()
 {
   using namespace thrust::placeholders;
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector v(5);
 

--- a/thrust/testing/cuda/transform.cu
+++ b/thrust/testing/cuda/transform.cu
@@ -14,8 +14,8 @@ __global__ void transform_kernel(
 template <typename ExecutionPolicy>
 void TestTransformUnaryDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -74,8 +74,8 @@ __global__ void transform_if_kernel(
 template <typename ExecutionPolicy>
 void TestTransformIfUnaryNoStencilDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -141,8 +141,8 @@ __global__ void transform_if_kernel(
 template <typename ExecutionPolicy>
 void TestTransformIfUnaryDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -217,8 +217,8 @@ __global__ void transform_kernel(
 template <typename ExecutionPolicy>
 void TestTransformBinaryDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -286,8 +286,8 @@ __global__ void transform_if_kernel(
 template <typename ExecutionPolicy>
 void TestTransformIfBinaryDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -351,8 +351,8 @@ DECLARE_UNITTEST(TestTransformIfBinaryDeviceDevice);
 
 void TestTransformUnaryCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector::iterator iter;
 
@@ -381,8 +381,8 @@ DECLARE_UNITTEST(TestTransformUnaryCudaStreams);
 
 void TestTransformBinaryCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector::iterator iter;
 

--- a/thrust/testing/cuda/transform_reduce.cu
+++ b/thrust/testing/cuda/transform_reduce.cu
@@ -14,8 +14,8 @@ __global__ void transform_reduce_kernel(
 template <typename ExecutionPolicy>
 void TestTransformReduceDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = typename Vector::value_type;
 
   Vector data(3);
   data[0] = 1;
@@ -49,8 +49,8 @@ DECLARE_UNITTEST(TestTransformReduceDeviceDevice);
 
 void TestTransformReduceCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(3);
   data[0] = 1;

--- a/thrust/testing/cuda/transform_scan.cu
+++ b/thrust/testing/cuda/transform_scan.cu
@@ -45,8 +45,8 @@ __global__ void transform_exclusive_scan_kernel(
 template <typename ExecutionPolicy>
 void TestTransformScanDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -169,8 +169,8 @@ DECLARE_UNITTEST(TestTransformScanDeviceDevice);
 
 void TestTransformScanCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector::iterator iter;
 
@@ -265,8 +265,8 @@ DECLARE_UNITTEST(TestTransformScanCudaStreams);
 
 void TestTransformScanConstAccumulator()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector::iterator iter;
 

--- a/thrust/testing/cuda/uninitialized_copy.cu
+++ b/thrust/testing/cuda/uninitialized_copy.cu
@@ -13,7 +13,7 @@ __global__ void uninitialized_copy_kernel(ExecutionPolicy exec, Iterator1 first,
 template <typename ExecutionPolicy>
 void TestUninitializedCopyDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector v1(5);
   v1[0] = 0;
@@ -50,7 +50,7 @@ DECLARE_UNITTEST(TestUninitializedCopyDeviceDevice);
 
 void TestUninitializedCopyCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector v1(5);
   v1[0] = 0;
@@ -88,7 +88,7 @@ __global__ void uninitialized_copy_n_kernel(ExecutionPolicy exec, Iterator1 firs
 template <typename ExecutionPolicy>
 void TestUninitializedCopyNDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector v1(5);
   v1[0] = 0;
@@ -125,7 +125,7 @@ DECLARE_UNITTEST(TestUninitializedCopyNDeviceDevice);
 
 void TestUninitializedCopyNCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
+  using Vector = thrust::device_vector<int>;
 
   Vector v1(5);
   v1[0] = 0;

--- a/thrust/testing/cuda/uninitialized_fill.cu
+++ b/thrust/testing/cuda/uninitialized_fill.cu
@@ -13,8 +13,8 @@ __global__ void uninitialized_fill_kernel(ExecutionPolicy exec, Iterator first, 
 template <typename ExecutionPolicy>
 void TestUninitializedFillDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -95,8 +95,8 @@ DECLARE_UNITTEST(TestUninitializedFillDeviceDevice);
 
 void TestUninitializedFillCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -133,8 +133,8 @@ __global__ void uninitialized_fill_n_kernel(ExecutionPolicy exec, Iterator1 firs
 template <typename ExecutionPolicy>
 void TestUninitializedFillNDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -229,8 +229,8 @@ DECLARE_UNITTEST(TestUninitializedFillNDeviceDevice);
 
 void TestUninitializedFillNCudaStreams()
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector v(5);
   v[0] = 0;

--- a/thrust/testing/cuda/unique.cu
+++ b/thrust/testing/cuda/unique.cu
@@ -29,8 +29,8 @@ unique_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, BinaryPredi
 template <typename ExecutionPolicy>
 void TestUniqueDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(10);
   data[0] = 11;
@@ -100,8 +100,8 @@ DECLARE_UNITTEST(TestUniqueDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestUniqueCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(10);
   data[0] = 11;
@@ -176,8 +176,8 @@ __global__ void unique_copy_kernel(
 template <typename ExecutionPolicy>
 void TestUniqueCopyDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(10);
   data[0] = 11;
@@ -250,8 +250,8 @@ DECLARE_UNITTEST(TestUniqueCopyDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestUniqueCopyCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(10);
   data[0] = 11;
@@ -327,8 +327,8 @@ unique_count_kernel(ExecutionPolicy exec, Iterator1 first, Iterator1 last, Binar
 template <typename ExecutionPolicy>
 void TestUniqueCountDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(10);
   data[0] = 11;
@@ -383,8 +383,8 @@ DECLARE_UNITTEST(TestUniqueCountDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestUniqueCountCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector data(10);
   data[0] = 11;

--- a/thrust/testing/cuda/unique_by_key.cu
+++ b/thrust/testing/cuda/unique_by_key.cu
@@ -66,13 +66,13 @@ __global__ void unique_by_key_kernel(
 template <typename ExecutionPolicy>
 void TestUniqueByKeyDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector keys;
   Vector values;
 
-  typedef thrust::pair<typename Vector::iterator, typename Vector::iterator> iter_pair;
+  using iter_pair = thrust::pair<typename Vector::iterator, typename Vector::iterator>;
   thrust::device_vector<iter_pair> new_last_vec(1);
   iter_pair new_last;
 
@@ -148,13 +148,13 @@ DECLARE_UNITTEST(TestUniqueByKeyDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestUniqueByKeyCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector keys;
   Vector values;
 
-  typedef thrust::pair<Vector::iterator, Vector::iterator> iter_pair;
+  using iter_pair = thrust::pair<Vector::iterator, Vector::iterator>;
   iter_pair new_last;
 
   // basic test
@@ -256,13 +256,13 @@ __global__ void unique_by_key_copy_kernel(
 template <typename ExecutionPolicy>
 void TestUniqueCopyByKeyDevice(ExecutionPolicy exec)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector keys;
   Vector values;
 
-  typedef thrust::pair<typename Vector::iterator, typename Vector::iterator> iter_pair;
+  using iter_pair = thrust::pair<typename Vector::iterator, typename Vector::iterator>;
   thrust::device_vector<iter_pair> new_last_vec(1);
   iter_pair new_last;
 
@@ -349,13 +349,13 @@ DECLARE_UNITTEST(TestUniqueCopyByKeyDeviceNoSync);
 template <typename ExecutionPolicy>
 void TestUniqueCopyByKeyCudaStreams(ExecutionPolicy policy)
 {
-  typedef thrust::device_vector<int> Vector;
-  typedef Vector::value_type T;
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
 
   Vector keys;
   Vector values;
 
-  typedef thrust::pair<Vector::iterator, Vector::iterator> iter_pair;
+  using iter_pair = thrust::pair<Vector::iterator, Vector::iterator>;
   iter_pair new_last;
 
   // basic test

--- a/thrust/testing/dependencies_aware_policies.cu
+++ b/thrust/testing/dependencies_aware_policies.cu
@@ -92,13 +92,13 @@ struct TestDependencyAttachment
   }
 };
 
-typedef policy_info<thrust::detail::seq_t, thrust::system::detail::sequential::execution_policy> sequential_info;
-typedef policy_info<thrust::system::cpp::detail::par_t, thrust::system::cpp::detail::execution_policy> cpp_par_info;
-typedef policy_info<thrust::system::omp::detail::par_t, thrust::system::omp::detail::execution_policy> omp_par_info;
-typedef policy_info<thrust::system::tbb::detail::par_t, thrust::system::tbb::detail::execution_policy> tbb_par_info;
+using sequential_info = policy_info<thrust::detail::seq_t, thrust::system::detail::sequential::execution_policy>;
+using cpp_par_info    = policy_info<thrust::system::cpp::detail::par_t, thrust::system::cpp::detail::execution_policy>;
+using omp_par_info    = policy_info<thrust::system::omp::detail::par_t, thrust::system::omp::detail::execution_policy>;
+using tbb_par_info    = policy_info<thrust::system::tbb::detail::par_t, thrust::system::tbb::detail::execution_policy>;
 
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-typedef policy_info<thrust::system::cuda::detail::par_t, thrust::cuda_cub::execute_on_stream_base> cuda_par_info;
+using cuda_par_info = policy_info<thrust::system::cuda::detail::par_t, thrust::cuda_cub::execute_on_stream_base>;
 #endif
 
 SimpleUnitTest<TestDependencyAttachment,

--- a/thrust/testing/device_ptr.cu
+++ b/thrust/testing/device_ptr.cu
@@ -51,7 +51,7 @@ DECLARE_UNITTEST(TestDevicePointerManipulation);
 
 void TestMakeDevicePointer()
 {
-  typedef int T;
+  using T = int;
 
   T* raw_ptr = 0;
 
@@ -68,7 +68,7 @@ DECLARE_UNITTEST(TestMakeDevicePointer);
 template <typename Vector>
 void TestRawPointerCast()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector vec(3);
 

--- a/thrust/testing/device_reference.cu
+++ b/thrust/testing/device_reference.cu
@@ -5,7 +5,7 @@
 
 void TestDeviceReferenceConstructorFromDeviceReference()
 {
-  typedef int T;
+  using T = int;
 
   thrust::device_vector<T> v(1, 0);
   thrust::device_reference<T> ref = v[0];
@@ -30,7 +30,7 @@ DECLARE_UNITTEST(TestDeviceReferenceConstructorFromDeviceReference);
 
 void TestDeviceReferenceConstructorFromDevicePointer()
 {
-  typedef int T;
+  using T = int;
 
   thrust::device_vector<T> v(1, 0);
   thrust::device_ptr<T> ptr = &v[0];
@@ -57,7 +57,7 @@ DECLARE_UNITTEST(TestDeviceReferenceConstructorFromDevicePointer);
 void TestDeviceReferenceAssignmentFromDeviceReference()
 {
   // test same types
-  typedef int T0;
+  using T0 = int;
   thrust::device_vector<T0> v0(2, 0);
   thrust::device_reference<T0> ref0 = v0[0];
   thrust::device_reference<T0> ref1 = v0[1];
@@ -71,7 +71,7 @@ void TestDeviceReferenceAssignmentFromDeviceReference()
   ASSERT_EQUAL(ref0, ref1);
 
   // test different types
-  typedef float T1;
+  using T1 = float;
   thrust::device_vector<T1> v1(1, 0.0f);
   thrust::device_reference<T1> ref2 = v1[0];
 
@@ -86,7 +86,7 @@ DECLARE_UNITTEST(TestDeviceReferenceAssignmentFromDeviceReference);
 
 void TestDeviceReferenceManipulation()
 {
-  typedef int T1;
+  using T1 = int;
 
   thrust::device_vector<T1> v(1, 0);
   thrust::device_ptr<T1> ptr = &v[0];
@@ -209,7 +209,7 @@ DECLARE_UNITTEST(TestDeviceReferenceManipulation);
 
 void TestDeviceReferenceSwap()
 {
-  typedef int T;
+  using T = int;
 
   thrust::device_vector<T> v(2);
   thrust::device_reference<T> ref1 = v.front();

--- a/thrust/testing/discard_iterator.cu
+++ b/thrust/testing/discard_iterator.cu
@@ -76,8 +76,8 @@ void TestZippedDiscardIterator()
 {
   using namespace thrust;
 
-  typedef tuple<discard_iterator<>> IteratorTuple1;
-  typedef zip_iterator<IteratorTuple1> ZipIterator1;
+  using IteratorTuple1 = tuple<discard_iterator<>>;
+  using ZipIterator1   = zip_iterator<IteratorTuple1>;
 
   IteratorTuple1 t = thrust::make_tuple(thrust::make_discard_iterator());
 
@@ -90,8 +90,8 @@ void TestZippedDiscardIterator()
 
   ASSERT_EQUAL(10, thrust::get<0>(z_iter1_first.get_iterator_tuple()) - thrust::make_discard_iterator());
 
-  typedef tuple<int*, discard_iterator<>> IteratorTuple2;
-  typedef zip_iterator<IteratorTuple2> ZipIterator2;
+  using IteratorTuple2 = tuple<int*, discard_iterator<>>;
+  using ZipIterator2   = zip_iterator<IteratorTuple2>;
 
   ZipIterator2 z_iter_first = thrust::make_zip_iterator(thrust::make_tuple((int*) 0, thrust::make_discard_iterator()));
   ZipIterator2 z_iter_last  = z_iter_first + 10;

--- a/thrust/testing/distance.cu
+++ b/thrust/testing/distance.cu
@@ -7,7 +7,7 @@
 template <typename Vector>
 void TestDistance()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector v(100);
 

--- a/thrust/testing/docs/doxybook_test.h
+++ b/thrust/testing/docs/doxybook_test.h
@@ -135,7 +135,7 @@ class test_derived_class : test_class<int, double>
 
   double test_derived_member_variable = 3.14; ///< A test member variable.
 
-  typedef double test_typedef;
+  using test_typedef = double;
 
   /*! \brief \c test_derived_member_function is a function intended to exercise
    *  and test Doxybook rendering.

--- a/thrust/testing/equal.cu
+++ b/thrust/testing/equal.cu
@@ -9,7 +9,7 @@
 template <class Vector>
 void TestEqualSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v1(5);
   Vector v2(5);

--- a/thrust/testing/fill.cu
+++ b/thrust/testing/fill.cu
@@ -12,7 +12,7 @@ THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 template <class Vector>
 void TestFillSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -123,7 +123,7 @@ DECLARE_VARIABLE_UNITTEST(TestFill);
 template <class Vector>
 void TestFillNSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -248,7 +248,7 @@ DECLARE_VARIABLE_UNITTEST(TestFillN);
 template <typename Vector>
 void TestFillZipIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v1(3, T(0));
   Vector v2(3, T(0));
@@ -272,8 +272,8 @@ DECLARE_VECTOR_UNITTEST(TestFillZipIterator);
 
 void TestFillTuple()
 {
-  typedef int T;
-  typedef thrust::tuple<T, T> Tuple;
+  using T     = int;
+  using Tuple = thrust::tuple<T, T>;
 
   thrust::host_vector<Tuple> h(3, Tuple(0, 0));
   thrust::device_vector<Tuple> d(3, Tuple(0, 0));
@@ -292,7 +292,7 @@ struct TypeWithTrivialAssigment
 
 void TestFillWithTrivialAssignment()
 {
-  typedef TypeWithTrivialAssigment T;
+  using T = TypeWithTrivialAssigment;
 
   thrust::host_vector<T> h(1);
   thrust::device_vector<T> d(1);
@@ -349,7 +349,7 @@ struct TypeWithNonTrivialAssigment
 
 void TestFillWithNonTrivialAssignment()
 {
-  typedef TypeWithNonTrivialAssigment T;
+  using T = TypeWithNonTrivialAssigment;
 
   thrust::host_vector<T> h(1);
   thrust::device_vector<T> d(1);

--- a/thrust/testing/find.cu
+++ b/thrust/testing/find.cu
@@ -106,7 +106,7 @@ DECLARE_UNITTEST(TestFindDispatchImplicit);
 template <class Vector>
 void TestFindIfSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector vec(5);
   vec[0] = 1;
@@ -162,7 +162,7 @@ DECLARE_UNITTEST(TestFindIfDispatchImplicit);
 template <class Vector>
 void TestFindIfNotSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector vec(5);
   vec[0] = 0;

--- a/thrust/testing/for_each.cu
+++ b/thrust/testing/for_each.cu
@@ -25,7 +25,7 @@ public:
 template <class Vector>
 void TestForEachSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector input(5);
   Vector output(7, (T) 0);
@@ -90,7 +90,7 @@ DECLARE_UNITTEST(TestForEachDispatchImplicit);
 template <class Vector>
 void TestForEachNSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector input(5);
   Vector output(7, (T) 0);

--- a/thrust/testing/functional.cu
+++ b/thrust/testing/functional.cu
@@ -21,8 +21,8 @@ const size_t NUM_SAMPLES = 10000;
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestUnaryFunctional()
 {
-  typedef typename InputVector::value_type InputType;
-  typedef typename OutputVector::value_type OutputType;
+  using InputType  = typename InputVector::value_type;
+  using OutputType = typename OutputVector::value_type;
 
   thrust::host_vector<InputType> std_input = unittest::random_samples<InputType>(NUM_SAMPLES);
   thrust::host_vector<OutputType> std_output(NUM_SAMPLES);
@@ -39,8 +39,8 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestUnaryFunctional()
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestBinaryFunctional()
 {
-  typedef typename InputVector::value_type InputType;
-  typedef typename OutputVector::value_type OutputType;
+  using InputType  = typename InputVector::value_type;
+  using OutputType = typename OutputVector::value_type;
 
   thrust::host_vector<InputType> std_input1 = unittest::random_samples<InputType>(NUM_SAMPLES);
   thrust::host_vector<InputType> std_input2 = unittest::random_samples<InputType>(NUM_SAMPLES);
@@ -179,7 +179,7 @@ DECLARE_UNARY_LOGICAL_FUNCTIONAL_UNITTEST(logical_not, LogicalNot);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestIdentityFunctional()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector input(4);
   input[0] = 0;
@@ -198,7 +198,7 @@ DECLARE_VECTOR_UNITTEST(TestIdentityFunctional);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject1stFunctional()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector lhs(4);
   Vector rhs(4);
@@ -222,7 +222,7 @@ DECLARE_VECTOR_UNITTEST(TestProject1stFunctional);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject2ndFunctional()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector lhs(4);
   Vector rhs(4);
@@ -246,7 +246,7 @@ DECLARE_VECTOR_UNITTEST(TestProject2ndFunctional);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMaximumFunctional()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector input1(4);
   Vector input2(4);
@@ -273,7 +273,7 @@ DECLARE_VECTOR_UNITTEST(TestMaximumFunctional);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMinimumFunctional()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector input1(4);
   Vector input2(4);
@@ -300,7 +300,7 @@ DECLARE_VECTOR_UNITTEST(TestMinimumFunctional);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestNot1()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector input(5);
   input[0] = 1;
@@ -333,7 +333,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestNot1);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestNot2()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector input1(5);
   Vector input2(5);

--- a/thrust/testing/functional_arithmetic.cu
+++ b/thrust/testing/functional_arithmetic.cu
@@ -11,8 +11,8 @@ const size_t NUM_SAMPLES = 10000;
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
 void TestBinaryFunctional()
 {
-  typedef typename InputVector::value_type InputType;
-  typedef typename OutputVector::value_type OutputType;
+  using InputType  = typename InputVector::value_type;
+  using OutputType = typename OutputVector::value_type;
 
   thrust::host_vector<InputType> std_input1 = unittest::random_samples<InputType>(NUM_SAMPLES);
   thrust::host_vector<InputType> std_input2 = unittest::random_samples<InputType>(NUM_SAMPLES);

--- a/thrust/testing/functional_bitwise.cu
+++ b/thrust/testing/functional_bitwise.cu
@@ -44,8 +44,8 @@ struct bit_xor
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
 void TestBinaryFunctional()
 {
-  typedef typename InputVector::value_type InputType;
-  typedef typename OutputVector::value_type OutputType;
+  using InputType  = typename InputVector::value_type;
+  using OutputType = typename OutputVector::value_type;
 
   thrust::host_vector<InputType> std_input1 = unittest::random_samples<InputType>(NUM_SAMPLES);
   thrust::host_vector<InputType> std_input2 = unittest::random_samples<InputType>(NUM_SAMPLES);

--- a/thrust/testing/functional_logical.cu
+++ b/thrust/testing/functional_logical.cu
@@ -11,8 +11,8 @@ const size_t NUM_SAMPLES = 10000;
 template <class InputVector, class OutputVector, class Operator, class ReferenceOperator>
 void TestBinaryFunctional()
 {
-  typedef typename InputVector::value_type InputType;
-  typedef typename OutputVector::value_type OutputType;
+  using InputType  = typename InputVector::value_type;
+  using OutputType = typename OutputVector::value_type;
 
   thrust::host_vector<InputType> std_input1 = unittest::random_samples<InputType>(NUM_SAMPLES);
   thrust::host_vector<InputType> std_input2 = unittest::random_samples<InputType>(NUM_SAMPLES);

--- a/thrust/testing/functional_placeholders_arithmetic.cu
+++ b/thrust/testing/functional_placeholders_arithmetic.cu
@@ -12,9 +12,9 @@
     {                                                                                                             \
       static const size_t num_samples = 10000;                                                                    \
       const size_t zero               = 0;                                                                        \
-      typedef typename Vector::value_type T;                                                                      \
-      Vector lhs = unittest::random_samples<T>(num_samples);                                                      \
-      Vector rhs = unittest::random_samples<T>(num_samples);                                                      \
+      using T                         = typename Vector::value_type;                                              \
+      Vector lhs                      = unittest::random_samples<T>(num_samples);                                 \
+      Vector rhs                      = unittest::random_samples<T>(num_samples);                                 \
       thrust::replace(rhs.begin(), rhs.end(), T(0), T(1));                                                        \
                                                                                                                   \
       Vector reference(lhs.size());                                                                               \
@@ -56,8 +56,8 @@ BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(Modulus, %, thrust::modulus, SmallIntegralTy
   void TestFunctionalPlaceholders##name()                                                 \
   {                                                                                       \
     static const size_t num_samples = 10000;                                              \
-    typedef typename Vector::value_type T;                                                \
-    Vector input = unittest::random_samples<T>(num_samples);                              \
+    using T                         = typename Vector::value_type;                        \
+    Vector input                    = unittest::random_samples<T>(num_samples);           \
                                                                                           \
     Vector reference(input.size());                                                       \
     thrust::transform(input.begin(), input.end(), reference.begin(), functor<T>());       \

--- a/thrust/testing/functional_placeholders_bitwise.cu
+++ b/thrust/testing/functional_placeholders_bitwise.cu
@@ -13,21 +13,21 @@ struct rebind_vector;
 template <typename T, typename U, typename Allocator>
 struct rebind_vector<thrust::host_vector<T, Allocator>, U>
 {
-  typedef typename thrust::detail::allocator_traits<Allocator> alloc_traits;
-  typedef typename alloc_traits::template rebind_alloc<U> new_alloc;
-  typedef thrust::host_vector<U, new_alloc> type;
+  using alloc_traits = typename thrust::detail::allocator_traits<Allocator>;
+  using new_alloc    = typename alloc_traits::template rebind_alloc<U>;
+  using type         = thrust::host_vector<U, new_alloc>;
 };
 
 template <typename T, typename U, typename Allocator>
 struct rebind_vector<thrust::device_vector<T, Allocator>, U>
 {
-  typedef thrust::device_vector<U, typename Allocator::template rebind<U>::other> type;
+  using type = thrust::device_vector<U, typename Allocator::template rebind<U>::other>;
 };
 
 template <typename T, typename U, typename Allocator>
 struct rebind_vector<thrust::universal_vector<T, Allocator>, U>
 {
-  typedef thrust::universal_vector<U, typename Allocator::template rebind<U>::other> type;
+  using type = thrust::universal_vector<U, typename Allocator::template rebind<U>::other>;
 };
 
 #define BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(name, op, reference_functor, type_list)                               \
@@ -38,9 +38,9 @@ struct rebind_vector<thrust::universal_vector<T, Allocator>, U>
     {                                                                                                             \
       constexpr size_t NUM_SAMPLES = 10000;                                                                       \
       constexpr size_t ZERO        = 0;                                                                           \
-      typedef typename Vector::value_type T;                                                                      \
-      Vector lhs = unittest::random_samples<T>(NUM_SAMPLES);                                                      \
-      Vector rhs = unittest::random_samples<T>(NUM_SAMPLES);                                                      \
+      using T                      = typename Vector::value_type;                                                 \
+      Vector lhs                   = unittest::random_samples<T>(NUM_SAMPLES);                                    \
+      Vector rhs                   = unittest::random_samples<T>(NUM_SAMPLES);                                    \
       thrust::replace(rhs.begin(), rhs.end(), T(0), T(1));                                                        \
                                                                                                                   \
       Vector reference(lhs.size());                                                                               \
@@ -87,9 +87,9 @@ struct bit_negate_reference
 template <typename Vector>
 void TestFunctionalPlaceholdersBitNegate()
 {
-  typedef typename Vector::value_type T;
-  typedef typename rebind_vector<Vector, bool>::type bool_vector;
-  Vector input = unittest::random_samples<T>(num_samples);
+  using T           = typename Vector::value_type;
+  using bool_vector = typename rebind_vector<Vector, bool>::type;
+  Vector input      = unittest::random_samples<T>(num_samples);
 
   bool_vector reference(input.size());
   thrust::transform(input.begin(), input.end(), reference.begin(), bit_negate_reference<T>());

--- a/thrust/testing/functional_placeholders_compound_assignment.cu
+++ b/thrust/testing/functional_placeholders_compound_assignment.cu
@@ -11,9 +11,9 @@
     void operator()(const size_t)                                                                              \
     {                                                                                                          \
       const size_t num_samples = 10000;                                                                        \
-      typedef typename Vector::value_type T;                                                                   \
-      Vector lhs = unittest::random_samples<T>(num_samples);                                                   \
-      Vector rhs = unittest::random_samples<T>(num_samples);                                                   \
+      using T                  = typename Vector::value_type;                                                  \
+      Vector lhs               = unittest::random_samples<T>(num_samples);                                     \
+      Vector rhs               = unittest::random_samples<T>(num_samples);                                     \
       thrust::replace(rhs.begin(), rhs.end(), T(0), T(1));                                                     \
                                                                                                                \
       Vector lhs_reference = lhs;                                                                              \
@@ -198,8 +198,8 @@ struct suffix_decrement_reference
   void TestFunctionalPlaceholdersPrefix##name()                                                               \
   {                                                                                                           \
     const size_t num_samples = 10000;                                                                         \
-    typedef typename Vector::value_type T;                                                                    \
-    Vector input = unittest::random_samples<T>(num_samples);                                                  \
+    using T                  = typename Vector::value_type;                                                   \
+    Vector input             = unittest::random_samples<T>(num_samples);                                      \
                                                                                                               \
     Vector input_reference = input;                                                                           \
     Vector reference(input.size());                                                                           \
@@ -222,8 +222,8 @@ PREFIX_FUNCTIONAL_PLACEHOLDERS_TEST(Decrement, --, prefix_decrement_reference);
   void TestFunctionalPlaceholdersSuffix##name()                                                               \
   {                                                                                                           \
     const size_t num_samples = 10000;                                                                         \
-    typedef typename Vector::value_type T;                                                                    \
-    Vector input = unittest::random_samples<T>(num_samples);                                                  \
+    using T                  = typename Vector::value_type;                                                   \
+    Vector input             = unittest::random_samples<T>(num_samples);                                      \
                                                                                                               \
     Vector input_reference = input;                                                                           \
     Vector reference(input.size());                                                                           \

--- a/thrust/testing/functional_placeholders_logical.cu
+++ b/thrust/testing/functional_placeholders_logical.cu
@@ -12,31 +12,31 @@ struct rebind_vector;
 template <typename T, typename U, typename Allocator>
 struct rebind_vector<thrust::host_vector<T, Allocator>, U>
 {
-  typedef typename thrust::detail::allocator_traits<Allocator> alloc_traits;
-  typedef typename alloc_traits::template rebind_alloc<U> new_alloc;
-  typedef thrust::host_vector<U, new_alloc> type;
+  using alloc_traits = typename thrust::detail::allocator_traits<Allocator>;
+  using new_alloc    = typename alloc_traits::template rebind_alloc<U>;
+  using type         = thrust::host_vector<U, new_alloc>;
 };
 
 template <typename T, typename U, typename Allocator>
 struct rebind_vector<thrust::device_vector<T, Allocator>, U>
 {
-  typedef thrust::device_vector<U, typename Allocator::template rebind<U>::other> type;
+  using type = thrust::device_vector<U, typename Allocator::template rebind<U>::other>;
 };
 
 template <typename T, typename U, typename Allocator>
 struct rebind_vector<thrust::universal_vector<T, Allocator>, U>
 {
-  typedef thrust::universal_vector<U, typename Allocator::template rebind<U>::other> type;
+  using type = thrust::universal_vector<U, typename Allocator::template rebind<U>::other>;
 };
 
 #define BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(name, reference_operator, functor)                        \
   template <typename Vector>                                                                          \
   void TestFunctionalPlaceholders##name()                                                             \
   {                                                                                                   \
-    typedef typename Vector::value_type T;                                                            \
-    typedef typename rebind_vector<Vector, bool>::type bool_vector;                                   \
-    Vector lhs = unittest::random_samples<T>(num_samples);                                            \
-    Vector rhs = unittest::random_samples<T>(num_samples);                                            \
+    using T           = typename Vector::value_type;                                                  \
+    using bool_vector = typename rebind_vector<Vector, bool>::type;                                   \
+    Vector lhs        = unittest::random_samples<T>(num_samples);                                     \
+    Vector rhs        = unittest::random_samples<T>(num_samples);                                     \
                                                                                                       \
     bool_vector reference(lhs.size());                                                                \
     thrust::transform(lhs.begin(), lhs.end(), rhs.begin(), reference.begin(), functor<T>());          \
@@ -55,9 +55,9 @@ BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(LogicalOr, ||, thrust::logical_or);
 template <typename Vector>
 void TestFunctionalPlaceholdersLogicalNot()
 {
-  typedef typename Vector::value_type T;
-  typedef typename rebind_vector<Vector, bool>::type bool_vector;
-  Vector input = unittest::random_samples<T>(num_samples);
+  using T           = typename Vector::value_type;
+  using bool_vector = typename rebind_vector<Vector, bool>::type;
+  Vector input      = unittest::random_samples<T>(num_samples);
 
   if (input.size() > 0)
   {

--- a/thrust/testing/functional_placeholders_miscellaneous.cu
+++ b/thrust/testing/functional_placeholders_miscellaneous.cu
@@ -24,7 +24,7 @@ struct TestFunctionalPlaceholdersValue
   void operator()(const size_t)
   {
     const size_t n = 10000;
-    typedef typename Vector::value_type T;
+    using T        = typename Vector::value_type;
 
     T a(13);
 
@@ -51,7 +51,7 @@ struct TestFunctionalPlaceholdersTransformIterator
   void operator()(const size_t)
   {
     const size_t n = 10000;
-    typedef typename Vector::value_type T;
+    using T        = typename Vector::value_type;
 
     T a(13);
 

--- a/thrust/testing/functional_placeholders_relational.cu
+++ b/thrust/testing/functional_placeholders_relational.cu
@@ -12,31 +12,31 @@ struct rebind_vector;
 template <typename T, typename U, typename Allocator>
 struct rebind_vector<thrust::host_vector<T, Allocator>, U>
 {
-  typedef typename thrust::detail::allocator_traits<Allocator> alloc_traits;
-  typedef typename alloc_traits::template rebind_alloc<U> new_alloc;
-  typedef thrust::host_vector<U, new_alloc> type;
+  using alloc_traits = typename thrust::detail::allocator_traits<Allocator>;
+  using new_alloc    = typename alloc_traits::template rebind_alloc<U>;
+  using type         = thrust::host_vector<U, new_alloc>;
 };
 
 template <typename T, typename U, typename Allocator>
 struct rebind_vector<thrust::device_vector<T, Allocator>, U>
 {
-  typedef thrust::device_vector<U, typename Allocator::template rebind<U>::other> type;
+  using type = thrust::device_vector<U, typename Allocator::template rebind<U>::other>;
 };
 
 template <typename T, typename U, typename Allocator>
 struct rebind_vector<thrust::universal_vector<T, Allocator>, U>
 {
-  typedef thrust::universal_vector<U, typename Allocator::template rebind<U>::other> type;
+  using type = thrust::universal_vector<U, typename Allocator::template rebind<U>::other>;
 };
 
 #define BINARY_FUNCTIONAL_PLACEHOLDERS_TEST(name, reference_operator, functor)                        \
   template <typename Vector>                                                                          \
   void TestFunctionalPlaceholdersBinary##name()                                                       \
   {                                                                                                   \
-    typedef typename Vector::value_type T;                                                            \
-    typedef typename rebind_vector<Vector, bool>::type bool_vector;                                   \
-    Vector lhs = unittest::random_samples<T>(num_samples);                                            \
-    Vector rhs = unittest::random_samples<T>(num_samples);                                            \
+    using T           = typename Vector::value_type;                                                  \
+    using bool_vector = typename rebind_vector<Vector, bool>::type;                                   \
+    Vector lhs        = unittest::random_samples<T>(num_samples);                                     \
+    Vector rhs        = unittest::random_samples<T>(num_samples);                                     \
                                                                                                       \
     bool_vector reference(lhs.size());                                                                \
     thrust::transform(lhs.begin(), lhs.end(), rhs.begin(), reference.begin(), functor<T>());          \

--- a/thrust/testing/generate.cu
+++ b/thrust/testing/generate.cu
@@ -25,7 +25,7 @@ struct return_value
 template <class Vector>
 void TestGenerateSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector result(5);
 
@@ -111,7 +111,7 @@ DECLARE_VARIABLE_UNITTEST(TestGenerateToDiscardIterator);
 template <class Vector>
 void TestGenerateNSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector result(5);
 
@@ -186,7 +186,7 @@ DECLARE_VARIABLE_UNITTEST(TestGenerateNToDiscardIterator);
 template <typename Vector>
 void TestGenerateZipIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v1(3, T(0));
   Vector v2(3, T(0));
@@ -206,8 +206,8 @@ DECLARE_VECTOR_UNITTEST(TestGenerateZipIterator);
 
 void TestGenerateTuple()
 {
-  typedef int T;
-  typedef thrust::tuple<T, T> Tuple;
+  using T     = int;
+  using Tuple = thrust::tuple<T, T>;
 
   thrust::host_vector<Tuple> h(3, Tuple(0, 0));
   thrust::device_vector<Tuple> d(3, Tuple(0, 0));

--- a/thrust/testing/inner_product.cu
+++ b/thrust/testing/inner_product.cu
@@ -10,7 +10,7 @@
 template <class Vector>
 void TestInnerProductSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v1(3);
   Vector v2(3);
@@ -65,7 +65,7 @@ DECLARE_UNITTEST(TestInnerProductDispatchImplicit);
 template <class Vector>
 void TestInnerProductWithOperator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v1(3);
   Vector v2(3);

--- a/thrust/testing/is_partitioned.cu
+++ b/thrust/testing/is_partitioned.cu
@@ -16,7 +16,7 @@ struct is_even
 template <typename Vector>
 void TestIsPartitionedSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(4);
   v[0] = 1;
@@ -52,7 +52,7 @@ DECLARE_VECTOR_UNITTEST(TestIsPartitionedSimple);
 template <class Vector>
 void TestIsPartitioned()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   const size_t n = (1 << 16) + 13;
 

--- a/thrust/testing/is_sorted.cu
+++ b/thrust/testing/is_sorted.cu
@@ -6,7 +6,7 @@
 template <class Vector>
 void TestIsSortedSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(4);
   v[0] = 0;
@@ -60,7 +60,7 @@ DECLARE_VECTOR_UNITTEST(TestIsSortedRepeatedElements);
 template <class Vector>
 void TestIsSorted()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   const size_t n = (1 << 16) + 13;
 

--- a/thrust/testing/is_sorted_until.cu
+++ b/thrust/testing/is_sorted_until.cu
@@ -6,8 +6,8 @@
 template <typename Vector>
 void TestIsSortedUntilSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector v(4);
   v[0] = 0;
@@ -83,7 +83,7 @@ DECLARE_VECTOR_UNITTEST(TestIsSortedUntilRepeatedElements);
 template <class Vector>
 void TestIsSortedUntil()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   const size_t n = (1 << 16) + 13;
 

--- a/thrust/testing/logical.cu
+++ b/thrust/testing/logical.cu
@@ -7,7 +7,7 @@
 template <class Vector>
 void TestAllOf()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(3, 1);
 
@@ -62,7 +62,7 @@ DECLARE_UNITTEST(TestAllOfDispatchImplicit);
 template <class Vector>
 void TestAnyOf()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(3, 1);
 
@@ -117,7 +117,7 @@ DECLARE_UNITTEST(TestAnyOfDispatchImplicit);
 template <class Vector>
 void TestNoneOf()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(3, 1);
 

--- a/thrust/testing/max_element.cu
+++ b/thrust/testing/max_element.cu
@@ -8,7 +8,7 @@
 template <class Vector>
 void TestMaxElementSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(6);
   data[0] = 3;
@@ -29,7 +29,7 @@ DECLARE_VECTOR_UNITTEST(TestMaxElementSimple);
 template <class Vector>
 void TestMaxElementWithTransform()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(6);
   data[0] = 3;

--- a/thrust/testing/memory.cu
+++ b/thrust/testing/memory.cu
@@ -71,7 +71,7 @@ get_temporary_buffer(my_old_temporary_allocation_system, std::ptrdiff_t)
 template <typename Pointer>
 void return_temporary_buffer(my_old_temporary_allocation_system, Pointer p)
 {
-  typedef typename thrust::detail::pointer_traits<Pointer>::raw_pointer RP;
+  using RP = typename thrust::detail::pointer_traits<Pointer>::raw_pointer;
   ASSERT_EQUAL(p.get(), reinterpret_cast<RP>(4217));
 }
 
@@ -103,7 +103,7 @@ void return_temporary_buffer(my_new_temporary_allocation_system, Pointer)
 template <typename Pointer>
 void return_temporary_buffer(my_new_temporary_allocation_system, Pointer p, std::ptrdiff_t n)
 {
-  typedef typename thrust::detail::pointer_traits<Pointer>::raw_pointer RP;
+  using RP = typename thrust::detail::pointer_traits<Pointer>::raw_pointer;
   ASSERT_EQUAL(p.get(), reinterpret_cast<RP>(1742));
   ASSERT_EQUAL(n, 413);
 }
@@ -166,7 +166,7 @@ void TestGetTemporaryBuffer()
   const std::ptrdiff_t n = 9001;
 
   thrust::device_system_tag dev_tag;
-  typedef thrust::pointer<int, thrust::device_system_tag> pointer;
+  using pointer                                    = thrust::pointer<int, thrust::device_system_tag>;
   thrust::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(dev_tag, n);
 
   ASSERT_EQUAL(ptr_and_sz.second, n);
@@ -187,8 +187,8 @@ void TestMalloc()
   const std::ptrdiff_t n = 9001;
 
   thrust::device_system_tag dev_tag;
-  typedef thrust::pointer<int, thrust::device_system_tag> pointer;
-  pointer ptr = pointer(static_cast<int*>(thrust::malloc(dev_tag, sizeof(int) * n).get()));
+  using pointer = thrust::pointer<int, thrust::device_system_tag>;
+  pointer ptr   = pointer(static_cast<int*>(thrust::malloc(dev_tag, sizeof(int) * n).get()));
 
   const int ref_val = 13;
   thrust::device_vector<int> ref(n, ref_val);
@@ -253,7 +253,7 @@ void TestGetTemporaryBufferDispatchExplicit()
   const std::ptrdiff_t n = 9001;
 
   my_memory_system sys(0);
-  typedef thrust::pointer<int, thrust::device_system_tag> pointer;
+  using pointer                                    = thrust::pointer<int, thrust::device_system_tag>;
   thrust::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(sys, n);
 
   ASSERT_EQUAL(ptr_and_sz.second, n);
@@ -301,9 +301,9 @@ DECLARE_UNITTEST(TestGetTemporaryBufferDispatchImplicit);
 
 void TestTemporaryBufferOldCustomization()
 {
-  typedef my_old_namespace::my_old_temporary_allocation_system system;
-  typedef thrust::pointer<int, system> pointer;
-  typedef thrust::pair<pointer, std::ptrdiff_t> pointer_and_size;
+  using system           = my_old_namespace::my_old_temporary_allocation_system;
+  using pointer          = thrust::pointer<int, system>;
+  using pointer_and_size = thrust::pair<pointer, std::ptrdiff_t>;
 
   system sys;
 
@@ -321,9 +321,9 @@ DECLARE_UNITTEST(TestTemporaryBufferOldCustomization);
 
 void TestTemporaryBufferNewCustomization()
 {
-  typedef my_new_namespace::my_new_temporary_allocation_system system;
-  typedef thrust::pointer<int, system> pointer;
-  typedef thrust::pair<pointer, std::ptrdiff_t> pointer_and_size;
+  using system           = my_new_namespace::my_new_temporary_allocation_system;
+  using pointer          = thrust::pointer<int, system>;
+  using pointer_and_size = thrust::pair<pointer, std::ptrdiff_t>;
 
   system sys;
 

--- a/thrust/testing/min_and_max.cu
+++ b/thrust/testing/min_and_max.cu
@@ -18,7 +18,7 @@ struct TestMin
     ASSERT_EQUAL(three, thrust::min THRUST_PREVENT_MACRO_SUBSTITUTION(two, three, thrust::greater<T>()));
     ASSERT_EQUAL(three, thrust::min THRUST_PREVENT_MACRO_SUBSTITUTION(three, two, thrust::greater<T>()));
 
-    typedef key_value<T, T> KV;
+    using KV = key_value<T, T>;
     KV two_and_two(two, two);
     KV two_and_three(two, three);
 
@@ -55,7 +55,7 @@ struct TestMax
     ASSERT_EQUAL(two, thrust::max THRUST_PREVENT_MACRO_SUBSTITUTION(two, three, thrust::greater<T>()));
     ASSERT_EQUAL(two, thrust::max THRUST_PREVENT_MACRO_SUBSTITUTION(three, two, thrust::greater<T>()));
 
-    typedef key_value<T, T> KV;
+    using KV = key_value<T, T>;
     KV two_and_two(two, two);
     KV two_and_three(two, three);
 

--- a/thrust/testing/min_element.cu
+++ b/thrust/testing/min_element.cu
@@ -6,7 +6,7 @@
 template <class Vector>
 void TestMinElementSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(6);
   data[0] = 3;
@@ -27,7 +27,7 @@ DECLARE_VECTOR_UNITTEST(TestMinElementSimple);
 template <class Vector>
 void TestMinElementWithTransform()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(6);
   data[0] = 3;

--- a/thrust/testing/minmax_element.cu
+++ b/thrust/testing/minmax_element.cu
@@ -24,7 +24,7 @@ DECLARE_VECTOR_UNITTEST(TestMinMaxElementSimple);
 template <class Vector>
 void TestMinMaxElementWithTransform()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(6);
   data[0] = 3;
@@ -111,7 +111,7 @@ DECLARE_UNITTEST(TestMinMaxElementDispatchImplicit);
 
 void TestMinMaxElementWithBigIndexesHelper(int magnitude)
 {
-  typedef thrust::counting_iterator<long long> Iter;
+  using Iter = thrust::counting_iterator<long long>;
   Iter begin(1);
   Iter end = begin + (1ll << magnitude);
   ASSERT_EQUAL(thrust::distance(begin, end), 1ll << magnitude);

--- a/thrust/testing/mr_disjoint_pool.cu
+++ b/thrust/testing/mr_disjoint_pool.cu
@@ -38,7 +38,7 @@ struct pointer_traits<alloc_id>
   template <typename>
   struct rebind
   {
-    typedef alloc_id other;
+    using other = alloc_id;
   };
 
   // implemented for the purposes of alignment test in disjoint pool's do_deallocate
@@ -102,7 +102,7 @@ void TestDisjointPool()
   dummy_resource upstream;
   thrust::mr::new_delete_resource bookkeeper;
 
-  typedef PoolTemplate<dummy_resource, thrust::mr::new_delete_resource> Pool;
+  using Pool = PoolTemplate<dummy_resource, thrust::mr::new_delete_resource>;
 
   thrust::mr::pool_options opts = Pool::get_default_options();
   opts.cache_oversized          = false;
@@ -191,7 +191,7 @@ void TestDisjointPoolCachingOversized()
   dummy_resource upstream;
   thrust::mr::new_delete_resource bookkeeper;
 
-  typedef PoolTemplate<dummy_resource, thrust::mr::new_delete_resource> Pool;
+  using Pool = PoolTemplate<dummy_resource, thrust::mr::new_delete_resource>;
 
   thrust::mr::pool_options opts = Pool::get_default_options();
   opts.cache_oversized          = true;
@@ -266,7 +266,7 @@ DECLARE_UNITTEST(TestDisjointSynchronizedPoolCachingOversized);
 template <template <typename, typename> class PoolTemplate>
 void TestDisjointGlobalPool()
 {
-  typedef PoolTemplate<thrust::mr::new_delete_resource, thrust::mr::new_delete_resource> Pool;
+  using Pool = PoolTemplate<thrust::mr::new_delete_resource, thrust::mr::new_delete_resource>;
 
   ASSERT_EQUAL(thrust::mr::get_global_resource<Pool>() != nullptr, true);
 }

--- a/thrust/testing/mr_pool.cu
+++ b/thrust/testing/mr_pool.cu
@@ -9,13 +9,13 @@
 template <typename T>
 struct reference
 {
-  typedef T& type;
+  using type = T&;
 };
 
 template <>
 struct reference<void>
 {
-  typedef void type;
+  using type = void;
 };
 
 struct unit
@@ -30,7 +30,7 @@ struct tracked_pointer
                               typename reference<T>::type,
                               std::ptrdiff_t>
 {
-  typedef T* raw_pointer;
+  using raw_pointer = T*;
 
   std::size_t id;
   std::size_t size;
@@ -161,7 +161,7 @@ void TestPool()
 
   upstream.id_to_allocate = -1u;
 
-  typedef PoolTemplate<tracked_resource> Pool;
+  using Pool = PoolTemplate<tracked_resource>;
 
   thrust::mr::pool_options opts = Pool::get_default_options();
   opts.cache_oversized          = false;
@@ -251,7 +251,7 @@ void TestPoolCachingOversized()
 
   upstream.id_to_allocate = -1u;
 
-  typedef PoolTemplate<tracked_resource> Pool;
+  using Pool = PoolTemplate<tracked_resource>;
 
   thrust::mr::pool_options opts = Pool::get_default_options();
   opts.cache_oversized          = true;
@@ -356,7 +356,7 @@ DECLARE_UNITTEST(TestSynchronizedPoolCachingOversized);
 template <template <typename> class PoolTemplate>
 void TestGlobalPool()
 {
-  typedef PoolTemplate<thrust::mr::new_delete_resource> Pool;
+  using Pool = PoolTemplate<thrust::mr::new_delete_resource>;
 
   ASSERT_EQUAL(thrust::mr::get_global_resource<Pool>() != nullptr, true);
 }

--- a/thrust/testing/omp/nvcc_independence.cpp
+++ b/thrust/testing/omp/nvcc_independence.cpp
@@ -9,7 +9,7 @@
 
 void TestNvccIndependenceTransform()
 {
-  typedef int T;
+  using T     = int;
   const int n = 10;
 
   thrust::host_vector<T> h_input   = unittest::random_integers<T>(n);
@@ -27,7 +27,7 @@ DECLARE_UNITTEST(TestNvccIndependenceTransform);
 
 void TestNvccIndependenceReduce()
 {
-  typedef int T;
+  using T     = int;
   const int n = 10;
 
   thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);
@@ -44,7 +44,7 @@ DECLARE_UNITTEST(TestNvccIndependenceReduce);
 
 void TestNvccIndependenceExclusiveScan()
 {
-  typedef int T;
+  using T     = int;
   const int n = 10;
 
   thrust::host_vector<T> h_input   = unittest::random_integers<T>(n);
@@ -61,7 +61,7 @@ DECLARE_UNITTEST(TestNvccIndependenceExclusiveScan);
 
 void TestNvccIndependenceSort()
 {
-  typedef int T;
+  using T     = int;
   const int n = 10;
 
   thrust::host_vector<T> h_data   = unittest::random_integers<T>(n);

--- a/thrust/testing/omp/reduce_intervals.cu
+++ b/thrust/testing/omp/reduce_intervals.cu
@@ -8,8 +8,8 @@
 template <typename InputIterator, typename OutputIterator, typename BinaryFunction, typename Decomposition>
 void reduce_intervals(InputIterator input, OutputIterator output, BinaryFunction binary_op, Decomposition decomp)
 {
-  typedef typename thrust::iterator_value<OutputIterator>::type OutputType;
-  typedef typename Decomposition::index_type index_type;
+  using OutputType = typename thrust::iterator_value<OutputIterator>::type;
+  using index_type = typename Decomposition::index_type;
 
   // wrap binary_op
   thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op(binary_op);
@@ -38,8 +38,8 @@ void reduce_intervals(InputIterator input, OutputIterator output, BinaryFunction
 
 void TestOmpReduceIntervalsSimple()
 {
-  typedef int T;
-  typedef thrust::device_vector<T> Vector;
+  using T      = int;
+  using Vector = thrust::device_vector<T>;
 
   using thrust::system::detail::internal::uniform_decomposition;
   using thrust::system::omp::detail::reduce_intervals;

--- a/thrust/testing/pair.cu
+++ b/thrust/testing/pair.cu
@@ -9,7 +9,7 @@ struct TestPairManipulation
 {
   void operator()(void)
   {
-    typedef thrust::pair<T, T> P;
+    using P = thrust::pair<T, T>;
 
     // test null constructor
     P p1;
@@ -78,7 +78,7 @@ struct TestPairComparison
 {
   void operator()(void)
   {
-    typedef thrust::pair<T, T> P;
+    using P = thrust::pair<T, T>;
 
     P x, y;
 
@@ -293,7 +293,7 @@ void TestPairSwap()
   ASSERT_EQUAL(x, b.first);
   ASSERT_EQUAL(y, b.second);
 
-  typedef thrust::pair<user_swappable, user_swappable> swappable_pair;
+  using swappable_pair = thrust::pair<user_swappable, user_swappable>;
 
   thrust::host_vector<swappable_pair> h_v1(1), h_v2(1);
   thrust::device_vector<swappable_pair> d_v1(1), d_v2(1);

--- a/thrust/testing/pair_reduce.cu
+++ b/thrust/testing/pair_reduce.cu
@@ -30,7 +30,7 @@ struct TestPairReduce
 {
   void operator()(const size_t n)
   {
-    typedef thrust::pair<T, T> P;
+    using P = thrust::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);

--- a/thrust/testing/pair_scan.cu
+++ b/thrust/testing/pair_scan.cu
@@ -31,7 +31,7 @@ struct TestPairScan
 {
   void operator()(const size_t n)
   {
-    typedef thrust::pair<T, T> P;
+    using P = thrust::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);

--- a/thrust/testing/pair_scan_by_key.cu
+++ b/thrust/testing/pair_scan_by_key.cu
@@ -30,7 +30,7 @@ struct TestPairScanByKey
 {
   void operator()(const size_t n)
   {
-    typedef thrust::pair<T, T> P;
+    using P = thrust::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);

--- a/thrust/testing/pair_sort.cu
+++ b/thrust/testing/pair_sort.cu
@@ -18,7 +18,7 @@ struct TestPairStableSortByKey
 {
   void operator()(const size_t n)
   {
-    typedef thrust::pair<T, T> P;
+    using P = thrust::pair<T, T>;
 
     // host arrays
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);

--- a/thrust/testing/pair_sort_by_key.cu
+++ b/thrust/testing/pair_sort_by_key.cu
@@ -17,7 +17,7 @@ struct TestPairStableSort
 {
   void operator()(const size_t n)
   {
-    typedef thrust::pair<T, T> P;
+    using P = thrust::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);

--- a/thrust/testing/pair_transform.cu
+++ b/thrust/testing/pair_transform.cu
@@ -28,7 +28,7 @@ struct TestPairTransform
 {
   void operator()(const size_t n)
   {
-    typedef thrust::pair<T, T> P;
+    using P = thrust::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -20,13 +20,13 @@ struct is_even
   }
 };
 
-typedef unittest::type_list<unittest::int8_t, unittest::int16_t, unittest::int32_t> PartitionTypes;
+using PartitionTypes = unittest::type_list<unittest::int8_t, unittest::int16_t, unittest::int32_t>;
 
 template <typename Vector>
 void TestPartitionSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   // GCC 11 miscompiles and segfaults for certain versions of this test.
   // It's not reproducible on other compilers, and the test passes when
@@ -63,8 +63,8 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionSimple);
 template <typename Vector>
 void TestPartitionStencilSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector data(5);
   data[0] = 0;
@@ -97,7 +97,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionStencilSimple);
 template <typename Vector>
 void TestPartitionCopySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -131,7 +131,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionCopySimple);
 template <typename Vector>
 void TestPartitionCopyStencilSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 0;
@@ -172,8 +172,8 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPartitionCopyStencilSimple);
 template <typename Vector>
 void TestStablePartitionSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector data(5);
   data[0] = 1;
@@ -199,8 +199,8 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestStablePartitionSimple);
 template <typename Vector>
 void TestStablePartitionStencilSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector data(5);
   data[0] = 1;
@@ -233,7 +233,7 @@ DECLARE_VECTOR_UNITTEST(TestStablePartitionStencilSimple);
 template <typename Vector>
 void TestStablePartitionCopySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -267,7 +267,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestStablePartitionCopySimple);
 template <typename Vector>
 void TestStablePartitionCopyStencilSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -951,9 +951,9 @@ void TestPartitionZipIterator()
   data1[4] = 2;
   data2[4] = 1;
 
-  typedef typename Vector::iterator Iterator;
-  typedef thrust::tuple<Iterator, Iterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using Iterator      = typename Vector::iterator;
+  using IteratorTuple = thrust::tuple<Iterator, Iterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator begin = thrust::make_zip_iterator(thrust::make_tuple(data1.begin(), data2.begin()));
   ZipIterator end   = thrust::make_zip_iterator(thrust::make_tuple(data1.end(), data2.end()));
@@ -1004,9 +1004,9 @@ void TestPartitionStencilZipIterator()
   stencil1[4] = 2;
   stencil2[4] = 1;
 
-  typedef typename Vector::iterator Iterator;
-  typedef thrust::tuple<Iterator, Iterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using Iterator      = typename Vector::iterator;
+  using IteratorTuple = thrust::tuple<Iterator, Iterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator stencil_begin = thrust::make_zip_iterator(thrust::make_tuple(stencil1.begin(), stencil2.begin()));
 
@@ -1042,9 +1042,9 @@ void TestStablePartitionZipIterator()
   data1[4] = 2;
   data2[4] = 1;
 
-  typedef typename Vector::iterator Iterator;
-  typedef thrust::tuple<Iterator, Iterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using Iterator      = typename Vector::iterator;
+  using IteratorTuple = thrust::tuple<Iterator, Iterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator begin = thrust::make_zip_iterator(thrust::make_tuple(data1.begin(), data2.begin()));
   ZipIterator end   = thrust::make_zip_iterator(thrust::make_tuple(data1.end(), data2.end()));
@@ -1095,9 +1095,9 @@ void TestStablePartitionStencilZipIterator()
   stencil1[4] = 2;
   stencil2[4] = 1;
 
-  typedef typename Vector::iterator Iterator;
-  typedef thrust::tuple<Iterator, Iterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using Iterator      = typename Vector::iterator;
+  using IteratorTuple = thrust::tuple<Iterator, Iterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator stencil_begin = thrust::make_zip_iterator(thrust::make_tuple(stencil1.begin(), stencil2.begin()));
 

--- a/thrust/testing/partition_point.cu
+++ b/thrust/testing/partition_point.cu
@@ -16,8 +16,8 @@ struct is_even
 template <typename Vector>
 void TestPartitionPointSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector v(4);
   v[0] = 1;
@@ -40,8 +40,8 @@ DECLARE_VECTOR_UNITTEST(TestPartitionPointSimple);
 template <class Vector>
 void TestPartitionPoint()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   const size_t n = (1 << 16) + 13;
 

--- a/thrust/testing/permutation_iterator.cu
+++ b/thrust/testing/permutation_iterator.cu
@@ -11,8 +11,8 @@
 template <class Vector>
 void TestPermutationIteratorSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector source(8);
   Vector indices(4);
@@ -61,7 +61,7 @@ static_assert(cuda::std::is_trivially_copyable<thrust::permutation_iterator<int*
 template <class Vector>
 void TestPermutationIteratorGather()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector source(8);
   Vector indices(4);
@@ -89,7 +89,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorGather);
 template <class Vector>
 void TestPermutationIteratorScatter()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector source(4, 10);
   Vector indices(4);
@@ -148,8 +148,8 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestMakePermutationIterator);
 template <typename Vector>
 void TestPermutationIteratorReduce()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector source(8);
   Vector indices(4);
@@ -183,11 +183,11 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorReduce);
 
 void TestPermutationIteratorHostDeviceGather()
 {
-  typedef int T;
-  typedef thrust::host_vector<T> HostVector;
-  typedef thrust::host_vector<T> DeviceVector;
-  typedef HostVector::iterator HostIterator;
-  typedef DeviceVector::iterator DeviceIterator;
+  using T              = int;
+  using HostVector     = thrust::host_vector<T>;
+  using DeviceVector   = thrust::host_vector<T>;
+  using HostIterator   = HostVector::iterator;
+  using DeviceIterator = DeviceVector::iterator;
 
   HostVector h_source(8);
   HostVector h_indices(4);
@@ -229,11 +229,11 @@ DECLARE_UNITTEST(TestPermutationIteratorHostDeviceGather);
 
 void TestPermutationIteratorHostDeviceScatter()
 {
-  typedef int T;
-  typedef thrust::host_vector<T> HostVector;
-  typedef thrust::host_vector<T> DeviceVector;
-  typedef HostVector::iterator HostIterator;
-  typedef DeviceVector::iterator DeviceIterator;
+  using T              = int;
+  using HostVector     = thrust::host_vector<T>;
+  using DeviceVector   = thrust::host_vector<T>;
+  using HostIterator   = HostVector::iterator;
+  using DeviceIterator = DeviceVector::iterator;
 
   HostVector h_source(4, 10);
   HostVector h_indices(4);

--- a/thrust/testing/random.cu
+++ b/thrust/testing/random.cu
@@ -142,7 +142,7 @@ struct ValidateEngineUnequal
 template <typename Distribution, typename Engine>
 struct ValidateDistributionMin
 {
-  typedef Engine random_engine;
+  using random_engine = Engine;
 
   _CCCL_HOST_DEVICE ValidateDistributionMin(const Distribution& dd)
       : d(dd)
@@ -168,7 +168,7 @@ struct ValidateDistributionMin
 template <typename Distribution, typename Engine>
 struct ValidateDistributionMax
 {
-  typedef Engine random_engine;
+  using random_engine = Engine;
 
   _CCCL_HOST_DEVICE ValidateDistributionMax(const Distribution& dd)
       : d(dd)
@@ -327,7 +327,7 @@ void TestEngineUnequal()
 
 void TestRanlux24BaseValidation()
 {
-  typedef thrust::random::ranlux24_base Engine;
+  using Engine = thrust::random::ranlux24_base;
 
   TestEngineValidation<Engine, 7937952u>();
 }
@@ -335,7 +335,7 @@ DECLARE_UNITTEST(TestRanlux24BaseValidation);
 
 void TestRanlux24BaseMin()
 {
-  typedef thrust::random::ranlux24_base Engine;
+  using Engine = thrust::random::ranlux24_base;
 
   TestEngineMin<Engine>();
 }
@@ -343,7 +343,7 @@ DECLARE_UNITTEST(TestRanlux24BaseMin);
 
 void TestRanlux24BaseMax()
 {
-  typedef thrust::random::ranlux24_base Engine;
+  using Engine = thrust::random::ranlux24_base;
 
   TestEngineMax<Engine>();
 }
@@ -351,7 +351,7 @@ DECLARE_UNITTEST(TestRanlux24BaseMax);
 
 void TestRanlux24BaseSaveRestore()
 {
-  typedef thrust::random::ranlux24_base Engine;
+  using Engine = thrust::random::ranlux24_base;
 
   TestEngineSaveRestore<Engine>();
 }
@@ -359,7 +359,7 @@ DECLARE_UNITTEST(TestRanlux24BaseSaveRestore);
 
 void TestRanlux24BaseEqual()
 {
-  typedef thrust::random::ranlux24_base Engine;
+  using Engine = thrust::random::ranlux24_base;
 
   TestEngineEqual<Engine>();
 }
@@ -367,7 +367,7 @@ DECLARE_UNITTEST(TestRanlux24BaseEqual);
 
 void TestRanlux24BaseUnequal()
 {
-  typedef thrust::random::ranlux24_base Engine;
+  using Engine = thrust::random::ranlux24_base;
 
   TestEngineUnequal<Engine>();
 }
@@ -375,7 +375,7 @@ DECLARE_UNITTEST(TestRanlux24BaseUnequal);
 
 void TestRanlux48BaseValidation()
 {
-  typedef thrust::random::ranlux48_base Engine;
+  using Engine = thrust::random::ranlux48_base;
 
   TestEngineValidation<Engine, 192113843633948ull>();
 }
@@ -383,7 +383,7 @@ DECLARE_UNITTEST(TestRanlux48BaseValidation);
 
 void TestRanlux48BaseMin()
 {
-  typedef thrust::random::ranlux48_base Engine;
+  using Engine = thrust::random::ranlux48_base;
 
   TestEngineMin<Engine>();
 }
@@ -391,7 +391,7 @@ DECLARE_UNITTEST(TestRanlux48BaseMin);
 
 void TestRanlux48BaseMax()
 {
-  typedef thrust::random::ranlux48_base Engine;
+  using Engine = thrust::random::ranlux48_base;
 
   TestEngineMax<Engine>();
 }
@@ -399,7 +399,7 @@ DECLARE_UNITTEST(TestRanlux48BaseMax);
 
 void TestRanlux48BaseSaveRestore()
 {
-  typedef thrust::random::ranlux48_base Engine;
+  using Engine = thrust::random::ranlux48_base;
 
   TestEngineSaveRestore<Engine>();
 }
@@ -407,7 +407,7 @@ DECLARE_UNITTEST(TestRanlux48BaseSaveRestore);
 
 void TestRanlux48BaseEqual()
 {
-  typedef thrust::random::ranlux48_base Engine;
+  using Engine = thrust::random::ranlux48_base;
 
   TestEngineEqual<Engine>();
 }
@@ -423,7 +423,7 @@ void TestRanlux48BaseUnequal()
 #else
 void TestRanlux48BaseUnequal()
 {
-  typedef thrust::random::ranlux48_base Engine;
+  using Engine = thrust::random::ranlux48_base;
 
   TestEngineUnequal<Engine>();
 }
@@ -432,7 +432,7 @@ DECLARE_UNITTEST(TestRanlux48BaseUnequal);
 
 void TestMinstdRandValidation()
 {
-  typedef thrust::random::minstd_rand Engine;
+  using Engine = thrust::random::minstd_rand;
 
   TestEngineValidation<Engine, 399268537u>();
 }
@@ -440,7 +440,7 @@ DECLARE_UNITTEST(TestMinstdRandValidation);
 
 void TestMinstdRandMin()
 {
-  typedef thrust::random::minstd_rand Engine;
+  using Engine = thrust::random::minstd_rand;
 
   TestEngineMin<Engine>();
 }
@@ -448,7 +448,7 @@ DECLARE_UNITTEST(TestMinstdRandMin);
 
 void TestMinstdRandMax()
 {
-  typedef thrust::random::minstd_rand Engine;
+  using Engine = thrust::random::minstd_rand;
 
   TestEngineMax<Engine>();
 }
@@ -456,7 +456,7 @@ DECLARE_UNITTEST(TestMinstdRandMax);
 
 void TestMinstdRandSaveRestore()
 {
-  typedef thrust::random::minstd_rand Engine;
+  using Engine = thrust::random::minstd_rand;
 
   TestEngineSaveRestore<Engine>();
 }
@@ -464,7 +464,7 @@ DECLARE_UNITTEST(TestMinstdRandSaveRestore);
 
 void TestMinstdRandEqual()
 {
-  typedef thrust::random::minstd_rand Engine;
+  using Engine = thrust::random::minstd_rand;
 
   TestEngineEqual<Engine>();
 }
@@ -472,7 +472,7 @@ DECLARE_UNITTEST(TestMinstdRandEqual);
 
 void TestMinstdRandUnequal()
 {
-  typedef thrust::random::minstd_rand Engine;
+  using Engine = thrust::random::minstd_rand;
 
   TestEngineUnequal<Engine>();
 }
@@ -480,7 +480,7 @@ DECLARE_UNITTEST(TestMinstdRandUnequal);
 
 void TestMinstdRand0Validation()
 {
-  typedef thrust::random::minstd_rand0 Engine;
+  using Engine = thrust::random::minstd_rand0;
 
   TestEngineValidation<Engine, 1043618065u>();
 }
@@ -488,7 +488,7 @@ DECLARE_UNITTEST(TestMinstdRand0Validation);
 
 void TestMinstdRand0Min()
 {
-  typedef thrust::random::minstd_rand0 Engine;
+  using Engine = thrust::random::minstd_rand0;
 
   TestEngineMin<Engine>();
 }
@@ -496,7 +496,7 @@ DECLARE_UNITTEST(TestMinstdRand0Min);
 
 void TestMinstdRand0Max()
 {
-  typedef thrust::random::minstd_rand0 Engine;
+  using Engine = thrust::random::minstd_rand0;
 
   TestEngineMax<Engine>();
 }
@@ -504,7 +504,7 @@ DECLARE_UNITTEST(TestMinstdRand0Max);
 
 void TestMinstdRand0SaveRestore()
 {
-  typedef thrust::random::minstd_rand0 Engine;
+  using Engine = thrust::random::minstd_rand0;
 
   TestEngineSaveRestore<Engine>();
 }
@@ -512,7 +512,7 @@ DECLARE_UNITTEST(TestMinstdRand0SaveRestore);
 
 void TestMinstdRand0Equal()
 {
-  typedef thrust::random::minstd_rand0 Engine;
+  using Engine = thrust::random::minstd_rand0;
 
   TestEngineEqual<Engine>();
 }
@@ -520,7 +520,7 @@ DECLARE_UNITTEST(TestMinstdRand0Equal);
 
 void TestMinstdRand0Unequal()
 {
-  typedef thrust::random::minstd_rand0 Engine;
+  using Engine = thrust::random::minstd_rand0;
 
   TestEngineUnequal<Engine>();
 }
@@ -528,7 +528,7 @@ DECLARE_UNITTEST(TestMinstdRand0Unequal);
 
 void TestTaus88Validation()
 {
-  typedef thrust::random::taus88 Engine;
+  using Engine = thrust::random::taus88;
 
   TestEngineValidation<Engine, 3535848941ull>();
 }
@@ -536,7 +536,7 @@ DECLARE_UNITTEST(TestTaus88Validation);
 
 void TestTaus88Min()
 {
-  typedef thrust::random::taus88 Engine;
+  using Engine = thrust::random::taus88;
 
   TestEngineMin<Engine>();
 }
@@ -544,7 +544,7 @@ DECLARE_UNITTEST(TestTaus88Min);
 
 void TestTaus88Max()
 {
-  typedef thrust::random::taus88 Engine;
+  using Engine = thrust::random::taus88;
 
   TestEngineMax<Engine>();
 }
@@ -552,7 +552,7 @@ DECLARE_UNITTEST(TestTaus88Max);
 
 void TestTaus88SaveRestore()
 {
-  typedef thrust::random::taus88 Engine;
+  using Engine = thrust::random::taus88;
 
   TestEngineSaveRestore<Engine>();
 }
@@ -560,7 +560,7 @@ DECLARE_UNITTEST(TestTaus88SaveRestore);
 
 void TestTaus88Equal()
 {
-  typedef thrust::random::taus88 Engine;
+  using Engine = thrust::random::taus88;
 
   TestEngineEqual<Engine>();
 }
@@ -568,7 +568,7 @@ DECLARE_UNITTEST(TestTaus88Equal);
 
 void TestTaus88Unequal()
 {
-  typedef thrust::random::taus88 Engine;
+  using Engine = thrust::random::taus88;
 
   TestEngineUnequal<Engine>();
 }
@@ -576,7 +576,7 @@ DECLARE_UNITTEST(TestTaus88Unequal);
 
 void TestRanlux24Validation()
 {
-  typedef thrust::random::ranlux24 Engine;
+  using Engine = thrust::random::ranlux24;
 
   TestEngineValidation<Engine, 9901578>();
 }
@@ -584,7 +584,7 @@ DECLARE_UNITTEST(TestRanlux24Validation);
 
 void TestRanlux24Min()
 {
-  typedef thrust::random::ranlux24 Engine;
+  using Engine = thrust::random::ranlux24;
 
   TestEngineMin<Engine>();
 }
@@ -592,7 +592,7 @@ DECLARE_UNITTEST(TestRanlux24Min);
 
 void TestRanlux24Max()
 {
-  typedef thrust::random::ranlux24 Engine;
+  using Engine = thrust::random::ranlux24;
 
   TestEngineMax<Engine>();
 }
@@ -600,7 +600,7 @@ DECLARE_UNITTEST(TestRanlux24Max);
 
 void TestRanlux24SaveRestore()
 {
-  typedef thrust::random::ranlux24 Engine;
+  using Engine = thrust::random::ranlux24;
 
   TestEngineSaveRestore<Engine>();
 }
@@ -608,7 +608,7 @@ DECLARE_UNITTEST(TestRanlux24SaveRestore);
 
 void TestRanlux24Equal()
 {
-  typedef thrust::random::ranlux24 Engine;
+  using Engine = thrust::random::ranlux24;
 
   TestEngineEqual<Engine>();
 }
@@ -616,7 +616,7 @@ DECLARE_UNITTEST(TestRanlux24Equal);
 
 void TestRanlux24Unequal()
 {
-  typedef thrust::random::ranlux24 Engine;
+  using Engine = thrust::random::ranlux24;
 
   TestEngineUnequal<Engine>();
 }
@@ -624,7 +624,7 @@ DECLARE_UNITTEST(TestRanlux24Unequal);
 
 void TestRanlux48Validation()
 {
-  typedef thrust::random::ranlux48 Engine;
+  using Engine = thrust::random::ranlux48;
 
   TestEngineValidation<Engine, 88229545517833ull>();
 }
@@ -632,7 +632,7 @@ DECLARE_UNITTEST(TestRanlux48Validation);
 
 void TestRanlux48Min()
 {
-  typedef thrust::random::ranlux48 Engine;
+  using Engine = thrust::random::ranlux48;
 
   TestEngineMin<Engine>();
 }
@@ -640,7 +640,7 @@ DECLARE_UNITTEST(TestRanlux48Min);
 
 void TestRanlux48Max()
 {
-  typedef thrust::random::ranlux48 Engine;
+  using Engine = thrust::random::ranlux48;
 
   TestEngineMax<Engine>();
 }
@@ -648,7 +648,7 @@ DECLARE_UNITTEST(TestRanlux48Max);
 
 void TestRanlux48SaveRestore()
 {
-  typedef thrust::random::ranlux48 Engine;
+  using Engine = thrust::random::ranlux48;
 
   TestEngineSaveRestore<Engine>();
 }
@@ -656,7 +656,7 @@ DECLARE_UNITTEST(TestRanlux48SaveRestore);
 
 void TestRanlux48Equal()
 {
-  typedef thrust::random::ranlux48 Engine;
+  using Engine = thrust::random::ranlux48;
 
   TestEngineEqual<Engine>();
 }
@@ -664,7 +664,7 @@ DECLARE_UNITTEST(TestRanlux48Equal);
 
 void TestRanlux48Unequal()
 {
-  typedef thrust::random::ranlux48 Engine;
+  using Engine = thrust::random::ranlux48;
 
   TestEngineUnequal<Engine>();
 }
@@ -674,7 +674,7 @@ THRUST_DISABLE_MSVC_WARNING_BEGIN(4305) // truncation warning
 template <typename Distribution, typename Validator>
 void ValidateDistributionCharacteristic()
 {
-  typedef typename Validator::random_engine Engine;
+  using Engine = typename Validator::random_engine;
 
   // test default-constructed Distribution
 
@@ -753,8 +753,8 @@ void TestDistributionSaveRestore()
 
 void TestUniformIntDistributionMin()
 {
-  typedef thrust::random::uniform_int_distribution<int> int_dist;
-  typedef thrust::random::uniform_int_distribution<unsigned int> uint_dist;
+  using int_dist  = thrust::random::uniform_int_distribution<int>;
+  using uint_dist = thrust::random::uniform_int_distribution<unsigned int>;
 
   ValidateDistributionCharacteristic<int_dist, ValidateDistributionMin<int_dist, thrust::minstd_rand>>();
   ValidateDistributionCharacteristic<uint_dist, ValidateDistributionMin<uint_dist, thrust::minstd_rand>>();
@@ -763,8 +763,8 @@ DECLARE_UNITTEST(TestUniformIntDistributionMin);
 
 void TestUniformIntDistributionMax()
 {
-  typedef thrust::random::uniform_int_distribution<int> int_dist;
-  typedef thrust::random::uniform_int_distribution<unsigned int> uint_dist;
+  using int_dist  = thrust::random::uniform_int_distribution<int>;
+  using uint_dist = thrust::random::uniform_int_distribution<unsigned int>;
 
   ValidateDistributionCharacteristic<int_dist, ValidateDistributionMax<int_dist, thrust::minstd_rand>>();
   ValidateDistributionCharacteristic<uint_dist, ValidateDistributionMax<uint_dist, thrust::minstd_rand>>();
@@ -773,8 +773,8 @@ DECLARE_UNITTEST(TestUniformIntDistributionMax);
 
 void TestUniformIntDistributionSaveRestore()
 {
-  typedef thrust::random::uniform_int_distribution<int> int_dist;
-  typedef thrust::random::uniform_int_distribution<unsigned int> uint_dist;
+  using int_dist  = thrust::random::uniform_int_distribution<int>;
+  using uint_dist = thrust::random::uniform_int_distribution<unsigned int>;
 
   TestDistributionSaveRestore<int_dist>();
   TestDistributionSaveRestore<uint_dist>();
@@ -783,8 +783,8 @@ DECLARE_UNITTEST(TestUniformIntDistributionSaveRestore);
 
 void TestUniformRealDistributionMin()
 {
-  typedef thrust::random::uniform_real_distribution<float> float_dist;
-  typedef thrust::random::uniform_real_distribution<double> double_dist;
+  using float_dist  = thrust::random::uniform_real_distribution<float>;
+  using double_dist = thrust::random::uniform_real_distribution<double>;
 
   ValidateDistributionCharacteristic<float_dist, ValidateDistributionMin<float_dist, thrust::minstd_rand>>();
   ValidateDistributionCharacteristic<double_dist, ValidateDistributionMin<double_dist, thrust::minstd_rand>>();
@@ -793,8 +793,8 @@ DECLARE_UNITTEST(TestUniformRealDistributionMin);
 
 void TestUniformRealDistributionMax()
 {
-  typedef thrust::random::uniform_real_distribution<float> float_dist;
-  typedef thrust::random::uniform_real_distribution<double> double_dist;
+  using float_dist  = thrust::random::uniform_real_distribution<float>;
+  using double_dist = thrust::random::uniform_real_distribution<double>;
 
   ValidateDistributionCharacteristic<float_dist, ValidateDistributionMax<float_dist, thrust::minstd_rand>>();
   ValidateDistributionCharacteristic<double_dist, ValidateDistributionMax<double_dist, thrust::minstd_rand>>();
@@ -803,8 +803,8 @@ DECLARE_UNITTEST(TestUniformRealDistributionMax);
 
 void TestUniformRealDistributionSaveRestore()
 {
-  typedef thrust::random::uniform_real_distribution<float> float_dist;
-  typedef thrust::random::uniform_real_distribution<double> double_dist;
+  using float_dist  = thrust::random::uniform_real_distribution<float>;
+  using double_dist = thrust::random::uniform_real_distribution<double>;
 
   TestDistributionSaveRestore<float_dist>();
   TestDistributionSaveRestore<double_dist>();
@@ -813,8 +813,8 @@ DECLARE_UNITTEST(TestUniformRealDistributionSaveRestore);
 
 void TestNormalDistributionMin()
 {
-  typedef thrust::random::normal_distribution<float> float_dist;
-  typedef thrust::random::normal_distribution<double> double_dist;
+  using float_dist  = thrust::random::normal_distribution<float>;
+  using double_dist = thrust::random::normal_distribution<double>;
 
   ValidateDistributionCharacteristic<float_dist, ValidateDistributionMin<float_dist, thrust::minstd_rand>>();
   ValidateDistributionCharacteristic<double_dist, ValidateDistributionMin<double_dist, thrust::minstd_rand>>();
@@ -823,8 +823,8 @@ DECLARE_UNITTEST(TestNormalDistributionMin);
 
 void TestNormalDistributionMax()
 {
-  typedef thrust::random::normal_distribution<float> float_dist;
-  typedef thrust::random::normal_distribution<double> double_dist;
+  using float_dist  = thrust::random::normal_distribution<float>;
+  using double_dist = thrust::random::normal_distribution<double>;
 
   ValidateDistributionCharacteristic<float_dist, ValidateDistributionMax<float_dist, thrust::minstd_rand>>();
   ValidateDistributionCharacteristic<double_dist, ValidateDistributionMax<double_dist, thrust::minstd_rand>>();
@@ -833,8 +833,8 @@ DECLARE_UNITTEST(TestNormalDistributionMax);
 
 void TestNormalDistributionSaveRestore()
 {
-  typedef thrust::random::normal_distribution<float> float_dist;
-  typedef thrust::random::normal_distribution<double> double_dist;
+  using float_dist  = thrust::random::normal_distribution<float>;
+  using double_dist = thrust::random::normal_distribution<double>;
 
   TestDistributionSaveRestore<float_dist>();
   TestDistributionSaveRestore<double_dist>();

--- a/thrust/testing/reduce.cu
+++ b/thrust/testing/reduce.cu
@@ -28,7 +28,7 @@ struct is_equal_div_10_reduce
 template <class Vector>
 void TestReduceSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(3);
   v[0] = 1;
@@ -165,7 +165,7 @@ template <typename Vector>
 void TestReduceWithIndirection()
 {
   // add numbers modulo 3 with external lookup table
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(7);
   data[0] = 0;

--- a/thrust/testing/reduce_by_key.cu
+++ b/thrust/testing/reduce_by_key.cu
@@ -47,7 +47,7 @@ void initialize_values(Vector& values)
 template <typename Vector>
 void TestReduceByKeySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector keys;
   Vector values;
@@ -129,7 +129,7 @@ struct TestReduceByKey
 {
   void operator()(const size_t n)
   {
-    typedef unsigned int V; // ValueType
+    using V = unsigned int; // ValueType
 
     thrust::host_vector<K> h_keys   = unittest::random_integers<bool>(n);
     thrust::host_vector<V> h_vals   = unittest::random_integers<V>(n);
@@ -141,13 +141,13 @@ struct TestReduceByKey
     thrust::device_vector<K> d_keys_output(n);
     thrust::device_vector<V> d_vals_output(n);
 
-    typedef typename thrust::host_vector<K>::iterator HostKeyIterator;
-    typedef typename thrust::host_vector<V>::iterator HostValIterator;
-    typedef typename thrust::device_vector<K>::iterator DeviceKeyIterator;
-    typedef typename thrust::device_vector<V>::iterator DeviceValIterator;
+    using HostKeyIterator   = typename thrust::host_vector<K>::iterator;
+    using HostValIterator   = typename thrust::host_vector<V>::iterator;
+    using DeviceKeyIterator = typename thrust::device_vector<K>::iterator;
+    using DeviceValIterator = typename thrust::device_vector<V>::iterator;
 
-    typedef typename thrust::pair<HostKeyIterator, HostValIterator> HostIteratorPair;
-    typedef typename thrust::pair<DeviceKeyIterator, DeviceValIterator> DeviceIteratorPair;
+    using HostIteratorPair   = typename thrust::pair<HostKeyIterator, HostValIterator>;
+    using DeviceIteratorPair = typename thrust::pair<DeviceKeyIterator, DeviceValIterator>;
 
     HostIteratorPair h_last =
       thrust::reduce_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys_output.begin(), h_vals_output.begin());
@@ -175,7 +175,7 @@ struct TestReduceByKeyToDiscardIterator
 {
   void operator()(const size_t n)
   {
-    typedef unsigned int V; // ValueType
+    using V = unsigned int; // ValueType
 
     thrust::host_vector<K> h_keys   = unittest::random_integers<bool>(n);
     thrust::host_vector<V> h_vals   = unittest::random_integers<V>(n);

--- a/thrust/testing/remove.cu
+++ b/thrust/testing/remove.cu
@@ -30,7 +30,7 @@ struct is_true : thrust::unary_function<T, bool>
 template <typename Vector>
 void TestRemoveSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -87,7 +87,7 @@ DECLARE_UNITTEST(TestRemoveDispatchImplicit);
 template <typename Vector>
 void TestRemoveCopySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -147,7 +147,7 @@ DECLARE_UNITTEST(TestRemoveCopyDispatchImplicit);
 template <typename Vector>
 void TestRemoveIfSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -204,7 +204,7 @@ DECLARE_UNITTEST(TestRemoveIfDispatchImplicit);
 template <typename Vector>
 void TestRemoveIfStencilSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -269,7 +269,7 @@ DECLARE_UNITTEST(TestRemoveIfStencilDispatchImplicit);
 template <typename Vector>
 void TestRemoveCopyIfSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -329,7 +329,7 @@ DECLARE_UNITTEST(TestRemoveCopyIfDispatchImplicit);
 template <typename Vector>
 void TestRemoveCopyIfStencilSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -511,11 +511,11 @@ void TestRemoveCopyToDiscardIteratorZipped(const size_t n)
   size_t num_zeros    = thrust::count(h_data.begin(), h_data.end(), T(0));
   size_t num_nonzeros = h_data.size() - num_zeros;
 
-  typedef thrust::tuple<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> Tuple1;
-  typedef thrust::tuple<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> Tuple2;
+  using Tuple1 = thrust::tuple<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>>;
+  using Tuple2 = thrust::tuple<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>>;
 
-  typedef thrust::zip_iterator<Tuple1> ZipIterator1;
-  typedef thrust::zip_iterator<Tuple2> ZipIterator2;
+  using ZipIterator1 = thrust::zip_iterator<Tuple1>;
+  using ZipIterator2 = thrust::zip_iterator<Tuple2>;
 
   ZipIterator1 h_result = thrust::remove_copy(
     thrust::make_zip_iterator(thrust::make_tuple(h_data.begin(), h_data.begin())),

--- a/thrust/testing/replace.cu
+++ b/thrust/testing/replace.cu
@@ -26,7 +26,7 @@
 template <class Vector>
 void TestReplaceSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -103,7 +103,7 @@ DECLARE_VARIABLE_UNITTEST(TestReplace);
 template <class Vector>
 void TestReplaceCopySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -220,7 +220,7 @@ struct less_than_five
 template <class Vector>
 void TestReplaceIfSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -278,7 +278,7 @@ DECLARE_UNITTEST(TestReplaceIfDispatchImplicit);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceIfStencilSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -373,7 +373,7 @@ DECLARE_VARIABLE_UNITTEST(TestReplaceIfStencil);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;
@@ -437,7 +437,7 @@ DECLARE_UNITTEST(TestReplaceCopyIfDispatchImplicit);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfStencilSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(5);
   data[0] = 1;

--- a/thrust/testing/reverse.cu
+++ b/thrust/testing/reverse.cu
@@ -4,7 +4,7 @@
 
 #include <unittest/unittest.h>
 
-typedef unittest::type_list<unittest::int8_t, unittest::int16_t, unittest::int32_t> ReverseTypes;
+using ReverseTypes = unittest::type_list<unittest::int8_t, unittest::int16_t, unittest::int32_t>;
 
 template <typename Vector>
 void TestReverseSimple()
@@ -73,7 +73,7 @@ void TestReverseCopySimple()
   }
 #endif // _CCCL_COMPILER_GCC
 
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector input(5);
   input[0] = 1;

--- a/thrust/testing/reverse_iterator.cu
+++ b/thrust/testing/reverse_iterator.cu
@@ -87,7 +87,7 @@ DECLARE_VECTOR_UNITTEST(TestReverseIteratorCopy);
 
 void TestReverseIteratorExclusiveScanSimple()
 {
-  typedef int T;
+  using T        = int;
   const size_t n = 10;
 
   thrust::host_vector<T> h_data(n);

--- a/thrust/testing/scan.cu
+++ b/thrust/testing/scan.cu
@@ -22,7 +22,7 @@ struct max_functor
 template <class Vector>
 void TestScanSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   // icc miscompiles the intermediate sum updates for custom_numeric.
   // The issue doesn't happen with opts disabled, or on other compilers.
@@ -213,7 +213,7 @@ DECLARE_UNITTEST(TestExclusiveScanDispatchImplicit);
 
 void TestInclusiveScan32()
 {
-  typedef int T;
+  using T  = int;
   size_t n = 32;
 
   thrust::host_vector<T> h_input   = unittest::random_integers<T>(n);
@@ -231,7 +231,7 @@ DECLARE_UNITTEST(TestInclusiveScan32);
 
 void TestExclusiveScan32()
 {
-  typedef int T;
+  using T  = int;
   size_t n = 32;
   T init   = 13;
 
@@ -543,7 +543,7 @@ template <typename Vector>
 void TestInclusiveScanWithIndirection()
 {
   // add numbers modulo 3 with external lookup table
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(7);
   data[0] = 0;
@@ -593,7 +593,7 @@ template <typename Vector>
 void TestInclusiveScanWithConstAccumulator()
 {
   // add numbers modulo 3 with external lookup table
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(7);
   data[0] = 0;
@@ -662,8 +662,8 @@ THRUST_NAMESPACE_BEGIN
 template <>
 struct iterator_traits<only_set_when_expected_it>
 {
-  typedef long long value_type;
-  typedef only_set_when_expected_it reference;
+  using value_type = long long;
+  using reference  = only_set_when_expected_it;
 };
 THRUST_NAMESPACE_END
 

--- a/thrust/testing/scan_by_key.exclusive.cu
+++ b/thrust/testing/scan_by_key.exclusive.cu
@@ -10,8 +10,8 @@
 template <typename Vector>
 void TestExclusiveScanByKeySimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector keys(7);
   Vector vals(7);
@@ -125,7 +125,7 @@ struct head_flag_predicate
 template <typename Vector>
 void TestScanByKeyHeadFlags()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector keys(7);
   Vector vals(7);

--- a/thrust/testing/scan_by_key.inclusive.cu
+++ b/thrust/testing/scan_by_key.inclusive.cu
@@ -10,8 +10,8 @@
 template <typename Vector>
 void TestInclusiveScanByKeySimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector keys(7);
   Vector vals(7);
@@ -115,7 +115,7 @@ struct head_flag_predicate
 template <typename Vector>
 void TestScanByKeyHeadFlags()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector keys(7);
   Vector vals(7);
@@ -148,7 +148,7 @@ DECLARE_VECTOR_UNITTEST(TestScanByKeyHeadFlags);
 template <typename Vector>
 void TestInclusiveScanByKeyTransformIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector keys(7);
   Vector vals(7);

--- a/thrust/testing/set_difference.cu
+++ b/thrust/testing/set_difference.cu
@@ -51,7 +51,7 @@ DECLARE_UNITTEST(TestSetDifferenceDispatchImplicit);
 template <typename Vector>
 void TestSetDifferenceSimple()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector a(4), b(5);
 

--- a/thrust/testing/set_difference_by_key.cu
+++ b/thrust/testing/set_difference_by_key.cu
@@ -80,7 +80,7 @@ DECLARE_UNITTEST(TestSetDifferenceByKeyDispatchImplicit);
 template <typename Vector>
 void TestSetDifferenceByKeySimple()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector a_key(4), b_key(5);
   Vector a_val(4), b_val(5);

--- a/thrust/testing/set_difference_by_key_descending.cu
+++ b/thrust/testing/set_difference_by_key_descending.cu
@@ -7,8 +7,8 @@
 template <typename Vector>
 void TestSetDifferenceByKeyDescendingSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector a_key(4), a_val(4);
   Vector b_key(5), b_val(5);

--- a/thrust/testing/set_difference_descending.cu
+++ b/thrust/testing/set_difference_descending.cu
@@ -7,8 +7,8 @@
 template <typename Vector>
 void TestSetDifferenceDescendingSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector a(4), b(5);
 

--- a/thrust/testing/set_difference_key_value.cu
+++ b/thrust/testing/set_difference_key_value.cu
@@ -7,7 +7,7 @@
 template <typename U>
 void TestSetDifferenceKeyValue(size_t n)
 {
-  typedef key_value<U, U> T;
+  using T = key_value<U, U>;
 
   thrust::host_vector<U> h_keys_a   = unittest::random_integers<U>(n);
   thrust::host_vector<U> h_values_a = unittest::random_integers<U>(n);

--- a/thrust/testing/set_intersection.cu
+++ b/thrust/testing/set_intersection.cu
@@ -52,7 +52,7 @@ DECLARE_UNITTEST(TestSetIntersectionDispatchImplicit);
 template <typename Vector>
 void TestSetIntersectionSimple()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector a(3), b(4);
 

--- a/thrust/testing/set_intersection_by_key.cu
+++ b/thrust/testing/set_intersection_by_key.cu
@@ -75,7 +75,7 @@ DECLARE_UNITTEST(TestSetIntersectionByKeyDispatchImplicit);
 template <typename Vector>
 void TestSetIntersectionByKeySimple()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a_key(3), b_key(4);

--- a/thrust/testing/set_intersection_by_key_descending.cu
+++ b/thrust/testing/set_intersection_by_key_descending.cu
@@ -7,8 +7,8 @@
 template <typename Vector>
 void TestSetIntersectionByKeyDescendingSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a_key(3), b_key(4);

--- a/thrust/testing/set_intersection_descending.cu
+++ b/thrust/testing/set_intersection_descending.cu
@@ -7,8 +7,8 @@
 template <typename Vector>
 void TestSetIntersectionDescendingSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector a(3), b(4);
 

--- a/thrust/testing/set_intersection_key_value.cu
+++ b/thrust/testing/set_intersection_key_value.cu
@@ -7,7 +7,7 @@
 template <typename U>
 void TestSetIntersectionKeyValue(size_t n)
 {
-  typedef key_value<U, U> T;
+  using T = key_value<U, U>;
 
   thrust::host_vector<U> h_keys_a   = unittest::random_integers<U>(n);
   thrust::host_vector<U> h_values_a = unittest::random_integers<U>(n);

--- a/thrust/testing/set_symmetric_difference.cu
+++ b/thrust/testing/set_symmetric_difference.cu
@@ -51,7 +51,7 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceDispatchImplicit);
 template <typename Vector>
 void TestSetSymmetricDifferenceSimple()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a(4), b(5);
@@ -179,7 +179,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetSymmetricDifferenceMultiset);
 template <typename U>
 void TestSetSymmetricDifferenceKeyValue(size_t n)
 {
-  typedef key_value<U, U> T;
+  using T = key_value<U, U>;
 
   thrust::host_vector<U> h_keys_a   = unittest::random_integers<U>(n);
   thrust::host_vector<U> h_values_a = unittest::random_integers<U>(n);

--- a/thrust/testing/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/set_symmetric_difference_by_key.cu
@@ -80,7 +80,7 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyDispatchImplicit);
 template <typename Vector>
 void TestSetSymmetricDifferenceByKeySimple()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector a_key(4), b_key(5);
   Vector a_val(4), b_val(5);

--- a/thrust/testing/set_symmetric_difference_by_key_descending.cu
+++ b/thrust/testing/set_symmetric_difference_by_key_descending.cu
@@ -7,8 +7,8 @@
 template <typename Vector>
 void TestSetSymmetricDifferenceByKeyDescendingSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector a_key(4), b_key(5);
   Vector a_val(4), b_val(5);

--- a/thrust/testing/set_symmetric_difference_descending.cu
+++ b/thrust/testing/set_symmetric_difference_descending.cu
@@ -7,8 +7,8 @@
 template <typename Vector>
 void TestSetSymmetricDifferenceDescendingSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a(4), b(5);

--- a/thrust/testing/set_union.cu
+++ b/thrust/testing/set_union.cu
@@ -51,7 +51,7 @@ DECLARE_UNITTEST(TestSetUnionDispatchImplicit);
 template <typename Vector>
 void TestSetUnionSimple()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector a(3), b(4);
 
@@ -82,7 +82,7 @@ DECLARE_VECTOR_UNITTEST(TestSetUnionSimple);
 template <typename Vector>
 void TestSetUnionWithEquivalentElementsSimple()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector a(3), b(5);
 

--- a/thrust/testing/set_union_by_key.cu
+++ b/thrust/testing/set_union_by_key.cu
@@ -80,7 +80,7 @@ DECLARE_UNITTEST(TestSetUnionByKeyDispatchImplicit);
 template <typename Vector>
 void TestSetUnionByKeySimple()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector a_key(3), b_key(4);

--- a/thrust/testing/set_union_by_key_descending.cu
+++ b/thrust/testing/set_union_by_key_descending.cu
@@ -7,8 +7,8 @@
 template <typename Vector>
 void TestSetUnionByKeyDescendingSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector a_key(3), b_key(4);
   Vector a_val(3), b_val(4);

--- a/thrust/testing/set_union_descending.cu
+++ b/thrust/testing/set_union_descending.cu
@@ -7,8 +7,8 @@
 template <typename Vector>
 void TestSetUnionDescendingSimple()
 {
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  using T        = typename Vector::value_type;
+  using Iterator = typename Vector::iterator;
 
   Vector a(3), b(4);
 

--- a/thrust/testing/set_union_key_value.cu
+++ b/thrust/testing/set_union_key_value.cu
@@ -7,7 +7,7 @@
 template <typename U>
 void TestSetUnionKeyValue(size_t n)
 {
-  typedef key_value<U, U> T;
+  using T = key_value<U, U>;
 
   thrust::host_vector<U> h_keys_a   = unittest::random_integers<U>(n);
   thrust::host_vector<U> h_values_a = unittest::random_integers<U>(n);
@@ -47,7 +47,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetUnionKeyValue);
 template <typename U>
 void TestSetUnionKeyValueDescending(size_t n)
 {
-  typedef key_value<U, U> T;
+  using T = key_value<U, U>;
 
   thrust::host_vector<U> h_keys_a   = unittest::random_integers<U>(n);
   thrust::host_vector<U> h_values_a = unittest::random_integers<U>(n);

--- a/thrust/testing/shuffle.cu
+++ b/thrust/testing/shuffle.cu
@@ -494,7 +494,7 @@ DECLARE_UNITTEST(TestBijectionLength);
 template <typename Vector>
 void TestShuffleKeyPosition()
 {
-  typedef typename Vector::value_type T;
+  using T            = typename Vector::value_type;
   size_t m           = 20;
   size_t num_samples = 100;
   thrust::host_vector<size_t> index_sum(m, 0);
@@ -554,7 +554,7 @@ struct vector_compare
 template <typename Vector>
 void TestShuffleUniformPermutation()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   size_t m                  = 5;
   size_t num_samples        = 1000;
@@ -586,7 +586,7 @@ DECLARE_VECTOR_UNITTEST(TestShuffleUniformPermutation);
 template <typename Vector>
 void TestShuffleEvenSpacingBetweenOccurances()
 {
-  typedef typename Vector::value_type T;
+  using T                     = typename Vector::value_type;
   const uint64_t shuffle_size = 10;
   const uint64_t num_samples  = 1000;
 
@@ -640,7 +640,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestShuffleEvenSpacingBetweenOccurances);
 template <typename Vector>
 void TestShuffleEvenDistribution()
 {
-  typedef typename Vector::value_type T;
+  using T                        = typename Vector::value_type;
   const uint64_t shuffle_sizes[] = {10, 100, 500};
   thrust::default_random_engine g(0xD5);
   for (auto shuffle_size : shuffle_sizes)

--- a/thrust/testing/sort_by_key_variable_bits.cu
+++ b/thrust/testing/sort_by_key_variable_bits.cu
@@ -6,15 +6,8 @@
 
 using namespace unittest;
 
-typedef unittest::type_list<
-#if !(defined(__GNUC__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ <= 1))
-  // XXX GCC 4.1 miscompiles the char sorts with -O2 for some reason
-  unittest::uint8_t,
-#endif
-  unittest::uint16_t,
-  unittest::uint32_t,
-  unittest::uint64_t>
-  UnsignedIntegerTypes;
+using UnsignedIntegerTypes =
+  unittest::type_list<unittest::uint8_t, unittest::uint16_t, unittest::uint32_t, unittest::uint64_t>;
 
 template <typename T>
 struct TestSortByKeyVariableBits

--- a/thrust/testing/sort_permutation_iterator.cu
+++ b/thrust/testing/sort_permutation_iterator.cu
@@ -10,7 +10,7 @@ template <typename Iterator>
 class strided_range
 {
 public:
-  typedef typename thrust::iterator_difference<Iterator>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<Iterator>::type;
 
   struct stride_functor : public thrust::unary_function<difference_type, difference_type>
   {
@@ -26,12 +26,12 @@ public:
     }
   };
 
-  typedef typename thrust::counting_iterator<difference_type> CountingIterator;
-  typedef typename thrust::transform_iterator<stride_functor, CountingIterator> TransformIterator;
-  typedef typename thrust::permutation_iterator<Iterator, TransformIterator> PermutationIterator;
+  using CountingIterator    = typename thrust::counting_iterator<difference_type>;
+  using TransformIterator   = typename thrust::transform_iterator<stride_functor, CountingIterator>;
+  using PermutationIterator = typename thrust::permutation_iterator<Iterator, TransformIterator>;
 
   // type of the strided_range iterator
-  typedef PermutationIterator iterator;
+  using iterator = PermutationIterator;
 
   // construct strided_range for the range [first,last)
   strided_range(Iterator first, Iterator last, difference_type stride)
@@ -59,7 +59,7 @@ protected:
 template <class Vector>
 void TestSortPermutationIterator()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector A(10);
   A[0] = 2;
@@ -93,7 +93,7 @@ DECLARE_VECTOR_UNITTEST(TestSortPermutationIterator);
 template <class Vector>
 void TestStableSortPermutationIterator()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   Vector A(10);
   A[0] = 2;
@@ -127,7 +127,7 @@ DECLARE_VECTOR_UNITTEST(TestStableSortPermutationIterator);
 template <class Vector>
 void TestSortByKeyPermutationIterator()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector A(10), B(10);
@@ -175,7 +175,7 @@ DECLARE_VECTOR_UNITTEST(TestSortByKeyPermutationIterator);
 template <class Vector>
 void TestStableSortByKeyPermutationIterator()
 {
-  typedef typename Vector::iterator Iterator;
+  using Iterator = typename Vector::iterator;
 
   // clang-format off
   Vector A(10), B(10);

--- a/thrust/testing/sort_variable_bits.cu
+++ b/thrust/testing/sort_variable_bits.cu
@@ -6,15 +6,8 @@
 
 using namespace unittest;
 
-typedef unittest::type_list<
-#if !(defined(__GNUC__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ <= 1))
-  // XXX GCC 4.1 miscompiles the char sorts with -O2 for some reason
-  unittest::uint8_t,
-#endif
-  unittest::uint16_t,
-  unittest::uint32_t,
-  unittest::uint64_t>
-  UnsignedIntegerTypes;
+using UnsignedIntegerTypes =
+  unittest::type_list<unittest::uint8_t, unittest::uint16_t, unittest::uint32_t, unittest::uint64_t>;
 
 template <typename T>
 struct TestSortVariableBits

--- a/thrust/testing/stable_sort.cu
+++ b/thrust/testing/stable_sort.cu
@@ -75,7 +75,7 @@ void InitializeSimpleStableKeySortTest(Vector& unsorted_keys, Vector& sorted_key
 template <class Vector>
 void TestStableSortSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector unsorted_keys;
   Vector sorted_keys;
@@ -140,7 +140,7 @@ template <typename Vector>
 void TestStableSortWithIndirection()
 {
   // add numbers modulo 3 with external lookup table
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(7);
   data[0] = 1;

--- a/thrust/testing/stable_sort_by_key.cu
+++ b/thrust/testing/stable_sort_by_key.cu
@@ -81,7 +81,7 @@ void InitializeSimpleStableKeyValueSortTest(
 template <class Vector>
 void TestStableSortByKeySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector unsorted_keys, unsorted_values;
   Vector sorted_keys, sorted_values;

--- a/thrust/testing/tabulate.cu
+++ b/thrust/testing/tabulate.cu
@@ -42,7 +42,7 @@ template <class Vector>
 void TestTabulateSimple()
 {
   using namespace thrust::placeholders;
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
 

--- a/thrust/testing/transform.cu
+++ b/thrust/testing/transform.cu
@@ -19,7 +19,7 @@
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformUnarySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -79,7 +79,7 @@ DECLARE_UNITTEST(TestTransformUnaryDispatchImplicit);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfUnaryNoStencilSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -144,7 +144,7 @@ DECLARE_UNITTEST(TestTransformIfUnaryNoStencilDispatchImplicit);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfUnarySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -216,7 +216,7 @@ DECLARE_UNITTEST(TestTransformIfUnaryDispatchImplicit);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformBinarySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -285,7 +285,7 @@ DECLARE_UNITTEST(TestTransformBinaryDispatchImplicit);
 template <class Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfBinarySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -440,14 +440,14 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformUnaryToDiscardIteratorZip
   thrust::host_vector<T> h_output(n);
   thrust::device_vector<T> d_output(n);
 
-  typedef typename thrust::host_vector<T>::iterator Iterator1;
-  typedef typename thrust::device_vector<T>::iterator Iterator2;
+  using Iterator1 = typename thrust::host_vector<T>::iterator;
+  using Iterator2 = typename thrust::device_vector<T>::iterator;
 
-  typedef thrust::tuple<Iterator1, thrust::discard_iterator<>> Tuple1;
-  typedef thrust::tuple<Iterator2, thrust::discard_iterator<>> Tuple2;
+  using Tuple1 = thrust::tuple<Iterator1, thrust::discard_iterator<>>;
+  using Tuple2 = thrust::tuple<Iterator2, thrust::discard_iterator<>>;
 
-  typedef thrust::zip_iterator<Tuple1> ZipIterator1;
-  typedef thrust::zip_iterator<Tuple2> ZipIterator2;
+  using ZipIterator1 = thrust::zip_iterator<Tuple1>;
+  using ZipIterator2 = thrust::zip_iterator<Tuple2>;
 
   ZipIterator1 z1(thrust::make_tuple(h_output.begin(), thrust::make_discard_iterator()));
   ZipIterator2 z2(thrust::make_tuple(d_output.begin(), thrust::make_discard_iterator()));
@@ -766,7 +766,7 @@ template <typename Vector>
 THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformWithIndirection()
 {
   // add numbers modulo 3 with external lookup table
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector input1(7);
   Vector input2(7);

--- a/thrust/testing/transform_input_output_iterator.cu
+++ b/thrust/testing/transform_input_output_iterator.cu
@@ -10,11 +10,11 @@
 template <class Vector>
 void TestTransformInputOutputIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
-  typedef thrust::negate<T> InputFunction;
-  typedef thrust::square<T> OutputFunction;
-  typedef typename Vector::iterator Iterator;
+  using InputFunction  = thrust::negate<T>;
+  using OutputFunction = thrust::square<T>;
+  using Iterator       = typename Vector::iterator;
 
   Vector input(4);
   Vector squared(4);
@@ -54,10 +54,10 @@ DECLARE_VECTOR_UNITTEST(TestTransformInputOutputIterator);
 template <class Vector>
 void TestMakeTransformInputOutputIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
-  typedef thrust::negate<T> InputFunction;
-  typedef thrust::square<T> OutputFunction;
+  using InputFunction  = thrust::negate<T>;
+  using OutputFunction = thrust::square<T>;
 
   Vector input(4);
   Vector negated(4);

--- a/thrust/testing/transform_iterator.cu
+++ b/thrust/testing/transform_iterator.cu
@@ -12,10 +12,10 @@
 template <class Vector>
 void TestTransformIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
-  typedef thrust::negate<T> UnaryFunction;
-  typedef typename Vector::iterator Iterator;
+  using UnaryFunction = thrust::negate<T>;
+  using Iterator      = typename Vector::iterator;
 
   Vector input(4);
   Vector output(4);
@@ -38,10 +38,10 @@ DECLARE_VECTOR_UNITTEST(TestTransformIterator);
 template <class Vector>
 void TestMakeTransformIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
-  typedef thrust::negate<T> UnaryFunction;
-  typedef typename Vector::iterator Iterator;
+  using UnaryFunction = thrust::negate<T>;
+  using Iterator      = typename Vector::iterator;
 
   Vector input(4);
   Vector output(4);

--- a/thrust/testing/transform_output_iterator.cu
+++ b/thrust/testing/transform_output_iterator.cu
@@ -12,10 +12,10 @@
 template <class Vector>
 void TestTransformOutputIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
-  typedef thrust::square<T> UnaryFunction;
-  typedef typename Vector::iterator Iterator;
+  using UnaryFunction = thrust::square<T>;
+  using Iterator      = typename Vector::iterator;
 
   Vector input(4);
   Vector output(4);
@@ -41,9 +41,9 @@ DECLARE_VECTOR_UNITTEST(TestTransformOutputIterator);
 template <class Vector>
 void TestMakeTransformOutputIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
-  typedef thrust::square<T> UnaryFunction;
+  using UnaryFunction = thrust::square<T>;
 
   Vector input(4);
   Vector output(4);

--- a/thrust/testing/transform_reduce.cu
+++ b/thrust/testing/transform_reduce.cu
@@ -44,7 +44,7 @@ DECLARE_UNITTEST(TestTransformReduceDispatchImplicit);
 template <class Vector>
 void TestTransformReduceSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(3);
   data[0] = 1;
@@ -91,8 +91,8 @@ DECLARE_VARIABLE_UNITTEST(TestTransformReduceFromConst);
 template <class Vector>
 void TestTransformReduceCountingIterator()
 {
-  typedef typename Vector::value_type T;
-  typedef typename thrust::iterator_system<typename Vector::iterator>::type space;
+  using T     = typename Vector::value_type;
+  using space = typename thrust::iterator_system<typename Vector::iterator>::type;
 
   thrust::counting_iterator<T, space> first(1);
 

--- a/thrust/testing/transform_scan.cu
+++ b/thrust/testing/transform_scan.cu
@@ -86,7 +86,7 @@ DECLARE_UNITTEST(TestTransformExclusiveScanDispatchImplicit);
 template <class Vector>
 void TestTransformScanSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   typename Vector::iterator iter;
 
@@ -282,8 +282,8 @@ VariableUnitTest<TestTransformScan, IntegralTypes> TestTransformScanInstance;
 template <class Vector>
 void TestTransformScanCountingIterator()
 {
-  typedef typename Vector::value_type T;
-  typedef typename thrust::iterator_system<typename Vector::iterator>::type space;
+  using T     = typename Vector::value_type;
+  using space = typename thrust::iterator_system<typename Vector::iterator>::type;
 
   thrust::counting_iterator<T, space> first(1);
 

--- a/thrust/testing/trivial_sequence.cu
+++ b/thrust/testing/trivial_sequence.cu
@@ -7,10 +7,10 @@
 template <typename Iterator>
 void test(Iterator first, Iterator last)
 {
-  typedef typename thrust::iterator_system<Iterator>::type System;
+  using System = typename thrust::iterator_system<Iterator>::type;
   System system;
   thrust::detail::trivial_sequence<Iterator, System> ts(system, first, last);
-  typedef typename thrust::iterator_traits<Iterator>::value_type ValueType;
+  using ValueType = typename thrust::iterator_traits<Iterator>::value_type;
 
   ASSERT_EQUAL_QUIET((ValueType) ts.begin()[0], ValueType(0, 11));
   ASSERT_EQUAL_QUIET((ValueType) ts.begin()[1], ValueType(2, 11));
@@ -24,7 +24,7 @@ void test(Iterator first, Iterator last)
   ts.begin()[3] = ValueType(0, 0);
   ts.begin()[4] = ValueType(0, 0);
 
-  typedef typename thrust::detail::trivial_sequence<Iterator, System>::iterator_type TrivialIterator;
+  using TrivialIterator = typename thrust::detail::trivial_sequence<Iterator, System>::iterator_type;
 
   ASSERT_EQUAL((bool) thrust::is_contiguous_iterator<Iterator>::value, false);
   ASSERT_EQUAL((bool) thrust::is_contiguous_iterator<TrivialIterator>::value, true);

--- a/thrust/testing/tuple.cu
+++ b/thrust/testing/tuple.cu
@@ -480,7 +480,7 @@ void TestTupleSwap()
   ASSERT_EQUAL(b, thrust::get<1>(t2));
   ASSERT_EQUAL(c, thrust::get<2>(t2));
 
-  typedef thrust::tuple<user_swappable, user_swappable, user_swappable, user_swappable> swappable_tuple;
+  using swappable_tuple = thrust::tuple<user_swappable, user_swappable, user_swappable, user_swappable>;
 
   thrust::host_vector<swappable_tuple> h_v1(1), h_v2(1);
   thrust::device_vector<swappable_tuple> d_v1(1), d_v2(1);

--- a/thrust/testing/type_traits.cu
+++ b/thrust/testing/type_traits.cu
@@ -11,8 +11,8 @@
 
 void TestIsContiguousIterator()
 {
-  typedef thrust::host_vector<int> HostVector;
-  typedef thrust::device_vector<int> DeviceVector;
+  using HostVector   = thrust::host_vector<int>;
+  using DeviceVector = thrust::device_vector<int>;
 
   ASSERT_EQUAL((bool) thrust::is_contiguous_iterator<int*>::value, true);
   ASSERT_EQUAL((bool) thrust::is_contiguous_iterator<thrust::device_ptr<int>>::value, true);
@@ -25,12 +25,12 @@ void TestIsContiguousIterator()
 
   ASSERT_EQUAL((bool) thrust::is_contiguous_iterator<thrust::device_ptr<int>>::value, true);
 
-  typedef thrust::tuple<HostVector::iterator, HostVector::iterator> HostIteratorTuple;
+  using HostIteratorTuple = thrust::tuple<HostVector::iterator, HostVector::iterator>;
 
-  typedef thrust::constant_iterator<int> ConstantIterator;
-  typedef thrust::counting_iterator<int> CountingIterator;
-  typedef thrust::transform_iterator<thrust::identity<int>, HostVector::iterator> TransformIterator;
-  typedef thrust::zip_iterator<HostIteratorTuple> ZipIterator;
+  using ConstantIterator  = thrust::constant_iterator<int>;
+  using CountingIterator  = thrust::counting_iterator<int>;
+  using TransformIterator = thrust::transform_iterator<thrust::identity<int>, HostVector::iterator>;
+  using ZipIterator       = thrust::zip_iterator<HostIteratorTuple>;
 
   ASSERT_EQUAL((bool) thrust::is_contiguous_iterator<ConstantIterator>::value, false);
   ASSERT_EQUAL((bool) thrust::is_contiguous_iterator<CountingIterator>::value, false);
@@ -42,106 +42,106 @@ DECLARE_UNITTEST(TestIsContiguousIterator);
 void TestIsCommutative()
 {
   {
-    typedef int T;
-    typedef thrust::plus<T> Op;
+    using T  = int;
+    using Op = thrust::plus<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
   }
   {
-    typedef int T;
-    typedef thrust::multiplies<T> Op;
+    using T  = int;
+    using Op = thrust::multiplies<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
   }
   {
-    typedef int T;
-    typedef thrust::minimum<T> Op;
+    using T  = int;
+    using Op = thrust::minimum<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
   }
   {
-    typedef int T;
-    typedef thrust::maximum<T> Op;
+    using T  = int;
+    using Op = thrust::maximum<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
   }
   {
-    typedef int T;
-    typedef thrust::logical_or<T> Op;
+    using T  = int;
+    using Op = thrust::logical_or<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
   }
   {
-    typedef int T;
-    typedef thrust::logical_and<T> Op;
+    using T  = int;
+    using Op = thrust::logical_and<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
   }
   {
-    typedef int T;
-    typedef thrust::bit_or<T> Op;
+    using T  = int;
+    using Op = thrust::bit_or<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
   }
   {
-    typedef int T;
-    typedef thrust::bit_and<T> Op;
+    using T  = int;
+    using Op = thrust::bit_and<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
   }
   {
-    typedef int T;
-    typedef thrust::bit_xor<T> Op;
-    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
-  }
-
-  {
-    typedef char T;
-    typedef thrust::plus<T> Op;
-    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
-  }
-  {
-    typedef short T;
-    typedef thrust::plus<T> Op;
-    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
-  }
-  {
-    typedef long T;
-    typedef thrust::plus<T> Op;
-    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
-  }
-  {
-    typedef long long T;
-    typedef thrust::plus<T> Op;
-    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
-  }
-  {
-    typedef float T;
-    typedef thrust::plus<T> Op;
-    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
-  }
-  {
-    typedef double T;
-    typedef thrust::plus<T> Op;
+    using T  = int;
+    using Op = thrust::bit_xor<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
   }
 
   {
-    typedef int T;
-    typedef thrust::minus<T> Op;
+    using T  = char;
+    using Op = thrust::plus<T>;
+    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
+  }
+  {
+    using T  = short;
+    using Op = thrust::plus<T>;
+    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
+  }
+  {
+    using T  = long;
+    using Op = thrust::plus<T>;
+    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
+  }
+  {
+    using T  = long long;
+    using Op = thrust::plus<T>;
+    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
+  }
+  {
+    using T  = float;
+    using Op = thrust::plus<T>;
+    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
+  }
+  {
+    using T  = double;
+    using Op = thrust::plus<T>;
+    ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, true);
+  }
+
+  {
+    using T  = int;
+    using Op = thrust::minus<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, false);
   }
   {
-    typedef int T;
-    typedef thrust::divides<T> Op;
+    using T  = int;
+    using Op = thrust::divides<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, false);
   }
   {
-    typedef float T;
-    typedef thrust::divides<T> Op;
+    using T  = float;
+    using Op = thrust::divides<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, false);
   }
   {
-    typedef float T;
-    typedef thrust::minus<T> Op;
+    using T  = float;
+    using Op = thrust::minus<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, false);
   }
 
   {
-    typedef thrust::tuple<int, int> T;
-    typedef thrust::plus<T> Op;
+    using T  = thrust::tuple<int, int>;
+    using Op = thrust::plus<T>;
     ASSERT_EQUAL((bool) thrust::detail::is_commutative<Op>::value, false);
   }
 }

--- a/thrust/testing/uninitialized_copy.cu
+++ b/thrust/testing/uninitialized_copy.cu
@@ -147,7 +147,7 @@ struct TestUninitializedCopyNonPODDevice
 {
   void operator()(const size_t)
   {
-    typedef CopyConstructTest T;
+    using T = CopyConstructTest;
 
     thrust::device_vector<T> v1(5), v2(5);
 
@@ -172,7 +172,7 @@ struct TestUninitializedCopyNNonPODDevice
 {
   void operator()(const size_t)
   {
-    typedef CopyConstructTest T;
+    using T = CopyConstructTest;
 
     thrust::device_vector<T> v1(5), v2(5);
 
@@ -197,7 +197,7 @@ struct TestUninitializedCopyNonPODHost
 {
   void operator()(const size_t)
   {
-    typedef CopyConstructTest T;
+    using T = CopyConstructTest;
 
     thrust::host_vector<T> v1(5), v2(5);
 
@@ -222,7 +222,7 @@ struct TestUninitializedCopyNNonPODHost
 {
   void operator()(const size_t)
   {
-    typedef CopyConstructTest T;
+    using T = CopyConstructTest;
 
     thrust::host_vector<T> v1(5), v2(5);
 

--- a/thrust/testing/uninitialized_fill.cu
+++ b/thrust/testing/uninitialized_fill.cu
@@ -77,7 +77,7 @@ DECLARE_UNITTEST(TestUninitializedFillNDispatchImplicit);
 template <class Vector>
 void TestUninitializedFillPOD()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -157,7 +157,7 @@ struct TestUninitializedFillNonPOD
 {
   void operator()(const size_t)
   {
-    typedef CopyConstructTest T;
+    using T                 = CopyConstructTest;
     thrust::device_ptr<T> v = thrust::device_malloc<T>(5);
 
     T exemplar;
@@ -187,7 +187,7 @@ DECLARE_UNITTEST(TestUninitializedFillNonPOD);
 template <class Vector>
 void TestUninitializedFillNPOD()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(5);
   v[0] = 0;
@@ -246,7 +246,7 @@ struct TestUninitializedFillNNonPOD
 {
   void operator()(const size_t)
   {
-    typedef CopyConstructTest T;
+    using T                 = CopyConstructTest;
     thrust::device_ptr<T> v = thrust::device_malloc<T>(5);
 
     T exemplar;

--- a/thrust/testing/unique.cu
+++ b/thrust/testing/unique.cu
@@ -123,7 +123,7 @@ struct is_equal_div_10_unique
 template <typename Vector>
 void TestUniqueSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(10);
   data[0] = 11;
@@ -186,7 +186,7 @@ VariableUnitTest<TestUnique, IntegralTypes> TestUniqueInstance;
 template <typename Vector>
 void TestUniqueCopySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(10);
   data[0] = 11;
@@ -282,7 +282,7 @@ VariableUnitTest<TestUniqueCopyToDiscardIterator, IntegralTypes> TestUniqueCopyT
 template <typename Vector>
 void TestUniqueCountSimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector data(10);
   data[0] = 11;

--- a/thrust/testing/unique_by_key.cu
+++ b/thrust/testing/unique_by_key.cu
@@ -149,7 +149,7 @@ void initialize_values(Vector& values)
 template <typename Vector>
 void TestUniqueByKeySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector keys;
   Vector values;
@@ -197,7 +197,7 @@ DECLARE_INTEGRAL_VECTOR_UNITTEST(TestUniqueByKeySimple);
 template <typename Vector>
 void TestUniqueCopyByKeySimple()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector keys;
   Vector values;
@@ -252,20 +252,20 @@ struct TestUniqueByKey
 {
   void operator()(const size_t n)
   {
-    typedef unsigned int V; // ValueType
+    using V = unsigned int; // ValueType
 
     thrust::host_vector<K> h_keys   = unittest::random_integers<bool>(n);
     thrust::host_vector<V> h_vals   = unittest::random_integers<V>(n);
     thrust::device_vector<K> d_keys = h_keys;
     thrust::device_vector<V> d_vals = h_vals;
 
-    typedef typename thrust::host_vector<K>::iterator HostKeyIterator;
-    typedef typename thrust::host_vector<V>::iterator HostValIterator;
-    typedef typename thrust::device_vector<K>::iterator DeviceKeyIterator;
-    typedef typename thrust::device_vector<V>::iterator DeviceValIterator;
+    using HostKeyIterator   = typename thrust::host_vector<K>::iterator;
+    using HostValIterator   = typename thrust::host_vector<V>::iterator;
+    using DeviceKeyIterator = typename thrust::device_vector<K>::iterator;
+    using DeviceValIterator = typename thrust::device_vector<V>::iterator;
 
-    typedef typename thrust::pair<HostKeyIterator, HostValIterator> HostIteratorPair;
-    typedef typename thrust::pair<DeviceKeyIterator, DeviceValIterator> DeviceIteratorPair;
+    using HostIteratorPair   = typename thrust::pair<HostKeyIterator, HostValIterator>;
+    using DeviceIteratorPair = typename thrust::pair<DeviceKeyIterator, DeviceValIterator>;
 
     HostIteratorPair h_last   = thrust::unique_by_key(h_keys.begin(), h_keys.end(), h_vals.begin());
     DeviceIteratorPair d_last = thrust::unique_by_key(d_keys.begin(), d_keys.end(), d_vals.begin());
@@ -291,7 +291,7 @@ struct TestUniqueCopyByKey
 {
   void operator()(const size_t n)
   {
-    typedef unsigned int V; // ValueType
+    using V = unsigned int; // ValueType
 
     thrust::host_vector<K> h_keys   = unittest::random_integers<bool>(n);
     thrust::host_vector<V> h_vals   = unittest::random_integers<V>(n);
@@ -303,13 +303,13 @@ struct TestUniqueCopyByKey
     thrust::device_vector<K> d_keys_output(n);
     thrust::device_vector<V> d_vals_output(n);
 
-    typedef typename thrust::host_vector<K>::iterator HostKeyIterator;
-    typedef typename thrust::host_vector<V>::iterator HostValIterator;
-    typedef typename thrust::device_vector<K>::iterator DeviceKeyIterator;
-    typedef typename thrust::device_vector<V>::iterator DeviceValIterator;
+    using HostKeyIterator   = typename thrust::host_vector<K>::iterator;
+    using HostValIterator   = typename thrust::host_vector<V>::iterator;
+    using DeviceKeyIterator = typename thrust::device_vector<K>::iterator;
+    using DeviceValIterator = typename thrust::device_vector<V>::iterator;
 
-    typedef typename thrust::pair<HostKeyIterator, HostValIterator> HostIteratorPair;
-    typedef typename thrust::pair<DeviceKeyIterator, DeviceValIterator> DeviceIteratorPair;
+    using HostIteratorPair   = typename thrust::pair<HostKeyIterator, HostValIterator>;
+    using DeviceIteratorPair = typename thrust::pair<DeviceKeyIterator, DeviceValIterator>;
 
     HostIteratorPair h_last = thrust::unique_by_key_copy(
       h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys_output.begin(), h_vals_output.begin());
@@ -337,7 +337,7 @@ struct TestUniqueCopyByKeyToDiscardIterator
 {
   void operator()(const size_t n)
   {
-    typedef unsigned int V; // ValueType
+    using V = unsigned int; // ValueType
 
     thrust::host_vector<K> h_keys   = unittest::random_integers<bool>(n);
     thrust::host_vector<V> h_vals   = unittest::random_integers<V>(n);

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -104,13 +104,13 @@ double const DEFAULT_ABSOLUTE_TOL = 1e-4;
 template <typename T>
 struct value_type
 {
-  typedef ::cuda::std::__remove_const_t<::cuda::std::__libcpp_remove_reference_t<T>> type;
+  using type = ::cuda::std::__remove_const_t<::cuda::std::__libcpp_remove_reference_t<T>>;
 };
 
 template <typename T>
 struct value_type<THRUST_NS_QUALIFIER::device_reference<T>>
 {
-  typedef typename value_type<T>::type type;
+  using type = typename value_type<T>::type;
 };
 
 ////
@@ -396,8 +396,8 @@ void assert_equal(
   const std::string& filename = "unknown",
   int lineno                  = -1)
 {
-  typedef typename THRUST_NS_QUALIFIER::iterator_difference<ForwardIterator1>::type difference_type;
-  typedef typename THRUST_NS_QUALIFIER::iterator_value<ForwardIterator1>::type InputType;
+  using difference_type = typename THRUST_NS_QUALIFIER::iterator_difference<ForwardIterator1>::type;
+  using InputType       = typename THRUST_NS_QUALIFIER::iterator_value<ForwardIterator1>::type;
 
   bool failure = false;
 
@@ -482,7 +482,7 @@ void assert_equal(
   const std::string& filename = "unknown",
   int lineno                  = -1)
 {
-  typedef typename THRUST_NS_QUALIFIER::iterator_traits<ForwardIterator1>::value_type InputType;
+  using InputType = typename THRUST_NS_QUALIFIER::iterator_traits<ForwardIterator1>::value_type;
   assert_equal(first1, last1, first2, last2, THRUST_NS_QUALIFIER::equal_to<InputType>(), filename, lineno);
 }
 
@@ -497,7 +497,7 @@ void assert_almost_equal(
   const double a_tol          = DEFAULT_ABSOLUTE_TOL,
   const double r_tol          = DEFAULT_RELATIVE_TOL)
 {
-  typedef typename THRUST_NS_QUALIFIER::iterator_traits<ForwardIterator1>::value_type InputType;
+  using InputType = typename THRUST_NS_QUALIFIER::iterator_traits<ForwardIterator1>::value_type;
   assert_equal(first1, last1, first2, last2, almost_equal_to<InputType>(a_tol, r_tol), filename, lineno);
 }
 

--- a/thrust/testing/unittest/meta.h
+++ b/thrust/testing/unittest/meta.h
@@ -24,19 +24,19 @@ struct type_list
 template <typename List, unsigned int i>
 struct get_type
 {
-  typedef null_type type;
+  using type = null_type;
 };
 
 template <typename T, typename... Ts>
 struct get_type<type_list<T, Ts...>, 0>
 {
-  typedef T type;
+  using type = T;
 };
 
 template <typename T, typename... Ts, unsigned int i>
 struct get_type<type_list<T, Ts...>, i>
 {
-  typedef typename get_type<type_list<Ts...>, i - 1>::type type;
+  using type = typename get_type<type_list<Ts...>, i - 1>::type;
 };
 
 template <typename T, unsigned int i>
@@ -56,7 +56,7 @@ struct for_each_type
     f(n);
 
     // get the next type
-    typedef typename get_type<TypeList, i + 1>::type next_type;
+    using next_type = typename get_type<TypeList, i + 1>::type;
 
     // recurse to i + 1
     for_each_type<TypeList, Function, next_type, i + 1> loop;
@@ -70,7 +70,7 @@ struct for_each_type
     f();
 
     // get the next type
-    typedef typename get_type<TypeList, i + 1>::type next_type;
+    using next_type = typename get_type<TypeList, i + 1>::type;
 
     // recurse to i + 1
     for_each_type<TypeList, Function, next_type, i + 1> loop;
@@ -100,13 +100,13 @@ struct for_each_type<TypeList, Function, null_type, i>
 template <template <typename> class Template, typename T>
 struct ApplyTemplate1
 {
-  typedef Template<T> type;
+  using type = Template<T>;
 };
 
 template <template <typename> class Template>
 struct ApplyTemplate1<Template, null_type>
 {
-  typedef null_type type;
+  using type = null_type;
 };
 
 // this type and its specializations instantiates
@@ -116,25 +116,25 @@ struct ApplyTemplate1<Template, null_type>
 template <template <typename, typename> class Template, typename T1, typename T2>
 struct ApplyTemplate2
 {
-  typedef Template<T1, T2> type;
+  using type = Template<T1, T2>;
 };
 
 template <template <typename, typename> class Template, typename T>
 struct ApplyTemplate2<Template, T, null_type>
 {
-  typedef null_type type;
+  using type = null_type;
 };
 
 template <template <typename, typename> class Template, typename T>
 struct ApplyTemplate2<Template, null_type, T>
 {
-  typedef null_type type;
+  using type = null_type;
 };
 
 template <template <typename, typename> class Template>
 struct ApplyTemplate2<Template, null_type, null_type>
 {
-  typedef null_type type;
+  using type = null_type;
 };
 
 // this type creates a new type_list by applying a Template to each of
@@ -145,7 +145,7 @@ struct transform1;
 template <typename... Ts, template <typename> class Template>
 struct transform1<type_list<Ts...>, Template>
 {
-  typedef type_list<typename ApplyTemplate1<Template, Ts>::type...> type;
+  using type = type_list<typename ApplyTemplate1<Template, Ts>::type...>;
 };
 
 template <typename TypeList1, typename TypeList2, template <typename, typename> class Template>
@@ -154,7 +154,7 @@ struct transform2;
 template <typename... T1s, typename... T2s, template <typename, typename> class Template>
 struct transform2<type_list<T1s...>, type_list<T2s...>, Template>
 {
-  typedef type_list<typename ApplyTemplate2<Template, T1s, T2s>::type...> type;
+  using type = type_list<typename ApplyTemplate2<Template, T1s, T2s>::type...>;
 };
 
 } // namespace unittest

--- a/thrust/testing/unittest/runtime_static_assert.h
+++ b/thrust/testing/unittest/runtime_static_assert.h
@@ -23,8 +23,8 @@ _CCCL_HOST_DEVICE void assert_static(bool condition, const char* filename, int l
 
 #  define ASSERT_STATIC_ASSERT(X)                                                              \
     {                                                                                          \
-      bool triggered = false;                                                                  \
-      typedef unittest::static_assert_exception ex_t;                                          \
+      bool triggered                      = false;                                             \
+      using ex_t                          = unittest::static_assert_exception;                 \
       thrust::device_ptr<ex_t> device_ptr = thrust::device_new<ex_t>();                        \
       ex_t* raw_ptr                       = thrust::raw_pointer_cast(device_ptr);              \
       ::cudaMemcpyToSymbol(unittest::detail::device_exception, &raw_ptr, sizeof(ex_t*));       \
@@ -56,7 +56,7 @@ _CCCL_HOST_DEVICE void assert_static(bool condition, const char* filename, int l
 #  define ASSERT_STATIC_ASSERT(X)                                                              \
     {                                                                                          \
       bool triggered = false;                                                                  \
-      typedef unittest::static_assert_exception ex_t;                                          \
+      using ex_t     = unittest::static_assert_exception;                                      \
       try                                                                                      \
       {                                                                                        \
         X;                                                                                     \

--- a/thrust/testing/unittest/testframework.cu
+++ b/thrust/testing/unittest/testframework.cu
@@ -431,7 +431,7 @@ bool UnitTestDriver::run_tests(const ArgumentSet& args, const ArgumentMap& kwarg
   {
     // all non-keyword arguments are assumed to be test names or partial test names
 
-    typedef TestMap::iterator TestMapIterator;
+    using TestMapIterator = TestMap::iterator;
 
     // vector to accumulate tests
     std::vector<UnitTest*> tests_to_run;

--- a/thrust/testing/unittest/testframework.h
+++ b/thrust/testing/unittest/testframework.h
@@ -21,11 +21,11 @@
 #include "util.h"
 
 // define some common lists of types
-typedef unittest::type_list<int, unsigned int, float> ThirtyTwoBitTypes;
+using ThirtyTwoBitTypes = unittest::type_list<int, unsigned int, float>;
 
-typedef unittest::type_list<long long, unsigned long long, double> SixtyFourBitTypes;
+using SixtyFourBitTypes = unittest::type_list<long long, unsigned long long, double>;
 
-typedef unittest::type_list<
+using IntegralTypes = unittest::type_list<
   char,
   signed char,
   unsigned char,
@@ -36,21 +36,20 @@ typedef unittest::type_list<
   long,
   unsigned long,
   long long,
-  unsigned long long>
-  IntegralTypes;
+  unsigned long long>;
 
-typedef unittest::type_list<signed char, signed short, signed int, signed long, signed long long> SignedIntegralTypes;
+using SignedIntegralTypes = unittest::type_list<signed char, short, int, long, long long>;
 
-typedef unittest::type_list<unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>
-  UnsignedIntegralTypes;
+using UnsignedIntegralTypes =
+  unittest::type_list<unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>;
 
-typedef unittest::type_list<char, signed char, unsigned char> ByteTypes;
+using ByteTypes = unittest::type_list<char, signed char, unsigned char>;
 
-typedef unittest::type_list<char, signed char, unsigned char, short, unsigned short> SmallIntegralTypes;
+using SmallIntegralTypes = unittest::type_list<char, signed char, unsigned char, short, unsigned short>;
 
-typedef unittest::type_list<long long, unsigned long long> LargeIntegralTypes;
+using LargeIntegralTypes = unittest::type_list<long long, unsigned long long>;
 
-typedef unittest::type_list<float, double> FloatingPointTypes;
+using FloatingPointTypes = unittest::type_list<float, double>;
 
 // A type that behaves as if it was a normal numeric type,
 // so it can be used in the same tests as "normal" numeric types.
@@ -218,7 +217,7 @@ class integer_traits<custom_numeric> : public integer_traits_base<int, INT_MIN, 
 
 THRUST_NAMESPACE_END
 
-typedef unittest::type_list<
+using NumericTypes = unittest::type_list<
   char,
   signed char,
   unsigned char,
@@ -232,10 +231,9 @@ typedef unittest::type_list<
   unsigned long long,
   float,
   double,
-  custom_numeric>
-  NumericTypes;
+  custom_numeric>;
 
-typedef unittest::type_list<
+using BuiltinNumericTypes = unittest::type_list<
   char,
   signed char,
   unsigned char,
@@ -248,8 +246,7 @@ typedef unittest::type_list<
   long long,
   unsigned long long,
   float,
-  double>
-  BuiltinNumericTypes;
+  double>;
 
 inline void chop_prefix(std::string& str, const std::string& prefix)
 {
@@ -288,8 +285,8 @@ enum TestStatus
   UnknownException = 4
 };
 
-typedef std::set<std::string> ArgumentSet;
-typedef std::map<std::string, std::string> ArgumentMap;
+using ArgumentSet = std::set<std::string>;
+using ArgumentMap = std::map<std::string, std::string>;
 
 std::vector<size_t> get_test_sizes();
 void set_test_sizes(const std::string&);
@@ -313,7 +310,7 @@ class UnitTestDriver;
 
 class UnitTestDriver
 {
-  typedef std::map<std::string, UnitTest*> TestMap;
+  using TestMap = std::map<std::string, UnitTest*>;
 
   TestMap test_map;
 
@@ -539,7 +536,7 @@ public:
   void run()
   {
     // get the first type in the list
-    typedef typename unittest::get_type<TypeList, 0>::type first_type;
+    using first_type = typename unittest::get_type<TypeList, 0>::type;
 
     unittest::for_each_type<TypeList, TestName, first_type, 0> for_each;
 
@@ -566,7 +563,7 @@ public:
     for (size_t i = 0; i != sizes.size(); ++i)
     {
       // get the first type in the list
-      typedef typename unittest::get_type<TypeList, 0>::type first_type;
+      using first_type = typename unittest::get_type<TypeList, 0>::type;
 
       unittest::for_each_type<TypeList, TestName, first_type, 0> loop;
 
@@ -597,13 +594,13 @@ struct VectorUnitTest : public UnitTest
   void run()
   {
     // zip up the type list with Alloc
-    typedef typename unittest::transform1<TypeList, Alloc>::type AllocList;
+    using AllocList = typename unittest::transform1<TypeList, Alloc>::type;
 
     // zip up the type list & alloc list with Vector
-    typedef typename unittest::transform2<TypeList, AllocList, Vector>::type VectorList;
+    using VectorList = typename unittest::transform2<TypeList, AllocList, Vector>::type;
 
     // get the first type in the list
-    typedef typename unittest::get_type<VectorList, 0>::type first_type;
+    using first_type = typename unittest::get_type<VectorList, 0>::type;
 
     unittest::for_each_type<VectorList, TestName, first_type, 0> loop;
 

--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -70,7 +70,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorInitializerList);
 template <class Vector>
 void TestVectorFrontBack()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v(3);
   v[0] = 0;
@@ -85,8 +85,8 @@ DECLARE_VECTOR_UNITTEST(TestVectorFrontBack);
 template <class Vector>
 void TestVectorData()
 {
-  typedef typename Vector::pointer PointerT;
-  typedef typename Vector::const_pointer PointerConstT;
+  using PointerT      = typename Vector::pointer;
+  using PointerConstT = typename Vector::const_pointer;
 
   Vector v(3);
   v[0] = 0;
@@ -144,7 +144,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorElementAssignment);
 template <class Vector>
 void TestVectorFromSTLVector()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   std::vector<T> stl_vector(3);
   stl_vector[0] = 0;
@@ -170,7 +170,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorFromSTLVector);
 template <class Vector>
 void TestVectorFillAssign()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   thrust::host_vector<T> v;
   v.assign(3, 13);
@@ -185,7 +185,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorFillAssign);
 template <class Vector>
 void TestVectorAssignFromSTLVector()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   std::vector<T> stl_vector(3);
   stl_vector[0] = 0;
@@ -205,7 +205,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorAssignFromSTLVector);
 template <class Vector>
 void TestVectorFromBiDirectionalIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   std::list<T> stl_list;
   stl_list.push_back(0);
@@ -224,7 +224,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorFromBiDirectionalIterator);
 template <class Vector>
 void TestVectorAssignFromBiDirectionalIterator()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   std::list<T> stl_list;
   stl_list.push_back(0);
@@ -244,7 +244,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorAssignFromBiDirectionalIterator);
 template <class Vector>
 void TestVectorAssignFromHostVector()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   thrust::host_vector<T> h(3);
   h[0] = 0;
@@ -261,7 +261,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorAssignFromHostVector);
 template <class Vector>
 void TestVectorToAndFromHostVector()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   thrust::host_vector<T> h(3);
   h[0] = 0;
@@ -302,7 +302,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorToAndFromHostVector);
 template <class Vector>
 void TestVectorAssignFromDeviceVector()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   thrust::device_vector<T> d(3);
   d[0] = 0;
@@ -319,7 +319,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorAssignFromDeviceVector);
 template <class Vector>
 void TestVectorToAndFromDeviceVector()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   thrust::device_vector<T> h(3);
   h[0] = 0;
@@ -360,7 +360,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorToAndFromDeviceVector);
 template <class Vector>
 void TestVectorWithInitialValue()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   const T init = 17;
 
@@ -823,7 +823,7 @@ DECLARE_VECTOR_UNITTEST(TestVectorUninitialisedCopy);
 template <class Vector>
 void TestVectorShrinkToFit()
 {
-  typedef typename Vector::value_type T;
+  using T = typename Vector::value_type;
 
   Vector v;
 
@@ -868,7 +868,7 @@ void TestVectorContainingLargeType()
   // Thrust issue #5
   // http://code.google.com/p/thrust/issues/detail?id=5
   const static int N = 100;
-  typedef LargeStruct<N> T;
+  using T            = LargeStruct<N>;
 
   thrust::device_vector<T> dv1;
   thrust::host_vector<T> hv1;

--- a/thrust/testing/vector_allocators.cu
+++ b/thrust/testing/vector_allocators.cu
@@ -8,7 +8,7 @@
 template <typename BaseAlloc, bool PropagateOnSwap>
 class stateful_allocator : public BaseAlloc
 {
-  typedef thrust::detail::allocator_traits<BaseAlloc> base_traits;
+  using base_traits = thrust::detail::allocator_traits<BaseAlloc>;
 
 public:
   stateful_allocator(int i)
@@ -45,10 +45,10 @@ public:
   static int last_allocated;
   static int last_deallocated;
 
-  typedef typename base_traits::pointer pointer;
-  typedef typename base_traits::const_pointer const_pointer;
-  typedef typename base_traits::reference reference;
-  typedef typename base_traits::const_reference const_reference;
+  using pointer         = typename base_traits::pointer;
+  using const_pointer   = typename base_traits::const_pointer;
+  using reference       = typename base_traits::reference;
+  using const_reference = typename base_traits::const_reference;
 
   pointer allocate(std::size_t size)
   {
@@ -92,10 +92,10 @@ public:
     return os;
   }
 
-  typedef thrust::detail::false_type is_always_equal;
-  typedef thrust::detail::true_type propagate_on_container_copy_assignment;
-  typedef thrust::detail::true_type propagate_on_container_move_assignment;
-  typedef thrust::detail::integral_constant<bool, PropagateOnSwap> propagate_on_container_swap;
+  using is_always_equal                        = thrust::detail::false_type;
+  using propagate_on_container_copy_assignment = thrust::detail::true_type;
+  using propagate_on_container_move_assignment = thrust::detail::true_type;
+  using propagate_on_container_swap            = thrust::detail::integral_constant<bool, PropagateOnSwap>;
 
 private:
   int state;
@@ -107,22 +107,22 @@ int stateful_allocator<BaseAlloc, PropagateOnSwap>::last_allocated = 0;
 template <typename BaseAlloc, bool PropagateOnSwap>
 int stateful_allocator<BaseAlloc, PropagateOnSwap>::last_deallocated = 0;
 
-typedef stateful_allocator<std::allocator<int>, true> host_alloc;
-typedef stateful_allocator<thrust::device_allocator<int>, true> device_alloc;
+using host_alloc   = stateful_allocator<std::allocator<int>, true>;
+using device_alloc = stateful_allocator<thrust::device_allocator<int>, true>;
 
-typedef thrust::host_vector<int, host_alloc> host_vector;
-typedef thrust::device_vector<int, device_alloc> device_vector;
+using host_vector   = thrust::host_vector<int, host_alloc>;
+using device_vector = thrust::device_vector<int, device_alloc>;
 
-typedef stateful_allocator<std::allocator<int>, false> host_alloc_nsp;
-typedef stateful_allocator<thrust::device_allocator<int>, false> device_alloc_nsp;
+using host_alloc_nsp   = stateful_allocator<std::allocator<int>, false>;
+using device_alloc_nsp = stateful_allocator<thrust::device_allocator<int>, false>;
 
-typedef thrust::host_vector<int, host_alloc_nsp> host_vector_nsp;
-typedef thrust::device_vector<int, device_alloc_nsp> device_vector_nsp;
+using host_vector_nsp   = thrust::host_vector<int, host_alloc_nsp>;
+using device_vector_nsp = thrust::device_vector<int, device_alloc_nsp>;
 
 template <typename Vector>
 void TestVectorAllocatorConstructors()
 {
-  typedef typename Vector::allocator_type Alloc;
+  using Alloc = typename Vector::allocator_type;
   Alloc alloc1(1);
   Alloc alloc2(2);
 
@@ -180,7 +180,7 @@ void TestVectorAllocatorPropagateOnCopyAssignment()
     thrust::detail::allocator_traits<typename Vector::allocator_type>::propagate_on_container_copy_assignment::value,
     true);
 
-  typedef typename Vector::allocator_type Alloc;
+  using Alloc = typename Vector::allocator_type;
   Alloc alloc1(1);
   Alloc alloc2(2);
 
@@ -209,12 +209,12 @@ DECLARE_UNITTEST(TestVectorAllocatorPropagateOnCopyAssignmentDevice);
 template <typename Vector>
 void TestVectorAllocatorPropagateOnMoveAssignment()
 {
-  typedef typename Vector::allocator_type Alloc;
+  using Alloc = typename Vector::allocator_type;
   ASSERT_EQUAL(
     thrust::detail::allocator_traits<typename Vector::allocator_type>::propagate_on_container_copy_assignment::value,
     true);
 
-  typedef typename Vector::allocator_type Alloc;
+  using Alloc = typename Vector::allocator_type;
   Alloc alloc1(1);
   Alloc alloc2(2);
 
@@ -246,7 +246,7 @@ DECLARE_UNITTEST(TestVectorAllocatorPropagateOnMoveAssignmentDevice);
 template <typename Vector>
 void TestVectorAllocatorPropagateOnSwap()
 {
-  typedef typename Vector::allocator_type Alloc;
+  using Alloc = typename Vector::allocator_type;
   Alloc alloc1(1);
   Alloc alloc2(2);
 

--- a/thrust/testing/vector_insert.cu
+++ b/thrust/testing/vector_insert.cu
@@ -8,7 +8,7 @@ struct TestVectorRangeInsertSimple
 {
   void operator()(size_t)
   {
-    typedef typename Vector::value_type T;
+    using T = typename Vector::value_type;
 
     Vector v1(5);
     thrust::sequence(v1.begin(), v1.end());
@@ -173,7 +173,7 @@ struct TestVectorFillInsertSimple
 {
   void operator()(size_t)
   {
-    typedef typename Vector::value_type T;
+    using T = typename Vector::value_type;
 
     // test when insertion range fits inside capacity
     // and the size of the insertion is greater than the number

--- a/thrust/testing/vector_manipulation.cu
+++ b/thrust/testing/vector_manipulation.cu
@@ -7,8 +7,8 @@
 template <class Vector>
 void TestVectorManipulation(size_t n)
 {
-  typedef typename Vector::iterator Iterator;
-  typedef typename Vector::value_type T;
+  using Iterator = typename Vector::iterator;
+  using T        = typename Vector::value_type;
 
   thrust::host_vector<T> src = unittest::random_samples<T>(n);
   ASSERT_EQUAL(src.size(), n);

--- a/thrust/testing/zip_iterator.cu
+++ b/thrust/testing/zip_iterator.cu
@@ -27,11 +27,11 @@ struct TestZipIteratorManipulation
     sequence(v1.begin(), v1.end());
     sequence(v2.begin(), v2.end());
 
-    typedef tuple<typename Vector::iterator, typename Vector::iterator> IteratorTuple;
+    using IteratorTuple = tuple<typename Vector::iterator, typename Vector::iterator>;
 
     IteratorTuple t = make_tuple(v0.begin(), v1.begin());
 
-    typedef zip_iterator<IteratorTuple> ZipIterator;
+    using ZipIterator = zip_iterator<IteratorTuple>;
 
     // test construction
     ZipIterator iter0 = make_zip_iterator(t);
@@ -104,16 +104,16 @@ struct TestZipIteratorReference
     using namespace thrust;
 
     // test host types
-    typedef typename host_vector<T>::iterator Iterator1;
-    typedef typename host_vector<T>::const_iterator Iterator2;
-    typedef tuple<Iterator1, Iterator2> IteratorTuple1;
-    typedef zip_iterator<IteratorTuple1> ZipIterator1;
+    using Iterator1      = typename host_vector<T>::iterator;
+    using Iterator2      = typename host_vector<T>::const_iterator;
+    using IteratorTuple1 = tuple<Iterator1, Iterator2>;
+    using ZipIterator1   = zip_iterator<IteratorTuple1>;
 
-    typedef typename iterator_reference<ZipIterator1>::type zip_iterator_reference_type1;
+    using zip_iterator_reference_type1 = typename iterator_reference<ZipIterator1>::type;
 
     host_vector<T> h_variable(1);
 
-    typedef tuple<T&, const T&> reference_type1;
+    using reference_type1 = tuple<T&, const T&>;
 
     reference_type1 ref1(*h_variable.begin(), *h_variable.cbegin());
     zip_iterator_reference_type1 test1(*h_variable.begin(), *h_variable.cbegin());
@@ -123,16 +123,16 @@ struct TestZipIteratorReference
     ASSERT_EQUAL(get<1>(ref1), get<1>(test1));
 
     // test device types
-    typedef typename device_vector<T>::iterator Iterator3;
-    typedef typename device_vector<T>::const_iterator Iterator4;
-    typedef tuple<Iterator3, Iterator4> IteratorTuple2;
-    typedef zip_iterator<IteratorTuple2> ZipIterator2;
+    using Iterator3      = typename device_vector<T>::iterator;
+    using Iterator4      = typename device_vector<T>::const_iterator;
+    using IteratorTuple2 = tuple<Iterator3, Iterator4>;
+    using ZipIterator2   = zip_iterator<IteratorTuple2>;
 
-    typedef typename iterator_reference<ZipIterator2>::type zip_iterator_reference_type2;
+    using zip_iterator_reference_type2 = typename iterator_reference<ZipIterator2>::type;
 
     device_vector<T> d_variable(1);
 
-    typedef tuple<device_reference<T>, device_reference<const T>> reference_type2;
+    using reference_type2 = tuple<device_reference<T>, device_reference<const T>>;
 
     reference_type2 ref2(*d_variable.begin(), *d_variable.cbegin());
     zip_iterator_reference_type2 test2(*d_variable.begin(), *d_variable.cbegin());
@@ -153,12 +153,12 @@ struct TestZipIteratorTraversal
 
 #if 0
     // test host types
-    typedef typename host_vector<T>::iterator          Iterator1;
-    typedef typename host_vector<T>::const_iterator    Iterator2;
-    typedef tuple<Iterator1,Iterator2>                 IteratorTuple1;
-    typedef zip_iterator<IteratorTuple1> ZipIterator1;
+    using Iterator1 = typename host_vector<T>::iterator         ;
+    using Iterator2 = typename host_vector<T>::const_iterator   ;
+    using IteratorTuple1 = tuple<Iterator1,Iterator2>                ;
+    using ZipIterator1 = zip_iterator<IteratorTuple1>;
 
-    typedef typename iterator_traversal<ZipIterator1>::type zip_iterator_traversal_type1;
+    using zip_iterator_traversal_type1 = typename iterator_traversal<ZipIterator1>::type;
 #endif
 
     // ASSERT_EQUAL(true, (::cuda::std::is_convertible<zip_iterator_traversal_type1,
@@ -166,12 +166,12 @@ struct TestZipIteratorTraversal
 
 #if 0
     // test device types
-    typedef typename device_vector<T>::iterator        Iterator3;
-    typedef typename device_vector<T>::const_iterator  Iterator4;
-    typedef tuple<Iterator3,Iterator4>                 IteratorTuple2;
-    typedef zip_iterator<IteratorTuple2> ZipIterator2;
+    using Iterator3 = typename device_vector<T>::iterator       ;
+    using Iterator4 = typename device_vector<T>::const_iterator ;
+    using IteratorTuple2 = tuple<Iterator3,Iterator4>                ;
+    using ZipIterator2 = zip_iterator<IteratorTuple2>;
 
-    typedef typename iterator_traversal<ZipIterator2>::type zip_iterator_traversal_type2;
+    using zip_iterator_traversal_type2 = typename iterator_traversal<ZipIterator2>::type;
 #endif
 
     // ASSERT_EQUAL(true, (::cuda::std::is_convertible<zip_iterator_traversal_type2,
@@ -191,24 +191,24 @@ struct TestZipIteratorSystem
 
 #if 0
     // test host types
-    typedef typename host_vector<T>::iterator          Iterator1;
-    typedef typename host_vector<T>::const_iterator    Iterator2;
-    typedef tuple<Iterator1,Iterator2>                 IteratorTuple1;
-    typedef zip_iterator<IteratorTuple1> ZipIterator1;
+    using Iterator1 = typename host_vector<T>::iterator         ;
+    using Iterator2 = typename host_vector<T>::const_iterator   ;
+    using IteratorTuple1 = tuple<Iterator1,Iterator2>                ;
+    using ZipIterator1 = zip_iterator<IteratorTuple1>;
 
-    typedef typename iterator_system<ZipIterator1>::type zip_iterator_system_type1;
+    using zip_iterator_system_type1 = typename iterator_system<ZipIterator1>::type;
 #endif
 
     // ASSERT_EQUAL(true, (::cuda::std::is_same<zip_iterator_system_type1, experimental::space::host>::value) );
 
 #if 0
     // test device types
-    typedef typename device_vector<T>::iterator        Iterator3;
-    typedef typename device_vector<T>::const_iterator  Iterator4;
-    typedef tuple<Iterator3,Iterator4>                 IteratorTuple2;
-    typedef zip_iterator<IteratorTuple1> ZipIterator2;
+    using Iterator3 = typename device_vector<T>::iterator       ;
+    using Iterator4 = typename device_vector<T>::const_iterator ;
+    using IteratorTuple2 = tuple<Iterator3,Iterator4>                ;
+    using ZipIterator2 = zip_iterator<IteratorTuple1>;
 
-    typedef typename iterator_system<ZipIterator2>::type zip_iterator_system_type2;
+    using zip_iterator_system_type2 = typename iterator_system<ZipIterator2>::type;
 #endif
 
     // ASSERT_EQUAL(true, (::cuda::std::is_convertible<zip_iterator_system_type2, experimental::space::device>::value)
@@ -216,12 +216,12 @@ struct TestZipIteratorSystem
 
 #if 0
     // test any
-    typedef counting_iterator<T>         Iterator5;
-    typedef counting_iterator<const T>   Iterator6;
-    typedef tuple<Iterator5, Iterator6>                IteratorTuple3;
-    typedef zip_iterator<IteratorTuple3> ZipIterator3;
+    using Iterator5 = counting_iterator<T>        ;
+    using Iterator6 = counting_iterator<const T>  ;
+    using IteratorTuple3 = tuple<Iterator5, Iterator6>               ;
+    using ZipIterator3 = zip_iterator<IteratorTuple3>;
 
-    typedef typename iterator_system<ZipIterator3>::type zip_iterator_system_type3;
+    using zip_iterator_system_type3 = typename iterator_system<ZipIterator3>::type;
 #endif
 
     // ASSERT_EQUAL(true, (::cuda::std::is_convertible<zip_iterator_system_type3,
@@ -230,40 +230,40 @@ struct TestZipIteratorSystem
 
 #if 0
     // test host/any
-    typedef tuple<Iterator1, Iterator5>                IteratorTuple4;
-    typedef zip_iterator<IteratorTuple4> ZipIterator4;
+    using IteratorTuple4 = tuple<Iterator1, Iterator5>               ;
+    using ZipIterator4 = zip_iterator<IteratorTuple4>;
 
-    typedef typename iterator_system<ZipIterator4>::type zip_iterator_system_type4;
+    using zip_iterator_system_type4 = typename iterator_system<ZipIterator4>::type;
 #endif
 
     // ASSERT_EQUAL(true, (::cuda::std::is_convertible<zip_iterator_system_type4, thrust::host_system_tag>::value) );
 
 #if 0
     // test any/host
-    typedef tuple<Iterator5, Iterator1>                IteratorTuple5;
-    typedef zip_iterator<IteratorTuple5> ZipIterator5;
+    using IteratorTuple5 = tuple<Iterator5, Iterator1>               ;
+    using ZipIterator5 = zip_iterator<IteratorTuple5>;
 
-    typedef typename iterator_system<ZipIterator5>::type zip_iterator_system_type5;
+    using zip_iterator_system_type5 = typename iterator_system<ZipIterator5>::type;
 #endif
 
     // ASSERT_EQUAL(true, (::cuda::std::is_convertible<zip_iterator_system_type5, thrust::host_system_tag>::value) );
 
 #if 0
     // test device/any
-    typedef tuple<Iterator3, Iterator5>                IteratorTuple6;
-    typedef zip_iterator<IteratorTuple6> ZipIterator6;
+    using IteratorTuple6 = tuple<Iterator3, Iterator5>               ;
+    using ZipIterator6 = zip_iterator<IteratorTuple6>;
 
-    typedef typename iterator_system<ZipIterator6>::type zip_iterator_system_type6;
+    using zip_iterator_system_type6 = typename iterator_system<ZipIterator6>::type;
 #endif
 
     // ASSERT_EQUAL(true, (::cuda::std::is_convertible<zip_iterator_system_type6, thrust::device_system_tag>::value) );
 
 #if 0
     // test any/device
-    typedef tuple<Iterator5, Iterator3>                IteratorTuple7;
-    typedef zip_iterator<IteratorTuple7> ZipIterator7;
+    using IteratorTuple7 = tuple<Iterator5, Iterator3>               ;
+    using ZipIterator7 = zip_iterator<IteratorTuple7>;
 
-    typedef typename iterator_system<ZipIterator7>::type zip_iterator_system_type7;
+    using zip_iterator_system_type7 = typename iterator_system<ZipIterator7>::type;
 #endif
 
     // ASSERT_EQUAL(true, (::cuda::std::is_convertible<zip_iterator_system_type7, thrust::device_system_tag>::value) );
@@ -362,13 +362,13 @@ void TestZipIteratorCopyAoSToSoA()
 
   const size_t n = 1;
 
-  typedef tuple<int, int> structure;
-  typedef host_vector<structure> host_array_of_structures;
-  typedef device_vector<structure> device_array_of_structures;
+  using structure                  = tuple<int, int>;
+  using host_array_of_structures   = host_vector<structure>;
+  using device_array_of_structures = device_vector<structure>;
 
-  typedef zip_iterator<tuple<host_vector<int>::iterator, host_vector<int>::iterator>> host_structure_of_arrays;
+  using host_structure_of_arrays = zip_iterator<tuple<host_vector<int>::iterator, host_vector<int>::iterator>>;
 
-  typedef zip_iterator<tuple<device_vector<int>::iterator, device_vector<int>::iterator>> device_structure_of_arrays;
+  using device_structure_of_arrays = zip_iterator<tuple<device_vector<int>::iterator, device_vector<int>::iterator>>;
 
   host_array_of_structures h_aos(n, make_tuple(7, 13));
   device_array_of_structures d_aos(n, make_tuple(7, 13));
@@ -409,13 +409,13 @@ void TestZipIteratorCopySoAToAoS()
 
   const size_t n = 1;
 
-  typedef tuple<int, int> structure;
-  typedef host_vector<structure> host_array_of_structures;
-  typedef device_vector<structure> device_array_of_structures;
+  using structure                  = tuple<int, int>;
+  using host_array_of_structures   = host_vector<structure>;
+  using device_array_of_structures = device_vector<structure>;
 
-  typedef zip_iterator<tuple<host_vector<int>::iterator, host_vector<int>::iterator>> host_structure_of_arrays;
+  using host_structure_of_arrays = zip_iterator<tuple<host_vector<int>::iterator, host_vector<int>::iterator>>;
 
-  typedef zip_iterator<tuple<device_vector<int>::iterator, device_vector<int>::iterator>> device_structure_of_arrays;
+  using device_structure_of_arrays = zip_iterator<tuple<device_vector<int>::iterator, device_vector<int>::iterator>>;
 
   host_vector<int> h_field0(n, 7), h_field1(n, 13);
   device_vector<int> d_field0(n, 7), d_field1(n, 13);

--- a/thrust/testing/zip_iterator_reduce.cu
+++ b/thrust/testing/zip_iterator_reduce.cu
@@ -28,7 +28,7 @@ struct TestZipIteratorReduce
     device_vector<T> d_data0 = h_data0;
     device_vector<T> d_data1 = h_data1;
 
-    typedef tuple<T, T> Tuple;
+    using Tuple = tuple<T, T>;
 
     // run on host
     Tuple h_result = reduce(

--- a/thrust/testing/zip_iterator_reduce_by_key.cu
+++ b/thrust/testing/zip_iterator_reduce_by_key.cu
@@ -34,7 +34,7 @@ struct TestZipIteratorReduceByKey
     device_vector<T> d_data1 = h_data1;
     device_vector<T> d_data2 = h_data2;
 
-    typedef tuple<T, T> Tuple;
+    using Tuple = tuple<T, T>;
 
     // integer key, tuple value
     {

--- a/thrust/testing/zip_iterator_scan.cu
+++ b/thrust/testing/zip_iterator_scan.cu
@@ -32,7 +32,7 @@ struct TestZipIteratorScan
     device_vector<T> d_data0 = h_data0;
     device_vector<T> d_data1 = h_data1;
 
-    typedef tuple<T, T> Tuple;
+    using Tuple = tuple<T, T>;
 
     host_vector<Tuple> h_result(n);
     device_vector<Tuple> d_result(n);

--- a/thrust/thrust/complex.h
+++ b/thrust/thrust/complex.h
@@ -175,7 +175,7 @@ struct complex
 public:
   /*! \p value_type is the type of \p complex's real and imaginary parts.
    */
-  typedef T value_type;
+  using value_type = T;
 
   /* --- Constructors --- */
 

--- a/thrust/thrust/detail/adjacent_difference.inl
+++ b/thrust/thrust/detail/adjacent_difference.inl
@@ -64,8 +64,8 @@ OutputIterator adjacent_difference(InputIterator first, InputIterator last, Outp
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -79,8 +79,8 @@ adjacent_difference(InputIterator first, InputIterator last, OutputIterator resu
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/allocator/allocator_traits.h
+++ b/thrust/thrust/detail/allocator/allocator_traits.h
@@ -66,8 +66,8 @@ __THRUST_DEFINE_HAS_MEMBER_FUNCTION(has_member_system_impl, system)
 template <typename Alloc, typename U>
 struct has_rebind
 {
-  typedef char yes_type;
-  typedef int no_type;
+  using yes_type = char;
+  using no_type  = int;
 
   template <typename S>
   static yes_type test(typename S::template rebind<U>::other*);
@@ -76,7 +76,7 @@ struct has_rebind
 
   static bool const value = sizeof(test<U>(0)) == sizeof(yes_type);
 
-  typedef thrust::detail::integral_constant<bool, value> type;
+  using type = thrust::detail::integral_constant<bool, value>;
 };
 
 _CCCL_SUPPRESS_DEPRECATED_PUSH
@@ -105,87 +105,87 @@ struct has_rebind<std::allocator<T>, U> : false_type
 template <typename T>
 struct nested_pointer
 {
-  typedef typename T::pointer type;
+  using type = typename T::pointer;
 };
 
 template <typename T>
 struct nested_const_pointer
 {
-  typedef typename T::const_pointer type;
+  using type = typename T::const_pointer;
 };
 
 template <typename T>
 struct nested_reference
 {
-  typedef typename T::reference type;
+  using type = typename T::reference;
 };
 
 template <typename T>
 struct nested_const_reference
 {
-  typedef typename T::const_reference type;
+  using type = typename T::const_reference;
 };
 
 template <typename T>
 struct nested_void_pointer
 {
-  typedef typename T::void_pointer type;
+  using type = typename T::void_pointer;
 };
 
 template <typename T>
 struct nested_const_void_pointer
 {
-  typedef typename T::const_void_pointer type;
+  using type = typename T::const_void_pointer;
 };
 
 template <typename T>
 struct nested_difference_type
 {
-  typedef typename T::difference_type type;
+  using type = typename T::difference_type;
 };
 
 template <typename T>
 struct nested_size_type
 {
-  typedef typename T::size_type type;
+  using type = typename T::size_type;
 };
 
 template <typename T>
 struct nested_propagate_on_container_copy_assignment
 {
-  typedef typename T::propagate_on_container_copy_assignment type;
+  using type = typename T::propagate_on_container_copy_assignment;
 };
 
 template <typename T>
 struct nested_propagate_on_container_move_assignment
 {
-  typedef typename T::propagate_on_container_move_assignment type;
+  using type = typename T::propagate_on_container_move_assignment;
 };
 
 template <typename T>
 struct nested_propagate_on_container_swap
 {
-  typedef typename T::propagate_on_container_swap type;
+  using type = typename T::propagate_on_container_swap;
 };
 
 template <typename T>
 struct nested_is_always_equal
 {
-  typedef typename T::is_always_equal type;
+  using type = typename T::is_always_equal;
 };
 
 template <typename T>
 struct nested_system_type
 {
-  typedef typename T::system_type type;
+  using type = typename T::system_type;
 };
 
 template <typename Alloc>
 struct has_member_system
 {
-  typedef typename allocator_system<Alloc>::type system_type;
+  using system_type = typename allocator_system<Alloc>::type;
 
-  typedef typename has_member_system_impl<Alloc, system_type&(void)>::type type;
+  using type              = typename has_member_system_impl<Alloc, system_type&()>::type;
   static const bool value = type::value;
 };
 
@@ -194,19 +194,19 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 template <class Alloc, class U, bool = has_rebind<Alloc, U>::value>
 struct rebind_alloc
 {
-  typedef typename Alloc::template rebind<U>::other type;
+  using type = typename Alloc::template rebind<U>::other;
 };
 
 template <template <typename, typename...> class Alloc, typename T, typename... Args, typename U>
 struct rebind_alloc<Alloc<T, Args...>, U, true>
 {
-  typedef typename Alloc<T, Args...>::template rebind<U>::other type;
+  using type = typename Alloc<T, Args...>::template rebind<U>::other;
 };
 
 template <template <typename, typename...> class Alloc, typename T, typename... Args, typename U>
 struct rebind_alloc<Alloc<T, Args...>, U, false>
 {
-  typedef Alloc<U, Args...> type;
+  using type = Alloc<U, Args...>;
 };
 
 } // namespace allocator_traits_detail
@@ -214,61 +214,70 @@ struct rebind_alloc<Alloc<T, Args...>, U, false>
 template <typename Alloc>
 struct allocator_traits
 {
-  typedef Alloc allocator_type;
+  using allocator_type = Alloc;
 
-  typedef typename allocator_type::value_type value_type;
+  using value_type = typename allocator_type::value_type;
 
-  typedef typename eval_if<allocator_traits_detail::has_pointer<allocator_type>::value,
-                           allocator_traits_detail::nested_pointer<allocator_type>,
-                           identity_<value_type*>>::type pointer;
+  using pointer = typename eval_if<allocator_traits_detail::has_pointer<allocator_type>::value,
+                                   allocator_traits_detail::nested_pointer<allocator_type>,
+                                   identity_<value_type*>>::type;
 
 private:
   template <typename T>
   struct rebind_pointer
   {
-    typedef typename pointer_traits<pointer>::template rebind<T>::other type;
+    using type = typename pointer_traits<pointer>::template rebind<T>::other;
   };
 
 public:
-  typedef typename eval_if<allocator_traits_detail::has_const_pointer<allocator_type>::value,
-                           allocator_traits_detail::nested_const_pointer<allocator_type>,
-                           rebind_pointer<const value_type>>::type const_pointer;
+  using const_pointer =
+    typename eval_if<allocator_traits_detail::has_const_pointer<allocator_type>::value,
+                     allocator_traits_detail::nested_const_pointer<allocator_type>,
+                     rebind_pointer<const value_type>>::type;
 
-  typedef typename eval_if<allocator_traits_detail::has_void_pointer<allocator_type>::value,
-                           allocator_traits_detail::nested_void_pointer<allocator_type>,
-                           rebind_pointer<void>>::type void_pointer;
+  using void_pointer =
+    typename eval_if<allocator_traits_detail::has_void_pointer<allocator_type>::value,
+                     allocator_traits_detail::nested_void_pointer<allocator_type>,
+                     rebind_pointer<void>>::type;
 
-  typedef typename eval_if<allocator_traits_detail::has_const_void_pointer<allocator_type>::value,
-                           allocator_traits_detail::nested_const_void_pointer<allocator_type>,
-                           rebind_pointer<const void>>::type const_void_pointer;
+  using const_void_pointer =
+    typename eval_if<allocator_traits_detail::has_const_void_pointer<allocator_type>::value,
+                     allocator_traits_detail::nested_const_void_pointer<allocator_type>,
+                     rebind_pointer<const void>>::type;
 
-  typedef typename eval_if<allocator_traits_detail::has_difference_type<allocator_type>::value,
-                           allocator_traits_detail::nested_difference_type<allocator_type>,
-                           pointer_difference<pointer>>::type difference_type;
+  using difference_type =
+    typename eval_if<allocator_traits_detail::has_difference_type<allocator_type>::value,
+                     allocator_traits_detail::nested_difference_type<allocator_type>,
+                     pointer_difference<pointer>>::type;
 
-  typedef typename eval_if<allocator_traits_detail::has_size_type<allocator_type>::value,
-                           allocator_traits_detail::nested_size_type<allocator_type>,
-                           ::cuda::std::make_unsigned<difference_type>>::type size_type;
+  using size_type = typename eval_if<allocator_traits_detail::has_size_type<allocator_type>::value,
+                                     allocator_traits_detail::nested_size_type<allocator_type>,
+                                     ::cuda::std::make_unsigned<difference_type>>::type;
 
-  typedef typename eval_if<allocator_traits_detail::has_propagate_on_container_copy_assignment<allocator_type>::value,
-                           allocator_traits_detail::nested_propagate_on_container_copy_assignment<allocator_type>,
-                           identity_<false_type>>::type propagate_on_container_copy_assignment;
+  using propagate_on_container_copy_assignment =
+    typename eval_if<allocator_traits_detail::has_propagate_on_container_copy_assignment<allocator_type>::value,
+                     allocator_traits_detail::nested_propagate_on_container_copy_assignment<allocator_type>,
+                     identity_<false_type>>::type;
 
-  typedef typename eval_if<allocator_traits_detail::has_propagate_on_container_move_assignment<allocator_type>::value,
-                           allocator_traits_detail::nested_propagate_on_container_move_assignment<allocator_type>,
-                           identity_<false_type>>::type propagate_on_container_move_assignment;
+  using propagate_on_container_move_assignment =
+    typename eval_if<allocator_traits_detail::has_propagate_on_container_move_assignment<allocator_type>::value,
+                     allocator_traits_detail::nested_propagate_on_container_move_assignment<allocator_type>,
+                     identity_<false_type>>::type;
 
-  typedef typename eval_if<allocator_traits_detail::has_propagate_on_container_swap<allocator_type>::value,
-                           allocator_traits_detail::nested_propagate_on_container_swap<allocator_type>,
-                           identity_<false_type>>::type propagate_on_container_swap;
+  using propagate_on_container_swap =
+    typename eval_if<allocator_traits_detail::has_propagate_on_container_swap<allocator_type>::value,
+                     allocator_traits_detail::nested_propagate_on_container_swap<allocator_type>,
+                     identity_<false_type>>::type;
 
-  typedef typename eval_if<allocator_traits_detail::has_is_always_equal<allocator_type>::value,
-                           allocator_traits_detail::nested_is_always_equal<allocator_type>,
-                           ::cuda::std::is_empty<allocator_type>>::type is_always_equal;
+  using is_always_equal =
+    typename eval_if<allocator_traits_detail::has_is_always_equal<allocator_type>::value,
+                     allocator_traits_detail::nested_is_always_equal<allocator_type>,
+                     ::cuda::std::is_empty<allocator_type>>::type;
 
-  typedef typename eval_if<allocator_traits_detail::has_system_type<allocator_type>::value,
-                           allocator_traits_detail::nested_system_type<allocator_type>,
-                           thrust::iterator_system<pointer>>::type system_type;
+  using system_type =
+    typename eval_if<allocator_traits_detail::has_system_type<allocator_type>::value,
+                     allocator_traits_detail::nested_system_type<allocator_type>,
+                     thrust::iterator_system<pointer>>::type;
 
   // XXX rebind and rebind_traits are alias templates
   //     and so are omitted while c++11 is unavailable
@@ -283,9 +292,9 @@ public:
   // rebind_* mechanisms.
   using other = allocator_traits;
 
-  // Deprecated std::allocator typedefs that we need:
-  typedef typename thrust::detail::pointer_traits<pointer>::reference reference;
-  typedef typename thrust::detail::pointer_traits<const_pointer>::reference const_reference;
+  // Deprecated std::allocator aliases that we need:
+  using reference       = typename thrust::detail::pointer_traits<pointer>::reference;
+  using const_reference = typename thrust::detail::pointer_traits<const_pointer>::reference;
 
   inline _CCCL_HOST_DEVICE static pointer allocate(allocator_type& a, size_type n);
 
@@ -312,7 +321,7 @@ public:
 
 // we consider a type an allocator if T::value_type exists
 // it doesn't make much sense (containers, which are not allocators, will fulfill this requirement),
-// but allocator_traits is specified to work for any type with that nested typedef
+// but allocator_traits is specified to work for any type with that nested alias
 template <typename T>
 struct is_allocator : allocator_traits_detail::has_value_type<T>
 {};
@@ -322,15 +331,15 @@ template <typename Alloc>
 struct allocator_system
 {
   // the type of the allocator's system
-  typedef typename eval_if<allocator_traits_detail::has_system_type<Alloc>::value,
-                           allocator_traits_detail::nested_system_type<Alloc>,
-                           thrust::iterator_system<typename allocator_traits<Alloc>::pointer>>::type type;
+  using type = typename eval_if<allocator_traits_detail::has_system_type<Alloc>::value,
+                                allocator_traits_detail::nested_system_type<Alloc>,
+                                thrust::iterator_system<typename allocator_traits<Alloc>::pointer>>::type;
 
   // the type that get returns
-  typedef typename eval_if<allocator_traits_detail::has_member_system<Alloc>::value, // if Alloc.system() exists
-                           ::cuda::std::add_lvalue_reference<type>, // then get() needs to return a reference
-                           identity_<type> // else get() needs to return a value
-                           >::type get_result_type;
+  using get_result_type =
+    typename eval_if<allocator_traits_detail::has_member_system<Alloc>::value,
+                     ::cuda::std::add_lvalue_reference<type>,
+                     identity_<type>>::type;
 
   _CCCL_HOST_DEVICE inline static get_result_type get(Alloc& a);
 };

--- a/thrust/thrust/detail/allocator/allocator_traits.inl
+++ b/thrust/thrust/detail/allocator/allocator_traits.inl
@@ -128,12 +128,12 @@ __THRUST_DEFINE_IS_CALL_POSSIBLE(has_member_allocate_with_hint_impl, allocate)
 template <typename Alloc>
 class has_member_allocate_with_hint
 {
-  typedef typename allocator_traits<Alloc>::pointer pointer;
-  typedef typename allocator_traits<Alloc>::size_type size_type;
-  typedef typename allocator_traits<Alloc>::const_void_pointer const_void_pointer;
+  using pointer            = typename allocator_traits<Alloc>::pointer;
+  using size_type          = typename allocator_traits<Alloc>::size_type;
+  using const_void_pointer = typename allocator_traits<Alloc>::const_void_pointer;
 
 public:
-  typedef typename has_member_allocate_with_hint_impl<Alloc, pointer(size_type, const_void_pointer)>::type type;
+  using type = typename has_member_allocate_with_hint_impl<Alloc, pointer(size_type, const_void_pointer)>::type;
   static const bool value = type::value;
 };
 
@@ -244,10 +244,10 @@ __THRUST_DEFINE_IS_CALL_POSSIBLE(has_member_max_size_impl, max_size)
 template <typename Alloc>
 class has_member_max_size
 {
-  typedef typename allocator_traits<Alloc>::size_type size_type;
+  using size_type = typename allocator_traits<Alloc>::size_type;
 
 public:
-  typedef typename has_member_max_size_impl<Alloc, size_type()>::type type;
+  using type              = typename has_member_max_size_impl<Alloc, size_type()>::type;
   static const bool value = type::value;
 };
 
@@ -264,7 +264,7 @@ _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!has_member_max_size<Alloc>::value,
                                              typename allocator_traits<Alloc>::size_type>
 max_size(const Alloc&)
 {
-  typedef typename allocator_traits<Alloc>::size_type size_type;
+  using size_type = typename allocator_traits<Alloc>::size_type;
   return thrust::detail::integer_traits<size_type>::const_max;
 }
 

--- a/thrust/thrust/detail/allocator/copy_construct_range.inl
+++ b/thrust/thrust/detail/allocator/copy_construct_range.inl
@@ -93,8 +93,8 @@ _CCCL_HOST_DEVICE enable_if_convertible_t<FromSystem, ToSystem, Pointer> uniniti
   Pointer result)
 {
   // zip up the iterators
-  typedef thrust::tuple<InputIterator, Pointer> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator, Pointer>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator begin = thrust::make_zip_iterator(thrust::make_tuple(first, result));
   ZipIterator end   = begin;
@@ -104,8 +104,8 @@ _CCCL_HOST_DEVICE enable_if_convertible_t<FromSystem, ToSystem, Pointer> uniniti
   thrust::advance(end, n);
 
   // create a functor
-  typedef typename iterator_traits<InputIterator>::value_type InputType;
-  typedef typename iterator_traits<Pointer>::value_type OutputType;
+  using InputType  = typename iterator_traits<InputIterator>::value_type;
+  using OutputType = typename iterator_traits<Pointer>::value_type;
 
   // do the for_each
   // note we use to_system to dispatch the for_each
@@ -129,14 +129,14 @@ _CCCL_HOST_DEVICE enable_if_convertible_t<FromSystem, ToSystem, Pointer> uniniti
   Pointer result)
 {
   // zip up the iterators
-  typedef thrust::tuple<InputIterator, Pointer> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator, Pointer>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator begin = thrust::make_zip_iterator(thrust::make_tuple(first, result));
 
   // create a functor
-  typedef typename iterator_traits<InputIterator>::value_type InputType;
-  typedef typename iterator_traits<Pointer>::value_type OutputType;
+  using InputType  = typename iterator_traits<InputIterator>::value_type;
+  using OutputType = typename iterator_traits<Pointer>::value_type;
 
   // do the for_each_n
   // note we use to_system to dispatch the for_each_n

--- a/thrust/thrust/detail/allocator/malloc_allocator.h
+++ b/thrust/thrust/detail/allocator/malloc_allocator.h
@@ -36,11 +36,11 @@ template <typename T, typename System, typename Pointer>
 class malloc_allocator : public thrust::detail::tagged_allocator<T, System, Pointer>
 {
 private:
-  typedef thrust::detail::tagged_allocator<T, System, Pointer> super_t;
+  using super_t = thrust::detail::tagged_allocator<T, System, Pointer>;
 
 public:
-  typedef typename super_t::pointer pointer;
-  typedef typename super_t::size_type size_type;
+  using pointer   = typename super_t::pointer;
+  using size_type = typename super_t::size_type;
 
   pointer allocate(size_type cnt);
 

--- a/thrust/thrust/detail/allocator/no_throw_allocator.h
+++ b/thrust/thrust/detail/allocator/no_throw_allocator.h
@@ -36,7 +36,7 @@ template <typename BaseAllocator>
 struct no_throw_allocator : BaseAllocator
 {
 private:
-  typedef BaseAllocator super_t;
+  using super_t = BaseAllocator;
 
 public:
   inline _CCCL_HOST_DEVICE no_throw_allocator(const BaseAllocator& other = BaseAllocator())
@@ -46,7 +46,7 @@ public:
   template <typename U>
   struct rebind
   {
-    typedef no_throw_allocator<typename super_t::template rebind<U>::other> other;
+    using other = no_throw_allocator<typename super_t::template rebind<U>::other>;
   }; // end rebind
 
   _CCCL_HOST_DEVICE void deallocate(typename super_t::pointer p, typename super_t::size_type n)

--- a/thrust/thrust/detail/allocator/tagged_allocator.h
+++ b/thrust/thrust/detail/allocator/tagged_allocator.h
@@ -39,17 +39,17 @@ template <typename Tag, typename Pointer>
 class tagged_allocator<void, Tag, Pointer>
 {
 public:
-  typedef void value_type;
-  typedef typename thrust::detail::pointer_traits<Pointer>::template rebind<void>::other pointer;
-  typedef typename thrust::detail::pointer_traits<Pointer>::template rebind<const void>::other const_pointer;
-  typedef std::size_t size_type;
-  typedef typename thrust::detail::pointer_traits<Pointer>::difference_type difference_type;
-  typedef Tag system_type;
+  using value_type      = void;
+  using pointer         = typename thrust::detail::pointer_traits<Pointer>::template rebind<void>::other;
+  using const_pointer   = typename thrust::detail::pointer_traits<Pointer>::template rebind<const void>::other;
+  using size_type       = std::size_t;
+  using difference_type = typename thrust::detail::pointer_traits<Pointer>::difference_type;
+  using system_type     = Tag;
 
   template <typename U>
   struct rebind
   {
-    typedef tagged_allocator<U, Tag, Pointer> other;
+    using other = tagged_allocator<U, Tag, Pointer>;
   }; // end rebind
 };
 
@@ -57,19 +57,19 @@ template <typename T, typename Tag, typename Pointer>
 class tagged_allocator
 {
 public:
-  typedef T value_type;
-  typedef typename thrust::detail::pointer_traits<Pointer>::template rebind<T>::other pointer;
-  typedef typename thrust::detail::pointer_traits<Pointer>::template rebind<const T>::other const_pointer;
-  typedef typename thrust::iterator_reference<pointer>::type reference;
-  typedef typename thrust::iterator_reference<const_pointer>::type const_reference;
-  typedef std::size_t size_type;
-  typedef typename thrust::detail::pointer_traits<pointer>::difference_type difference_type;
-  typedef Tag system_type;
+  using value_type      = T;
+  using pointer         = typename thrust::detail::pointer_traits<Pointer>::template rebind<T>::other;
+  using const_pointer   = typename thrust::detail::pointer_traits<Pointer>::template rebind<const T>::other;
+  using reference       = typename thrust::iterator_reference<pointer>::type;
+  using const_reference = typename thrust::iterator_reference<const_pointer>::type;
+  using size_type       = std::size_t;
+  using difference_type = typename thrust::detail::pointer_traits<pointer>::difference_type;
+  using system_type     = Tag;
 
   template <typename U>
   struct rebind
   {
-    typedef tagged_allocator<U, Tag, Pointer> other;
+    using other = tagged_allocator<U, Tag, Pointer>;
   }; // end rebind
 
   _CCCL_HOST_DEVICE inline tagged_allocator();

--- a/thrust/thrust/detail/allocator/temporary_allocator.h
+++ b/thrust/thrust/detail/allocator/temporary_allocator.h
@@ -42,13 +42,13 @@ template <typename T, typename System>
 class temporary_allocator : public thrust::detail::tagged_allocator<T, System, thrust::pointer<T, System>>
 {
 private:
-  typedef thrust::detail::tagged_allocator<T, System, thrust::pointer<T, System>> super_t;
+  using super_t = thrust::detail::tagged_allocator<T, System, thrust::pointer<T, System>>;
 
   System& m_system;
 
 public:
-  typedef typename super_t::pointer pointer;
-  typedef typename super_t::size_type size_type;
+  using pointer   = typename super_t::pointer;
+  using size_type = typename super_t::size_type;
 
   inline _CCCL_HOST_DEVICE temporary_allocator(const temporary_allocator& other)
       : super_t()
@@ -70,7 +70,7 @@ public:
   } // end system()
 
 private:
-  typedef thrust::pair<pointer, size_type> pointer_and_size;
+  using pointer_and_size = thrust::pair<pointer, size_type>;
 }; // end temporary_allocator
 
 } // namespace detail

--- a/thrust/thrust/detail/allocator_aware_execution_policy.h
+++ b/thrust/thrust/detail/allocator_aware_execution_policy.h
@@ -49,15 +49,15 @@ struct allocator_aware_execution_policy
   template <typename MemoryResource>
   struct execute_with_memory_resource_type
   {
-    typedef thrust::detail::execute_with_allocator<thrust::mr::allocator<thrust::detail::max_align_t, MemoryResource>,
-                                                   ExecutionPolicyCRTPBase>
-      type;
+    using type =
+      thrust::detail::execute_with_allocator<thrust::mr::allocator<thrust::detail::max_align_t, MemoryResource>,
+                                             ExecutionPolicyCRTPBase>;
   };
 
   template <typename Allocator>
   struct execute_with_allocator_type
   {
-    typedef thrust::detail::execute_with_allocator<Allocator, ExecutionPolicyCRTPBase> type;
+    using type = thrust::detail::execute_with_allocator<Allocator, ExecutionPolicyCRTPBase>;
   };
 
   template <typename MemoryResource>

--- a/thrust/thrust/detail/binary_search.inl
+++ b/thrust/thrust/detail/binary_search.inl
@@ -265,7 +265,7 @@ ForwardIterator lower_bound(ForwardIterator first, ForwardIterator last, const L
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -277,7 +277,7 @@ ForwardIterator lower_bound(ForwardIterator first, ForwardIterator last, const T
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -289,7 +289,7 @@ ForwardIterator upper_bound(ForwardIterator first, ForwardIterator last, const L
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -301,7 +301,7 @@ ForwardIterator upper_bound(ForwardIterator first, ForwardIterator last, const T
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -313,7 +313,7 @@ bool binary_search(ForwardIterator first, ForwardIterator last, const LessThanCo
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -325,7 +325,7 @@ bool binary_search(ForwardIterator first, ForwardIterator last, const T& value, 
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -338,7 +338,7 @@ equal_range(ForwardIterator first, ForwardIterator last, const LessThanComparabl
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -351,7 +351,7 @@ equal_range(ForwardIterator first, ForwardIterator last, const T& value, StrictW
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -372,9 +372,9 @@ OutputIterator lower_bound(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -394,9 +394,9 @@ OutputIterator lower_bound(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -416,9 +416,9 @@ OutputIterator upper_bound(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -438,9 +438,9 @@ OutputIterator upper_bound(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -460,9 +460,9 @@ OutputIterator binary_search(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -482,9 +482,9 @@ OutputIterator binary_search(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/complex/math_private.h
+++ b/thrust/thrust/detail/complex/math_private.h
@@ -44,11 +44,11 @@ namespace complex
 
 using thrust::complex;
 
-typedef union
+using ieee_float_shape_type = union
 {
   float value;
   uint32_t word;
-} ieee_float_shape_type;
+};
 
 _CCCL_HOST_DEVICE inline void get_float_word(uint32_t& i, float d)
 {
@@ -72,7 +72,7 @@ _CCCL_HOST_DEVICE inline void set_float_word(float& d, uint32_t i)
 }
 
 // Assumes little endian ordering
-typedef union
+using ieee_double_shape_type = union
 {
   double value;
   struct
@@ -84,7 +84,7 @@ typedef union
   {
     uint64_t w;
   } xparts;
-} ieee_double_shape_type;
+};
 
 _CCCL_HOST_DEVICE inline void get_high_word(uint32_t& i, double d)
 {

--- a/thrust/thrust/detail/config/global_workarounds.h
+++ b/thrust/thrust/detail/config/global_workarounds.h
@@ -28,7 +28,7 @@
 
 #include <thrust/detail/config/compiler.h>
 
-// XXX workaround gcc 4.8+'s complaints about unused local typedefs by silencing them globally
+// XXX workaround gcc 4.8+'s complaints about unused local aliases by silencing them globally
 #if defined(THRUST_GCC_VERSION) && (THRUST_GCC_VERSION >= 40800)
 #  if defined(__NVCC__) && (CUDART_VERSION >= 6000)
 #    pragma GCC diagnostic ignored "-Wunused-local-typedefs"

--- a/thrust/thrust/detail/contiguous_storage.h
+++ b/thrust/thrust/detail/contiguous_storage.h
@@ -43,20 +43,20 @@ template <typename T, typename Alloc>
 class contiguous_storage
 {
 private:
-  typedef thrust::detail::allocator_traits<Alloc> alloc_traits;
+  using alloc_traits = thrust::detail::allocator_traits<Alloc>;
 
 public:
-  typedef Alloc allocator_type;
-  typedef T value_type;
-  typedef typename alloc_traits::pointer pointer;
-  typedef typename alloc_traits::const_pointer const_pointer;
-  typedef typename alloc_traits::size_type size_type;
-  typedef typename alloc_traits::difference_type difference_type;
-  typedef typename alloc_traits::reference reference;
-  typedef typename alloc_traits::const_reference const_reference;
+  using allocator_type  = Alloc;
+  using value_type      = T;
+  using pointer         = typename alloc_traits::pointer;
+  using const_pointer   = typename alloc_traits::const_pointer;
+  using size_type       = typename alloc_traits::size_type;
+  using difference_type = typename alloc_traits::difference_type;
+  using reference       = typename alloc_traits::reference;
+  using const_reference = typename alloc_traits::const_reference;
 
-  typedef thrust::detail::normal_iterator<pointer> iterator;
-  typedef thrust::detail::normal_iterator<const_pointer> const_iterator;
+  using iterator       = thrust::detail::normal_iterator<pointer>;
+  using const_iterator = thrust::detail::normal_iterator<const_pointer>;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE explicit contiguous_storage(const allocator_type& alloc = allocator_type());

--- a/thrust/thrust/detail/copy.inl
+++ b/thrust/thrust/detail/copy.inl
@@ -99,8 +99,8 @@ _CCCL_HOST_DEVICE OutputIterator two_system_copy_n(
 template <typename InputIterator, typename OutputIterator>
 OutputIterator copy(InputIterator first, InputIterator last, OutputIterator result)
 {
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -111,8 +111,8 @@ OutputIterator copy(InputIterator first, InputIterator last, OutputIterator resu
 template <typename InputIterator, typename Size, typename OutputIterator>
 OutputIterator copy_n(InputIterator first, Size n, OutputIterator result)
 {
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/copy_if.inl
+++ b/thrust/thrust/detail/copy_if.inl
@@ -69,8 +69,8 @@ OutputIterator copy_if(InputIterator first, InputIterator last, OutputIterator r
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -84,9 +84,9 @@ copy_if(InputIterator1 first, InputIterator1 last, InputIterator2 stencil, Outpu
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/count.inl
+++ b/thrust/thrust/detail/count.inl
@@ -63,7 +63,7 @@ count(InputIterator first, InputIterator last, const EqualityComparable& value)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 
@@ -76,7 +76,7 @@ count_if(InputIterator first, InputIterator last, Predicate pred)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/cstdint.h
+++ b/thrust/thrust/detail/cstdint.h
@@ -38,33 +38,33 @@ namespace detail
 #if defined(_CCCL_COMPILER_MSVC)
 
 #  if (_MSC_VER < 1300)
-typedef signed char int8_t;
-typedef signed short int16_t;
-typedef signed int int32_t;
-typedef unsigned char uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int uint32_t;
+using int8_t   = signed char;
+using int16_t  = signed short;
+using int32_t  = signed int;
+using uint8_t  = unsigned char;
+using uint16_t = unsigned short;
+using uint32_t = unsigned int;
 #  else
-typedef signed __int8 int8_t;
-typedef signed __int16 int16_t;
-typedef signed __int32 int32_t;
-typedef unsigned __int8 uint8_t;
-typedef unsigned __int16 uint16_t;
-typedef unsigned __int32 uint32_t;
+using int8_t   = signed __int8;
+using int16_t  = signed __int16;
+using int32_t  = signed __int32;
+using uint8_t  = unsigned __int8;
+using uint16_t = unsigned __int16;
+using uint32_t = unsigned __int32;
 #  endif
-typedef signed __int64 int64_t;
-typedef unsigned __int64 uint64_t;
+using int64_t  = signed __int64;
+using uint64_t = unsigned __int64;
 
 #else
 
-typedef ::int8_t int8_t;
-typedef ::int16_t int16_t;
-typedef ::int32_t int32_t;
-typedef ::int64_t int64_t;
-typedef ::uint8_t uint8_t;
-typedef ::uint16_t uint16_t;
-typedef ::uint32_t uint32_t;
-typedef ::uint64_t uint64_t;
+using int8_t   = ::int8_t;
+using int16_t  = ::int16_t;
+using int32_t  = ::int32_t;
+using int64_t  = ::int64_t;
+using uint8_t  = ::uint8_t;
+using uint16_t = ::uint16_t;
+using uint32_t = ::uint32_t;
+using uint64_t = ::uint64_t;
 
 #endif
 
@@ -78,28 +78,28 @@ struct divine_uintptr_t;
 template <>
 struct divine_intptr_t<4>
 {
-  typedef thrust::detail::int32_t type;
+  using type = thrust::detail::int32_t;
 };
 template <>
 struct divine_uintptr_t<4>
 {
-  typedef thrust::detail::uint32_t type;
+  using type = thrust::detail::uint32_t;
 };
 
 // 64b platforms
 template <>
 struct divine_intptr_t<8>
 {
-  typedef thrust::detail::int64_t type;
+  using type = thrust::detail::int64_t;
 };
 template <>
 struct divine_uintptr_t<8>
 {
-  typedef thrust::detail::uint64_t type;
+  using type = thrust::detail::uint64_t;
 };
 
-typedef divine_intptr_t<>::type intptr_t;
-typedef divine_uintptr_t<>::type uintptr_t;
+using intptr_t  = divine_intptr_t<>::type;
+using uintptr_t = divine_uintptr_t<>::type;
 
 } // namespace detail
 

--- a/thrust/thrust/detail/device_free.inl
+++ b/thrust/thrust/detail/device_free.inl
@@ -36,7 +36,7 @@ void device_free(thrust::device_ptr<void> ptr)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef thrust::iterator_system<thrust::device_ptr<void>>::type system;
+  using system = thrust::iterator_system<thrust::device_ptr<void>>::type;
 
   // XXX lower to select_system(system) here
   system s;

--- a/thrust/thrust/detail/device_malloc.inl
+++ b/thrust/thrust/detail/device_malloc.inl
@@ -36,7 +36,7 @@ thrust::device_ptr<void> device_malloc(const std::size_t n)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef thrust::iterator_system<thrust::device_ptr<void>>::type system;
+  using system = thrust::iterator_system<thrust::device_ptr<void>>::type;
 
   // XXX lower to select_system(system) here
   system s;
@@ -49,7 +49,7 @@ thrust::device_ptr<T> device_malloc(const std::size_t n)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef thrust::iterator_system<thrust::device_ptr<void>>::type system;
+  using system = thrust::iterator_system<thrust::device_ptr<void>>::type;
 
   // XXX lower to select_system(system) here
   system s;

--- a/thrust/thrust/detail/equal.inl
+++ b/thrust/thrust/detail/equal.inl
@@ -63,8 +63,8 @@ bool equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -77,8 +77,8 @@ bool equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, B
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/execute_with_allocator.h
+++ b/thrust/thrust/detail/execute_with_allocator.h
@@ -42,11 +42,11 @@ template <typename T, typename Allocator, template <typename> class BaseSystem>
 _CCCL_HOST thrust::pair<T*, std::ptrdiff_t>
 get_temporary_buffer(thrust::detail::execute_with_allocator<Allocator, BaseSystem>& system, std::ptrdiff_t n)
 {
-  typedef ::cuda::std::__libcpp_remove_reference_t<Allocator> naked_allocator;
-  typedef typename thrust::detail::allocator_traits<naked_allocator> alloc_traits;
-  typedef typename alloc_traits::void_pointer void_pointer;
-  typedef typename alloc_traits::size_type size_type;
-  typedef typename alloc_traits::value_type value_type;
+  using naked_allocator = ::cuda::std::__libcpp_remove_reference_t<Allocator>;
+  using alloc_traits    = typename thrust::detail::allocator_traits<naked_allocator>;
+  using void_pointer    = typename alloc_traits::void_pointer;
+  using size_type       = typename alloc_traits::size_type;
+  using value_type      = typename alloc_traits::value_type;
 
   // How many elements of type value_type do we need to accommodate n elements
   // of type T?
@@ -62,12 +62,12 @@ template <typename Pointer, typename Allocator, template <typename> class BaseSy
 _CCCL_HOST void return_temporary_buffer(
   thrust::detail::execute_with_allocator<Allocator, BaseSystem>& system, Pointer p, std::ptrdiff_t n)
 {
-  typedef ::cuda::std::__libcpp_remove_reference_t<Allocator> naked_allocator;
-  typedef typename thrust::detail::allocator_traits<naked_allocator> alloc_traits;
-  typedef typename alloc_traits::pointer pointer;
-  typedef typename alloc_traits::size_type size_type;
-  typedef typename alloc_traits::value_type value_type;
-  typedef typename thrust::detail::pointer_traits<Pointer>::element_type T;
+  using naked_allocator = ::cuda::std::__libcpp_remove_reference_t<Allocator>;
+  using alloc_traits    = typename thrust::detail::allocator_traits<naked_allocator>;
+  using pointer         = typename alloc_traits::pointer;
+  using size_type       = typename alloc_traits::size_type;
+  using value_type      = typename alloc_traits::value_type;
+  using T               = typename thrust::detail::pointer_traits<Pointer>::element_type;
 
   size_type num_elements = divide_ri(sizeof(T) * n, sizeof(value_type));
 
@@ -80,11 +80,11 @@ _CCCL_HOST thrust::pair<T*, std::ptrdiff_t> get_temporary_buffer(
   thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>& system,
   std::ptrdiff_t n)
 {
-  typedef ::cuda::std::__libcpp_remove_reference_t<Allocator> naked_allocator;
-  typedef typename thrust::detail::allocator_traits<naked_allocator> alloc_traits;
-  typedef typename alloc_traits::void_pointer void_pointer;
-  typedef typename alloc_traits::size_type size_type;
-  typedef typename alloc_traits::value_type value_type;
+  using naked_allocator = ::cuda::std::__libcpp_remove_reference_t<Allocator>;
+  using alloc_traits    = typename thrust::detail::allocator_traits<naked_allocator>;
+  using void_pointer    = typename alloc_traits::void_pointer;
+  using size_type       = typename alloc_traits::size_type;
+  using value_type      = typename alloc_traits::value_type;
 
   // How many elements of type value_type do we need to accommodate n elements
   // of type T?
@@ -102,12 +102,12 @@ _CCCL_HOST void return_temporary_buffer(
   Pointer p,
   std::ptrdiff_t n)
 {
-  typedef ::cuda::std::__libcpp_remove_reference_t<Allocator> naked_allocator;
-  typedef typename thrust::detail::allocator_traits<naked_allocator> alloc_traits;
-  typedef typename alloc_traits::pointer pointer;
-  typedef typename alloc_traits::size_type size_type;
-  typedef typename alloc_traits::value_type value_type;
-  typedef typename thrust::detail::pointer_traits<Pointer>::element_type T;
+  using naked_allocator = ::cuda::std::__libcpp_remove_reference_t<Allocator>;
+  using alloc_traits    = typename thrust::detail::allocator_traits<naked_allocator>;
+  using pointer         = typename alloc_traits::pointer;
+  using size_type       = typename alloc_traits::size_type;
+  using value_type      = typename alloc_traits::value_type;
+  using T               = typename thrust::detail::pointer_traits<Pointer>::element_type;
 
   size_type num_elements = divide_ri(sizeof(T) * n, sizeof(value_type));
 

--- a/thrust/thrust/detail/execute_with_allocator_fwd.h
+++ b/thrust/thrust/detail/execute_with_allocator_fwd.h
@@ -38,7 +38,7 @@ template <typename Allocator, template <typename> class BaseSystem>
 struct execute_with_allocator : BaseSystem<execute_with_allocator<Allocator, BaseSystem>>
 {
 private:
-  typedef BaseSystem<execute_with_allocator<Allocator, BaseSystem>> super_t;
+  using super_t = BaseSystem<execute_with_allocator<Allocator, BaseSystem>>;
 
   Allocator alloc;
 

--- a/thrust/thrust/detail/extrema.inl
+++ b/thrust/thrust/detail/extrema.inl
@@ -101,7 +101,7 @@ ForwardIterator min_element(ForwardIterator first, ForwardIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -113,7 +113,7 @@ ForwardIterator min_element(ForwardIterator first, ForwardIterator last, BinaryP
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -125,7 +125,7 @@ ForwardIterator max_element(ForwardIterator first, ForwardIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -137,7 +137,7 @@ ForwardIterator max_element(ForwardIterator first, ForwardIterator last, BinaryP
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -149,7 +149,7 @@ thrust::pair<ForwardIterator, ForwardIterator> minmax_element(ForwardIterator fi
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -162,7 +162,7 @@ minmax_element(ForwardIterator first, ForwardIterator last, BinaryPredicate comp
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/fill.inl
+++ b/thrust/thrust/detail/fill.inl
@@ -60,7 +60,7 @@ _CCCL_HOST_DEVICE void fill(ForwardIterator first, ForwardIterator last, const T
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -72,7 +72,7 @@ _CCCL_HOST_DEVICE OutputIterator fill_n(OutputIterator first, Size n, const T& v
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<OutputIterator>::type System;
+  using System = typename thrust::iterator_system<OutputIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/find.inl
+++ b/thrust/thrust/detail/find.inl
@@ -73,7 +73,7 @@ InputIterator find(InputIterator first, InputIterator last, const T& value)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 
@@ -85,7 +85,7 @@ InputIterator find_if(InputIterator first, InputIterator last, Predicate pred)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 
@@ -97,7 +97,7 @@ InputIterator find_if_not(InputIterator first, InputIterator last, Predicate pre
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/for_each.inl
+++ b/thrust/thrust/detail/for_each.inl
@@ -50,7 +50,7 @@ template <typename InputIterator, typename UnaryFunction>
 InputIterator for_each(InputIterator first, InputIterator last, UnaryFunction f)
 {
   using thrust::system::detail::generic::select_system;
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
   return thrust::for_each(select_system(system), first, last, f);
@@ -71,7 +71,7 @@ InputIterator for_each_n(InputIterator first, Size n, UnaryFunction f)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
   return thrust::for_each_n(select_system(system), first, n, f);

--- a/thrust/thrust/detail/functional.inl
+++ b/thrust/thrust/detail/functional.inl
@@ -39,19 +39,19 @@ struct unary_traits_imp;
 template <typename Operation>
 struct unary_traits_imp<Operation*>
 {
-  typedef Operation function_type;
-  typedef const function_type& param_type;
-  typedef typename Operation::result_type result_type;
-  typedef typename Operation::argument_type argument_type;
+  using function_type = Operation;
+  using param_type    = const function_type&;
+  using result_type   = typename Operation::result_type;
+  using argument_type = typename Operation::argument_type;
 }; // end unary_traits_imp
 
 template <typename Result, typename Argument>
 struct unary_traits_imp<Result (*)(Argument)>
 {
-  typedef Result (*function_type)(Argument);
-  typedef Result (*param_type)(Argument);
-  typedef Result result_type;
-  typedef Argument argument_type;
+  using function_type = Result (*)(Argument);
+  using param_type    = Result (*)(Argument);
+  using result_type   = Result;
+  using argument_type = Argument;
 }; // end unary_traits_imp
 
 template <typename Operation>
@@ -60,21 +60,21 @@ struct binary_traits_imp;
 template <typename Operation>
 struct binary_traits_imp<Operation*>
 {
-  typedef Operation function_type;
-  typedef const function_type& param_type;
-  typedef typename Operation::result_type result_type;
-  typedef typename Operation::first_argument_type first_argument_type;
-  typedef typename Operation::second_argument_type second_argument_type;
+  using function_type        = Operation;
+  using param_type           = const function_type&;
+  using result_type          = typename Operation::result_type;
+  using first_argument_type  = typename Operation::first_argument_type;
+  using second_argument_type = typename Operation::second_argument_type;
 }; // end binary_traits_imp
 
 template <typename Result, typename Argument1, typename Argument2>
 struct binary_traits_imp<Result (*)(Argument1, Argument2)>
 {
-  typedef Result (*function_type)(Argument1, Argument2);
-  typedef Result (*param_type)(Argument1, Argument2);
-  typedef Result result_type;
-  typedef Argument1 first_argument_type;
-  typedef Argument2 second_argument_type;
+  using function_type        = Result (*)(Argument1, Argument2);
+  using param_type           = Result (*)(Argument1, Argument2);
+  using result_type          = Result;
+  using first_argument_type  = Argument1;
+  using second_argument_type = Argument2;
 }; // end binary_traits_imp
 
 } // namespace detail
@@ -82,39 +82,39 @@ struct binary_traits_imp<Result (*)(Argument1, Argument2)>
 template <typename Operation>
 struct unary_traits
 {
-  typedef typename detail::unary_traits_imp<Operation*>::function_type function_type;
-  typedef typename detail::unary_traits_imp<Operation*>::param_type param_type;
-  typedef typename detail::unary_traits_imp<Operation*>::result_type result_type;
-  typedef typename detail::unary_traits_imp<Operation*>::argument_type argument_type;
+  using function_type = typename detail::unary_traits_imp<Operation*>::function_type;
+  using param_type    = typename detail::unary_traits_imp<Operation*>::param_type;
+  using result_type   = typename detail::unary_traits_imp<Operation*>::result_type;
+  using argument_type = typename detail::unary_traits_imp<Operation*>::argument_type;
 }; // end unary_traits
 
 template <typename Result, typename Argument>
 struct unary_traits<Result (*)(Argument)>
 {
-  typedef Result (*function_type)(Argument);
-  typedef Result (*param_type)(Argument);
-  typedef Result result_type;
-  typedef Argument argument_type;
+  using function_type = Result (*)(Argument);
+  using param_type    = Result (*)(Argument);
+  using result_type   = Result;
+  using argument_type = Argument;
 }; // end unary_traits
 
 template <typename Operation>
 struct binary_traits
 {
-  typedef typename detail::binary_traits_imp<Operation*>::function_type function_type;
-  typedef typename detail::binary_traits_imp<Operation*>::param_type param_type;
-  typedef typename detail::binary_traits_imp<Operation*>::result_type result_type;
-  typedef typename detail::binary_traits_imp<Operation*>::first_argument_type first_argument_type;
-  typedef typename detail::binary_traits_imp<Operation*>::second_argument_type second_argument_type;
+  using function_type        = typename detail::binary_traits_imp<Operation*>::function_type;
+  using param_type           = typename detail::binary_traits_imp<Operation*>::param_type;
+  using result_type          = typename detail::binary_traits_imp<Operation*>::result_type;
+  using first_argument_type  = typename detail::binary_traits_imp<Operation*>::first_argument_type;
+  using second_argument_type = typename detail::binary_traits_imp<Operation*>::second_argument_type;
 }; // end binary_traits
 
 template <typename Result, typename Argument1, typename Argument2>
 struct binary_traits<Result (*)(Argument1, Argument2)>
 {
-  typedef Result (*function_type)(Argument1, Argument2);
-  typedef Result (*param_type)(Argument1, Argument2);
-  typedef Result result_type;
-  typedef Argument1 first_argument_type;
-  typedef Argument2 second_argument_type;
+  using function_type        = Result (*)(Argument1, Argument2);
+  using param_type           = Result (*)(Argument1, Argument2);
+  using result_type          = Result;
+  using first_argument_type  = Argument1;
+  using second_argument_type = Argument2;
 }; // end binary_traits
 
 template <typename Predicate>

--- a/thrust/thrust/detail/functional/actor.h
+++ b/thrust/thrust/detail/functional/actor.h
@@ -57,13 +57,13 @@ using eval_ref = typename std::conditional<thrust::detail::is_wrapped_reference<
 template <typename Action, typename Env>
 struct apply_actor
 {
-  typedef typename Action::template result<Env>::type type;
+  using type = typename Action::template result<Env>::type;
 };
 
 template <typename Eval>
 struct actor : Eval
 {
-  typedef Eval eval_type;
+  using eval_type = Eval;
 
   constexpr actor() = default;
 
@@ -80,7 +80,7 @@ struct actor : Eval
 template <typename T>
 struct as_actor
 {
-  typedef value<T> type;
+  using type = value<T>;
 
   static inline _CCCL_HOST_DEVICE type convert(const T& x)
   {
@@ -92,7 +92,7 @@ struct as_actor
 template <typename Eval>
 struct as_actor<actor<Eval>>
 {
-  typedef actor<Eval> type;
+  using type = actor<Eval>;
 
   static inline _CCCL_HOST_DEVICE const type& convert(const actor<Eval>& x)
   {
@@ -112,24 +112,22 @@ typename as_actor<T>::type _CCCL_HOST_DEVICE make_actor(const T& x)
 template <typename Eval>
 struct result_of_adaptable_function<thrust::detail::functional::actor<Eval>()>
 {
-  typedef
-    typename thrust::detail::functional::apply_actor<thrust::detail::functional::actor<Eval>, thrust::tuple<>>::type
-      type;
+  using type =
+    typename thrust::detail::functional::apply_actor<thrust::detail::functional::actor<Eval>, thrust::tuple<>>::type;
 }; // end result_of
 
 template <typename Eval, typename Arg1>
 struct result_of_adaptable_function<thrust::detail::functional::actor<Eval>(Arg1)>
 {
-  typedef
-    typename thrust::detail::functional::apply_actor<thrust::detail::functional::actor<Eval>, thrust::tuple<Arg1>>::type
-      type;
+  using type =
+    typename thrust::detail::functional::apply_actor<thrust::detail::functional::actor<Eval>, thrust::tuple<Arg1>>::type;
 }; // end result_of
 
 template <typename Eval, typename Arg1, typename Arg2>
 struct result_of_adaptable_function<thrust::detail::functional::actor<Eval>(Arg1, Arg2)>
 {
-  typedef typename thrust::detail::functional::apply_actor<thrust::detail::functional::actor<Eval>,
-                                                           thrust::tuple<Arg1, Arg2>>::type type;
+  using type = typename thrust::detail::functional::apply_actor<thrust::detail::functional::actor<Eval>,
+                                                                thrust::tuple<Arg1, Arg2>>::type;
 }; // end result_of
 
 } // namespace detail

--- a/thrust/thrust/detail/functional/argument.h
+++ b/thrust/thrust/detail/functional/argument.h
@@ -45,13 +45,13 @@ namespace functional
 template <unsigned int i, typename Env>
 struct argument_helper
 {
-  typedef typename thrust::tuple_element<i, Env>::type type;
+  using type = typename thrust::tuple_element<i, Env>::type;
 };
 
 template <unsigned int i>
 struct argument_helper<i, thrust::tuple<>>
 {
-  typedef thrust::tuple<> type;
+  using type = thrust::tuple<>;
 };
 
 template <unsigned int i>

--- a/thrust/thrust/detail/functional/composite.h
+++ b/thrust/thrust/detail/functional/composite.h
@@ -55,7 +55,7 @@ public:
   template <typename Env>
   struct result
   {
-    typedef typename Eval0::template result<thrust::tuple<typename Eval1::template result<Env>::type>>::type type;
+    using type = typename Eval0::template result<thrust::tuple<typename Eval1::template result<Env>::type>>::type;
   };
 
   _CCCL_HOST_DEVICE composite(const Eval0& e0, const Eval1& e1)
@@ -82,8 +82,8 @@ public:
   template <typename Env>
   struct result
   {
-    typedef typename Eval0::template result<
-      thrust::tuple<typename Eval1::template result<Env>::type, typename Eval2::template result<Env>::type>>::type type;
+    using type = typename Eval0::template result<
+      thrust::tuple<typename Eval1::template result<Env>::type, typename Eval2::template result<Env>::type>>::type;
   };
 
   _CCCL_HOST_DEVICE composite(const Eval0& e0, const Eval1& e1, const Eval2& e2)

--- a/thrust/thrust/detail/functional/operators/assignment_operator.h
+++ b/thrust/thrust/detail/functional/operators/assignment_operator.h
@@ -63,7 +63,7 @@ struct assign
 template <typename Eval, typename T>
 struct assign_result
 {
-  typedef actor<composite<transparent_binary_operator<assign>, actor<Eval>, typename as_actor<T>::type>> type;
+  using type = actor<composite<transparent_binary_operator<assign>, actor<Eval>, typename as_actor<T>::type>>;
 }; // end assign_result
 
 template <typename Eval, typename T>

--- a/thrust/thrust/detail/functional/placeholder.h
+++ b/thrust/thrust/detail/functional/placeholder.h
@@ -37,7 +37,7 @@ namespace functional
 template <unsigned int i>
 struct placeholder
 {
-  typedef actor<argument<i>> type;
+  using type = actor<argument<i>>;
 };
 
 } // namespace functional

--- a/thrust/thrust/detail/functional/value.h
+++ b/thrust/thrust/detail/functional/value.h
@@ -52,7 +52,7 @@ public:
   template <typename Env>
   struct result
   {
-    typedef T type;
+    using type = T;
   };
 
   _CCCL_HOST_DEVICE value(const T& arg)

--- a/thrust/thrust/detail/gather.inl
+++ b/thrust/thrust/detail/gather.inl
@@ -100,9 +100,9 @@ gather(InputIterator map_first, InputIterator map_last, RandomAccessIterator inp
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<RandomAccessIterator>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -121,10 +121,10 @@ OutputIterator gather_if(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<RandomAccessIterator>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -150,10 +150,10 @@ OutputIterator gather_if(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<RandomAccessIterator>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/generate.inl
+++ b/thrust/thrust/detail/generate.inl
@@ -60,7 +60,7 @@ void generate(ForwardIterator first, ForwardIterator last, Generator gen)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -72,7 +72,7 @@ OutputIterator generate_n(OutputIterator first, Size n, Generator gen)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<OutputIterator>::type System;
+  using System = typename thrust::iterator_system<OutputIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/inner_product.inl
+++ b/thrust/thrust/detail/inner_product.inl
@@ -78,8 +78,8 @@ OutputType inner_product(InputIterator1 first1, InputIterator1 last1, InputItera
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -102,8 +102,8 @@ OutputType inner_product(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/internal_functional.h
+++ b/thrust/thrust/detail/internal_functional.h
@@ -47,7 +47,7 @@ namespace detail
 template <typename Predicate>
 struct unary_negate
 {
-  typedef bool result_type;
+  using result_type = bool;
 
   Predicate pred;
 
@@ -66,7 +66,7 @@ struct unary_negate
 template <typename Predicate>
 struct binary_negate
 {
-  typedef bool result_type;
+  using result_type = bool;
 
   Predicate pred;
 
@@ -114,7 +114,7 @@ struct predicate_to_integral
 template <typename T1>
 struct equal_to
 {
-  typedef bool result_type;
+  using result_type = bool;
 
   template <typename T2>
   _CCCL_HOST_DEVICE bool operator()(const T1& lhs, const T2& rhs) const
@@ -143,7 +143,7 @@ struct equal_to_value
 template <typename Predicate>
 struct tuple_binary_predicate
 {
-  typedef bool result_type;
+  using result_type = bool;
 
   _CCCL_HOST_DEVICE tuple_binary_predicate(const Predicate& p)
       : pred(p)
@@ -161,7 +161,7 @@ struct tuple_binary_predicate
 template <typename Predicate>
 struct tuple_not_binary_predicate
 {
-  typedef bool result_type;
+  using result_type = bool;
 
   _CCCL_HOST_DEVICE tuple_not_binary_predicate(const Predicate& p)
       : pred(p)
@@ -179,7 +179,7 @@ struct tuple_not_binary_predicate
 template <typename Generator>
 struct host_generate_functor
 {
-  typedef void result_type;
+  using result_type = void;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE host_generate_functor(Generator g)
@@ -212,7 +212,7 @@ struct host_generate_functor
 template <typename Generator>
 struct device_generate_functor
 {
-  typedef void result_type;
+  using result_type = void;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE device_generate_functor(Generator g)
@@ -252,7 +252,7 @@ struct generate_functor
 template <typename ResultType, typename BinaryFunction>
 struct zipped_binary_op
 {
-  typedef ResultType result_type;
+  using result_type = ResultType;
 
   _CCCL_HOST_DEVICE zipped_binary_op(BinaryFunction binary_op)
       : m_binary_op(binary_op)
@@ -291,7 +291,7 @@ struct enable_if_non_const_reference_or_tuple_of_iterator_references
 template <typename UnaryFunction>
 struct unary_transform_functor
 {
-  typedef void result_type;
+  using result_type = void;
 
   UnaryFunction f;
 

--- a/thrust/thrust/detail/logical.inl
+++ b/thrust/thrust/detail/logical.inl
@@ -73,7 +73,7 @@ bool all_of(InputIterator first, InputIterator last, Predicate pred)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 
@@ -85,7 +85,7 @@ bool any_of(InputIterator first, InputIterator last, Predicate pred)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 
@@ -97,7 +97,7 @@ bool none_of(InputIterator first, InputIterator last, Predicate pred)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/memory_algorithms.h
+++ b/thrust/thrust/detail/memory_algorithms.h
@@ -41,9 +41,8 @@ _CCCL_HOST_DEVICE void destroy_at(T* location)
 template <typename Allocator, typename T>
 _CCCL_HOST_DEVICE void destroy_at(Allocator const& alloc, T* location)
 {
-  typedef
-    typename detail::allocator_traits<::cuda::std::__remove_cv_t<::cuda::std::__libcpp_remove_reference_t<Allocator>>>::
-      template rebind_traits<T>::other traits;
+  using traits = typename detail::allocator_traits<
+    ::cuda::std::__remove_cv_t<::cuda::std::__libcpp_remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
 
   typename traits::allocator_type alloc_T(alloc);
 
@@ -64,10 +63,9 @@ _CCCL_HOST_DEVICE ForwardIt destroy(ForwardIt first, ForwardIt last)
 template <typename Allocator, typename ForwardIt>
 _CCCL_HOST_DEVICE ForwardIt destroy(Allocator const& alloc, ForwardIt first, ForwardIt last)
 {
-  typedef typename iterator_traits<ForwardIt>::value_type T;
-  typedef
-    typename detail::allocator_traits<::cuda::std::__remove_cv_t<::cuda::std::__libcpp_remove_reference_t<Allocator>>>::
-      template rebind_traits<T>::other traits;
+  using T      = typename iterator_traits<ForwardIt>::value_type;
+  using traits = typename detail::allocator_traits<
+    ::cuda::std::__remove_cv_t<::cuda::std::__libcpp_remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
 
   typename traits::allocator_type alloc_T(alloc);
 
@@ -93,10 +91,9 @@ _CCCL_HOST_DEVICE ForwardIt destroy_n(ForwardIt first, Size n)
 template <typename Allocator, typename ForwardIt, typename Size>
 _CCCL_HOST_DEVICE ForwardIt destroy_n(Allocator const& alloc, ForwardIt first, Size n)
 {
-  typedef typename iterator_traits<ForwardIt>::value_type T;
-  typedef
-    typename detail::allocator_traits<::cuda::std::__remove_cv_t<::cuda::std::__libcpp_remove_reference_t<Allocator>>>::
-      template rebind_traits<T>::other traits;
+  using T      = typename iterator_traits<ForwardIt>::value_type;
+  using traits = typename detail::allocator_traits<
+    ::cuda::std::__remove_cv_t<::cuda::std::__libcpp_remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
 
   typename traits::allocator_type alloc_T(alloc);
 

--- a/thrust/thrust/detail/merge.inl
+++ b/thrust/thrust/detail/merge.inl
@@ -146,9 +146,9 @@ merge(InputIterator1 first1,
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -163,9 +163,9 @@ merge(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputI
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -194,12 +194,12 @@ thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<InputIterator4>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System5;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System6;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<InputIterator4>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System6 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -239,12 +239,12 @@ thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<InputIterator4>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System5;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System6;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<InputIterator4>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System6 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/mismatch.inl
+++ b/thrust/thrust/detail/mismatch.inl
@@ -63,8 +63,8 @@ thrust::pair<InputIterator1, InputIterator2> mismatch(InputIterator1 first1, Inp
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -78,8 +78,8 @@ mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, Bin
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/numeric_traits.h
+++ b/thrust/thrust/detail/numeric_traits.h
@@ -39,7 +39,7 @@ namespace detail
 {
 
 // XXX good enough for the platforms we care about
-typedef long long intmax_t;
+using intmax_t = long long;
 
 template <typename Number>
 struct is_signed : integral_constant<bool, std::numeric_limits<Number>::is_signed>
@@ -86,17 +86,16 @@ private:
   };
 
 public:
-  typedef
+  using type =
     typename eval_if<and_<std::numeric_limits<Integer>::is_signed,
-                          // digits is the number of no-sign bits
                           (!std::numeric_limits<Integer>::is_bounded
                            || (int(std::numeric_limits<Integer>::digits) + 1 >= num_digits<intmax_t>::value))>::value,
                      identity_<Integer>,
-                     eval_if<int(std::numeric_limits<Integer>::digits) + 1 < num_digits<signed int>::value,
-                             identity_<signed int>,
-                             eval_if<int(std::numeric_limits<Integer>::digits) + 1 < num_digits<signed long>::value,
-                                     identity_<signed long>,
-                                     identity_<intmax_t>>>>::type type;
+                     eval_if<int(std::numeric_limits<Integer>::digits) + 1 < num_digits<int>::value,
+                             identity_<int>,
+                             eval_if<int(std::numeric_limits<Integer>::digits) + 1 < num_digits<long>::value,
+                                     identity_<long>,
+                                     identity_<intmax_t>>>>::type;
 }; // end integer_difference
 
 template <typename Number>
@@ -107,7 +106,7 @@ struct numeric_difference
 template <typename Number>
 _CCCL_HOST_DEVICE typename numeric_difference<Number>::type numeric_distance(Number x, Number y)
 {
-  typedef typename numeric_difference<Number>::type difference_type;
+  using difference_type = typename numeric_difference<Number>::type;
   return difference_type(y) - difference_type(x);
 } // end numeric_distance
 

--- a/thrust/thrust/detail/overlapped_copy.h
+++ b/thrust/thrust/detail/overlapped_copy.h
@@ -95,7 +95,7 @@ RandomAccessIterator2 overlapped_copy(
   RandomAccessIterator1 last,
   RandomAccessIterator2 result)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<RandomAccessIterator1>::type;
 
   // make a temporary copy of [first,last), and copy into it first
   thrust::detail::temporary_array<value_type, DerivedPolicy> temp(exec, first, last);
@@ -108,10 +108,10 @@ template <typename RandomAccessIterator1, typename RandomAccessIterator2>
 RandomAccessIterator2
 overlapped_copy(RandomAccessIterator1 first, RandomAccessIterator1 last, RandomAccessIterator2 result)
 {
-  typedef typename thrust::iterator_system<RandomAccessIterator2>::type System1;
-  typedef typename thrust::iterator_system<RandomAccessIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<RandomAccessIterator2>::type;
+  using System2 = typename thrust::iterator_system<RandomAccessIterator2>::type;
 
-  typedef typename thrust::detail::minimum_system<System1, System2>::type System;
+  using System = typename thrust::detail::minimum_system<System1, System2>::type;
 
   // XXX presumes System is default constructible
   System system;

--- a/thrust/thrust/detail/partition.inl
+++ b/thrust/thrust/detail/partition.inl
@@ -192,7 +192,7 @@ ForwardIterator partition(ForwardIterator first, ForwardIterator last, Predicate
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -204,8 +204,8 @@ ForwardIterator partition(ForwardIterator first, ForwardIterator last, InputIter
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -218,7 +218,7 @@ ForwardIterator stable_partition(ForwardIterator first, ForwardIterator last, Pr
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -230,8 +230,8 @@ ForwardIterator stable_partition(ForwardIterator first, ForwardIterator last, In
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -245,9 +245,9 @@ thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -271,10 +271,10 @@ thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator1>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator1>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -291,9 +291,9 @@ thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -317,10 +317,10 @@ thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -336,7 +336,7 @@ ForwardIterator partition_point(ForwardIterator first, ForwardIterator last, Pre
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -348,7 +348,7 @@ bool is_partitioned(InputIterator first, InputIterator last, Predicate pred)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/pointer.h
+++ b/thrust/thrust/detail/pointer.h
@@ -88,32 +88,34 @@ struct pointer_base
 {
   // void pointers should have no element type
   // note that we remove_cv from the Element type to get the value_type
-  typedef typename thrust::detail::eval_if<::cuda::std::is_void<typename thrust::remove_cvref<Element>::type>::value,
-                                           thrust::detail::identity_<void>,
-                                           ::cuda::std::remove_cv<Element>>::type value_type;
+  using value_type =
+    typename thrust::detail::eval_if<::cuda::std::is_void<typename thrust::remove_cvref<Element>::type>::value,
+                                     thrust::detail::identity_<void>,
+                                     ::cuda::std::remove_cv<Element>>::type;
 
   // if no Derived type is given, just use pointer
-  typedef typename thrust::detail::eval_if<::cuda::std::is_same<Derived, use_default>::value,
-                                           thrust::detail::identity_<pointer<Element, Tag, Reference, Derived>>,
-                                           thrust::detail::identity_<Derived>>::type derived_type;
+  using derived_type =
+    typename thrust::detail::eval_if<::cuda::std::is_same<Derived, use_default>::value,
+                                     thrust::detail::identity_<pointer<Element, Tag, Reference, Derived>>,
+                                     thrust::detail::identity_<Derived>>::type;
 
   // void pointers should have no reference type
   // if no Reference type is given, just use reference
-  typedef typename thrust::detail::eval_if<
+  using reference_type = typename thrust::detail::eval_if<
     ::cuda::std::is_void<typename thrust::remove_cvref<Element>::type>::value,
     thrust::detail::identity_<void>,
     thrust::detail::eval_if<::cuda::std::is_same<Reference, use_default>::value,
                             thrust::detail::identity_<reference<Element, derived_type>>,
-                            thrust::detail::identity_<Reference>>>::type reference_type;
+                            thrust::detail::identity_<Reference>>>::type;
 
-  typedef thrust::iterator_adaptor<derived_type, // pass along the type of our Derived class to iterator_adaptor
-                                   Element*, // we adapt a raw pointer
-                                   value_type, // the value type
-                                   Tag, // system tag
-                                   thrust::random_access_traversal_tag, // pointers have random access traversal
-                                   reference_type, // pass along our Reference type
-                                   std::ptrdiff_t>
-    type;
+  using type =
+    thrust::iterator_adaptor<derived_type,
+                             Element*,
+                             value_type,
+                             Tag,
+                             thrust::random_access_traversal_tag,
+                             reference_type,
+                             std::ptrdiff_t>;
 }; // end pointer_base
 
 } // namespace detail
@@ -130,9 +132,9 @@ template <typename Element, typename Tag, typename Reference, typename Derived>
 class pointer : public thrust::detail::pointer_base<Element, Tag, Reference, Derived>::type
 {
 private:
-  typedef typename thrust::detail::pointer_base<Element, Tag, Reference, Derived>::type super_t;
+  using super_t = typename thrust::detail::pointer_base<Element, Tag, Reference, Derived>::type;
 
-  typedef typename thrust::detail::pointer_base<Element, Tag, Reference, Derived>::derived_type derived_type;
+  using derived_type = typename thrust::detail::pointer_base<Element, Tag, Reference, Derived>::derived_type;
 
   // friend iterator_core_access to give it access to dereference
   friend class thrust::iterator_core_access;
@@ -144,7 +146,7 @@ private:
   using typename super_t::base_type;
 
 public:
-  typedef typename super_t::base_type raw_pointer;
+  using raw_pointer = typename super_t::base_type;
 
   // constructors
 

--- a/thrust/thrust/detail/pointer.inl
+++ b/thrust/thrust/detail/pointer.inl
@@ -110,8 +110,8 @@ _CCCL_HOST_DEVICE typename pointer<Element, Tag, Reference, Derived>::super_t::r
 pointer<Element, Tag, Reference, Derived>::dereference() const
 {
   // Need to handle cpp refs and fancy refs differently:
-  typedef typename super_t::reference RefT;
-  typedef typename ::cuda::std::is_reference<RefT>::type IsCppRef;
+  using RefT     = typename super_t::reference;
+  using IsCppRef = typename ::cuda::std::is_reference<RefT>::type;
 
   const derived_type& derivedPtr = static_cast<const derived_type&>(*this);
 

--- a/thrust/thrust/detail/range/head_flags.h
+++ b/thrust/thrust/detail/range/head_flags.h
@@ -41,7 +41,7 @@ template <typename RandomAccessIterator,
           typename IndexType       = typename thrust::iterator_difference<RandomAccessIterator>::type>
 class head_flags_with_init
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type init_type;
+  using init_type = typename thrust::iterator_value<RandomAccessIterator>::type;
 
   // XXX WAR cudafe issue
   // private:
@@ -53,7 +53,7 @@ public:
     init_type init;
     IndexType n;
 
-    typedef ValueType result_type;
+    using result_type = ValueType;
 
     _CCCL_HOST_DEVICE head_flag_functor(init_type init, IndexType n)
         : binary_pred()
@@ -81,13 +81,12 @@ public:
     }
   };
 
-  typedef thrust::counting_iterator<IndexType> counting_iterator;
+  using counting_iterator = thrust::counting_iterator<IndexType>;
 
 public:
-  typedef thrust::transform_iterator<
+  using iterator = thrust::transform_iterator<
     head_flag_functor,
-    thrust::zip_iterator<thrust::tuple<counting_iterator, RandomAccessIterator, RandomAccessIterator>>>
-    iterator;
+    thrust::zip_iterator<thrust::tuple<counting_iterator, RandomAccessIterator, RandomAccessIterator>>>;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE head_flags_with_init(RandomAccessIterator first, RandomAccessIterator last, init_type init)
@@ -143,7 +142,7 @@ public:
     BinaryPredicate binary_pred; // this must be the first member for performance reasons
     IndexType n;
 
-    typedef ValueType result_type;
+    using result_type = ValueType;
 
     _CCCL_HOST_DEVICE head_flag_functor(IndexType n)
         : binary_pred()
@@ -166,13 +165,12 @@ public:
     }
   };
 
-  typedef thrust::counting_iterator<IndexType> counting_iterator;
+  using counting_iterator = thrust::counting_iterator<IndexType>;
 
 public:
-  typedef thrust::transform_iterator<
+  using iterator = thrust::transform_iterator<
     head_flag_functor,
-    thrust::zip_iterator<thrust::tuple<counting_iterator, RandomAccessIterator, RandomAccessIterator>>>
-    iterator;
+    thrust::zip_iterator<thrust::tuple<counting_iterator, RandomAccessIterator, RandomAccessIterator>>>;
 
   _CCCL_HOST_DEVICE head_flags(RandomAccessIterator first, RandomAccessIterator last)
       : m_begin(thrust::make_transform_iterator(

--- a/thrust/thrust/detail/range/tail_flags.h
+++ b/thrust/thrust/detail/range/tail_flags.h
@@ -51,7 +51,7 @@ public:
     RandomAccessIterator iter;
     IndexType n;
 
-    typedef ValueType result_type;
+    using result_type = ValueType;
 
     _CCCL_HOST_DEVICE tail_flag_functor(RandomAccessIterator first, RandomAccessIterator last)
         : binary_pred()
@@ -72,10 +72,10 @@ public:
     }
   };
 
-  typedef thrust::counting_iterator<IndexType> counting_iterator;
+  using counting_iterator = thrust::counting_iterator<IndexType>;
 
 public:
-  typedef thrust::transform_iterator<tail_flag_functor, counting_iterator> iterator;
+  using iterator = thrust::transform_iterator<tail_flag_functor, counting_iterator>;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE tail_flags(RandomAccessIterator first, RandomAccessIterator last)

--- a/thrust/thrust/detail/raw_pointer_cast.h
+++ b/thrust/thrust/detail/raw_pointer_cast.h
@@ -38,14 +38,14 @@ _CCCL_HOST_DEVICE typename thrust::detail::pointer_traits<Pointer>::raw_pointer 
 template <typename ToPointer, typename FromPointer>
 _CCCL_HOST_DEVICE ToPointer reinterpret_pointer_cast(FromPointer ptr)
 {
-  typedef typename thrust::detail::pointer_element<ToPointer>::type to_element;
+  using to_element = typename thrust::detail::pointer_element<ToPointer>::type;
   return ToPointer(reinterpret_cast<to_element*>(thrust::raw_pointer_cast(ptr)));
 }
 
 template <typename ToPointer, typename FromPointer>
 _CCCL_HOST_DEVICE ToPointer static_pointer_cast(FromPointer ptr)
 {
-  typedef typename thrust::detail::pointer_element<ToPointer>::type to_element;
+  using to_element = typename thrust::detail::pointer_element<ToPointer>::type;
   return ToPointer(static_cast<to_element*>(thrust::raw_pointer_cast(ptr)));
 }
 

--- a/thrust/thrust/detail/raw_reference_cast.h
+++ b/thrust/thrust/detail/raw_reference_cast.h
@@ -78,7 +78,7 @@ struct raw_reference_impl : ::cuda::std::add_lvalue_reference<T>
 template <typename T>
 struct raw_reference_impl<T, ::cuda::std::__enable_if_t<is_wrapped_reference<::cuda::std::__remove_cv_t<T>>::value>>
 {
-  typedef ::cuda::std::__add_lvalue_reference_t<typename pointer_element<typename T::pointer>::type> type;
+  using type = ::cuda::std::__add_lvalue_reference_t<typename pointer_element<typename T::pointer>::type>;
 };
 
 } // namespace raw_reference_detail
@@ -112,13 +112,13 @@ struct raw_reference_tuple_helper
 template <typename... Ts>
 struct raw_reference_tuple_helper<thrust::tuple<Ts...>>
 {
-  typedef thrust::tuple<typename raw_reference_tuple_helper<Ts>::type...> type;
+  using type = thrust::tuple<typename raw_reference_tuple_helper<Ts>::type...>;
 };
 
 template <typename... Ts>
 struct raw_reference_tuple_helper<thrust::detail::tuple_of_iterator_references<Ts...>>
 {
-  typedef thrust::detail::tuple_of_iterator_references<typename raw_reference_tuple_helper<Ts>::type...> type;
+  using type = thrust::detail::tuple_of_iterator_references<typename raw_reference_tuple_helper<Ts>::type...>;
 };
 
 } // namespace raw_reference_detail
@@ -132,22 +132,22 @@ template <typename... Ts>
 struct raw_reference<thrust::tuple<Ts...>>
 {
 private:
-  typedef thrust::tuple<Ts...> tuple_type;
+  using tuple_type = thrust::tuple<Ts...>;
 
 public:
-  typedef typename eval_if<is_unwrappable<tuple_type>::value,
-                           raw_reference_detail::raw_reference_tuple_helper<tuple_type>,
-                           ::cuda::std::add_lvalue_reference<tuple_type>>::type type;
+  using type = typename eval_if<is_unwrappable<tuple_type>::value,
+                                raw_reference_detail::raw_reference_tuple_helper<tuple_type>,
+                                ::cuda::std::add_lvalue_reference<tuple_type>>::type;
 };
 
 template <typename... Ts>
 struct raw_reference<thrust::detail::tuple_of_iterator_references<Ts...>>
 {
 private:
-  typedef detail::tuple_of_iterator_references<Ts...> tuple_type;
+  using tuple_type = detail::tuple_of_iterator_references<Ts...>;
 
 public:
-  typedef typename raw_reference_detail::raw_reference_tuple_helper<tuple_type>::type type;
+  using type = typename raw_reference_detail::raw_reference_tuple_helper<tuple_type>::type;
 };
 
 } // namespace detail

--- a/thrust/thrust/detail/reduce.inl
+++ b/thrust/thrust/detail/reduce.inl
@@ -153,7 +153,7 @@ typename thrust::iterator_traits<InputIterator>::value_type reduce(InputIterator
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 
@@ -165,7 +165,7 @@ T reduce(InputIterator first, InputIterator last, T init)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 
@@ -177,7 +177,7 @@ T reduce(InputIterator first, InputIterator last, T init, BinaryFunction binary_
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 
@@ -194,10 +194,10 @@ thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -223,10 +223,10 @@ thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -260,10 +260,10 @@ thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/remove.inl
+++ b/thrust/thrust/detail/remove.inl
@@ -120,7 +120,7 @@ ForwardIterator remove(ForwardIterator first, ForwardIterator last, const T& val
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -132,8 +132,8 @@ OutputIterator remove_copy(InputIterator first, InputIterator last, OutputIterat
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -146,7 +146,7 @@ ForwardIterator remove_if(ForwardIterator first, ForwardIterator last, Predicate
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -158,8 +158,8 @@ ForwardIterator remove_if(ForwardIterator first, ForwardIterator last, InputIter
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -172,8 +172,8 @@ OutputIterator remove_copy_if(InputIterator first, InputIterator last, OutputIte
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -187,9 +187,9 @@ remove_copy_if(InputIterator1 first, InputIterator1 last, InputIterator2 stencil
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/replace.inl
+++ b/thrust/thrust/detail/replace.inl
@@ -131,8 +131,8 @@ replace_copy_if(InputIterator first, InputIterator last, OutputIterator result, 
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -151,9 +151,9 @@ OutputIterator replace_copy_if(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -169,8 +169,8 @@ replace_copy(InputIterator first, InputIterator last, OutputIterator result, con
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -183,7 +183,7 @@ void replace_if(ForwardIterator first, ForwardIterator last, Predicate pred, con
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -195,8 +195,8 @@ void replace_if(ForwardIterator first, ForwardIterator last, InputIterator stenc
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System1;
-  typedef typename thrust::iterator_system<InputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<ForwardIterator>::type;
+  using System2 = typename thrust::iterator_system<InputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -209,7 +209,7 @@ void replace(ForwardIterator first, ForwardIterator last, const T& old_value, co
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/reverse.inl
+++ b/thrust/thrust/detail/reverse.inl
@@ -60,7 +60,7 @@ void reverse(BidirectionalIterator first, BidirectionalIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<BidirectionalIterator>::type System;
+  using System = typename thrust::iterator_system<BidirectionalIterator>::type;
 
   System system;
 
@@ -72,8 +72,8 @@ OutputIterator reverse_copy(BidirectionalIterator first, BidirectionalIterator l
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<BidirectionalIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<BidirectionalIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/scan.inl
+++ b/thrust/thrust/detail/scan.inl
@@ -245,8 +245,8 @@ OutputIterator inclusive_scan(InputIterator first, InputIterator last, OutputIte
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -259,8 +259,8 @@ OutputIterator inclusive_scan(InputIterator first, InputIterator last, OutputIte
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -273,8 +273,8 @@ OutputIterator exclusive_scan(InputIterator first, InputIterator last, OutputIte
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -287,8 +287,8 @@ OutputIterator exclusive_scan(InputIterator first, InputIterator last, OutputIte
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -302,8 +302,8 @@ exclusive_scan(InputIterator first, InputIterator last, OutputIterator result, T
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -317,9 +317,9 @@ inclusive_scan_by_key(InputIterator1 first1, InputIterator1 last1, InputIterator
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -334,9 +334,9 @@ OutputIterator inclusive_scan_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -361,9 +361,9 @@ OutputIterator inclusive_scan_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -379,9 +379,9 @@ exclusive_scan_by_key(InputIterator1 first1, InputIterator1 last1, InputIterator
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -396,9 +396,9 @@ exclusive_scan_by_key(InputIterator1 first1, InputIterator1 last1, InputIterator
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -418,9 +418,9 @@ OutputIterator exclusive_scan_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -447,9 +447,9 @@ OutputIterator exclusive_scan_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/scatter.inl
+++ b/thrust/thrust/detail/scatter.inl
@@ -91,9 +91,9 @@ void scatter(InputIterator1 first, InputIterator1 last, InputIterator2 map, Rand
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<RandomAccessIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -108,10 +108,10 @@ void scatter_if(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<RandomAccessIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -135,10 +135,10 @@ void scatter_if(InputIterator1 first,
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<RandomAccessIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/sequence.inl
+++ b/thrust/thrust/detail/sequence.inl
@@ -69,7 +69,7 @@ void sequence(ForwardIterator first, ForwardIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -81,7 +81,7 @@ void sequence(ForwardIterator first, ForwardIterator last, T init)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -93,7 +93,7 @@ void sequence(ForwardIterator first, ForwardIterator last, T init, T step)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/set_operations.inl
+++ b/thrust/thrust/detail/set_operations.inl
@@ -445,9 +445,9 @@ OutputIterator set_difference(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -462,9 +462,9 @@ OutputIterator set_difference(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -493,12 +493,12 @@ thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<InputIterator4>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System5;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System6;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<InputIterator4>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System6 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -538,12 +538,12 @@ thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<InputIterator4>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System5;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System6;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<InputIterator4>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System6 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -575,9 +575,9 @@ OutputIterator set_intersection(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -592,9 +592,9 @@ OutputIterator set_intersection(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -621,11 +621,11 @@ thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System5;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -661,11 +661,11 @@ thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System5;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -695,9 +695,9 @@ OutputIterator set_symmetric_difference(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -713,9 +713,9 @@ OutputIterator set_symmetric_difference(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -745,12 +745,12 @@ thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<InputIterator4>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System5;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System6;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<InputIterator4>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System6 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -790,12 +790,12 @@ thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<InputIterator4>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System5;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System6;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<InputIterator4>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System6 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -827,9 +827,9 @@ OutputIterator set_union(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -844,9 +844,9 @@ OutputIterator set_union(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -875,12 +875,12 @@ thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<InputIterator4>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System5;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System6;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<InputIterator4>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System6 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -920,12 +920,12 @@ thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<InputIterator4>::type System4;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System5;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System6;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<InputIterator4>::type;
+  using System5 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System6 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/shuffle.inl
+++ b/thrust/thrust/detail/shuffle.inl
@@ -46,7 +46,7 @@ _CCCL_HOST_DEVICE void shuffle(RandomIterator first, RandomIterator last, URBG&&
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomIterator>::type System;
+  using System = typename thrust::iterator_system<RandomIterator>::type;
   System system;
 
   return thrust::shuffle(select_system(system), first, last, g);
@@ -70,8 +70,8 @@ _CCCL_HOST_DEVICE void shuffle_copy(RandomIterator first, RandomIterator last, O
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<RandomIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/sort.inl
+++ b/thrust/thrust/detail/sort.inl
@@ -188,7 +188,7 @@ void sort(RandomAccessIterator first, RandomAccessIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System;
+  using System = typename thrust::iterator_system<RandomAccessIterator>::type;
 
   System system;
 
@@ -200,7 +200,7 @@ _CCCL_HOST_DEVICE void sort(RandomAccessIterator first, RandomAccessIterator las
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System;
+  using System = typename thrust::iterator_system<RandomAccessIterator>::type;
 
   System system;
 
@@ -212,7 +212,7 @@ void stable_sort(RandomAccessIterator first, RandomAccessIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System;
+  using System = typename thrust::iterator_system<RandomAccessIterator>::type;
 
   System system;
 
@@ -224,7 +224,7 @@ void stable_sort(RandomAccessIterator first, RandomAccessIterator last, StrictWe
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomAccessIterator>::type System;
+  using System = typename thrust::iterator_system<RandomAccessIterator>::type;
 
   System system;
 
@@ -240,8 +240,8 @@ void sort_by_key(RandomAccessIterator1 keys_first, RandomAccessIterator1 keys_la
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomAccessIterator1>::type System1;
-  typedef typename thrust::iterator_system<RandomAccessIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<RandomAccessIterator1>::type;
+  using System2 = typename thrust::iterator_system<RandomAccessIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -257,8 +257,8 @@ void sort_by_key(RandomAccessIterator1 keys_first,
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomAccessIterator1>::type System1;
-  typedef typename thrust::iterator_system<RandomAccessIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<RandomAccessIterator1>::type;
+  using System2 = typename thrust::iterator_system<RandomAccessIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -272,8 +272,8 @@ void stable_sort_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomAccessIterator1>::type System1;
-  typedef typename thrust::iterator_system<RandomAccessIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<RandomAccessIterator1>::type;
+  using System2 = typename thrust::iterator_system<RandomAccessIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -289,8 +289,8 @@ void stable_sort_by_key(RandomAccessIterator1 keys_first,
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<RandomAccessIterator1>::type System1;
-  typedef typename thrust::iterator_system<RandomAccessIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<RandomAccessIterator1>::type;
+  using System2 = typename thrust::iterator_system<RandomAccessIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -303,7 +303,7 @@ bool is_sorted(ForwardIterator first, ForwardIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -315,7 +315,7 @@ bool is_sorted(ForwardIterator first, ForwardIterator last, Compare comp)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -327,7 +327,7 @@ ForwardIterator is_sorted_until(ForwardIterator first, ForwardIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -339,7 +339,7 @@ ForwardIterator is_sorted_until(ForwardIterator first, ForwardIterator last, Com
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/static_map.h
+++ b/thrust/thrust/detail/static_map.h
@@ -91,14 +91,13 @@ template <unsigned int default_value,
           unsigned int value7 = default_value>
 struct static_map
 {
-  typedef cons<
+  using impl = cons<
     key_value<key0, value0>,
     cons<key_value<key1, value1>,
          cons<key_value<key2, value2>,
               cons<key_value<key3, value3>,
                    cons<key_value<key4, value4>,
-                        cons<key_value<key5, value5>, cons<key_value<key6, value6>, cons<key_value<key7, value7>>>>>>>>>
-    impl;
+                        cons<key_value<key5, value5>, cons<key_value<key6, value6>, cons<key_value<key7, value7>>>>>>>>>;
 
   template <unsigned int key>
   struct static_get

--- a/thrust/thrust/detail/swap_ranges.inl
+++ b/thrust/thrust/detail/swap_ranges.inl
@@ -51,8 +51,8 @@ ForwardIterator2 swap_ranges(ForwardIterator1 first1, ForwardIterator1 last1, Fo
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator1>::type System1;
-  typedef typename thrust::iterator_system<ForwardIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<ForwardIterator1>::type;
+  using System2 = typename thrust::iterator_system<ForwardIterator2>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/tabulate.inl
+++ b/thrust/thrust/detail/tabulate.inl
@@ -50,7 +50,7 @@ void tabulate(ForwardIterator first, ForwardIterator last, UnaryOperation unary_
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/temporary_array.h
+++ b/thrust/thrust/detail/temporary_array.h
@@ -57,13 +57,13 @@ template <typename T, typename System>
 class temporary_array : public contiguous_storage<T, no_throw_allocator<temporary_allocator<T, System>>>
 {
 private:
-  typedef contiguous_storage<T, no_throw_allocator<temporary_allocator<T, System>>> super_t;
+  using super_t = contiguous_storage<T, no_throw_allocator<temporary_allocator<T, System>>>;
 
   // to help out the constructor
-  typedef no_throw_allocator<temporary_allocator<T, System>> alloc_type;
+  using alloc_type = no_throw_allocator<temporary_allocator<T, System>>;
 
 public:
-  typedef typename super_t::size_type size_type;
+  using size_type = typename super_t::size_type;
 
   _CCCL_HOST_DEVICE temporary_array(thrust::execution_policy<System>& system);
 
@@ -100,7 +100,7 @@ template <typename Iterator, typename System>
 class tagged_iterator_range
 {
 public:
-  typedef thrust::detail::tagged_iterator<Iterator, System> iterator;
+  using iterator = thrust::detail::tagged_iterator<Iterator, System>;
 
   template <typename Ignored1, typename Ignored2>
   tagged_iterator_range(const Ignored1&, const Ignored2&, Iterator first, Iterator last)
@@ -134,7 +134,7 @@ struct move_to_system_base
 template <typename Iterator, typename FromSystem, typename ToSystem>
 class move_to_system : public move_to_system_base<Iterator, FromSystem, ToSystem>::type
 {
-  typedef typename move_to_system_base<Iterator, FromSystem, ToSystem>::type super_t;
+  using super_t = typename move_to_system_base<Iterator, FromSystem, ToSystem>::type;
 
 public:
   move_to_system(thrust::execution_policy<FromSystem>& from_system,

--- a/thrust/thrust/detail/temporary_buffer.h
+++ b/thrust/thrust/detail/temporary_buffer.h
@@ -46,8 +46,8 @@ _CCCL_HOST_DEVICE
   thrust::pointer<T, DerivedPolicy> ptr =
     thrust::pointer<T, DerivedPolicy>(static_cast<T*>(thrust::raw_pointer_cast(p.first)));
 
-  typedef thrust::pair<thrust::pointer<T, DerivedPolicy>, typename thrust::pointer<T, DerivedPolicy>::difference_type>
-    result_type;
+  using result_type =
+    thrust::pair<thrust::pointer<T, DerivedPolicy>, typename thrust::pointer<T, DerivedPolicy>::difference_type>;
   return result_type(ptr, p.second);
 } // end down_cast_pair()
 

--- a/thrust/thrust/detail/transform.inl
+++ b/thrust/thrust/detail/transform.inl
@@ -139,8 +139,8 @@ OutputIterator transform(InputIterator first, InputIterator last, OutputIterator
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -154,9 +154,9 @@ transform(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, Ou
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -171,8 +171,8 @@ transform_if(InputIterator first, InputIterator last, ForwardIterator result, Un
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<ForwardIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<ForwardIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -195,9 +195,9 @@ ForwardIterator transform_if(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<ForwardIterator>::type System3;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<ForwardIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -223,10 +223,10 @@ ForwardIterator transform_if(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<InputIterator3>::type System3;
-  typedef typename thrust::iterator_system<ForwardIterator>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<InputIterator3>::type;
+  using System4 = typename thrust::iterator_system<ForwardIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/transform_reduce.inl
+++ b/thrust/thrust/detail/transform_reduce.inl
@@ -57,7 +57,7 @@ OutputType transform_reduce(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System;
+  using System = typename thrust::iterator_system<InputIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/transform_scan.inl
+++ b/thrust/thrust/detail/transform_scan.inl
@@ -80,8 +80,8 @@ OutputIterator transform_inclusive_scan(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -100,8 +100,8 @@ OutputIterator transform_exclusive_scan(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/trivial_sequence.h
+++ b/thrust/thrust/detail/trivial_sequence.h
@@ -52,7 +52,7 @@ struct _trivial_sequence
 template <typename Iterator, typename DerivedPolicy>
 struct _trivial_sequence<Iterator, DerivedPolicy, thrust::detail::true_type>
 {
-  typedef Iterator iterator_type;
+  using iterator_type = Iterator;
   Iterator first, last;
 
   _CCCL_HOST_DEVICE _trivial_sequence(thrust::execution_policy<DerivedPolicy>&, Iterator _first, Iterator _last)
@@ -85,8 +85,8 @@ struct _trivial_sequence<Iterator, DerivedPolicy, thrust::detail::true_type>
 template <typename Iterator, typename DerivedPolicy>
 struct _trivial_sequence<Iterator, DerivedPolicy, thrust::detail::false_type>
 {
-  typedef typename thrust::iterator_value<Iterator>::type iterator_value;
-  typedef typename thrust::detail::temporary_array<iterator_value, DerivedPolicy>::iterator iterator_type;
+  using iterator_value = typename thrust::iterator_value<Iterator>::type;
+  using iterator_type  = typename thrust::detail::temporary_array<iterator_value, DerivedPolicy>::iterator;
 
   thrust::detail::temporary_array<iterator_value, DerivedPolicy> buffer;
 
@@ -119,7 +119,7 @@ template <typename Iterator, typename DerivedPolicy>
 struct trivial_sequence
     : detail::_trivial_sequence<Iterator, DerivedPolicy, typename thrust::is_contiguous_iterator<Iterator>::type>
 {
-  typedef _trivial_sequence<Iterator, DerivedPolicy, typename thrust::is_contiguous_iterator<Iterator>::type> super_t;
+  using super_t = _trivial_sequence<Iterator, DerivedPolicy, typename thrust::is_contiguous_iterator<Iterator>::type>;
 
   _CCCL_HOST_DEVICE trivial_sequence(thrust::execution_policy<DerivedPolicy>& exec, Iterator first, Iterator last)
       : super_t(exec, first, last)

--- a/thrust/thrust/detail/tuple_meta_transform.h
+++ b/thrust/thrust/detail/tuple_meta_transform.h
@@ -44,16 +44,16 @@ struct tuple_meta_transform_WAR_NVCC;
 template <typename Tuple, template <typename> class UnaryMetaFunction, size_t... Is>
 struct tuple_meta_transform_WAR_NVCC<Tuple, UnaryMetaFunction, thrust::index_sequence<Is...>>
 {
-  typedef thrust::tuple<typename UnaryMetaFunction<typename thrust::tuple_element<Is, Tuple>::type>::type...> type;
+  using type = thrust::tuple<typename UnaryMetaFunction<typename thrust::tuple_element<Is, Tuple>::type>::type...>;
 };
 
 template <typename Tuple, template <typename> class UnaryMetaFunction>
 struct tuple_meta_transform
 {
-  typedef
+  using type =
     typename tuple_meta_transform_WAR_NVCC<Tuple,
                                            UnaryMetaFunction,
-                                           thrust::make_index_sequence<thrust::tuple_size<Tuple>::value>>::type type;
+                                           thrust::make_index_sequence<thrust::tuple_size<Tuple>::value>>::type;
 };
 
 } // namespace detail

--- a/thrust/thrust/detail/tuple_transform.h
+++ b/thrust/thrust/detail/tuple_transform.h
@@ -47,7 +47,7 @@ struct tuple_transform_functor<Tuple, UnaryMetaFunction, UnaryFunction, thrust::
   static _CCCL_HOST typename tuple_meta_transform<Tuple, UnaryMetaFunction>::type
   do_it_on_the_host(const Tuple& t, UnaryFunction f)
   {
-    typedef typename tuple_meta_transform<Tuple, UnaryMetaFunction>::type XfrmTuple;
+    using XfrmTuple = typename tuple_meta_transform<Tuple, UnaryMetaFunction>::type;
 
     return XfrmTuple(f(thrust::get<Is>(t))...);
   }
@@ -55,7 +55,7 @@ struct tuple_transform_functor<Tuple, UnaryMetaFunction, UnaryFunction, thrust::
   static _CCCL_HOST_DEVICE typename tuple_meta_transform<Tuple, UnaryMetaFunction>::type
   do_it_on_the_host_or_device(const Tuple& t, UnaryFunction f)
   {
-    typedef typename tuple_meta_transform<Tuple, UnaryMetaFunction>::type XfrmTuple;
+    using XfrmTuple = typename tuple_meta_transform<Tuple, UnaryMetaFunction>::type;
 
     return XfrmTuple(f(thrust::get<Is>(t))...);
   }

--- a/thrust/thrust/detail/type_traits.h
+++ b/thrust/thrust/detail/type_traits.h
@@ -76,13 +76,13 @@ struct eval_if
 template <typename Then, typename Else>
 struct eval_if<true, Then, Else>
 {
-  typedef typename Then::type type;
+  using type = typename Then::type;
 }; // end eval_if
 
 template <typename Then, typename Else>
 struct eval_if<false, Then, Else>
 {
-  typedef typename Else::type type;
+  using type = typename Else::type;
 }; // end eval_if
 
 template <typename T>
@@ -90,7 +90,7 @@ template <typename T>
 //  XXX WAR nvcc's confusion with thrust::identity
 struct identity_
 {
-  typedef T type;
+  using type = T;
 }; // end identity
 
 template <bool, typename T>
@@ -99,7 +99,7 @@ struct lazy_enable_if
 template <typename T>
 struct lazy_enable_if<true, T>
 {
-  typedef typename T::type type;
+  using type = typename T::type;
 };
 
 template <bool condition, typename T = void>
@@ -122,7 +122,7 @@ struct is_numeric : ::cuda::std::_And<::cuda::std::is_convertible<int, T>, ::cud
 
 struct largest_available_float
 {
-  typedef double type;
+  using type = double;
 };
 
 // T1 wins if they are both the same size

--- a/thrust/thrust/detail/type_traits/function_traits.h
+++ b/thrust/thrust/detail/type_traits/function_traits.h
@@ -67,7 +67,7 @@ __THRUST_DEFINE_HAS_NESTED_TYPE(has_second_argument_type, second_argument_type)
 template <typename AdaptableBinaryFunction>
 struct result_type
 {
-  typedef typename AdaptableBinaryFunction::result_type type;
+  using type = typename AdaptableBinaryFunction::result_type;
 };
 
 template <typename T>

--- a/thrust/thrust/detail/type_traits/has_nested_type.h
+++ b/thrust/thrust/detail/type_traits/has_nested_type.h
@@ -28,16 +28,16 @@
 
 #include <thrust/detail/type_traits.h>
 
-#define __THRUST_DEFINE_HAS_NESTED_TYPE(trait_name, nested_type_name) \
-  template <typename T>                                               \
-  struct trait_name                                                   \
-  {                                                                   \
-    typedef char yes_type;                                            \
-    typedef int no_type;                                              \
-    template <typename S>                                             \
-    static yes_type test(typename S::nested_type_name*);              \
-    template <typename S>                                             \
-    static no_type test(...);                                         \
-    static bool const value = sizeof(test<T>(0)) == sizeof(yes_type); \
-    typedef thrust::detail::integral_constant<bool, value> type;      \
+#define __THRUST_DEFINE_HAS_NESTED_TYPE(trait_name, nested_type_name)         \
+  template <typename T>                                                       \
+  struct trait_name                                                           \
+  {                                                                           \
+    using yes_type = char;                                                    \
+    using no_type  = int;                                                     \
+    template <typename S>                                                     \
+    static yes_type test(typename S::nested_type_name*);                      \
+    template <typename S>                                                     \
+    static no_type test(...);                                                 \
+    static bool const value = sizeof(test<T>(0)) == sizeof(yes_type);         \
+    using type              = thrust::detail::integral_constant<bool, value>; \
   };

--- a/thrust/thrust/detail/type_traits/is_call_possible.h
+++ b/thrust/thrust/detail/type_traits/is_call_possible.h
@@ -51,13 +51,13 @@ U& operator,(U&, void_exp_result<T>);
 template <typename src_type, typename dest_type>
 struct clone_constness
 {
-  typedef dest_type type;
+  using type = dest_type;
 };
 
 template <typename src_type, typename dest_type>
 struct clone_constness<const src_type, dest_type>
 {
-  typedef const dest_type type;
+  using type = const dest_type;
 };
 
 } // namespace is_call_possible_detail
@@ -83,7 +83,7 @@ THRUST_NAMESPACE_END
       no member_function_name(...) const;                                                                              \
     };                                                                                                                 \
                                                                                                                        \
-    typedef typename thrust::detail::is_call_possible_detail::clone_constness<T, derived>::type derived_type;          \
+    using derived_type = typename thrust::detail::is_call_possible_detail::clone_constness<T, derived>::type;          \
                                                                                                                        \
     template <typename U, typename Result>                                                                             \
     struct return_value_check                                                                                          \
@@ -163,5 +163,5 @@ THRUST_NAMESPACE_END
                                                                                                                        \
   public:                                                                                                              \
     static const bool value = impl<trait_name##_has_member<T, Signature>::value, Signature>::value;                    \
-    typedef thrust::detail::integral_constant<bool, value> type;                                                       \
+    using type              = thrust::detail::integral_constant<bool, value>;                                          \
   };

--- a/thrust/thrust/detail/type_traits/minimum_type.h
+++ b/thrust/thrust/detail/type_traits/minimum_type.h
@@ -47,19 +47,19 @@ struct minimum_type_impl
 template <typename T1, typename T2>
 struct minimum_type_impl<T1, T2, true, false>
 {
-  typedef T2 type;
+  using type = T2;
 }; // end minimum_type_impl
 
 template <typename T1, typename T2>
 struct minimum_type_impl<T1, T2, false, true>
 {
-  typedef T1 type;
+  using type = T1;
 }; // end minimum_type_impl
 
 template <typename T1, typename T2>
 struct minimum_type_impl<T1, T2, true, true>
 {
-  typedef T1 type;
+  using type = T1;
 }; // end minimum_type_impl
 
 template <typename T1, typename T2>
@@ -73,7 +73,7 @@ struct primitive_minimum_type
 template <typename T>
 struct primitive_minimum_type<T, T>
 {
-  typedef T type;
+  using type = T;
 }; // end primitive_minimum_type
 
 // XXX this belongs somewhere more general

--- a/thrust/thrust/detail/type_traits/pointer_traits.h
+++ b/thrust/thrust/detail/type_traits/pointer_traits.h
@@ -43,19 +43,19 @@ struct pointer_element;
 template <template <typename> class Ptr, typename Arg>
 struct pointer_element<Ptr<Arg>>
 {
-  typedef Arg type;
+  using type = Arg;
 };
 
 template <template <typename, typename> class Ptr, typename Arg1, typename Arg2>
 struct pointer_element<Ptr<Arg1, Arg2>>
 {
-  typedef Arg1 type;
+  using type = Arg1;
 };
 
 template <template <typename, typename, typename> class Ptr, typename Arg1, typename Arg2, typename Arg3>
 struct pointer_element<Ptr<Arg1, Arg2, Arg3>>
 {
-  typedef Arg1 type;
+  using type = Arg1;
 };
 
 template <template <typename, typename, typename, typename> class Ptr,
@@ -65,7 +65,7 @@ template <template <typename, typename, typename, typename> class Ptr,
           typename Arg4>
 struct pointer_element<Ptr<Arg1, Arg2, Arg3, Arg4>>
 {
-  typedef Arg1 type;
+  using type = Arg1;
 };
 
 template <template <typename, typename, typename, typename, typename> class Ptr,
@@ -76,25 +76,25 @@ template <template <typename, typename, typename, typename, typename> class Ptr,
           typename Arg5>
 struct pointer_element<Ptr<Arg1, Arg2, Arg3, Arg4, Arg5>>
 {
-  typedef Arg1 type;
+  using type = Arg1;
 };
 
 template <typename T>
 struct pointer_element<T*>
 {
-  typedef T type;
+  using type = T;
 };
 
 template <typename Ptr>
 struct pointer_difference
 {
-  typedef typename Ptr::difference_type type;
+  using type = typename Ptr::difference_type;
 };
 
 template <typename T>
 struct pointer_difference<T*>
 {
-  typedef std::ptrdiff_t type;
+  using type = std::ptrdiff_t;
 };
 
 template <typename Ptr, typename T>
@@ -186,13 +186,13 @@ struct pointer_raw_pointer_impl
 template <typename T>
 struct pointer_raw_pointer_impl<T*>
 {
-  typedef T* type;
+  using type = T*;
 };
 
 template <typename Ptr>
 struct pointer_raw_pointer_impl<Ptr, ::cuda::std::__enable_if_t<has_raw_pointer<Ptr>::value>>
 {
-  typedef typename Ptr::raw_pointer type;
+  using type = typename Ptr::raw_pointer;
 };
 
 } // namespace pointer_traits_detail
@@ -233,15 +233,15 @@ struct pointer_to_param
 template <typename Ptr>
 struct pointer_traits
 {
-  typedef Ptr pointer;
-  typedef typename Ptr::reference reference;
-  typedef typename pointer_element<Ptr>::type element_type;
-  typedef typename pointer_difference<Ptr>::type difference_type;
+  using pointer         = Ptr;
+  using reference       = typename Ptr::reference;
+  using element_type    = typename pointer_element<Ptr>::type;
+  using difference_type = typename pointer_difference<Ptr>::type;
 
   template <typename U>
   struct rebind
   {
-    typedef typename rebind_pointer<Ptr, U>::type other;
+    using other = typename rebind_pointer<Ptr, U>::type;
   };
 
   _CCCL_HOST_DEVICE inline static pointer
@@ -255,7 +255,7 @@ struct pointer_traits
   }
 
   // thrust additions follow
-  typedef typename pointer_raw_pointer<Ptr>::type raw_pointer;
+  using raw_pointer = typename pointer_raw_pointer<Ptr>::type;
 
   _CCCL_HOST_DEVICE inline static raw_pointer get(pointer ptr)
   {
@@ -266,15 +266,15 @@ struct pointer_traits
 template <typename T>
 struct pointer_traits<T*>
 {
-  typedef T* pointer;
-  typedef T& reference;
-  typedef T element_type;
-  typedef typename pointer_difference<T*>::type difference_type;
+  using pointer         = T*;
+  using reference       = T&;
+  using element_type    = T;
+  using difference_type = typename pointer_difference<T*>::type;
 
   template <typename U>
   struct rebind
   {
-    typedef U* other;
+    using other = U*;
   };
 
   _CCCL_HOST_DEVICE inline static pointer
@@ -284,7 +284,7 @@ struct pointer_traits<T*>
   }
 
   // thrust additions follow
-  typedef typename pointer_raw_pointer<T*>::type raw_pointer;
+  using raw_pointer = typename pointer_raw_pointer<T*>::type;
 
   _CCCL_HOST_DEVICE inline static raw_pointer get(pointer ptr)
   {
@@ -295,15 +295,15 @@ struct pointer_traits<T*>
 template <>
 struct pointer_traits<void*>
 {
-  typedef void* pointer;
-  typedef void reference;
-  typedef void element_type;
-  typedef pointer_difference<void*>::type difference_type;
+  using pointer         = void*;
+  using reference       = void;
+  using element_type    = void;
+  using difference_type = pointer_difference<void*>::type;
 
   template <typename U>
   struct rebind
   {
-    typedef U* other;
+    using other = U*;
   };
 
   _CCCL_HOST_DEVICE inline static pointer pointer_to(pointer_traits_detail::pointer_to_param<element_type>::type r)
@@ -312,7 +312,7 @@ struct pointer_traits<void*>
   }
 
   // thrust additions follow
-  typedef pointer_raw_pointer<void*>::type raw_pointer;
+  using raw_pointer = pointer_raw_pointer<void*>::type;
 
   _CCCL_HOST_DEVICE inline static raw_pointer get(pointer ptr)
   {
@@ -323,15 +323,15 @@ struct pointer_traits<void*>
 template <>
 struct pointer_traits<const void*>
 {
-  typedef const void* pointer;
-  typedef const void reference;
-  typedef const void element_type;
-  typedef pointer_difference<const void*>::type difference_type;
+  using pointer         = const void*;
+  using reference       = const void;
+  using element_type    = const void;
+  using difference_type = pointer_difference<const void*>::type;
 
   template <typename U>
   struct rebind
   {
-    typedef U* other;
+    using other = U*;
   };
 
   _CCCL_HOST_DEVICE inline static pointer pointer_to(pointer_traits_detail::pointer_to_param<element_type>::type r)
@@ -340,7 +340,7 @@ struct pointer_traits<const void*>
   }
 
   // thrust additions follow
-  typedef pointer_raw_pointer<const void*>::type raw_pointer;
+  using raw_pointer = pointer_raw_pointer<const void*>::type;
 
   _CCCL_HOST_DEVICE inline static raw_pointer get(pointer ptr)
   {

--- a/thrust/thrust/detail/uninitialized_copy.inl
+++ b/thrust/thrust/detail/uninitialized_copy.inl
@@ -60,8 +60,8 @@ ForwardIterator uninitialized_copy(InputIterator first, InputIterator last, Forw
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<ForwardIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<ForwardIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -74,8 +74,8 @@ ForwardIterator uninitialized_copy_n(InputIterator first, Size n, ForwardIterato
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<ForwardIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<ForwardIterator>::type;
 
   System1 system1;
   System2 system2;

--- a/thrust/thrust/detail/uninitialized_fill.inl
+++ b/thrust/thrust/detail/uninitialized_fill.inl
@@ -60,7 +60,7 @@ void uninitialized_fill(ForwardIterator first, ForwardIterator last, const T& x)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -72,7 +72,7 @@ ForwardIterator uninitialized_fill_n(ForwardIterator first, Size n, const T& x)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/unique.inl
+++ b/thrust/thrust/detail/unique.inl
@@ -165,7 +165,7 @@ ForwardIterator unique(ForwardIterator first, ForwardIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -177,7 +177,7 @@ ForwardIterator unique(ForwardIterator first, ForwardIterator last, BinaryPredic
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -189,8 +189,8 @@ OutputIterator unique_copy(InputIterator first, InputIterator last, OutputIterat
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -203,8 +203,8 @@ OutputIterator unique_copy(InputIterator first, InputIterator last, OutputIterat
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator>::type System1;
-  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
 
   System1 system1;
   System2 system2;
@@ -218,8 +218,8 @@ unique_by_key(ForwardIterator1 keys_first, ForwardIterator1 keys_last, ForwardIt
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator1>::type System1;
-  typedef typename thrust::iterator_system<ForwardIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<ForwardIterator1>::type;
+  using System2 = typename thrust::iterator_system<ForwardIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -233,8 +233,8 @@ thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator1>::type System1;
-  typedef typename thrust::iterator_system<ForwardIterator2>::type System2;
+  using System1 = typename thrust::iterator_system<ForwardIterator1>::type;
+  using System2 = typename thrust::iterator_system<ForwardIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -252,10 +252,10 @@ thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -281,10 +281,10 @@ thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<InputIterator1>::type System1;
-  typedef typename thrust::iterator_system<InputIterator2>::type System2;
-  typedef typename thrust::iterator_system<OutputIterator1>::type System3;
-  typedef typename thrust::iterator_system<OutputIterator2>::type System4;
+  using System1 = typename thrust::iterator_system<InputIterator1>::type;
+  using System2 = typename thrust::iterator_system<InputIterator2>::type;
+  using System3 = typename thrust::iterator_system<OutputIterator1>::type;
+  using System4 = typename thrust::iterator_system<OutputIterator2>::type;
 
   System1 system1;
   System2 system2;
@@ -329,7 +329,7 @@ unique_count(ForwardIterator first, ForwardIterator last, BinaryPredicate binary
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 
@@ -343,7 +343,7 @@ unique_count(ForwardIterator first, ForwardIterator last)
 {
   using thrust::system::detail::generic::select_system;
 
-  typedef typename thrust::iterator_system<ForwardIterator>::type System;
+  using System = typename thrust::iterator_system<ForwardIterator>::type;
 
   System system;
 

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -49,24 +49,24 @@ template <typename T, typename Alloc>
 class vector_base
 {
 private:
-  typedef thrust::detail::contiguous_storage<T, Alloc> storage_type;
+  using storage_type = thrust::detail::contiguous_storage<T, Alloc>;
 
 public:
-  // typedefs
-  typedef typename storage_type::value_type value_type;
-  typedef typename storage_type::pointer pointer;
-  typedef typename storage_type::const_pointer const_pointer;
-  typedef typename storage_type::reference reference;
-  typedef typename storage_type::const_reference const_reference;
-  typedef typename storage_type::size_type size_type;
-  typedef typename storage_type::difference_type difference_type;
-  typedef typename storage_type::allocator_type allocator_type;
+  // aliases
+  using value_type      = typename storage_type::value_type;
+  using pointer         = typename storage_type::pointer;
+  using const_pointer   = typename storage_type::const_pointer;
+  using reference       = typename storage_type::reference;
+  using const_reference = typename storage_type::const_reference;
+  using size_type       = typename storage_type::size_type;
+  using difference_type = typename storage_type::difference_type;
+  using allocator_type  = typename storage_type::allocator_type;
 
-  typedef typename storage_type::iterator iterator;
-  typedef typename storage_type::const_iterator const_iterator;
+  using iterator       = typename storage_type::iterator;
+  using const_iterator = typename storage_type::const_iterator;
 
-  typedef thrust::reverse_iterator<iterator> reverse_iterator;
-  typedef thrust::reverse_iterator<const_iterator> const_reverse_iterator;
+  using reverse_iterator       = thrust::reverse_iterator<iterator>;
+  using const_reverse_iterator = thrust::reverse_iterator<const_iterator>;
 
   /*! This constructor creates an empty vector_base.
    */

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -277,7 +277,7 @@ vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last)
 {
   // check the type of InputIterator: if it's an integral type,
   // we need to interpret this call as (size_type, value_type)
-  typedef ::cuda::std::is_integral<InputIterator> Integer;
+  using Integer = ::cuda::std::is_integral<InputIterator>;
 
   init_dispatch(first, last, Integer());
 } // end vector_base::vector_base()
@@ -290,7 +290,7 @@ vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last, cons
 {
   // check the type of InputIterator: if it's an integral type,
   // we need to interpret this call as (size_type, value_type)
-  typedef ::cuda::std::is_integral<InputIterator> Integer;
+  using Integer = ::cuda::std::is_integral<InputIterator>;
 
   init_dispatch(first, last, Integer());
 } // end vector_base::vector_base()
@@ -602,7 +602,7 @@ void vector_base<T, Alloc>::assign(InputIterator first, InputIterator last)
 {
   // we could have received assign(n, x), so disambiguate on the
   // type of InputIterator
-  typedef typename ::cuda::std::is_integral<InputIterator> integral;
+  using integral = typename ::cuda::std::is_integral<InputIterator>;
 
   assign_dispatch(first, last, integral());
 } // end vector_base::assign()
@@ -640,7 +640,7 @@ void vector_base<T, Alloc>::insert(iterator position, InputIterator first, Input
 {
   // we could have received insert(position, n, x), so disambiguate on the
   // type of InputIterator
-  typedef typename ::cuda::std::is_integral<InputIterator> integral;
+  using integral = typename ::cuda::std::is_integral<InputIterator>;
 
   insert_dispatch(position, first, last, integral());
 } // end vector_base::insert()
@@ -1127,8 +1127,8 @@ bool vector_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 fi
 {
   typename thrust::iterator_difference<InputIterator1>::type n = thrust::distance(first1, last1);
 
-  typedef typename thrust::iterator_system<InputIterator1>::type FromSystem1;
-  typedef typename thrust::iterator_system<InputIterator2>::type FromSystem2;
+  using FromSystem1 = typename thrust::iterator_system<InputIterator1>::type;
+  using FromSystem2 = typename thrust::iterator_system<InputIterator2>::type;
 
   // bring both ranges to the host system
   // note that these copies are no-ops if the range is already convertible to the host system
@@ -1146,8 +1146,8 @@ bool vector_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 fi
 template <typename InputIterator1, typename InputIterator2>
 bool vector_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2)
 {
-  typedef typename thrust::iterator_system<InputIterator1>::type system1;
-  typedef typename thrust::iterator_system<InputIterator2>::type system2;
+  using system1 = typename thrust::iterator_system<InputIterator1>::type;
+  using system2 = typename thrust::iterator_system<InputIterator2>::type;
 
   // dispatch on the sameness of the two systems
   return vector_equal(first1, last1, first2, ::cuda::std::is_same<system1, system2>());

--- a/thrust/thrust/device_allocator.h
+++ b/thrust/thrust/device_allocator.h
@@ -51,7 +51,7 @@ THRUST_NAMESPACE_BEGIN
 template <typename Upstream>
 class device_ptr_memory_resource final : public thrust::mr::memory_resource<device_ptr<void>>
 {
-  typedef typename Upstream::pointer upstream_ptr;
+  using upstream_ptr = typename Upstream::pointer;
 
 public:
   /*! Initialize the adaptor with the global instance of the upstream resource. Obtains
@@ -93,7 +93,7 @@ template <typename T>
 class device_allocator
     : public thrust::mr::stateless_resource_allocator<T, device_ptr_memory_resource<device_memory_resource>>
 {
-  typedef thrust::mr::stateless_resource_allocator<T, device_ptr_memory_resource<device_memory_resource>> base;
+  using base = thrust::mr::stateless_resource_allocator<T, device_ptr_memory_resource<device_memory_resource>>;
 
 public:
   /*! The \p rebind metafunction provides the type of a \p device_allocator
@@ -104,9 +104,9 @@ public:
   template <typename U>
   struct rebind
   {
-    /*! The typedef \p other gives the type of the rebound \p device_allocator.
+    /*! The alias \p other gives the type of the rebound \p device_allocator.
      */
-    typedef device_allocator<U> other;
+    using other = device_allocator<U>;
   };
 
   /*! Default constructor has no effect. */

--- a/thrust/thrust/device_malloc_allocator.h
+++ b/thrust/thrust/device_malloc_allocator.h
@@ -68,25 +68,25 @@ class device_malloc_allocator
 {
 public:
   /*! Type of element allocated, \c T. */
-  typedef T value_type;
+  using value_type = T;
 
   /*! Pointer to allocation, \c device_ptr<T>. */
-  typedef device_ptr<T> pointer;
+  using pointer = device_ptr<T>;
 
   /*! \c const pointer to allocation, \c device_ptr<const T>. */
-  typedef device_ptr<const T> const_pointer;
+  using const_pointer = device_ptr<const T>;
 
   /*! Reference to allocated element, \c device_reference<T>. */
-  typedef device_reference<T> reference;
+  using reference = device_reference<T>;
 
   /*! \c const reference to allocated element, \c device_reference<const T>. */
-  typedef device_reference<const T> const_reference;
+  using const_reference = device_reference<const T>;
 
   /*! Type of allocation size, \c std::size_t. */
-  typedef std::size_t size_type;
+  using size_type = std::size_t;
 
   /*! Type of allocation difference, \c pointer::difference_type. */
-  typedef typename pointer::difference_type difference_type;
+  using difference_type = typename pointer::difference_type;
 
   /*! The \p rebind metafunction provides the type of a \p device_malloc_allocator
    *  instantiated with another type.
@@ -96,9 +96,9 @@ public:
   template <typename U>
   struct rebind
   {
-    /*! The typedef \p other gives the type of the rebound \p device_malloc_allocator.
+    /*! The alias \p other gives the type of the rebound \p device_malloc_allocator.
      */
-    typedef device_malloc_allocator<U> other;
+    using other = device_malloc_allocator<U>;
   }; // end rebind
 
   /*! No-argument constructor has no effect. */

--- a/thrust/thrust/device_new_allocator.h
+++ b/thrust/thrust/device_new_allocator.h
@@ -58,25 +58,25 @@ class device_new_allocator
 {
 public:
   /*! Type of element allocated, \c T. */
-  typedef T value_type;
+  using value_type = T;
 
   /*! Pointer to allocation, \c device_ptr<T>. */
-  typedef device_ptr<T> pointer;
+  using pointer = device_ptr<T>;
 
   /*! \c const pointer to allocation, \c device_ptr<const T>. */
-  typedef device_ptr<const T> const_pointer;
+  using const_pointer = device_ptr<const T>;
 
   /*! Reference to allocated element, \c device_reference<T>. */
-  typedef device_reference<T> reference;
+  using reference = device_reference<T>;
 
   /*! \c const reference to allocated element, \c device_reference<const T>. */
-  typedef device_reference<const T> const_reference;
+  using const_reference = device_reference<const T>;
 
   /*! Type of allocation size, \c ::cuda::std::size_t. */
-  typedef ::cuda::std::size_t size_type;
+  using size_type = ::cuda::std::size_t;
 
   /*! Type of allocation difference, \c pointer::difference_type. */
-  typedef typename pointer::difference_type difference_type;
+  using difference_type = typename pointer::difference_type;
 
   /*! The \p rebind metafunction provides the type of a \p device_new_allocator
    *  instantiated with another type.
@@ -86,9 +86,9 @@ public:
   template <typename U>
   struct rebind
   {
-    /*! The typedef \p other gives the type of the rebound \p device_new_allocator.
+    /*! The alias \p other gives the type of the rebound \p device_new_allocator.
      */
-    typedef device_new_allocator<U> other;
+    using other = device_new_allocator<U>;
   }; // end rebind
 
   /*! No-argument constructor has no effect. */

--- a/thrust/thrust/device_reference.h
+++ b/thrust/thrust/device_reference.h
@@ -192,16 +192,16 @@ template <typename T>
 class device_reference : public thrust::reference<T, thrust::device_ptr<T>, thrust::device_reference<T>>
 {
 private:
-  typedef thrust::reference<T, thrust::device_ptr<T>, thrust::device_reference<T>> super_t;
+  using super_t = thrust::reference<T, thrust::device_ptr<T>, thrust::device_reference<T>>;
 
 public:
   /*! The type of the value referenced by this type of \p device_reference.
    */
-  typedef typename super_t::value_type value_type;
+  using value_type = typename super_t::value_type;
 
   /*! The type of the expression <tt>&ref</tt>, where <tt>ref</tt> is a \p device_reference.
    */
-  typedef typename super_t::pointer pointer;
+  using pointer = typename super_t::pointer;
 
   /*! This copy constructor accepts a const reference to another
    *  \p device_reference. After this \p device_reference is constructed,

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -59,13 +59,13 @@ template <typename T, typename Alloc = thrust::device_allocator<T>>
 class device_vector : public detail::vector_base<T, Alloc>
 {
 private:
-  typedef detail::vector_base<T, Alloc> Parent;
+  using Parent = detail::vector_base<T, Alloc>;
 
 public:
   /*! \cond
    */
-  typedef typename Parent::size_type size_type;
-  typedef typename Parent::value_type value_type;
+  using size_type  = typename Parent::size_type;
+  using value_type = typename Parent::value_type;
   /*! \endcond
    */
 

--- a/thrust/thrust/execution_policy.h
+++ b/thrust/thrust/execution_policy.h
@@ -55,9 +55,9 @@ THRUST_NAMESPACE_BEGIN
 namespace detail
 {
 
-typedef thrust::system::__THRUST_HOST_SYSTEM_NAMESPACE::detail::par_t host_t;
+using host_t = thrust::system::cpp::detail::par_t;
 
-typedef thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::detail::par_t device_t;
+using device_t = thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::detail::par_t;
 
 } // namespace detail
 

--- a/thrust/thrust/functional.h
+++ b/thrust/thrust/functional.h
@@ -53,7 +53,7 @@ struct binary_traits;
  *  or member variables, but only type information. The only reason it exists
  *  is to make it more convenient to define types that are models of the
  *  concept Adaptable Unary Function. Specifically, any model of Adaptable
- *  Unary Function must define nested \c typedefs. Those \c typedefs are
+ *  Unary Function must define nested aliases. Those are
  *  provided by the base class \p unary_function.
  *
  *  The following code snippet demonstrates how to construct an
@@ -80,19 +80,19 @@ struct unary_function
   /*! \typedef argument_type
    *  \brief The type of the function object's argument.
    */
-  typedef Argument argument_type;
+  using argument_type = Argument;
 
   /*! \typedef result_type;
    *  \brief The type of the function object's result.
    */
-  typedef Result result_type;
+  using result_type = Result;
 }; // end unary_function
 
 /*! \p binary_function is an empty base class: it contains no member functions
  *  or member variables, but only type information. The only reason it exists
  *  is to make it more convenient to define types that are models of the
  *  concept Adaptable Binary Function. Specifically, any model of Adaptable
- *  Binary Function must define nested \c typedefs. Those \c typedefs are
+ *  Binary Function must define nested aliases. Those are
  *  provided by the base class \p binary_function.
  *
  *  The following code snippet demonstrates how to construct an
@@ -119,17 +119,17 @@ struct binary_function
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef Argument1 first_argument_type;
+  using first_argument_type = Argument1;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef Argument2 second_argument_type;
+  using second_argument_type = Argument2;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef Result result_type;
+  using result_type = Result;
 }; // end binary_function
 
 /*! \}
@@ -215,17 +215,17 @@ struct plus
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>lhs + rhs</tt>.
    */
@@ -278,17 +278,17 @@ struct minus
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>lhs - rhs</tt>.
    */
@@ -341,17 +341,17 @@ struct multiplies
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>lhs * rhs</tt>.
    */
@@ -404,17 +404,17 @@ struct divides
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>lhs / rhs</tt>.
    */
@@ -467,17 +467,17 @@ struct modulus
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>lhs % rhs</tt>.
    */
@@ -527,12 +527,12 @@ struct negate
   /*! \typedef argument_type
    *  \brief The type of the function object's argument.
    */
-  typedef T argument_type;
+  using argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>-x</tt>.
    */
@@ -581,12 +581,12 @@ struct square
   /*! \typedef argument_type
    *  \brief The type of the function object's argument.
    */
-  typedef T argument_type;
+  using argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>x*x</tt>.
    */
@@ -625,17 +625,17 @@ struct equal_to
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef bool result_type;
+  using result_type = bool;
 
   /*! Function call operator. The return value is <tt>lhs == rhs</tt>.
    */
@@ -666,17 +666,17 @@ struct not_equal_to
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef bool result_type;
+  using result_type = bool;
 
   /*! Function call operator. The return value is <tt>lhs != rhs</tt>.
    */
@@ -707,17 +707,17 @@ struct greater
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef bool result_type;
+  using result_type = bool;
 
   /*! Function call operator. The return value is <tt>lhs > rhs</tt>.
    */
@@ -748,17 +748,17 @@ struct less
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef bool result_type;
+  using result_type = bool;
 
   /*! Function call operator. The return value is <tt>lhs < rhs</tt>.
    */
@@ -789,17 +789,17 @@ struct greater_equal
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef bool result_type;
+  using result_type = bool;
 
   /*! Function call operator. The return value is <tt>lhs >= rhs</tt>.
    */
@@ -830,17 +830,17 @@ struct less_equal
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef bool result_type;
+  using result_type = bool;
 
   /*! Function call operator. The return value is <tt>lhs <= rhs</tt>.
    */
@@ -878,17 +878,17 @@ struct logical_and
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef bool result_type;
+  using result_type = bool;
 
   /*! Function call operator. The return value is <tt>lhs && rhs</tt>.
    */
@@ -918,17 +918,17 @@ struct logical_or
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef bool result_type;
+  using result_type = bool;
 
   /*! Function call operator. The return value is <tt>lhs || rhs</tt>.
    */
@@ -972,17 +972,17 @@ struct logical_not
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef bool result_type;
+  using result_type = bool;
 
   /*! Function call operator. The return value is <tt>!x</tt>.
    */
@@ -1042,17 +1042,17 @@ struct bit_and
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>lhs & rhs</tt>.
    */
@@ -1104,17 +1104,17 @@ struct bit_or
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>lhs | rhs</tt>.
    */
@@ -1166,17 +1166,17 @@ struct bit_xor
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>lhs ^ rhs</tt>.
    */
@@ -1223,12 +1223,12 @@ struct identity
   /*! \typedef argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T argument_type;
+  using argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>x</tt>.
    */
@@ -1272,17 +1272,17 @@ struct maximum
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>rhs < lhs ? lhs : rhs</tt>.
    */
@@ -1326,17 +1326,17 @@ struct minimum
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T first_argument_type;
+  using first_argument_type = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T second_argument_type;
+  using second_argument_type = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T result_type;
+  using result_type = T;
 
   /*! Function call operator. The return value is <tt>lhs < rhs ? lhs : rhs</tt>.
    */
@@ -1373,17 +1373,17 @@ struct project1st
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T1 first_argument_type;
+  using first_argument_type = T1;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T2 second_argument_type;
+  using second_argument_type = T2;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T1 result_type;
+  using result_type = T1;
 
   /*! Function call operator. The return value is <tt>lhs</tt>.
    */
@@ -1430,17 +1430,17 @@ struct project2nd
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
    */
-  typedef T1 first_argument_type;
+  using first_argument_type = T1;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    */
-  typedef T2 second_argument_type;
+  using second_argument_type = T2;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    */
-  typedef T2 result_type;
+  using result_type = T2;
 
   /*! Function call operator. The return value is <tt>rhs</tt>.
    */

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -60,13 +60,13 @@ template <typename T, typename Alloc = std::allocator<T>>
 class host_vector : public detail::vector_base<T, Alloc>
 {
 private:
-  typedef detail::vector_base<T, Alloc> Parent;
+  using Parent = detail::vector_base<T, Alloc>;
 
 public:
   /*! \cond
    */
-  typedef typename Parent::size_type size_type;
-  typedef typename Parent::value_type value_type;
+  using size_type  = typename Parent::size_type;
+  using value_type = typename Parent::value_type;
   /*! \endcond
    */
 

--- a/thrust/thrust/iterator/constant_iterator.h
+++ b/thrust/thrust/iterator/constant_iterator.h
@@ -105,13 +105,13 @@ class constant_iterator : public detail::constant_iterator_base<Value, Increment
   /*! \cond
    */
   friend class thrust::iterator_core_access;
-  typedef typename detail::constant_iterator_base<Value, Incrementable, System>::type super_t;
-  typedef typename detail::constant_iterator_base<Value, Incrementable, System>::incrementable incrementable;
-  typedef typename detail::constant_iterator_base<Value, Incrementable, System>::base_iterator base_iterator;
+  using super_t       = typename detail::constant_iterator_base<Value, Incrementable, System>::type;
+  using incrementable = typename detail::constant_iterator_base<Value, Incrementable, System>::incrementable;
+  using base_iterator = typename detail::constant_iterator_base<Value, Incrementable, System>::base_iterator;
 
 public:
-  typedef typename super_t::reference reference;
-  typedef typename super_t::value_type value_type;
+  using reference  = typename super_t::reference;
+  using value_type = typename super_t::value_type;
 
   /*! \endcond
    */

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -115,7 +115,7 @@ THRUST_NAMESPACE_BEGIN
  *   thrust::device_vector<int> indices(8);
  *
  *   // compute indices of nonzero elements
- *   typedef thrust::device_vector<int>::iterator IndexIterator;
+ *   using IndexIterator = thrust::device_vector<int>::iterator;
  *
  *   // use make_counting_iterator to define the sequence [0, 8)
  *   IndexIterator indices_end = thrust::copy_if(thrust::make_counting_iterator(0),
@@ -139,13 +139,13 @@ class counting_iterator : public detail::counting_iterator_base<Incrementable, S
 {
   /*! \cond
    */
-  typedef typename detail::counting_iterator_base<Incrementable, System, Traversal, Difference>::type super_t;
+  using super_t = typename detail::counting_iterator_base<Incrementable, System, Traversal, Difference>::type;
 
   friend class thrust::iterator_core_access;
 
 public:
-  typedef typename super_t::reference reference;
-  typedef typename super_t::difference_type difference_type;
+  using reference       = typename super_t::reference;
+  using difference_type = typename super_t::difference_type;
 
   /*! \endcond
    */
@@ -196,7 +196,7 @@ private:
   _CCCL_HOST_DEVICE bool
   equal(counting_iterator<OtherIncrementable, OtherSystem, OtherTraversal, OtherDifference> const& y) const
   {
-    typedef thrust::detail::counting_iterator_equal<difference_type, Incrementable, OtherIncrementable> e;
+    using e = thrust::detail::counting_iterator_equal<difference_type, Incrementable, OtherIncrementable>;
     return e::equal(this->base(), y.base());
   }
 
@@ -204,11 +204,11 @@ private:
   _CCCL_HOST_DEVICE difference_type
   distance_to(counting_iterator<OtherIncrementable, System, Traversal, Difference> const& y) const
   {
-    typedef typename thrust::detail::eval_if<
+    using d = typename thrust::detail::eval_if<
       thrust::detail::is_numeric<Incrementable>::value,
       thrust::detail::identity_<thrust::detail::number_distance<difference_type, Incrementable, OtherIncrementable>>,
       thrust::detail::identity_<
-        thrust::detail::iterator_distance<difference_type, Incrementable, OtherIncrementable>>>::type d;
+        thrust::detail::iterator_distance<difference_type, Incrementable, OtherIncrementable>>>::type;
 
     return d::distance(this->base(), y.base());
   }

--- a/thrust/thrust/iterator/detail/constant_iterator_base.h
+++ b/thrust/thrust/iterator/detail/constant_iterator_base.h
@@ -41,31 +41,28 @@ namespace detail
 template <typename Value, typename Incrementable, typename System>
 struct constant_iterator_base
 {
-  typedef Value value_type;
+  using value_type = Value;
 
   // the reference type is the same as the value_type.
   // we wish to avoid returning a reference to the internal state
   // of the constant_iterator, which is prone to subtle bugs.
   // consider the temporary iterator created in the expression
   // *(iter + i)
-  typedef value_type reference;
+  using reference = value_type;
 
   // the incrementable type is int unless otherwise specified
-  typedef
-    typename thrust::detail::ia_dflt_help<Incrementable, thrust::detail::identity_<thrust::detail::intmax_t>>::type
-      incrementable;
+  using incrementable =
+    typename thrust::detail::ia_dflt_help<Incrementable, thrust::detail::identity_<thrust::detail::intmax_t>>::type;
 
-  typedef typename thrust::counting_iterator<incrementable, System, thrust::random_access_traversal_tag> base_iterator;
+  using base_iterator = typename thrust::counting_iterator<incrementable, System, thrust::random_access_traversal_tag>;
 
-  typedef
-    typename thrust::iterator_adaptor<constant_iterator<Value, Incrementable, System>,
-                                      base_iterator,
-                                      value_type, // XXX we may need to pass const value_type here as boost
-                                                  // counting_iterator does
-                                      typename thrust::iterator_system<base_iterator>::type,
-                                      typename thrust::iterator_traversal<base_iterator>::type,
-                                      reference>
-      type;
+  using type = typename thrust::iterator_adaptor<
+    constant_iterator<Value, Incrementable, System>,
+    base_iterator,
+    value_type,
+    typename thrust::iterator_system<base_iterator>::type,
+    typename thrust::iterator_traversal<base_iterator>::type,
+    reference>;
 }; // end constant_iterator_base
 
 } // namespace detail

--- a/thrust/thrust/iterator/detail/counting_iterator.inl
+++ b/thrust/thrust/iterator/detail/counting_iterator.inl
@@ -45,40 +45,38 @@ namespace detail
 template <typename Incrementable, typename System, typename Traversal, typename Difference>
 struct counting_iterator_base
 {
-  typedef typename thrust::detail::eval_if<
-    // use any_system_tag if we are given use_default
-    ::cuda::std::is_same<System, use_default>::value,
-    thrust::detail::identity_<thrust::any_system_tag>,
-    thrust::detail::identity_<System>>::type system;
+  using system = typename thrust::detail::eval_if<::cuda::std::is_same<System, use_default>::value,
+                                                  thrust::detail::identity_<thrust::any_system_tag>,
+                                                  thrust::detail::identity_<System>>::type;
 
-  typedef typename thrust::detail::ia_dflt_help<
+  using traversal = typename thrust::detail::ia_dflt_help<
     Traversal,
     thrust::detail::eval_if<thrust::detail::is_numeric<Incrementable>::value,
                             thrust::detail::identity_<random_access_traversal_tag>,
-                            thrust::iterator_traversal<Incrementable>>>::type traversal;
+                            thrust::iterator_traversal<Incrementable>>>::type;
 
   // unlike Boost, we explicitly use std::ptrdiff_t as the difference type
   // for floating point counting_iterators
-  typedef typename thrust::detail::ia_dflt_help<
+  using difference = typename thrust::detail::ia_dflt_help<
     Difference,
     thrust::detail::eval_if<thrust::detail::is_numeric<Incrementable>::value,
                             thrust::detail::eval_if<::cuda::std::is_integral<Incrementable>::value,
                                                     thrust::detail::numeric_difference<Incrementable>,
                                                     thrust::detail::identity_<std::ptrdiff_t>>,
-                            thrust::iterator_difference<Incrementable>>>::type difference;
+                            thrust::iterator_difference<Incrementable>>>::type;
 
   // our implementation departs from Boost's in that counting_iterator::dereference
   // returns a copy of its counter, rather than a reference to it. returning a reference
   // to the internal state of an iterator causes subtle bugs (consider the temporary
   // iterator created in the expression *(iter + i)) and has no compelling use case
-  typedef thrust::iterator_adaptor<counting_iterator<Incrementable, System, Traversal, Difference>, // self
-                                   Incrementable, // Base
-                                   Incrementable, // XXX we may need to pass const here as Boost does
-                                   system,
-                                   traversal,
-                                   Incrementable,
-                                   difference>
-    type;
+  using type =
+    thrust::iterator_adaptor<counting_iterator<Incrementable, System, Traversal, Difference>,
+                             Incrementable,
+                             Incrementable,
+                             system,
+                             traversal,
+                             Incrementable,
+                             difference>;
 }; // end counting_iterator_base
 
 template <typename Difference, typename Incrementable1, typename Incrementable2>
@@ -118,7 +116,7 @@ struct counting_iterator_equal<Difference,
 {
   _CCCL_HOST_DEVICE static bool equal(Incrementable1 x, Incrementable2 y)
   {
-    typedef number_distance<Difference, Incrementable1, Incrementable2> d;
+    using d = number_distance<Difference, Incrementable1, Incrementable2>;
     return d::distance(x, y) == 0;
   }
 };

--- a/thrust/thrust/iterator/detail/device_system_tag.h
+++ b/thrust/thrust/iterator/detail/device_system_tag.h
@@ -33,6 +33,6 @@
 
 THRUST_NAMESPACE_BEGIN
 
-typedef thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::tag device_system_tag;
+using device_system_tag = thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::tag;
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/iterator/detail/discard_iterator_base.h
+++ b/thrust/thrust/iterator/detail/discard_iterator_base.h
@@ -45,20 +45,19 @@ struct discard_iterator_base
 {
   // XXX value_type should actually be void
   //     but this interferes with zip_iterator<discard_iterator>
-  typedef any_assign value_type;
-  typedef any_assign& reference;
-  typedef std::ptrdiff_t incrementable;
+  using value_type    = any_assign;
+  using reference     = any_assign&;
+  using incrementable = std::ptrdiff_t;
 
-  typedef typename thrust::counting_iterator<incrementable, System, thrust::random_access_traversal_tag> base_iterator;
+  using base_iterator = typename thrust::counting_iterator<incrementable, System, thrust::random_access_traversal_tag>;
 
-  typedef
-    typename thrust::iterator_adaptor<discard_iterator<System>,
-                                      base_iterator,
-                                      value_type,
-                                      typename thrust::iterator_system<base_iterator>::type,
-                                      typename thrust::iterator_traversal<base_iterator>::type,
-                                      reference>
-      type;
+  using type = typename thrust::iterator_adaptor<
+    discard_iterator<System>,
+    base_iterator,
+    value_type,
+    typename thrust::iterator_system<base_iterator>::type,
+    typename thrust::iterator_traversal<base_iterator>::type,
+    reference>;
 }; // end discard_iterator_base
 
 } // namespace detail

--- a/thrust/thrust/iterator/detail/host_system_tag.h
+++ b/thrust/thrust/iterator/detail/host_system_tag.h
@@ -33,6 +33,6 @@
 
 THRUST_NAMESPACE_BEGIN
 
-typedef thrust::system::__THRUST_HOST_SYSTEM_NAMESPACE::tag host_system_tag;
+using host_system_tag = thrust::system::__THRUST_HOST_SYSTEM_NAMESPACE::tag;
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/iterator/detail/iterator_adaptor_base.h
+++ b/thrust/thrust/iterator/detail/iterator_adaptor_base.h
@@ -66,20 +66,21 @@ template <typename Derived,
           typename Difference>
 struct iterator_adaptor_base
 {
-  typedef typename ia_dflt_help<Value, iterator_value<Base>>::type value;
+  using value = typename ia_dflt_help<Value, iterator_value<Base>>::type;
 
-  typedef typename ia_dflt_help<System, thrust::iterator_system<Base>>::type system;
+  using system = typename ia_dflt_help<System, thrust::iterator_system<Base>>::type;
 
-  typedef typename ia_dflt_help<Traversal, thrust::iterator_traversal<Base>>::type traversal;
+  using traversal = typename ia_dflt_help<Traversal, thrust::iterator_traversal<Base>>::type;
 
-  typedef typename ia_dflt_help<Reference,
-                                thrust::detail::eval_if<::cuda::std::is_same<Value, use_default>::value,
-                                                        thrust::iterator_reference<Base>,
-                                                        ::cuda::std::add_lvalue_reference<Value>>>::type reference;
+  using reference =
+    typename ia_dflt_help<Reference,
+                          thrust::detail::eval_if<::cuda::std::is_same<Value, use_default>::value,
+                                                  thrust::iterator_reference<Base>,
+                                                  ::cuda::std::add_lvalue_reference<Value>>>::type;
 
-  typedef typename ia_dflt_help<Difference, iterator_difference<Base>>::type difference;
+  using difference = typename ia_dflt_help<Difference, iterator_difference<Base>>::type;
 
-  typedef thrust::iterator_facade<Derived, value, system, traversal, reference, difference> type;
+  using type = thrust::iterator_facade<Derived, value, system, traversal, reference, difference>;
 }; // end iterator_adaptor_base
 
 } // namespace detail

--- a/thrust/thrust/iterator/detail/iterator_category_with_system_and_traversal.h
+++ b/thrust/thrust/iterator/detail/iterator_category_with_system_and_traversal.h
@@ -41,7 +41,7 @@ struct iterator_category_to_system;
 template <typename Category, typename System, typename Traversal>
 struct iterator_category_to_system<iterator_category_with_system_and_traversal<Category, System, Traversal>>
 {
-  typedef System type;
+  using type = System;
 }; // end iterator_category_to_system
 
 // specialize iterator_category_to_traversal for iterator_category_with_system_and_traversal
@@ -51,7 +51,7 @@ struct iterator_category_to_traversal;
 template <typename Category, typename System, typename Traversal>
 struct iterator_category_to_traversal<iterator_category_with_system_and_traversal<Category, System, Traversal>>
 {
-  typedef Traversal type;
+  using type = Traversal;
 }; // end iterator_category_to_traversal
 
 } // namespace detail

--- a/thrust/thrust/iterator/detail/iterator_facade_category.h
+++ b/thrust/thrust/iterator/detail/iterator_facade_category.h
@@ -150,11 +150,10 @@ struct iterator_facade_default_category_device
 template <typename Traversal, typename ValueParam, typename Reference>
 struct iterator_facade_default_category_any
 {
-  typedef thrust::detail::iterator_category_with_system_and_traversal<
+  using type = thrust::detail::iterator_category_with_system_and_traversal<
     typename iterator_facade_default_category_std<Traversal, ValueParam, Reference>::type,
     thrust::any_system_tag,
-    Traversal>
-    type;
+    Traversal>;
 }; // end iterator_facade_default_category_any
 
 template <typename System, typename Traversal, typename ValueParam, typename Reference>
@@ -184,26 +183,26 @@ struct iterator_facade_default_category
 template <typename System, typename Traversal, typename ValueParam, typename Reference>
 struct iterator_facade_category_impl
 {
-  typedef typename iterator_facade_default_category<System, Traversal, ValueParam, Reference>::type category;
+  using category = typename iterator_facade_default_category<System, Traversal, ValueParam, Reference>::type;
 
   // we must be able to deduce both Traversal & System from category
   // otherwise, munge them all together
-  typedef typename thrust::detail::eval_if<
+  using type = typename thrust::detail::eval_if<
     ::cuda::std::_And<
       ::cuda::std::is_same<Traversal, typename thrust::detail::iterator_category_to_traversal<category>::type>,
       ::cuda::std::is_same<System, typename thrust::detail::iterator_category_to_system<category>::type>>::value,
     thrust::detail::identity_<category>,
     thrust::detail::identity_<
-      thrust::detail::iterator_category_with_system_and_traversal<category, System, Traversal>>>::type type;
+      thrust::detail::iterator_category_with_system_and_traversal<category, System, Traversal>>>::type;
 }; // end iterator_facade_category_impl
 
 template <typename CategoryOrSystem, typename CategoryOrTraversal, typename ValueParam, typename Reference>
 struct iterator_facade_category
 {
-  typedef typename thrust::detail::eval_if<
+  using type = typename thrust::detail::eval_if<
     thrust::detail::is_iterator_category<CategoryOrTraversal>::value,
-    thrust::detail::identity_<CategoryOrTraversal>, // categories are fine as-is
-    iterator_facade_category_impl<CategoryOrSystem, CategoryOrTraversal, ValueParam, Reference>>::type type;
+    thrust::detail::identity_<CategoryOrTraversal>,
+    iterator_facade_category_impl<CategoryOrSystem, CategoryOrTraversal, ValueParam, Reference>>::type;
 }; // end iterator_facade_category
 
 } // namespace detail

--- a/thrust/thrust/iterator/detail/iterator_traits.inl
+++ b/thrust/thrust/iterator/detail/iterator_traits.inl
@@ -36,7 +36,7 @@ THRUST_NAMESPACE_BEGIN
 template <typename Iterator>
 struct iterator_value
 {
-  typedef typename thrust::iterator_traits<Iterator>::value_type type;
+  using type = typename thrust::iterator_traits<Iterator>::value_type;
 }; // end iterator_value
 
 template <typename Iterator>
@@ -45,7 +45,7 @@ using iterator_value_t = typename iterator_value<Iterator>::type;
 template <typename Iterator>
 struct iterator_pointer
 {
-  typedef typename thrust::iterator_traits<Iterator>::pointer type;
+  using type = typename thrust::iterator_traits<Iterator>::pointer;
 }; // end iterator_pointer
 
 template <typename Iterator>
@@ -54,7 +54,7 @@ using iterator_pointer_t = typename iterator_pointer<Iterator>::type;
 template <typename Iterator>
 struct iterator_reference
 {
-  typedef typename iterator_traits<Iterator>::reference type;
+  using type = typename iterator_traits<Iterator>::reference;
 }; // end iterator_reference
 
 template <typename Iterator>
@@ -63,7 +63,7 @@ using iterator_reference_t = typename iterator_reference<Iterator>::type;
 template <typename Iterator>
 struct iterator_difference
 {
-  typedef typename thrust::iterator_traits<Iterator>::difference_type type;
+  using type = typename thrust::iterator_traits<Iterator>::difference_type;
 }; // end iterator_difference
 
 template <typename Iterator>
@@ -91,13 +91,13 @@ struct iterator_system : detail::iterator_system_impl<Iterator>
 template <>
 struct iterator_system<void*>
 {
-  typedef thrust::iterator_system<int*>::type type;
+  using type = thrust::iterator_system<int*>::type;
 }; // end iterator_system<void*>
 
 template <>
 struct iterator_system<const void*>
 {
-  typedef thrust::iterator_system<const int*>::type type;
+  using type = thrust::iterator_system<const int*>::type;
 }; // end iterator_system<void*>
 
 template <typename Iterator>

--- a/thrust/thrust/iterator/detail/join_iterator.h
+++ b/thrust/thrust/iterator/detail/join_iterator.h
@@ -43,20 +43,20 @@ namespace join_iterator_detail
 template <typename RandomAccessIterator1, typename RandomAccessIterator2, typename Difference, typename Reference>
 struct join_iterator_base
 {
-  typedef ::cuda::std::__libcpp_remove_reference_t<Reference> value_type;
+  using value_type = ::cuda::std::__libcpp_remove_reference_t<Reference>;
 
-  typedef typename thrust::iterator_system<RandomAccessIterator1>::type system1;
-  typedef typename thrust::iterator_system<RandomAccessIterator2>::type system2;
-  typedef typename thrust::detail::minimum_system<system1, system2>::type system;
+  using system1 = typename thrust::iterator_system<RandomAccessIterator1>::type;
+  using system2 = typename thrust::iterator_system<RandomAccessIterator2>::type;
+  using system  = typename thrust::detail::minimum_system<system1, system2>::type;
 
-  typedef thrust::iterator_adaptor<join_iterator<RandomAccessIterator1, RandomAccessIterator2, Difference, Reference>,
-                                   thrust::counting_iterator<Difference>,
-                                   value_type,
-                                   system,
-                                   thrust::random_access_traversal_tag,
-                                   Reference,
-                                   Difference>
-    type;
+  using type =
+    thrust::iterator_adaptor<join_iterator<RandomAccessIterator1, RandomAccessIterator2, Difference, Reference>,
+                             thrust::counting_iterator<Difference>,
+                             value_type,
+                             system,
+                             thrust::random_access_traversal_tag,
+                             Reference,
+                             Difference>;
 }; // end join_iterator_base
 
 } // namespace join_iterator_detail
@@ -70,9 +70,9 @@ class join_iterator
         join_iterator_base<RandomAccessIterator1, RandomAccessIterator2, Difference, Reference>::type
 {
 private:
-  typedef typename join_iterator_detail::
-    join_iterator_base<RandomAccessIterator1, RandomAccessIterator2, Difference, Reference>::type super_t;
-  typedef typename super_t::difference_type size_type;
+  using super_t = typename join_iterator_detail::
+    join_iterator_base<RandomAccessIterator1, RandomAccessIterator2, Difference, Reference>::type;
+  using size_type = typename super_t::difference_type;
 
 public:
   inline _CCCL_HOST_DEVICE join_iterator(RandomAccessIterator1 first1, size_type n, RandomAccessIterator2 first2)

--- a/thrust/thrust/iterator/detail/normal_iterator.h
+++ b/thrust/thrust/iterator/detail/normal_iterator.h
@@ -42,7 +42,7 @@ namespace detail
 template <typename Pointer>
 class normal_iterator : public iterator_adaptor<normal_iterator<Pointer>, Pointer>
 {
-  typedef iterator_adaptor<normal_iterator<Pointer>, Pointer> super_t;
+  using super_t = iterator_adaptor<normal_iterator<Pointer>, Pointer>;
 
 public:
   _CCCL_HOST_DEVICE normal_iterator() {}

--- a/thrust/thrust/iterator/detail/permutation_iterator_base.h
+++ b/thrust/thrust/iterator/detail/permutation_iterator_base.h
@@ -42,16 +42,16 @@ namespace detail
 template <typename ElementIterator, typename IndexIterator>
 struct permutation_iterator_base
 {
-  typedef typename thrust::iterator_system<ElementIterator>::type System1;
-  typedef typename thrust::iterator_system<IndexIterator>::type System2;
+  using System1 = typename thrust::iterator_system<ElementIterator>::type;
+  using System2 = typename thrust::iterator_system<IndexIterator>::type;
 
-  typedef thrust::iterator_adaptor<permutation_iterator<ElementIterator, IndexIterator>,
-                                   IndexIterator,
-                                   typename thrust::iterator_value<ElementIterator>::type,
-                                   typename detail::minimum_system<System1, System2>::type,
-                                   thrust::use_default,
-                                   typename thrust::iterator_reference<ElementIterator>::type>
-    type;
+  using type =
+    thrust::iterator_adaptor<permutation_iterator<ElementIterator, IndexIterator>,
+                             IndexIterator,
+                             typename thrust::iterator_value<ElementIterator>::type,
+                             typename detail::minimum_system<System1, System2>::type,
+                             thrust::use_default,
+                             typename thrust::iterator_reference<ElementIterator>::type>;
 }; // end permutation_iterator_base
 
 } // namespace detail

--- a/thrust/thrust/iterator/detail/reverse_iterator_base.h
+++ b/thrust/thrust/iterator/detail/reverse_iterator_base.h
@@ -40,7 +40,7 @@ namespace detail
 template <typename BidirectionalIterator>
 struct reverse_iterator_base
 {
-  typedef thrust::iterator_adaptor<thrust::reverse_iterator<BidirectionalIterator>, BidirectionalIterator> type;
+  using type = thrust::iterator_adaptor<thrust::reverse_iterator<BidirectionalIterator>, BidirectionalIterator>;
 }; // end reverse_iterator_base
 
 } // namespace detail

--- a/thrust/thrust/iterator/detail/tagged_iterator.h
+++ b/thrust/thrust/iterator/detail/tagged_iterator.h
@@ -40,21 +40,21 @@ class tagged_iterator;
 template <typename Iterator, typename Tag>
 struct tagged_iterator_base
 {
-  typedef thrust::iterator_adaptor<tagged_iterator<Iterator, Tag>,
-                                   Iterator,
-                                   typename thrust::iterator_value<Iterator>::type,
-                                   Tag,
-                                   typename thrust::iterator_traversal<Iterator>::type,
-                                   typename thrust::iterator_reference<Iterator>::type,
-                                   typename thrust::iterator_difference<Iterator>::type>
-    type;
+  using type =
+    thrust::iterator_adaptor<tagged_iterator<Iterator, Tag>,
+                             Iterator,
+                             typename thrust::iterator_value<Iterator>::type,
+                             Tag,
+                             typename thrust::iterator_traversal<Iterator>::type,
+                             typename thrust::iterator_reference<Iterator>::type,
+                             typename thrust::iterator_difference<Iterator>::type>;
 }; // end tagged_iterator_base
 
 template <typename Iterator, typename Tag>
 class tagged_iterator : public tagged_iterator_base<Iterator, Tag>::type
 {
 private:
-  typedef typename tagged_iterator_base<Iterator, Tag>::type super_t;
+  using super_t = typename tagged_iterator_base<Iterator, Tag>::type;
 
 public:
   _CCCL_HOST_DEVICE tagged_iterator() {}

--- a/thrust/thrust/iterator/detail/transform_input_output_iterator.inl
+++ b/thrust/thrust/iterator/detail/transform_input_output_iterator.inl
@@ -90,13 +90,13 @@ private:
   using iterator_value_type = typename thrust::iterator_value<Iterator>::type;
 
 public:
-  typedef thrust::iterator_adaptor<transform_input_output_iterator<InputFunction, OutputFunction, Iterator>,
-                                   Iterator,
-                                   detail::invoke_result_t<InputFunction, iterator_value_type>,
-                                   thrust::use_default,
-                                   thrust::use_default,
-                                   transform_input_output_iterator_proxy<InputFunction, OutputFunction, Iterator>>
-    type;
+  using type =
+    thrust::iterator_adaptor<transform_input_output_iterator<InputFunction, OutputFunction, Iterator>,
+                             Iterator,
+                             detail::invoke_result_t<InputFunction, iterator_value_type>,
+                             thrust::use_default,
+                             thrust::use_default,
+                             transform_input_output_iterator_proxy<InputFunction, OutputFunction, Iterator>>;
 };
 
 // Register transform_input_output_iterator_proxy with 'is_proxy_reference' from

--- a/thrust/thrust/iterator/detail/transform_iterator.inl
+++ b/thrust/thrust/iterator/detail/transform_iterator.inl
@@ -46,29 +46,21 @@ struct transform_iterator_base
 {
 private:
   // By default, dereferencing the iterator yields the same as the function.
-  typedef typename thrust::detail::ia_dflt_help<
+  using reference = typename thrust::detail::ia_dflt_help<
     Reference,
-    thrust::detail::result_of_adaptable_function<UnaryFunc(typename thrust::iterator_value<Iterator>::type)>>::type
-    reference;
+    thrust::detail::result_of_adaptable_function<UnaryFunc(typename thrust::iterator_value<Iterator>::type)>>::type;
 
   // To get the default for Value: remove cvref on the result type.
   using value_type = typename thrust::detail::ia_dflt_help<Value, thrust::remove_cvref<reference>>::type;
 
 public:
-  typedef thrust::iterator_adaptor<transform_iterator<UnaryFunc, Iterator, Reference, Value>,
-                                   Iterator,
-                                   value_type,
-                                   thrust::use_default // Leave the system alone
-                                                       //, thrust::use_default   // Leave the traversal alone
-                                                       // use the Iterator's category to let any system iterators remain
-                                                       // random access even though transform_iterator's reference type
-                                                       // may not be a reference
-                                                       // XXX figure out why only iterators whose reference types are
-                                                       // true references are random access
-                                   ,
-                                   typename thrust::iterator_traits<Iterator>::iterator_category,
-                                   reference>
-    type;
+  using type =
+    thrust::iterator_adaptor<transform_iterator<UnaryFunc, Iterator, Reference, Value>,
+                             Iterator,
+                             value_type,
+                             thrust::use_default,
+                             typename thrust::iterator_traits<Iterator>::iterator_category,
+                             reference>;
 };
 
 } // namespace detail

--- a/thrust/thrust/iterator/detail/transform_output_iterator.inl
+++ b/thrust/thrust/iterator/detail/transform_output_iterator.inl
@@ -65,13 +65,13 @@ private:
 template <typename UnaryFunction, typename OutputIterator>
 struct transform_output_iterator_base
 {
-  typedef thrust::iterator_adaptor<transform_output_iterator<UnaryFunction, OutputIterator>,
-                                   OutputIterator,
-                                   thrust::use_default,
-                                   thrust::use_default,
-                                   thrust::use_default,
-                                   transform_output_iterator_proxy<UnaryFunction, OutputIterator>>
-    type;
+  using type =
+    thrust::iterator_adaptor<transform_output_iterator<UnaryFunction, OutputIterator>,
+                             OutputIterator,
+                             thrust::use_default,
+                             thrust::use_default,
+                             thrust::use_default,
+                             transform_output_iterator_proxy<UnaryFunction, OutputIterator>>;
 };
 
 // Register transform_output_iterator_proxy with 'is_proxy_reference' from

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -106,7 +106,7 @@ public:
   inline _CCCL_HOST_DEVICE tuple_of_iterator_references&
   operator=(const thrust::reference<thrust::tuple<Us...>, Pointer, Derived>& other)
   {
-    typedef thrust::tuple<Us...> tuple_type;
+    using tuple_type = thrust::tuple<Us...>;
 
     // XXX perhaps this could be accelerated
     super_t::operator=(tuple_type{other});

--- a/thrust/thrust/iterator/detail/zip_iterator_base.h
+++ b/thrust/thrust/iterator/detail/zip_iterator_base.h
@@ -94,7 +94,7 @@ struct dereference_iterator
   template <typename Iterator>
   struct apply
   {
-    typedef typename iterator_traits<Iterator>::reference type;
+    using type = typename iterator_traits<Iterator>::reference;
   }; // end apply
 
   // XXX silence warnings of the form "calling a __host__ function from a __host__ __device__ function is not allowed
@@ -131,16 +131,16 @@ struct tuple_meta_accumulate;
 template <class BinaryMetaFun, typename StartType>
 struct tuple_meta_accumulate<thrust::tuple<>, BinaryMetaFun, StartType>
 {
-  typedef typename thrust::detail::identity_<StartType>::type type;
+  using type = typename thrust::detail::identity_<StartType>::type;
 };
 
 template <class BinaryMetaFun, typename StartType, typename T, typename... Ts>
 struct tuple_meta_accumulate<thrust::tuple<T, Ts...>, BinaryMetaFun, StartType>
 {
-  typedef
+  using type =
     typename apply2<BinaryMetaFun,
                     T,
-                    typename tuple_meta_accumulate<thrust::tuple<Ts...>, BinaryMetaFun, StartType>::type>::type type;
+                    typename tuple_meta_accumulate<thrust::tuple<Ts...>, BinaryMetaFun, StartType>::type>::type;
 };
 
 template <typename Fun>
@@ -193,11 +193,10 @@ struct minimum_category_lambda
 template <typename IteratorTuple>
 struct minimum_traversal_category_in_iterator_tuple
 {
-  typedef typename tuple_meta_transform<IteratorTuple, thrust::iterator_traversal>::type tuple_of_traversal_tags;
+  using tuple_of_traversal_tags = typename tuple_meta_transform<IteratorTuple, thrust::iterator_traversal>::type;
 
-  typedef typename tuple_impl_specific::
-    tuple_meta_accumulate<tuple_of_traversal_tags, minimum_category_lambda, thrust::random_access_traversal_tag>::type
-      type;
+  using type = typename tuple_impl_specific::
+    tuple_meta_accumulate<tuple_of_traversal_tags, minimum_category_lambda, thrust::random_access_traversal_tag>::type;
 };
 
 struct minimum_system_lambda
@@ -212,11 +211,11 @@ struct minimum_system_lambda
 template <typename IteratorTuple>
 struct minimum_system_in_iterator_tuple
 {
-  typedef
-    typename thrust::detail::tuple_meta_transform<IteratorTuple, thrust::iterator_system>::type tuple_of_system_tags;
+  using tuple_of_system_tags =
+    typename thrust::detail::tuple_meta_transform<IteratorTuple, thrust::iterator_system>::type;
 
-  typedef typename tuple_impl_specific::
-    tuple_meta_accumulate<tuple_of_system_tags, minimum_system_lambda, thrust::any_system_tag>::type type;
+  using type = typename tuple_impl_specific::
+    tuple_meta_accumulate<tuple_of_system_tags, minimum_system_lambda, thrust::any_system_tag>::type;
 };
 
 namespace zip_iterator_base_ns
@@ -228,19 +227,19 @@ struct tuple_of_iterator_references_helper;
 template <typename Tuple, size_t... Is>
 struct tuple_of_iterator_references_helper<Tuple, thrust::index_sequence<Is...>>
 {
-  typedef thrust::detail::tuple_of_iterator_references<typename thrust::tuple_element<Is, Tuple>::type...> type;
+  using type = thrust::detail::tuple_of_iterator_references<typename thrust::tuple_element<Is, Tuple>::type...>;
 };
 
 template <typename IteratorTuple>
 struct tuple_of_iterator_references
 {
   // get a thrust::tuple of the iterators' references
-  typedef typename tuple_meta_transform<IteratorTuple, iterator_reference>::type tuple_of_references;
+  using tuple_of_references = typename tuple_meta_transform<IteratorTuple, thrust::iterator_reference>::type;
 
   // map thrust::tuple<T...> to tuple_of_iterator_references<T...>
-  typedef typename tuple_of_iterator_references_helper<
+  using type = typename tuple_of_iterator_references_helper<
     tuple_of_references,
-    thrust::make_index_sequence<thrust::tuple_size<tuple_of_references>::value>>::type type;
+    thrust::make_index_sequence<thrust::tuple_size<tuple_of_references>::value>>::type;
 };
 
 } // namespace zip_iterator_base_ns
@@ -258,30 +257,29 @@ struct zip_iterator_base
   // private:
   //  reference type is the type of the tuple obtained from the
   //  iterators' reference types.
-  typedef typename zip_iterator_base_ns::tuple_of_iterator_references<IteratorTuple>::type reference;
+  using reference = typename zip_iterator_base_ns::tuple_of_iterator_references<IteratorTuple>::type;
 
   // Boost's Value type is the same as reference type.
-  // typedef reference value_type;
-  typedef typename tuple_of_value_types<IteratorTuple>::type value_type;
+  // using value_type = reference;
+  using value_type = typename tuple_of_value_types<IteratorTuple>::type;
 
   // Difference type is the first iterator's difference type
-  typedef typename thrust::iterator_traits<typename thrust::tuple_element<0, IteratorTuple>::type>::difference_type
-    difference_type;
+  using difference_type =
+    typename thrust::iterator_traits<typename thrust::tuple_element<0, IteratorTuple>::type>::difference_type;
 
   // Iterator system is the minimum system tag in the
   // iterator tuple
-  typedef typename minimum_system_in_iterator_tuple<IteratorTuple>::type system;
+  using system = typename minimum_system_in_iterator_tuple<IteratorTuple>::type;
 
   // Traversal category is the minimum traversal category in the
   // iterator tuple
-  typedef typename minimum_traversal_category_in_iterator_tuple<IteratorTuple>::type traversal_category;
+  using traversal_category = typename minimum_traversal_category_in_iterator_tuple<IteratorTuple>::type;
 
 public:
   // The iterator facade type from which the zip iterator will
   // be derived.
-  typedef thrust::
-    iterator_facade<zip_iterator<IteratorTuple>, value_type, system, traversal_category, reference, difference_type>
-      type;
+  using type = thrust::
+    iterator_facade<zip_iterator<IteratorTuple>, value_type, system, traversal_category, reference, difference_type>;
 }; // end zip_iterator_base
 
 } // namespace detail

--- a/thrust/thrust/iterator/discard_iterator.h
+++ b/thrust/thrust/iterator/discard_iterator.h
@@ -102,13 +102,13 @@ class discard_iterator : public detail::discard_iterator_base<System>::type
   /*! \cond
    */
   friend class thrust::iterator_core_access;
-  typedef typename detail::discard_iterator_base<System>::type super_t;
-  typedef typename detail::discard_iterator_base<System>::incrementable incrementable;
-  typedef typename detail::discard_iterator_base<System>::base_iterator base_iterator;
+  using super_t       = typename detail::discard_iterator_base<System>::type;
+  using incrementable = typename detail::discard_iterator_base<System>::incrementable;
+  using base_iterator = typename detail::discard_iterator_base<System>::base_iterator;
 
 public:
-  typedef typename super_t::reference reference;
-  typedef typename super_t::value_type value_type;
+  using reference  = typename super_t::reference;
+  using value_type = typename super_t::value_type;
 
   /*! \endcond
    */

--- a/thrust/thrust/iterator/iterator_adaptor.h
+++ b/thrust/thrust/iterator/iterator_adaptor.h
@@ -77,10 +77,10 @@ THRUST_NAMESPACE_BEGIN
  *  {
  *    public:
  *      // shorthand for the name of the iterator_adaptor we're deriving from
- *      typedef thrust::iterator_adaptor<
+ *      using super_t = thrust::iterator_adaptor<
  *        repeat_iterator<Iterator>,
  *        Iterator
- *      > super_t;
+ *      >;
  *
  *      __host__ __device__
  *      repeat_iterator(const Iterator &x, int n) : super_t(x), begin(x), n(n) {}
@@ -135,8 +135,8 @@ class iterator_adaptor
   friend class thrust::iterator_core_access;
 
 protected:
-  typedef
-    typename detail::iterator_adaptor_base<Derived, Base, Value, System, Traversal, Reference, Difference>::type super_t;
+  using super_t =
+    typename detail::iterator_adaptor_base<Derived, Base, Value, System, Traversal, Reference, Difference>::type;
 
   /*! \endcond
    */
@@ -155,13 +155,13 @@ public:
 
   /*! The type of iterator this \p iterator_adaptor's \p adapts.
    */
-  typedef Base base_type;
+  using base_type = Base;
 
   /*! \cond
    */
-  typedef typename super_t::reference reference;
+  using reference = typename super_t::reference;
 
-  typedef typename super_t::difference_type difference_type;
+  using difference_type = typename super_t::difference_type;
   /*! \endcond
    */
 

--- a/thrust/thrust/iterator/iterator_categories.h
+++ b/thrust/thrust/iterator/iterator_categories.h
@@ -152,7 +152,7 @@ struct random_access_device_iterator_tag
  *  output_host_iterator_tag, forward_host_iterator_tag,
  *  bidirectional_host_iterator_tag, random_access_host_iterator_tag
  */
-typedef std::input_iterator_tag input_host_iterator_tag;
+using input_host_iterator_tag = std::input_iterator_tag;
 
 /*! \p output_host_iterator_tag is an empty class: it has no member
  *  functions, member variables, or nested types. It is used solely as a "tag": a
@@ -166,7 +166,7 @@ typedef std::input_iterator_tag input_host_iterator_tag;
  *  input_host_iterator_tag, forward_host_iterator_tag,
  *  bidirectional_host_iterator_tag, random_access_host_iterator_tag
  */
-typedef std::output_iterator_tag output_host_iterator_tag;
+using output_host_iterator_tag = std::output_iterator_tag;
 
 /*! \p forward_host_iterator_tag is an empty class: it has no member
  *  functions, member variables, or nested types. It is used solely as a "tag": a
@@ -180,7 +180,7 @@ typedef std::output_iterator_tag output_host_iterator_tag;
  *  input_host_iterator_tag, output_host_iterator_tag,
  *  bidirectional_host_iterator_tag, random_access_host_iterator_tag
  */
-typedef std::forward_iterator_tag forward_host_iterator_tag;
+using forward_host_iterator_tag = std::forward_iterator_tag;
 
 /*! \p bidirectional_host_iterator_tag is an empty class: it has no member
  *  functions, member variables, or nested types. It is used solely as a "tag": a
@@ -194,7 +194,7 @@ typedef std::forward_iterator_tag forward_host_iterator_tag;
  *  input_host_iterator_tag, output_host_iterator_tag,
  *  forward_host_iterator_tag, random_access_host_iterator_tag
  */
-typedef std::bidirectional_iterator_tag bidirectional_host_iterator_tag;
+using bidirectional_host_iterator_tag = std::bidirectional_iterator_tag;
 
 /*! \p random_access_host_iterator_tag is an empty class: it has no member
  *  functions, member variables, or nested types. It is used solely as a "tag": a
@@ -208,7 +208,7 @@ typedef std::bidirectional_iterator_tag bidirectional_host_iterator_tag;
  *  input_host_iterator_tag, output_host_iterator_tag,
  *  forward_host_iterator_tag, bidirectional_host_iterator_tag
  */
-typedef std::random_access_iterator_tag random_access_host_iterator_tag;
+using random_access_host_iterator_tag = std::random_access_iterator_tag;
 
 /*! \} // end iterator_tag_classes
  */

--- a/thrust/thrust/iterator/iterator_facade.h
+++ b/thrust/thrust/iterator/iterator_facade.h
@@ -331,11 +331,11 @@ private:
 public:
   /*! The type of element pointed to by \p iterator_facade.
    */
-  typedef ::cuda::std::__remove_const_t<Value> value_type;
+  using value_type = ::cuda::std::__remove_const_t<Value>;
 
   /*! The return type of \p iterator_facade::operator*().
    */
-  typedef Reference reference;
+  using reference = Reference;
 
   /*! The return type of \p iterator_facade's non-existent \c operator->()
    *  member function. Unlike \c boost::iterator_facade, \p iterator_facade
@@ -344,17 +344,17 @@ public:
    *  that these expressions are not allowed. This limitation may be relaxed in a
    *  future version of Thrust.
    */
-  typedef void pointer;
+  using pointer = void;
 
   /*! The type of expressions of the form <tt>x - y</tt> where <tt>x</tt> and <tt>y</tt>
    *  are of type \p iterator_facade.
    */
-  typedef Difference difference_type;
+  using difference_type = Difference;
 
   /*! The type of iterator category of \p iterator_facade.
    */
-  typedef
-    typename thrust::detail::iterator_facade_category<System, Traversal, Value, Reference>::type iterator_category;
+  using iterator_category =
+    typename thrust::detail::iterator_facade_category<System, Traversal, Value, Reference>::type;
 
   /*! \p operator*() dereferences this \p iterator_facade.
    *  \return A reference to the element pointed to by this \p iterator_facade.

--- a/thrust/thrust/iterator/permutation_iterator.h
+++ b/thrust/thrust/iterator/permutation_iterator.h
@@ -97,8 +97,8 @@ THRUST_NAMESPACE_BEGIN
  *  indices[2] = 1;
  *  indices[3] = 3;
  *
- *  typedef thrust::device_vector<float>::iterator ElementIterator;
- *  typedef thrust::device_vector<int>::iterator   IndexIterator;
+ *  using ElementIterator = thrust::device_vector<float>::iterator;
+ *  using IndexIterator = thrust::device_vector<int>::iterator  ;
  *
  *  thrust::permutation_iterator<ElementIterator,IndexIterator> iter(values.begin(), indices.begin());
  *
@@ -128,7 +128,7 @@ class permutation_iterator : public thrust::detail::permutation_iterator_base<El
    */
 
 private:
-  typedef typename detail::permutation_iterator_base<ElementIterator, IndexIterator>::type super_t;
+  using super_t = typename detail::permutation_iterator_base<ElementIterator, IndexIterator>::type;
 
   friend class thrust::iterator_core_access;
   /*! \endcond

--- a/thrust/thrust/iterator/reverse_iterator.h
+++ b/thrust/thrust/iterator/reverse_iterator.h
@@ -79,7 +79,7 @@ THRUST_NAMESPACE_BEGIN
  *  v[2] = 2.0f;
  *  v[3] = 3.0f;
  *
- *  typedef thrust::device_vector<float>::iterator Iterator;
+ *  using Iterator = thrust::device_vector<float>::iterator;
  *
  *  // note that we point the iterator to the *end* of the device_vector
  *  thrust::reverse_iterator<Iterator> iter(values.end());
@@ -94,7 +94,7 @@ THRUST_NAMESPACE_BEGIN
  *  \endcode
  *
  *  Since reversing a range is a common operation, containers like \p device_vector
- *  have nested typedefs for declaration shorthand and methods for constructing
+ *  have nested aliases for declaration shorthand and methods for constructing
  *  reverse_iterators. The following code snippet is equivalent to the previous:
  *
  *  \code
@@ -154,7 +154,7 @@ class reverse_iterator : public detail::reverse_iterator_base<BidirectionalItera
    */
 
 private:
-  typedef typename thrust::detail::reverse_iterator_base<BidirectionalIterator>::type super_t;
+  using super_t = typename thrust::detail::reverse_iterator_base<BidirectionalIterator>::type;
 
   friend class thrust::iterator_core_access;
   /*! \endcond

--- a/thrust/thrust/iterator/transform_input_output_iterator.h
+++ b/thrust/thrust/iterator/transform_input_output_iterator.h
@@ -100,7 +100,7 @@ class transform_input_output_iterator
    */
 
 public:
-  typedef typename detail::transform_input_output_iterator_base<InputFunction, OutputFunction, Iterator>::type super_t;
+  using super_t = typename detail::transform_input_output_iterator_base<InputFunction, OutputFunction, Iterator>::type;
 
   friend class thrust::iterator_core_access;
   /*! \endcond

--- a/thrust/thrust/iterator/transform_iterator.h
+++ b/thrust/thrust/iterator/transform_iterator.h
@@ -91,7 +91,7 @@ THRUST_NAMESPACE_BEGIN
  *    v[2] = 9.0f;
  *    v[3] = 16.0f;
  *
- *    typedef thrust::device_vector<float>::iterator FloatIterator;
+ *    using FloatIterator = thrust::device_vector<float>::iterator;
  *
  *    thrust::transform_iterator<square_root, FloatIterator> iter(v.begin(), square_root());
  *
@@ -147,7 +147,7 @@ THRUST_NAMESPACE_BEGIN
  *  Note that in the previous two examples the transform functor (namely \c square_root
  *  and \c square) inherits from \c thrust::unary_function.  Inheriting from
  *  \c thrust::unary_function ensures that a functor is a valid \c AdaptableUnaryFunction
- *  and provides all the necessary \c typedef declarations.  The \p transform_iterator
+ *  and provides all the necessary nested alias.  The \p transform_iterator
  *  can also be applied to a \c UnaryFunction that does not inherit from
  *  \c thrust::unary_function using an optional template argument.  The following example
  *  illustrates how to use the third template argument to specify the \c result_type of
@@ -175,7 +175,7 @@ THRUST_NAMESPACE_BEGIN
  *    v[2] = 9.0f;
  *    v[3] = 16.0f;
  *
- *    typedef thrust::device_vector<float>::iterator FloatIterator;
+ *    using FloatIterator = thrust::device_vector<float>::iterator;
  *
  *    // note: float result_type is specified explicitly
  *    thrust::transform_iterator<square_root, FloatIterator, float> iter(v.begin(), square_root());
@@ -200,7 +200,7 @@ class transform_iterator
    */
 
 public:
-  typedef typename detail::transform_iterator_base<AdaptableUnaryFunction, Iterator, Reference, Value>::type super_t;
+  using super_t = typename detail::transform_iterator_base<AdaptableUnaryFunction, Iterator, Reference, Value>::type;
 
   friend class thrust::iterator_core_access;
   /*! \endcond

--- a/thrust/thrust/iterator/transform_output_iterator.h
+++ b/thrust/thrust/iterator/transform_output_iterator.h
@@ -74,7 +74,7 @@ THRUST_NAMESPACE_BEGIN
  *  {
  *    thrust::device_vector<float> v(4);
  *
- *    typedef thrust::device_vector<float>::iterator FloatIterator;
+ *    using FloatIterator = thrust::device_vector<float>::iterator;
  *    thrust::transform_output_iterator<square_root, FloatIterator> iter(v.begin(), square_root());
  *
  *    iter[0] =  1.0f;    // stores sqrtf( 1.0f)
@@ -101,7 +101,7 @@ class transform_output_iterator : public detail::transform_output_iterator_base<
    */
 
 public:
-  typedef typename detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type super_t;
+  using super_t = typename detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type;
 
   friend class thrust::iterator_core_access;
   /*! \endcond

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -81,7 +81,7 @@ THRUST_NAMESPACE_BEGIN
  *  // alias for a tuple of these iterators
  *  using IteratorTuple = thrust::tuple<IntIterator, FloatIterator, CharIterator>;
  *
- *  // typedef the zip_iterator of this tuple
+ *  // alias the zip_iterator of this tuple
  *  using ZipIterator = thrust::zip_iterator<IteratorTuple>;
  *
  *  // finally, create the zip_iterator
@@ -175,7 +175,7 @@ public:
    */
 
 private:
-  typedef typename detail::zip_iterator_base<IteratorTuple>::type super_t;
+  using super_t = typename detail::zip_iterator_base<IteratorTuple>::type;
 
   friend class thrust::iterator_core_access;
 

--- a/thrust/thrust/memory.h
+++ b/thrust/thrust/memory.h
@@ -81,7 +81,7 @@ template<typename Element, typename Tag, typename Reference = thrust::use_defaul
   public:
     /*! The type of the raw pointer
      */
-    typedef typename super_t::base_type raw_pointer;
+    using raw_pointer = typename super_t::base_type;
 
     /*! \p pointer's default constructor initializes its encapsulated pointer to \c 0
      */
@@ -244,10 +244,10 @@ malloc(const thrust::detail::execution_policy_base<DerivedPolicy>& system, std::
  *  // allocate storage for 100 ints with thrust::get_temporary_buffer
  *  const int N = 100;
  *
- *  typedef thrust::pair<
+ *  using ptr_and_size_t = thrust::pair<
  *    thrust::pointer<int,thrust::device_system_tag>,
  *    std::ptrdiff_t
- *  > ptr_and_size_t;
+ *  >;
  *
  *  thrust::device_system_tag device_sys;
  *  ptr_and_size_t ptr_and_size = thrust::get_temporary_buffer<int>(device_sys, N);
@@ -326,10 +326,10 @@ _CCCL_HOST_DEVICE void free(const thrust::detail::execution_policy_base<DerivedP
  *  // allocate storage for 100 ints with thrust::get_temporary_buffer
  *  const int N = 100;
  *
- *  typedef thrust::pair<
+ *  using ptr_and_size_t = thrust::pair<
  *    thrust::pointer<int,thrust::device_system_tag>,
  *    std::ptrdiff_t
- *  > ptr_and_size_t;
+ *  >;
  *
  *  thrust::device_system_tag device_sys;
  *  ptr_and_size_t ptr_and_size = thrust::get_temporary_buffer<int>(device_sys, N);

--- a/thrust/thrust/mismatch.h
+++ b/thrust/thrust/mismatch.h
@@ -79,7 +79,7 @@ THRUST_NAMESPACE_BEGIN
  *  vec1[2] = 3;  vec2[2] = 8;
  *  vec1[3] = 7;  vec2[3] = 7;
  *
- *  typedef thrust::device_vector<int>::iterator Iterator;
+ *  using Iterator = thrust::device_vector<int>::iterator;
  *  thrust::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(thrust::device, vec1.begin(), vec1.end(), vec2.begin());
@@ -130,7 +130,7 @@ mismatch(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
  *  vec1[2] = 3;  vec2[2] = 8;
  *  vec1[3] = 7;  vec2[3] = 7;
  *
- *  typedef thrust::device_vector<int>::iterator Iterator;
+ *  using Iterator = thrust::device_vector<int>::iterator;
  *  thrust::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(vec1.begin(), vec1.end(), vec2.begin());
@@ -184,7 +184,7 @@ mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2);
  *  vec1[2] = 3;  vec2[2] = 8;
  *  vec1[3] = 7;  vec2[3] = 7;
  *
- *  typedef thrust::device_vector<int>::iterator Iterator;
+ *  using Iterator = thrust::device_vector<int>::iterator;
  *  thrust::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(thrust::device, vec1.begin(), vec1.end(), vec2.begin(), thrust::equal_to<int>());
@@ -237,7 +237,7 @@ _CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
  *  vec1[2] = 3;  vec2[2] = 8;
  *  vec1[3] = 7;  vec2[3] = 7;
  *
- *  typedef thrust::device_vector<int>::iterator Iterator;
+ *  using Iterator = thrust::device_vector<int>::iterator;
  *  thrust::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(vec1.begin(), vec1.end(), vec2.begin(), thrust::equal_to<int>());

--- a/thrust/thrust/mr/allocator.h
+++ b/thrust/thrust/mr/allocator.h
@@ -62,29 +62,29 @@ class allocator : private validator<MR>
 {
 public:
   /*! The pointer to void type of this allocator. */
-  typedef typename MR::pointer void_pointer;
+  using void_pointer = typename MR::pointer;
 
   /*! The value type allocated by this allocator. Equivalent to \p T. */
-  typedef T value_type;
+  using value_type = T;
   /*! The pointer type allocated by this allocator. Equivaled to the pointer type of \p MR rebound to \p T. */
-  typedef typename thrust::detail::pointer_traits<void_pointer>::template rebind<T>::other pointer;
+  using pointer = typename thrust::detail::pointer_traits<void_pointer>::template rebind<T>::other;
   /*! The pointer to const type. Equivalent to a pointer type of \p MR rebound to <tt>const T</tt>. */
-  typedef typename thrust::detail::pointer_traits<void_pointer>::template rebind<const T>::other const_pointer;
+  using const_pointer = typename thrust::detail::pointer_traits<void_pointer>::template rebind<const T>::other;
   /*! The reference to the type allocated by this allocator. Supports smart references. */
-  typedef typename thrust::detail::pointer_traits<pointer>::reference reference;
+  using reference = typename thrust::detail::pointer_traits<pointer>::reference;
   /*! The const reference to the type allocated by this allocator. Supports smart references. */
-  typedef typename thrust::detail::pointer_traits<const_pointer>::reference const_reference;
+  using const_reference = typename thrust::detail::pointer_traits<const_pointer>::reference;
   /*! The size type of this allocator. Always \p std::size_t. */
-  typedef std::size_t size_type;
+  using size_type = std::size_t;
   /*! The difference type between pointers allocated by this allocator. */
-  typedef typename thrust::detail::pointer_traits<pointer>::difference_type difference_type;
+  using difference_type = typename thrust::detail::pointer_traits<pointer>::difference_type;
 
   /*! Specifies that the allocator shall be propagated on container copy assignment. */
-  typedef detail::true_type propagate_on_container_copy_assignment;
+  using propagate_on_container_copy_assignment = detail::true_type;
   /*! Specifies that the allocator shall be propagated on container move assignment. */
-  typedef detail::true_type propagate_on_container_move_assignment;
+  using propagate_on_container_move_assignment = detail::true_type;
   /*! Specifies that the allocator shall be propagated on container swap. */
-  typedef detail::true_type propagate_on_container_swap;
+  using propagate_on_container_swap = detail::true_type;
 
   /*! The \p rebind metafunction provides the type of an \p allocator instantiated with another type.
    *
@@ -93,9 +93,9 @@ public:
   template <typename U>
   struct rebind
   {
-    /*! The typedef \p other gives the type of the rebound \p allocator.
+    /*! The alias \p other gives the type of the rebound \p allocator.
      */
-    typedef allocator<U, MR> other;
+    using other = allocator<U, MR>;
   };
 
   /*! Calculates the maximum number of elements allocated by this allocator.
@@ -182,7 +182,7 @@ using polymorphic_allocator = allocator<T, polymorphic_adaptor_resource<Pointer>
 template <typename T, typename Upstream>
 class stateless_resource_allocator : public thrust::mr::allocator<T, Upstream>
 {
-  typedef thrust::mr::allocator<T, Upstream> base;
+  using base = thrust::mr::allocator<T, Upstream>;
 
 public:
   /*! The \p rebind metafunction provides the type of an \p stateless_resource_allocator instantiated with another type.
@@ -192,9 +192,9 @@ public:
   template <typename U>
   struct rebind
   {
-    /*! The typedef \p other gives the type of the rebound \p stateless_resource_allocator.
+    /*! The alias \p other gives the type of the rebound \p stateless_resource_allocator.
      */
-    typedef stateless_resource_allocator<U, Upstream> other;
+    using other = stateless_resource_allocator<U, Upstream>;
   };
 
   /*! Default constructor. Uses \p get_global_resource to get the global instance of \p Upstream and initializes the

--- a/thrust/thrust/mr/device_memory_resource.h
+++ b/thrust/thrust/mr/device_memory_resource.h
@@ -33,9 +33,9 @@
 
 THRUST_NAMESPACE_BEGIN
 
-typedef thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::memory_resource device_memory_resource;
-typedef thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_memory_resource universal_memory_resource;
-typedef thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_host_pinned_memory_resource
-  universal_host_pinned_memory_resource;
+using device_memory_resource    = thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::memory_resource;
+using universal_memory_resource = thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_memory_resource;
+using universal_host_pinned_memory_resource =
+  thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::universal_host_pinned_memory_resource;
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/mr/disjoint_pool.h
+++ b/thrust/thrust/mr/disjoint_pool.h
@@ -163,8 +163,8 @@ public:
   }
 
 private:
-  typedef typename Upstream::pointer void_ptr;
-  typedef typename thrust::detail::pointer_traits<void_ptr>::template rebind<char>::other char_ptr;
+  using void_ptr = typename Upstream::pointer;
+  using char_ptr = typename thrust::detail::pointer_traits<void_ptr>::template rebind<char>::other;
 
   struct chunk_descriptor
   {
@@ -172,7 +172,7 @@ private:
     void_ptr pointer;
   };
 
-  typedef thrust::host_vector<chunk_descriptor, allocator<chunk_descriptor, Bookkeeper>> chunk_vector;
+  using chunk_vector = thrust::host_vector<chunk_descriptor, allocator<chunk_descriptor, Bookkeeper>>;
 
   struct oversized_block_descriptor
   {
@@ -223,10 +223,10 @@ private:
     std::size_t requested;
   };
 
-  typedef thrust::host_vector<oversized_block_descriptor, allocator<oversized_block_descriptor, Bookkeeper>>
-    oversized_block_vector;
+  using oversized_block_vector =
+    thrust::host_vector<oversized_block_descriptor, allocator<oversized_block_descriptor, Bookkeeper>>;
 
-  typedef thrust::host_vector<void_ptr, allocator<void_ptr, Bookkeeper>> pointer_vector;
+  using pointer_vector = thrust::host_vector<void_ptr, allocator<void_ptr, Bookkeeper>>;
 
   struct pool
   {
@@ -248,7 +248,7 @@ private:
     std::size_t previous_allocated_count;
   };
 
-  typedef thrust::host_vector<pool, allocator<pool, Bookkeeper>> pool_vector;
+  using pool_vector = thrust::host_vector<pool, allocator<pool, Bookkeeper>>;
 
   Upstream* m_upstream;
   Bookkeeper* m_bookkeeper;

--- a/thrust/thrust/mr/disjoint_sync_pool.h
+++ b/thrust/thrust/mr/disjoint_sync_pool.h
@@ -51,10 +51,10 @@ namespace mr
 template <typename Upstream, typename Bookkeeper>
 struct disjoint_synchronized_pool_resource : public memory_resource<typename Upstream::pointer>
 {
-  typedef disjoint_unsynchronized_pool_resource<Upstream, Bookkeeper> unsync_pool;
-  typedef std::lock_guard<std::mutex> lock_t;
+  using unsync_pool = disjoint_unsynchronized_pool_resource<Upstream, Bookkeeper>;
+  using lock_t      = std::lock_guard<std::mutex>;
 
-  typedef typename Upstream::pointer void_ptr;
+  using void_ptr = typename Upstream::pointer;
 
 public:
   /*! Get the default options for a disjoint pool. These are meant to be a sensible set of values for many use cases,

--- a/thrust/thrust/mr/host_memory_resource.h
+++ b/thrust/thrust/mr/host_memory_resource.h
@@ -33,6 +33,6 @@
 
 THRUST_NAMESPACE_BEGIN
 
-typedef thrust::system::__THRUST_HOST_SYSTEM_NAMESPACE::memory_resource host_memory_resource;
+using host_memory_resource = thrust::system::cpp::memory_resource;
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/mr/memory_resource.h
+++ b/thrust/thrust/mr/memory_resource.h
@@ -60,7 +60,7 @@ class memory_resource
 public:
   /*! Alias for the template parameter.
    */
-  typedef Pointer pointer;
+  using pointer = Pointer;
 
   /*! Virtual destructor, defaulted when possible.
    */
@@ -140,7 +140,7 @@ class memory_resource<void*>
 #endif
 {
 public:
-  typedef void* pointer;
+  using pointer = void*;
 
   virtual ~memory_resource() = default;
 

--- a/thrust/thrust/mr/pool.h
+++ b/thrust/thrust/mr/pool.h
@@ -152,18 +152,18 @@ public:
   }
 
 private:
-  typedef typename Upstream::pointer void_ptr;
-  typedef thrust::detail::pointer_traits<void_ptr> void_ptr_traits;
-  typedef typename void_ptr_traits::template rebind<char>::other char_ptr;
+  using void_ptr        = typename Upstream::pointer;
+  using void_ptr_traits = thrust::detail::pointer_traits<void_ptr>;
+  using char_ptr        = typename void_ptr_traits::template rebind<char>::other;
 
   struct block_descriptor;
   struct chunk_descriptor;
   struct oversized_block_descriptor;
 
-  typedef typename void_ptr_traits::template rebind<block_descriptor>::other block_descriptor_ptr;
-  typedef typename void_ptr_traits::template rebind<chunk_descriptor>::other chunk_descriptor_ptr;
-  typedef typename void_ptr_traits::template rebind<oversized_block_descriptor>::other oversized_block_descriptor_ptr;
-  typedef thrust::detail::pointer_traits<oversized_block_descriptor_ptr> oversized_block_ptr_traits;
+  using block_descriptor_ptr           = typename void_ptr_traits::template rebind<block_descriptor>::other;
+  using chunk_descriptor_ptr           = typename void_ptr_traits::template rebind<chunk_descriptor>::other;
+  using oversized_block_descriptor_ptr = typename void_ptr_traits::template rebind<oversized_block_descriptor>::other;
+  using oversized_block_ptr_traits     = thrust::detail::pointer_traits<oversized_block_descriptor_ptr>;
 
   struct block_descriptor
   {
@@ -204,7 +204,7 @@ private:
     std::size_t previous_allocated_count;
   };
 
-  typedef thrust::host_vector<pool, allocator<pool, Upstream>> pool_vector;
+  using pool_vector = thrust::host_vector<pool, allocator<pool, Upstream>>;
 
   Upstream* m_upstream;
 

--- a/thrust/thrust/mr/sync_pool.h
+++ b/thrust/thrust/mr/sync_pool.h
@@ -49,10 +49,10 @@ namespace mr
 template <typename Upstream>
 struct synchronized_pool_resource : public memory_resource<typename Upstream::pointer>
 {
-  typedef unsynchronized_pool_resource<Upstream> unsync_pool;
-  typedef std::lock_guard<std::mutex> lock_t;
+  using unsync_pool = unsynchronized_pool_resource<Upstream>;
+  using lock_t      = std::lock_guard<std::mutex>;
 
-  typedef typename Upstream::pointer void_ptr;
+  using void_ptr = typename Upstream::pointer;
 
 public:
   /*! Get the default options for a pool. These are meant to be a sensible set of values for many use cases,

--- a/thrust/thrust/per_device_resource.h
+++ b/thrust/thrust/per_device_resource.h
@@ -58,7 +58,7 @@ _CCCL_HOST MR* get_per_device_resource(const thrust::detail::execution_policy_ba
 template <typename T, typename Upstream, typename ExecutionPolicy>
 class per_device_allocator : public thrust::mr::allocator<T, Upstream>
 {
-  typedef thrust::mr::allocator<T, Upstream> base;
+  using base = thrust::mr::allocator<T, Upstream>;
 
 public:
   /*! The \p rebind metafunction provides the type of an \p per_device_allocator instantiated with another type.
@@ -68,9 +68,9 @@ public:
   template <typename U>
   struct rebind
   {
-    /*! The typedef \p other gives the type of the rebound \p per_device_allocator.
+    /*! The alias \p other gives the type of the rebound \p per_device_allocator.
      */
-    typedef per_device_allocator<U, Upstream, ExecutionPolicy> other;
+    using other = per_device_allocator<U, Upstream, ExecutionPolicy>;
   };
 
   /*! Default constructor. Uses \p get_global_resource to get the global instance of \p Upstream and initializes the

--- a/thrust/thrust/random.h
+++ b/thrust/thrust/random.h
@@ -70,7 +70,7 @@ namespace random
  *  \note The 10000th consecutive invocation of a default-constructed object of type \p ranlux24
  *        shall produce the value \c 9901578 .
  */
-typedef discard_block_engine<ranlux24_base, 223, 23> ranlux24;
+using ranlux24 = discard_block_engine<ranlux24_base, 223, 23>;
 
 /*! \typedef ranlux48
  *  \brief A random number engine with predefined parameters which implements the
@@ -78,7 +78,7 @@ typedef discard_block_engine<ranlux24_base, 223, 23> ranlux24;
  *  \note The 10000th consecutive invocation of a default-constructed object of type \p ranlux48
  *        shall produce the value \c 88229545517833 .
  */
-typedef discard_block_engine<ranlux48_base, 389, 11> ranlux48;
+using ranlux48 = discard_block_engine<ranlux48_base, 389, 11>;
 
 /*! \typedef taus88
  *  \brief A random number engine with predefined parameters which implements
@@ -87,21 +87,21 @@ typedef discard_block_engine<ranlux48_base, 389, 11> ranlux48;
  *  \note The 10000th consecutive invocation of a default-constructed object of type \p taus88
  *        shall produce the value \c 3535848941 .
  */
-typedef xor_combine_engine<linear_feedback_shift_engine<thrust::detail::uint32_t, 32u, 31u, 13u, 12u>,
-                           0,
-                           xor_combine_engine<linear_feedback_shift_engine<thrust::detail::uint32_t, 32u, 29u, 2u, 4u>,
-                                              0,
-                                              linear_feedback_shift_engine<thrust::detail::uint32_t, 32u, 28u, 3u, 17u>,
-                                              0>,
-                           0>
-  taus88;
+using taus88 =
+  xor_combine_engine<linear_feedback_shift_engine<thrust::detail::uint32_t, 32U, 31U, 13U, 12U>,
+                     0,
+                     xor_combine_engine<linear_feedback_shift_engine<thrust::detail::uint32_t, 32U, 29U, 2U, 4U>,
+                                        0,
+                                        linear_feedback_shift_engine<thrust::detail::uint32_t, 32U, 28U, 3U, 17U>,
+                                        0>,
+                     0>;
 
 /*! \typedef default_random_engine
  *  \brief An implementation-defined "default" random number engine.
  *  \note \p default_random_engine is currently an alias for \p minstd_rand, and may change
  *        in a future version.
  */
-typedef minstd_rand default_random_engine;
+using default_random_engine = minstd_rand;
 
 /*! \} // end predefined_random
  */

--- a/thrust/thrust/random/detail/discard_block_engine.inl
+++ b/thrust/thrust/random/detail/discard_block_engine.inl
@@ -104,8 +104,8 @@ template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>&
 discard_block_engine<Engine, p, r>::stream_out(std::basic_ostream<CharT, Traits>& os) const
 {
-  typedef std::basic_ostream<CharT, Traits> ostream_type;
-  typedef typename ostream_type::ios_base ios_base;
+  using ostream_type = std::basic_ostream<CharT, Traits>;
+  using ios_base     = typename ostream_type::ios_base;
 
   // save old flags & fill character
   const typename ios_base::fmtflags flags = os.flags();
@@ -129,8 +129,8 @@ template <typename Engine, size_t p, size_t r>
 template <typename CharT, typename Traits>
 std::basic_istream<CharT, Traits>& discard_block_engine<Engine, p, r>::stream_in(std::basic_istream<CharT, Traits>& is)
 {
-  typedef std::basic_istream<CharT, Traits> istream_type;
-  typedef typename istream_type::ios_base ios_base;
+  using istream_type = std::basic_istream<CharT, Traits>;
+  using ios_base     = typename istream_type::ios_base;
 
   // save old flags
   const typename ios_base::fmtflags flags = is.flags();

--- a/thrust/thrust/random/detail/linear_congruential_engine.inl
+++ b/thrust/thrust/random/detail/linear_congruential_engine.inl
@@ -73,8 +73,8 @@ template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>&
 linear_congruential_engine<UIntType, a, c, m>::stream_out(std::basic_ostream<CharT, Traits>& os) const
 {
-  typedef std::basic_ostream<CharT, Traits> ostream_type;
-  typedef typename ostream_type::ios_base ios_base;
+  using ostream_type = std::basic_ostream<CharT, Traits>;
+  using ios_base     = typename ostream_type::ios_base;
 
   // save old flags & fill character
   const typename ios_base::fmtflags flags = os.flags();
@@ -98,8 +98,8 @@ template <typename CharT, typename Traits>
 std::basic_istream<CharT, Traits>&
 linear_congruential_engine<UIntType, a, c, m>::stream_in(std::basic_istream<CharT, Traits>& is)
 {
-  typedef std::basic_istream<CharT, Traits> istream_type;
-  typedef typename istream_type::ios_base ios_base;
+  using istream_type = std::basic_istream<CharT, Traits>;
+  using ios_base     = typename istream_type::ios_base;
 
   // save old flags
   const typename ios_base::fmtflags flags = is.flags();

--- a/thrust/thrust/random/detail/linear_congruential_engine_discard.h
+++ b/thrust/thrust/random/detail/linear_congruential_engine_discard.h
@@ -87,7 +87,7 @@ struct linear_congruential_engine_discard
   template <typename LinearCongruentialEngine>
   _CCCL_HOST_DEVICE static void discard(LinearCongruentialEngine& lcg, unsigned long long z)
   {
-    typedef typename LinearCongruentialEngine::result_type result_type;
+    using result_type   = typename LinearCongruentialEngine::result_type;
     const result_type c = LinearCongruentialEngine::increment;
     const result_type a = LinearCongruentialEngine::multiplier;
     const result_type m = LinearCongruentialEngine::modulus;

--- a/thrust/thrust/random/detail/linear_feedback_shift_engine.inl
+++ b/thrust/thrust/random/detail/linear_feedback_shift_engine.inl
@@ -69,8 +69,8 @@ template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>&
 linear_feedback_shift_engine<UIntType, w, k, q, s>::stream_out(std::basic_ostream<CharT, Traits>& os) const
 {
-  typedef std::basic_ostream<CharT, Traits> ostream_type;
-  typedef typename ostream_type::ios_base ios_base;
+  using ostream_type = std::basic_ostream<CharT, Traits>;
+  using ios_base     = typename ostream_type::ios_base;
 
   // save old flags & fill character
   const typename ios_base::fmtflags flags = os.flags();
@@ -94,8 +94,8 @@ template <typename CharT, typename Traits>
 std::basic_istream<CharT, Traits>&
 linear_feedback_shift_engine<UIntType, w, k, q, s>::stream_in(std::basic_istream<CharT, Traits>& is)
 {
-  typedef std::basic_istream<CharT, Traits> istream_type;
-  typedef typename istream_type::ios_base ios_base;
+  using istream_type = std::basic_istream<CharT, Traits>;
+  using ios_base     = typename istream_type::ios_base;
 
   // save old flags
   const typename ios_base::fmtflags flags = is.flags();

--- a/thrust/thrust/random/detail/normal_distribution.inl
+++ b/thrust/thrust/random/detail/normal_distribution.inl
@@ -136,8 +136,8 @@ template <typename RealType>
 template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>& normal_distribution<RealType>::stream_out(std::basic_ostream<CharT, Traits>& os) const
 {
-  typedef std::basic_ostream<CharT, Traits> ostream_type;
-  typedef typename ostream_type::ios_base ios_base;
+  using ostream_type = std::basic_ostream<CharT, Traits>;
+  using ios_base     = typename ostream_type::ios_base;
 
   // save old flags and fill character
   const typename ios_base::fmtflags flags = os.flags();
@@ -159,8 +159,8 @@ template <typename RealType>
 template <typename CharT, typename Traits>
 std::basic_istream<CharT, Traits>& normal_distribution<RealType>::stream_in(std::basic_istream<CharT, Traits>& is)
 {
-  typedef std::basic_istream<CharT, Traits> istream_type;
-  typedef typename istream_type::ios_base ios_base;
+  using istream_type = std::basic_istream<CharT, Traits>;
+  using ios_base     = typename istream_type::ios_base;
 
   // save old flags
   const typename ios_base::fmtflags flags = is.flags();

--- a/thrust/thrust/random/detail/normal_distribution_base.h
+++ b/thrust/thrust/random/detail/normal_distribution_base.h
@@ -149,9 +149,9 @@ template <typename RealType>
 struct normal_distribution_base
 {
 #if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_NVCC && !defined(_NVHPC_CUDA)
-  typedef normal_distribution_nvcc<RealType> type;
+  using type = normal_distribution_nvcc<RealType>;
 #else
-  typedef normal_distribution_portable<RealType> type;
+  using type = normal_distribution_portable<RealType>;
 #endif
 };
 

--- a/thrust/thrust/random/detail/subtract_with_carry_engine.inl
+++ b/thrust/thrust/random/detail/subtract_with_carry_engine.inl
@@ -105,8 +105,8 @@ template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>&
 subtract_with_carry_engine<UIntType, w, s, r>::stream_out(std::basic_ostream<CharT, Traits>& os) const
 {
-  typedef std::basic_ostream<CharT, Traits> ostream_type;
-  typedef typename ostream_type::ios_base ios_base;
+  using ostream_type = std::basic_ostream<CharT, Traits>;
+  using ios_base     = typename ostream_type::ios_base;
 
   const typename ios_base::fmtflags flags = os.flags();
   const CharT fill                        = os.fill();
@@ -132,8 +132,8 @@ template <typename CharType, typename Traits>
 std::basic_istream<CharType, Traits>&
 subtract_with_carry_engine<UIntType, w, s, r>::stream_in(std::basic_istream<CharType, Traits>& is)
 {
-  typedef std::basic_istream<CharType, Traits> istream_type;
-  typedef typename istream_type::ios_base ios_base;
+  using istream_type = std::basic_istream<CharType, Traits>;
+  using ios_base     = typename istream_type::ios_base;
 
   const typename ios_base::fmtflags flags = is.flags();
   is.flags(ios_base::dec | ios_base::skipws);

--- a/thrust/thrust/random/detail/uniform_int_distribution.inl
+++ b/thrust/thrust/random/detail/uniform_int_distribution.inl
@@ -66,7 +66,7 @@ uniform_int_distribution<IntType>::operator()(UniformRandomNumberGenerator& urng
   //     values if the range of the RNG is smaller than the range of the distribution
   //     we should improve this implementation in a later version
 
-  typedef typename thrust::detail::largest_available_float::type float_type;
+  using float_type = typename thrust::detail::largest_available_float::type;
 
   const float_type real_min(static_cast<float_type>(parm.first));
   const float_type real_max(static_cast<float_type>(parm.second));
@@ -127,8 +127,8 @@ template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>&
 uniform_int_distribution<IntType>::stream_out(std::basic_ostream<CharT, Traits>& os) const
 {
-  typedef std::basic_ostream<CharT, Traits> ostream_type;
-  typedef typename ostream_type::ios_base ios_base;
+  using ostream_type = std::basic_ostream<CharT, Traits>;
+  using ios_base     = typename ostream_type::ios_base;
 
   // save old flags and fill character
   const typename ios_base::fmtflags flags = os.flags();
@@ -150,8 +150,8 @@ template <typename IntType>
 template <typename CharT, typename Traits>
 std::basic_istream<CharT, Traits>& uniform_int_distribution<IntType>::stream_in(std::basic_istream<CharT, Traits>& is)
 {
-  typedef std::basic_istream<CharT, Traits> istream_type;
-  typedef typename istream_type::ios_base ios_base;
+  using istream_type = std::basic_istream<CharT, Traits>;
+  using ios_base     = typename istream_type::ios_base;
 
   // save old flags
   const typename ios_base::fmtflags flags = is.flags();

--- a/thrust/thrust/random/detail/uniform_real_distribution.inl
+++ b/thrust/thrust/random/detail/uniform_real_distribution.inl
@@ -127,8 +127,8 @@ template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>&
 uniform_real_distribution<RealType>::stream_out(std::basic_ostream<CharT, Traits>& os) const
 {
-  typedef std::basic_ostream<CharT, Traits> ostream_type;
-  typedef typename ostream_type::ios_base ios_base;
+  using ostream_type = std::basic_ostream<CharT, Traits>;
+  using ios_base     = typename ostream_type::ios_base;
 
   // save old flags and fill character
   const typename ios_base::fmtflags flags = os.flags();
@@ -150,8 +150,8 @@ template <typename RealType>
 template <typename CharT, typename Traits>
 std::basic_istream<CharT, Traits>& uniform_real_distribution<RealType>::stream_in(std::basic_istream<CharT, Traits>& is)
 {
-  typedef std::basic_istream<CharT, Traits> istream_type;
-  typedef typename istream_type::ios_base ios_base;
+  using istream_type = std::basic_istream<CharT, Traits>;
+  using ios_base     = typename istream_type::ios_base;
 
   // save old flags
   const typename ios_base::fmtflags flags = is.flags();

--- a/thrust/thrust/random/detail/xor_combine_engine.inl
+++ b/thrust/thrust/random/detail/xor_combine_engine.inl
@@ -102,8 +102,8 @@ template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits>&
 xor_combine_engine<Engine1, s1, Engine2, s2>::stream_out(std::basic_ostream<CharT, Traits>& os) const
 {
-  typedef std::basic_ostream<CharT, Traits> ostream_type;
-  typedef typename ostream_type::ios_base ios_base;
+  using ostream_type = std::basic_ostream<CharT, Traits>;
+  using ios_base     = typename ostream_type::ios_base;
 
   // save old flags and fill character
   const typename ios_base::fmtflags flags = os.flags();
@@ -127,8 +127,8 @@ template <typename CharT, typename Traits>
 std::basic_istream<CharT, Traits>&
 xor_combine_engine<Engine1, s1, Engine2, s2>::stream_in(std::basic_istream<CharT, Traits>& is)
 {
-  typedef std::basic_istream<CharT, Traits> istream_type;
-  typedef typename istream_type::ios_base ios_base;
+  using istream_type = std::basic_istream<CharT, Traits>;
+  using ios_base     = typename istream_type::ios_base;
 
   // save old flags
   const typename ios_base::fmtflags flags = is.flags();

--- a/thrust/thrust/random/detail/xor_combine_engine_max.h
+++ b/thrust/thrust/random/detail/xor_combine_engine_max.h
@@ -99,7 +99,7 @@ struct xor_combine_engine_max_aux;
 template <typename result_type, result_type a, result_type b, int d>
 struct xor_combine_engine_max_aux_case4
 {
-  typedef xor_combine_engine_max_aux_constants<result_type, a, b, d> constants;
+  using constants = xor_combine_engine_max_aux_constants<result_type, a, b, d>;
 
   static const result_type k_plus_1_times_two_to_the_p =
     lshift<result_type, math::plus<result_type, constants::k, 1>::value, constants::p>::value;
@@ -118,7 +118,7 @@ struct xor_combine_engine_max_aux_case4
 template <typename result_type, result_type a, result_type b, int d>
 struct xor_combine_engine_max_aux_case3
 {
-  typedef xor_combine_engine_max_aux_constants<result_type, a, b, d> constants;
+  using constants = xor_combine_engine_max_aux_constants<result_type, a, b, d>;
 
   static const result_type k_plus_1_times_two_to_the_p =
     lshift<result_type, math::plus<result_type, constants::k, 1>::value, constants::p>::value;
@@ -137,7 +137,7 @@ struct xor_combine_engine_max_aux_case3
 template <typename result_type, result_type a, result_type b, int d>
 struct xor_combine_engine_max_aux_case2
 {
-  typedef xor_combine_engine_max_aux_constants<result_type, a, b, d> constants;
+  using constants = xor_combine_engine_max_aux_constants<result_type, a, b, d>;
 
   static const result_type k_plus_1_times_two_to_the_p =
     lshift<result_type, math::plus<result_type, constants::k, 1>::value, constants::p>::value;
@@ -156,7 +156,7 @@ struct xor_combine_engine_max_aux_case1
 template <typename result_type, result_type a, result_type b, int d>
 struct xor_combine_engine_max_aux_2
 {
-  typedef xor_combine_engine_max_aux_constants<result_type, a, b, d> constants;
+  using constants = xor_combine_engine_max_aux_constants<result_type, a, b, d>;
 
   static const result_type value = thrust::detail::eval_if<
     // if k is odd...

--- a/thrust/thrust/random/discard_block_engine.h
+++ b/thrust/thrust/random/discard_block_engine.h
@@ -88,12 +88,12 @@ public:
   /*! \typedef base_type
    *  \brief The type of the adapted base random number engine.
    */
-  typedef Engine base_type;
+  using base_type = Engine;
 
   /*! \typedef result_type
    *  \brief The type of the unsigned integer produced by this \p linear_congruential_engine.
    */
-  typedef typename base_type::result_type result_type;
+  using result_type = typename base_type::result_type;
 
   // engine characteristics
 

--- a/thrust/thrust/random/linear_congruential_engine.h
+++ b/thrust/thrust/random/linear_congruential_engine.h
@@ -125,7 +125,7 @@ public:
   /*! \typedef result_type
    *  \brief The type of the unsigned integer produced by this \p linear_congruential_engine.
    */
-  typedef UIntType result_type;
+  using result_type = UIntType;
 
   // engine characteristics
 
@@ -263,7 +263,7 @@ operator>>(std::basic_istream<CharT, Traits>& is, linear_congruential_engine<UIn
  *  \note The 10000th consecutive invocation of a default-constructed object of type \p minstd_rand0
  *        shall produce the value \c 1043618065 .
  */
-typedef linear_congruential_engine<thrust::detail::uint32_t, 16807, 0, 2147483647> minstd_rand0;
+using minstd_rand0 = linear_congruential_engine<thrust::detail::uint32_t, 16807, 0, 2147483647>;
 
 /*! \typedef minstd_rand
  *  \brief A random number engine with predefined parameters which implements a version of
@@ -271,7 +271,7 @@ typedef linear_congruential_engine<thrust::detail::uint32_t, 16807, 0, 214748364
  *  \note The 10000th consecutive invocation of a default-constructed object of type \p minstd_rand
  *        shall produce the value \c 399268537 .
  */
-typedef linear_congruential_engine<thrust::detail::uint32_t, 48271, 0, 2147483647> minstd_rand;
+using minstd_rand = linear_congruential_engine<thrust::detail::uint32_t, 48271, 0, 2147483647>;
 
 /*! \} // predefined_random
  */

--- a/thrust/thrust/random/linear_feedback_shift_engine.h
+++ b/thrust/thrust/random/linear_feedback_shift_engine.h
@@ -75,7 +75,7 @@ public:
   /*! \typedef result_type
    *  \brief The type of the unsigned integer produced by this \p linear_feedback_shift_engine.
    */
-  typedef UIntType result_type;
+  using result_type = UIntType;
 
   // engine characteristics
 

--- a/thrust/thrust/random/normal_distribution.h
+++ b/thrust/thrust/random/normal_distribution.h
@@ -88,7 +88,7 @@ template <typename RealType = double>
 class normal_distribution : public detail::normal_distribution_base<RealType>::type
 {
 private:
-  typedef typename detail::normal_distribution_base<RealType>::type super_t;
+  using super_t = typename detail::normal_distribution_base<RealType>::type;
 
 public:
   // types
@@ -96,12 +96,12 @@ public:
   /*! \typedef result_type
    *  \brief The type of the floating point number produced by this \p normal_distribution.
    */
-  typedef RealType result_type;
+  using result_type = RealType;
 
   /*! \typedef param_type
    *  \brief The type of the object encapsulating this \p normal_distribution's parameters.
    */
-  typedef thrust::pair<RealType, RealType> param_type;
+  using param_type = thrust::pair<RealType, RealType>;
 
   // constructors and reset functions
 

--- a/thrust/thrust/random/subtract_with_carry_engine.h
+++ b/thrust/thrust/random/subtract_with_carry_engine.h
@@ -87,7 +87,7 @@ public:
   /*! \typedef result_type
    *  \brief The type of the unsigned integer produced by this \p subtract_with_carry_engine.
    */
-  typedef UIntType result_type;
+  using result_type = UIntType;
 
   // engine characteristics
 
@@ -219,7 +219,7 @@ operator>>(std::basic_istream<CharT, Traits>& is, subtract_with_carry_engine<UIn
  *  \note The 10000th consecutive invocation of a default-constructed object of type \p ranlux24_base
  *        shall produce the value \c 7937952 .
  */
-typedef subtract_with_carry_engine<thrust::detail::uint32_t, 24, 10, 24> ranlux24_base;
+using ranlux24_base = subtract_with_carry_engine<thrust::detail::uint32_t, 24, 10, 24>;
 
 // XXX N2111 uses uint_fast64_t here
 
@@ -229,7 +229,7 @@ typedef subtract_with_carry_engine<thrust::detail::uint32_t, 24, 10, 24> ranlux2
  *  \note The 10000th consecutive invocation of a default-constructed object of type \p ranlux48_base
  *        shall produce the value \c 192113843633948 .
  */
-typedef subtract_with_carry_engine<thrust::detail::uint64_t, 48, 5, 12> ranlux48_base;
+using ranlux48_base = subtract_with_carry_engine<thrust::detail::uint64_t, 48, 5, 12>;
 
 /*! \} // end predefined_random
  */

--- a/thrust/thrust/random/uniform_int_distribution.h
+++ b/thrust/thrust/random/uniform_int_distribution.h
@@ -100,12 +100,12 @@ public:
   /*! \typedef result_type
    *  \brief The type of the integer produced by this \p uniform_int_distribution.
    */
-  typedef IntType result_type;
+  using result_type = IntType;
 
   /*! \typedef param_type
    *  \brief The type of the object encapsulating this \p uniform_int_distribution's parameters.
    */
-  typedef thrust::pair<IntType, IntType> param_type;
+  using param_type = thrust::pair<IntType, IntType>;
 
   // constructors and reset functions
 

--- a/thrust/thrust/random/uniform_real_distribution.h
+++ b/thrust/thrust/random/uniform_real_distribution.h
@@ -98,12 +98,12 @@ public:
   /*! \typedef result_type
    *  \brief The type of the floating point number produced by this \p uniform_real_distribution.
    */
-  typedef RealType result_type;
+  using result_type = RealType;
 
   /*! \typedef param_type
    *  \brief The type of the object encapsulating this \p uniform_real_distribution's parameters.
    */
-  typedef thrust::pair<RealType, RealType> param_type;
+  using param_type = thrust::pair<RealType, RealType>;
 
   // constructors and reset functions
 

--- a/thrust/thrust/random/xor_combine_engine.h
+++ b/thrust/thrust/random/xor_combine_engine.h
@@ -86,20 +86,20 @@ public:
   /*! \typedef base1_type
    *  \brief The type of the first adapted base random number engine.
    */
-  typedef Engine1 base1_type;
+  using base1_type = Engine1;
 
   /*! \typedef base2_type
    *  \brief The type of the second adapted base random number engine.
    */
-  typedef Engine2 base2_type;
+  using base2_type = Engine2;
 
   /*! \typedef result_type
    *  \brief The type of the unsigned integer produced by this \p xor_combine_engine.
    */
-  typedef typename thrust::detail::eval_if<
+  using result_type = typename thrust::detail::eval_if<
     (sizeof(typename base2_type::result_type) > sizeof(typename base1_type::result_type)),
     thrust::detail::identity_<typename base2_type::result_type>,
-    thrust::detail::identity_<typename base1_type::result_type>>::type result_type;
+    thrust::detail::identity_<typename base1_type::result_type>>::type;
 
   /*! The size of the first shift used in the generation algorithm.
    */

--- a/thrust/thrust/system/cpp/detail/execution_policy.h
+++ b/thrust/thrust/system/cpp/detail/execution_policy.h
@@ -63,7 +63,7 @@ struct tag : execution_policy<tag>
 template <typename Derived>
 struct execution_policy : thrust::system::detail::sequential::execution_policy<Derived>
 {
-  typedef tag tag_type;
+  using tag_type = tag;
   operator tag() const
   {
     return tag();

--- a/thrust/thrust/system/cpp/memory_resource.h
+++ b/thrust/thrust/system/cpp/memory_resource.h
@@ -42,10 +42,10 @@ namespace cpp
 //! \cond
 namespace detail
 {
-typedef thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::cpp::pointer<void>> native_resource;
+using native_resource = thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::cpp::pointer<void>>;
 
-typedef thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::cpp::universal_pointer<void>>
-  universal_native_resource;
+using universal_native_resource =
+  thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::cpp::universal_pointer<void>>;
 } // namespace detail
 //! \endcond
 
@@ -57,13 +57,13 @@ typedef thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thru
 /*! The memory resource for the Standard C++ system. Uses \p
  *  mr::new_delete_resource and tags it with \p cpp::pointer.
  */
-typedef detail::native_resource memory_resource;
+using memory_resource = detail::native_resource;
 /*! The unified memory resource for the Standard C++ system. Uses
  *  \p mr::new_delete_resource and tags it with \p cpp::universal_pointer.
  */
-typedef detail::universal_native_resource universal_memory_resource;
+using universal_memory_resource = detail::universal_native_resource;
 /*! An alias for \p cpp::universal_memory_resource. */
-typedef detail::native_resource universal_host_pinned_memory_resource;
+using universal_host_pinned_memory_resource = detail::native_resource;
 
 /*! \} // memory_resources
  */

--- a/thrust/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/thrust/system/cuda/detail/adjacent_difference.h
@@ -211,7 +211,7 @@ template <class Derived, class InputIt, class OutputIt>
 OutputIt _CCCL_HOST_DEVICE
 adjacent_difference(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result)
 {
-  typedef typename iterator_traits<InputIt>::value_type input_type;
+  using input_type = typename iterator_traits<InputIt>::value_type;
   return cuda_cub::adjacent_difference(policy, first, last, result, minus<input_type>());
 }
 

--- a/thrust/thrust/system/cuda/detail/core/agent_launcher.h
+++ b/thrust/thrust/system/cuda/detail/core/agent_launcher.h
@@ -112,8 +112,8 @@ struct AgentLauncher : Agent
   {
     MAX_SHMEM_PER_BLOCK = 48 * 1024,
   };
-  typedef typename has_enough_shmem<Agent, MAX_SHMEM_PER_BLOCK>::type has_enough_shmem_t;
-  typedef has_enough_shmem<Agent, MAX_SHMEM_PER_BLOCK> shm1;
+  using has_enough_shmem_t = typename has_enough_shmem<Agent, MAX_SHMEM_PER_BLOCK>::type;
+  using shm1               = has_enough_shmem<Agent, MAX_SHMEM_PER_BLOCK>;
 
   template <class Size>
   THRUST_RUNTIME_FUNCTION AgentLauncher(AgentPlan plan_, Size count_, cudaStream_t stream_, char const* name_)

--- a/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
+++ b/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
@@ -48,7 +48,7 @@ namespace launcher
 
 struct _CCCL_VISIBILITY_HIDDEN triple_chevron
 {
-  typedef size_t Size;
+  using Size = size_t;
   dim3 const grid;
   dim3 const block;
   Size const shared_mem;

--- a/thrust/thrust/system/cuda/detail/core/util.h
+++ b/thrust/thrust/system/cuda/detail/core/util.h
@@ -126,7 +126,7 @@ struct sm60
 // list of sm, checked from left to right order
 // the rightmost is the lowest sm arch supported
 // --------------------------------------------
-typedef typelist<sm60, sm52, sm35, sm30> sm_list;
+using sm_list = typelist<sm60, sm52, sm35, sm30>;
 
 // lowest supported SM arch
 // --------------------------------------------------------------------------
@@ -141,10 +141,10 @@ struct lowest_supported_sm_arch_impl<SM, typelist<Head, Tail...>>
 template <class SM>
 struct lowest_supported_sm_arch_impl<SM, typelist<>>
 {
-  typedef SM type;
+  using type = SM;
 };
 
-typedef typename lowest_supported_sm_arch_impl<void, sm_list>::type lowest_supported_sm_arch;
+using lowest_supported_sm_arch = typename lowest_supported_sm_arch_impl<void, sm_list>::type;
 
 // metafunction to match next viable PtxPlan specialization
 // --------------------------------------------------------------------------
@@ -199,10 +199,9 @@ struct specialize_plan_msvc10_war
   // if Plan has tuning type, this means it has SM-specific tuning
   // so loop through sm_list to find match,
   // otherwise just specialize on provided SM
-  typedef ::cuda::std::conditional<has_tuning_t<Plan<lowest_supported_sm_arch>>::value,
-                                   specialize_plan_impl_loop<Plan, SM, sm_list>,
-                                   Plan<SM>>
-    type;
+  using type = ::cuda::std::conditional<has_tuning_t<Plan<lowest_supported_sm_arch>>::value,
+                                        specialize_plan_impl_loop<Plan, SM, sm_list>,
+                                        Plan<SM>>;
 };
 
 template <template <class> class Plan, class SM = THRUST_TUNING_ARCH>
@@ -255,7 +254,7 @@ struct has_enough_shmem_impl<V, A, S, typelist<>>
   {
     value = V
   };
-  typedef ::cuda::std::__conditional_t<value, thrust::detail::true_type, thrust::detail::false_type> type;
+  using type = ::cuda::std::__conditional_t<value, thrust::detail::true_type, thrust::detail::false_type>;
 };
 
 template <class Agent, size_t MAX_SHMEM>
@@ -312,7 +311,7 @@ __THRUST_DEFINE_HAS_NESTED_TYPE(has_Plan, Plan)
 template <class Agent>
 struct return_Plan
 {
-  typedef typename Agent::Plan type;
+  using type = typename Agent::Plan;
 };
 
 template <class Agent>
@@ -329,7 +328,7 @@ struct get_agent_plan_impl;
 template <class Agent, class SM, class... Tail>
 struct get_agent_plan_impl<Agent, typelist<SM, Tail...>>
 {
-  typedef typename get_plan<Agent>::type Plan;
+  using Plan = typename get_plan<Agent>::type;
   Plan THRUST_RUNTIME_FUNCTION static get(int ptx_version)
   {
     if (ptx_version >= SM::ver)
@@ -346,10 +345,10 @@ struct get_agent_plan_impl<Agent, typelist<SM, Tail...>>
 template <class Agent>
 struct get_agent_plan_impl<Agent, typelist<lowest_supported_sm_arch>>
 {
-  typedef typename get_plan<Agent>::type Plan;
+  using Plan = typename get_plan<Agent>::type;
   Plan THRUST_RUNTIME_FUNCTION static get(int /* ptx_version */)
   {
-    typedef typename get_plan<Agent>::type Plan;
+    using Plan = typename get_plan<Agent>::type;
     return Plan(specialize_plan<Agent::template PtxPlan, lowest_supported_sm_arch>());
   }
 };
@@ -511,13 +510,13 @@ THRUST_RUNTIME_FUNCTION inline size_t vshmem_size(size_t shmem_per_block, size_t
 template <class PtxPlan, class It>
 struct LoadIterator
 {
-  typedef typename iterator_traits<It>::value_type value_type;
-  typedef typename iterator_traits<It>::difference_type size_type;
+  using value_type = typename iterator_traits<It>::value_type;
+  using size_type  = typename iterator_traits<It>::difference_type;
 
-  typedef ::cuda::std::__conditional_t<is_contiguous_iterator<It>::value,
-                                       cub::CacheModifiedInputIterator<PtxPlan::LOAD_MODIFIER, value_type, size_type>,
-                                       It>
-    type;
+  using type =
+    ::cuda::std::__conditional_t<is_contiguous_iterator<It>::value,
+                                 cub::CacheModifiedInputIterator<PtxPlan::LOAD_MODIFIER, value_type, size_type>,
+                                 It>;
 }; // struct Iterator
 
 template <class PtxPlan, class It>
@@ -546,7 +545,7 @@ struct get_arch;
 template <template <class> class Plan, class Arch>
 struct get_arch<Plan<Arch>>
 {
-  typedef Arch type;
+  using type = Arch;
 };
 
 // BlockLoad
@@ -699,7 +698,7 @@ inline void _CCCL_DEVICE sync_threadblock()
 template <class T>
 struct uninitialized
 {
-  typedef typename cub::UnitWord<T>::DeviceWord DeviceWord;
+  using DeviceWord = typename cub::UnitWord<T>::DeviceWord;
 
   enum
   {
@@ -725,8 +724,8 @@ struct uninitialized
 template <class T, size_t N>
 struct uninitialized_array
 {
-  typedef T value_type;
-  typedef T ref[N];
+  using value_type = T;
+  using ref        = T[N];
   enum
   {
     SIZE = N

--- a/thrust/thrust/system/cuda/detail/count.h
+++ b/thrust/thrust/system/cuda/detail/count.h
@@ -51,8 +51,8 @@ template <class Derived, class InputIt, class UnaryPred>
 typename iterator_traits<InputIt>::difference_type _CCCL_HOST_DEVICE
 count_if(execution_policy<Derived>& policy, InputIt first, InputIt last, UnaryPred unary_pred)
 {
-  typedef typename iterator_traits<InputIt>::difference_type size_type;
-  typedef transform_input_iterator_t<size_type, InputIt, UnaryPred> flag_iterator_t;
+  using size_type       = typename iterator_traits<InputIt>::difference_type;
+  using flag_iterator_t = transform_input_iterator_t<size_type, InputIt, UnaryPred>;
 
   return cuda_cub::reduce_n(
     policy, flag_iterator_t(first, unary_pred), thrust::distance(first, last), size_type(0), plus<size_type>());

--- a/thrust/thrust/system/cuda/detail/cross_system.h
+++ b/thrust/thrust/system/cuda/detail/cross_system.h
@@ -46,8 +46,8 @@ namespace cuda_cub
 template <class Sys1, class Sys2>
 struct cross_system : execution_policy<cross_system<Sys1, Sys2>>
 {
-  typedef thrust::execution_policy<Sys1> policy1;
-  typedef thrust::execution_policy<Sys2> policy2;
+  using policy1 = thrust::execution_policy<Sys1>;
+  using policy2 = thrust::execution_policy<Sys2>;
 
   policy1& sys1;
   policy2& sys2;

--- a/thrust/thrust/system/cuda/detail/equal.h
+++ b/thrust/thrust/system/cuda/detail/equal.h
@@ -55,7 +55,7 @@ equal(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, InputI
 template <class Derived, class InputIt1, class InputIt2>
 bool _CCCL_HOST_DEVICE equal(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2)
 {
-  typedef typename thrust::iterator_value<InputIt1>::type InputType1;
+  using InputType1 = typename thrust::iterator_value<InputIt1>::type;
   return cuda_cub::equal(policy, first1, last1, first2, equal_to<InputType1>());
 }
 

--- a/thrust/thrust/system/cuda/detail/execution_policy.h
+++ b/thrust/thrust/system/cuda/detail/execution_policy.h
@@ -58,7 +58,7 @@ struct execution_policy;
 template <>
 struct execution_policy<tag> : thrust::execution_policy<tag>
 {
-  typedef tag tag_type;
+  using tag_type = tag;
 };
 
 struct tag
@@ -70,7 +70,7 @@ struct tag
 template <class Derived>
 struct execution_policy : thrust::execution_policy<Derived>
 {
-  typedef tag tag_type;
+  using tag_type = tag;
   operator tag() const
   {
     return tag();

--- a/thrust/thrust/system/cuda/detail/extrema.h
+++ b/thrust/thrust/system/cuda/detail/extrema.h
@@ -61,7 +61,7 @@ template <class InputType, class IndexType, class Predicate>
 struct arg_min_f
 {
   Predicate predicate;
-  typedef tuple<InputType, IndexType> pair_type;
+  using pair_type = tuple<InputType, IndexType>;
 
   _CCCL_HOST_DEVICE arg_min_f(Predicate p)
       : predicate(p)
@@ -100,7 +100,7 @@ template <class InputType, class IndexType, class Predicate>
 struct arg_max_f
 {
   Predicate predicate;
-  typedef tuple<InputType, IndexType> pair_type;
+  using pair_type = tuple<InputType, IndexType>;
 
   _CCCL_HOST_DEVICE arg_max_f(Predicate p)
       : predicate(p)
@@ -140,11 +140,11 @@ struct arg_minmax_f
 {
   Predicate predicate;
 
-  typedef tuple<InputType, IndexType> pair_type;
-  typedef tuple<pair_type, pair_type> two_pairs_type;
+  using pair_type      = tuple<InputType, IndexType>;
+  using two_pairs_type = tuple<pair_type, pair_type>;
 
-  typedef arg_min_f<InputType, IndexType, Predicate> arg_min_t;
-  typedef arg_max_f<InputType, IndexType, Predicate> arg_max_t;
+  using arg_min_t = arg_min_f<InputType, IndexType, Predicate>;
+  using arg_max_t = arg_max_f<InputType, IndexType, Predicate>;
 
   _CCCL_HOST_DEVICE arg_minmax_f(Predicate p)
       : predicate(p)
@@ -186,14 +186,14 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   using core::cuda_optional;
   using core::get_agent_plan;
 
-  typedef typename detail::make_unsigned_special<Size>::type UnsignedSize;
+  using UnsignedSize = typename detail::make_unsigned_special<Size>::type;
 
   if (num_items == 0)
   {
     return cudaErrorNotSupported;
   }
 
-  typedef AgentLauncher<__reduce::ReduceAgent<InputIt, OutputIt, T, Size, ReductionOp>> reduce_agent;
+  using reduce_agent = AgentLauncher<__reduce::ReduceAgent<InputIt, OutputIt, T, Size, ReductionOp>>;
 
   typename reduce_agent::Plan reduce_plan = reduce_agent::get_plan(stream);
 
@@ -278,7 +278,7 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
       // then fill the device with threadblocks
       reduce_grid_size = static_cast<int>((min) (num_tiles, static_cast<size_t>(reduce_device_occupancy)));
 
-      typedef AgentLauncher<__reduce::DrainAgent<Size>> drain_agent;
+      using drain_agent    = AgentLauncher<__reduce::DrainAgent<Size>>;
       AgentPlan drain_plan = drain_agent::get_plan();
       drain_plan.grid_size = 1;
       drain_agent da(drain_plan, stream, "__reduce::drain_agent");
@@ -295,7 +295,7 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
     ra.launch(input_it, d_block_reductions, num_items, even_share, queue, reduction_op);
     CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
 
-    typedef AgentLauncher<__reduce::ReduceAgent<T*, OutputIt, T, Size, ReductionOp>> reduce_agent_single;
+    using reduce_agent_single = AgentLauncher<__reduce::ReduceAgent<T*, OutputIt, T, Size, ReductionOp>>;
 
     reduce_plan.grid_size = 1;
     reduce_agent_single ra1(reduce_plan, stream, vshmem_ptr, "reduce_agent: single tile reduce");
@@ -364,18 +364,18 @@ element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPr
     return last;
   }
 
-  typedef typename iterator_traits<ItemsIt>::value_type InputType;
-  typedef typename iterator_traits<ItemsIt>::difference_type IndexType;
+  using InputType = typename iterator_traits<ItemsIt>::value_type;
+  using IndexType = typename iterator_traits<ItemsIt>::difference_type;
 
   IndexType num_items = static_cast<IndexType>(thrust::distance(first, last));
 
-  typedef tuple<ItemsIt, counting_iterator_t<IndexType>> iterator_tuple;
-  typedef zip_iterator<iterator_tuple> zip_iterator;
+  using iterator_tuple = tuple<ItemsIt, counting_iterator_t<IndexType>>;
+  using zip_iterator   = zip_iterator<iterator_tuple>;
 
   iterator_tuple iter_tuple = thrust::make_tuple(first, counting_iterator_t<IndexType>(0));
 
-  typedef ArgFunctor<InputType, IndexType, BinaryPred> arg_min_t;
-  typedef tuple<InputType, IndexType> T;
+  using arg_min_t = ArgFunctor<InputType, IndexType, BinaryPred>;
+  using T         = tuple<InputType, IndexType>;
 
   zip_iterator begin = make_zip_iterator(iter_tuple);
 
@@ -400,7 +400,7 @@ min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, Bina
 template <class Derived, class ItemsIt>
 ItemsIt _CCCL_HOST_DEVICE min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
 {
-  typedef typename iterator_value<ItemsIt>::type value_type;
+  using value_type = typename iterator_value<ItemsIt>::type;
   return cuda_cub::min_element(policy, first, last, less<value_type>());
 }
 
@@ -419,7 +419,7 @@ max_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, Bina
 template <class Derived, class ItemsIt>
 ItemsIt _CCCL_HOST_DEVICE max_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
 {
-  typedef typename iterator_value<ItemsIt>::type value_type;
+  using value_type = typename iterator_value<ItemsIt>::type;
   return cuda_cub::max_element(policy, first, last, less<value_type>());
 }
 
@@ -464,7 +464,7 @@ minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, B
 template <class Derived, class ItemsIt>
 pair<ItemsIt, ItemsIt> _CCCL_HOST_DEVICE minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
 {
-  typedef typename iterator_value<ItemsIt>::type value_type;
+  using value_type = typename iterator_value<ItemsIt>::type;
   return cuda_cub::minmax_element(policy, first, last, less<value_type>());
 }
 

--- a/thrust/thrust/system/cuda/detail/find.h
+++ b/thrust/thrust/system/cuda/detail/find.h
@@ -97,7 +97,7 @@ template <class Derived, class InputIt, class Size, class Predicate>
 InputIt _CCCL_HOST_DEVICE
 find_if_n(execution_policy<Derived>& policy, InputIt first, Size num_items, Predicate predicate)
 {
-  typedef typename thrust::tuple<bool, Size> result_type;
+  using result_type = typename thrust::tuple<bool, Size>;
 
   // empty sequence
   if (num_items == 0)
@@ -116,9 +116,9 @@ find_if_n(execution_policy<Derived>& policy, InputIt first, Size num_items, Pred
   const Size interval_size      = (thrust::min)(interval_threshold, num_items);
 
   // force transform_iterator output to bool
-  typedef transform_input_iterator_t<bool, InputIt, Predicate> XfrmIterator;
-  typedef thrust::tuple<XfrmIterator, counting_iterator_t<Size>> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using XfrmIterator  = transform_input_iterator_t<bool, InputIt, Predicate>;
+  using IteratorTuple = thrust::tuple<XfrmIterator, counting_iterator_t<Size>>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   IteratorTuple iter_tuple = thrust::make_tuple(XfrmIterator(first, predicate), counting_iterator_t<Size>(0));
 

--- a/thrust/thrust/system/cuda/detail/for_each.h
+++ b/thrust/thrust/system/cuda/detail/for_each.h
@@ -72,7 +72,7 @@ Input THRUST_FUNCTION for_each_n(execution_policy<Derived>& policy, Input first,
 template <class Derived, class Input, class UnaryOp>
 Input THRUST_FUNCTION for_each(execution_policy<Derived>& policy, Input first, Input last, UnaryOp op)
 {
-  typedef typename iterator_traits<Input>::difference_type size_type;
+  using size_type = typename iterator_traits<Input>::difference_type;
   size_type count = static_cast<size_type>(thrust::distance(first, last));
 
   return THRUST_NS_QUALIFIER::cuda_cub::for_each_n(policy, first, count, op);

--- a/thrust/thrust/system/cuda/detail/get_value.h
+++ b/thrust/thrust/system/cuda/detail/get_value.h
@@ -46,7 +46,7 @@ template <typename DerivedPolicy, typename Pointer>
 inline _CCCL_HOST_DEVICE typename thrust::iterator_value<Pointer>::type
 get_value_msvc2005_war(execution_policy<DerivedPolicy>& exec, Pointer ptr)
 {
-  typedef typename thrust::iterator_value<Pointer>::type result_type;
+  using result_type = typename thrust::iterator_value<Pointer>::type;
 
   // XXX war nvbugs/881631
   struct war_nvbugs_881631

--- a/thrust/thrust/system/cuda/detail/inner_product.h
+++ b/thrust/thrust/system/cuda/detail/inner_product.h
@@ -58,9 +58,9 @@ T _CCCL_HOST_DEVICE inner_product(
   ReduceOp reduce_op,
   ProductOp product_op)
 {
-  typedef typename iterator_traits<InputIt1>::difference_type size_type;
-  size_type num_items = static_cast<size_type>(thrust::distance(first1, last1));
-  typedef transform_pair_of_input_iterators_t<T, InputIt1, InputIt2, ProductOp> binop_iterator_t;
+  using size_type        = typename iterator_traits<InputIt1>::difference_type;
+  size_type num_items    = static_cast<size_type>(thrust::distance(first1, last1));
+  using binop_iterator_t = transform_pair_of_input_iterators_t<T, InputIt1, InputIt2, ProductOp>;
 
   return cuda_cub::reduce_n(policy, binop_iterator_t(first1, first2, product_op), num_items, init, reduce_op);
 }

--- a/thrust/thrust/system/cuda/detail/internal/copy_cross_system.h
+++ b/thrust/thrust/system/cuda/detail/internal/copy_cross_system.h
@@ -85,7 +85,7 @@ OutputIt _CCCL_HOST cross_system_copy_n(
   thrust::detail::true_type) // trivial copy
 
 {
-  typedef typename iterator_traits<InputIt>::value_type InputTy;
+  using InputTy = typename iterator_traits<InputIt>::value_type;
   if (n > 0)
   {
     trivial_device_copy(
@@ -110,7 +110,7 @@ OutputIt _CCCL_HOST cross_system_copy_n(
   thrust::detail::false_type) // non-trivial copy
 {
   // get type of the input data
-  typedef typename thrust::iterator_value<InputIt>::type InputTy;
+  using InputTy = typename thrust::iterator_value<InputIt>::type;
 
   // copy input data into host temp storage
   InputIt last = first;
@@ -152,7 +152,7 @@ OutputIt _CCCL_HOST cross_system_copy_n(
 
 {
   // get type of the input data
-  typedef typename thrust::iterator_value<InputIt>::type InputTy;
+  using InputTy = typename thrust::iterator_value<InputIt>::type;
 
   // allocate device temp storage
   thrust::detail::temporary_array<InputTy, D> d_in_ptr(device_s, num_items);

--- a/thrust/thrust/system/cuda/detail/internal/copy_device_to_device.h
+++ b/thrust/thrust/system/cuda/detail/internal/copy_device_to_device.h
@@ -57,8 +57,8 @@ template <class Derived, class InputIt, class OutputIt>
 OutputIt THRUST_RUNTIME_FUNCTION device_to_device(
   execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result, thrust::detail::true_type)
 {
-  typedef typename thrust::iterator_traits<InputIt>::value_type InputTy;
-  const auto n = thrust::distance(first, last);
+  using InputTy = typename thrust::iterator_traits<InputIt>::value_type;
+  const auto n  = thrust::distance(first, last);
   if (n > 0)
   {
     cudaError status;
@@ -77,7 +77,7 @@ template <class Derived, class InputIt, class OutputIt>
 OutputIt THRUST_RUNTIME_FUNCTION device_to_device(
   execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result, thrust::detail::false_type)
 {
-  typedef typename thrust::iterator_traits<InputIt>::value_type InputTy;
+  using InputTy = typename thrust::iterator_traits<InputIt>::value_type;
   return cuda_cub::transform(policy, first, last, result, thrust::identity<InputTy>());
 }
 

--- a/thrust/thrust/system/cuda/detail/make_unsigned_special.h
+++ b/thrust/thrust/system/cuda/detail/make_unsigned_special.h
@@ -39,7 +39,7 @@ struct make_unsigned_special;
 template <>
 struct make_unsigned_special<int>
 {
-  typedef unsigned int type;
+  using type = unsigned int;
 };
 
 // this is special, because CUDA's atomicAdd doesn't have an overload
@@ -47,13 +47,13 @@ struct make_unsigned_special<int>
 template <>
 struct make_unsigned_special<long>
 {
-  typedef unsigned long long type;
+  using type = unsigned long long;
 };
 
 template <>
 struct make_unsigned_special<long long>
 {
-  typedef unsigned long long type;
+  using type = unsigned long long;
 };
 
 } // namespace detail

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -63,8 +63,8 @@ template <class KeysIt1, class KeysIt2, class Size, class BinaryPred>
 Size THRUST_DEVICE_FUNCTION
 merge_path(KeysIt1 keys1, KeysIt2 keys2, Size keys1_count, Size keys2_count, Size diag, BinaryPred binary_pred)
 {
-  typedef typename iterator_traits<KeysIt1>::value_type key1_type;
-  typedef typename iterator_traits<KeysIt2>::value_type key2_type;
+  using key1_type = typename iterator_traits<KeysIt1>::value_type;
+  using key2_type = typename iterator_traits<KeysIt2>::value_type;
 
   Size keys1_begin = thrust::max<Size>(0, diag - keys2_count);
   Size keys1_end   = thrust::min<Size>(diag, keys1_count);
@@ -101,7 +101,7 @@ THRUST_DEVICE_FUNCTION void serial_merge(
   int keys1_end = keys1_beg + keys1_count;
   int keys2_end = keys2_beg + keys2_count;
 
-  typedef typename iterator_value<It>::type key_type;
+  using key_type = typename iterator_value<It>::type;
 
   key_type key1 = keys_shared[keys1_beg];
   key_type key2 = keys_shared[keys2_beg];
@@ -151,7 +151,7 @@ struct PartitionAgent
   struct PtxPlan : PtxPolicy<256>
   {};
 
-  typedef core::specialize_plan<PtxPlan> ptx_plan;
+  using ptx_plan = core::specialize_plan<PtxPlan>;
 
   THRUST_AGENT_ENTRY(
     KeysIt1 keys1,
@@ -202,8 +202,8 @@ struct Tuning<sm30, TSize>
     ITEMS_PER_THREAD            = items_per_thread<NOMINAL_4B_ITEMS_PER_THREAD, INPUT_SIZE>::value
   };
 
-  typedef PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE>
-    type;
+  using type =
+    PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE>;
 }; // Tuning sm300
 
 template <class TSize>
@@ -215,8 +215,8 @@ struct Tuning<sm60, TSize> : Tuning<sm30, TSize>
     ITEMS_PER_THREAD            = items_per_thread<NOMINAL_4B_ITEMS_PER_THREAD, Tuning::INPUT_SIZE>::value
   };
 
-  typedef PtxPolicy<512, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE>
-    type;
+  using type =
+    PtxPolicy<512, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE>;
 }; // Tuning sm52
 
 template <class TSize>
@@ -228,8 +228,8 @@ struct Tuning<sm52, TSize> : Tuning<sm30, TSize>
     ITEMS_PER_THREAD            = items_per_thread<NOMINAL_4B_ITEMS_PER_THREAD, Tuning::INPUT_SIZE>::value
   };
 
-  typedef PtxPolicy<512, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_STORE_WARP_TRANSPOSE>
-    type;
+  using type =
+    PtxPolicy<512, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_STORE_WARP_TRANSPOSE>;
 }; // Tuning sm52
 
 template <class TSize>
@@ -242,8 +242,8 @@ struct Tuning<sm35, TSize> : Tuning<sm30, TSize>
     ITEMS_PER_THREAD            = items_per_thread<NOMINAL_4B_ITEMS_PER_THREAD, Tuning::INPUT_SIZE>::value
   };
 
-  typedef PtxPolicy<256, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_STORE_WARP_TRANSPOSE>
-    type;
+  using type =
+    PtxPolicy<256, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_STORE_WARP_TRANSPOSE>;
 }; // Tuning sm350
 
 template <size_t VALUE>
@@ -261,36 +261,36 @@ template <class KeysIt1,
           class MERGE_ITEMS>
 struct MergeAgent
 {
-  typedef typename iterator_traits<KeysIt1>::value_type key1_type;
-  typedef typename iterator_traits<KeysIt2>::value_type key2_type;
-  typedef typename iterator_traits<ItemsIt1>::value_type item1_type;
-  typedef typename iterator_traits<ItemsIt2>::value_type item2_type;
+  using key1_type  = typename iterator_traits<KeysIt1>::value_type;
+  using key2_type  = typename iterator_traits<KeysIt2>::value_type;
+  using item1_type = typename iterator_traits<ItemsIt1>::value_type;
+  using item2_type = typename iterator_traits<ItemsIt2>::value_type;
 
-  typedef key1_type key_type;
-  typedef item1_type item_type;
+  using key_type  = key1_type;
+  using item_type = item1_type;
 
-  typedef ::cuda::std::__conditional_t<MERGE_ITEMS::value,
-                                       integer_constant<sizeof(key_type) + sizeof(item_type)>,
-                                       integer_constant<sizeof(key_type)>>
-    tuning_type;
+  using tuning_type =
+    ::cuda::std::__conditional_t<MERGE_ITEMS::value,
+                                 integer_constant<sizeof(key_type) + sizeof(item_type)>,
+                                 integer_constant<sizeof(key_type)>>;
 
   template <class Arch>
   struct PtxPlan : Tuning<Arch, tuning_type>::type
   {
-    typedef Tuning<Arch, tuning_type> tuning;
+    using tuning = Tuning<Arch, tuning_type>;
 
-    typedef typename core::LoadIterator<PtxPlan, KeysIt1>::type KeysLoadIt1;
-    typedef typename core::LoadIterator<PtxPlan, KeysIt2>::type KeysLoadIt2;
-    typedef typename core::LoadIterator<PtxPlan, ItemsIt1>::type ItemsLoadIt1;
-    typedef typename core::LoadIterator<PtxPlan, ItemsIt2>::type ItemsLoadIt2;
+    using KeysLoadIt1  = typename core::LoadIterator<PtxPlan, KeysIt1>::type;
+    using KeysLoadIt2  = typename core::LoadIterator<PtxPlan, KeysIt2>::type;
+    using ItemsLoadIt1 = typename core::LoadIterator<PtxPlan, ItemsIt1>::type;
+    using ItemsLoadIt2 = typename core::LoadIterator<PtxPlan, ItemsIt2>::type;
 
-    typedef typename core::BlockLoad<PtxPlan, KeysLoadIt1>::type BlockLoadKeys1;
-    typedef typename core::BlockLoad<PtxPlan, KeysLoadIt2>::type BlockLoadKeys2;
-    typedef typename core::BlockLoad<PtxPlan, ItemsLoadIt1>::type BlockLoadItems1;
-    typedef typename core::BlockLoad<PtxPlan, ItemsLoadIt2>::type BlockLoadItems2;
+    using BlockLoadKeys1  = typename core::BlockLoad<PtxPlan, KeysLoadIt1>::type;
+    using BlockLoadKeys2  = typename core::BlockLoad<PtxPlan, KeysLoadIt2>::type;
+    using BlockLoadItems1 = typename core::BlockLoad<PtxPlan, ItemsLoadIt1>::type;
+    using BlockLoadItems2 = typename core::BlockLoad<PtxPlan, ItemsLoadIt2>::type;
 
-    typedef typename core::BlockStore<PtxPlan, KeysOutputIt, key_type>::type BlockStoreKeys;
-    typedef typename core::BlockStore<PtxPlan, ItemsOutputIt, item_type>::type BlockStoreItems;
+    using BlockStoreKeys  = typename core::BlockStore<PtxPlan, KeysOutputIt, key_type>::type;
+    using BlockStoreItems = typename core::BlockStore<PtxPlan, ItemsOutputIt, item_type>::type;
 
     // gather required temporary storage in a union
     //
@@ -308,19 +308,19 @@ struct MergeAgent
     }; // union TempStorage
   }; // struct PtxPlan
 
-  typedef typename core::specialize_plan_msvc10_war<PtxPlan>::type::type ptx_plan;
+  using ptx_plan = typename core::specialize_plan_msvc10_war<PtxPlan>::type::type;
 
-  typedef typename ptx_plan::KeysLoadIt1 KeysLoadIt1;
-  typedef typename ptx_plan::KeysLoadIt2 KeysLoadIt2;
-  typedef typename ptx_plan::ItemsLoadIt1 ItemsLoadIt1;
-  typedef typename ptx_plan::ItemsLoadIt2 ItemsLoadIt2;
-  typedef typename ptx_plan::BlockLoadKeys1 BlockLoadKeys1;
-  typedef typename ptx_plan::BlockLoadKeys2 BlockLoadKeys2;
-  typedef typename ptx_plan::BlockLoadItems1 BlockLoadItems1;
-  typedef typename ptx_plan::BlockLoadItems2 BlockLoadItems2;
-  typedef typename ptx_plan::BlockStoreKeys BlockStoreKeys;
-  typedef typename ptx_plan::BlockStoreItems BlockStoreItems;
-  typedef typename ptx_plan::TempStorage TempStorage;
+  using KeysLoadIt1     = typename ptx_plan::KeysLoadIt1;
+  using KeysLoadIt2     = typename ptx_plan::KeysLoadIt2;
+  using ItemsLoadIt1    = typename ptx_plan::ItemsLoadIt1;
+  using ItemsLoadIt2    = typename ptx_plan::ItemsLoadIt2;
+  using BlockLoadKeys1  = typename ptx_plan::BlockLoadKeys1;
+  using BlockLoadKeys2  = typename ptx_plan::BlockLoadKeys2;
+  using BlockLoadItems1 = typename ptx_plan::BlockLoadItems1;
+  using BlockLoadItems2 = typename ptx_plan::BlockLoadItems2;
+  using BlockStoreKeys  = typename ptx_plan::BlockStoreKeys;
+  using BlockStoreItems = typename ptx_plan::BlockStoreItems;
+  using TempStorage     = typename ptx_plan::TempStorage;
 
   enum
   {
@@ -627,11 +627,10 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
 
   using core::AgentPlan;
   using core::get_agent_plan;
-  typedef core::AgentLauncher<
-    MergeAgent<KeysIt1, KeysIt2, ItemsIt1, ItemsIt2, Size, KeysOutputIt, ItemsOutputIt, CompareOp, MERGE_ITEMS>>
-    merge_agent;
+  using merge_agent = core::AgentLauncher<
+    MergeAgent<KeysIt1, KeysIt2, ItemsIt1, ItemsIt2, Size, KeysOutputIt, ItemsOutputIt, CompareOp, MERGE_ITEMS>>;
 
-  typedef core::AgentLauncher<PartitionAgent<KeysIt1, KeysIt2, Size, CompareOp>> partition_agent;
+  using partition_agent = core::AgentLauncher<PartitionAgent<KeysIt1, KeysIt2, Size, CompareOp>>;
 
   cudaError_t status = cudaSuccess;
 
@@ -696,7 +695,7 @@ THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ItemsOutputIt> merge(
   ItemsOutputIt items_result,
   CompareOp compare_op)
 {
-  typedef typename iterator_traits<KeysIt1>::difference_type size_type;
+  using size_type = typename iterator_traits<KeysIt1>::difference_type;
 
   size_type num_keys1 = static_cast<size_type>(thrust::distance(keys1_first, keys1_last));
   size_type num_keys2 = static_cast<size_type>(thrust::distance(keys2_first, keys2_last));
@@ -788,7 +787,7 @@ merge(execution_policy<Derived>& policy,
       KeysIt2 keys2_last,
       ResultIt result)
 {
-  typedef typename thrust::iterator_value<KeysIt1>::type keys_type;
+  using keys_type = typename thrust::iterator_value<KeysIt1>::type;
   return cuda_cub::merge(policy, keys1_first, keys1_last, keys2_first, keys2_last, result, less<keys_type>());
 }
 
@@ -852,7 +851,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE merge_by_key(
   KeysOutputIt keys_result,
   ItemsOutputIt items_result)
 {
-  typedef typename thrust::iterator_value<KeysIt1>::type keys_type;
+  using keys_type = typename thrust::iterator_value<KeysIt1>::type;
   return cuda_cub::merge_by_key(
     policy,
     keys1_first,

--- a/thrust/thrust/system/cuda/detail/mismatch.h
+++ b/thrust/thrust/system/cuda/detail/mismatch.h
@@ -67,7 +67,7 @@ template <class Derived, class InputIt1, class InputIt2, class BinaryPred>
 pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
 mismatch(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2, BinaryPred binary_pred)
 {
-  typedef transform_pair_of_input_iterators_t<bool, InputIt1, InputIt2, BinaryPred> transform_t;
+  using transform_t = transform_pair_of_input_iterators_t<bool, InputIt1, InputIt2, BinaryPred>;
 
   transform_t transform_first = transform_t(first1, first2, binary_pred);
 
@@ -82,7 +82,7 @@ template <class Derived, class InputIt1, class InputIt2>
 pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
 mismatch(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2)
 {
-  typedef typename thrust::iterator_value<InputIt1>::type InputType1;
+  using InputType1 = typename thrust::iterator_value<InputIt1>::type;
   return cuda_cub::mismatch(policy, first1, last1, first2, equal_to<InputType1>());
 }
 

--- a/thrust/thrust/system/cuda/detail/par.h
+++ b/thrust/thrust/system/cuda/detail/par.h
@@ -102,7 +102,7 @@ private:
 
 struct execute_on_stream : execute_on_stream_base<execute_on_stream>
 {
-  typedef execute_on_stream_base<execute_on_stream> base_t;
+  using base_t = execute_on_stream_base<execute_on_stream>;
 
   _CCCL_HOST_DEVICE execute_on_stream()
       : base_t(){};
@@ -112,7 +112,7 @@ struct execute_on_stream : execute_on_stream_base<execute_on_stream>
 
 struct execute_on_stream_nosync : execute_on_stream_nosync_base<execute_on_stream_nosync>
 {
-  typedef execute_on_stream_nosync_base<execute_on_stream_nosync> base_t;
+  using base_t = execute_on_stream_nosync_base<execute_on_stream_nosync>;
 
   _CCCL_HOST_DEVICE execute_on_stream_nosync()
       : base_t(){};
@@ -125,13 +125,13 @@ struct par_t
     , thrust::detail::allocator_aware_execution_policy<execute_on_stream_base>
     , thrust::detail::dependencies_aware_execution_policy<execute_on_stream_base>
 {
-  typedef execution_policy<par_t> base_t;
+  using base_t = execution_policy<par_t>;
 
   _CCCL_HOST_DEVICE constexpr par_t()
       : base_t()
   {}
 
-  typedef execute_on_stream stream_attachment_type;
+  using stream_attachment_type = execute_on_stream;
 
   THRUST_RUNTIME_FUNCTION stream_attachment_type on(cudaStream_t const& stream) const
   {
@@ -144,13 +144,13 @@ struct par_nosync_t
     , thrust::detail::allocator_aware_execution_policy<execute_on_stream_nosync_base>
     , thrust::detail::dependencies_aware_execution_policy<execute_on_stream_nosync_base>
 {
-  typedef execution_policy<par_nosync_t> base_t;
+  using base_t = execution_policy<par_nosync_t>;
 
   _CCCL_HOST_DEVICE constexpr par_nosync_t()
       : base_t()
   {}
 
-  typedef execute_on_stream_nosync stream_attachment_type;
+  using stream_attachment_type = execute_on_stream_nosync;
 
   THRUST_RUNTIME_FUNCTION stream_attachment_type on(cudaStream_t const& stream) const
   {

--- a/thrust/thrust/system/cuda/detail/par_to_seq.h
+++ b/thrust/thrust/system/cuda/detail/par_to_seq.h
@@ -54,7 +54,7 @@ struct has_par<0> : thrust::detail::false_type
 template <class Policy>
 struct cvt_to_seq_impl
 {
-  typedef thrust::detail::seq_t seq_t;
+  using seq_t = thrust::detail::seq_t;
 
   static seq_t _CCCL_HOST_DEVICE doit(Policy&)
   {
@@ -68,13 +68,13 @@ struct cvt_to_seq_impl<
     thrust::detail::execute_with_allocator<Allocator,
                                            execute_on_stream_base> >
 {
-  typedef thrust::detail::execute_with_allocator<Allocator,
+  using Policy = thrust::detail::execute_with_allocator<Allocator,
                                                  execute_on_stream_base>
-      Policy;
-  typedef thrust::detail::execute_with_allocator<
+     ;
+  using seq_t = thrust::detail::execute_with_allocator<
       Allocator,
       thrust::system::detail::sequential::execution_policy>
-      seq_t;
+     ;
 
 
   static seq_t _CCCL_HOST_DEVICE

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -119,43 +119,43 @@ struct Tuning<sm30, T>
     SCALE_FACTOR_1B = sizeof(T),
   };
 
-  typedef PtxPolicy<256,
-                    CUB_MAX(1, 20 / SCALE_FACTOR_4B),
-                    2,
-                    cub::BLOCK_REDUCE_WARP_REDUCTIONS,
-                    cub::LOAD_DEFAULT,
-                    cub::GRID_MAPPING_RAKE>
-    type;
+  using type =
+    PtxPolicy<256,
+              (((20 / SCALE_FACTOR_4B) > (1)) ? (20 / SCALE_FACTOR_4B) : (1)),
+              2,
+              cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+              cub::LOAD_DEFAULT,
+              cub::GRID_MAPPING_RAKE>;
 }; // Tuning sm30
 
 template <class T>
 struct Tuning<sm35, T> : Tuning<sm30, T>
 {
   // ReducePolicy1B (GTX Titan: 228.7 GB/s @ 192M 1B items)
-  typedef PtxPolicy<128,
-                    CUB_MAX(1, 24 / Tuning::SCALE_FACTOR_1B),
-                    4,
-                    cub::BLOCK_REDUCE_WARP_REDUCTIONS,
-                    cub::LOAD_LDG,
-                    cub::GRID_MAPPING_DYNAMIC>
-    ReducePolicy1B;
+  using ReducePolicy1B =
+    PtxPolicy<128,
+              (((24 / Tuning::SCALE_FACTOR_1B) > (1)) ? (24 / Tuning::SCALE_FACTOR_1B) : (1)),
+              4,
+              cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+              cub::LOAD_LDG,
+              cub::GRID_MAPPING_DYNAMIC>;
 
   // ReducePolicy4B types (GTX Titan: 255.1 GB/s @ 48M 4B items)
-  typedef PtxPolicy<256,
-                    CUB_MAX(1, 20 / Tuning::SCALE_FACTOR_4B),
-                    4,
-                    cub::BLOCK_REDUCE_WARP_REDUCTIONS,
-                    cub::LOAD_LDG,
-                    cub::GRID_MAPPING_DYNAMIC>
-    ReducePolicy4B;
+  using ReducePolicy4B =
+    PtxPolicy<256,
+              (((20 / Tuning::SCALE_FACTOR_4B) > (1)) ? (20 / Tuning::SCALE_FACTOR_4B) : (1)),
+              4,
+              cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+              cub::LOAD_LDG,
+              cub::GRID_MAPPING_DYNAMIC>;
 
-  typedef ::cuda::std::__conditional_t<(sizeof(T) < 4), ReducePolicy1B, ReducePolicy4B> type;
+  using type = ::cuda::std::__conditional_t<(sizeof(T) < 4), ReducePolicy1B, ReducePolicy4B>;
 }; // Tuning sm35
 
 template <class InputIt, class OutputIt, class T, class Size, class ReductionOp>
 struct ReduceAgent
 {
-  typedef typename detail::make_unsigned_special<Size>::type UnsignedSize;
+  using UnsignedSize = typename detail::make_unsigned_special<Size>::type;
 
   template <class Arch>
   struct PtxPlan : Tuning<Arch, T>::type
@@ -164,13 +164,13 @@ struct ReduceAgent
     // that this PtxPlan may have specializations for different Arch
     // via Tuning<Arch,T> type.
     //
-    typedef Tuning<Arch, T> tuning;
+    using tuning = Tuning<Arch, T>;
 
-    typedef typename cub::CubVector<T, PtxPlan::VECTOR_LOAD_LENGTH> Vector;
-    typedef typename core::LoadIterator<PtxPlan, InputIt>::type LoadIt;
-    typedef cub::BlockReduce<T, PtxPlan::BLOCK_THREADS, PtxPlan::BLOCK_ALGORITHM, 1, 1, Arch::ver> BlockReduce;
+    using Vector      = typename cub::CubVector<T, PtxPlan::VECTOR_LOAD_LENGTH>;
+    using LoadIt      = typename core::LoadIterator<PtxPlan, InputIt>::type;
+    using BlockReduce = cub::BlockReduce<T, PtxPlan::BLOCK_THREADS, PtxPlan::BLOCK_ALGORITHM, 1, 1, Arch::ver>;
 
-    typedef cub::CacheModifiedInputIterator<PtxPlan::LOAD_MODIFIER, Vector, Size> VectorLoadIt;
+    using VectorLoadIt = cub::CacheModifiedInputIterator<PtxPlan::LOAD_MODIFIER, Vector, Size>;
 
     struct TempStorage
     {
@@ -204,13 +204,13 @@ struct ReduceAgent
   // ptx_plan type *must* only be used from device code
   // Its use from host code will result in *undefined behaviour*
   //
-  typedef typename core::specialize_plan_msvc10_war<PtxPlan>::type::type ptx_plan;
+  using ptx_plan = typename core::specialize_plan_msvc10_war<PtxPlan>::type::type;
 
-  typedef typename ptx_plan::TempStorage TempStorage;
-  typedef typename ptx_plan::Vector Vector;
-  typedef typename ptx_plan::LoadIt LoadIt;
-  typedef typename ptx_plan::BlockReduce BlockReduce;
-  typedef typename ptx_plan::VectorLoadIt VectorLoadIt;
+  using TempStorage  = typename ptx_plan::TempStorage;
+  using Vector       = typename ptx_plan::Vector;
+  using LoadIt       = typename ptx_plan::LoadIt;
+  using BlockReduce  = typename ptx_plan::BlockReduce;
+  using VectorLoadIt = typename ptx_plan::VectorLoadIt;
 
   enum
   {
@@ -401,9 +401,9 @@ struct ReduceAgent
     //
     THRUST_DEVICE_FUNCTION T consume_range(Size block_offset, Size block_end)
     {
-      typedef is_true<ATTEMPT_VECTORIZATION> attempt_vec;
-      typedef is_true<true && ATTEMPT_VECTORIZATION> path_a;
-      typedef is_true<false && ATTEMPT_VECTORIZATION> path_b;
+      using attempt_vec = is_true<ATTEMPT_VECTORIZATION>;
+      using path_a      = is_true<true && ATTEMPT_VECTORIZATION>;
+      using path_b      = is_true<false && ATTEMPT_VECTORIZATION>;
 
       return is_aligned(input_it + block_offset, attempt_vec())
              ? consume_range_impl(block_offset, block_end, path_a())
@@ -418,9 +418,9 @@ struct ReduceAgent
       cub::GridQueue<UnsignedSize>& /*queue*/,
       thrust::detail::integral_constant<cub::GridMappingStrategy, cub::GRID_MAPPING_RAKE> /*is_rake*/)
     {
-      typedef is_true<ATTEMPT_VECTORIZATION> attempt_vec;
-      typedef is_true<true && ATTEMPT_VECTORIZATION> path_a;
-      typedef is_true<false && ATTEMPT_VECTORIZATION> path_b;
+      using attempt_vec = is_true<ATTEMPT_VECTORIZATION>;
+      using path_a      = is_true<true && ATTEMPT_VECTORIZATION>;
+      using path_b      = is_true<false && ATTEMPT_VECTORIZATION>;
 
       // Initialize even-share descriptor for this thread block
       even_share.template BlockInit<ITEMS_PER_TILE, cub::GRID_MAPPING_RAKE>();
@@ -511,9 +511,9 @@ struct ReduceAgent
       cub::GridQueue<UnsignedSize>& queue,
       thrust::detail::integral_constant<cub::GridMappingStrategy, cub::GRID_MAPPING_DYNAMIC>)
     {
-      typedef is_true<ATTEMPT_VECTORIZATION> attempt_vec;
-      typedef is_true<true && ATTEMPT_VECTORIZATION> path_a;
-      typedef is_true<false && ATTEMPT_VECTORIZATION> path_b;
+      using attempt_vec = is_true<ATTEMPT_VECTORIZATION>;
+      using path_a      = is_true<true && ATTEMPT_VECTORIZATION>;
+      using path_b      = is_true<false && ATTEMPT_VECTORIZATION>;
 
       return is_aligned(input_it, attempt_vec())
              ? consume_tiles_impl(num_items, queue, path_a())
@@ -578,7 +578,7 @@ struct ReduceAgent
   {
     TempStorage& storage = *reinterpret_cast<TempStorage*>(shmem);
 
-    typedef thrust::detail::integral_constant<cub::GridMappingStrategy, ptx_plan::GRID_MAPPING> grid_mapping;
+    using grid_mapping = thrust::detail::integral_constant<cub::GridMappingStrategy, ptx_plan::GRID_MAPPING>;
 
     T block_aggregate =
       impl(storage, input_it, reduction_op).consume_tiles(num_items, even_share, queue, grid_mapping());
@@ -593,12 +593,12 @@ struct ReduceAgent
 template <class Size>
 struct DrainAgent
 {
-  typedef typename detail::make_unsigned_special<Size>::type UnsignedSize;
+  using UnsignedSize = typename detail::make_unsigned_special<Size>::type;
 
   template <class Arch>
   struct PtxPlan : PtxPolicy<1>
   {};
-  typedef core::specialize_plan<PtxPlan> ptx_plan;
+  using ptx_plan = core::specialize_plan<PtxPlan>;
 
   //---------------------------------------------------------------------
   // Agent entry point
@@ -626,14 +626,14 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   using core::cuda_optional;
   using core::get_agent_plan;
 
-  typedef typename detail::make_unsigned_special<Size>::type UnsignedSize;
+  using UnsignedSize = typename detail::make_unsigned_special<Size>::type;
 
   if (num_items == 0)
   {
     return cudaErrorNotSupported;
   }
 
-  typedef AgentLauncher<ReduceAgent<InputIt, OutputIt, T, Size, ReductionOp>> reduce_agent;
+  using reduce_agent = AgentLauncher<ReduceAgent<InputIt, OutputIt, T, Size, ReductionOp>>;
 
   typename reduce_agent::Plan reduce_plan = reduce_agent::get_plan(stream);
 
@@ -718,7 +718,7 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
       // then fill the device with threadblocks
       reduce_grid_size = static_cast<int>((min) (num_tiles, static_cast<size_t>(reduce_device_occupancy)));
 
-      typedef AgentLauncher<DrainAgent<Size>> drain_agent;
+      using drain_agent    = AgentLauncher<DrainAgent<Size>>;
       AgentPlan drain_plan = drain_agent::get_plan();
       drain_plan.grid_size = 1;
       drain_agent da(drain_plan, stream, "__reduce::drain_agent");
@@ -735,7 +735,7 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
     ra.launch(input_it, d_block_reductions, num_items, even_share, queue, reduction_op);
     CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
 
-    typedef AgentLauncher<ReduceAgent<T*, OutputIt, T, Size, ReductionOp>> reduce_agent_single;
+    using reduce_agent_single = AgentLauncher<ReduceAgent<T*, OutputIt, T, Size, ReductionOp>>;
 
     reduce_plan.grid_size = 1;
     reduce_agent_single ra1(reduce_plan, stream, vshmem_ptr, "reduce_agent: single tile reduce");
@@ -871,7 +871,7 @@ reduce_n(execution_policy<Derived>& policy, InputIt first, Size num_items, T ini
 template <class Derived, class InputIt, class T, class BinaryOp>
 _CCCL_HOST_DEVICE T reduce(execution_policy<Derived>& policy, InputIt first, InputIt last, T init, BinaryOp binary_op)
 {
-  typedef typename iterator_traits<InputIt>::difference_type size_type;
+  using size_type = typename iterator_traits<InputIt>::difference_type;
   // FIXME: Check for RA iterator.
   size_type num_items = static_cast<size_type>(thrust::distance(first, last));
   return cuda_cub::reduce_n(policy, first, num_items, init, binary_op);
@@ -887,7 +887,7 @@ template <class Derived, class InputIt>
 _CCCL_HOST_DEVICE typename iterator_traits<InputIt>::value_type
 reduce(execution_policy<Derived>& policy, InputIt first, InputIt last)
 {
-  typedef typename iterator_traits<InputIt>::value_type value_type;
+  using value_type = typename iterator_traits<InputIt>::value_type;
   return cuda_cub::reduce(policy, first, last, value_type(0));
 }
 

--- a/thrust/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/thrust/system/cuda/detail/reduce_by_key.h
@@ -133,8 +133,8 @@ struct Tuning<sm30, Key, Value>
                                          / COMBINED_INPUT_BYTES)>::value>::value,
   };
 
-  typedef PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>
-    type;
+  using type =
+    PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>;
 }; // Tuning sm30
 
 template <class Key, class Value>
@@ -157,8 +157,8 @@ struct Tuning<sm35, Key, Value> : Tuning<sm30, Key, Value>
             value>::value,
   };
 
-  typedef PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_SCAN_WARP_SCANS>
-    type;
+  using type =
+    PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_SCAN_WARP_SCANS>;
 }; // Tuning sm35
 
 template <class Key, class Value>
@@ -181,8 +181,8 @@ struct Tuning<sm52, Key, Value> : Tuning<sm30, Key, Value>
             value>::value,
   };
 
-  typedef PtxPolicy<256, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_SCAN_WARP_SCANS>
-    type;
+  using type =
+    PtxPolicy<256, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_SCAN_WARP_SCANS>;
 }; // Tuning sm52
 
 template <class KeysInputIt,
@@ -195,32 +195,33 @@ template <class KeysInputIt,
           class Size>
 struct ReduceByKeyAgent
 {
-  typedef typename iterator_traits<KeysInputIt>::value_type key_type;
-  typedef typename iterator_traits<ValuesInputIt>::value_type value_type;
-  typedef Size size_type;
+  using key_type   = typename iterator_traits<KeysInputIt>::value_type;
+  using value_type = typename iterator_traits<ValuesInputIt>::value_type;
+  using size_type  = Size;
 
-  typedef cub::KeyValuePair<size_type, value_type> size_value_pair_t;
-  typedef cub::KeyValuePair<key_type, value_type> key_value_pair_t;
+  using size_value_pair_t = cub::KeyValuePair<size_type, value_type>;
+  using key_value_pair_t  = cub::KeyValuePair<key_type, value_type>;
 
-  typedef cub::ReduceByKeyScanTileState<value_type, size_type> ScanTileState;
-  typedef cub::ReduceBySegmentOp<ReductionOp> ReduceBySegmentOp;
+  using ScanTileState     = cub::ReduceByKeyScanTileState<value_type, size_type>;
+  using ReduceBySegmentOp = cub::ReduceBySegmentOp<ReductionOp>;
 
   template <class Arch>
   struct PtxPlan : Tuning<Arch, key_type, value_type>::type
   {
-    typedef Tuning<Arch, key_type, value_type> tuning;
+    using tuning = Tuning<Arch, key_type, value_type>;
 
-    typedef typename core::LoadIterator<PtxPlan, KeysInputIt>::type KeysLoadIt;
-    typedef typename core::LoadIterator<PtxPlan, ValuesInputIt>::type ValuesLoadIt;
+    using KeysLoadIt   = typename core::LoadIterator<PtxPlan, KeysInputIt>::type;
+    using ValuesLoadIt = typename core::LoadIterator<PtxPlan, ValuesInputIt>::type;
 
-    typedef typename core::BlockLoad<PtxPlan, KeysLoadIt>::type BlockLoadKeys;
-    typedef typename core::BlockLoad<PtxPlan, ValuesLoadIt>::type BlockLoadValues;
+    using BlockLoadKeys   = typename core::BlockLoad<PtxPlan, KeysLoadIt>::type;
+    using BlockLoadValues = typename core::BlockLoad<PtxPlan, ValuesLoadIt>::type;
 
-    typedef cub::BlockDiscontinuity<key_type, PtxPlan::BLOCK_THREADS, 1, 1, Arch::ver> BlockDiscontinuityKeys;
+    using BlockDiscontinuityKeys = cub::BlockDiscontinuity<key_type, PtxPlan::BLOCK_THREADS, 1, 1, Arch::ver>;
 
-    typedef cub::TilePrefixCallbackOp<size_value_pair_t, ReduceBySegmentOp, ScanTileState, Arch::ver> TilePrefixCallback;
-    typedef cub::BlockScan<size_value_pair_t, PtxPlan::BLOCK_THREADS, PtxPlan::SCAN_ALGORITHM, 1, 1, Arch::ver>
-      BlockScan;
+    using TilePrefixCallback =
+      cub::TilePrefixCallbackOp<size_value_pair_t, ReduceBySegmentOp, ScanTileState, Arch::ver>;
+    using BlockScan =
+      cub::BlockScan<size_value_pair_t, PtxPlan::BLOCK_THREADS, PtxPlan::SCAN_ALGORITHM, 1, 1, Arch::ver>;
 
     union TempStorage
     {
@@ -238,16 +239,16 @@ struct ReduceByKeyAgent
     }; // union TempStorage
   }; // struct PtxPlan
 
-  typedef typename core::specialize_plan_msvc10_war<PtxPlan>::type::type ptx_plan;
+  using ptx_plan = typename core::specialize_plan_msvc10_war<PtxPlan>::type::type;
 
-  typedef typename ptx_plan::KeysLoadIt KeysLoadIt;
-  typedef typename ptx_plan::ValuesLoadIt ValuesLoadIt;
-  typedef typename ptx_plan::BlockLoadKeys BlockLoadKeys;
-  typedef typename ptx_plan::BlockLoadValues BlockLoadValues;
-  typedef typename ptx_plan::BlockDiscontinuityKeys BlockDiscontinuityKeys;
-  typedef typename ptx_plan::TilePrefixCallback TilePrefixCallback;
-  typedef typename ptx_plan::BlockScan BlockScan;
-  typedef typename ptx_plan::TempStorage TempStorage;
+  using KeysLoadIt             = typename ptx_plan::KeysLoadIt;
+  using ValuesLoadIt           = typename ptx_plan::ValuesLoadIt;
+  using BlockLoadKeys          = typename ptx_plan::BlockLoadKeys;
+  using BlockLoadValues        = typename ptx_plan::BlockLoadValues;
+  using BlockDiscontinuityKeys = typename ptx_plan::BlockDiscontinuityKeys;
+  using TilePrefixCallback     = typename ptx_plan::TilePrefixCallback;
+  using BlockScan              = typename ptx_plan::BlockScan;
+  using TempStorage            = typename ptx_plan::TempStorage;
 
   enum
   {
@@ -749,7 +750,7 @@ struct InitAgent
   template <class Arch>
   struct PtxPlan : PtxPolicy<128>
   {};
-  typedef core::specialize_plan<PtxPlan> ptx_plan;
+  using ptx_plan = core::specialize_plan<PtxPlan>;
 
   //---------------------------------------------------------------------
   // Agent entry point
@@ -795,12 +796,11 @@ THRUST_RUNTIME_FUNCTION cudaError_t doit_step(
     return cudaErrorNotSupported;
   }
 
-  typedef AgentLauncher<
-    ReduceByKeyAgent<KeysInputIt, ValuesInputIt, KeysOutputIt, ValuesOutputIt, EqualityOp, ReductionOp, NumRunsOutputIt, Size>>
-    reduce_by_key_agent;
+  using reduce_by_key_agent = AgentLauncher<
+    ReduceByKeyAgent<KeysInputIt, ValuesInputIt, KeysOutputIt, ValuesOutputIt, EqualityOp, ReductionOp, NumRunsOutputIt, Size>>;
 
-  typedef typename reduce_by_key_agent::ScanTileState ScanTileState;
-  typedef AgentLauncher<InitAgent<ScanTileState, Size, NumRunsOutputIt>> init_agent;
+  using ScanTileState = typename reduce_by_key_agent::ScanTileState;
+  using init_agent    = AgentLauncher<InitAgent<ScanTileState, Size, NumRunsOutputIt>>;
 
   AgentPlan reduce_by_key_plan = reduce_by_key_agent::get_plan(stream);
   AgentPlan init_plan          = init_agent::get_plan();
@@ -1016,9 +1016,9 @@ pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
   ValOutputIt values_output,
   BinaryPred binary_pred)
 {
-  typedef typename thrust::detail::eval_if<thrust::detail::is_output_iterator<ValOutputIt>::value,
-                                           thrust::iterator_value<ValInputIt>,
-                                           thrust::iterator_value<ValOutputIt>>::type value_type;
+  using value_type = typename thrust::detail::eval_if<thrust::detail::is_output_iterator<ValOutputIt>::value,
+                                                      thrust::iterator_value<ValInputIt>,
+                                                      thrust::iterator_value<ValOutputIt>>::type;
   return cuda_cub::reduce_by_key(
     policy, keys_first, keys_last, values_first, keys_output, values_output, binary_pred, plus<value_type>());
 }
@@ -1032,7 +1032,7 @@ pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
   KeyOutputIt keys_output,
   ValOutputIt values_output)
 {
-  typedef typename thrust::iterator_value<KeyInputIt>::type KeyT;
+  using KeyT = typename thrust::iterator_value<KeyInputIt>::type;
   return cuda_cub::reduce_by_key(
     policy, keys_first, keys_last, values_first, keys_output, values_output, equal_to<KeyT>());
 }

--- a/thrust/thrust/system/cuda/detail/replace.h
+++ b/thrust/thrust/system/cuda/detail/replace.h
@@ -127,8 +127,8 @@ OutputIt _CCCL_HOST_DEVICE replace_copy_if(
   Predicate predicate,
   T const& new_value)
 {
-  typedef typename iterator_traits<OutputIt>::value_type output_type;
-  typedef __replace::new_value_if_f<Predicate, T, output_type> new_value_if_t;
+  using output_type    = typename iterator_traits<OutputIt>::value_type;
+  using new_value_if_t = __replace::new_value_if_f<Predicate, T, output_type>;
   return cuda_cub::transform(policy, first, last, result, new_value_if_t(predicate, new_value));
 }
 
@@ -142,8 +142,8 @@ OutputIt _CCCL_HOST_DEVICE replace_copy_if(
   Predicate predicate,
   T const& new_value)
 {
-  typedef typename iterator_traits<OutputIt>::value_type output_type;
-  typedef __replace::new_value_if_f<Predicate, T, output_type> new_value_if_t;
+  using output_type    = typename iterator_traits<OutputIt>::value_type;
+  using new_value_if_t = __replace::new_value_if_f<Predicate, T, output_type>;
   return cuda_cub::transform(policy, first, last, stencil, result, new_value_if_t(predicate, new_value));
 }
 

--- a/thrust/thrust/system/cuda/detail/reverse.h
+++ b/thrust/thrust/system/cuda/detail/reverse.h
@@ -71,7 +71,7 @@ ResultIt _CCCL_HOST_DEVICE reverse_copy(execution_policy<Derived>& policy, Items
 template <class Derived, class ItemsIt>
 void _CCCL_HOST_DEVICE reverse(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
 {
-  typedef typename thrust::iterator_difference<ItemsIt>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<ItemsIt>::type;
 
   // find the midpoint of [first,last)
   difference_type N = thrust::distance(first, last);

--- a/thrust/thrust/system/cuda/detail/set_operations.h
+++ b/thrust/thrust/system/cuda/detail/set_operations.h
@@ -124,7 +124,7 @@ THRUST_DEVICE_FUNCTION Size biased_binary_search(It data, Size count, T key, Int
 template <bool UpperBound, class Size, class It1, class It2, class Comp>
 THRUST_DEVICE_FUNCTION Size merge_path(It1 a, Size aCount, It2 b, Size bCount, Size diag, Comp comp)
 {
-  typedef typename thrust::iterator_traits<It1>::value_type T;
+  using T = typename thrust::iterator_traits<It1>::value_type;
 
   Size begin = thrust::max<Size>(0, diag - bCount);
   Size end   = thrust::min<Size>(diag, aCount);
@@ -151,7 +151,7 @@ template <class It1, class It2, class Size, class Size2, class CompareOp>
 THRUST_DEVICE_FUNCTION pair<Size, Size>
 balanced_path(It1 keys1, It2 keys2, Size num_keys1, Size num_keys2, Size diag, Size2 levels, CompareOp compare_op)
 {
-  typedef typename iterator_traits<It1>::value_type T;
+  using T = typename iterator_traits<It1>::value_type;
 
   Size index1 = merge_path<false>(keys1, num_keys1, keys2, num_keys2, diag, compare_op);
   Size index2 = diag - index1;
@@ -234,8 +234,8 @@ struct Tuning<sm30, T, U>
                                          / COMBINED_INPUT_BYTES)>::value>::value,
   };
 
-  typedef PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>
-    type;
+  using type =
+    PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>;
 }; // tuning sm30
 
 template <class T, class U>
@@ -255,8 +255,8 @@ struct Tuning<sm52, T, U>
                                          / COMBINED_INPUT_BYTES)>::value>::value,
   };
 
-  typedef PtxPolicy<256, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>
-    type;
+  using type =
+    PtxPolicy<256, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>;
 }; // tuning sm52
 
 template <class T, class U>
@@ -276,8 +276,8 @@ struct Tuning<sm60, T, U>
                                          / COMBINED_INPUT_BYTES)>::value>::value,
   };
 
-  typedef PtxPolicy<512, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>
-    type;
+  using type =
+    PtxPolicy<512, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>;
 }; // tuning sm60
 
 template <class KeysIt1,
@@ -292,34 +292,34 @@ template <class KeysIt1,
           class HAS_VALUES>
 struct SetOpAgent
 {
-  typedef typename iterator_traits<KeysIt1>::value_type key1_type;
-  typedef typename iterator_traits<KeysIt2>::value_type key2_type;
-  typedef typename iterator_traits<ValuesIt1>::value_type value1_type;
-  typedef typename iterator_traits<ValuesIt2>::value_type value2_type;
+  using key1_type   = typename iterator_traits<KeysIt1>::value_type;
+  using key2_type   = typename iterator_traits<KeysIt2>::value_type;
+  using value1_type = typename iterator_traits<ValuesIt1>::value_type;
+  using value2_type = typename iterator_traits<ValuesIt2>::value_type;
 
-  typedef key1_type key_type;
-  typedef value1_type value_type;
+  using key_type   = key1_type;
+  using value_type = value1_type;
 
-  typedef cub::ScanTileState<Size> ScanTileState;
+  using ScanTileState = cub::ScanTileState<Size>;
 
   template <class Arch>
   struct PtxPlan : Tuning<Arch, key_type, value_type>::type
   {
-    typedef Tuning<Arch, key_type, value_type> tuning;
+    using tuning = Tuning<Arch, key_type, value_type>;
 
-    typedef typename core::LoadIterator<PtxPlan, KeysIt1>::type KeysLoadIt1;
-    typedef typename core::LoadIterator<PtxPlan, KeysIt2>::type KeysLoadIt2;
-    typedef typename core::LoadIterator<PtxPlan, ValuesIt1>::type ValuesLoadIt1;
-    typedef typename core::LoadIterator<PtxPlan, ValuesIt2>::type ValuesLoadIt2;
+    using KeysLoadIt1   = typename core::LoadIterator<PtxPlan, KeysIt1>::type;
+    using KeysLoadIt2   = typename core::LoadIterator<PtxPlan, KeysIt2>::type;
+    using ValuesLoadIt1 = typename core::LoadIterator<PtxPlan, ValuesIt1>::type;
+    using ValuesLoadIt2 = typename core::LoadIterator<PtxPlan, ValuesIt2>::type;
 
-    typedef typename core::BlockLoad<PtxPlan, KeysLoadIt1>::type BlockLoadKeys1;
-    typedef typename core::BlockLoad<PtxPlan, KeysLoadIt2>::type BlockLoadKeys2;
-    typedef typename core::BlockLoad<PtxPlan, ValuesLoadIt1>::type BlockLoadValues1;
-    typedef typename core::BlockLoad<PtxPlan, ValuesLoadIt2>::type BlockLoadValues2;
+    using BlockLoadKeys1   = typename core::BlockLoad<PtxPlan, KeysLoadIt1>::type;
+    using BlockLoadKeys2   = typename core::BlockLoad<PtxPlan, KeysLoadIt2>::type;
+    using BlockLoadValues1 = typename core::BlockLoad<PtxPlan, ValuesLoadIt1>::type;
+    using BlockLoadValues2 = typename core::BlockLoad<PtxPlan, ValuesLoadIt2>::type;
 
-    typedef cub::TilePrefixCallbackOp<Size, cub::Sum, ScanTileState, Arch::ver> TilePrefixCallback;
+    using TilePrefixCallback = cub::TilePrefixCallbackOp<Size, cub::Sum, ScanTileState, Arch::ver>;
 
-    typedef cub::BlockScan<Size, PtxPlan::BLOCK_THREADS, PtxPlan::SCAN_ALGORITHM, 1, 1, Arch::ver> BlockScan;
+    using BlockScan = cub::BlockScan<Size, PtxPlan::BLOCK_THREADS, PtxPlan::SCAN_ALGORITHM, 1, 1, Arch::ver>;
 
     // gather required temporary storage in a union
     //
@@ -353,22 +353,22 @@ struct SetOpAgent
     }; // union TempStorage
   }; // struct PtxPlan
 
-  typedef typename core::specialize_plan_msvc10_war<PtxPlan>::type::type ptx_plan;
+  using ptx_plan = typename core::specialize_plan_msvc10_war<PtxPlan>::type::type;
 
-  typedef typename ptx_plan::KeysLoadIt1 KeysLoadIt1;
-  typedef typename ptx_plan::KeysLoadIt2 KeysLoadIt2;
-  typedef typename ptx_plan::ValuesLoadIt1 ValuesLoadIt1;
-  typedef typename ptx_plan::ValuesLoadIt2 ValuesLoadIt2;
+  using KeysLoadIt1   = typename ptx_plan::KeysLoadIt1;
+  using KeysLoadIt2   = typename ptx_plan::KeysLoadIt2;
+  using ValuesLoadIt1 = typename ptx_plan::ValuesLoadIt1;
+  using ValuesLoadIt2 = typename ptx_plan::ValuesLoadIt2;
 
-  typedef typename ptx_plan::BlockLoadKeys1 BlockLoadKeys1;
-  typedef typename ptx_plan::BlockLoadKeys2 BlockLoadKeys2;
-  typedef typename ptx_plan::BlockLoadValues1 BlockLoadValues1;
-  typedef typename ptx_plan::BlockLoadValues2 BlockLoadValues2;
+  using BlockLoadKeys1   = typename ptx_plan::BlockLoadKeys1;
+  using BlockLoadKeys2   = typename ptx_plan::BlockLoadKeys2;
+  using BlockLoadValues1 = typename ptx_plan::BlockLoadValues1;
+  using BlockLoadValues2 = typename ptx_plan::BlockLoadValues2;
 
-  typedef typename ptx_plan::TilePrefixCallback TilePrefixCallback;
-  typedef typename ptx_plan::BlockScan BlockScan;
+  using TilePrefixCallback = typename ptx_plan::TilePrefixCallback;
+  using BlockScan          = typename ptx_plan::BlockScan;
 
-  typedef typename ptx_plan::TempStorage TempStorage;
+  using TempStorage = typename ptx_plan::TempStorage;
 
   enum
   {
@@ -750,7 +750,7 @@ struct PartitionAgent
   struct PtxPlan : PtxPolicy<256>
   {};
 
-  typedef core::specialize_plan<PtxPlan> ptx_plan;
+  using ptx_plan = core::specialize_plan<PtxPlan>;
 
   //---------------------------------------------------------------------
   // Agent entry point
@@ -784,7 +784,7 @@ struct InitAgent
   struct PtxPlan : PtxPolicy<128>
   {};
 
-  typedef core::specialize_plan<PtxPlan> ptx_plan;
+  using ptx_plan = core::specialize_plan<PtxPlan>;
 
   //---------------------------------------------------------------------
   // Agent entry point
@@ -1078,14 +1078,13 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   using core::AgentLauncher;
   using core::AgentPlan;
 
-  typedef AgentLauncher<
-    SetOpAgent<KeysIt1, KeysIt2, ValuesIt1, ValuesIt2, KeysOutputIt, ValuesOutputIt, Size, CompareOp, SetOp, HAS_VALUES>>
-    set_op_agent;
+  using set_op_agent = AgentLauncher<
+    SetOpAgent<KeysIt1, KeysIt2, ValuesIt1, ValuesIt2, KeysOutputIt, ValuesOutputIt, Size, CompareOp, SetOp, HAS_VALUES>>;
 
-  typedef AgentLauncher<PartitionAgent<KeysIt1, KeysIt2, Size, CompareOp>> partition_agent;
+  using partition_agent = AgentLauncher<PartitionAgent<KeysIt1, KeysIt2, Size, CompareOp>>;
 
-  typedef typename set_op_agent::ScanTileState ScanTileState;
-  typedef AgentLauncher<InitAgent<ScanTileState, Size>> init_agent;
+  using ScanTileState = typename set_op_agent::ScanTileState;
+  using init_agent    = AgentLauncher<InitAgent<ScanTileState, Size>>;
 
   AgentPlan set_op_plan    = set_op_agent::get_plan(stream);
   AgentPlan init_plan      = init_agent::get_plan();
@@ -1170,7 +1169,7 @@ THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ValuesOutputIt> set_operations(
   CompareOp compare_op,
   SetOp set_op)
 {
-  typedef typename iterator_traits<KeysIt1>::difference_type size_type;
+  using size_type = typename iterator_traits<KeysIt1>::difference_type;
 
   size_type num_keys1 = static_cast<size_type>(thrust::distance(keys1_first, keys1_last));
   size_type num_keys2 = static_cast<size_type>(thrust::distance(keys2_first, keys2_last));
@@ -1296,7 +1295,7 @@ OutputIt _CCCL_HOST_DEVICE set_difference(
   ItemsIt2 items2_last,
   OutputIt result)
 {
-  typedef typename thrust::iterator_value<ItemsIt1>::type value_type;
+  using value_type = typename thrust::iterator_value<ItemsIt1>::type;
   return cuda_cub::set_difference(
     policy, items1_first, items1_last, items2_first, items2_last, result, less<value_type>());
 }
@@ -1343,7 +1342,7 @@ OutputIt _CCCL_HOST_DEVICE set_intersection(
   ItemsIt2 items2_last,
   OutputIt result)
 {
-  typedef typename thrust::iterator_value<ItemsIt1>::type value_type;
+  using value_type = typename thrust::iterator_value<ItemsIt1>::type;
   return cuda_cub::set_intersection(
     policy, items1_first, items1_last, items2_first, items2_last, result, less<value_type>());
 }
@@ -1390,7 +1389,7 @@ OutputIt _CCCL_HOST_DEVICE set_symmetric_difference(
   ItemsIt2 items2_last,
   OutputIt result)
 {
-  typedef typename thrust::iterator_value<ItemsIt1>::type value_type;
+  using value_type = typename thrust::iterator_value<ItemsIt1>::type;
   return cuda_cub::set_symmetric_difference(
     policy, items1_first, items1_last, items2_first, items2_last, result, less<value_type>());
 }
@@ -1437,7 +1436,7 @@ OutputIt _CCCL_HOST_DEVICE set_union(
   ItemsIt2 items2_last,
   OutputIt result)
 {
-  typedef typename thrust::iterator_value<ItemsIt1>::type value_type;
+  using value_type = typename thrust::iterator_value<ItemsIt1>::type;
   return cuda_cub::set_union(policy, items1_first, items1_last, items2_first, items2_last, result, less<value_type>());
 }
 
@@ -1510,7 +1509,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_difference_by_key(
   KeysOutputIt keys_result,
   ItemsOutputIt items_result)
 {
-  typedef typename thrust::iterator_value<KeysIt1>::type value_type;
+  using value_type = typename thrust::iterator_value<KeysIt1>::type;
   return cuda_cub::set_difference_by_key(
     policy,
     keys1_first,
@@ -1584,7 +1583,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_intersection_by_key(
   KeysOutputIt keys_result,
   ItemsOutputIt items_result)
 {
-  typedef typename thrust::iterator_value<KeysIt1>::type value_type;
+  using value_type = typename thrust::iterator_value<KeysIt1>::type;
   return cuda_cub::set_intersection_by_key(
     policy,
     keys1_first,
@@ -1660,7 +1659,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_symmetric_difference_by_
   KeysOutputIt keys_result,
   ItemsOutputIt items_result)
 {
-  typedef typename thrust::iterator_value<KeysIt1>::type value_type;
+  using value_type = typename thrust::iterator_value<KeysIt1>::type;
   return cuda_cub::set_symmetric_difference_by_key(
     policy,
     keys1_first,
@@ -1737,7 +1736,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_union_by_key(
   KeysOutputIt keys_result,
   ItemsOutputIt items_result)
 {
-  typedef typename thrust::iterator_value<KeysIt1>::type value_type;
+  using value_type = typename thrust::iterator_value<KeysIt1>::type;
   return cuda_cub::set_union_by_key(
     policy,
     keys1_first,

--- a/thrust/thrust/system/cuda/detail/sort.h
+++ b/thrust/thrust/system/cuda/detail/sort.h
@@ -128,7 +128,7 @@ THRUST_RUNTIME_FUNCTION void merge_sort(
   execution_policy<Derived>& policy, KeysIt keys_first, KeysIt keys_last, ItemsIt items_first, CompareOp compare_op)
 
 {
-  typedef typename iterator_traits<KeysIt>::difference_type size_type;
+  using size_type = typename iterator_traits<KeysIt>::difference_type;
 
   size_type count = static_cast<size_type>(thrust::distance(keys_first, keys_last));
 
@@ -450,14 +450,14 @@ void _CCCL_HOST_DEVICE stable_sort_by_key(
 template <class Derived, class ItemsIt>
 void _CCCL_HOST_DEVICE sort(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
 {
-  typedef typename thrust::iterator_value<ItemsIt>::type item_type;
+  using item_type = typename thrust::iterator_value<ItemsIt>::type;
   cuda_cub::sort(policy, first, last, less<item_type>());
 }
 
 template <class Derived, class ItemsIt>
 void _CCCL_HOST_DEVICE stable_sort(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
 {
-  typedef typename thrust::iterator_value<ItemsIt>::type item_type;
+  using item_type = typename thrust::iterator_value<ItemsIt>::type;
   cuda_cub::stable_sort(policy, first, last, less<item_type>());
 }
 
@@ -465,7 +465,7 @@ template <class Derived, class KeysIt, class ValuesIt>
 void _CCCL_HOST_DEVICE
 sort_by_key(execution_policy<Derived>& policy, KeysIt keys_first, KeysIt keys_last, ValuesIt values)
 {
-  typedef typename thrust::iterator_value<KeysIt>::type key_type;
+  using key_type = typename thrust::iterator_value<KeysIt>::type;
   cuda_cub::sort_by_key(policy, keys_first, keys_last, values, less<key_type>());
 }
 
@@ -473,7 +473,7 @@ template <class Derived, class KeysIt, class ValuesIt>
 void _CCCL_HOST_DEVICE
 stable_sort_by_key(execution_policy<Derived>& policy, KeysIt keys_first, KeysIt keys_last, ValuesIt values)
 {
-  typedef typename thrust::iterator_value<KeysIt>::type key_type;
+  using key_type = typename thrust::iterator_value<KeysIt>::type;
   cuda_cub::stable_sort_by_key(policy, keys_first, keys_last, values, less<key_type>());
 }
 

--- a/thrust/thrust/system/cuda/detail/swap_ranges.h
+++ b/thrust/thrust/system/cuda/detail/swap_ranges.h
@@ -59,8 +59,8 @@ struct swap_f
   ItemsIt1 items1;
   ItemsIt2 items2;
 
-  typedef typename iterator_traits<ItemsIt1>::value_type value1_type;
-  typedef typename iterator_traits<ItemsIt2>::value_type value2_type;
+  using value1_type = typename iterator_traits<ItemsIt1>::value_type;
+  using value2_type = typename iterator_traits<ItemsIt2>::value_type;
 
   THRUST_FUNCTION
   swap_f(ItemsIt1 items1_, ItemsIt2 items2_)
@@ -90,7 +90,7 @@ template <class Derived, class ItemsIt1, class ItemsIt2>
 ItemsIt2 _CCCL_HOST_DEVICE
 swap_ranges(execution_policy<Derived>& policy, ItemsIt1 first1, ItemsIt1 last1, ItemsIt2 first2)
 {
-  typedef typename iterator_traits<ItemsIt1>::difference_type size_type;
+  using size_type = typename iterator_traits<ItemsIt1>::difference_type;
 
   size_type num_items = static_cast<size_type>(thrust::distance(first1, last1));
 

--- a/thrust/thrust/system/cuda/detail/tabulate.h
+++ b/thrust/thrust/system/cuda/detail/tabulate.h
@@ -72,11 +72,11 @@ struct functor
 template <class Derived, class Iterator, class TabulateOp>
 void _CCCL_HOST_DEVICE tabulate(execution_policy<Derived>& policy, Iterator first, Iterator last, TabulateOp tabulate_op)
 {
-  typedef typename iterator_traits<Iterator>::difference_type size_type;
+  using size_type = typename iterator_traits<Iterator>::difference_type;
 
   size_type count = thrust::distance(first, last);
 
-  typedef __tabulate::functor<Iterator, TabulateOp, size_type> functor_t;
+  using functor_t = __tabulate::functor<Iterator, TabulateOp, size_type>;
 
   cuda_cub::parallel_for(policy, functor_t(first, tabulate_op), count);
 }

--- a/thrust/thrust/system/cuda/detail/transform.h
+++ b/thrust/thrust/system/cuda/detail/transform.h
@@ -193,7 +193,7 @@ OutputIt THRUST_FUNCTION unary(
     return result;
   }
 
-  typedef unary_transform_f<InputIt, OutputIt, StencilIt, TransformOp, Predicate> unary_transform_t;
+  using unary_transform_t = unary_transform_f<InputIt, OutputIt, StencilIt, TransformOp, Predicate>;
 
   cuda_cub::parallel_for(policy, unary_transform_t(items, result, stencil, transform_op, predicate), num_items);
 
@@ -223,7 +223,7 @@ OutputIt THRUST_FUNCTION binary(
     return result;
   }
 
-  typedef binary_transform_f<InputIt1, InputIt2, OutputIt, StencilIt, TransformOp, Predicate> binary_transform_t;
+  using binary_transform_t = binary_transform_f<InputIt1, InputIt2, OutputIt, StencilIt, TransformOp, Predicate>;
 
   cuda_cub::parallel_for(
     policy, binary_transform_t(items1, items2, result, stencil, transform_op, predicate), num_items);
@@ -251,7 +251,7 @@ OutputIt THRUST_FUNCTION transform_if(
   TransformOp transform_op,
   Predicate predicate)
 {
-  typedef typename iterator_traits<InputIt>::difference_type size_type;
+  using size_type     = typename iterator_traits<InputIt>::difference_type;
   size_type num_items = static_cast<size_type>(thrust::distance(first, last));
   return __transform::unary(policy, first, result, num_items, stencil, transform_op, predicate);
 } // func transform_if
@@ -296,7 +296,7 @@ OutputIt THRUST_FUNCTION transform_if(
   TransformOp transform_op,
   Predicate predicate)
 {
-  typedef typename iterator_traits<InputIt1>::difference_type size_type;
+  using size_type     = typename iterator_traits<InputIt1>::difference_type;
   size_type num_items = static_cast<size_type>(thrust::distance(first1, last1));
   return __transform::binary(policy, first1, first2, result, num_items, stencil, transform_op, predicate);
 } // func transform_if

--- a/thrust/thrust/system/cuda/detail/transform_reduce.h
+++ b/thrust/thrust/system/cuda/detail/transform_reduce.h
@@ -131,7 +131,7 @@ template <class Derived, class InputIt, class TransformOp, class T, class Reduce
 T _CCCL_HOST_DEVICE transform_reduce(
   execution_policy<Derived>& policy, InputIt first, InputIt last, TransformOp transform_op, T init, ReduceOp reduce_op)
 {
-  typedef typename iterator_traits<InputIt>::difference_type size_type;
+  using size_type           = typename iterator_traits<InputIt>::difference_type;
   const size_type num_items = static_cast<size_type>(thrust::distance(first, last));
 
   THRUST_CDP_DISPATCH(

--- a/thrust/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/thrust/system/cuda/detail/transform_scan.h
@@ -62,9 +62,9 @@ OutputIt _CCCL_HOST_DEVICE transform_inclusive_scan(
   using result_type = thrust::detail::invoke_result_t<TransformOp, input_type>;
   using value_type  = thrust::remove_cvref_t<result_type>;
 
-  typedef typename iterator_traits<InputIt>::difference_type size_type;
-  size_type num_items = static_cast<size_type>(thrust::distance(first, last));
-  typedef transform_input_iterator_t<value_type, InputIt, TransformOp> transformed_iterator_t;
+  using size_type              = typename iterator_traits<InputIt>::difference_type;
+  size_type num_items          = static_cast<size_type>(thrust::distance(first, last));
+  using transformed_iterator_t = transform_input_iterator_t<value_type, InputIt, TransformOp>;
 
   return cuda_cub::inclusive_scan_n(policy, transformed_iterator_t(first, transform_op), num_items, result, scan_op);
 }
@@ -82,9 +82,9 @@ OutputIt _CCCL_HOST_DEVICE transform_exclusive_scan(
   // Use the initial value type per https://wg21.link/P0571
   using result_type = thrust::remove_cvref_t<InitialValueType>;
 
-  typedef typename iterator_traits<InputIt>::difference_type size_type;
-  size_type num_items = static_cast<size_type>(thrust::distance(first, last));
-  typedef transform_input_iterator_t<result_type, InputIt, TransformOp> transformed_iterator_t;
+  using size_type              = typename iterator_traits<InputIt>::difference_type;
+  size_type num_items          = static_cast<size_type>(thrust::distance(first, last));
+  using transformed_iterator_t = transform_input_iterator_t<result_type, InputIt, TransformOp>;
 
   return cuda_cub::exclusive_scan_n(
     policy, transformed_iterator_t(first, transform_op), num_items, result, init, scan_op);

--- a/thrust/thrust/system/cuda/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_copy.h
@@ -58,8 +58,8 @@ struct functor
   InputIt input;
   OutputIt output;
 
-  typedef typename iterator_traits<InputIt>::value_type InputType;
-  typedef typename iterator_traits<OutputIt>::value_type OutputType;
+  using InputType  = typename iterator_traits<InputIt>::value_type;
+  using OutputType = typename iterator_traits<OutputIt>::value_type;
 
   THRUST_FUNCTION
   functor(InputIt input_, OutputIt output_)
@@ -88,7 +88,7 @@ template <class Derived, class InputIt, class Size, class OutputIt>
 OutputIt _CCCL_HOST_DEVICE
 uninitialized_copy_n(execution_policy<Derived>& policy, InputIt first, Size count, OutputIt result)
 {
-  typedef __uninitialized_copy::functor<InputIt, OutputIt> functor_t;
+  using functor_t = __uninitialized_copy::functor<InputIt, OutputIt>;
 
   cuda_cub::parallel_for(policy, functor_t(first, result), count);
 

--- a/thrust/thrust/system/cuda/detail/uninitialized_fill.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_fill.h
@@ -58,7 +58,7 @@ struct functor
   Iterator items;
   T value;
 
-  typedef typename iterator_traits<Iterator>::value_type value_type;
+  using value_type = typename iterator_traits<Iterator>::value_type;
 
   THRUST_FUNCTION
   functor(Iterator items_, T const& value_)
@@ -86,7 +86,7 @@ template <class Derived, class Iterator, class Size, class T>
 Iterator _CCCL_HOST_DEVICE
 uninitialized_fill_n(execution_policy<Derived>& policy, Iterator first, Size count, T const& x)
 {
-  typedef __uninitialized_fill::functor<Iterator, T> functor_t;
+  using functor_t = __uninitialized_fill::functor<Iterator, T>;
 
   cuda_cub::parallel_for(policy, functor_t(first, x), count);
 

--- a/thrust/thrust/system/cuda/detail/unique.h
+++ b/thrust/thrust/system/cuda/detail/unique.h
@@ -133,8 +133,8 @@ struct Tuning<sm52, T>
     ITEMS_PER_THREAD = items_per_thread<T, NOMINAL_4B_ITEMS_PER_THREAD>::value
   };
 
-  typedef PtxPolicy<64, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_SCAN_WARP_SCANS>
-    type;
+  using type =
+    PtxPolicy<64, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_SCAN_WARP_SCANS>;
 }; // Tuning for sm52
 
 template <class T>
@@ -148,8 +148,8 @@ struct Tuning<sm35, T>
     ITEMS_PER_THREAD = items_per_thread<T, NOMINAL_4B_ITEMS_PER_THREAD>::value
   };
 
-  typedef PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_SCAN_WARP_SCANS>
-    type;
+  using type =
+    PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_LDG, cub::BLOCK_SCAN_WARP_SCANS>;
 }; // Tuning for sm35
 
 template <class T>
@@ -163,32 +163,32 @@ struct Tuning<sm30, T>
     ITEMS_PER_THREAD = items_per_thread<T, NOMINAL_4B_ITEMS_PER_THREAD>::value
   };
 
-  typedef PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>
-    type;
+  using type =
+    PtxPolicy<128, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE, cub::LOAD_DEFAULT, cub::BLOCK_SCAN_WARP_SCANS>;
 }; // Tuning for sm30
 
 template <class ItemsIt, class ItemsOutputIt, class BinaryPred, class Size, class NumSelectedOutIt>
 struct UniqueAgent
 {
-  typedef typename iterator_traits<ItemsIt>::value_type item_type;
+  using item_type = typename iterator_traits<ItemsIt>::value_type;
 
-  typedef cub::ScanTileState<Size> ScanTileState;
+  using ScanTileState = cub::ScanTileState<Size>;
 
   template <class Arch>
   struct PtxPlan : Tuning<Arch, item_type>::type
   {
-    typedef Tuning<Arch, item_type> tuning;
+    using tuning = Tuning<Arch, item_type>;
 
-    typedef typename core::LoadIterator<PtxPlan, ItemsIt>::type ItemsLoadIt;
+    using ItemsLoadIt = typename core::LoadIterator<PtxPlan, ItemsIt>::type;
 
-    typedef typename core::BlockLoad<PtxPlan, ItemsLoadIt>::type BlockLoadItems;
+    using BlockLoadItems = typename core::BlockLoad<PtxPlan, ItemsLoadIt>::type;
 
-    typedef cub::BlockDiscontinuity<item_type, PtxPlan::BLOCK_THREADS, 1, 1, Arch::ver> BlockDiscontinuityItems;
+    using BlockDiscontinuityItems = cub::BlockDiscontinuity<item_type, PtxPlan::BLOCK_THREADS, 1, 1, Arch::ver>;
 
-    typedef cub::TilePrefixCallbackOp<Size, cub::Sum, ScanTileState, Arch::ver> TilePrefixCallback;
-    typedef cub::BlockScan<Size, PtxPlan::BLOCK_THREADS, PtxPlan::SCAN_ALGORITHM, 1, 1, Arch::ver> BlockScan;
+    using TilePrefixCallback = cub::TilePrefixCallbackOp<Size, cub::Sum, ScanTileState, Arch::ver>;
+    using BlockScan          = cub::BlockScan<Size, PtxPlan::BLOCK_THREADS, PtxPlan::SCAN_ALGORITHM, 1, 1, Arch::ver>;
 
-    typedef core::uninitialized_array<item_type, PtxPlan::ITEMS_PER_TILE> shared_items_t;
+    using shared_items_t = core::uninitialized_array<item_type, PtxPlan::ITEMS_PER_TILE>;
 
     union TempStorage
     {
@@ -205,15 +205,15 @@ struct UniqueAgent
     }; // union TempStorage
   }; // struct PtxPlan
 
-  typedef typename core::specialize_plan_msvc10_war<PtxPlan>::type::type ptx_plan;
+  using ptx_plan = typename core::specialize_plan_msvc10_war<PtxPlan>::type::type;
 
-  typedef typename ptx_plan::ItemsLoadIt ItemsLoadIt;
-  typedef typename ptx_plan::BlockLoadItems BlockLoadItems;
-  typedef typename ptx_plan::BlockDiscontinuityItems BlockDiscontinuityItems;
-  typedef typename ptx_plan::TilePrefixCallback TilePrefixCallback;
-  typedef typename ptx_plan::BlockScan BlockScan;
-  typedef typename ptx_plan::shared_items_t shared_items_t;
-  typedef typename ptx_plan::TempStorage TempStorage;
+  using ItemsLoadIt             = typename ptx_plan::ItemsLoadIt;
+  using BlockLoadItems          = typename ptx_plan::BlockLoadItems;
+  using BlockDiscontinuityItems = typename ptx_plan::BlockDiscontinuityItems;
+  using TilePrefixCallback      = typename ptx_plan::TilePrefixCallback;
+  using BlockScan               = typename ptx_plan::BlockScan;
+  using shared_items_t          = typename ptx_plan::shared_items_t;
+  using TempStorage             = typename ptx_plan::TempStorage;
 
   enum
   {
@@ -465,7 +465,7 @@ struct InitAgent
   template <class Arch>
   struct PtxPlan : PtxPolicy<128>
   {};
-  typedef core::specialize_plan<PtxPlan> ptx_plan;
+  using ptx_plan = core::specialize_plan<PtxPlan>;
 
   //---------------------------------------------------------------------
   // Agent entry point
@@ -497,11 +497,11 @@ static cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   using core::AgentPlan;
   using core::get_agent_plan;
 
-  typedef AgentLauncher<UniqueAgent<ItemsInputIt, ItemsOutputIt, BinaryPred, Size, NumSelectedOutIt>> unique_agent;
+  using unique_agent = AgentLauncher<UniqueAgent<ItemsInputIt, ItemsOutputIt, BinaryPred, Size, NumSelectedOutIt>>;
 
-  typedef typename unique_agent::ScanTileState ScanTileState;
+  using ScanTileState = typename unique_agent::ScanTileState;
 
-  typedef AgentLauncher<InitAgent<ScanTileState, NumSelectedOutIt, Size>> init_agent;
+  using init_agent = AgentLauncher<InitAgent<ScanTileState, NumSelectedOutIt, Size>>;
 
   using core::get_plan;
   typename get_plan<init_agent>::type init_plan     = init_agent::get_plan();
@@ -557,8 +557,8 @@ THRUST_RUNTIME_FUNCTION ItemsOutputIt unique(
   ItemsOutputIt items_result,
   BinaryPred binary_pred)
 {
-  //  typedef typename iterator_traits<ItemsInputIt>::difference_type size_type;
-  typedef int size_type;
+  //  using size_type = typename iterator_traits<ItemsInputIt>::difference_type;
+  using size_type = int;
 
   size_type num_items       = static_cast<size_type>(thrust::distance(items_first, items_last));
   size_t temp_storage_bytes = 0;
@@ -623,7 +623,7 @@ unique_copy(execution_policy<Derived>& policy, InputIt first, InputIt last, Outp
 template <class Derived, class InputIt, class OutputIt>
 OutputIt _CCCL_HOST_DEVICE unique_copy(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result)
 {
-  typedef typename iterator_traits<InputIt>::value_type input_type;
+  using input_type = typename iterator_traits<InputIt>::value_type;
   return cuda_cub::unique_copy(policy, first, last, result, equal_to<input_type>());
 }
 
@@ -641,7 +641,7 @@ unique(execution_policy<Derived>& policy, ForwardIt first, ForwardIt last, Binar
 template <class Derived, class ForwardIt>
 ForwardIt _CCCL_HOST_DEVICE unique(execution_policy<Derived>& policy, ForwardIt first, ForwardIt last)
 {
-  typedef typename iterator_traits<ForwardIt>::value_type input_type;
+  using input_type = typename iterator_traits<ForwardIt>::value_type;
   return cuda_cub::unique(policy, first, last, equal_to<input_type>());
 }
 

--- a/thrust/thrust/system/cuda/detail/unique_by_key.h
+++ b/thrust/thrust/system/cuda/detail/unique_by_key.h
@@ -272,7 +272,7 @@ pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE unique_by_key_copy(
   KeyOutputIt keys_result,
   ValOutputIt values_result)
 {
-  typedef typename iterator_traits<KeyInputIt>::value_type key_type;
+  using key_type = typename iterator_traits<KeyInputIt>::value_type;
   return cuda_cub::unique_by_key_copy(
     policy, keys_first, keys_last, values_first, keys_result, values_result, equal_to<key_type>());
 }
@@ -297,7 +297,7 @@ template <class Derived, class KeyInputIt, class ValInputIt>
 pair<KeyInputIt, ValInputIt> _CCCL_HOST_DEVICE
 unique_by_key(execution_policy<Derived>& policy, KeyInputIt keys_first, KeyInputIt keys_last, ValInputIt values_first)
 {
-  typedef typename iterator_traits<KeyInputIt>::value_type key_type;
+  using key_type = typename iterator_traits<KeyInputIt>::value_type;
   return cuda_cub::unique_by_key(policy, keys_first, keys_last, values_first, equal_to<key_type>());
 }
 

--- a/thrust/thrust/system/cuda/detail/util.h
+++ b/thrust/thrust/system/cuda/detail/util.h
@@ -253,12 +253,12 @@ _CCCL_HOST_DEVICE inline void throw_on_error(cudaError_t status, char const* msg
 template <class ValueType, class InputIt, class UnaryOp>
 struct transform_input_iterator_t
 {
-  typedef transform_input_iterator_t self_t;
-  typedef typename iterator_traits<InputIt>::difference_type difference_type;
-  typedef ValueType value_type;
-  typedef void pointer;
-  typedef value_type reference;
-  typedef std::random_access_iterator_tag iterator_category;
+  using self_t            = transform_input_iterator_t;
+  using difference_type   = typename iterator_traits<InputIt>::difference_type;
+  using value_type        = ValueType;
+  using pointer           = void;
+  using reference         = value_type;
+  using iterator_category = std::random_access_iterator_tag;
 
   InputIt input;
   mutable UnaryOp op;
@@ -360,12 +360,12 @@ struct transform_input_iterator_t
 template <class ValueType, class InputIt1, class InputIt2, class BinaryOp>
 struct transform_pair_of_input_iterators_t
 {
-  typedef transform_pair_of_input_iterators_t self_t;
-  typedef typename iterator_traits<InputIt1>::difference_type difference_type;
-  typedef ValueType value_type;
-  typedef void pointer;
-  typedef value_type reference;
-  typedef std::random_access_iterator_tag iterator_category;
+  using self_t            = transform_pair_of_input_iterators_t;
+  using difference_type   = typename iterator_traits<InputIt1>::difference_type;
+  using value_type        = ValueType;
+  using pointer           = void;
+  using reference         = value_type;
+  using iterator_category = std::random_access_iterator_tag;
 
   InputIt1 input1;
   InputIt2 input2;
@@ -489,12 +489,12 @@ struct identity
 template <class T>
 struct counting_iterator_t
 {
-  typedef counting_iterator_t self_t;
-  typedef T difference_type;
-  typedef T value_type;
-  typedef void pointer;
-  typedef T reference;
-  typedef std::random_access_iterator_tag iterator_category;
+  using self_t            = counting_iterator_t;
+  using difference_type   = T;
+  using value_type        = T;
+  using pointer           = void;
+  using reference         = T;
+  using iterator_category = std::random_access_iterator_tag;
 
   T count;
 

--- a/thrust/thrust/system/cuda/memory_resource.h
+++ b/thrust/thrust/system/cuda/memory_resource.h
@@ -48,8 +48,8 @@ namespace cuda
 namespace detail
 {
 
-typedef cudaError_t(CUDARTAPI* allocation_fn)(void**, std::size_t);
-typedef cudaError_t(CUDARTAPI* deallocation_fn)(void*);
+using allocation_fn   = cudaError_t (*)(void**, std::size_t);
+using deallocation_fn = cudaError_t (*)(void*);
 
 template <allocation_fn Alloc, deallocation_fn Dealloc, typename Pointer>
 class cuda_memory_resource final : public mr::memory_resource<Pointer>
@@ -90,11 +90,11 @@ inline cudaError_t CUDARTAPI cudaMallocManaged(void** ptr, std::size_t bytes)
   return ::cudaMallocManaged(ptr, bytes, cudaMemAttachGlobal);
 }
 
-typedef detail::cuda_memory_resource<cudaMalloc, cudaFree, thrust::cuda::pointer<void>> device_memory_resource;
-typedef detail::cuda_memory_resource<detail::cudaMallocManaged, cudaFree, thrust::cuda::universal_pointer<void>>
-  managed_memory_resource;
-typedef detail::cuda_memory_resource<cudaMallocHost, cudaFreeHost, thrust::cuda::universal_pointer<void>>
-  pinned_memory_resource;
+using device_memory_resource = detail::cuda_memory_resource<cudaMalloc, cudaFree, thrust::cuda::pointer<void>>;
+using managed_memory_resource =
+  detail::cuda_memory_resource<detail::cudaMallocManaged, cudaFree, thrust::cuda::universal_pointer<void>>;
+using pinned_memory_resource =
+  detail::cuda_memory_resource<cudaMallocHost, cudaFreeHost, thrust::cuda::universal_pointer<void>>;
 
 } // namespace detail
 //! \endcond
@@ -102,17 +102,17 @@ typedef detail::cuda_memory_resource<cudaMallocHost, cudaFreeHost, thrust::cuda:
 /*! The memory resource for the CUDA system. Uses <tt>cudaMalloc</tt> and wraps
  *  the result with \p cuda::pointer.
  */
-typedef detail::device_memory_resource memory_resource;
+using memory_resource = detail::device_memory_resource;
 /*! The universal memory resource for the CUDA system. Uses
  *  <tt>cudaMallocManaged</tt> and wraps the result with
  *  \p cuda::universal_pointer.
  */
-typedef detail::managed_memory_resource universal_memory_resource;
+using universal_memory_resource = detail::managed_memory_resource;
 /*! The host pinned memory resource for the CUDA system. Uses
  *  <tt>cudaMallocHost</tt> and wraps the result with \p
  *  cuda::universal_pointer.
  */
-typedef detail::pinned_memory_resource universal_host_pinned_memory_resource;
+using universal_host_pinned_memory_resource = detail::pinned_memory_resource;
 
 } // namespace cuda
 } // namespace system

--- a/thrust/thrust/system/detail/generic/adjacent_difference.inl
+++ b/thrust/thrust/system/detail/generic/adjacent_difference.inl
@@ -44,7 +44,7 @@ template <typename DerivedPolicy, typename InputIterator, typename OutputIterato
 _CCCL_HOST_DEVICE OutputIterator adjacent_difference(
   thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator result)
 {
-  typedef typename thrust::iterator_traits<InputIterator>::value_type InputType;
+  using InputType = typename thrust::iterator_traits<InputIterator>::value_type;
   thrust::minus<InputType> binary_op;
 
   return thrust::adjacent_difference(exec, first, last, result, binary_op);
@@ -58,7 +58,7 @@ _CCCL_HOST_DEVICE OutputIterator adjacent_difference(
   OutputIterator result,
   BinaryFunction binary_op)
 {
-  typedef typename thrust::iterator_traits<InputIterator>::value_type InputType;
+  using InputType = typename thrust::iterator_traits<InputIterator>::value_type;
 
   if (first == last)
   {

--- a/thrust/thrust/system/detail/generic/binary_search.inl
+++ b/thrust/thrust/system/detail/generic/binary_search.inl
@@ -160,7 +160,7 @@ _CCCL_HOST_DEVICE OutputType binary_search(
   thrust::detail::temporary_array<OutputType, DerivedPolicy> d_output(exec, 1);
 
   { // copy value to device
-    typedef typename thrust::iterator_system<const T*>::type value_in_system_t;
+    using value_in_system_t = typename thrust::iterator_system<const T*>::type;
     value_in_system_t value_in_system;
     using thrust::system::detail::generic::select_system;
     thrust::copy_n(select_system(thrust::detail::derived_cast(thrust::detail::strip_const(value_in_system)),
@@ -176,7 +176,7 @@ _CCCL_HOST_DEVICE OutputType binary_search(
 
   OutputType output;
   { // copy result to host and return
-    typedef typename thrust::iterator_system<OutputType*>::type result_out_system_t;
+    using result_out_system_t = typename thrust::iterator_system<OutputType*>::type;
     result_out_system_t result_out_system;
     using thrust::system::detail::generic::select_system;
     thrust::copy_n(select_system(thrust::detail::derived_cast(thrust::detail::strip_const(exec)),
@@ -224,7 +224,7 @@ _CCCL_HOST_DEVICE ForwardIterator lower_bound(
   const T& value,
   StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::difference_type difference_type;
+  using difference_type = typename thrust::iterator_traits<ForwardIterator>::difference_type;
 
   return begin + detail::binary_search<difference_type>(exec, begin, end, value, comp, detail::lbf());
 }
@@ -245,7 +245,7 @@ _CCCL_HOST_DEVICE ForwardIterator upper_bound(
   const T& value,
   StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::difference_type difference_type;
+  using difference_type = typename thrust::iterator_traits<ForwardIterator>::difference_type;
 
   return begin + detail::binary_search<difference_type>(exec, begin, end, value, comp, detail::ubf());
 }

--- a/thrust/thrust/system/detail/generic/copy.inl
+++ b/thrust/thrust/system/detail/generic/copy.inl
@@ -46,7 +46,7 @@ template <typename DerivedPolicy, typename InputIterator, typename OutputIterato
 _CCCL_HOST_DEVICE OutputIterator
 copy(thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator result)
 {
-  typedef typename thrust::iterator_value<InputIterator>::type T;
+  using T = typename thrust::iterator_value<InputIterator>::type;
   return thrust::transform(exec, first, last, result, thrust::identity<T>());
 } // end copy()
 
@@ -54,13 +54,13 @@ template <typename DerivedPolicy, typename InputIterator, typename Size, typenam
 _CCCL_HOST_DEVICE OutputIterator
 copy_n(thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, Size n, OutputIterator result)
 {
-  typedef typename thrust::iterator_value<InputIterator>::type value_type;
-  typedef thrust::identity<value_type> xfrm_type;
+  using value_type = typename thrust::iterator_value<InputIterator>::type;
+  using xfrm_type  = thrust::identity<value_type>;
 
-  typedef thrust::detail::unary_transform_functor<xfrm_type> functor_type;
+  using functor_type = thrust::detail::unary_transform_functor<xfrm_type>;
 
-  typedef thrust::tuple<InputIterator, OutputIterator> iterator_tuple;
-  typedef thrust::zip_iterator<iterator_tuple> zip_iter;
+  using iterator_tuple = thrust::tuple<InputIterator, OutputIterator>;
+  using zip_iter       = thrust::zip_iterator<iterator_tuple>;
 
   zip_iter zipped = thrust::make_zip_iterator(thrust::make_tuple(first, result));
 

--- a/thrust/thrust/system/detail/generic/copy_if.inl
+++ b/thrust/thrust/system/detail/generic/copy_if.inl
@@ -122,7 +122,7 @@ _CCCL_HOST_DEVICE OutputIterator copy_if(
   OutputIterator result,
   Predicate pred)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::difference_type difference_type;
+  using difference_type = typename thrust::iterator_traits<InputIterator1>::difference_type;
 
   // empty sequence
   if (first == last)

--- a/thrust/thrust/system/detail/generic/count.inl
+++ b/thrust/thrust/system/detail/generic/count.inl
@@ -76,8 +76,8 @@ template <typename DerivedPolicy, typename InputIterator, typename Predicate>
 _CCCL_HOST_DEVICE typename thrust::iterator_traits<InputIterator>::difference_type
 count_if(thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, Predicate pred)
 {
-  typedef typename thrust::iterator_traits<InputIterator>::value_type InputType;
-  typedef typename thrust::iterator_traits<InputIterator>::difference_type CountType;
+  using InputType = typename thrust::iterator_traits<InputIterator>::value_type;
+  using CountType = typename thrust::iterator_traits<InputIterator>::difference_type;
 
   thrust::system::detail::generic::count_if_transform<InputType, Predicate, CountType> unary_op(pred);
   thrust::plus<CountType> binary_op;

--- a/thrust/thrust/system/detail/generic/equal.inl
+++ b/thrust/thrust/system/detail/generic/equal.inl
@@ -42,7 +42,7 @@ template <typename DerivedPolicy, typename InputIterator1, typename InputIterato
 _CCCL_HOST_DEVICE bool
 equal(thrust::execution_policy<DerivedPolicy>& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::value_type InputType1;
+  using InputType1 = typename thrust::iterator_traits<InputIterator1>::value_type;
 
   return thrust::equal(exec, first1, last1, first2, thrust::detail::equal_to<InputType1>());
 }

--- a/thrust/thrust/system/detail/generic/extrema.inl
+++ b/thrust/thrust/system/detail/generic/extrema.inl
@@ -159,7 +159,7 @@ template <typename DerivedPolicy, typename ForwardIterator>
 _CCCL_HOST_DEVICE ForwardIterator
 min_element(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last)
 {
-  typedef typename thrust::iterator_value<ForwardIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<ForwardIterator>::type;
 
   return thrust::min_element(exec, first, last, thrust::less<value_type>());
 } // end min_element()
@@ -173,8 +173,8 @@ _CCCL_HOST_DEVICE ForwardIterator min_element(
     return last;
   }
 
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
-  typedef typename thrust::iterator_traits<ForwardIterator>::difference_type IndexType;
+  using InputType = typename thrust::iterator_traits<ForwardIterator>::value_type;
+  using IndexType = typename thrust::iterator_traits<ForwardIterator>::difference_type;
 
   thrust::tuple<InputType, IndexType> result = thrust::reduce(
     exec,
@@ -190,7 +190,7 @@ template <typename DerivedPolicy, typename ForwardIterator>
 _CCCL_HOST_DEVICE ForwardIterator
 max_element(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last)
 {
-  typedef typename thrust::iterator_value<ForwardIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<ForwardIterator>::type;
 
   return thrust::max_element(exec, first, last, thrust::less<value_type>());
 } // end max_element()
@@ -204,8 +204,8 @@ _CCCL_HOST_DEVICE ForwardIterator max_element(
     return last;
   }
 
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
-  typedef typename thrust::iterator_traits<ForwardIterator>::difference_type IndexType;
+  using InputType = typename thrust::iterator_traits<ForwardIterator>::value_type;
+  using IndexType = typename thrust::iterator_traits<ForwardIterator>::difference_type;
 
   thrust::tuple<InputType, IndexType> result = thrust::reduce(
     exec,
@@ -221,7 +221,7 @@ template <typename DerivedPolicy, typename ForwardIterator>
 _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator>
 minmax_element(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last)
 {
-  typedef typename thrust::iterator_value<ForwardIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<ForwardIterator>::type;
 
   return thrust::minmax_element(exec, first, last, thrust::less<value_type>());
 } // end minmax_element()
@@ -235,8 +235,8 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
     return thrust::make_pair(last, last);
   }
 
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
-  typedef typename thrust::iterator_traits<ForwardIterator>::difference_type IndexType;
+  using InputType = typename thrust::iterator_traits<ForwardIterator>::value_type;
+  using IndexType = typename thrust::iterator_traits<ForwardIterator>::difference_type;
 
   thrust::tuple<thrust::tuple<InputType, IndexType>, thrust::tuple<InputType, IndexType>> result =
     thrust::transform_reduce(

--- a/thrust/thrust/system/detail/generic/find.inl
+++ b/thrust/thrust/system/detail/generic/find.inl
@@ -78,8 +78,8 @@ template <typename DerivedPolicy, typename InputIterator, typename Predicate>
 _CCCL_HOST_DEVICE InputIterator
 find_if(thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, Predicate pred)
 {
-  typedef typename thrust::iterator_traits<InputIterator>::difference_type difference_type;
-  typedef typename thrust::tuple<bool, difference_type> result_type;
+  using difference_type = typename thrust::iterator_traits<InputIterator>::difference_type;
+  using result_type     = typename thrust::tuple<bool, difference_type>;
 
   // empty sequence
   if (first == last)
@@ -97,9 +97,9 @@ find_if(thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, Inpu
   const difference_type interval_size      = (thrust::min)(interval_threshold, n);
 
   // force transform_iterator output to bool
-  typedef thrust::transform_iterator<Predicate, InputIterator, bool> XfrmIterator;
-  typedef thrust::tuple<XfrmIterator, thrust::counting_iterator<difference_type>> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using XfrmIterator  = thrust::transform_iterator<Predicate, InputIterator, bool>;
+  using IteratorTuple = thrust::tuple<XfrmIterator, thrust::counting_iterator<difference_type>>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   IteratorTuple iter_tuple =
     thrust::make_tuple(XfrmIterator(first, pred), thrust::counting_iterator<difference_type>(0));

--- a/thrust/thrust/system/detail/generic/gather.inl
+++ b/thrust/thrust/system/detail/generic/gather.inl
@@ -68,7 +68,7 @@ _CCCL_HOST_DEVICE OutputIterator gather_if(
   RandomAccessIterator input_first,
   OutputIterator result)
 {
-  typedef typename thrust::iterator_value<InputIterator2>::type StencilType;
+  using StencilType = typename thrust::iterator_value<InputIterator2>::type;
   return thrust::gather_if(exec, map_first, map_last, stencil, input_first, result, thrust::identity<StencilType>());
 } // end gather_if()
 
@@ -87,7 +87,7 @@ _CCCL_HOST_DEVICE OutputIterator gather_if(
   OutputIterator result,
   Predicate pred)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type InputType;
+  using InputType = typename thrust::iterator_value<RandomAccessIterator>::type;
   return thrust::transform_if(
     exec,
     thrust::make_permutation_iterator(input_first, map_first),

--- a/thrust/thrust/system/detail/generic/inner_product.inl
+++ b/thrust/thrust/system/detail/generic/inner_product.inl
@@ -66,7 +66,7 @@ _CCCL_HOST_DEVICE OutputType inner_product(
   BinaryFunction1 binary_op1,
   BinaryFunction2 binary_op2)
 {
-  typedef thrust::zip_iterator<thrust::tuple<InputIterator1, InputIterator2>> ZipIter;
+  using ZipIter = thrust::zip_iterator<thrust::tuple<InputIterator1, InputIterator2>>;
 
   ZipIter first = thrust::make_zip_iterator(thrust::make_tuple(first1, first2));
 

--- a/thrust/thrust/system/detail/generic/merge.inl
+++ b/thrust/thrust/system/detail/generic/merge.inl
@@ -68,7 +68,7 @@ _CCCL_HOST_DEVICE OutputIterator merge(
   InputIterator2 last2,
   OutputIterator result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::merge(exec, first1, last1, first2, last2, result, thrust::less<value_type>());
 } // end merge()
 
@@ -92,13 +92,13 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
   OutputIterator2 values_result,
   Compare comp)
 {
-  typedef thrust::tuple<InputIterator1, InputIterator3> iterator_tuple1;
-  typedef thrust::tuple<InputIterator2, InputIterator4> iterator_tuple2;
-  typedef thrust::tuple<OutputIterator1, OutputIterator2> iterator_tuple3;
+  using iterator_tuple1 = thrust::tuple<InputIterator1, InputIterator3>;
+  using iterator_tuple2 = thrust::tuple<InputIterator2, InputIterator4>;
+  using iterator_tuple3 = thrust::tuple<OutputIterator1, OutputIterator2>;
 
-  typedef thrust::zip_iterator<iterator_tuple1> zip_iterator1;
-  typedef thrust::zip_iterator<iterator_tuple2> zip_iterator2;
-  typedef thrust::zip_iterator<iterator_tuple3> zip_iterator3;
+  using zip_iterator1 = thrust::zip_iterator<iterator_tuple1>;
+  using zip_iterator2 = thrust::zip_iterator<iterator_tuple2>;
+  using zip_iterator3 = thrust::zip_iterator<iterator_tuple3>;
 
   zip_iterator1 zipped_first1 = thrust::make_zip_iterator(thrust::make_tuple(keys_first1, values_first1));
   zip_iterator1 zipped_last1  = thrust::make_zip_iterator(thrust::make_tuple(keys_last1, values_first1));
@@ -135,7 +135,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
   OutputIterator1 keys_result,
   OutputIterator2 values_result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::merge_by_key(
     exec,
     keys_first1,

--- a/thrust/thrust/system/detail/generic/mismatch.inl
+++ b/thrust/thrust/system/detail/generic/mismatch.inl
@@ -56,8 +56,8 @@ _CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
   BinaryPredicate pred)
 {
   // Contributed by Erich Elsen
-  typedef thrust::tuple<InputIterator1, InputIterator2> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator1, InputIterator2>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator zipped_first = thrust::make_zip_iterator(thrust::make_tuple(first1, first2));
   ZipIterator zipped_last  = thrust::make_zip_iterator(thrust::make_tuple(last1, first2));

--- a/thrust/thrust/system/detail/generic/partition.inl
+++ b/thrust/thrust/system/detail/generic/partition.inl
@@ -49,7 +49,7 @@ template <typename DerivedPolicy, typename ForwardIterator, typename Predicate>
 _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, Predicate pred)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
+  using InputType = typename thrust::iterator_traits<ForwardIterator>::value_type;
 
   // copy input to temp buffer
   thrust::detail::temporary_array<InputType, DerivedPolicy> temp(exec, first, last);
@@ -72,7 +72,7 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   InputIterator stencil,
   Predicate pred)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
+  using InputType = typename thrust::iterator_traits<ForwardIterator>::value_type;
 
   // copy input to temp buffer
   thrust::detail::temporary_array<InputType, DerivedPolicy> temp(exec, first, last);

--- a/thrust/thrust/system/detail/generic/reduce.inl
+++ b/thrust/thrust/system/detail/generic/reduce.inl
@@ -44,7 +44,7 @@ template <typename ExecutionPolicy, typename InputIterator>
 _CCCL_HOST_DEVICE typename thrust::iterator_traits<InputIterator>::value_type
 reduce(thrust::execution_policy<ExecutionPolicy>& exec, InputIterator first, InputIterator last)
 {
-  typedef typename thrust::iterator_value<InputIterator>::type InputType;
+  using InputType = typename thrust::iterator_value<InputIterator>::type;
 
   // use InputType(0) as init by default
   return thrust::reduce(exec, first, last, InputType(0));

--- a/thrust/thrust/system/detail/generic/reduce_by_key.inl
+++ b/thrust/thrust/system/detail/generic/reduce_by_key.inl
@@ -55,7 +55,7 @@ struct reduce_by_key_functor
 {
   AssociativeOperator binary_op;
 
-  typedef typename thrust::tuple<ValueType, TailFlagType> result_type;
+  using result_type = typename thrust::tuple<ValueType, TailFlagType>;
 
   _CCCL_HOST_DEVICE reduce_by_key_functor(AssociativeOperator _binary_op)
       : binary_op(_binary_op)
@@ -87,9 +87,9 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   BinaryPredicate binary_pred,
   BinaryFunction binary_op)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::difference_type difference_type;
+  using difference_type = typename thrust::iterator_traits<InputIterator1>::difference_type;
 
-  typedef unsigned int FlagType; // TODO use difference_type
+  using FlagType = unsigned int; // TODO use difference_type
 
   // Use the input iterator's value type per https://wg21.link/P0571
   using ValueType = typename thrust::iterator_value<InputIterator2>::type;
@@ -154,7 +154,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   OutputIterator1 keys_output,
   OutputIterator2 values_output)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type KeyType;
+  using KeyType = typename thrust::iterator_value<InputIterator1>::type;
 
   // use equal_to<KeyType> as default BinaryPredicate
   return thrust::reduce_by_key(
@@ -176,9 +176,9 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   OutputIterator2 values_output,
   BinaryPredicate binary_pred)
 {
-  typedef typename thrust::detail::eval_if<thrust::detail::is_output_iterator<OutputIterator2>::value,
-                                           thrust::iterator_value<InputIterator2>,
-                                           thrust::iterator_value<OutputIterator2>>::type T;
+  using T = typename thrust::detail::eval_if<thrust::detail::is_output_iterator<OutputIterator2>::value,
+                                             thrust::iterator_value<InputIterator2>,
+                                             thrust::iterator_value<OutputIterator2>>::type;
 
   // use plus<T> as default BinaryFunction
   return thrust::reduce_by_key(

--- a/thrust/thrust/system/detail/generic/remove.inl
+++ b/thrust/thrust/system/detail/generic/remove.inl
@@ -68,7 +68,7 @@ template <typename DerivedPolicy, typename ForwardIterator, typename Predicate>
 _CCCL_HOST_DEVICE ForwardIterator
 remove_if(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, Predicate pred)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
+  using InputType = typename thrust::iterator_traits<ForwardIterator>::value_type;
 
   // create temporary storage for an intermediate result
   thrust::detail::temporary_array<InputType, DerivedPolicy> temp(exec, first, last);
@@ -85,7 +85,7 @@ _CCCL_HOST_DEVICE ForwardIterator remove_if(
   InputIterator stencil,
   Predicate pred)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
+  using InputType = typename thrust::iterator_traits<ForwardIterator>::value_type;
 
   // create temporary storage for an intermediate result
   thrust::detail::temporary_array<InputType, DerivedPolicy> temp(exec, first, last);

--- a/thrust/thrust/system/detail/generic/replace.inl
+++ b/thrust/thrust/system/detail/generic/replace.inl
@@ -96,7 +96,7 @@ _CCCL_HOST_DEVICE OutputIterator replace_copy_if(
   Predicate pred,
   const T& new_value)
 {
-  typedef typename thrust::iterator_traits<OutputIterator>::value_type OutputType;
+  using OutputType = typename thrust::iterator_traits<OutputIterator>::value_type;
 
   detail::new_value_if<Predicate, T, OutputType> op(pred, new_value);
   return thrust::transform(exec, first, last, result, op);
@@ -117,7 +117,7 @@ _CCCL_HOST_DEVICE OutputIterator replace_copy_if(
   Predicate pred,
   const T& new_value)
 {
-  typedef typename thrust::iterator_traits<OutputIterator>::value_type OutputType;
+  using OutputType = typename thrust::iterator_traits<OutputIterator>::value_type;
 
   detail::new_value_if<Predicate, T, OutputType> op(pred, new_value);
   return thrust::transform(exec, first, last, stencil, result, op);

--- a/thrust/thrust/system/detail/generic/reverse.inl
+++ b/thrust/thrust/system/detail/generic/reverse.inl
@@ -45,7 +45,7 @@ template <typename ExecutionPolicy, typename BidirectionalIterator>
 _CCCL_HOST_DEVICE void
 reverse(thrust::execution_policy<ExecutionPolicy>& exec, BidirectionalIterator first, BidirectionalIterator last)
 {
-  typedef typename thrust::iterator_difference<BidirectionalIterator>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<BidirectionalIterator>::type;
 
   // find the midpoint of [first,last)
   difference_type N = thrust::distance(first, last);

--- a/thrust/thrust/system/detail/generic/scan_by_key.inl
+++ b/thrust/thrust/system/detail/generic/scan_by_key.inl
@@ -51,7 +51,7 @@ struct segmented_scan_functor
 {
   AssociativeOperator binary_op;
 
-  typedef typename thrust::tuple<OutputType, HeadFlagType> result_type;
+  using result_type = typename thrust::tuple<OutputType, HeadFlagType>;
 
   _CCCL_HOST_DEVICE segmented_scan_functor(AssociativeOperator _binary_op)
       : binary_op(_binary_op)
@@ -144,7 +144,7 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan_by_key(
   InputIterator2 first2,
   OutputIterator result)
 {
-  typedef typename thrust::iterator_traits<InputIterator2>::value_type InitType;
+  using InitType = typename thrust::iterator_traits<InputIterator2>::value_type;
   return thrust::exclusive_scan_by_key(exec, first1, last1, first2, result, InitType{});
 }
 

--- a/thrust/thrust/system/detail/generic/scatter.inl
+++ b/thrust/thrust/system/detail/generic/scatter.inl
@@ -69,7 +69,7 @@ _CCCL_HOST_DEVICE void scatter_if(
   RandomAccessIterator output)
 {
   // default predicate is identity
-  typedef typename thrust::iterator_value<InputIterator3>::type StencilType;
+  using StencilType = typename thrust::iterator_value<InputIterator3>::type;
   thrust::scatter_if(exec, first, last, map, stencil, output, thrust::identity<StencilType>());
 } // end scatter_if()
 
@@ -88,7 +88,7 @@ _CCCL_HOST_DEVICE void scatter_if(
   RandomAccessIterator output,
   Predicate pred)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type InputType;
+  using InputType = typename thrust::iterator_value<InputIterator1>::type;
   thrust::transform_if(
     exec, first, last, stencil, thrust::make_permutation_iterator(output, map), thrust::identity<InputType>(), pred);
 } // end scatter_if()

--- a/thrust/thrust/system/detail/generic/select_system_exists.h
+++ b/thrust/thrust/system/detail/generic/select_system_exists.h
@@ -44,8 +44,8 @@ namespace detail
 namespace generic_type_traits_ns
 {
 
-typedef char yes;
-typedef char (&no)[2];
+using yes = char;
+using no  = char (&)[2];
 
 struct any_conversion
 {

--- a/thrust/thrust/system/detail/generic/sequence.inl
+++ b/thrust/thrust/system/detail/generic/sequence.inl
@@ -41,7 +41,7 @@ template <typename DerivedPolicy, typename ForwardIterator>
 _CCCL_HOST_DEVICE void
 sequence(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type T;
+  using T = typename thrust::iterator_traits<ForwardIterator>::value_type;
 
   thrust::sequence(exec, first, last, T(0));
 } // end sequence()

--- a/thrust/thrust/system/detail/generic/set_operations.inl
+++ b/thrust/thrust/system/detail/generic/set_operations.inl
@@ -50,7 +50,7 @@ _CCCL_HOST_DEVICE OutputIterator set_difference(
   InputIterator2 last2,
   OutputIterator result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::set_difference(exec, first1, last1, first2, last2, result, thrust::less<value_type>());
 } // end set_difference()
 
@@ -72,7 +72,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_
   OutputIterator1 keys_result,
   OutputIterator2 values_result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::set_difference_by_key(
     exec,
     keys_first1,
@@ -106,13 +106,13 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_
   OutputIterator2 values_result,
   StrictWeakOrdering comp)
 {
-  typedef thrust::tuple<InputIterator1, InputIterator3> iterator_tuple1;
-  typedef thrust::tuple<InputIterator2, InputIterator4> iterator_tuple2;
-  typedef thrust::tuple<OutputIterator1, OutputIterator2> iterator_tuple3;
+  using iterator_tuple1 = thrust::tuple<InputIterator1, InputIterator3>;
+  using iterator_tuple2 = thrust::tuple<InputIterator2, InputIterator4>;
+  using iterator_tuple3 = thrust::tuple<OutputIterator1, OutputIterator2>;
 
-  typedef thrust::zip_iterator<iterator_tuple1> zip_iterator1;
-  typedef thrust::zip_iterator<iterator_tuple2> zip_iterator2;
-  typedef thrust::zip_iterator<iterator_tuple3> zip_iterator3;
+  using zip_iterator1 = thrust::zip_iterator<iterator_tuple1>;
+  using zip_iterator2 = thrust::zip_iterator<iterator_tuple2>;
+  using zip_iterator3 = thrust::zip_iterator<iterator_tuple3>;
 
   zip_iterator1 zipped_first1 = thrust::make_zip_iterator(thrust::make_tuple(keys_first1, values_first1));
   zip_iterator1 zipped_last1  = thrust::make_zip_iterator(thrust::make_tuple(keys_last1, values_first1));
@@ -140,7 +140,7 @@ _CCCL_HOST_DEVICE OutputIterator set_intersection(
   InputIterator2 last2,
   OutputIterator result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::set_intersection(exec, first1, last1, first2, last2, result, thrust::less<value_type>());
 } // end set_intersection()
 
@@ -160,7 +160,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersectio
   OutputIterator1 keys_result,
   OutputIterator2 values_result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::set_intersection_by_key(
     exec,
     keys_first1,
@@ -191,16 +191,16 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersectio
   OutputIterator2 values_result,
   StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<InputIterator3>::type value_type1;
-  typedef thrust::constant_iterator<value_type1> constant_iterator;
+  using value_type1       = typename thrust::iterator_value<InputIterator3>::type;
+  using constant_iterator = thrust::constant_iterator<value_type1>;
 
-  typedef thrust::tuple<InputIterator1, InputIterator3> iterator_tuple1;
-  typedef thrust::tuple<InputIterator2, constant_iterator> iterator_tuple2;
-  typedef thrust::tuple<OutputIterator1, OutputIterator2> iterator_tuple3;
+  using iterator_tuple1 = thrust::tuple<InputIterator1, InputIterator3>;
+  using iterator_tuple2 = thrust::tuple<InputIterator2, constant_iterator>;
+  using iterator_tuple3 = thrust::tuple<OutputIterator1, OutputIterator2>;
 
-  typedef thrust::zip_iterator<iterator_tuple1> zip_iterator1;
-  typedef thrust::zip_iterator<iterator_tuple2> zip_iterator2;
-  typedef thrust::zip_iterator<iterator_tuple3> zip_iterator3;
+  using zip_iterator1 = thrust::zip_iterator<iterator_tuple1>;
+  using zip_iterator2 = thrust::zip_iterator<iterator_tuple2>;
+  using zip_iterator3 = thrust::zip_iterator<iterator_tuple3>;
 
   // fabricate a values_first2 by repeating a default-constructed value_type1
   // XXX assumes value_type1 is default-constructible
@@ -232,7 +232,7 @@ _CCCL_HOST_DEVICE OutputIterator set_symmetric_difference(
   InputIterator2 last2,
   OutputIterator result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::set_symmetric_difference(exec, first1, last1, first2, last2, result, thrust::less<value_type>());
 } // end set_symmetric_difference()
 
@@ -254,7 +254,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_d
   OutputIterator1 keys_result,
   OutputIterator2 values_result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::set_symmetric_difference_by_key(
     exec,
     keys_first1,
@@ -288,13 +288,13 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_d
   OutputIterator2 values_result,
   StrictWeakOrdering comp)
 {
-  typedef thrust::tuple<InputIterator1, InputIterator3> iterator_tuple1;
-  typedef thrust::tuple<InputIterator2, InputIterator4> iterator_tuple2;
-  typedef thrust::tuple<OutputIterator1, OutputIterator2> iterator_tuple3;
+  using iterator_tuple1 = thrust::tuple<InputIterator1, InputIterator3>;
+  using iterator_tuple2 = thrust::tuple<InputIterator2, InputIterator4>;
+  using iterator_tuple3 = thrust::tuple<OutputIterator1, OutputIterator2>;
 
-  typedef thrust::zip_iterator<iterator_tuple1> zip_iterator1;
-  typedef thrust::zip_iterator<iterator_tuple2> zip_iterator2;
-  typedef thrust::zip_iterator<iterator_tuple3> zip_iterator3;
+  using zip_iterator1 = thrust::zip_iterator<iterator_tuple1>;
+  using zip_iterator2 = thrust::zip_iterator<iterator_tuple2>;
+  using zip_iterator3 = thrust::zip_iterator<iterator_tuple3>;
 
   zip_iterator1 zipped_first1 = thrust::make_zip_iterator(thrust::make_tuple(keys_first1, values_first1));
   zip_iterator1 zipped_last1  = thrust::make_zip_iterator(thrust::make_tuple(keys_last1, values_first1));
@@ -323,7 +323,7 @@ _CCCL_HOST_DEVICE OutputIterator set_union(
   InputIterator2 last2,
   OutputIterator result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::set_union(exec, first1, last1, first2, last2, result, thrust::less<value_type>());
 } // end set_union()
 
@@ -345,7 +345,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_ke
   OutputIterator1 keys_result,
   OutputIterator2 values_result)
 {
-  typedef typename thrust::iterator_value<InputIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator1>::type;
   return thrust::set_union_by_key(
     exec,
     keys_first1,
@@ -379,13 +379,13 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_ke
   OutputIterator2 values_result,
   StrictWeakOrdering comp)
 {
-  typedef thrust::tuple<InputIterator1, InputIterator3> iterator_tuple1;
-  typedef thrust::tuple<InputIterator2, InputIterator4> iterator_tuple2;
-  typedef thrust::tuple<OutputIterator1, OutputIterator2> iterator_tuple3;
+  using iterator_tuple1 = thrust::tuple<InputIterator1, InputIterator3>;
+  using iterator_tuple2 = thrust::tuple<InputIterator2, InputIterator4>;
+  using iterator_tuple3 = thrust::tuple<OutputIterator1, OutputIterator2>;
 
-  typedef thrust::zip_iterator<iterator_tuple1> zip_iterator1;
-  typedef thrust::zip_iterator<iterator_tuple2> zip_iterator2;
-  typedef thrust::zip_iterator<iterator_tuple3> zip_iterator3;
+  using zip_iterator1 = thrust::zip_iterator<iterator_tuple1>;
+  using zip_iterator2 = thrust::zip_iterator<iterator_tuple2>;
+  using zip_iterator3 = thrust::zip_iterator<iterator_tuple3>;
 
   zip_iterator1 zipped_first1 = thrust::make_zip_iterator(thrust::make_tuple(keys_first1, values_first1));
   zip_iterator1 zipped_last1  = thrust::make_zip_iterator(thrust::make_tuple(keys_last1, values_first1));

--- a/thrust/thrust/system/detail/generic/sort.inl
+++ b/thrust/thrust/system/detail/generic/sort.inl
@@ -46,7 +46,7 @@ template <typename DerivedPolicy, typename RandomAccessIterator>
 _CCCL_HOST_DEVICE void
 sort(thrust::execution_policy<DerivedPolicy>& exec, RandomAccessIterator first, RandomAccessIterator last)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<RandomAccessIterator>::type;
   thrust::sort(exec, first, last, thrust::less<value_type>());
 } // end sort()
 
@@ -68,7 +68,7 @@ _CCCL_HOST_DEVICE void sort_by_key(
   RandomAccessIterator1 keys_last,
   RandomAccessIterator2 values_first)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<RandomAccessIterator1>::type;
   thrust::sort_by_key(exec, keys_first, keys_last, values_first, thrust::less<value_type>());
 } // end sort_by_key()
 
@@ -91,7 +91,7 @@ template <typename DerivedPolicy, typename RandomAccessIterator>
 _CCCL_HOST_DEVICE void
 stable_sort(thrust::execution_policy<DerivedPolicy>& exec, RandomAccessIterator first, RandomAccessIterator last)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<RandomAccessIterator>::type;
   thrust::stable_sort(exec, first, last, thrust::less<value_type>());
 } // end stable_sort()
 
@@ -102,7 +102,7 @@ _CCCL_HOST_DEVICE void stable_sort_by_key(
   RandomAccessIterator1 keys_last,
   RandomAccessIterator2 values_first)
 {
-  typedef typename iterator_value<RandomAccessIterator1>::type value_type;
+  using value_type = typename iterator_value<RandomAccessIterator1>::type;
   thrust::stable_sort_by_key(exec, keys_first, keys_last, values_first, thrust::less<value_type>());
 } // end stable_sort_by_key()
 
@@ -124,7 +124,7 @@ template <typename DerivedPolicy, typename ForwardIterator>
 _CCCL_HOST_DEVICE ForwardIterator
 is_sorted_until(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last)
 {
-  typedef typename thrust::iterator_value<ForwardIterator>::type InputType;
+  using InputType = typename thrust::iterator_value<ForwardIterator>::type;
 
   return thrust::is_sorted_until(exec, first, last, thrust::less<InputType>());
 } // end is_sorted_until()
@@ -138,8 +138,8 @@ _CCCL_HOST_DEVICE ForwardIterator is_sorted_until(
     return last;
   }
 
-  typedef thrust::tuple<ForwardIterator, ForwardIterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<ForwardIterator, ForwardIterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ForwardIterator first_plus_one = first;
   thrust::advance(first_plus_one, 1);

--- a/thrust/thrust/system/detail/generic/swap_ranges.inl
+++ b/thrust/thrust/system/detail/generic/swap_ranges.inl
@@ -63,8 +63,8 @@ _CCCL_HOST_DEVICE ForwardIterator2 swap_ranges(
   ForwardIterator1 last1,
   ForwardIterator2 first2)
 {
-  typedef thrust::tuple<ForwardIterator1, ForwardIterator2> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<ForwardIterator1, ForwardIterator2>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator result = thrust::for_each(
     exec,

--- a/thrust/thrust/system/detail/generic/tabulate.inl
+++ b/thrust/thrust/system/detail/generic/tabulate.inl
@@ -43,7 +43,7 @@ template <typename DerivedPolicy, typename ForwardIterator, typename UnaryOperat
 _CCCL_HOST_DEVICE void tabulate(
   thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, UnaryOperation unary_op)
 {
-  typedef typename iterator_difference<ForwardIterator>::type difference_type;
+  using difference_type = typename iterator_difference<ForwardIterator>::type;
 
   // by default, counting_iterator uses a 64b difference_type on 32b platforms to avoid overflowing its counter.
   // this causes problems when a zip_iterator is created in transform's implementation -- ForwardIterator is

--- a/thrust/thrust/system/detail/generic/transform.inl
+++ b/thrust/thrust/system/detail/generic/transform.inl
@@ -49,11 +49,11 @@ _CCCL_HOST_DEVICE OutputIterator transform(
   OutputIterator result,
   UnaryFunction op)
 {
-  typedef thrust::detail::unary_transform_functor<UnaryFunction> UnaryTransformFunctor;
+  using UnaryTransformFunctor = thrust::detail::unary_transform_functor<UnaryFunction>;
 
   // make an iterator tuple
-  typedef thrust::tuple<InputIterator, OutputIterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator, OutputIterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator zipped_result = thrust::for_each(
     exec,
@@ -78,11 +78,11 @@ _CCCL_HOST_DEVICE OutputIterator transform(
   BinaryFunction op)
 {
   // given the minimal system, determine the binary transform functor we need
-  typedef thrust::detail::binary_transform_functor<BinaryFunction> BinaryTransformFunctor;
+  using BinaryTransformFunctor = thrust::detail::binary_transform_functor<BinaryFunction>;
 
   // make an iterator tuple
-  typedef thrust::tuple<InputIterator1, InputIterator2, OutputIterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator1, InputIterator2, OutputIterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator zipped_result = thrust::for_each(
     exec,
@@ -106,11 +106,11 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if(
   UnaryFunction unary_op,
   Predicate pred)
 {
-  typedef thrust::detail::unary_transform_if_functor<UnaryFunction, Predicate> UnaryTransformIfFunctor;
+  using UnaryTransformIfFunctor = thrust::detail::unary_transform_if_functor<UnaryFunction, Predicate>;
 
   // make an iterator tuple
-  typedef thrust::tuple<InputIterator, ForwardIterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator, ForwardIterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator zipped_result = thrust::for_each(
     exec,
@@ -136,11 +136,11 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if(
   UnaryFunction unary_op,
   Predicate pred)
 {
-  typedef thrust::detail::unary_transform_if_with_stencil_functor<UnaryFunction, Predicate> UnaryTransformIfFunctor;
+  using UnaryTransformIfFunctor = thrust::detail::unary_transform_if_with_stencil_functor<UnaryFunction, Predicate>;
 
   // make an iterator tuple
-  typedef thrust::tuple<InputIterator1, InputIterator2, ForwardIterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator1, InputIterator2, ForwardIterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator zipped_result = thrust::for_each(
     exec,
@@ -168,11 +168,11 @@ _CCCL_HOST_DEVICE ForwardIterator transform_if(
   BinaryFunction binary_op,
   Predicate pred)
 {
-  typedef thrust::detail::binary_transform_if_functor<BinaryFunction, Predicate> BinaryTransformIfFunctor;
+  using BinaryTransformIfFunctor = thrust::detail::binary_transform_if_functor<BinaryFunction, Predicate>;
 
   // make an iterator tuple
-  typedef thrust::tuple<InputIterator1, InputIterator2, InputIterator3, ForwardIterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator1, InputIterator2, InputIterator3, ForwardIterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator zipped_result = thrust::for_each(
     exec,

--- a/thrust/thrust/system/detail/generic/uninitialized_copy.inl
+++ b/thrust/thrust/system/detail/generic/uninitialized_copy.inl
@@ -65,8 +65,8 @@ _CCCL_HOST_DEVICE ForwardIterator uninitialized_copy(
   thrust::detail::false_type) // ::cuda::std::is_trivially_copy_constructible
 {
   // zip up the iterators
-  typedef thrust::tuple<InputIterator, ForwardIterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator, ForwardIterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator begin = thrust::make_zip_iterator(thrust::make_tuple(first, result));
   ZipIterator end   = begin;
@@ -76,8 +76,8 @@ _CCCL_HOST_DEVICE ForwardIterator uninitialized_copy(
   thrust::advance(end, n);
 
   // create a functor
-  typedef typename iterator_traits<InputIterator>::value_type InputType;
-  typedef typename iterator_traits<ForwardIterator>::value_type OutputType;
+  using InputType  = typename iterator_traits<InputIterator>::value_type;
+  using OutputType = typename iterator_traits<ForwardIterator>::value_type;
 
   detail::uninitialized_copy_functor<InputType, OutputType> f;
 
@@ -110,14 +110,14 @@ _CCCL_HOST_DEVICE ForwardIterator uninitialized_copy_n(
   thrust::detail::false_type) // ::cuda::std::is_trivially_copy_constructible
 {
   // zip up the iterators
-  typedef thrust::tuple<InputIterator, ForwardIterator> IteratorTuple;
-  typedef thrust::zip_iterator<IteratorTuple> ZipIterator;
+  using IteratorTuple = thrust::tuple<InputIterator, ForwardIterator>;
+  using ZipIterator   = thrust::zip_iterator<IteratorTuple>;
 
   ZipIterator zipped_first = thrust::make_zip_iterator(thrust::make_tuple(first, result));
 
   // create a functor
-  typedef typename iterator_traits<InputIterator>::value_type InputType;
-  typedef typename iterator_traits<ForwardIterator>::value_type OutputType;
+  using InputType  = typename iterator_traits<InputIterator>::value_type;
+  using OutputType = typename iterator_traits<ForwardIterator>::value_type;
 
   detail::uninitialized_copy_functor<InputType, OutputType> f;
 
@@ -146,9 +146,9 @@ template <typename ExecutionPolicy, typename InputIterator, typename ForwardIter
 _CCCL_HOST_DEVICE ForwardIterator uninitialized_copy(
   thrust::execution_policy<ExecutionPolicy>& exec, InputIterator first, InputIterator last, ForwardIterator result)
 {
-  typedef typename iterator_traits<ForwardIterator>::value_type ResultType;
+  using ResultType = typename iterator_traits<ForwardIterator>::value_type;
 
-  typedef typename ::cuda::std::is_trivially_copy_constructible<ResultType>::type ResultTypeHasTrivialCopyConstructor;
+  using ResultTypeHasTrivialCopyConstructor = typename ::cuda::std::is_trivially_copy_constructible<ResultType>::type;
 
   return thrust::system::detail::generic::detail::uninitialized_copy(
     exec, first, last, result, ResultTypeHasTrivialCopyConstructor());
@@ -158,9 +158,9 @@ template <typename ExecutionPolicy, typename InputIterator, typename Size, typen
 _CCCL_HOST_DEVICE ForwardIterator uninitialized_copy_n(
   thrust::execution_policy<ExecutionPolicy>& exec, InputIterator first, Size n, ForwardIterator result)
 {
-  typedef typename iterator_traits<ForwardIterator>::value_type ResultType;
+  using ResultType = typename iterator_traits<ForwardIterator>::value_type;
 
-  typedef typename ::cuda::std::is_trivially_copy_constructible<ResultType>::type ResultTypeHasTrivialCopyConstructor;
+  using ResultTypeHasTrivialCopyConstructor = typename ::cuda::std::is_trivially_copy_constructible<ResultType>::type;
 
   return thrust::system::detail::generic::detail::uninitialized_copy_n(
     exec, first, n, result, ResultTypeHasTrivialCopyConstructor());

--- a/thrust/thrust/system/detail/generic/uninitialized_fill.inl
+++ b/thrust/thrust/system/detail/generic/uninitialized_fill.inl
@@ -60,7 +60,7 @@ _CCCL_HOST_DEVICE void uninitialized_fill(
   const T& x,
   thrust::detail::false_type) // ::cuda::std::is_trivially_copy_constructible
 {
-  typedef typename iterator_traits<ForwardIterator>::value_type ValueType;
+  using ValueType = typename iterator_traits<ForwardIterator>::value_type;
 
   thrust::for_each(exec, first, last, thrust::detail::uninitialized_fill_functor<ValueType>(x));
 } // end uninitialized_fill()
@@ -84,7 +84,7 @@ _CCCL_HOST_DEVICE ForwardIterator uninitialized_fill_n(
   const T& x,
   thrust::detail::false_type) // ::cuda::std::is_trivially_copy_constructible
 {
-  typedef typename iterator_traits<ForwardIterator>::value_type ValueType;
+  using ValueType = typename iterator_traits<ForwardIterator>::value_type;
 
   return thrust::for_each_n(exec, first, n, thrust::detail::uninitialized_fill_functor<ValueType>(x));
 } // end uninitialized_fill()
@@ -95,9 +95,9 @@ template <typename DerivedPolicy, typename ForwardIterator, typename T>
 _CCCL_HOST_DEVICE void uninitialized_fill(
   thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, const T& x)
 {
-  typedef typename iterator_traits<ForwardIterator>::value_type ValueType;
+  using ValueType = typename iterator_traits<ForwardIterator>::value_type;
 
-  typedef ::cuda::std::is_trivially_copy_constructible<ValueType> ValueTypeHasTrivialCopyConstructor;
+  using ValueTypeHasTrivialCopyConstructor = ::cuda::std::is_trivially_copy_constructible<ValueType>;
 
   thrust::system::detail::generic::detail::uninitialized_fill(
     exec, first, last, x, ValueTypeHasTrivialCopyConstructor());
@@ -107,9 +107,9 @@ template <typename DerivedPolicy, typename ForwardIterator, typename Size, typen
 _CCCL_HOST_DEVICE ForwardIterator
 uninitialized_fill_n(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, Size n, const T& x)
 {
-  typedef typename iterator_traits<ForwardIterator>::value_type ValueType;
+  using ValueType = typename iterator_traits<ForwardIterator>::value_type;
 
-  typedef ::cuda::std::is_trivially_copy_constructible<ValueType> ValueTypeHasTrivialCopyConstructor;
+  using ValueTypeHasTrivialCopyConstructor = ::cuda::std::is_trivially_copy_constructible<ValueType>;
 
   return thrust::system::detail::generic::detail::uninitialized_fill_n(
     exec, first, n, x, ValueTypeHasTrivialCopyConstructor());

--- a/thrust/thrust/system/detail/generic/unique.inl
+++ b/thrust/thrust/system/detail/generic/unique.inl
@@ -49,7 +49,7 @@ template <typename DerivedPolicy, typename ForwardIterator>
 _CCCL_HOST_DEVICE ForwardIterator
 unique(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
+  using InputType = typename thrust::iterator_traits<ForwardIterator>::value_type;
 
   return thrust::unique(exec, first, last, thrust::equal_to<InputType>());
 } // end unique()
@@ -61,7 +61,7 @@ _CCCL_HOST_DEVICE ForwardIterator unique(
   ForwardIterator last,
   BinaryPredicate binary_pred)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type InputType;
+  using InputType = typename thrust::iterator_traits<ForwardIterator>::value_type;
 
   thrust::detail::temporary_array<InputType, DerivedPolicy> input(exec, first, last);
 
@@ -72,7 +72,7 @@ template <typename DerivedPolicy, typename InputIterator, typename OutputIterato
 _CCCL_HOST_DEVICE OutputIterator unique_copy(
   thrust::execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator output)
 {
-  typedef typename thrust::iterator_value<InputIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator>::type;
   return thrust::unique_copy(exec, first, last, output, thrust::equal_to<value_type>());
 } // end unique_copy()
 
@@ -109,7 +109,7 @@ template <typename DerivedPolicy, typename ForwardIterator>
 _CCCL_HOST_DEVICE typename thrust::iterator_traits<ForwardIterator>::difference_type
 unique_count(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last)
 {
-  typedef typename thrust::iterator_value<ForwardIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<ForwardIterator>::type;
   return thrust::unique_count(exec, first, last, thrust::equal_to<value_type>());
 } // end unique_copy()
 

--- a/thrust/thrust/system/detail/generic/unique_by_key.inl
+++ b/thrust/thrust/system/detail/generic/unique_by_key.inl
@@ -51,7 +51,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key
   ForwardIterator1 keys_last,
   ForwardIterator2 values_first)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator1>::value_type KeyType;
+  using KeyType = typename thrust::iterator_traits<ForwardIterator1>::value_type;
   return thrust::unique_by_key(exec, keys_first, keys_last, values_first, thrust::equal_to<KeyType>());
 } // end unique_by_key()
 
@@ -63,8 +63,8 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key
   ForwardIterator2 values_first,
   BinaryPredicate binary_pred)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator1>::value_type InputType1;
-  typedef typename thrust::iterator_traits<ForwardIterator2>::value_type InputType2;
+  using InputType1 = typename thrust::iterator_traits<ForwardIterator1>::value_type;
+  using InputType2 = typename thrust::iterator_traits<ForwardIterator2>::value_type;
 
   ForwardIterator2 values_last = values_first + (keys_last - keys_first);
 
@@ -87,7 +87,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_c
   OutputIterator1 keys_output,
   OutputIterator2 values_output)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::value_type KeyType;
+  using KeyType = typename thrust::iterator_traits<InputIterator1>::value_type;
   return thrust::unique_by_key_copy(
     exec, keys_first, keys_last, values_first, keys_output, values_output, thrust::equal_to<KeyType>());
 } // end unique_by_key_copy()
@@ -107,7 +107,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_c
   OutputIterator2 values_output,
   BinaryPredicate binary_pred)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::difference_type difference_type;
+  using difference_type = typename thrust::iterator_traits<InputIterator1>::difference_type;
 
   difference_type n = thrust::distance(keys_first, keys_last);
 

--- a/thrust/thrust/system/detail/internal/decompose.h
+++ b/thrust/thrust/system/detail/internal/decompose.h
@@ -38,7 +38,7 @@ template <typename IndexType>
 class index_range
 {
 public:
-  typedef IndexType index_type;
+  using index_type = IndexType;
 
   _CCCL_HOST_DEVICE index_range(index_type begin, index_type end)
       : m_begin(begin)
@@ -69,8 +69,8 @@ template <typename IndexType>
 class uniform_decomposition
 {
 public:
-  typedef IndexType index_type;
-  typedef index_range<index_type> range_type;
+  using index_type = IndexType;
+  using range_type = index_range<index_type>;
 
   _CCCL_HOST_DEVICE uniform_decomposition(index_type N, index_type granularity, index_type max_intervals)
       : m_N(N)

--- a/thrust/thrust/system/detail/sequential/adjacent_difference.h
+++ b/thrust/thrust/system/detail/sequential/adjacent_difference.h
@@ -49,7 +49,7 @@ _CCCL_HOST_DEVICE OutputIterator adjacent_difference(
   OutputIterator result,
   BinaryFunction binary_op)
 {
-  typedef typename thrust::iterator_traits<InputIterator>::value_type InputType;
+  using InputType = typename thrust::iterator_traits<InputIterator>::value_type;
 
   if (first == last)
   {

--- a/thrust/thrust/system/detail/sequential/binary_search.h
+++ b/thrust/thrust/system/detail/sequential/binary_search.h
@@ -55,7 +55,7 @@ _CCCL_HOST_DEVICE ForwardIterator lower_bound(
   // wrap comp
   thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
 
-  typedef typename thrust::iterator_difference<ForwardIterator>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<ForwardIterator>::type;
 
   difference_type len = thrust::distance(first, last);
 
@@ -93,7 +93,7 @@ _CCCL_HOST_DEVICE ForwardIterator upper_bound(
   // wrap comp
   thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
 
-  typedef typename thrust::iterator_difference<ForwardIterator>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<ForwardIterator>::type;
 
   difference_type len = thrust::distance(first, last);
 

--- a/thrust/thrust/system/detail/sequential/copy.inl
+++ b/thrust/thrust/system/detail/sequential/copy.inl
@@ -58,7 +58,7 @@ copy(InputIterator first,
      OutputIterator result,
      thrust::detail::true_type) // is_indirectly_trivially_relocatable_to
 {
-  typedef typename thrust::iterator_difference<InputIterator>::type Size;
+  using Size = typename thrust::iterator_difference<InputIterator>::type;
 
   const Size n = last - first;
   thrust::system::detail::sequential::trivial_copy_n(get(&*first), n, get(&*result));

--- a/thrust/thrust/system/detail/sequential/general_copy.h
+++ b/thrust/thrust/system/detail/sequential/general_copy.h
@@ -73,7 +73,7 @@ inline _CCCL_HOST_DEVICE
   typename thrust::detail::disable_if<reference_is_assignable<InputIterator, OutputIterator>::value>::type
   iter_assign(OutputIterator dst, InputIterator src)
 {
-  typedef typename thrust::iterator_value<InputIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<InputIterator>::type;
 
   // insert a temporary and hope for the best
   *dst = static_cast<value_type>(*src);

--- a/thrust/thrust/system/detail/sequential/insertion_sort.h
+++ b/thrust/thrust/system/detail/sequential/insertion_sort.h
@@ -42,7 +42,7 @@ _CCCL_EXEC_CHECK_DISABLE
 template <typename RandomAccessIterator, typename StrictWeakOrdering>
 _CCCL_HOST_DEVICE void insertion_sort(RandomAccessIterator first, RandomAccessIterator last, StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<RandomAccessIterator>::type;
 
   if (first == last)
   {
@@ -86,8 +86,8 @@ template <typename RandomAccessIterator1, typename RandomAccessIterator2, typena
 _CCCL_HOST_DEVICE void insertion_sort_by_key(
   RandomAccessIterator1 first1, RandomAccessIterator1 last1, RandomAccessIterator2 first2, StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type value_type1;
-  typedef typename thrust::iterator_value<RandomAccessIterator2>::type value_type2;
+  using value_type1 = typename thrust::iterator_value<RandomAccessIterator1>::type;
+  using value_type2 = typename thrust::iterator_value<RandomAccessIterator2>::type;
 
   if (first1 == last1)
   {

--- a/thrust/thrust/system/detail/sequential/partition.h
+++ b/thrust/thrust/system/detail/sequential/partition.h
@@ -58,7 +58,7 @@ _CCCL_HOST_DEVICE void iter_swap(ForwardIterator1 iter1, ForwardIterator2 iter2)
   // XXX this isn't correct because it doesn't use thrust::swap
   using namespace thrust::detail;
 
-  typedef typename thrust::iterator_value<ForwardIterator1>::type T;
+  using T = typename thrust::iterator_value<ForwardIterator1>::type;
 
   T temp = *iter1;
   *iter1 = *iter2;
@@ -160,10 +160,10 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   // wrap pred
   thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
 
-  typedef typename thrust::iterator_value<ForwardIterator>::type T;
+  using T = typename thrust::iterator_value<ForwardIterator>::type;
 
-  typedef thrust::detail::temporary_array<T, DerivedPolicy> TempRange;
-  typedef typename TempRange::iterator TempIterator;
+  using TempRange    = thrust::detail::temporary_array<T, DerivedPolicy>;
+  using TempIterator = typename TempRange::iterator;
 
   TempRange temp(exec, first, last);
 
@@ -202,10 +202,10 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   // wrap pred
   thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
 
-  typedef typename thrust::iterator_value<ForwardIterator>::type T;
+  using T = typename thrust::iterator_value<ForwardIterator>::type;
 
-  typedef thrust::detail::temporary_array<T, DerivedPolicy> TempRange;
-  typedef typename TempRange::iterator TempIterator;
+  using TempRange    = thrust::detail::temporary_array<T, DerivedPolicy>;
+  using TempIterator = typename TempRange::iterator;
 
   TempRange temp(exec, first, last);
 

--- a/thrust/thrust/system/detail/sequential/reduce_by_key.h
+++ b/thrust/thrust/system/detail/sequential/reduce_by_key.h
@@ -55,8 +55,8 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   BinaryPredicate binary_pred,
   BinaryFunction binary_op)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::value_type InputKeyType;
-  typedef typename thrust::iterator_traits<InputIterator2>::value_type InputValueType;
+  using InputKeyType   = typename thrust::iterator_traits<InputIterator1>::value_type;
+  using InputValueType = typename thrust::iterator_traits<InputIterator2>::value_type;
 
   // Use the input iterator's value type per https://wg21.link/P0571
   using TemporaryType = typename thrust::iterator_value<InputIterator2>::type;

--- a/thrust/thrust/system/detail/sequential/sort.inl
+++ b/thrust/thrust/system/detail/sequential/sort.inl
@@ -63,7 +63,7 @@ _CCCL_HOST_DEVICE void stable_sort(
   thrust::system::detail::sequential::stable_primitive_sort(exec, first, last);
 
   // if comp is greater<T> then reverse the keys
-  typedef typename thrust::iterator_traits<RandomAccessIterator>::value_type KeyType;
+  using KeyType = typename thrust::iterator_traits<RandomAccessIterator>::value_type;
 
   if (needs_reverse<KeyType, StrictWeakOrdering>::value)
   {
@@ -84,7 +84,7 @@ _CCCL_HOST_DEVICE void stable_sort_by_key(
   thrust::detail::true_type)
 {
   // if comp is greater<T> then reverse the keys and values
-  typedef typename thrust::iterator_traits<RandomAccessIterator1>::value_type KeyType;
+  using KeyType = typename thrust::iterator_traits<RandomAccessIterator1>::value_type;
 
   // note, we also have to reverse the (unordered) input to preserve stability
   if (needs_reverse<KeyType, StrictWeakOrdering>::value)

--- a/thrust/thrust/system/detail/sequential/stable_merge_sort.inl
+++ b/thrust/thrust/system/detail/sequential/stable_merge_sort.inl
@@ -52,7 +52,7 @@ _CCCL_HOST_DEVICE void inplace_merge(
   RandomAccessIterator last,
   StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<RandomAccessIterator>::type;
 
   thrust::detail::temporary_array<value_type, DerivedPolicy> a(exec, first, middle);
   thrust::detail::temporary_array<value_type, DerivedPolicy> b(exec, middle, last);
@@ -72,8 +72,8 @@ _CCCL_HOST_DEVICE void inplace_merge_by_key(
   RandomAccessIterator2 first2,
   StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type value_type1;
-  typedef typename thrust::iterator_value<RandomAccessIterator2>::type value_type2;
+  using value_type1 = typename thrust::iterator_value<RandomAccessIterator1>::type;
+  using value_type2 = typename thrust::iterator_value<RandomAccessIterator2>::type;
 
   RandomAccessIterator2 middle2 = first2 + (middle1 - first1);
   RandomAccessIterator2 last2   = first2 + (last1 - first1);
@@ -191,8 +191,8 @@ _CCCL_HOST_DEVICE void iterative_stable_merge_sort(
   RandomAccessIterator last,
   StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type value_type;
-  typedef typename thrust::iterator_difference<RandomAccessIterator>::type difference_type;
+  using value_type      = typename thrust::iterator_value<RandomAccessIterator>::type;
+  using difference_type = typename thrust::iterator_difference<RandomAccessIterator>::type;
 
   difference_type n = last - first;
 
@@ -235,9 +235,9 @@ _CCCL_HOST_DEVICE void iterative_stable_merge_sort_by_key(
   RandomAccessIterator2 values_first,
   StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type value_type1;
-  typedef typename thrust::iterator_value<RandomAccessIterator2>::type value_type2;
-  typedef typename thrust::iterator_difference<RandomAccessIterator1>::type difference_type;
+  using value_type1     = typename thrust::iterator_value<RandomAccessIterator1>::type;
+  using value_type2     = typename thrust::iterator_value<RandomAccessIterator2>::type;
+  using difference_type = typename thrust::iterator_difference<RandomAccessIterator1>::type;
 
   difference_type n = keys_last - keys_first;
 

--- a/thrust/thrust/system/detail/sequential/stable_radix_sort.inl
+++ b/thrust/thrust/system/detail/sequential/stable_radix_sort.inl
@@ -151,9 +151,9 @@ struct RadixEncoder<double> : public thrust::unary_function<double, thrust::deta
 template <unsigned int RadixBits, typename KeyType>
 struct bucket_functor
 {
-  typedef RadixEncoder<KeyType> Encoder;
-  typedef typename Encoder::result_type EncodedType;
-  typedef size_t result_type;
+  using Encoder                    = RadixEncoder<KeyType>;
+  using EncodedType                = typename Encoder::result_type;
+  using result_type                = size_t;
   static const EncodedType BitMask = static_cast<EncodedType>((1 << RadixBits) - 1);
 
   Encoder encode;
@@ -188,7 +188,7 @@ inline _CCCL_HOST_DEVICE void radix_shuffle_n(
   Integer bit_shift,
   size_t* histogram)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type KeyType;
+  using KeyType = typename thrust::iterator_value<RandomAccessIterator1>::type;
 
   // note that we are going to mutate the histogram during this sequential scatter
   thrust::scatter(
@@ -216,7 +216,7 @@ _CCCL_HOST_DEVICE void radix_shuffle_n(
   Integer bit_shift,
   size_t* histogram)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type KeyType;
+  using KeyType = typename thrust::iterator_value<RandomAccessIterator1>::type;
 
   // note that we are going to mutate the histogram during this sequential scatter
   thrust::scatter(
@@ -242,10 +242,10 @@ _CCCL_HOST_DEVICE void radix_sort(
   RandomAccessIterator4 vals2,
   const size_t N)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type KeyType;
+  using KeyType = typename thrust::iterator_value<RandomAccessIterator1>::type;
 
-  typedef RadixEncoder<KeyType> Encoder;
-  typedef typename Encoder::result_type EncodedType;
+  using Encoder     = RadixEncoder<KeyType>;
+  using EncodedType = typename Encoder::result_type;
 
   const unsigned int NumHistograms = (8 * sizeof(EncodedType) + (RadixBits - 1)) / RadixBits;
   const unsigned int HistogramSize = 1 << RadixBits;
@@ -528,7 +528,7 @@ _CCCL_HOST_DEVICE void radix_sort(
   RandomAccessIterator2 keys2,
   const size_t N)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type KeyType;
+  using KeyType = typename thrust::iterator_value<RandomAccessIterator1>::type;
   radix_sort_dispatcher<sizeof(KeyType)>()(exec, keys1, keys2, N);
 }
 
@@ -545,7 +545,7 @@ _CCCL_HOST_DEVICE void radix_sort(
   RandomAccessIterator4 vals2,
   const size_t N)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type KeyType;
+  using KeyType = typename thrust::iterator_value<RandomAccessIterator1>::type;
   radix_sort_dispatcher<sizeof(KeyType)>()(exec, keys1, keys2, vals1, vals2, N);
 }
 
@@ -555,7 +555,7 @@ template <typename DerivedPolicy, typename RandomAccessIterator>
 _CCCL_HOST_DEVICE void stable_radix_sort(
   sequential::execution_policy<DerivedPolicy>& exec, RandomAccessIterator first, RandomAccessIterator last)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type KeyType;
+  using KeyType = typename thrust::iterator_value<RandomAccessIterator>::type;
 
   size_t N = last - first;
 
@@ -571,8 +571,8 @@ _CCCL_HOST_DEVICE void stable_radix_sort_by_key(
   RandomAccessIterator1 last1,
   RandomAccessIterator2 first2)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type KeyType;
-  typedef typename thrust::iterator_value<RandomAccessIterator2>::type ValueType;
+  using KeyType   = typename thrust::iterator_value<RandomAccessIterator1>::type;
+  using ValueType = typename thrust::iterator_value<RandomAccessIterator2>::type;
 
   size_t N = last1 - first1;
 

--- a/thrust/thrust/system/detail/sequential/unique.h
+++ b/thrust/thrust/system/detail/sequential/unique.h
@@ -50,7 +50,7 @@ _CCCL_HOST_DEVICE OutputIterator unique_copy(
   OutputIterator output,
   BinaryPredicate binary_pred)
 {
-  typedef typename thrust::iterator_traits<InputIterator>::value_type T;
+  using T = typename thrust::iterator_traits<InputIterator>::value_type;
 
   if (first != last)
   {
@@ -92,7 +92,7 @@ template <typename DerivedPolicy, typename ForwardIterator, typename BinaryPredi
 _CCCL_HOST_DEVICE typename thrust::iterator_traits<ForwardIterator>::difference_type unique_count(
   sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, BinaryPredicate binary_pred)
 {
-  typedef typename thrust::iterator_traits<ForwardIterator>::value_type T;
+  using T = typename thrust::iterator_traits<ForwardIterator>::value_type;
   typename thrust::iterator_traits<ForwardIterator>::difference_type count{};
 
   if (first != last)

--- a/thrust/thrust/system/detail/sequential/unique_by_key.h
+++ b/thrust/thrust/system/detail/sequential/unique_by_key.h
@@ -57,8 +57,8 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_c
   OutputIterator2 values_output,
   BinaryPredicate binary_pred)
 {
-  typedef typename thrust::iterator_traits<InputIterator1>::value_type InputKeyType;
-  typedef typename thrust::iterator_traits<OutputIterator2>::value_type OutputValueType;
+  using InputKeyType    = typename thrust::iterator_traits<InputIterator1>::value_type;
+  using OutputValueType = typename thrust::iterator_traits<OutputIterator2>::value_type;
 
   if (keys_first != keys_last)
   {

--- a/thrust/thrust/system/omp/detail/copy.inl
+++ b/thrust/thrust/system/omp/detail/copy.inl
@@ -90,10 +90,10 @@ template <typename DerivedPolicy, typename InputIterator, typename OutputIterato
 OutputIterator
 copy(execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator result)
 {
-  typedef typename thrust::iterator_traversal<InputIterator>::type traversal1;
-  typedef typename thrust::iterator_traversal<OutputIterator>::type traversal2;
+  using traversal1 = typename thrust::iterator_traversal<InputIterator>::type;
+  using traversal2 = typename thrust::iterator_traversal<OutputIterator>::type;
 
-  typedef typename thrust::detail::minimum_type<traversal1, traversal2>::type traversal;
+  using traversal = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
 
   // dispatch on minimum traversal
   return thrust::system::omp::detail::dispatch::copy(exec, first, last, result, traversal());
@@ -102,10 +102,10 @@ copy(execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator l
 template <typename DerivedPolicy, typename InputIterator, typename Size, typename OutputIterator>
 OutputIterator copy_n(execution_policy<DerivedPolicy>& exec, InputIterator first, Size n, OutputIterator result)
 {
-  typedef typename thrust::iterator_traversal<InputIterator>::type traversal1;
-  typedef typename thrust::iterator_traversal<OutputIterator>::type traversal2;
+  using traversal1 = typename thrust::iterator_traversal<InputIterator>::type;
+  using traversal2 = typename thrust::iterator_traversal<OutputIterator>::type;
 
-  typedef typename thrust::detail::minimum_type<traversal1, traversal2>::type traversal;
+  using traversal = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
 
   // dispatch on minimum traversal
   return thrust::system::omp::detail::dispatch::copy_n(exec, first, n, result, traversal());

--- a/thrust/thrust/system/omp/detail/execution_policy.h
+++ b/thrust/thrust/system/omp/detail/execution_policy.h
@@ -66,7 +66,7 @@ struct tag : execution_policy<tag>
 template <typename Derived>
 struct execution_policy : thrust::system::cpp::detail::execution_policy<Derived>
 {
-  typedef tag tag_type;
+  using tag_type = tag;
   operator tag() const
   {
     return tag();

--- a/thrust/thrust/system/omp/detail/for_each.inl
+++ b/thrust/thrust/system/omp/detail/for_each.inl
@@ -62,7 +62,7 @@ RandomAccessIterator for_each_n(execution_policy<DerivedPolicy>&, RandomAccessIt
   thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f(f);
 
   // use a signed type for the iteration variable or suffer the consequences of warnings
-  typedef typename thrust::iterator_difference<RandomAccessIterator>::type DifferenceType;
+  using DifferenceType    = typename thrust::iterator_difference<RandomAccessIterator>::type;
   DifferenceType signed_n = n;
 
   THRUST_PRAGMA_OMP(parallel for)

--- a/thrust/thrust/system/omp/detail/reduce.inl
+++ b/thrust/thrust/system/omp/detail/reduce.inl
@@ -47,7 +47,7 @@ OutputType reduce(execution_policy<DerivedPolicy>& exec,
                   OutputType init,
                   BinaryFunction binary_op)
 {
-  typedef typename thrust::iterator_difference<InputIterator>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<InputIterator>::type;
 
   const difference_type n = thrust::distance(first, last);
 

--- a/thrust/thrust/system/omp/detail/reduce_intervals.inl
+++ b/thrust/thrust/system/omp/detail/reduce_intervals.inl
@@ -63,12 +63,12 @@ void reduce_intervals(
     "OpenMP compiler support is not enabled");
 
 #if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
-  typedef typename thrust::iterator_value<OutputIterator>::type OutputType;
+  using OutputType = typename thrust::iterator_value<OutputIterator>::type;
 
   // wrap binary_op
   thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op(binary_op);
 
-  typedef thrust::detail::intptr_t index_type;
+  using index_type = thrust::detail::intptr_t;
 
   index_type n = static_cast<index_type>(decomp.size());
 

--- a/thrust/thrust/system/omp/detail/sort.inl
+++ b/thrust/thrust/system/omp/detail/sort.inl
@@ -56,7 +56,7 @@ void inplace_merge(execution_policy<DerivedPolicy>& exec,
                    RandomAccessIterator last,
                    StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type value_type;
+  using value_type = typename thrust::iterator_value<RandomAccessIterator>::type;
 
   thrust::detail::temporary_array<value_type, DerivedPolicy> a(exec, first, middle);
   thrust::detail::temporary_array<value_type, DerivedPolicy> b(exec, middle, last);
@@ -76,8 +76,8 @@ void inplace_merge_by_key(
   RandomAccessIterator2 first2,
   StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type value_type1;
-  typedef typename thrust::iterator_value<RandomAccessIterator2>::type value_type2;
+  using value_type1 = typename thrust::iterator_value<RandomAccessIterator1>::type;
+  using value_type2 = typename thrust::iterator_value<RandomAccessIterator2>::type;
 
   RandomAccessIterator2 middle2 = first2 + (middle1 - first1);
   RandomAccessIterator2 last2   = first2 + (last1 - first1);
@@ -109,7 +109,7 @@ void stable_sort(
 
   // Avoid issues on compilers that don't provide `omp_get_num_threads()`.
 #if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
-  typedef typename thrust::iterator_difference<RandomAccessIterator>::type IndexType;
+  using IndexType = typename thrust::iterator_difference<RandomAccessIterator>::type;
 
   if (first == last)
   {
@@ -188,7 +188,7 @@ void stable_sort_by_key(
 
   // Avoid issues on compilers that don't provide `omp_get_num_threads()`.
 #if (THRUST_DEVICE_COMPILER_IS_OMP_CAPABLE == THRUST_TRUE)
-  typedef typename thrust::iterator_difference<RandomAccessIterator1>::type IndexType;
+  using IndexType = typename thrust::iterator_difference<RandomAccessIterator1>::type;
 
   if (keys_first == keys_last)
   {

--- a/thrust/thrust/system/omp/memory_resource.h
+++ b/thrust/thrust/system/omp/memory_resource.h
@@ -42,10 +42,10 @@ namespace omp
 //! \cond
 namespace detail
 {
-typedef thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::omp::pointer<void>> native_resource;
+using native_resource = thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::omp::pointer<void>>;
 
-typedef thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::omp::universal_pointer<void>>
-  universal_native_resource;
+using universal_native_resource =
+  thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::omp::universal_pointer<void>>;
 } // namespace detail
 //! \endcond
 
@@ -57,13 +57,13 @@ typedef thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thru
 /*! The memory resource for the OpenMP system. Uses \p mr::new_delete_resource
  *  and tags it with \p omp::pointer.
  */
-typedef detail::native_resource memory_resource;
+using memory_resource = detail::native_resource;
 /*! The unified memory resource for the OpenMP system. Uses
  *  \p mr::new_delete_resource and tags it with \p omp::universal_pointer.
  */
-typedef detail::universal_native_resource universal_memory_resource;
+using universal_memory_resource = detail::universal_native_resource;
 /*! An alias for \p omp::universal_memory_resource. */
-typedef detail::native_resource universal_host_pinned_memory_resource;
+using universal_host_pinned_memory_resource = detail::native_resource;
 
 /*! \}
  */

--- a/thrust/thrust/system/tbb/detail/copy.inl
+++ b/thrust/thrust/system/tbb/detail/copy.inl
@@ -91,10 +91,10 @@ template <typename DerivedPolicy, typename InputIterator, typename OutputIterato
 OutputIterator
 copy(execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator last, OutputIterator result)
 {
-  typedef typename thrust::iterator_traversal<InputIterator>::type traversal1;
-  typedef typename thrust::iterator_traversal<OutputIterator>::type traversal2;
+  using traversal1 = typename thrust::iterator_traversal<InputIterator>::type;
+  using traversal2 = typename thrust::iterator_traversal<OutputIterator>::type;
 
-  typedef typename thrust::detail::minimum_type<traversal1, traversal2>::type traversal;
+  using traversal = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
 
   // dispatch on minimum traversal
   return thrust::system::tbb::detail::dispatch::copy(exec, first, last, result, traversal());
@@ -103,10 +103,10 @@ copy(execution_policy<DerivedPolicy>& exec, InputIterator first, InputIterator l
 template <typename DerivedPolicy, typename InputIterator, typename Size, typename OutputIterator>
 OutputIterator copy_n(execution_policy<DerivedPolicy>& exec, InputIterator first, Size n, OutputIterator result)
 {
-  typedef typename thrust::iterator_traversal<InputIterator>::type traversal1;
-  typedef typename thrust::iterator_traversal<OutputIterator>::type traversal2;
+  using traversal1 = typename thrust::iterator_traversal<InputIterator>::type;
+  using traversal2 = typename thrust::iterator_traversal<OutputIterator>::type;
 
-  typedef typename thrust::detail::minimum_type<traversal1, traversal2>::type traversal;
+  using traversal = typename thrust::detail::minimum_type<traversal1, traversal2>::type;
 
   // dispatch on minimum traversal
   return thrust::system::tbb::detail::dispatch::copy_n(exec, first, n, result, traversal());

--- a/thrust/thrust/system/tbb/detail/copy_if.inl
+++ b/thrust/thrust/system/tbb/detail/copy_if.inl
@@ -115,8 +115,8 @@ template <typename InputIterator1, typename InputIterator2, typename OutputItera
 OutputIterator
 copy_if(tag, InputIterator1 first, InputIterator1 last, InputIterator2 stencil, OutputIterator result, Predicate pred)
 {
-  typedef typename thrust::iterator_difference<InputIterator1>::type Size;
-  typedef typename copy_if_detail::body<InputIterator1, InputIterator2, OutputIterator, Predicate, Size> Body;
+  using Size = typename thrust::iterator_difference<InputIterator1>::type;
+  using Body = typename copy_if_detail::body<InputIterator1, InputIterator2, OutputIterator, Predicate, Size>;
 
   Size n = thrust::distance(first, last);
 

--- a/thrust/thrust/system/tbb/detail/execution_policy.h
+++ b/thrust/thrust/system/tbb/detail/execution_policy.h
@@ -65,7 +65,7 @@ struct tag : execution_policy<tag>
 template <typename Derived>
 struct execution_policy : thrust::system::cpp::detail::execution_policy<Derived>
 {
-  typedef tag tag_type;
+  using tag_type = tag;
   operator tag() const
   {
     return tag();

--- a/thrust/thrust/system/tbb/detail/merge.inl
+++ b/thrust/thrust/system/tbb/detail/merge.inl
@@ -263,8 +263,8 @@ merge(execution_policy<DerivedPolicy>&,
       OutputIterator result,
       StrictWeakOrdering comp)
 {
-  typedef typename merge_detail::range<InputIterator1, InputIterator2, OutputIterator, StrictWeakOrdering> Range;
-  typedef merge_detail::body Body;
+  using Range = typename merge_detail::range<InputIterator1, InputIterator2, OutputIterator, StrictWeakOrdering>;
+  using Body  = merge_detail::body;
   Range range(first1, last1, first2, last2, result, comp);
   Body body;
 
@@ -295,10 +295,15 @@ thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
   OutputIterator2 values_result,
   StrictWeakOrdering comp)
 {
-  typedef typename merge_by_key_detail::
-    range<InputIterator1, InputIterator2, InputIterator3, InputIterator4, OutputIterator1, OutputIterator2, StrictWeakOrdering>
-      Range;
-  typedef merge_by_key_detail::body Body;
+  using Range = typename merge_by_key_detail::range<
+    InputIterator1,
+    InputIterator2,
+    InputIterator3,
+    InputIterator4,
+    OutputIterator1,
+    OutputIterator2,
+    StrictWeakOrdering>;
+  using Body = merge_by_key_detail::body;
 
   Range range(
     keys_first1, keys_last1, keys_first2, keys_last2, values_first3, values_first4, keys_result, values_result, comp);

--- a/thrust/thrust/system/tbb/detail/reduce.inl
+++ b/thrust/thrust/system/tbb/detail/reduce.inl
@@ -114,7 +114,7 @@ template <typename DerivedPolicy, typename InputIterator, typename OutputType, t
 OutputType reduce(
   execution_policy<DerivedPolicy>&, InputIterator begin, InputIterator end, OutputType init, BinaryFunction binary_op)
 {
-  typedef typename thrust::iterator_difference<InputIterator>::type Size;
+  using Size = typename thrust::iterator_difference<InputIterator>::type;
 
   Size n = thrust::distance(begin, end);
 
@@ -124,7 +124,7 @@ OutputType reduce(
   }
   else
   {
-    typedef typename reduce_detail::body<InputIterator, OutputType, BinaryFunction> Body;
+    using Body = typename reduce_detail::body<InputIterator, OutputType, BinaryFunction>;
     Body reduce_body(begin, init, binary_op);
     ::tbb::parallel_reduce(::tbb::blocked_range<Size>(0, n), reduce_body);
     return binary_op(init, reduce_body.sum);

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.inl
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.inl
@@ -158,7 +158,7 @@ template <typename Iterator1,
           typename BinaryFunction>
 struct serial_reduce_by_key_body
 {
-  typedef typename thrust::iterator_difference<Iterator1>::type size_type;
+  using size_type = typename thrust::iterator_difference<Iterator1>::type;
 
   Iterator1 keys_first;
   Iterator2 values_first;
@@ -217,8 +217,8 @@ struct serial_reduce_by_key_body
     Iterator6 my_carry_result  = carry_result + interval_idx;
 
     // consume the rest of the interval with reduce_by_key
-    typedef typename thrust::iterator_value<Iterator1>::type key_type;
-    typedef typename partial_sum_type<Iterator2, BinaryFunction>::type value_type;
+    using key_type   = typename thrust::iterator_value<Iterator1>::type;
+    using value_type = typename partial_sum_type<Iterator2, BinaryFunction>::type;
 
     // XXX is there a way to pose this so that we don't require default construction of carry?
     thrust::pair<key_type, value_type> carry;
@@ -310,8 +310,8 @@ thrust::pair<Iterator3, Iterator4> reduce_by_key(
   BinaryPredicate binary_pred,
   BinaryFunction binary_op)
 {
-  typedef typename thrust::iterator_difference<Iterator1>::type difference_type;
-  difference_type n = keys_last - keys_first;
+  using difference_type = typename thrust::iterator_difference<Iterator1>::type;
+  difference_type n     = keys_last - keys_first;
   if (n == 0)
   {
     return thrust::make_pair(keys_result, values_result);
@@ -362,7 +362,7 @@ thrust::pair<Iterator3, Iterator4> reduce_by_key(
 
   // do a reduce_by_key serially in each thread
   // the final interval never has a carry by definition, so don't reserve space for it
-  typedef typename reduce_by_key_detail::partial_sum_type<Iterator2, BinaryFunction>::type carry_type;
+  using carry_type = typename reduce_by_key_detail::partial_sum_type<Iterator2, BinaryFunction>::type;
   thrust::detail::temporary_array<carry_type, DerivedPolicy> carries(0, exec, num_intervals - 1);
 
   // force grainsize == 1 with simple_partioner()

--- a/thrust/thrust/system/tbb/detail/reduce_intervals.h
+++ b/thrust/thrust/system/tbb/detail/reduce_intervals.h
@@ -81,7 +81,7 @@ struct body
     RandomAccessIterator1 my_last  = first + offset_to_last;
 
     // carefully pass the init value for the interval with raw_reference_cast
-    typedef typename BinaryFunction::result_type sum_type;
+    using sum_type = typename BinaryFunction::result_type;
     result[interval_idx] =
       thrust::reduce(thrust::seq, my_first + 1, my_last, sum_type(thrust::raw_reference_cast(*my_first)), binary_op);
   }
@@ -127,7 +127,7 @@ void reduce_intervals(
   Size interval_size,
   RandomAccessIterator2 result)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type value_type;
+  using value_type = typename thrust::iterator_value<RandomAccessIterator1>::type;
 
   return thrust::system::tbb::detail::reduce_intervals(
     exec, first, last, interval_size, result, thrust::plus<value_type>());

--- a/thrust/thrust/system/tbb/detail/scan.inl
+++ b/thrust/thrust/system/tbb/detail/scan.inl
@@ -240,7 +240,7 @@ inclusive_scan(tag, InputIterator first, InputIterator last, OutputIterator resu
 
   if (n != 0)
   {
-    typedef typename scan_detail::inclusive_body<InputIterator, OutputIterator, BinaryFunction, ValueType> Body;
+    using Body = typename scan_detail::inclusive_body<InputIterator, OutputIterator, BinaryFunction, ValueType>;
     Body scan_body(first, result, binary_op, *first);
     ::tbb::parallel_scan(::tbb::blocked_range<Size>(0, n), scan_body);
   }
@@ -264,7 +264,7 @@ OutputIterator exclusive_scan(
 
   if (n != 0)
   {
-    typedef typename scan_detail::exclusive_body<InputIterator, OutputIterator, BinaryFunction, ValueType> Body;
+    using Body = typename scan_detail::exclusive_body<InputIterator, OutputIterator, BinaryFunction, ValueType>;
     Body scan_body(first, result, binary_op, init);
     ::tbb::parallel_scan(::tbb::blocked_range<Size>(0, n), scan_body);
   }

--- a/thrust/thrust/system/tbb/detail/sort.inl
+++ b/thrust/thrust/system/tbb/detail/sort.inl
@@ -94,7 +94,7 @@ void merge_sort(execution_policy<DerivedPolicy>& exec,
                 StrictWeakOrdering comp,
                 bool inplace)
 {
-  typedef typename thrust::iterator_difference<Iterator1>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<Iterator1>::type;
 
   difference_type n = thrust::distance(first1, last1);
 
@@ -114,7 +114,7 @@ void merge_sort(execution_policy<DerivedPolicy>& exec,
   Iterator2 mid2  = first2 + (n / 2);
   Iterator2 last2 = first2 + n;
 
-  typedef merge_sort_closure<DerivedPolicy, Iterator1, Iterator2, StrictWeakOrdering> Closure;
+  using Closure = merge_sort_closure<DerivedPolicy, Iterator1, Iterator2, StrictWeakOrdering>;
 
   Closure left(exec, first1, mid1, first2, comp, !inplace);
   Closure right(exec, mid1, last1, mid2, comp, !inplace);
@@ -212,7 +212,7 @@ void merge_sort_by_key(
   StrictWeakOrdering comp,
   bool inplace)
 {
-  typedef typename thrust::iterator_difference<Iterator1>::type difference_type;
+  using difference_type = typename thrust::iterator_difference<Iterator1>::type;
 
   difference_type n = thrust::distance(first1, last1);
 
@@ -236,8 +236,8 @@ void merge_sort_by_key(
     return;
   }
 
-  typedef merge_sort_by_key_closure<DerivedPolicy, Iterator1, Iterator2, Iterator3, Iterator4, StrictWeakOrdering>
-    Closure;
+  using Closure =
+    merge_sort_by_key_closure<DerivedPolicy, Iterator1, Iterator2, Iterator3, Iterator4, StrictWeakOrdering>;
 
   Closure left(exec, first1, mid1, first2, first3, first4, comp, !inplace);
   Closure right(exec, mid1, last1, mid2, mid3, mid4, comp, !inplace);
@@ -260,7 +260,7 @@ template <typename DerivedPolicy, typename RandomAccessIterator, typename Strict
 void stable_sort(
   execution_policy<DerivedPolicy>& exec, RandomAccessIterator first, RandomAccessIterator last, StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator>::type key_type;
+  using key_type = typename thrust::iterator_value<RandomAccessIterator>::type;
 
   thrust::detail::temporary_array<key_type, DerivedPolicy> temp(exec, first, last);
 
@@ -278,8 +278,8 @@ void stable_sort_by_key(
   RandomAccessIterator2 first2,
   StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_value<RandomAccessIterator1>::type key_type;
-  typedef typename thrust::iterator_value<RandomAccessIterator2>::type val_type;
+  using key_type = typename thrust::iterator_value<RandomAccessIterator1>::type;
+  using val_type = typename thrust::iterator_value<RandomAccessIterator2>::type;
 
   RandomAccessIterator2 last2 = first2 + thrust::distance(first1, last1);
 

--- a/thrust/thrust/system/tbb/memory_resource.h
+++ b/thrust/thrust/system/tbb/memory_resource.h
@@ -42,10 +42,10 @@ namespace tbb
 //! \cond
 namespace detail
 {
-typedef thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::tbb::pointer<void>> native_resource;
+using native_resource = thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::tbb::pointer<void>>;
 
-typedef thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::tbb::universal_pointer<void>>
-  universal_native_resource;
+using universal_native_resource =
+  thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thrust::tbb::universal_pointer<void>>;
 } // namespace detail
 //! \endcond
 
@@ -57,13 +57,13 @@ typedef thrust::mr::fancy_pointer_resource<thrust::mr::new_delete_resource, thru
 /*! The memory resource for the TBB system. Uses \p mr::new_delete_resource and
  *  tags it with \p tbb::pointer.
  */
-typedef detail::native_resource memory_resource;
+using memory_resource = detail::native_resource;
 /*! The unified memory resource for the TBB system. Uses
  *  \p mr::new_delete_resource and tags it with \p tbb::universal_pointer.
  */
-typedef detail::universal_native_resource universal_memory_resource;
+using universal_memory_resource = detail::universal_native_resource;
 /*! An alias for \p tbb::universal_memory_resource. */
-typedef detail::native_resource universal_host_pinned_memory_resource;
+using universal_host_pinned_memory_resource = detail::native_resource;
 
 /*! \} // memory_resources
  */


### PR DESCRIPTION
This PR replaces all occurences of typedef (except a few comments on the math functors) by alias declarations in Thrust.

This was done using a combination of:
* clang-tidy modernize-use-using
* regex replace: "typedef ([\w<>,:\s*&+:\[\]\.]+)\s+([\w_]+);" by "using $2 = $1;"
* manual search and edits

Fixes a part of: #1747