### PR TITLE
Handle sccache absence more carefully

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -189,12 +189,9 @@ function configure_preset()
     return $status
 }
 
-function build_preset() {
-    local BUILD_NAME=$1
-    local PRESET=$2
-    local green="1;32"
-    local red="1;31"
-    local GROUP_NAME="🏗️  Build ${BUILD_NAME}"
+function build_preset_with_sccache() {
+    local PRESET=$1
+    local GROUP_NAME=$2
 
     local preset_dir="${BUILD_DIR}/${PRESET}"
     local sccache_json="${preset_dir}/sccache_stats.json"
@@ -231,6 +228,29 @@ function build_preset() {
     fi
 
     return $status
+}
+
+function build_preset_without_sccache() {
+    local PRESET=$1
+    local GROUP_NAME=$2
+
+    pushd .. > /dev/null
+    run_command "$GROUP_NAME" cmake --build --preset=$PRESET -v
+    status=$?
+    popd > /dev/null
+
+    return $status
+}
+
+function build_preset() {
+    local BUILD_NAME=$1
+    local PRESET=$2
+    local GROUP_NAME="🏗️  Build ${BUILD_NAME}"
+    if [ -z ${SCCACHE_BUCKET:-} ]; then
+        build_preset_without_sccache $PRESET $GROUP_NAME
+    else
+        build_preset_with_sccache $PRESET $GROUP_NAME
+    fi
 }
 
 function test_preset()

--- a/ci/infra_cccl.sh
+++ b/ci/infra_cccl.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+source /opt/devcontainer/bin/update-envvars.sh
+unset_envvar "CMAKE_C_COMPILER_LAUNCHER"
+unset_envvar "CMAKE_CXX_COMPILER_LAUNCHER"
+unset_envvar "CMAKE_CUDA_COMPILER_LAUNCHER"
+
 source "$(dirname "$0")/build_common.sh"
 
 print_environment_details


### PR DESCRIPTION
## Description

This PR tries to handle lack of `sccache` more gracefully, and also changes a small test to build without `sccache` as a smoke test. 

closes #2237

https://github.com/NVIDIA/cccl/commit/95b81b6164483a3ae25138e19e84b305394000a4 simulates "missing sccache" in the  `ci/infra_cccl.sh` test by un-setting `CMAKE_*_COMPILER_LAUNCHER` env vars at the start. A couple of notes:

* Is actually-missing what we want to smoke-test for? Would it be preferable to unset `SCCACHE_BUCKET` instead?
* Since this is a small test with only two entries, IMO it is better to KISS and just apply the change unconditionally. But extra plumbing could be added to configure this e.g. from the `matrix.yml`

https://github.com/NVIDIA/cccl/commit/b036d5d7bd442f6cc7616fe60e18d1f87facea0b puts "bare" usage of `sccache` behind a conditional check for `SCCACHE_BUCKET`. I only found such usage in `ci/build_common.sh` but let me know if I missed any occurrences. 


