### PR TITLE
[CUDAX] Add event_ref::is_done() and update event tests

### DIFF
--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -90,6 +90,29 @@ public:
     _CCCL_TRY_CUDA_API(::cudaEventSynchronize, "Failed to wait for CUDA event", __event_);
   }
 
+  //! @brief Checks if all the work in the stream prior to the record of the event has completed.
+  //!
+  //! If is_done returns true, calling wait() on this event will return immediately
+  //!
+  //! @throws cuda_error if the event query fails
+  bool is_done() const
+  {
+    assert(__event_ != nullptr);
+    cudaError_t __status = ::cudaEventQuery(__event_);
+    if (__status == cudaSuccess)
+    {
+      return true;
+    }
+    else if (__status == cudaErrorNotReady)
+    {
+      return false;
+    }
+    else
+    {
+      ::cuda::__throw_cuda_error(__status, "Failed to query CUDA event");
+    }
+  }
+
   //! @brief Retrieve the native `cudaEvent_t` handle.
   //!
   //! @return cudaEvent_t The native handle being held by the event_ref object.

--- a/cudax/include/cuda/experimental/__event/event_ref.cuh
+++ b/cudax/include/cuda/experimental/__event/event_ref.cuh
@@ -95,7 +95,7 @@ public:
   //! If is_done returns true, calling wait() on this event will return immediately
   //!
   //! @throws cuda_error if the event query fails
-  bool is_done() const
+  _CCCL_NODISCARD bool is_done() const
   {
     assert(__event_ != nullptr);
     cudaError_t __status = ::cudaEventQuery(__event_);

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -14,13 +14,11 @@
 #include <catch2/catch.hpp>
 #include <utility.cuh>
 
-constexpr auto one_thread_dims = cudax::make_hierarchy(cudax::block_dims<1>(), cudax::grid_dims<1>());
-
 TEST_CASE("Can create a stream and launch work into it", "[stream]")
 {
   cudax::stream str;
   ::test::managed<int> i(0);
-  cudax::launch(str, one_thread_dims, ::test::assign_42{}, i.get());
+  cudax::launch(str, ::test::one_thread_dims, ::test::assign_42{}, i.get());
   str.wait();
   CUDAX_REQUIRE(*i == 42);
 }
@@ -33,7 +31,7 @@ TEST_CASE("From native handle", "[stream]")
     auto stream = cudax::stream::from_native_handle(handle);
 
     ::test::managed<int> i(0);
-    cudax::launch(stream, one_thread_dims, ::test::assign_42{}, i.get());
+    cudax::launch(stream, ::test::one_thread_dims, ::test::assign_42{}, i.get());
     stream.wait();
     CUDAX_REQUIRE(*i == 42);
     (void) stream.release();
@@ -50,10 +48,10 @@ TEST_CASE("Can add dependency into a stream", "[stream]")
     ::test::managed<int> i(0);
     ::cuda::atomic_ref atomic_i(*i);
 
-    cudax::launch(waitee, one_thread_dims, ::test::spin_until_80{}, i.get());
-    cudax::launch(waitee, one_thread_dims, ::test::assign_42{}, i.get());
+    cudax::launch(waitee, ::test::one_thread_dims, ::test::spin_until_80{}, i.get());
+    cudax::launch(waitee, ::test::one_thread_dims, ::test::assign_42{}, i.get());
     insert_dependency();
-    cudax::launch(waiter, one_thread_dims, ::test::verify_42{}, i.get());
+    cudax::launch(waiter, ::test::one_thread_dims, ::test::verify_42{}, i.get());
     CUDAX_REQUIRE(atomic_i.load() != 42);
     CUDAX_REQUIRE(!waiter.ready());
     atomic_i.store(80);


### PR DESCRIPTION
I think we missed adding an API equivalent to `cudaEventQuery`. This PR adds `cudax::event_ref::is_done(), which checks if a work captured in an event is done. It allows to implement a non-blocking way to pool an event, instead of blocking in wait().

This change also does some small updates to the event testing, which used some test utilities implemented before we had launch/stream in `cudax`.