### PR TITLE
Add CI slack notifications.

### DIFF
--- a/.github/actions/workflow-build/action.yml
+++ b/.github/actions/workflow-build/action.yml
@@ -25,6 +25,15 @@ inputs:
     description: "Path to the matrix parser script (default if blank: build-workflow.py from action dir)"
     default: ""
     required: false
+  slack_token:
+    description: "The Slack token to use for notifications. No notifications will be sent if not provided."
+    required: false
+  slack_log:
+    description: "Slack channel ID for verbose notifications."
+    required: false
+  slack_alert:
+    description: "Slack channel ID for alert notifications."
+    required: false
 
 outputs:
   workflow:
@@ -34,6 +43,20 @@ outputs:
 runs:
   using: "composite"
   steps:
+
+    - name: Send Slack log notification
+      if: ${{inputs.slack_token != '' && inputs.slack_log != '' }}
+      uses: slackapi/slack-github-action@v1.26.0
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack_token }}
+        WORKFLOW_TYPE: ${{ github.workflow }} # nightly, weekly, pr, etc.
+        SUMMARY_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      with:
+        channel-id: ${{ inputs.slack_log }}
+        slack-message: |
+          Workflow '${{ env.WORKFLOW_TYPE }}' starting...
+
+          Details: ${{ env.SUMMARY_URL }}
 
     - name: Inspect changes
       if: ${{ inputs.inspect_changes_script != '' && inputs.inspect_changes_base_sha != '' }}
@@ -99,3 +122,18 @@ runs:
         name: workflow
         path: workflow/
         compression-level: 0
+
+    - name: Send Slack error notification
+      if: ${{ failure() && inputs.slack_token != '' && (inputs.slack_alert != '' || inputs.slack_log != '') }}
+      uses: slackapi/slack-github-action@v1.26.0
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack_token }}
+        WORKFLOW_TYPE: ${{ github.workflow }} # nightly, weekly, pr, etc.
+        SUMMARY_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+        CHANNEL_SEP: ${{ (inputs.slack_log != '' && inputs.slack_alert != '') && ',' || ''}}
+      with:
+        channel-id: '${{ inputs.slack_log }}${{env.CHANNEL_SEP}}${{ inputs.slack_alert }}'
+        slack-message: |
+          Workflow '${{ env.WORKFLOW_TYPE }}' encountered an error while preparing to run.
+
+          Details: ${{ env.SUMMARY_URL }}

--- a/.github/actions/workflow-results/action.yml
+++ b/.github/actions/workflow-results/action.yml
@@ -8,11 +8,20 @@ inputs:
   pr_number:
     description: "The PR number to comment on, if applicable. No comment will be made if not provided."
     required: false
+  slack_token:
+    description: "The Slack token to use for notifications. No notifications will be sent if not provided."
+    required: false
+  slack_log:
+    description: "Slack channel ID for verbose notifications."
+    required: false
+  slack_alert:
+    description: "Slack channel ID for alert notifications."
+    required: false
 
 outputs:
   success:
     description: "Whether any jobs failed."
-    value: ${{ steps.check-dispatch.outputs.success }}
+    value: ${{ steps.check-success.outputs.success }}
 
 runs:
   using: "composite"
@@ -112,6 +121,10 @@ runs:
         printf "SUMMARY=%s\n" "$(cat final_summary.md | url_encode_string)" | tee -a "${GITHUB_OUTPUT}"
         echo "::endgroup::"
 
+        echo "::group::GHA Output: EXEC_SUMMARY"
+        printf "EXEC_SUMMARY=%s\n" "$(cat execution/heading.txt)" | tee -a "${GITHUB_OUTPUT}"
+        echo "::endgroup::"
+
         cp final_summary.md ${GITHUB_STEP_SUMMARY}
 
     - name: Comment on PR
@@ -140,7 +153,7 @@ runs:
           });
 
     - name: Check for job success
-      id: check-dispatch
+      id: check-success
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
         echo "::group::Checking for success artifacts"
@@ -162,3 +175,38 @@ runs:
         fi
 
         echo "success=true" >> "${GITHUB_OUTPUT}"
+
+    - name: Send Slack log notification
+      if: ${{ always() && inputs.slack_token != '' && inputs.slack_log != '' }}
+      uses: slackapi/slack-github-action@v1.26.0
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack_token }}
+        WORKFLOW_TYPE: ${{ github.workflow }} # nightly, weekly, pr, etc.
+        STATUS: ${{ steps.check-success.outcome }}
+        EXEC_SUMMARY: ${{ steps.final-summary.outputs.EXEC_SUMMARY }}
+        SUMMARY_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      with:
+        channel-id: ${{ inputs.slack_log }}
+        slack-message: |
+          Workflow '${{ env.WORKFLOW_TYPE }}' has finished with status `${{ env.STATUS }}`:
+
+          ${{ env.EXEC_SUMMARY }}
+
+          Details: ${{ env.SUMMARY_URL }}
+
+    - name: Send Slack alert notification
+      if: ${{ failure() && inputs.slack_token != '' && inputs.slack_alert != '' }}
+      uses: slackapi/slack-github-action@v1.26.0
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack_token }}
+        WORKFLOW_TYPE: ${{ github.workflow }} # nightly, weekly, pr, etc.
+        EXEC_SUMMARY: ${{ steps.final-summary.outputs.EXEC_SUMMARY }}
+        SUMMARY_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      with:
+        channel-id: ${{ inputs.slack_alert }}
+        slack-message: |
+          Workflow '${{ env.WORKFLOW_TYPE }}' has failed:
+
+          ${{ env.EXEC_SUMMARY }}
+
+          Details: ${{ env.SUMMARY_URL }}

--- a/.github/actions/workflow-results/parse-job-times.py
+++ b/.github/actions/workflow-results/parse-job-times.py
@@ -120,7 +120,7 @@ def main():
     for id, stats in result.items():
         job_seconds = stats['job_seconds']
         command_seconds = stats['command_seconds']
-        overhead = (job_seconds - command_seconds) * 100 / command_seconds
+        overhead = (job_seconds - command_seconds) * 100 / command_seconds if command_seconds > 0 else 100
         print(f"{stats['job_duration']:10} {stats['command_duration']:10} {overhead:10.0f} {stats['name']}")
     print("::endgroup::")
 

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -2,6 +2,15 @@ name: Build all RAPIDS repositories
 
 on:
   workflow_call:
+    inputs:
+      slack_token:
+        description: "The Slack token to use for notifications. No notifications will be sent if not provided."
+        required: false
+        type: string
+      slack_alert:
+        description: "Slack channel ID for alert notifications."
+        required: false
+        type: string
 
 jobs:
   check-event:
@@ -156,3 +165,22 @@ jobs:
             --volume "$RUNNER_TEMP/ci.sh:/ci.sh" \
             --volume "$RUNNER_TEMP/ci-entrypoint.sh:/ci-entrypoint.sh" \
             -- /ci-entrypoint.sh ./ci/rapids/rapids-entrypoint.sh /ci.sh
+
+  notify-failure:
+    name: Notify Slack of RAPIDS failure
+    if: ${{ failure() && inputs.slack_token != '' && inputs.slack_alert != '' }}
+    needs: build-rapids
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ inputs.slack_token }}
+          WORKFLOW_TYPE: ${{ github.workflow }}
+          SUMMARY_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+        with:
+          channel-id: ${{ inputs.slack_alert }}
+          slack-message: |
+            RAPIDS build in workflow '${{ env.WORKFLOW_TYPE }}' failed.
+
+            Details: ${{ env.SUMMARY_URL }}

--- a/.github/workflows/ci-workflow-nightly.yml
+++ b/.github/workflows/ci-workflow-nightly.yml
@@ -46,6 +46,9 @@ jobs:
         uses: ./.github/actions/workflow-build
         with:
           workflows: nightly
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
+          slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}
 
   dispatch-groups-linux-two-stage:
     name: ${{ matrix.name }}
@@ -128,6 +131,11 @@ jobs:
       - name: Check workflow success
         id: check-workflow
         uses: ./.github/actions/workflow-results
+        with:
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
+          slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}
+
 
   build-rapids:
     name: Build RAPIDS
@@ -139,38 +147,6 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/build-rapids.yml
-
-  # Check all other job statuses. This job gates branch protection checks.
-  ci:
-    name: CI
-    # !! Important: This job is used for branch protection checks.
-    # !! Need to use always() instead of !cancelled() because skipped jobs count as success
-    # !! for Github branch protection checks. Yes, really: by default, branch protections
-    # !! can be bypassed by cancelling CI. See NVIDIA/cccl#605.
-    if: ${{ always() }}
-    needs:
-      - verify-workflow
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check results
-        run: |
-          status="success"
-
-          check_result() {
-            name=$1
-            expected=$2
-            result=$3
-
-            echo "Checking if $name job result ('$result') is '$expected'..."
-            if [[ "$result" != "$expected" ]]; then
-              echo "$name job failed"
-
-              status="failed"
-            fi
-          }
-
-          check_result "verify-workflow"      "success" "${{needs.verify-workflow.result}}"
-
-          if [[ "$status" != "success" ]]; then
-            exit 1
-          fi
+    with:
+      slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+      slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}


### PR DESCRIPTION
The notifications are just for nightlies/weeklies/etc.

There will be two slack channels -- one that only reports failures, and one that reports everything. The first is meant to be monitored by the team so we know when things break, the other is more of a log for looking at historical results, runtimes, detecting startup issues, etc.