### PR TITLE
fix `cuda_memory_resource` test for properly aligned memory

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_memory_resource/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/cuda_memory_resource/allocate.pass.cpp
@@ -47,7 +47,8 @@ void test()
     ensure_device_ptr(ptr);
 
     // also check the alignment
-    const auto alignment = reinterpret_cast<cuda::std::uintptr_t>(ptr);
+    const auto address   = reinterpret_cast<cuda::std::uintptr_t>(ptr);
+    const auto alignment = address & (~address + 1ULL);
     assert(alignment >= desired_alignment);
     res.deallocate(ptr, 42, desired_alignment);
   }


### PR DESCRIPTION
## Description
The `cuda_memory_resource` tests include the following:

```c++
    // also check the alignment
    const auto alignment = reinterpret_cast<cuda::std::uintptr_t>(ptr);
    assert(alignment >= desired_alignment);
```

The intention here was to compare the pointer _alignment_ -- not the pointer _value_ -- against the desired alignment. This pr fixes the think-o.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
