### PR TITLE
Make the thrust dispatch mechanisms configurable

### DIFF
--- a/docs/thrust/cmake_options.rst
+++ b/docs/thrust/cmake_options.rst
@@ -74,9 +74,9 @@ Generic CMake Options
    -  Allows the user to force Thrust to use a specific size for the offset type. Default
       is ``Dynamic``.
 
-      -  ``Dynamic`` lets thrust choose the index type based on input size, allowing
+      -  ``Dynamic`` lets Thrust choose the index type based on input size, allowing
          large inputs and optimal performance at the cost of increased compile time and binary size
-      -  ``Force32bit`` forces Thrust to use a 32bit offset type. This improves compile time and
+      -  ``Force32bit`` forces Thrust to use a 32 bit offset type. This improves compile time and
          binary size but limits the input size.
       -  ``Force64bit`` forces Thrust to use a 64bit offset type. This improves compile time and
          binary size and allows large input sizes. However, it might degrade runtime performance

--- a/docs/thrust/cmake_options.rst
+++ b/docs/thrust/cmake_options.rst
@@ -73,6 +73,7 @@ Generic CMake Options
 
    -  Allows the user to force Thrust to use a specific size for the offset type. Default
       is ``Dynamic``.
+
       -  ``Dynamic`` lets thrust choose the index type based on input size, allowing
          large inputs and optimal performance at the cost of increased compile time and binary size
       -  ``Force32bit`` forces Thrust to use a 32bit offset type. This improves compile time and

--- a/docs/thrust/cmake_options.rst
+++ b/docs/thrust/cmake_options.rst
@@ -78,8 +78,8 @@ Generic CMake Options
          large inputs and optimal performance at the cost of increased compile time and binary size
       -  ``Force32bit`` forces Thrust to use a 32bit offset type. This improves compile time and
          binary size but limits the input size.
-      -  ``Force32bit`` forces Thrust to use a 64bit offset type. This improves compile time and
-         binary size and allow large input sizes. However, it might degrade runtime performance
+      -  ``Force64bit`` forces Thrust to use a 64bit offset type. This improves compile time and
+         binary size and allows large input sizes. However, it might degrade runtime performance
 
 Single Config CMake Options
 ---------------------------

--- a/docs/thrust/cmake_options.rst
+++ b/docs/thrust/cmake_options.rst
@@ -75,11 +75,12 @@ Generic CMake Options
       is ``Dynamic``.
 
       -  ``Dynamic`` lets Thrust choose the index type based on input size, allowing
-         large inputs and optimal performance at the cost of increased compile time and binary size
+         large inputs and optimal performance at the cost of increased compile time and binary size,
+         as Thrust will compile each kernel twice, once for 32 bit and once for 64 bit.
       -  ``Force32bit`` forces Thrust to use a 32 bit offset type. This improves compile time and
          binary size but limits the input size.
-      -  ``Force64bit`` forces Thrust to use a 64bit offset type. This improves compile time and
-         binary size and allows large input sizes. However, it might degrade runtime performance
+      -  ``Force64bit`` forces Thrust to use a 64 bit offset type. This improves compile time and
+         binary size and allows large input sizes. However, it might degrade runtime performance.
 
 Single Config CMake Options
 ---------------------------

--- a/docs/thrust/cmake_options.rst
+++ b/docs/thrust/cmake_options.rst
@@ -69,6 +69,17 @@ Generic CMake Options
    -  If true, installation rules will be generated for thrust. Default
       is ``ON``.
 
+-  ``THRUST_DISPATCH_TYPE={Dynamic, Force32bit, Force64bit}``
+
+   -  Allows the user to force Thrust to use a specific size for the offset type. Default
+      is ``Dynamic``.
+      -  ``Dynamic`` lets thrust choose the index type based on input size, allowing
+         large inputs and optimal performance at the cost of increased compile time and binary size
+      -  ``Force32bit`` forces Thrust to use a 32bit offset type. This improves compile time and
+         binary size but limits the input size.
+      -  ``Force32bit`` forces Thrust to use a 64bit offset type. This improves compile time and
+         binary size and allow large input sizes. However, it might degrade runtime performance
+
 Single Config CMake Options
 ---------------------------
 

--- a/thrust/CMakeLists.txt
+++ b/thrust/CMakeLists.txt
@@ -59,15 +59,9 @@ option(THRUST_ENABLE_TESTING "Build Thrust testing suite." "ON")
 option(THRUST_ENABLE_EXAMPLES "Build Thrust examples." "ON")
 option(THRUST_ENABLE_BENCHMARKS "Build Thrust runtime benchmarks." "${CCCL_ENABLE_BENCHMARKS}")
 
-# Force the offset type to 32bit. Improves compile times and binary size at the expense of limiting input sizes
-option(THRUST_FORCE_32BIT_OFFSET_TYPE "Requires thrust to use 32 bit offset types." "OFF")
-
-# Force the offset type to 64bit. Improves compile times and binary size potentially degrading runtime performance
-option(THRUST_FORCE_64BIT_OFFSET_TYPE "Requires thrust to use 64 bit offset types." "OFF")
-
-if (THRUST_FORCE_32BIT_OFFSET_TYPE AND THRUST_FORCE_64BIT_OFFSET_TYPE)
-  message(FATAL_ERROR "Only THRUST_FORCE_32BIT_OFFSET_TYPE or THRUST_FORCE_64BIT_OFFSET_TYPE may be defined!")
-endif()
+# Allow the user to optionally select offset type dispatch to fixed 32 or 64 bit types
+set(THRUST_DISPATCH_TYPE "Dynamic" CACHE STRING "Select thrust offset type dispatch." FORCE)
+set_property(CACHE THRUST_DISPATCH_TYPE PROPERTY STRINGS "Dynamic" "Force32bit" "Force64bit")
 
 # Check if we're actually building anything before continuing. If not, no need
 # to search for deps, etc. This is a common approach for packagers that just

--- a/thrust/CMakeLists.txt
+++ b/thrust/CMakeLists.txt
@@ -59,6 +59,16 @@ option(THRUST_ENABLE_TESTING "Build Thrust testing suite." "ON")
 option(THRUST_ENABLE_EXAMPLES "Build Thrust examples." "ON")
 option(THRUST_ENABLE_BENCHMARKS "Build Thrust runtime benchmarks." "${CCCL_ENABLE_BENCHMARKS}")
 
+# Force the offset type to 32bit. Improves compile times and binary size at the expense of limiting input sizes
+option(THRUST_FORCE_32BIT_OFFSET_TYPE "Requires thrust to use 32 bit offset types." "OFF")
+
+# Force the offset type to 64bit. Improves compile times and binary size potentially degrading runtime performance
+option(THRUST_FORCE_64BIT_OFFSET_TYPE "Requires thrust to use 64 bit offset types." "OFF")
+
+if (THRUST_FORCE_32BIT_OFFSET_TYPE AND THRUST_FORCE_64BIT_OFFSET_TYPE)
+  message(FATAL_ERROR "Only THRUST_FORCE_32BIT_OFFSET_TYPE or THRUST_FORCE_64BIT_OFFSET_TYPE may be defined!")
+endif()
+
 # Check if we're actually building anything before continuing. If not, no need
 # to search for deps, etc. This is a common approach for packagers that just
 # need the install rules. See GH issue NVIDIA/thrust#1211.

--- a/thrust/CMakeLists.txt
+++ b/thrust/CMakeLists.txt
@@ -60,7 +60,7 @@ option(THRUST_ENABLE_EXAMPLES "Build Thrust examples." "ON")
 option(THRUST_ENABLE_BENCHMARKS "Build Thrust runtime benchmarks." "${CCCL_ENABLE_BENCHMARKS}")
 
 # Allow the user to optionally select offset type dispatch to fixed 32 or 64 bit types
-set(THRUST_DISPATCH_TYPE "Dynamic" CACHE STRING "Select thrust offset type dispatch." FORCE)
+set(THRUST_DISPATCH_TYPE "Dynamic" CACHE STRING "Select Thrust offset type dispatch." FORCE)
 set_property(CACHE THRUST_DISPATCH_TYPE PROPERTY STRINGS "Dynamic" "Force32bit" "Force64bit")
 
 # Check if we're actually building anything before continuing. If not, no need

--- a/thrust/cmake/ThrustBuildCompilerTargets.cmake
+++ b/thrust/cmake/ThrustBuildCompilerTargets.cmake
@@ -131,11 +131,9 @@ function(thrust_build_compiler_targets)
     )
   endforeach()
 
-  if (THRUST_FORCE_32BIT_OFFSET_TYPE)
+  if (THRUST_DISPATCH_TYPE STREQUAL "Force32bit")
     list(APPEND cxx_compile_definitions "THRUST_FORCE_32BIT_OFFSET_TYPE")
-  endif()
-
-  if (THRUST_FORCE_64BIT_OFFSET_TYPE)
+  elseif (THRUST_DISPATCH_TYPE STREQUAL "Force64bit")
     list(APPEND cxx_compile_definitions "THRUST_FORCE_64BIT_OFFSET_TYPE")
   endif()
 

--- a/thrust/cmake/ThrustBuildCompilerTargets.cmake
+++ b/thrust/cmake/ThrustBuildCompilerTargets.cmake
@@ -131,6 +131,14 @@ function(thrust_build_compiler_targets)
     )
   endforeach()
 
+  if (THRUST_FORCE_32BIT_OFFSET_TYPE)
+    list(APPEND cxx_compile_definitions "THRUST_FORCE_32BIT_OFFSET_TYPE")
+  endif()
+
+  if (THRUST_FORCE_64BIT_OFFSET_TYPE)
+    list(APPEND cxx_compile_definitions "THRUST_FORCE_64BIT_OFFSET_TYPE")
+  endif()
+
   foreach (cxx_definition IN LISTS cxx_compile_definitions)
     # Add these for both CUDA and CXX targets:
     target_compile_definitions(thrust.compiler_interface INTERFACE

--- a/thrust/cmake/ThrustBuildCompilerTargets.cmake
+++ b/thrust/cmake/ThrustBuildCompilerTargets.cmake
@@ -132,9 +132,9 @@ function(thrust_build_compiler_targets)
   endforeach()
 
   if (THRUST_DISPATCH_TYPE STREQUAL "Force32bit")
-    list(APPEND cxx_compile_definitions "THRUST_FORCE_32BIT_OFFSET_TYPE")
+    list(APPEND cxx_compile_definitions "THRUST_FORCE_32_BIT_OFFSET_TYPE")
   elseif (THRUST_DISPATCH_TYPE STREQUAL "Force64bit")
-    list(APPEND cxx_compile_definitions "THRUST_FORCE_64BIT_OFFSET_TYPE")
+    list(APPEND cxx_compile_definitions "THRUST_FORCE_64_BIT_OFFSET_TYPE")
   endif()
 
   foreach (cxx_definition IN LISTS cxx_compile_definitions)

--- a/thrust/cmake/ThrustHeaderTesting.cmake
+++ b/thrust/cmake/ThrustHeaderTesting.cmake
@@ -150,13 +150,13 @@ foreach(thrust_target IN LISTS THRUST_TARGETS)
   set(header_definitions
     "THRUST_WRAPPED_NAMESPACE=wrapped_thrust"
     "CUB_WRAPPED_NAMESPACE=wrapped_cub"
-    "THRUST_FORCE_32BIT_OFFSET_TYPE")
+    "THRUST_FORCE_32_BIT_OFFSET_TYPE")
   thrust_add_header_test(${thrust_target} offset_32 "${header_definitions}")
 
   set(header_definitions
     "THRUST_WRAPPED_NAMESPACE=wrapped_thrust"
     "CUB_WRAPPED_NAMESPACE=wrapped_cub"
-    "THRUST_FORCE_64BIT_OFFSET_TYPE")
+    "THRUST_FORCE_64_BIT_OFFSET_TYPE")
   thrust_add_header_test(${thrust_target} offset_64 "${header_definitions}")
 
   thrust_get_target_property(config_device ${thrust_target} DEVICE)

--- a/thrust/cmake/ThrustHeaderTesting.cmake
+++ b/thrust/cmake/ThrustHeaderTesting.cmake
@@ -146,6 +146,19 @@ foreach(thrust_target IN LISTS THRUST_TARGETS)
     "CUB_WRAPPED_NAMESPACE=wrapped_cub")
   thrust_add_header_test(${thrust_target} base "${header_definitions}")
 
+  # We need to ensure that the different dispatch mechanisms work
+  set(header_definitions
+    "THRUST_WRAPPED_NAMESPACE=wrapped_thrust"
+    "CUB_WRAPPED_NAMESPACE=wrapped_cub"
+    "THRUST_FORCE_32BIT_OFFSET_TYPE")
+  thrust_add_header_test(${thrust_target} offset_32 "${header_definitions}")
+
+  set(header_definitions
+    "THRUST_WRAPPED_NAMESPACE=wrapped_thrust"
+    "CUB_WRAPPED_NAMESPACE=wrapped_cub"
+    "THRUST_FORCE_64BIT_OFFSET_TYPE")
+  thrust_add_header_test(${thrust_target} offset_64 "${header_definitions}")
+
   thrust_get_target_property(config_device ${thrust_target} DEVICE)
   if ("CUDA" STREQUAL "${config_device}")
     # Check that BF16 support can be disabled

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -77,7 +77,12 @@
     if (static_cast<std::uint64_t>(count)                                                    \
         > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max)) \
     {                                                                                        \
-      throw ::std::runtime_error("Offset type overflow");                                    \
+      throw ::std::runtime_error(                                                            \
+        "Input size exceeds the maximum allowable value for " #index_type                    \
+        " (" + std::to_string(thrust::detail::integer_traits<index_type>::const_max) + "). " \
+        #index_type " was used because the macro THRUST_FORCE_32BIT_OFFSET_TYPE was defined. "\
+        "To handle larger input sizes, either remove this macro to dynamically dispatch "    \
+        "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE.")
     }
 
 //! @brief Ensures that the sizes of the inputs do not overflow the offset type, but two counts
@@ -85,7 +90,12 @@
     if (static_cast<std::uint64_t>(count1) + static_cast<std::uint64_t>(count2)              \
         > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max)) \
     {                                                                                        \
-      throw ::std::runtime_error("Offset type overflow");                                    \
+      throw ::std::runtime_error(                                                            \
+        "Combined input sizes exceed the maximum allowable value for " #index_type           \
+        " (" + std::to_string(thrust::detail::integer_traits<index_type>::const_max) + "). " \
+        #index_type " was used because the macro THRUST_FORCE_32BIT_OFFSET_TYPE was defined. "\
+        "To handle larger input sizes, either remove this macro to dynamically dispatch "    \
+        "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE."); \```
     }
 
 //! @brief Always dispatches to 32 bit offset version of an algorithm but throws if count would overflow

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -35,9 +35,9 @@
 #include <stdexcept>
 #include <string>
 
-#if defined(THRUST_FORCE_32BIT_OFFSET_TYPE) && defined(THRUST_FORCE_64BIT_OFFSET_TYPE)
-#  error "Only THRUST_FORCE_32BIT_OFFSET_TYPE or THRUST_FORCE_64BIT_OFFSET_TYPE may be defined!"
-#endif // THRUST_FORCE_32BIT_OFFSET_TYPE && THRUST_FORCE_64BIT_OFFSET_TYPE
+#if defined(THRUST_FORCE_32_BIT_OFFSET_TYPE) && defined(THRUST_FORCE_64_BIT_OFFSET_TYPE)
+#  error "Only THRUST_FORCE_32_BIT_OFFSET_TYPE or THRUST_FORCE_64_BIT_OFFSET_TYPE may be defined!"
+#endif // THRUST_FORCE_32_BIT_OFFSET_TYPE && THRUST_FORCE_64_BIT_OFFSET_TYPE
 
 #define _THRUST_INDEX_TYPE_DISPATCH(index_type, status, call, count, arguments) \
   {                                                                             \
@@ -71,7 +71,7 @@
     }                                                                                                           \
   }
 
-#if defined(THRUST_FORCE_64BIT_OFFSET_TYPE)
+#if defined(THRUST_FORCE_64_BIT_OFFSET_TYPE)
 //! @brief Always dispatches to 64 bit offset version of an algorithm
 #  define THRUST_INDEX_TYPE_DISPATCH(status, call, count, arguments) \
     _THRUST_INDEX_TYPE_DISPATCH_GUARD_UNDERFLOW(count)               \
@@ -97,32 +97,32 @@
     _THRUST_INDEX_TYPE_DISPATCH_GUARD_UNDERFLOW(count)                                     \
     _THRUST_INDEX_TYPE_DISPATCH(std::uint64_t, status, call_64, count, arguments)
 
-#elif defined(THRUST_FORCE_32BIT_OFFSET_TYPE)
+#elif defined(THRUST_FORCE_32_BIT_OFFSET_TYPE)
 
 //! @brief Ensures that the size of the input does not overflow the offset type
-#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(index_type, count)                                \
-    if (static_cast<std::uint64_t>(count)                                                              \
-        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))           \
-    {                                                                                                  \
-      throw ::std::runtime_error(                                                                      \
-        "Input size exceeds the maximum allowable value for " #index_type " ("                         \
-        + std::to_string(thrust::detail::integer_traits<index_type>::const_max)                        \
-        + "). " #index_type " was used because the macro THRUST_FORCE_32BIT_OFFSET_TYPE was defined. " \
-          "To handle larger input sizes, either remove this macro to dynamically dispatch "            \
-          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE.");         \
+#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(index_type, count)                                 \
+    if (static_cast<std::uint64_t>(count)                                                               \
+        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))            \
+    {                                                                                                   \
+      throw ::std::runtime_error(                                                                       \
+        "Input size exceeds the maximum allowable value for " #index_type " ("                          \
+        + std::to_string(thrust::detail::integer_traits<index_type>::const_max)                         \
+        + "). " #index_type " was used because the macro THRUST_FORCE_32_BIT_OFFSET_TYPE was defined. " \
+          "To handle larger input sizes, either remove this macro to dynamically dispatch "             \
+          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64_BIT_OFFSET_TYPE.");         \
     }
 
 //! @brief Ensures that the sizes of the inputs do not overflow the offset type, but two counts
-#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW2(index_type, count1, count2)                      \
-    if (static_cast<std::uint64_t>(count1) + static_cast<std::uint64_t>(count2)                        \
-        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))           \
-    {                                                                                                  \
-      throw ::std::runtime_error(                                                                      \
-        "Combined input sizes exceed the maximum allowable value for " #index_type " ("                \
-        + std::to_string(thrust::detail::integer_traits<index_type>::const_max)                        \
-        + "). " #index_type " was used because the macro THRUST_FORCE_32BIT_OFFSET_TYPE was defined. " \
-          "To handle larger input sizes, either remove this macro to dynamically dispatch "            \
-          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE.");         \
+#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW2(index_type, count1, count2)                       \
+    if (static_cast<std::uint64_t>(count1) + static_cast<std::uint64_t>(count2)                         \
+        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))            \
+    {                                                                                                   \
+      throw ::std::runtime_error(                                                                       \
+        "Combined input sizes exceed the maximum allowable value for " #index_type " ("                 \
+        + std::to_string(thrust::detail::integer_traits<index_type>::const_max)                         \
+        + "). " #index_type " was used because the macro THRUST_FORCE_32_BIT_OFFSET_TYPE was defined. " \
+          "To handle larger input sizes, either remove this macro to dynamically dispatch "             \
+          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64_BIT_OFFSET_TYPE.");         \
     }
 
 //! @brief Always dispatches to 32 bit offset version of an algorithm but throws if count would overflow
@@ -155,7 +155,7 @@
     _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(std::uint32_t, count)                       \
     _THRUST_INDEX_TYPE_DISPATCH(std::uint32_t, status, call_32, count, arguments)
 
-#else // ^^^ THRUST_FORCE_32BIT_OFFSET_TYPE ^^^ / vvv !THRUST_FORCE_32BIT_OFFSET_TYPE vvv
+#else // ^^^ THRUST_FORCE_32_BIT_OFFSET_TYPE ^^^ / vvv !THRUST_FORCE_32_BIT_OFFSET_TYPE vvv
 
 #  define _THRUST_INDEX_TYPE_DISPATCH_SELECT(index_type, count) \
     (static_cast<std::uint64_t>(count)                          \
@@ -218,4 +218,4 @@
     else                                                                                   \
       _THRUST_INDEX_TYPE_DISPATCH(std::uint64_t, status, call_64, count, arguments)
 
-#endif // !THRUST_FORCE_32BIT_OFFSET_TYPE
+#endif // !THRUST_FORCE_32_BIT_OFFSET_TYPE

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -30,92 +30,145 @@
 #include <thrust/detail/preprocessor.h>
 
 #include <cstdint>
+#include <stdexcept>
 
-/**
- * Dispatch between 32-bit and 64-bit index based versions of the same algorithm implementation. This version assumes
- * that callables for both branches consist of the same tokens, and is intended to be used with Thrust-style dispatch
- * interfaces, that always deduce the size type from the arguments.
- */
-#define THRUST_INDEX_TYPE_DISPATCH(status, call, count, arguments)         \
-  if (count <= thrust::detail::integer_traits<std::int32_t>::const_max)    \
-  {                                                                        \
-    auto THRUST_PP_CAT2(count, _fixed) = static_cast<std::int32_t>(count); \
-    status                             = call arguments;                   \
-  }                                                                        \
-  else                                                                     \
-  {                                                                        \
-    auto THRUST_PP_CAT2(count, _fixed) = static_cast<std::int64_t>(count); \
-    status                             = call arguments;                   \
-  }
+#if defined(THRUST_FORCE_32BIT_OFFSET_TYPE) && defined(THRUST_FORCE_64BIT_OFFSET_TYPE)
+#  error "Only THRUST_FORCE_32BIT_OFFSET_TYPE or THRUST_FORCE_64BIT_OFFSET_TYPE may be defined!"
+#endif // THRUST_FORCE_32BIT_OFFSET_TYPE && THRUST_FORCE_64BIT_OFFSET_TYPE
 
-/**
- * Dispatch between 32-bit and 64-bit index based versions of the same algorithm implementation. This version assumes
- * that callables for both branches consist of the same tokens, and is intended to be used with Thrust-style dispatch
- * interfaces, that always deduce the size type from the arguments.
- *
- * This version of the macro supports providing two count variables, which is necessary for set algorithms.
- */
-#define THRUST_DOUBLE_INDEX_TYPE_DISPATCH(status, call, count1, count2, arguments) \
-  if (count1 + count2 <= thrust::detail::integer_traits<std::int32_t>::const_max)  \
-  {                                                                                \
-    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<std::int32_t>(count1);       \
-    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<std::int32_t>(count2);       \
-    status                              = call arguments;                          \
-  }                                                                                \
-  else                                                                             \
-  {                                                                                \
-    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<std::int64_t>(count1);       \
-    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<std::int64_t>(count2);       \
-    status                              = call arguments;                          \
-  }
-
-/**
- * Dispatch between 32-bit and 64-bit index based versions of the same algorithm implementation. This version allows
- * using different token sequences for callables in both branches, and is intended to be used with CUB-style dispatch
- * interfaces, where the "simple" interface always forces the size to be `int` (making it harder for us to use), but the
- * complex interface that we end up using doesn't actually provide a way to fully deduce the type from just the call,
- * making the size type appear in the token sequence of the callable.
- *
- * See reduce_n_impl to see an example of how this is meant to be used.
- */
-#define THRUST_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count, arguments) \
-  if (count <= thrust::detail::integer_traits<std::int32_t>::const_max)         \
+#define _THRUST_INDEX_TYPE_DISPATCH(index_type, status, call, count, arguments) \
   {                                                                             \
-    auto THRUST_PP_CAT2(count, _fixed) = static_cast<std::int32_t>(count);      \
-    status                             = call_32 arguments;                     \
-  }                                                                             \
-  else                                                                          \
-  {                                                                             \
-    auto THRUST_PP_CAT2(count, _fixed) = static_cast<std::int64_t>(count);      \
-    status                             = call_64 arguments;                     \
+    auto THRUST_PP_CAT2(count, _fixed) = static_cast<index_type>(count);        \
+    status                             = call arguments;                        \
   }
 
-/// Like \ref THRUST_INDEX_TYPE_DISPATCH2 but dispatching to uint32_t and uint64_t, respectively, depending on the
-/// `count` argument. `count` must not be negative.
-#define THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count, arguments)       \
-  if (static_cast<std::uint64_t>(count)                                                        \
-      <= static_cast<std::uint64_t>(thrust::detail::integer_traits<std::uint32_t>::const_max)) \
-  {                                                                                            \
-    auto THRUST_PP_CAT2(count, _fixed) = static_cast<std::uint32_t>(count);                    \
-    status                             = call_32 arguments;                                    \
-  }                                                                                            \
-  else                                                                                         \
-  {                                                                                            \
-    auto THRUST_PP_CAT2(count, _fixed) = static_cast<std::uint64_t>(count);                    \
-    status                             = call_64 arguments;                                    \
+#define _THRUST_INDEX_TYPE_DISPATCH2(index_type, status, call, count1, count2, arguments) \
+  {                                                                                       \
+    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<index_type>(count1);                \
+    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<index_type>(count2);                \
+    status                              = call arguments;                                 \
   }
 
-/// Like \ref THRUST_INDEX_TYPE_DISPATCH2 but uses two counts.
-#define THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count1, count2, arguments) \
-  if (count1 + count2 <= thrust::detail::integer_traits<std::int32_t>::const_max)               \
-  {                                                                                             \
-    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<std::int32_t>(count1);                    \
-    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<std::int32_t>(count2);                    \
-    status                              = call_32 arguments;                                    \
-  }                                                                                             \
-  else                                                                                          \
-  {                                                                                             \
-    auto THRUST_PP_CAT2(count1, _fixed) = static_cast<std::int64_t>(count1);                    \
-    auto THRUST_PP_CAT2(count2, _fixed) = static_cast<std::int64_t>(count2);                    \
-    status                              = call_64 arguments;                                    \
-  }
+#if defined(THRUST_FORCE_64BIT_OFFSET_TYPE)
+//! @brief Always dispatches to 64 bit offset version of an algorithm
+#  define THRUST_INDEX_TYPE_DISPATCH(status, call, count, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH(std::int64_t, status, call, count, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH but with two counts
+#  define THRUST_DOUBLE_INDEX_TYPE_DISPATCH(status, call, count1, count2, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH2(std::int64_t, status, call, count1, count2, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH but with two different call implementations
+#  define THRUST_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH(std::int64_t, status, call_64, count, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH2 but uses two counts.
+#  define THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count1, count2, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH2(std::int64_t, status, call_64, count1, count2, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH2 but always dispatching to uint64_t. `count` must not be negative.
+#  define THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH(std::uint64_t, status, call_64, count, arguments)
+
+#elif defined(THRUST_FORCE_32BIT_OFFSET_TYPE)
+
+//! @brief Ensures that the size of the input does not overflow the offset type
+#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(index_type, count)                      \
+    if (static_cast<std::uint64_t>(count)                                                    \
+        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max)) \
+    {                                                                                        \
+      throw ::std::runtime_error("Offset type overflow");                                    \
+    }
+
+//! @brief Ensures that the sizes of the inputs do not overflow the offset type, but two counts
+#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW2(index_type, count1, count2)            \
+    if (static_cast<std::uint64_t>(count1) + static_cast<std::uint64_t>(count2)              \
+        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max)) \
+    {                                                                                        \
+      throw ::std::runtime_error("Offset type overflow");                                    \
+    }
+
+//! @brief Always dispatches to 32 bit offset version of an algorithm but throws if count would overflow
+#  define THRUST_INDEX_TYPE_DISPATCH(status, call, count, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(std::int32_t, count)  \
+    _THRUST_INDEX_TYPE_DISPATCH(std::int32_t, status, call, count, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH but with two counts
+#  define THRUST_DOUBLE_INDEX_TYPE_DISPATCH(status, call, count1, count2, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW2(std::int32_t, count1, count2)        \
+    _THRUST_INDEX_TYPE_DISPATCH2(std::int32_t, status, call, count1, count2, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH but with two different call implementations
+#  define THRUST_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(std::int32_t, count)               \
+    _THRUST_INDEX_TYPE_DISPATCH(std::int32_t, status, call_32, count, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH2 but uses two counts.
+#  define THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count1, count2, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW2(std::int32_t, count1, count2)                     \
+    _THRUST_INDEX_TYPE_DISPATCH2(std::int32_t, status, call_32, count1, count2, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH but always dispatching to uint64_t. `count` must not be negative.
+#  define THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count, arguments) \
+    _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(std::uint32_t, count)                       \
+    _THRUST_INDEX_TYPE_DISPATCH(std::uint32_t, status, call_32, count, arguments)
+
+#else // ^^^ THRUST_FORCE_32BIT_OFFSET_TYPE ^^^ / vvv !THRUST_FORCE_32BIT_OFFSET_TYPE vvv
+
+#  define _THRUST_INDEX_TYPE_DISPATCH_SELECT(index_type, count) \
+    (static_cast<std::uint64_t>(count)                          \
+     <= static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))
+
+#  define _THRUST_INDEX_TYPE_DISPATCH_SELECT2(index_type, count1, count2)    \
+    (static_cast<std::uint64_t>(count1) + static_cast<std::uint64_t>(count2) \
+     <= static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))
+
+//! Dispatch between 32-bit and 64-bit index_type based versions of the same algorithm implementation. This version
+//! assumes that callables for both branches consist of the same tokens, and is intended to be used with Thrust-style
+//! dispatch interfaces, that always deduce the size type from the arguments.
+#  define THRUST_INDEX_TYPE_DISPATCH(status, call, count, arguments)            \
+    if _THRUST_INDEX_TYPE_DISPATCH_SELECT (std::int32_t, count)                 \
+      _THRUST_INDEX_TYPE_DISPATCH(std::int32_t, status, call, count, arguments) \
+    else                                                                        \
+      _THRUST_INDEX_TYPE_DISPATCH(std::int64_t, status, call, count, arguments)
+
+//! Dispatch between 32-bit and 64-bit index_type based versions of the same algorithm implementation. This version
+//! assumes that callables for both branches consist of the same tokens, and is intended to be used with Thrust-style
+//! dispatch interfaces, that always deduce the size type from the arguments.
+//!
+//! This version of the macro supports providing two count variables, which is necessary for set algorithms.
+#  define THRUST_DOUBLE_INDEX_TYPE_DISPATCH(status, call, count1, count2, arguments)      \
+    if _THRUST_INDEX_TYPE_DISPATCH_SELECT2 (std::int32_t, count1, count2)                 \
+      _THRUST_INDEX_TYPE_DISPATCH2(std::int32_t, status, call, count1, count2, arguments) \
+    else                                                                                  \
+      _THRUST_INDEX_TYPE_DISPATCH2(std::int64_t, status, call, count1, count2, arguments)
+
+//! Dispatch between 32-bit and 64-bit index_type based versions of the same algorithm implementation. This version
+//! allows using different token sequences for callables in both branches, and is intended to be used with CUB-style
+//! dispatch interfaces, where the "simple" interface always forces the size to be `int` (making it harder for us to
+//! use), but the complex interface that we end up using doesn't actually provide a way to fully deduce the type from
+//! just the call, making the size type appear in the token sequence of the callable.
+//!
+//!  See reduce_n_impl to see an example of how this is meant to be used.
+#  define THRUST_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count, arguments)  \
+    if _THRUST_INDEX_TYPE_DISPATCH_SELECT (std::int32_t, count)                    \
+      _THRUST_INDEX_TYPE_DISPATCH(std::int32_t, status, call_32, count, arguments) \
+    else                                                                           \
+      _THRUST_INDEX_TYPE_DISPATCH(std::int64_t, status, call_64, count, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH2 but uses two counts.
+#  define THRUST_DOUBLE_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count1, count2, arguments) \
+    if _THRUST_INDEX_TYPE_DISPATCH_SELECT2 (std::int32_t, count1, count2)                         \
+      _THRUST_INDEX_TYPE_DISPATCH2(std::int32_t, status, call_32, count1, count2, arguments)      \
+    else                                                                                          \
+      _THRUST_INDEX_TYPE_DISPATCH2(std::int64_t, status, call_64, count1, count2, arguments)
+
+//! Like \ref THRUST_INDEX_TYPE_DISPATCH2 but dispatching to uint32_t and uint64_t, respectively, depending on the
+//! `count` argument. `count` must not be negative.
+#  define THRUST_UNSIGNED_INDEX_TYPE_DISPATCH2(status, call_32, call_64, count, arguments) \
+    if _THRUST_INDEX_TYPE_DISPATCH_SELECT (std::uint32_t, count)                           \
+      _THRUST_INDEX_TYPE_DISPATCH(std::uint32_t, status, call_32, count, arguments)        \
+    else                                                                                   \
+      _THRUST_INDEX_TYPE_DISPATCH(std::uint64_t, status, call_64, count, arguments)
+
+#endif // !THRUST_FORCE_32BIT_OFFSET_TYPE

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -30,8 +30,8 @@
 #include <thrust/detail/integer_traits.h>
 #include <thrust/detail/preprocessor.h>
 
-#include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/detail/libcxx/include/stdexcept>
+#include <cuda/std/type_traits>
 
 #include <cstdint>
 #include <string>

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -26,13 +26,14 @@
 #  pragma system_header
 #endif // no system header
 
+#include <thrust/detail/integer_math.h>
 #include <thrust/detail/integer_traits.h>
 #include <thrust/detail/preprocessor.h>
 
 #include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/detail/libcxx/include/stdexcept>
 
 #include <cstdint>
-#include <stdexcept>
 #include <string>
 
 #if defined(THRUST_FORCE_32_BIT_OFFSET_TYPE) && defined(THRUST_FORCE_64_BIT_OFFSET_TYPE)
@@ -52,24 +53,15 @@
     status                              = call arguments;                                 \
   }
 
-#define _THRUST_INDEX_TYPE_DISPATCH_GUARD_UNDERFLOW(count)                                        \
-  _CCCL_IF_CONSTEXPR (_CCCL_TRAIT(_CUDA_VSTD::is_signed, decltype(count)))                        \
-  {                                                                                               \
-    if (count < 0)                                                                                \
-    {                                                                                             \
-      throw ::std::runtime_error("Invalid input range. Passed size is " + std::to_string(count)); \
-    }                                                                                             \
+#define _THRUST_INDEX_TYPE_DISPATCH_GUARD_UNDERFLOW(count)                           \
+  if (thrust::detail::is_negative(count))                                            \
+  {                                                                                  \
+    ::cuda::std::__throw_runtime_error("Invalid input range, passed negative size"); \
   }
 
-#define _THRUST_INDEX_TYPE_DISPATCH_GUARD_UNDERFLOW2(count1, count2)                                            \
-  _CCCL_IF_CONSTEXPR (_CCCL_TRAIT(_CUDA_VSTD::is_signed, decltype(count1)))                                     \
-  {                                                                                                             \
-    if (count1 < 0 || count2 < 0)                                                                               \
-    {                                                                                                           \
-      throw ::std::runtime_error(                                                                               \
-        "Invalid input ranges. Passed sizes are " + std::to_string(count1) + " and " + std::to_string(count2)); \
-    }                                                                                                           \
-  }
+#define _THRUST_INDEX_TYPE_DISPATCH_GUARD_UNDERFLOW2(count1, count2) \
+  _THRUST_INDEX_TYPE_DISPATCH_GUARD_UNDERFLOW(count1)                \
+  _THRUST_INDEX_TYPE_DISPATCH_GUARD_UNDERFLOW(count2)
 
 #if defined(THRUST_FORCE_64_BIT_OFFSET_TYPE)
 //! @brief Always dispatches to 64 bit offset version of an algorithm
@@ -100,29 +92,27 @@
 #elif defined(THRUST_FORCE_32_BIT_OFFSET_TYPE)
 
 //! @brief Ensures that the size of the input does not overflow the offset type
-#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(index_type, count)                                 \
-    if (static_cast<std::uint64_t>(count)                                                               \
-        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))            \
-    {                                                                                                   \
-      throw ::std::runtime_error(                                                                       \
-        "Input size exceeds the maximum allowable value for " #index_type " ("                          \
-        + std::to_string(thrust::detail::integer_traits<index_type>::const_max)                         \
-        + "). " #index_type " was used because the macro THRUST_FORCE_32_BIT_OFFSET_TYPE was defined. " \
-          "To handle larger input sizes, either remove this macro to dynamically dispatch "             \
-          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64_BIT_OFFSET_TYPE.");         \
+#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(index_type, count)                       \
+    if (static_cast<std::uint64_t>(count)                                                     \
+        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))  \
+    {                                                                                         \
+      ::cuda::std::__throw_runtime_error(                                                     \
+        "Input size exceeds the maximum allowable value for " #index_type                     \
+        ". It was used because the macro THRUST_FORCE_32_BIT_OFFSET_TYPE was defined. "       \
+        "To handle larger input sizes, either remove this macro to dynamically dispatch "     \
+        "between 32-bit and 64-bit index types, or define THRUST_FORCE_64_BIT_OFFSET_TYPE."); \
     }
 
 //! @brief Ensures that the sizes of the inputs do not overflow the offset type, but two counts
-#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW2(index_type, count1, count2)                       \
-    if (static_cast<std::uint64_t>(count1) + static_cast<std::uint64_t>(count2)                         \
-        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))            \
-    {                                                                                                   \
-      throw ::std::runtime_error(                                                                       \
-        "Combined input sizes exceed the maximum allowable value for " #index_type " ("                 \
-        + std::to_string(thrust::detail::integer_traits<index_type>::const_max)                         \
-        + "). " #index_type " was used because the macro THRUST_FORCE_32_BIT_OFFSET_TYPE was defined. " \
-          "To handle larger input sizes, either remove this macro to dynamically dispatch "             \
-          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64_BIT_OFFSET_TYPE.");         \
+#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW2(index_type, count1, count2)             \
+    if (static_cast<std::uint64_t>(count1) + static_cast<std::uint64_t>(count2)               \
+        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))  \
+    {                                                                                         \
+      ::cuda::std::__throw_runtime_error(                                                     \
+        "Input size exceeds the maximum allowable value for " #index_type                     \
+        ". It was used because the macro THRUST_FORCE_32_BIT_OFFSET_TYPE was defined. "       \
+        "To handle larger input sizes, either remove this macro to dynamically dispatch "     \
+        "between 32-bit and 64-bit index types, or define THRUST_FORCE_64_BIT_OFFSET_TYPE."); \
     }
 
 //! @brief Always dispatches to 32 bit offset version of an algorithm but throws if count would overflow

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -73,29 +73,29 @@
 #elif defined(THRUST_FORCE_32BIT_OFFSET_TYPE)
 
 //! @brief Ensures that the size of the input does not overflow the offset type
-#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(index_type, count)                      \
-    if (static_cast<std::uint64_t>(count)                                                    \
-        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max)) \
-    {                                                                                        \
-      throw ::std::runtime_error(                                                            \
-        "Input size exceeds the maximum allowable value for " #index_type                    \
-        " (" + std::to_string(thrust::detail::integer_traits<index_type>::const_max) + "). " \
-        #index_type " was used because the macro THRUST_FORCE_32BIT_OFFSET_TYPE was defined. "\
-        "To handle larger input sizes, either remove this macro to dynamically dispatch "    \
-        "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE.")
+#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW(index_type, count)                                \
+    if (static_cast<std::uint64_t>(count)                                                              \
+        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))           \
+    {                                                                                                  \
+      throw ::std::runtime_error(                                                                      \
+        "Input size exceeds the maximum allowable value for " #index_type " ("                         \
+        + std::to_string(thrust::detail::integer_traits<index_type>::const_max)                        \
+        + "). " #index_type " was used because the macro THRUST_FORCE_32BIT_OFFSET_TYPE was defined. " \
+          "To handle larger input sizes, either remove this macro to dynamically dispatch "            \
+          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE.")          \
     }
 
 //! @brief Ensures that the sizes of the inputs do not overflow the offset type, but two counts
-#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW2(index_type, count1, count2)            \
-    if (static_cast<std::uint64_t>(count1) + static_cast<std::uint64_t>(count2)              \
-        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max)) \
-    {                                                                                        \
-      throw ::std::runtime_error(                                                            \
-        "Combined input sizes exceed the maximum allowable value for " #index_type           \
-        " (" + std::to_string(thrust::detail::integer_traits<index_type>::const_max) + "). " \
-        #index_type " was used because the macro THRUST_FORCE_32BIT_OFFSET_TYPE was defined. "\
-        "To handle larger input sizes, either remove this macro to dynamically dispatch "    \
-        "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE."); \```
+#  define _THRUST_INDEX_TYPE_DISPATCH_GUARD_OVERFLOW2(index_type, count1, count2)                      \
+    if (static_cast<std::uint64_t>(count1) + static_cast<std::uint64_t>(count2)                        \
+        > static_cast<std::uint64_t>(thrust::detail::integer_traits<index_type>::const_max))           \
+    {                                                                                                  \
+      throw ::std::runtime_error(                                                                      \
+        "Combined input sizes exceed the maximum allowable value for " #index_type " ("                \
+        + std::to_string(thrust::detail::integer_traits<index_type>::const_max)                        \
+        + "). " #index_type " was used because the macro THRUST_FORCE_32BIT_OFFSET_TYPE was defined. " \
+          "To handle larger input sizes, either remove this macro to dynamically dispatch "            \
+          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE.");         \
     }
 
 //! @brief Always dispatches to 32 bit offset version of an algorithm but throws if count would overflow

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -82,7 +82,7 @@
         + std::to_string(thrust::detail::integer_traits<index_type>::const_max)                        \
         + "). " #index_type " was used because the macro THRUST_FORCE_32BIT_OFFSET_TYPE was defined. " \
           "To handle larger input sizes, either remove this macro to dynamically dispatch "            \
-          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE.")          \
+          "between 32-bit and 64-bit index types, or define THRUST_FORCE_64BIT_OFFSET_TYPE.");         \
     }
 
 //! @brief Ensures that the sizes of the inputs do not overflow the offset type, but two counts


### PR DESCRIPTION
The current dispatch mechanisms trades compile time and binary size for performance and flexibility.

Allow users to tune that depending on their needs

Fixes #1958
