### PR TITLE
Deprecate/replace more of Thrust functional

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/diagnostic.h
+++ b/libcudacxx/include/cuda/std/__cccl/diagnostic.h
@@ -80,21 +80,33 @@
     _CCCL_DIAG_SUPPRESS_CLANG("-Wdeprecated") \
     _CCCL_DIAG_SUPPRESS_CLANG("-Wdeprecated-declarations")
 #  define _CCCL_SUPPRESS_DEPRECATED_POP _CCCL_DIAG_POP
-#elif defined(_CCCL_COMPILER_GCC) || defined(_CCCL_COMPILER_ICC)
+#elif defined(_CCCL_COMPILER_ICC)
+#  define _CCCL_SUPPRESS_DEPRECATED_PUSH \
+    _CCCL_DIAG_PUSH                      \
+    _CCCL_DIAG_SUPPRESS_ICC(1478)
+#  define _CCCL_SUPPRESS_DEPRECATED_POP _CCCL_DIAG_POP
+#elif defined(_CCCL_COMPILER_GCC)
 #  define _CCCL_SUPPRESS_DEPRECATED_PUSH    \
     _CCCL_DIAG_PUSH                         \
     _CCCL_DIAG_SUPPRESS_GCC("-Wdeprecated") \
     _CCCL_DIAG_SUPPRESS_GCC("-Wdeprecated-declarations")
+#  define _CCCL_SUPPRESS_DEPRECATED_POP _CCCL_DIAG_POP
+#elif defined(_CCCL_COMPILER_NVHPC)
+#  define _CCCL_SUPPRESS_DEPRECATED_PUSH \
+    _CCCL_DIAG_PUSH                      \
+    _CCCL_DIAG_SUPPRESS_NVHPC(deprecated_entity)
 #  define _CCCL_SUPPRESS_DEPRECATED_POP _CCCL_DIAG_POP
 #elif defined(_CCCL_COMPILER_MSVC)
 #  define _CCCL_SUPPRESS_DEPRECATED_PUSH \
     _CCCL_DIAG_PUSH                      \
     _CCCL_DIAG_SUPPRESS_MSVC(4996)
 #  define _CCCL_SUPPRESS_DEPRECATED_POP _CCCL_DIAG_POP
-#else // !_CCCL_COMPILER_CLANG && !_CCCL_COMPILER_GCC
+#else // !_CCCL_COMPILER_CLANG && !_CCCL_COMPILER_ICC && && !_CCCL_COMPILER_GCC && !_CCCL_COMPILER_NVHPC &&
+      // !_CCCL_COMPILER_MSVC
 #  define _CCCL_SUPPRESS_DEPRECATED_PUSH
 #  define _CCCL_SUPPRESS_DEPRECATED_POP
-#endif // !_CCCL_COMPILER_CLANG && !_CCCL_COMPILER_GCC
+#endif // !_CCCL_COMPILER_CLANG && !_CCCL_COMPILER_ICC && && !_CCCL_COMPILER_GCC && !_CCCL_COMPILER_NVHPC &&
+       // !_CCCL_COMPILER_MSVC
 
 // Enable us to selectively silence cuda compiler warnings
 #if defined(_CCCL_CUDA_COMPILER)

--- a/thrust/testing/dereference.cu
+++ b/thrust/testing/dereference.cu
@@ -71,6 +71,32 @@ void TestDeviceDereferenceTransformIterator()
 }
 DECLARE_UNITTEST(TestDeviceDereferenceTransformIterator);
 
+void TestDeviceDereferenceTransformIteratorInputConversion()
+{
+  thrust::device_vector<int> input = unittest::random_integers<int>(100);
+  thrust::device_vector<double> output(input.size(), 0);
+
+  simple_copy(thrust::make_transform_iterator(input.begin(), thrust::identity<double>()),
+              thrust::make_transform_iterator(input.end(), thrust::identity<double>()),
+              output.begin());
+
+  ASSERT_EQUAL(input == output, true);
+}
+DECLARE_UNITTEST(TestDeviceDereferenceTransformIteratorInputConversion);
+
+void TestDeviceDereferenceTransformIteratorOutputConversion()
+{
+  thrust::device_vector<int> input = unittest::random_integers<int>(100);
+  thrust::device_vector<double> output(input.size(), 0);
+
+  simple_copy(thrust::make_transform_iterator(input.begin(), thrust::identity<int>()),
+              thrust::make_transform_iterator(input.end(), thrust::identity<int>()),
+              output.begin());
+
+  ASSERT_EQUAL(input == output, true);
+}
+DECLARE_UNITTEST(TestDeviceDereferenceTransformIteratorOutputConversion);
+
 void TestDeviceDereferenceCountingIterator()
 {
   thrust::counting_iterator<int> first(1);

--- a/thrust/thrust/detail/type_traits/result_of_adaptable_function.h
+++ b/thrust/thrust/detail/type_traits/result_of_adaptable_function.h
@@ -53,12 +53,15 @@ public:
   using type = typename impl<Signature>::type;
 };
 
+// TODO(bgruber): remove this specialization eventually
 // specialization for invocations which define result_type
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename Functor, typename... ArgTypes>
 struct result_of_adaptable_function<Functor(ArgTypes...), ::cuda::std::void_t<typename Functor::result_type>>
 {
   using type = typename Functor::result_type;
 };
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace detail
 THRUST_NAMESPACE_END

--- a/thrust/thrust/functional.h
+++ b/thrust/thrust/functional.h
@@ -154,19 +154,6 @@ struct THRUST_DEPRECATED binary_function
  *  \{
  */
 
-#define THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(func, impl)                                            \
-  template <>                                                                                           \
-  struct func<void>                                                                                     \
-  {                                                                                                     \
-    using is_transparent = void;                                                                        \
-    _CCCL_EXEC_CHECK_DISABLE                                                                            \
-    template <typename T>                                                                               \
-    _CCCL_HOST_DEVICE constexpr auto operator()(T&& x) const noexcept(noexcept(impl)) -> decltype(impl) \
-    {                                                                                                   \
-      return impl;                                                                                      \
-    }                                                                                                   \
-  }
-
 #define THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION(func, impl)                                                      \
   template <>                                                                                                      \
   struct func<void>                                                                                                \
@@ -179,9 +166,6 @@ struct THRUST_DEPRECATED binary_function
       return impl;                                                                                                 \
     }                                                                                                              \
   }
-
-#define THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(func, op) \
-  THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION(func, THRUST_FWD(t1) op THRUST_FWD(t2))
 
 /*! \p plus is a function object. Specifically, it is an Adaptable Binary Function.
  *  If \c f is an object of class <tt>plus<T></tt>, and \c x and \c y are objects
@@ -425,38 +409,11 @@ struct modulus : public ::cuda::std::modulus<T>
  *  \see unary_function
  */
 template <typename T = void>
-struct negate
+struct negate : ::cuda::std::negate<T>
 {
-  /*! \typedef argument_type
-   *  \brief The type of the function object's argument.
-   */
-  using argument_type = T;
-
-  /*! \typedef result_type
-   *  \brief The type of the function object's result;
-   */
-  using result_type = T;
-
-#if defined(_CCCL_COMPILER_MSVC)
-  _CCCL_DIAG_PUSH
-  _CCCL_DIAG_SUPPRESS_MSVC(4146) // unary minus operator applied to unsigned type, result still unsigned
-#endif // _CCCL_COMPILER_MSVC
-
-  /*! Function call operator. The return value is <tt>-x</tt>.
-   */
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_HOST_DEVICE constexpr T operator()(const T& x) const
-  {
-    return -x;
-  }
-
-#if defined(_CCCL_COMPILER_MSVC)
-  _CCCL_DIAG_POP
-#endif // _CCCL_COMPILER_MSVC
-
+  using argument_type _LIBCUDACXX_DEPRECATED_IN_CXX11 = T;
+  using result_type _LIBCUDACXX_DEPRECATED_IN_CXX11   = T;
 }; // end negate
-
-THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(negate, -THRUST_FWD(x));
 
 /*! \p square is a function object. Specifically, it is an Adaptable Unary Function.
  *  If \c f is an object of class <tt>square<T></tt>, and \c x is an object
@@ -491,18 +448,9 @@ THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(negate, -THRUST_FWD(x));
 template <typename T = void>
 struct square
 {
-  /*! \typedef argument_type
-   *  \brief The type of the function object's argument.
-   */
-  using argument_type = T;
+  using argument_type _LIBCUDACXX_DEPRECATED_IN_CXX11 = T;
+  using result_type _LIBCUDACXX_DEPRECATED_IN_CXX11   = T;
 
-  /*! \typedef result_type
-   *  \brief The type of the function object's result;
-   */
-  using result_type = T;
-
-  /*! Function call operator. The return value is <tt>x*x</tt>.
-   */
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE constexpr T operator()(const T& x) const
   {
@@ -510,7 +458,18 @@ struct square
   }
 }; // end square
 
-THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(square, x* x);
+template <>
+struct square<void>
+{
+  using is_transparent = void;
+
+  _CCCL_EXEC_CHECK_DISABLE
+  template <typename T>
+  _CCCL_HOST_DEVICE constexpr T operator()(const T& x) const noexcept(noexcept(x * x))
+  {
+    return x * x;
+  }
+};
 
 /*! \}
  */
@@ -881,16 +840,10 @@ struct bit_xor : public ::cuda::std::bit_xor<T>
 template <typename T = void>
 struct identity
 {
-  /*! \typedef argument_type
-   *  \brief The type of the function object's first argument.
-   */
-  using argument_type = T;
+  using argument_type _LIBCUDACXX_DEPRECATED_IN_CXX11 = T;
+  using result_type _LIBCUDACXX_DEPRECATED_IN_CXX11   = T;
 
-  /*! \typedef result_type
-   *  \brief The type of the function object's result;
-   */
-  using result_type = T;
-
+  // FIXME(bgruber): this should take T&& and forward, to not add const to a mutable reference or dangle a temporary arg
   /*! Function call operator. The return value is <tt>x</tt>.
    */
   _CCCL_EXEC_CHECK_DISABLE
@@ -900,7 +853,9 @@ struct identity
   }
 }; // end identity
 
-THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(identity, THRUST_FWD(x));
+template <>
+struct identity<void> : ::cuda::std::__identity
+{};
 
 /*! \p maximum is a function object that takes two arguments and returns the greater
  *  of the two. Specifically, it is an Adaptable Binary Function. If \c f is an
@@ -934,19 +889,19 @@ struct maximum : ::cuda::maximum<T>
    *  \brief The type of the function object's first argument.
    *  deprecated [Since 2.6]
    */
-  using first_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T;
+  using first_argument_type _LIBCUDACXX_DEPRECATED_IN_CXX11 = T;
 
   /*! \typedef second_argument_type
    *  \brief The type of the function object's second argument.
    *  deprecated [Since 2.6]
    */
-  using second_argument_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T;
+  using second_argument_type _LIBCUDACXX_DEPRECATED_IN_CXX11 = T;
 
   /*! \typedef result_type
    *  \brief The type of the function object's result;
    *  deprecated [Since 2.6]
    */
-  using result_type _CCCL_ALIAS_ATTRIBUTE(THRUST_DEPRECATED) = T;
+  using result_type _LIBCUDACXX_DEPRECATED_IN_CXX11 = T;
 }; // end maximum
 
 /*! \p minimum is a function object that takes two arguments and returns the lesser
@@ -1382,9 +1337,7 @@ THRUST_INLINE_CONSTANT thrust::detail::functional::placeholder<9>::type _10;
 /*! \} // placeholder_objects
  */
 
-#undef THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION
 #undef THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION
-#undef THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP
 
 THRUST_NAMESPACE_END
 

--- a/thrust/thrust/iterator/detail/transform_iterator.inl
+++ b/thrust/thrust/iterator/detail/transform_iterator.inl
@@ -45,7 +45,7 @@ struct make_transform_iterator_base
 private:
   // FIXME(bgruber): the next line should be correct, but thrust::identity<T> lies and advertises a ::return_type of T,
   // while its operator() returns const T& (which __invoke_of correctly detects), which causes transform_iterator to
-  // crash during dereferencing.
+  // crash (or cause UB) during dereferencing. Check the test `thrust.test.dereference` for the OMP and TBB backends.
   // using wrapped_func_ret_t = ::cuda::std::__invoke_of<UnaryFunc, iterator_value_t<Iterator>>;
   using wrapped_func_ret_t = result_of_adaptable_function<UnaryFunc(iterator_value_t<Iterator>)>;
 

--- a/thrust/thrust/iterator/transform_iterator.h
+++ b/thrust/thrust/iterator/transform_iterator.h
@@ -305,10 +305,15 @@ private:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE typename super_t::reference dereference() const
   {
-    // Create a temporary to allow iterators with wrapped references to
-    // convert to their value type before calling m_f. Note that this
-    // disallows non-constant operations through m_f.
+    // TODO(bgruber): we should do as `std::ranges::transform_view::iterator` does:
+    // `return std::invoke(m_f, *this->base());` and return `decltype(auto)`
+
+    // Create a temporary to allow iterators with wrapped references to convert to their value type before calling m_f.
+    // Note that this disallows non-constant operations through m_f.
     typename thrust::iterator_value<Iterator>::type const& x = *this->base();
+    // FIXME(bgruber): x may be a reference to a temporary (e.g. if the base iterator is a counting_iterator). If `m_f`
+    // does not produce an independent copy and super_t::reference is a reference, we return a dangling reference (e.g.
+    // `thrust::identity<T>` because it does not forward. `thrust::identity<void>` shoud work).
     return m_f(x);
   }
 


### PR DESCRIPTION
After #1872, a few function objects remained to be based on the libcu++ ones and have their nested aliased deprecated. This is addressed by this PR.

- [x] Requires/Includes #2730