### PR TITLE
Add new runners to nightly matrix.

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -51,7 +51,8 @@ workflows:
     - {jobs: ['test'],  ctk: '11.1', gpu: 'v100',     sm: 'gpu', cxx: 'gcc6',    std: [11]}
     - {jobs: ['test'],  ctk: '11.1', gpu: 't4',       sm: 'gpu', cxx: 'clang9',  std: [17]}
     - {jobs: ['test'],  ctk: '11.8', gpu: 'rtx2080',  sm: 'gpu', cxx: 'gcc11',   std: [17]}
-    - {jobs: ['test'],  ctk: 'curr', gpu: 'rtxa6000', sm: 'gpu', cxx: 'gcc7',    std: [14]}
+    - {jobs: ['test'],  ctk: 'curr', gpu: 'a100',     sm: 'gpu', cxx: 'gcc7',    std: [11], cpu: 'arm64'}
+    - {jobs: ['test'],  ctk: 'curr', gpu: 'rtxa6000', sm: 'gpu', cxx: 'gcc9',    std: [14]}
     - {jobs: ['test'],  ctk: 'curr', gpu: 'l4',       sm: 'gpu', cxx: 'gcc13',   std: 'all'}
     - {jobs: ['test'],  ctk: 'curr', gpu: 'rtx4090',  sm: 'gpu', cxx: 'clang9',  std: [11]}
     # H100 runners are currently flakey, only build since those use CPU-only runners:
@@ -224,6 +225,7 @@ gpus:
   v100:     { sm: 70 }                # 32 GB,  40 runners
   t4:       { sm: 75, testing: true } # 16 GB,   8 runners
   rtx2080:  { sm: 75, testing: true } #  8 GB,   8 runners
+  a100:     { sm: 80, testing: true } #  ? GB,   4 runners, arm64 only
   rtxa6000: { sm: 86, testing: true } # 48 GB,  12 runners
   l4:       { sm: 89, testing: true } # 24 GB,  48 runners
   rtx4090:  { sm: 89, testing: true } # 24 GB,  10 runners


### PR DESCRIPTION
We now have a testing pool with A100+arm64. The runners team asked us to add this to our matrix to help with testing.