### PR TITLE
Refactor Thrust's logical meta functions

### DIFF
--- a/docs/thrust/api_docs/utility/type_traits.rst
+++ b/docs/thrust/api_docs/utility/type_traits.rst
@@ -8,7 +8,4 @@ Type Traits
    :maxdepth: 1
 
    ${repo_docs_api_path}/*struct*proclaim__contiguous__iterator*
-   ${repo_docs_api_path}/*struct*conjunction*
-   ${repo_docs_api_path}/*struct*disjunction*
-   ${repo_docs_api_path}/*struct*negation*
    ${repo_docs_api_path}/*typedef_group__type__traits*

--- a/libcudacxx/include/cuda/std/__type_traits/negation.h
+++ b/libcudacxx/include/cuda/std/__type_traits/negation.h
@@ -28,13 +28,13 @@ template <class _Pred>
 struct _Not : bool_constant<!_Pred::value>
 {};
 
-#if _CCCL_STD_VER > 2011
 template <class _Tp>
 struct negation : _Not<_Tp>
 {};
+#if _CCCL_STD_VER >= 2014
 template <class _Tp>
 _LIBCUDACXX_INLINE_VAR constexpr bool negation_v = !_Tp::value;
-#endif // _CCCL_STD_VER > 2014
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/thrust/thrust/type_traits/logical_metafunctions.h
+++ b/thrust/thrust/type_traits/logical_metafunctions.h
@@ -14,14 +14,6 @@
  *  limitations under the License.
  */
 
-/*! \file
- *  \brief C++17's
- *  <a href="https://en.cppreference.com/w/cpp/types/conjunction"><tt>std::conjunction</tt></a>,
- *  <a href="https://en.cppreference.com/w/cpp/types/disjunction"><tt>std::disjunction</tt></a>,
- *  and <a href="https://en.cppreference.com/w/cpp/types/negation"><tt>std::negation</tt></a>
- *  metafunctions and related extensions.
- */
-
 #pragma once
 
 #include <thrust/detail/config.h>
@@ -34,267 +26,84 @@
 #  pragma system_header
 #endif // no system header
 
-#include <type_traits>
+#include <cuda/std/__type_traits/conjunction.h>
+#include <cuda/std/__type_traits/disjunction.h>
+#include <cuda/std/__type_traits/negation.h>
 
 THRUST_NAMESPACE_BEGIN
 
-/*! \addtogroup utility
- *  \{
- */
+//! \addtogroup utility
+//! \{
+//! \addtogroup type_traits Type Traits
+//! \{
 
-/*! \addtogroup type_traits Type Traits
- *  \{
- */
-
-/*! \brief <a href="https://en.cppreference.com/w/cpp/types/integral_constant"><tt>std::integral_constant</tt></a>
- *  whose value is <tt>(... && Ts::value)</tt>.
- *
- *  \see conjunction_v
- *  \see conjunction_value
- *  \see <a href="https://en.cppreference.com/w/cpp/types/conjunction"><tt>std::conjunction</tt></a>
- */
-#if _CCCL_STD_VER >= 2017
-template <typename... Ts>
-using conjunction = std::conjunction<Ts...>;
-#else // Older than C++17.
-template <typename... Ts>
-struct conjunction;
-
-/*! \cond
- */
-
-template <>
-struct conjunction<> : std::true_type
-{};
-
-template <typename T>
-struct conjunction<T> : T
-{};
-
-template <typename T0, typename T1>
-struct conjunction<T0, T1> : std::conditional<T0::value, T1, T0>::type
-{};
-
-template <typename T0, typename T1, typename T2, typename... TN>
-struct conjunction<T0, T1, T2, TN...> : std::conditional<T0::value, conjunction<T1, T2, TN...>, T0>::type
-{};
-
-/*! \endcond
- */
+using ::cuda::std::conjunction;
+using ::cuda::std::disjunction;
+using ::cuda::std::negation;
+#if _CCCL_STD_VER >= 2014 && !defined(_LIBCUDACXX_HAS_NO_VARIABLE_TEMPLATES)
+using ::cuda::std::conjunction_v;
+using ::cuda::std::disjunction_v;
+using ::cuda::std::negation_v;
 #endif
 
-/*! \brief <tt>constexpr bool</tt> whose value is <tt>(... && Ts::value)</tt>.
- *
- *  \see conjunction
- *  \see conjunction_value
- *  \see <a href="https://en.cppreference.com/w/cpp/types/conjunction"><tt>std::conjunction</tt></a>
- */
-#if _CCCL_STD_VER >= 2014
-template <typename... Ts>
-constexpr bool conjunction_v = conjunction<Ts...>::value;
-#endif
-
-/*! \brief <a href="https://en.cppreference.com/w/cpp/types/integral_constant"><tt>std::integral_constant</tt></a>
- *  whose value is <tt>(... || Ts::value)</tt>.
- *
- *  \see disjunction_v
- *  \see disjunction_value
- *  \see <a href="https://en.cppreference.com/w/cpp/types/disjunction"><tt>std::disjunction</tt></a>
- */
-#if _CCCL_STD_VER >= 2017
-template <typename... Ts>
-using disjunction = std::disjunction<Ts...>;
-#else // Older than C++17.
-template <typename... Ts>
-struct disjunction;
-
-/*! \cond
- */
-
-template <>
-struct disjunction<> : std::false_type
-{};
-
-template <typename T>
-struct disjunction<T> : T
-{};
-
-template <typename T0, typename... TN>
-struct disjunction<T0, TN...> : std::conditional<T0::value != false, T0, disjunction<TN...>>::type
-{};
-
-/*! \endcond
- */
-#endif
-
-/*! \brief <tt>constexpr bool</tt> whose value is <tt>(... || Ts::value)</tt>.
- *
- *  \see disjunction
- *  \see disjunction_value
- *  \see <a href="https://en.cppreference.com/w/cpp/types/disjunction"><tt>std::disjunction</tt></a>
- */
-#if _CCCL_STD_VER >= 2014
-template <typename... Ts>
-constexpr bool disjunction_v = disjunction<Ts...>::value;
-#endif
-
-/*! \brief <a href="https://en.cppreference.com/w/cpp/types/integral_constant"><tt>std::integral_constant</tt></a>
- *  whose value is <tt>!Ts::value</tt>.
- *
- *  \see negation_v
- *  \see negation_value
- *  \see <a href="https://en.cppreference.com/w/cpp/types/negation"><tt>std::negation</tt></a>
- */
-#if _CCCL_STD_VER >= 2017
-template <typename T>
-using negation = std::negation<T>;
-#else // Older than C++17.
-template <typename T>
-struct negation;
-
-/*! \cond
- */
-
-template <typename T>
-struct negation : std::integral_constant<bool, !T::value>
-{};
-
-/*! \endcond
- */
-#endif
-
-/*! \brief <tt>constexpr bool</tt> whose value is <tt>!Ts::value</tt>.
- *
- *  \see negation
- *  \see negation_value
- *  \see <a href="https://en.cppreference.com/w/cpp/types/negation"><tt>std::negation</tt></a>
- */
-#if _CCCL_STD_VER >= 2014
-template <typename T>
-constexpr bool negation_v = negation<T>::value;
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-
-/*! \brief <a href="https://en.cppreference.com/w/cpp/types/integral_constant"><tt>std::integral_constant</tt></a>
- *  whose value is <tt>(... && Bs)</tt>.
- *
- *  \see conjunction_value_v
- *  \see conjunction
- *  \see <a href="https://en.cppreference.com/w/cpp/types/conjunction"><tt>std::conjunction</tt></a>
- */
+//! \brief <a href="https://en.cppreference.com/w/cpp/types/integral_constant"><tt>std::integral_constant</tt></a>
+//! whose value is <tt>(... && Bs)</tt>.
+//!
+//! \see conjunction_value_v
+//! \see conjunction
+//! \see <a href="https://en.cppreference.com/w/cpp/types/conjunction"><tt>std::conjunction</tt></a>
 template <bool... Bs>
-struct conjunction_value;
+using conjunction_value = conjunction<::cuda::std::bool_constant<Bs>...>;
 
 #if _CCCL_STD_VER >= 2014
-/*! \brief <tt>constexpr bool</tt> whose value is <tt>(... && Bs)</tt>.
- *
- *  \see conjunction_value
- *  \see conjunction
- *  \see <a href="https://en.cppreference.com/w/cpp/types/conjunction"><tt>std::conjunction</tt></a>
- */
+//! \brief <tt>constexpr bool</tt> whose value is <tt>(... && Bs)</tt>.
+//!
+//! \see conjunction_value
+//! \see conjunction
+//! \see <a href="https://en.cppreference.com/w/cpp/types/conjunction"><tt>std::conjunction</tt></a>
 template <bool... Bs>
 constexpr bool conjunction_value_v = conjunction_value<Bs...>::value;
 #endif
 
-/*! \cond
- */
-
-template <>
-struct conjunction_value<> : std::true_type
-{};
-
-template <bool B>
-struct conjunction_value<B> : std::integral_constant<bool, B>
-{};
-
-template <bool B, bool... Bs>
-struct conjunction_value<B, Bs...> : std::integral_constant<bool, B && conjunction_value<Bs...>::value>
-{};
-
-/*! \endcond
- */
-
-///////////////////////////////////////////////////////////////////////////////
-
-/*! \brief <a href="https://en.cppreference.com/w/cpp/types/integral_constant"><tt>std::integral_constant</tt></a>
- *  whose value is <tt>(... || Bs)</tt>.
- *
- *  \see disjunction_value_v
- *  \see disjunction
- *  \see <a href="https://en.cppreference.com/w/cpp/types/disjunction"><tt>std::disjunction</tt></a>
- */
+//! \brief <a href="https://en.cppreference.com/w/cpp/types/integral_constant"><tt>std::integral_constant</tt></a>
+//! whose value is <tt>(... || Bs)</tt>.
+//!
+//! \see disjunction_value_v
+//! \see disjunction
+//! \see <a href="https://en.cppreference.com/w/cpp/types/disjunction"><tt>std::disjunction</tt></a>
 template <bool... Bs>
-struct disjunction_value;
+using disjunction_value = disjunction<::cuda::std::bool_constant<Bs>...>;
 
 #if _CCCL_STD_VER >= 2014
-/*! \brief <tt>constexpr bool</tt> whose value is <tt>(... || Bs)</tt>.
- *
- *  \see disjunction_value
- *  \see disjunction
- *  \see <a href="https://en.cppreference.com/w/cpp/types/disjunction"><tt>std::disjunction</tt></a>
- */
+//! \brief <tt>constexpr bool</tt> whose value is <tt>(... || Bs)</tt>.
+//!
+//! \see disjunction_value
+//! \see disjunction
+//! \see <a href="https://en.cppreference.com/w/cpp/types/disjunction"><tt>std::disjunction</tt></a>
 template <bool... Bs>
 constexpr bool disjunction_value_v = disjunction_value<Bs...>::value;
 #endif
 
-/*! \cond
- */
-
-template <>
-struct disjunction_value<> : std::false_type
-{};
-
+//! \brief <a href="https://en.cppreference.com/w/cpp/types/integral_constant"><tt>std::integral_constant</tt></a>
+//! whose value is <tt>!Bs</tt>.
+//!
+//! \see negation_value_v
+//! \see negation
+//! \see <a href="https://en.cppreference.com/w/cpp/types/negation"><tt>std::negation</tt></a>
 template <bool B>
-struct disjunction_value<B> : std::integral_constant<bool, B>
-{};
-
-template <bool B, bool... Bs>
-struct disjunction_value<B, Bs...> : std::integral_constant<bool, B || disjunction_value<Bs...>::value>
-{};
-
-/*! \endcond
- */
-
-///////////////////////////////////////////////////////////////////////////////
-
-/*! \brief <a href="https://en.cppreference.com/w/cpp/types/integral_constant"><tt>std::integral_constant</tt></a>
- *  whose value is <tt>!Bs</tt>.
- *
- *  \see negation_value_v
- *  \see negation
- *  \see <a href="https://en.cppreference.com/w/cpp/types/negation"><tt>std::negation</tt></a>
- */
-template <bool B>
-struct negation_value;
+using negation_value = ::cuda::std::bool_constant<!B>;
 
 #if _CCCL_STD_VER >= 2014
-/*! \brief <tt>constexpr bool</tt> whose value is <tt>!Ts::value</tt>.
- *
- *  \see negation_value
- *  \see negation
- *  \see <a href="https://en.cppreference.com/w/cpp/types/negation"><tt>std::negation</tt></a>
- */
+//! \brief <tt>constexpr bool</tt> whose value is <tt>!Ts::value</tt>.
+//!
+//! \see negation_value
+//! \see negation
+//! \see <a href="https://en.cppreference.com/w/cpp/types/negation"><tt>std::negation</tt></a>
 template <bool B>
 constexpr bool negation_value_v = negation_value<B>::value;
 #endif
 
-/*! \cond
- */
-
-template <bool B>
-struct negation_value : std::integral_constant<bool, !B>
-{};
-
-/*! \endcond
- */
-
-///////////////////////////////////////////////////////////////////////////////
-
-/*! \} // type traits
- */
-
-/*! \} // utility
- */
+//! \} // type traits
+//! \} // utility
 
 THRUST_NAMESPACE_END


### PR DESCRIPTION
Refactors Thrust's `conjunction`, `disjunction` and `negation` to be based on libcu++. Also makes libcu++'s `negation` available in C++11. Then simplifies the definition of the corresponding `xxx_values` functions in Thrust.