### PR TITLE
Harden thrust algorithms against evil iterators that overload `operator,`

### DIFF
--- a/thrust/thrust/system/detail/sequential/general_copy.h
+++ b/thrust/thrust/system/detail/sequential/general_copy.h
@@ -85,7 +85,7 @@ _CCCL_EXEC_CHECK_DISABLE
 template <typename InputIterator, typename OutputIterator>
 _CCCL_HOST_DEVICE OutputIterator general_copy(InputIterator first, InputIterator last, OutputIterator result)
 {
-  for (; first != last; ++first, ++result)
+  for (; first != last; ++first, (void) ++result)
   {
     // gcc 4.2 crashes while instantiating iter_assign
 #if defined(_CCCL_COMPILER_GCC) && (THRUST_GCC_VERSION < 40300)
@@ -102,7 +102,7 @@ _CCCL_EXEC_CHECK_DISABLE
 template <typename InputIterator, typename Size, typename OutputIterator>
 _CCCL_HOST_DEVICE OutputIterator general_copy_n(InputIterator first, Size n, OutputIterator result)
 {
-  for (; n > Size(0); ++first, ++result, --n)
+  for (; n > Size(0); ++first, (void) ++result, (void) --n)
   {
     // gcc 4.2 crashes while instantiating iter_assign
 #if defined(_CCCL_COMPILER_GCC) && (THRUST_GCC_VERSION < 40300)

--- a/thrust/thrust/system/detail/sequential/partition.h
+++ b/thrust/thrust/system/detail/sequential/partition.h
@@ -210,7 +210,7 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   TempRange temp(exec, first, last);
 
   InputIterator stencil_iter = stencil;
-  for (TempIterator iter = temp.begin(); iter != temp.end(); ++iter, ++stencil_iter)
+  for (TempIterator iter = temp.begin(); iter != temp.end(); ++iter, (void) ++stencil_iter)
   {
     if (wrapped_pred(*stencil_iter))
     {
@@ -222,7 +222,7 @@ _CCCL_HOST_DEVICE ForwardIterator stable_partition(
   ForwardIterator middle = first;
   stencil_iter           = stencil;
 
-  for (TempIterator iter = temp.begin(); iter != temp.end(); ++iter, ++stencil_iter)
+  for (TempIterator iter = temp.begin(); iter != temp.end(); ++iter, (void) ++stencil_iter)
   {
     if (!wrapped_pred(*stencil_iter))
     {
@@ -287,7 +287,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partitio
   // wrap pred
   thrust::detail::wrapped_function<Predicate, bool> wrapped_pred{pred};
 
-  for (; first != last; ++first, ++stencil)
+  for (; first != last; ++first, (void) ++stencil)
   {
     if (wrapped_pred(*stencil))
     {

--- a/thrust/thrust/system/detail/sequential/reduce_by_key.h
+++ b/thrust/thrust/system/detail/sequential/reduce_by_key.h
@@ -66,7 +66,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
     InputKeyType temp_key    = *keys_first;
     TemporaryType temp_value = *values_first;
 
-    for (++keys_first, ++values_first; keys_first != keys_last; ++keys_first, ++values_first)
+    for (++keys_first, ++values_first; keys_first != keys_last; ++keys_first, (void) ++values_first)
     {
       InputKeyType key     = *keys_first;
       InputValueType value = *values_first;

--- a/thrust/thrust/system/detail/sequential/scan.h
+++ b/thrust/thrust/system/detail/sequential/scan.h
@@ -68,7 +68,7 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan(
 
     *result = *first;
 
-    for (++first, ++result; first != last; ++first, ++result)
+    for (++first, ++result; first != last; ++first, (void) ++result)
     {
       *result = sum = wrapped_binary_op(sum, *first);
     }
@@ -144,7 +144,7 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan(
     *result = sum;
     sum     = binary_op(sum, tmp);
 
-    for (++first, ++result; first != last; ++first, ++result)
+    for (++first, ++result; first != last; ++first, (void) ++result)
     {
       tmp     = *first;
       *result = sum;

--- a/thrust/thrust/system/detail/sequential/scan_by_key.h
+++ b/thrust/thrust/system/detail/sequential/scan_by_key.h
@@ -70,7 +70,7 @@ _CCCL_HOST_DEVICE OutputIterator inclusive_scan_by_key(
 
     *result = prev_value;
 
-    for (++first1, ++first2, ++result; first1 != last1; ++first1, ++first2, ++result)
+    for (++first1, ++first2, ++result; first1 != last1; ++first1, (void) ++first2, (void) ++result)
     {
       KeyType key = *first1;
 
@@ -123,7 +123,7 @@ _CCCL_HOST_DEVICE OutputIterator exclusive_scan_by_key(
 
     next = binary_op(next, temp_value);
 
-    for (++first1, ++first2, ++result; first1 != last1; ++first1, ++first2, ++result)
+    for (++first1, ++first2, ++result; first1 != last1; ++first1, (void) ++first2, (void) ++result)
     {
       KeyType key = *first1;
 

--- a/thrust/thrust/system/detail/sequential/unique_by_key.h
+++ b/thrust/thrust/system/detail/sequential/unique_by_key.h
@@ -65,7 +65,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_c
     InputKeyType temp_key      = *keys_first;
     OutputValueType temp_value = *values_first;
 
-    for (++keys_first, ++values_first; keys_first != keys_last; ++keys_first, ++values_first)
+    for (++keys_first, ++values_first; keys_first != keys_last; ++keys_first, (void) ++values_first)
     {
       InputKeyType key      = *keys_first;
       OutputValueType value = *values_first;


### PR DESCRIPTION
We need to guard against such iterators in libcu++, so our tests conventionallly contain iterators that delete `operator,`. To allow using thrust with such iterators we need to add the void casts
