### PR TITLE
Make `cuda::std::min` constexpr in C++11

### DIFF
--- a/libcudacxx/include/cuda/std/__algorithm/min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min.h
@@ -30,19 +30,17 @@ _CCCL_PUSH_MACROS
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Compare>
-_CCCL_NODISCARD inline _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 const _Tp&
+_CCCL_NODISCARD inline _LIBCUDACXX_INLINE_VISIBILITY constexpr const _Tp&
 min(const _Tp& __a, const _Tp& __b, _Compare __comp)
 {
   return __comp(__b, __a) ? __b : __a;
 }
 
 template <class _Tp>
-_CCCL_NODISCARD inline _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 const _Tp& min(const _Tp& __a, const _Tp& __b)
+_CCCL_NODISCARD inline _LIBCUDACXX_INLINE_VISIBILITY constexpr const _Tp& min(const _Tp& __a, const _Tp& __b)
 {
   return _CUDA_VSTD::min(__a, __b, __less{});
 }
-
-#ifndef _LIBCUDACXX_CXX03_LANG
 
 template <class _Tp, class _Compare>
 _CCCL_NODISCARD inline _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 _Tp
@@ -56,8 +54,6 @@ _CCCL_NODISCARD inline _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 _Tp m
 {
   return *_CUDA_VSTD::min_element(__t.begin(), __t.end(), __less{});
 }
-
-#endif // _LIBCUDACXX_CXX03_LANG
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/min.pass.cpp
@@ -54,6 +54,10 @@ int main(int, char**)
   test();
 #if TEST_STD_VER >= 2014
   static_assert(test(), "");
+#else // TEST_STD_VER >= 2014
+  constexpr int x = 0;
+  constexpr int y = 1;
+  static_assert(&cuda::std::min(x, y) == &x, "");
 #endif // TEST_STD_VER >= 2014
 
   return 0;

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/min_comp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.min.max/min_comp.pass.cpp
@@ -56,6 +56,10 @@ int main(int, char**)
   test();
 #if TEST_STD_VER >= 2014
   static_assert(test(), "");
+#else // TEST_STD_VER >= 2014
+  constexpr int x = 0;
+  constexpr int y = 1;
+  static_assert(&cuda::std::min(x, y, cuda::std::greater<int>()) == &y, "");
 #endif // TEST_STD_VER >= 2014
 
   return 0;


### PR DESCRIPTION
This should fix our rmm builds
