### PR TITLE
experimental wrapper types for `cudaEvent_t` that provide a modern C++ interface.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -117,15 +117,12 @@ IncludeCategories:
   - Regex:           '^<thrust/'
     Priority:            3
     SortPriority:        2
-  - Regex:           '^<cuda/experimental'
-    Priority:            5
-    SortPriority:        4
   - Regex:           '^<cuda/'
     Priority:            4
     SortPriority:        3
   - Regex:           '^<[a-z_]*>$'
-    Priority:            6
-    SortPriority:        5
+    Priority:            5
+    SortPriority:        4
   - Regex:           '^<cuda'
     Priority:            0
     SortPriority:        0

--- a/.clang-format
+++ b/.clang-format
@@ -117,12 +117,15 @@ IncludeCategories:
   - Regex:           '^<thrust/'
     Priority:            3
     SortPriority:        2
+  - Regex:           '^<cuda/experimental'
+    Priority:            5
+    SortPriority:        4
   - Regex:           '^<cuda/'
     Priority:            4
     SortPriority:        3
   - Regex:           '^<[a-z_]*>$'
-    Priority:            5
-    SortPriority:        4
+    Priority:            6
+    SortPriority:        5
   - Regex:           '^<cuda'
     Priority:            0
     SortPriority:        0

--- a/cudax/include/cuda/experimental/__detail/utility.cuh
+++ b/cudax/include/cuda/experimental/__detail/utility.cuh
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_DETAIL_UTILITY_H
+#define __CUDAX_DETAIL_UTILITY_H
+
+namespace cuda::experimental
+{
+struct uninit_t
+{
+  explicit uninit_t() = default;
+};
+
+inline constexpr uninit_t uninit{};
+} // namespace cuda::experimental
+
+#endif // __CUDAX_DETAIL_UTILITY_H

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -28,7 +28,6 @@
 #include <cuda/std/cstddef>
 #include <cuda/std/utility>
 
-// CUDAX headers here
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__event/event_ref.cuh>
 

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -28,29 +28,22 @@
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/cstddef>
 #include <cuda/std/utility>
-#include <cuda/stream_ref>
 
 // CUDAX headers here
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__event/event_ref.cuh>
 
-#include <cassert>
-
 namespace cuda::experimental
 {
 class timed_event;
 
-/**
- * @brief An owning wrapper for an untimed `cudaEvent_t`.
- */
+//! @brief An owning wrapper for an untimed `cudaEvent_t`.
 class event : public event_ref
 {
   friend class timed_event;
 
 public:
-  /**
-   * @brief Flags to use when creating the event.
-   */
+  //! @brief Flags to use when creating the event.
   enum class flags : unsigned int
   {
     none          = cudaEventDefault,
@@ -58,47 +51,37 @@ public:
     interprocess  = cudaEventInterprocess
   };
 
-  /**
-   * @brief Construct a new `event` object with timing disabled.
-   *
-   * @throws cuda_error if the event creation fails.
-   */
+  //! @brief Construct a new `event` object with timing disabled.
+  //!
+  //! @throws cuda_error if the event creation fails.
   event()
       : event(static_cast<unsigned int>(cudaEventDisableTiming))
   {}
 
-  /**
-   * @brief Construct a new `event` object with the specified flags.
-   *
-   * @throws cuda_error if the event creation fails.
-   */
+  //! @brief Construct a new `event` object with the specified flags.
+  //!
+  //! @throws cuda_error if the event creation fails.
   explicit event(flags __flags)
       : event(static_cast<unsigned int>(__flags) | static_cast<unsigned int>(cudaEventDisableTiming))
   {}
 
-  /**
-   * @brief Construct a new `event` object into the moved-from state.
-   *
-   * @post `get()` returns `cudaEvent_t()`.
-   */
+  //! @brief Construct a new `event` object into the moved-from state.
+  //!
+  //! @post `get()` returns `cudaEvent_t()`.
   explicit constexpr event(uninit_t) noexcept {}
 
-  /**
-   * @brief Move-construct a new `event` object
-   *
-   * @param __other
-   *
-   * @post `__other` is in a moved-from state.
-   */
+  //! @brief Move-construct a new `event` object
+  //!
+  //! @param __other
+  //!
+  //! @post `__other` is in a moved-from state.
   constexpr event(event&& __other) noexcept
       : event_ref(_CUDA_VSTD::exchange(__other.__event_, {}))
   {}
 
-  /**
-   * @brief Destroy the `event` object
-   *
-   * @note If the event fails to be destroyed, the error is silently ignored.
-   */
+  //! @brief Destroy the `event` object
+  //!
+  //! @note If the event fails to be destroyed, the error is silently ignored.
   ~event()
   {
     if (__event_ != nullptr)
@@ -107,33 +90,29 @@ public:
     }
   }
 
-  /**
-   * @brief Construct an `event` object from a native `cudaEvent_t` handle.
-   *
-   * @param __evnt The native handle
-   *
-   * @return event The constructed `event` object
-   *
-   * @note The constructed `event` object takes ownership of the native handle.
-   */
+  //! @brief Construct an `event` object from a native `cudaEvent_t` handle.
+  //!
+  //! @param __evnt The native handle
+  //!
+  //! @return event The constructed `event` object
+  //!
+  //! @note The constructed `event` object takes ownership of the native handle.
   _CCCL_NODISCARD static event from_native_handle(::cudaEvent_t __evnt) noexcept
   {
     return event(__evnt);
   }
 
-  /// Disallow construction from an `int`, e.g., `0`.
+  // Disallow construction from an `int`, e.g., `0`.
   static event from_native_handle(int) = delete;
 
-  /// Disallow construction from `nullptr`.
+  // Disallow construction from `nullptr`.
   static event from_native_handle(_CUDA_VSTD::nullptr_t) = delete;
 
-  /**
-   * @brief Retrieve the native `cudaEvent_t` handle and give up ownership.
-   *
-   * @return cudaEvent_t The native handle being held by the `event` object.
-   *
-   * @post The event object is in a moved-from state.
-   */
+  //! @brief Retrieve the native `cudaEvent_t` handle and give up ownership.
+  //!
+  //! @return cudaEvent_t The native handle being held by the `event` object.
+  //!
+  //! @post The event object is in a moved-from state.
   _CCCL_NODISCARD constexpr ::cudaEvent_t release() noexcept
   {
     return _CUDA_VSTD::exchange(__event_, {});

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -110,15 +110,15 @@ public:
   /**
    * @brief Construct an `event` object from a native `cudaEvent_t` handle.
    *
-   * @param __event The native handle
+   * @param __evnt The native handle
    *
    * @return event The constructed `event` object
    *
    * @note The constructed `event` object takes ownership of the native handle.
    */
-  _CCCL_NODISCARD static event from_native_handle(::cudaEvent_t __event) noexcept
+  _CCCL_NODISCARD static event from_native_handle(::cudaEvent_t __evnt) noexcept
   {
-    return event(__event);
+    return event(__evnt);
   }
 
   /// Disallow construction from an `int`, e.g., `0`.
@@ -147,8 +147,8 @@ public:
 private:
   // Use `event::from_native_handle(e)` to construct an owning `event`
   // object from a `cudaEvent_t` handle.
-  explicit constexpr event(::cudaEvent_t __event) noexcept
-      : event_ref(__event)
+  explicit constexpr event(::cudaEvent_t __evnt) noexcept
+      : event_ref(__evnt)
   {}
 
   explicit event(unsigned int __flags)

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -16,8 +16,6 @@
 
 #include <cuda/std/detail/__config>
 
-#include "cuda/std/detail/libcxx/include/__config"
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -1,0 +1,162 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX_EVENT_DETAIL_H
+#define _CUDAX_EVENT_DETAIL_H
+
+#include <cuda_runtime_api.h>
+// cuda_runtime_api needs to come first
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/std/__exception/cuda_error.h>
+#include <cuda/std/cstddef>
+#include <cuda/std/utility>
+#include <cuda/stream_ref>
+
+// CUDAX headers here
+#include <cuda/experimental/__detail/utility.cuh>
+#include <cuda/experimental/__event/event_ref.cuh>
+
+#include <cassert>
+
+namespace cuda::experimental
+{
+class timed_event;
+
+/**
+ * @brief An owning wrapper for an untimed `cudaEvent_t`.
+ */
+class event : public event_ref
+{
+  friend class timed_event;
+
+public:
+  /**
+   * @brief Flags to use when creating the event.
+   */
+  enum class flags : unsigned int
+  {
+    none          = cudaEventDefault,
+    blocking_sync = cudaEventBlockingSync,
+    interprocess  = cudaEventInterprocess
+  };
+
+  /**
+   * @brief Construct a new `event` object with timing disabled.
+   *
+   * @throws cuda_error if the event creation fails.
+   */
+  event()
+      : event(static_cast<unsigned int>(cudaEventDisableTiming))
+  {}
+
+  /**
+   * @brief Construct a new `event` object with the specified flags.
+   *
+   * @throws cuda_error if the event creation fails.
+   */
+  explicit event(flags __flags)
+      : event(static_cast<unsigned int>(__flags) | static_cast<unsigned int>(cudaEventDisableTiming))
+  {}
+
+  /**
+   * @brief Construct a new `event` object into the moved-from state.
+   *
+   * @post `get()` returns `cudaEvent_t()`.
+   */
+  explicit constexpr event(uninit_t) noexcept {}
+
+  /**
+   * @brief Move-construct a new `event` object
+   *
+   * @param __other
+   *
+   * @post `__other` is in a moved-from state.
+   */
+  constexpr event(event&& __other) noexcept
+      : event_ref(_CUDA_VSTD::exchange(__other.__event_, {}))
+  {}
+
+  /**
+   * @brief Destroy the `event` object
+   *
+   * @note If the event fails to be destroyed, the error is silently ignored.
+   */
+  ~event()
+  {
+    if (__event_ != nullptr)
+    {
+      [[maybe_unused]] auto __status = ::cudaEventDestroy(__event_);
+    }
+  }
+
+  /**
+   * @brief Construct an `event` object from a native `cudaEvent_t` handle.
+   *
+   * @param __event The native handle
+   *
+   * @return event The constructed `event` object
+   *
+   * @note The constructed `event` object takes ownership of the native handle.
+   */
+  _CCCL_NODISCARD static event from_native_handle(::cudaEvent_t __event) noexcept
+  {
+    return event(__event);
+  }
+
+  /// Disallow construction from an `int`, e.g., `0`.
+  static event from_native_handle(int) = delete;
+
+  /// Disallow construction from `nullptr`.
+  static event from_native_handle(_CUDA_VSTD::nullptr_t) = delete;
+
+  /**
+   * @brief Retrieve the native `cudaEvent_t` handle and give up ownership.
+   *
+   * @return cudaEvent_t The native handle being held by the `event` object.
+   *
+   * @post The event object is in a moved-from state.
+   */
+  _CCCL_NODISCARD constexpr ::cudaEvent_t release() noexcept
+  {
+    return _CUDA_VSTD::exchange(__event_, {});
+  }
+
+  _CCCL_NODISCARD_FRIEND constexpr flags operator|(flags __lhs, flags __rhs) noexcept
+  {
+    return static_cast<flags>(static_cast<unsigned int>(__lhs) | static_cast<unsigned int>(__rhs));
+  }
+
+private:
+  // Use `event::from_native_handle(e)` to construct an owning `event`
+  // object from a `cudaEvent_t` handle.
+  explicit constexpr event(::cudaEvent_t __event) noexcept
+      : event_ref(__event)
+  {}
+
+  explicit event(unsigned int __flags)
+  {
+    _CCCL_TRY_CUDA_API(
+      ::cudaEventCreateWithFlags, "Failed to create CUDA event", &__event_, static_cast<unsigned int>(__flags));
+  }
+};
+} // namespace cuda::experimental
+
+#endif // _CUDAX_EVENT_DETAIL_H

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -27,7 +27,6 @@
 #endif // no system header
 
 #include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/cstddef>
 #include <cuda/std/utility>
 

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -11,6 +11,44 @@
 #ifndef _CUDAX_EVENT_DETAIL_H
 #define _CUDAX_EVENT_DETAIL_H
 
+/*
+    event synopsis
+namespace cuda::experimental {
+class event : public event_ref {
+public:
+    enum class flags : unsigned int { none, blocking_sync, interprocess };
+
+    event();
+    event(flags);
+    event(uninit_t) noexcept;
+    event(event&&) noexcept;
+    ~event();
+
+    [[nodiscard]] static event from_native_handle(cudaEvent_t) noexcept;
+    static event from_native_handle(int) = delete;
+    static event from_native_handle(nullptr_t) = delete;
+
+    [[nodiscard]] cudaEvent_t release() noexcept;
+
+    [[nodiscard]] friend flags operator|(flags, flags) noexcept;
+
+    // From event_ref:
+    using value_type = cudaEvent_t;
+
+    void record(stream_ref) const;
+
+    void wait(stream_ref) const;
+
+    [[nodiscard]] cudaEvent_t get() const noexcept;
+
+    [[nodiscard]] explicit operator bool() const noexcept;
+
+    [[nodiscard]] friend bool operator==(event_ref, event_ref);
+    [[nodiscard]] friend bool operator!=(event_ref, event_ref);
+};
+}  // cuda::experimenal
+*/
+
 #include <cuda_runtime_api.h>
 // cuda_runtime_api needs to come first
 
@@ -88,6 +126,17 @@ public:
     {
       [[maybe_unused]] auto __status = ::cudaEventDestroy(__event_);
     }
+  }
+
+  //! @brief Move-assign an `event` object
+  //!
+  //! @param __other
+  //!
+  //! @post `__other` is in a moved-from state.
+  constexpr event& operator=(event&& __other) noexcept
+  {
+    __event_ = _CUDA_VSTD::exchange(__other.__event_, {});
+    return *this;
   }
 
   //! @brief Construct an `event` object from a native `cudaEvent_t` handle.

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -25,7 +25,6 @@
 #endif // no system header
 
 #include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/cassert>
 #include <cuda/std/cstddef>
 #include <cuda/std/utility>

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -11,6 +11,36 @@
 #ifndef _CUDAX_EVENT_REF_DETAIL_H
 #define _CUDAX_EVENT_REF_DETAIL_H
 
+/*
+    event_ref synopsis
+namespace cuda::experimental {
+class event_ref {
+public:
+    using value_type = cudaEvent_t;
+
+    event_ref() = default;
+    event_ref(cudaEvent_t event_) noexcept : event(event_) {}
+
+    event_ref(int) = delete;
+    event_ref(nullptr_t) = delete;
+
+    void record(stream_ref) const;
+
+    void wait(stream_ref) const;
+
+    [[nodiscard]] cudaEvent_t get() const noexcept;
+
+    [[nodiscard]] explicit operator bool() const noexcept;
+
+    [[nodiscard]] friend bool operator==(event_ref, event_ref);
+    [[nodiscard]] friend bool operator!=(event_ref, event_ref);
+
+private:
+    cudaEvent_t event{}; // exposition only
+};
+}  // cuda::experimenal
+*/
+
 #include <cuda_runtime_api.h>
 // cuda_runtime_api needs to come first
 
@@ -68,13 +98,13 @@ public:
 
   /// Disallow construction from `nullptr`.
   event_ref(_CUDA_VSTD::nullptr_t) = delete;
+
   //! @brief Records an event on the specified stream
   //!
   //! @param __stream
   //!
   //! @throws cuda_error if the event record fails
-
-  void record(stream_ref __stream)
+  void record(stream_ref __stream) const
   {
     assert(__event_ != nullptr);
     assert(__stream.get() != nullptr);

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -18,7 +18,6 @@ class event_ref {
 public:
     using value_type = cudaEvent_t;
 
-    event_ref() = default;
     event_ref(cudaEvent_t event_) noexcept : event(event_) {}
 
     event_ref(int) = delete;
@@ -78,9 +77,6 @@ private:
 public:
   using value_type = ::cudaEvent_t;
 
-  //! @brief Construct a new `event_ref` that does refer to an event.
-  event_ref() = default;
-
   //! @brief Construct a new `event_ref` object from a `cudaEvent_t`
   //!
   //! This constructor provides an implicit conversion from `cudaEvent_t`
@@ -129,6 +125,14 @@ public:
   _CCCL_NODISCARD constexpr ::cudaEvent_t get() const noexcept
   {
     return __event_;
+  }
+
+  //! @brief Checks if the `event_ref` is valid
+  //!
+  //! @return true if the `event_ref` is valid, false otherwise.
+  _CCCL_NODISCARD explicit constexpr operator bool() const noexcept
+  {
+    return __event_ != nullptr;
   }
 
   //! @brief Compares two `event_ref`s for equality

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -11,35 +11,6 @@
 #ifndef _CUDAX_EVENT_REF_DETAIL_H
 #define _CUDAX_EVENT_REF_DETAIL_H
 
-/*
-    event_ref synopsis
-namespace cuda::experimental {
-class event_ref {
-public:
-    using value_type = cudaEvent_t;
-
-    event_ref(cudaEvent_t event_) noexcept : event(event_) {}
-
-    event_ref(int) = delete;
-    event_ref(nullptr_t) = delete;
-
-    void record(stream_ref) const;
-
-    void wait(stream_ref) const;
-
-    [[nodiscard]] cudaEvent_t get() const noexcept;
-
-    [[nodiscard]] explicit operator bool() const noexcept;
-
-    [[nodiscard]] friend bool operator==(event_ref, event_ref);
-    [[nodiscard]] friend bool operator!=(event_ref, event_ref);
-
-private:
-    cudaEvent_t event{}; // exposition only
-};
-}  // cuda::experimenal
-*/
-
 #include <cuda_runtime_api.h>
 // cuda_runtime_api needs to come first
 
@@ -72,7 +43,7 @@ private:
   friend class event;
   friend class timed_event;
 
-  ::cudaEvent_t __event_{0};
+  ::cudaEvent_t __event_{};
 
 public:
   using value_type = ::cudaEvent_t;

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -1,0 +1,149 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX_EVENT_REF_DETAIL_H
+#define _CUDAX_EVENT_REF_DETAIL_H
+
+#include <cuda_runtime_api.h>
+// cuda_runtime_api needs to come first
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/std/__exception/cuda_error.h>
+#include <cuda/std/cstddef>
+#include <cuda/std/utility>
+#include <cuda/stream_ref>
+
+#include <cassert>
+
+namespace cuda::experimental
+{
+class event;
+class timed_event;
+
+/**
+ * @brief An non-owning wrapper for an untimed `cudaEvent_t`.
+ */
+class event_ref
+{
+private:
+  friend class event;
+  friend class timed_event;
+
+  ::cudaEvent_t __event_{0};
+
+public:
+  using value_type = ::cudaEvent_t;
+
+  /**
+   * @brief Construct a new `event_ref` that does refer to an event.
+   */
+  event_ref() = default;
+
+  /**
+   * @brief Construct a new `event_ref` object from a `cudaEvent_t`
+   *
+   * This constructor provides an implicit conversion from `cudaEvent_t`
+   *
+   * @post `get() == __event`
+   *
+   * @note: It is the callers responsibilty to ensure the `event_ref` does not
+   * outlive the event denoted by the `cudaEvent_t` handle.
+   */
+  constexpr event_ref(::cudaEvent_t __event) noexcept
+      : __event_(__event)
+  {}
+
+  /// Disallow construction from an `int`, e.g., `0`.
+  event_ref(int) = delete;
+
+  /// Disallow construction from `nullptr`.
+  event_ref(_CUDA_VSTD::nullptr_t) = delete;
+
+  /**
+   * @brief Records an event on the specified stream
+   *
+   * @param __stream
+   *
+   * @throws cuda_error if the event record fails
+   */
+  void record(stream_ref __stream)
+  {
+    assert(__event_ != nullptr);
+    assert(__stream.get() != nullptr);
+    _CCCL_TRY_CUDA_API(::cudaEventRecord, "Failed to record CUDA event", __event_, __stream.get());
+  }
+
+  /**
+   * @brief Waits for a CUDA event_ref to complete on the specified stream
+   *
+   * @param __stream The stream to wait on
+   *
+   * @throws cuda_error if the event_ref wait fails
+   */
+  void wait(stream_ref __stream) const
+  {
+    assert(__event_ != nullptr);
+    assert(__stream.get() != nullptr);
+    _CCCL_TRY_CUDA_API(::cudaStreamWaitEvent, "Failed to wait for CUDA event", __stream.get(), __event_);
+  }
+
+  /**
+   * @brief Retrieve the native `cudaEvent_t` handle.
+   *
+   * @return cudaEvent_t The native handle being held by the event_ref object.
+   */
+  _CCCL_NODISCARD constexpr ::cudaEvent_t get() const noexcept
+  {
+    return __event_;
+  }
+
+  /**
+   * @brief Compares two `event_ref`s for equality
+   *
+   * @note Allows comparison with `cudaEvent_t` due to implicit conversion to
+   * `event_ref`.
+   *
+   * @param lhs The first `event_ref` to compare
+   * @param rhs The second `event_ref` to compare
+   * @return true if `lhs` and `rhs` refer to the same `cudaEvent_t` object.
+   */
+  _CCCL_NODISCARD_FRIEND constexpr bool operator==(event_ref __lhs, event_ref __rhs) noexcept
+  {
+    return __lhs.__event_ == __rhs.__event_;
+  }
+
+  /**
+   * @brief Compares two `event_ref`s for inequality
+   *
+   * @note Allows comparison with `cudaEvent_t` due to implicit conversion to
+   * `event_ref`.
+   *
+   * @param lhs The first `event_ref` to compare
+   * @param rhs The second `event_ref` to compare
+   * @return true if `lhs` and `rhs` refer to different `cudaEvent_t` objects.
+   */
+  _CCCL_NODISCARD_FRIEND constexpr bool operator!=(event_ref __lhs, event_ref __rhs) noexcept
+  {
+    return __lhs.__event_ != __rhs.__event_;
+  }
+};
+} // namespace cuda::experimental
+
+#endif // _CUDAX_EVENT_REF_DETAIL_H

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -77,16 +77,14 @@ public:
     _CCCL_TRY_CUDA_API(::cudaEventRecord, "Failed to record CUDA event", __event_, __stream.get());
   }
 
-  //! @brief Waits for a CUDA event_ref to complete on the specified stream
+  //! @brief Waits until all the work in the stream prior to the record of the
+  //!        event has completed.
   //!
-  //! @param __stream The stream to wait on
-  //!
-  //! @throws cuda_error if the event_ref wait fails
-  void wait(stream_ref __stream) const
+  //! @throws cuda_error if waiting for the event fails
+  void wait() const
   {
     assert(__event_ != nullptr);
-    assert(__stream.get() != nullptr);
-    _CCCL_TRY_CUDA_API(::cudaStreamWaitEvent, "Failed to wait for CUDA event", __stream.get(), __event_);
+    _CCCL_TRY_CUDA_API(::cudaEventSynchronize, "Failed to wait for CUDA event", __event_);
   }
 
   //! @brief Retrieve the native `cudaEvent_t` handle.

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -61,13 +61,13 @@ public:
    *
    * This constructor provides an implicit conversion from `cudaEvent_t`
    *
-   * @post `get() == __event`
+   * @post `get() == __evnt`
    *
    * @note: It is the callers responsibilty to ensure the `event_ref` does not
    * outlive the event denoted by the `cudaEvent_t` handle.
    */
-  constexpr event_ref(::cudaEvent_t __event) noexcept
-      : __event_(__event)
+  constexpr event_ref(::cudaEvent_t __evnt) noexcept
+      : __event_(__evnt)
   {}
 
   /// Disallow construction from an `int`, e.g., `0`.

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -26,20 +26,17 @@
 
 #include <cuda/std/__cuda/api_wrapper.h>
 #include <cuda/std/__exception/cuda_error.h>
+#include <cuda/std/cassert>
 #include <cuda/std/cstddef>
 #include <cuda/std/utility>
 #include <cuda/stream_ref>
-
-#include <cassert>
 
 namespace cuda::experimental
 {
 class event;
 class timed_event;
 
-/**
- * @brief An non-owning wrapper for an untimed `cudaEvent_t`.
- */
+//! @brief An non-owning wrapper for an untimed `cudaEvent_t`.
 class event_ref
 {
 private:
@@ -51,21 +48,17 @@ private:
 public:
   using value_type = ::cudaEvent_t;
 
-  /**
-   * @brief Construct a new `event_ref` that does refer to an event.
-   */
+  //! @brief Construct a new `event_ref` that does refer to an event.
   event_ref() = default;
 
-  /**
-   * @brief Construct a new `event_ref` object from a `cudaEvent_t`
-   *
-   * This constructor provides an implicit conversion from `cudaEvent_t`
-   *
-   * @post `get() == __evnt`
-   *
-   * @note: It is the callers responsibilty to ensure the `event_ref` does not
-   * outlive the event denoted by the `cudaEvent_t` handle.
-   */
+  //! @brief Construct a new `event_ref` object from a `cudaEvent_t`
+  //!
+  //! This constructor provides an implicit conversion from `cudaEvent_t`
+  //!
+  //! @post `get() == __evnt`
+  //!
+  //! @note: It is the callers responsibilty to ensure the `event_ref` does not
+  //! outlive the event denoted by the `cudaEvent_t` handle.
   constexpr event_ref(::cudaEvent_t __evnt) noexcept
       : __event_(__evnt)
   {}
@@ -75,14 +68,12 @@ public:
 
   /// Disallow construction from `nullptr`.
   event_ref(_CUDA_VSTD::nullptr_t) = delete;
+  //! @brief Records an event on the specified stream
+  //!
+  //! @param __stream
+  //!
+  //! @throws cuda_error if the event record fails
 
-  /**
-   * @brief Records an event on the specified stream
-   *
-   * @param __stream
-   *
-   * @throws cuda_error if the event record fails
-   */
   void record(stream_ref __stream)
   {
     assert(__event_ != nullptr);
@@ -90,13 +81,11 @@ public:
     _CCCL_TRY_CUDA_API(::cudaEventRecord, "Failed to record CUDA event", __event_, __stream.get());
   }
 
-  /**
-   * @brief Waits for a CUDA event_ref to complete on the specified stream
-   *
-   * @param __stream The stream to wait on
-   *
-   * @throws cuda_error if the event_ref wait fails
-   */
+  //! @brief Waits for a CUDA event_ref to complete on the specified stream
+  //!
+  //! @param __stream The stream to wait on
+  //!
+  //! @throws cuda_error if the event_ref wait fails
   void wait(stream_ref __stream) const
   {
     assert(__event_ != nullptr);
@@ -104,41 +93,35 @@ public:
     _CCCL_TRY_CUDA_API(::cudaStreamWaitEvent, "Failed to wait for CUDA event", __stream.get(), __event_);
   }
 
-  /**
-   * @brief Retrieve the native `cudaEvent_t` handle.
-   *
-   * @return cudaEvent_t The native handle being held by the event_ref object.
-   */
+  //! @brief Retrieve the native `cudaEvent_t` handle.
+  //!
+  //! @return cudaEvent_t The native handle being held by the event_ref object.
   _CCCL_NODISCARD constexpr ::cudaEvent_t get() const noexcept
   {
     return __event_;
   }
 
-  /**
-   * @brief Compares two `event_ref`s for equality
-   *
-   * @note Allows comparison with `cudaEvent_t` due to implicit conversion to
-   * `event_ref`.
-   *
-   * @param lhs The first `event_ref` to compare
-   * @param rhs The second `event_ref` to compare
-   * @return true if `lhs` and `rhs` refer to the same `cudaEvent_t` object.
-   */
+  //! @brief Compares two `event_ref`s for equality
+  //!
+  //! @note Allows comparison with `cudaEvent_t` due to implicit conversion to
+  //! `event_ref`.
+  //!
+  //! @param lhs The first `event_ref` to compare
+  //! @param rhs The second `event_ref` to compare
+  //! @return true if `lhs` and `rhs` refer to the same `cudaEvent_t` object.
   _CCCL_NODISCARD_FRIEND constexpr bool operator==(event_ref __lhs, event_ref __rhs) noexcept
   {
     return __lhs.__event_ == __rhs.__event_;
   }
 
-  /**
-   * @brief Compares two `event_ref`s for inequality
-   *
-   * @note Allows comparison with `cudaEvent_t` due to implicit conversion to
-   * `event_ref`.
-   *
-   * @param lhs The first `event_ref` to compare
-   * @param rhs The second `event_ref` to compare
-   * @return true if `lhs` and `rhs` refer to different `cudaEvent_t` objects.
-   */
+  //! @brief Compares two `event_ref`s for inequality
+  //!
+  //! @note Allows comparison with `cudaEvent_t` due to implicit conversion to
+  //! `event_ref`.
+  //!
+  //! @param lhs The first `event_ref` to compare
+  //! @param rhs The second `event_ref` to compare
+  //! @return true if `lhs` and `rhs` refer to different `cudaEvent_t` objects.
   _CCCL_NODISCARD_FRIEND constexpr bool operator!=(event_ref __lhs, event_ref __rhs) noexcept
   {
     return __lhs.__event_ != __rhs.__event_;

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -11,48 +11,6 @@
 #ifndef _CUDAX_TIMED_EVENT_DETAIL_H
 #define _CUDAX_TIMED_EVENT_DETAIL_H
 
-/*
-    timed_event synopsis
-namespace cuda::experimental {
-class timed_event : public event {
-public:
-    timed_event(stream_ref, flags = flags::none);
-    timed_event(uninit_t) noexcept;
-    timed_event(timed_event&&) noexcept;
-    ~timed_event();
-    timed_event& operator=(timed_event&&) noexcept;
-
-    [[nodiscard]] static timed_event from_native_handle(cudaEvent_t) noexcept;
-    static timed_event from_native_handle(int) = delete;
-    static timed_event from_native_handle(nullptr_t) = delete;
-
-    [[nodiscard]] friend auto operator-(const timed_event& end, const timed_event& start) noexcept
-        -> cuda::std::chrono::nanoseconds;
-
-    // from event:
-    enum class flags : unsigned int { none, blocking_sync, interprocess };
-
-    [[nodiscard]] cudaEvent_t release() noexcept;
-
-    [[nodiscard]] friend flags operator|(flags, flags) noexcept;
-
-    // From event_ref:
-    using value_type = cudaEvent_t;
-
-    void record(stream_ref) const;
-
-    void wait(stream_ref) const;
-
-    [[nodiscard]] cudaEvent_t get() const noexcept;
-
-    [[nodiscard]] explicit operator bool() const noexcept;
-
-    [[nodiscard]] friend bool operator==(event_ref, event_ref);
-    [[nodiscard]] friend bool operator!=(event_ref, event_ref);
-};
-}  // cuda::experimenal
-*/
-
 #include <cuda_runtime_api.h>
 // cuda_runtime_api needs to come first
 
@@ -97,6 +55,11 @@ public:
   explicit constexpr timed_event(uninit_t) noexcept
       : event(uninit)
   {}
+
+  timed_event(timed_event&&) noexcept            = default;
+  timed_event(const timed_event&)                = delete;
+  timed_event& operator=(timed_event&&) noexcept = default;
+  timed_event& operator=(const timed_event&)     = delete;
 
   //! @brief Construct a `timed_event` object from a native `cudaEvent_t` handle.
   //!

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX_TIMED_EVENT_DETAIL_H
+#define _CUDAX_TIMED_EVENT_DETAIL_H
+
+#include <cuda_runtime_api.h>
+// cuda_runtime_api needs to come first
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/std/__exception/cuda_error.h>
+#include <cuda/std/chrono>
+#include <cuda/std/cstddef>
+#include <cuda/stream_ref>
+
+// CUDAX headers here
+#include <cuda/experimental/__detail/utility.cuh>
+#include <cuda/experimental/__event/event.cuh>
+
+#include <cassert>
+
+namespace cuda::experimental
+{
+/**
+ * @brief An owning wrapper for a `cudaEvent_t` with timing enabled.
+ */
+class timed_event : public event
+{
+public:
+  /**
+   * @brief Construct a new `timed_event` object with timing enabled.
+   *
+   * @throws cuda_error if the event creation fails.
+   */
+  timed_event()
+      : event(static_cast<unsigned int>(cudaEventDefault))
+  {}
+
+  /**
+   * @brief Construct a new `timed_event` object with the specified flags.
+   *
+   * @throws cuda_error if the event creation fails.
+   */
+  explicit timed_event(flags __flags)
+      : event(static_cast<unsigned int>(__flags))
+  {}
+
+  /**
+   * @brief Construct a new `timed_event` object into the moved-from state.
+   *
+   * @post `get()` returns `cudaEvent_t()`.
+   */
+  explicit constexpr timed_event(uninit_t) noexcept
+      : event(uninit)
+  {}
+
+  /**
+   * @brief Construct a `timed_event` object from a native `cudaEvent_t` handle.
+   *
+   * @param __event The native handle
+   *
+   * @return timed_event The constructed `timed_event` object
+   *
+   * @note The constructed `timed_event` object takes ownership of the native handle.
+   */
+  _CCCL_NODISCARD static timed_event from_native_handle(::cudaEvent_t __event) noexcept
+  {
+    return timed_event(__event);
+  }
+
+  /// Disallow construction from an `int`, e.g., `0`.
+  static timed_event from_native_handle(int) = delete;
+
+  /// Disallow construction from `nullptr`.
+  static timed_event from_native_handle(_CUDA_VSTD::nullptr_t) = delete;
+
+  /**
+   * @brief Compute the time elapsed between two `timed_event` objects.
+   *
+   * @throws cuda_error if the query for the elapsed time fails.
+   *
+   * @param __end The `timed_event` object representing the end time.
+   * @param __start The `timed_event` object representing the start time.
+   *
+   * @return cuda::std::chrono::microseconds The elapsed time in microseconds.
+   */
+  _CCCL_NODISCARD_FRIEND _CUDA_VSTD::chrono::microseconds operator-(const timed_event& __end, const timed_event& __start)
+  {
+    float __ms = 0.0f;
+    _CCCL_TRY_CUDA_API(
+      ::cudaEventElapsedTime, "Failed to get CUDA event elapsed time", &__ms, __start.get(), __end.get());
+    return _CUDA_VSTD::chrono::microseconds(static_cast<_CUDA_VSTD::chrono::microseconds::rep>(__ms * 1'000.0f));
+  }
+
+private:
+  // Use `timed_event::from_native_handle(e)` to construct an owning `timed_event`
+  // object from a `cudaEvent_t` handle.
+  explicit constexpr timed_event(::cudaEvent_t __event) noexcept
+      : event(__event)
+  {}
+};
+} // namespace cuda::experimental
+
+#endif // _CUDAX_TIMED_EVENT_DETAIL_H

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -25,7 +25,6 @@
 #endif // no system header
 
 #include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/chrono>
 #include <cuda/std/cstddef>
 

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -11,6 +11,49 @@
 #ifndef _CUDAX_TIMED_EVENT_DETAIL_H
 #define _CUDAX_TIMED_EVENT_DETAIL_H
 
+/*
+    timed_event synopsis
+namespace cuda::experimental {
+class timed_event : public event {
+public:
+    timed_event();
+    timed_event(flags);
+    timed_event(uninit_t) noexcept;
+    timed_event(timed_event&&) noexcept;
+    ~timed_event();
+    timed_event& operator=(timed_event&&) noexcept;
+
+    [[nodiscard]] static timed_event from_native_handle(cudaEvent_t) noexcept;
+    static timed_event from_native_handle(int) = delete;
+    static timed_event from_native_handle(nullptr_t) = delete;
+
+    [[nodiscard]] friend auto operator-(const timed_event& end, const timed_event& start) noexcept
+        -> cuda::std::chrono::nanoseconds;
+
+    // from event:
+    enum class flags : unsigned int { none, blocking_sync, interprocess };
+
+    [[nodiscard]] cudaEvent_t release() noexcept;
+
+    [[nodiscard]] friend flags operator|(flags, flags) noexcept;
+
+    // From event_ref:
+    using value_type = cudaEvent_t;
+
+    void record(stream_ref) const;
+
+    void wait(stream_ref) const;
+
+    [[nodiscard]] cudaEvent_t get() const noexcept;
+
+    [[nodiscard]] explicit operator bool() const noexcept;
+
+    [[nodiscard]] friend bool operator==(event_ref, event_ref);
+    [[nodiscard]] friend bool operator!=(event_ref, event_ref);
+};
+}  // cuda::experimenal
+*/
+
 #include <cuda_runtime_api.h>
 // cuda_runtime_api needs to come first
 

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -28,7 +28,6 @@
 #include <cuda/std/chrono>
 #include <cuda/std/cstddef>
 
-// CUDAX headers here
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__event/event.cuh>
 

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -99,14 +99,16 @@ public:
    * @param __end The `timed_event` object representing the end time.
    * @param __start The `timed_event` object representing the start time.
    *
-   * @return cuda::std::chrono::microseconds The elapsed time in microseconds.
+   * @return cuda::std::chrono::nanoseconds The elapsed time in nanoseconds.
+   *
+   * @note The elapsed time has a resolution of approximately 0.5 microseconds.
    */
-  _CCCL_NODISCARD_FRIEND _CUDA_VSTD::chrono::microseconds operator-(const timed_event& __end, const timed_event& __start)
+  _CCCL_NODISCARD_FRIEND _CUDA_VSTD::chrono::nanoseconds operator-(const timed_event& __end, const timed_event& __start)
   {
     float __ms = 0.0f;
     _CCCL_TRY_CUDA_API(
       ::cudaEventElapsedTime, "Failed to get CUDA event elapsed time", &__ms, __start.get(), __end.get());
-    return _CUDA_VSTD::chrono::microseconds(static_cast<_CUDA_VSTD::chrono::microseconds::rep>(__ms * 1'000.0f));
+    return _CUDA_VSTD::chrono::nanoseconds(static_cast<_CUDA_VSTD::chrono::nanoseconds::rep>(__ms * 1'000'000.0));
   }
 
 private:

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -28,81 +28,66 @@
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/chrono>
 #include <cuda/std/cstddef>
-#include <cuda/stream_ref>
 
 // CUDAX headers here
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__event/event.cuh>
 
-#include <cassert>
-
 namespace cuda::experimental
 {
-/**
- * @brief An owning wrapper for a `cudaEvent_t` with timing enabled.
- */
+//! @brief An owning wrapper for a `cudaEvent_t` with timing enabled.
 class timed_event : public event
 {
 public:
-  /**
-   * @brief Construct a new `timed_event` object with timing enabled.
-   *
-   * @throws cuda_error if the event creation fails.
-   */
+  //! @brief Construct a new `timed_event` object with timing enabled.
+  //!
+  //! @throws cuda_error if the event creation fails.
   timed_event()
       : event(static_cast<unsigned int>(cudaEventDefault))
   {}
 
-  /**
-   * @brief Construct a new `timed_event` object with the specified flags.
-   *
-   * @throws cuda_error if the event creation fails.
-   */
+  //! @brief Construct a new `timed_event` object with the specified flags.
+  //!
+  //! @throws cuda_error if the event creation fails.
   explicit timed_event(flags __flags)
       : event(static_cast<unsigned int>(__flags))
   {}
 
-  /**
-   * @brief Construct a new `timed_event` object into the moved-from state.
-   *
-   * @post `get()` returns `cudaEvent_t()`.
-   */
+  //! @brief Construct a new `timed_event` object into the moved-from state.
+  //!
+  //! @post `get()` returns `cudaEvent_t()`.
   explicit constexpr timed_event(uninit_t) noexcept
       : event(uninit)
   {}
 
-  /**
-   * @brief Construct a `timed_event` object from a native `cudaEvent_t` handle.
-   *
-   * @param __evnt The native handle
-   *
-   * @return timed_event The constructed `timed_event` object
-   *
-   * @note The constructed `timed_event` object takes ownership of the native handle.
-   */
+  //! @brief Construct a `timed_event` object from a native `cudaEvent_t` handle.
+  //!
+  //! @param __evnt The native handle
+  //!
+  //! @return timed_event The constructed `timed_event` object
+  //!
+  //! @note The constructed `timed_event` object takes ownership of the native handle.
   _CCCL_NODISCARD static timed_event from_native_handle(::cudaEvent_t __evnt) noexcept
   {
     return timed_event(__evnt);
   }
 
-  /// Disallow construction from an `int`, e.g., `0`.
+  // Disallow construction from an `int`, e.g., `0`.
   static timed_event from_native_handle(int) = delete;
 
-  /// Disallow construction from `nullptr`.
+  // Disallow construction from `nullptr`.
   static timed_event from_native_handle(_CUDA_VSTD::nullptr_t) = delete;
 
-  /**
-   * @brief Compute the time elapsed between two `timed_event` objects.
-   *
-   * @throws cuda_error if the query for the elapsed time fails.
-   *
-   * @param __end The `timed_event` object representing the end time.
-   * @param __start The `timed_event` object representing the start time.
-   *
-   * @return cuda::std::chrono::nanoseconds The elapsed time in nanoseconds.
-   *
-   * @note The elapsed time has a resolution of approximately 0.5 microseconds.
-   */
+  //! @brief Compute the time elapsed between two `timed_event` objects.
+  //!
+  //! @throws cuda_error if the query for the elapsed time fails.
+  //!
+  //! @param __end The `timed_event` object representing the end time.
+  //! @param __start The `timed_event` object representing the start time.
+  //!
+  //! @return cuda::std::chrono::nanoseconds The elapsed time in nanoseconds.
+  //!
+  //! @note The elapsed time has a resolution of approximately 0.5 microseconds.
   _CCCL_NODISCARD_FRIEND _CUDA_VSTD::chrono::nanoseconds operator-(const timed_event& __end, const timed_event& __start)
   {
     float __ms = 0.0f;

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -16,8 +16,7 @@
 namespace cuda::experimental {
 class timed_event : public event {
 public:
-    timed_event();
-    timed_event(flags);
+    timed_event(stream_ref, flags = flags::none);
     timed_event(uninit_t) noexcept;
     timed_event(timed_event&&) noexcept;
     ~timed_event();
@@ -82,19 +81,15 @@ namespace cuda::experimental
 class timed_event : public event
 {
 public:
-  //! @brief Construct a new `timed_event` object with timing enabled.
+  //! @brief Construct a new `timed_event` object with the specified flags
+  //!        and record the event on the specified stream.
   //!
   //! @throws cuda_error if the event creation fails.
-  timed_event()
-      : event(static_cast<unsigned int>(cudaEventDefault))
-  {}
-
-  //! @brief Construct a new `timed_event` object with the specified flags.
-  //!
-  //! @throws cuda_error if the event creation fails.
-  explicit timed_event(flags __flags)
+  explicit timed_event(stream_ref __stream, flags __flags = flags::none)
       : event(static_cast<unsigned int>(__flags))
-  {}
+  {
+    record(__stream);
+  }
 
   //! @brief Construct a new `timed_event` object into the moved-from state.
   //!

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -74,15 +74,15 @@ public:
   /**
    * @brief Construct a `timed_event` object from a native `cudaEvent_t` handle.
    *
-   * @param __event The native handle
+   * @param __evnt The native handle
    *
    * @return timed_event The constructed `timed_event` object
    *
    * @note The constructed `timed_event` object takes ownership of the native handle.
    */
-  _CCCL_NODISCARD static timed_event from_native_handle(::cudaEvent_t __event) noexcept
+  _CCCL_NODISCARD static timed_event from_native_handle(::cudaEvent_t __evnt) noexcept
   {
-    return timed_event(__event);
+    return timed_event(__evnt);
   }
 
   /// Disallow construction from an `int`, e.g., `0`.
@@ -112,8 +112,8 @@ public:
 private:
   // Use `timed_event::from_native_handle(e)` to construct an owning `timed_event`
   // object from a `cudaEvent_t` handle.
-  explicit constexpr timed_event(::cudaEvent_t __event) noexcept
-      : event(__event)
+  explicit constexpr timed_event(::cudaEvent_t __evnt) noexcept
+      : event(__evnt)
   {}
 };
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -11,10 +11,11 @@
 #ifndef _CUDAX__HIERARCHY_HIERARCHY_DIMENSIONS
 #define _CUDAX__HIERARCHY_HIERARCHY_DIMENSIONS
 
-#include <cuda/experimental/__hierarchy/level_dimensions.cuh>
+#include <cuda/std/__utility/declval.h>
 #include <cuda/std/tuple>
 
-#include "cuda/std/__utility/declval.h"
+#include <cuda/experimental/__hierarchy/level_dimensions.cuh>
+
 #include <nv/target>
 
 #if _CCCL_STD_VER >= 2017

--- a/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
@@ -11,8 +11,9 @@
 #ifndef _CUDAX__HIERARCHY_LEVEL_DIMENSIONS
 #define _CUDAX__HIERARCHY_LEVEL_DIMENSIONS
 
-#include <cuda/experimental/__hierarchy/hierarchy_levels.cuh>
 #include <cuda/std/type_traits>
+
+#include <cuda/experimental/__hierarchy/hierarchy_levels.cuh>
 
 #if _CCCL_STD_VER >= 2017
 namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -10,9 +10,11 @@
 
 #ifndef _CUDAX__LAUNCH_CONFIGURATION
 #define _CUDAX__LAUNCH_CONFIGURATION
-#include <cuda/experimental/hierarchy.cuh>
+
 #include <cuda/std/span>
 #include <cuda/std/tuple>
+
+#include <cuda/experimental/hierarchy.cuh>
 
 #if _CCCL_STD_VER >= 2017
 namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -12,9 +12,10 @@
 #define _CUDAX__LAUNCH_LAUNCH
 #include <cuda_runtime.h>
 
-#include <cuda/experimental/__launch/configuration.cuh>
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/stream_ref>
+
+#include <cuda/experimental/__launch/configuration.cuh>
 
 #if _CCCL_STD_VER >= 2017
 namespace cuda::experimental

--- a/cudax/include/cuda/experimental/event.cuh
+++ b/cudax/include/cuda/experimental/event.cuh
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX_EVENT_H
+#define _CUDAX_EVENT_H
+
+#include <cuda/experimental/__event/event.cuh>
+#include <cuda/experimental/__event/event_ref.cuh>
+#include <cuda/experimental/__event/timed_event.cuh>
+
+#endif // _CUDAX_EVENT_H

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -47,18 +47,18 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   add_dependencies(${config_prefix}.all ${config_meta_target})
 
   # Add tests:
-  Cudax_add_catch2_test(test_target hierarchy_tests ${cn_target}
+  cudax_add_catch2_test(test_target hierarchy_tests ${cn_target}
     hierarchy/hierarchy_smoke.cu
     hierarchy/hierarchy_custom_types.cu
   )
 
-  Cudax_add_catch2_test(test_target launch_tests ${cn_target}
+  cudax_add_catch2_test(test_target launch_tests ${cn_target}
     launch/launch_smoke.cu
     launch/configuration.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
 
-  Cudax_add_catch2_test(test_target event_tests ${cn_target}
+  cudax_add_catch2_test(test_target event_tests ${cn_target}
     event/event_smoke.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -61,4 +61,5 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   Cudax_add_catch2_test(test_target event_tests ${cn_target}
     event/event_smoke.cu
   )
+  target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
 endforeach()

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -57,4 +57,8 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     launch/configuration.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
+
+  Cudax_add_catch2_test(test_target event_tests ${cn_target}
+    event/event_smoke.cu
+  )
 endforeach()

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -1,0 +1,118 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda_runtime_api.h>
+// cuda_runtime_api needs to come first
+
+#include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/std/utility>
+#include <cuda/stream_ref>
+
+#include <new> // IWYU pragma: keep (needed for placement new)
+
+namespace
+{
+namespace test
+{
+struct stream : cuda::stream_ref
+{
+  stream()
+      : cuda::stream_ref(::cudaStream_t{})
+  {
+    ::cudaStream_t stream{};
+    _CCCL_TRY_CUDA_API(::cudaStreamCreate, "failed to create a CUDA stream", &stream);
+    static_cast<cuda::stream_ref&>(*this) = cuda::stream_ref(stream);
+  }
+
+  cuda::stream_ref ref() const noexcept
+  {
+    return *this;
+  }
+
+  void wait() const
+  {
+    _CCCL_TRY_CUDA_API(::cudaStreamSynchronize, "failed to synchronize a CUDA stream", get());
+  }
+
+  ~stream()
+  {
+    [[maybe_unused]] auto status = ::cudaStreamDestroy(get());
+  }
+};
+
+struct _malloc_managed
+{
+private:
+  void* pv = nullptr;
+
+public:
+  explicit _malloc_managed(std::size_t size)
+  {
+    _CCCL_TRY_CUDA_API(::cudaMallocManaged, "failed to allocate managed memory", &pv, size);
+  }
+
+  ~_malloc_managed()
+  {
+    [[maybe_unused]] auto status = ::cudaFree(pv);
+  }
+
+  template <class T>
+  T* get_as() const noexcept
+  {
+    return static_cast<T*>(pv);
+  }
+};
+
+template <class T>
+struct managed
+{
+private:
+  _malloc_managed _mem;
+
+public:
+  explicit managed(T t)
+      : _mem(sizeof(T))
+  {
+    ::new (_mem.get_as<void>()) T(_CUDA_VSTD::move(t));
+  }
+
+  ~managed()
+  {
+    get()->~T();
+  }
+
+  T* get() noexcept
+  {
+    return _mem.get_as<T>();
+  }
+  const T* get() const noexcept
+  {
+    return _mem.get_as<T>();
+  }
+
+  T& operator*() noexcept
+  {
+    return *get();
+  }
+  const T& operator*() const noexcept
+  {
+    return *get();
+  }
+};
+
+/// A kernel that takes a callable object and invokes it with a set of arguments
+template <class Fn, class... Args>
+__global__ void invokernel(Fn fn, Args... args)
+{
+  fn(args...);
+}
+
+} // namespace test
+} // namespace

--- a/cudax/test/event/event_smoke.cu
+++ b/cudax/test/event/event_smoke.cu
@@ -41,7 +41,8 @@ TEST_CASE("can copy construct an event_ref and compare for equality", "[event]")
   const cudax::event_ref ref2 = ref;
   CUDAX_REQUIRE(ref2 == ref);
   CUDAX_REQUIRE(!(ref != ref2));
-  CUDAX_REQUIRE(ref != cudax::event_ref{});
+  CUDAX_REQUIRE((ref ? true : false)); // test contextual convertibility to bool
+  CUDAX_REQUIRE(!!ref);
   CUDAX_REQUIRE(::cudaEvent_t{} != ref);
   CUDAX_REQUIRE(::cudaEventDestroy(event) == ::cudaSuccess);
 }

--- a/cudax/test/event/event_smoke.cu
+++ b/cudax/test/event/event_smoke.cu
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/experimental/event.cuh>
+
+#include "../hierarchy/testing_common.cuh"
+#include <catch2/catch.hpp>
+
+namespace
+{
+cudax::event_ref fn_takes_event_ref(cudax::event_ref ref)
+{
+  return ref;
+}
+} // namespace
+
+TEST_CASE("can construct an event_ref from a cudaEvent_t", "[event]")
+{
+  ::cudaEvent_t event;
+  CUDAX_REQUIRE(::cudaEventCreate(&event) == ::cudaSuccess);
+  cudax::event_ref ref(event);
+  CUDAX_REQUIRE(ref.get() == event);
+  // test implicit converstion from cudaEvent_t:
+  cudax::event_ref ref2 = ::fn_takes_event_ref(event);
+  CUDAX_REQUIRE(ref2.get() == event);
+  CUDAX_REQUIRE(::cudaEventDestroy(event) == ::cudaSuccess);
+}
+
+TEST_CASE("can copy construct an event_ref and compare for equality", "[event]")
+{
+  ::cudaEvent_t event;
+  CUDAX_REQUIRE(::cudaEventCreate(&event) == ::cudaSuccess);
+  const cudax::event_ref ref(event);
+  const cudax::event_ref ref2 = ref;
+  CUDAX_REQUIRE(ref2 == ref);
+  CUDAX_REQUIRE(!(ref != ref2));
+  CUDAX_REQUIRE(ref != cudax::event_ref{});
+  CUDAX_REQUIRE(::cudaEvent_t{} != ref);
+  CUDAX_REQUIRE(::cudaEventDestroy(event) == ::cudaSuccess);
+}

--- a/cudax/test/event/event_smoke.cu
+++ b/cudax/test/event/event_smoke.cu
@@ -80,7 +80,7 @@ TEST_CASE("can use event_ref to record and wait on an event", "[event]")
     },
     i.get());
   ref.record(stream);
-  ref.wait(stream);
+  ref.wait();
   CUDAX_REQUIRE(*i == 42);
 
   stream.wait();
@@ -99,12 +99,12 @@ TEST_CASE("can wait on an event", "[event]")
   test::stream stream;
   ::test::managed<int> i(0);
   ::test::invokernel<<<1, 1, 0, stream.get()>>>(
-    [] _CCCL_HOST_DEVICE(int* pi) {
+    [] _CCCL_DEVICE(int* pi) {
       *pi = 42;
     },
     i.get());
   cudax::event ev(stream);
-  ev.wait(stream);
+  ev.wait();
   CUDAX_REQUIRE(*i == 42);
   stream.wait();
 }
@@ -115,12 +115,12 @@ TEST_CASE("can take the difference of two timed_event objects", "[event]")
   ::test::managed<int> i(0);
   cudax::timed_event start(stream);
   ::test::invokernel<<<1, 1, 0, stream.get()>>>(
-    [] _CCCL_HOST_DEVICE(int* pi) {
+    [] _CCCL_DEVICE(int* pi) {
       *pi = 42;
     },
     i.get());
   cudax::timed_event end(stream);
-  end.wait(stream);
+  end.wait();
   CUDAX_REQUIRE(*i == 42);
   auto elapsed = end - start;
   CUDAX_REQUIRE(elapsed.count() >= 0);

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -9,11 +9,8 @@
 //===----------------------------------------------------------------------===//
 #define LIBCUDACXX_ENABLE_EXCEPTIONS
 #include <cuda/atomic>
-#include <cuda/experimental/launch.cuh>
 
-#include <functional>
-#include <iostream>
-#include <type_traits>
+#include <cuda/experimental/launch.cuh>
 
 #include "../hierarchy/testing_common.cuh"
 


### PR DESCRIPTION
This commit adds some simple, modern C++ wrappers for `cudaEvent_t`, namely:

* `cuda::experimental::event_ref` is a non-owning wrapper around a `cudaEvent_t`.

* `cuda::experimental::event` is an owning wrapper around a `cudaEvent_t`.

* `cuda::experimental::timed_event` is a `cuda::experimental::event` that also records the time at which it was recorded.

It also adds a constructor tag `cuda::experimental::uninit` that can be used to defer initialization of the object.