### PR TITLE
Ensure that `cuda_memory_resource` allocates memory on the proper device

### DIFF
--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -53,6 +53,7 @@
 // for backward compatibility
 #include <cub/util_temporary_storage.cuh>
 
+#include <cuda/std/__cuda/ensure_current_device.h>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
@@ -105,36 +106,11 @@ CUB_RUNTIME_FUNCTION inline int CurrentDevice()
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
-/**
- * \brief RAII helper which saves the current device and switches to the
- *        specified device on construction and switches to the saved device on
- *        destruction.
- */
-struct SwitchDevice
-{
-private:
-  int const old_device;
-  bool const needs_reset;
 
-public:
-  _CCCL_HOST inline SwitchDevice(int new_device)
-      : old_device(CurrentDevice())
-      , needs_reset(old_device != new_device)
-  {
-    if (needs_reset)
-    {
-      CubDebug(cudaSetDevice(new_device));
-    }
-  }
+//! @brief RAII helper which saves the current device and switches to the specified device on construction and switches
+//! to the saved device on destruction.
+using SwitchDevice = ::cuda::__ensure_current_device;
 
-  _CCCL_HOST inline ~SwitchDevice()
-  {
-    if (needs_reset)
-    {
-      CubDebug(cudaSetDevice(old_device));
-    }
-  }
-};
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /**

--- a/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
+++ b/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
@@ -47,4 +47,34 @@
     (void) __status;                                   \
   }
 
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+//! @brief `__cuda_set_device_wrapper` is a simple helper that sets the current device to a given target and resets it
+//! back in its destructor
+struct __cuda_set_device_wrapper
+{
+  int __target_device_   = 0;
+  int __original_device_ = 0;
+
+  __cuda_set_device_wrapper(const int __target_device)
+      : __target_device_(__target_device)
+  {
+    _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to query current device", &__original_device_);
+    if (__original_device_ != __target_device_)
+    {
+      _CCCL_TRY_CUDA_API(::cudaSetDevice, "Failed to set device", __target_device_);
+    }
+  }
+
+  ~__cuda_set_device_wrapper()
+  {
+    if (__original_device_ != __target_device_)
+    {
+      _CCCL_TRY_CUDA_API(::cudaSetDevice, "Failed to set device", __original_device_);
+    }
+  }
+};
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
 #endif //_CUDA__STD__CUDA_API_WRAPPER_H

--- a/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
+++ b/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
@@ -47,34 +47,4 @@
     (void) __status;                                   \
   }
 
-_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
-
-//! @brief `__cuda_set_device_wrapper` is a simple helper that sets the current device to a given target and resets it
-//! back in its destructor
-struct __cuda_set_device_wrapper
-{
-  int __target_device_   = 0;
-  int __original_device_ = 0;
-
-  __cuda_set_device_wrapper(const int __target_device)
-      : __target_device_(__target_device)
-  {
-    _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to query current device", &__original_device_);
-    if (__original_device_ != __target_device_)
-    {
-      _CCCL_TRY_CUDA_API(::cudaSetDevice, "Failed to set device", __target_device_);
-    }
-  }
-
-  ~__cuda_set_device_wrapper()
-  {
-    if (__original_device_ != __target_device_)
-    {
-      _CCCL_TRY_CUDA_API(::cudaSetDevice, "Failed to set device", __original_device_);
-    }
-  }
-};
-
-_LIBCUDACXX_END_NAMESPACE_CUDA
-
 #endif //_CUDA__STD__CUDA_API_WRAPPER_H

--- a/libcudacxx/include/cuda/std/__cuda/ensure_current_device.h
+++ b/libcudacxx/include/cuda/std/__cuda/ensure_current_device.h
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA__STD__CUDA_ENSURE_CURRENT_DEVICE_H
+#define _CUDA__STD__CUDA_ENSURE_CURRENT_DEVICE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#  include <cuda_runtime_api.h>
+#endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+
+#include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/std/__exception/cuda_error.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+//! @brief `__ensure_current_device` is a simple helper that the current device is set to the right one.
+//! Only changes the current device if the target device is not the current one
+struct __ensure_current_device
+{
+  int __target_device_   = 0;
+  int __original_device_ = 0;
+
+  //! @brief Querries the current device and if that is different than \p __target_device sets the current device to
+  //! \p __target_device
+  __ensure_current_device(const int __target_device)
+      : __target_device_(__target_device)
+  {
+    _CCCL_TRY_CUDA_API(::cudaGetDevice, "Failed to query current device", &__original_device_);
+    if (__original_device_ != __target_device_)
+    {
+      _CCCL_TRY_CUDA_API(::cudaSetDevice, "Failed to set device", __target_device_);
+    }
+  }
+
+  //! @brief If the \p __original_device was not equal to \p __target_device sets the current device back to
+  //! \p __original_device
+  ~__ensure_current_device()
+  {
+    if (__original_device_ != __target_device_)
+    {
+      _CCCL_TRY_CUDA_API(::cudaSetDevice, "Failed to set device", __original_device_);
+    }
+  }
+};
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif //_CUDA__STD__CUDA_ENSURE_CURRENT_DEVICE_H

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_memory_resource/traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_memory_resource/traits.pass.cpp
@@ -17,14 +17,14 @@
 #include <cuda/std/type_traits>
 
 using resource = cuda::mr::cuda_memory_resource;
-static_assert(cuda::std::is_trivial<resource>::value, "");
-static_assert(cuda::std::is_trivially_default_constructible<resource>::value, "");
+static_assert(!cuda::std::is_trivial<resource>::value, "");
+static_assert(!cuda::std::is_trivially_default_constructible<resource>::value, "");
 static_assert(cuda::std::is_trivially_copy_constructible<resource>::value, "");
 static_assert(cuda::std::is_trivially_move_constructible<resource>::value, "");
 static_assert(cuda::std::is_trivially_copy_assignable<resource>::value, "");
 static_assert(cuda::std::is_trivially_move_assignable<resource>::value, "");
 static_assert(cuda::std::is_trivially_destructible<resource>::value, "");
-static_assert(cuda::std::is_empty<resource>::value, "");
+static_assert(!cuda::std::is_empty<resource>::value, "");
 
 int main(int, char**)
 {


### PR DESCRIPTION
`cudaMalloc` always allocates memory on the current device, so we must make sure that we set the current device to the right one.

By default we always allocate on device 0