### PR TITLE
fair binary semaphore implementation 

### DIFF
--- a/libcudacxx/include/cuda/std/__cuda/semaphore.h
+++ b/libcudacxx/include/cuda/std/__cuda/semaphore.h
@@ -175,7 +175,7 @@ private:
     cuda::atomic<ptrdiff_t, _Sco> skipped_tickets;
     cuda::atomic<ptrdiff_t, _Sco> ticketing;
 
-    _LIBCUDACXX_INLINE_VISIBILITY bool try_acq_impl(ptrdiff_t ctr)
+    _LIBCUDACXX_INLINE_VISIBILITY bool __try_acq_impl(ptrdiff_t ctr)
     {
 
         if (counter.compare_exchange_weak(ctr,

--- a/libcudacxx/include/cuda/std/__cuda/semaphore.h
+++ b/libcudacxx/include/cuda/std/__cuda/semaphore.h
@@ -12,6 +12,7 @@
 #define _LIBCUDACXX___CUDA_SEMAPHORE_H
 
 #include <cuda/std/detail/__config>
+#include <cuda/atomic>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -22,6 +23,19 @@
 #endif // no system header
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+void simple_backoff()
+{
+    int wait_iterations = 1;
+    volatile int ctr = 0;
+    const int max_iterations = 1024;
+
+    for (int i = 0; i < wait_iterations; ++i)
+    {
+        ctr++;
+    }
+    wait_iterations = (wait_iterations * 2 >= max_iterations) ? max_iterations : wait_iterations * 2;
+}
 
 template <thread_scope _Sco, ptrdiff_t __least_max_value = INT_MAX>
 class counting_semaphore : public _CUDA_VSTD::__semaphore_base<__least_max_value, _Sco>
@@ -38,8 +52,152 @@ public:
   counting_semaphore& operator=(const counting_semaphore&) = delete;
 };
 
+template <thread_scope _Sco, ptrdiff_t __least_max_value = INT_MAX>
+struct fair_counting_semaphore
+{
+};
+
 template <thread_scope _Sco>
-using binary_semaphore = counting_semaphore<_Sco, 1>;
+struct binary_semaphore : fair_counting_semaphore<_Sco, 1>
+{
+public:
+    _LIBCUDACXX_INLINE_VISIBILITY static constexpr ptrdiff_t max() noexcept
+    {
+        return static_cast<ptrdiff_t>(1);
+    }
+
+    _LIBCUDACXX_INLINE_VISIBILITY bool try_acquire()
+    {
+        ptrdiff_t ctr = counter.load(cuda::memory_order_relaxed);
+        return try_acq_impl(ctr);
+    }
+
+    _LIBCUDACXX_INLINE_VISIBILITY void acquire()
+    {
+        ptrdiff_t ctr = counter.load(cuda::memory_order_relaxed);
+        while (!try_acq_impl(ctr))
+        {
+            counter.wait(ctr);
+        }
+        int32_t cur_tickets = (ticketing.load(cuda::memory_order_relaxed) & 0xFFFFFFFF);
+        auto limit = _CUDA_VSTD::numeric_limits<int32_t>::max();
+        if (limit >= cur_tickets + 1)
+        {
+            auto prev = ticketing.fetch_add(1);
+            while (!our_turn(prev + 1))
+            {
+                simple_backoff();
+            }
+        }
+    }
+
+    _LIBCUDACXX_INLINE_VISIBILITY bool __acquire_slow_timed(
+        _CUDA_VSTD::chrono::nanoseconds const &__rel_time)
+    {
+        return __libcpp_thread_poll_with_backoff(
+            [this]()
+            {
+                ptrdiff_t ctr = counter.load(cuda::memory_order_relaxed);
+                while (!try_acq_impl(ctr))
+                {
+                    counter.wait(ctr);
+                }
+                int32_t cur_tickets = (ticketing.load(cuda::memory_order_relaxed) & 0xFFFFFFFF);
+                auto limit = _CUDA_VSTD::numeric_limits<int32_t>::max();
+                if (limit >= cur_tickets + 1)
+                {
+                    auto prev = ticketing.fetch_add(1);
+                    while (!our_turn(prev + 1))
+                    {
+                        simple_backoff();
+                    }
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            },
+            __rel_time);
+    }
+
+    _LIBCUDACXX_INLINE_VISIBILITY void release(ptrdiff_t update = 1)
+    {
+        counter.fetch_add(1);
+        ticketing.fetch_add(static_cast<ptrdiff_t>(1) << 32, cuda::memory_order_relaxed);
+        // we need to notify all because no guarantee of who
+        // gets it
+        counter.notify_all();
+        ticketing.notify_all();
+    }
+
+    template <class Rep, class Period>
+    _LIBCUDACXX_INLINE_VISIBILITY bool try_acquire_for(_CUDA_VSTD::chrono::duration<Rep, Period> const &__rel_time)
+    {
+        bool result = __acquire_slow_timed(__rel_time);
+        if (result)
+        {
+            return true;
+        }
+        else
+        {
+            skipped_tickets.fetch_add(1, cuda::memory_order_relaxed);
+            return false;
+        }
+    }
+
+    template <class Clock, class Duration>
+    _LIBCUDACXX_INLINE_VISIBILITY bool try_acquire_until(_CUDA_VSTD::chrono::time_point<Clock, Duration> const &__abs_time)
+    {
+        bool result = __acquire_slow_timed(__abs_time - Clock::now());
+        if (result)
+        {
+            return true;
+        }
+        else
+        {
+            skipped_tickets.fetch_add(1, cuda::memory_order_relaxed);
+            return false;
+        }
+    }
+
+    _LIBCUDACXX_INLINE_VISIBILITY constexpr explicit binary_semaphore(ptrdiff_t ctr = 1) : counter(ctr), ticketing(0)
+    {
+        assert(ctr == 1);
+    }
+
+    ~binary_semaphore() = default;
+    binary_semaphore(const binary_semaphore &) = delete;
+    binary_semaphore operator=(const binary_semaphore &) = delete;
+
+private:
+    cuda::atomic<ptrdiff_t, _Sco> counter;
+    cuda::atomic<ptrdiff_t, _Sco> skipped_tickets;
+    cuda::atomic<ptrdiff_t, _Sco> ticketing;
+
+    _LIBCUDACXX_INLINE_VISIBILITY bool try_acq_impl(ptrdiff_t ctr)
+    {
+
+        if (counter.compare_exchange_weak(ctr,
+                                          static_cast<ptrdiff_t>(ctr - 1),
+                                          cuda::memory_order_acquire,
+                                          cuda::memory_order_relaxed))
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    _LIBCUDACXX_INLINE_VISIBILITY bool our_turn(ptrdiff_t ticket_num)
+    {
+        auto tick = ticketing.load(cuda::memory_order_relaxed);
+        int32_t serving_ticket = tick >> 32;
+        auto skipped = skipped_tickets.load(cuda::memory_order_relaxed);
+        return ((skipped + ticket_num) == serving_ticket);
+    }
+};
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
 


### PR DESCRIPTION
I initially made a PR here https://github.com/NVIDIA/cccl/pull/2193 but after discussing it was determined it would be a lot easier to create a fair binary semaphore implementation(which should cover most cases). 

Summary:
1) I've confirmed the reproducer example here https://github.com/NVIDIA/cccl/issues/450 does not hang. 
2) The GPU tests seem to be passing successfully. 
3) There are **three atomic variables**. `counter`, `skipped_tickets`, and `ticketing`. `skipped_tickets` is required because of methods like `try_acquire_for`, we need a way to handle the fact that we've added a ticket to the queue, but need to mitigate the effects of that on the entire system. If you were to do a simple atomic subtraction, this will lead to incorrect results because globally, other threads will not be able to know if another thread is to be skipped since locally they have no way of attaining that information. `our_turn` is who is responsible for loading it. 
4) `atomic::wait()` and `atomic::notify_all` imo are not suitable solutions for this implementation because as I understand it, they will not assure notifications are in FIFO order. So with that being said, since we don't know who is going to wake up by using `notify_one`, we are required to use `notify_all`. 
5) I will add comments to different areas of the code in this PR to highlight where I think needs attention.

cc @miscco @jrhemstad @gonzalobg 


