### PR TITLE
Include container toolkit in manual prereqs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -63,6 +63,7 @@ For more information about the sccache configuration and authentication, see the
 ## Quickstart: Docker (Manual Approach) <a name="docker"></a>
 
 ### Prerequisites
+- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 - [Docker](https://docs.docker.com/desktop/install/linux-install/)
 
 ### Steps


### PR DESCRIPTION
This PR adds a missing bullet and link to the NVIDIA Container Toolkit installation instructions in the *Prerequisites* sub-section for *Quickstart: Docker (Manual Approach)*