### PR TITLE
Spell value initialization where used in thrust vectors

### DIFF
--- a/thrust/thrust/detail/allocator/value_initialize_range.h
+++ b/thrust/thrust/detail/allocator/value_initialize_range.h
@@ -31,9 +31,9 @@ namespace detail
 {
 
 template <typename Allocator, typename Pointer, typename Size>
-_CCCL_HOST_DEVICE inline void default_construct_range(Allocator& a, Pointer p, Size n);
+_CCCL_HOST_DEVICE inline void value_initialize_range(Allocator& a, Pointer p, Size n);
 
 } // namespace detail
 THRUST_NAMESPACE_END
 
-#include <thrust/detail/allocator/default_construct_range.inl>
+#include <thrust/detail/allocator/value_initialize_range.inl>

--- a/thrust/thrust/detail/allocator/value_initialize_range.inl
+++ b/thrust/thrust/detail/allocator/value_initialize_range.inl
@@ -73,7 +73,7 @@ struct needs_default_construct_via_allocator<std::allocator<U>, T>
 template <typename Allocator, typename Pointer, typename Size>
 _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<
   needs_default_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>::value>
-default_construct_range(Allocator& a, Pointer p, Size n)
+value_initialize_range(Allocator& a, Pointer p, Size n)
 {
   thrust::for_each_n(allocator_system<Allocator>::get(a), p, n, construct1_via_allocator<Allocator>(a));
 }
@@ -81,7 +81,7 @@ default_construct_range(Allocator& a, Pointer p, Size n)
 template <typename Allocator, typename Pointer, typename Size>
 _CCCL_HOST_DEVICE
 typename disable_if<needs_default_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>::value>::type
-default_construct_range(Allocator& a, Pointer p, Size n)
+value_initialize_range(Allocator& a, Pointer p, Size n)
 {
   thrust::uninitialized_fill_n(allocator_system<Allocator>::get(a), p, n, typename pointer_element<Pointer>::type());
 }
@@ -89,9 +89,9 @@ default_construct_range(Allocator& a, Pointer p, Size n)
 } // namespace allocator_traits_detail
 
 template <typename Allocator, typename Pointer, typename Size>
-_CCCL_HOST_DEVICE void default_construct_range(Allocator& a, Pointer p, Size n)
+_CCCL_HOST_DEVICE void value_initialize_range(Allocator& a, Pointer p, Size n)
 {
-  return allocator_traits_detail::default_construct_range(a, p, n);
+  return allocator_traits_detail::value_initialize_range(a, p, n);
 }
 
 } // namespace detail

--- a/thrust/thrust/detail/contiguous_storage.h
+++ b/thrust/thrust/detail/contiguous_storage.h
@@ -102,7 +102,7 @@ public:
 
   _CCCL_HOST_DEVICE void swap(contiguous_storage& x);
 
-  _CCCL_HOST_DEVICE void default_construct_n(iterator first, size_type n);
+  _CCCL_HOST_DEVICE void value_initialize_n(iterator first, size_type n);
 
   _CCCL_HOST_DEVICE void uninitialized_fill_n(iterator first, size_type n, const value_type& value);
 

--- a/thrust/thrust/detail/contiguous_storage.inl
+++ b/thrust/thrust/detail/contiguous_storage.inl
@@ -27,9 +27,9 @@
 #endif // no system header
 #include <thrust/detail/allocator/allocator_traits.h>
 #include <thrust/detail/allocator/copy_construct_range.h>
-#include <thrust/detail/allocator/default_construct_range.h>
 #include <thrust/detail/allocator/destroy_range.h>
 #include <thrust/detail/allocator/fill_construct_range.h>
+#include <thrust/detail/allocator/value_initialize_range.h>
 #include <thrust/detail/contiguous_storage.h>
 #include <thrust/detail/swap.h>
 
@@ -203,10 +203,10 @@ _CCCL_HOST_DEVICE void contiguous_storage<T, Alloc>::swap(contiguous_storage& x)
 } // end contiguous_storage::swap()
 
 template <typename T, typename Alloc>
-_CCCL_HOST_DEVICE void contiguous_storage<T, Alloc>::default_construct_n(iterator first, size_type n)
+_CCCL_HOST_DEVICE void contiguous_storage<T, Alloc>::value_initialize_n(iterator first, size_type n)
 {
-  default_construct_range(m_allocator, first.base(), n);
-} // end contiguous_storage::default_construct_n()
+  value_initialize_range(m_allocator, first.base(), n);
+} // end contiguous_storage::value_initialize_n()
 
 template <typename T, typename Alloc>
 _CCCL_HOST_DEVICE void

--- a/thrust/thrust/detail/temporary_array.inl
+++ b/thrust/thrust/detail/temporary_array.inl
@@ -51,7 +51,7 @@ _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<avoid_initialization<T>::value> con
 template <typename T, typename TemporaryArray, typename Size>
 _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!avoid_initialization<T>::value> construct_values(TemporaryArray& a, Size n)
 {
-  a.default_construct_n(a.begin(), n);
+  a.value_initialize_n(a.begin(), n);
 } // end construct_values()
 
 } // namespace temporary_array_detail

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -77,14 +77,12 @@ public:
    */
   explicit vector_base(const Alloc& alloc);
 
-  /*! This constructor creates a vector_base with default-constructed
-   *  elements.
+  /*! This constructor creates a vector_base with value-initialized elements.
    *  \param n The number of elements to create.
    */
   explicit vector_base(size_type n);
 
-  /*! This constructor creates a vector_base with default-constructed
-   *  elements.
+  /*! This constructor creates a vector_base with value-initialized elements.
    *  \param n The number of elements to create.
    *  \param alloc The allocator to use by this vector_base.
    */
@@ -210,7 +208,7 @@ public:
    *  This method will resize this vector_base to the specified number of
    *  elements. If the number is smaller than this vector_base's current
    *  size this vector_base is truncated, otherwise this vector_base is
-   *  extended and new elements are default constructed.
+   *  extended and new elements are value initialized.
    */
   void resize(size_type new_size);
 
@@ -499,7 +497,7 @@ private:
   template <typename ForwardIterator>
   void range_init(ForwardIterator first, ForwardIterator last, thrust::random_access_traversal_tag);
 
-  void default_init(size_type n);
+  void value_init(size_type n);
 
   void fill_init(size_type n, const T& x);
 
@@ -512,7 +510,7 @@ private:
   template <typename InputIteratorOrIntegralType>
   void insert_dispatch(iterator position, InputIteratorOrIntegralType n, InputIteratorOrIntegralType x, true_type);
 
-  // this method appends n default-constructed elements at the end
+  // this method appends n value-initialized elements at the end
   void append(size_type n);
 
   // this method performs insertion from a fill value

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -64,7 +64,7 @@ vector_base<T, Alloc>::vector_base(size_type n)
     : m_storage()
     , m_size(0)
 {
-  default_init(n);
+  value_init(n);
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
@@ -72,7 +72,7 @@ vector_base<T, Alloc>::vector_base(size_type n, const Alloc& alloc)
     : m_storage(alloc)
     , m_size(0)
 {
-  default_init(n);
+  value_init(n);
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
@@ -212,16 +212,16 @@ void vector_base<T, Alloc>::init_dispatch(IteratorOrIntegralType n, IteratorOrIn
 } // end vector_base::init_dispatch()
 
 template <typename T, typename Alloc>
-void vector_base<T, Alloc>::default_init(size_type n)
+void vector_base<T, Alloc>::value_init(size_type n)
 {
   if (n > 0)
   {
     m_storage.allocate(n);
     m_size = n;
 
-    m_storage.default_construct_n(begin(), size());
+    m_storage.value_initialize_n(begin(), size());
   } // end if
-} // end vector_base::default_init()
+} // end vector_base::value_init()
 
 template <typename T, typename Alloc>
 void vector_base<T, Alloc>::fill_init(size_type n, const T& x)
@@ -792,7 +792,7 @@ void vector_base<T, Alloc>::append(size_type n)
       // we've got room for all of them
 
       // default construct new elements at the end of the vector
-      m_storage.default_construct_n(end(), n);
+      m_storage.value_initialize_n(end(), n);
 
       // extend the size
       m_size += n;
@@ -822,7 +822,7 @@ void vector_base<T, Alloc>::append(size_type n)
         new_end = m_storage.uninitialized_copy(begin(), end(), new_storage.begin());
 
         // construct new elements to insert
-        new_storage.default_construct_n(new_end, n);
+        new_storage.value_initialize_n(new_end, n);
         new_end += n;
       } // end try
       catch (...)

--- a/thrust/thrust/device_reference.h
+++ b/thrust/thrust/device_reference.h
@@ -298,7 +298,7 @@ public:
   }
 
 // declare these members for the purpose of Doxygenating them
-// they actually exist in a derived-from class
+// they actually exist in a base class
 #if 0
     /*! Address-of operator returns a \p device_ptr pointing to the object
      *  referenced by this \p device_reference. It does not return the
@@ -960,7 +960,7 @@ _CCCL_HOST_DEVICE void swap(device_reference<T>& x, device_reference<T>& y)
 }
 
 // declare these methods for the purpose of Doxygenating them
-// they actually are defined for a derived-from class
+// they actually are defined for a base class
 #if THRUST_DOXYGEN
 /*! Writes to an output stream the value of a \p device_reference.
  *

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -272,7 +272,7 @@ public:
   {}
 
 // declare these members for the purpose of Doxygenating them
-// they actually exist in a derived-from class
+// they actually exist in a base class
 #if 0
     /*! \brief Resizes this vector to the specified number of elements.
      *  \param new_size Number of elements this vector should contain.

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -274,7 +274,7 @@ public:
   {}
 
 // declare these members for the purpose of Doxygenating them
-// they actually exist in a derived-from class
+// they actually exist in a base class
 #if 0
     /*! \brief Resizes this vector to the specified number of elements.
      *  \param new_size Number of elements this vector should contain.


### PR DESCRIPTION
Thrust vectors use the term "default initialization" in a few places while they actually mean "value initialization". This PR corrects the misspelling.