### PR TITLE
Do not hardcode Thrust's host system to cpp.

### DIFF
--- a/thrust/thrust/execution_policy.h
+++ b/thrust/thrust/execution_policy.h
@@ -55,7 +55,7 @@ THRUST_NAMESPACE_BEGIN
 namespace detail
 {
 
-using host_t = thrust::system::cpp::detail::par_t;
+using host_t = thrust::system::__THRUST_HOST_SYSTEM_NAMESPACE::detail::par_t;
 
 using device_t = thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::detail::par_t;
 


### PR DESCRIPTION
## Description

Thrust ended up getting hardcoded to use CPP as the HOST backend, regardless of the actual setting.

This fixes #2098.