### PR TITLE
Benchmark analysis: Print all top rows when asked for

### DIFF
--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -273,7 +273,8 @@ def case_top(alpha, N, algname, ct_point_name, case_dfs):
 
     for subbench in case_dfs:
         case_dfs[subbench] = extract_complete_variants(case_dfs[subbench])
-    print(extract_scores(case_dfs).head(N))
+    with pd.option_context('display.max_rows', None):
+        print(extract_scores(case_dfs).head(N))
 
 
 def top(args):


### PR DESCRIPTION
Analyzing the top 10 result of a tuning run like
```
benchmarks/scripts/analyze.py --top 10 ./cccl_meta_bench.db
```
prints those nicely. However, sometimes I need more output, e.g. `--top 150`. Such output is truncated:
```
cub.bench.transform.babelstream[T{ct}=I8]:
              variant     score      mins     means       maxs
130  tpb_896.alg_4 ()  8.592724  1.333333  8.592724  21.716392
145  tpb_992.alg_4 ()  8.563333  1.333333  8.563333  21.537903
115  tpb_800.alg_4 ()  8.510113  1.333333  8.510113  22.333335
90   tpb_640.alg_4 ()  8.495584  1.333333  8.495584  20.472222
120  tpb_832.alg_4 ()  8.401476  1.333333  8.401476  21.676473
..                ...       ...       ...       ...        ...
137  tpb_960.alg_1 ()  0.575716  0.377841  0.575716   0.705357
132  tpb_928.alg_1 ()  0.566222  0.377841  0.566222   0.705357
117  tpb_832.alg_1 ()  0.551207  0.377841  0.551207   0.705357
122  tpb_864.alg_1 ()  0.539873  0.377841  0.539873   0.699115
112  tpb_800.alg_1 ()  0.523036  0.346354  0.523036   0.705357

[146 rows x 5 columns]
```

This PR removes the truncation and prints the number of rows that the user asked for.