### PR TITLE
Fix trivial_copy_device_to_device execution space

### DIFF
--- a/thrust/thrust/system/cuda/detail/util.h
+++ b/thrust/thrust/system/cuda/detail/util.h
@@ -162,7 +162,7 @@ THRUST_HOST_FUNCTION cudaError_t trivial_copy_to_device(Type* dst, Type const* s
 }
 
 template <class Policy, class Type>
-_CCCL_HOST_DEVICE cudaError_t trivial_copy_device_to_device(Policy& policy, Type* dst, Type const* src, size_t count)
+THRUST_HOST_FUNCTION cudaError_t trivial_copy_device_to_device(Policy& policy, Type* dst, Type const* src, size_t count)
 {
   cudaError_t status = cudaSuccess;
   if (count == 0)

--- a/thrust/thrust/system/cuda/detail/util.h
+++ b/thrust/thrust/system/cuda/detail/util.h
@@ -162,7 +162,6 @@ THRUST_HOST_FUNCTION cudaError_t trivial_copy_to_device(Type* dst, Type const* s
 }
 
 template <class Policy, class Type>
-
 THRUST_RUNTIME_FUNCTION cudaError_t
 trivial_copy_device_to_device(Policy& policy, Type* dst, Type const* src, size_t count)
 {

--- a/thrust/thrust/system/cuda/detail/util.h
+++ b/thrust/thrust/system/cuda/detail/util.h
@@ -163,7 +163,8 @@ THRUST_HOST_FUNCTION cudaError_t trivial_copy_to_device(Type* dst, Type const* s
 
 template <class Policy, class Type>
 
-THRUST_RUNTIME_FUNCTION cudaError_t trivial_copy_device_to_device(Policy& policy, Type* dst, Type const* src, size_t count)
+THRUST_RUNTIME_FUNCTION cudaError_t
+trivial_copy_device_to_device(Policy& policy, Type* dst, Type const* src, size_t count)
 {
   cudaError_t status = cudaSuccess;
   if (count == 0)

--- a/thrust/thrust/system/cuda/detail/util.h
+++ b/thrust/thrust/system/cuda/detail/util.h
@@ -162,7 +162,8 @@ THRUST_HOST_FUNCTION cudaError_t trivial_copy_to_device(Type* dst, Type const* s
 }
 
 template <class Policy, class Type>
-THRUST_HOST_FUNCTION cudaError_t trivial_copy_device_to_device(Policy& policy, Type* dst, Type const* src, size_t count)
+
+THRUST_RUNTIME_FUNCTION cudaError_t trivial_copy_device_to_device(Policy& policy, Type* dst, Type const* src, size_t count)
 {
   cudaError_t status = cudaSuccess;
   if (count == 0)


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/2163

<!-- Provide a standalone description of changes in this PR. -->
Prior to this PR we used to annotate `trivial_copy_device_to_device` as host device function. When building with `--keep-device-functions`, nvcc kept external symbols to device version of memcpy async, but device runtime was never linked. This leads to ptxas error in the issue above.

Given that `trivial_copy_device_to_device` is only used from `THRUST_RUNTIME_FUNCTION`, it's safe to replace `_CCCL_HOST_DEVICE` with `THRUST_RUNTIME_FUNCTION` to avoid dependency on device version of memcpy async. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
