### PR TITLE
Avoid constraint recursion in the `resource` concept

### DIFF
--- a/libcudacxx/include/cuda/__memory_resource/cuda_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/cuda_managed_memory_resource.h
@@ -80,7 +80,7 @@ public:
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),
-                       "Invalid alignment passed to cuda_memory_resource::deallocate.");
+                       "Invalid alignment passed to cuda_managed_memory_resource::deallocate.");
     _CCCL_ASSERT_CUDA_API(::cudaFree, "cuda_managed_memory_resource::deallocate failed", __ptr);
     (void) __alignment;
   }
@@ -102,8 +102,8 @@ public:
   }
 #    endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Equality comparison between a \c cuda_memory_resource and another resource
-  //! @param __lhs The \c cuda_memory_resource
+  //! @brief Equality comparison between a \c cuda_managed_memory_resource and another resource
+  //! @param __lhs The \c cuda_managed_memory_resource
   //! @param __rhs The resource to compare to
   //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
   //! resources. Otherwise, returns false.

--- a/libcudacxx/include/cuda/__memory_resource/cuda_pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/cuda_pinned_memory_resource.h
@@ -82,7 +82,7 @@ public:
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),
-                       "Invalid alignment passed to cuda_memory_resource::deallocate.");
+                       "Invalid alignment passed to cuda_pinned_memory_resource::deallocate.");
     _CCCL_ASSERT_CUDA_API(::cudaFreeHost, "cuda_pinned_memory_resource::deallocate failed", __ptr);
     (void) __alignment;
   }
@@ -104,8 +104,8 @@ public:
   }
 #    endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Equality comparison between a \c cuda_memory_resource and another resource
-  //! @param __lhs The \c cuda_memory_resource
+  //! @brief Equality comparison between a \c cuda_pinned_memory_resource and another resource
+  //! @param __lhs The \c cuda_pinned_memory_resource
   //! @param __rhs The resource to compare to
   //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
   //! resources. Otherwise, returns false.

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_managed_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_managed_memory_resource/equality.pass.cpp
@@ -56,6 +56,13 @@ struct async_resource : public resource<Accessibilty>
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
 
+// test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
+struct derived_managed_resource : cuda::mr::cuda_managed_memory_resource
+{
+  using cuda::mr::cuda_managed_memory_resource::cuda_managed_memory_resource;
+};
+static_assert(cuda::mr::resource<derived_managed_resource>, "");
+
 void test()
 {
   cuda::mr::cuda_managed_memory_resource first{};

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_memory_resource/equality.pass.cpp
@@ -66,6 +66,13 @@ static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>
 static_assert(cuda::mr::async_resource_with<async_resource<AccessibilityType::Device>, cuda::mr::device_accessible>,
               "");
 
+// test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
+struct derived_resource : cuda::mr::cuda_memory_resource
+{
+  using cuda::mr::cuda_memory_resource::cuda_memory_resource;
+};
+static_assert(cuda::mr::resource<derived_resource>, "");
+
 // Ensure that we can only
 
 void test()

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_pinned_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_pinned_memory_resource/equality.pass.cpp
@@ -56,6 +56,13 @@ struct async_resource : public resource<Accessibilty>
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
 
+// test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
+struct derived_pinned_resource : cuda::mr::cuda_pinned_memory_resource
+{
+  using cuda::mr::cuda_pinned_memory_resource::cuda_pinned_memory_resource;
+};
+static_assert(cuda::mr::resource<derived_pinned_resource>, "");
+
 void test()
 {
   cuda::mr::cuda_pinned_memory_resource first{};


### PR DESCRIPTION
Pulled out into a separate PR to keep CI time down with the samples

Fixes #2214

Authored-by: Eric Niebler <eniebler@nvidia.com>
