### PR TITLE
add `cudax::distribute<threadsPrBlock>(numElements)`

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -839,6 +839,32 @@ constexpr auto hierarchy_add_level(const hierarchy_dimensions_fragment<Unit, Lev
   return hierarchy & ::cuda::std::forward<NewLevel>(level);
 }
 
+/**
+ * @brief A shorthand for creating a hierarchy of CUDA threads by evenly
+ * distributing elements among blocks and threads.
+ *
+ * @par Snippet
+ * @code
+ * #include <cudax/hierarchy_dimensions.cuh>
+ * using namespace cuda::experimental;
+ *
+ * constexpr int threadsPerBlock = 256;
+ * auto dims = distribute<threadsPerBlock>(numElements);
+ *
+ * // Equivalent to:
+ * constexpr int threadsPerBlock = 256;
+ * int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
+ * auto dims = make_hierarchy(grid_dims(blocksPerGrid), block_dims<threadsPerBlock>());
+ * @endcode
+ */
+template <int _ThreadsPerBlock>
+constexpr auto distribute(int numElements) noexcept
+{
+  int blocksPerGrid = (numElements + _ThreadsPerBlock - 1) / _ThreadsPerBlock;
+  return ::cuda::experimental::make_hierarchy(
+    ::cuda::experimental::grid_dims(blocksPerGrid), ::cuda::experimental::block_dims<_ThreadsPerBlock>());
+}
+
 } // namespace cuda::experimental
 #endif // _CCCL_STD_VER >= 2017
 #endif // _CUDAX__HIERARCHY_HIERARCHY_DIMENSIONS

--- a/cudax/test/hierarchy/hierarchy_smoke.cu
+++ b/cudax/test/hierarchy/hierarchy_smoke.cu
@@ -512,3 +512,13 @@ TEST_CASE("Trivially constructable", "[hierarchy]")
   // static_assert(std::is_trivially_copyable_v<decltype(cudax::std::make_tuple(cudax::block_dims<256>(),
   // cudax::grid_dims<256>()))>);
 }
+
+TEST_CASE("cudax::distribute", "[hierarchy]")
+{
+  int numElements               = 50000;
+  constexpr int threadsPerBlock = 256;
+  auto dims                     = cudax::distribute<threadsPerBlock>(numElements);
+
+  CUDAX_REQUIRE(dims.count(cudax::thread, cudax::block) == 256);
+  CUDAX_REQUIRE(dims.count(cudax::block, cudax::grid) == (numElements + threadsPerBlock - 1) / threadsPerBlock);
+}


### PR DESCRIPTION
… as a way to evenly distribute elements over thread blocks.

## Description

`cudax::distribute<threadsPrBlock>(numElements)` is a shortcut notation for:

```c++
int blocksPerGrid = (numElements + threadsPrBlock - 1) / threadsPrBlock;
return cudax::make_hierarchy(cudax::grid_dims(blocksPerGrid), cudax::block_dims<threadsPrBlock>());
```

This will be used in the compute all hands presentation about cudax