### PR TITLE
Add thurst::transform_inclusive_scan with init value

### DIFF
--- a/thrust/testing/cuda/transform_scan.cu
+++ b/thrust/testing/cuda/transform_scan.cu
@@ -127,7 +127,7 @@ void TestTransformScanDevice(ExecutionPolicy exec)
   }
 
   iter = iter_vec[0];
-  ref  = {2, -1, 1, -3, 2};
+  ref  = {3, 2, -1, 1, -3};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(ref, output);

--- a/thrust/testing/cuda/transform_scan.cu
+++ b/thrust/testing/cuda/transform_scan.cu
@@ -70,15 +70,9 @@ void TestTransformScanDevice(ExecutionPolicy exec)
 
   typename Vector::iterator iter;
 
-  Vector input(5);
-  Vector ref(5);
+  Vector input{1, 3, -2, 4, -5};
+  Vector ref{-1, -4, -2, -6, -1};
   Vector output(5);
-
-  input[0] = 1;
-  input[1] = 3;
-  input[2] = -2;
-  input[3] = 4;
-  input[4] = -5;
 
   Vector input_copy(input);
 
@@ -92,12 +86,7 @@ void TestTransformScanDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  iter   = iter_vec[0];
-  ref[0] = -1;
-  ref[1] = -4;
-  ref[2] = -2;
-  ref[3] = -6;
-  ref[4] = -1;
+  iter = iter_vec[0];
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(ref, output);
@@ -110,12 +99,8 @@ void TestTransformScanDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  iter   = iter_vec[0];
-  ref[0] = 2;
-  ref[1] = -1;
-  ref[2] = 1;
-  ref[3] = -3;
-  ref[4] = 2;
+  iter = iter_vec[0];
+  ref  = {2, -1, 1, -3, 2};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(ref, output);
@@ -128,11 +113,7 @@ void TestTransformScanDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  ref[0] = 0;
-  ref[1] = -1;
-  ref[2] = -4;
-  ref[3] = -2;
-  ref[4] = -6;
+  ref = {0, -1, -4, -2, -6};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(ref, output);
@@ -145,12 +126,8 @@ void TestTransformScanDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  iter   = iter_vec[0];
-  ref[0] = 3;
-  ref[1] = 2;
-  ref[2] = -1;
-  ref[3] = 1;
-  ref[4] = -3;
+  iter = iter_vec[0];
+  ref  = {2, -1, 1, -3, 2};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(ref, output);
@@ -164,12 +141,8 @@ void TestTransformScanDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  iter   = iter_vec[0];
-  ref[0] = -1;
-  ref[1] = -4;
-  ref[2] = -2;
-  ref[3] = -6;
-  ref[4] = -1;
+  iter = iter_vec[0];
+  ref  = {-1, -4, -2, -6, -1};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(ref, input);
 
@@ -182,12 +155,8 @@ void TestTransformScanDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  iter   = iter_vec[0];
-  ref[0] = 2;
-  ref[1] = -1;
-  ref[2] = 1;
-  ref[3] = -3;
-  ref[4] = 2;
+  iter = iter_vec[0];
+  ref  = {2, -1, 1, -3, 2};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(ref, input);
 
@@ -200,12 +169,8 @@ void TestTransformScanDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  iter   = iter_vec[0];
-  ref[0] = 3;
-  ref[1] = 2;
-  ref[2] = -1;
-  ref[3] = 1;
-  ref[4] = -3;
+  iter = iter_vec[0];
+  ref  = {3, 2, -1, 1, -3};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(ref, input);
 }
@@ -230,15 +195,9 @@ void TestTransformScanCudaStreams()
 
   Vector::iterator iter;
 
-  Vector input(5);
-  Vector result(5);
+  Vector input{1, 3, -2, 4, -5};
+  Vector result{-1, -4, -2, -6, -1};
   Vector output(5);
-
-  input[0] = 1;
-  input[1] = 3;
-  input[2] = -2;
-  input[3] = 4;
-  input[4] = -5;
 
   Vector input_copy(input);
 
@@ -250,11 +209,6 @@ void TestTransformScanCudaStreams()
     thrust::cuda::par.on(s), input.begin(), input.end(), output.begin(), thrust::negate<T>(), thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = -1;
-  result[1] = -4;
-  result[2] = -2;
-  result[3] = -6;
-  result[4] = -1;
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -264,11 +218,7 @@ void TestTransformScanCudaStreams()
     thrust::cuda::par.on(s), input.begin(), input.end(), output.begin(), thrust::negate<T>(), 3, thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = 2;
-  result[1] = -1;
-  result[2] = 1;
-  result[3] = -3;
-  result[4] = 2;
+  result = {2, -1, 1, -3, 2};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -278,11 +228,7 @@ void TestTransformScanCudaStreams()
     thrust::cuda::par.on(s), input.begin(), input.end(), output.begin(), thrust::negate<T>(), 0, thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = 0;
-  result[1] = -1;
-  result[2] = -4;
-  result[3] = -2;
-  result[4] = -6;
+  result = {0, -1, -4, -2, -6};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -292,11 +238,7 @@ void TestTransformScanCudaStreams()
     thrust::cuda::par.on(s), input.begin(), input.end(), output.begin(), thrust::negate<T>(), 3, thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = 3;
-  result[1] = 2;
-  result[2] = -1;
-  result[3] = 1;
-  result[4] = -3;
+  result = {3, 2, -1, 1, -3};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -307,11 +249,7 @@ void TestTransformScanCudaStreams()
     thrust::cuda::par.on(s), input.begin(), input.end(), input.begin(), thrust::negate<T>(), thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = -1;
-  result[1] = -4;
-  result[2] = -2;
-  result[3] = -6;
-  result[4] = -1;
+  result = {-1, -4, -2, -6, -1};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(input, result);
 
@@ -321,11 +259,7 @@ void TestTransformScanCudaStreams()
     thrust::cuda::par.on(s), input.begin(), input.end(), input.begin(), thrust::negate<T>(), 3, thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = 2;
-  result[1] = -1;
-  result[2] = 1;
-  result[3] = -3;
-  result[4] = 2;
+  result = {2, -1, 1, -3, 2};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(input, result);
 
@@ -335,11 +269,7 @@ void TestTransformScanCudaStreams()
     thrust::cuda::par.on(s), input.begin(), input.end(), input.begin(), thrust::negate<T>(), 3, thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = 3;
-  result[1] = 2;
-  result[2] = -1;
-  result[3] = 1;
-  result[4] = -3;
+  result = {3, 2, -1, 1, -3};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(input, result);
 
@@ -354,15 +284,9 @@ void TestTransformScanConstAccumulator()
 
   Vector::iterator iter;
 
-  Vector input(5);
+  Vector input{1, 3, -2, 4, -5};
   Vector reference(5);
   Vector output(5);
-
-  input[0] = 1;
-  input[1] = 3;
-  input[2] = -2;
-  input[3] = 4;
-  input[4] = -5;
 
   thrust::transform_inclusive_scan(input.begin(), input.end(), output.begin(), thrust::identity<T>(), thrust::plus<T>());
   thrust::inclusive_scan(input.begin(), input.end(), reference.begin(), thrust::plus<T>());

--- a/thrust/testing/transform_scan.cu
+++ b/thrust/testing/transform_scan.cu
@@ -109,26 +109,15 @@ void TestTransformScanSimple()
 
   typename Vector::iterator iter;
 
-  Vector input(5);
-  Vector result(5);
+  Vector input{1, 3, -2, 4, -5};
+  Vector result{-1, -4, -2, -6, -1};
   Vector output(5);
-
-  input[0] = 1;
-  input[1] = 3;
-  input[2] = -2;
-  input[3] = 4;
-  input[4] = -5;
 
   Vector input_copy(input);
 
   // inclusive scan
   iter = thrust::transform_inclusive_scan(
     input.begin(), input.end(), output.begin(), thrust::negate<T>(), thrust::plus<T>());
-  result[0] = -1;
-  result[1] = -4;
-  result[2] = -2;
-  result[3] = -6;
-  result[4] = -1;
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -136,11 +125,7 @@ void TestTransformScanSimple()
   // inclusive scan with 0 init
   iter = thrust::transform_inclusive_scan(
     input.begin(), input.end(), output.begin(), thrust::negate<T>(), 0, thrust::plus<T>());
-  result[0] = -1;
-  result[1] = -4;
-  result[2] = -2;
-  result[3] = -6;
-  result[4] = -1;
+  result = {-1, -4, -2, -6, -1};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -148,11 +133,7 @@ void TestTransformScanSimple()
   // exclusive scan with 0 init
   iter = thrust::transform_exclusive_scan(
     input.begin(), input.end(), output.begin(), thrust::negate<T>(), 0, thrust::plus<T>());
-  result[0] = 0;
-  result[1] = -1;
-  result[2] = -4;
-  result[3] = -2;
-  result[4] = -6;
+  result = {0, -1, -4, -2, -6};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -160,11 +141,7 @@ void TestTransformScanSimple()
   // inclusive scan with nonzero init
   iter = thrust::transform_inclusive_scan(
     input.begin(), input.end(), output.begin(), thrust::negate<T>(), 3, thrust::plus<T>());
-  result[0] = 2;
-  result[1] = -1;
-  result[2] = 1;
-  result[3] = -3;
-  result[4] = 2;
+  result = {2, -1, 1, -3, 2};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -172,11 +149,7 @@ void TestTransformScanSimple()
   // exclusive scan with nonzero init
   iter = thrust::transform_exclusive_scan(
     input.begin(), input.end(), output.begin(), thrust::negate<T>(), 3, thrust::plus<T>());
-  result[0] = 3;
-  result[1] = 2;
-  result[2] = -1;
-  result[3] = 1;
-  result[4] = -3;
+  result = {3, 2, -1, 1, -3};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -185,11 +158,7 @@ void TestTransformScanSimple()
   input = input_copy;
   iter =
     thrust::transform_inclusive_scan(input.begin(), input.end(), input.begin(), thrust::negate<T>(), thrust::plus<T>());
-  result[0] = -1;
-  result[1] = -4;
-  result[2] = -2;
-  result[3] = -6;
-  result[4] = -1;
+  result = {-1, -4, -2, -6, -1};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(input, result);
 
@@ -197,11 +166,7 @@ void TestTransformScanSimple()
   input = input_copy;
   iter  = thrust::transform_inclusive_scan(
     input.begin(), input.end(), input.begin(), thrust::negate<T>(), 3, thrust::plus<T>());
-  result[0] = 2;
-  result[1] = -1;
-  result[2] = 1;
-  result[3] = -3;
-  result[4] = 2;
+  result = {2, -1, 1, -3, 2};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(input, result);
 
@@ -209,11 +174,7 @@ void TestTransformScanSimple()
   input = input_copy;
   iter  = thrust::transform_exclusive_scan(
     input.begin(), input.end(), input.begin(), thrust::negate<T>(), 3, thrust::plus<T>());
-  result[0] = 3;
-  result[1] = 2;
-  result[2] = -1;
-  result[3] = 1;
-  result[4] = -3;
+  result = {3, 2, -1, 1, -3};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(input, result);
 }
@@ -255,25 +216,14 @@ void TestTransformInclusiveScanDifferentTypes()
 {
   typename thrust::host_vector<int>::iterator h_iter;
 
-  thrust::host_vector<Record> h_input(5);
+  thrust::host_vector<Record> h_input{{1}, {3}, {-2}, {4}, {-5}};
   thrust::host_vector<int> h_output(5);
-  thrust::host_vector<int> result(5);
-
-  h_input[0] = {1};
-  h_input[1] = {3};
-  h_input[2] = {-2};
-  h_input[3] = {4};
-  h_input[4] = {-5};
+  thrust::host_vector<int> result{-1, -4, -2, -6, -1};
 
   thrust::host_vector<Record> input_copy(h_input);
 
   h_iter =
     thrust::transform_inclusive_scan(h_input.begin(), h_input.end(), h_output.begin(), negate{}, thrust::plus<int>{});
-  result[0] = -1;
-  result[1] = -4;
-  result[2] = -2;
-  result[3] = -6;
-  result[4] = -1;
   ASSERT_EQUAL(std::size_t(h_iter - h_output.begin()), h_input.size());
   ASSERT_EQUAL(h_input, input_copy);
   ASSERT_EQUAL(h_output, result);
@@ -358,9 +308,8 @@ void TestTransformScanCountingIterator()
 
   thrust::transform_inclusive_scan(first, first + 3, result.begin(), thrust::negate<T>(), thrust::plus<T>());
 
-  ASSERT_EQUAL(result[0], -1);
-  ASSERT_EQUAL(result[1], -3);
-  ASSERT_EQUAL(result[2], -6);
+  Vector ref{-1, -3, -6};
+  ASSERT_EQUAL(result, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestTransformScanCountingIterator);
 
@@ -415,46 +364,19 @@ void TestValueCategoryDeduction()
   thrust::transform_inclusive_scan(
     thrust::device, vec.cbegin(), vec.cend(), vec.begin(), thrust::identity<>{}, thrust::maximum<>{});
 
-  ASSERT_EQUAL(T{5}, vec[0]);
-  ASSERT_EQUAL(T{5}, vec[1]);
-  ASSERT_EQUAL(T{5}, vec[2]);
-  ASSERT_EQUAL(T{8}, vec[3]);
-  ASSERT_EQUAL(T{8}, vec[4]);
-  ASSERT_EQUAL(T{8}, vec[5]);
-  ASSERT_EQUAL(T{8}, vec[6]);
-  ASSERT_EQUAL(T{8}, vec[7]);
-  ASSERT_EQUAL(T{8}, vec[8]);
-  ASSERT_EQUAL(T{9}, vec[9]);
+  ASSERT_EQUAL((thrust::device_vector<T>{5, 5, 5, 8, 8, 8, 8, 8, 8, 9}), vec);
 
   vec.assign((T*) a_h, a_h + 10);
 
   thrust::transform_inclusive_scan(
     thrust::device, vec.cbegin(), vec.cend(), vec.begin(), thrust::identity<>{}, T{}, thrust::maximum<>{});
 
-  ASSERT_EQUAL(T{5}, vec[0]);
-  ASSERT_EQUAL(T{5}, vec[1]);
-  ASSERT_EQUAL(T{5}, vec[2]);
-  ASSERT_EQUAL(T{8}, vec[3]);
-  ASSERT_EQUAL(T{8}, vec[4]);
-  ASSERT_EQUAL(T{8}, vec[5]);
-  ASSERT_EQUAL(T{8}, vec[6]);
-  ASSERT_EQUAL(T{8}, vec[7]);
-  ASSERT_EQUAL(T{8}, vec[8]);
-  ASSERT_EQUAL(T{9}, vec[9]);
+  ASSERT_EQUAL((thrust::device_vector<T>{5, 5, 5, 8, 8, 8, 8, 8, 8, 9}), vec);
 
   vec.assign((T*) a_h, a_h + 10);
   thrust::transform_exclusive_scan(
     thrust::device, vec.cbegin(), vec.cend(), vec.begin(), thrust::identity<>{}, T{}, thrust::maximum<>{});
 
-  ASSERT_EQUAL(T{0}, vec[0]);
-  ASSERT_EQUAL(T{5}, vec[1]);
-  ASSERT_EQUAL(T{5}, vec[2]);
-  ASSERT_EQUAL(T{5}, vec[3]);
-  ASSERT_EQUAL(T{8}, vec[4]);
-  ASSERT_EQUAL(T{8}, vec[5]);
-  ASSERT_EQUAL(T{8}, vec[6]);
-  ASSERT_EQUAL(T{8}, vec[7]);
-  ASSERT_EQUAL(T{8}, vec[8]);
-  ASSERT_EQUAL(T{8}, vec[9]);
+  ASSERT_EQUAL((thrust::device_vector<T>{0, 5, 5, 5, 8, 8, 8, 8, 8, 8}), vec);
 }
 DECLARE_GENERIC_UNITTEST(TestValueCategoryDeduction);

--- a/thrust/testing/transform_scan.cu
+++ b/thrust/testing/transform_scan.cu
@@ -26,6 +26,25 @@ void TestTransformInclusiveScanDispatchExplicit()
 }
 DECLARE_UNITTEST(TestTransformInclusiveScanDispatchExplicit);
 
+template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename T, typename AssociativeOperator>
+OutputIterator transform_inclusive_scan(
+  my_system& system, InputIterator, InputIterator, OutputIterator result, UnaryFunction, T, AssociativeOperator)
+{
+  system.validate_dispatch();
+  return result;
+}
+
+void TestTransformInclusiveScanInitDispatchExplicit()
+{
+  thrust::device_vector<int> vec(1);
+
+  my_system sys(0);
+  thrust::transform_inclusive_scan(sys, vec.begin(), vec.begin(), vec.begin(), 0, 0, 0);
+
+  ASSERT_EQUAL(true, sys.is_valid());
+}
+DECLARE_UNITTEST(TestTransformInclusiveScanInitDispatchExplicit);
+
 template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename AssociativeOperator>
 OutputIterator transform_inclusive_scan(
   my_tag, InputIterator, InputIterator, OutputIterator result, UnaryFunction, AssociativeOperator)

--- a/thrust/thrust/detail/transform_scan.inl
+++ b/thrust/thrust/detail/transform_scan.inl
@@ -60,6 +60,27 @@ template <typename DerivedPolicy,
           typename UnaryFunction,
           typename T,
           typename AssociativeOperator>
+_CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator result,
+  UnaryFunction unary_op,
+  T init,
+  AssociativeOperator binary_op)
+{
+  using thrust::system::detail::generic::transform_inclusive_scan;
+  return transform_inclusive_scan(
+    thrust::detail::derived_cast(thrust::detail::strip_const(exec)), first, last, result, unary_op, init, binary_op);
+}
+
+_CCCL_EXEC_CHECK_DISABLE
+template <typename DerivedPolicy,
+          typename InputIterator,
+          typename OutputIterator,
+          typename UnaryFunction,
+          typename T,
+          typename AssociativeOperator>
 _CCCL_HOST_DEVICE OutputIterator transform_exclusive_scan(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator first,
@@ -88,6 +109,27 @@ OutputIterator transform_inclusive_scan(
 
   return thrust::transform_inclusive_scan(select_system(system1, system2), first, last, result, unary_op, binary_op);
 } // end transform_inclusive_scan()
+
+template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename T, typename AssociativeOperator>
+OutputIterator transform_inclusive_scan(
+  InputIterator first,
+  InputIterator last,
+  OutputIterator result,
+  UnaryFunction unary_op,
+  T init,
+  AssociativeOperator binary_op)
+{
+  using thrust::system::detail::generic::select_system;
+
+  using System1 = typename thrust::iterator_system<InputIterator>::type;
+  using System2 = typename thrust::iterator_system<OutputIterator>::type;
+
+  System1 system1;
+  System2 system2;
+
+  return thrust::transform_inclusive_scan(
+    select_system(system1, system2), first, last, result, unary_op, init, binary_op);
+} // end transform_exclusive_scan()
 
 template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename T, typename AssociativeOperator>
 OutputIterator transform_exclusive_scan(

--- a/thrust/thrust/detail/transform_scan.inl
+++ b/thrust/thrust/detail/transform_scan.inl
@@ -129,7 +129,7 @@ OutputIterator transform_inclusive_scan(
 
   return thrust::transform_inclusive_scan(
     select_system(system1, system2), first, last, result, unary_op, init, binary_op);
-} // end transform_exclusive_scan()
+} // end transform_inclusive_scan()
 
 template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename T, typename AssociativeOperator>
 OutputIterator transform_exclusive_scan(

--- a/thrust/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/thrust/system/cuda/detail/transform_scan.h
@@ -79,11 +79,13 @@ OutputIt _CCCL_HOST_DEVICE transform_inclusive_scan(
   InitialValueType init,
   ScanOp scan_op)
 {
-  using result_type = ::cuda::std::__accumulator_t<ScanOp, cub::detail::value_t<InputIt>, InitialValueType>;
+  using input_type  = typename thrust::iterator_value<InputIt>::type;
+  using result_type = thrust::detail::invoke_result_t<TransformOp, input_type>;
+  using value_type  = thrust::remove_cvref_t<result_type>;
 
   using size_type              = typename iterator_traits<InputIt>::difference_type;
   size_type num_items          = static_cast<size_type>(thrust::distance(first, last));
-  using transformed_iterator_t = transform_input_iterator_t<result_type, InputIt, TransformOp>;
+  using transformed_iterator_t = transform_input_iterator_t<value_type, InputIt, TransformOp>;
 
   return cuda_cub::inclusive_scan_n(
     policy, transformed_iterator_t(first, transform_op), num_items, result, init, scan_op);

--- a/thrust/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/thrust/system/cuda/detail/transform_scan.h
@@ -70,6 +70,26 @@ OutputIt _CCCL_HOST_DEVICE transform_inclusive_scan(
 }
 
 template <class Derived, class InputIt, class OutputIt, class TransformOp, class InitialValueType, class ScanOp>
+OutputIt _CCCL_HOST_DEVICE transform_inclusive_scan(
+  execution_policy<Derived>& policy,
+  InputIt first,
+  InputIt last,
+  OutputIt result,
+  TransformOp transform_op,
+  InitialValueType init,
+  ScanOp scan_op)
+{
+  using result_type = thrust::remove_cvref_t<InitialValueType>; // cuda::std::__accumulator_t?
+
+  using size_type              = typename iterator_traits<InputIt>::difference_type;
+  size_type num_items          = static_cast<size_type>(thrust::distance(first, last));
+  using transformed_iterator_t = transform_input_iterator_t<result_type, InputIt, TransformOp>;
+
+  return cuda_cub::inclusive_scan_n(
+    policy, transformed_iterator_t(first, transform_op), num_items, result, init, scan_op);
+}
+
+template <class Derived, class InputIt, class OutputIt, class TransformOp, class InitialValueType, class ScanOp>
 OutputIt _CCCL_HOST_DEVICE transform_exclusive_scan(
   execution_policy<Derived>& policy,
   InputIt first,

--- a/thrust/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/thrust/system/cuda/detail/transform_scan.h
@@ -79,7 +79,7 @@ OutputIt _CCCL_HOST_DEVICE transform_inclusive_scan(
   InitialValueType init,
   ScanOp scan_op)
 {
-  using result_type = thrust::remove_cvref_t<InitialValueType>; // cuda::std::__accumulator_t?
+  using result_type = ::cuda::std::__accumulator_t<ScanOp, cub::detail::value_t<InputIt>, InitialValueType>;
 
   using size_type              = typename iterator_traits<InputIt>::difference_type;
   size_type num_items          = static_cast<size_type>(thrust::distance(first, last));

--- a/thrust/thrust/system/detail/generic/transform_scan.h
+++ b/thrust/thrust/system/detail/generic/transform_scan.h
@@ -53,6 +53,21 @@ template <typename ExecutionPolicy,
           typename OutputIterator,
           typename UnaryFunction,
           typename T,
+          typename BinaryFunction>
+_CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
+  thrust::execution_policy<ExecutionPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator result,
+  UnaryFunction unary_op,
+  T init,
+  BinaryFunction binary_op);
+
+template <typename ExecutionPolicy,
+          typename InputIterator,
+          typename OutputIterator,
+          typename UnaryFunction,
+          typename T,
           typename AssociativeOperator>
 _CCCL_HOST_DEVICE OutputIterator transform_exclusive_scan(
   thrust::execution_policy<ExecutionPolicy>& exec,

--- a/thrust/thrust/system/detail/generic/transform_scan.inl
+++ b/thrust/thrust/system/detail/generic/transform_scan.inl
@@ -69,6 +69,29 @@ template <typename ExecutionPolicy,
           typename OutputIterator,
           typename UnaryFunction,
           typename InitialValueType,
+          typename BinaryFunction>
+_CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
+  thrust::execution_policy<ExecutionPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator result,
+  UnaryFunction unary_op,
+  InitialValueType init,
+  BinaryFunction binary_op)
+{
+  using ValueType = thrust::remove_cvref_t<InitialValueType>; // cuda::std::__accumulator_t?
+
+  thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
+  thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);
+
+  return thrust::inclusive_scan(exec, _first, _last, result, init, binary_op);
+} // end transform_inclusive_scan()
+
+template <typename ExecutionPolicy,
+          typename InputIterator,
+          typename OutputIterator,
+          typename UnaryFunction,
+          typename InitialValueType,
           typename AssociativeOperator>
 _CCCL_HOST_DEVICE OutputIterator transform_exclusive_scan(
   thrust::execution_policy<ExecutionPolicy>& exec,

--- a/thrust/thrust/system/detail/generic/transform_scan.inl
+++ b/thrust/thrust/system/detail/generic/transform_scan.inl
@@ -79,7 +79,9 @@ _CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
   InitialValueType init,
   BinaryFunction binary_op)
 {
-  using ValueType = thrust::remove_cvref_t<InitialValueType>; // cuda::std::__accumulator_t?
+  using InputType  = typename thrust::iterator_value<InputIterator>::type;
+  using ResultType = thrust::detail::invoke_result_t<UnaryFunction, InputType>;
+  using ValueType  = thrust::remove_cvref_t<ResultType>;
 
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _first(first, unary_op);
   thrust::transform_iterator<UnaryFunction, InputIterator, ValueType> _last(last, unary_op);

--- a/thrust/thrust/transform_scan.h
+++ b/thrust/thrust/transform_scan.h
@@ -174,8 +174,8 @@ OutputIterator transform_inclusive_scan(
  *  performing an \p inclusive_scan on the tranformed sequence.  In most
  *  cases, fusing these two operations together is more efficient, since
  *  fewer memory reads and writes are required. In \p transform_inclusive_scan,
- *  <tt>binary_op(unary_op(\*first), init)</tt> is assigned to
- *  <tt>\*result</tt> and the result of <tt>binary_op(unary_op(\*result),
+ *  if <tt>binary_op(init, unary_op(\*first))</tt> is <tt>accum</tt>, it is assigned to
+ *  <tt>\*result</tt> and the result of <tt>binary_op(accum,
  *  unary_op(\*(first + 1)))</tt> is assigned to <tt>\*(result + 1)</tt>,
  *  and so on. The transform scan operation is permitted to be in-place.
  *
@@ -186,7 +186,7 @@ OutputIterator transform_inclusive_scan(
  *  \param last The end of the input sequence.
  *  \param result The beginning of the output sequence.
  *  \param unary_op The function used to tranform the input sequence.
- *  \param init The initial value of the \p inclusive_scan
+ *  \param init The initial value of the \p transform_inclusive_scan
  *  \param binary_op The associatve operator used to 'sum' transformed values.
  *  \return The end of the output sequence.
  *
@@ -239,6 +239,7 @@ _CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
   InputIterator first,
   InputIterator last,
   OutputIterator result,
+  UnaryFunction unary_op,
   T init,
   AssociativeOperator binary_op);
 
@@ -247,9 +248,9 @@ _CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
  *  tranformation defined by \p unary_op into a temporary sequence and then
  *  performing an \p inclusive_scan on the tranformed sequence.  In most
  *  cases, fusing these two operations together is more efficient, since
- *  fewer memory reads and writes are required. In \p transform_inclusive_scan,
- *  <tt>binary_op(unary_op(\*first), init)</tt> is assigned to
- *  <tt>\*result</tt> and the result of <tt>binary_op(unary_op(\*result),
+ *  fewer memory reads and writes are required.In \p transform_inclusive_scan,
+ *  if <tt>binary_op(init, unary_op(\*first))</tt> is <tt>accum</tt>, it is assigned to
+ *  <tt>\*result</tt> and the result of <tt>binary_op(accum,
  *  unary_op(\*(first + 1)))</tt> is assigned to <tt>\*(result + 1)</tt>,
  *  and so on. The transform scan operation is permitted to be in-place.
  *
@@ -257,7 +258,7 @@ _CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
  *  \param last The end of the input sequence.
  *  \param result The beginning of the output sequence.
  *  \param unary_op The function used to tranform the input sequence.
- *  \param init The initial value of the \p inclusive_scan
+ *  \param init The initial value of the \p transform_inclusive_scan
  *  \param binary_op The associatve operator used to 'sum' transformed values.
  *  \return The end of the output sequence.
  *

--- a/thrust/thrust/transform_scan.h
+++ b/thrust/thrust/transform_scan.h
@@ -197,14 +197,14 @@ OutputIterator transform_inclusive_scan(
  *  Iterator</a>.
  *  \tparam UnaryFunction is a model of <a href="https://en.cppreference.com/w/cpp/utility/functional/unary_function">
  *  Unary Function</a> and accepts inputs of \c InputIterator's \c value_type.  \c UnaryFunction's result_type is
- * convertable to \c OutputIterator's \c value_type.
+ *  convertable to \c OutputIterator's \c value_type.
  *  \tparam T is convertible to \c OutputIterator's \c value_type.
  *  \tparam AssociativeOperator is a model of
- * <ahref="https://en.cppreference.com/w/cpp/utility/functional/binary_function"> Binary Function</a> and \c
- * AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
+ *  <ahref="https://en.cppreference.com/w/cpp/utility/functional/binary_function"> Binary Function</a> and \c
+ *  AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
  *
  *  \pre \p first may equal \p result, but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
- * first))</tt> shall not overlap otherwise.
+ *  first))</tt> shall not overlap otherwise.
  *
  *  The following code snippet demonstrates how to use \p transform_inclusive_scan using the
  *  \p thrust::host execution policy for parallelization:

--- a/thrust/thrust/transform_scan.h
+++ b/thrust/thrust/transform_scan.h
@@ -168,6 +168,66 @@ template <typename InputIterator, typename OutputIterator, typename UnaryFunctio
 OutputIterator transform_inclusive_scan(
   InputIterator first, InputIterator last, OutputIterator result, UnaryFunction unary_op, AssociativeOperator binary_op);
 
+/*! \p transform_inclusive_scan fuses the \p transform and \p inclusive_scan
+ *  operations.  \p transform_inclusive_scan is equivalent to performing a
+ *  tranformation defined by \p unary_op into a temporary sequence and then
+ *  performing an \p inclusive_scan on the tranformed sequence.  In most
+ *  cases, fusing these two operations together is more efficient, since
+ *  fewer memory reads and writes are required. In \p transform_inclusive_scan,
+ *  <tt>binary_op(unary_op(\*first), init)</tt> is assigned to
+ *  <tt>\*result</tt> and the result of <tt>binary_op(unary_op(\*result),
+ *  unary_op(\*(first + 1)))</tt> is assigned to <tt>\*(result + 1)</tt>,
+ *  and so on. The transform scan operation is permitted to be in-place.
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param first The beginning of the input sequence.
+ *  \param last The end of the input sequence.
+ *  \param result The beginning of the output sequence.
+ *  \param unary_op The function used to tranform the input sequence.
+ *  \param init The initial value of the \p inclusive_scan
+ *  \param binary_op The associatve operator used to 'sum' transformed values.
+ *  \return The end of the output sequence.
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam InputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
+ *  Iterator</a> and \c InputIterator's \c value_type is convertible to \c unary_op's input type.
+ *  \tparam OutputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
+ *  Iterator</a>.
+ *  \tparam UnaryFunction is a model of <a href="https://en.cppreference.com/w/cpp/utility/functional/unary_function">
+ *  Unary Function</a> and accepts inputs of \c InputIterator's \c value_type.  \c UnaryFunction's result_type is
+ * convertable to \c OutputIterator's \c value_type.
+ *  \tparam T is convertible to \c OutputIterator's \c value_type.
+ *  \tparam AssociativeOperator is a model of
+ * <ahref="https://en.cppreference.com/w/cpp/utility/functional/binary_function"> Binary Function</a> and \c
+ * AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
+ *
+ *  \pre \p first may equal \p result, but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
+ * first))</tt> shall not overlap otherwise.
+ *
+ *  The following code snippet demonstrates how to use \p transform_inclusive_scan using the
+ *  \p thrust::host execution policy for parallelization:
+ *
+ *  \code
+ *  #include <thrust/transform_scan.h>
+ *  #include <thrust/execution_policy.h>
+ *  ...
+ *
+ *  int data[6] = {1, 0, 2, 2, 1, 3};
+ *
+ *  thrust::negate<int> unary_op;
+ *  thrust::plus<int> binary_op;
+ *
+ *  thrust::transform_inclusive_scan(thrust::host, data, data + 6, data, unary_op, 4, binary_op); // in-place scan
+ *
+ *  // data is now {3, 3, 1, -1, -2, -5}
+ *  \endcode
+ *
+ *  \see \p transform
+ *  \see \p inclusive_scan
+ *
+ */
 template <typename DerivedPolicy,
           typename InputIterator,
           typename OutputIterator,
@@ -179,6 +239,69 @@ _CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
   InputIterator first,
   InputIterator last,
   OutputIterator result,
+  T init,
+  AssociativeOperator binary_op);
+
+/*! \p transform_inclusive_scan fuses the \p transform and \p inclusive_scan
+ *  operations.  \p transform_inclusive_scan is equivalent to performing a
+ *  tranformation defined by \p unary_op into a temporary sequence and then
+ *  performing an \p inclusive_scan on the tranformed sequence.  In most
+ *  cases, fusing these two operations together is more efficient, since
+ *  fewer memory reads and writes are required. In \p transform_inclusive_scan,
+ *  <tt>binary_op(unary_op(\*first), init)</tt> is assigned to
+ *  <tt>\*result</tt> and the result of <tt>binary_op(unary_op(\*result),
+ *  unary_op(\*(first + 1)))</tt> is assigned to <tt>\*(result + 1)</tt>,
+ *  and so on. The transform scan operation is permitted to be in-place.
+ *
+ *  \param first The beginning of the input sequence.
+ *  \param last The end of the input sequence.
+ *  \param result The beginning of the output sequence.
+ *  \param unary_op The function used to tranform the input sequence.
+ *  \param init The initial value of the \p inclusive_scan
+ *  \param binary_op The associatve operator used to 'sum' transformed values.
+ *  \return The end of the output sequence.
+ *
+ *  \tparam InputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input
+ *  Iterator</a> and \c InputIterator's \c value_type is convertible to \c unary_op's input type.
+ *  \tparam OutputIterator is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output
+ *  Iterator</a>.
+ *  \tparam UnaryFunction is a model of <a href="https://en.cppreference.com/w/cpp/utility/functional/unary_function">
+ *  Unary Function</a> and accepts inputs of \c InputIterator's \c value_type.  \c UnaryFunction's result_type is
+ * convertable to \c OutputIterator's \c value_type.
+ *  \tparam T is convertible to \c OutputIterator's \c value_type.
+ *  \tparam AssociativeOperator is a model of
+ * <ahref="https://en.cppreference.com/w/cpp/utility/functional/binary_function"> Binary Function</a> and \c
+ * AssociativeOperator's \c result_type is convertible to \c OutputIterator's \c value_type.
+ *
+ *  \pre \p first may equal \p result, but the range <tt>[first, last)</tt> and the range <tt>[result, result + (last -
+ * first))</tt> shall not overlap otherwise.
+ *
+ *  The following code snippet demonstrates how to use \p transform_inclusive_scan
+ *
+ *  \code
+ *  #include <thrust/transform_scan.h>
+ *  ...
+ *
+ *  int data[6] = {1, 0, 2, 2, 1, 3};
+ *
+ *  thrust::negate<int> unary_op;
+ *  thrust::plus<int> binary_op;
+ *
+ *  thrust::transform_inclusive_scan(data, data + 6, data, unary_op, 4, binary_op); // in-place scan
+ *
+ *  // data is now {3, 3, 1, -1, -2, -5}
+ *  \endcode
+ *
+ *  \see \p transform
+ *  \see \p inclusive_scan
+ *
+ */
+template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename T, typename AssociativeOperator>
+OutputIterator transform_inclusive_scan(
+  InputIterator first,
+  InputIterator last,
+  OutputIterator result,
+  UnaryFunction unary_op,
   T init,
   AssociativeOperator binary_op);
 
@@ -308,15 +431,6 @@ _CCCL_HOST_DEVICE OutputIterator transform_exclusive_scan(
  */
 template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename T, typename AssociativeOperator>
 OutputIterator transform_exclusive_scan(
-  InputIterator first,
-  InputIterator last,
-  OutputIterator result,
-  UnaryFunction unary_op,
-  T init,
-  AssociativeOperator binary_op);
-
-template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename T, typename AssociativeOperator>
-OutputIterator transform_inclusive_scan(
   InputIterator first,
   InputIterator last,
   OutputIterator result,

--- a/thrust/thrust/transform_scan.h
+++ b/thrust/thrust/transform_scan.h
@@ -168,6 +168,20 @@ template <typename InputIterator, typename OutputIterator, typename UnaryFunctio
 OutputIterator transform_inclusive_scan(
   InputIterator first, InputIterator last, OutputIterator result, UnaryFunction unary_op, AssociativeOperator binary_op);
 
+template <typename DerivedPolicy,
+          typename InputIterator,
+          typename OutputIterator,
+          typename UnaryFunction,
+          typename T,
+          typename AssociativeOperator>
+_CCCL_HOST_DEVICE OutputIterator transform_inclusive_scan(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  InputIterator first,
+  InputIterator last,
+  OutputIterator result,
+  T init,
+  AssociativeOperator binary_op);
+
 /*! \p transform_exclusive_scan fuses the \p transform and \p exclusive_scan
  *  operations.  \p transform_exclusive_scan is equivalent to performing a
  *  tranformation defined by \p unary_op into a temporary sequence and then
@@ -294,6 +308,15 @@ _CCCL_HOST_DEVICE OutputIterator transform_exclusive_scan(
  */
 template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename T, typename AssociativeOperator>
 OutputIterator transform_exclusive_scan(
+  InputIterator first,
+  InputIterator last,
+  OutputIterator result,
+  UnaryFunction unary_op,
+  T init,
+  AssociativeOperator binary_op);
+
+template <typename InputIterator, typename OutputIterator, typename UnaryFunction, typename T, typename AssociativeOperator>
+OutputIterator transform_inclusive_scan(
   InputIterator first,
   InputIterator last,
   OutputIterator result,


### PR DESCRIPTION
Resolves #2318. Adds `thrust::transform_inclusive_scan` support for initial value. Relies on #2346.