### PR TITLE
[CUDAX] rename `device` to `device_ref`, add immovable `device` as a place to cache properties

### DIFF
--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -24,7 +24,7 @@
 #include <cuda/std/__cccl/attributes.h>
 #include <cuda/std/__cuda/api_wrapper.h>
 
-#include <cuda/experimental/__device/device.cuh>
+#include <cuda/experimental/__device/device_ref.cuh>
 
 namespace cuda::experimental
 {
@@ -41,7 +41,7 @@ struct __attr_with_type
     return _Attr;
   }
 
-  _CCCL_NODISCARD type operator()(device __dev) const
+  _CCCL_NODISCARD type operator()(device_ref __dev) const
   {
     return __dev.attr<_Attr>();
   }
@@ -50,27 +50,27 @@ struct __attr_with_type
 
 // TODO: give this a strong type for kilohertz
 template <>
-struct device::__attr<::cudaDevAttrClockRate> //
+struct device_ref::__attr<::cudaDevAttrClockRate> //
     : detail::__attr_with_type<::cudaDevAttrClockRate, int>
 {};
 template <>
-struct device::__attr<::cudaDevAttrGpuOverlap> //
+struct device_ref::__attr<::cudaDevAttrGpuOverlap> //
     : detail::__attr_with_type<::cudaDevAttrGpuOverlap, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrKernelExecTimeout> //
+struct device_ref::__attr<::cudaDevAttrKernelExecTimeout> //
     : detail::__attr_with_type<::cudaDevAttrKernelExecTimeout, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrIntegrated> //
+struct device_ref::__attr<::cudaDevAttrIntegrated> //
     : detail::__attr_with_type<::cudaDevAttrIntegrated, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrCanMapHostMemory> //
+struct device_ref::__attr<::cudaDevAttrCanMapHostMemory> //
     : detail::__attr_with_type<::cudaDevAttrCanMapHostMemory, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrComputeMode> //
+struct device_ref::__attr<::cudaDevAttrComputeMode> //
     : detail::__attr_with_type<::cudaDevAttrComputeMode, ::cudaComputeMode>
 {
   static constexpr type default_mode           = cudaComputeModeDefault;
@@ -78,133 +78,133 @@ struct device::__attr<::cudaDevAttrComputeMode> //
   static constexpr type exclusive_process_mode = cudaComputeModeExclusiveProcess;
 };
 template <>
-struct device::__attr<::cudaDevAttrConcurrentKernels> //
+struct device_ref::__attr<::cudaDevAttrConcurrentKernels> //
     : detail::__attr_with_type<::cudaDevAttrConcurrentKernels, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrEccEnabled> //
+struct device_ref::__attr<::cudaDevAttrEccEnabled> //
     : detail::__attr_with_type<::cudaDevAttrEccEnabled, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrTccDriver> //
+struct device_ref::__attr<::cudaDevAttrTccDriver> //
     : detail::__attr_with_type<::cudaDevAttrTccDriver, bool>
 {};
 // TODO: give this a strong type for kilohertz
 template <>
-struct device::__attr<::cudaDevAttrMemoryClockRate> //
+struct device_ref::__attr<::cudaDevAttrMemoryClockRate> //
     : detail::__attr_with_type<::cudaDevAttrMemoryClockRate, int>
 {};
 // TODO: give this a strong type for bits
 template <>
-struct device::__attr<::cudaDevAttrGlobalMemoryBusWidth> //
+struct device_ref::__attr<::cudaDevAttrGlobalMemoryBusWidth> //
     : detail::__attr_with_type<::cudaDevAttrGlobalMemoryBusWidth, int>
 {};
 // TODO: give this a strong type for bytes
 template <>
-struct device::__attr<::cudaDevAttrL2CacheSize> //
+struct device_ref::__attr<::cudaDevAttrL2CacheSize> //
     : detail::__attr_with_type<::cudaDevAttrL2CacheSize, int>
 {};
 template <>
-struct device::__attr<::cudaDevAttrUnifiedAddressing> //
+struct device_ref::__attr<::cudaDevAttrUnifiedAddressing> //
     : detail::__attr_with_type<::cudaDevAttrUnifiedAddressing, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrStreamPrioritiesSupported> //
+struct device_ref::__attr<::cudaDevAttrStreamPrioritiesSupported> //
     : detail::__attr_with_type<::cudaDevAttrStreamPrioritiesSupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrGlobalL1CacheSupported> //
+struct device_ref::__attr<::cudaDevAttrGlobalL1CacheSupported> //
     : detail::__attr_with_type<::cudaDevAttrGlobalL1CacheSupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrLocalL1CacheSupported> //
+struct device_ref::__attr<::cudaDevAttrLocalL1CacheSupported> //
     : detail::__attr_with_type<::cudaDevAttrLocalL1CacheSupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrManagedMemory> //
+struct device_ref::__attr<::cudaDevAttrManagedMemory> //
     : detail::__attr_with_type<::cudaDevAttrManagedMemory, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrIsMultiGpuBoard> //
+struct device_ref::__attr<::cudaDevAttrIsMultiGpuBoard> //
     : detail::__attr_with_type<::cudaDevAttrIsMultiGpuBoard, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrHostNativeAtomicSupported> //
+struct device_ref::__attr<::cudaDevAttrHostNativeAtomicSupported> //
     : detail::__attr_with_type<::cudaDevAttrHostNativeAtomicSupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrPageableMemoryAccess> //
+struct device_ref::__attr<::cudaDevAttrPageableMemoryAccess> //
     : detail::__attr_with_type<::cudaDevAttrPageableMemoryAccess, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrConcurrentManagedAccess> //
+struct device_ref::__attr<::cudaDevAttrConcurrentManagedAccess> //
     : detail::__attr_with_type<::cudaDevAttrConcurrentManagedAccess, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrComputePreemptionSupported> //
+struct device_ref::__attr<::cudaDevAttrComputePreemptionSupported> //
     : detail::__attr_with_type<::cudaDevAttrComputePreemptionSupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrCanUseHostPointerForRegisteredMem> //
+struct device_ref::__attr<::cudaDevAttrCanUseHostPointerForRegisteredMem> //
     : detail::__attr_with_type<::cudaDevAttrCanUseHostPointerForRegisteredMem, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrCooperativeLaunch> //
+struct device_ref::__attr<::cudaDevAttrCooperativeLaunch> //
     : detail::__attr_with_type<::cudaDevAttrCooperativeLaunch, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrCooperativeMultiDeviceLaunch> //
+struct device_ref::__attr<::cudaDevAttrCooperativeMultiDeviceLaunch> //
     : detail::__attr_with_type<::cudaDevAttrCooperativeMultiDeviceLaunch, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrCanFlushRemoteWrites> //
+struct device_ref::__attr<::cudaDevAttrCanFlushRemoteWrites> //
     : detail::__attr_with_type<::cudaDevAttrCanFlushRemoteWrites, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrHostRegisterSupported> //
+struct device_ref::__attr<::cudaDevAttrHostRegisterSupported> //
     : detail::__attr_with_type<::cudaDevAttrHostRegisterSupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrDirectManagedMemAccessFromHost> //
+struct device_ref::__attr<::cudaDevAttrDirectManagedMemAccessFromHost> //
     : detail::__attr_with_type<::cudaDevAttrDirectManagedMemAccessFromHost, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrSparseCudaArraySupported> //
+struct device_ref::__attr<::cudaDevAttrSparseCudaArraySupported> //
     : detail::__attr_with_type<::cudaDevAttrSparseCudaArraySupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrMemoryPoolsSupported> //
+struct device_ref::__attr<::cudaDevAttrMemoryPoolsSupported> //
     : detail::__attr_with_type<::cudaDevAttrMemoryPoolsSupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrGPUDirectRDMASupported> //
+struct device_ref::__attr<::cudaDevAttrGPUDirectRDMASupported> //
     : detail::__attr_with_type<::cudaDevAttrGPUDirectRDMASupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrDeferredMappingCudaArraySupported> //
+struct device_ref::__attr<::cudaDevAttrDeferredMappingCudaArraySupported> //
     : detail::__attr_with_type<::cudaDevAttrDeferredMappingCudaArraySupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrIpcEventSupport> //
+struct device_ref::__attr<::cudaDevAttrIpcEventSupport> //
     : detail::__attr_with_type<::cudaDevAttrIpcEventSupport, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrPageableMemoryAccessUsesHostPageTables>
+struct device_ref::__attr<::cudaDevAttrPageableMemoryAccessUsesHostPageTables>
     : detail::__attr_with_type<::cudaDevAttrPageableMemoryAccessUsesHostPageTables, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrHostRegisterReadOnlySupported> //
+struct device_ref::__attr<::cudaDevAttrHostRegisterReadOnlySupported> //
     : detail::__attr_with_type<::cudaDevAttrHostRegisterReadOnlySupported, bool>
 {};
 template <>
-struct device::__attr<::cudaDevAttrGPUDirectRDMAFlushWritesOptions> //
+struct device_ref::__attr<::cudaDevAttrGPUDirectRDMAFlushWritesOptions> //
     : detail::__attr_with_type<::cudaDevAttrGPUDirectRDMAFlushWritesOptions, ::cudaFlushGPUDirectRDMAWritesOptions>
 {
   static constexpr type host    = ::cudaFlushGPUDirectRDMAWritesOptionHost;
   static constexpr type mem_ops = ::cudaFlushGPUDirectRDMAWritesOptionMemOps;
 };
 template <>
-struct device::__attr<::cudaDevAttrGPUDirectRDMAWritesOrdering> //
+struct device_ref::__attr<::cudaDevAttrGPUDirectRDMAWritesOrdering> //
     : detail::__attr_with_type<::cudaDevAttrGPUDirectRDMAWritesOrdering, ::cudaGPUDirectRDMAWritesOrdering>
 {
   static constexpr type none        = ::cudaGPUDirectRDMAWritesOrderingNone;
@@ -213,12 +213,12 @@ struct device::__attr<::cudaDevAttrGPUDirectRDMAWritesOrdering> //
 };
 // TODO: This is a bitmask. What are the possible values?
 template <>
-struct device::__attr<::cudaDevAttrMemoryPoolSupportedHandleTypes> //
+struct device_ref::__attr<::cudaDevAttrMemoryPoolSupportedHandleTypes> //
     : detail::__attr_with_type<::cudaDevAttrMemoryPoolSupportedHandleTypes, unsigned int>
 {};
 #if CUDART_VERSION >= 12020
 template <>
-struct device::__attr<::cudaDevAttrNumaConfig> //
+struct device_ref::__attr<::cudaDevAttrNumaConfig> //
     : detail::__attr_with_type<::cudaDevAttrNumaConfig, ::cudaDeviceNumaConfig>
 {
   static constexpr type none      = ::cudaDeviceNumaConfigNone;
@@ -226,7 +226,7 @@ struct device::__attr<::cudaDevAttrNumaConfig> //
 };
 #endif
 
-struct device::attrs
+struct device_ref::attrs
 {
   // Maximum number of threads per block
   using max_threads_per_block_t = __attr<::cudaDevAttrMaxThreadsPerBlock>;

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -21,150 +21,32 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__cccl/attributes.h>
-#include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/std/__type_traits/decay.h>
+#include <cuda/experimental/__device/device_ref.cuh>
 
 namespace cuda::experimental
 {
-// Dummy struct for now to be able to reference it in other places
-// TODO this might be device_ref instead
-// TODO proper implementation
-//! @brief A non-owning representation of a CUDA device
-class device
+// TODO: this will be the element type of the the global `devices` array. It is
+// where we can cache device properties.
+//
+//! @brief An immovable "owning" representation of a CUDA device.
+class device : public device_ref
 {
-  int __id_ = 0;
+  // TODO: put a mutable thread-safe (or thread_local) cache of device
+  // properties here.
 
-  template <::cudaDeviceAttr _Attr>
-  struct __attr
-  {
-    using type = int;
-
-    _CCCL_NODISCARD constexpr operator ::cudaDeviceAttr() const noexcept
-    {
-      return _Attr;
-    }
-
-    _CCCL_NODISCARD type operator()(device __dev) const
-    {
-      return __dev.attr<_Attr>();
-    }
-  };
-
-public:
-  struct attrs;
-
-  //! @brief For a given attribute, returns the type of the attribute value.
-  //!
-  //! @par Example
-  //! @code
-  //! using threads_per_block_t = device::attr_result_t<device::attrs::max_threads_per_block>;
-  //! static_assert(std::is_same_v<threads_per_block_t, int>);
-  //! @endcode
-  //!
-  //! @sa device::attrs
-  template <::cudaDeviceAttr _Attr>
-  using attr_result_t = typename __attr<_Attr>::type;
-
-  //! @brief Create a `device` object from a native device ordinal.
-  /*implicit*/ constexpr device(int __id) noexcept
-      : __id_(__id)
-  {}
-
-  //! @brief Retrieve the native ordinal of the device
-  //!
-  //! @return int The native device ordinal held by the device object
-  _CCCL_NODISCARD constexpr int get() const noexcept
-  {
-    return __id_;
-  }
-
-  //! @brief Retrieve the specified attribute for the device
-  //!
-  //! @param __attr The attribute to query. See `device::attrs` for the available
-  //!        attributes.
-  //!
-  //! @throws cuda_error if the attribute query fails
-  //!
-  //! @sa device::attrs
-  template <::cudaDeviceAttr _Attr>
-  _CCCL_NODISCARD auto attr([[maybe_unused]] device::__attr<_Attr> __attr) const
-  {
-    int __value = 0;
-    _CCCL_TRY_CUDA_API(::cudaDeviceGetAttribute, "failed to get device attribute", &__value, _Attr, get());
-    return static_cast<typename device::__attr<_Attr>::type>(__value);
-  }
-
-  //! @overload
-  template <::cudaDeviceAttr _Attr>
-  _CCCL_NODISCARD auto attr() const
-  {
-    return attr(__attr<_Attr>());
-  }
-};
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
-
-//! @brief RAII helper which saves the current device and switches to the
-//!        specified device on construction and switches to the saved device on
-//!        destruction.
-//!
-struct __scoped_device
-{
 private:
-  // The original device ordinal, or -1 if the device was not changed.
-  int const __old_device;
+  friend class device_ref;
 
-  //! @brief Returns the current device ordinal.
-  //!
-  //! @throws cuda_error if the device query fails.
-  static int __current_device()
-  {
-    int device = -1;
-    _CCCL_TRY_CUDA_API(cudaGetDevice, "failed to get the current device", &device);
-    return device;
-  }
-
-  explicit __scoped_device(int new_device, int old_device) noexcept
-      : __old_device(new_device == old_device ? -1 : old_device)
+  explicit constexpr device(int __id) noexcept
+      : device_ref(__id)
   {}
 
-public:
-  //! @brief Construct a new `__scoped_device` object and switch to the specified
-  //!        device.
-  //!
-  //! @param new_device The device to switch to
-  //!
-  //! @throws cuda_error if the device switch fails
-  explicit __scoped_device(device new_device)
-      : __scoped_device(new_device.get(), __current_device())
-  {
-    if (__old_device != -1)
-    {
-      _CCCL_TRY_CUDA_API(cudaSetDevice, "failed to set the current device", new_device.get());
-    }
-  }
-
-  __scoped_device(__scoped_device&&)                 = delete;
-  __scoped_device(__scoped_device const&)            = delete;
-  __scoped_device& operator=(__scoped_device&&)      = delete;
-  __scoped_device& operator=(__scoped_device const&) = delete;
-
-  //! @brief Destroy the `__scoped_device` object and switch back to the original
-  //!        device.
-  //!
-  //! @throws cuda_error if the device switch fails. If the destructor is called
-  //!         during stack unwinding, the program is automatically terminated.
-  ~__scoped_device() noexcept(false)
-  {
-    if (__old_device != -1)
-    {
-      _CCCL_TRY_CUDA_API(cudaSetDevice, "failed to restore the current device", __old_device);
-    }
-  }
+  // `device` objects are not movable or copyable.
+  device(device&&)                 = delete;
+  device(const device&)            = delete;
+  device& operator=(device&&)      = delete;
+  device& operator=(const device&) = delete;
 };
-
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__DEVICE_DEVICE_REF
+#define _CUDAX__DEVICE_DEVICE_REF
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/std/__type_traits/decay.h>
+
+namespace cuda::experimental
+{
+class device;
+
+//! @brief A non-owning representation of a CUDA device
+class device_ref
+{
+  friend class device;
+
+  int __id_ = 0;
+
+  template <::cudaDeviceAttr _Attr>
+  struct __attr
+  {
+    using type = int;
+
+    _CCCL_NODISCARD constexpr operator ::cudaDeviceAttr() const noexcept
+    {
+      return _Attr;
+    }
+
+    _CCCL_NODISCARD type operator()(device_ref __dev) const
+    {
+      return __dev.attr<_Attr>();
+    }
+  };
+
+public:
+  struct attrs;
+
+  //! @brief For a given attribute, returns the type of the attribute value.
+  //!
+  //! @par Example
+  //! @code
+  //! using threads_per_block_t = device_ref::attr_result_t<device_ref::attrs::max_threads_per_block>;
+  //! static_assert(std::is_same_v<threads_per_block_t, int>);
+  //! @endcode
+  //!
+  //! @sa device_ref::attrs
+  template <::cudaDeviceAttr _Attr>
+  using attr_result_t = typename __attr<_Attr>::type;
+
+  //! @brief Create a `device_ref` object from a native device ordinal.
+  /*implicit*/ constexpr device_ref(int __id) noexcept
+      : __id_(__id)
+  {}
+
+  //! @brief Retrieve the native ordinal of the `device_ref`
+  //!
+  //! @return int The native device ordinal held by the `device_ref` object
+  _CCCL_NODISCARD constexpr int get() const noexcept
+  {
+    return __id_;
+  }
+
+  //! @brief Retrieve the specified attribute for the `device_ref`
+  //!
+  //! @param __attr The attribute to query. See `device_ref::attrs` for the available
+  //!        attributes.
+  //!
+  //! @throws cuda_error if the attribute query fails
+  //!
+  //! @sa device_ref::attrs
+  template <::cudaDeviceAttr _Attr>
+  _CCCL_NODISCARD auto attr([[maybe_unused]] device_ref::__attr<_Attr> __attr) const
+  {
+    int __value = 0;
+    _CCCL_TRY_CUDA_API(::cudaDeviceGetAttribute, "failed to get device attribute", &__value, _Attr, get());
+    return static_cast<typename device_ref::__attr<_Attr>::type>(__value);
+  }
+
+  //! @overload
+  template <::cudaDeviceAttr _Attr>
+  _CCCL_NODISCARD auto attr() const
+  {
+    return attr(__attr<_Attr>());
+  }
+};
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
+
+//! @brief RAII helper which saves the current device and switches to the
+//!        specified device on construction and switches to the saved device on
+//!        destruction.
+//!
+struct __scoped_device
+{
+private:
+  // The original device ordinal, or -1 if the device was not changed.
+  int const __old_device;
+
+  //! @brief Returns the current device ordinal.
+  //!
+  //! @throws cuda_error if the device query fails.
+  static int __current_device()
+  {
+    int device = -1;
+    _CCCL_TRY_CUDA_API(cudaGetDevice, "failed to get the current device", &device);
+    return device;
+  }
+
+  explicit __scoped_device(int new_device, int old_device) noexcept
+      : __old_device(new_device == old_device ? -1 : old_device)
+  {}
+
+public:
+  //! @brief Construct a new `__scoped_device` object and switch to the specified
+  //!        device.
+  //!
+  //! @param new_device The device to switch to
+  //!
+  //! @throws cuda_error if the device switch fails
+  explicit __scoped_device(device_ref new_device)
+      : __scoped_device(new_device.get(), __current_device())
+  {
+    if (__old_device != -1)
+    {
+      _CCCL_TRY_CUDA_API(cudaSetDevice, "failed to set the current device", new_device.get());
+    }
+  }
+
+  __scoped_device(__scoped_device&&)                 = delete;
+  __scoped_device(__scoped_device const&)            = delete;
+  __scoped_device& operator=(__scoped_device&&)      = delete;
+  __scoped_device& operator=(__scoped_device const&) = delete;
+
+  //! @brief Destroy the `__scoped_device` object and switch back to the original
+  //!        device.
+  //!
+  //! @throws cuda_error if the device switch fails. If the destructor is called
+  //!         during stack unwinding, the program is automatically terminated.
+  ~__scoped_device() noexcept(false)
+  {
+    if (__old_device != -1)
+    {
+      _CCCL_TRY_CUDA_API(cudaSetDevice, "failed to restore the current device", __old_device);
+    }
+  }
+};
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+} // namespace cuda::experimental
+
+#endif // _CUDAX__DEVICE_DEVICE_REF

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -25,7 +25,7 @@
 #include <cuda/std/__cuda/api_wrapper.h>
 #include <cuda/stream_ref>
 
-#include <cuda/experimental/__device/device.cuh>
+#include <cuda/experimental/__device/device_ref.cuh>
 #include <cuda/experimental/__event/timed_event.cuh>
 
 namespace cuda::experimental
@@ -49,7 +49,7 @@ struct stream : stream_ref
   //! Priority is defaulted to stream::default_priority
   //!
   //! @throws cuda_error if stream creation fails
-  explicit stream(device __dev, int __priority = default_priority)
+  explicit stream(device_ref __dev, int __priority = default_priority)
   {
     __scoped_device dev_setter(__dev);
     _CCCL_TRY_CUDA_API(
@@ -60,7 +60,7 @@ struct stream : stream_ref
   //!
   //! @throws cuda_error if stream creation fails.
   stream()
-      : stream(device{0})
+      : stream(device_ref{0})
   {}
 
   //! @brief Construct a new `stream` object into the moved-from state.

--- a/cudax/include/cuda/experimental/device.cuh
+++ b/cudax/include/cuda/experimental/device.cuh
@@ -13,5 +13,6 @@
 
 #include <cuda/experimental/__device/attributes.cuh>
 #include <cuda/experimental/__device/device.cuh>
+#include <cuda/experimental/__device/device_ref.cuh>
 
 #endif // __CUDAX_DEVICE__

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -18,7 +18,7 @@ namespace
 template <const auto& Attr, ::cudaDeviceAttr ExpectedAttr, class ExpectedResult>
 [[maybe_unused]] auto test_device_attribute()
 {
-  cudax::device dev0(0);
+  cudax::device_ref dev0(0);
   STATIC_REQUIRE(Attr == ExpectedAttr);
   STATIC_REQUIRE(::cuda::std::is_same_v<cudax::device::attr_result_t<Attr>, ExpectedResult>);
 
@@ -33,6 +33,7 @@ template <const auto& Attr, ::cudaDeviceAttr ExpectedAttr, class ExpectedResult>
 TEST_CASE("Smoke", "[device]")
 {
   using cudax::device;
+  using cudax::device_ref;
 
   SECTION("Attributes")
   {
@@ -193,7 +194,7 @@ TEST_CASE("Smoke", "[device]")
       STATIC_REQUIRE(::cudaComputeModeProhibited == device::attrs::compute_mode.prohibited_mode);
       STATIC_REQUIRE(::cudaComputeModeExclusiveProcess == device::attrs::compute_mode.exclusive_process_mode);
 
-      auto mode = device(0).attr(device::attrs::compute_mode);
+      auto mode = device_ref(0).attr(device::attrs::compute_mode);
       CUDAX_REQUIRE((mode == device::attrs::compute_mode.default_mode || //
                      mode == device::attrs::compute_mode.prohibited_mode || //
                      mode == device::attrs::compute_mode.exclusive_process_mode));
@@ -206,7 +207,7 @@ TEST_CASE("Smoke", "[device]")
       STATIC_REQUIRE(
         ::cudaFlushGPUDirectRDMAWritesOptionMemOps == device::attrs::gpu_direct_rdma_flush_writes_options.mem_ops);
 
-      auto options = device(0).attr(device::attrs::gpu_direct_rdma_flush_writes_options);
+      auto options = device_ref(0).attr(device::attrs::gpu_direct_rdma_flush_writes_options);
       CUDAX_REQUIRE((options == device::attrs::gpu_direct_rdma_flush_writes_options.host || //
                      options == device::attrs::gpu_direct_rdma_flush_writes_options.mem_ops));
     }
@@ -218,7 +219,7 @@ TEST_CASE("Smoke", "[device]")
       STATIC_REQUIRE(
         ::cudaGPUDirectRDMAWritesOrderingAllDevices == device::attrs::gpu_direct_rdma_writes_ordering.all_devices);
 
-      auto ordering = device(0).attr(device::attrs::gpu_direct_rdma_writes_ordering);
+      auto ordering = device_ref(0).attr(device::attrs::gpu_direct_rdma_writes_ordering);
       CUDAX_REQUIRE((ordering == device::attrs::gpu_direct_rdma_writes_ordering.none || //
                      ordering == device::attrs::gpu_direct_rdma_writes_ordering.owner || //
                      ordering == device::attrs::gpu_direct_rdma_writes_ordering.all_devices));
@@ -230,7 +231,7 @@ TEST_CASE("Smoke", "[device]")
       STATIC_REQUIRE(::cudaDeviceNumaConfigNone == device::attrs::numa_config.none);
       STATIC_REQUIRE(::cudaDeviceNumaConfigNumaNode == device::attrs::numa_config.numa_node);
 
-      auto config = device(0).attr(device::attrs::numa_config);
+      auto config = device_ref(0).attr(device::attrs::numa_config);
       CUDAX_REQUIRE((config == device::attrs::numa_config.none || //
                      config == device::attrs::numa_config.numa_node));
     }


### PR DESCRIPTION

## Description

#2100 will add a global `cuda::devices` array. @pciolkosz mentioned that this would be a good place to keep a primary context. it would also be an excellent place to cache device properties.

to that end, we need a "heavyweight" object to represent a device. given our naming scheme, the logical name for that is `device`, and the current `device` should be renamed to `device_ref`.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
refs #2081 

