### PR TITLE
fix use of `cudaStream_t` as if it were a stream wrapper

### DIFF
--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -151,7 +151,7 @@ struct stream : stream_ref
   {
     // TODO consider an optimization to not create an event every time and instead have one persistent event or one per
     // stream
-    assert(__stream.get() != detail::invalid_stream);
+    assert(__stream != detail::invalid_stream);
     event __tmp(__other);
     wait(__tmp);
   }


### PR DESCRIPTION
## Description

`cudax::stream::wait(stream_ref)` contains the line:

```c++
assert(__stream.get() != detail::invalid_stream);
```

but `__stream` is a `cudaStream_t`, so `__stream.get()` doesn't compile.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #2189

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

