### PR TITLE
Test thrust headers for disabled half/bf16 support

### DIFF
--- a/cub/cmake/CubHeaderTesting.cmake
+++ b/cub/cmake/CubHeaderTesting.cmake
@@ -42,12 +42,14 @@ set(header_definitions
   "CUB_WRAPPED_NAMESPACE=wrapped_cub")
 cub_add_header_test(base "${header_definitions}")
 
+# Check that BF16 support can be disabled
 set(header_definitions
   "THRUST_WRAPPED_NAMESPACE=wrapped_thrust"
   "CUB_WRAPPED_NAMESPACE=wrapped_cub"
   "CCCL_DISABLE_BF16_SUPPORT")
 cub_add_header_test(bf16 "${header_definitions}")
 
+# Check that half support can be disabled
 set(header_definitions
   "THRUST_WRAPPED_NAMESPACE=wrapped_thrust"
   "CUB_WRAPPED_NAMESPACE=wrapped_cub"

--- a/thrust/cmake/header_test.in
+++ b/thrust/cmake/header_test.in
@@ -64,3 +64,18 @@
 #endif // THRUST_IGNORE_MACRO_CHECKS
 
 #include <thrust/${header}>
+
+#if defined(CCCL_DISABLE_BF16_SUPPORT)
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+#error Thrust should not include cuda_bf16.h when BF16 support is disabled
+#endif // __CUDA_BF16_TYPES_EXIST__
+#endif // CCCL_DISABLE_BF16_SUPPORT
+
+#if defined(CCCL_DISABLE_FP16_SUPPORT)
+#if defined(__CUDA_FP16_TYPES_EXIST__)
+#error Thrust should not include cuda_fp16.h when half support is disabled
+#endif // __CUDA_FP16_TYPES_EXIST__
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+#error Thrust should not include cuda_bf16.h when half support is disabled
+#endif // __CUDA_BF16_TYPES_EXIST__
+#endif // CCCL_DISABLE_FP16_SUPPORT


### PR DESCRIPTION
This PR tests Thrust's headers for disabled half and BF16 support.

This was requested by @gevtushenko in: https://github.com/NVIDIA/cccl/pull/2168#discussion_r1702028337

For reviewing: disable whitespace comparisons.