### PR TITLE
Add a test for Thrust scan with non-commutative op

### DIFF
--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -7,6 +7,8 @@
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/universal_vector.h>
 
+#include <cuda/std/utility>
+
 #include <unittest/exceptions.h>
 #include <unittest/util.h>
 
@@ -386,6 +388,17 @@ public:
 ////
 // check sequences
 
+inline int promote_char(char c)
+{
+  return c;
+}
+
+template <typename T>
+T&& promote_char(T&& t)
+{
+  return ::cuda::std::forward<T>(t);
+}
+
 template <typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
 void assert_equal(
   ForwardIterator1 first1,
@@ -435,16 +448,7 @@ void assert_equal(
 
       if (mismatches <= MAX_OUTPUT_LINES)
       {
-        _CCCL_IF_CONSTEXPR (sizeof(InputType) == 1)
-        {
-          f << "  [" << i << "] " << *first1 + InputType() << "  " << *first2 + InputType() << "\n"; // unprintable
-                                                                                                     // chars are a
-                                                                                                     // problem
-        }
-        else
-        {
-          f << "  [" << i << "] " << *first1 << "  " << *first2 << "\n";
-        }
+        f << "  [" << i << "] " << promote_char(*first1) << "  " << promote_char(*first2) << "\n";
       }
     }
 


### PR DESCRIPTION
Thrust's scan algorithms do not require a commutative scan operation, so here is a test for that.