### PR TITLE
Fix Thrust::vector ctor selection for int,int

### DIFF
--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -37,6 +37,8 @@
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/reverse_iterator.h>
 
+#include <cuda/std/__iterator/iterator_traits.h>
+
 #include <initializer_list>
 #include <vector>
 
@@ -186,7 +188,8 @@ public:
    *  \param first The beginning of the range.
    *  \param last The end of the range.
    */
-  template <typename InputIterator>
+  template <typename InputIterator,
+            ::cuda::std::__enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int> = 0>
   vector_base(InputIterator first, InputIterator last);
 
   /*! This constructor builds a vector_base from a range.
@@ -194,7 +197,8 @@ public:
    *  \param last The end of the range.
    *  \param alloc The allocator to use by this vector_base.
    */
-  template <typename InputIterator>
+  template <typename InputIterator,
+            ::cuda::std::__enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int> = 0>
   vector_base(InputIterator first, InputIterator last, const Alloc& alloc);
 
   /*! The destructor erases the elements.

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -270,7 +270,8 @@ void vector_base<T, Alloc>::range_init(ForwardIterator first, ForwardIterator la
 } // end vector_base::range_init()
 
 template <typename T, typename Alloc>
-template <typename InputIterator>
+template <typename InputIterator,
+          ::cuda::std::__enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int>>
 vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last)
     : m_storage()
     , m_size(0)
@@ -283,7 +284,8 @@ vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last)
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
-template <typename InputIterator>
+template <typename InputIterator,
+          ::cuda::std::__enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int>>
 vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last, const Alloc& alloc)
     : m_storage(alloc)
     , m_size(0)


### PR DESCRIPTION
`thrust::device_vector<int> v(5, 10)` should create a vector with 5 integers of value 10, and not attempt the iterator pair constructor.