### PR TITLE
Allow installing components when downstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,17 +25,18 @@ endif()
 # Support adding CCCL to a parent project via add_subdirectory.
 if (NOT CCCL_TOPLEVEL_PROJECT)
   include(cmake/CCCLAddSubdir.cmake)
-  return()
 endif()
 
 # We require a higher cmake version for dev builds
-cmake_minimum_required(VERSION 3.21)
+if (CCCL_TOPLEVEL_PROJECT)
+  cmake_minimum_required(VERSION 3.21)
+endif()
 
-option(CCCL_ENABLE_LIBCUDACXX "Enable the libcu++ developer build." ON)
-option(CCCL_ENABLE_CUB "Enable the CUB developer build." ON)
-option(CCCL_ENABLE_THRUST "Enable the Thrust developer build." ON)
-option(CCCL_ENABLE_TESTING "Enable CUDA C++ Core Library tests." ON)
-option(CCCL_ENABLE_EXAMPLES "Enable CUDA C++ Core Library examples." ON)
+option(CCCL_ENABLE_LIBCUDACXX "Enable the libcu++ developer build." ${CCCL_TOPLEVEL_PROJECT})
+option(CCCL_ENABLE_CUB "Enable the CUB developer build." ${CCCL_TOPLEVEL_PROJECT})
+option(CCCL_ENABLE_THRUST "Enable the Thrust developer build." ${CCCL_TOPLEVEL_PROJECT})
+option(CCCL_ENABLE_TESTING "Enable CUDA C++ Core Library tests." ${CCCL_TOPLEVEL_PROJECT})
+option(CCCL_ENABLE_EXAMPLES "Enable CUDA C++ Core Library examples." ${CCCL_TOPLEVEL_PROJECT})
 option(CCCL_ENABLE_BENCHMARKS "Enable CUDA C++ Core Library benchmarks." OFF)
 
 option(CCCL_ENABLE_UNSTABLE "Enable targets and developer build options for unstable projects." OFF)
@@ -44,27 +45,28 @@ if (CCCL_ENABLE_UNSTABLE)
   option(CCCL_ENABLE_CUDAX "Enable the CUDA Experimental developer build." ON)
 endif()
 
-
 include(CTest)
 enable_testing()
 
-include(cmake/CCCLUtilities.cmake) # include this first
-include(cmake/CCCLClangdCompileInfo.cmake)
+if (CCCL_TOPLEVEL_PROJECT)
+  include(cmake/CCCLUtilities.cmake) # include this first
+  include(cmake/CCCLClangdCompileInfo.cmake)
+endif()
 
 if (CCCL_ENABLE_LIBCUDACXX)
-  set(LIBCUDACXX_TOPLEVEL_PROJECT ON)
+  set(LIBCUDACXX_TOPLEVEL_PROJECT ${CCCL_TOPLEVEL_PROJECT})
 endif()
 
 if (CCCL_ENABLE_CUB)
-  set(CUB_TOPLEVEL_PROJECT ON)
+  set(CUB_TOPLEVEL_PROJECT ${CCCL_TOPLEVEL_PROJECT})
 endif()
 
 if (CCCL_ENABLE_THRUST)
-  set(THRUST_TOPLEVEL_PROJECT ON)
+  set(THRUST_TOPLEVEL_PROJECT ${CCCL_TOPLEVEL_PROJECT})
 endif()
 
 if (CCCL_ENABLE_CUDAX)
-  set(cudax_TOPLEVEL_PROJECT ON)
+  set(cudax_TOPLEVEL_PROJECT ${CCCL_TOPLEVEL_PROJECT})
 endif()
 
 add_subdirectory(libcudacxx)


### PR DESCRIPTION
resolves https://github.com/NVIDIA/cccl/issues/1205
In the @acts-project we adopt an (admittedly somewhat unconventional) build system in which software A depends on B, and B depends on CCCL. The setup is that we want to install B into a prefix, and then try to build A against B. The problem arises is that we are using CMake to dynamically fetch CCCL using the so-called "FetchContent" mechanism, which downloads CCCL and then adds it as a subdirectory.

The core problem is that installing software B which has included CCCL does not actually install CCCL in the same prefix, so software A cannot then load software B as CCCL is not installed. The reason this happens is that CMakeLists.txt:28 (at the time of writing) returns from the CMake configuration stage early, and leaves the CUB, Thrust, and libcudacxx directories unincluded (see lines 70 to 72).

Although this is, again, an unconventional and rare scenario, it should be easy to add support for this kind of build, and I hope the CCCL devs would agree that it might be worth doing. In this commit, I remove the early return and replace it with additional if-statements. This commit should leave any existing workflows completely untouched, but should make it easier to use CCCL in the way we do in @acts-project.

Resolves #1205. 