### PR TITLE
Cleanup the `<cuda/std/bit>` header

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/clz.h
+++ b/libcudacxx/include/cuda/std/__bit/clz.h
@@ -26,7 +26,7 @@
 
 #if defined(_CCCL_COMPILER_MSVC)
 #  include <intrin.h>
-#endif
+#endif // _CCCL_COMPILER_MSVC
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__bit/countl.h
+++ b/libcudacxx/include/cuda/std/__bit/countl.h
@@ -1,0 +1,120 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___BIT_COUNTL_H
+#define _LIBCUDACXX___BIT_COUNTL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__bit/clz.h>
+#include <cuda/std/__bit/rotate.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_unsigned_integer.h>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// Forward decl for recursive use in split word operations
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countl_zero(_Tp __t) noexcept;
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
+__countl_zero_dispatch(_Tp __t) noexcept
+{
+  return __libcpp_clz(static_cast<uint32_t>(__t)) - (numeric_limits<uint32_t>::digits - numeric_limits<_Tp>::digits);
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
+__countl_zero_dispatch(_Tp __t) noexcept
+{
+  return __libcpp_clz(static_cast<uint64_t>(__t)) - (numeric_limits<uint64_t>::digits - numeric_limits<_Tp>::digits);
+}
+
+template <typename _Tp, int _St = sizeof(_Tp) / sizeof(uint64_t)>
+struct __countl_zero_rotl_impl
+{
+  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __short_circuit(_Tp __t, int __cur)
+  {
+    // This stops processing early if the current word is not empty
+    return (__cur == numeric_limits<uint64_t>::digits)
+           ? __cur + __countl_zero_rotl_impl<_Tp, _St - 1>::__count(__t)
+           : __cur;
+  }
+
+  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __countl_iter(_Tp __t)
+  {
+    // After rotating pass result of clz to another step for processing
+    return __short_circuit(__t, __countl_zero(static_cast<uint64_t>(__t)));
+  }
+
+  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t)
+  {
+    return __countl_iter(__rotl(__t, numeric_limits<uint64_t>::digits));
+  }
+};
+
+template <typename _Tp>
+struct __countl_zero_rotl_impl<_Tp, 1>
+{
+  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t)
+  {
+    return __countl_zero(static_cast<uint64_t>(__rotl(__t, numeric_limits<uint64_t>::digits)));
+  }
+};
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
+__countl_zero_dispatch(_Tp __t) noexcept
+{
+  return __countl_zero_rotl_impl<_Tp>::__count(__t);
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countl_zero(_Tp __t) noexcept
+{
+  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countl_zero requires unsigned");
+  return __t ? __countl_zero_dispatch(__t) : numeric_limits<_Tp>::digits;
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countl_one(_Tp __t) noexcept
+{
+  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countl_one requires unsigned");
+  return __t != numeric_limits<_Tp>::max() ? __countl_zero(static_cast<_Tp>(~__t)) : numeric_limits<_Tp>::digits;
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+countl_zero(_Tp __t) noexcept
+{
+  return __countl_zero(__t);
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+countl_one(_Tp __t) noexcept
+{
+  return __countl_one(__t);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___BIT_COUNTL_H

--- a/libcudacxx/include/cuda/std/__bit/countr.h
+++ b/libcudacxx/include/cuda/std/__bit/countr.h
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___BIT_COUNTR_H
+#define _LIBCUDACXX___BIT_COUNTR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__bit/ctz.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_unsigned_integer.h>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// Forward decl for recursive use in split word operations
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countr_zero(_Tp __t) noexcept;
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
+__countr_zero_dispatch(_Tp __t) noexcept
+{
+  return __libcpp_ctz(static_cast<uint32_t>(__t));
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
+__countr_zero_dispatch(_Tp __t) noexcept
+{
+  return __libcpp_ctz(static_cast<uint64_t>(__t));
+}
+
+template <typename _Tp, int _St = sizeof(_Tp) / sizeof(uint64_t)>
+struct __countr_zero_rsh_impl
+{
+  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __short_circuit(_Tp __t, int __cur, int __count)
+  {
+    // Stops processing early if non-zero
+    return (__cur == numeric_limits<uint64_t>::digits)
+           ? __countr_zero_rsh_impl<_Tp, _St - 1>::__count(__t, __cur + __count)
+           : __cur + __count;
+  }
+
+  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t, int __count)
+  {
+    return __short_circuit(__t >> numeric_limits<uint64_t>::digits, __countr_zero(static_cast<uint64_t>(__t)), __count);
+  }
+};
+
+template <typename _Tp>
+struct __countr_zero_rsh_impl<_Tp, 1>
+{
+  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t, int __count)
+  {
+    return __count + __countr_zero(static_cast<uint64_t>(__t));
+  }
+};
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
+__countr_zero_dispatch(_Tp __t) noexcept
+{
+  return __countr_zero_rsh_impl<_Tp>::__count(__t, 0);
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countr_zero(_Tp __t) noexcept
+{
+  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countr_zero requires unsigned");
+
+  return __t ? __countr_zero_dispatch(__t) : numeric_limits<_Tp>::digits;
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countr_one(_Tp __t) noexcept
+{
+  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countr_one requires unsigned");
+  return __t != numeric_limits<_Tp>::max() ? __countr_zero(static_cast<_Tp>(~__t)) : numeric_limits<_Tp>::digits;
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+countr_zero(_Tp __t) noexcept
+{
+  return __countr_zero(__t);
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+countr_one(_Tp __t) noexcept
+{
+  return __countr_one(__t);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___BIT_COUNTR_H

--- a/libcudacxx/include/cuda/std/__bit/ctz.h
+++ b/libcudacxx/include/cuda/std/__bit/ctz.h
@@ -26,7 +26,7 @@
 
 #if defined(_CCCL_COMPILER_MSVC)
 #  include <intrin.h>
-#endif
+#endif // _CCCL_COMPILER_MSVC
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__bit/endian.h
+++ b/libcudacxx/include/cuda/std/__bit/endian.h
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___BIT_ENDIAN_H
+#define _LIBCUDACXX___BIT_ENDIAN_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+enum class endian
+{
+  little = 0xDEAD,
+  big    = 0xFACE,
+#if defined(_LIBCUDACXX_LITTLE_ENDIAN)
+  native = little
+#elif defined(_LIBCUDACXX_BIG_ENDIAN)
+  native = big
+#else
+  native = 0xCAFE
+#endif
+};
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___BIT_ENDIAN_H

--- a/libcudacxx/include/cuda/std/__bit/has_single_bit.h
+++ b/libcudacxx/include/cuda/std/__bit/has_single_bit.h
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___BIT_HAS_SINGLE_BIT_H
+#define _LIBCUDACXX___BIT_HAS_SINGLE_BIT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_unsigned_integer.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr bool __has_single_bit(_Tp __t) noexcept
+{
+  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__has_single_bit requires unsigned");
+  return __t != 0 && (((__t & (__t - 1)) == 0));
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, bool>
+has_single_bit(_Tp __t) noexcept
+{
+  return __has_single_bit(__t);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___BIT_HAS_SINGLE_BIT_H

--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___BIT_INTEGRAL_H
+#define _LIBCUDACXX___BIT_INTEGRAL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__bit/countl.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_unsigned_integer.h>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr uint32_t __bit_log2(_Tp __t) noexcept
+{
+  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__bit_log2 requires unsigned");
+  return numeric_limits<_Tp>::digits - 1 - __countl_zero(__t);
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) >= sizeof(uint32_t), _Tp> __ceil2(_Tp __t) noexcept
+{
+  return _Tp{1} << (numeric_limits<_Tp>::digits - __countl_zero((_Tp) (__t - 1u)));
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) < sizeof(uint32_t), _Tp> __ceil2(_Tp __t) noexcept
+{
+  return (_Tp) ((1u << ((numeric_limits<_Tp>::digits - __countl_zero((_Tp) (__t - 1u)))
+                        + (numeric_limits<unsigned>::digits - numeric_limits<_Tp>::digits)))
+                >> (numeric_limits<unsigned>::digits - numeric_limits<_Tp>::digits));
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
+bit_floor(_Tp __t) noexcept
+{
+  return __t == 0 ? 0 : static_cast<_Tp>(_Tp{1} << __bit_log2(__t));
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
+bit_ceil(_Tp __t) noexcept
+{
+  return (__t < 2) ? 1 : static_cast<_Tp>(__ceil2(__t));
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
+bit_width(_Tp __t) noexcept
+{
+  return __t == 0 ? 0 : static_cast<_Tp>(__bit_log2(__t) + 1);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___BIT_INTEGRAL_H

--- a/libcudacxx/include/cuda/std/__bit/popc.h
+++ b/libcudacxx/include/cuda/std/__bit/popc.h
@@ -26,7 +26,7 @@
 
 #if defined(_CCCL_COMPILER_MSVC)
 #  include <intrin.h>
-#endif
+#endif // _CCCL_COMPILER_MSVC
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__bit/popcount.h
+++ b/libcudacxx/include/cuda/std/__bit/popcount.h
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___BIT_POPCOUNT_H
+#define _LIBCUDACXX___BIT_POPCOUNT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__bit/popc.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_unsigned_integer.h>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
+__popcount_dispatch(_Tp __t) noexcept
+{
+  return __libcpp_popc(static_cast<uint32_t>(__t));
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
+__popcount_dispatch(_Tp __t) noexcept
+{
+  return __libcpp_popc(static_cast<uint64_t>(__t));
+}
+
+template <typename _Tp, int _St = sizeof(_Tp) / sizeof(uint64_t)>
+struct __popcount_rsh_impl
+{
+  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t)
+  {
+    return __popcount_rsh_impl<_Tp, _St - 1>::__count(__t >> numeric_limits<uint64_t>::digits)
+         + __libcpp_popc(static_cast<uint64_t>(__t));
+  }
+};
+
+template <typename _Tp>
+struct __popcount_rsh_impl<_Tp, 1>
+{
+  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t)
+  {
+    return __libcpp_popc(static_cast<uint64_t>(__t));
+  }
+};
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
+__popcount_dispatch(_Tp __t) noexcept
+{
+  return __popcount_rsh_impl<_Tp>::__count(__t);
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr int __popcount(_Tp __t) noexcept
+{
+  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__libcpp_popcount requires unsigned");
+
+  return __popcount_dispatch(__t);
+}
+
+template <class _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+popcount(_Tp __t) noexcept
+{
+  return __popcount(__t);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___BIT_POPCOUNT_H

--- a/libcudacxx/include/cuda/std/__bit/reference.h
+++ b/libcudacxx/include/cuda/std/__bit/reference.h
@@ -23,11 +23,8 @@
 #include <cuda/std/__algorithm/copy_n.h>
 #include <cuda/std/__algorithm/fill_n.h>
 #include <cuda/std/__algorithm/min.h>
-// TODO: modularize bit a bit
-#include <cuda/std/bit>
-// #include <cuda/std/__bit/countr.h>
-// #include <cuda/std/__bit/invert_if.h>
-// #include <cuda/std/__bit/popcount.h>
+#include <cuda/std/__bit/countr.h>
+#include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__memory/construct_at.h>
 #include <cuda/std/__memory/pointer_traits.h>

--- a/libcudacxx/include/cuda/std/__bit/rotate.h
+++ b/libcudacxx/include/cuda/std/__bit/rotate.h
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___BIT_ROTATE_H
+#define _LIBCUDACXX___BIT_ROTATE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_unsigned_integer.h>
+#include <cuda/std/limits>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Tp>
+_CCCL_NODISCARD _LIBCUDACXX_INLINE_VISIBILITY constexpr _Tp __rotl(_Tp __t, unsigned int __cnt) noexcept
+{
+  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__rotl requires unsigned");
+  using __nlt = numeric_limits<_Tp>;
+
+  return ((__cnt % __nlt::digits) == 0)
+         ? __t
+         : (__t << (__cnt % __nlt::digits)) | (__t >> (__nlt::digits - (__cnt % __nlt::digits)));
+}
+
+template <class _Tp>
+_CCCL_NODISCARD _LIBCUDACXX_INLINE_VISIBILITY constexpr _Tp __rotr(_Tp __t, unsigned int __cnt) noexcept
+{
+  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__rotr requires unsigned");
+  using __nlt = numeric_limits<_Tp>;
+
+  return ((__cnt % __nlt::digits) == 0)
+         ? __t
+         : (__t >> (__cnt % __nlt::digits)) | (__t << (__nlt::digits - (__cnt % __nlt::digits)));
+}
+
+template <class _Tp>
+_CCCL_NODISCARD _LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
+rotl(_Tp __t, unsigned int __cnt) noexcept
+{
+  return __rotl(__t, __cnt);
+}
+
+// rotr
+template <class _Tp>
+_CCCL_NODISCARD _LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
+rotr(_Tp __t, unsigned int __cnt) noexcept
+{
+  return __rotr(__t, __cnt);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___BIT_ROTATE_H

--- a/libcudacxx/include/cuda/std/bit
+++ b/libcudacxx/include/cuda/std/bit
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__bit/bit_cast.h>
 #include <cuda/std/__bit/clz.h>
+#include <cuda/std/__bit/countl.h>
 #include <cuda/std/__bit/countr.h>
 #include <cuda/std/__bit/ctz.h>
 #include <cuda/std/__bit/endian.h>
@@ -44,77 +45,6 @@ _CCCL_PUSH_MACROS
 #endif // _CCCL_COMPILER_IBM
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-// Forward decl for recursive use in split word operations
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countl_zero(_Tp __t) noexcept;
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
-__countl_zero_dispatch(_Tp __t) noexcept
-{
-  return __libcpp_clz(static_cast<uint32_t>(__t)) - (numeric_limits<uint32_t>::digits - numeric_limits<_Tp>::digits);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
-__countl_zero_dispatch(_Tp __t) noexcept
-{
-  return __libcpp_clz(static_cast<uint64_t>(__t)) - (numeric_limits<uint64_t>::digits - numeric_limits<_Tp>::digits);
-}
-
-template <typename _Tp, int _St = sizeof(_Tp) / sizeof(uint64_t)>
-struct __countl_zero_rotl_impl
-{
-  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __short_circuit(_Tp __t, int __cur)
-  {
-    // This stops processing early if the current word is not empty
-    return (__cur == numeric_limits<uint64_t>::digits)
-           ? __cur + __countl_zero_rotl_impl<_Tp, _St - 1>::__count(__t)
-           : __cur;
-  }
-
-  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __countl_iter(_Tp __t)
-  {
-    // After rotating pass result of clz to another step for processing
-    return __short_circuit(__t, __countl_zero(static_cast<uint64_t>(__t)));
-  }
-
-  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t)
-  {
-    return __countl_iter(__rotl(__t, numeric_limits<uint64_t>::digits));
-  }
-};
-
-template <typename _Tp>
-struct __countl_zero_rotl_impl<_Tp, 1>
-{
-  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t)
-  {
-    return __countl_zero(static_cast<uint64_t>(__rotl(__t, numeric_limits<uint64_t>::digits)));
-  }
-};
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
-__countl_zero_dispatch(_Tp __t) noexcept
-{
-  return __countl_zero_rotl_impl<_Tp>::__count(__t);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countl_zero(_Tp __t) noexcept
-{
-  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countl_zero requires unsigned");
-  return __t ? __countl_zero_dispatch(__t) : numeric_limits<_Tp>::digits;
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countl_one(_Tp __t) noexcept
-{
-  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countl_one requires unsigned");
-  return __t != numeric_limits<_Tp>::max() ? __countl_zero(static_cast<_Tp>(~__t)) : numeric_limits<_Tp>::digits;
-}
 
 template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
@@ -184,20 +114,6 @@ _LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) < sizeof(uint3
   return (_Tp) ((1u << ((numeric_limits<_Tp>::digits - __countl_zero((_Tp) (__t - 1u)))
                         + (numeric_limits<unsigned>::digits - numeric_limits<_Tp>::digits)))
                 >> (numeric_limits<unsigned>::digits - numeric_limits<_Tp>::digits));
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
-countl_zero(_Tp __t) noexcept
-{
-  return __countl_zero(__t);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
-countl_one(_Tp __t) noexcept
-{
-  return __countl_one(__t);
 }
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/bit
+++ b/libcudacxx/include/cuda/std/bit
@@ -22,34 +22,14 @@
 #endif // no system header
 
 #include <cuda/std/__bit/bit_cast.h>
-#include <cuda/std/__bit/clz.h>
 #include <cuda/std/__bit/countl.h>
 #include <cuda/std/__bit/countr.h>
-#include <cuda/std/__bit/ctz.h>
 #include <cuda/std/__bit/endian.h>
 #include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/__bit/integral.h>
-#include <cuda/std/__bit/popc.h>
 #include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__bit/rotate.h>
-#include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/is_unsigned_integer.h>
-#include <cuda/std/cstdint>
 #include <cuda/std/detail/libcxx/include/__assert> // all public C++ headers provide the assertion handler
-#include <cuda/std/detail/libcxx/include/__debug>
-#include <cuda/std/limits>
 #include <cuda/std/version>
-
-_CCCL_PUSH_MACROS
-
-#if defined(_CCCL_COMPILER_IBM)
-#  include <cuda/std/detail/libcxx/include/support/ibm/support.h>
-#endif // _CCCL_COMPILER_IBM
-
-_LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-_LIBCUDACXX_END_NAMESPACE_STD
-
-_CCCL_POP_MACROS
 
 #endif // _CUDA_STD_BIT

--- a/libcudacxx/include/cuda/std/bit
+++ b/libcudacxx/include/cuda/std/bit
@@ -24,6 +24,7 @@
 #include <cuda/std/__bit/bit_cast.h>
 #include <cuda/std/__bit/clz.h>
 #include <cuda/std/__bit/ctz.h>
+#include <cuda/std/__bit/endian.h>
 #include <cuda/std/__bit/popc.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_unsigned_integer.h>
@@ -354,19 +355,6 @@ bit_width(_Tp __t) noexcept
 {
   return __t == 0 ? 0 : static_cast<_Tp>(__bit_log2(__t) + 1);
 }
-
-enum class endian
-{
-  little = 0xDEAD,
-  big    = 0xFACE,
-#if defined(_LIBCUDACXX_LITTLE_ENDIAN)
-  native = little
-#elif defined(_LIBCUDACXX_BIG_ENDIAN)
-  native = big
-#else
-  native = 0xCAFE
-#endif
-};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/bit
+++ b/libcudacxx/include/cuda/std/bit
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__bit/bit_cast.h>
 #include <cuda/std/__bit/clz.h>
+#include <cuda/std/__bit/countr.h>
 #include <cuda/std/__bit/ctz.h>
 #include <cuda/std/__bit/endian.h>
 #include <cuda/std/__bit/has_single_bit.h>
@@ -43,65 +44,6 @@ _CCCL_PUSH_MACROS
 #endif // _CCCL_COMPILER_IBM
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-// Forward decl for recursive use in split word operations
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countr_zero(_Tp __t) noexcept;
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
-__countr_zero_dispatch(_Tp __t) noexcept
-{
-  return __libcpp_ctz(static_cast<uint32_t>(__t));
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
-__countr_zero_dispatch(_Tp __t) noexcept
-{
-  return __libcpp_ctz(static_cast<uint64_t>(__t));
-}
-
-template <typename _Tp, int _St = sizeof(_Tp) / sizeof(uint64_t)>
-struct __countr_zero_rsh_impl
-{
-  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __short_circuit(_Tp __t, int __cur, int __count)
-  {
-    // Stops processing early if non-zero
-    return (__cur == numeric_limits<uint64_t>::digits)
-           ? __countr_zero_rsh_impl<_Tp, _St - 1>::__count(__t, __cur + __count)
-           : __cur + __count;
-  }
-
-  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t, int __count)
-  {
-    return __short_circuit(__t >> numeric_limits<uint64_t>::digits, __countr_zero(static_cast<uint64_t>(__t)), __count);
-  }
-};
-
-template <typename _Tp>
-struct __countr_zero_rsh_impl<_Tp, 1>
-{
-  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t, int __count)
-  {
-    return __count + __countr_zero(static_cast<uint64_t>(__t));
-  }
-};
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
-__countr_zero_dispatch(_Tp __t) noexcept
-{
-  return __countr_zero_rsh_impl<_Tp>::__count(__t, 0);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countr_zero(_Tp __t) noexcept
-{
-  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countr_zero requires unsigned");
-
-  return __t ? __countr_zero_dispatch(__t) : numeric_limits<_Tp>::digits;
-}
 
 // Forward decl for recursive use in split word operations
 template <class _Tp>
@@ -172,13 +114,6 @@ _LIBCUDACXX_INLINE_VISIBILITY constexpr int __countl_one(_Tp __t) noexcept
 {
   static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countl_one requires unsigned");
   return __t != numeric_limits<_Tp>::max() ? __countl_zero(static_cast<_Tp>(~__t)) : numeric_limits<_Tp>::digits;
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr int __countr_one(_Tp __t) noexcept
-{
-  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__countr_one requires unsigned");
-  return __t != numeric_limits<_Tp>::max() ? __countr_zero(static_cast<_Tp>(~__t)) : numeric_limits<_Tp>::digits;
 }
 
 template <class _Tp>
@@ -263,20 +198,6 @@ _LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integ
 countl_one(_Tp __t) noexcept
 {
   return __countl_one(__t);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
-countr_zero(_Tp __t) noexcept
-{
-  return __countr_zero(__t);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
-countr_one(_Tp __t) noexcept
-{
-  return __countr_one(__t);
 }
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/bit
+++ b/libcudacxx/include/cuda/std/bit
@@ -26,6 +26,7 @@
 #include <cuda/std/__bit/ctz.h>
 #include <cuda/std/__bit/endian.h>
 #include <cuda/std/__bit/popc.h>
+#include <cuda/std/__bit/rotate.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_unsigned_integer.h>
 #include <cuda/std/cstdint>
@@ -41,28 +42,6 @@ _CCCL_PUSH_MACROS
 #endif // _CCCL_COMPILER_IBM
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr _Tp __rotl(_Tp __t, uint32_t __cnt) noexcept
-{
-  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__rotl requires unsigned");
-  using __nlt = numeric_limits<_Tp>;
-
-  return ((__cnt % __nlt::digits) == 0)
-         ? __t
-         : (__t << (__cnt % __nlt::digits)) | (__t >> (__nlt::digits - (__cnt % __nlt::digits)));
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr _Tp __rotr(_Tp __t, uint32_t __cnt) noexcept
-{
-  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__rotr requires unsigned");
-  using __nlt = numeric_limits<_Tp>;
-
-  return ((__cnt % __nlt::digits) == 0)
-         ? __t
-         : (__t >> (__cnt % __nlt::digits)) | (__t << (__nlt::digits - (__cnt % __nlt::digits)));
-}
 
 // Forward decl for recursive use in split word operations
 template <class _Tp>
@@ -276,21 +255,6 @@ _LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) < sizeof(uint3
   return (_Tp) ((1u << ((numeric_limits<_Tp>::digits - __countl_zero((_Tp) (__t - 1u)))
                         + (numeric_limits<unsigned>::digits - numeric_limits<_Tp>::digits)))
                 >> (numeric_limits<unsigned>::digits - numeric_limits<_Tp>::digits));
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
-rotl(_Tp __t, uint32_t __cnt) noexcept
-{
-  return __rotl(__t, __cnt);
-}
-
-// rotr
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
-rotr(_Tp __t, uint32_t __cnt) noexcept
-{
-  return __rotr(__t, __cnt);
 }
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/bit
+++ b/libcudacxx/include/cuda/std/bit
@@ -28,7 +28,9 @@
 #include <cuda/std/__bit/ctz.h>
 #include <cuda/std/__bit/endian.h>
 #include <cuda/std/__bit/has_single_bit.h>
+#include <cuda/std/__bit/integral.h>
 #include <cuda/std/__bit/popc.h>
+#include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__bit/rotate.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_unsigned_integer.h>
@@ -45,104 +47,6 @@ _CCCL_PUSH_MACROS
 #endif // _CCCL_COMPILER_IBM
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
-__popcount_dispatch(_Tp __t) noexcept
-{
-  return __libcpp_popc(static_cast<uint32_t>(__t));
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
-__popcount_dispatch(_Tp __t) noexcept
-{
-  return __libcpp_popc(static_cast<uint64_t>(__t));
-}
-
-template <typename _Tp, int _St = sizeof(_Tp) / sizeof(uint64_t)>
-struct __popcount_rsh_impl
-{
-  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t)
-  {
-    return __popcount_rsh_impl<_Tp, _St - 1>::__count(__t >> numeric_limits<uint64_t>::digits)
-         + __libcpp_popc(static_cast<uint64_t>(__t));
-  }
-};
-
-template <typename _Tp>
-struct __popcount_rsh_impl<_Tp, 1>
-{
-  static _LIBCUDACXX_INLINE_VISIBILITY constexpr int __count(_Tp __t)
-  {
-    return __libcpp_popc(static_cast<uint64_t>(__t));
-  }
-};
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
-__popcount_dispatch(_Tp __t) noexcept
-{
-  return __popcount_rsh_impl<_Tp>::__count(__t);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr int __popcount(_Tp __t) noexcept
-{
-  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__libcpp_popcount requires unsigned");
-
-  return __popcount_dispatch(__t);
-}
-
-// integral log base 2
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr uint32_t __bit_log2(_Tp __t) noexcept
-{
-  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__bit_log2 requires unsigned");
-  return numeric_limits<_Tp>::digits - 1 - __countl_zero(__t);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) >= sizeof(uint32_t), _Tp> __ceil2(_Tp __t) noexcept
-{
-  return _Tp{1} << (numeric_limits<_Tp>::digits - __countl_zero((_Tp) (__t - 1u)));
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) < sizeof(uint32_t), _Tp> __ceil2(_Tp __t) noexcept
-{
-  return (_Tp) ((1u << ((numeric_limits<_Tp>::digits - __countl_zero((_Tp) (__t - 1u)))
-                        + (numeric_limits<unsigned>::digits - numeric_limits<_Tp>::digits)))
-                >> (numeric_limits<unsigned>::digits - numeric_limits<_Tp>::digits));
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
-popcount(_Tp __t) noexcept
-{
-  return __popcount(__t);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
-bit_floor(_Tp __t) noexcept
-{
-  return __t == 0 ? 0 : static_cast<_Tp>(_Tp{1} << __bit_log2(__t));
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
-bit_ceil(_Tp __t) noexcept
-{
-  return (__t < 2) ? 1 : static_cast<_Tp>(__ceil2(__t));
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
-bit_width(_Tp __t) noexcept
-{
-  return __t == 0 ? 0 : static_cast<_Tp>(__bit_log2(__t) + 1);
-}
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/bit
+++ b/libcudacxx/include/cuda/std/bit
@@ -25,6 +25,7 @@
 #include <cuda/std/__bit/clz.h>
 #include <cuda/std/__bit/ctz.h>
 #include <cuda/std/__bit/endian.h>
+#include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/__bit/popc.h>
 #include <cuda/std/__bit/rotate.h>
 #include <cuda/std/__type_traits/enable_if.h>
@@ -237,13 +238,6 @@ _LIBCUDACXX_INLINE_VISIBILITY constexpr uint32_t __bit_log2(_Tp __t) noexcept
 }
 
 template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr bool __has_single_bit(_Tp __t) noexcept
-{
-  static_assert(__libcpp_is_unsigned_integer<_Tp>::value, "__has_single_bit requires unsigned");
-  return __t != 0 && (((__t & (__t - 1)) == 0));
-}
-
-template <class _Tp>
 _LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<sizeof(_Tp) >= sizeof(uint32_t), _Tp> __ceil2(_Tp __t) noexcept
 {
   return _Tp{1} << (numeric_limits<_Tp>::digits - __countl_zero((_Tp) (__t - 1u)));
@@ -290,13 +284,6 @@ _LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integ
 popcount(_Tp __t) noexcept
 {
   return __popcount(__t);
-}
-
-template <class _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, bool>
-has_single_bit(_Tp __t) noexcept
-{
-  return __has_single_bit(__t);
 }
 
 template <class _Tp>


### PR DESCRIPTION
This moves all functionality within `<cuda/std/bit>` header into individual files and cleanes up the implementation a bit