### PR TITLE
Cleanup common testing headers and correct asserts in launch testing

### DIFF
--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -26,6 +26,7 @@ function(cudax_add_catch2_test target_name_var test_name cn_target) # ARGN=test 
   set(test_sources ${ARGN})
 
   add_executable(${test_target} ${test_sources})
+  target_include_directories(${test_target} PRIVATE "common")
   target_link_libraries(${test_target} PRIVATE ${cn_target} Catch2::Catch2 catch2_main)
   target_link_libraries(${test_target} PRIVATE ${cn_target} cudax::Thrust)
   target_compile_options(${test_target} PRIVATE "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE")

--- a/cudax/test/common/host_device.cuh
+++ b/cudax/test/common/host_device.cuh
@@ -8,67 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __TESTING_COMMON_H__
-#define __TESTING_COMMON_H__
+#ifndef __COMMON_HOST_DEVICE_H__
+#define __COMMON_HOST_DEVICE_H__
 
-#include <cuda/experimental/hierarchy.cuh>
-
-#include <exception>
-#include <iostream>
-#include <sstream>
-
-#include <catch2/catch.hpp>
-
-namespace cudax = cuda::experimental;
-
-#define CUDART(call) REQUIRE((call) == cudaSuccess)
-
-inline void __device__ cudax_require_impl(
-  bool condition, const char* condition_text, const char* filename, unsigned int linenum, const char* funcname)
-{
-  if (!condition)
-  {
-    // TODO do warp aggregate prints for easier readibility?
-    printf("%s:%u: %s: block: [%d,%d,%d], thread: [%d,%d,%d] Condition `%s` failed.\n",
-           filename,
-           linenum,
-           funcname,
-           blockIdx.x,
-           blockIdx.y,
-           blockIdx.z,
-           threadIdx.x,
-           threadIdx.y,
-           threadIdx.z,
-           condition_text);
-    __trap();
-  }
-}
-
-// TODO make it work on NVC++
-#ifdef __CUDA_ARCH__
-#  define CUDAX_REQUIRE(condition) cudax_require_impl(condition, #condition, __FILE__, __LINE__, __PRETTY_FUNCTION__);
-#else
-#  define CUDAX_REQUIRE REQUIRE
-#endif
-
-bool constexpr __host__ __device__ operator==(const dim3& lhs, const dim3& rhs)
-{
-  return (lhs.x == rhs.x) && (lhs.y == rhs.y) && (lhs.z == rhs.z);
-}
-
-namespace Catch
-{
-template <>
-struct StringMaker<dim3>
-{
-  static std::string convert(dim3 const& dims)
-  {
-    std::ostringstream oss;
-    oss << "(" << dims.x << ", " << dims.y << ", " << dims.z << ")";
-    return oss.str();
-  }
-};
-} // namespace Catch
+#include "testing.cuh"
 
 template <typename Dims, typename Lambda>
 void __global__ lambda_launcher(const Dims dims, const Lambda lambda)
@@ -155,4 +98,4 @@ void apply_each(const Fn& fn, const Tuple& tuple)
     tuple);
 }
 
-#endif
+#endif // __COMMON_HOST_DEVICE_H__

--- a/cudax/test/common/testing.cuh
+++ b/cudax/test/common/testing.cuh
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __COMMON_TESTING_H__
+#define __COMMON_TESTING_H__
+
+#include <cuda/experimental/hierarchy.cuh>
+
+#include <exception>
+#include <iostream>
+#include <sstream>
+
+#include <catch2/catch.hpp>
+
+namespace cudax = cuda::experimental;
+
+#define CUDART(call) REQUIRE((call) == cudaSuccess)
+
+inline void __device__ cudax_require_impl(
+  bool condition, const char* condition_text, const char* filename, unsigned int linenum, const char* funcname)
+{
+  if (!condition)
+  {
+    // TODO do warp aggregate prints for easier readibility?
+    printf("%s:%u: %s: block: [%d,%d,%d], thread: [%d,%d,%d] Condition `%s` failed.\n",
+           filename,
+           linenum,
+           funcname,
+           blockIdx.x,
+           blockIdx.y,
+           blockIdx.z,
+           threadIdx.x,
+           threadIdx.y,
+           threadIdx.z,
+           condition_text);
+    __trap();
+  }
+}
+
+// TODO make it work on NVC++
+#ifdef __CUDA_ARCH__
+#  define CUDAX_REQUIRE(condition) cudax_require_impl(condition, #condition, __FILE__, __LINE__, __PRETTY_FUNCTION__);
+#else
+#  define CUDAX_REQUIRE REQUIRE
+#endif
+
+bool constexpr __host__ __device__ operator==(const dim3& lhs, const dim3& rhs)
+{
+  return (lhs.x == rhs.x) && (lhs.y == rhs.y) && (lhs.z == rhs.z);
+}
+
+namespace Catch
+{
+template <>
+struct StringMaker<dim3>
+{
+  static std::string convert(dim3 const& dims)
+  {
+    std::ostringstream oss;
+    oss << "(" << dims.x << ", " << dims.y << ", " << dims.z << ")";
+    return oss.str();
+  }
+};
+} // namespace Catch
+
+#endif // __COMMON_TESTING_H__

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __COMMON_UTILITY_H__
+#define __COMMON_UTILITY_H__
+
 #include <cuda_runtime_api.h>
 // cuda_runtime_api needs to come first
 
@@ -18,8 +21,7 @@
 
 #include <new> // IWYU pragma: keep (needed for placement new)
 
-// TODO unify the common testing header
-#include "../hierarchy/testing_common.cuh"
+#include "testing.cuh"
 
 namespace
 {
@@ -174,3 +176,4 @@ inline void empty_driver_stack()
 
 } // namespace test
 } // namespace
+#endif // __COMMON_UTILITY_H__

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -10,7 +10,7 @@
 
 #include <cuda/experimental/device.cuh>
 
-#include "../hierarchy/testing_common.cuh"
+#include "../common/testing.cuh"
 #include "cuda/std/__type_traits/is_same.h"
 
 namespace

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -10,8 +10,8 @@
 
 #include <cuda/experimental/device.cuh>
 
-#include "../common/testing.cuh"
 #include "cuda/std/__type_traits/is_same.h"
+#include <testing.cuh>
 
 namespace
 {

--- a/cudax/test/event/event_smoke.cu
+++ b/cudax/test/event/event_smoke.cu
@@ -10,8 +10,8 @@
 
 #include <cuda/experimental/event.cuh>
 
-#include "../common/utility.cuh"
 #include <catch2/catch.hpp>
+#include <utility.cuh>
 
 namespace
 {

--- a/cudax/test/event/event_smoke.cu
+++ b/cudax/test/event/event_smoke.cu
@@ -11,7 +11,6 @@
 #include <cuda/experimental/event.cuh>
 
 #include "../common/utility.cuh"
-#include "../hierarchy/testing_common.cuh"
 #include <catch2/catch.hpp>
 
 namespace

--- a/cudax/test/hierarchy/hierarchy_custom_types.cu
+++ b/cudax/test/hierarchy/hierarchy_custom_types.cu
@@ -10,7 +10,7 @@
 
 #include <iostream>
 
-#include "testing_common.cuh"
+#include "../common/host_device.cuh"
 #include <cooperative_groups.h>
 
 struct custom_level : public cudax::hierarchy_level
@@ -25,7 +25,7 @@ struct custom_level_dims : public cudax::level_dimensions<Level, Dims>
 {
   int dummy;
   constexpr custom_level_dims()
-      : cudax::level_dimensions<Level, Dims>() {};
+      : cudax::level_dimensions<Level, Dims>(){};
 };
 
 struct custom_level_test

--- a/cudax/test/hierarchy/hierarchy_custom_types.cu
+++ b/cudax/test/hierarchy/hierarchy_custom_types.cu
@@ -10,8 +10,8 @@
 
 #include <iostream>
 
-#include "../common/host_device.cuh"
 #include <cooperative_groups.h>
+#include <host_device.cuh>
 
 struct custom_level : public cudax::hierarchy_level
 {
@@ -25,7 +25,7 @@ struct custom_level_dims : public cudax::level_dimensions<Level, Dims>
 {
   int dummy;
   constexpr custom_level_dims()
-      : cudax::level_dimensions<Level, Dims>(){};
+      : cudax::level_dimensions<Level, Dims>() {};
 };
 
 struct custom_level_test

--- a/cudax/test/hierarchy/hierarchy_smoke.cu
+++ b/cudax/test/hierarchy/hierarchy_smoke.cu
@@ -10,8 +10,8 @@
 
 #include <iostream>
 
-#include "../common/host_device.cuh"
 #include <cooperative_groups.h>
+#include <host_device.cuh>
 
 namespace cg = cooperative_groups;
 

--- a/cudax/test/hierarchy/hierarchy_smoke.cu
+++ b/cudax/test/hierarchy/hierarchy_smoke.cu
@@ -10,7 +10,7 @@
 
 #include <iostream>
 
-#include "testing_common.cuh"
+#include "../common/host_device.cuh"
 #include <cooperative_groups.h>
 
 namespace cg = cooperative_groups;

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -14,7 +14,7 @@
 #include <cuda/experimental/launch.cuh>
 #undef cudaLaunchKernelEx
 
-#include "../hierarchy/testing_common.cuh"
+#include "../common/host_device.cuh"
 
 static cudaLaunchConfig_t expectedConfig;
 static bool replacementCalled = false;

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -14,7 +14,7 @@
 #include <cuda/experimental/launch.cuh>
 #undef cudaLaunchKernelEx
 
-#include "../common/host_device.cuh"
+#include <host_device.cuh>
 
 static cudaLaunchConfig_t expectedConfig;
 static bool replacementCalled = false;

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -11,7 +11,7 @@
 
 #include <cuda/experimental/launch.cuh>
 
-#include "../common/testing.cuh"
+#include <testing.cuh>
 
 __managed__ bool kernel_run_proof = false;
 

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -11,7 +11,7 @@
 
 #include <cuda/experimental/launch.cuh>
 
-#include "../hierarchy/testing_common.cuh"
+#include "../common/testing.cuh"
 
 __managed__ bool kernel_run_proof = false;
 
@@ -37,7 +37,7 @@ struct functor_taking_config
   __device__ void operator()(Config conf, int grid_size)
   {
     static_assert(conf.dims.static_count(cudax::thread, cudax::block) == BlockSize);
-    assert(conf.dims.count(cudax::block, cudax::grid) == grid_size);
+    CUDAX_REQUIRE(conf.dims.count(cudax::block, cudax::grid) == grid_size);
     kernel_run_proof = true;
   }
 };
@@ -49,7 +49,7 @@ struct functor_taking_dims
   __device__ void operator()(Dimensions dims, int grid_size)
   {
     static_assert(dims.static_count(cudax::thread, cudax::block) == BlockSize);
-    assert(dims.count(cudax::block, cudax::grid) == grid_size);
+    CUDAX_REQUIRE(dims.count(cudax::block, cudax::grid) == grid_size);
     kernel_run_proof = true;
   }
 };
@@ -84,7 +84,7 @@ struct dynamic_smem_single
   {
     auto& dynamic_smem = cudax::dynamic_smem_ref(conf);
     static_assert(::cuda::std::is_same_v<SmemType&, decltype(dynamic_smem)>);
-    assert(__isShared(&dynamic_smem));
+    CUDAX_REQUIRE(__isShared(&dynamic_smem));
     kernel_run_proof = true;
   }
 };
@@ -98,8 +98,8 @@ struct dynamic_smem_span
     auto dynamic_smem = cudax::dynamic_smem_span(conf);
     static_assert(decltype(dynamic_smem)::extent == Extent);
     static_assert(::cuda::std::is_same_v<SmemType&, decltype(dynamic_smem[1])>);
-    assert(dynamic_smem.size() == size);
-    assert(__isShared(&dynamic_smem[1]));
+    CUDAX_REQUIRE(dynamic_smem.size() == size);
+    CUDAX_REQUIRE(__isShared(&dynamic_smem[1]));
     kernel_run_proof = true;
   }
 };

--- a/cudax/test/stream/get_stream.cu
+++ b/cudax/test/stream/get_stream.cu
@@ -10,8 +10,8 @@
 
 #include <cuda/experimental/stream.cuh>
 
-#include "../common/utility.cuh"
 #include <catch2/catch.hpp>
+#include <utility.cuh>
 
 TEST_CASE("Can call get_stream on a cudaStream_t", "[stream]")
 {

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -11,8 +11,8 @@
 #include <cuda/experimental/launch.cuh>
 #include <cuda/experimental/stream.cuh>
 
-#include "../common/utility.cuh"
 #include <catch2/catch.hpp>
+#include <utility.cuh>
 
 constexpr auto one_thread_dims = cudax::make_hierarchy(cudax::block_dims<1>(), cudax::grid_dims<1>());
 

--- a/cudax/test/utility/driver_api.cu
+++ b/cudax/test/utility/driver_api.cu
@@ -10,7 +10,7 @@
 
 #include <cuda/experimental/__utility/driver_api.cuh>
 
-#include "../common/testing.cuh"
+#include <testing.cuh>
 
 TEST_CASE("Call each driver api", "[utility]")
 {

--- a/cudax/test/utility/driver_api.cu
+++ b/cudax/test/utility/driver_api.cu
@@ -10,7 +10,7 @@
 
 #include <cuda/experimental/__utility/driver_api.cuh>
 
-#include "../hierarchy/testing_common.cuh"
+#include "../common/testing.cuh"
 
 TEST_CASE("Call each driver api", "[utility]")
 {

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -13,7 +13,7 @@
 #include <cuda/experimental/event.cuh>
 #include <cuda/experimental/launch.cuh>
 
-#include "../common/utility.cuh"
+#include <utility.cuh>
 
 namespace driver = cuda::experimental::detail::driver;
 


### PR DESCRIPTION
This PR moves common testing header out of hierarchy subdirectory and splits out the host/dev testing part.

It also fixes asserts left in launch testing after custom device side assert was added