### PR TITLE
Fix bug remaining on thrust::inclusive_scan with init value with CDP

### DIFF
--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -257,7 +257,8 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n(
 {
   THRUST_CDP_DISPATCH(
     (result = thrust::cuda_cub::detail::inclusive_scan_n_impl(policy, first, num_items, result, init, scan_op);),
-    (result = thrust::inclusive_scan(cvt_to_seq(derived_cast(policy)), first, first + num_items, result, scan_op);));
+    (result =
+       thrust::inclusive_scan(cvt_to_seq(derived_cast(policy)), first, first + num_items, result, init, scan_op);));
   return result;
 }
 


### PR DESCRIPTION
Fixes bug remaining from #1940 in the `thrust::inclusive_scan` implementation with initial value that uses CDP. Also adds test, which because omitted, led to the oversight of the bug.

#2326 relies on it.