### PR TITLE
add IWYU `export` pragma on config headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 
 # Contributing to CCCL
 
-Thank you for your interest in contributing to the CUDA C++ Core Libraries (CCCL)! 
+Thank you for your interest in contributing to the CUDA C++ Core Libraries (CCCL)!
 
 Looking for ideas for your first contribution? Check out: ![GitHub Issues or Pull Requests by label](https://img.shields.io/github/issues/nvidia/cccl/good%20first%20issue)
 

--- a/cub/cub/config.cuh
+++ b/cub/cub/config.cuh
@@ -33,7 +33,7 @@
 #pragma once
 
 // For _CCCL_IMPLICIT_SYSTEM_HEADER
-#include <cuda/__cccl_config>
+#include <cuda/__cccl_config> // IWYU pragma: export
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -43,9 +43,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cub/util_arch.cuh>
-#include <cub/util_compiler.cuh>
-#include <cub/util_cpp_dialect.cuh>
-#include <cub/util_deprecated.cuh>
-#include <cub/util_macro.cuh>
-#include <cub/util_namespace.cuh>
+#include <cub/util_arch.cuh> // IWYU pragma: export
+#include <cub/util_compiler.cuh> // IWYU pragma: export
+#include <cub/util_cpp_dialect.cuh> // IWYU pragma: export
+#include <cub/util_deprecated.cuh> // IWYU pragma: export
+#include <cub/util_macro.cuh> // IWYU pragma: export
+#include <cub/util_namespace.cuh> // IWYU pragma: export

--- a/cub/cub/util_arch.cuh
+++ b/cub/cub/util_arch.cuh
@@ -43,7 +43,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cub/util_cpp_dialect.cuh>
+#include <cub/util_cpp_dialect.cuh> // IWYU pragma: export
 #include <cub/util_macro.cuh>
 #include <cub/util_namespace.cuh>
 

--- a/cub/cub/util_cpp_dialect.cuh
+++ b/cub/cub/util_cpp_dialect.cuh
@@ -40,7 +40,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cub/util_compiler.cuh>
+#include <cub/util_compiler.cuh> // IWYU pragma: export
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -47,13 +47,13 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cub/detail/device_synchronize.cuh>
+#include <cub/detail/device_synchronize.cuh> // IWYU pragma: export
 #include <cub/util_debug.cuh>
 #include <cub/util_type.cuh>
 // for backward compatibility
 #include <cub/util_temporary_storage.cuh>
 
-#include <cuda/std/__cuda/ensure_current_device.h>
+#include <cuda/std/__cuda/ensure_current_device.h> // IWYU pragma: export
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 

--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -42,8 +42,8 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cub/detail/detect_cuda_runtime.cuh>
-#include <cub/util_namespace.cuh>
+#include <cub/detail/detect_cuda_runtime.cuh> // IWYU pragma: export
+#include <cub/util_namespace.cuh> // IWYU pragma: export
 
 #include <cuda/std/utility>
 

--- a/libcudacxx/include/cuda/__cccl_config
+++ b/libcudacxx/include/cuda/__cccl_config
@@ -11,17 +11,17 @@
 #ifndef _CUDA__CCCL_CONFIG
 #define _CUDA__CCCL_CONFIG
 
-#include <cuda/std/__cccl/attributes.h>
-#include <cuda/std/__cccl/compiler.h>
-#include <cuda/std/__cccl/diagnostic.h>
-#include <cuda/std/__cccl/dialect.h>
-#include <cuda/std/__cccl/exceptions.h>
-#include <cuda/std/__cccl/execution_space.h>
-#include <cuda/std/__cccl/extended_floating_point.h>
-#include <cuda/std/__cccl/ptx_isa.h>
-#include <cuda/std/__cccl/sequence_access.h>
-#include <cuda/std/__cccl/system_header.h>
-#include <cuda/std/__cccl/version.h>
-#include <cuda/std/__cccl/visibility.h>
+#include <cuda/std/__cccl/attributes.h> // IWYU pragma: export
+#include <cuda/std/__cccl/compiler.h> // IWYU pragma: export
+#include <cuda/std/__cccl/diagnostic.h> // IWYU pragma: export
+#include <cuda/std/__cccl/dialect.h> // IWYU pragma: export
+#include <cuda/std/__cccl/exceptions.h> // IWYU pragma: export
+#include <cuda/std/__cccl/execution_space.h> // IWYU pragma: export
+#include <cuda/std/__cccl/extended_floating_point.h> // IWYU pragma: export
+#include <cuda/std/__cccl/ptx_isa.h> // IWYU pragma: export
+#include <cuda/std/__cccl/sequence_access.h> // IWYU pragma: export
+#include <cuda/std/__cccl/system_header.h> // IWYU pragma: export
+#include <cuda/std/__cccl/version.h> // IWYU pragma: export
+#include <cuda/std/__cccl/visibility.h> // IWYU pragma: export
 
 #endif // _CUDA__CCCL_CONFIG

--- a/libcudacxx/include/cuda/std/detail/__config
+++ b/libcudacxx/include/cuda/std/detail/__config
@@ -11,7 +11,7 @@
 #ifndef __cuda_std__
 #define __cuda_std__
 
-#include <cuda/std/__cccl/version.h>
+#include <cuda/std/__cccl/version.h> // IWYU pragma: export
 
 #define _LIBCUDACXX_CUDA_API_VERSION       CCCL_VERSION
 #define _LIBCUDACXX_CUDA_API_VERSION_MAJOR CCCL_MAJOR_VERSION
@@ -36,6 +36,6 @@
 #  endif
 #endif
 
-#include <cuda/std/detail/libcxx/include/__config>
+#include <cuda/std/detail/libcxx/include/__config> // IWYU pragma: export
 
 #endif //__cuda_std__

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -11,7 +11,7 @@
 #ifndef _LIBCUDACXX_CONFIG
 #define _LIBCUDACXX_CONFIG
 
-#include <cuda/__cccl_config>
+#include <cuda/__cccl_config> // IWYU pragma: export
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -11,7 +11,7 @@
 #ifndef _CUDA_STD_VERSION
 #define _CUDA_STD_VERSION
 
-#include <cuda/std/detail/__config>
+#include <cuda/std/detail/__config> // IWYU pragma: export
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/version
+++ b/libcudacxx/include/cuda/version
@@ -11,6 +11,6 @@
 #ifndef _CUDA_VERSION
 #define _CUDA_VERSION
 
-#include <cuda/std/version>
+#include <cuda/std/version> // IWYU pragma: export
 
 #endif // _CUDA_VERSION

--- a/thrust/thrust/detail/config.h
+++ b/thrust/thrust/detail/config.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include <thrust/detail/config/config.h>
-#include <thrust/version.h>
+#include <thrust/detail/config/config.h> // IWYU pragma: export
+#include <thrust/version.h> // IWYU pragma: export
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/thrust/thrust/detail/config/config.h
+++ b/thrust/thrust/detail/config/config.h
@@ -21,7 +21,7 @@
 #pragma once
 
 // For _CCCL_IMPLICIT_SYSTEM_HEADER
-#include <cuda/__cccl_config>
+#include <cuda/__cccl_config> // IWYU pragma: export
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -33,14 +33,14 @@
 
 // NOTE: The order of these #includes matters.
 
-#include <thrust/detail/config/compiler.h>
-#include <thrust/detail/config/cpp_compatibility.h>
-#include <thrust/detail/config/cpp_dialect.h>
-#include <thrust/detail/config/deprecated.h>
-#include <thrust/detail/config/simple_defines.h>
+#include <thrust/detail/config/compiler.h> // IWYU pragma: export
+#include <thrust/detail/config/cpp_compatibility.h> // IWYU pragma: export
+#include <thrust/detail/config/cpp_dialect.h> // IWYU pragma: export
+#include <thrust/detail/config/deprecated.h> // IWYU pragma: export
+#include <thrust/detail/config/simple_defines.h> // IWYU pragma: export
 // host_system.h & device_system.h must be #included as early as possible because other config headers depend on it
-#include <thrust/detail/config/host_system.h>
+#include <thrust/detail/config/host_system.h> // IWYU pragma: export
 
-#include <thrust/detail/config/device_system.h>
-#include <thrust/detail/config/global_workarounds.h>
-#include <thrust/detail/config/namespace.h>
+#include <thrust/detail/config/device_system.h> // IWYU pragma: export
+#include <thrust/detail/config/global_workarounds.h> // IWYU pragma: export
+#include <thrust/detail/config/namespace.h> // IWYU pragma: export

--- a/thrust/thrust/detail/config/cpp_compatibility.h
+++ b/thrust/thrust/detail/config/cpp_compatibility.h
@@ -26,7 +26,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/detail/config/cpp_dialect.h>
+#include <thrust/detail/config/cpp_dialect.h> // IWYU pragma: export
 
 #include <cuda/std/cstddef>
 

--- a/thrust/thrust/detail/config/cpp_dialect.h
+++ b/thrust/thrust/detail/config/cpp_dialect.h
@@ -30,7 +30,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/detail/config/compiler.h>
+#include <thrust/detail/config/compiler.h> // IWYU pragma: export
 
 // Deprecation warnings may be silenced by defining the following macros. These
 // may be combined.

--- a/thrust/thrust/system/cuda/config.h
+++ b/thrust/thrust/system/cuda/config.h
@@ -33,7 +33,7 @@
 #  define THRUST_DEBUG_SYNC_FLAG false
 #endif
 
-#include <thrust/detail/config.h>
+#include <thrust/detail/config.h> // IWYU pragma: export
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -45,9 +45,9 @@
 
 // We don't directly include <cub/version.cuh> since it doesn't exist in
 // older releases. This header will always pull in version info:
-#include <cub/detail/detect_cuda_runtime.cuh>
-#include <cub/util_debug.cuh>
-#include <cub/util_namespace.cuh>
+#include <cub/detail/detect_cuda_runtime.cuh> // IWYU pragma: export
+#include <cub/util_debug.cuh> // IWYU pragma: export
+#include <cub/util_namespace.cuh> // IWYU pragma: export
 
 /**
  * \def THRUST_RUNTIME_FUNCTION

--- a/thrust/thrust/version.h
+++ b/thrust/thrust/version.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <thrust/detail/config/config.h>
+#include <thrust/detail/config/config.h> // IWYU pragma: export
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -38,7 +38,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/version>
+#include <cuda/version> // IWYU pragma: export
 
 //  This is the only Thrust header that is guaranteed to
 //  change with every Thrust release.


### PR DESCRIPTION
## Description

When working in the devcontainers, the `clangd`/`clang-format` integration causes extra `#include`s to be added automatically. They get added because clang's "include what you use" tool (IWYU) doesn't consider transitive includes when determining what headers need to be included.

This PR adds the `export` IWYU pragma to the `#include`s in CCCL's config headers so that a `#include` of `<cuda/__cccl_config>` or `<cuda/std/detail/__config>` will behave as if all of the transitive headers were included directly. This should be enough to keep IWYU from automatically adding headers it shouldn't.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
