### PR TITLE
Fix `zip_function` together with `proclaim_return_type`

### DIFF
--- a/thrust/testing/zip_function.cmake
+++ b/thrust/testing/zip_function.cmake
@@ -1,0 +1,4 @@
+# We need to test cuda::proclaim_return_type
+if ("NVIDIA" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
+    target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
+endif()


### PR DESCRIPTION
When using `zip_function` with `proclaim_return_type` it wants to deduce the return type from the invoke expression inside of `proclaim_return_type`
which is not possible because device lambdas do not have a return type.

This seems to be a nvcc bug, but one we can work around with.

Fixes #2344
