### PR TITLE
Add tests for transform_iterator's reference type

### DIFF
--- a/thrust/thrust/detail/reference.h
+++ b/thrust/thrust/detail/reference.h
@@ -308,7 +308,7 @@ private:
   pointer const ptr;
 
   // `thrust::detail::is_wrapped_reference` is a trait that indicates whether
-  // a type is a fancy reference. It detects such types by loooking for a
+  // a type is a fancy reference. It detects such types by looking for a
   // nested `wrapped_reference_hint` type.
   struct wrapped_reference_hint
   {};


### PR DESCRIPTION
Since I had a fight with Thrust's `transform_iterator` today, I decided to independently push some tests nailing the status-quo on its reference type.