### PR TITLE
avoid constraint recursion in the `resource` concept

### DIFF
--- a/libcudacxx/include/cuda/__memory_resource/cuda_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/cuda_managed_memory_resource.h
@@ -80,7 +80,7 @@ public:
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),
-                       "Invalid alignment passed to cuda_memory_resource::deallocate.");
+                       "Invalid alignment passed to cuda_managed_memory_resource::deallocate.");
     _CCCL_ASSERT_CUDA_API(::cudaFree, "cuda_managed_memory_resource::deallocate failed", __ptr);
     (void) __alignment;
   }
@@ -102,8 +102,8 @@ public:
   }
 #    endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Equality comparison between a \c cuda_memory_resource and another resource
-  //! @param __lhs The \c cuda_memory_resource
+  //! @brief Equality comparison between a \c cuda_managed_memory_resource and another resource
+  //! @param __lhs The \c cuda_managed_memory_resource
   //! @param __rhs The resource to compare to
   //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
   //! resources. Otherwise, returns false.

--- a/libcudacxx/include/cuda/__memory_resource/cuda_pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/cuda_pinned_memory_resource.h
@@ -82,7 +82,7 @@ public:
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),
-                       "Invalid alignment passed to cuda_memory_resource::deallocate.");
+                       "Invalid alignment passed to cuda_pinned_memory_resource::deallocate.");
     _CCCL_ASSERT_CUDA_API(::cudaFreeHost, "cuda_pinned_memory_resource::deallocate failed", __ptr);
     (void) __alignment;
   }
@@ -104,8 +104,8 @@ public:
   }
 #    endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Equality comparison between a \c cuda_memory_resource and another resource
-  //! @param __lhs The \c cuda_memory_resource
+  //! @brief Equality comparison between a \c cuda_pinned_memory_resource and another resource
+  //! @param __lhs The \c cuda_pinned_memory_resource
   //! @param __rhs The resource to compare to
   //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
   //! resources. Otherwise, returns false.

--- a/libcudacxx/include/cuda/__memory_resource/resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource.h
@@ -25,6 +25,7 @@
 
 #  include <cuda/__memory_resource/get_property.h>
 #  include <cuda/std/__concepts/all_of.h>
+#  include <cuda/std/__concepts/convertible_to.h>
 #  include <cuda/std/__concepts/equality_comparable.h>
 #  include <cuda/std/__concepts/same_as.h>
 #  include <cuda/std/__type_traits/decay.h>
@@ -99,10 +100,15 @@ template <class _Resource, class... _Properties>
 _LIBCUDACXX_CONCEPT async_resource_with =
   async_resource<_Resource> && _CUDA_VSTD::__all_of<has_property<_Resource, _Properties>...>;
 
+template <bool, class _OtherResource>
+_CCCL_GLOBAL_CONSTANT bool __different_resource__ = resource<_OtherResource>;
+
+template <class _OtherResource>
+_CCCL_GLOBAL_CONSTANT bool __different_resource__<true, _OtherResource> = false;
+
 template <class _Resource, class _OtherResource>
 _LIBCUDACXX_CONCEPT __different_resource =
-  (!_CUDA_VSTD::same_as<_CUDA_VSTD::decay_t<_Resource>, _CUDA_VSTD::decay_t<_OtherResource>>)
-  && resource<_OtherResource>;
+  __different_resource__<_CUDA_VSTD::convertible_to<_OtherResource const&, _Resource const&>, _OtherResource>;
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_MR
 

--- a/libcudacxx/include/cuda/__memory_resource/resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource.h
@@ -100,15 +100,29 @@ template <class _Resource, class... _Properties>
 _LIBCUDACXX_CONCEPT async_resource_with =
   async_resource<_Resource> && _CUDA_VSTD::__all_of<has_property<_Resource, _Properties>...>;
 
-template <bool, class _OtherResource>
-_CCCL_GLOBAL_CONSTANT bool __different_resource__ = resource<_OtherResource>;
+template <bool _Convertible>
+struct __different_resource__
+{
+  template <class _OtherResource>
+  static constexpr bool __value(_OtherResource*) noexcept
+  {
+    return resource<_OtherResource>;
+  }
+};
 
-template <class _OtherResource>
-_CCCL_GLOBAL_CONSTANT bool __different_resource__<true, _OtherResource> = false;
+template <>
+struct __different_resource__<true>
+{
+  static constexpr bool __value(void*) noexcept
+  {
+    return false;
+  }
+};
 
 template <class _Resource, class _OtherResource>
 _LIBCUDACXX_CONCEPT __different_resource =
-  __different_resource__<_CUDA_VSTD::convertible_to<_OtherResource const&, _Resource const&>, _OtherResource>;
+  __different_resource__<_CUDA_VSTD::convertible_to<_OtherResource const&, _Resource const&>>::__value(
+    static_cast<_OtherResource*>(nullptr));
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_MR
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_managed_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_managed_memory_resource/equality.pass.cpp
@@ -56,6 +56,13 @@ struct async_resource : public resource<Accessibilty>
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
 
+// test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
+struct derived_managed_resource : cuda::mr::cuda_managed_memory_resource
+{
+  using cuda::mr::cuda_managed_memory_resource::cuda_managed_memory_resource;
+};
+static_assert(cuda::mr::resource<derived_managed_resource>, "");
+
 void test()
 {
   cuda::mr::cuda_managed_memory_resource first{};

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_memory_resource/equality.pass.cpp
@@ -66,6 +66,13 @@ static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>
 static_assert(cuda::mr::async_resource_with<async_resource<AccessibilityType::Device>, cuda::mr::device_accessible>,
               "");
 
+// test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
+struct derived_resource : cuda::mr::cuda_memory_resource
+{
+  using cuda::mr::cuda_memory_resource::cuda_memory_resource;
+};
+static_assert(cuda::mr::resource<derived_resource>, "");
+
 // Ensure that we can only
 
 void test()

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_pinned_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_pinned_memory_resource/equality.pass.cpp
@@ -56,6 +56,13 @@ struct async_resource : public resource<Accessibilty>
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
 
+// test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
+struct derived_pinned_resource : cuda::mr::cuda_pinned_memory_resource
+{
+  using cuda::mr::cuda_pinned_memory_resource::cuda_pinned_memory_resource;
+};
+static_assert(cuda::mr::resource<derived_pinned_resource>, "");
+
 void test()
 {
   cuda::mr::cuda_pinned_memory_resource first{};


### PR DESCRIPTION
## Description
The `mr::resource` concept requires equality comparable, but the models of the `resource` concept have comparison operations that are constrained with the `mr::resource` concept, leading to constraint recursion.

The change in the PR avoids the recursion by only testing arguments to `operator==` for satisfaction of the `resource` concept if the argument is not convertible to the class being defined.


<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #2214 


<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
