### PR TITLE
Remove obsolete Thrust function traits

### DIFF
--- a/thrust/thrust/detail/type_traits/function_traits.h
+++ b/thrust/thrust/detail/type_traits/function_traits.h
@@ -27,7 +27,6 @@
 #endif // no system header
 
 #include <thrust/detail/type_traits.h>
-#include <thrust/detail/type_traits/has_nested_type.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -53,32 +52,6 @@ struct bit_xor;
 
 namespace detail
 {
-
-// some metafunctions which check for the nested types of the adaptable functions
-
-__THRUST_DEFINE_HAS_NESTED_TYPE(has_result_type, result_type)
-
-__THRUST_DEFINE_HAS_NESTED_TYPE(has_argument_type, argument_type)
-
-__THRUST_DEFINE_HAS_NESTED_TYPE(has_first_argument_type, first_argument_type)
-
-__THRUST_DEFINE_HAS_NESTED_TYPE(has_second_argument_type, second_argument_type)
-
-template <typename AdaptableBinaryFunction>
-struct result_type
-{
-  using type = typename AdaptableBinaryFunction::result_type;
-};
-
-template <typename T>
-struct is_adaptable_unary_function : ::cuda::std::_And<has_result_type<T>, has_argument_type<T>>
-{};
-
-template <typename T>
-struct is_adaptable_binary_function
-    : ::cuda::std::_And<has_result_type<T>, ::cuda::std::_And<has_first_argument_type<T>, has_second_argument_type<T>>>
-{};
-
 template <typename BinaryFunction>
 struct is_commutative : public thrust::detail::false_type
 {};

--- a/thrust/thrust/detail/type_traits/result_of_adaptable_function.h
+++ b/thrust/thrust/detail/type_traits/result_of_adaptable_function.h
@@ -33,10 +33,8 @@
 THRUST_NAMESPACE_BEGIN
 namespace detail
 {
-
-// Sets `type` to the result of the specified Signature invocation. If the
-// callable defines a `result_type` alias member, that type is used instead.
-// Use invoke_result / result_of when FuncType::result_type is not defined.
+// Sets `type` to the result of the specified Signature invocation. If the callable defines a `result_type` alias
+// member, that type is used instead. Use invoke_result / result_of when FuncType::result_type is not defined.
 template <typename Signature, typename Enable = void>
 struct result_of_adaptable_function
 {
@@ -56,8 +54,7 @@ public:
 
 // specialization for invocations which define result_type
 template <typename Functor, typename... ArgTypes>
-struct result_of_adaptable_function<Functor(ArgTypes...),
-                                    ::cuda::std::__enable_if_t<thrust::detail::has_result_type<Functor>::value>>
+struct result_of_adaptable_function<Functor(ArgTypes...), ::cuda::std::__void_t<typename Functor::result_type>>
 {
   using type = typename Functor::result_type;
 };

--- a/thrust/thrust/iterator/detail/iterator_traits.inl
+++ b/thrust/thrust/iterator/detail/iterator_traits.inl
@@ -77,7 +77,7 @@ struct iterator_system_impl
 {};
 
 template <typename Iterator>
-struct iterator_system_impl<Iterator, typename voider<typename iterator_traits<Iterator>::iterator_category>::type>
+struct iterator_system_impl<Iterator, void_t<typename iterator_traits<Iterator>::iterator_category>>
     : detail::iterator_category_to_system<typename iterator_traits<Iterator>::iterator_category>
 {};
 

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.inl
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.inl
@@ -58,17 +58,8 @@ inline L divide_ri(const L x, const R y)
   return (x + (y - 1)) / y;
 }
 
-template <typename InputIterator, typename BinaryFunction, typename OutputIterator = void>
-struct partial_sum_type
-    : thrust::detail::eval_if<thrust::detail::has_result_type<BinaryFunction>::value,
-                              thrust::detail::result_type<BinaryFunction>,
-                              thrust::detail::eval_if<thrust::detail::is_output_iterator<OutputIterator>::value,
-                                                      thrust::iterator_value<InputIterator>,
-                                                      thrust::iterator_value<OutputIterator>>>
-{};
-
 template <typename InputIterator, typename BinaryFunction>
-struct partial_sum_type<InputIterator, BinaryFunction, void>
+struct partial_sum_type
     : thrust::detail::eval_if<thrust::detail::has_result_type<BinaryFunction>::value,
                               thrust::detail::result_type<BinaryFunction>,
                               thrust::iterator_value<InputIterator>>

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.inl
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.inl
@@ -35,6 +35,7 @@
 #include <thrust/system/tbb/detail/execution_policy.h>
 #include <thrust/system/tbb/detail/reduce_by_key.h>
 #include <thrust/system/tbb/detail/reduce_intervals.h>
+#include <thrust/type_traits/void_t.h>
 
 #include <cassert>
 #include <thread>
@@ -58,12 +59,17 @@ inline L divide_ri(const L x, const R y)
   return (x + (y - 1)) / y;
 }
 
-template <typename InputIterator, typename BinaryFunction>
+template <typename InputIterator, typename BinaryFunction, typename SFINAE = void>
 struct partial_sum_type
-    : thrust::detail::eval_if<thrust::detail::has_result_type<BinaryFunction>::value,
-                              thrust::detail::result_type<BinaryFunction>,
-                              thrust::iterator_value<InputIterator>>
-{};
+{
+  using type = typename thrust::iterator_value<InputIterator>::type;
+};
+
+template <typename InputIterator, typename BinaryFunction>
+struct partial_sum_type<InputIterator, BinaryFunction, void_t<typename BinaryFunction::result_type>>
+{
+  using type = typename BinaryFunction::result_type;
+};
 
 template <typename InputIterator1, typename InputIterator2, typename BinaryPredicate, typename BinaryFunction>
 thrust::pair<InputIterator1,

--- a/thrust/thrust/type_traits/void_t.h
+++ b/thrust/thrust/type_traits/void_t.h
@@ -30,10 +30,6 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_STD_VER >= 2017
-#  include <type_traits>
-#endif
-
 THRUST_NAMESPACE_BEGIN
 
 /*! \addtogroup utility
@@ -45,17 +41,14 @@ THRUST_NAMESPACE_BEGIN
  */
 
 template <typename...>
-struct voider
+struct THRUST_DEPRECATED_BECAUSE("Use ::cuda::std::void_t") voider
 {
   using type = void;
 };
 
-#if _CCCL_STD_VER >= 2017
-using std::void_t;
-#else
+// TODO(bgruber): deprecate and replace by cuda::std::void_t eventually
 template <typename... Ts>
-using void_t = typename voider<Ts...>::type;
-#endif
+using void_t = void;
 
 /*! \} // type traits
  */


### PR DESCRIPTION
This PR removes several internal function traits that are based on C++11-deprecated and C++17-removed `::result_type` alias of functors. 