### PR TITLE
Fix including `<complex>` when bad CUDA bfloat/half macros are used.

### DIFF
--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -56,15 +56,6 @@ struct __type_to_vector<__nv_bfloat16>
   using __type = __nv_bfloat162;
 };
 
-// This is a workaround against the user defining macros __CUDA_NO_BFLOAT16_CONVERSIONS__ __CUDA_NO_BFLOAT16_OPERATORS__
-template <>
-struct __complex_can_implicitly_construct<float, __nv_bfloat16> : true_type
-{};
-
-template <>
-struct __complex_can_implicitly_construct<double, __nv_bfloat16> : true_type
-{};
-
 template <>
 struct __libcpp_complex_overload_traits<__nv_bfloat16, false, false>
 {
@@ -231,6 +222,15 @@ public:
     return __hbeq2(__lhs.__repr_, __rhs.__repr_);
   }
 };
+
+// This is a workaround against the user defining macros __CUDA_NO_BFLOAT16_CONVERSIONS__ __CUDA_NO_BFLOAT16_OPERATORS__
+template <>
+struct __complex_can_implicitly_construct<float, __nv_bfloat16> : true_type
+{};
+
+template <>
+struct __complex_can_implicitly_construct<double, __nv_bfloat16> : true_type
+{};
 
 template <> // complex<float>
 template <> // complex<__half>

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -123,15 +123,6 @@ public:
       : __repr_(__convert_to_bfloat16(__c.real()), __convert_to_bfloat16(__c.imag()))
   {}
 
-  _LIBCUDACXX_INLINE_VISIBILITY operator complex<float>() const
-  {
-    return complex<float>{__bfloat162float(__repr_.x), __bfloat162float(__repr_.y)};
-  }
-  _LIBCUDACXX_INLINE_VISIBILITY operator complex<double>() const
-  {
-    return complex<double>{__bfloat162float(__repr_.x), __bfloat162float(__repr_.y)};
-  }
-
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator=(const value_type& __re)
   {
     __repr_.x = __re;

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -90,6 +90,15 @@ public:
       : __repr_(static_cast<value_type>(__c.real()), static_cast<value_type>(__c.imag()))
   {}
 
+  template <class _Up,
+            __enable_if_t<!__complex_can_implicitly_construct<value_type, _Up>::value, int> = 0,
+            __enable_if_t<!_CCCL_TRAIT(is_constructible, value_type, _Up)
+                            && (_CCCL_TRAIT(is_same, _Up, float) || _CCCL_TRAIT(is_same, _Up, double)),
+                          int>                                                              = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY explicit complex(const complex<_Up>& __c)
+      : __repr_(__float2bfloat16(__c.real()), __float2bfloat16(__c.imag()))
+  {}
+
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator=(const value_type& __re)
   {
     __repr_.x = __re;
@@ -155,24 +164,24 @@ public:
 
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator+=(const value_type& __re)
   {
-    __repr_.x += __re;
+    __repr_.x = __hadd(__repr_.x, __re);
     return *this;
   }
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator-=(const value_type& __re)
   {
-    __repr_.x -= __re;
+    __repr_.x = __hsub(__repr_.x, __re);
     return *this;
   }
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator*=(const value_type& __re)
   {
-    __repr_.x *= __re;
-    __repr_.y *= __re;
+    __repr_.x = __hmul(__repr_.x, __re);
+    __repr_.y = __hmul(__repr_.y, __re);
     return *this;
   }
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator/=(const value_type& __re)
   {
-    __repr_.x /= __re;
-    __repr_.y /= __re;
+    __repr_.x = __hdiv(__repr_.x, __re);
+    __repr_.y = __hdiv(__repr_.y, __re);
     return *this;
   }
 
@@ -197,7 +206,7 @@ public:
 
 inline _LIBCUDACXX_INLINE_VISIBILITY __nv_bfloat16 arg(__nv_bfloat16 __re)
 {
-  return _CUDA_VSTD::atan2f(__nv_bfloat16(0), __re);
+  return _CUDA_VSTD::atan2(__int2bfloat16_rn(0), __re);
 }
 
 // We have performance issues with some trigonometric functions with __nv_bfloat16

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -234,21 +234,21 @@ public:
 
 template <> // complex<float>
 template <> // complex<__half>
-_LIBCUDACXX_INLINE_VISIBILITY complex<float>::complex(const complex<__nv_bfloat16>& __c)
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<float>::complex(const complex<__nv_bfloat16>& __c)
     : __re_(__bfloat162float(__c.real()))
     , __im_(__bfloat162float(__c.imag()))
 {}
 
 template <> // complex<double>
 template <> // complex<__half>
-_LIBCUDACXX_INLINE_VISIBILITY complex<double>::complex(const complex<__nv_bfloat16>& __c)
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<double>::complex(const complex<__nv_bfloat16>& __c)
     : __re_(__bfloat162float(__c.real()))
     , __im_(__bfloat162float(__c.imag()))
 {}
 
 template <> // complex<float>
 template <> // complex<__nv_bfloat16>
-_LIBCUDACXX_INLINE_VISIBILITY complex<float>& complex<float>::operator=(const complex<__nv_bfloat16>& __c)
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<float>& complex<float>::operator=(const complex<__nv_bfloat16>& __c)
 {
   __re_ = __bfloat162float(__c.real());
   __im_ = __bfloat162float(__c.imag());
@@ -257,7 +257,7 @@ _LIBCUDACXX_INLINE_VISIBILITY complex<float>& complex<float>::operator=(const co
 
 template <> // complex<double>
 template <> // complex<__nv_bfloat16>
-_LIBCUDACXX_INLINE_VISIBILITY complex<double>& complex<double>::operator=(const complex<__nv_bfloat16>& __c)
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<double>& complex<double>::operator=(const complex<__nv_bfloat16>& __c)
 {
   __re_ = __bfloat162float(__c.real());
   __im_ = __bfloat162float(__c.imag());

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -239,7 +239,7 @@ _LIBCUDACXX_INLINE_VISIBILITY complex<float>::complex(const complex<__nv_bfloat1
     , __im_(__bfloat162float(__c.imag()))
 {}
 
-template <> // complex<float>
+template <> // complex<double>
 template <> // complex<__half>
 _LIBCUDACXX_INLINE_VISIBILITY complex<double>::complex(const complex<__nv_bfloat16>& __c)
     : __re_(__bfloat162float(__c.real()))
@@ -255,7 +255,7 @@ _LIBCUDACXX_INLINE_VISIBILITY complex<float>& complex<float>::operator=(const co
   return *this;
 }
 
-template <> // complex<float>
+template <> // complex<double>
 template <> // complex<__nv_bfloat16>
 _LIBCUDACXX_INLINE_VISIBILITY complex<double>& complex<double>::operator=(const complex<__nv_bfloat16>& __c)
 {

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -60,6 +60,39 @@ struct __libcpp_complex_overload_traits<__half, false, false>
   typedef complex<__half> _ComplexType;
 };
 
+// This is a workaround against the user defining macros __CUDA_NO_HALF_CONVERSIONS__ __CUDA_NO_HALF_OPERATORS__
+template <>
+struct __complex_can_implicitly_construct<__half, float> : true_type
+{};
+
+template <>
+struct __complex_can_implicitly_construct<__half, double> : true_type
+{};
+
+template <>
+struct __complex_can_implicitly_construct<float, __half> : true_type
+{};
+
+template <>
+struct __complex_can_implicitly_construct<double, __half> : true_type
+{};
+
+template <class _Tp>
+inline _LIBCUDACXX_INLINE_VISIBILITY __half __convert_to_half(const _Tp& __value) noexcept
+{
+  return __value;
+}
+
+inline _LIBCUDACXX_INLINE_VISIBILITY __half __convert_to_half(const float& __value) noexcept
+{
+  return __float2half(__value);
+}
+
+inline _LIBCUDACXX_INLINE_VISIBILITY __half __convert_to_half(const double& __value) noexcept
+{
+  return __double2half(__value);
+}
+
 template <>
 class _LIBCUDACXX_TEMPLATE_VIS _CCCL_ALIGNAS(alignof(__half2)) complex<__half>
 {
@@ -77,21 +110,14 @@ public:
 
   template <class _Up, __enable_if_t<__complex_can_implicitly_construct<value_type, _Up>::value, int> = 0>
   _LIBCUDACXX_INLINE_VISIBILITY complex(const complex<_Up>& __c)
-      : __repr_(static_cast<value_type>(__c.real()), static_cast<value_type>(__c.imag()))
+      : __repr_(__convert_to_half(__c.real()), __convert_to_half(__c.imag()))
   {}
 
   template <class _Up,
             __enable_if_t<!__complex_can_implicitly_construct<value_type, _Up>::value, int> = 0,
             __enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Up), int>              = 0>
   _LIBCUDACXX_INLINE_VISIBILITY explicit complex(const complex<_Up>& __c)
-      : __repr_(static_cast<value_type>(__c.real()), static_cast<value_type>(__c.imag()))
-  {}
-
-  _LIBCUDACXX_INLINE_VISIBILITY explicit complex(const complex<float>& __c)
-      : __repr_(__float2half(__c.real()), __float2half(__c.imag()))
-  {}
-  _LIBCUDACXX_INLINE_VISIBILITY explicit complex(const complex<double>& __c)
-      : __repr_(__double2half(__c.real()), __double2half(__c.imag()))
+      : __repr_(__convert_to_half(__c.real()), __convert_to_half(__c.imag()))
   {}
 
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator=(const value_type& __re)
@@ -104,21 +130,8 @@ public:
   template <class _Up>
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator=(const complex<_Up>& __c)
   {
-    __repr_.x = __c.real();
-    __repr_.y = __c.imag();
-    return *this;
-  }
-
-  _LIBCUDACXX_INLINE_VISIBILITY complex& operator=(const complex<float>& __c)
-  {
-    __repr_.x = __float2half(__c.real());
-    __repr_.y = __float2half(__c.imag());
-    return *this;
-  }
-  _LIBCUDACXX_INLINE_VISIBILITY complex& operator=(const complex<double>& __c)
-  {
-    __repr_.x = __double2half(__c.real());
-    __repr_.y = __double2half(__c.imag());
+    __repr_.x = __convert_to_half(__c.real());
+    __repr_.y = __convert_to_half(__c.imag());
     return *this;
   }
 
@@ -211,15 +224,6 @@ public:
     return __hbeq2(__lhs.__repr_, __rhs.__repr_);
   }
 };
-
-// This is a workaround against the user defining macros __CUDA_NO_HALF_CONVERSIONS__ __CUDA_NO_HALF_OPERATORS__
-template <>
-struct __complex_can_implicitly_construct<float, __half> : true_type
-{};
-
-template <>
-struct __complex_can_implicitly_construct<double, __half> : true_type
-{};
 
 template <> // complex<float>
 template <> // complex<__half>

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -228,7 +228,7 @@ _LIBCUDACXX_INLINE_VISIBILITY complex<float>::complex(const complex<__half>& __c
     , __im_(__half2float(__c.imag()))
 {}
 
-template <> // complex<float>
+template <> // complex<double>
 template <> // complex<__half>
 _LIBCUDACXX_INLINE_VISIBILITY complex<double>::complex(const complex<__half>& __c)
     : __re_(__half2float(__c.real()))
@@ -244,7 +244,7 @@ _LIBCUDACXX_INLINE_VISIBILITY complex<float>& complex<float>::operator=(const co
   return *this;
 }
 
-template <> // complex<float>
+template <> // complex<double>
 template <> // complex<__half>
 _LIBCUDACXX_INLINE_VISIBILITY complex<double>& complex<double>::operator=(const complex<__half>& __c)
 {

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -223,21 +223,21 @@ public:
 
 template <> // complex<float>
 template <> // complex<__half>
-_LIBCUDACXX_INLINE_VISIBILITY complex<float>::complex(const complex<__half>& __c)
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<float>::complex(const complex<__half>& __c)
     : __re_(__half2float(__c.real()))
     , __im_(__half2float(__c.imag()))
 {}
 
 template <> // complex<double>
 template <> // complex<__half>
-_LIBCUDACXX_INLINE_VISIBILITY complex<double>::complex(const complex<__half>& __c)
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<double>::complex(const complex<__half>& __c)
     : __re_(__half2float(__c.real()))
     , __im_(__half2float(__c.imag()))
 {}
 
 template <> // complex<float>
 template <> // complex<__half>
-_LIBCUDACXX_INLINE_VISIBILITY complex<float>& complex<float>::operator=(const complex<__half>& __c)
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<float>& complex<float>::operator=(const complex<__half>& __c)
 {
   __re_ = __half2float(__c.real());
   __im_ = __half2float(__c.imag());
@@ -246,7 +246,7 @@ _LIBCUDACXX_INLINE_VISIBILITY complex<float>& complex<float>::operator=(const co
 
 template <> // complex<double>
 template <> // complex<__half>
-_LIBCUDACXX_INLINE_VISIBILITY complex<double>& complex<double>::operator=(const complex<__half>& __c)
+inline _LIBCUDACXX_INLINE_VISIBILITY complex<double>& complex<double>::operator=(const complex<__half>& __c)
 {
   __re_ = __half2float(__c.real());
   __im_ = __half2float(__c.imag());

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -87,6 +87,15 @@ public:
       : __repr_(static_cast<value_type>(__c.real()), static_cast<value_type>(__c.imag()))
   {}
 
+  template <class _Up,
+            __enable_if_t<!__complex_can_implicitly_construct<value_type, _Up>::value, int> = 0,
+            __enable_if_t<!_CCCL_TRAIT(is_constructible, value_type, _Up)
+                            && (_CCCL_TRAIT(is_same, _Up, float) || _CCCL_TRAIT(is_same, _Up, double)),
+                          int>                                                              = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY explicit complex(const complex<_Up>& __c)
+      : __repr_(__float2half(__c.real()), __float2half(__c.imag()))
+  {}
+
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator=(const value_type& __re)
   {
     __repr_.x = __re;
@@ -152,24 +161,24 @@ public:
 
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator+=(const value_type& __re)
   {
-    __repr_.x += __re;
+    __repr_.x = __hadd(__repr_.x, __re);
     return *this;
   }
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator-=(const value_type& __re)
   {
-    __repr_.x -= __re;
+    __repr_.x = __hsub(__repr_.x, __re);
     return *this;
   }
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator*=(const value_type& __re)
   {
-    __repr_.x *= __re;
-    __repr_.y *= __re;
+    __repr_.x = __hmul(__repr_.x, __re);
+    __repr_.y = __hmul(__repr_.y, __re);
     return *this;
   }
   _LIBCUDACXX_INLINE_VISIBILITY complex& operator/=(const value_type& __re)
   {
-    __repr_.x /= __re;
-    __repr_.y /= __re;
+    __repr_.x = __hdiv(__repr_.x, __re);
+    __repr_.y = __hdiv(__repr_.y, __re);
     return *this;
   }
 
@@ -194,7 +203,7 @@ public:
 
 inline _LIBCUDACXX_INLINE_VISIBILITY __half arg(__half __re)
 {
-  return _CUDA_VSTD::atan2f(__half(0), __re);
+  return _CUDA_VSTD::atan2(__int2half_rn(0), __re);
 }
 
 // We have performance issues with some trigonometric functions with __half

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -53,15 +53,6 @@ struct __type_to_vector<__half>
   using __type = __half2;
 };
 
-// This is a workaround against the user defining macros __CUDA_NO_HALF_CONVERSIONS__ __CUDA_NO_HALF_OPERATORS__
-template <>
-struct __complex_can_implicitly_construct<float, __half> : true_type
-{};
-
-template <>
-struct __complex_can_implicitly_construct<double, __half> : true_type
-{};
-
 template <>
 struct __libcpp_complex_overload_traits<__half, false, false>
 {
@@ -220,6 +211,15 @@ public:
     return __hbeq2(__lhs.__repr_, __rhs.__repr_);
   }
 };
+
+// This is a workaround against the user defining macros __CUDA_NO_HALF_CONVERSIONS__ __CUDA_NO_HALF_OPERATORS__
+template <>
+struct __complex_can_implicitly_construct<float, __half> : true_type
+{};
+
+template <>
+struct __complex_can_implicitly_construct<double, __half> : true_type
+{};
 
 template <> // complex<float>
 template <> // complex<__half>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -310,24 +310,6 @@ public:
       , __im_(static_cast<_Tp>(__c.imag()))
   {}
 
-#ifdef _LIBCUDACXX_HAS_NVFP16
-  template <class _Up,
-            __enable_if_t<!_CCCL_TRAIT(is_constructible, _Tp, _Up) && _CCCL_TRAIT(is_same, _Up, __half), int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit constexpr complex(const complex<_Up>& __c)
-      : __re_(__half2float(__c.real()))
-      , __im_(__half2float(__c.imag()))
-  {}
-#endif // _LIBCUDACXX_HAS_NVFP16
-
-#ifdef _LIBCUDACXX_HAS_NVBF16
-  template <class _Up,
-            __enable_if_t<!_CCCL_TRAIT(is_constructible, _Tp, _Up) && _CCCL_TRAIT(is_same, _Up, __nv_bfloat16), int> = 0>
-  _LIBCUDACXX_INLINE_VISIBILITY explicit constexpr complex(const complex<_Up>& __c)
-      : __re_(__bfloat162float(__c.real()))
-      , __im_(__bfloat162float(__c.imag()))
-  {}
-#endif // _LIBCUDACXX_HAS_NVBF16
-
   _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 complex& operator=(const value_type& __re)
   {
     __re_ = __re;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -310,6 +310,24 @@ public:
       , __im_(static_cast<_Tp>(__c.imag()))
   {}
 
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  template <class _Up,
+            __enable_if_t<!_CCCL_TRAIT(is_constructible, _Tp, _Up) && _CCCL_TRAIT(is_same, _Up, __half), int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY explicit constexpr complex(const complex<_Up>& __c)
+      : __re_(__half2float(__c.real()))
+      , __im_(__half2float(__c.imag()))
+  {}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  template <class _Up,
+            __enable_if_t<!_CCCL_TRAIT(is_constructible, _Tp, _Up) && _CCCL_TRAIT(is_same, _Up, __nv_bfloat16), int> = 0>
+  _LIBCUDACXX_INLINE_VISIBILITY explicit constexpr complex(const complex<_Up>& __c)
+      : __re_(__bfloat162float(__c.real()))
+      , __im_(__bfloat162float(__c.imag()))
+  {}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
   _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 complex& operator=(const value_type& __re)
   {
     __re_ = __re;

--- a/libcudacxx/test/libcudacxx/cuda/complex/half_bfloat/complex.bad_macros.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/half_bfloat/complex.bad_macros.pass.cpp
@@ -11,6 +11,8 @@
 #define __CUDA_NO_HALF_OPERATORS__       1
 #define __CUDA_NO_BFLOAT16_CONVERSIONS__ 1
 #define __CUDA_NO_BFLOAT16_OPERATORS__   1
+#define __CUDA_NO_HALF2_OPERATORS__      1
+#define __CUDA_NO_BFLOAT162_OPERATORS__  1
 
 #include <cuda/std/cassert>
 #include <cuda/std/complex>
@@ -22,10 +24,8 @@ __host__ __device__ void test_assignment(cuda::std::complex<U> v = {})
 {
   cuda::std::complex<T> converting(v);
 
-  /* TODO: Fix assignment when the macros above are defined
-    cuda::std::complex<T> assigning{};
-    assigning = v;
-  */
+  cuda::std::complex<T> assigning{};
+  assigning = v;
 }
 
 __host__ __device__ void test()

--- a/libcudacxx/test/libcudacxx/cuda/complex/half_bfloat/complex.bad_macros.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/half_bfloat/complex.bad_macros.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#define __CUDA_NO_HALF_CONVERSIONS__     1
+#define __CUDA_NO_HALF_OPERATORS__       1
+#define __CUDA_NO_BFLOAT16_CONVERSIONS__ 1
+#define __CUDA_NO_BFLOAT16_OPERATORS__   1
+
+#include <cuda/std/cassert>
+#include <cuda/std/complex>
+
+#include "test_macros.h"
+
+template <class T, class U>
+__host__ __device__ void test_assignment(cuda::std::complex<U> v = {})
+{
+  cuda::std::complex<T> converting(v);
+
+  /* TODO: Fix assignment when the macros above are defined
+    cuda::std::complex<T> assigning{};
+    assigning = v;
+  */
+}
+
+__host__ __device__ void test()
+{
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test_assignment<__half, float>();
+  test_assignment<__half, double>();
+  test_assignment<float, __half>();
+  test_assignment<double, __half>();
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test_assignment<__nv_bfloat16, float>();
+  test_assignment<__nv_bfloat16, double>();
+  test_assignment<float, __nv_bfloat16>();
+  test_assignment<double, __nv_bfloat16>();
+#endif // _LIBCUDACXX_HAS_NVBF16
+}
+
+int main(int arg, char** argv)
+{
+  test();
+  return 0;
+}


### PR DESCRIPTION
## Description

closes nvbug 4739601

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
