### PR TITLE
Fix use of doxygen \file command

### DIFF
--- a/cub/cub/block/block_adjacent_difference.cuh
+++ b/cub/cub/block/block_adjacent_difference.cuh
@@ -26,8 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file The cub::BlockAdjacentDifference class provides collective methods for computing
-//! the differences of adjacent elements partitioned across a CUDA thread block.
+//! @file
+//! The cub::BlockAdjacentDifference class provides collective methods for computing the differences of adjacent
+//! elements partitioned across a CUDA thread block.
 
 #pragma once
 

--- a/cub/cub/block/block_load.cuh
+++ b/cub/cub/block/block_load.cuh
@@ -26,7 +26,8 @@
  *
  ******************************************************************************/
 
-//! @file block_load.cuh Operations for reading linear tiles of data into the CUDA thread block.
+//! @file
+//! block_load.cuh Operations for reading linear tiles of data into the CUDA thread block.
 
 #pragma once
 

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -26,7 +26,8 @@
  *
  ******************************************************************************/
 
-//! @file cub::BlockRadixRank provides operations for ranking unsigned integer types within a CUDA thread block
+//! @file
+//! cub::BlockRadixRank provides operations for ranking unsigned integer types within a CUDA thread block
 
 #pragma once
 

--- a/cub/cub/block/block_reduce.cuh
+++ b/cub/cub/block/block_reduce.cuh
@@ -26,8 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file The cub::BlockReduce class provides :ref:`collective <collective-primitives>` methods for computing
-//!       a parallel reduction of items partitioned across a CUDA thread block.
+//! @file
+//! The cub::BlockReduce class provides :ref:`collective <collective-primitives>` methods for computing a parallel
+//! reduction of items partitioned across a CUDA thread block.
 
 #pragma once
 

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -26,8 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file The cub::BlockScan class provides :ref:`collective <collective-primitives>` methods for computing a
-//!       parallel prefix sum/scan of items partitioned across a CUDA thread block.
+//! @file
+//! The cub::BlockScan class provides :ref:`collective <collective-primitives>` methods for computing a parallel prefix
+//! sum/scan of items partitioned across a CUDA thread block.
 
 #pragma once
 

--- a/cub/cub/block/block_shuffle.cuh
+++ b/cub/cub/block/block_shuffle.cuh
@@ -26,8 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file The cub::BlockShuffle class provides :ref:`collective <collective-primitives>` methods for shuffling
-//!       data partitioned across a CUDA thread block.
+//! @file
+//! The cub::BlockShuffle class provides :ref:`collective <collective-primitives>` methods for shuffling data
+//! partitioned across a CUDA thread block.
 
 #pragma once
 

--- a/cub/cub/block/block_store.cuh
+++ b/cub/cub/block/block_store.cuh
@@ -26,7 +26,8 @@
  *
  ******************************************************************************/
 
-//! @file Operations for writing linear segments of data from the CUDA thread block
+//! @file
+//! Operations for writing linear segments of data from the CUDA thread block
 
 #pragma once
 

--- a/cub/cub/device/device_copy.cuh
+++ b/cub/cub/device/device_copy.cuh
@@ -25,7 +25,8 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceCopy provides device-wide, parallel operations for copying data.
+//! @file
+//! cub::DeviceCopy provides device-wide, parallel operations for copying data.
 
 #pragma once
 

--- a/cub/cub/device/device_histogram.cuh
+++ b/cub/cub/device/device_histogram.cuh
@@ -26,9 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceHistogram provides device-wide parallel operations for
-//!       constructing histogram(s) from a sequence of samples data residing
-//!       within device-accessible memory.
+//! @file
+//! cub::DeviceHistogram provides device-wide parallel operations for constructing histogram(s) from a sequence of
+//! samples data residing within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_memcpy.cuh
+++ b/cub/cub/device/device_memcpy.cuh
@@ -25,7 +25,8 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceMemcpy provides device-wide, parallel operations for copying data.
+//! @file
+//! cub::DeviceMemcpy provides device-wide, parallel operations for copying data.
 
 #pragma once
 

--- a/cub/cub/device/device_partition.cuh
+++ b/cub/cub/device/device_partition.cuh
@@ -26,8 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DevicePartition provides device-wide, parallel operations for
-//!       partitioning sequences of data items residing within device-accessible memory.
+//! @file
+//! cub::DevicePartition provides device-wide, parallel operations for partitioning sequences of data items residing
+//! within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_radix_sort.cuh
+++ b/cub/cub/device/device_radix_sort.cuh
@@ -26,9 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceRadixSort provides device-wide, parallel operations for
-//!       computing a radix sort across a sequence of data items residing within
-//!       device-accessible memory.
+//! @file
+//! cub::DeviceRadixSort provides device-wide, parallel operations for computing a radix sort across a sequence of data
+//! items residing within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -26,9 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceReduce provides device-wide, parallel operations for
-//!       computing a reduction across a sequence of data items residing within
-//!       device-accessible memory.
+//! @file
+//! cub::DeviceReduce provides device-wide, parallel operations for computing a reduction across a sequence of data
+//! items residing within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -26,9 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceRunLengthEncode provides device-wide, parallel operations
-//!       for computing a run-length encoding across a sequence of data items
-//!       residing within device-accessible memory.
+//! @file
+//! cub::DeviceRunLengthEncode provides device-wide, parallel operations for computing a run-length encoding across a
+//! sequence of data items residing within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -26,8 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceScan provides device-wide, parallel operations for computing a prefix scan across
-//!       a sequence of data items residing within device-accessible memory.
+//! @file
+//! cub::DeviceScan provides device-wide, parallel operations for computing a prefix scan across a sequence of data
+//! items residing within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_segmented_radix_sort.cuh
+++ b/cub/cub/device/device_segmented_radix_sort.cuh
@@ -26,8 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceSegmentedRadixSort provides device-wide, parallel operations for computing a batched radix sort
-//!       across multiple, non-overlapping sequences of data items residing within device-accessible memory.
+//! @file
+//! cub::DeviceSegmentedRadixSort provides device-wide, parallel operations for computing a batched radix sort across
+//! multiple, non-overlapping sequences of data items residing within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -26,9 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceSegmentedReduce provides device-wide, parallel operations
-//!       for computing a batched reduction across multiple sequences of data
-//!       items residing within device-accessible memory.
+//! @file
+//! cub::DeviceSegmentedReduce provides device-wide, parallel operations for computing a batched reduction across
+//! multiple sequences of data items residing within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_segmented_sort.cuh
+++ b/cub/cub/device/device_segmented_sort.cuh
@@ -25,9 +25,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceSegmentedSort provides device-wide, parallel operations for
-//!       computing a batched sort across multiple, non-overlapping sequences of
-//!       data items residing within device-accessible memory.
+//! @file
+//! cub::DeviceSegmentedSort provides device-wide, parallel operations for computing a batched sort across multiple,
+//! non-overlapping sequences of data items residing within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -26,9 +26,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceSelect provides device-wide, parallel operations for
-//!       compacting selected items from sequences of data items residing within
-//!       device-accessible memory.
+//! @file
+//! cub::DeviceSelect provides device-wide, parallel operations for compacting selected items from sequences of data
+//! items residing within device-accessible memory.
 
 #pragma once
 

--- a/cub/cub/device/device_spmv.cuh
+++ b/cub/cub/device/device_spmv.cuh
@@ -27,8 +27,9 @@
  *
  ******************************************************************************/
 
-//! @file cub::DeviceSpmv provides device-wide parallel operations for performing
-//!       sparse-matrix * vector multiplication (SpMV).
+//! @file
+//! cub::DeviceSpmv provides device-wide parallel operations for performing sparse-matrix * vector multiplication
+//! (SpMV).
 
 #pragma once
 

--- a/cub/cub/util_cpp_dialect.cuh
+++ b/cub/cub/util_cpp_dialect.cuh
@@ -25,7 +25,8 @@
  *
  ******************************************************************************/
 
-//! @file Detect the version of the C++ standard used by the compiler.
+//! @file
+//! Detect the version of the C++ standard used by the compiler.
 
 #pragma once
 

--- a/cub/cub/warp/warp_load.cuh
+++ b/cub/cub/warp/warp_load.cuh
@@ -25,7 +25,8 @@
  *
  ******************************************************************************/
 
-//! @file Operations for reading linear tiles of data into the CUDA warp.
+//! @file
+//! Operations for reading linear tiles of data into the CUDA warp.
 
 #pragma once
 

--- a/cub/cub/warp/warp_store.cuh
+++ b/cub/cub/warp/warp_store.cuh
@@ -25,7 +25,8 @@
  *
  ******************************************************************************/
 
-//! @file Operations for writing linear segments of data from the CUDA warp
+//! @file
+//! Operations for writing linear segments of data from the CUDA warp
 
 #pragma once
 

--- a/cub/test/catch2_main.cuh
+++ b/cub/test/catch2_main.cuh
@@ -29,10 +29,10 @@
 
 #include <iostream>
 
-//! @file This file includes a custom Catch2 main function. When CMake is configured to build
-//!       each test as a separate executable, this header is included into each test. On the other
-//!       hand, when all the tests are compiled into a single executable, this header is excluded
-//!       from the tests and included into catch2_runner.cpp
+//! @file
+//! This file includes a custom Catch2 main function. When CMake is configured to build each test as a separate
+//! executable, this header is included into each test. On the other hand, when all the tests are compiled into a single
+//! executable, this header is excluded from the tests and included into catch2_runner.cpp
 
 #ifdef CUB_CONFIG_MAIN
 #  define CATCH_CONFIG_RUNNER

--- a/cub/test/catch2_runner.cpp
+++ b/cub/test/catch2_runner.cpp
@@ -25,8 +25,9 @@
  *
  ******************************************************************************/
 
-//! @file This file includes a custom Catch2 main function when CMake is configured to build
-//!       all tests into a single executable.
+//! @file
+//! This file includes a custom Catch2 main function when CMake is configured to build all tests into a single
+//! executable.
 
 #define CUB_CONFIG_MAIN
 #define CUB_EXCLUDE_CATCH2_HELPER_IMPL

--- a/cub/test/catch2_runner_helper.cu
+++ b/cub/test/catch2_runner_helper.cu
@@ -25,9 +25,9 @@
  *
  ******************************************************************************/
 
-//! @file This file includes CUDA-specific utilities for custom Catch2 main function when CMake is
-//!       configured to build all tests into a single executable. In this case, we have to have
-//!       a CUDA target in the final Catch2 executable, otherwise CMake confuses linker options and
-//!       MSVC/RDC build fails.
+//! @file
+//! This file includes CUDA-specific utilities for custom Catch2 main function when CMake is configured to build all
+//! tests into a single executable. In this case, we have to have a CUDA target in the final Catch2 executable,
+//! otherwise CMake confuses linker options and MSVC/RDC build fails.
 
 #include "catch2_runner_helper.inl"

--- a/cub/test/catch2_runner_helper.inl
+++ b/cub/test/catch2_runner_helper.inl
@@ -27,10 +27,10 @@
 
 #pragma once
 
-//! @file This file includes implementation of CUDA-specific utilities for custom Catch2 main
-//!       When CMake is configured to include all the tests into a single executable, this file
-//!       is only included into catch2_runner_helper.cu. When CMake is configured to compile
-//!       each test as a separate binary, this file is included into each test.
+//! @file
+//! This file includes implementation of CUDA-specific utilities for custom Catch2 main When CMake is configured to
+//! include all the tests into a single executable, this file is only included into catch2_runner_helper.cu. When CMake
+//! is configured to compile each test as a separate binary, this file is included into each test.
 
 #include <iostream>
 

--- a/cub/test/catch2_test_launch_helper.h
+++ b/cub/test/catch2_test_launch_helper.h
@@ -31,7 +31,8 @@
 
 #include "catch2_test_helper.h"
 
-//! @file This file contains utilities for device-scope API tests
+//! @file
+//! This file contains utilities for device-scope API tests
 //!
 //! Device-scope API in CUB can be launched from the host or device side.
 //! Utilities in this file facilitate testing in both cases.

--- a/cudax/include/cuda/experimental/__container/uninitialized_buffer.h
+++ b/cudax/include/cuda/experimental/__container/uninitialized_buffer.h
@@ -30,7 +30,8 @@
 #if _CCCL_STD_VER >= 2014 && !defined(_CCCL_COMPILER_MSVC_2017) \
   && defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
 
-//! @file The \c uninitialized_buffer class provides a typed buffer allocated from a given memory resource.
+//! @file
+//! The \c uninitialized_buffer class provides a typed buffer allocated from a given memory resource.
 namespace cuda::experimental
 {
 

--- a/libcudacxx/include/cuda/memory_resource
+++ b/libcudacxx/include/cuda/memory_resource
@@ -21,7 +21,8 @@
 #endif // no system header
 
 //!@rst
-//! @file Defines facilities to allocate and deallocate memory in a type safe manner
+//! @file
+//! Defines facilities to allocate and deallocate memory in a type safe manner
 //!
 //! .. note::
 //!

--- a/thrust/thrust/system/cpp/pointer.h
+++ b/thrust/thrust/system/cpp/pointer.h
@@ -14,9 +14,8 @@
  *  limitations under the License.
  */
 
-/*! \file thrust/system/cpp/memory.h
- *  \brief Managing memory associated with Thrust's TBB system.
- */
+//! \file
+//! Managing memory associated with Thrust's TBB system.
 
 #pragma once
 


### PR DESCRIPTION
The doxygen `\file` command is followed by the name of the documented file. Additional documentation for the file content has to be placed on the following line.

This PR fixed corresponding warnings.