### PR TITLE
update contributing docs prereqs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,8 @@ There are multiple options for building and running our tests. Which option you 
 
 #### Building
 
+Building CCCL requires you to have a working installation of sccache. Follow the docs here https://github.com/mozilla/sccache?tab=readme-ov-file#installation
+
 Use the build scripts provided in the `ci/` directory to build tests for each component. Building tests does not require a GPU.
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ There are multiple options for building and running our tests. Which option you 
 
 #### Building
 
-Building CCCL requires you to have a working installation of sccache. Follow the docs here https://github.com/mozilla/sccache?tab=readme-ov-file#installation
+Building CCCL requires you to have a working installation of sccache. Follow the docs here https://github.com/mozilla/sccache?tab=readme-ov-file#installation. Note that by using the devcontainers, sccache will already be installed.
 
 Use the build scripts provided in the `ci/` directory to build tests for each component. Building tests does not require a GPU.
 


### PR DESCRIPTION
Attempting to build CCCL without sccache installed will lead to `Notice: sccache is not available. Skipping...` . 

I personally run into troubles with devcontainers which is how I discovered this when trying to build locally. 