### PR TITLE
Use libcu++ void_t everywhere

### DIFF
--- a/cub/cub/block/radix_rank_sort_operations.cuh
+++ b/cub/cub/block/radix_rank_sort_operations.cuh
@@ -199,10 +199,6 @@ _CCCL_HOST_DEVICE void for_each_member(F f, DecomposerT decomposer, T& aggregate
 
 namespace radix
 {
-
-template <class...>
-using void_t = void;
-
 template <class T, class = void>
 struct is_fundamental_type
 {
@@ -210,7 +206,7 @@ struct is_fundamental_type
 };
 
 template <class T>
-struct is_fundamental_type<T, void_t<typename Traits<T>::UnsignedBits>>
+struct is_fundamental_type<T, ::cuda::std::void_t<typename Traits<T>::UnsignedBits>>
 {
   static constexpr bool value = true;
 };

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -825,16 +825,16 @@ struct DoubleBuffer
  * \brief Defines a structure \p detector_name that is templated on type \p T.  The \p detector_name struct exposes a
  * constant member \p value indicating whether or not parameter \p T exposes a nested type \p nested_type_name
  */
-#  define CUB_DEFINE_DETECT_NESTED_TYPE(detector_name, nested_type_name)                                  \
-    template <typename T, typename = void>                                                                \
-    struct detector_name : ::cuda::std::false_type                                                        \
-    {                                                                                                     \
-      CUB_DEPRECATED_BECAUSE("Use ::value instead") static constexpr bool VALUE = false;                  \
-    };                                                                                                    \
-    template <typename T>                                                                                 \
-    struct detector_name<T, ::cuda::std::__void_t<typename T::nested_type_name>> : ::cuda::std::true_type \
-    {                                                                                                     \
-      CUB_DEPRECATED_BECAUSE("Use ::value instead") static constexpr bool VALUE = true;                   \
+#  define CUB_DEFINE_DETECT_NESTED_TYPE(detector_name, nested_type_name)                                \
+    template <typename T, typename = void>                                                              \
+    struct detector_name : ::cuda::std::false_type                                                      \
+    {                                                                                                   \
+      CUB_DEPRECATED_BECAUSE("Use ::value instead") static constexpr bool VALUE = false;                \
+    };                                                                                                  \
+    template <typename T>                                                                               \
+    struct detector_name<T, ::cuda::std::void_t<typename T::nested_type_name>> : ::cuda::std::true_type \
+    {                                                                                                   \
+      CUB_DEPRECATED_BECAUSE("Use ::value instead") static constexpr bool VALUE = true;                 \
     };
 
 /******************************************************************************
@@ -854,7 +854,7 @@ struct BinaryOpHasIdxParam : ::cuda::std::false_type
 template <typename T, typename BinaryOp>
 struct BinaryOpHasIdxParam<T,
                            BinaryOp,
-                           ::cuda::std::__void_t<decltype(::cuda::std::declval<BinaryOp>()(
+                           ::cuda::std::void_t<decltype(::cuda::std::declval<BinaryOp>()(
                              ::cuda::std::declval<T>(), ::cuda::std::declval<T>(), int{}))>> : ::cuda::std::true_type
 {
   CUB_DEPRECATED_BECAUSE("Use ::value instead") static constexpr bool HAS_PARAM = true;

--- a/libcudacxx/include/cuda/std/__complex/vector_support.h
+++ b/libcudacxx/include/cuda/std/__complex/vector_support.h
@@ -67,7 +67,7 @@ struct __complex_can_implicitly_construct : false_type
 {};
 
 template <class _Dest, class _Source>
-struct __complex_can_implicitly_construct<_Dest, _Source, __void_t<decltype(_Dest{_CUDA_VSTD::declval<_Source>()})>>
+struct __complex_can_implicitly_construct<_Dest, _Source, void_t<decltype(_Dest{_CUDA_VSTD::declval<_Source>()})>>
     : true_type
 {};
 
@@ -82,7 +82,7 @@ struct __has_vector_type : false_type
 {};
 
 template <class _Tp>
-struct __has_vector_type<_Tp, __void_t<__type_to_vector_t<_Tp>>> : true_type
+struct __has_vector_type<_Tp, void_t<__type_to_vector_t<_Tp>>> : true_type
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__concepts/destructible.h
+++ b/libcudacxx/include/cuda/std/__concepts/destructible.h
@@ -48,7 +48,7 @@ _LIBCUDACXX_INLINE_VAR constexpr bool __destructible_impl<_Tp,
 #    if defined(_CCCL_COMPILER_GCC)
                                                           __enable_if_t<_CCCL_TRAIT(is_destructible, _Tp)>>
 #    else // ^^^ _CCCL_COMPILER_GCC ^^^ / vvv !_CCCL_COMPILER_GCC vvv
-                                                          __void_t<decltype(_CUDA_VSTD::declval<_Tp>().~_Tp())>>
+                                                          void_t<decltype(_CUDA_VSTD::declval<_Tp>().~_Tp())>>
 #    endif // !_CCCL_COMPILER_GCC
   = noexcept(_CUDA_VSTD::declval<_Tp>().~_Tp());
 

--- a/libcudacxx/include/cuda/std/__cuda/barrier.h
+++ b/libcudacxx/include/cuda/std/__cuda/barrier.h
@@ -26,7 +26,7 @@
 #endif // no system header
 
 #include <cuda/std/__atomic/api/owned.h>
-#include <cuda/std/__type_traits/void_t.h> // _CUDA_VSTD::__void_t
+#include <cuda/std/__type_traits/void_t.h> // _CUDA_VSTD::void_t
 #include <cuda/std/detail/libcxx/include/cstdlib> // _LIBCUDACXX_UNREACHABLE
 
 #if defined(_CCCL_CUDA_COMPILER)
@@ -1063,7 +1063,7 @@ struct __get_size_align
 
 // aligned_size_t<n> overload: return n.
 template <typename T>
-struct __get_size_align<T, _CUDA_VSTD::__void_t<decltype(T::align)>>
+struct __get_size_align<T, _CUDA_VSTD::void_t<decltype(T::align)>>
 {
   static constexpr int align = T::align;
 };

--- a/libcudacxx/include/cuda/std/__functional/is_transparent.h
+++ b/libcudacxx/include/cuda/std/__functional/is_transparent.h
@@ -33,7 +33,7 @@ struct __is_transparent : false_type
 {};
 
 template <class _Tp, class _Up>
-struct __is_transparent<_Tp, _Up, __void_t<typename _Tp::is_transparent>> : true_type
+struct __is_transparent<_Tp, _Up, void_t<typename _Tp::is_transparent>> : true_type
 {};
 
 #endif

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -52,7 +52,7 @@ struct __cccl_type_is_defined : _CUDA_VSTD::false_type
 {};
 
 template <class _Tp>
-struct __cccl_type_is_defined<_Tp, _CUDA_VSTD::__void_t<decltype(sizeof(_Tp))>> : _CUDA_VSTD::true_type
+struct __cccl_type_is_defined<_Tp, _CUDA_VSTD::void_t<decltype(sizeof(_Tp))>> : _CUDA_VSTD::true_type
 {};
 
 // detect whether the used STL has contiguous_iterator_tag defined
@@ -206,11 +206,11 @@ private:
   _LIBCUDACXX_INLINE_VISIBILITY static false_type __test(...);
   template <class _Up>
   _LIBCUDACXX_INLINE_VISIBILITY static true_type
-  __test(__void_t<typename _Up::iterator_category>* = nullptr,
-         __void_t<typename _Up::difference_type>*   = nullptr,
-         __void_t<typename _Up::value_type>*        = nullptr,
-         __void_t<typename _Up::reference>*         = nullptr,
-         __void_t<typename _Up::pointer>*           = nullptr);
+  __test(void_t<typename _Up::iterator_category>* = nullptr,
+         void_t<typename _Up::difference_type>*   = nullptr,
+         void_t<typename _Up::value_type>*        = nullptr,
+         void_t<typename _Up::reference>*         = nullptr,
+         void_t<typename _Up::pointer>*           = nullptr);
 
 public:
   static const bool value = decltype(__test<_Tp>(0, 0, 0, 0, 0))::value;

--- a/libcudacxx/include/cuda/std/__memory/allocator_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_traits.h
@@ -43,12 +43,12 @@ _CCCL_NV_DIAG_SUPPRESS(1215)
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if _CCCL_STD_VER <= 2014
-#  define _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(NAME, PROPERTY)     \
-    template <class _Tp, class = void>                             \
-    struct NAME : false_type                                       \
-    {};                                                            \
-    template <class _Tp>                                           \
-    struct NAME<_Tp, __void_t<typename _Tp::PROPERTY>> : true_type \
+#  define _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(NAME, PROPERTY)   \
+    template <class _Tp, class = void>                           \
+    struct NAME : false_type                                     \
+    {};                                                          \
+    template <class _Tp>                                         \
+    struct NAME<_Tp, void_t<typename _Tp::PROPERTY>> : true_type \
     {}
 
 #else // ^^^ _CCCL_STD_VER <= 2014 ^^^ / vvv _CCCL_STD_VER >= 2017 vvv
@@ -56,7 +56,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
     template <class _Tp, class = void>                         \
     inline constexpr bool NAME##_v = false;                    \
     template <class _Tp>                                       \
-    inline constexpr bool NAME##_v<_Tp, __void_t<typename _Tp::PROPERTY>> = true;
+    inline constexpr bool NAME##_v<_Tp, void_t<typename _Tp::PROPERTY>> = true;
 #endif // _CCCL_STD_VER >= 2017
 
 // __pointer
@@ -190,7 +190,7 @@ template <class _Tp, class _Up, class = void>
 struct __has_rebind_other : false_type
 {};
 template <class _Tp, class _Up>
-struct __has_rebind_other<_Tp, _Up, __void_t<typename _Tp::template rebind<_Up>::other>> : true_type
+struct __has_rebind_other<_Tp, _Up, void_t<typename _Tp::template rebind<_Up>::other>> : true_type
 {};
 
 template <class _Tp, class _Up, bool = __has_rebind_other<_Tp, _Up>::value>

--- a/libcudacxx/include/cuda/std/__memory/construct_at.h
+++ b/libcudacxx/include/cuda/std/__memory/construct_at.h
@@ -85,7 +85,7 @@ struct __is_narrowing_impl<_To, _From> : true_type
 // This is a bit hacky, but we rely on the fact that arithmetic types cannot have more than one argument to their
 // constructor
 template <class _To, class _From>
-struct __is_narrowing_impl<_To, _From, __void_t<decltype(_To{_CUDA_VSTD::declval<_From>()})>> : false_type
+struct __is_narrowing_impl<_To, _From, void_t<decltype(_To{_CUDA_VSTD::declval<_From>()})>> : false_type
 {};
 
 template <class _Tp, class... _Args>

--- a/libcudacxx/include/cuda/std/__memory/pointer_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/pointer_traits.h
@@ -40,7 +40,7 @@ struct __has_element_type : false_type
 {};
 
 template <class _Tp>
-struct __has_element_type<_Tp, __void_t<typename _Tp::element_type>> : true_type
+struct __has_element_type<_Tp, void_t<typename _Tp::element_type>> : true_type
 {};
 
 template <class _Ptr, bool = __has_element_type<_Ptr>::value>
@@ -123,7 +123,7 @@ struct __has_difference_type : false_type
 {};
 
 template <class _Tp>
-struct __has_difference_type<_Tp, __void_t<typename _Tp::difference_type>> : true_type
+struct __has_difference_type<_Tp, void_t<typename _Tp::difference_type>> : true_type
 {};
 
 template <class _Ptr, bool = __has_difference_type<_Ptr>::value>

--- a/libcudacxx/include/cuda/std/__memory/uses_allocator.h
+++ b/libcudacxx/include/cuda/std/__memory/uses_allocator.h
@@ -33,7 +33,7 @@ template <class _Tp, class = void>
 struct __has_allocator_type : false_type
 {};
 template <class _Tp>
-struct __has_allocator_type<_Tp, __void_t<typename _Tp::allocator_type>> : true_type
+struct __has_allocator_type<_Tp, void_t<typename _Tp::allocator_type>> : true_type
 {};
 
 template <class _Tp, class _Alloc, bool = _CCCL_TRAIT(__has_allocator_type, _Tp)>
@@ -46,7 +46,7 @@ struct __uses_allocator<_Tp, _Alloc, true> : is_convertible<_Alloc, typename _Tp
 template <class _Tp, class = void>
 _LIBCUDACXX_INLINE_VAR constexpr bool __has_allocator_type_v = false;
 template <class _Tp>
-_LIBCUDACXX_INLINE_VAR constexpr bool __has_allocator_type_v<_Tp, __void_t<typename _Tp::allocator_type>> = true;
+_LIBCUDACXX_INLINE_VAR constexpr bool __has_allocator_type_v<_Tp, void_t<typename _Tp::allocator_type>> = true;
 
 template <class _Tp, class _Alloc, bool = _CCCL_TRAIT(__has_allocator_type, _Tp)>
 _LIBCUDACXX_INLINE_VAR constexpr bool __uses_allocator_v = false;

--- a/libcudacxx/include/cuda/std/__type_traits/common_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/common_type.h
@@ -61,7 +61,7 @@ struct __common_type2_imp
 
 // sub-bullet 3 - "if decay_t<decltype(false ? declval<D1>() : declval<D2>())> ..."
 template <class _Tp, class _Up>
-struct __common_type2_imp<_Tp, _Up, __void_t<__cond_type<_Tp, _Up>>>
+struct __common_type2_imp<_Tp, _Up, void_t<__cond_type<_Tp, _Up>>>
 {
   typedef _LIBCUDACXX_NODEBUG_TYPE __decay_t<__cond_type<_Tp, _Up>> type;
 };
@@ -74,13 +74,13 @@ template <class... _Tp>
 struct __common_types;
 
 template <class _Tp, class _Up>
-struct __common_type_impl<__common_types<_Tp, _Up>, __void_t<__common_type_t<_Tp, _Up>>>
+struct __common_type_impl<__common_types<_Tp, _Up>, void_t<__common_type_t<_Tp, _Up>>>
 {
   typedef __common_type_t<_Tp, _Up> type;
 };
 
 template <class _Tp, class _Up, class _Vp, class... _Rest>
-struct __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...>, __void_t<__common_type_t<_Tp, _Up>>>
+struct __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...>, void_t<__common_type_t<_Tp, _Up>>>
     : __common_type_impl<__common_types<__common_type_t<_Tp, _Up>, _Vp, _Rest...>>
 {};
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_allocator.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_allocator.h
@@ -33,8 +33,8 @@ struct __is_allocator : false_type
 
 template <typename _Alloc>
 struct __is_allocator<_Alloc,
-                      __void_t<typename _Alloc::value_type>,
-                      __void_t<decltype(_CUDA_VSTD::declval<_Alloc&>().allocate(size_t(0)))>> : true_type
+                      void_t<typename _Alloc::value_type>,
+                      void_t<decltype(_CUDA_VSTD::declval<_Alloc&>().allocate(size_t(0)))>> : true_type
 {};
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__type_traits/void_t.h
+++ b/libcudacxx/include/cuda/std/__type_traits/void_t.h
@@ -22,13 +22,11 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011
 template <class...>
 using void_t = void;
-#endif
 
 template <class...>
-using __void_t = void;
+using __void_t _LIBCUDACXX_DEPRECATED = void;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/variant
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/variant
@@ -1366,7 +1366,7 @@ struct __narrowing_check
   {};
 
   template <class _Dest, class _Source>
-  struct __narrowing_check_impl<_Dest, _Source, __void_t<decltype(_Dest{_CUDA_VSTD::declval<_Source>()})>>
+  struct __narrowing_check_impl<_Dest, _Source, void_t<decltype(_Dest{_CUDA_VSTD::declval<_Source>()})>>
   {
     using type = __type_identity<_Dest>;
   };

--- a/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.constructor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/stream_ref/stream_ref.constructor.pass.cpp
@@ -17,15 +17,12 @@ static_assert(cuda::std::is_default_constructible<cuda::stream_ref>::value, "");
 static_assert(!cuda::std::is_constructible<cuda::stream_ref, int>::value, "");
 static_assert(!cuda::std::is_constructible<cuda::stream_ref, cuda::std::nullptr_t>::value, "");
 
-template <class...>
-using void_t = void;
-
 #if TEST_STD_VER < 2014
 template <class T, class = void>
 struct has_value_type : cuda::std::false_type
 {};
 template <class T>
-struct has_value_type<T, void_t<typename T::value_type>> : cuda::std::true_type
+struct has_value_type<T, cuda::std::void_t<typename T::value_type>> : cuda::std::true_type
 {};
 static_assert(has_value_type<cuda::stream_ref>::value, "");
 #else
@@ -33,7 +30,7 @@ template <class T, class = void>
 constexpr bool has_value_type = false;
 
 template <class T>
-constexpr bool has_value_type_v<T, void_t<typename T::value_type>> = true;
+constexpr bool has_value_type_v<T, cuda::std::void_t<typename T::value_type>> = true;
 static_assert(has_value_type<cuda::stream_ref>, "");
 #endif
 

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary.prop.query/void_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary.prop.query/void_t.pass.cpp
@@ -10,7 +10,7 @@
 
 // void_t
 
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03
 
 // XFAIL: gcc-5.1, gcc-5.2
 

--- a/thrust/thrust/detail/functional/operators/operator_adaptors.h
+++ b/thrust/thrust/detail/functional/operators/operator_adaptors.h
@@ -29,7 +29,6 @@
 #include <thrust/detail/type_deduction.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/tuple.h>
-#include <thrust/type_traits/void_t.h>
 
 #include <type_traits>
 

--- a/thrust/thrust/detail/type_traits/result_of_adaptable_function.h
+++ b/thrust/thrust/detail/type_traits/result_of_adaptable_function.h
@@ -28,6 +28,8 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/detail/type_traits/function_traits.h>
 
+#include <cuda/std/__type_traits/void_t.h>
+
 #include <type_traits>
 
 THRUST_NAMESPACE_BEGIN
@@ -54,7 +56,7 @@ public:
 
 // specialization for invocations which define result_type
 template <typename Functor, typename... ArgTypes>
-struct result_of_adaptable_function<Functor(ArgTypes...), ::cuda::std::__void_t<typename Functor::result_type>>
+struct result_of_adaptable_function<Functor(ArgTypes...), ::cuda::std::void_t<typename Functor::result_type>>
 {
   using type = typename Functor::result_type;
 };

--- a/thrust/thrust/iterator/detail/iterator_traits.inl
+++ b/thrust/thrust/iterator/detail/iterator_traits.inl
@@ -29,7 +29,8 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/iterator/detail/iterator_category_to_traversal.h>
 #include <thrust/iterator/iterator_categories.h>
-#include <thrust/type_traits/void_t.h>
+
+#include <cuda/std/__type_traits/void_t.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -77,7 +78,7 @@ struct iterator_system_impl
 {};
 
 template <typename Iterator>
-struct iterator_system_impl<Iterator, void_t<typename iterator_traits<Iterator>::iterator_category>>
+struct iterator_system_impl<Iterator, ::cuda::std::void_t<typename iterator_traits<Iterator>::iterator_category>>
     : detail::iterator_category_to_system<typename iterator_traits<Iterator>::iterator_category>
 {};
 

--- a/thrust/thrust/iterator/iterator_traits.h
+++ b/thrust/thrust/iterator/iterator_traits.h
@@ -38,7 +38,6 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/type_traits/void_t.h>
 
 #include <iterator>
 

--- a/thrust/thrust/optional.h
+++ b/thrust/thrust/optional.h
@@ -26,6 +26,8 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/swap.h>
 
+#include <cuda/std/__type_traits/void_t.h>
+
 #define THRUST_OPTIONAL_VERSION_MAJOR 0
 #define THRUST_OPTIONAL_VERSION_MINOR 2
 
@@ -167,15 +169,6 @@ _CCCL_HOST_DEVICE constexpr auto invoke(Fn&& f, Args&&... args) noexcept(noexcep
 }
 #endif
 
-// std::void_t from C++17
-template <class...>
-struct voider
-{
-  using type = void;
-};
-template <class... Ts>
-using void_t = typename voider<Ts...>::type;
-
 // Trait for checking if a type is a thrust::optional
 template <class T>
 struct is_optional_impl : std::false_type
@@ -197,7 +190,8 @@ using get_map_return = optional<fixup_void<invoke_result_t<F, U>>>;
 template <class F, class = void, class... U>
 struct returns_void_impl;
 template <class F, class... U>
-struct returns_void_impl<F, void_t<invoke_result_t<F, U...>>, U...> : std::is_void<invoke_result_t<F, U...>>
+struct returns_void_impl<F, ::cuda::std::void_t<invoke_result_t<F, U...>>, U...>
+    : std::is_void<invoke_result_t<F, U...>>
 {};
 template <class F, class... U>
 using returns_void = returns_void_impl<F, void, U...>;

--- a/thrust/thrust/system/cuda/detail/core/util.h
+++ b/thrust/thrust/system/cuda/detail/core/util.h
@@ -224,7 +224,7 @@ struct temp_storage_size
 };
 
 template <class Agent>
-struct temp_storage_size<Agent, ::cuda::std::__void_t<typename Agent::TempStorage>>
+struct temp_storage_size<Agent, ::cuda::std::void_t<typename Agent::TempStorage>>
 {
   static constexpr std::size_t value = sizeof(typename Agent::TempStorage);
 };

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.inl
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.inl
@@ -35,7 +35,8 @@
 #include <thrust/system/tbb/detail/execution_policy.h>
 #include <thrust/system/tbb/detail/reduce_by_key.h>
 #include <thrust/system/tbb/detail/reduce_intervals.h>
-#include <thrust/type_traits/void_t.h>
+
+#include <cuda/std/__type_traits/void_t.h>
 
 #include <cassert>
 #include <thread>
@@ -66,7 +67,7 @@ struct partial_sum_type
 };
 
 template <typename InputIterator, typename BinaryFunction>
-struct partial_sum_type<InputIterator, BinaryFunction, void_t<typename BinaryFunction::result_type>>
+struct partial_sum_type<InputIterator, BinaryFunction, ::cuda::std::void_t<typename BinaryFunction::result_type>>
 {
   using type = typename BinaryFunction::result_type;
 };

--- a/thrust/thrust/type_traits/void_t.h
+++ b/thrust/thrust/type_traits/void_t.h
@@ -46,9 +46,8 @@ struct THRUST_DEPRECATED_BECAUSE("Use ::cuda::std::void_t") voider
   using type = void;
 };
 
-// TODO(bgruber): deprecate and replace by cuda::std::void_t eventually
 template <typename... Ts>
-using void_t = void;
+using void_t THRUST_DEPRECATED_BECAUSE("Use ::cuda::std::void_t") = void;
 
 /*! \} // type traits
  */


### PR DESCRIPTION
* Make libcu++ void_t available in C++11
* Replace uses of CUB and Thrust's void_t by libcu++
* Deprecate Thrust's void_t
* Deprecate libcu++'s __void_t

- [x] Depends on (includes) #1962. Please merge this one first.