### PR TITLE
Simplify thrust::detail::wrapped_function

### DIFF
--- a/thrust/testing/omp/reduce_intervals.cu
+++ b/thrust/testing/omp/reduce_intervals.cu
@@ -12,7 +12,7 @@ void reduce_intervals(InputIterator input, OutputIterator output, BinaryFunction
   using index_type = typename Decomposition::index_type;
 
   // wrap binary_op
-  thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op(binary_op);
+  thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op{binary_op};
 
   for (index_type i = 0; i < decomp.size(); ++i, ++output)
   {

--- a/thrust/thrust/detail/function.h
+++ b/thrust/thrust/detail/function.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2008-2013 NVIDIA Corporation
+ *  Copyright 2024 NVIDIA Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -31,119 +31,19 @@ THRUST_NAMESPACE_BEGIN
 
 namespace detail
 {
-
 template <typename Function, typename Result>
 struct wrapped_function
 {
   // mutable because Function::operator() might be const
   mutable Function m_f;
 
-  inline _CCCL_HOST_DEVICE wrapped_function()
-      : m_f()
-  {}
-
-  inline _CCCL_HOST_DEVICE wrapped_function(const Function& f)
-      : m_f(f)
-  {}
-
   _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE Result operator()(Argument& x) const
+  template <typename... Ts>
+  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE Result operator()(Ts&&... args) const
   {
-    return static_cast<Result>(m_f(thrust::raw_reference_cast(x)));
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE Result operator()(const Argument& x) const
-  {
-    return static_cast<Result>(m_f(thrust::raw_reference_cast(x)));
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument1, typename Argument2>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE Result operator()(Argument1& x, Argument2& y) const
-  {
-    return static_cast<Result>(m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y)));
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument1, typename Argument2>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE Result operator()(const Argument1& x, Argument2& y) const
-  {
-    return static_cast<Result>(m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y)));
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument1, typename Argument2>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE Result operator()(const Argument1& x, const Argument2& y) const
-  {
-    return static_cast<Result>(m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y)));
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument1, typename Argument2>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE Result operator()(Argument1& x, const Argument2& y) const
-  {
-    return static_cast<Result>(m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y)));
+    return static_cast<Result>(m_f(thrust::raw_reference_cast(std::forward<Ts>(args))...));
   }
 }; // end wrapped_function
-
-// Specialize for void return types:
-template <typename Function>
-struct wrapped_function<Function, void>
-{
-  // mutable because Function::operator() might be const
-  mutable Function m_f;
-  inline _CCCL_HOST_DEVICE wrapped_function()
-      : m_f()
-  {}
-
-  inline _CCCL_HOST_DEVICE wrapped_function(const Function& f)
-      : m_f(f)
-  {}
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE void operator()(Argument& x) const
-  {
-    m_f(thrust::raw_reference_cast(x));
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE void operator()(const Argument& x) const
-  {
-    m_f(thrust::raw_reference_cast(x));
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument1, typename Argument2>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE void operator()(Argument1& x, Argument2& y) const
-  {
-    m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y));
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument1, typename Argument2>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE void operator()(const Argument1& x, Argument2& y) const
-  {
-    m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y));
-  }
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument1, typename Argument2>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE void operator()(const Argument1& x, const Argument2& y) const
-  {
-    m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y));
-  }
-  _CCCL_EXEC_CHECK_DISABLE
-  template <typename Argument1, typename Argument2>
-  _CCCL_FORCEINLINE _CCCL_HOST_DEVICE void operator()(Argument1& x, const Argument2& y) const
-  {
-    m_f(thrust::raw_reference_cast(x), thrust::raw_reference_cast(y));
-  }
-}; // end wrapped_function
-
 } // namespace detail
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/detail/function.h
+++ b/thrust/thrust/detail/function.h
@@ -41,7 +41,7 @@ struct wrapped_function
   template <typename... Ts>
   _CCCL_FORCEINLINE _CCCL_HOST_DEVICE Result operator()(Ts&&... args) const
   {
-    return static_cast<Result>(m_f(thrust::raw_reference_cast(std::forward<Ts>(args))...));
+    return static_cast<Result>(m_f(thrust::raw_reference_cast(::cuda::std::forward<Ts>(args))...));
   }
 }; // end wrapped_function
 } // namespace detail

--- a/thrust/thrust/system/detail/generic/binary_search.inl
+++ b/thrust/thrust/system/detail/generic/binary_search.inl
@@ -83,7 +83,7 @@ struct bsf
   {
     RandomAccessIterator iter = thrust::system::detail::generic::scalar::lower_bound(begin, end, value, comp);
 
-    thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+    thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
     return iter != end && !wrapped_comp(value, *iter);
   }

--- a/thrust/thrust/system/detail/generic/scalar/binary_search.inl
+++ b/thrust/thrust/system/detail/generic/scalar/binary_search.inl
@@ -48,7 +48,7 @@ _CCCL_HOST_DEVICE RandomAccessIterator
 lower_bound_n(RandomAccessIterator first, Size n, const T& val, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   Size start = 0, i;
   while (start < n)
@@ -82,7 +82,7 @@ _CCCL_HOST_DEVICE RandomAccessIterator
 upper_bound_n(RandomAccessIterator first, Size n, const T& val, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   Size start = 0, i;
   while (start < n)
@@ -123,7 +123,7 @@ _CCCL_HOST_DEVICE bool binary_search(RandomAccessIterator first, RandomAccessIte
   RandomAccessIterator iter = thrust::system::detail::generic::scalar::lower_bound(first, last, value, comp);
 
   // wrap comp
-  thrust::detail::wrapped_function<Compare, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<Compare, bool> wrapped_comp{comp};
 
   return iter != last && !wrapped_comp(value, *iter);
 }

--- a/thrust/thrust/system/detail/sequential/binary_search.h
+++ b/thrust/thrust/system/detail/sequential/binary_search.h
@@ -53,7 +53,7 @@ _CCCL_HOST_DEVICE ForwardIterator lower_bound(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   using difference_type = typename thrust::iterator_difference<ForwardIterator>::type;
 
@@ -91,7 +91,7 @@ _CCCL_HOST_DEVICE ForwardIterator upper_bound(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   using difference_type = typename thrust::iterator_difference<ForwardIterator>::type;
 
@@ -131,7 +131,7 @@ _CCCL_HOST_DEVICE bool binary_search(
   ForwardIterator iter = sequential::lower_bound(exec, first, last, val, comp);
 
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   return iter != last && !wrapped_comp(val, *iter);
 }

--- a/thrust/thrust/system/detail/sequential/copy_if.h
+++ b/thrust/thrust/system/detail/sequential/copy_if.h
@@ -54,7 +54,7 @@ _CCCL_HOST_DEVICE OutputIterator copy_if(
   OutputIterator result,
   Predicate pred)
 {
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (first != last)
   {

--- a/thrust/thrust/system/detail/sequential/extrema.h
+++ b/thrust/thrust/system/detail/sequential/extrema.h
@@ -47,7 +47,7 @@ _CCCL_HOST_DEVICE ForwardIterator min_element(
   sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   ForwardIterator imin = first;
 
@@ -68,7 +68,7 @@ _CCCL_HOST_DEVICE ForwardIterator max_element(
   sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   ForwardIterator imax = first;
 
@@ -89,7 +89,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
   sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<BinaryPredicate, bool> wrapped_comp{comp};
 
   ForwardIterator imin = first;
   ForwardIterator imax = first;

--- a/thrust/thrust/system/detail/sequential/find.h
+++ b/thrust/thrust/system/detail/sequential/find.h
@@ -46,7 +46,7 @@ _CCCL_HOST_DEVICE InputIterator
 find_if(execution_policy<DerivedPolicy>&, InputIterator first, InputIterator last, Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (first != last)
   {

--- a/thrust/thrust/system/detail/sequential/for_each.h
+++ b/thrust/thrust/system/detail/sequential/for_each.h
@@ -46,7 +46,7 @@ _CCCL_HOST_DEVICE InputIterator
 for_each(sequential::execution_policy<DerivedPolicy>&, InputIterator first, InputIterator last, UnaryFunction f)
 {
   // wrap f
-  thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f(f);
+  thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f{f};
 
   for (; first != last; ++first)
   {
@@ -61,7 +61,7 @@ _CCCL_HOST_DEVICE InputIterator
 for_each_n(sequential::execution_policy<DerivedPolicy>&, InputIterator first, Size n, UnaryFunction f)
 {
   // wrap f
-  thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f(f);
+  thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f{f};
 
   for (Size i = 0; i != n; i++)
   {

--- a/thrust/thrust/system/detail/sequential/insertion_sort.h
+++ b/thrust/thrust/system/detail/sequential/insertion_sort.h
@@ -50,7 +50,7 @@ _CCCL_HOST_DEVICE void insertion_sort(RandomAccessIterator first, RandomAccessIt
   }
 
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   for (RandomAccessIterator i = first + 1; i != last; ++i)
   {
@@ -95,7 +95,7 @@ _CCCL_HOST_DEVICE void insertion_sort_by_key(
   }
 
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   RandomAccessIterator1 i1 = first1 + 1;
   RandomAccessIterator2 i2 = first2 + 1;

--- a/thrust/thrust/system/detail/sequential/merge.inl
+++ b/thrust/thrust/system/detail/sequential/merge.inl
@@ -54,7 +54,7 @@ _CCCL_HOST_DEVICE OutputIterator merge(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {
@@ -97,7 +97,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (keys_first1 != keys_last1 && keys_first2 != keys_last2)
   {

--- a/thrust/thrust/system/detail/sequential/partition.h
+++ b/thrust/thrust/system/detail/sequential/partition.h
@@ -76,7 +76,7 @@ partition(sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, F
   }
 
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (wrapped_pred(*first))
   {
@@ -116,7 +116,7 @@ _CCCL_HOST_DEVICE ForwardIterator partition(
   }
 
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (wrapped_pred(*stencil_first))
   {
@@ -158,7 +158,7 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   }
 
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   using T = typename thrust::iterator_value<ForwardIterator>::type;
 
@@ -200,7 +200,7 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   using T = typename thrust::iterator_value<ForwardIterator>::type;
 
@@ -249,7 +249,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partitio
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   for (; first != last; ++first)
   {
@@ -285,7 +285,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partitio
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   for (; first != last; ++first, ++stencil)
   {

--- a/thrust/thrust/system/detail/sequential/reduce.h
+++ b/thrust/thrust/system/detail/sequential/reduce.h
@@ -50,7 +50,7 @@ _CCCL_HOST_DEVICE OutputType reduce(
   BinaryFunction binary_op)
 {
   // wrap binary_op
-  thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op(binary_op);
+  thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op{binary_op};
 
   // initialize the result
   OutputType result = init;

--- a/thrust/thrust/system/detail/sequential/remove.h
+++ b/thrust/thrust/system/detail/sequential/remove.h
@@ -46,7 +46,7 @@ _CCCL_HOST_DEVICE ForwardIterator
 remove_if(sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   // advance iterators until wrapped_pred(*first) is true or we reach the end of input
   while (first != last && !wrapped_pred(*first))
@@ -87,7 +87,7 @@ _CCCL_HOST_DEVICE ForwardIterator remove_if(
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   // advance iterators until wrapped_pred(*stencil) is true or we reach the end of input
   while (first != last && !wrapped_pred(*stencil))
@@ -131,7 +131,7 @@ _CCCL_HOST_DEVICE OutputIterator remove_copy_if(
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (first != last)
   {
@@ -162,7 +162,7 @@ _CCCL_HOST_DEVICE OutputIterator remove_copy_if(
   Predicate pred)
 {
   // wrap pred
-  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred(pred);
+  thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
   while (first != last)
   {

--- a/thrust/thrust/system/detail/sequential/scan.h
+++ b/thrust/thrust/system/detail/sequential/scan.h
@@ -59,7 +59,7 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan(
   using ValueType = typename thrust::iterator_value<InputIterator>::type;
 
   // wrap binary_op
-  thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op(binary_op);
+  thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op{binary_op};
 
   if (first != last)
   {

--- a/thrust/thrust/system/detail/sequential/scan_by_key.h
+++ b/thrust/thrust/system/detail/sequential/scan_by_key.h
@@ -61,7 +61,7 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan_by_key(
   using ValueType = typename thrust::iterator_traits<InputIterator2>::value_type;
 
   // wrap binary_op
-  thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op(binary_op);
+  thrust::detail::wrapped_function<BinaryFunction, ValueType> wrapped_binary_op{binary_op};
 
   if (first1 != last1)
   {

--- a/thrust/thrust/system/detail/sequential/set_operations.h
+++ b/thrust/thrust/system/detail/sequential/set_operations.h
@@ -57,7 +57,7 @@ _CCCL_HOST_DEVICE OutputIterator set_difference(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {
@@ -97,7 +97,7 @@ _CCCL_HOST_DEVICE OutputIterator set_intersection(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {
@@ -137,7 +137,7 @@ _CCCL_HOST_DEVICE OutputIterator set_symmetric_difference(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {
@@ -179,7 +179,7 @@ _CCCL_HOST_DEVICE OutputIterator set_union(
   StrictWeakOrdering comp)
 {
   // wrap comp
-  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp(comp);
+  thrust::detail::wrapped_function<StrictWeakOrdering, bool> wrapped_comp{comp};
 
   while (first1 != last1 && first2 != last2)
   {

--- a/thrust/thrust/system/omp/detail/for_each.inl
+++ b/thrust/thrust/system/omp/detail/for_each.inl
@@ -59,7 +59,7 @@ RandomAccessIterator for_each_n(execution_policy<DerivedPolicy>&, RandomAccessIt
   }
 
   // create a wrapped function for f
-  thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f(f);
+  thrust::detail::wrapped_function<UnaryFunction, void> wrapped_f{f};
 
   // use a signed type for the iteration variable or suffer the consequences of warnings
   using DifferenceType    = typename thrust::iterator_difference<RandomAccessIterator>::type;

--- a/thrust/thrust/system/omp/detail/reduce_intervals.inl
+++ b/thrust/thrust/system/omp/detail/reduce_intervals.inl
@@ -67,7 +67,7 @@ void reduce_intervals(
   using OutputType = typename thrust::iterator_value<OutputIterator>::type;
 
   // wrap binary_op
-  thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op(binary_op);
+  thrust::detail::wrapped_function<BinaryFunction, OutputType> wrapped_binary_op{binary_op};
 
   using index_type = std::intptr_t;
 

--- a/thrust/thrust/system/tbb/detail/copy_if.inl
+++ b/thrust/thrust/system/tbb/detail/copy_if.inl
@@ -56,7 +56,7 @@ struct body
       : first(first)
       , stencil(stencil)
       , result(result)
-      , pred(pred)
+      , pred{pred}
       , sum(0)
   {}
 
@@ -64,7 +64,7 @@ struct body
       : first(b.first)
       , stencil(b.stencil)
       , result(b.result)
-      , pred(b.pred)
+      , pred{b.pred}
       , sum(0)
   {}
 

--- a/thrust/thrust/system/tbb/detail/reduce.inl
+++ b/thrust/thrust/system/tbb/detail/reduce.inl
@@ -57,7 +57,7 @@ struct body
       : first(first)
       , sum(init)
       , first_call(true)
-      , binary_op(binary_op)
+      , binary_op{binary_op}
   {}
 
   // note: we only initalize sum with b.sum to avoid calling OutputType's default constructor
@@ -65,7 +65,7 @@ struct body
       : first(b.first)
       , sum(b.sum)
       , first_call(true)
-      , binary_op(b.binary_op)
+      , binary_op{b.binary_op}
   {}
 
   template <typename Size>

--- a/thrust/thrust/system/tbb/detail/scan.inl
+++ b/thrust/thrust/system/tbb/detail/scan.inl
@@ -59,7 +59,7 @@ struct inclusive_body
   inclusive_body(InputIterator input, OutputIterator output, BinaryFunction binary_op, ValueType dummy)
       : input(input)
       , output(output)
-      , binary_op(binary_op)
+      , binary_op{binary_op}
       , sum(dummy)
       , first_call(true)
   {}
@@ -67,7 +67,7 @@ struct inclusive_body
   inclusive_body(inclusive_body& b, ::tbb::split)
       : input(b.input)
       , output(b.output)
-      , binary_op(b.binary_op)
+      , binary_op{b.binary_op}
       , sum(b.sum)
       , first_call(true)
   {}
@@ -153,7 +153,7 @@ struct exclusive_body
   exclusive_body(InputIterator input, OutputIterator output, BinaryFunction binary_op, ValueType init)
       : input(input)
       , output(output)
-      , binary_op(binary_op)
+      , binary_op{binary_op}
       , sum(init)
       , first_call(true)
   {}
@@ -161,7 +161,7 @@ struct exclusive_body
   exclusive_body(exclusive_body& b, ::tbb::split)
       : input(b.input)
       , output(b.output)
-      , binary_op(b.binary_op)
+      , binary_op{b.binary_op}
       , sum(b.sum)
       , first_call(true)
   {}


### PR DESCRIPTION
This PR simplifies `thrust::detail::wrapped_function` by using variadic templates and deleting the unnecessary `void` specialization. The changelog mentions the `void` specialization was introduced in Thrust 1.10.0 and a necessary workaround for MSVC, but the problematic MSVC version is no longer supported.