### PR TITLE
Rename the memory resources to drop the superfluous prefix `cuda_`

### DIFF
--- a/cudax/test/containers/uninitialized_buffer.cu
+++ b/cudax/test/containers/uninitialized_buffer.cu
@@ -61,7 +61,7 @@ TEMPLATE_TEST_CASE(
   static_assert(!cuda::std::is_copy_constructible<uninitialized_buffer>::value, "");
   static_assert(!cuda::std::is_copy_assignable<uninitialized_buffer>::value, "");
 
-  cuda::mr::cuda_memory_resource resource{};
+  cuda::mr::device_memory_resource resource{};
 
   SECTION("construction")
   {
@@ -89,7 +89,7 @@ TEMPLATE_TEST_CASE(
   {
     static_assert(!cuda::std::is_copy_assignable<uninitialized_buffer>::value, "");
     {
-      cuda::mr::cuda_managed_memory_resource other_resource{};
+      cuda::mr::managed_memory_resource other_resource{};
       uninitialized_buffer input{other_resource, 42};
       uninitialized_buffer buf{resource, 1337};
       const auto* old_ptr       = buf.data();

--- a/libcudacxx/include/cuda/__memory_resource/device_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/device_memory_resource.h
@@ -39,20 +39,20 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA_MR
 
-//! @brief cuda_memory_resource uses `cudaMalloc` / `cudaFree` for allocation / deallocation.
+//! @brief device_memory_resource uses `cudaMalloc` / `cudaFree` for allocation / deallocation.
 //! By default uses device 0 to allocate memory
-class cuda_memory_resource
+class device_memory_resource
 {
 private:
   int __device_id_{0};
 
 public:
-  //! @brief default constructs a cuda_memory_resource allocating memory on device 0
-  cuda_memory_resource() = default;
+  //! @brief default constructs a device_memory_resource allocating memory on device 0
+  device_memory_resource() = default;
 
-  //! @brief default constructs a cuda_memory_resource allocating memory on device \p __device_id
+  //! @brief default constructs a device_memory_resource allocating memory on device \p __device_id
   //! @param __device_id The id of the device we are allocating memory on
-  constexpr cuda_memory_resource(const int __device_id) noexcept
+  constexpr device_memory_resource(const int __device_id) noexcept
       : __device_id_(__device_id)
   {}
 
@@ -85,65 +85,65 @@ public:
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),
-                       "Invalid alignment passed to cuda_memory_resource::deallocate.");
-    _CCCL_ASSERT_CUDA_API(::cudaFree, "cuda_memory_resource::deallocate failed", __ptr);
+                       "Invalid alignment passed to device_memory_resource::deallocate.");
+    _CCCL_ASSERT_CUDA_API(::cudaFree, "device_memory_resource::deallocate failed", __ptr);
     (void) __alignment;
   }
 
-  //! @brief Equality comparison with another \c cuda_memory_resource
-  //! @param __other The other \c cuda_memory_resource
+  //! @brief Equality comparison with another \c device_memory_resource
+  //! @param __other The other \c device_memory_resource
   //! @return true, if both resources hold the same device id
-  _CCCL_NODISCARD constexpr bool operator==(cuda_memory_resource const& __other) const noexcept
+  _CCCL_NODISCARD constexpr bool operator==(device_memory_resource const& __other) const noexcept
   {
     return __device_id_ == __other.__device_id_;
   }
 #    if _CCCL_STD_VER <= 2017
-  //! @brief Inequality comparison with another \c cuda_memory_resource
-  //! @param __other The other \c cuda_memory_resource
+  //! @brief Inequality comparison with another \c device_memory_resource
+  //! @param __other The other \c device_memory_resource
   //! @return true, if both resources hold different device id's
-  _CCCL_NODISCARD constexpr bool operator!=(cuda_memory_resource const& __other) const noexcept
+  _CCCL_NODISCARD constexpr bool operator!=(device_memory_resource const& __other) const noexcept
   {
     return __device_id_ != __other.__device_id_;
   }
 #    endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Equality comparison between a \c cuda_memory_resource and another resource
-  //! @param __lhs The \c cuda_memory_resource
+  //! @brief Equality comparison between a \c device_memory_resource and another resource
+  //! @param __lhs The \c device_memory_resource
   //! @param __rhs The resource to compare to
   //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
   //! resources. Otherwise, returns false.
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(cuda_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator==(device_memory_resource const& __lhs, _Resource const& __rhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<device_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
 #    if _CCCL_STD_VER <= 2017
-  //! @copydoc cuda_memory_resource::operator==<_Resource>(cuda_memory_resource const&, _Resource const&)
+  //! @copydoc device_memory_resource::operator==<_Resource>(device_memory_resource const&, _Resource const&)
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __rhs, cuda_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __rhs, device_memory_resource const& __lhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<device_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
-  //! @copydoc cuda_memory_resource::operator==<_Resource>(cuda_memory_resource const&, _Resource const&)
+  //! @copydoc device_memory_resource::operator==<_Resource>(device_memory_resource const&, _Resource const&)
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(cuda_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator!=(device_memory_resource const& __lhs, _Resource const& __rhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<device_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
-  //! @copydoc cuda_memory_resource::operator==<_Resource>(cuda_memory_resource const&, _Resource const&)
+  //! @copydoc device_memory_resource::operator==<_Resource>(device_memory_resource const&, _Resource const&)
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __rhs, cuda_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __rhs, device_memory_resource const& __lhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<device_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
 #    endif // _CCCL_STD_VER <= 2017
 
   //! @brief Enables the \c device_accessible property
-  friend constexpr void get_property(cuda_memory_resource const&, device_accessible) noexcept {}
+  friend constexpr void get_property(device_memory_resource const&, device_accessible) noexcept {}
 
   //! @brief Checks whether the passed in alignment is valid
   static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
@@ -151,7 +151,10 @@ public:
     return __alignment <= default_cuda_malloc_alignment && (default_cuda_malloc_alignment % __alignment == 0);
   }
 };
-static_assert(resource_with<cuda_memory_resource, device_accessible>, "");
+static_assert(resource_with<device_memory_resource, device_accessible>, "");
+
+// For backward compatability
+using cuda_memory_resource _LIBCUDACXX_DEPRECATED = device_memory_resource;
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_MR
 

--- a/libcudacxx/include/cuda/__memory_resource/managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/managed_memory_resource.h
@@ -38,8 +38,8 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA_MR
 
-//! @brief \c cuda_managed_memory_resource uses `cudaMallocManaged` / `cudaFree` for allocation / deallocation.
-class cuda_managed_memory_resource
+//! @brief \c managed_memory_resource uses `cudaMallocManaged` / `cudaFree` for allocation / deallocation.
+class managed_memory_resource
 {
 private:
   unsigned int __flags_ = cudaMemAttachGlobal;
@@ -47,10 +47,10 @@ private:
   static constexpr unsigned int __available_flags = cudaMemAttachGlobal | cudaMemAttachHost;
 
 public:
-  constexpr cuda_managed_memory_resource(const unsigned int __flags = cudaMemAttachGlobal) noexcept
+  constexpr managed_memory_resource(const unsigned int __flags = cudaMemAttachGlobal) noexcept
       : __flags_(__flags & __available_flags)
   {
-    _LIBCUDACXX_ASSERT(__flags_ == __flags, "Unexpected flags passed to cuda_managed_memory_resource");
+    _LIBCUDACXX_ASSERT(__flags_ == __flags, "Unexpected flags passed to managed_memory_resource");
   }
 
   //! @brief Allocate CUDA unified memory of size at least \p __bytes.
@@ -80,74 +80,70 @@ public:
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),
-                       "Invalid alignment passed to cuda_managed_memory_resource::deallocate.");
-    _CCCL_ASSERT_CUDA_API(::cudaFree, "cuda_managed_memory_resource::deallocate failed", __ptr);
+                       "Invalid alignment passed to managed_memory_resource::deallocate.");
+    _CCCL_ASSERT_CUDA_API(::cudaFree, "managed_memory_resource::deallocate failed", __ptr);
     (void) __alignment;
   }
 
-  //! @brief Equality comparison with another \c cuda_managed_memory_resource
-  //! @param __other The other \c cuda_managed_memory_resource
-  //! @return Whether both \c cuda_managed_memory_resource were constructed with the same flags
-  _CCCL_NODISCARD constexpr bool operator==(cuda_managed_memory_resource const& __other) const noexcept
+  //! @brief Equality comparison with another \c managed_memory_resource
+  //! @param __other The other \c managed_memory_resource
+  //! @return Whether both \c managed_memory_resource were constructed with the same flags
+  _CCCL_NODISCARD constexpr bool operator==(managed_memory_resource const& __other) const noexcept
   {
     return __flags_ == __other.__flags_;
   }
 #    if _CCCL_STD_VER <= 2017
-  //! @brief Inequality comparison with another \c cuda_managed_memory_resource
-  //! @param __other The other \c cuda_managed_memory_resource
-  //! @return Whether both \c cuda_managed_memory_resource were constructed with different flags
-  _CCCL_NODISCARD constexpr bool operator!=(cuda_managed_memory_resource const& __other) const noexcept
+  //! @brief Inequality comparison with another \c managed_memory_resource
+  //! @param __other The other \c managed_memory_resource
+  //! @return Whether both \c managed_memory_resource were constructed with different flags
+  _CCCL_NODISCARD constexpr bool operator!=(managed_memory_resource const& __other) const noexcept
   {
     return __flags_ != __other.__flags_;
   }
 #    endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Equality comparison between a \c cuda_managed_memory_resource and another resource
-  //! @param __lhs The \c cuda_managed_memory_resource
+  //! @brief Equality comparison between a \c managed_memory_resource and another resource
+  //! @param __lhs The \c managed_memory_resource
   //! @param __rhs The resource to compare to
   //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
   //! resources. Otherwise, returns false.
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(cuda_managed_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_managed_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator==(managed_memory_resource const& __lhs, _Resource const& __rhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<managed_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_managed_memory_resource&>(__lhs)}
-        == resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<managed_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
 #    if _CCCL_STD_VER <= 2017
-  //! @copydoc cuda_managed_memory_resource::operator<_Resource>==(cuda_managed_memory_resource const&, _Resource
+  //! @copydoc managed_memory_resource::operator<_Resource>==(managed_memory_resource const&, _Resource
   //! const&)
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __rhs, cuda_managed_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_managed_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __rhs, managed_memory_resource const& __lhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<managed_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_managed_memory_resource&>(__lhs)}
-        == resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<managed_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
-  //! @copydoc cuda_managed_memory_resource::operator<_Resource>==(cuda_managed_memory_resource const&, _Resource
+  //! @copydoc managed_memory_resource::operator<_Resource>==(managed_memory_resource const&, _Resource
   //! const&)
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(cuda_managed_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_managed_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator!=(managed_memory_resource const& __lhs, _Resource const& __rhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<managed_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_managed_memory_resource&>(__lhs)}
-        != resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<managed_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
-  //! @copydoc cuda_managed_memory_resource::operator<_Resource>==(cuda_managed_memory_resource const&, _Resource
+  //! @copydoc managed_memory_resource::operator<_Resource>==(managed_memory_resource const&, _Resource
   //! const&)
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __rhs, cuda_managed_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_managed_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __rhs, managed_memory_resource const& __lhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<managed_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_managed_memory_resource&>(__lhs)}
-        != resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<managed_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
 #    endif // _CCCL_STD_VER <= 2017
 
   //! @brief Enables the \c device_accessible property
-  friend constexpr void get_property(cuda_managed_memory_resource const&, device_accessible) noexcept {}
+  friend constexpr void get_property(managed_memory_resource const&, device_accessible) noexcept {}
   //! @brief Enables the \c host_accessible property
-  friend constexpr void get_property(cuda_managed_memory_resource const&, host_accessible) noexcept {}
+  friend constexpr void get_property(managed_memory_resource const&, host_accessible) noexcept {}
 
   //! @brief Checks whether the passed in alignment is valid
   static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
@@ -155,8 +151,11 @@ public:
     return __alignment <= default_cuda_malloc_alignment && (default_cuda_malloc_alignment % __alignment == 0);
   }
 };
-static_assert(resource_with<cuda_managed_memory_resource, device_accessible>, "");
-static_assert(resource_with<cuda_managed_memory_resource, host_accessible>, "");
+static_assert(resource_with<managed_memory_resource, device_accessible>, "");
+static_assert(resource_with<managed_memory_resource, host_accessible>, "");
+
+// For backward compatability
+using cuda_managed_memory_resource _LIBCUDACXX_DEPRECATED = managed_memory_resource;
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_MR
 

--- a/libcudacxx/include/cuda/__memory_resource/pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/pinned_memory_resource.h
@@ -39,8 +39,8 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA_MR
 
-//! @brief cuda_pinned_memory_resource uses `cudaMallocHost` / `cudaFreeHost` for allocation / deallocation.
-class cuda_pinned_memory_resource
+//! @brief pinned_memory_resource uses `cudaMallocHost` / `cudaFreeHost` for allocation / deallocation.
+class pinned_memory_resource
 {
 private:
   unsigned int __flags_ = cudaHostAllocDefault;
@@ -49,10 +49,10 @@ private:
     cudaHostAllocDefault | cudaHostAllocPortable | cudaHostAllocMapped | cudaHostAllocWriteCombined;
 
 public:
-  constexpr cuda_pinned_memory_resource(const unsigned int __flags = cudaHostAllocDefault) noexcept
+  constexpr pinned_memory_resource(const unsigned int __flags = cudaHostAllocDefault) noexcept
       : __flags_(__flags & __available_flags)
   {
-    _LIBCUDACXX_ASSERT(__flags_ == __flags, "Unexpected flags passed to cuda_pinned_memory_resource");
+    _LIBCUDACXX_ASSERT(__flags_ == __flags, "Unexpected flags passed to pinned_memory_resource");
   }
 
   //! @brief Allocate host memory of size at least \p __bytes.
@@ -82,71 +82,67 @@ public:
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),
-                       "Invalid alignment passed to cuda_pinned_memory_resource::deallocate.");
-    _CCCL_ASSERT_CUDA_API(::cudaFreeHost, "cuda_pinned_memory_resource::deallocate failed", __ptr);
+                       "Invalid alignment passed to pinned_memory_resource::deallocate.");
+    _CCCL_ASSERT_CUDA_API(::cudaFreeHost, "pinned_memory_resource::deallocate failed", __ptr);
     (void) __alignment;
   }
 
-  //! @brief Equality comparison with another \c cuda_pinned_memory_resource
-  //! @param __other The other \c cuda_pinned_memory_resource
-  //! @return Whether both \c cuda_pinned_memory_resource were constructed with the same flags
-  _CCCL_NODISCARD constexpr bool operator==(cuda_pinned_memory_resource const& __other) const noexcept
+  //! @brief Equality comparison with another \c pinned_memory_resource
+  //! @param __other The other \c pinned_memory_resource
+  //! @return Whether both \c pinned_memory_resource were constructed with the same flags
+  _CCCL_NODISCARD constexpr bool operator==(pinned_memory_resource const& __other) const noexcept
   {
     return __flags_ == __other.__flags_;
   }
 #    if _CCCL_STD_VER <= 2017
-  //! @brief Equality comparison with another \c cuda_pinned_memory_resource
-  //! @param __other The other \c cuda_pinned_memory_resource
-  //! @return Whether both \c cuda_pinned_memory_resource were constructed with different flags
-  _CCCL_NODISCARD constexpr bool operator!=(cuda_pinned_memory_resource const& __other) const noexcept
+  //! @brief Equality comparison with another \c pinned_memory_resource
+  //! @param __other The other \c pinned_memory_resource
+  //! @return Whether both \c pinned_memory_resource were constructed with different flags
+  _CCCL_NODISCARD constexpr bool operator!=(pinned_memory_resource const& __other) const noexcept
   {
     return __flags_ != __other.__flags_;
   }
 #    endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Equality comparison between a \c cuda_pinned_memory_resource and another resource
-  //! @param __lhs The \c cuda_pinned_memory_resource
+  //! @brief Equality comparison between a \c pinned_memory_resource and another resource
+  //! @param __lhs The \c pinned_memory_resource
   //! @param __rhs The resource to compare to
   //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
   //! resources. Otherwise, returns false.
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(cuda_pinned_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_pinned_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator==(pinned_memory_resource const& __lhs, _Resource const& __rhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<pinned_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_pinned_memory_resource&>(__lhs)}
-        == resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<pinned_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
 #    if _CCCL_STD_VER <= 2017
-  //! @copydoc cuda_pinned_memory_resource::operator<_Resource>==(cuda_pinned_memory_resource const&, _Resource const&)
+  //! @copydoc pinned_memory_resource::operator<_Resource>==(pinned_memory_resource const&, _Resource const&)
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __rhs, cuda_pinned_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_pinned_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __rhs, pinned_memory_resource const& __lhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<pinned_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_pinned_memory_resource&>(__lhs)}
-        == resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<pinned_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
-  //! @copydoc cuda_pinned_memory_resource::operator<_Resource>==(cuda_pinned_memory_resource const&, _Resource const&)
+  //! @copydoc pinned_memory_resource::operator<_Resource>==(pinned_memory_resource const&, _Resource const&)
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(cuda_pinned_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_pinned_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator!=(pinned_memory_resource const& __lhs, _Resource const& __rhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<pinned_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_pinned_memory_resource&>(__lhs)}
-        != resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<pinned_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
-  //! @copydoc cuda_pinned_memory_resource::operator<_Resource>==(cuda_pinned_memory_resource const&, _Resource const&)
+  //! @copydoc pinned_memory_resource::operator<_Resource>==(pinned_memory_resource const&, _Resource const&)
   template <class _Resource>
-  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __rhs, cuda_pinned_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<cuda_pinned_memory_resource, _Resource>)
+  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __rhs, pinned_memory_resource const& __lhs) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<pinned_memory_resource, _Resource>)
   {
-    return resource_ref<>{const_cast<cuda_pinned_memory_resource&>(__lhs)}
-        != resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<>{const_cast<pinned_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
   }
 #    endif // _CCCL_STD_VER <= 2017
 
   //! @brief Enables the \c device_accessible property
-  friend constexpr void get_property(cuda_pinned_memory_resource const&, device_accessible) noexcept {}
+  friend constexpr void get_property(pinned_memory_resource const&, device_accessible) noexcept {}
   //! @brief Enables the \c host_accessible property
-  friend constexpr void get_property(cuda_pinned_memory_resource const&, host_accessible) noexcept {}
+  friend constexpr void get_property(pinned_memory_resource const&, host_accessible) noexcept {}
 
   //! @brief Checks whether the passed in alignment is valid
   static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept
@@ -154,8 +150,11 @@ public:
     return __alignment <= default_cuda_malloc_host_alignment && (default_cuda_malloc_host_alignment % __alignment == 0);
   }
 };
-static_assert(resource_with<cuda_pinned_memory_resource, device_accessible>, "");
-static_assert(resource_with<cuda_pinned_memory_resource, host_accessible>, "");
+static_assert(resource_with<pinned_memory_resource, device_accessible>, "");
+static_assert(resource_with<pinned_memory_resource, host_accessible>, "");
+
+// For backward compatability
+using cuda_pinned_memory_resource _LIBCUDACXX_DEPRECATED = pinned_memory_resource;
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_MR
 

--- a/libcudacxx/include/cuda/memory_resource
+++ b/libcudacxx/include/cuda/memory_resource
@@ -31,10 +31,10 @@
 //!
 //!@endrst
 
-#include <cuda/__memory_resource/cuda_managed_memory_resource.h>
-#include <cuda/__memory_resource/cuda_memory_resource.h>
-#include <cuda/__memory_resource/cuda_pinned_memory_resource.h>
+#include <cuda/__memory_resource/device_memory_resource.h>
 #include <cuda/__memory_resource/get_property.h>
+#include <cuda/__memory_resource/managed_memory_resource.h>
+#include <cuda/__memory_resource/pinned_memory_resource.h>
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/__memory_resource/resource.h>
 #include <cuda/__memory_resource/resource_ref.h>

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/device_memory_resource/traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/device_memory_resource/traits.pass.cpp
@@ -15,7 +15,7 @@
 #include <cuda/memory_resource>
 #include <cuda/std/type_traits>
 
-using resource = cuda::mr::cuda_memory_resource;
+using resource = cuda::mr::device_memory_resource;
 static_assert(!cuda::std::is_trivial<resource>::value, "");
 static_assert(!cuda::std::is_trivially_default_constructible<resource>::value, "");
 static_assert(cuda::std::is_trivially_copy_constructible<resource>::value, "");

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/managed_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/managed_memory_resource/equality.pass.cpp
@@ -57,29 +57,29 @@ static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>,
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
 
 // test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
-struct derived_managed_resource : cuda::mr::cuda_managed_memory_resource
+struct derived_managed_resource : cuda::mr::managed_memory_resource
 {
-  using cuda::mr::cuda_managed_memory_resource::cuda_managed_memory_resource;
+  using cuda::mr::managed_memory_resource::managed_memory_resource;
 };
 static_assert(cuda::mr::resource<derived_managed_resource>, "");
 
 void test()
 {
-  cuda::mr::cuda_managed_memory_resource first{};
-  { // comparison against a plain cuda_managed_memory_resource
-    cuda::mr::cuda_managed_memory_resource second{};
+  cuda::mr::managed_memory_resource first{};
+  { // comparison against a plain managed_memory_resource
+    cuda::mr::managed_memory_resource second{};
     assert(first == second);
     assert(!(first != second));
   }
 
-  { // comparison against a plain cuda_managed_memory_resource with a different flag set
-    cuda::mr::cuda_managed_memory_resource second{cudaMemAttachHost};
+  { // comparison against a plain managed_memory_resource with a different flag set
+    cuda::mr::managed_memory_resource second{cudaMemAttachHost};
     assert(!(first == second));
     assert((first != second));
   }
 
-  { // comparison against a cuda_managed_memory_resource wrapped inside a resource_ref<>
-    cuda::mr::cuda_managed_memory_resource second{};
+  { // comparison against a managed_memory_resource wrapped inside a resource_ref<>
+    cuda::mr::managed_memory_resource second{};
     assert(first == cuda::mr::resource_ref<>{second});
     assert(!(first != cuda::mr::resource_ref<>{second}));
     assert(cuda::mr::resource_ref<>{second} == first);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/managed_memory_resource/traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/managed_memory_resource/traits.pass.cpp
@@ -15,7 +15,7 @@
 #include <cuda/memory_resource>
 #include <cuda/std/type_traits>
 
-using resource = cuda::mr::cuda_managed_memory_resource;
+using resource = cuda::mr::managed_memory_resource;
 static_assert(!cuda::std::is_trivial<resource>::value, "");
 static_assert(!cuda::std::is_trivially_default_constructible<resource>::value, "");
 static_assert(cuda::std::is_trivially_copy_constructible<resource>::value, "");

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/pinned_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/pinned_memory_resource/equality.pass.cpp
@@ -40,16 +40,9 @@ struct resource
   {
     return false;
   }
-
-  template <AccessibilityType Accessibilty2                                         = Accessibilty,
-            cuda::std::enable_if_t<Accessibilty2 == AccessibilityType::Device, int> = 0>
-  friend void get_property(const resource&, cuda::mr::device_accessible) noexcept
-  {}
 };
 static_assert(cuda::mr::resource<resource<AccessibilityType::Host>>, "");
-static_assert(!cuda::mr::resource_with<resource<AccessibilityType::Host>, cuda::mr::device_accessible>, "");
 static_assert(cuda::mr::resource<resource<AccessibilityType::Device>>, "");
-static_assert(cuda::mr::resource_with<resource<AccessibilityType::Device>, cuda::mr::device_accessible>, "");
 
 template <AccessibilityType Accessibilty>
 struct async_resource : public resource<Accessibilty>
@@ -61,40 +54,32 @@ struct async_resource : public resource<Accessibilty>
   void deallocate_async(void*, size_t, size_t, cuda::stream_ref) {}
 };
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
-static_assert(!cuda::mr::async_resource_with<async_resource<AccessibilityType::Host>, cuda::mr::device_accessible>, "");
 static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
-static_assert(cuda::mr::async_resource_with<async_resource<AccessibilityType::Device>, cuda::mr::device_accessible>,
-              "");
 
 // test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
-struct derived_resource : cuda::mr::cuda_memory_resource
+struct derived_pinned_resource : cuda::mr::pinned_memory_resource
 {
-  using cuda::mr::cuda_memory_resource::cuda_memory_resource;
+  using cuda::mr::pinned_memory_resource::pinned_memory_resource;
 };
-static_assert(cuda::mr::resource<derived_resource>, "");
-
-// Ensure that we can only
+static_assert(cuda::mr::resource<derived_pinned_resource>, "");
 
 void test()
 {
-  cuda::mr::cuda_memory_resource first{};
-  { // comparison against a plain cuda_memory_resource
-    cuda::mr::cuda_memory_resource second{};
+  cuda::mr::pinned_memory_resource first{};
+  { // comparison against a plain pinned_memory_resource
+    cuda::mr::pinned_memory_resource second{cudaHostAllocDefault};
     assert(first == second);
     assert(!(first != second));
   }
 
-  { // comparison against a cuda_memory_resource wrapped inside a resource_ref<device_accessible>
-    cuda::mr::cuda_memory_resource second{};
-    cuda::mr::resource_ref<cuda::mr::device_accessible> second_ref{second};
-    assert(first == second_ref);
-    assert(!(first != second_ref));
-    assert(second_ref == first);
-    assert(!(second_ref != first));
+  { // comparison against a plain pinned_memory_resource with a different flag set
+    cuda::mr::pinned_memory_resource second{cudaHostAllocPortable};
+    assert(!(first == second));
+    assert((first != second));
   }
 
-  { // comparison against a cuda_memory_resource wrapped inside a resource_ref<>
-    cuda::mr::cuda_memory_resource second{};
+  { // comparison against a pinned_memory_resource wrapped inside a resource_ref<>
+    cuda::mr::pinned_memory_resource second{};
     cuda::mr::resource_ref<> second_ref{second};
     assert(first == second_ref);
     assert(!(first != second_ref));
@@ -102,7 +87,7 @@ void test()
     assert(!(second_ref != first));
   }
 
-  { // comparison against a different resource
+  { // comparison against a different resource through resource_ref
     resource<AccessibilityType::Host> host_resource{};
     resource<AccessibilityType::Device> device_resource{};
     assert(!(first == host_resource));
@@ -119,15 +104,13 @@ void test()
   { // comparison against a different resource through resource_ref
     async_resource<AccessibilityType::Host> host_async_resource{};
     async_resource<AccessibilityType::Device> device_async_resource{};
-    cuda::mr::resource_ref<> host_ref{host_async_resource};
-    cuda::mr::resource_ref<> device_ref{device_async_resource};
-    assert(!(first == host_ref));
-    assert(first != host_ref);
+    assert(!(first == host_async_resource));
+    assert(first != host_async_resource);
     assert(!(first == device_async_resource));
     assert(first != device_async_resource);
 
-    assert(!(host_ref == first));
-    assert(host_ref != first);
+    assert(!(host_async_resource == first));
+    assert(host_async_resource != first);
     assert(!(device_async_resource == first));
     assert(device_async_resource != first);
   }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/pinned_memory_resource/traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/pinned_memory_resource/traits.pass.cpp
@@ -15,7 +15,7 @@
 #include <cuda/memory_resource>
 #include <cuda/std/type_traits>
 
-using resource = cuda::mr::cuda_pinned_memory_resource;
+using resource = cuda::mr::pinned_memory_resource;
 static_assert(!cuda::std::is_trivial<resource>::value, "");
 static_assert(!cuda::std::is_trivially_default_constructible<resource>::value, "");
 static_assert(cuda::std::is_trivially_copy_constructible<resource>::value, "");


### PR DESCRIPTION
Adding `cuda_` as a prefix to a name already inside the namespace cuda is a bit much.

Lets shorten so that users do not have to type that much