### PR TITLE
Assure placeholder expressions are semi-regular

### DIFF
--- a/thrust/testing/functional_placeholders_miscellaneous.cu
+++ b/thrust/testing/functional_placeholders_miscellaneous.cu
@@ -91,3 +91,21 @@ void TestFunctionalPlaceholdersArgumentValueCategories()
   ASSERT_EQUAL(expr(::cuda::std::move(a), ::cuda::std::move(b)), 13); // pass x-value
 }
 DECLARE_UNITTEST(TestFunctionalPlaceholdersArgumentValueCategories);
+
+void TestFunctionalPlaceholdersSemiRegular()
+{
+  using namespace thrust::placeholders;
+  using Expr = decltype(_1 * _1 + _2 * _2);
+  Expr expr; // default-constructible
+  ASSERT_EQUAL(expr(2, 3), 13);
+  Expr expr2 = expr; // copy-constructible
+  ASSERT_EQUAL(expr2(2, 3), 13);
+  Expr expr3;
+  expr3 = expr; // copy-assignable
+  ASSERT_EQUAL(expr3(2, 3), 13);
+
+#if _CCCL_STD_VER >= 2014
+  static_assert(::cuda::std::semiregular<Expr>, "");
+#endif // _CCCL_STD_VER >= 2014
+}
+DECLARE_UNITTEST(TestFunctionalPlaceholdersSemiRegular);

--- a/thrust/thrust/detail/functional/actor.h
+++ b/thrust/thrust/detail/functional/actor.h
@@ -102,6 +102,8 @@ struct composite;
 template <typename Eval, typename SubExpr>
 struct composite<Eval, SubExpr>
 {
+  constexpr composite() = default;
+
   // TODO(bgruber): drop ctor and use aggregate initialization in C++17
   _CCCL_HOST_DEVICE composite(const Eval& eval, const SubExpr& subexpr)
       : m_eval(eval)
@@ -123,6 +125,8 @@ private:
 template <typename Eval, typename SubExpr1, typename SubExpr2>
 struct composite<Eval, SubExpr1, SubExpr2>
 {
+  constexpr composite() = default;
+
   // TODO(bgruber): drop ctor and use aggregate initialization in C++17
   _CCCL_HOST_DEVICE composite(const Eval& eval, const SubExpr1& subexpr1, const SubExpr2& subexpr2)
       : m_eval(eval)
@@ -151,6 +155,8 @@ struct actor;
 template <typename F>
 struct operator_adaptor : F
 {
+  constexpr operator_adaptor() = default;
+
   _CCCL_HOST_DEVICE operator_adaptor(F f)
       : F(::cuda::std::move(f))
   {}


### PR DESCRIPTION
Adds a Thrust test and a few default constructors to make placeholder expressions default-constructible, copy-constructible and copy-assignable placeholder. This allows them to be used in more places.