### PR TITLE
Add a fast, low memory "limited" mode to CUB testing.

### DIFF
--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -580,6 +580,14 @@ def remove_dispatch_job_from_container(job, container):
     return False
 
 
+def index_of_dispatch_job_in_container(job, container):
+    "Find the index of a dispatch job in a container, using compare_dispatch_jobs."
+    for idx, job2 in enumerate(container):
+        if compare_dispatch_jobs(job, job2):
+            return idx
+    return None
+
+
 def finalize_workflow_dispatch_groups(workflow_dispatch_groups_orig):
     workflow_dispatch_groups = copy.deepcopy(workflow_dispatch_groups_orig)
 
@@ -614,7 +622,7 @@ def finalize_workflow_dispatch_groups(workflow_dispatch_groups_orig):
             producer = producers[0]
 
             if dispatch_job_in_container(producer, merged_producers):
-                producer_index = merged_producers.index(producers)
+                producer_index = index_of_dispatch_job_in_container(producer, merged_producers)
                 matching_consumers = merged_consumers[producer_index]
 
                 producer_name = producer['name']

--- a/ci/build_cub.sh
+++ b/ci/build_cub.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "$0")/build_common.sh"
 
 print_environment_details

--- a/ci/build_cudax.sh
+++ b/ci/build_cudax.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "$0")/build_common.sh"
 
 print_environment_details

--- a/ci/build_libcudacxx.sh
+++ b/ci/build_libcudacxx.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "$0")/build_common.sh"
 
 print_environment_details

--- a/ci/build_thrust.sh
+++ b/ci/build_thrust.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "$0")/build_common.sh"
 
 print_environment_details

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -46,7 +46,7 @@ workflows:
     - {jobs: ['infra'], project: 'cccl', ctk: '11.1', cxx: ['gcc6', 'clang9']}
     - {jobs: ['infra'], project: 'cccl', ctk: 'curr', cxx: ['gcc', 'clang']}
     # Edge-case jobs
-    - {jobs: ['limited'], project: 'cub'}
+    - {jobs: ['limited'], project: 'cub', std: 17}
 
   nightly:
   # libcudacxx build fails, CUB tests fail:

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -45,6 +45,8 @@ workflows:
     # cccl-infra:
     - {jobs: ['infra'], project: 'cccl', ctk: '11.1', cxx: ['gcc6', 'clang9']}
     - {jobs: ['infra'], project: 'cccl', ctk: 'curr', cxx: ['gcc', 'clang']}
+    # Edge-case jobs
+    - {jobs: ['limited'], project: 'cub'}
 
   nightly:
   # libcudacxx build fails, CUB tests fail:
@@ -200,6 +202,9 @@ jobs:
   test_lid1:  { name: 'DeviceLaunch', gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-lid1'} }
   # - captured in a CUDA graph for deferred launch (lid2):
   test_lid2:  { name: 'GraphCapture', gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-lid2'} }
+  # Limited build reduces the number of runtime test cases, available device memory, etc, and may be used
+  # to reduce test runtime in limited environments.
+  limited:    { name: "SmallGMem",   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-limited'} }
 
   # Thrust:
   test_cpu: { name: 'TestCPU', gpu: false, needs: 'build', invoke: { prefix: 'test', args: '-cpu-only'} }

--- a/ci/pretty_printing.sh
+++ b/ci/pretty_printing.sh
@@ -97,6 +97,10 @@ function print_time_summary() {
         fi
     done
 
+    if [ "$max_length" -eq 0 ]; then
+        return
+    fi
+
     echo "Time Summary:"
     for group in "${!command_durations[@]}"; do
         printf "%-${max_length}s : %s seconds\n" "$group" "${command_durations[$group]}"

--- a/ci/test_cub.sh
+++ b/ci/test_cub.sh
@@ -6,10 +6,11 @@ NO_LID=false
 LID0=false
 LID1=false
 LID2=false
+LIMITED=false
 
 ci_dir=$(dirname "$0")
 
-new_args=$("${ci_dir}/util/extract_switches.sh" -no-lid -lid0 -lid1 -lid2 -- "$@")
+new_args=$("${ci_dir}/util/extract_switches.sh" -no-lid -lid0 -lid1 -lid2 -limited -- "$@")
 eval set -- ${new_args}
 while true; do
   case "$1" in
@@ -29,6 +30,10 @@ while true; do
     LID2=true
     shift
     ;;
+  -limited)
+    LIMITED=true
+    shift
+    ;;
   --)
     shift
     break
@@ -39,6 +44,21 @@ while true; do
     ;;
   esac
 done
+
+if $LIMITED; then
+
+  export CCCL_SEED_COUNT_OVERRIDE=1
+  readonly device_mem_GiB=8
+  export CCCL_DEVICE_MEMORY_LIMIT=$((${device_mem_GiB} * 1024 * 1024 * 1024))
+  export CCCL_DEBUG_CHECKED_ALLOC_FAILURES=1
+
+
+  echo "Configuring limited environment:"
+  echo "  CCCL_SEED_COUNT_OVERRIDE=${CCCL_SEED_COUNT_OVERRIDE}"
+  echo "  CCCL_DEVICE_MEMORY_LIMIT=${CCCL_DEVICE_MEMORY_LIMIT} (${device_mem_GiB} GiB)"
+  echo "  CCCL_DEBUG_CHECKED_ALLOC_FAILURES=${CCCL_DEBUG_CHECKED_ALLOC_FAILURES}"
+  echo
+fi
 
 source "${ci_dir}/build_common.sh"
 

--- a/cub/test/catch2_test_helper.h
+++ b/cub/test/catch2_test_helper.h
@@ -30,6 +30,7 @@
 #include <cub/util_compiler.cuh>
 
 #include <cstdint>
+#include <cstdlib>
 #include <tuple>
 #include <type_traits>
 
@@ -251,10 +252,22 @@ struct Catch::StringMaker<cudaError>
 
 #define CUB_TEST_STR(a) #a
 
+namespace detail
+{
+inline std::size_t adjust_seed_count(std::size_t requested)
+{
+  // Setting this environment variable forces a fixed number of seeds to be generated, regardless of the requested
+  // count. Set to 1 to reduce redundant, expensive testing when using sanitizers, etc.
+  static const char* override_str = std::getenv("CCCL_SEED_COUNT_OVERRIDE");
+  static int override             = override_str ? std::atoi(override_str) : 0;
+  return override_str ? override : requested;
+}
+} // namespace detail
+
 #define CUB_SEED(N)                                                                                                    \
   c2h::seed_t                                                                                                          \
   {                                                                                                                    \
     GENERATE_COPY(take(                                                                                                \
-      N,                                                                                                               \
+      detail::adjust_seed_count(N),                                                                                    \
       random(std::numeric_limits<unsigned long long int>::min(), std::numeric_limits<unsigned long long int>::max()))) \
   }


### PR DESCRIPTION
### Summary

1. Add the ability to run CUB's tests with a limited global memory pool (ensures that we can run tests in a limited environment).
2. Allow the CUB_SEED generator to be globally overridden for "fast" tests and/or more extensive fuzzing.
3. Introduce a new `-configure` option to the build scripts that only configures the build directory.
4. Adds a CI job that ensures CUB tests can run with only 8GiB total memory.

### Detailed changes:

- Add `CCCL_DEVICE_MEMORY_LIMIT` env var: Limit the total memory allocations to this number of bytes.
- Add `CCCL_DEBUG_CHECKED_ALLOC_FAILURES` env var: Print info about each checked alloc failure prior to throwing exceptions.
- Add `CCCL_SEED_COUNT_OVERRIDE` env var: overrides the number of test sections generated by `CUB_SEED`.
- Add `limited` flag / CI job for CUB.
  - Forces `CUB_SEED` to only generate a single test case, ignoring requested number of seeds.
  - Limits the total global device memory usage to 8 GiB.
  - Prints allocation details when checked allocator fails.
- Add a `-configure` option to CI scripts that just configures the build and exits.