### PR TITLE
Workaround GCC 13 issue with empty histogram decoder op

### DIFF
--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -847,7 +847,7 @@ public:
   {
 // GCC 14 rightfully warns that when a value-initialized array of this struct is copied using memcpy, uninitialized
 // bytes may be accessed. To avoid this, we add a dummy member, so value initialization actually initializes the memory.
-#if defined(_CCCL_COMPILER_GCC) && (__GNUC__ == 13 || __GNUC__ == 14)
+#if defined(_CCCL_COMPILER_GCC) && __GNUC__ >= 13
     char dummy;
 #endif
 

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -847,7 +847,7 @@ public:
   {
 // GCC 14 rightfully warns that when a value-initialized array of this struct is copied using memcpy, uninitialized
 // bytes may be accessed. To avoid this, we add a dummy member, so value initialization actually initializes the memory.
-#if defined(_CCCL_COMPILER_GCC) && __GNUC__ == 14
+#if defined(_CCCL_COMPILER_GCC) && (__GNUC__ == 13 || __GNUC__ == 14)
     char dummy;
 #endif
 


### PR DESCRIPTION
I have fixed this in the past for GCC 14, but the issue is now appearing in the CI for GCC 13 as well, undeterministically though. It may be that the issue was introduced in a GCC 13 minor version that the CI has runners are now updating to.

Issue:
```
FAILED: cub/test/CMakeFiles/cub.cpp17.test.device_histogram.lid_0.dir/catch2_test_device_histogram.cu.o 
  /usr/bin/sccache /usr/local/cuda/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/usr/bin/g++ -DTEST_LAUNCH=0 -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DVAR_IDX=0 -D_CCCL_NO_SYSTEM_HEADER -I/home/coder/cccl/cub/test -I/home/coder/cccl/cub/cub/cmake/../.. -I/home/coder/cccl/libcudacxx/lib/cmake/libcudacxx/../../../include -I/home/coder/cccl/thrust/thrust/cmake/../.. -isystem /home/coder/cccl/build/cuda12.5-gcc13/cub-cpp17/_deps/catch2-src/single_include -isystem /usr/local/cuda/targets/x86_64-linux/include -isystem /home/coder/cccl/build/cuda12.5-gcc13/cub-cpp17/Metal/include -O3 -DNDEBUG -std=c++17 "--generate-code=arch=compute_90a,code=[compute_90a,sm_90a]" -Xcompiler=-Werror -Xcompiler=-Wall -Xcompiler=-Wextra -Xcompiler=-Winit-self -Xcompiler=-Woverloaded-virtual -Xcompiler=-Wcast-qual -Xcompiler=-Wpointer-arith -Xcompiler=-Wvla -Xcompiler=-Wno-gnu-line-marker -Xcompiler=-Wno-gnu-zero-variadic-macro-arguments -Xcompiler=-Wno-unused-function -Xcompiler=-Wno-noexcept-type -Wreorder -Xcudafe=--display_error_number -Xcudafe=--promote_warnings -Wno-deprecated-gpu-targets -MD -MT cub/test/CMakeFiles/cub.cpp17.test.device_histogram.lid_0.dir/catch2_test_device_histogram.cu.o -MF cub/test/CMakeFiles/cub.cpp17.test.device_histogram.lid_0.dir/catch2_test_device_histogram.cu.o.d -x cu -c /home/coder/cccl/cub/test/catch2_test_device_histogram.cu -o cub/test/CMakeFiles/cub.cpp17.test.device_histogram.lid_0.dir/catch2_test_device_histogram.cu.o
  In function ‘void* memmove(void*, const void*, size_t)’,
      inlined from ‘constexpr bool cuda::std::__4::__dispatch_memmove(_Up*, _Tp*, size_t) [with _Tp = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform; _Up = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform]’ at /home/coder/cccl/libcudacxx/lib/cmake/libcudacxx/../../../include/cuda/std/__algorithm/copy.h:67:26,
      inlined from ‘constexpr cuda::std::__4::pair<_Tp*, _Up*> cuda::std::__4::__copy(_Tp*, _Tp*, _Up*) [with _AlgPolicy = _ClassicAlgPolicy; _Tp = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform; _Up = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform; typename enable_if<is_same_v<typename remove_const<_Ip>::type, _Up>, int>::type <anonymous> = 0; typename enable_if<is_trivially_copyable_v<_Up>, int>::type <anonymous> = 0]’ at /home/coder/cccl/libcudacxx/lib/cmake/libcudacxx/../../../include/cuda/std/__algorithm/copy.h:117:23,
      inlined from ‘constexpr _OutputIterator cuda::std::__4::copy(_InputIterator, _InputIterator, _OutputIterator) [with _InputIterator = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform*; _OutputIterator = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform*]’ at /home/coder/cccl/libcudacxx/lib/cmake/libcudacxx/../../../include/cuda/std/__algorithm/copy.h:144:40,
      inlined from ‘cudaError_t cub::CUB_200600_900_NS::detail::dispatch_histogram<NUM_CHANNELS, NUM_ACTIVE_CHANNELS, PRIVATIZED_SMEM_BINS, SampleIteratorT, CounterT, PrivatizedDecodeOpT, OutputDecodeOpT, OffsetT, MaxPolicyT>::Invoke(DeviceHistogramInitKernelT, DeviceHistogramSweepKernelT) [with ActivePolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900; DeviceHistogramInitKernelT = void (*)(cuda::std::__4::array<int, 1>, cuda::std::__4::array<unsigned int*, 1>, cub::CUB_200600_900_NS::GridQueue<int>); DeviceHistogramSweepKernelT = void (*)(cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, cuda::std::__4::array<int, 1>, cuda::std::__4::array<int, 1>, cuda::std::__4::array<unsigned int*, 1>, cuda::std::__4::array<unsigned int*, 1>, cuda::std::__4::array<cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform, 1>, cuda::std::__4::array<cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::ScaleTransform, 1>, int, int, int, int, cub::CUB_200600_900_NS::GridQueue<int>); int NUM_CHANNELS = 1; int NUM_ACTIVE_CHANNELS = 1; int PRIVATIZED_SMEM_BINS = 0; SampleIteratorT = cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>; CounterT = unsigned int; PrivatizedDecodeOpT = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::ScaleTransform; OutputDecodeOpT = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform; OffsetT = int; MaxPolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900]’ at /home/coder/cccl/cub/cub/cmake/../../cub/device/dispatch/dispatch_histogram.cuh:420:16,
      inlined from ‘cudaError_t cub::CUB_200600_900_NS::detail::dispatch_histogram<NUM_CHANNELS, NUM_ACTIVE_CHANNELS, PRIVATIZED_SMEM_BINS, SampleIteratorT, CounterT, PrivatizedDecodeOpT, OutputDecodeOpT, OffsetT, MaxPolicyT>::Invoke() [with ActivePolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900; int NUM_CHANNELS = 1; int NUM_ACTIVE_CHANNELS = 1; int PRIVATIZED_SMEM_BINS = 0; SampleIteratorT = cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>; CounterT = unsigned int; PrivatizedDecodeOpT = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::ScaleTransform; OutputDecodeOpT = cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform; OffsetT = int; MaxPolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900]’ at /home/coder/cccl/cub/cub/cmake/../../cub/device/dispatch/dispatch_histogram.cuh:506:31,
      inlined from ‘static cudaError_t cub::CUB_200600_900_NS::ChainedPolicy<PolicyPtxVersion, PolicyT, PrevPolicyT>::do_invoke(FunctorT&, cuda::std::__4::true_type) [with FunctorT = cub::CUB_200600_900_NS::detail::dispatch_histogram<1, 1, 0, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::ScaleTransform, cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900>; int PolicyPtxVersion = 900; PolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900; PrevPolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy500]’ at /home/coder/cccl/cub/cub/cmake/../../cub/util_device.cuh:695:37,
      inlined from ‘static cudaError_t cub::CUB_200600_900_NS::ChainedPolicy<PolicyPtxVersion, PolicyT, PrevPolicyT>::invoke_static(FunctorT&, cuda::std::__4::true_type) [with int DevicePtxVersion = 900; FunctorT = cub::CUB_200600_900_NS::detail::dispatch_histogram<1, 1, 0, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::ScaleTransform, cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900>; int PolicyPtxVersion = 900; PolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900; PrevPolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy500]’ at /home/coder/cccl/cub/cub/cmake/../../cub/util_device.cuh:681:17,
      inlined from ‘static cudaError_t cub::CUB_200600_900_NS::ChainedPolicy<PolicyPtxVersion, PolicyT, PrevPolicyT>::runtime_to_compiletime(int, FunctorT&) [with int ...CudaArches = {900}; FunctorT = cub::CUB_200600_900_NS::detail::dispatch_histogram<1, 1, 0, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::ScaleTransform, cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900>; int PolicyPtxVersion = 900; PolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900; PrevPolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy500]’ at /home/coder/cccl/cub/cub/cmake/../../cub/util_device.cuh:660:99,
      inlined from ‘static cudaError_t cub::CUB_200600_900_NS::ChainedPolicy<PolicyPtxVersion, PolicyT, PrevPolicyT>::Invoke(int, FunctorT&) [with FunctorT = cub::CUB_200600_900_NS::detail::dispatch_histogram<1, 1, 0, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::ScaleTransform, cub::CUB_200600_900_NS::DispatchHistogram<1, 1, cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>, unsigned int, short unsigned int, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1> >::PassThruTransform, int, cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900>; int PolicyPtxVersion = 900; PolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy900; PrevPolicyT = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>::Policy500]’ at /home/coder/cccl/cub/cub/cmake/../../cub/util_device.cuh:641:37,
      inlined from ‘static cudaError_t cub::CUB_200600_900_NS::DispatchHistogram<NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, LevelT, OffsetT, SelectedPolicy>::DispatchEven(void*, size_t&, SampleIteratorT, CounterT**, const int*, const LevelT*, const LevelT*, OffsetT, OffsetT, OffsetT, cudaStream_t, cub::CUB_200600_900_NS::Int2Type<0>) [with int NUM_CHANNELS = 1; int NUM_ACTIVE_CHANNELS = 1; SampleIteratorT = cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>; CounterT = unsigned int; LevelT = short unsigned int; OffsetT = int; SelectedPolicy = cub::CUB_200600_900_NS::detail::device_histogram_policy_hub<short unsigned int, unsigned int, 1, 1>]’ at /home/coder/cccl/cub/cub/cmake/../../cub/device/dispatch/dispatch_histogram.cuh:1376:21,
      inlined from ‘static cudaError_t cub::CUB_200600_900_NS::DeviceHistogram::MultiHistogramEven(void*, size_t&, SampleIteratorT, CounterT**, const int*, const LevelT*, const LevelT*, OffsetT, OffsetT, size_t, cudaStream_t) [with int NUM_CHANNELS = 1; int NUM_ACTIVE_CHANNELS = 1; SampleIteratorT = cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>; CounterT = unsigned int; LevelT = short unsigned int; OffsetT = int]’ at /home/coder/cccl/cub/cub/cmake/../../cub/device/device_histogram.cuh:824:120:
  /usr/include/x86_64-linux-gnu/bits/string_fortified.h:36:31: error: ‘*(unsigned char*)(&output_decode_op[0])’ may be used uninitialized [-Werror=maybe-uninitialized]
     36 |   return __builtin___memmove_chk (__dest, __src, __len,
        |        ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~                               
  /home/coder/cccl/cub/cub/cmake/../../cub/device/dispatch/dispatch_histogram.cuh: In static member function ‘static cudaError_t cub::CUB_200600_900_NS::DeviceHistogram::MultiHistogramEven(void*, size_t&, SampleIteratorT, CounterT**, const int*, const LevelT*, const LevelT*, OffsetT, OffsetT, size_t, cudaStream_t) [with int NUM_CHANNELS = 1; int NUM_ACTIVE_CHANNELS = 1; SampleIteratorT = cub::CUB_200600_900_NS::CountingInputIterator<short unsigned int, long int>; CounterT = unsigned int; LevelT = short unsigned int; OffsetT = int]’:
  /home/coder/cccl/cub/cub/cmake/../../cub/device/dispatch/dispatch_histogram.cuh:1320:17: note: ‘*(unsigned char*)(&output_decode_op[0])’ was declared here
   1320 |       OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS]{};
        |                 ^~~~~~~~~~~~~~~~
```