### PR TITLE
Do not query NVRTC for cuda runtime header

### DIFF
--- a/cub/cub/detail/detect_cuda_runtime.cuh
+++ b/cub/cub/detail/detect_cuda_runtime.cuh
@@ -44,7 +44,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda_runtime_api.h>
+// CUDA headers might not be present when using NVRTC, see NVIDIA/cccl#2095 for detail
+#if !defined(_CCCL_COMPILER_NVRTC)
+#  include <cuda_runtime_api.h>
+#endif // !_CCCL_COMPILER_NVRTC
 
 #ifdef DOXYGEN_SHOULD_SKIP_THIS // Only parse this during doxygen passes:
 


### PR DESCRIPTION
This may fail as discussed in #2095

Fixes 2095
