### PR TITLE
Proclaim pair and tuple trivially relocatable

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -1467,6 +1467,9 @@ inline namespace literals
 inline namespace complex_literals
 {
 #  ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
+// NOTE: if you get a warning from GCC <7 here that "literal operator suffixes not preceded by ‘_’ are reserved for
+// future standardization" then we are sorry. The warning was implemented before GCC 7, but can only be disabled since
+// GCC 7. See also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69523
 _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_INLINE_VISIBILITY constexpr complex<long double> operator""il(long double __im)
 {
   return {0.0l, __im};

--- a/thrust/thrust/pair.h
+++ b/thrust/thrust/pair.h
@@ -30,6 +30,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <thrust/type_traits/is_trivially_relocatable.h>
+
+#include <cuda/std/__type_traits/conjunction.h>
 #include <cuda/std/utility>
 
 THRUST_NAMESPACE_BEGIN
@@ -116,6 +119,11 @@ make_pair(T1&& t1, T2&& t2)
 }
 
 using _CUDA_VSTD::get;
+
+template <typename T, typename U>
+struct proclaim_trivially_relocatable<pair<T, U>>
+    : ::cuda::std::conjunction<is_trivially_relocatable<T>, is_trivially_relocatable<U>>
+{};
 
 /*! \endcond
  */

--- a/thrust/thrust/tuple.h
+++ b/thrust/thrust/tuple.h
@@ -39,6 +39,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <thrust/type_traits/is_trivially_relocatable.h>
+
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
@@ -231,6 +233,10 @@ inline _CCCL_HOST_DEVICE tuple<Ts&...> tie(Ts&... ts) noexcept
 }
 
 using _CUDA_VSTD::get;
+
+template <typename... Ts>
+struct proclaim_trivially_relocatable<tuple<Ts...>> : ::cuda::std::conjunction<is_trivially_relocatable<Ts>...>
+{};
 
 /*! \endcond
  */

--- a/thrust/thrust/type_traits/is_trivially_relocatable.h
+++ b/thrust/thrust/type_traits/is_trivially_relocatable.h
@@ -36,6 +36,10 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/type_traits/is_contiguous_iterator.h>
 
+#include <cuda/std/__fwd/pair.h>
+#include <cuda/std/__fwd/tuple.h>
+#include <cuda/std/__type_traits/conjunction.h>
+
 #include <type_traits>
 
 THRUST_NAMESPACE_BEGIN
@@ -284,6 +288,18 @@ THRUST_PROCLAIM_TRIVIALLY_RELOCATABLE(double2)
 THRUST_PROCLAIM_TRIVIALLY_RELOCATABLE(double3)
 THRUST_PROCLAIM_TRIVIALLY_RELOCATABLE(double4)
 #endif
+
+THRUST_NAMESPACE_BEGIN
+template <typename T, typename U>
+struct proclaim_trivially_relocatable<::cuda::std::pair<T, U>>
+    : ::cuda::std::conjunction<is_trivially_relocatable<T>, is_trivially_relocatable<U>>
+{};
+
+template <typename... Ts>
+struct proclaim_trivially_relocatable<::cuda::std::tuple<Ts...>>
+    : ::cuda::std::conjunction<is_trivially_relocatable<Ts>...>
+{};
+THRUST_NAMESPACE_END
 
 /*! \endcond
  */


### PR DESCRIPTION
We check whether a type is trivially relocatable in several places in Thrust to decide whether we can copy a type by means of `memcpy` or `cudaMemcpy`. This PR adds `pair` and `tuple` to those types, when their respective elements are trivially relocatable.

New unit test also covers `complex`.