### PR TITLE
[CUDAX] Branch out an experimental version of stream_ref

### DIFF
--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -23,10 +23,9 @@
 #endif // no system header
 
 #include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/stream_ref>
 
 #include <cuda/experimental/__device/device_ref.cuh>
-#include <cuda/experimental/__event/timed_event.cuh>
+#include <cuda/experimental/__stream/stream_ref.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
 
 namespace cuda::experimental
@@ -110,69 +109,7 @@ struct stream : stream_ref
 
   stream& operator=(const stream&) = delete;
 
-  // Ideally records and waits below would be in stream_ref, but we can't have it depend on cudax yet
-
-  //! @brief Create a new event and record it into this stream
-  //!
-  //! @return A new event that was recorded into this stream
-  //!
-  //! @throws cuda_error if event creation or record failed
-  _CCCL_NODISCARD event record_event(event::flags __flags = event::flags::none) const
-  {
-    return event(*this, __flags);
-  }
-
-  //! @brief Create a new timed event and record it into this stream
-  //!
-  //! @return A new timed event that was recorded into this stream
-  //!
-  //! @throws cuda_error if event creation or record failed
-  _CCCL_NODISCARD timed_event record_timed_event(event::flags __flags = event::flags::none) const
-  {
-    return timed_event(*this, __flags);
-  }
-
   using stream_ref::wait;
-
-  //! @brief Make all future work submitted into this stream depend on completion of the specified event
-  //!
-  //! @param __ev Event that this stream should wait for
-  //!
-  //! @throws cuda_error if inserting the dependency fails
-  void wait(event_ref __ev) const
-  {
-    assert(__ev.get() != nullptr);
-    // Need to use driver API, cudaStreamWaitEvent would push dev 0 if stack was empty
-    detail::driver::streamWaitEvent(get(), __ev.get());
-  }
-
-  //! @brief Make all future work submitted into this stream depend on completion of all work from the specified
-  //! stream
-  //!
-  //! @param __other Stream that this stream should wait for
-  //!
-  //! @throws cuda_error if inserting the dependency fails
-  void wait(stream_ref __other) const
-  {
-    // TODO consider an optimization to not create an event every time and instead have one persistent event or one
-    // per stream
-    assert(__stream != detail::invalid_stream);
-    event __tmp(__other);
-    wait(__tmp);
-  }
-
-  //! @brief Get device under which this stream was created.
-  //!
-  //! @throws cuda_error if device check fails
-  device_ref device() const
-  {
-    // Because the stream can come from_native_handle, we can't just loop over devices comparing contexts,
-    // lower to CUDART for this instead
-    __ensure_current_device __dev_setter(*this);
-    int result;
-    _CCCL_TRY_CUDA_API(cudaGetDevice, "Could not get device from a stream", &result);
-    return result;
-  }
 
   //! @brief Construct an `stream` object from a native `cudaStream_t` handle.
   //!

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -50,6 +50,7 @@ struct stream : stream_ref
   //!
   //! @throws cuda_error if stream creation fails
   explicit stream(device_ref __dev, int __priority = default_priority)
+      : stream_ref(detail::invalid_stream)
   {
     [[maybe_unused]] __ensure_current_device __dev_setter(__dev);
     _CCCL_TRY_CUDA_API(

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -109,8 +109,6 @@ struct stream : stream_ref
 
   stream& operator=(const stream&) = delete;
 
-  using stream_ref::wait;
-
   //! @brief Construct an `stream` object from a native `cudaStream_t` handle.
   //!
   //! @param __handle The native handle

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__STREAM_STREAM_REF
+#define _CUDAX__STREAM_STREAM_REF
+
+#include <cuda/std/detail/__config>
+#include <cuda_runtime_api.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/stream_ref>
+
+#include <cuda/experimental/__device/device_ref.cuh>
+#include <cuda/experimental/__event/timed_event.cuh>
+#include <cuda/experimental/__utility/ensure_current_device.cuh>
+
+namespace cuda::experimental
+{
+
+//! @brief An non-owning wrapper for cudaStream_t.
+struct stream_ref : ::cuda::stream_ref
+{
+  using ::cuda::stream_ref::stream_ref;
+
+  //! @brief Create a new event and record it into this stream
+  //!
+  //! @return A new event that was recorded into this stream
+  //!
+  //! @throws cuda_error if event creation or record failed
+  _CCCL_NODISCARD event record_event(event::flags __flags = event::flags::none) const
+  {
+    return event(*this, __flags);
+  }
+
+  //! @brief Create a new timed event and record it into this stream
+  //!
+  //! @return A new timed event that was recorded into this stream
+  //!
+  //! @throws cuda_error if event creation or record failed
+  _CCCL_NODISCARD timed_event record_timed_event(event::flags __flags = event::flags::none) const
+  {
+    return timed_event(*this, __flags);
+  }
+
+  using ::cuda::stream_ref::wait;
+
+  //! @brief Make all future work submitted into this stream depend on completion of the specified event
+  //!
+  //! @param __ev Event that this stream should wait for
+  //!
+  //! @throws cuda_error if inserting the dependency fails
+  void wait(event_ref __ev) const
+  {
+    assert(__ev.get() != nullptr);
+    // Need to use driver API, cudaStreamWaitEvent would push dev 0 if stack was empty
+    detail::driver::streamWaitEvent(get(), __ev.get());
+  }
+
+  //! @brief Make all future work submitted into this stream depend on completion of all work from the specified
+  //! stream
+  //!
+  //! @param __other Stream that this stream should wait for
+  //!
+  //! @throws cuda_error if inserting the dependency fails
+  void wait(stream_ref __other) const
+  {
+    // TODO consider an optimization to not create an event every time and instead have one persistent event or one
+    // per stream
+    assert(__stream != detail::invalid_stream);
+    event __tmp(__other);
+    wait(__tmp);
+  }
+
+  //! @brief Get device under which this stream was created.
+  //!
+  //! @throws cuda_error if device check fails
+  device_ref device() const
+  {
+    // Because the stream can come from_native_handle, we can't just loop over devices comparing contexts,
+    // lower to CUDART for this instead
+    __ensure_current_device __dev_setter(*this);
+    int result;
+    _CCCL_TRY_CUDA_API(cudaGetDevice, "Could not get device from a stream", &result);
+    return result;
+  }
+};
+
+} // namespace cuda::experimental
+
+#endif // _CUDAX__STREAM_STREAM_REF

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -32,7 +32,7 @@
 namespace cuda::experimental
 {
 
-//! @brief An non-owning wrapper for cudaStream_t.
+//! @brief A non-owning wrapper for cudaStream_t.
 struct stream_ref : ::cuda::stream_ref
 {
   using ::cuda::stream_ref::stream_ref;

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -35,8 +35,9 @@ namespace cuda::experimental
 //! @brief A non-owning wrapper for cudaStream_t.
 struct stream_ref : ::cuda::stream_ref
 {
-  // TODO consider removing the argumentless constructor, currently creates a NULL stream reference
   using ::cuda::stream_ref::stream_ref;
+
+  stream_ref() = delete;
 
   //! @brief Create a new event and record it into this stream
   //!

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -12,8 +12,6 @@
 #define _CUDAX__STREAM_STREAM_REF
 
 #include <cuda/std/detail/__config>
-#include <cuda_runtime_api.h>
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -21,6 +19,8 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
+#include <cuda_runtime_api.h>
 
 #include <cuda/std/__cuda/api_wrapper.h>
 #include <cuda/stream_ref>

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -35,6 +35,7 @@ namespace cuda::experimental
 //! @brief A non-owning wrapper for cudaStream_t.
 struct stream_ref : ::cuda::stream_ref
 {
+  // TODO consider removing the argumentless constructor, currently creates a NULL stream reference
   using ::cuda::stream_ref::stream_ref;
 
   //! @brief Create a new event and record it into this stream

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -39,11 +39,9 @@ TEST_CASE("From native handle", "[stream]")
   CUDART(cudaStreamDestroy(handle));
 }
 
-TEST_CASE("Can add dependency into a stream", "[stream]")
+template <typename StreamType>
+void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
 {
-  cudax::stream waiter, waitee;
-  CUDAX_REQUIRE(waiter != waitee);
-
   auto verify_dependency = [&](const auto& insert_dependency) {
     ::test::managed<int> i(0);
     ::cuda::atomic_ref atomic_i(*i);
@@ -91,6 +89,15 @@ TEST_CASE("Can add dependency into a stream", "[stream]")
   }
 }
 
+TEST_CASE("Can add dependency into a stream", "[stream]")
+{
+  cudax::stream waiter, waitee;
+  CUDAX_REQUIRE(waiter != waitee);
+
+  add_dependency_test<cudax::stream>(waiter, waitee);
+  add_dependency_test<cudax::stream_ref>(waiter, waitee);
+}
+
 TEST_CASE("Stream priority", "[stream]")
 {
   cudax::stream stream_default_prio;
@@ -111,4 +118,6 @@ TEST_CASE("Stream get device", "[stream]")
   CUDART(cudaStreamCreate(&stream_handle));
   auto stream_cudart = cudax::stream::from_native_handle(stream_handle);
   CUDAX_REQUIRE(stream_cudart.device() == *std::prev(cudax::devices.end()));
+  auto stream_ref_cudart = cudax::stream_ref(stream_handle);
+  CUDAX_REQUIRE(stream_ref_cudart.device() == *std::prev(cudax::devices.end()));
 }

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -42,6 +42,8 @@ TEST_CASE("From native handle", "[stream]")
 template <typename StreamType>
 void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
 {
+  CUDAX_REQUIRE(waiter != waitee);
+
   auto verify_dependency = [&](const auto& insert_dependency) {
     ::test::managed<int> i(0);
     ::cuda::atomic_ref atomic_i(*i);
@@ -92,7 +94,6 @@ void add_dependency_test(const StreamType& waiter, const StreamType& waitee)
 TEST_CASE("Can add dependency into a stream", "[stream]")
 {
   cudax::stream waiter, waitee;
-  CUDAX_REQUIRE(waiter != waitee);
 
   add_dependency_test<cudax::stream>(waiter, waitee);
   add_dependency_test<cudax::stream_ref>(waiter, waitee);


### PR DESCRIPTION
I was recently asked how to implement a function that uses cudax that takes a stream as an argument and internally creates a stream on the same device.

With `cudax::stream` its easy, you can just do `cudax::stream(input_stream.device())`.
That is not possible with `cuda::stream_ref`, because it does not have `.device()` member. We can't add it to `cuda::stream_ref`, because libcu++ can't depend on cudax.

I think the best solution is to introduce `cudax::stream_ref` that will inherit from `cuda::stream_ref` and extend it with experimental features. It will also be less confusing when we have both `cudax::stream` and `cudax::stream_ref` in the same namespace.

There might be some confusion on what is the difference between `cuda::stream_ref` and `cudax::stream_ref`, but I think the benefit outweighs it. We also need to be sometimes careful to use the correct version of the type inside other APIs implementation.

When we exit experimental namespace, new functionality will be propagated down from the `cudax::stream_ref` to the `cuda::` equivalent. The only issue would be removal of the argument less constructor, which currently creates NULL stream reference.