### PR TITLE
Integrate Python docs

### DIFF
--- a/.github/actions/docs-build/action.yml
+++ b/.github/actions/docs-build/action.yml
@@ -36,6 +36,8 @@ runs:
         cp -rf ./docs/_build/docs/thrust/latest/* _site/thrust
         mkdir _site/cudax
         cp -rf ./docs/_build/docs/cudax/latest/* _site/cudax
+        mkdir _site/cuda_cooperative
+        cp -rf ./docs/_build/docs/cuda_cooperative/latest/* _site/cuda_cooperative
         ./docs/scrape_docs.bash ./_site
 
     # Update docs as workflow artifact:

--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -1,0 +1,52 @@
+.. _cccl-cpp-libraries:
+
+CCCL C++ Libraries
+==================
+
+.. toctree::
+   :hidden:
+   :maxdepth: 3
+
+   libcu++ <https://nvidia.github.io/cccl/libcudacxx/>
+   CUB <https://nvidia.github.io/cccl/cub/>
+   Thrust <https://nvidia.github.io/cccl/thrust/>
+   Cuda Experimental <https://nvidia.github.io/cccl/cudax/>
+
+Welcome to the CUDA Core Compute Libraries (CCCL) libraries for C++.
+
+The concept for the  CCCL C++ librarires grew organically out of the Thrust,
+CUB, and libcudacxx projects that were developed independently over the years
+with a similar goal: to provide high-quality, high-performance, and
+easy-to-use C++ abstractions for CUDA developers. Naturally, there was a lot
+of overlap among the three projects, and it became clear the community would
+be better served by unifying them into a single repository.
+
+- `libcu++ <https://nvidia.github.io/cccl/libcudacxx/>`__
+  is the CUDA C++ Standard Library. It provides an implementation of the C++
+  Standard Library that works in both host and device code. Additionally, it
+  provides abstractions for CUDA-specific hardware features like
+  synchronization primitives, cache control, atomics, and more.
+
+- `CUB <https://nvidia.github.io/cccl/cub/>`__
+  is a lower-level, CUDA-specific library designed for speed-of-light parallel
+  algorithms across all GPU architectures. In addition to device-wide
+  algorithms, it provides *cooperative algorithms* like block-wide reduction
+  and warp-wide scan, providing CUDA kernel developers with building blocks to
+  create speed-of-light, custom kernels.
+
+- `Thrust <https://nvidia.github.io/cccl/thrust/>`__
+  is the C++ parallel algorithms library which inspired the introduction of
+  parallel algorithms to the C++ Standard Library. Thrust's high-level
+  interface greatly enhances programmer productivity while enabling performance
+  portability between GPUs and multicore CPUs via configurable backends that
+  allow using multiple parallel programming frameworks (such as CUDA, TBB, and
+  OpenMP).
+
+- `Cuda Experimental <https://nvidia.github.io/cccl/cudax/>`__
+  is a library of exerimental features that are still in the design process.
+
+The main goal of the CCCL C++ libraries is to fill a similar role that the
+Standard C++ Library fills for Standard C++: provide general-purpose,
+speed-of-light tools to CUDA C++ developers, allowing them to focus on
+solving the problems that matter. Unifying these projects is the first step
+towards realizing that goal.

--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -1,7 +1,7 @@
 .. _cccl-cpp-libraries:
 
-CCCL C++ Libraries
-==================
+CUDA C++ Core Libraries
+=======================
 
 .. toctree::
    :hidden:

--- a/docs/cuda_cooperative/index.rst
+++ b/docs/cuda_cooperative/index.rst
@@ -1,6 +1,6 @@
-.. _pycudax-module:
+.. _cuda_cooperative-module:
 
-CUDA
+CUDA Cooperative
 ==================================================
 
 .. warning::

--- a/docs/gen_docs.bash
+++ b/docs/gen_docs.bash
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-## This script just wraps launching a docs build within a container
-## Tag is passed on as the first argument ${1}
+# This script just wraps launching a repo docs build within a container
+#
+# Additional options, e.g --stage sphinx will be passed on to repo.sh
 
 set -e
 
@@ -36,7 +37,7 @@ if [ ! -n "$(find img -name '*.png')" ]; then
     done
 fi
 
-if ! ./repo.sh docs; then
+if ! ./repo.sh docs "$@"; then
     echo "!!! There were errors while generating"
     exit 1
 fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,27 +1,16 @@
-CUDA C++ Core Libraries
-=======================
+CUDA Core Compute Libraries
+===========================
 
 .. toctree::
    :hidden:
    :maxdepth: 3
 
-   libcu++ <https://nvidia.github.io/cccl/libcudacxx/>
-   CUB <https://nvidia.github.io/cccl/cub/>
-   Thrust <https://nvidia.github.io/cccl/thrust/>
-   Cuda Experimental <https://nvidia.github.io/cccl/cudax/>
+   cpp
+   python
 
-Welcome to the CUDA C++ Core Libraries (CCCL) where our mission is to make CUDA C++ more delightful.
+Welcome to the CUDA Core Compute Libraries (CCCL) where our mission is to
+make CUDA C++ and Python more delightful.
 
-The concept for the CUDA C++ Core Libraries (CCCL) grew organically out of the Thrust, CUB, and libcudacxx projects that were developed independently over the years with a similar goal: to provide high-quality, high-performance, and easy-to-use C++ abstractions for CUDA developers.
-Naturally, there was a lot of overlap among the three projects, and it became clear the community would be better served by unifying them into a single repository.
+- :ref:`cccl-cpp-libraries`
 
-- `libcu++ <https://nvidia.github.io/cccl/libcudacxx/>`__ is the CUDA C++ Standard Library. It provides an implementation of the C++ Standard Library that works in both host and device code. Additionally, it provides abstractions for CUDA-specific hardware features like synchronization primitives, cache control, atomics, and more.
-
-- `CUB <https://nvidia.github.io/cccl/cub/>`__ is a lower-level, CUDA-specific library designed for speed-of-light parallel algorithms across all GPU architectures. In addition to device-wide algorithms, it provides *cooperative algorithms* like block-wide reduction and warp-wide scan, providing CUDA kernel developers with building blocks to create speed-of-light, custom kernels.
-
-- `Thrust <https://nvidia.github.io/cccl/thrust/>`__ is the C++ parallel algorithms library which inspired the introduction of parallel algorithms to the C++ Standard Library. Thrust's high-level interface greatly enhances programmer productivity while enabling performance portability between GPUs and multicore CPUs via configurable backends that allow using multiple parallel programming frameworks (such as CUDA, TBB, and OpenMP).
-
-- `Cuda Experimental <https://nvidia.github.io/cccl/cudax/>`__ is a library of exerimental features that are still in the design process.
-
-The main goal of CCCL is to fill a similar role that the Standard C++ Library fills for Standard C++: provide general-purpose, speed-of-light tools to CUDA C++ developers, allowing them to focus on solving the problems that matter.
-Unifying these projects is the first step towards realizing that goal.
+- :ref:`cccl-python-libraries`

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -1,7 +1,7 @@
 .. _cccl-python-libraries:
 
-CCCL Python Libraries
-=====================
+CUDA Python Core Libraries
+==========================
 
 .. toctree::
    :hidden:

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -1,0 +1,15 @@
+.. _cccl-python-libraries:
+
+CCCL Python Libraries
+=====================
+
+.. toctree::
+   :hidden:
+   :maxdepth: 3
+
+   cuda.cooperative <https://nvidia.github.io/cccl/cuda_cooperative/>
+
+Welcome to the CUDA Core Compute Libraries (CCCL) libraries for Python.
+
+- `cuda.cooperative <https://nvidia.github.io/cccl/cuda_cooperative/>`__
+  is a still-experimental library exposing cooperative algorithms to Python.

--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -25,14 +25,14 @@ sphinx_exclude_patterns = [
     "VERSION.md",
 ]
 
-project_build_order = [ "libcudacxx", "cudax", "cub", "thrust", "cccl", "pycuda" ]
+project_build_order = [ "libcudacxx", "cudax", "cub", "thrust", "cccl", "cuda_cooperative" ]
 
 # deps can be used to link to other projects' documentation
 deps = [
     [ "libcudacxx", "_build/docs/libcudacxx/latest" ],
     [ "cub", "_build/docs/cub/latest" ],
     [ "thrust", "_build/docs/thrust/latest" ],
-    [ "pycuda", "_build/docs/pycuda/latest" ],
+    [ "cuda_cooperative", "_build/docs/cuda_cooperative/latest" ],
 ]
 
 [repo_docs.projects.libcudacxx]
@@ -281,9 +281,9 @@ doxygen_conf_extra = """
   STRIP_FROM_PATH        = ../../thrust
 """
 
-[repo_docs.projects.pycuda]
-name = "pycuda"
-docs_root = "pycuda"
+[repo_docs.projects.cuda_cooperative]
+name = "cuda.cooperative"
+docs_root = "cuda_cooperative"
 logo = "../img/logo.png"
 
 repo_url         = "https://github.com/NVIDIA/cccl/python/cuda"


### PR DESCRIPTION
fixes: #2155 

This PR integrates the Python project docs (currently `cuda.cooperative`) into the CCCL docs:

* Top level landing page renamed to reflect "CUDA Core Compute Libraries" evolution
* Separate sub-landing pages for C++ and Python (C++ landing is more or less the previous top-level page)

See screenshots below to see the structure. The text content on the new top level and python landing pages is currently minimal. It would be good to get input from experienced team members about what is to be said here. 

Additionally, this PR updates `gen_docs.bash` to pass `@1` on to `repo.sh`. This allows for much faster Sphinx-only docs rebuilding with
```sh
./docs/gen_docs.bash --stage sphinx
```


## Top-level landing

![2024-08-05_12-14](https://github.com/user-attachments/assets/9d1f6615-501c-4145-8d05-8123bed91b0b)

## C++ landing

![2024-08-05_12-15](https://github.com/user-attachments/assets/70e03096-5ce3-4501-bbea-38ed684c5ebb)

## Python landing

![2024-08-05_12-15_1](https://github.com/user-attachments/assets/a253e2e0-1675-4ffe-869d-55c5ded6372d)

