### PR TITLE
use `NV_IF_TARGET` to conditionally compile CUDAX tests

### DIFF
--- a/cudax/test/containers/uninitialized_buffer.cu
+++ b/cudax/test/containers/uninitialized_buffer.cu
@@ -20,13 +20,13 @@
 
 #include <cuda/experimental/buffer>
 
-#include <catch2/catch.hpp>
+#include "testing.cuh"
 
 struct do_not_construct
 {
   do_not_construct()
   {
-    CHECK(false);
+    CUDAX_CHECK(false);
   }
 };
 
@@ -68,20 +68,20 @@ TEMPLATE_TEST_CASE(
     static_assert(!cuda::std::is_copy_constructible<uninitialized_buffer>::value, "");
     {
       uninitialized_buffer from_count{resource, 42};
-      CHECK(from_count.data() != nullptr);
-      CHECK(from_count.size() == 42);
+      CUDAX_CHECK(from_count.data() != nullptr);
+      CUDAX_CHECK(from_count.size() == 42);
     }
     {
       uninitialized_buffer input{resource, 42};
       const TestType* ptr = input.data();
 
       uninitialized_buffer from_rvalue{cuda::std::move(input)};
-      CHECK(from_rvalue.data() == ptr);
-      CHECK(from_rvalue.size() == 42);
+      CUDAX_CHECK(from_rvalue.data() == ptr);
+      CUDAX_CHECK(from_rvalue.size() == 42);
 
       // Ensure that we properly reset the input buffer
-      CHECK(input.data() == nullptr);
-      CHECK(input.size() == 0);
+      CUDAX_CHECK(input.data() == nullptr);
+      CUDAX_CHECK(input.size() == 0);
     }
   }
 
@@ -96,13 +96,13 @@ TEMPLATE_TEST_CASE(
       const auto* old_input_ptr = input.data();
 
       buf = cuda::std::move(input);
-      CHECK(buf.data() != old_ptr);
-      CHECK(buf.data() == old_input_ptr);
-      CHECK(buf.size() == 42);
-      CHECK(buf.resource() == other_resource);
+      CUDAX_CHECK(buf.data() != old_ptr);
+      CUDAX_CHECK(buf.data() == old_input_ptr);
+      CUDAX_CHECK(buf.size() == 42);
+      CUDAX_CHECK(buf.resource() == other_resource);
 
-      CHECK(input.data() == nullptr);
-      CHECK(input.size() == 0);
+      CUDAX_CHECK(input.data() == nullptr);
+      CUDAX_CHECK(input.size() == 0);
     }
 
     { // Ensure self move assignment doesnt do anything
@@ -110,25 +110,25 @@ TEMPLATE_TEST_CASE(
       const auto* old_ptr = buf.data();
 
       buf = cuda::std::move(buf);
-      CHECK(buf.data() == old_ptr);
-      CHECK(buf.size() == 1337);
+      CUDAX_CHECK(buf.data() == old_ptr);
+      CUDAX_CHECK(buf.size() == 1337);
     }
   }
 
   SECTION("access")
   {
     uninitialized_buffer buf{resource, 42};
-    CHECK(buf.data() != nullptr);
-    CHECK(buf.size() == 42);
-    CHECK(buf.begin() == buf.data());
-    CHECK(buf.end() == buf.begin() + buf.size());
-    CHECK(buf.resource() == resource);
+    CUDAX_CHECK(buf.data() != nullptr);
+    CUDAX_CHECK(buf.size() == 42);
+    CUDAX_CHECK(buf.begin() == buf.data());
+    CUDAX_CHECK(buf.end() == buf.begin() + buf.size());
+    CUDAX_CHECK(buf.resource() == resource);
 
-    CHECK(cuda::std::as_const(buf).data() != nullptr);
-    CHECK(cuda::std::as_const(buf).size() == 42);
-    CHECK(cuda::std::as_const(buf).begin() == buf.data());
-    CHECK(cuda::std::as_const(buf).end() == buf.begin() + buf.size());
-    CHECK(cuda::std::as_const(buf).resource() == resource);
+    CUDAX_CHECK(cuda::std::as_const(buf).data() != nullptr);
+    CUDAX_CHECK(cuda::std::as_const(buf).size() == 42);
+    CUDAX_CHECK(cuda::std::as_const(buf).begin() == buf.data());
+    CUDAX_CHECK(cuda::std::as_const(buf).end() == buf.begin() + buf.size());
+    CUDAX_CHECK(cuda::std::as_const(buf).resource() == resource);
   }
 
   SECTION("properties")
@@ -143,8 +143,8 @@ TEMPLATE_TEST_CASE(
   {
     uninitialized_buffer buf{resource, 42};
     const cuda::std::span<TestType> as_span{buf};
-    CHECK(as_span.data() == buf.data());
-    CHECK(as_span.size() == 42);
+    CUDAX_CHECK(as_span.data() == buf.data());
+    CUDAX_CHECK(as_span.size() == 42);
   }
 
   SECTION("Actually use memory")
@@ -154,7 +154,7 @@ TEMPLATE_TEST_CASE(
       uninitialized_buffer buf{resource, 42};
       thrust::fill(thrust::device, buf.begin(), buf.end(), TestType{2});
       const auto res = thrust::reduce(thrust::device, buf.begin(), buf.end(), TestType{0}, thrust::plus<int>());
-      CHECK(res == TestType{84});
+      CUDAX_CHECK(res == TestType{84});
     }
   }
 }

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -26,11 +26,11 @@ cudaLaunchKernelExTestReplacement(const cudaLaunchConfig_t* config, void (*kerne
   replacementCalled = true;
   bool has_cluster  = false;
 
-  CHECK(expectedConfig.numAttrs == config->numAttrs);
-  CHECK(expectedConfig.blockDim == config->blockDim);
-  CHECK(expectedConfig.gridDim == config->gridDim);
-  CHECK(expectedConfig.stream == config->stream);
-  CHECK(expectedConfig.dynamicSmemBytes == config->dynamicSmemBytes);
+  CUDAX_CHECK(expectedConfig.numAttrs == config->numAttrs);
+  CUDAX_CHECK(expectedConfig.blockDim == config->blockDim);
+  CUDAX_CHECK(expectedConfig.gridDim == config->gridDim);
+  CUDAX_CHECK(expectedConfig.stream == config->stream);
+  CUDAX_CHECK(expectedConfig.dynamicSmemBytes == config->dynamicSmemBytes);
 
   for (unsigned int i = 0; i < expectedConfig.numAttrs; ++i)
   {
@@ -44,26 +44,26 @@ cudaLaunchKernelExTestReplacement(const cudaLaunchConfig_t* config, void (*kerne
         switch (expectedAttr.id)
         {
           case cudaLaunchAttributeClusterDimension:
-            CHECK(expectedAttr.val.clusterDim.x == actualAttr.val.clusterDim.x);
-            CHECK(expectedAttr.val.clusterDim.y == actualAttr.val.clusterDim.y);
-            CHECK(expectedAttr.val.clusterDim.z == actualAttr.val.clusterDim.z);
+            CUDAX_CHECK(expectedAttr.val.clusterDim.x == actualAttr.val.clusterDim.x);
+            CUDAX_CHECK(expectedAttr.val.clusterDim.y == actualAttr.val.clusterDim.y);
+            CUDAX_CHECK(expectedAttr.val.clusterDim.z == actualAttr.val.clusterDim.z);
             has_cluster = true;
             break;
           case cudaLaunchAttributeCooperative:
-            CHECK(expectedAttr.val.cooperative == actualAttr.val.cooperative);
+            CUDAX_CHECK(expectedAttr.val.cooperative == actualAttr.val.cooperative);
             break;
           case cudaLaunchAttributePriority:
-            CHECK(expectedAttr.val.priority == actualAttr.val.priority);
+            CUDAX_CHECK(expectedAttr.val.priority == actualAttr.val.priority);
             break;
           default:
-            CHECK(false);
+            CUDAX_CHECK(false);
             break;
         }
         break;
       }
     }
     INFO("Searched attribute is " << expectedAttr.id);
-    CHECK(j != expectedConfig.numAttrs);
+    CUDAX_CHECK(j != expectedConfig.numAttrs);
   }
 
   if (!has_cluster || !skip_device_exec(arch_filter<std::less<int>, 90>))
@@ -186,5 +186,5 @@ TEST_CASE("Launch configuration", "[launch]")
   }
 
   CUDART(cudaStreamDestroy(stream));
-  CHECK(replacementCalled);
+  CUDAX_CHECK(replacementCalled);
 }

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -18,7 +18,7 @@ __managed__ bool kernel_run_proof = false;
 void check_kernel_run(cudaStream_t stream)
 {
   CUDART(cudaStreamSynchronize(stream));
-  CHECK(kernel_run_proof);
+  CUDAX_CHECK(kernel_run_proof);
   kernel_run_proof = false;
 }
 
@@ -118,7 +118,7 @@ struct launch_transform_to_int_convertible
         , value_(value)
     {
       // Check that the constructor runs before the kernel is launched
-      CHECK_FALSE(kernel_run_proof);
+      CUDAX_CHECK_FALSE(kernel_run_proof);
     }
 
     // Immovable to ensure that __launch_transform doesn't copy the returned
@@ -129,7 +129,7 @@ struct launch_transform_to_int_convertible
     {
       // Check that the destructor runs after the kernel is launched
       CUDART(cudaStreamSynchronize(stream_));
-      CHECK(kernel_run_proof);
+      CUDAX_CHECK(kernel_run_proof);
     }
 
     using __as_kernel_arg = int;

--- a/cudax/test/stream/get_stream.cu
+++ b/cudax/test/stream/get_stream.cu
@@ -17,14 +17,14 @@ TEST_CASE("Can call get_stream on a cudaStream_t", "[stream]")
 {
   ::cudaStream_t str = nullptr;
   auto ref           = ::cuda::experimental::get_stream(str);
-  CHECK(str == ref);
+  CUDAX_CHECK(str == ref);
 }
 
 TEST_CASE("Can call get_stream on a cudax::stream", "[stream]")
 {
   cudax::stream str;
   auto ref = ::cuda::experimental::get_stream(str);
-  CHECK(str == ref);
+  CUDAX_CHECK(str == ref);
 }
 
 struct something_stream_ordered
@@ -41,7 +41,7 @@ TEST_CASE("Can call get_stream on a type with a get_stream method", "[stream]")
 {
   something_stream_ordered str{};
   auto ref = ::cuda::experimental::get_stream(str);
-  CHECK(str.stream_ == ref);
+  CUDAX_CHECK(str.stream_ == ref);
 }
 
 struct non_const_get_stream

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -92,7 +92,7 @@ TEST_CASE("ensure current device", "[device]")
       CUDAX_REQUIRE(driver::ctxGetCurrent() == driver::streamGetCtx(stream.get()));
     }
 
-    CHECK(test::count_driver_stack() == 0);
+    CUDAX_CHECK(test::count_driver_stack() == 0);
 
     {
       // Check NULL stream ref is handled ok

--- a/thrust/thrust/iterator/detail/tabulate_output_iterator.inl
+++ b/thrust/thrust/iterator/detail/tabulate_output_iterator.inl
@@ -51,12 +51,12 @@ private:
 // Alias template for the iterator_adaptor instantiation to be used for tabulate_output_iterator
 template <typename BinaryFunction, typename System, typename DifferenceT>
 using tabulate_output_iterator_base =
-    thrust::iterator_adaptor<tabulate_output_iterator<BinaryFunction, System, DifferenceT>,
-                             counting_iterator<DifferenceT>,
-                             thrust::use_default,
-                             System,
-                             thrust::use_default,
-                             tabulate_output_iterator_proxy<BinaryFunction, DifferenceT>>;
+  thrust::iterator_adaptor<tabulate_output_iterator<BinaryFunction, System, DifferenceT>,
+                           counting_iterator<DifferenceT>,
+                           thrust::use_default,
+                           System,
+                           thrust::use_default,
+                           tabulate_output_iterator_proxy<BinaryFunction, DifferenceT>>;
 
 // Register tabulate_output_iterator_proxy with 'is_proxy_reference' from
 // type_traits to enable its use with algorithms.


### PR DESCRIPTION
## Description

This PR addresses the "`// TODO make it work on NVC++`" comment in `cudax/test/common/testing.cuh`. It uses the `NV_IF_TARGET` macro instead of checking whether `__CUDA_ARCH__` is defined or not. It provides `CUDAX_` flavors for the Catch2 macros used by the CUDAX tests. This way they can be compiled on host or device, with nvcc or with nvc++.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
