### PR TITLE
Add tests to ensure that we properly propagate common_type for complex types

### DIFF
--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.special/double_float_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.special/double_float_explicit.pass.cpp
@@ -35,5 +35,9 @@ int main(int, char**)
     static_assert(cf.imag() == cd.imag(), "");
   }
 
+  static_assert(cuda::std::is_same<cuda::std::common_type<cuda::std::complex<double>, cuda::std::complex<float>>::type,
+                                   cuda::std::complex<cuda::std::common_type<double, float>::type>>::value,
+                "");
+
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.special/float_double_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.special/float_double_explicit.pass.cpp
@@ -35,5 +35,9 @@ int main(int, char**)
     static_assert(cf.imag() == cd.imag(), "");
   }
 
+  static_assert(cuda::std::is_same<cuda::std::common_type<cuda::std::complex<float>, cuda::std::complex<double>>::type,
+                                   cuda::std::complex<cuda::std::common_type<float, double>::type>>::value,
+                "");
+
   return 0;
 }


### PR DESCRIPTION
It seems we regressed this sometime in the 2.5 time frame.

Add some tests to ensure that this does not happen again

Fixes #2013
