### PR TITLE
Deprecate more nested aliases in thrust functors

### DIFF
--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -138,6 +138,7 @@ doxygen_aliases = [
 # more information on the format can be found at:
 #     https://www.doxygen.nl/manual/config.html#cfg_predefined
 doxygen_predefined = [
+    "_CCCL_ALIAS_ATTRIBUTE(x)=",
     "_CCCL_HOST",
     "_CCCL_DEVICE",
     "_CCCL_HOST_DEVICE",
@@ -232,6 +233,7 @@ doxygen_aliases = []
 # more information on the format can be found at:
 #     https://www.doxygen.nl/manual/config.html#cfg_predefined
 doxygen_predefined = [
+  "_CCCL_ALIAS_ATTRIBUTE(x)=",
   "_CCCL_DEVICE=",
   "_CCCL_EXEC_CHECK_DISABLE=",
   "_CCCL_FORCEINLINE=",

--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -76,6 +76,13 @@
 #  define _CCCL_NODISCARD_FRIEND _CCCL_NODISCARD friend
 #endif // !_CCCL_CUDACC_BELOW_11_3 && !_CCCL_COMPILER_CLANG
 
+// NVCC below 11.3 does not support attributes on alias declarations
+#ifdef _CCCL_CUDACC_BELOW_11_3
+#  define _CCCL_ALIAS_ATTRIBUTE(...)
+#else // ^^^ _CCCL_CUDACC_BELOW_11_3 ^^^ / vvv !_CCCL_CUDACC_BELOW_11_3 vvv
+#  define _CCCL_ALIAS_ATTRIBUTE(...) __VA_ARGS__
+#endif // !_CCCL_CUDACC_BELOW_11_3
+
 #if defined(_CCCL_COMPILER_MSVC)
 #  define _CCCL_NORETURN __declspec(noreturn)
 #elif __has_cpp_attribute(noreturn)

--- a/thrust/thrust/functional.h
+++ b/thrust/thrust/functional.h
@@ -1271,18 +1271,21 @@ struct maximum
 {
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
+   *  deprecated [Since 2.6]
    */
-  using first_argument_type = T;
+  using first_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
+   *  deprecated [Since 2.6]
    */
-  using second_argument_type = T;
+  using second_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
+   *  deprecated [Since 2.6]
    */
-  using result_type = T;
+  using result_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T;
 
   /*! Function call operator. The return value is <tt>rhs < lhs ? lhs : rhs</tt>.
    */
@@ -1325,18 +1328,21 @@ struct minimum
 {
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
+   *  deprecated [Since 2.6]
    */
-  using first_argument_type = T;
+  using first_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
+   *  deprecated [Since 2.6]
    */
-  using second_argument_type = T;
+  using second_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
+   *  deprecated [Since 2.6]
    */
-  using result_type = T;
+  using result_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T;
 
   /*! Function call operator. The return value is <tt>lhs < rhs ? lhs : rhs</tt>.
    */
@@ -1372,18 +1378,21 @@ struct project1st
 {
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
+   *  deprecated [Since 2.6]
    */
-  using first_argument_type = T1;
+  using first_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T1;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
+   *  deprecated [Since 2.6]
    */
-  using second_argument_type = T2;
+  using second_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T2;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
+   *  deprecated [Since 2.6]
    */
-  using result_type = T1;
+  using result_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T1;
 
   /*! Function call operator. The return value is <tt>lhs</tt>.
    */
@@ -1429,18 +1438,21 @@ struct project2nd
 {
   /*! \typedef first_argument_type
    *  \brief The type of the function object's first argument.
+   *  deprecated [Since 2.6]
    */
-  using first_argument_type = T1;
+  using first_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T1;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
+   *  deprecated [Since 2.6]
    */
-  using second_argument_type = T2;
+  using second_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T2;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
+   *  deprecated [Since 2.6]
    */
-  using result_type = T2;
+  using result_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T2;
 
   /*! Function call operator. The return value is <tt>rhs</tt>.
    */


### PR DESCRIPTION
Deprecate the `first_argument_type`, `second_argument_type` and `result_type` on more thrust functors. Those were deprecated on standard library functors in C++17 and removed in C++20.