### PR TITLE
Fix the `clang-format` path in the devcontainers

### DIFF
--- a/.devcontainer/cuda11.1-gcc6/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc6/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda11.1-gcc7/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc7/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda11.1-gcc8/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc8/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda11.1-gcc9/devcontainer.json
+++ b/.devcontainer/cuda11.1-gcc9/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda11.1-llvm9/devcontainer.json
+++ b/.devcontainer/cuda11.1-llvm9/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda11.8-gcc11/devcontainer.json
+++ b/.devcontainer/cuda11.8-gcc11/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-llvm10/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm10/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-llvm11/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm11/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-llvm12/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm12/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-llvm13/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm13/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.0-llvm9/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm9/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc10/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc11/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc12/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc13/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc7/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc8/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.5-gcc9/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-llvm10/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm10/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-llvm11/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm11/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-llvm12/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm12/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-llvm13/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm13/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm14/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm15/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm16/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm17/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-llvm9/devcontainer.json
+++ b/.devcontainer/cuda12.5-llvm9/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/cuda12.5-oneapi2023.2.0/devcontainer.json
+++ b/.devcontainer/cuda12.5-oneapi2023.2.0/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,7 @@
       "settings": {
         "editor.defaultFormatter": "xaver.clang-format",
         "editor.formatOnSave": true,
-        "clang-format.executable": "/usr/local/bin/clang-format",
+        "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--compile-commands-dir=${workspaceFolder}"
         ],


### PR DESCRIPTION
In the devcontainers `clang-format` is now installed into `/usr/bin/clang-format`
