### PR TITLE
[CUDAX] Add an API to get device_ref from stream and add comparison operator to device_ref

### DIFF
--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -117,6 +117,14 @@ private:
   device(const device&)            = delete;
   device& operator=(device&&)      = delete;
   device& operator=(const device&) = delete;
+
+  friend bool operator==(const device& __lhs, int __rhs) = delete;
+  friend bool operator==(int __lhs, const device& __rhs) = delete;
+
+#if _CCCL_STD_VER <= 2017
+  friend bool operator!=(const device& __lhs, int __rhs) = delete;
+  friend bool operator!=(int __lhs, const device& __rhs) = delete;
+#endif // _CCCL_STD_VER <= 2017
 };
 
 namespace detail

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -67,6 +67,7 @@ public:
     return __lhs.__id_ == __rhs.__id_;
   }
 
+#if _CCCL_STD_VER <= 2017
   //! @brief Compares two `device_ref`s for inequality
   //!
   //! @note Allows comparison with `int` due to implicit conversion to
@@ -79,6 +80,7 @@ public:
   {
     return __lhs.__id_ != __rhs.__id_;
   }
+#endif // _CCCL_STD_VER <= 2017
 
   //! @brief Retrieve the specified attribute for the device
   //!

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -54,6 +54,32 @@ public:
     return __id_;
   }
 
+  //! @brief Compares two `device_ref`s for equality
+  //!
+  //! @note Allows comparison with `int` due to implicit conversion to
+  //! `device_ref`.
+  //!
+  //! @param __lhs The first `device_ref` to compare
+  //! @param __rhs The second `device_ref` to compare
+  //! @return true if `lhs` and `rhs` refer to the same device ordinal
+  _CCCL_NODISCARD_FRIEND constexpr bool operator==(device_ref __lhs, device_ref __rhs) noexcept
+  {
+    return __lhs.__id_ == __rhs.__id_;
+  }
+
+  //! @brief Compares two `device_ref`s for inequality
+  //!
+  //! @note Allows comparison with `int` due to implicit conversion to
+  //! `device_ref`.
+  //!
+  //! @param __lhs The first `device_ref` to compare
+  //! @param __rhs The second `device_ref` to compare
+  //! @return true if `lhs` and `rhs` refer to different device ordinal
+  _CCCL_NODISCARD_FRIEND constexpr bool operator!=(device_ref __lhs, device_ref __rhs) noexcept
+  {
+    return __lhs.__id_ != __rhs.__id_;
+  }
+
   //! @brief Retrieve the specified attribute for the device
   //!
   //! @param __attr The attribute to query. See `device::attrs` for the available

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -111,8 +111,8 @@ public:
   //! @note Allows comparison with `cudaEvent_t` due to implicit conversion to
   //! `event_ref`.
   //!
-  //! @param lhs The first `event_ref` to compare
-  //! @param rhs The second `event_ref` to compare
+  //! @param __lhs The first `event_ref` to compare
+  //! @param __rhs The second `event_ref` to compare
   //! @return true if `lhs` and `rhs` refer to the same `cudaEvent_t` object.
   _CCCL_NODISCARD_FRIEND constexpr bool operator==(event_ref __lhs, event_ref __rhs) noexcept
   {
@@ -124,8 +124,8 @@ public:
   //! @note Allows comparison with `cudaEvent_t` due to implicit conversion to
   //! `event_ref`.
   //!
-  //! @param lhs The first `event_ref` to compare
-  //! @param rhs The second `event_ref` to compare
+  //! @param __lhs The first `event_ref` to compare
+  //! @param __rhs The second `event_ref` to compare
   //! @return true if `lhs` and `rhs` refer to different `cudaEvent_t` objects.
   _CCCL_NODISCARD_FRIEND constexpr bool operator!=(event_ref __lhs, event_ref __rhs) noexcept
   {

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -161,6 +161,19 @@ struct stream : stream_ref
     wait(__tmp);
   }
 
+  //! @brief Get device under which this stream was created.
+  //!
+  //! @throws cuda_error if device check fails
+  device_ref device() const
+  {
+    // Because the stream can come from_native_handle, we can't just loop over devices comparing contexts,
+    // lower to CUDART for this instead
+    __ensure_current_device __dev_setter(*this);
+    int result;
+    _CCCL_TRY_CUDA_API(cudaGetDevice, "Could not get device from a stream", &result);
+    return result;
+  }
+
   //! @brief Construct an `stream` object from a native `cudaStream_t` handle.
   //!
   //! @param __handle The native handle

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -39,8 +39,10 @@ TEST_CASE("Smoke", "[device]")
   {
     CUDAX_REQUIRE(device_ref{0} == device_ref{0});
     CUDAX_REQUIRE(device_ref{0} == 0);
+    CUDAX_REQUIRE(0 == device_ref{0});
     CUDAX_REQUIRE(device_ref{1} != device_ref{0});
     CUDAX_REQUIRE(device_ref{1} != 2);
+    CUDAX_REQUIRE(1 != device_ref{2});
   }
 
   SECTION("Attributes")

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -282,11 +282,10 @@ TEST_CASE("global devices vector", "[device]")
   CUDAX_REQUIRE(cudax::devices.size() == static_cast<size_t>(cudax::devices.end() - cudax::devices.begin()));
 
   CUDAX_REQUIRE(0 == cudax::devices[0].get());
-  CUDAX_REQUIRE(0 == cudax::devices[0]);
   CUDAX_REQUIRE(cudax::device_ref{0} == cudax::devices[0]);
 
   CUDAX_REQUIRE(0 == (*cudax::devices.begin()).get());
-  CUDAX_REQUIRE(0 == *cudax::devices.begin());
+  CUDAX_REQUIRE(cudax::device_ref{0} == *cudax::devices.begin());
 
   CUDAX_REQUIRE(0 == cudax::devices.begin()->get());
   CUDAX_REQUIRE(0 == cudax::devices.begin()[0].get());
@@ -294,7 +293,6 @@ TEST_CASE("global devices vector", "[device]")
   if (cudax::devices.size() > 1)
   {
     CUDAX_REQUIRE(1 == cudax::devices[1].get());
-    CUDAX_REQUIRE(0 != cudax::devices[1]);
     CUDAX_REQUIRE(cudax::device_ref{0} != cudax::devices[1].get());
 
     CUDAX_REQUIRE(1 == (*std::next(cudax::devices.begin())).get());

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -35,6 +35,14 @@ TEST_CASE("Smoke", "[device]")
   using cudax::device;
   using cudax::device_ref;
 
+  SECTION("Compare")
+  {
+    CUDAX_REQUIRE(device_ref{0} == device_ref{0});
+    CUDAX_REQUIRE(device_ref{0} == 0);
+    CUDAX_REQUIRE(device_ref{1} != device_ref{0});
+    CUDAX_REQUIRE(device_ref{1} != 2);
+  }
+
   SECTION("Attributes")
   {
     ::test_device_attribute<device::attrs::max_threads_per_block, ::cudaDevAttrMaxThreadsPerBlock, int>();
@@ -272,13 +280,21 @@ TEST_CASE("global devices vector", "[device]")
   CUDAX_REQUIRE(cudax::devices.size() == static_cast<size_t>(cudax::devices.end() - cudax::devices.begin()));
 
   CUDAX_REQUIRE(0 == cudax::devices[0].get());
+  CUDAX_REQUIRE(0 == cudax::devices[0]);
+  CUDAX_REQUIRE(cudax::device_ref{0} == cudax::devices[0]);
+
   CUDAX_REQUIRE(0 == (*cudax::devices.begin()).get());
+  CUDAX_REQUIRE(0 == *cudax::devices.begin());
+
   CUDAX_REQUIRE(0 == cudax::devices.begin()->get());
   CUDAX_REQUIRE(0 == cudax::devices.begin()[0].get());
 
   if (cudax::devices.size() > 1)
   {
     CUDAX_REQUIRE(1 == cudax::devices[1].get());
+    CUDAX_REQUIRE(0 != cudax::devices[1]);
+    CUDAX_REQUIRE(cudax::device_ref{0} != cudax::devices[1].get());
+
     CUDAX_REQUIRE(1 == (*std::next(cudax::devices.begin())).get());
     CUDAX_REQUIRE(1 == std::next(cudax::devices.begin())->get());
     CUDAX_REQUIRE(1 == cudax::devices.begin()[1].get());

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -108,7 +108,7 @@ TEST_CASE("Stream get device", "[stream]")
   cudax::stream dev0_stream(cudax::device_ref{0});
   CUDAX_REQUIRE(dev0_stream.device() == 0);
 
-  cudaSetDevice(cudax::devices.size() - 1);
+  cudaSetDevice(static_cast<int>(cudax::devices.size() - 1));
   cudaStream_t stream_handle;
   CUDART(cudaStreamCreate(&stream_handle));
   auto stream_cudart = cudax::stream::from_native_handle(stream_handle);

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -102,3 +102,15 @@ TEST_CASE("Stream priority", "[stream]")
   cudax::stream stream(0, priority);
   CUDAX_REQUIRE(stream.priority() == priority);
 }
+
+TEST_CASE("Stream get device", "[stream]")
+{
+  cudax::stream dev0_stream(cudax::device_ref{0});
+  CUDAX_REQUIRE(dev0_stream.device() == 0);
+
+  cudaSetDevice(cudax::devices.size() - 1);
+  cudaStream_t stream_handle;
+  CUDART(cudaStreamCreate(&stream_handle));
+  auto stream_cudart = cudax::stream::from_native_handle(stream_handle);
+  CUDAX_REQUIRE(stream_cudart.device() == *std::prev(cudax::devices.end()));
+}


### PR DESCRIPTION
Getting a device from a stream is not possible in the CUDA Runtime right now, but thanks to us using the Driver API for the device switching we can now provide such API.

This PR also adds comparison operators for device_ref