### PR TITLE
Add missing annotations for deprecated debug_sync APIs

### DIFF
--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -1593,6 +1593,7 @@ public:
   }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t DispatchEven(
     void* d_temp_storage,
     size_t& temp_storage_bytes,

--- a/cub/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle.cuh
@@ -544,6 +544,7 @@ struct DeviceRleDispatch
   }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Dispatch(
     void* d_temp_storage,
     size_t& temp_storage_bytes,


### PR DESCRIPTION
Adds two missing deprecation annotations to CUB APIs that have a `debug_synchronous` parameter.

- [x] Merge after #2209