### PR TITLE
Do no redefine `__ELF__` macro

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -88,7 +88,9 @@ extern "C++" {
 #  endif
 
 #  if (defined(_CCCL_COMPILER_NVHPC) && defined(__linux__)) || defined(_CCCL_COMPILER_NVRTC)
-#    define __ELF__
+#    ifndef __ELF__
+#      define __ELF__
+#    endif // !__ELF__
 #  endif
 
 #  if defined(__ELF__)


### PR DESCRIPTION
We currently employ a workaround against an nvc++ bug where `__ELF__` is not properly defined.

However, we should not define that macro if it is already present.

Fixes [BUG]: incompatible redefinition of macro "__ELF__" with NVC++ host compiler #1995
