### PR TITLE
[CUDAX] Add compute_capability device attribute and handle arch_traits for future architectures

### DIFF
--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -189,6 +189,11 @@ inline const ::std::vector<device>& all_devices::__devices()
 //! * device_ref
 inline constexpr detail::all_devices devices{};
 
+inline arch_traits_t device_ref::arch_traits() const
+{
+  return devices[get()].arch_traits();
+}
+
 } // namespace cuda::experimental
 
 #endif // _CUDAX__DEVICE_ALL_DEVICES

--- a/cudax/include/cuda/experimental/__device/all_devices.cuh
+++ b/cudax/include/cuda/experimental/__device/all_devices.cuh
@@ -189,7 +189,7 @@ inline const ::std::vector<device>& all_devices::__devices()
 //! * device_ref
 inline constexpr detail::all_devices devices{};
 
-inline arch_traits_t device_ref::arch_traits() const
+inline const arch_traits_t& device_ref::arch_traits() const
 {
   return devices[get()].arch_traits();
 }

--- a/cudax/include/cuda/experimental/__device/arch_traits.cuh
+++ b/cudax/include/cuda/experimental/__device/arch_traits.cuh
@@ -419,6 +419,7 @@ _CCCL_NODISCARD inline constexpr arch_traits_t __arch_traits_might_be_unknown(in
     __traits.elect_intrinsic    = __arch >= 900;
     __traits.cp_async_supported = __arch >= 800;
     __traits.tma_supported      = __arch >= 900;
+    return __traits;
   }
 }
 } // namespace detail

--- a/cudax/include/cuda/experimental/__device/arch_traits.cuh
+++ b/cudax/include/cuda/experimental/__device/arch_traits.cuh
@@ -24,6 +24,8 @@
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/limits>
 
+#include <cuda/experimental/__device/attributes.cuh>
+
 namespace cuda::experimental
 {
 
@@ -119,11 +121,11 @@ struct arch_traits_t : public detail::arch_common_traits
   // Maximum number of thread blocks that can reside on a multiprocessor
   int max_blocks_per_multiprocessor;
 
-  // Maximum resident warps per multiprocessor
-  int max_warps_per_multiprocessor;
-
   // Maximum resident threads per multiprocessor
   int max_threads_per_multiprocessor;
+
+  // Maximum resident warps per multiprocessor
+  int max_warps_per_multiprocessor;
 
   // Shared memory reserved by CUDA driver per block in bytes
   int reserved_shared_memory_per_block;
@@ -159,9 +161,9 @@ inline constexpr arch_traits_t sm_600_traits = []() constexpr {
   __traits.compute_capability                   = 600;
   __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
   __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_warps_per_multiprocessor         = 64;
-  __traits.max_threads_per_multiprocessor =
-    __traits.max_warps_per_multiprocessor * detail::arch_common_traits::warp_size;
+  __traits.max_threads_per_multiprocessor       = 2048;
+  __traits.max_warps_per_multiprocessor =
+    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block  = 0;
   __traits.max_shared_memory_per_block_optin = 48 * 1024;
 
@@ -181,9 +183,9 @@ inline constexpr arch_traits_t sm_700_traits = []() constexpr {
   __traits.compute_capability                   = 700;
   __traits.max_shared_memory_per_multiprocessor = 96 * 1024;
   __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_warps_per_multiprocessor         = 64;
-  __traits.max_threads_per_multiprocessor =
-    __traits.max_warps_per_multiprocessor * detail::arch_common_traits::warp_size;
+  __traits.max_threads_per_multiprocessor       = 2048;
+  __traits.max_warps_per_multiprocessor =
+    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 0;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -204,9 +206,9 @@ inline constexpr arch_traits_t sm_750_traits = []() constexpr {
   __traits.compute_capability                   = 750;
   __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
   __traits.max_blocks_per_multiprocessor        = 16;
-  __traits.max_warps_per_multiprocessor         = 32;
-  __traits.max_threads_per_multiprocessor =
-    __traits.max_warps_per_multiprocessor * detail::arch_common_traits::warp_size;
+  __traits.max_threads_per_multiprocessor       = 1024;
+  __traits.max_warps_per_multiprocessor =
+    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 0;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -227,9 +229,9 @@ inline constexpr arch_traits_t sm_800_traits = []() constexpr {
   __traits.compute_capability                   = 800;
   __traits.max_shared_memory_per_multiprocessor = 164 * 1024;
   __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_warps_per_multiprocessor         = 64;
-  __traits.max_threads_per_multiprocessor =
-    __traits.max_warps_per_multiprocessor * detail::arch_common_traits::warp_size;
+  __traits.max_threads_per_multiprocessor       = 2048;
+  __traits.max_warps_per_multiprocessor =
+    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 1024;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -250,9 +252,9 @@ inline constexpr arch_traits_t sm_860_traits = []() constexpr {
   __traits.compute_capability                   = 860;
   __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
   __traits.max_blocks_per_multiprocessor        = 16;
-  __traits.max_warps_per_multiprocessor         = 48;
-  __traits.max_threads_per_multiprocessor =
-    __traits.max_warps_per_multiprocessor * detail::arch_common_traits::warp_size;
+  __traits.max_threads_per_multiprocessor       = 1536;
+  __traits.max_warps_per_multiprocessor =
+    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 1024;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -273,9 +275,9 @@ inline constexpr arch_traits_t sm_890_traits = []() constexpr {
   __traits.compute_capability                   = 890;
   __traits.max_shared_memory_per_multiprocessor = 100 * 1024;
   __traits.max_blocks_per_multiprocessor        = 24;
-  __traits.max_warps_per_multiprocessor         = 48;
-  __traits.max_threads_per_multiprocessor =
-    __traits.max_warps_per_multiprocessor * detail::arch_common_traits::warp_size;
+  __traits.max_threads_per_multiprocessor       = 1536;
+  __traits.max_warps_per_multiprocessor =
+    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 1024;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -296,9 +298,9 @@ inline constexpr arch_traits_t sm_900_traits = []() constexpr {
   __traits.compute_capability                   = 900;
   __traits.max_shared_memory_per_multiprocessor = 228 * 1024;
   __traits.max_blocks_per_multiprocessor        = 32;
-  __traits.max_warps_per_multiprocessor         = 64;
-  __traits.max_threads_per_multiprocessor =
-    __traits.max_warps_per_multiprocessor * detail::arch_common_traits::warp_size;
+  __traits.max_threads_per_multiprocessor       = 2048;
+  __traits.max_warps_per_multiprocessor =
+    __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
   __traits.reserved_shared_memory_per_block = 1024;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
@@ -311,6 +313,8 @@ inline constexpr arch_traits_t sm_900_traits = []() constexpr {
 
   return __traits;
 }();
+
+inline constexpr unsigned int __highest_known_arch = 900;
 
 } // namespace detail
 
@@ -384,6 +388,40 @@ _CCCL_DEVICE constexpr inline arch_traits_t current_arch()
   return arch_traits_t{};
 #endif
 }
+
+namespace detail
+{
+_CCCL_NODISCARD inline constexpr arch_traits_t __arch_traits_might_be_unknown(int __device, unsigned int __arch)
+{
+  if (__arch <= __highest_known_arch)
+  {
+    return arch_traits(__arch);
+  }
+  else
+  {
+    // If the architecture is unknown, we need to craft the arch_traits from attributes
+    arch_traits_t __traits{};
+    __traits.compute_capability_major = __arch / 100;
+    __traits.compute_capability_minor = (__arch / 10) % 10;
+    __traits.compute_capability       = __arch;
+    __traits.max_shared_memory_per_multiprocessor =
+      detail::__device_attrs::max_shared_memory_per_multiprocessor(__device);
+    __traits.max_blocks_per_multiprocessor  = detail::__device_attrs::max_blocks_per_multiprocessor(__device);
+    __traits.max_threads_per_multiprocessor = detail::__device_attrs::max_threads_per_multiprocessor(__device);
+    __traits.max_warps_per_multiprocessor =
+      __traits.max_threads_per_multiprocessor / detail::arch_common_traits::warp_size;
+    __traits.reserved_shared_memory_per_block = detail::__device_attrs::reserved_shared_memory_per_block(__device);
+    __traits.max_shared_memory_per_block_optin =
+      __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+
+    __traits.cluster_supported  = __arch >= 900;
+    __traits.redux_intrinisic   = __arch >= 800;
+    __traits.elect_intrinsic    = __arch >= 900;
+    __traits.cp_async_supported = __arch >= 800;
+    __traits.tma_supported      = __arch >= 900;
+  }
+}
+} // namespace detail
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -723,6 +723,8 @@ struct __device_attrs
 
 #endif // CUDART_VERSION >= 12020
 
+  // Combines major and minor compute capability in a 100 * major + 10 * minor format, allows to query full compute
+  // capability in a single query
   struct compute_capability_t
   {
     _CCCL_NODISCARD int operator()(device_ref __dev_id) const

--- a/cudax/include/cuda/experimental/__device/attributes.cuh
+++ b/cudax/include/cuda/experimental/__device/attributes.cuh
@@ -24,7 +24,7 @@
 #include <cuda/std/__cccl/attributes.h>
 #include <cuda/std/__cuda/api_wrapper.h>
 
-#include <cuda/experimental/__device/device.cuh>
+#include <cuda/experimental/__device/device_ref.cuh>
 
 namespace cuda::experimental
 {
@@ -257,9 +257,8 @@ struct __dev_attr<::cudaDevAttrNumaConfig> //
   static constexpr type numa_node = ::cudaDeviceNumaConfigNumaNode;
 };
 #endif
-} // namespace detail
 
-struct device::attrs
+struct __device_attrs
 {
   // Maximum number of threads per block
   using max_threads_per_block_t = detail::__dev_attr<::cudaDevAttrMaxThreadsPerBlock>;
@@ -734,12 +733,8 @@ struct device::attrs
   static constexpr compute_capability_t compute_capability{};
 };
 
-inline arch_traits_t device_ref::arch_traits() const
-{
-  // TODO we might want to get the CC with device init and store it device struct
-  return cuda::experimental::arch_traits(
-    attr<cudaDevAttrComputeCapabilityMajor>() * 100 + attr<cudaDevAttrComputeCapabilityMinor>() * 10);
-}
+} // namespace detail
+
 } // namespace cuda::experimental
 
 #endif // _CUDAX__DEVICE_ATTRIBUTES_

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -78,7 +78,7 @@ public:
 #  endif
 #endif
 
-  const arch_traits_t& arch_traits() const
+  const arch_traits_t& arch_traits() const noexcept
   {
     return __traits;
   }

--- a/cudax/include/cuda/experimental/__device/device.cuh
+++ b/cudax/include/cuda/experimental/__device/device.cuh
@@ -78,7 +78,7 @@ public:
 #  endif
 #endif
 
-  inline arch_traits_t arch_traits() const
+  const arch_traits_t& arch_traits() const
   {
     return __traits;
   }
@@ -111,11 +111,15 @@ private:
   mutable CUcontext __primary_ctx = nullptr;
   mutable CUdevice __device{};
   mutable ::std::once_flag __init_once;
-  const arch_traits_t __traits;
+
+  // TODO should this be a reference/pointer to the constexpr traits instances?
+  //  Do we care about lazy init?
+  //  We should have some of the attributes just return from the arch traits
+  arch_traits_t __traits;
 
   explicit device(int __id)
       : device_ref(__id)
-      , __traits(cuda::experimental::arch_traits(attrs::compute_capability(__id)))
+      , __traits(detail::__arch_traits_might_be_unknown(__id, attrs::compute_capability(__id)))
   {}
 
   // `device` objects are not movable or copyable.

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -92,12 +92,10 @@ public:
   //! @throws cuda_error if the attribute query fails
   //!
   //! @sa device::attrs
-  template <::cudaDeviceAttr _Attr>
-  _CCCL_NODISCARD auto attr([[maybe_unused]] detail::__dev_attr<_Attr> __attr) const
+  template <typename _Attr>
+  _CCCL_NODISCARD auto attr(_Attr __attr) const
   {
-    int __value = 0;
-    _CCCL_TRY_CUDA_API(::cudaDeviceGetAttribute, "failed to get device attribute", &__value, _Attr, get());
-    return static_cast<typename detail::__dev_attr<_Attr>::type>(__value);
+    return __attr(*this);
   }
 
   //! @overload

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -23,11 +23,10 @@
 
 #include <cuda/std/__cuda/api_wrapper.h>
 
-#include <cuda/experimental/__device/arch_traits.cuh>
-
 namespace cuda::experimental
 {
 class device;
+struct arch_traits_t;
 
 namespace detail
 {
@@ -105,7 +104,7 @@ public:
     return attr(detail::__dev_attr<_Attr>());
   }
 
-  arch_traits_t arch_traits() const;
+  const arch_traits_t& arch_traits() const;
 };
 
 } // namespace cuda::experimental

--- a/cudax/test/device/arch_traits.cu
+++ b/cudax/test/device/arch_traits.cu
@@ -133,6 +133,7 @@ TEST_CASE("Traits", "[device]")
       traits.max_registers_per_multiprocessor == dev.attr(cudax::device::attrs::max_registers_per_multiprocessor));
     CUDAX_REQUIRE(traits.compute_capability_major == dev.attr(cudax::device::attrs::compute_capability_major));
     CUDAX_REQUIRE(traits.compute_capability_minor == dev.attr(cudax::device::attrs::compute_capability_minor));
+    CUDAX_REQUIRE(traits.compute_capability == dev.attr(cudax::device::attrs::compute_capability));
     CUDAX_REQUIRE(traits.max_shared_memory_per_multiprocessor
                   == dev.attr(cudax::device::attrs::max_shared_memory_per_multiprocessor));
     CUDAX_REQUIRE(

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -270,6 +270,13 @@ TEST_CASE("Smoke", "[device]")
                      config == device::attrs::numa_config.numa_node));
     }
 #endif
+    SECTION("Compute capability")
+    {
+      int compute_cap       = device_ref(0).attr(device::attrs::compute_capability);
+      int compute_cap_major = device_ref(0).attr(device::attrs::compute_capability_major);
+      int compute_cap_minor = device_ref(0).attr(device::attrs::compute_capability_minor);
+      CUDAX_REQUIRE(compute_cap == 100 * compute_cap_major + 10 * compute_cap_minor);
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds reroutes device attributes a little in order to allow attributes that don't have a corresponding `cudaDeviceAttr`. Instead of the attribute `operator()` calling into the device, the device calls into `operator()` of the attribute. This way, the call operator of the attribute can do something else than call `cudaDeviceGetAttribute`. The first such attribute is `compute_capability`, which calls into `_major` and `_minor` parts and returns compute capabilities in the same format `arch_traits` expects them.

This PR also puts `arch_traits_t` into `device` object. This way repeated access to them does not need to query compute capability each time and in the future we could have some device attribute queries skip calling into the driver.
In order to handle future architectures, when old program is run on a new hardware, when we notice the driver returning compute capabilities higher than the highest known in the implementation, we instead craft the `arch_traits_t` from device attribute queries.