### PR TITLE
refactor cmake so more cudax samples can be easily added

### DIFF
--- a/cudax/samples/CMakeLists.txt
+++ b/cudax/samples/CMakeLists.txt
@@ -32,6 +32,7 @@ CPMAddPackage(
   GITHUB_REPOSITORY ${CCCL_REPOSITORY}
   GIT_TAG ${CCCL_TAG}
   GIT_SHALLOW ON
+  # The following is required to make the `CCCL::cudax` target available:
   OPTIONS "CCCL_ENABLE_UNSTABLE ON"
 )
 
@@ -40,35 +41,31 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   set(CMAKE_CUDA_ARCHITECTURES 86)
 endif()
 
-# Creates a cmake executable target for the main program
-add_executable(vector_add vector_add/vector_add.cu)
+add_library(cudax_samples_interface INTERFACE)
 
-# "Links" the CCCL::cudax CMake target to the `vector_add` executable. This
-# configures everything needed to use CCCL's headers, including setting up
-# include paths, compiler flags, etc.
-target_link_libraries(vector_add
-  PUBLIC
-    CCCL::cudax
-    CCCL::CCCL
-    CCCL::Thrust
-    CCCL::libcudacxx
-  INTERFACE cudax.compiler_interface
+target_compile_definitions(
+  cudax_samples_interface INTERFACE
+  LIBCUDACXX_ENABLE_EXCEPTIONS
+  LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 )
 
-# TODO: These are temporary until the main branch catches up with the latest changes
-target_compile_definitions(vector_add PUBLIC LIBCUDACXX_ENABLE_EXCEPTIONS)
+target_link_libraries(cudax_samples_interface INTERFACE CCCL::CCCL CCCL::cudax)
 
 if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
   # mdspan on windows only works in C++20 mode
-  target_compile_features(vector_add PUBLIC cxx_std_20)
+  target_compile_features(cudax_samples_interface INTERFACE cxx_std_20)
 
-  # cudax requires dim3 to be usable from a constexpr context, and the CUDART headers require
-  # __cplusplus to be defined for this to work:
-  target_compile_options(vector_add PRIVATE
+  # cudax requires dim3 to be usable from a constexpr context, and the CUDART
+  # headers require __cplusplus to be defined for this to work:
+  target_compile_options(cudax_samples_interface INTERFACE
     $<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus /Zc:preprocessor>
     $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcompiler=/Zc:__cplusplus -Xcompiler=/Zc:preprocessor>
   )
 endif()
+
+# The vector_add sample demonstrates a simple CUDA kernel that adds two vectors
+add_executable(vector_add vector_add/vector_add.cu)
+target_link_libraries(vector_add PUBLIC cudax_samples_interface)
 
 # This is only relevant for internal testing and not needed by end users.
 include(CTest)


### PR DESCRIPTION
## Description

We will want to add more cudax samples. This PR factors the cmake target settings into a reusable cmake interface target `cuda_samples_interface` and redefines the `vector_add` target in terms of that.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
