### PR TITLE
Add script to update RAPIDS version.

### DIFF
--- a/.devcontainer/cuda11.1-gcc6/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc6/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc6-cuda11.1",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc6-cuda11.1",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda11.1-gcc7/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc7-cuda11.1",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc7-cuda11.1",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda11.1-gcc8/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc8-cuda11.1",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc8-cuda11.1",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda11.1-gcc9/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc9-cuda11.1",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc9-cuda11.1",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda11.1-llvm9/devcontainer.json
+++ b/.devcontainer/cuda11.1-llvm9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm9-cuda11.1",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm9-cuda11.1",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda11.8-gcc11/devcontainer.json
+++ b/.devcontainer/cuda11.8-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc11-cuda11.8",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc11-cuda11.8",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc10-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc10-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc11-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc11-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc12-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc12-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc9-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc9-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-llvm10/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm10-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm10-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-llvm11/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm11-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm11-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-llvm12/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm12-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm12-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-llvm13/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm13-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm13-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm14-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm14-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.0-llvm9/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm9-cuda12.0",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm9-cuda12.0",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.2-rapids-conda
+++ b/.devcontainer/cuda12.2-rapids-conda
@@ -1,1 +1,0 @@
-../ci/rapids/cuda12.2-conda

--- a/.devcontainer/cuda12.2-rapids-conda
+++ b/.devcontainer/cuda12.2-rapids-conda
@@ -1,0 +1,1 @@
+../ci/rapids/cuda12.2-conda

--- a/.devcontainer/cuda12.5-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc10-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc10-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc11-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc11-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc12-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc12-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc13-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc13-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc7-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc7-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc8-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc8-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc9-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc9-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-llvm10/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm10-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm10-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-llvm11/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm11-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm11-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-llvm12/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm12-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm12-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-llvm13/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm13-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm13-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm14-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm14-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm15-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm15-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm16/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm16-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm16-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm17/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm17-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm17-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-llvm9/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-llvm9-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-llvm9-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-oneapi2023.2.0/devcontainer.json
+++ b/.devcontainer/cuda12.5-oneapi2023.2.0/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-oneapi2023.2.0-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-oneapi2023.2.0-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.devcontainer/cuda12.5-rapids-conda
+++ b/.devcontainer/cuda12.5-rapids-conda
@@ -1,0 +1,1 @@
+../ci/rapids/cuda12.5-conda

--- a/.devcontainer/cuda12.5-rapids-conda
+++ b/.devcontainer/cuda12.5-rapids-conda
@@ -1,1 +1,0 @@
-../ci/rapids/cuda12.5-conda

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:24.08-cpp-gcc13-cuda12.5",
+  "image": "rapidsai/devcontainers:24.10-cpp-gcc13-cuda12.5",
   "hostRequirements": {
     "gpu": "optional"
   },

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -61,20 +61,20 @@ jobs:
           CI: true
           RAPIDS_LIBS: ${{ matrix.libs }}
           # Uncomment any of these to customize the git repo and branch for a RAPIDS lib:
-          # RAPIDS_cmake_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_cudf_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_cudf_kafka_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_cugraph_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_cugraph_ops_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_cuml_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_cumlprims_mg_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_cuspatial_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_cuvs_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_KvikIO_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_raft_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_rmm_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
-          # RAPIDS_ucxx_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-0.39"}'
-          # RAPIDS_wholegraph_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.08"}'
+          # RAPIDS_cmake_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_cudf_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_cudf_kafka_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_cugraph_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_cugraph_ops_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_cuml_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_cumlprims_mg_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_cuspatial_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_cuvs_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_KvikIO_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_raft_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_rmm_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
+          # RAPIDS_ucxx_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-0.40"}'
+          # RAPIDS_wholegraph_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-24.10"}'
         run: |
           cat <<"EOF" > "$RUNNER_TEMP/ci-entrypoint.sh"
           #! /usr/bin/env bash

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -36,10 +36,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { cuda: '12.2', libs: 'rmm KvikIO cudf cudf_kafka cuspatial',        }
-          - { cuda: '12.2', libs: 'rmm ucxx raft cuvs',                          }
-          - { cuda: '12.2', libs: 'rmm ucxx raft cumlprims_mg cuml',             }
-          - { cuda: '12.2', libs: 'rmm ucxx raft cugraph-ops wholegraph cugraph' }
+          - { cuda: '12.5', libs: 'rmm KvikIO cudf cudf_kafka cuspatial',        }
+          - { cuda: '12.5', libs: 'rmm ucxx raft cuvs',                          }
+          - { cuda: '12.5', libs: 'rmm ucxx raft cumlprims_mg cuml',             }
+          - { cuda: '12.5', libs: 'rmm ucxx raft cugraph-ops wholegraph cugraph' }
     permissions:
       id-token: write
       contents: read

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -99,7 +99,7 @@ workflows:
 
 
 # The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers
-devcontainer_version: '24.08'
+devcontainer_version: '24.10'
 
 # All supported C++ standards:
 all_stds: [11, 14, 17, 20]

--- a/ci/rapids/cuda12.2-conda/devcontainer.json
+++ b/ci/rapids/cuda12.2-conda/devcontainer.json
@@ -1,13 +1,13 @@
 {
-  "image": "rapidsai/devcontainers:24.08-cpp-mambaforge-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.10-cpp-mambaforge-ubuntu22.04",
   "runArgs": [
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-24.08-cuda12.2-conda"
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-24.10-cuda12.2-conda"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
-    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:24.8": {}
+    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:24.10": {}
   },
   "overrideFeatureInstallOrder": [
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils"

--- a/ci/rapids/cuda12.5-conda/devcontainer.json
+++ b/ci/rapids/cuda12.5-conda/devcontainer.json
@@ -3,7 +3,7 @@
   "runArgs": [
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-24.10-cuda12.2-conda"
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-24.10-cuda12.5-conda"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
@@ -15,7 +15,7 @@
   "containerEnv": {
     "CI": "${localEnv:CI}",
     "CUDAARCHS": "70-real",
-    "CUDA_VERSION": "12.2",
+    "CUDA_VERSION": "12.5",
     "DEFAULT_CONDA_ENV": "rapids",
     "PYTHONSAFEPATH": "1",
     "PYTHONUNBUFFERED": "1",

--- a/ci/update_rapids_version.sh
+++ b/ci/update_rapids_version.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+##########################
+# RAPIDS Version Updater #
+##########################
+
+## Usage
+# bash update_rapids_version.sh <new_version>
+
+# Format is YY.MM.PP - no leading 'v' or trailing 'a'
+NEXT_FULL_TAG=$1
+
+#Get <major>.<minor> for next version
+NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
+NEXT_PATCH=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[3]}')
+NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
+NEXT_UCXX_SHORT_TAG="$(curl -sL https://version.gpuci.io/rapids/${NEXT_SHORT_TAG})"
+
+# Need to distutils-normalize the versions for some use cases
+NEXT_SHORT_TAG_PEP440=$(python -c "from setuptools.extern import packaging; print(packaging.version.Version('${NEXT_SHORT_TAG}'))")
+
+echo "Updating RAPIDS and devcontainers to $NEXT_FULL_TAG"
+
+# Inplace sed replace; workaround for Linux and Mac
+function sed_runner() {
+    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+}
+
+# Update CI files
+sed_runner "/devcontainer_version/ s/'[0-9.]*'/'${NEXT_SHORT_TAG}'/g" ci/matrix.yaml
+for FILE in .github/workflows/*.yml; do
+  sed_runner "/rapidsai/ s/\"branch-.*\"/\"branch-${NEXT_SHORT_TAG}\"/g" "${FILE}"
+  sed_runner "/ucxx/ s/\"branch-.*\"/\"branch-${NEXT_UCXX_SHORT_TAG}\"/g" "${FILE}"
+done
+
+function update_devcontainer() {
+    sed_runner "s@rapidsai/devcontainers:[0-9.]*@rapidsai/devcontainers:${NEXT_SHORT_TAG}@g" "${1}"
+    sed_runner "s@rapidsai/devcontainers/features/rapids-build-utils:[0-9.]*@rapidsai/devcontainers/features/rapids-build-utils:${NEXT_SHORT_TAG_PEP440}@" "${1}"
+    sed_runner "s@\${localWorkspaceFolderBasename}-rapids-[0-9.]*@\${localWorkspaceFolderBasename}-rapids-${NEXT_SHORT_TAG}@g" "${1}"
+}
+
+# Update .devcontainer files
+find .devcontainer/ ci/rapids/ -type f -name devcontainer.json -print0 | while IFS= read -r -d '' filename; do
+    update_devcontainer "${filename}"
+done


### PR DESCRIPTION
## Description

This PR adds an update script to manage RAPIDS and devcontainer updates. It also applies the script, updating the versions to 24.10. The update script can be invoked like this: `ci/update_rapids_version.sh 24.10.00`

Supersedes #2079:

> @miscco fixed some compilation errors caused by removing long-time deprecated CUB facilities in: https://github.com/rapidsai/cudf/pull/16377. However, this fixes were targeted to the 24.10 branch, while our CI keeps building the 24.08 branch.
>
> This PR changes our CI jobs to build against with the 24.10 branch.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
