### PR TITLE
Fix hardcoding __THRUST_HOST_SYSTEM_NAMESPACE to cpp

### DIFF
--- a/thrust/thrust/mr/host_memory_resource.h
+++ b/thrust/thrust/mr/host_memory_resource.h
@@ -33,6 +33,6 @@
 
 THRUST_NAMESPACE_BEGIN
 
-using host_memory_resource = thrust::system::cpp::memory_resource;
+using host_memory_resource = thrust::system::__THRUST_HOST_SYSTEM_NAMESPACE::memory_resource;
 
 THRUST_NAMESPACE_END


### PR DESCRIPTION
This change was erroneously introduced in 91b78d8;

Fixes: #2098
