### PR TITLE
Fix issues with comments in the concept emulation

### DIFF
--- a/libcudacxx/include/cuda/std/__concepts/movable.h
+++ b/libcudacxx/include/cuda/std/__concepts/movable.h
@@ -39,11 +39,10 @@ concept movable = is_object_v<_Tp> && move_constructible<_Tp> && assignable_from
 template <class _Tp>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   _Movable_,
-  requires()( //
-    requires(is_object_v<_Tp>),
-    requires(move_constructible<_Tp>),
-    requires(assignable_from<_Tp&, _Tp>),
-    requires(swappable<_Tp>)));
+  requires()(requires(is_object_v<_Tp>),
+             requires(move_constructible<_Tp>),
+             requires(assignable_from<_Tp&, _Tp>),
+             requires(swappable<_Tp>)));
 
 template <class _Tp>
 _LIBCUDACXX_CONCEPT movable = _LIBCUDACXX_FRAGMENT(_Movable_, _Tp);

--- a/libcudacxx/include/cuda/std/__concepts/predicate.h
+++ b/libcudacxx/include/cuda/std/__concepts/predicate.h
@@ -38,9 +38,7 @@ concept predicate = regular_invocable<_Fn, _Args...> && __boolean_testable<invok
 template <class _Fn, class... _Args>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   _Predicate_,
-  requires()( //
-    requires(regular_invocable<_Fn, _Args...>),
-    requires(__boolean_testable<invoke_result_t<_Fn, _Args...>>)));
+  requires()(requires(regular_invocable<_Fn, _Args...>), requires(__boolean_testable<invoke_result_t<_Fn, _Args...>>)));
 
 template <class _Fn, class... _Args>
 _LIBCUDACXX_CONCEPT predicate = _LIBCUDACXX_FRAGMENT(_Predicate_, _Fn, _Args...);

--- a/libcudacxx/include/cuda/std/__cuda/barrier.h
+++ b/libcudacxx/include/cuda/std/__cuda/barrier.h
@@ -560,17 +560,17 @@ _CCCL_NODISCARD _CCCL_DEVICE inline barrier<thread_scope_block>::arrival_token b
                            "Transaction count update cannot exceed 2^20 - 1.");
 
   barrier<thread_scope_block>::arrival_token __token = {};
+  // On architectures pre-sm90, arrive_tx is not supported.
+  // We do not check for the statespace of the barrier here. This is
+  // on purpose. This allows debugging tools like memcheck/racecheck
+  // to detect that we are passing a pointer with the wrong state
+  // space to mbarrier.arrive. If we checked for the state space here,
+  // and __trap() if wrong, then those tools would not be able to help
+  // us in release builds. In debug builds, the error would be caught
+  // by the asserts at the top of this function.
   NV_IF_ELSE_TARGET(
-    // On architectures pre-sm90, arrive_tx is not supported.
     NV_PROVIDES_SM_90,
     (
-      // We do not check for the statespace of the barrier here. This is
-      // on purpose. This allows debugging tools like memcheck/racecheck
-      // to detect that we are passing a pointer with the wrong state
-      // space to mbarrier.arrive. If we checked for the state space here,
-      // and __trap() if wrong, then those tools would not be able to help
-      // us in release builds. In debug builds, the error would be caught
-      // by the asserts at the top of this function.
 
       auto __native_handle = barrier_native_handle(__b); auto __bh = __cvta_generic_to_shared(__native_handle);
       if (__arrive_count_update == 1) {
@@ -614,8 +614,8 @@ barrier_expect_tx(barrier<thread_scope_block>& __b, _CUDA_VSTD::ptrdiff_t __tran
   // and __trap() if wrong, then those tools would not be able to help
   // us in release builds. In debug builds, the error would be caught
   // by the asserts at the top of this function.
+  // On architectures pre-sm90, arrive_tx is not supported.
   NV_IF_ELSE_TARGET(
-    // On architectures pre-sm90, arrive_tx is not supported.
     NV_PROVIDES_SM_90,
     (auto __bh = __cvta_generic_to_shared(barrier_native_handle(__b));
      asm("mbarrier.expect_tx.relaxed.cta.shared::cta.b64 [%0], %1;"

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -95,9 +95,7 @@ template <class _Tp>
 using __with_reference = _Tp&;
 
 template <class _Tp>
-_LIBCUDACXX_CONCEPT_FRAGMENT(__can_reference_,
-                             requires() //
-                             (typename(__with_reference<_Tp>)));
+_LIBCUDACXX_CONCEPT_FRAGMENT(__can_reference_, requires()(typename(__with_reference<_Tp>)));
 
 template <class _Tp>
 _LIBCUDACXX_CONCEPT __can_reference = _LIBCUDACXX_FRAGMENT(__can_reference_, _Tp);
@@ -528,11 +526,10 @@ namespace __iterator_traits_detail
 template <class _Ip>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __cpp17_iterator_,
-  requires(_Ip __i)( //
-    requires(__can_reference<decltype(*__i)>),
-    requires(same_as<_Ip&, decltype(++__i)>),
-    requires(__can_reference<decltype(*__i++)>),
-    requires(copyable<_Ip>)));
+  requires(_Ip __i)(requires(__can_reference<decltype(*__i)>),
+                    requires(same_as<_Ip&, decltype(++__i)>),
+                    requires(__can_reference<decltype(*__i++)>),
+                    requires(copyable<_Ip>)));
 
 template <class _Ip>
 _LIBCUDACXX_CONCEPT __cpp17_iterator = _LIBCUDACXX_FRAGMENT(__cpp17_iterator_, _Ip);
@@ -580,7 +577,7 @@ _LIBCUDACXX_CONCEPT __cpp17_bidirectional_iterator = _LIBCUDACXX_FRAGMENT(__cpp1
 template <class _Ip>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __cpp17_random_access_iterator_,
-  requires(_Ip __i, typename incrementable_traits<_Ip>::difference_type __n)( //
+  requires(_Ip __i, typename incrementable_traits<_Ip>::difference_type __n)(
     requires(same_as<_Ip&, decltype(__i += __n)>),
     requires(same_as<_Ip&, decltype(__i -= __n)>),
     requires(same_as<_Ip, decltype(__i + __n)>),
@@ -655,9 +652,7 @@ struct __iterator_traits_member_pointer_or_arrow_or_void<_Ip, enable_if_t<__has_
 };
 
 template <class _Ip>
-_LIBCUDACXX_CONCEPT_FRAGMENT(__has_operator_arrow_,
-                             requires(_Ip& __i) //
-                             (__i.operator->()));
+_LIBCUDACXX_CONCEPT_FRAGMENT(__has_operator_arrow_, requires(_Ip& __i)(__i.operator->()));
 
 template <class _Ip>
 _LIBCUDACXX_CONCEPT __has_operator_arrow = _LIBCUDACXX_FRAGMENT(__has_operator_arrow_, _Ip);

--- a/libcudacxx/include/cuda/std/__iterator/sortable.h
+++ b/libcudacxx/include/cuda/std/__iterator/sortable.h
@@ -39,9 +39,7 @@ concept sortable = permutable<_Iter> && indirect_strict_weak_order<_Comp, projec
 template <class _Iter, class _Comp, class _Proj>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __sortable_,
-  requires()( //
-    requires(permutable<_Iter>),
-    requires(indirect_strict_weak_order<_Comp, projected<_Iter, _Proj>>)));
+  requires()(requires(permutable<_Iter>), requires(indirect_strict_weak_order<_Comp, projected<_Iter, _Proj>>)));
 
 template <class _Iter, class _Comp = _CUDA_VRANGES::less, class _Proj = identity>
 _LIBCUDACXX_CONCEPT sortable = _LIBCUDACXX_FRAGMENT(__sortable_, _Iter, _Comp, _Proj);

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -134,7 +134,7 @@ _LIBCUDACXX_CONCEPT_FRAGMENT(
 template <class _From, class _To>
 _LIBCUDACXX_CONCEPT __convertible_to_non_slicing = _LIBCUDACXX_FRAGMENT(__convertible_to_non_slicing_, _From, _To);
 
-// We relaxthe requirement on tuple_size due to a gcc issue
+// We relax the requirement on tuple_size due to a gcc issue
 template <class _Tp>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __pair_like_,

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -134,13 +134,14 @@ _LIBCUDACXX_CONCEPT_FRAGMENT(
 template <class _From, class _To>
 _LIBCUDACXX_CONCEPT __convertible_to_non_slicing = _LIBCUDACXX_FRAGMENT(__convertible_to_non_slicing_, _From, _To);
 
+// We relaxthe requirement on tuple_size due to a gcc issue
 template <class _Tp>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __pair_like_,
   requires(_Tp __t)(
     requires(!is_reference_v<_Tp>),
     typename(typename tuple_size<_Tp>::type),
-    requires(tuple_size<_Tp>::value == 2), // relaxed because of gcc issues
+    requires(tuple_size<_Tp>::value == 2),
     typename(tuple_element_t<0, remove_const_t<_Tp>>),
     typename(tuple_element_t<1, remove_const_t<_Tp>>),
     requires(convertible_to<decltype(_CUDA_VSTD::get<0>(__t)), const tuple_element_t<0, _Tp>&>),

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/span
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/span
@@ -285,14 +285,12 @@ concept __integral_constant_like =
 template <class _Tp>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __integral_constant_like_,
-  requires()( //
-    requires(_CCCL_TRAIT(is_integral, decltype(_Tp::value))),
-    requires(!_CCCL_TRAIT(is_same, bool, remove_const_t<decltype(_Tp::value)>)),
-    requires(convertible_to<_Tp, decltype(_Tp::value)>),
-    requires(equality_comparable_with<_Tp, decltype(_Tp::value)>),
-    (integral_constant<bool, _Tp() == _Tp::value>::value),
-    (integral_constant<bool, static_cast<decltype(_Tp::value)>(_Tp()) == _Tp::value>::value) //
-    ));
+  requires()(requires(_CCCL_TRAIT(is_integral, decltype(_Tp::value))),
+             requires(!_CCCL_TRAIT(is_same, bool, remove_const_t<decltype(_Tp::value)>)),
+             requires(convertible_to<_Tp, decltype(_Tp::value)>),
+             requires(equality_comparable_with<_Tp, decltype(_Tp::value)>),
+             (integral_constant<bool, _Tp() == _Tp::value>::value),
+             (integral_constant<bool, static_cast<decltype(_Tp::value)>(_Tp()) == _Tp::value>::value)));
 template <class _Tp>
 _LIBCUDACXX_CONCEPT __integral_constant_like = _LIBCUDACXX_FRAGMENT(__integral_constant_like_, _Tp);
 #  endif // _CCCL_STD_VER <= 2017

--- a/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concept.default.init/default_initializable.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/concepts/concepts.lang/concept.default.init/default_initializable.verify.cpp
@@ -20,9 +20,7 @@
 #include "test_macros.h"
 
 template <class T>
-_LIBCUDACXX_CONCEPT_FRAGMENT(brace_initializable_,
-                             requires() //
-                             (T{}));
+_LIBCUDACXX_CONCEPT_FRAGMENT(brace_initializable_, requires()(T{}));
 
 template <class T>
 _LIBCUDACXX_CONCEPT brace_initializable = _LIBCUDACXX_FRAGMENT(brace_initializable_, T);

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_result_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_result_t.compile.pass.cpp
@@ -30,9 +30,7 @@ template <class F, class... Is>
 constexpr bool has_indirect_result = requires { typename cuda::std::indirect_result_t<F, Is...>; };
 #else
 template <class F, class... Is>
-_LIBCUDACXX_CONCEPT_FRAGMENT(has_indirect_result_,
-                             requires() //
-                             (typename(cuda::std::indirect_result_t<F, Is...>)));
+_LIBCUDACXX_CONCEPT_FRAGMENT(has_indirect_result_, requires()(typename(cuda::std::indirect_result_t<F, Is...>)));
 
 template <class F, class... Is>
 _LIBCUDACXX_CONCEPT has_indirect_result = _LIBCUDACXX_FRAGMENT(has_indirect_result_, F, Is...);

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/projected/projected.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/projected/projected.compile.pass.cpp
@@ -60,9 +60,7 @@ template <class I, class F>
 constexpr bool projectable = requires { typename cuda::std::projected<I, F>; };
 #else
 template <class I, class F>
-_LIBCUDACXX_CONCEPT_FRAGMENT(projectable_,
-                             requires() //
-                             (typename(cuda::std::projected<I, F>)));
+_LIBCUDACXX_CONCEPT_FRAGMENT(projectable_, requires()(typename(cuda::std::projected<I, F>)));
 
 template <class I, class F>
 _LIBCUDACXX_CONCEPT projectable = _LIBCUDACXX_FRAGMENT(projectable_, I, F);

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/indirectly_readable_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/indirectly_readable_traits.compile.pass.cpp
@@ -26,8 +26,7 @@ concept value_type_matches =
 #else
 template <class T>
 _LIBCUDACXX_CONCEPT_FRAGMENT(has_no_value_type_,
-                             requires() //
-                             (typename(typename cuda::std::indirectly_readable_traits<T>::value_type)));
+                             requires()(typename(typename cuda::std::indirectly_readable_traits<T>::value_type)));
 
 template <class T>
 _LIBCUDACXX_CONCEPT has_no_value_type = !_LIBCUDACXX_FRAGMENT(has_no_value_type_, T);

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.readable/iter_common_reference_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.readable/iter_common_reference_t.compile.pass.cpp
@@ -65,9 +65,7 @@ template <class T>
 constexpr bool has_common_reference = requires { typename cuda::std::iter_common_reference_t<T>; };
 #else
 template <class T>
-_LIBCUDACXX_CONCEPT_FRAGMENT(has_common_reference_,
-                             requires() //
-                             (typename(cuda::std::iter_common_reference_t<T>)));
+_LIBCUDACXX_CONCEPT_FRAGMENT(has_common_reference_, requires()(typename(cuda::std::iter_common_reference_t<T>)));
 
 template <class T>
 _LIBCUDACXX_CONCEPT has_common_reference = _LIBCUDACXX_FRAGMENT(has_common_reference_, T);


### PR DESCRIPTION
Those comments were ment to force clang-format into doing not so bad things with the concept emulation.

However, with the recent versions of clang-format this is not necessary anymore
