### PR TITLE
Avoid ADL issues with `thrust::distance`

### DIFF
--- a/thrust/thrust/system/cuda/detail/async/copy.h
+++ b/thrust/thrust/system/cuda/detail/async/copy.h
@@ -330,7 +330,8 @@ auto async_copy(thrust::cuda::execution_policy<FromPolicy>& from_exec,
                 ForwardIt first,
                 Sentinel last,
                 OutputIt output)
-  THRUST_RETURNS(thrust::system::cuda::detail::async_copy_n(from_exec, to_exec, first, distance(first, last), output))
+  THRUST_RETURNS(
+    thrust::system::cuda::detail::async_copy_n(from_exec, to_exec, first, thrust::distance(first, last), output))
 
   // ADL entry point.
   template <typename FromPolicy, typename ToPolicy, typename ForwardIt, typename Sentinel, typename OutputIt>
@@ -339,7 +340,8 @@ auto async_copy(thrust::cuda::execution_policy<FromPolicy>& from_exec,
                   ForwardIt first,
                   Sentinel last,
                   OutputIt output)
-    THRUST_RETURNS(thrust::system::cuda::detail::async_copy_n(from_exec, to_exec, first, distance(first, last), output))
+    THRUST_RETURNS(
+      thrust::system::cuda::detail::async_copy_n(from_exec, to_exec, first, thrust::distance(first, last), output))
 
   // ADL entry point.
   template <typename FromPolicy, typename ToPolicy, typename ForwardIt, typename Sentinel, typename OutputIt>
@@ -348,7 +350,8 @@ auto async_copy(thrust::cuda::execution_policy<FromPolicy>& from_exec,
                   ForwardIt first,
                   Sentinel last,
                   OutputIt output)
-    THRUST_RETURNS(thrust::system::cuda::detail::async_copy_n(from_exec, to_exec, first, distance(first, last), output))
+    THRUST_RETURNS(
+      thrust::system::cuda::detail::async_copy_n(from_exec, to_exec, first, thrust::distance(first, last), output))
 
 } // namespace cuda_cub
 

--- a/thrust/thrust/system/cuda/detail/async/exclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/exclusive_scan.h
@@ -155,7 +155,7 @@ auto async_exclusive_scan(
   InitialValueType&& init,
   BinaryOp&& op)
   THRUST_RETURNS(thrust::system::cuda::detail::async_exclusive_scan_n(
-    policy, first, distance(first, THRUST_FWD(last)), THRUST_FWD(out), THRUST_FWD(init), THRUST_FWD(op)))
+    policy, first, thrust::distance(first, THRUST_FWD(last)), THRUST_FWD(out), THRUST_FWD(init), THRUST_FWD(op)))
 
 } // namespace cuda_cub
 

--- a/thrust/thrust/system/cuda/detail/async/for_each.h
+++ b/thrust/thrust/system/cuda/detail/async/for_each.h
@@ -122,7 +122,8 @@ namespace cuda_cub
 // ADL entry point.
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename UnaryFunction>
 auto async_for_each(execution_policy<DerivedPolicy>& policy, ForwardIt first, Sentinel last, UnaryFunction&& func)
-  THRUST_RETURNS(thrust::system::cuda::detail::async_for_each_n(policy, first, distance(first, last), THRUST_FWD(func)));
+  THRUST_RETURNS(
+    thrust::system::cuda::detail::async_for_each_n(policy, first, thrust::distance(first, last), THRUST_FWD(func)));
 
 } // namespace cuda_cub
 

--- a/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
@@ -138,7 +138,7 @@ template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typenam
 auto async_inclusive_scan(
   execution_policy<DerivedPolicy>& policy, ForwardIt first, Sentinel&& last, OutputIt&& out, BinaryOp&& op)
   THRUST_RETURNS(thrust::system::cuda::detail::async_inclusive_scan_n(
-    policy, first, distance(first, THRUST_FWD(last)), THRUST_FWD(out), THRUST_FWD(op)))
+    policy, first, thrust::distance(first, THRUST_FWD(last)), THRUST_FWD(out), THRUST_FWD(op)))
 
 } // namespace cuda_cub
 

--- a/thrust/thrust/system/cuda/detail/async/sort.h
+++ b/thrust/thrust/system/cuda/detail/async/sort.h
@@ -314,7 +314,8 @@ template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typenam
 auto async_stable_sort(execution_policy<DerivedPolicy>& policy, ForwardIt first, Sentinel last, StrictWeakOrdering comp)
   // A GCC 5 bug requires an explicit trailing return type here, so stick with
   // THRUST_DECLTYPE_RETURNS for now.
-  THRUST_DECLTYPE_RETURNS(thrust::system::cuda::detail::async_stable_sort_n(policy, first, distance(first, last), comp))
+  THRUST_DECLTYPE_RETURNS(
+    thrust::system::cuda::detail::async_stable_sort_n(policy, first, thrust::distance(first, last), comp))
 
 } // namespace cuda_cub
 

--- a/thrust/thrust/system/cuda/detail/async/transform.h
+++ b/thrust/thrust/system/cuda/detail/async/transform.h
@@ -127,8 +127,8 @@ namespace cuda_cub
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename OutputIt, typename UnaryOperation>
 auto async_transform(
   execution_policy<DerivedPolicy>& policy, ForwardIt first, Sentinel last, OutputIt output, UnaryOperation&& op)
-  THRUST_RETURNS(
-    thrust::system::cuda::detail::async_transform_n(policy, first, distance(first, last), output, THRUST_FWD(op)));
+  THRUST_RETURNS(thrust::system::cuda::detail::async_transform_n(
+    policy, first, thrust::distance(first, last), output, THRUST_FWD(op)));
 
 } // namespace cuda_cub
 

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -65,8 +65,8 @@ merge(execution_policy<Derived>& policy,
 {
   THRUST_CDP_DISPATCH(
     (using size_type         = typename iterator_traits<KeysIt1>::difference_type;
-     const auto num_keys1    = static_cast<size_type>(distance(keys1_begin, keys1_end));
-     const auto num_keys2    = static_cast<size_type>(distance(keys2_begin, keys2_end));
+     const auto num_keys1    = static_cast<size_type>(thrust::distance(keys1_begin, keys1_end));
+     const auto num_keys2    = static_cast<size_type>(thrust::distance(keys2_begin, keys2_end));
      const auto num_keys_out = num_keys1 + num_keys2;
      if (num_keys_out == 0) { return result_begin; }
 
@@ -153,8 +153,8 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE merge_by_key(
   THRUST_CDP_DISPATCH(
     (using size_type = typename iterator_traits<KeysIt1>::difference_type;
 
-     const auto num_keys1    = static_cast<size_type>(distance(keys1_begin, keys1_end));
-     const auto num_keys2    = static_cast<size_type>(distance(keys2_begin, keys2_end));
+     const auto num_keys1    = static_cast<size_type>(thrust::distance(keys1_begin, keys1_end));
+     const auto num_keys2    = static_cast<size_type>(thrust::distance(keys2_begin, keys2_end));
      const auto num_keys_out = num_keys1 + num_keys2;
      if (num_keys_out == 0) { return {keys_out_begin, items_out_begin}; }
 


### PR DESCRIPTION
We almost always pull in cuda::std::distance, which would be ambiguous with `thrust::distance` if the used type pulls in `cuda::std::` within a thrust algorithm

This has been found by our rmm test suite :green_heart: