### PR TITLE
Implement `any_resource`, an owning wrapper around a memory resource

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.h
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.h
@@ -1,0 +1,205 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__MEMORY_RESOURCE_ANY_RESOURCE_H
+#define _CUDAX__MEMORY_RESOURCE_ANY_RESOURCE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__memory_resource/any_resource.h>
+#include <cuda/__memory_resource/get_property.h>
+#include <cuda/__memory_resource/resource.h>
+#include <cuda/std/__concepts/_One_of.h>
+#include <cuda/std/__memory/construct_at.h>
+#include <cuda/std/__type_traits/is_nothrow_constructible.h>
+
+#if _CCCL_STD_VER >= 2014
+
+namespace cuda::experimental::mr
+{
+
+template <class>
+_LIBCUDACXX_INLINE_VAR constexpr bool __is_basic_any_resource = false;
+
+template <_CUDA_VMR::_AllocType _Alloc_type, class... _Properties>
+class basic_any_resource
+    : public _CUDA_VMR::_Resource_ref_base<_Alloc_type, false>
+    , private _CUDA_VMR::_Filtered_vtable<_Properties...>
+{
+private:
+  template <_CUDA_VMR::_AllocType, class...>
+  friend class basic_any_resource;
+
+  template <class...>
+  friend struct _CUDA_VMR::_Resource_vtable;
+
+  using __vtable = _CUDA_VMR::_Filtered_vtable<_Properties...>;
+
+  template <class... _OtherProperties>
+  static constexpr bool __properties_match =
+    _CUDA_VSTD::__all_of<_CUDA_VSTD::_One_of<_Properties, _OtherProperties...>...>;
+
+  void* __get_object() const noexcept
+  {
+    return this->__static_vtable->__is_small_fn() ? this->__object.__ptr_ : static_cast<void*>(this->__object.__buf_);
+  }
+
+public:
+  //! @brief Constructs a \c basic_any_resource from a type that satisfies the \c resource or \c async_resource concept
+  //! as well as all properties
+  //! @param __res The resource to be wrapped within the \c basic_any_resource
+  _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
+  _LIBCUDACXX_REQUIRES((!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _AllocType::_Default)
+                         _LIBCUDACXX_AND resource_with<_Resource, _Properties...>)
+  basic_any_resource(_Resource& __res) noexcept
+      : _Resource_ref_base<_Alloc_type, true>(_CUDA_VSTD::addressof(__res), &__alloc_vtable<_Alloc_type, _Resource>)
+      , __vtable(__vtable::template _Create<_Resource>())
+  {}
+
+  //! @brief Constructs a \c any_resource from a type that satisfies the \c async_resource concept  as well as all
+  //! properties. This ignores the async interface of the passed in resource
+  //! @param __res The resource to be wrapped within the \c any_resource
+  _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
+  _LIBCUDACXX_REQUIRES((!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _AllocType::_Async)
+                         _LIBCUDACXX_AND async_resource_with<_Resource, _Properties...>)
+  basic_any_resource(_Resource& __res) noexcept
+      : _Resource_ref_base<_Alloc_type, true>(_CUDA_VSTD::addressof(__res), &__alloc_vtable<_Alloc_type, _Resource>)
+      , __vtable(__vtable::template _Create<_Resource>())
+  {}
+
+  //! @brief Constructs a \c basic_any_resource from a type that satisfies the \c resource or \c async_resource concept
+  //! as well as all properties
+  //! @param __res Pointer to a resource to be wrapped within the \c basic_any_resource
+  _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
+  _LIBCUDACXX_REQUIRES((!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _AllocType::_Default)
+                         _LIBCUDACXX_AND resource_with<_Resource, _Properties...>)
+  basic_any_resource(_Resource* __res) noexcept
+      : _Resource_ref_base<_Alloc_type, true>(__res, &__alloc_vtable<_Alloc_type, _Resource>)
+      , __vtable(__vtable::template _Create<_Resource>())
+  {}
+
+  //! @brief Constructs a \c any_resource from a type that satisfies the \c async_resource concept  as well as all
+  //! properties. This ignores the async interface of the passed in resource
+  //! @param __res Pointer to a resource to be wrapped within the \c any_resource
+  _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
+  _LIBCUDACXX_REQUIRES((!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _AllocType::_Async)
+                         _LIBCUDACXX_AND async_resource_with<_Resource, _Properties...>)
+  basic_any_resource(_Resource* __res) noexcept
+      : _Resource_ref_base<_Alloc_type, true>(__res, &__alloc_vtable<_Alloc_type, _Resource>)
+      , __vtable(__vtable::template _Create<_Resource>())
+  {}
+
+  //! @brief Conversion from a \c basic_any_resource with the same set of properties but in a different order
+  //! @param __ref The other \c basic_any_resource
+  _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
+  _LIBCUDACXX_REQUIRES(__properties_match<_OtherProperties...>)
+  basic_any_resource(basic_any_resource<_Alloc_type, _OtherProperties...> __ref) noexcept
+      : _Resource_ref_base<_Alloc_type, true>(__ref.__object, __ref.__static_vtable)
+      , __vtable(__ref)
+  {}
+
+  //! @brief Conversion from a \c async_any_resource with the same set of properties but in a different order to a
+  //! \c any_resource
+  //! @param __ref The other \c async_any_resource
+  _LIBCUDACXX_TEMPLATE(_AllocType _OtherAllocType, class... _OtherProperties)
+  _LIBCUDACXX_REQUIRES((_OtherAllocType == _AllocType::_Async) _LIBCUDACXX_AND(_OtherAllocType != _Alloc_type)
+                         _LIBCUDACXX_AND __properties_match<_OtherProperties...>)
+  basic_any_resource(basic_any_resource<_OtherAllocType, _OtherProperties...> __ref) noexcept
+      : _Resource_ref_base<_Alloc_type, true>(__ref.__object, __ref.__static_vtable)
+      , __vtable(__ref)
+  {}
+
+  basic_any_resource(basic_any_resource&)            = delete;
+  basic_any_resource& operator=(basic_any_resource&) = delete;
+
+  basic_any_resource(basic_any_resource&&) = delete;
+  basic_any_resource& operator=(basic_any_resource&& __other) noexcept
+  {
+    // destroy the excisting resource
+    this->~basic_any_resource();
+
+    // construct from
+    _CUDA_VSTD::__construct_at(this, __other);
+  }
+
+  //! @brief Destroys the stored resource
+  ~basic_any_resource() noexcept
+  {
+    this->__static_vtable->__destroy_fn(this->__get_object());
+    if (!this->__static_vtable->__is_small_fn()) // free the allocated storage
+    {
+      delete this->__get_object();
+    }
+  }
+
+  //! @brief Equality comparison between two \c basic_any_resource
+  //! @param __rhs The other \c basic_any_resource
+  //! @return Checks whether both resources have the same equality function stored in their vtable and if so returns
+  //! the result of that equality comparison. Otherwise returns false.
+  _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
+  _LIBCUDACXX_REQUIRES((sizeof...(_Properties) == sizeof...(_OtherProperties))
+                         _LIBCUDACXX_AND __properties_match<_OtherProperties...>)
+  _CCCL_NODISCARD bool operator==(const basic_any_resource<_Alloc_type, _OtherProperties...>& __rhs) const
+  {
+    return (this->__static_vtable->__equal_fn == __rhs.__static_vtable->__equal_fn)
+        && this->__static_vtable->__equal_fn(this->__object, __rhs.__object);
+  }
+
+  //! @brief Inequality comparison between two \c basic_any_resource
+  //! @param __rhs The other \c basic_any_resource
+  //! @return Checks whether both resources have the same equality function stored in their vtable and if so returns
+  //! the inverse result of that equality comparison. Otherwise returns true.
+  _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
+  _LIBCUDACXX_REQUIRES((sizeof...(_Properties) == sizeof...(_OtherProperties))
+                         _LIBCUDACXX_AND __properties_match<_OtherProperties...>)
+  _CCCL_NODISCARD bool operator!=(const basic_any_resource<_Alloc_type, _OtherProperties...>& __rhs) const
+  {
+    return !(*this == __rhs);
+  }
+
+  //! @brief Forwards the stateless properties
+  _LIBCUDACXX_TEMPLATE(class _Property)
+  _LIBCUDACXX_REQUIRES((!property_with_value<_Property>) _LIBCUDACXX_AND _CUDA_VSTD::_One_of<_Property, _Properties...>)
+  friend void get_property(const basic_any_resource&, _Property) noexcept {}
+
+  //! @brief Forwards the stateful properties
+  _LIBCUDACXX_TEMPLATE(class _Property)
+  _LIBCUDACXX_REQUIRES(property_with_value<_Property> _LIBCUDACXX_AND _CUDA_VSTD::_One_of<_Property, _Properties...>)
+  _CCCL_NODISCARD_FRIEND __property_value_t<_Property> get_property(const basic_any_resource& __res, _Property) noexcept
+  {
+    return __res._Property_vtable<_Property>::__property_fn(__res.__object);
+  }
+};
+
+//! @brief Checks whether a passed in type is a specialization of basic_any_resource
+template <_AllocType _Alloc_type, class... _Properties>
+_LIBCUDACXX_INLINE_VAR constexpr bool __is_basic_any_resource<basic_any_resource<_Alloc_type, _Properties...>> = true;
+
+//! @brief Type erased wrapper around a `resource` that satisfies \tparam _Properties
+//! @tparam _Properties The properties that any resource wrapped within the `any_resource` needs to satisfy
+template <class... _Properties>
+using any_resource = basic_any_resource<_AllocType::_Default, _Properties...>;
+
+//! @brief Type erased wrapper around a `async_resource` that satisfies \tparam _Properties
+//! @tparam _Properties The properties that any async resource wrapped within the `async_any_resource` needs to satisfy
+template <class... _Properties>
+using async_any_resource = basic_any_resource<_AllocType::_Async, _Properties...>;
+} // namespace cuda::experimental::mr
+
+#endif // _CCCL_STD_VER >= 2014
+#endif //_CUDA__MEMORY_RESOURCE_ANY_RESOURCE_H

--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.h
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.h
@@ -21,19 +21,24 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__memory_resource/any_resource.h>
-#include <cuda/__memory_resource/get_property.h>
-#include <cuda/__memory_resource/resource.h>
-#include <cuda/std/__concepts/_One_of.h>
-#include <cuda/std/__memory/construct_at.h>
-#include <cuda/std/__type_traits/is_nothrow_constructible.h>
+#if !defined(_CCCL_COMPILER_MSVC_2017) && defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
 
-#if _CCCL_STD_VER >= 2014
+#  include <cuda/__memory_resource/get_property.h>
+#  include <cuda/__memory_resource/resource.h>
+#  include <cuda/__memory_resource/resource_ref.h>
+#  include <cuda/std/__concepts/_One_of.h>
+#  include <cuda/std/__memory/construct_at.h>
+#  include <cuda/std/__type_traits/is_nothrow_constructible.h>
+#  include <cuda/std/__type_traits/remove_cvref.h>
+#  include <cuda/std/__utility/exchange.h>
+#  include <cuda/std/__utility/forward.h>
+#  include <cuda/std/__utility/in_place.h>
+
+#  if _CCCL_STD_VER >= 2014
 
 namespace cuda::experimental::mr
 {
-
-template <class>
+template <class _Ty, class _Uy = _CUDA_VSTD::remove_cvref_t<_Ty>>
 _LIBCUDACXX_INLINE_VAR constexpr bool __is_basic_any_resource = false;
 
 template <_CUDA_VMR::_AllocType _Alloc_type, class... _Properties>
@@ -54,97 +59,129 @@ private:
   static constexpr bool __properties_match =
     _CUDA_VSTD::__all_of<_CUDA_VSTD::_One_of<_Properties, _OtherProperties...>...>;
 
-  void* __get_object() const noexcept
+  template <typename _Resource>
+  basic_any_resource(_CUDA_VSTD::in_place_t,
+                     _Resource&& __res) noexcept(_CUDA_VMR::_IsSmall<_CUDA_VSTD::remove_cvref_t<_Resource>>())
+      : _CUDA_VMR::_Resource_ref_base<_Alloc_type, false>(
+          nullptr, &_CUDA_VMR::__alloc_vtable<_Alloc_type, _CUDA_VSTD::remove_cvref_t<_Resource>>)
+      , __vtable(__vtable::template _Create<_CUDA_VSTD::remove_cvref_t<_Resource>>())
   {
-    return this->__static_vtable->__is_small_fn() ? this->__object.__ptr_ : static_cast<void*>(this->__object.__buf_);
+    using __resource_t        = _CUDA_VSTD::remove_cvref_t<_Resource>;
+    constexpr bool __is_small = _CUDA_VMR::_IsSmall<__resource_t>();
+    if constexpr (__is_small)
+    {
+      ::new (static_cast<void*>(this->__object.__buf_)) __resource_t(_CUDA_VSTD::forward<_Resource>(__res));
+    }
+    else
+    {
+      this->__object.__ptr_ = new __resource_t(_CUDA_VSTD::forward<_Resource>(__res));
+    }
   }
 
 public:
   //! @brief Constructs a \c basic_any_resource from a type that satisfies the \c resource or \c async_resource concept
   //! as well as all properties
   //! @param __res The resource to be wrapped within the \c basic_any_resource
-  _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
-  _LIBCUDACXX_REQUIRES((!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _AllocType::_Default)
-                         _LIBCUDACXX_AND resource_with<_Resource, _Properties...>)
-  basic_any_resource(_Resource& __res) noexcept
-      : _Resource_ref_base<_Alloc_type, true>(_CUDA_VSTD::addressof(__res), &__alloc_vtable<_Alloc_type, _Resource>)
-      , __vtable(__vtable::template _Create<_Resource>())
+  _LIBCUDACXX_TEMPLATE(class _Resource, _CUDA_VMR::_AllocType _Alloc_type2 = _Alloc_type)
+  _LIBCUDACXX_REQUIRES(
+    (!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _CUDA_VMR::_AllocType::_Default)
+      _LIBCUDACXX_AND _CUDA_VMR::resource_with<_CUDA_VSTD::remove_cvref_t<_Resource>, _Properties...>)
+  basic_any_resource(_Resource&& __res) noexcept
+      : basic_any_resource(_CUDA_VSTD::in_place, _CUDA_VSTD::forward<_Resource>(__res))
   {}
 
-  //! @brief Constructs a \c any_resource from a type that satisfies the \c async_resource concept  as well as all
+  //! @brief Constructs a \c basic_any_resource from a type that satisfies the \c async_resource concept as well as all
   //! properties. This ignores the async interface of the passed in resource
-  //! @param __res The resource to be wrapped within the \c any_resource
-  _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
-  _LIBCUDACXX_REQUIRES((!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _AllocType::_Async)
-                         _LIBCUDACXX_AND async_resource_with<_Resource, _Properties...>)
-  basic_any_resource(_Resource& __res) noexcept
-      : _Resource_ref_base<_Alloc_type, true>(_CUDA_VSTD::addressof(__res), &__alloc_vtable<_Alloc_type, _Resource>)
-      , __vtable(__vtable::template _Create<_Resource>())
-  {}
-
-  //! @brief Constructs a \c basic_any_resource from a type that satisfies the \c resource or \c async_resource concept
-  //! as well as all properties
-  //! @param __res Pointer to a resource to be wrapped within the \c basic_any_resource
-  _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
-  _LIBCUDACXX_REQUIRES((!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _AllocType::_Default)
-                         _LIBCUDACXX_AND resource_with<_Resource, _Properties...>)
-  basic_any_resource(_Resource* __res) noexcept
-      : _Resource_ref_base<_Alloc_type, true>(__res, &__alloc_vtable<_Alloc_type, _Resource>)
-      , __vtable(__vtable::template _Create<_Resource>())
-  {}
-
-  //! @brief Constructs a \c any_resource from a type that satisfies the \c async_resource concept  as well as all
-  //! properties. This ignores the async interface of the passed in resource
-  //! @param __res Pointer to a resource to be wrapped within the \c any_resource
-  _LIBCUDACXX_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
-  _LIBCUDACXX_REQUIRES((!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _AllocType::_Async)
-                         _LIBCUDACXX_AND async_resource_with<_Resource, _Properties...>)
-  basic_any_resource(_Resource* __res) noexcept
-      : _Resource_ref_base<_Alloc_type, true>(__res, &__alloc_vtable<_Alloc_type, _Resource>)
-      , __vtable(__vtable::template _Create<_Resource>())
+  //! @param __res The resource to be wrapped within the \c basic_any_resource
+  _LIBCUDACXX_TEMPLATE(class _Resource, _CUDA_VMR::_AllocType _Alloc_type2 = _Alloc_type)
+  _LIBCUDACXX_REQUIRES(
+    (!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_Alloc_type2 == _CUDA_VMR::_AllocType::_Async)
+      _LIBCUDACXX_AND _CUDA_VMR::async_resource_with<_CUDA_VSTD::remove_cvref_t<_Resource>, _Properties...>)
+  basic_any_resource(_Resource&& __res) noexcept
+      : basic_any_resource(_CUDA_VSTD::in_place, _CUDA_VSTD::forward<_Resource>(__res))
   {}
 
   //! @brief Conversion from a \c basic_any_resource with the same set of properties but in a different order
   //! @param __ref The other \c basic_any_resource
   _LIBCUDACXX_TEMPLATE(class... _OtherProperties)
   _LIBCUDACXX_REQUIRES(__properties_match<_OtherProperties...>)
-  basic_any_resource(basic_any_resource<_Alloc_type, _OtherProperties...> __ref) noexcept
-      : _Resource_ref_base<_Alloc_type, true>(__ref.__object, __ref.__static_vtable)
-      , __vtable(__ref)
-  {}
+  basic_any_resource(basic_any_resource<_Alloc_type, _OtherProperties...> __other) noexcept
+      : _CUDA_VMR::_Resource_ref_base<_Alloc_type, false>(
+          nullptr, _CUDA_VSTD::exchange(__other.__static_vtable, nullptr))
+      , __vtable(__other)
+  {
+    _LIBCUDACXX_ASSERT(this->__static_vtable != nullptr, "copying from a moved-from object");
+    this->__static_vtable->__move_fn(&this->__object, &__other.__object);
+  }
 
   //! @brief Conversion from a \c async_any_resource with the same set of properties but in a different order to a
   //! \c any_resource
   //! @param __ref The other \c async_any_resource
-  _LIBCUDACXX_TEMPLATE(_AllocType _OtherAllocType, class... _OtherProperties)
-  _LIBCUDACXX_REQUIRES((_OtherAllocType == _AllocType::_Async) _LIBCUDACXX_AND(_OtherAllocType != _Alloc_type)
-                         _LIBCUDACXX_AND __properties_match<_OtherProperties...>)
-  basic_any_resource(basic_any_resource<_OtherAllocType, _OtherProperties...> __ref) noexcept
-      : _Resource_ref_base<_Alloc_type, true>(__ref.__object, __ref.__static_vtable)
-      , __vtable(__ref)
-  {}
+  _LIBCUDACXX_TEMPLATE(_CUDA_VMR::_AllocType _OtherAllocType, class... _OtherProperties)
+  _LIBCUDACXX_REQUIRES((_OtherAllocType == _CUDA_VMR::_AllocType::_Async) _LIBCUDACXX_AND(
+    _OtherAllocType != _Alloc_type) _LIBCUDACXX_AND __properties_match<_OtherProperties...>)
+  basic_any_resource(basic_any_resource<_OtherAllocType, _OtherProperties...> __other) noexcept
+      : _CUDA_VMR::_Resource_ref_base<_Alloc_type, false>(
+          nullptr, _CUDA_VSTD::exchange(__other.__static_vtable, nullptr))
+      , __vtable(__other)
+  {
+    _LIBCUDACXX_ASSERT(this->__static_vtable != nullptr, "copying from a moved-from object");
+    this->__static_vtable->__move_fn(&this->__object, &__other.__object);
+  }
 
-  basic_any_resource(basic_any_resource&)            = delete;
-  basic_any_resource& operator=(basic_any_resource&) = delete;
+  basic_any_resource(basic_any_resource&& __other) noexcept
+      : _CUDA_VMR::_Resource_ref_base<_Alloc_type, false>(
+          nullptr, _CUDA_VSTD::exchange(__other.__static_vtable, nullptr))
+      , __vtable(__other)
+  {
+    _LIBCUDACXX_ASSERT(this->__static_vtable != nullptr, "copying from a moved-from object");
+    this->__static_vtable->__move_fn(&this->__object, &__other.__object);
+  }
 
-  basic_any_resource(basic_any_resource&&) = delete;
   basic_any_resource& operator=(basic_any_resource&& __other) noexcept
   {
-    // destroy the excisting resource
-    this->~basic_any_resource();
+    if (this->__static_vtable != nullptr)
+    {
+      this->__static_vtable->__destroy_fn(&this->__object);
+      this->__static_vtable = nullptr;
+    }
 
-    // construct from
-    _CUDA_VSTD::__construct_at(this, __other);
+    if (__other.__static_vtable != nullptr)
+    {
+      this->__static_vtable = _CUDA_VSTD::exchange(__other.__static_vtable, nullptr);
+      this->__static_vtable->__move_fn(&this->__object, &__other.__object);
+    }
+
+    return *this;
+  }
+
+  basic_any_resource(const basic_any_resource& __other)
+      : _CUDA_VMR::_Resource_ref_base<_Alloc_type, false>(nullptr, __other.__static_vtable)
+      , __vtable(__other)
+  {
+    _LIBCUDACXX_ASSERT(this->__static_vtable != nullptr, "copying from a moved-from object");
+    this->__static_vtable->__copy_fn(&this->__object, &__other.__object);
+  }
+
+  basic_any_resource& operator=(basic_any_resource& __other)
+  {
+    return this == &__other ? *this : operator=(basic_any_resource(__other));
   }
 
   //! @brief Destroys the stored resource
   ~basic_any_resource() noexcept
   {
-    this->__static_vtable->__destroy_fn(this->__get_object());
-    if (!this->__static_vtable->__is_small_fn()) // free the allocated storage
+    if (this->__static_vtable != nullptr)
     {
-      delete this->__get_object();
+      this->__static_vtable->__destroy_fn(&this->__object);
     }
+  }
+
+  void swap(basic_any_resource& __other) noexcept
+  {
+    auto __tmp = _CUDA_VSTD::move(__other);
+    __other    = _CUDA_VSTD::move(*this);
+    *this      = _CUDA_VSTD::move(__tmp);
   }
 
   //! @brief Equality comparison between two \c basic_any_resource
@@ -182,24 +219,30 @@ public:
   _LIBCUDACXX_REQUIRES(property_with_value<_Property> _LIBCUDACXX_AND _CUDA_VSTD::_One_of<_Property, _Properties...>)
   _CCCL_NODISCARD_FRIEND __property_value_t<_Property> get_property(const basic_any_resource& __res, _Property) noexcept
   {
-    return __res._Property_vtable<_Property>::__property_fn(__res.__object);
+    _CUDA_VMR::_Property_vtable<_Property> const& __prop = __res;
+    return __prop.__property_fn(__res.__object);
   }
 };
 
 //! @brief Checks whether a passed in type is a specialization of basic_any_resource
-template <_AllocType _Alloc_type, class... _Properties>
-_LIBCUDACXX_INLINE_VAR constexpr bool __is_basic_any_resource<basic_any_resource<_Alloc_type, _Properties...>> = true;
+template <class _Ty, _CUDA_VMR::_AllocType _Alloc_type, class... _Properties>
+_LIBCUDACXX_INLINE_VAR constexpr bool __is_basic_any_resource<_Ty, basic_any_resource<_Alloc_type, _Properties...>> =
+  true;
 
 //! @brief Type erased wrapper around a `resource` that satisfies \tparam _Properties
 //! @tparam _Properties The properties that any resource wrapped within the `any_resource` needs to satisfy
 template <class... _Properties>
-using any_resource = basic_any_resource<_AllocType::_Default, _Properties...>;
+using any_resource = basic_any_resource<_CUDA_VMR::_AllocType::_Default, _Properties...>;
 
 //! @brief Type erased wrapper around a `async_resource` that satisfies \tparam _Properties
 //! @tparam _Properties The properties that any async resource wrapped within the `async_any_resource` needs to satisfy
 template <class... _Properties>
-using async_any_resource = basic_any_resource<_AllocType::_Async, _Properties...>;
+using async_any_resource = basic_any_resource<_CUDA_VMR::_AllocType::_Async, _Properties...>;
+
 } // namespace cuda::experimental::mr
 
-#endif // _CCCL_STD_VER >= 2014
-#endif //_CUDA__MEMORY_RESOURCE_ANY_RESOURCE_H
+#  endif // _CCCL_STD_VER >= 2014
+
+#endif // !_CCCL_COMPILER_MSVC_2017 && LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+
+#endif //_CUDAX__MEMORY_RESOURCE_ANY_RESOURCE_H

--- a/cudax/include/cuda/experimental/memory_resource.cuh
+++ b/cudax/include/cuda/experimental/memory_resource.cuh
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_MEMORY_RESOURCE___
+#define __CUDAX_MEMORY_RESOURCE___
+
+#include <cuda/experimental/__memory_resource/any_resource.h>
+
+#endif // __CUDAX_MEMORY_RESOURCE___

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -88,4 +88,8 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   cudax_add_catch2_test(test_target containers ${cn_target}
     containers/uninitialized_buffer.cu
   )
+
+  cudax_add_catch2_test(test_target memory_resource ${cn_target}
+    memory_resource/any_resource.cu
+  )
 endforeach()

--- a/cudax/test/memory_resource/any_resource.cu
+++ b/cudax/test/memory_resource/any_resource.cu
@@ -1,0 +1,152 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/experimental/memory_resource.cuh>
+
+#include "cuda/std/detail/libcxx/include/cstddef"
+#include <catch2/catch.hpp>
+#include <testing.cuh>
+
+struct Counts
+{
+  int object_count     = 0;
+  int move_count       = 0;
+  int copy_count       = 0;
+  int allocate_count   = 0;
+  int deallocate_count = 0;
+  int equal_to_count   = 0;
+  int new_count        = 0;
+  int delete_count     = 0;
+
+  friend bool operator==(const Counts& lhs, const Counts& rhs) noexcept
+  {
+    return lhs.object_count == rhs.object_count && //
+           lhs.move_count == rhs.move_count && //
+           lhs.copy_count == rhs.copy_count && //
+           lhs.allocate_count == rhs.allocate_count && //
+           lhs.deallocate_count == rhs.deallocate_count && //
+           lhs.equal_to_count == rhs.equal_to_count && //
+           lhs.new_count == rhs.new_count && //
+           lhs.delete_count == rhs.delete_count; //
+  }
+
+  friend bool operator!=(const Counts& lhs, const Counts& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+};
+
+struct big_resource
+{
+  int data;
+  unsigned long cookie[3] = {0xDEADBEEF, 0xDEADBEEF, 0xDEADBEEF};
+
+  static Counts counts;
+
+  explicit big_resource(int i) noexcept
+      : data(i)
+  {
+    ++counts.object_count;
+  }
+
+  big_resource(big_resource&& other) noexcept
+      : data(other.data)
+  {
+    ++counts.move_count;
+    ++counts.object_count;
+    other._assert_valid();
+    cookie[0] = cookie[1] = cookie[2] = 0x0C07FEFE;
+  }
+
+  big_resource(const big_resource& other) noexcept
+      : data(other.data)
+  {
+    ++counts.copy_count;
+    ++counts.object_count;
+    other._assert_valid();
+  }
+
+  ~big_resource()
+  {
+    --counts.object_count;
+  }
+
+  void* allocate(std::size_t, std::size_t)
+  {
+    ++counts.allocate_count;
+    _assert_valid();
+    return nullptr;
+  }
+
+  void deallocate(void*, std::size_t, std::size_t) noexcept
+  {
+    ++counts.deallocate_count;
+    _assert_valid();
+    return;
+  }
+
+  friend bool operator==(const big_resource& lhs, const big_resource& rhs)
+  {
+    ++counts.equal_to_count;
+    lhs._assert_valid();
+    rhs._assert_valid();
+    return lhs.data == rhs.data;
+  }
+
+  friend bool operator!=(const big_resource& lhs, const big_resource& rhs)
+  {
+    FAIL("any_resource should only be calling operator==");
+    return lhs.data != rhs.data;
+  }
+
+  void _assert_valid() const noexcept
+  {
+    REQUIRE(cookie[0] == 0xDEADBEEF);
+    REQUIRE(cookie[1] == 0xDEADBEEF);
+    REQUIRE(cookie[2] == 0xDEADBEEF);
+  }
+
+  static void* operator new(::cuda::std::size_t size)
+  {
+    ++counts.new_count;
+    return ::operator new(size);
+  }
+
+  static void operator delete(void* pv)
+  {
+    ++counts.delete_count;
+    return ::operator delete(pv);
+  }
+};
+
+static_assert(sizeof(big_resource) > sizeof(cuda::mr::_AnyResourceStorage));
+
+Counts big_resource::counts{};
+
+TEST_CASE("any_resource", "[container][resource]")
+{
+  SECTION("construct and destruct a big resource")
+  {
+    Counts expected{};
+    CHECK(big_resource::counts == expected);
+    {
+      cudax::mr::any_resource<> mr{big_resource{42}};
+      ++expected.new_count;
+      ++expected.object_count;
+      ++expected.move_count;
+      CHECK(big_resource::counts == expected);
+    }
+    ++expected.delete_count;
+    --expected.object_count;
+    CHECK(big_resource::counts == expected);
+  }
+
+  big_resource::counts = Counts();
+}

--- a/libcudacxx/include/cuda/__memory_resource/device_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/device_memory_resource.h
@@ -81,7 +81,7 @@ public:
   //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`
   //! @param __bytes The number of bytes that was passed to the `allocate` call that returned \p __ptr.
   //! @param __alignment The alignment that was passed to the `allocate` call that returned \p __ptr.
-  void deallocate(void* __ptr, const size_t, const size_t __alignment = default_cuda_malloc_alignment) const
+  void deallocate(void* __ptr, const size_t, const size_t __alignment = default_cuda_malloc_alignment) const noexcept
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),

--- a/libcudacxx/include/cuda/__memory_resource/managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/managed_memory_resource.h
@@ -76,7 +76,7 @@ public:
   //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`
   //! @param __bytes The number of bytes that was passed to the `allocate` call that returned \p __ptr.
   //! @param __alignment The alignment that was passed to the `allocate` call that returned \p __ptr.
-  void deallocate(void* __ptr, const size_t, const size_t __alignment = default_cuda_malloc_alignment) const
+  void deallocate(void* __ptr, const size_t, const size_t __alignment = default_cuda_malloc_alignment) const noexcept
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),

--- a/libcudacxx/include/cuda/__memory_resource/pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/pinned_memory_resource.h
@@ -78,7 +78,8 @@ public:
   //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`
   //! @param __bytes The number of bytes that was passed to the `allocate` call that returned \p __ptr.
   //! @param __alignment The alignment that was passed to the `allocate` call that returned \p __ptr.
-  void deallocate(void* __ptr, const size_t, const size_t __alignment = default_cuda_malloc_host_alignment) const
+  void
+  deallocate(void* __ptr, const size_t, const size_t __alignment = default_cuda_malloc_host_alignment) const noexcept
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _LIBCUDACXX_ASSERT(__is_valid_alignment(__alignment),


### PR DESCRIPTION
## Description

This PR adds `cudax::mr::any_resource` and `cudax::mr::any_async_resource`, owning type-erased wrappers for memory resources. It reuses a lot of machinery from `cuda::mr::resource_ref`. A future PR will change the cudax containers to use `any_resource` instead of `resource_ref` to address potential lifetime issues.

This PR is a work in progress. It needs more tests.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #1426 

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
