### PR TITLE
Restore RAPIDS devcontainer

### DIFF
--- a/.devcontainer/cuda12.2-rapids-conda
+++ b/.devcontainer/cuda12.2-rapids-conda
@@ -1,0 +1,1 @@
+../ci/rapids/cuda12.2-conda

--- a/.devcontainer/make_devcontainers.sh
+++ b/.devcontainer/make_devcontainers.sh
@@ -113,6 +113,11 @@ valid_subdirs=()
 # The img folder should not be removed:
 valid_subdirs+=("img")
 
+# Don't remove RAPIDS containers:
+for rapids_container in *rapids*; do
+    valid_subdirs+=("${rapids_container}")
+done
+
 # For each unique combination
 for combination in $combinations; do
     cuda_version=$(echo "$combination" | jq -r '.cuda')


### PR DESCRIPTION
## Description

PR #1935 removed the RAPIDS devcontainer configuration. Now CI shows errors like:

```
Unknown CUDA [12.2] compiler [rapids-conda] combination
Requested devcontainer .devcontainer/cuda12.2-rapids-conda/devcontainer.json does not exist
```

This PR restores the deleted devcontainer configuration.

See also: https://github.com/NVIDIA/cccl/pull/1935#issuecomment-2213947175

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
