### PR TITLE
Fixes formatting of `tabulate_output_iterator.inl`

### DIFF
--- a/thrust/thrust/iterator/detail/tabulate_output_iterator.inl
+++ b/thrust/thrust/iterator/detail/tabulate_output_iterator.inl
@@ -51,12 +51,12 @@ private:
 // Alias template for the iterator_adaptor instantiation to be used for tabulate_output_iterator
 template <typename BinaryFunction, typename System, typename DifferenceT>
 using tabulate_output_iterator_base =
-    thrust::iterator_adaptor<tabulate_output_iterator<BinaryFunction, System, DifferenceT>,
-                             counting_iterator<DifferenceT>,
-                             thrust::use_default,
-                             System,
-                             thrust::use_default,
-                             tabulate_output_iterator_proxy<BinaryFunction, DifferenceT>>;
+  thrust::iterator_adaptor<tabulate_output_iterator<BinaryFunction, System, DifferenceT>,
+                           counting_iterator<DifferenceT>,
+                           thrust::use_default,
+                           System,
+                           thrust::use_default,
+                           tabulate_output_iterator_proxy<BinaryFunction, DifferenceT>>;
 
 // Register tabulate_output_iterator_proxy with 'is_proxy_reference' from
 // type_traits to enable its use with algorithms.


### PR DESCRIPTION
## Description

Fixes mis-formatted code introduced in https://github.com/NVIDIA/cccl/pull/2282

