### PR TITLE
Add github token to nightly workflow-results action.

### DIFF
--- a/.github/workflows/ci-workflow-nightly.yml
+++ b/.github/workflows/ci-workflow-nightly.yml
@@ -133,6 +133,7 @@ jobs:
         id: check-workflow
         uses: ./.github/actions/workflow-results
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
           slack_log: ${{ secrets.SLACK_CHANNEL_CI_LOG }}
           slack_alert: ${{ secrets.SLACK_CHANNEL_CI_ALERT }}


### PR DESCRIPTION
This is needed to fetch the runtime info from the GHA API.

This only modifies the nightly workflow, the PR tests are unaffected:
[skip-matrix][skip-vdc][skip-rapids][skip-docs]