### PR TITLE
Fix line break issues that break doxygen code examples

### DIFF
--- a/thrust/thrust/partition.h
+++ b/thrust/thrust/partition.h
@@ -161,10 +161,11 @@ ForwardIterator partition(ForwardIterator first, ForwardIterator last, Predicate
 /*! \p partition reorders the elements <tt>[first, last)</tt> based on the function
  *  object \p pred applied to a stencil range <tt>[stencil, stencil + (last - first))</tt>,
  *  such that all of the elements whose corresponding stencil element satisfies \p pred precede all of the elements
- * whose corresponding stencil element fails to satisfy it. The postcondition is that, for some iterator \c middle in
- * the range <tt>[first, last)</tt>, <tt>pred(*stencil_i)</tt> is \c true for every iterator \c stencil_i in the range
- * <tt>[stencil,stencil + (middle - first))</tt> and \c false for every iterator \c stencil_i in the range <tt>[stencil
- * + (middle - first), stencil + (last - first))</tt>. The return value of \p stable_partition is \c middle.
+ *  whose corresponding stencil element fails to satisfy it. The postcondition is that, for some iterator \c middle in
+ *  the range <tt>[first, last)</tt>, <tt>pred(*stencil_i)</tt> is \c true for every iterator \c stencil_i in the range
+ *  <tt>[stencil,stencil + (middle - first))</tt> and \c false for every iterator \c stencil_i in the range
+ *  <tt>[stencil + (middle - first), stencil + (last - first))</tt>.
+ *  The return value of \p stable_partition is \c middle.
  *
  *  Note that the relative order of elements in the two reordered sequences is not
  *  necessarily the same as it was in the original sequence. A different algorithm,
@@ -229,10 +230,11 @@ _CCCL_HOST_DEVICE ForwardIterator partition(
 /*! \p partition reorders the elements <tt>[first, last)</tt> based on the function
  *  object \p pred applied to a stencil range <tt>[stencil, stencil + (last - first))</tt>,
  *  such that all of the elements whose corresponding stencil element satisfies \p pred precede all of the elements
- * whose corresponding stencil element fails to satisfy it. The postcondition is that, for some iterator \c middle in
- * the range <tt>[first, last)</tt>, <tt>pred(*stencil_i)</tt> is \c true for every iterator \c stencil_i in the range
- * <tt>[stencil,stencil + (middle - first))</tt> and \c false for every iterator \c stencil_i in the range <tt>[stencil
- * + (middle - first), stencil + (last - first))</tt>. The return value of \p stable_partition is \c middle.
+ *  whose corresponding stencil element fails to satisfy it. The postcondition is that, for some iterator \c middle in
+ *  the range <tt>[first, last)</tt>, <tt>pred(*stencil_i)</tt> is \c true for every iterator \c stencil_i in the range
+ *  <tt>[stencil,stencil + (middle - first))</tt> and \c false for every iterator \c stencil_i in the range
+ *  <tt>[stencil + (middle - first), stencil + (last - first))</tt>.
+ *  The return value of \p stable_partition is \c middle.
  *
  *  Note that the relative order of elements in the two reordered sequences is not
  *  necessarily the same as it was in the original sequence. A different algorithm,

--- a/thrust/thrust/remove.h
+++ b/thrust/thrust/remove.h
@@ -550,8 +550,8 @@ OutputIterator remove_copy_if(InputIterator first, InputIterator last, OutputIte
  * href="https://en.cppreference.com/w/cpp/concepts/predicate">Predicate</a>.
  *
  *  \pre The range <tt>[first, last)</tt> shall not overlap the range <tt>[result, result + (last - first))</tt>.
- *  \pre The range <tt>[stencil, stencil + (last - first))</tt> shall not overlap the range <tt>[result, result + (last
- * - first))</tt>.
+ *  \pre The range <tt>[stencil, stencil + (last - first))</tt> shall not overlap the range
+ *  <tt>[result, result + (last - first))</tt>.
  *
  *  The following code snippet demonstrates how to use \p remove_if to remove
  *  specific elements from an array of integers using the \p thrust::host execution policy for
@@ -610,8 +610,8 @@ _CCCL_HOST_DEVICE ForwardIterator remove_if(
  * href="https://en.cppreference.com/w/cpp/concepts/predicate">Predicate</a>.
  *
  *  \pre The range <tt>[first, last)</tt> shall not overlap the range <tt>[result, result + (last - first))</tt>.
- *  \pre The range <tt>[stencil, stencil + (last - first))</tt> shall not overlap the range <tt>[result, result + (last
- * - first))</tt>.
+ *  \pre The range <tt>[stencil, stencil + (last - first))</tt> shall not overlap the range
+ *  <tt>[result, result + (last - first))</tt>.
  *
  *  The following code snippet demonstrates how to use \p remove_if to remove
  *  specific elements from an array of integers.
@@ -668,8 +668,8 @@ ForwardIterator remove_if(ForwardIterator first, ForwardIterator last, InputIter
  * href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output Iterator</a>. \tparam Predicate is a model
  * of <a href="https://en.cppreference.com/w/cpp/concepts/predicate">Predicate</a>.
  *
- *  \pre The range <tt>[stencil, stencil + (last - first))</tt> shall not overlap the range <tt>[result, result + (last
- * - first))</tt>.
+ *  \pre The range <tt>[stencil, stencil + (last - first))</tt> shall not overlap the range
+ *  <tt>[result, result + (last - first))</tt>.
  *
  *  The following code snippet demonstrates how to use \p remove_copy_if to copy
  *  a sequence of numbers to an output range while omitting specific elements using the \p thrust::host
@@ -732,8 +732,8 @@ _CCCL_HOST_DEVICE OutputIterator remove_copy_if(
  * href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output Iterator</a>. \tparam Predicate is a model
  * of <a href="https://en.cppreference.com/w/cpp/concepts/predicate">Predicate</a>.
  *
- *  \pre The range <tt>[stencil, stencil + (last - first))</tt> shall not overlap the range <tt>[result, result + (last
- * - first))</tt>.
+ *  \pre The range <tt>[stencil, stencil + (last - first))</tt> shall not overlap the range
+ *  <tt>[result, result + (last - first))</tt>.
  *
  *  The following code snippet demonstrates how to use \p remove_copy_if to copy
  *  a sequence of numbers to an output range while omitting specific elements.

--- a/thrust/thrust/scan.h
+++ b/thrust/thrust/scan.h
@@ -74,8 +74,8 @@ THRUST_NAMESPACE_BEGIN
  * Iterator</a>, and if \c x and \c y are objects of \c OutputIterator's \c value_type, then <tt>x + y</tt> is defined.
  * If \c T is \c OutputIterator's \c value_type, then <tt>T(0)</tt> is defined.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan to compute an in-place
  *  prefix sum using the \p thrust::host execution policy for parallelization:
@@ -131,8 +131,8 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan(
  * Iterator</a>, and if \c x and \c y are objects of \c OutputIterator's \c value_type, then <tt>x + y</tt> is defined.
  * If \c T is \c OutputIterator's \c value_type, then <tt>T(0)</tt> is defined.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan
  *
@@ -186,8 +186,8 @@ OutputIterator inclusive_scan(InputIterator first, InputIterator last, OutputIte
  * href="https://en.cppreference.com/w/cpp/utility/functional/binary_function">Binary Function</a> and \c
  * AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan to compute an in-place
  *  prefix sum using the \p thrust::host execution policy for parallelization:
@@ -242,8 +242,8 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan(
  * href="https://en.cppreference.com/w/cpp/utility/functional/binary_function">Binary Function</a> and \c
  * AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan
  *
@@ -291,8 +291,8 @@ inclusive_scan(InputIterator first, InputIterator last, OutputIterator result, A
  * Iterator</a>, and if \c x and \c y are objects of \c OutputIterator's \c value_type, then <tt>x + y</tt> is defined.
  * If \c T is \c OutputIterator's \c value_type, then <tt>T(0)</tt> is defined.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan to compute an in-place
  *  prefix sum using the \p thrust::host execution policy for parallelization:
@@ -342,8 +342,8 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan(
  * Iterator</a>, and if \c x and \c y are objects of \c OutputIterator's \c value_type, then <tt>x + y</tt> is defined.
  * If \c T is \c OutputIterator's \c value_type, then <tt>T(0)</tt> is defined.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan
  *
@@ -391,8 +391,8 @@ OutputIterator exclusive_scan(InputIterator first, InputIterator last, OutputIte
  * Iterator</a>, and if \c x and \c y are objects of \c OutputIterator's \c value_type, then <tt>x + y</tt> is defined.
  *  \tparam T is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan to compute an in-place
  *  prefix sum using the \p thrust::host execution policy for parallelization:
@@ -443,8 +443,8 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan(
  * Iterator</a>, and if \c x and \c y are objects of \c OutputIterator's \c value_type, then <tt>x + y</tt> is defined.
  *  \tparam T is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan
  *
@@ -498,8 +498,8 @@ OutputIterator exclusive_scan(InputIterator first, InputIterator last, OutputIte
  * href="https://en.cppreference.com/w/cpp/utility/functional/binary_function">Binary Function</a> and \c
  * AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan to compute an in-place
  *  prefix sum using the \p thrust::host execution policy for parallelization:
@@ -561,8 +561,8 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan(
  * href="https://en.cppreference.com/w/cpp/utility/functional/binary_function">Binary Function</a> and \c
  * AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  \pre \p first may equal \p result but the range <tt>[first, last)</tt> and the range
+ *  <tt>[result, result + (last - first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan
  *
@@ -628,9 +628,10 @@ exclusive_scan(InputIterator first, InputIterator last, OutputIterator result, T
  * href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output Iterator</a>, and if \c x and \c y are
  * objects of \c OutputIterator's \c value_type, then <tt>binary_op(x,y)</tt> is defined.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan_by_key using the \p thrust::host
  *  execution policy for parallelization:
@@ -694,9 +695,10 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan_by_key(
  * href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output Iterator</a>, and if \c x and \c y are
  * objects of \c OutputIterator's \c value_type, then <tt>binary_op(x,y)</tt> is defined.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan_by_key
  *
@@ -759,9 +761,10 @@ inclusive_scan_by_key(InputIterator1 first1, InputIterator1 last1, InputIterator
  * objects of \c OutputIterator's \c value_type, then <tt>binary_op(x,y)</tt> is defined. \tparam BinaryPredicate is a
  * model of <a href="https://en.cppreference.com/w/cpp/named_req/BinaryPredicate">Binary Predicate</a>.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan_by_key using the \p thrust::host
  *  execution policy for parallelization:
@@ -835,9 +838,10 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan_by_key(
  * objects of \c OutputIterator's \c value_type, then <tt>binary_op(x,y)</tt> is defined. \tparam BinaryPredicate is a
  * model of <a href="https://en.cppreference.com/w/cpp/named_req/BinaryPredicate">Binary Predicate</a>.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan_by_key
  *
@@ -911,9 +915,10 @@ OutputIterator inclusive_scan_by_key(
  * href="https://en.cppreference.com/w/cpp/utility/functional/binary_function">Binary Function</a> and \c
  * AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan_by_key using the \p thrust::host
  *  execution policy for parallelization:
@@ -994,9 +999,10 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan_by_key(
  * href="https://en.cppreference.com/w/cpp/utility/functional/binary_function">Binary Function</a> and \c
  * AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p inclusive_scan_by_key
  *
@@ -1061,9 +1067,10 @@ OutputIterator inclusive_scan_by_key(
  *  \param first2 The beginning of the input value sequence.
  *  \param result The beginning of the output value sequence.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan_by_key using the
  *  \p thrust::host execution policy for parallelization:
@@ -1118,9 +1125,10 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan_by_key(
  *  \param first2 The beginning of the input value sequence.
  *  \param result The beginning of the output value sequence.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan_by_key.
  *
@@ -1166,9 +1174,10 @@ exclusive_scan_by_key(InputIterator1 first1, InputIterator1 last1, InputIterator
  *  \param init The initial of the exclusive sum value.
  *  \return The end of the output sequence.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan_by_key using the \p
  *  thrust::host execution policy for parallelization:
@@ -1223,9 +1232,10 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan_by_key(
  *  \param init The initial of the exclusive sum value.
  *  \return The end of the output sequence.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan_by_key
  *
@@ -1281,9 +1291,10 @@ OutputIterator exclusive_scan_by_key(
  *  \param binary_pred The binary predicate used to determine equality of keys.
  *  \return The end of the output sequence.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan_by_key using the
  *  \p thrust::host execution policy for parallelization:
@@ -1352,9 +1363,10 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan_by_key(
  *  \param binary_pred The binary predicate used to determine equality of keys.
  *  \return The end of the output sequence.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan_by_key
  *
@@ -1434,9 +1446,10 @@ OutputIterator exclusive_scan_by_key(
  * is a model of <a href="https://en.cppreference.com/w/cpp/utility/functional/binary_function">Binary Function</a> and
  * \c AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan_by_key using the
  *  \p thrust::host execution policy for parallelization:
@@ -1525,9 +1538,10 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan_by_key(
  * is a model of <a href="https://en.cppreference.com/w/cpp/utility/functional/binary_function">Binary Function</a> and
  * \c AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
  *
- *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1
- * - first1))</tt> shall not overlap otherwise. \pre \p first2 may equal \p result but the range <tt>[first2, first2 +
- * (last1 - first1)</tt> and range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
+ *  \pre \p first2 may equal \p result but the range <tt>[first2, first2 + (last1 - first1)</tt> and the range
+ *  <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p exclusive_scan_by_key
  *

--- a/thrust/thrust/scatter.h
+++ b/thrust/thrust/scatter.h
@@ -64,13 +64,13 @@ THRUST_NAMESPACE_BEGIN
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[first,last)` for all iterators `i` in the range `[map,map + (last - first))`.
  *
- *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range `[map,map
- * + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
+ *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
+ *  `[map, map + (last - first))` for all iterators `i` in the range `[map, map + (last - first))`.
  *
- *  \pre The expression `result[*i]` shall be valid for all iterators in the range `[map,map + (last - first))`.
+ *  \pre The expression `result[*i]` shall be valid for all iterators in the range `[map, map + (last - first))`.
  *
- *  The following code snippet demonstrates how to use \p scatter to
- *  reorder a range using the \p thrust::device execution policy for parallelization:
+ *  The following code snippet demonstrates how to use \p scatter to reorder a range using
+ *  the \p thrust::device execution policy for parallelization:
  *
  *  \code
  *  #include <thrust/scatter.h>
@@ -125,13 +125,12 @@ scatter(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[first,last)` for all iterators `i` in the range `[map,map + (last - first))`.
  *
- *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range `[map,map
- * + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
+ *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
+ *  `[map,map + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
  *
  *  \pre The expression `result[*i]` shall be valid for all iterators in the range `[map,map + (last - first))`.
  *
- *  The following code snippet demonstrates how to use \p scatter to
- *  reorder a range.
+ *  The following code snippet demonstrates how to use \p scatter to reorder a range.
  *
  *  \code
  *  #include <thrust/scatter.h>
@@ -187,14 +186,14 @@ void scatter(InputIterator1 first, InputIterator1 last, InputIterator2 map, Rand
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[first,last)` for all iterators `i` in the range `[map,map + (last - first))`.
  *
- *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range `[map,map
- * + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
+ *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
+ *  `[map,map + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
  *
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[stencil,stencil + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
  *
  *  \pre The expression `result[*i]` shall be valid for all iterators `i` in the range `[map,map + (last - first))` for
- * which the following condition holds: `*(stencil + i) != false`.
+ *  which the following condition holds: `*(stencil + i) != false`.
  *
  *  \code
  *  #include <thrust/scatter.h>
@@ -251,14 +250,14 @@ _CCCL_HOST_DEVICE void scatter_if(
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[first,last)` for all iterators `i` in the range `[map,map + (last - first))`.
  *
- *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range `[map,map
- * + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
+ *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
+ *  `[map,map + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
  *
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[stencil,stencil + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
  *
  *  \pre The expression `result[*i]` shall be valid for all iterators `i` in the range `[map,map + (last - first))` for
- * which the following condition holds: `*(stencil + i) != false`.
+ *  which the following condition holds: `*(stencil + i) != false`.
  *
  *  \code
  *  #include <thrust/scatter.h>
@@ -311,8 +310,8 @@ void scatter_if(
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[first,last)` for all iterators `i` in the range `[map,map + (last - first))`.
  *
- *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range `[map,map
- * + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
+ *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
+ *  `[map,map + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
  *
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[stencil,stencil + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
@@ -391,8 +390,8 @@ _CCCL_HOST_DEVICE void scatter_if(
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[first,last)` for all iterators `i` in the range `[map,map + (last - first))`.
  *
- *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range `[map,map
- * + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
+ *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
+ *  `[map,map + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.
  *
  *  \pre The iterator `result + i` shall not refer to any element referenced by any iterator `j` in the range
  * `[stencil,stencil + (last - first))` for all iterators `i` in the range `[map,map + (last - first))`.

--- a/thrust/thrust/unique.h
+++ b/thrust/thrust/unique.h
@@ -1013,17 +1013,16 @@ _CCCL_HOST_DEVICE typename thrust::iterator_traits<ForwardIterator>::difference_
  *
  *  This version of \p unique_count uses the function object \p binary_pred to test for equality.
  *
- *  \param exec The execution policy to use for parallelization.
  *  \param first The beginning of the input range.
  *  \param last  The end of the input range.
  *  \param binary_pred  The binary predicate used to determine equality.
  *  \return The number of runs of equal elements in <tt>[first, new_last)</tt>
  *
- *  \tparam DerivedPolicy The name of the derived execution policy.
  *  \tparam ForwardIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
- * Iterator</a>, and \p ForwardIterator's \c value_type is convertible to \p BinaryPredicate's \c first_argument_type
- * and to \p BinaryPredicate's \c second_argument_type. \tparam BinaryPredicate is a model of <a
- * href="https://en.cppreference.com/w/cpp/named_req/BinaryPredicate">Binary Predicate</a>.
+ *  Iterator</a>, and \p ForwardIterator's \c value_type is convertible to \p BinaryPredicate's \c first_argument_type
+ *  and to \p BinaryPredicate's \c second_argument_type.
+ *  \tparam BinaryPredicate is a model of <a
+ *  href="https://en.cppreference.com/w/cpp/named_req/BinaryPredicate">Binary Predicate</a>.
  *
  *  The following code snippet demonstrates how to use \p unique_count to
  *  determine the number of runs of equal elements:
@@ -1051,17 +1050,16 @@ unique_count(ForwardIterator first, ForwardIterator last, BinaryPredicate binary
  *
  *  This version of \p unique_count uses \c operator== to test for equality.
  *
- *  \param exec The execution policy to use for parallelization.
  *  \param first The beginning of the input range.
  *  \param last  The end of the input range.
  *  \param binary_pred  The binary predicate used to determine equality.
  *  \return The number of runs of equal elements in <tt>[first, new_last)</tt>
  *
- *  \tparam DerivedPolicy The name of the derived execution policy.
  *  \tparam ForwardIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
- * Iterator</a>, and \p ForwardIterator's \c value_type is convertible to \p BinaryPredicate's \c first_argument_type
- * and to \p BinaryPredicate's \c second_argument_type. \tparam BinaryPredicate is a model of <a
- * href="https://en.cppreference.com/w/cpp/named_req/BinaryPredicate">Binary Predicate</a>.
+ *  Iterator</a>, and \p ForwardIterator's \c value_type is convertible to \p BinaryPredicate's \c first_argument_type
+ *  and to \p BinaryPredicate's \c second_argument_type.
+ *  \tparam BinaryPredicate is a model of <a
+ *  href="https://en.cppreference.com/w/cpp/named_req/BinaryPredicate">Binary Predicate</a>.
  *
  *  The following code snippet demonstrates how to use \p unique_count to
  *  determine the number of runs of equal elements:


### PR DESCRIPTION
It seems that the thrust doxygen is a bit brittle at times.

This should fix some broken code samples