### PR TITLE
Fix documentation generation for thrust::pair

### DIFF
--- a/docs/thrust/api_docs/utility/pair.rst
+++ b/docs/thrust/api_docs/utility/pair.rst
@@ -9,5 +9,5 @@ Pair
    :glob:
    :maxdepth: 1
 
-   ${repo_docs_api_path}/*typedef_group__pair*
+   ${repo_docs_api_path}/*struct*pair*
    ${repo_docs_api_path}/*function_group__pair*


### PR DESCRIPTION
Fixes: #1975

I checked the generated documentation locally, and it generates the same page as the current online documentation:

![image](https://github.com/NVIDIA/cccl/assets/1224051/5ff7e6b8-4d96-423c-bd7c-070554332ebc)
