### PR TITLE
Rename and refactor transform_iterator_base

### DIFF
--- a/thrust/thrust/iterator/detail/transform_iterator.inl
+++ b/thrust/thrust/iterator/detail/transform_iterator.inl
@@ -25,11 +25,9 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/detail/type_traits.h>
 #include <thrust/detail/type_traits/result_of_adaptable_function.h>
 #include <thrust/iterator/iterator_adaptor.h>
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/iterator/transform_iterator.h>
 #include <thrust/type_traits/remove_cvref.h>
 
 THRUST_NAMESPACE_BEGIN
@@ -40,27 +38,29 @@ class transform_iterator;
 namespace detail
 {
 
-// Compute the iterator_adaptor instantiation to be used for transform_iterator
+// Type function to compute the iterator_adaptor instantiation to be used for transform_iterator
 template <class UnaryFunc, class Iterator, class Reference, class Value>
-struct transform_iterator_base
+struct make_transform_iterator_base
 {
 private:
-  // By default, dereferencing the iterator yields the same as the function.
-  using reference = typename thrust::detail::ia_dflt_help<
-    Reference,
-    thrust::detail::result_of_adaptable_function<UnaryFunc(typename thrust::iterator_value<Iterator>::type)>>::type;
+  // FIXME(bgruber): the next line should be correct, but thrust::identity<T> lies and advertises a ::return_type of T,
+  // while its operator() returns const T& (which __invoke_of correctly detects), which causes transform_iterator to
+  // crash during dereferencing.
+  // using wrapped_func_ret_t = ::cuda::std::__invoke_of<UnaryFunc, iterator_value_t<Iterator>>;
+  using wrapped_func_ret_t = result_of_adaptable_function<UnaryFunc(iterator_value_t<Iterator>)>;
 
-  // To get the default for Value: remove cvref on the result type.
-  using value_type = typename thrust::detail::ia_dflt_help<Value, thrust::remove_cvref<reference>>::type;
+  // By default, dereferencing the iterator yields the same as the function.
+  using reference  = typename ia_dflt_help<Reference, wrapped_func_ret_t>::type;
+  using value_type = typename ia_dflt_help<Value, remove_cvref<reference>>::type;
 
 public:
   using type =
-    thrust::iterator_adaptor<transform_iterator<UnaryFunc, Iterator, Reference, Value>,
-                             Iterator,
-                             value_type,
-                             thrust::use_default,
-                             typename thrust::iterator_traits<Iterator>::iterator_category,
-                             reference>;
+    iterator_adaptor<transform_iterator<UnaryFunc, Iterator, Reference, Value>,
+                     Iterator,
+                     value_type,
+                     use_default,
+                     typename iterator_traits<Iterator>::iterator_category,
+                     reference>;
 };
 
 } // namespace detail

--- a/thrust/thrust/iterator/transform_iterator.h
+++ b/thrust/thrust/iterator/transform_iterator.h
@@ -194,13 +194,14 @@ THRUST_NAMESPACE_BEGIN
  */
 template <class AdaptableUnaryFunction, class Iterator, class Reference = use_default, class Value = use_default>
 class transform_iterator
-    : public detail::transform_iterator_base<AdaptableUnaryFunction, Iterator, Reference, Value>::type
+    : public detail::make_transform_iterator_base<AdaptableUnaryFunction, Iterator, Reference, Value>::type
 {
   /*! \cond
    */
 
 public:
-  using super_t = typename detail::transform_iterator_base<AdaptableUnaryFunction, Iterator, Reference, Value>::type;
+  using super_t =
+    typename detail::make_transform_iterator_base<AdaptableUnaryFunction, Iterator, Reference, Value>::type;
 
   friend class thrust::iterator_core_access;
   /*! \endcond


### PR DESCRIPTION
It turns out `transform_iterator_base` is not a base, but just a type function producing the base, so I renamed it; plus a few simplifications of the class (notable removing the dependence on `result_of_adaptable_function`).