### PR TITLE
2118 [CUDAX] Change the RAII device swapper to use driver API and add it in places where it was missing

### DIFF
--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -189,43 +189,6 @@ inline const ::std::vector<device>& all_devices::__devices()
 //! * device_ref
 inline constexpr detail::all_devices devices{};
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
-
-//! @brief RAII helper which saves the current device and switches to the
-//!        specified device on construction and switches to the saved device on
-//!        destruction.
-//!
-struct __scoped_device
-{
-  //! @brief Construct a new `__scoped_device` object and switch to the specified
-  //!        device.
-  //!
-  //! @param new_device The device to switch to
-  //!
-  //! @throws cuda_error if the device switch fails
-  explicit __scoped_device(device_ref new_device)
-  {
-    auto ctx = devices[new_device.get()].primary_context();
-    detail::driver::ctxPush(ctx);
-  }
-
-  __scoped_device(__scoped_device&&)                 = delete;
-  __scoped_device(__scoped_device const&)            = delete;
-  __scoped_device& operator=(__scoped_device&&)      = delete;
-  __scoped_device& operator=(__scoped_device const&) = delete;
-
-  //! @brief Destroy the `__scoped_device` object and switch back to the original
-  //!        device.
-  //!
-  //! @throws cuda_error if the device switch fails. If the destructor is called
-  //!         during stack unwinding, the program is automatically terminated.
-  ~__scoped_device() noexcept(false)
-  {
-    detail::driver::ctxPop();
-  }
-};
-
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 } // namespace cuda::experimental
 
 #endif // _CUDAX__DEVICE_ALL_DEVICES

--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -189,6 +189,43 @@ inline const ::std::vector<device>& all_devices::__devices()
 //! * device_ref
 inline constexpr detail::all_devices devices{};
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
+
+//! @brief RAII helper which saves the current device and switches to the
+//!        specified device on construction and switches to the saved device on
+//!        destruction.
+//!
+struct __scoped_device
+{
+  //! @brief Construct a new `__scoped_device` object and switch to the specified
+  //!        device.
+  //!
+  //! @param new_device The device to switch to
+  //!
+  //! @throws cuda_error if the device switch fails
+  explicit __scoped_device(device_ref new_device)
+  {
+    auto ctx = devices[new_device.get()].primary_context();
+    detail::driver::ctxPush(ctx);
+  }
+
+  __scoped_device(__scoped_device&&)                 = delete;
+  __scoped_device(__scoped_device const&)            = delete;
+  __scoped_device& operator=(__scoped_device&&)      = delete;
+  __scoped_device& operator=(__scoped_device const&) = delete;
+
+  //! @brief Destroy the `__scoped_device` object and switch back to the original
+  //!        device.
+  //!
+  //! @throws cuda_error if the device switch fails. If the destructor is called
+  //!         during stack unwinding, the program is automatically terminated.
+  ~__scoped_device() noexcept(false)
+  {
+    detail::driver::ctxPop();
+  }
+};
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 } // namespace cuda::experimental
 
 #endif // _CUDAX__DEVICE_ALL_DEVICES

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -39,7 +39,7 @@ struct __emplace_device
 {
   int __id_;
 
-  _CCCL_NODISCARD constexpr operator device() const noexcept;
+  _CCCL_NODISCARD operator device() const noexcept;
 
   _CCCL_NODISCARD constexpr const __emplace_device* operator->() const noexcept;
 };
@@ -104,7 +104,7 @@ private:
 
 namespace detail
 {
-_CCCL_NODISCARD inline constexpr __emplace_device::operator device() const noexcept
+_CCCL_NODISCARD inline __emplace_device::operator device() const noexcept
 {
   return device(__id_);
 }

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -103,69 +103,6 @@ public:
   }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
-
-//! @brief RAII helper which saves the current device and switches to the
-//!        specified device on construction and switches to the saved device on
-//!        destruction.
-//!
-struct __scoped_device
-{
-private:
-  // The original device ordinal, or -1 if the device was not changed.
-  int const __old_device;
-
-  //! @brief Returns the current device ordinal.
-  //!
-  //! @throws cuda_error if the device query fails.
-  static int __current_device()
-  {
-    int device = -1;
-    _CCCL_TRY_CUDA_API(cudaGetDevice, "failed to get the current device", &device);
-    return device;
-  }
-
-  explicit __scoped_device(int new_device, int old_device) noexcept
-      : __old_device(new_device == old_device ? -1 : old_device)
-  {}
-
-public:
-  //! @brief Construct a new `__scoped_device` object and switch to the specified
-  //!        device.
-  //!
-  //! @param new_device The device to switch to
-  //!
-  //! @throws cuda_error if the device switch fails
-  explicit __scoped_device(device_ref new_device)
-      : __scoped_device(new_device.get(), __current_device())
-  {
-    if (__old_device != -1)
-    {
-      _CCCL_TRY_CUDA_API(cudaSetDevice, "failed to set the current device", new_device.get());
-    }
-  }
-
-  __scoped_device(__scoped_device&&)                 = delete;
-  __scoped_device(__scoped_device const&)            = delete;
-  __scoped_device& operator=(__scoped_device&&)      = delete;
-  __scoped_device& operator=(__scoped_device const&) = delete;
-
-  //! @brief Destroy the `__scoped_device` object and switch back to the original
-  //!        device.
-  //!
-  //! @throws cuda_error if the device switch fails. If the destructor is called
-  //!         during stack unwinding, the program is automatically terminated.
-  ~__scoped_device() noexcept(false)
-  {
-    if (__old_device != -1)
-    {
-      _CCCL_TRY_CUDA_API(cudaSetDevice, "failed to restore the current device", __old_device);
-    }
-  }
-};
-
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 } // namespace cuda::experimental
 
 #endif // _CUDAX__DEVICE_DEVICE_REF

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -22,7 +22,6 @@
 #endif // no system header
 
 #include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/std/__type_traits/decay.h>
 
 namespace cuda::experimental
 {

--- a/cudax/include/cuda/experimental/__event/event.cuh
+++ b/cudax/include/cuda/experimental/__event/event.cuh
@@ -150,7 +150,7 @@ private:
   explicit event(stream_ref __stream, unsigned int __flags)
       : event_ref(::cudaEvent_t{})
   {
-    detail::__ensure_current_device dev_setter(__stream);
+    [[maybe_unused]] __ensure_current_device __dev_setter(__stream);
     _CCCL_TRY_CUDA_API(
       ::cudaEventCreateWithFlags, "Failed to create CUDA event", &__event_, static_cast<unsigned int>(__flags));
   }

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -30,6 +30,8 @@
 #include <cuda/std/utility>
 #include <cuda/stream_ref>
 
+#include <cuda/experimental/__utility/driver_api.cuh>
+
 namespace cuda::experimental
 {
 class event;
@@ -74,7 +76,8 @@ public:
   {
     assert(__event_ != nullptr);
     assert(__stream.get() != nullptr);
-    _CCCL_TRY_CUDA_API(::cudaEventRecord, "Failed to record CUDA event", __event_, __stream.get());
+    // Need to use driver API, cudaEventRecord will push dev 0 if stack is empty
+    detail::driver::eventRecord(__event_, __stream.get());
   }
 
   //! @brief Waits until all the work in the stream prior to the record of the

--- a/cudax/include/cuda/experimental/__event/timed_event.cuh
+++ b/cudax/include/cuda/experimental/__event/timed_event.cuh
@@ -42,7 +42,7 @@ public:
   //!
   //! @throws cuda_error if the event creation fails.
   explicit timed_event(stream_ref __stream, flags __flags = flags::none)
-      : event(static_cast<unsigned int>(__flags))
+      : event(__stream, static_cast<unsigned int>(__flags))
   {
     record(__stream);
   }

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -16,6 +16,7 @@
 #include <cuda/stream_ref>
 
 #include <cuda/experimental/__launch/configuration.cuh>
+#include <cuda/experimental/__utility/ensure_current_device.cuh>
 
 #if _CCCL_STD_VER >= 2017
 namespace cuda::experimental
@@ -119,6 +120,7 @@ template <typename... Args, typename... Config, typename Dimensions, typename Ke
 void launch(
   ::cuda::stream_ref stream, const kernel_config<Dimensions, Config...>& conf, const Kernel& kernel, Args... args)
 {
+  detail::__ensure_current_device dev_setter(stream);
   cudaError_t status;
   if constexpr (::cuda::std::is_invocable_v<Kernel, kernel_config<Dimensions, Config...>, Args...>)
   {
@@ -181,6 +183,7 @@ void launch(
 template <typename... Args, typename... Levels, typename Kernel>
 void launch(::cuda::stream_ref stream, const hierarchy_dimensions<Levels...>& dims, const Kernel& kernel, Args... args)
 {
+  detail::__ensure_current_device dev_setter(stream);
   cudaError_t status;
   if constexpr (::cuda::std::is_invocable_v<Kernel, hierarchy_dimensions<Levels...>, Args...>)
   {
@@ -245,6 +248,7 @@ void launch(::cuda::stream_ref stream,
             void (*kernel)(kernel_config<Dimensions, Config...>, ExpArgs...),
             ActArgs&&... args)
 {
+  detail::__ensure_current_device dev_setter(stream);
   cudaError_t status = [&](ExpArgs... args) {
     return detail::launch_impl(stream, conf, kernel, conf, args...);
   }(std::forward<ActArgs>(args)...);
@@ -299,6 +303,7 @@ void launch(::cuda::stream_ref stream,
             void (*kernel)(hierarchy_dimensions<Levels...>, ExpArgs...),
             ActArgs&&... args)
 {
+  detail::__ensure_current_device dev_setter(stream);
   cudaError_t status = [&](ExpArgs... args) {
     return detail::launch_impl(stream, kernel_config(dims), kernel, dims, args...);
   }(std::forward<ActArgs>(args)...);
@@ -354,6 +359,7 @@ void launch(::cuda::stream_ref stream,
             void (*kernel)(ExpArgs...),
             ActArgs&&... args)
 {
+  detail::__ensure_current_device dev_setter(stream);
   cudaError_t status = [&](ExpArgs... args) {
     return detail::launch_impl(stream, conf, kernel, args...);
   }(std::forward<ActArgs>(args)...);
@@ -406,6 +412,7 @@ template <typename... ExpArgs, typename... ActArgs, typename... Levels>
 void launch(
   ::cuda::stream_ref stream, const hierarchy_dimensions<Levels...>& dims, void (*kernel)(ExpArgs...), ActArgs&&... args)
 {
+  detail::__ensure_current_device dev_setter(stream);
   cudaError_t status = [&](ExpArgs... args) {
     return detail::launch_impl(stream, kernel_config(dims), kernel, args...);
   }(std::forward<ActArgs>(args)...);

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -120,7 +120,7 @@ template <typename... Args, typename... Config, typename Dimensions, typename Ke
 void launch(
   ::cuda::stream_ref stream, const kernel_config<Dimensions, Config...>& conf, const Kernel& kernel, Args... args)
 {
-  detail::__ensure_current_device dev_setter(stream);
+  [[maybe_unused]] __ensure_current_device __dev_setter(stream);
   cudaError_t status;
   if constexpr (::cuda::std::is_invocable_v<Kernel, kernel_config<Dimensions, Config...>, Args...>)
   {
@@ -183,7 +183,7 @@ void launch(
 template <typename... Args, typename... Levels, typename Kernel>
 void launch(::cuda::stream_ref stream, const hierarchy_dimensions<Levels...>& dims, const Kernel& kernel, Args... args)
 {
-  detail::__ensure_current_device dev_setter(stream);
+  [[maybe_unused]] __ensure_current_device __dev_setter(stream);
   cudaError_t status;
   if constexpr (::cuda::std::is_invocable_v<Kernel, hierarchy_dimensions<Levels...>, Args...>)
   {
@@ -248,7 +248,7 @@ void launch(::cuda::stream_ref stream,
             void (*kernel)(kernel_config<Dimensions, Config...>, ExpArgs...),
             ActArgs&&... args)
 {
-  detail::__ensure_current_device dev_setter(stream);
+  [[maybe_unused]] __ensure_current_device __dev_setter(stream);
   cudaError_t status = [&](ExpArgs... args) {
     return detail::launch_impl(stream, conf, kernel, conf, args...);
   }(std::forward<ActArgs>(args)...);
@@ -303,7 +303,7 @@ void launch(::cuda::stream_ref stream,
             void (*kernel)(hierarchy_dimensions<Levels...>, ExpArgs...),
             ActArgs&&... args)
 {
-  detail::__ensure_current_device dev_setter(stream);
+  [[maybe_unused]] __ensure_current_device __dev_setter(stream);
   cudaError_t status = [&](ExpArgs... args) {
     return detail::launch_impl(stream, kernel_config(dims), kernel, dims, args...);
   }(std::forward<ActArgs>(args)...);
@@ -359,7 +359,7 @@ void launch(::cuda::stream_ref stream,
             void (*kernel)(ExpArgs...),
             ActArgs&&... args)
 {
-  detail::__ensure_current_device dev_setter(stream);
+  [[maybe_unused]] __ensure_current_device __dev_setter(stream);
   cudaError_t status = [&](ExpArgs... args) {
     return detail::launch_impl(stream, conf, kernel, args...);
   }(std::forward<ActArgs>(args)...);
@@ -412,7 +412,7 @@ template <typename... ExpArgs, typename... ActArgs, typename... Levels>
 void launch(
   ::cuda::stream_ref stream, const hierarchy_dimensions<Levels...>& dims, void (*kernel)(ExpArgs...), ActArgs&&... args)
 {
-  detail::__ensure_current_device dev_setter(stream);
+  [[maybe_unused]] __ensure_current_device __dev_setter(stream);
   cudaError_t status = [&](ExpArgs... args) {
     return detail::launch_impl(stream, kernel_config(dims), kernel, args...);
   }(std::forward<ActArgs>(args)...);

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -25,7 +25,7 @@
 #include <cuda/std/__cuda/api_wrapper.h>
 #include <cuda/stream_ref>
 
-#include <cuda/experimental/__device/device_ref.cuh>
+#include <cuda/experimental/__device/all_devices.cuh>
 #include <cuda/experimental/__event/timed_event.cuh>
 
 namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -25,7 +25,7 @@
 #include <cuda/std/__cuda/api_wrapper.h>
 #include <cuda/stream_ref>
 
-#include <cuda/experimental/__device/all_devices.cuh>
+#include <cuda/experimental/__device/device_ref.cuh>
 #include <cuda/experimental/__event/timed_event.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
 

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -52,7 +52,7 @@ struct stream : stream_ref
   //! @throws cuda_error if stream creation fails
   explicit stream(device_ref __dev, int __priority = default_priority)
   {
-    detail::__ensure_current_device dev_setter(__dev);
+    [[maybe_unused]] __ensure_current_device __dev_setter(__dev);
     _CCCL_TRY_CUDA_API(
       ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamDefault, __priority);
   }
@@ -146,15 +146,16 @@ struct stream : stream_ref
     detail::driver::streamWaitEvent(get(), __ev.get());
   }
 
-  //! @brief Make all future work submitted into this stream depend on completion of all work from the specified stream
+  //! @brief Make all future work submitted into this stream depend on completion of all work from the specified
+  //! stream
   //!
   //! @param __other Stream that this stream should wait for
   //!
   //! @throws cuda_error if inserting the dependency fails
   void wait(stream_ref __other) const
   {
-    // TODO consider an optimization to not create an event every time and instead have one persistent event or one per
-    // stream
+    // TODO consider an optimization to not create an event every time and instead have one persistent event or one
+    // per stream
     assert(__stream != detail::invalid_stream);
     event __tmp(__other);
     wait(__tmp);

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -27,6 +27,7 @@
 
 #include <cuda/experimental/__device/all_devices.cuh>
 #include <cuda/experimental/__event/timed_event.cuh>
+#include <cuda/experimental/__utility/ensure_current_device.cuh>
 
 namespace cuda::experimental
 {
@@ -51,7 +52,7 @@ struct stream : stream_ref
   //! @throws cuda_error if stream creation fails
   explicit stream(device_ref __dev, int __priority = default_priority)
   {
-    __scoped_device dev_setter(__dev);
+    detail::__ensure_current_device dev_setter(__dev);
     _CCCL_TRY_CUDA_API(
       ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamDefault, __priority);
   }
@@ -89,7 +90,9 @@ struct stream : stream_ref
   {
     if (__stream != detail::invalid_stream)
     {
-      [[maybe_unused]] auto status = ::cudaStreamDestroy(__stream);
+      // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
+      // Alternative would be to store the device and push/pop here
+      [[maybe_unused]] auto status = detail::driver::streamDestroy(__stream);
     }
   }
 
@@ -139,7 +142,8 @@ struct stream : stream_ref
   void wait(event_ref __ev) const
   {
     assert(__ev.get() != nullptr);
-    _CCCL_TRY_CUDA_API(::cudaStreamWaitEvent, "Failed to make a stream wait for an event", get(), __ev.get());
+    // Need to use driver API, cudaStreamWaitEvent would push dev 0 if stack was empty
+    detail::driver::streamWaitEvent(get(), __ev.get());
   }
 
   //! @brief Make all future work submitted into this stream depend on completion of all work from the specified stream

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -71,6 +71,38 @@ inline CUcontext ctxGetCurrent()
   return result;
 }
 
+inline CUdevice deviceGet(int ordinal)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDeviceGet);
+  CUdevice result;
+  call_driver_fn(driver_fn, "Failed to get device", &result, ordinal);
+  return result;
+}
+
+inline CUcontext primaryCtxRetain(CUdevice dev)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRetain);
+  CUcontext result;
+  call_driver_fn(driver_fn, "Failed to retain context for a device", &result, dev);
+  return result;
+}
+
+inline void primaryCtxRelease(CUdevice dev)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRelease);
+  // TODO we might need to ignore failure here
+  call_driver_fn(driver_fn, "Failed to release context for a device", dev);
+}
+
+inline bool isPrimaryCtxActive(CUdevice dev)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxGetState);
+  int result;
+  unsigned int dummy;
+  call_driver_fn(driver_fn, "Failed to check the primary ctx state", dev, &dummy, &result);
+  return result == 1;
+}
+
 inline CUcontext streamGetCtx(CUstream stream)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuStreamGetCtx);

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -25,8 +25,13 @@ inline void* get_driver_entry_point(const char* name)
 {
   void* fn;
   cudaDriverEntryPointQueryResult result;
+#if CUDART_VERSION >= 12050
   // For minor version compatibility request the 12.0 version of everything for now
   cudaGetDriverEntryPointByVersion(name, &fn, 12000, cudaEnableDefault, &result);
+#else
+  // Versioned get entry point not available before 12.5, but we don't need anything versioned before that
+  cudaGetDriverEntryPoint(name, &fn, cudaEnableDefault, &result);
+#endif
   if (result != cudaDriverEntryPointSuccess)
   {
     if (result == cudaDriverEntryPointVersionNotSufficent)

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -30,9 +30,8 @@
 
 namespace cuda::experimental::detail
 {
-//! @brief RAII helper which saves the current device and switches to the
-//!        specified device on construction and switches to the saved device on
-//!        destruction.
+//! @brief RAII helper which on construction sets the current device to the specified one or one a
+//! stream was created under. It sets the state back on destruction.
 //!
 struct __ensure_current_device
 {
@@ -48,6 +47,12 @@ struct __ensure_current_device
     detail::driver::ctxPush(ctx);
   }
 
+  //! @brief Construct a new `__ensure_current_device` object and switch to the device
+  //!        under which the specified stream was created.
+  //!
+  //! @param stream Stream indicating the device to switch to
+  //!
+  //! @throws cuda_error if the device switch fails
   explicit __ensure_current_device(stream_ref stream)
   {
     auto ctx = detail::driver::streamGetCtx(stream.get());

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -28,7 +28,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 
-namespace cuda::experimental::detail
+namespace cuda::experimental
 {
 //! @brief RAII helper which on construction sets the current device to the specified one or one a
 //! stream was created under. It sets the state back on destruction.
@@ -75,6 +75,6 @@ struct __ensure_current_device
     detail::driver::ctxPop();
   }
 };
-} // namespace cuda::experimental::detail
+} // namespace cuda::experimental
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 #endif // _CUDAX__UTILITY_ENSURE_CURRENT_DEVICE

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -72,7 +72,7 @@ struct __ensure_current_device
   ~__ensure_current_device() noexcept(false)
   {
     // TODO would it make sense to assert here that we pushed and popped the same thing?
-    auto ctx = detail::driver::ctxPop();
+    detail::driver::ctxPop();
   }
 };
 } // namespace cuda::experimental::detail

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__UTILITY_ENSURE_CURRENT_DEVICE
+#define _CUDAX__UTILITY_ENSURE_CURRENT_DEVICE
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/stream_ref>
+
+#include <cuda/experimental/__device/all_devices.cuh>
+#include <cuda/experimental/__utility/driver_api.cuh>
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
+
+namespace cuda::experimental::detail
+{
+//! @brief RAII helper which saves the current device and switches to the
+//!        specified device on construction and switches to the saved device on
+//!        destruction.
+//!
+struct __ensure_current_device
+{
+  //! @brief Construct a new `__ensure_current_device` object and switch to the specified
+  //!        device.
+  //!
+  //! @param new_device The device to switch to
+  //!
+  //! @throws cuda_error if the device switch fails
+  explicit __ensure_current_device(device_ref new_device)
+  {
+    auto ctx = devices[new_device.get()].primary_context();
+    detail::driver::ctxPush(ctx);
+  }
+
+  explicit __ensure_current_device(stream_ref stream)
+  {
+    auto ctx = detail::driver::streamGetCtx(stream.get());
+    detail::driver::ctxPush(ctx);
+  }
+
+  __ensure_current_device(__ensure_current_device&&)                 = delete;
+  __ensure_current_device(__ensure_current_device const&)            = delete;
+  __ensure_current_device& operator=(__ensure_current_device&&)      = delete;
+  __ensure_current_device& operator=(__ensure_current_device const&) = delete;
+
+  //! @brief Destroy the `__ensure_current_device` object and switch back to the original
+  //!        device.
+  //!
+  //! @throws cuda_error if the device switch fails. If the destructor is called
+  //!         during stack unwinding, the program is automatically terminated.
+  ~__ensure_current_device() noexcept(false)
+  {
+    // TODO would it make sense to assert here that we pushed and popped the same thing?
+    auto ctx = detail::driver::ctxPop();
+  }
+};
+} // namespace cuda::experimental::detail
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+#endif // _CUDAX__UTILITY_ENSURE_CURRENT_DEVICE

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -80,6 +80,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
 
   cudax_add_catch2_test(test_target misc_tests ${cn_target}
     utility/driver_api.cu
+    utility/ensure_current_device.cu
   )
 
   cudax_add_catch2_test(test_target containers ${cn_target}

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -29,6 +29,7 @@ function(cudax_add_catch2_test target_name_var test_name cn_target) # ARGN=test 
   target_link_libraries(${test_target} PRIVATE ${cn_target} Catch2::Catch2 catch2_main)
   target_link_libraries(${test_target} PRIVATE ${cn_target} cudax::Thrust)
   target_compile_options(${test_target} PRIVATE "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE")
+  target_compile_options(${test_target} PRIVATE "-DLIBCUDACXX_ENABLE_EXCEPTIONS")
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
   cudax_clone_target_properties(${test_target} ${cn_target})
   set_target_properties(${test_target} PROPERTIES

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -260,9 +260,9 @@ TEST_CASE("global devices vector", "[device]")
     CUDAX_REQUIRE(1 == std::next(cudax::devices.begin())->get());
     CUDAX_REQUIRE(1 == cudax::devices.begin()[1].get());
 
-    CUDAX_REQUIRE(0 == (*std::prev(cudax::devices.end())).get());
-    CUDAX_REQUIRE(0 == std::prev(cudax::devices.end())->get());
-    CUDAX_REQUIRE(0 == cudax::devices.end()[-1].get());
+    CUDAX_REQUIRE(cudax::devices.size() - 1 == (*std::prev(cudax::devices.end())).get());
+    CUDAX_REQUIRE(cudax::devices.size() - 1 == std::prev(cudax::devices.end())->get());
+    CUDAX_REQUIRE(cudax::devices.size() - 1 == cudax::devices.end()[-1].get());
   }
 
   try

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define LIBCUDACXX_ENABLE_EXCEPTIONS
 #include <cuda/experimental/device.cuh>
 
 #include "../hierarchy/testing_common.cuh"

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define LIBCUDACXX_ENABLE_EXCEPTIONS
 // Test translation of launch function arguments to cudaLaunchConfig_t sent to cudaLaunchKernelEx internally
 // We replace cudaLaunchKernelEx with a test function here through a macro to intercept the cudaLaunchConfig_t
 #define cudaLaunchKernelEx cudaLaunchKernelExTestReplacement

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -7,7 +7,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-#define LIBCUDACXX_ENABLE_EXCEPTIONS
 #include <cuda/atomic>
 
 #include <cuda/experimental/launch.cuh>

--- a/cudax/test/stream/get_stream.cu
+++ b/cudax/test/stream/get_stream.cu
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define LIBCUDACXX_ENABLE_EXCEPTIONS
 #include <cuda/experimental/stream.cuh>
 
 #include "../common/utility.cuh"

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define LIBCUDACXX_ENABLE_EXCEPTIONS
 #include <cuda/experimental/launch.cuh>
 #include <cuda/experimental/stream.cuh>
 

--- a/cudax/test/utility/driver_api.cu
+++ b/cudax/test/utility/driver_api.cu
@@ -15,6 +15,7 @@
 
 TEST_CASE("Call each one", "[driver api]")
 {
+  namespace driver = cuda::experimental::detail::driver;
   cudaStream_t stream;
   // Assumes the ctx stack was empty or had one ctx, should be the case unless some other
   // test leaves 2+ ctxs on the stack
@@ -22,23 +23,48 @@ TEST_CASE("Call each one", "[driver api]")
   // Pushes the primary context if the stack is empty
   CUDART(cudaStreamCreate(&stream));
 
-  auto ctx = cuda::experimental::detail::driver::ctxGetCurrent();
+  auto ctx = driver::ctxGetCurrent();
   CUDAX_REQUIRE(ctx != nullptr);
 
-  cuda::experimental::detail::driver::ctxPop();
-  CUDAX_REQUIRE(cuda::experimental::detail::driver::ctxGetCurrent() == nullptr);
+  // Confirm pop will leave the stack empty
+  driver::ctxPop();
+  CUDAX_REQUIRE(driver::ctxGetCurrent() == nullptr);
 
-  cuda::experimental::detail::driver::ctxPush(ctx);
-  CUDAX_REQUIRE(cuda::experimental::detail::driver::ctxGetCurrent() == ctx);
+  // Confirm we can push multiple times
+  driver::ctxPush(ctx);
+  CUDAX_REQUIRE(driver::ctxGetCurrent() == ctx);
 
-  cuda::experimental::detail::driver::ctxPush(ctx);
-  CUDAX_REQUIRE(cuda::experimental::detail::driver::ctxGetCurrent() == ctx);
+  driver::ctxPush(ctx);
+  CUDAX_REQUIRE(driver::ctxGetCurrent() == ctx);
 
-  cuda::experimental::detail::driver::ctxPop();
-  CUDAX_REQUIRE(cuda::experimental::detail::driver::ctxGetCurrent() == ctx);
+  driver::ctxPop();
+  CUDAX_REQUIRE(driver::ctxGetCurrent() == ctx);
 
-  auto stream_ctx = cuda::experimental::detail::driver::streamGetCtx(stream);
+  // Confirm stream ctx match
+  auto stream_ctx = driver::streamGetCtx(stream);
   CUDAX_REQUIRE(ctx == stream_ctx);
+
+  CUDART(cudaStreamDestroy(stream));
+
+  CUDAX_REQUIRE(driver::deviceGet(0) == 0);
+
+  // Confirm we can retain the primary ctx that cudart retained first
+  auto primary_ctx = driver::primaryCtxRetain(0);
+  CUDAX_REQUIRE(ctx == primary_ctx);
+
+  driver::ctxPop();
+  CUDAX_REQUIRE(driver::ctxGetCurrent() == nullptr);
+
+  CUDAX_REQUIRE(driver::isPrimaryCtxActive(0));
+  // Confirm we can reset the primary context with double release
+  driver::primaryCtxRelease(0);
+  driver::primaryCtxRelease(0);
+
+  CUDAX_REQUIRE(!driver::isPrimaryCtxActive(0));
+
+  // Confirm cudart can recover
+  CUDART(cudaStreamCreate(&stream));
+  CUDAX_REQUIRE(driver::ctxGetCurrent() == ctx);
 
   CUDART(cudaStreamDestroy(stream));
 }

--- a/cudax/test/utility/driver_api.cu
+++ b/cudax/test/utility/driver_api.cu
@@ -7,7 +7,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-#define LIBCUDACXX_ENABLE_EXCEPTIONS
 
 #include <cuda/experimental/__utility/driver_api.cuh>
 

--- a/cudax/test/utility/driver_api.cu
+++ b/cudax/test/utility/driver_api.cu
@@ -13,7 +13,7 @@
 
 #include "../hierarchy/testing_common.cuh"
 
-TEST_CASE("Call each one", "[driver api]")
+TEST_CASE("Call each driver api", "[utility]")
 {
   namespace driver = cuda::experimental::detail::driver;
   cudaStream_t stream;
@@ -66,5 +66,5 @@ TEST_CASE("Call each one", "[driver api]")
   CUDART(cudaStreamCreate(&stream));
   CUDAX_REQUIRE(driver::ctxGetCurrent() == ctx);
 
-  CUDART(cudaStreamDestroy(stream));
+  CUDART(driver::streamDestroy(stream));
 }

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -42,12 +42,12 @@ TEST_CASE("ensure current device", "[device]")
 {
   test::empty_driver_stack();
   // If possible use something different than CUDART default 0
-  int target_device = cudax::devices.size() - 1;
+  int target_device = static_cast<int>(cudax::devices.size() - 1);
   int dev_id        = 0;
 
   SECTION("device setter")
   {
-    recursive_check_device_setter(cudax::devices.size() - 1);
+    recursive_check_device_setter(target_device);
 
     CUDAX_REQUIRE(test::count_driver_stack() == 0);
   }
@@ -72,7 +72,7 @@ TEST_CASE("ensure current device", "[device]")
       }
       {
         auto lambda = [&](int dev_id) {
-          cudax::stream another_stream(target_device);
+          cudax::stream another_stream(dev_id);
           CUDAX_REQUIRE(test::count_driver_stack() == 0);
           stream.wait(another_stream);
           CUDAX_REQUIRE(test::count_driver_stack() == 0);

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+#define LIBCUDACXX_ENABLE_EXCEPTIONS
+
+#include <cuda/experimental/__stream/stream.cuh>
+#include <cuda/experimental/__utility/ensure_current_device.cuh>
+#include <cuda/experimental/event.cuh>
+#include <cuda/experimental/launch.cuh>
+
+#include "../common/utility.cuh"
+
+namespace driver = cuda::experimental::detail::driver;
+
+void recursive_check_device_setter(int id)
+{
+  int cudart_id;
+  cudax::detail::__ensure_current_device setter(cudax::device_ref{id});
+  CUDAX_REQUIRE(test::count_driver_stack() == cudax::devices.size() - id);
+  auto ctx = driver::ctxGetCurrent();
+  CUDART(cudaGetDevice(&cudart_id));
+  CUDAX_REQUIRE(cudart_id == id);
+
+  if (id != 0)
+  {
+    recursive_check_device_setter(id - 1);
+
+    CUDAX_REQUIRE(test::count_driver_stack() == cudax::devices.size() - id);
+    CUDAX_REQUIRE(ctx == driver::ctxGetCurrent());
+    CUDART(cudaGetDevice(&cudart_id));
+    CUDAX_REQUIRE(cudart_id == id);
+  }
+}
+
+TEST_CASE("ensure current device", "[device]")
+{
+  test::empty_driver_stack();
+  // If possible use something different than CUDART default 0
+  int target_device = cudax::devices.size() - 1;
+  int dev_id        = 0;
+
+  SECTION("device setter")
+  {
+    recursive_check_device_setter(cudax::devices.size() - 1);
+
+    CUDAX_REQUIRE(test::count_driver_stack() == 0);
+  }
+
+  SECTION("stream interactions with driver stack")
+  {
+    {
+      cudax::stream stream(target_device);
+      CUDAX_REQUIRE(test::count_driver_stack() == 0);
+      {
+        cudax::detail::__ensure_current_device setter(cudax::device_ref{target_device});
+        CUDAX_REQUIRE(driver::ctxGetCurrent() == driver::streamGetCtx(stream.get()));
+      }
+      {
+        auto ev = stream.record_event();
+        CUDAX_REQUIRE(test::count_driver_stack() == 0);
+      }
+      CUDAX_REQUIRE(test::count_driver_stack() == 0);
+      {
+        auto ev = stream.record_timed_event();
+        CUDAX_REQUIRE(test::count_driver_stack() == 0);
+      }
+      {
+        auto lambda = [&](int dev_id) {
+          cudax::stream another_stream(target_device);
+          CUDAX_REQUIRE(test::count_driver_stack() == 0);
+          stream.wait(another_stream);
+          CUDAX_REQUIRE(test::count_driver_stack() == 0);
+          another_stream.wait(stream);
+          CUDAX_REQUIRE(test::count_driver_stack() == 0);
+        };
+        lambda(target_device);
+        if (cudax::devices.size() > 1)
+        {
+          lambda(0);
+        }
+      }
+
+      cudax::detail::__ensure_current_device setter(stream);
+      CUDAX_REQUIRE(test::count_driver_stack() == 1);
+      CUDART(cudaGetDevice(&dev_id));
+      CUDAX_REQUIRE(dev_id == target_device);
+      CUDAX_REQUIRE(driver::ctxGetCurrent() == driver::streamGetCtx(stream.get()));
+    }
+
+    CHECK(test::count_driver_stack() == 0);
+
+    {
+      // Check NULL stream ref is handled ok
+      cudax::detail::__ensure_current_device setter1(cudax::device_ref{target_device});
+      cudaStream_t null_stream = nullptr;
+      auto ref                 = cuda::stream_ref(null_stream);
+      auto ctx                 = driver::ctxGetCurrent();
+      CUDAX_REQUIRE(test::count_driver_stack() == 1);
+
+      cudax::detail::__ensure_current_device setter2(ref);
+      CUDAX_REQUIRE(test::count_driver_stack() == 2);
+      CUDAX_REQUIRE(ctx == driver::ctxGetCurrent());
+      CUDART(cudaGetDevice(&dev_id));
+      CUDAX_REQUIRE(dev_id == target_device);
+    }
+  }
+
+  SECTION("event interactions with driver stack")
+  {
+    {
+      cudax::stream stream(target_device);
+      CUDAX_REQUIRE(test::count_driver_stack() == 0);
+
+      cudax::event event(stream);
+      CUDAX_REQUIRE(test::count_driver_stack() == 0);
+
+      event.record(stream);
+      CUDAX_REQUIRE(test::count_driver_stack() == 0);
+    }
+    CUDAX_REQUIRE(test::count_driver_stack() == 0);
+  }
+
+  SECTION("launch interactions with driver stack")
+  {
+    cudax::stream stream(target_device);
+    CUDAX_REQUIRE(test::count_driver_stack() == 0);
+    cudax::launch(stream, cudax::make_hierarchy(cudax::block_dims<1>(), cudax::grid_dims<1>()), test::empty_kernel{});
+    CUDAX_REQUIRE(test::count_driver_stack() == 0);
+  }
+}

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -7,7 +7,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-#define LIBCUDACXX_ENABLE_EXCEPTIONS
 
 #include <cuda/experimental/__stream/stream.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -21,7 +21,7 @@ namespace driver = cuda::experimental::detail::driver;
 void recursive_check_device_setter(int id)
 {
   int cudart_id;
-  cudax::detail::__ensure_current_device setter(cudax::device_ref{id});
+  cudax::__ensure_current_device setter(cudax::device_ref{id});
   CUDAX_REQUIRE(test::count_driver_stack() == cudax::devices.size() - id);
   auto ctx = driver::ctxGetCurrent();
   CUDART(cudaGetDevice(&cudart_id));
@@ -58,7 +58,7 @@ TEST_CASE("ensure current device", "[device]")
       cudax::stream stream(target_device);
       CUDAX_REQUIRE(test::count_driver_stack() == 0);
       {
-        cudax::detail::__ensure_current_device setter(cudax::device_ref{target_device});
+        cudax::__ensure_current_device setter(cudax::device_ref{target_device});
         CUDAX_REQUIRE(driver::ctxGetCurrent() == driver::streamGetCtx(stream.get()));
       }
       {
@@ -86,7 +86,7 @@ TEST_CASE("ensure current device", "[device]")
         }
       }
 
-      cudax::detail::__ensure_current_device setter(stream);
+      cudax::__ensure_current_device setter(stream);
       CUDAX_REQUIRE(test::count_driver_stack() == 1);
       CUDART(cudaGetDevice(&dev_id));
       CUDAX_REQUIRE(dev_id == target_device);
@@ -97,13 +97,13 @@ TEST_CASE("ensure current device", "[device]")
 
     {
       // Check NULL stream ref is handled ok
-      cudax::detail::__ensure_current_device setter1(cudax::device_ref{target_device});
+      cudax::__ensure_current_device setter1(cudax::device_ref{target_device});
       cudaStream_t null_stream = nullptr;
       auto ref                 = cuda::stream_ref(null_stream);
       auto ctx                 = driver::ctxGetCurrent();
       CUDAX_REQUIRE(test::count_driver_stack() == 1);
 
-      cudax::detail::__ensure_current_device setter2(ref);
+      cudax::__ensure_current_device setter2(ref);
       CUDAX_REQUIRE(test::count_driver_stack() == 2);
       CUDAX_REQUIRE(ctx == driver::ctxGetCurrent());
       CUDART(cudaGetDevice(&dev_id));


### PR DESCRIPTION
In order to be able to select the current device based on a stream and to ensure no visible side-effects the device swapper needs to use driver API.

The type name was changed to `__ensure_current_device` to match what was added in #2073.

This change introduces primary context storing in `device` type. The context retain is lazy, it won't cause initialization of devices that are not explicitly used.
This primary context is then used in `__ensure_current_device` to push/pop it to the driver stack on construction/destruction.
Ideally, every API in `cudax` would leave the driver stack exactly the same as before it was called. I had to change some CUDART APIs to driver equivalents, because of extra stack changes introduced in the CUDART versions.
Added tests for most APIs to see if they would keep the stack empty through their usage.