### PR TITLE
Test tuple of iterator reference assignment

### DIFF
--- a/thrust/testing/tuple.cu
+++ b/thrust/testing/tuple.cu
@@ -525,3 +525,20 @@ void TestTupleCTAD(void)
   ASSERT_EQUAL(c, c2);
 }
 DECLARE_UNITTEST(TestTupleCTAD);
+
+void TestTupleOfIteratorReferenceAssignsFromConst()
+{
+  // tuple of mutable references
+  thrust::device_vector<int> v(10);
+  using devref = decltype(v[0]);
+  auto refs    = thrust::detail::tuple_of_iterator_references<devref>{thrust::tuple<devref>(v[0])};
+
+  // tuple of const references
+  const thrust::device_vector<int> cv(10);
+  using devcref = decltype(cv[0]);
+  auto crefs    = thrust::detail::tuple_of_iterator_references<devcref>{thrust::tuple<devcref>(cv[0])};
+
+  // should compile:
+  refs = crefs;
+}
+DECLARE_UNITTEST(TestTupleOfIteratorReferenceAssignsFromConst);


### PR DESCRIPTION
This PR was hunting the following bug, which does not seem to occur anymore. So here is just the test for it.

The problem seemed to be that when the assignment operator is instantiated:
```c++
template <typename... Ts>
class tuple_of_iterator_references : public thrust::tuple<Ts...>
{
  ...
  template <typename... Us>
  inline _CCCL_HOST_DEVICE tuple_of_iterator_references& operator=(const thrust::tuple<Us...>& other)
  {
    super_t::operator=(other);
    return *this;
  }
```
it will ultimately lead to a check whether a `tuple<Ts...>` is **constructible** from a `tuple<Us...>`, which asks wether a `device_reference<T>` is constructible from a `device_reference<const T>`, which rightfully fails. However, the correct check would whether  `tuple<Ts...>` is **assignable** from a `tuple<Us...>`.

What's so astounding is that this bug only surfaces on a few GCC versions.
