### PR TITLE
Remove a ton of lines in thrust tests

### DIFF
--- a/thrust/testing/adjacent_difference.cu
+++ b/thrust/testing/adjacent_difference.cu
@@ -11,39 +11,28 @@ void TestAdjacentDifferenceSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector input(4);
+  Vector input{1, 4, 6, 7};
   Vector output(4);
-  input[0] = 1;
-  input[1] = 4;
-  input[2] = 6;
-  input[3] = 7;
-
   typename Vector::iterator result;
 
   result = thrust::adjacent_difference(input.begin(), input.end(), output.begin());
 
   ASSERT_EQUAL(result - output.begin(), 4);
-  ASSERT_EQUAL(output[0], T(1));
-  ASSERT_EQUAL(output[1], T(3));
-  ASSERT_EQUAL(output[2], T(2));
-  ASSERT_EQUAL(output[3], T(1));
+  Vector ref{1, 3, 2, 1};
+  ASSERT_EQUAL(output, ref);
 
   result = thrust::adjacent_difference(input.begin(), input.end(), output.begin(), thrust::plus<T>());
 
   ASSERT_EQUAL(result - output.begin(), 4);
-  ASSERT_EQUAL(output[0], T(1));
-  ASSERT_EQUAL(output[1], T(5));
-  ASSERT_EQUAL(output[2], T(10));
-  ASSERT_EQUAL(output[3], T(13));
+  ref = {1, 5, 10, 13};
+  ASSERT_EQUAL(output, ref);
 
   // test in-place operation, result and first are permitted to be the same
   result = thrust::adjacent_difference(input.begin(), input.end(), input.begin());
 
   ASSERT_EQUAL(result - input.begin(), 4);
-  ASSERT_EQUAL(input[0], T(1));
-  ASSERT_EQUAL(input[1], T(3));
-  ASSERT_EQUAL(input[2], T(2));
-  ASSERT_EQUAL(input[3], T(1));
+  ref = {1, 3, 2, 1};
+  ASSERT_EQUAL(input, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestAdjacentDifferenceSimple);
 

--- a/thrust/testing/binary_search.cu
+++ b/thrust/testing/binary_search.cu
@@ -15,13 +15,7 @@ _CCCL_DIAG_SUPPRESS_MSVC(4244 4267) // possible loss of data
 template <class Vector>
 void TestScalarLowerBoundSimple()
 {
-  Vector vec(5);
-
-  vec[0] = 0;
-  vec[1] = 2;
-  vec[2] = 5;
-  vec[3] = 7;
-  vec[4] = 8;
+  Vector vec{0, 2, 5, 7, 8};
 
   ASSERT_EQUAL(thrust::lower_bound(vec.begin(), vec.end(), 0) - vec.begin(), 0);
   ASSERT_EQUAL(thrust::lower_bound(vec.begin(), vec.end(), 1) - vec.begin(), 1);
@@ -75,13 +69,7 @@ DECLARE_UNITTEST(TestScalarLowerBoundDispatchImplicit);
 template <class Vector>
 void TestScalarUpperBoundSimple()
 {
-  Vector vec(5);
-
-  vec[0] = 0;
-  vec[1] = 2;
-  vec[2] = 5;
-  vec[3] = 7;
-  vec[4] = 8;
+  Vector vec{0, 2, 5, 7, 8};
 
   ASSERT_EQUAL(thrust::upper_bound(vec.begin(), vec.end(), 0) - vec.begin(), 1);
   ASSERT_EQUAL(thrust::upper_bound(vec.begin(), vec.end(), 1) - vec.begin(), 1);
@@ -135,13 +123,7 @@ DECLARE_UNITTEST(TestScalarUpperBoundDispatchImplicit);
 template <class Vector>
 void TestScalarBinarySearchSimple()
 {
-  Vector vec(5);
-
-  vec[0] = 0;
-  vec[1] = 2;
-  vec[2] = 5;
-  vec[3] = 7;
-  vec[4] = 8;
+  Vector vec{0, 2, 5, 7, 8};
 
   ASSERT_EQUAL(thrust::binary_search(vec.begin(), vec.end(), 0), true);
   ASSERT_EQUAL(thrust::binary_search(vec.begin(), vec.end(), 1), false);
@@ -195,13 +177,7 @@ DECLARE_UNITTEST(TestScalarBinarySearchDispatchImplicit);
 template <class Vector>
 void TestScalarEqualRangeSimple()
 {
-  Vector vec(5);
-
-  vec[0] = 0;
-  vec[1] = 2;
-  vec[2] = 5;
-  vec[3] = 7;
-  vec[4] = 8;
+  Vector vec{0, 2, 5, 7, 8};
 
   ASSERT_EQUAL(thrust::equal_range(vec.begin(), vec.end(), 0).first - vec.begin(), 0);
   ASSERT_EQUAL(thrust::equal_range(vec.begin(), vec.end(), 1).first - vec.begin(), 1);

--- a/thrust/testing/binary_search_descending.cu
+++ b/thrust/testing/binary_search_descending.cu
@@ -14,13 +14,7 @@ void TestScalarLowerBoundDescendingSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector vec(5);
-
-  vec[0] = 8;
-  vec[1] = 7;
-  vec[2] = 5;
-  vec[3] = 2;
-  vec[4] = 0;
+  Vector vec{8, 7, 5, 2, 0};
 
   ASSERT_EQUAL_QUIET(vec.begin() + 4, thrust::lower_bound(vec.begin(), vec.end(), T{0}, thrust::greater<T>()));
   ASSERT_EQUAL_QUIET(vec.begin() + 4, thrust::lower_bound(vec.begin(), vec.end(), T{1}, thrust::greater<T>()));
@@ -40,13 +34,7 @@ void TestScalarUpperBoundDescendingSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector vec(5);
-
-  vec[0] = 8;
-  vec[1] = 7;
-  vec[2] = 5;
-  vec[3] = 2;
-  vec[4] = 0;
+  Vector vec{8, 7, 5, 2, 0};
 
   ASSERT_EQUAL_QUIET(vec.begin() + 5, thrust::upper_bound(vec.begin(), vec.end(), T{0}, thrust::greater<T>()));
   ASSERT_EQUAL_QUIET(vec.begin() + 4, thrust::upper_bound(vec.begin(), vec.end(), T{1}, thrust::greater<T>()));
@@ -66,13 +54,7 @@ void TestScalarBinarySearchDescendingSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector vec(5);
-
-  vec[0] = 8;
-  vec[1] = 7;
-  vec[2] = 5;
-  vec[3] = 2;
-  vec[4] = 0;
+  Vector vec{8, 7, 5, 2, 0};
 
   ASSERT_EQUAL(true, thrust::binary_search(vec.begin(), vec.end(), T{0}, thrust::greater<T>()));
   ASSERT_EQUAL(false, thrust::binary_search(vec.begin(), vec.end(), T{1}, thrust::greater<T>()));
@@ -92,13 +74,7 @@ void TestScalarEqualRangeDescendingSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector vec(5);
-
-  vec[0] = 8;
-  vec[1] = 7;
-  vec[2] = 5;
-  vec[3] = 2;
-  vec[4] = 0;
+  Vector vec{8, 7, 5, 2, 0};
 
   ASSERT_EQUAL_QUIET(vec.begin() + 4, thrust::equal_range(vec.begin(), vec.end(), T{0}, thrust::greater<T>()).first);
   ASSERT_EQUAL_QUIET(vec.begin() + 4, thrust::equal_range(vec.begin(), vec.end(), T{1}, thrust::greater<T>()).first);

--- a/thrust/testing/binary_search_vector.cu
+++ b/thrust/testing/binary_search_vector.cu
@@ -24,13 +24,7 @@ struct vector_like
 template <class Vector>
 void TestVectorLowerBoundSimple()
 {
-  Vector vec(5);
-
-  vec[0] = 0;
-  vec[1] = 2;
-  vec[2] = 5;
-  vec[3] = 7;
-  vec[4] = 8;
+  Vector vec{0, 2, 5, 7, 8};
 
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
@@ -47,16 +41,8 @@ void TestVectorLowerBoundSimple()
 
   ASSERT_EQUAL((output_end - integral_output.begin()), 10);
 
-  ASSERT_EQUAL(integral_output[0], 0);
-  ASSERT_EQUAL(integral_output[1], 1);
-  ASSERT_EQUAL(integral_output[2], 1);
-  ASSERT_EQUAL(integral_output[3], 2);
-  ASSERT_EQUAL(integral_output[4], 2);
-  ASSERT_EQUAL(integral_output[5], 2);
-  ASSERT_EQUAL(integral_output[6], 3);
-  ASSERT_EQUAL(integral_output[7], 3);
-  ASSERT_EQUAL(integral_output[8], 4);
-  ASSERT_EQUAL(integral_output[9], 5);
+  IntVector ref{0, 1, 1, 2, 2, 2, 3, 3, 4, 5};
+  ASSERT_EQUAL(integral_output, ref);
 
   //    // test with interator output type
   //    using IteratorVector = typename vector_like<Vector, typename Vector::iterator>::type;
@@ -120,13 +106,7 @@ DECLARE_UNITTEST(TestVectorLowerBoundDispatchImplicit);
 template <class Vector>
 void TestVectorUpperBoundSimple()
 {
-  Vector vec(5);
-
-  vec[0] = 0;
-  vec[1] = 2;
-  vec[2] = 5;
-  vec[3] = 7;
-  vec[4] = 8;
+  Vector vec{0, 2, 5, 7, 8};
 
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
@@ -141,16 +121,8 @@ void TestVectorUpperBoundSimple()
 
   ASSERT_EQUAL((output_end - integral_output.begin()), 10);
 
-  ASSERT_EQUAL(integral_output[0], 1);
-  ASSERT_EQUAL(integral_output[1], 1);
-  ASSERT_EQUAL(integral_output[2], 2);
-  ASSERT_EQUAL(integral_output[3], 2);
-  ASSERT_EQUAL(integral_output[4], 2);
-  ASSERT_EQUAL(integral_output[5], 3);
-  ASSERT_EQUAL(integral_output[6], 3);
-  ASSERT_EQUAL(integral_output[7], 4);
-  ASSERT_EQUAL(integral_output[8], 5);
-  ASSERT_EQUAL(integral_output[9], 5);
+  IntVector ref{1, 1, 2, 2, 2, 3, 3, 4, 5, 5};
+  ASSERT_EQUAL(integral_output, ref);
 
   //    // test with interator output type
   //    using IteratorVector = typename vector_like<Vector, typename Vector::iterator>::type;
@@ -214,13 +186,7 @@ DECLARE_UNITTEST(TestVectorUpperBoundDispatchImplicit);
 template <class Vector>
 void TestVectorBinarySearchSimple()
 {
-  Vector vec(5);
-
-  vec[0] = 0;
-  vec[1] = 2;
-  vec[2] = 5;
-  vec[3] = 7;
-  vec[4] = 8;
+  Vector vec{0, 2, 5, 7, 8};
 
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
@@ -236,16 +202,8 @@ void TestVectorBinarySearchSimple()
 
   ASSERT_EQUAL((bool_output_end - bool_output.begin()), 10);
 
-  ASSERT_EQUAL(bool_output[0], true);
-  ASSERT_EQUAL(bool_output[1], false);
-  ASSERT_EQUAL(bool_output[2], true);
-  ASSERT_EQUAL(bool_output[3], false);
-  ASSERT_EQUAL(bool_output[4], false);
-  ASSERT_EQUAL(bool_output[5], true);
-  ASSERT_EQUAL(bool_output[6], false);
-  ASSERT_EQUAL(bool_output[7], true);
-  ASSERT_EQUAL(bool_output[8], true);
-  ASSERT_EQUAL(bool_output[9], false);
+  BoolVector bool_ref{true, false, true, false, false, true, false, true, true, false};
+  ASSERT_EQUAL(bool_output, bool_ref);
 
   // test with integral output type
   IntVector integral_output(10, 2);
@@ -254,16 +212,8 @@ void TestVectorBinarySearchSimple()
 
   ASSERT_EQUAL((int_output_end - integral_output.begin()), 10);
 
-  ASSERT_EQUAL(integral_output[0], 1);
-  ASSERT_EQUAL(integral_output[1], 0);
-  ASSERT_EQUAL(integral_output[2], 1);
-  ASSERT_EQUAL(integral_output[3], 0);
-  ASSERT_EQUAL(integral_output[4], 0);
-  ASSERT_EQUAL(integral_output[5], 1);
-  ASSERT_EQUAL(integral_output[6], 0);
-  ASSERT_EQUAL(integral_output[7], 1);
-  ASSERT_EQUAL(integral_output[8], 1);
-  ASSERT_EQUAL(integral_output[9], 0);
+  IntVector int_ref{1, 0, 1, 0, 0, 1, 0, 1, 1, 0};
+  ASSERT_EQUAL(integral_output, int_ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorBinarySearchSimple);
 

--- a/thrust/testing/binary_search_vector_descending.cu
+++ b/thrust/testing/binary_search_vector_descending.cu
@@ -25,13 +25,7 @@ void TestVectorLowerBoundDescendingSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector vec(5);
-
-  vec[0] = 8;
-  vec[1] = 7;
-  vec[2] = 5;
-  vec[3] = 2;
-  vec[4] = 0;
+  Vector vec{8, 7, 5, 2, 0};
 
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
@@ -46,29 +40,15 @@ void TestVectorLowerBoundDescendingSimple()
 
   ASSERT_EQUAL_QUIET(integral_output.end(), output_end);
 
-  ASSERT_EQUAL(4, integral_output[0]);
-  ASSERT_EQUAL(4, integral_output[1]);
-  ASSERT_EQUAL(3, integral_output[2]);
-  ASSERT_EQUAL(3, integral_output[3]);
-  ASSERT_EQUAL(3, integral_output[4]);
-  ASSERT_EQUAL(2, integral_output[5]);
-  ASSERT_EQUAL(2, integral_output[6]);
-  ASSERT_EQUAL(1, integral_output[7]);
-  ASSERT_EQUAL(0, integral_output[8]);
-  ASSERT_EQUAL(0, integral_output[9]);
+  IntVector ref{4, 4, 3, 3, 3, 2, 2, 1, 0, 0};
+  ASSERT_EQUAL(ref, integral_output);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorLowerBoundDescendingSimple);
 
 template <class Vector>
 void TestVectorUpperBoundDescendingSimple()
 {
-  Vector vec(5);
-
-  vec[0] = 8;
-  vec[1] = 7;
-  vec[2] = 5;
-  vec[3] = 2;
-  vec[4] = 0;
+  Vector vec{8, 7, 5, 2, 0};
 
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
@@ -84,29 +64,15 @@ void TestVectorUpperBoundDescendingSimple()
 
   ASSERT_EQUAL_QUIET(output_end, integral_output.end());
 
-  ASSERT_EQUAL(5, integral_output[0]);
-  ASSERT_EQUAL(4, integral_output[1]);
-  ASSERT_EQUAL(4, integral_output[2]);
-  ASSERT_EQUAL(3, integral_output[3]);
-  ASSERT_EQUAL(3, integral_output[4]);
-  ASSERT_EQUAL(3, integral_output[5]);
-  ASSERT_EQUAL(2, integral_output[6]);
-  ASSERT_EQUAL(2, integral_output[7]);
-  ASSERT_EQUAL(1, integral_output[8]);
-  ASSERT_EQUAL(0, integral_output[9]);
+  IntVector ref{5, 4, 4, 3, 3, 3, 2, 2, 1, 0};
+  ASSERT_EQUAL(ref, integral_output);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorUpperBoundDescendingSimple);
 
 template <class Vector>
 void TestVectorBinarySearchDescendingSimple()
 {
-  Vector vec(5);
-
-  vec[0] = 8;
-  vec[1] = 7;
-  vec[2] = 5;
-  vec[3] = 2;
-  vec[4] = 0;
+  Vector vec{8, 7, 5, 2, 0};
 
   Vector input(10);
   thrust::sequence(input.begin(), input.end());
@@ -123,16 +89,8 @@ void TestVectorBinarySearchDescendingSimple()
 
   ASSERT_EQUAL_QUIET(bool_output_end, bool_output.end());
 
-  ASSERT_EQUAL(true, bool_output[0]);
-  ASSERT_EQUAL(false, bool_output[1]);
-  ASSERT_EQUAL(true, bool_output[2]);
-  ASSERT_EQUAL(false, bool_output[3]);
-  ASSERT_EQUAL(false, bool_output[4]);
-  ASSERT_EQUAL(true, bool_output[5]);
-  ASSERT_EQUAL(false, bool_output[6]);
-  ASSERT_EQUAL(true, bool_output[7]);
-  ASSERT_EQUAL(true, bool_output[8]);
-  ASSERT_EQUAL(false, bool_output[9]);
+  BoolVector bool_ref{true, false, true, false, false, true, false, true, true, false};
+  ASSERT_EQUAL(bool_ref, bool_output);
 
   // test with integral output type
   IntVector integral_output(10, 2);
@@ -141,16 +99,9 @@ void TestVectorBinarySearchDescendingSimple()
 
   ASSERT_EQUAL_QUIET(int_output_end, integral_output.end());
 
-  ASSERT_EQUAL(1, integral_output[0]);
-  ASSERT_EQUAL(0, integral_output[1]);
-  ASSERT_EQUAL(1, integral_output[2]);
-  ASSERT_EQUAL(0, integral_output[3]);
-  ASSERT_EQUAL(0, integral_output[4]);
-  ASSERT_EQUAL(1, integral_output[5]);
-  ASSERT_EQUAL(0, integral_output[6]);
-  ASSERT_EQUAL(1, integral_output[7]);
-  ASSERT_EQUAL(1, integral_output[8]);
-  ASSERT_EQUAL(0, integral_output[9]);
+  IntVector int_ref{1, 0, 1, 0, 0, 1, 0, 1, 1, 0};
+
+  ASSERT_EQUAL(int_ref, integral_output);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorBinarySearchDescendingSimple);
 

--- a/thrust/testing/constant_iterator.cu
+++ b/thrust/testing/constant_iterator.cu
@@ -121,10 +121,8 @@ void TestConstantIteratorCopy()
   ConstIter last  = first + result.size();
   thrust::copy(first, last, result.begin());
 
-  ASSERT_EQUAL(7, result[0]);
-  ASSERT_EQUAL(7, result[1]);
-  ASSERT_EQUAL(7, result[2]);
-  ASSERT_EQUAL(7, result[3]);
+  Vector ref(4, 7);
+  ASSERT_EQUAL(ref, result);
 };
 DECLARE_VECTOR_UNITTEST(TestConstantIteratorCopy);
 
@@ -144,17 +142,13 @@ void TestConstantIteratorTransform()
 
   thrust::transform(first1, last1, result.begin(), thrust::negate<T>());
 
-  ASSERT_EQUAL(-7, result[0]);
-  ASSERT_EQUAL(-7, result[1]);
-  ASSERT_EQUAL(-7, result[2]);
-  ASSERT_EQUAL(-7, result[3]);
+  Vector ref(4, -7);
+  ASSERT_EQUAL(ref, result);
 
   thrust::transform(first1, last1, first2, result.begin(), thrust::plus<T>());
 
-  ASSERT_EQUAL(10, result[0]);
-  ASSERT_EQUAL(10, result[1]);
-  ASSERT_EQUAL(10, result[2]);
-  ASSERT_EQUAL(10, result[3]);
+  ref = Vector(4, 10);
+  ASSERT_EQUAL(ref, result);
 };
 DECLARE_VECTOR_UNITTEST(TestConstantIteratorTransform);
 

--- a/thrust/testing/copy.cu
+++ b/thrust/testing/copy.cu
@@ -21,12 +21,7 @@ void TestCopyFromConstIterator()
 {
   using T = int;
 
-  std::vector<T> v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  std::vector<T> v{0, 1, 2, 3, 4};
 
   std::vector<int>::const_iterator begin = v.begin();
   std::vector<int>::const_iterator end   = v.end();
@@ -34,21 +29,16 @@ void TestCopyFromConstIterator()
   // copy to host_vector
   thrust::host_vector<T> h(5, (T) 10);
   thrust::host_vector<T>::iterator h_result = thrust::copy(begin, end, h.begin());
-  ASSERT_EQUAL(h[0], 0);
-  ASSERT_EQUAL(h[1], 1);
-  ASSERT_EQUAL(h[2], 2);
-  ASSERT_EQUAL(h[3], 3);
-  ASSERT_EQUAL(h[4], 4);
+
+  thrust::host_vector<T> href{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector
   thrust::device_vector<T> d(5, (T) 10);
   thrust::device_vector<T>::iterator d_result = thrust::copy(begin, end, d.begin());
-  ASSERT_EQUAL(d[0], 0);
-  ASSERT_EQUAL(d[1], 1);
-  ASSERT_EQUAL(d[2], 2);
-  ASSERT_EQUAL(d[3], 3);
-  ASSERT_EQUAL(d[4], 4);
+  thrust::device_vector<T> dref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
 DECLARE_UNITTEST(TestCopyFromConstIterator);
@@ -114,31 +104,21 @@ void TestCopyMatchingTypes()
 {
   using T = typename Vector::value_type;
 
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   // copy to host_vector
   thrust::host_vector<T> h(5, (T) 10);
   typename thrust::host_vector<T>::iterator h_result = thrust::copy(v.begin(), v.end(), h.begin());
-  ASSERT_EQUAL(h[0], 0);
-  ASSERT_EQUAL(h[1], 1);
-  ASSERT_EQUAL(h[2], 2);
-  ASSERT_EQUAL(h[3], 3);
-  ASSERT_EQUAL(h[4], 4);
+  thrust::host_vector<T> href{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector
   thrust::device_vector<T> d(5, (T) 10);
   typename thrust::device_vector<T>::iterator d_result = thrust::copy(v.begin(), v.end(), d.begin());
-  ASSERT_EQUAL(d[0], 0);
-  ASSERT_EQUAL(d[1], 1);
-  ASSERT_EQUAL(d[2], 2);
-  ASSERT_EQUAL(d[3], 3);
-  ASSERT_EQUAL(d[4], 4);
+
+  thrust::device_vector<T> dref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
 DECLARE_VECTOR_UNITTEST(TestCopyMatchingTypes);
@@ -149,32 +129,20 @@ _CCCL_DIAG_SUPPRESS_MSVC(4244) // '=': conversion from 'int' to '_Ty', possible 
 template <class Vector>
 void TestCopyMixedTypes()
 {
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   // copy to host_vector with different type
   thrust::host_vector<float> h(5, (float) 10);
   typename thrust::host_vector<float>::iterator h_result = thrust::copy(v.begin(), v.end(), h.begin());
-
-  ASSERT_EQUAL(h[0], 0);
-  ASSERT_EQUAL(h[1], 1);
-  ASSERT_EQUAL(h[2], 2);
-  ASSERT_EQUAL(h[3], 3);
-  ASSERT_EQUAL(h[4], 4);
+  thrust::host_vector<float> href{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector with different type
   thrust::device_vector<float> d(5, (float) 10);
   typename thrust::device_vector<float>::iterator d_result = thrust::copy(v.begin(), v.end(), d.begin());
-  ASSERT_EQUAL(d[0], 0);
-  ASSERT_EQUAL(d[1], 1);
-  ASSERT_EQUAL(d[2], 2);
-  ASSERT_EQUAL(d[3], 3);
-  ASSERT_EQUAL(d[4], 4);
+  thrust::device_vector<float> dref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestCopyMixedTypes);
@@ -183,10 +151,7 @@ _CCCL_DIAG_POP
 
 void TestCopyVectorBool()
 {
-  std::vector<bool> v(3);
-  v[0] = true;
-  v[1] = false;
-  v[2] = true;
+  std::vector<bool> v{true, false, true};
 
   thrust::host_vector<bool> h(3);
   thrust::device_vector<bool> d(3);
@@ -194,13 +159,11 @@ void TestCopyVectorBool()
   thrust::copy(v.begin(), v.end(), h.begin());
   thrust::copy(v.begin(), v.end(), d.begin());
 
-  ASSERT_EQUAL(h[0], true);
-  ASSERT_EQUAL(h[1], false);
-  ASSERT_EQUAL(h[2], true);
+  thrust::host_vector<bool> href{true, false, true};
+  ASSERT_EQUAL(h, href);
 
-  ASSERT_EQUAL(d[0], true);
-  ASSERT_EQUAL(d[1], false);
-  ASSERT_EQUAL(d[2], true);
+  thrust::device_vector<bool> dref{true, false, true};
+  ASSERT_EQUAL(d, dref);
 }
 DECLARE_UNITTEST(TestCopyVectorBool);
 
@@ -210,22 +173,14 @@ void TestCopyListTo()
   using T = typename Vector::value_type;
 
   // copy from list to Vector
-  std::list<T> l;
-  l.push_back(0);
-  l.push_back(1);
-  l.push_back(2);
-  l.push_back(3);
-  l.push_back(4);
+  std::list<T> l{0, 1, 2, 3, 4};
 
   Vector v(l.size());
 
   typename Vector::iterator v_result = thrust::copy(l.begin(), l.end(), v.begin());
 
-  ASSERT_EQUAL(v[0], T(0));
-  ASSERT_EQUAL(v[1], T(1));
-  ASSERT_EQUAL(v[2], T(2));
-  ASSERT_EQUAL(v[3], T(3));
-  ASSERT_EQUAL(v[4], T(4));
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v, ref);
   ASSERT_EQUAL_QUIET(v_result, v.end());
 
   l.clear();
@@ -280,21 +235,14 @@ void TestCopyIfSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   Vector dest(4);
 
   typename Vector::iterator dest_end = thrust::copy_if(v.begin(), v.end(), dest.begin(), is_true<T>());
 
-  ASSERT_EQUAL(1, dest[0]);
-  ASSERT_EQUAL(2, dest[1]);
-  ASSERT_EQUAL(3, dest[2]);
-  ASSERT_EQUAL(4, dest[3]);
+  Vector ref{1, 2, 3, 4};
+  ASSERT_EQUAL(ref, dest);
   ASSERT_EQUAL_QUIET(dest.end(), dest_end);
 }
 DECLARE_VECTOR_UNITTEST(TestCopyIfSimple);
@@ -408,27 +356,15 @@ void TestCopyIfStencilSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
-
-  Vector s(5);
-  s[0] = 1;
-  s[1] = 1;
-  s[2] = 0;
-  s[3] = 1;
-  s[4] = 0;
+  Vector v{0, 1, 2, 3, 4};
+  Vector s{1, 1, 0, 1, 0};
 
   Vector dest(3);
 
   typename Vector::iterator dest_end = thrust::copy_if(v.begin(), v.end(), s.begin(), dest.begin(), is_true<T>());
 
-  ASSERT_EQUAL(0, dest[0]);
-  ASSERT_EQUAL(1, dest[1]);
-  ASSERT_EQUAL(3, dest[2]);
+  Vector ref{0, 1, 3};
+  ASSERT_EQUAL(ref, dest);
   ASSERT_EQUAL_QUIET(dest.end(), dest_end);
 }
 DECLARE_VECTOR_UNITTEST(TestCopyIfStencilSimple);
@@ -577,6 +513,10 @@ void TestCopyZipIterator()
 {
   using T = typename Vector::value_type;
 
+  // initializer list doesn't work with GCC when
+  // Vector = thrust::host_vector<signed char>
+  // Vector v1{1, 2, 3};
+
   Vector v1(3);
   v1[0] = 1;
   v1[1] = 2;
@@ -609,12 +549,10 @@ void TestCopyConstantIteratorToZipIterator()
                thrust::make_constant_iterator(thrust::tuple<T, T>(4, 7)) + v1.size(),
                thrust::make_zip_iterator(thrust::make_tuple(v1.begin(), v2.begin())));
 
-  ASSERT_EQUAL(v1[0], 4);
-  ASSERT_EQUAL(v1[1], 4);
-  ASSERT_EQUAL(v1[2], 4);
-  ASSERT_EQUAL(v2[0], 7);
-  ASSERT_EQUAL(v2[1], 7);
-  ASSERT_EQUAL(v2[2], 7);
+  Vector ref1{4, 4, 4};
+  Vector ref2{7, 7, 7};
+  ASSERT_EQUAL(v1, ref1);
+  ASSERT_EQUAL(v2, ref2);
 };
 DECLARE_VECTOR_UNITTEST(TestCopyConstantIteratorToZipIterator);
 

--- a/thrust/testing/copy_n.cu
+++ b/thrust/testing/copy_n.cu
@@ -15,33 +15,22 @@ void TestCopyNFromConstIterator()
 {
   using T = int;
 
-  std::vector<T> v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  std::vector<T> v{0, 1, 2, 3, 4};
 
   std::vector<int>::const_iterator begin = v.begin();
 
   // copy to host_vector
   thrust::host_vector<T> h(5, (T) 10);
   thrust::host_vector<T>::iterator h_result = thrust::copy_n(begin, h.size(), h.begin());
-  ASSERT_EQUAL(h[0], 0);
-  ASSERT_EQUAL(h[1], 1);
-  ASSERT_EQUAL(h[2], 2);
-  ASSERT_EQUAL(h[3], 3);
-  ASSERT_EQUAL(h[4], 4);
+
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector
   thrust::device_vector<T> d(5, (T) 10);
   thrust::device_vector<T>::iterator d_result = thrust::copy_n(begin, d.size(), d.begin());
-  ASSERT_EQUAL(d[0], 0);
-  ASSERT_EQUAL(d[1], 1);
-  ASSERT_EQUAL(d[2], 2);
-  ASSERT_EQUAL(d[3], 3);
-  ASSERT_EQUAL(d[4], 4);
+
+  thrust::device_vector<T> dref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
 DECLARE_UNITTEST(TestCopyNFromConstIterator);
@@ -73,31 +62,20 @@ void TestCopyNMatchingTypes()
 {
   using T = typename Vector::value_type;
 
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   // copy to host_vector
   thrust::host_vector<T> h(5, (T) 10);
   typename thrust::host_vector<T>::iterator h_result = thrust::copy_n(v.begin(), v.size(), h.begin());
-  ASSERT_EQUAL(h[0], 0);
-  ASSERT_EQUAL(h[1], 1);
-  ASSERT_EQUAL(h[2], 2);
-  ASSERT_EQUAL(h[3], 3);
-  ASSERT_EQUAL(h[4], 4);
+  thrust::host_vector<T> href{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector
   thrust::device_vector<T> d(5, (T) 10);
   typename thrust::device_vector<T>::iterator d_result = thrust::copy_n(v.begin(), v.size(), d.begin());
-  ASSERT_EQUAL(d[0], 0);
-  ASSERT_EQUAL(d[1], 1);
-  ASSERT_EQUAL(d[2], 2);
-  ASSERT_EQUAL(d[3], 3);
-  ASSERT_EQUAL(d[4], 4);
+  thrust::device_vector<T> dref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
 DECLARE_VECTOR_UNITTEST(TestCopyNMatchingTypes);
@@ -108,32 +86,21 @@ _CCCL_DIAG_SUPPRESS_MSVC(4244) // '=': conversion from 'int' to '_Ty', possible 
 template <class Vector>
 void TestCopyNMixedTypes()
 {
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   // copy to host_vector with different type
   thrust::host_vector<float> h(5, (float) 10);
   typename thrust::host_vector<float>::iterator h_result = thrust::copy_n(v.begin(), v.size(), h.begin());
 
-  ASSERT_EQUAL(h[0], 0);
-  ASSERT_EQUAL(h[1], 1);
-  ASSERT_EQUAL(h[2], 2);
-  ASSERT_EQUAL(h[3], 3);
-  ASSERT_EQUAL(h[4], 4);
+  thrust::host_vector<float> href{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(h, href);
   ASSERT_EQUAL_QUIET(h_result, h.end());
 
   // copy to device_vector with different type
   thrust::device_vector<float> d(5, (float) 10);
   typename thrust::device_vector<float>::iterator d_result = thrust::copy_n(v.begin(), v.size(), d.begin());
-  ASSERT_EQUAL(d[0], 0);
-  ASSERT_EQUAL(d[1], 1);
-  ASSERT_EQUAL(d[2], 2);
-  ASSERT_EQUAL(d[3], 3);
-  ASSERT_EQUAL(d[4], 4);
+  thrust::device_vector<float> dref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(d, dref);
   ASSERT_EQUAL_QUIET(d_result, d.end());
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestCopyNMixedTypes);
@@ -142,10 +109,7 @@ _CCCL_DIAG_POP
 
 void TestCopyNVectorBool()
 {
-  std::vector<bool> v(3);
-  v[0] = true;
-  v[1] = false;
-  v[2] = true;
+  std::vector<bool> v{true, false, true};
 
   thrust::host_vector<bool> h(3);
   thrust::device_vector<bool> d(3);
@@ -153,13 +117,13 @@ void TestCopyNVectorBool()
   thrust::copy_n(v.begin(), v.size(), h.begin());
   thrust::copy_n(v.begin(), v.size(), d.begin());
 
-  ASSERT_EQUAL(h[0], true);
-  ASSERT_EQUAL(h[1], false);
-  ASSERT_EQUAL(h[2], true);
+  thrust::host_vector<bool> href{true, false, true};
+  ASSERT_EQUAL(h, href);
 
-  ASSERT_EQUAL(d[0], true);
-  ASSERT_EQUAL(d[1], false);
-  ASSERT_EQUAL(d[2], true);
+  thrust::device_vector<bool> dref{true, false, true};
+  ASSERT_EQUAL(d, dref);
+
+  ASSERT_EQUAL(d, dref);
 }
 DECLARE_UNITTEST(TestCopyNVectorBool);
 
@@ -169,22 +133,14 @@ void TestCopyNListTo()
   using T = typename Vector::value_type;
 
   // copy from list to Vector
-  std::list<T> l;
-  l.push_back(0);
-  l.push_back(1);
-  l.push_back(2);
-  l.push_back(3);
-  l.push_back(4);
+  std::list<T> l{0, 1, 2, 3, 4};
 
   Vector v(l.size());
 
   typename Vector::iterator v_result = thrust::copy_n(l.begin(), l.size(), v.begin());
 
-  ASSERT_EQUAL(v[0], T(0));
-  ASSERT_EQUAL(v[1], T(1));
-  ASSERT_EQUAL(v[2], T(2));
-  ASSERT_EQUAL(v[3], T(3));
-  ASSERT_EQUAL(v[4], T(4));
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v, ref);
   ASSERT_EQUAL_QUIET(v_result, v.end());
 
   l.clear();
@@ -218,10 +174,8 @@ void TestCopyNCountingIterator()
 
   thrust::copy_n(iter, 4, vec.begin());
 
-  ASSERT_EQUAL(vec[0], T(1));
-  ASSERT_EQUAL(vec[1], T(2));
-  ASSERT_EQUAL(vec[2], T(3));
-  ASSERT_EQUAL(vec[3], T(4));
+  Vector ref{1, 2, 3, 4};
+  ASSERT_EQUAL(vec, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestCopyNCountingIterator);
 
@@ -230,16 +184,8 @@ void TestCopyNZipIterator()
 {
   using T = typename Vector::value_type;
 
-  Vector v1(4);
-  v1[0] = 1;
-  v1[1] = 2;
-  v1[2] = 3;
-  v1[3] = 4;
-  Vector v2(4);
-  v2[0] = 4;
-  v2[1] = 5;
-  v2[2] = 6;
-  v2[3] = 7;
+  Vector v1{1, 2, 3, 4};
+  Vector v2{4, 5, 6, 7};
   Vector v3(4, T(0));
   Vector v4(4, T(0));
 
@@ -264,14 +210,11 @@ void TestCopyNConstantIteratorToZipIterator()
                  v1.size(),
                  thrust::make_zip_iterator(thrust::make_tuple(v1.begin(), v2.begin())));
 
-  ASSERT_EQUAL(v1[0], T(4));
-  ASSERT_EQUAL(v1[1], T(4));
-  ASSERT_EQUAL(v1[2], T(4));
-  ASSERT_EQUAL(v1[3], T(4));
-  ASSERT_EQUAL(v2[0], T(7));
-  ASSERT_EQUAL(v2[1], T(7));
-  ASSERT_EQUAL(v2[2], T(7));
-  ASSERT_EQUAL(v2[3], T(7));
+  Vector ref1(4, 4);
+  Vector ref2(4, 7);
+
+  ASSERT_EQUAL(v1, ref1);
+  ASSERT_EQUAL(v2, ref2);
 };
 DECLARE_VECTOR_UNITTEST(TestCopyNConstantIteratorToZipIterator);
 

--- a/thrust/testing/count.cu
+++ b/thrust/testing/count.cu
@@ -6,12 +6,7 @@
 template <class Vector>
 void TestCountSimple()
 {
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 1;
-  data[2] = 0;
-  data[3] = 0;
-  data[4] = 1;
+  Vector data{1, 1, 0, 0, 1};
 
   ASSERT_EQUAL(thrust::count(data.begin(), data.end(), 0), 2);
   ASSERT_EQUAL(thrust::count(data.begin(), data.end(), 1), 3);
@@ -46,12 +41,7 @@ void TestCountIfSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 6;
-  data[2] = 1;
-  data[3] = 9;
-  data[4] = 2;
+  Vector data{1, 6, 1, 9, 2};
 
   ASSERT_EQUAL(thrust::count_if(data.begin(), data.end(), greater_than_five<T>()), 2);
 }
@@ -73,12 +63,7 @@ DECLARE_VARIABLE_UNITTEST(TestCountIf);
 template <typename Vector>
 void TestCountFromConstIteratorSimple()
 {
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 1;
-  data[2] = 0;
-  data[3] = 0;
-  data[4] = 1;
+  Vector data{1, 1, 0, 0, 1};
 
   ASSERT_EQUAL(thrust::count(data.cbegin(), data.cend(), 0), 2);
   ASSERT_EQUAL(thrust::count(data.cbegin(), data.cend(), 1), 3);

--- a/thrust/testing/cuda/adjacent_difference.cu
+++ b/thrust/testing/cuda/adjacent_difference.cu
@@ -90,11 +90,6 @@ void TestAdjacentDifferenceCudaStreams()
   ASSERT_EQUAL(output, ref);
 
   cudaStreamDestroy(s);
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 3);
-  ASSERT_EQUAL(output[2], 2);
-
-  cudaStreamDestroy(s);
 }
 DECLARE_UNITTEST(TestAdjacentDifferenceCudaStreams);
 

--- a/thrust/testing/cuda/adjacent_difference.cu
+++ b/thrust/testing/cuda/adjacent_difference.cu
@@ -78,16 +78,18 @@ void TestAdjacentDifferenceCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  thrust::device_vector<int> input(3);
-  thrust::device_vector<int> output(3);
-  input[0] = 1;
-  input[1] = 4;
-  input[2] = 6;
+  thrust::device_vector<int> input{1, 4, 6};
+  thrust::device_vector<int> output(input.size());
 
   thrust::adjacent_difference(thrust::cuda::par.on(s), input.begin(), input.end(), output.begin());
 
   cudaStreamSynchronize(s);
 
+  thrust::device_vector<int> ref{1, 3, 2};
+
+  ASSERT_EQUAL(output, ref);
+
+  cudaStreamDestroy(s);
   ASSERT_EQUAL(output[0], 1);
   ASSERT_EQUAL(output[1], 3);
   ASSERT_EQUAL(output[2], 2);

--- a/thrust/testing/cuda/copy_if.cu
+++ b/thrust/testing/cuda/copy_if.cu
@@ -127,14 +127,8 @@ void TestCopyIfCudaStreams(ExecutionPolicy policy)
 {
   using Vector = thrust::device_vector<int>;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
-
-  Vector result(5);
+  Vector data{1, 2, 1, 3, 2};
+  Vector result(data.size());
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -142,9 +136,9 @@ void TestCopyIfCudaStreams(ExecutionPolicy policy)
   Vector::iterator end = thrust::copy_if(policy.on(s), data.begin(), data.end(), result.begin(), is_even<int>());
 
   ASSERT_EQUAL(end - result.begin(), 2);
-
-  ASSERT_EQUAL(result[0], 2);
-  ASSERT_EQUAL(result[1], 2);
+  result.resize(end - result.begin());
+  Vector ref{2, 2};
+  ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);
 }
@@ -262,21 +256,11 @@ void TestCopyIfStencilCudaStreams(ExecutionPolicy policy)
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   Vector result(5);
 
-  Vector stencil(5);
-  stencil[0] = 0;
-  stencil[1] = 1;
-  stencil[2] = 0;
-  stencil[3] = 0;
-  stencil[4] = 1;
+  Vector stencil{0, 1, 0, 0, 1};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -285,9 +269,10 @@ void TestCopyIfStencilCudaStreams(ExecutionPolicy policy)
     thrust::copy_if(policy.on(s), data.begin(), data.end(), stencil.begin(), result.begin(), thrust::identity<T>());
 
   ASSERT_EQUAL(end - result.begin(), 2);
+  result.resize(end - result.begin());
 
-  ASSERT_EQUAL(result[0], 2);
-  ASSERT_EQUAL(result[1], 2);
+  Vector ref{2, 2};
+  ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/cuda/count.cu
+++ b/thrust/testing/cuda/count.cu
@@ -89,12 +89,7 @@ DECLARE_VARIABLE_UNITTEST(TestCountIfDeviceDevice);
 
 void TestCountCudaStreams()
 {
-  thrust::device_vector<int> data(5);
-  data[0] = 1;
-  data[1] = 1;
-  data[2] = 0;
-  data[3] = 0;
-  data[4] = 1;
+  thrust::device_vector<int> data{1, 1, 0, 0, 1};
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/device_side_universal_vector.cu
+++ b/thrust/testing/cuda/device_side_universal_vector.cu
@@ -51,8 +51,7 @@ void TestUniversalVectorDeviceAccess()
 
   auto& in = *in_ptr;
   in.resize(2);
-  in[0] = 4;
-  in[1] = 2;
+  in = {4, 2};
 
   out_vector_t* out_ptr{};
   cudaMallocManaged(&out_ptr, sizeof(*out_ptr));
@@ -78,8 +77,7 @@ void TestConstUniversalVectorDeviceAccess()
   {
     auto& in = *in_ptr;
     in.resize(2);
-    in[0] = 4;
-    in[1] = 2;
+    in = {4, 2};
   }
 
   const auto& const_in = *in_ptr;

--- a/thrust/testing/cuda/fill.cu
+++ b/thrust/testing/cuda/fill.cu
@@ -173,12 +173,7 @@ DECLARE_VARIABLE_UNITTEST(TestFillNDeviceDevice);
 
 void TestFillCudaStreams()
 {
-  thrust::device_vector<int> v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  thrust::device_vector<int> v{0, 1, 2, 3, 4};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -186,38 +181,26 @@ void TestFillCudaStreams()
   thrust::fill(thrust::cuda::par.on(s), v.begin() + 1, v.begin() + 4, 7);
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 7);
-  ASSERT_EQUAL(v[2], 7);
-  ASSERT_EQUAL(v[3], 7);
-  ASSERT_EQUAL(v[4], 4);
+  thrust::device_vector<int> ref{0, 7, 7, 7, 4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::fill(thrust::cuda::par.on(s), v.begin() + 0, v.begin() + 3, 8);
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 8);
-  ASSERT_EQUAL(v[1], 8);
-  ASSERT_EQUAL(v[2], 8);
-  ASSERT_EQUAL(v[3], 7);
-  ASSERT_EQUAL(v[4], 4);
+  ref = {8, 8, 8, 7, 4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::fill(thrust::cuda::par.on(s), v.begin() + 2, v.end(), 9);
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 8);
-  ASSERT_EQUAL(v[1], 8);
-  ASSERT_EQUAL(v[2], 9);
-  ASSERT_EQUAL(v[3], 9);
-  ASSERT_EQUAL(v[4], 9);
+  ref = {8, 8, 9, 9, 9};
+  ASSERT_EQUAL(v, ref);
 
   thrust::fill(thrust::cuda::par.on(s), v.begin(), v.end(), 1);
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 1);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 1);
-  ASSERT_EQUAL(v[3], 1);
-  ASSERT_EQUAL(v[4], 1);
+  ref = {1, 1, 1, 1, 1};
+  ASSERT_EQUAL(v, ref);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/cuda/find.cu
+++ b/thrust/testing/cuda/find.cu
@@ -223,12 +223,7 @@ DECLARE_UNITTEST(TestFindIfNotDeviceDevice);
 
 void TestFindCudaStreams()
 {
-  thrust::device_vector<int> vec(5);
-  vec[0] = 1;
-  vec[1] = 2;
-  vec[2] = 3;
-  vec[3] = 3;
-  vec[4] = 5;
+  thrust::device_vector<int> vec{1, 2, 3, 3, 5};
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/for_each.cu
+++ b/thrust/testing/cuda/for_each.cu
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 
+#include "thrust/device_vector.h"
 #include <unittest/unittest.h>
 
 static const size_t NUM_REGISTERS = 64;
@@ -219,14 +220,8 @@ void TestForEachCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  thrust::device_vector<int> input(5);
+  thrust::device_vector<int> input{3, 2, 3, 4, 6};
   thrust::device_vector<int> output(7, 0);
-
-  input[0] = 3;
-  input[1] = 2;
-  input[2] = 3;
-  input[3] = 4;
-  input[4] = 6;
 
   mark_present_for_each<int> f;
   f.ptr = thrust::raw_pointer_cast(output.data());
@@ -235,13 +230,8 @@ void TestForEachCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(output[0], 0);
-  ASSERT_EQUAL(output[1], 0);
-  ASSERT_EQUAL(output[2], 1);
-  ASSERT_EQUAL(output[3], 1);
-  ASSERT_EQUAL(output[4], 1);
-  ASSERT_EQUAL(output[5], 0);
-  ASSERT_EQUAL(output[6], 1);
+  thrust::device_vector<int> ref{0, 0, 1, 1, 1, 0, 1};
+  ASSERT_EQUAL(output, ref);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/cuda/gather.cu
+++ b/thrust/testing/cuda/gather.cu
@@ -74,12 +74,9 @@ void TestGatherCudaStreams()
   thrust::gather(thrust::cuda::par.on(s), map.begin(), map.end(), src.begin(), dst.begin());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(dst[0], 6);
-  ASSERT_EQUAL(dst[1], 2);
-  ASSERT_EQUAL(dst[2], 1);
-  ASSERT_EQUAL(dst[3], 7);
-  ASSERT_EQUAL(dst[4], 2);
+  thrust::device_vector<int> ref = {6, 2, 1, 7, 2}; // destination vector
 
+  ASSERT_EQUAL(dst, ref);
   cudaStreamDestroy(s);
 }
 DECLARE_UNITTEST(TestGatherCudaStreams);
@@ -186,34 +183,10 @@ DECLARE_VARIABLE_UNITTEST(TestGatherIfDeviceDevice);
 
 void TestGatherIfCudaStreams()
 {
-  thrust::device_vector<int> flg(5); // predicate array
-  thrust::device_vector<int> map(5); // gather indices
-  thrust::device_vector<int> src(8); // source vector
-  thrust::device_vector<int> dst(5); // destination vector
-
-  flg[0] = 0;
-  flg[1] = 1;
-  flg[2] = 0;
-  flg[3] = 1;
-  flg[4] = 0;
-  map[0] = 6;
-  map[1] = 2;
-  map[2] = 1;
-  map[3] = 7;
-  map[4] = 2;
-  src[0] = 0;
-  src[1] = 1;
-  src[2] = 2;
-  src[3] = 3;
-  src[4] = 4;
-  src[5] = 5;
-  src[6] = 6;
-  src[7] = 7;
-  dst[0] = 0;
-  dst[1] = 0;
-  dst[2] = 0;
-  dst[3] = 0;
-  dst[4] = 0;
+  thrust::device_vector<int> flg{0, 1, 0, 1, 0}; // predicate array
+  thrust::device_vector<int> map{6, 2, 1, 7, 2}; // gather indices
+  thrust::device_vector<int> src{0, 1, 2, 3, 4, 5, 6, 7}; // source vector
+  thrust::device_vector<int> dst(5, 0); // destination vector
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -221,12 +194,9 @@ void TestGatherIfCudaStreams()
   thrust::gather_if(thrust::cuda::par.on(s), map.begin(), map.end(), flg.begin(), src.begin(), dst.begin());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(dst[0], 0);
-  ASSERT_EQUAL(dst[1], 2);
-  ASSERT_EQUAL(dst[2], 0);
-  ASSERT_EQUAL(dst[3], 7);
-  ASSERT_EQUAL(dst[4], 0);
+  thrust::device_vector<int> ref{0, 2, 0, 7, 0}; // destination vector
 
+  ASSERT_EQUAL(dst, ref);
   cudaStreamDestroy(s);
 }
 DECLARE_UNITTEST(TestGatherIfCudaStreams);

--- a/thrust/testing/cuda/remove.cu
+++ b/thrust/testing/cuda/remove.cu
@@ -329,12 +329,7 @@ void TestRemoveCudaStreams()
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -342,10 +337,10 @@ void TestRemoveCudaStreams()
   Vector::iterator end = thrust::remove(thrust::cuda::par.on(s), data.begin(), data.end(), (T) 2);
 
   ASSERT_EQUAL(end - data.begin(), 3);
+  data.erase(end, data.end());
 
-  ASSERT_EQUAL(data[0], 1);
-  ASSERT_EQUAL(data[1], 1);
-  ASSERT_EQUAL(data[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(data, ref);
 
   cudaStreamDestroy(s);
 }
@@ -356,12 +351,7 @@ void TestRemoveCopyCudaStreams()
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   Vector result(5);
 
@@ -371,10 +361,10 @@ void TestRemoveCopyCudaStreams()
   Vector::iterator end = thrust::remove_copy(thrust::cuda::par.on(s), data.begin(), data.end(), result.begin(), (T) 2);
 
   ASSERT_EQUAL(end - result.begin(), 3);
+  result.erase(end, result.end());
 
-  ASSERT_EQUAL(result[0], 1);
-  ASSERT_EQUAL(result[1], 1);
-  ASSERT_EQUAL(result[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);
 }
@@ -385,12 +375,7 @@ void TestRemoveIfCudaStreams()
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -398,10 +383,10 @@ void TestRemoveIfCudaStreams()
   Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s), data.begin(), data.end(), is_even<T>());
 
   ASSERT_EQUAL(end - data.begin(), 3);
+  data.erase(end, data.end());
 
-  ASSERT_EQUAL(data[0], 1);
-  ASSERT_EQUAL(data[1], 1);
-  ASSERT_EQUAL(data[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(data, ref);
 
   cudaStreamDestroy(s);
 }
@@ -412,19 +397,9 @@ void TestRemoveIfStencilCudaStreams()
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
-  Vector stencil(5);
-  stencil[0] = 0;
-  stencil[1] = 1;
-  stencil[2] = 0;
-  stencil[3] = 0;
-  stencil[4] = 1;
+  Vector stencil{0, 1, 0, 0, 1};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -433,10 +408,10 @@ void TestRemoveIfStencilCudaStreams()
     thrust::remove_if(thrust::cuda::par.on(s), data.begin(), data.end(), stencil.begin(), thrust::identity<T>());
 
   ASSERT_EQUAL(end - data.begin(), 3);
+  data.erase(end, data.end());
 
-  ASSERT_EQUAL(data[0], 1);
-  ASSERT_EQUAL(data[1], 1);
-  ASSERT_EQUAL(data[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(data, ref);
 
   cudaStreamDestroy(s);
 }
@@ -447,12 +422,7 @@ void TestRemoveCopyIfCudaStreams()
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   Vector result(5);
 
@@ -463,10 +433,10 @@ void TestRemoveCopyIfCudaStreams()
     thrust::remove_copy_if(thrust::cuda::par.on(s), data.begin(), data.end(), result.begin(), is_even<T>());
 
   ASSERT_EQUAL(end - result.begin(), 3);
+  result.erase(end, result.end());
 
-  ASSERT_EQUAL(result[0], 1);
-  ASSERT_EQUAL(result[1], 1);
-  ASSERT_EQUAL(result[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);
 }
@@ -477,19 +447,9 @@ void TestRemoveCopyIfStencilCudaStreams()
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
-  Vector stencil(5);
-  stencil[0] = 0;
-  stencil[1] = 1;
-  stencil[2] = 0;
-  stencil[3] = 0;
-  stencil[4] = 1;
+  Vector stencil{0, 1, 0, 0, 1};
 
   Vector result(5);
 
@@ -500,10 +460,10 @@ void TestRemoveCopyIfStencilCudaStreams()
     thrust::cuda::par.on(s), data.begin(), data.end(), stencil.begin(), result.begin(), thrust::identity<T>());
 
   ASSERT_EQUAL(end - result.begin(), 3);
+  result.erase(end, result.end());
 
-  ASSERT_EQUAL(result[0], 1);
-  ASSERT_EQUAL(result[1], 1);
-  ASSERT_EQUAL(result[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(result, ref);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/cuda/replace.cu
+++ b/thrust/testing/cuda/replace.cu
@@ -264,12 +264,7 @@ void TestReplaceCudaStreams()
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -279,12 +274,7 @@ void TestReplaceCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  Vector result(5);
-  result[0] = 4;
-  result[1] = 5;
-  result[2] = 4;
-  result[3] = 3;
-  result[4] = 5;
+  Vector result{4, 5, 4, 3, 5};
 
   ASSERT_EQUAL(data, result);
 

--- a/thrust/testing/cuda/reverse.cu
+++ b/thrust/testing/cuda/reverse.cu
@@ -79,12 +79,7 @@ DECLARE_UNITTEST(TestReverseCopyDeviceDevice);
 void TestReverseCudaStreams()
 {
   using Vector = thrust::device_vector<int>;
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 3;
-  data[3] = 4;
-  data[4] = 5;
+  Vector data{1, 2, 3, 4, 5};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -93,12 +88,7 @@ void TestReverseCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  Vector ref(5);
-  ref[0] = 5;
-  ref[1] = 4;
-  ref[2] = 3;
-  ref[3] = 2;
-  ref[4] = 1;
+  Vector ref{5, 4, 3, 2, 1};
 
   ASSERT_EQUAL(ref, data);
 
@@ -109,12 +99,7 @@ DECLARE_UNITTEST(TestReverseCudaStreams);
 void TestReverseCopyCudaStreams()
 {
   using Vector = thrust::device_vector<int>;
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 3;
-  data[3] = 4;
-  data[4] = 5;
+  Vector data{1, 2, 3, 4, 5};
 
   Vector result(5);
 
@@ -125,12 +110,7 @@ void TestReverseCopyCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  Vector ref(5);
-  ref[0] = 5;
-  ref[1] = 4;
-  ref[2] = 3;
-  ref[3] = 2;
-  ref[4] = 1;
+  Vector ref{5, 4, 3, 2, 1};
 
   ASSERT_EQUAL(ref, result);
 

--- a/thrust/testing/cuda/scan.cu
+++ b/thrust/testing/cuda/scan.cu
@@ -136,30 +136,20 @@ void TestScanCudaStreams()
 
   Vector::iterator iter;
 
-  Vector input(5);
-  Vector result(5);
+  Vector input{1, 3, -2, 4, -5};
+  Vector result{1, 4, 2, 6, 1};
   Vector output(5);
-
-  input[0] = 1;
-  input[1] = 3;
-  input[2] = -2;
-  input[3] = 4;
-  input[4] = -5;
 
   Vector input_copy(input);
 
   cudaStream_t s;
   cudaStreamCreate(&s);
-
   // inclusive scan
+
   iter = thrust::inclusive_scan(thrust::cuda::par.on(s), input.begin(), input.end(), output.begin());
+
   cudaStreamSynchronize(s);
 
-  result[0] = 1;
-  result[1] = 4;
-  result[2] = 2;
-  result[3] = 6;
-  result[4] = 1;
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -168,11 +158,7 @@ void TestScanCudaStreams()
   iter = thrust::exclusive_scan(thrust::cuda::par.on(s), input.begin(), input.end(), output.begin(), 0);
   cudaStreamSynchronize(s);
 
-  result[0] = 0;
-  result[1] = 1;
-  result[2] = 4;
-  result[3] = 2;
-  result[4] = 6;
+  result = {0, 1, 4, 2, 6};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -181,11 +167,7 @@ void TestScanCudaStreams()
   iter = thrust::exclusive_scan(thrust::cuda::par.on(s), input.begin(), input.end(), output.begin(), 3);
   cudaStreamSynchronize(s);
 
-  result[0] = 3;
-  result[1] = 4;
-  result[2] = 7;
-  result[3] = 5;
-  result[4] = 9;
+  result = {3, 4, 7, 5, 9};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -194,11 +176,7 @@ void TestScanCudaStreams()
   iter = thrust::inclusive_scan(thrust::cuda::par.on(s), input.begin(), input.end(), output.begin(), thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = 1;
-  result[1] = 4;
-  result[2] = 2;
-  result[3] = 6;
-  result[4] = 1;
+  result = {1, 4, 2, 6, 1};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -208,11 +186,7 @@ void TestScanCudaStreams()
     thrust::inclusive_scan(thrust::cuda::par.on(s), input.begin(), input.end(), output.begin(), 3, thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = 4;
-  result[1] = 7;
-  result[2] = 5;
-  result[3] = 9;
-  result[4] = 4;
+  result = {4, 7, 5, 9, 4};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -222,11 +196,7 @@ void TestScanCudaStreams()
     thrust::exclusive_scan(thrust::cuda::par.on(s), input.begin(), input.end(), output.begin(), 3, thrust::plus<T>());
   cudaStreamSynchronize(s);
 
-  result[0] = 3;
-  result[1] = 4;
-  result[2] = 7;
-  result[3] = 5;
-  result[4] = 9;
+  result = {3, 4, 7, 5, 9};
   ASSERT_EQUAL(std::size_t(iter - output.begin()), input.size());
   ASSERT_EQUAL(input, input_copy);
   ASSERT_EQUAL(output, result);
@@ -236,11 +206,7 @@ void TestScanCudaStreams()
   iter  = thrust::inclusive_scan(thrust::cuda::par.on(s), input.begin(), input.end(), input.begin());
   cudaStreamSynchronize(s);
 
-  result[0] = 1;
-  result[1] = 4;
-  result[2] = 2;
-  result[3] = 6;
-  result[4] = 1;
+  result = {1, 4, 2, 6, 1};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(input, result);
 
@@ -249,11 +215,7 @@ void TestScanCudaStreams()
   iter  = thrust::exclusive_scan(thrust::cuda::par.on(s), input.begin(), input.end(), input.begin(), 3);
   cudaStreamSynchronize(s);
 
-  result[0] = 3;
-  result[1] = 4;
-  result[2] = 7;
-  result[3] = 5;
-  result[4] = 9;
+  result = {3, 4, 7, 5, 9};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(input, result);
 
@@ -262,11 +224,7 @@ void TestScanCudaStreams()
   iter  = thrust::exclusive_scan(thrust::cuda::par.on(s), input.begin(), input.end(), input.begin());
   cudaStreamSynchronize(s);
 
-  result[0] = 0;
-  result[1] = 1;
-  result[2] = 4;
-  result[3] = 2;
-  result[4] = 6;
+  result = {0, 1, 4, 2, 6};
   ASSERT_EQUAL(std::size_t(iter - input.begin()), input.size());
   ASSERT_EQUAL(input, result);
 
@@ -292,32 +250,14 @@ struct const_ref_plus_mod3
 static void TestInclusiveScanWithConstAccumulator()
 {
   // add numbers modulo 3 with external lookup table
-  thrust::device_vector<int> data(7);
-  data[0] = 0;
-  data[1] = 1;
-  data[2] = 2;
-  data[3] = 1;
-  data[4] = 2;
-  data[5] = 0;
-  data[6] = 1;
+  thrust::device_vector<int> data{0, 1, 2, 1, 2, 0, 1};
 
-  thrust::device_vector<int> table(6);
-  table[0] = 0;
-  table[1] = 1;
-  table[2] = 2;
-  table[3] = 0;
-  table[4] = 1;
-  table[5] = 2;
+  thrust::device_vector<int> table{0, 1, 2, 0, 1, 2};
 
   thrust::inclusive_scan(
     data.begin(), data.end(), data.begin(), const_ref_plus_mod3<int>(thrust::raw_pointer_cast(&table[0])));
 
-  ASSERT_EQUAL(data[0], 0);
-  ASSERT_EQUAL(data[1], 1);
-  ASSERT_EQUAL(data[2], 0);
-  ASSERT_EQUAL(data[3], 1);
-  ASSERT_EQUAL(data[4], 0);
-  ASSERT_EQUAL(data[5], 0);
-  ASSERT_EQUAL(data[6], 1);
+  thrust::device_vector<int> ref{0, 1, 0, 1, 0, 0, 1};
+  ASSERT_EQUAL(data, ref);
 }
 DECLARE_UNITTEST(TestInclusiveScanWithConstAccumulator);

--- a/thrust/testing/cuda/scan_by_key.cu
+++ b/thrust/testing/cuda/scan_by_key.cu
@@ -135,20 +135,10 @@ void TestInclusiveScanByKeyCudaStreams()
   using T        = Vector::value_type;
   using Iterator = Vector::iterator;
 
-  Vector keys(7);
-  Vector vals(7);
+  Vector keys{0, 1, 1, 1, 2, 3, 3};
+  Vector vals{1, 2, 3, 4, 5, 6, 7};
 
   Vector output(7, 0);
-
-  // clang-format off
-  keys[0] = 0; vals[0] = 1;
-  keys[1] = 1; vals[1] = 2;
-  keys[2] = 1; vals[2] = 3;
-  keys[3] = 1; vals[3] = 4;
-  keys[4] = 2; vals[4] = 5;
-  keys[5] = 3; vals[5] = 6;
-  keys[6] = 3; vals[6] = 7;
-  // clang-format on
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -159,13 +149,8 @@ void TestInclusiveScanByKeyCudaStreams()
 
   ASSERT_EQUAL_QUIET(iter, output.end());
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 5);
-  ASSERT_EQUAL(output[3], 9);
-  ASSERT_EQUAL(output[4], 5);
-  ASSERT_EQUAL(output[5], 6);
-  ASSERT_EQUAL(output[6], 13);
+  Vector ref{1, 2, 5, 9, 5, 6, 13};
+  ASSERT_EQUAL(output, ref);
 
   thrust::inclusive_scan_by_key(
     thrust::cuda::par.on(s),
@@ -177,25 +162,15 @@ void TestInclusiveScanByKeyCudaStreams()
     thrust::multiplies<T>());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 6);
-  ASSERT_EQUAL(output[3], 24);
-  ASSERT_EQUAL(output[4], 5);
-  ASSERT_EQUAL(output[5], 6);
-  ASSERT_EQUAL(output[6], 42);
+  ref = {1, 2, 6, 24, 5, 6, 42};
+  ASSERT_EQUAL(output, ref);
 
   thrust::inclusive_scan_by_key(
     thrust::cuda::par.on(s), keys.begin(), keys.end(), vals.begin(), output.begin(), thrust::equal_to<T>());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 5);
-  ASSERT_EQUAL(output[3], 9);
-  ASSERT_EQUAL(output[4], 5);
-  ASSERT_EQUAL(output[5], 6);
-  ASSERT_EQUAL(output[6], 13);
+  ref = {1, 2, 5, 9, 5, 6, 13};
+  ASSERT_EQUAL(output, ref);
 
   cudaStreamDestroy(s);
 }
@@ -207,20 +182,10 @@ void TestExclusiveScanByKeyCudaStreams()
   using T        = Vector::value_type;
   using Iterator = Vector::iterator;
 
-  Vector keys(7);
-  Vector vals(7);
+  Vector keys{0, 1, 1, 1, 2, 3, 3};
+  Vector vals{1, 2, 3, 4, 5, 6, 7};
 
   Vector output(7, 0);
-
-  // clang-format off
-  keys[0] = 0; vals[0] = 1;
-  keys[1] = 1; vals[1] = 2;
-  keys[2] = 1; vals[2] = 3;
-  keys[3] = 1; vals[3] = 4;
-  keys[4] = 2; vals[4] = 5;
-  keys[5] = 3; vals[5] = 6;
-  keys[6] = 3; vals[6] = 7;
-  // clang-format on
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -231,24 +196,14 @@ void TestExclusiveScanByKeyCudaStreams()
 
   ASSERT_EQUAL_QUIET(iter, output.end());
 
-  ASSERT_EQUAL(output[0], 0);
-  ASSERT_EQUAL(output[1], 0);
-  ASSERT_EQUAL(output[2], 2);
-  ASSERT_EQUAL(output[3], 5);
-  ASSERT_EQUAL(output[4], 0);
-  ASSERT_EQUAL(output[5], 0);
-  ASSERT_EQUAL(output[6], 6);
+  Vector ref{0, 0, 2, 5, 0, 0, 6};
+  ASSERT_EQUAL(output, ref);
 
   thrust::exclusive_scan_by_key(thrust::cuda::par.on(s), keys.begin(), keys.end(), vals.begin(), output.begin(), T(10));
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(output[0], 10);
-  ASSERT_EQUAL(output[1], 10);
-  ASSERT_EQUAL(output[2], 12);
-  ASSERT_EQUAL(output[3], 15);
-  ASSERT_EQUAL(output[4], 10);
-  ASSERT_EQUAL(output[5], 10);
-  ASSERT_EQUAL(output[6], 16);
+  ref = {10, 10, 12, 15, 10, 10, 16};
+  ASSERT_EQUAL(output, ref);
 
   thrust::exclusive_scan_by_key(
     thrust::cuda::par.on(s),
@@ -261,24 +216,14 @@ void TestExclusiveScanByKeyCudaStreams()
     thrust::multiplies<T>());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(output[0], 10);
-  ASSERT_EQUAL(output[1], 10);
-  ASSERT_EQUAL(output[2], 20);
-  ASSERT_EQUAL(output[3], 60);
-  ASSERT_EQUAL(output[4], 10);
-  ASSERT_EQUAL(output[5], 10);
-  ASSERT_EQUAL(output[6], 60);
+  ref = {10, 10, 20, 60, 10, 10, 60};
+  ASSERT_EQUAL(output, ref);
 
   thrust::exclusive_scan_by_key(
     thrust::cuda::par.on(s), keys.begin(), keys.end(), vals.begin(), output.begin(), T(10), thrust::equal_to<T>());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(output[0], 10);
-  ASSERT_EQUAL(output[1], 10);
-  ASSERT_EQUAL(output[2], 12);
-  ASSERT_EQUAL(output[3], 15);
-  ASSERT_EQUAL(output[4], 10);
-  ASSERT_EQUAL(output[5], 10);
-  ASSERT_EQUAL(output[6], 16);
+  ref = {10, 10, 12, 15, 10, 10, 16};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_UNITTEST(TestExclusiveScanByKeyCudaStreams);

--- a/thrust/testing/cuda/scatter.cu
+++ b/thrust/testing/cuda/scatter.cu
@@ -137,15 +137,9 @@ void TestScatterCudaStreams()
 {
   using Vector = thrust::device_vector<int>;
 
-  Vector map(5); // scatter indices
-  Vector src(5); // source vector
-  Vector dst(8); // destination vector
-
-  // clang-format off
-  map[0] = 6; map[1] = 3; map[2] = 1; map[3] = 7; map[4] = 2;
-  src[0] = 0; src[1] = 1; src[2] = 2; src[3] = 3; src[4] = 4;
-  dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0; dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
-  // clang-format on
+  Vector map{6, 3, 1, 7, 2}; // scatter indices
+  Vector src{0, 1, 2, 3, 4}; // source vector
+  Vector dst(8, 0); // destination vector
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -154,14 +148,8 @@ void TestScatterCudaStreams()
 
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(dst[0], 0);
-  ASSERT_EQUAL(dst[1], 2);
-  ASSERT_EQUAL(dst[2], 4);
-  ASSERT_EQUAL(dst[3], 1);
-  ASSERT_EQUAL(dst[4], 0);
-  ASSERT_EQUAL(dst[5], 0);
-  ASSERT_EQUAL(dst[6], 0);
-  ASSERT_EQUAL(dst[7], 3);
+  Vector ref{0, 2, 4, 1, 0, 0, 0, 3};
+  ASSERT_EQUAL(dst, ref);
 
   cudaStreamDestroy(s);
 }
@@ -171,17 +159,10 @@ void TestScatterIfCudaStreams()
 {
   using Vector = thrust::device_vector<int>;
 
-  Vector flg(5); // predicate array
-  Vector map(5); // scatter indices
-  Vector src(5); // source vector
+  Vector flg{0, 1, 0, 1, 0}; // predicate array
+  Vector map{6, 3, 1, 7, 2}; // scatter indices
+  Vector src{0, 1, 2, 3, 4}; // source vector
   Vector dst(8); // destination vector
-
-  // clang-format off
-  flg[0] = 0; flg[1] = 1; flg[2] = 0; flg[3] = 1; flg[4] = 0;
-  map[0] = 6; map[1] = 3; map[2] = 1; map[3] = 7; map[4] = 2;
-  src[0] = 0; src[1] = 1; src[2] = 2; src[3] = 3; src[4] = 4;
-  dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0; dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
-  // clang-format on
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -189,14 +170,8 @@ void TestScatterIfCudaStreams()
   thrust::scatter_if(thrust::cuda::par.on(s), src.begin(), src.end(), map.begin(), flg.begin(), dst.begin());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(dst[0], 0);
-  ASSERT_EQUAL(dst[1], 0);
-  ASSERT_EQUAL(dst[2], 0);
-  ASSERT_EQUAL(dst[3], 1);
-  ASSERT_EQUAL(dst[4], 0);
-  ASSERT_EQUAL(dst[5], 0);
-  ASSERT_EQUAL(dst[6], 0);
-  ASSERT_EQUAL(dst[7], 3);
+  Vector ref{0, 0, 0, 1, 0, 0, 0, 3};
+  ASSERT_EQUAL(dst, ref);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/cuda/sequence.cu
+++ b/thrust/testing/cuda/sequence.cu
@@ -33,11 +33,8 @@ void TestSequenceDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
-  ASSERT_EQUAL(v[3], 3);
-  ASSERT_EQUAL(v[4], 4);
+  thrust::device_vector<int> ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v, ref);
 
   sequence_kernel<<<1, 1>>>(exec, v.begin(), v.end(), 10);
   {
@@ -45,11 +42,8 @@ void TestSequenceDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(v[1], 11);
-  ASSERT_EQUAL(v[2], 12);
-  ASSERT_EQUAL(v[3], 13);
-  ASSERT_EQUAL(v[4], 14);
+  ref = {10, 11, 12, 13, 14};
+  ASSERT_EQUAL(v, ref);
 
   sequence_kernel<<<1, 1>>>(exec, v.begin(), v.end(), 10, 2);
   {
@@ -57,11 +51,8 @@ void TestSequenceDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(v[1], 12);
-  ASSERT_EQUAL(v[2], 14);
-  ASSERT_EQUAL(v[3], 16);
-  ASSERT_EQUAL(v[4], 18);
+  ref = {10, 12, 14, 16, 18};
+  ASSERT_EQUAL(v, ref);
 }
 
 void TestSequenceDeviceSeq()
@@ -89,29 +80,20 @@ void TestSequenceCudaStreams()
   thrust::sequence(thrust::cuda::par.on(s), v.begin(), v.end());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
-  ASSERT_EQUAL(v[3], 3);
-  ASSERT_EQUAL(v[4], 4);
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::sequence(thrust::cuda::par.on(s), v.begin(), v.end(), 10);
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(v[1], 11);
-  ASSERT_EQUAL(v[2], 12);
-  ASSERT_EQUAL(v[3], 13);
-  ASSERT_EQUAL(v[4], 14);
+  ref = {10, 11, 12, 13, 14};
+  ASSERT_EQUAL(v, ref);
 
   thrust::sequence(thrust::cuda::par.on(s), v.begin(), v.end(), 10, 2);
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(v[1], 12);
-  ASSERT_EQUAL(v[2], 14);
-  ASSERT_EQUAL(v[3], 16);
-  ASSERT_EQUAL(v[4], 18);
+  ref = {10, 12, 14, 16, 18};
+  ASSERT_EQUAL(v, ref);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/cuda/set_difference.cu
+++ b/thrust/testing/cuda/set_difference.cu
@@ -23,17 +23,9 @@ void TestSetDifferenceDevice(ExecutionPolicy exec)
   using Vector   = thrust::device_vector<int>;
   using Iterator = typename Vector::iterator;
 
-  Vector a(4), b(5);
+  Vector a{0, 2, 4, 5}, b{0, 3, 3, 4, 6};
 
-  // clang-format off
-  a[0] = 0; a[1] = 2; a[2] = 4; a[3] = 5;
-  b[0] = 0; b[1] = 3; b[2] = 3; b[3] = 4; b[4] = 6;
-  // clang-format on
-
-  Vector ref(2);
-  ref[0] = 2;
-  ref[1] = 5;
-
+  Vector ref{2, 5};
   Vector result(2);
 
   thrust::device_vector<Iterator> end_vec(1);
@@ -66,17 +58,9 @@ void TestSetDifferenceCudaStreams()
   using Vector   = thrust::device_vector<int>;
   using Iterator = Vector::iterator;
 
-  Vector a(4), b(5);
+  Vector a{0, 2, 4, 5}, b{0, 3, 3, 4, 6};
 
-  // clang-format off
-  a[0] = 0; a[1] = 2; a[2] = 4; a[3] = 5;
-  b[0] = 0; b[1] = 3; b[2] = 3; b[3] = 4; b[4] = 6;
-  // clang-format on
-
-  Vector ref(2);
-  ref[0] = 2;
-  ref[1] = 5;
-
+  Vector ref{2, 5};
   Vector result(2);
 
   cudaStream_t s;

--- a/thrust/testing/cuda/set_difference_by_key.cu
+++ b/thrust/testing/cuda/set_difference_by_key.cu
@@ -35,21 +35,10 @@ void TestSetDifferenceByKeyDevice(ExecutionPolicy exec)
   using Vector   = thrust::device_vector<int>;
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a_key(4), b_key(5);
-  Vector a_val(4), b_val(5);
+  Vector a_key{0, 2, 4, 5}, b_key{0, 3, 3, 4, 6};
+  Vector a_val(4, 0), b_val(5, 1);
 
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4; a_key[3] = 5;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0; a_val[3] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4; b_key[4] = 6;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1; b_val[4] = 1;
-
-  Vector ref_key(2), ref_val(2);
-  ref_key[0] = 2; ref_key[1] = 5;
-  ref_val[0] = 0; ref_val[1] = 0;
-  // clang-format on
-
+  Vector ref_key{2, 5}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
   using iter_pair = thrust::pair<Iterator, Iterator>;
@@ -96,21 +85,10 @@ void TestSetDifferenceByKeyCudaStreams()
   using Vector   = thrust::device_vector<int>;
   using Iterator = Vector::iterator;
 
-  // clang-format off
-  Vector a_key(4), b_key(5);
-  Vector a_val(4), b_val(5);
+  Vector a_key{0, 2, 4, 5}, b_key{0, 3, 3, 4, 6};
+  Vector a_val(4, 0), b_val(5, 1);
 
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4; a_key[3] = 5;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0; a_val[3] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4; b_key[4] = 6;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1; b_val[4] = 1;
-
-  Vector ref_key(2), ref_val(2);
-  ref_key[0] = 2; ref_key[1] = 5;
-  ref_val[0] = 0; ref_val[1] = 0;
-  // clang-format on
-
+  Vector ref_key{2, 5}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
   cudaStream_t s;

--- a/thrust/testing/cuda/set_intersection.cu
+++ b/thrust/testing/cuda/set_intersection.cu
@@ -26,17 +26,9 @@ void TestSetIntersectionDevice(ExecutionPolicy exec)
   using Vector   = thrust::device_vector<int>;
   using Iterator = Vector::iterator;
 
-  Vector a(3), b(4);
+  Vector a{0, 2, 4}, b{0, 3, 3, 4};
 
-  // clang-format off
-  a[0] = 0; a[1] = 2; a[2] = 4;
-  b[0] = 0; b[1] = 3; b[2] = 3; b[3] = 4;
-  // clang-format on
-
-  Vector ref(2);
-  ref[0] = 0;
-  ref[1] = 4;
-
+  Vector ref{0, 4};
   Vector result(2);
   thrust::device_vector<Iterator> end_vec(1);
 
@@ -75,17 +67,9 @@ void TestSetIntersectionCudaStreams(ExecutionPolicy policy)
   using Vector   = thrust::device_vector<int>;
   using Iterator = Vector::iterator;
 
-  Vector a(3), b(4);
+  Vector a{0, 2, 4}, b{0, 3, 3, 4};
 
-  // clang-format off
-  a[0] = 0; a[1] = 2; a[2] = 4;
-  b[0] = 0; b[1] = 3; b[2] = 3; b[3] = 4;
-  // clang-format on
-
-  Vector ref(2);
-  ref[0] = 0;
-  ref[1] = 4;
-
+  Vector ref{0, 4};
   Vector result(2);
 
   cudaStream_t s;

--- a/thrust/testing/cuda/set_intersection_by_key.cu
+++ b/thrust/testing/cuda/set_intersection_by_key.cu
@@ -32,20 +32,10 @@ void TestSetIntersectionByKeyDevice(ExecutionPolicy exec)
   using Vector   = thrust::device_vector<int>;
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a_key(3), b_key(4);
-  Vector a_val(3);
+  Vector a_key{0, 2, 4}, b_key{0, 3, 3, 4};
+  Vector a_val(3, 0);
 
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4;
-
-  Vector ref_key(2), ref_val(2);
-  ref_key[0] = 0; ref_key[1] = 4;
-  ref_val[0] = 0; ref_val[1] = 0;
-  // clang-format on
-
+  Vector ref_key{0, 4}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
   using iter_pair = thrust::pair<Iterator, Iterator>;
@@ -97,20 +87,10 @@ void TestSetIntersectionByKeyCudaStreams(ExecutionPolicy policy)
   using Vector   = thrust::device_vector<int>;
   using Iterator = Vector::iterator;
 
-  // clang-format off
-  Vector a_key(3), b_key(4);
-  Vector a_val(3);
+  Vector a_key{0, 2, 4}, b_key{0, 3, 3, 4};
+  Vector a_val(3, 0);
 
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4;
-
-  Vector ref_key(2), ref_val(2);
-  ref_key[0] = 0; ref_key[1] = 4;
-  ref_val[0] = 0; ref_val[1] = 0;
-  // clang-format on
-
+  Vector ref_key{0, 4}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
   cudaStream_t s;

--- a/thrust/testing/cuda/set_symmetric_difference.cu
+++ b/thrust/testing/cuda/set_symmetric_difference.cu
@@ -23,16 +23,9 @@ void TestSetSymmetricDifferenceDevice(ExecutionPolicy exec)
   using Vector   = thrust::device_vector<int>;
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a(4), b(5);
+  Vector a{0, 2, 4, 6}, b{0, 3, 3, 4, 7};
 
-  a[0] = 0; a[1] = 2; a[2] = 4; a[3] = 6;
-  b[0] = 0; b[1] = 3; b[2] = 3; b[3] = 4; b[4] = 7;
-
-  Vector ref(5);
-  ref[0] = 2; ref[1] = 3; ref[2] = 3; ref[3] = 6; ref[4] = 7;
-  // clang-format on
-
+  Vector ref{2, 3, 3, 6, 7};
   Vector result(5);
   thrust::device_vector<Iterator> end_vec(1);
 
@@ -65,16 +58,9 @@ void TestSetSymmetricDifferenceCudaStreams()
   using Vector   = thrust::device_vector<int>;
   using Iterator = Vector::iterator;
 
-  // clang-format off
-  Vector a(4), b(5);
+  Vector a{0, 2, 4, 6}, b{0, 3, 3, 4, 7};
 
-  a[0] = 0; a[1] = 2; a[2] = 4; a[3] = 6;
-  b[0] = 0; b[1] = 3; b[2] = 3; b[3] = 4; b[4] = 7;
-
-  Vector ref(5);
-  ref[0] = 2; ref[1] = 3; ref[2] = 3; ref[3] = 6; ref[4] = 7;
-  // clang-format on
-
+  Vector ref{2, 3, 3, 6, 7};
   Vector result(5);
 
   cudaStream_t s;

--- a/thrust/testing/cuda/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/cuda/set_symmetric_difference_by_key.cu
@@ -34,21 +34,10 @@ void TestSetSymmetricDifferenceByKeyDevice(ExecutionPolicy exec)
   using Vector   = thrust::device_vector<int>;
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a_key(4), b_key(5);
-  Vector a_val(4), b_val(5);
+  Vector a_key{0, 2, 4, 6}, b_key{0, 3, 3, 4, 7};
+  Vector a_val(4, 0), b_val(5, 1);
 
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4; a_key[3] = 6;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0; a_val[3] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4; b_key[4] = 7;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1; b_val[4] = 1;
-
-  Vector ref_key(5), ref_val(5);
-  ref_key[0] = 2; ref_key[1] = 3; ref_key[2] = 3; ref_key[3] = 6; ref_key[4] = 7;
-  ref_val[0] = 0; ref_val[1] = 1; ref_val[2] = 1; ref_val[3] = 0; ref_val[4] = 1;
-  // clang-format on
-
+  Vector ref_key{2, 3, 3, 6, 7}, ref_val{0, 1, 1, 0, 1};
   Vector result_key(5), result_val(5);
 
   using iter_pair = thrust::pair<Iterator, Iterator>;
@@ -94,21 +83,10 @@ void TestSetSymmetricDifferenceByKeyCudaStreams()
   using Vector   = thrust::device_vector<int>;
   using Iterator = Vector::iterator;
 
-  // clang-format off
-  Vector a_key(4), b_key(5);
-  Vector a_val(4), b_val(5);
+  Vector a_key{0, 2, 4, 6}, b_key{0, 3, 3, 4, 7};
+  Vector a_val(4, 0), b_val(5, 1);
 
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4; a_key[3] = 6;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0; a_val[3] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4; b_key[4] = 7;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1; b_val[4] = 1;
-
-  Vector ref_key(5), ref_val(5);
-  ref_key[0] = 2; ref_key[1] = 3; ref_key[2] = 3; ref_key[3] = 6; ref_key[4] = 7;
-  ref_val[0] = 0; ref_val[1] = 1; ref_val[2] = 1; ref_val[3] = 0; ref_val[4] = 1;
-  // clang-format on
-
+  Vector ref_key{2, 3, 3, 6, 7}, ref_val{0, 1, 1, 0, 1};
   Vector result_key(5), result_val(5);
 
   cudaStream_t s;

--- a/thrust/testing/cuda/set_union.cu
+++ b/thrust/testing/cuda/set_union.cu
@@ -23,16 +23,9 @@ void TestSetUnionDevice(ExecutionPolicy exec)
   using Vector   = thrust::device_vector<int>;
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a(3), b(4);
+  Vector a{0, 2, 4}, b{0, 3, 3, 4};
 
-  a[0] = 0; a[1] = 2; a[2] = 4;
-  b[0] = 0; b[1] = 3; b[2] = 3; b[3] = 4;
-
-  Vector ref(5);
-  ref[0] = 0; ref[1] = 2; ref[2] = 3; ref[3] = 3; ref[4] = 4;
-  // clang-format on
-
+  Vector ref{0, 2, 3, 3, 4};
   Vector result(5);
   thrust::device_vector<Iterator> end_vec(1);
 
@@ -64,16 +57,9 @@ void TestSetUnionCudaStreams()
   using Vector   = thrust::device_vector<int>;
   using Iterator = Vector::iterator;
 
-  // clang-format off
-  Vector a(3), b(4);
+  Vector a{0, 2, 4}, b{0, 3, 3, 4};
 
-  a[0] = 0; a[1] = 2; a[2] = 4;
-  b[0] = 0; b[1] = 3; b[2] = 3; b[3] = 4;
-
-  Vector ref(5);
-  ref[0] = 0; ref[1] = 2; ref[2] = 3; ref[3] = 3; ref[4] = 4;
-  // clang-format on
-
+  Vector ref{0, 2, 3, 3, 4};
   Vector result(5);
 
   cudaStream_t s;

--- a/thrust/testing/cuda/set_union_by_key.cu
+++ b/thrust/testing/cuda/set_union_by_key.cu
@@ -34,21 +34,10 @@ void TestSetUnionByKeyDevice(ExecutionPolicy exec)
   using Vector   = thrust::device_vector<int>;
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a_key(3), b_key(4);
-  Vector a_val(3), b_val(4);
+  Vector a_key{0, 2, 4}, b_key{0, 3, 3, 4};
+  Vector a_val(3, 0), b_val(4, 1);
 
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1;
-
-  Vector ref_key(5), ref_val(5);
-  ref_key[0] = 0; ref_key[1] = 2; ref_key[2] = 3; ref_key[3] = 3; ref_key[4] = 4;
-  ref_val[0] = 0; ref_val[1] = 0; ref_val[2] = 1; ref_val[3] = 1; ref_val[4] = 0;
-  // clang-format on
-
+  Vector ref_key{0, 2, 3, 3, 4}, ref_val{0, 0, 1, 1, 0};
   Vector result_key(5), result_val(5);
 
   thrust::device_vector<thrust::pair<Iterator, Iterator>> end_vec(1);
@@ -93,21 +82,10 @@ void TestSetUnionByKeyCudaStreams()
   using Vector   = thrust::device_vector<int>;
   using Iterator = Vector::iterator;
 
-  Vector a_key(3), b_key(4);
-  Vector a_val(3), b_val(4);
+  Vector a_key{0, 2, 4}, b_key{0, 3, 3, 4};
+  Vector a_val(3, 0), b_val(4, 1);
 
-  // clang-format off
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1;
-
-  Vector ref_key(5), ref_val(5);
-  ref_key[0] = 0; ref_key[1] = 2; ref_key[2] = 3; ref_key[3] = 3; ref_key[4] = 4;
-  ref_val[0] = 0; ref_val[1] = 0; ref_val[2] = 1; ref_val[3] = 1; ref_val[4] = 0;
-  // clang-format on
-
+  Vector ref_key{0, 2, 3, 3, 4}, ref_val{0, 0, 1, 1, 0};
   Vector result_key(5), result_val(5);
 
   cudaStream_t s;

--- a/thrust/testing/cuda/sort.cu
+++ b/thrust/testing/cuda/sort.cu
@@ -98,18 +98,7 @@ VariableUnitTest<TestSortDeviceDevice, unittest::type_list<unittest::int8_t, uni
 
 void TestSortCudaStreams()
 {
-  thrust::device_vector<int> keys(10);
-
-  keys[0] = 9;
-  keys[1] = 3;
-  keys[2] = 2;
-  keys[3] = 0;
-  keys[4] = 4;
-  keys[5] = 7;
-  keys[6] = 8;
-  keys[7] = 1;
-  keys[8] = 5;
-  keys[9] = 6;
+  thrust::device_vector<int> keys{9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -125,18 +114,7 @@ DECLARE_UNITTEST(TestSortCudaStreams);
 
 void TestComparisonSortCudaStreams()
 {
-  thrust::device_vector<int> keys(10);
-
-  keys[0] = 9;
-  keys[1] = 3;
-  keys[2] = 2;
-  keys[3] = 0;
-  keys[4] = 4;
-  keys[5] = 7;
-  keys[6] = 8;
-  keys[7] = 1;
-  keys[8] = 5;
-  keys[9] = 6;
+  thrust::device_vector<int> keys{9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/sort_by_key.cu
+++ b/thrust/testing/cuda/sort_by_key.cu
@@ -93,8 +93,8 @@ VariableUnitTest<TestSortByKeyDeviceDevice, unittest::type_list<unittest::int8_t
 
 void TestComparisonSortByKeyCudaStreams()
 {
-  thrust::device_vector<int> keys = {9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
-  thrust::device_vector<int> vals = {9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
+  thrust::device_vector<int> keys{9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
+  thrust::device_vector<int> vals{9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -111,8 +111,8 @@ DECLARE_UNITTEST(TestComparisonSortByKeyCudaStreams);
 
 void TestSortByKeyCudaStreams()
 {
-  thrust::device_vector<int> keys = {9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
-  thrust::device_vector<int> vals = {9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
+  thrust::device_vector<int> keys{9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
+  thrust::device_vector<int> vals{9, 3, 2, 0, 4, 7, 8, 1, 5, 6};
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/swap_ranges.cu
+++ b/thrust/testing/cuda/swap_ranges.cu
@@ -15,35 +15,17 @@ void TestSwapRangesDevice(ExecutionPolicy exec)
 {
   using Vector = thrust::device_vector<int>;
 
-  Vector v1(5);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
-  v1[3] = 3;
-  v1[4] = 4;
-
-  Vector v2(5);
-  v2[0] = 5;
-  v2[1] = 6;
-  v2[2] = 7;
-  v2[3] = 8;
-  v2[4] = 9;
+  Vector v1{0, 1, 2, 3, 4};
+  Vector v2{5, 6, 7, 8, 9};
+  Vector v1_ref(v2);
+  Vector v2_ref(v1);
 
   swap_ranges_kernel<<<1, 1>>>(exec, v1.begin(), v1.end(), v2.begin());
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
-  ASSERT_EQUAL(v1[0], 5);
-  ASSERT_EQUAL(v1[1], 6);
-  ASSERT_EQUAL(v1[2], 7);
-  ASSERT_EQUAL(v1[3], 8);
-  ASSERT_EQUAL(v1[4], 9);
-
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
-  ASSERT_EQUAL(v2[3], 3);
-  ASSERT_EQUAL(v2[4], 4);
+  ASSERT_EQUAL(v1, v1_ref);
+  ASSERT_EQUAL(v2, v1_ref);
 }
 
 void TestSwapRangesDeviceSeq()
@@ -63,19 +45,10 @@ void TestSwapRangesCudaStreams()
 {
   using Vector = thrust::device_vector<int>;
 
-  Vector v1(5);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
-  v1[3] = 3;
-  v1[4] = 4;
-
-  Vector v2(5);
-  v2[0] = 5;
-  v2[1] = 6;
-  v2[2] = 7;
-  v2[3] = 8;
-  v2[4] = 9;
+  Vector v1{0, 1, 2, 3, 4};
+  Vector v2{5, 6, 7, 8, 9};
+  Vector v1_ref(v2);
+  Vector v2_ref(v1);
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -83,17 +56,8 @@ void TestSwapRangesCudaStreams()
   thrust::swap_ranges(thrust::cuda::par.on(s), v1.begin(), v1.end(), v2.begin());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v1[0], 5);
-  ASSERT_EQUAL(v1[1], 6);
-  ASSERT_EQUAL(v1[2], 7);
-  ASSERT_EQUAL(v1[3], 8);
-  ASSERT_EQUAL(v1[4], 9);
-
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
-  ASSERT_EQUAL(v2[3], 3);
-  ASSERT_EQUAL(v2[4], 4);
+  ASSERT_EQUAL(v1, v1_ref);
+  ASSERT_EQUAL(v2, v1_ref);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/cuda/swap_ranges.cu
+++ b/thrust/testing/cuda/swap_ranges.cu
@@ -25,7 +25,7 @@ void TestSwapRangesDevice(ExecutionPolicy exec)
   ASSERT_EQUAL(cudaSuccess, err);
 
   ASSERT_EQUAL(v1, v1_ref);
-  ASSERT_EQUAL(v2, v1_ref);
+  ASSERT_EQUAL(v2, v2_ref);
 }
 
 void TestSwapRangesDeviceSeq()
@@ -57,7 +57,7 @@ void TestSwapRangesCudaStreams()
   cudaStreamSynchronize(s);
 
   ASSERT_EQUAL(v1, v1_ref);
-  ASSERT_EQUAL(v2, v1_ref);
+  ASSERT_EQUAL(v2, v2_ref);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/cuda/tabulate.cu
+++ b/thrust/testing/cuda/tabulate.cu
@@ -26,11 +26,8 @@ void TestTabulateDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
-  ASSERT_EQUAL(v[3], 3);
-  ASSERT_EQUAL(v[4], 4);
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v, ref);
 
   tabulate_kernel<<<1, 1>>>(exec, v.begin(), v.end(), -_1);
   {
@@ -38,11 +35,8 @@ void TestTabulateDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], -1);
-  ASSERT_EQUAL(v[2], -2);
-  ASSERT_EQUAL(v[3], -3);
-  ASSERT_EQUAL(v[4], -4);
+  ref = {0, -1, -2, -3, -4};
+  ASSERT_EQUAL(v, ref);
 
   tabulate_kernel<<<1, 1>>>(exec, v.begin(), v.end(), _1 * _1 * _1);
   {
@@ -50,11 +44,8 @@ void TestTabulateDevice(ExecutionPolicy exec)
     ASSERT_EQUAL(cudaSuccess, err);
   }
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 8);
-  ASSERT_EQUAL(v[3], 27);
-  ASSERT_EQUAL(v[4], 64);
+  ref = {0, 1, 8, 27, 64};
+  ASSERT_EQUAL(v, ref);
 }
 
 void TestTabulateDeviceSeq()
@@ -84,29 +75,20 @@ void TestTabulateCudaStreams()
   thrust::tabulate(thrust::cuda::par.on(s), v.begin(), v.end(), thrust::identity<T>());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
-  ASSERT_EQUAL(v[3], 3);
-  ASSERT_EQUAL(v[4], 4);
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::tabulate(thrust::cuda::par.on(s), v.begin(), v.end(), -_1);
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], -1);
-  ASSERT_EQUAL(v[2], -2);
-  ASSERT_EQUAL(v[3], -3);
-  ASSERT_EQUAL(v[4], -4);
+  ref = {0, -1, -2, -3, -4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::tabulate(thrust::cuda::par.on(s), v.begin(), v.end(), _1 * _1 * _1);
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 8);
-  ASSERT_EQUAL(v[3], 27);
-  ASSERT_EQUAL(v[4], 64);
+  ref = {0, 1, 8, 27, 64};
+  ASSERT_EQUAL(v, ref);
 
   cudaStreamSynchronize(s);
 }

--- a/thrust/testing/cuda/transform.cu
+++ b/thrust/testing/cuda/transform.cu
@@ -19,15 +19,9 @@ void TestTransformUnaryDevice(ExecutionPolicy exec)
 
   typename Vector::iterator iter;
 
-  Vector input(3);
+  Vector input{1, -2, 3};
   Vector output(3);
-  Vector result(3);
-  input[0]  = 1;
-  input[1]  = -2;
-  input[2]  = 3;
-  result[0] = -1;
-  result[1] = 2;
-  result[2] = -3;
+  Vector result{-1, 2, -3};
 
   thrust::device_vector<typename Vector::iterator> iter_vec(1);
 
@@ -79,19 +73,9 @@ void TestTransformIfUnaryNoStencilDevice(ExecutionPolicy exec)
 
   typename Vector::iterator iter;
 
-  Vector input(3);
-  Vector output(3);
-  Vector result(3);
-
-  input[0]  = 0;
-  input[1]  = -2;
-  input[2]  = 0;
-  output[0] = -1;
-  output[1] = -2;
-  output[2] = -3;
-  result[0] = -1;
-  result[1] = 2;
-  result[2] = -3;
+  Vector input{0, -2, 0};
+  Vector output{-1, -2, -3};
+  Vector result{-1, 2, -3};
 
   thrust::device_vector<typename Vector::iterator> iter_vec(1);
 
@@ -146,23 +130,10 @@ void TestTransformIfUnaryDevice(ExecutionPolicy exec)
 
   typename Vector::iterator iter;
 
-  Vector input(3);
-  Vector stencil(3);
-  Vector output(3);
-  Vector result(3);
-
-  input[0]   = 1;
-  input[1]   = -2;
-  input[2]   = 3;
-  output[0]  = 1;
-  output[1]  = 2;
-  output[2]  = 3;
-  stencil[0] = 1;
-  stencil[1] = 0;
-  stencil[2] = 1;
-  result[0]  = -1;
-  result[1]  = 2;
-  result[2]  = -3;
+  Vector input{1, -2, 3};
+  Vector stencil{1, 0, 1};
+  Vector output{1, 2, 3};
+  Vector result{-1, 2, -3};
 
   thrust::device_vector<typename Vector::iterator> iter_vec(1);
 
@@ -222,19 +193,10 @@ void TestTransformBinaryDevice(ExecutionPolicy exec)
 
   typename Vector::iterator iter;
 
-  Vector input1(3);
-  Vector input2(3);
+  Vector input1{1, -2, 3};
+  Vector input2{-4, 5, 6};
   Vector output(3);
-  Vector result(3);
-  input1[0] = 1;
-  input1[1] = -2;
-  input1[2] = 3;
-  input2[0] = -4;
-  input2[1] = 5;
-  input2[2] = 6;
-  result[0] = 5;
-  result[1] = -7;
-  result[2] = -3;
+  Vector result{5, -7, -3};
 
   thrust::device_vector<typename Vector::iterator> iter_vec(1);
 
@@ -291,27 +253,11 @@ void TestTransformIfBinaryDevice(ExecutionPolicy exec)
 
   typename Vector::iterator iter;
 
-  Vector input1(3);
-  Vector input2(3);
-  Vector stencil(3);
-  Vector output(3);
-  Vector result(3);
-
-  input1[0]  = 1;
-  input1[1]  = -2;
-  input1[2]  = 3;
-  input2[0]  = -4;
-  input2[1]  = 5;
-  input2[2]  = 6;
-  stencil[0] = 0;
-  stencil[1] = 1;
-  stencil[2] = 0;
-  output[0]  = 1;
-  output[1]  = 2;
-  output[2]  = 3;
-  result[0]  = 5;
-  result[1]  = 2;
-  result[2]  = -3;
+  Vector input1{1, -2, 3};
+  Vector input2{-4, 5, 6};
+  Vector stencil{0, 1, 0};
+  Vector output{1, 2, 3};
+  Vector result{5, 2, -3};
 
   thrust::identity<T> identity;
 
@@ -356,15 +302,9 @@ void TestTransformUnaryCudaStreams()
 
   Vector::iterator iter;
 
-  Vector input(3);
+  Vector input{1, -2, 3};
   Vector output(3);
-  Vector result(3);
-  input[0]  = 1;
-  input[1]  = -2;
-  input[2]  = 3;
-  result[0] = -1;
-  result[1] = 2;
-  result[2] = -3;
+  Vector result{-1, 2, -3};
 
   cudaStream_t s;
   cudaStreamCreate(&s);
@@ -386,19 +326,10 @@ void TestTransformBinaryCudaStreams()
 
   Vector::iterator iter;
 
-  Vector input1(3);
-  Vector input2(3);
+  Vector input1{1, -2, 3};
+  Vector input2{-4, 5, 6};
   Vector output(3);
-  Vector result(3);
-  input1[0] = 1;
-  input1[1] = -2;
-  input1[2] = 3;
-  input2[0] = -4;
-  input2[1] = 5;
-  input2[2] = 6;
-  result[0] = 5;
-  result[1] = -7;
-  result[2] = -3;
+  Vector result{5, -7, -3};
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/transform_reduce.cu
+++ b/thrust/testing/cuda/transform_reduce.cu
@@ -17,11 +17,7 @@ void TestTransformReduceDevice(ExecutionPolicy exec)
   using Vector = thrust::device_vector<int>;
   using T      = typename Vector::value_type;
 
-  Vector data(3);
-  data[0] = 1;
-  data[1] = -2;
-  data[2] = 3;
-
+  Vector data{1, -2, 3};
   T init = 10;
 
   thrust::device_vector<T> result(1);
@@ -52,11 +48,7 @@ void TestTransformReduceCudaStreams()
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(3);
-  data[0] = 1;
-  data[1] = -2;
-  data[2] = 3;
-
+  Vector data{1, -2, 3};
   T init = 10;
 
   cudaStream_t s;

--- a/thrust/testing/cuda/uninitialized_copy.cu
+++ b/thrust/testing/cuda/uninitialized_copy.cu
@@ -15,12 +15,7 @@ void TestUninitializedCopyDevice(ExecutionPolicy exec)
 {
   using Vector = thrust::device_vector<int>;
 
-  Vector v1(5);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
-  v1[3] = 3;
-  v1[4] = 4;
+  Vector v1{0, 1, 2, 3, 4};
 
   // copy to Vector
   Vector v2(5);
@@ -28,11 +23,8 @@ void TestUninitializedCopyDevice(ExecutionPolicy exec)
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
-  ASSERT_EQUAL(v2[3], 3);
-  ASSERT_EQUAL(v2[4], 4);
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v2, ref);
 }
 
 void TestUninitializedCopyDeviceSeq()
@@ -52,12 +44,7 @@ void TestUninitializedCopyCudaStreams()
 {
   using Vector = thrust::device_vector<int>;
 
-  Vector v1(5);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
-  v1[3] = 3;
-  v1[4] = 4;
+  Vector v1{0, 1, 2, 3, 4};
 
   // copy to Vector
   Vector v2(5);
@@ -68,12 +55,7 @@ void TestUninitializedCopyCudaStreams()
   thrust::uninitialized_copy(thrust::cuda::par.on(s), v1.begin(), v1.end(), v2.begin());
   cudaStreamSynchronize(s);
 
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
-  ASSERT_EQUAL(v2[3], 3);
-  ASSERT_EQUAL(v2[4], 4);
-
+  ASSERT_EQUAL(v2, v1);
   cudaStreamDestroy(s);
 }
 DECLARE_UNITTEST(TestUninitializedCopyCudaStreams);
@@ -90,12 +72,7 @@ void TestUninitializedCopyNDevice(ExecutionPolicy exec)
 {
   using Vector = thrust::device_vector<int>;
 
-  Vector v1(5);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
-  v1[3] = 3;
-  v1[4] = 4;
+  Vector v1{0, 1, 2, 3, 4};
 
   // copy to Vector
   Vector v2(5);
@@ -103,11 +80,7 @@ void TestUninitializedCopyNDevice(ExecutionPolicy exec)
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
-  ASSERT_EQUAL(v2[3], 3);
-  ASSERT_EQUAL(v2[4], 4);
+  ASSERT_EQUAL(v2, v1);
 }
 
 void TestUninitializedCopyNDeviceSeq()
@@ -127,12 +100,7 @@ void TestUninitializedCopyNCudaStreams()
 {
   using Vector = thrust::device_vector<int>;
 
-  Vector v1(5);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
-  v1[3] = 3;
-  v1[4] = 4;
+  Vector v1{0, 1, 2, 3, 4};
 
   // copy to Vector
   Vector v2(5);
@@ -142,12 +110,7 @@ void TestUninitializedCopyNCudaStreams()
 
   thrust::uninitialized_copy_n(thrust::cuda::par.on(s), v1.begin(), v1.size(), v2.begin());
   cudaStreamSynchronize(s);
-
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
-  ASSERT_EQUAL(v2[3], 3);
-  ASSERT_EQUAL(v2[4], 4);
+  ASSERT_EQUAL(v2, v1);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/cuda/unique.cu
+++ b/thrust/testing/cuda/unique.cu
@@ -32,17 +32,7 @@ void TestUniqueDevice(ExecutionPolicy exec)
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(10);
-  data[0] = 11;
-  data[1] = 11;
-  data[2] = 12;
-  data[3] = 20;
-  data[4] = 29;
-  data[5] = 21;
-  data[6] = 21;
-  data[7] = 31;
-  data[8] = 31;
-  data[9] = 37;
+  Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
   thrust::device_vector<Vector::iterator> new_last_vec(1);
   Vector::iterator new_last;
@@ -56,13 +46,9 @@ void TestUniqueDevice(ExecutionPolicy exec)
   new_last = new_last_vec[0];
 
   ASSERT_EQUAL(new_last - data.begin(), 7);
-  ASSERT_EQUAL(data[0], 11);
-  ASSERT_EQUAL(data[1], 12);
-  ASSERT_EQUAL(data[2], 20);
-  ASSERT_EQUAL(data[3], 29);
-  ASSERT_EQUAL(data[4], 21);
-  ASSERT_EQUAL(data[5], 31);
-  ASSERT_EQUAL(data[6], 37);
+  data.erase(new_last, data.end());
+  Vector ref{11, 12, 20, 29, 21, 31, 37}; // should we consider calculating ref from std::algorithm if exists?
+  ASSERT_EQUAL(data, ref);
 
   unique_kernel<<<1, 1>>>(exec, data.begin(), new_last, is_equal_div_10_unique<T>(), new_last_vec.begin());
   {
@@ -73,9 +59,9 @@ void TestUniqueDevice(ExecutionPolicy exec)
   new_last = new_last_vec[0];
 
   ASSERT_EQUAL(new_last - data.begin(), 3);
-  ASSERT_EQUAL(data[0], 11);
-  ASSERT_EQUAL(data[1], 20);
-  ASSERT_EQUAL(data[2], 31);
+  data.erase(new_last, data.end());
+  ref = {11, 20, 31};
+  ASSERT_EQUAL(data, ref);
 }
 
 void TestUniqueDeviceSeq()
@@ -103,17 +89,7 @@ void TestUniqueCudaStreams(ExecutionPolicy policy)
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(10);
-  data[0] = 11;
-  data[1] = 11;
-  data[2] = 12;
-  data[3] = 20;
-  data[4] = 29;
-  data[5] = 21;
-  data[6] = 21;
-  data[7] = 31;
-  data[8] = 31;
-  data[9] = 37;
+  Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
   thrust::device_vector<Vector::iterator> new_last_vec(1);
   Vector::iterator new_last;
@@ -127,21 +103,17 @@ void TestUniqueCudaStreams(ExecutionPolicy policy)
   cudaStreamSynchronize(s);
 
   ASSERT_EQUAL(new_last - data.begin(), 7);
-  ASSERT_EQUAL(data[0], 11);
-  ASSERT_EQUAL(data[1], 12);
-  ASSERT_EQUAL(data[2], 20);
-  ASSERT_EQUAL(data[3], 29);
-  ASSERT_EQUAL(data[4], 21);
-  ASSERT_EQUAL(data[5], 31);
-  ASSERT_EQUAL(data[6], 37);
+  data.erase(new_last, data.end());
+  Vector ref{11, 12, 20, 29, 21, 31, 37};
+  ASSERT_EQUAL(data, ref);
 
   new_last = thrust::unique(streampolicy, data.begin(), new_last, is_equal_div_10_unique<T>());
   cudaStreamSynchronize(s);
 
   ASSERT_EQUAL(new_last - data.begin(), 3);
-  ASSERT_EQUAL(data[0], 11);
-  ASSERT_EQUAL(data[1], 20);
-  ASSERT_EQUAL(data[2], 31);
+  data.erase(new_last, data.end());
+  ref = {11, 20, 31};
+  ASSERT_EQUAL(data, ref);
 
   cudaStreamDestroy(s);
 }
@@ -179,17 +151,7 @@ void TestUniqueCopyDevice(ExecutionPolicy exec)
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(10);
-  data[0] = 11;
-  data[1] = 11;
-  data[2] = 12;
-  data[3] = 20;
-  data[4] = 29;
-  data[5] = 21;
-  data[6] = 21;
-  data[7] = 31;
-  data[8] = 31;
-  data[9] = 37;
+  Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
   Vector output(10, -1);
 
@@ -205,13 +167,9 @@ void TestUniqueCopyDevice(ExecutionPolicy exec)
   new_last = new_last_vec[0];
 
   ASSERT_EQUAL(new_last - output.begin(), 7);
-  ASSERT_EQUAL(output[0], 11);
-  ASSERT_EQUAL(output[1], 12);
-  ASSERT_EQUAL(output[2], 20);
-  ASSERT_EQUAL(output[3], 29);
-  ASSERT_EQUAL(output[4], 21);
-  ASSERT_EQUAL(output[5], 31);
-  ASSERT_EQUAL(output[6], 37);
+  output.erase(new_last, output.end());
+  Vector ref{11, 12, 20, 29, 21, 31, 37};
+  ASSERT_EQUAL(output, ref);
 
   unique_copy_kernel<<<1, 1>>>(
     exec, output.begin(), new_last, data.begin(), is_equal_div_10_unique<T>(), new_last_vec.begin());
@@ -223,9 +181,9 @@ void TestUniqueCopyDevice(ExecutionPolicy exec)
   new_last = new_last_vec[0];
 
   ASSERT_EQUAL(new_last - data.begin(), 3);
-  ASSERT_EQUAL(data[0], 11);
-  ASSERT_EQUAL(data[1], 20);
-  ASSERT_EQUAL(data[2], 31);
+  data.erase(new_last, data.end());
+  ref = {11, 20, 31};
+  ASSERT_EQUAL(data, ref);
 }
 
 void TestUniqueCopyDeviceSeq()
@@ -253,17 +211,7 @@ void TestUniqueCopyCudaStreams(ExecutionPolicy policy)
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(10);
-  data[0] = 11;
-  data[1] = 11;
-  data[2] = 12;
-  data[3] = 20;
-  data[4] = 29;
-  data[5] = 21;
-  data[6] = 21;
-  data[7] = 31;
-  data[8] = 31;
-  data[9] = 37;
+  Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
   Vector output(10, -1);
 
@@ -279,21 +227,17 @@ void TestUniqueCopyCudaStreams(ExecutionPolicy policy)
   cudaStreamSynchronize(s);
 
   ASSERT_EQUAL(new_last - output.begin(), 7);
-  ASSERT_EQUAL(output[0], 11);
-  ASSERT_EQUAL(output[1], 12);
-  ASSERT_EQUAL(output[2], 20);
-  ASSERT_EQUAL(output[3], 29);
-  ASSERT_EQUAL(output[4], 21);
-  ASSERT_EQUAL(output[5], 31);
-  ASSERT_EQUAL(output[6], 37);
+  output.erase(new_last, output.end());
+  Vector ref{11, 12, 20, 29, 21, 31, 37};
+  ASSERT_EQUAL(output, ref);
 
   new_last = thrust::unique_copy(streampolicy, output.begin(), new_last, data.begin(), is_equal_div_10_unique<T>());
   cudaStreamSynchronize(s);
 
   ASSERT_EQUAL(new_last - data.begin(), 3);
-  ASSERT_EQUAL(data[0], 11);
-  ASSERT_EQUAL(data[1], 20);
-  ASSERT_EQUAL(data[2], 31);
+  data.erase(new_last, data.end());
+  ref = {11, 20, 31};
+  ASSERT_EQUAL(data, ref);
 
   cudaStreamDestroy(s);
 }
@@ -330,17 +274,7 @@ void TestUniqueCountDevice(ExecutionPolicy exec)
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(10);
-  data[0] = 11;
-  data[1] = 11;
-  data[2] = 12;
-  data[3] = 20;
-  data[4] = 29;
-  data[5] = 21;
-  data[6] = 21;
-  data[7] = 31;
-  data[8] = 31;
-  data[9] = 37;
+  Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
   Vector output(1, -1);
 
@@ -386,17 +320,7 @@ void TestUniqueCountCudaStreams(ExecutionPolicy policy)
   using Vector = thrust::device_vector<int>;
   using T      = Vector::value_type;
 
-  Vector data(10);
-  data[0] = 11;
-  data[1] = 11;
-  data[2] = 12;
-  data[3] = 20;
-  data[4] = 29;
-  data[5] = 21;
-  data[6] = 21;
-  data[7] = 31;
-  data[8] = 31;
-  data[9] = 37;
+  Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/thrust/testing/cuda/unique_by_key.cu
+++ b/thrust/testing/cuda/unique_by_key.cu
@@ -17,30 +17,14 @@ template <typename Vector>
 void initialize_keys(Vector& keys)
 {
   keys.resize(9);
-  keys[0] = 11;
-  keys[1] = 11;
-  keys[2] = 21;
-  keys[3] = 20;
-  keys[4] = 21;
-  keys[5] = 21;
-  keys[6] = 21;
-  keys[7] = 37;
-  keys[8] = 37;
+  keys = {11, 11, 21, 20, 21, 21, 21, 37, 37};
 }
 
 template <typename Vector>
 void initialize_values(Vector& values)
 {
   values.resize(9);
-  values[0] = 0;
-  values[1] = 1;
-  values[2] = 2;
-  values[3] = 3;
-  values[4] = 4;
-  values[5] = 5;
-  values[6] = 6;
-  values[7] = 7;
-  values[8] = 8;
+  values = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 }
 
 #ifdef THRUST_TEST_DEVICE_SIDE
@@ -89,18 +73,14 @@ void TestUniqueByKeyDevice(ExecutionPolicy exec)
   new_last = new_last_vec[0];
 
   ASSERT_EQUAL(new_last.first - keys.begin(), 5);
-  ASSERT_EQUAL(new_last.second - values.begin(), 5);
-  ASSERT_EQUAL(keys[0], 11);
-  ASSERT_EQUAL(keys[1], 21);
-  ASSERT_EQUAL(keys[2], 20);
-  ASSERT_EQUAL(keys[3], 21);
-  ASSERT_EQUAL(keys[4], 37);
+  keys.erase(new_last.first, keys.end());
+  Vector keys_ref{11, 21, 20, 21, 37};
+  ASSERT_EQUAL(keys, keys_ref);
 
-  ASSERT_EQUAL(values[0], 0);
-  ASSERT_EQUAL(values[1], 2);
-  ASSERT_EQUAL(values[2], 3);
-  ASSERT_EQUAL(values[3], 4);
-  ASSERT_EQUAL(values[4], 7);
+  ASSERT_EQUAL(new_last.second - values.begin(), 5);
+  values.erase(new_last.second, values.end());
+  Vector values_ref{0, 2, 3, 4, 7};
+  ASSERT_EQUAL(values, values_ref);
 
   // test BinaryPredicate
   initialize_keys(keys);
@@ -116,14 +96,14 @@ void TestUniqueByKeyDevice(ExecutionPolicy exec)
   new_last = new_last_vec[0];
 
   ASSERT_EQUAL(new_last.first - keys.begin(), 3);
-  ASSERT_EQUAL(new_last.second - values.begin(), 3);
-  ASSERT_EQUAL(keys[0], 11);
-  ASSERT_EQUAL(keys[1], 21);
-  ASSERT_EQUAL(keys[2], 37);
+  keys.erase(new_last.first, keys.end());
+  keys_ref = {11, 21, 37};
+  ASSERT_EQUAL(keys, keys_ref);
 
-  ASSERT_EQUAL(values[0], 0);
-  ASSERT_EQUAL(values[1], 2);
-  ASSERT_EQUAL(values[2], 7);
+  ASSERT_EQUAL(new_last.second - values.begin(), 3);
+  values.erase(new_last.second, values.end());
+  values_ref = {0, 2, 7};
+  ASSERT_EQUAL(values, values_ref);
 }
 
 void TestUniqueByKeyDeviceSeq()
@@ -170,18 +150,14 @@ void TestUniqueByKeyCudaStreams(ExecutionPolicy policy)
   cudaStreamSynchronize(s);
 
   ASSERT_EQUAL(new_last.first - keys.begin(), 5);
-  ASSERT_EQUAL(new_last.second - values.begin(), 5);
-  ASSERT_EQUAL(keys[0], 11);
-  ASSERT_EQUAL(keys[1], 21);
-  ASSERT_EQUAL(keys[2], 20);
-  ASSERT_EQUAL(keys[3], 21);
-  ASSERT_EQUAL(keys[4], 37);
+  keys.erase(new_last.first, keys.end());
+  Vector keys_ref{11, 21, 20, 21, 37};
+  ASSERT_EQUAL(keys, keys_ref);
 
-  ASSERT_EQUAL(values[0], 0);
-  ASSERT_EQUAL(values[1], 2);
-  ASSERT_EQUAL(values[2], 3);
-  ASSERT_EQUAL(values[3], 4);
-  ASSERT_EQUAL(values[4], 7);
+  ASSERT_EQUAL(new_last.second - values.begin(), 5);
+  values.erase(new_last.second, values.end());
+  Vector values_ref{0, 2, 3, 4, 7};
+  ASSERT_EQUAL(values, values_ref);
 
   // test BinaryPredicate
   initialize_keys(keys);
@@ -190,14 +166,14 @@ void TestUniqueByKeyCudaStreams(ExecutionPolicy policy)
   new_last = thrust::unique_by_key(streampolicy, keys.begin(), keys.end(), values.begin(), is_equal_div_10_unique<T>());
 
   ASSERT_EQUAL(new_last.first - keys.begin(), 3);
-  ASSERT_EQUAL(new_last.second - values.begin(), 3);
-  ASSERT_EQUAL(keys[0], 11);
-  ASSERT_EQUAL(keys[1], 21);
-  ASSERT_EQUAL(keys[2], 37);
+  keys.erase(new_last.first, keys.end());
+  keys_ref = {11, 21, 37};
+  ASSERT_EQUAL(keys, keys_ref);
 
-  ASSERT_EQUAL(values[0], 0);
-  ASSERT_EQUAL(values[1], 2);
-  ASSERT_EQUAL(values[2], 7);
+  ASSERT_EQUAL(new_last.second - values.begin(), 3);
+  values.erase(new_last.second, values.end());
+  values_ref = {0, 2, 7};
+  ASSERT_EQUAL(values, values_ref);
 
   cudaStreamDestroy(s);
 }
@@ -283,18 +259,14 @@ void TestUniqueCopyByKeyDevice(ExecutionPolicy exec)
   new_last = new_last_vec[0];
 
   ASSERT_EQUAL(new_last.first - output_keys.begin(), 5);
-  ASSERT_EQUAL(new_last.second - output_values.begin(), 5);
-  ASSERT_EQUAL(output_keys[0], 11);
-  ASSERT_EQUAL(output_keys[1], 21);
-  ASSERT_EQUAL(output_keys[2], 20);
-  ASSERT_EQUAL(output_keys[3], 21);
-  ASSERT_EQUAL(output_keys[4], 37);
+  output_keys.erase(new_last.first, output_keys.end());
+  Vector keys_ref{11, 21, 20, 21, 37};
+  ASSERT_EQUAL(output_keys, keys_ref);
 
-  ASSERT_EQUAL(output_values[0], 0);
-  ASSERT_EQUAL(output_values[1], 2);
-  ASSERT_EQUAL(output_values[2], 3);
-  ASSERT_EQUAL(output_values[3], 4);
-  ASSERT_EQUAL(output_values[4], 7);
+  ASSERT_EQUAL(new_last.second - output_values.begin(), 5);
+  output_values.erase(new_last.second, output_values.end());
+  Vector values_ref{0, 2, 3, 4, 7};
+  ASSERT_EQUAL(output_values, values_ref);
 
   // test BinaryPredicate
   initialize_keys(keys);
@@ -317,14 +289,15 @@ void TestUniqueCopyByKeyDevice(ExecutionPolicy exec)
   new_last = new_last_vec[0];
 
   ASSERT_EQUAL(new_last.first - output_keys.begin(), 3);
-  ASSERT_EQUAL(new_last.second - output_values.begin(), 3);
-  ASSERT_EQUAL(output_keys[0], 11);
-  ASSERT_EQUAL(output_keys[1], 21);
-  ASSERT_EQUAL(output_keys[2], 37);
 
-  ASSERT_EQUAL(output_values[0], 0);
-  ASSERT_EQUAL(output_values[1], 2);
-  ASSERT_EQUAL(output_values[2], 7);
+  output_keys.erase(new_last.first, output_keys.end());
+  keys_ref = {11, 21, 37};
+  ASSERT_EQUAL(output_keys, keys_ref);
+
+  ASSERT_EQUAL(new_last.second - output_values.begin(), 3);
+  output_values.erase(new_last.second, output_values.end());
+  values_ref = {0, 2, 7};
+  ASSERT_EQUAL(output_values, values_ref);
 }
 
 void TestUniqueCopyByKeyDeviceSeq()
@@ -375,18 +348,14 @@ void TestUniqueCopyByKeyCudaStreams(ExecutionPolicy policy)
   cudaStreamSynchronize(s);
 
   ASSERT_EQUAL(new_last.first - output_keys.begin(), 5);
-  ASSERT_EQUAL(new_last.second - output_values.begin(), 5);
-  ASSERT_EQUAL(output_keys[0], 11);
-  ASSERT_EQUAL(output_keys[1], 21);
-  ASSERT_EQUAL(output_keys[2], 20);
-  ASSERT_EQUAL(output_keys[3], 21);
-  ASSERT_EQUAL(output_keys[4], 37);
+  output_keys.erase(new_last.first, output_keys.end());
+  Vector keys_ref{11, 21, 20, 21, 37};
+  ASSERT_EQUAL(output_keys, keys_ref);
 
-  ASSERT_EQUAL(output_values[0], 0);
-  ASSERT_EQUAL(output_values[1], 2);
-  ASSERT_EQUAL(output_values[2], 3);
-  ASSERT_EQUAL(output_values[3], 4);
-  ASSERT_EQUAL(output_values[4], 7);
+  ASSERT_EQUAL(new_last.second - output_values.begin(), 5);
+  output_values.erase(new_last.second, output_values.end());
+  Vector values_ref{0, 2, 3, 4, 7};
+  ASSERT_EQUAL(output_values, values_ref);
 
   // test BinaryPredicate
   initialize_keys(keys);
@@ -403,14 +372,14 @@ void TestUniqueCopyByKeyCudaStreams(ExecutionPolicy policy)
   cudaStreamSynchronize(s);
 
   ASSERT_EQUAL(new_last.first - output_keys.begin(), 3);
-  ASSERT_EQUAL(new_last.second - output_values.begin(), 3);
-  ASSERT_EQUAL(output_keys[0], 11);
-  ASSERT_EQUAL(output_keys[1], 21);
-  ASSERT_EQUAL(output_keys[2], 37);
+  output_keys.erase(new_last.first, output_keys.end());
+  keys_ref = {11, 21, 37};
+  ASSERT_EQUAL(output_keys, keys_ref);
 
-  ASSERT_EQUAL(output_values[0], 0);
-  ASSERT_EQUAL(output_values[1], 2);
-  ASSERT_EQUAL(output_values[2], 7);
+  ASSERT_EQUAL(new_last.second - output_values.begin(), 3);
+  output_values.erase(new_last.second, output_values.end());
+  values_ref = {0, 2, 7};
+  ASSERT_EQUAL(output_values, values_ref);
 
   cudaStreamDestroy(s);
 }

--- a/thrust/testing/dereference.cu
+++ b/thrust/testing/dereference.cu
@@ -80,11 +80,8 @@ void TestDeviceDereferenceCountingIterator()
 
   simple_copy(first, last, output.begin());
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 3);
-  ASSERT_EQUAL(output[3], 4);
-  ASSERT_EQUAL(output[4], 5);
+  thrust::device_vector<int> ref{1, 2, 3, 4, 5};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_UNITTEST(TestDeviceDereferenceCountingIterator);
 
@@ -99,11 +96,8 @@ void TestDeviceDereferenceTransformedCountingIterator()
               thrust::make_transform_iterator(last, thrust::negate<int>()),
               output.begin());
 
-  ASSERT_EQUAL(output[0], -1);
-  ASSERT_EQUAL(output[1], -2);
-  ASSERT_EQUAL(output[2], -3);
-  ASSERT_EQUAL(output[3], -4);
-  ASSERT_EQUAL(output[4], -5);
+  thrust::device_vector<int> ref{-1, -2, -3, -4, -5};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_UNITTEST(TestDeviceDereferenceTransformedCountingIterator);
 

--- a/thrust/testing/equal.cu
+++ b/thrust/testing/equal.cu
@@ -11,13 +11,8 @@ void TestEqualSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector v1(5);
-  Vector v2(5);
-
-  // clang-format off
-  v1[0] = 5; v1[1] = 2; v1[2] = 0; v1[3] = 0; v1[4] = 0;
-  v2[0] = 5; v2[1] = 2; v2[2] = 0; v2[3] = 6; v2[4] = 1;
-  // clang-format on
+  Vector v1{5, 2, 0, 0, 0};
+  Vector v2{5, 2, 0, 6, 1};
 
   ASSERT_EQUAL(thrust::equal(v1.begin(), v1.end(), v1.begin()), true);
   ASSERT_EQUAL(thrust::equal(v1.begin(), v1.end(), v2.begin()), false);

--- a/thrust/testing/fill.cu
+++ b/thrust/testing/fill.cu
@@ -15,44 +15,27 @@ void TestFillSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   thrust::fill(v.begin() + 1, v.begin() + 4, (T) 7);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 7);
-  ASSERT_EQUAL(v[2], 7);
-  ASSERT_EQUAL(v[3], 7);
-  ASSERT_EQUAL(v[4], 4);
+  Vector ref{0, 7, 7, 7, 4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::fill(v.begin() + 0, v.begin() + 3, (T) 8);
 
-  ASSERT_EQUAL(v[0], 8);
-  ASSERT_EQUAL(v[1], 8);
-  ASSERT_EQUAL(v[2], 8);
-  ASSERT_EQUAL(v[3], 7);
-  ASSERT_EQUAL(v[4], 4);
+  ref = {8, 8, 8, 7, 4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::fill(v.begin() + 2, v.end(), (T) 9);
 
-  ASSERT_EQUAL(v[0], 8);
-  ASSERT_EQUAL(v[1], 8);
-  ASSERT_EQUAL(v[2], 9);
-  ASSERT_EQUAL(v[3], 9);
-  ASSERT_EQUAL(v[4], 9);
+  ref = {8, 8, 9, 9, 9};
+  ASSERT_EQUAL(v, ref);
 
   thrust::fill(v.begin(), v.end(), (T) 1);
 
-  ASSERT_EQUAL(v[0], 1);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 1);
-  ASSERT_EQUAL(v[3], 1);
-  ASSERT_EQUAL(v[4], 1);
+  ref = Vector(5, 1);
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestFillSimple);
 
@@ -74,17 +57,13 @@ void TestFillMixedTypes()
 
   thrust::fill(v.begin(), v.end(), bool(true));
 
-  ASSERT_EQUAL(v[0], 1);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 1);
-  ASSERT_EQUAL(v[3], 1);
+  Vector ref(4, 1);
+  ASSERT_EQUAL(v, ref);
 
   thrust::fill(v.begin(), v.end(), char(20));
 
-  ASSERT_EQUAL(v[0], 20);
-  ASSERT_EQUAL(v[1], 20);
-  ASSERT_EQUAL(v[2], 20);
-  ASSERT_EQUAL(v[3], 20);
+  ref = Vector(4, 20);
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestFillMixedTypes);
 
@@ -126,47 +105,34 @@ void TestFillNSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   typename Vector::iterator iter = thrust::fill_n(v.begin() + 1, 3, (T) 7);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 7);
-  ASSERT_EQUAL(v[2], 7);
-  ASSERT_EQUAL(v[3], 7);
-  ASSERT_EQUAL(v[4], 4);
+  Vector ref{0, 7, 7, 7, 4};
+  ASSERT_EQUAL(v, ref);
+
   ASSERT_EQUAL_QUIET(v.begin() + 4, iter);
 
   iter = thrust::fill_n(v.begin() + 0, 3, (T) 8);
 
-  ASSERT_EQUAL(v[0], 8);
-  ASSERT_EQUAL(v[1], 8);
-  ASSERT_EQUAL(v[2], 8);
-  ASSERT_EQUAL(v[3], 7);
-  ASSERT_EQUAL(v[4], 4);
+  ref = {8, 8, 8, 7, 4};
+  ASSERT_EQUAL(v, ref);
+
   ASSERT_EQUAL_QUIET(v.begin() + 3, iter);
 
   iter = thrust::fill_n(v.begin() + 2, 3, (T) 9);
 
-  ASSERT_EQUAL(v[0], 8);
-  ASSERT_EQUAL(v[1], 8);
-  ASSERT_EQUAL(v[2], 9);
-  ASSERT_EQUAL(v[3], 9);
-  ASSERT_EQUAL(v[4], 9);
+  ref = {8, 8, 9, 9, 9};
+  ASSERT_EQUAL(v, ref);
+
   ASSERT_EQUAL_QUIET(v.end(), iter);
 
   iter = thrust::fill_n(v.begin(), v.size(), (T) 1);
 
-  ASSERT_EQUAL(v[0], 1);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 1);
-  ASSERT_EQUAL(v[3], 1);
-  ASSERT_EQUAL(v[4], 1);
+  ref = Vector(5, 1);
+  ASSERT_EQUAL(v, ref);
+
   ASSERT_EQUAL_QUIET(v.end(), iter);
 }
 DECLARE_VECTOR_UNITTEST(TestFillNSimple);
@@ -193,18 +159,14 @@ void TestFillNMixedTypes()
 
   typename Vector::iterator iter = thrust::fill_n(v.begin(), v.size(), bool(true));
 
-  ASSERT_EQUAL(v[0], 1);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 1);
-  ASSERT_EQUAL(v[3], 1);
+  Vector ref(4, 1);
+  ASSERT_EQUAL(v, ref);
   ASSERT_EQUAL_QUIET(v.end(), iter);
 
   iter = thrust::fill_n(v.begin(), v.size(), char(20));
 
-  ASSERT_EQUAL(v[0], 20);
-  ASSERT_EQUAL(v[1], 20);
-  ASSERT_EQUAL(v[2], 20);
-  ASSERT_EQUAL(v[3], 20);
+  ref = Vector(4, 20);
+  ASSERT_EQUAL(v, ref);
   ASSERT_EQUAL_QUIET(v.end(), iter);
 }
 DECLARE_VECTOR_UNITTEST(TestFillNMixedTypes);
@@ -259,15 +221,14 @@ void TestFillZipIterator()
                thrust::make_zip_iterator(thrust::make_tuple(v1.end(), v2.end(), v3.end())),
                thrust::tuple<T, T, T>(4, 7, 13));
 
-  ASSERT_EQUAL(4, v1[0]);
-  ASSERT_EQUAL(4, v1[1]);
-  ASSERT_EQUAL(4, v1[2]);
-  ASSERT_EQUAL(7, v2[0]);
-  ASSERT_EQUAL(7, v2[1]);
-  ASSERT_EQUAL(7, v2[2]);
-  ASSERT_EQUAL(13, v3[0]);
-  ASSERT_EQUAL(13, v3[1]);
-  ASSERT_EQUAL(13, v3[2]);
+  Vector ref1{4, 4, 4};
+  ASSERT_EQUAL(ref1, v1);
+
+  Vector ref2{7, 7, 7};
+  ASSERT_EQUAL(ref2, v2);
+
+  Vector ref3{13, 13, 13};
+  ASSERT_EQUAL(ref3, v3);
 };
 DECLARE_VECTOR_UNITTEST(TestFillZipIterator);
 

--- a/thrust/testing/find.cu
+++ b/thrust/testing/find.cu
@@ -52,12 +52,7 @@ struct less_than_value_pred
 template <class Vector>
 void TestFindSimple()
 {
-  Vector vec(5);
-  vec[0] = 1;
-  vec[1] = 2;
-  vec[2] = 3;
-  vec[3] = 3;
-  vec[4] = 5;
+  Vector vec{1, 2, 3, 3, 5};
 
   ASSERT_EQUAL(thrust::find(vec.begin(), vec.end(), 0) - vec.begin(), 5);
   ASSERT_EQUAL(thrust::find(vec.begin(), vec.end(), 1) - vec.begin(), 0);
@@ -108,12 +103,7 @@ void TestFindIfSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector vec(5);
-  vec[0] = 1;
-  vec[1] = 2;
-  vec[2] = 3;
-  vec[3] = 3;
-  vec[4] = 5;
+  Vector vec{1, 2, 3, 3, 5};
 
   ASSERT_EQUAL(thrust::find_if(vec.begin(), vec.end(), equal_to_value_pred<T>(0)) - vec.begin(), 5);
   ASSERT_EQUAL(thrust::find_if(vec.begin(), vec.end(), equal_to_value_pred<T>(1)) - vec.begin(), 0);
@@ -164,12 +154,7 @@ void TestFindIfNotSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector vec(5);
-  vec[0] = 0;
-  vec[1] = 1;
-  vec[2] = 2;
-  vec[3] = 3;
-  vec[4] = 4;
+  Vector vec{0, 1, 2, 3, 4};
 
   ASSERT_EQUAL(0, thrust::find_if_not(vec.begin(), vec.end(), less_than_value_pred<T>(0)) - vec.begin());
   ASSERT_EQUAL(1, thrust::find_if_not(vec.begin(), vec.end(), less_than_value_pred<T>(1)) - vec.begin());

--- a/thrust/testing/for_each.cu
+++ b/thrust/testing/for_each.cu
@@ -28,27 +28,16 @@ void TestForEachSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector input(5);
+  Vector input{3, 2, 3, 4, 6};
   Vector output(7, (T) 0);
-
-  input[0] = 3;
-  input[1] = 2;
-  input[2] = 3;
-  input[3] = 4;
-  input[4] = 6;
 
   mark_present_for_each<T> f;
   f.ptr = thrust::raw_pointer_cast(output.data());
 
   typename Vector::iterator result = thrust::for_each(input.begin(), input.end(), f);
 
-  ASSERT_EQUAL(output[0], 0);
-  ASSERT_EQUAL(output[1], 0);
-  ASSERT_EQUAL(output[2], 1);
-  ASSERT_EQUAL(output[3], 1);
-  ASSERT_EQUAL(output[4], 1);
-  ASSERT_EQUAL(output[5], 0);
-  ASSERT_EQUAL(output[6], 1);
+  Vector ref{0, 0, 1, 1, 1, 0, 1};
+  ASSERT_EQUAL(output, ref);
   ASSERT_EQUAL_QUIET(result, input.end());
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestForEachSimple);
@@ -93,27 +82,16 @@ void TestForEachNSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector input(5);
+  Vector input{3, 2, 3, 4, 6};
   Vector output(7, (T) 0);
-
-  input[0] = 3;
-  input[1] = 2;
-  input[2] = 3;
-  input[3] = 4;
-  input[4] = 6;
 
   mark_present_for_each<T> f;
   f.ptr = thrust::raw_pointer_cast(output.data());
 
   typename Vector::iterator result = thrust::for_each_n(input.begin(), input.size(), f);
 
-  ASSERT_EQUAL(output[0], 0);
-  ASSERT_EQUAL(output[1], 0);
-  ASSERT_EQUAL(output[2], 1);
-  ASSERT_EQUAL(output[3], 1);
-  ASSERT_EQUAL(output[4], 1);
-  ASSERT_EQUAL(output[5], 0);
-  ASSERT_EQUAL(output[6], 1);
+  Vector ref{0, 0, 1, 1, 1, 0, 1};
+  ASSERT_EQUAL(output, ref);
   ASSERT_EQUAL_QUIET(result, input.end());
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestForEachNSimple);
@@ -163,13 +141,8 @@ void TestForEachSimpleAnySystem()
   thrust::counting_iterator<int> result =
     thrust::for_each(thrust::make_counting_iterator(0), thrust::make_counting_iterator(5), f);
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 1);
-  ASSERT_EQUAL(output[2], 1);
-  ASSERT_EQUAL(output[3], 1);
-  ASSERT_EQUAL(output[4], 1);
-  ASSERT_EQUAL(output[5], 0);
-  ASSERT_EQUAL(output[6], 0);
+  thrust::device_vector<int> ref{1, 1, 1, 1, 1, 0, 0};
+  ASSERT_EQUAL(output, ref);
   ASSERT_EQUAL_QUIET(result, thrust::make_counting_iterator(5));
 }
 DECLARE_UNITTEST(TestForEachSimpleAnySystem);
@@ -183,13 +156,8 @@ void TestForEachNSimpleAnySystem()
 
   thrust::counting_iterator<int> result = thrust::for_each_n(thrust::make_counting_iterator(0), 5, f);
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 1);
-  ASSERT_EQUAL(output[2], 1);
-  ASSERT_EQUAL(output[3], 1);
-  ASSERT_EQUAL(output[4], 1);
-  ASSERT_EQUAL(output[5], 0);
-  ASSERT_EQUAL(output[6], 0);
+  thrust::device_vector<int> ref{1, 1, 1, 1, 1, 0, 0};
+  ASSERT_EQUAL(output, ref);
   ASSERT_EQUAL_QUIET(result, thrust::make_counting_iterator(5));
 }
 DECLARE_UNITTEST(TestForEachNSimpleAnySystem);

--- a/thrust/testing/functional.cu
+++ b/thrust/testing/functional.cu
@@ -186,11 +186,7 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestIdentityFunctional()
 {
   using T = typename Vector::value_type;
 
-  Vector input(4);
-  input[0] = 0;
-  input[1] = 1;
-  input[2] = 2;
-  input[3] = 3;
+  Vector input{0, 1, 2, 3};
 
   Vector output(4);
 
@@ -205,16 +201,8 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject1stFunctional()
 {
   using T = typename Vector::value_type;
 
-  Vector lhs(4);
-  Vector rhs(4);
-  lhs[0] = 0;
-  rhs[0] = 3;
-  lhs[1] = 1;
-  rhs[1] = 4;
-  lhs[2] = 2;
-  rhs[2] = 5;
-  lhs[2] = 3;
-  rhs[2] = 6;
+  Vector lhs{0, 1, 2, 3};
+  Vector rhs{3, 4, 5, 6};
 
   Vector output(4);
 
@@ -229,16 +217,8 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestProject2ndFunctional()
 {
   using T = typename Vector::value_type;
 
-  Vector lhs(4);
-  Vector rhs(4);
-  lhs[0] = 0;
-  rhs[0] = 3;
-  lhs[1] = 1;
-  rhs[1] = 4;
-  lhs[2] = 2;
-  rhs[2] = 5;
-  lhs[2] = 3;
-  rhs[2] = 6;
+  Vector lhs{0, 1, 2, 3};
+  Vector rhs{3, 4, 5, 6};
 
   Vector output(4);
 
@@ -253,25 +233,15 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMaximumFunctional()
 {
   using T = typename Vector::value_type;
 
-  Vector input1(4);
-  Vector input2(4);
-  input1[0] = 8;
-  input1[1] = 3;
-  input1[2] = 7;
-  input1[3] = 7;
-  input2[0] = 5;
-  input2[1] = 6;
-  input2[2] = 9;
-  input2[3] = 3;
+  Vector input1{8, 3, 7, 7};
+  Vector input2{5, 6, 9, 3};
 
   Vector output(4);
 
   thrust::transform(input1.begin(), input1.end(), input2.begin(), output.begin(), thrust::maximum<T>());
 
-  ASSERT_EQUAL(output[0], 8);
-  ASSERT_EQUAL(output[1], 6);
-  ASSERT_EQUAL(output[2], 9);
-  ASSERT_EQUAL(output[3], 7);
+  Vector ref{8, 6, 9, 7};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestMaximumFunctional);
 
@@ -280,25 +250,15 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestMinimumFunctional()
 {
   using T = typename Vector::value_type;
 
-  Vector input1(4);
-  Vector input2(4);
-  input1[0] = 8;
-  input1[1] = 3;
-  input1[2] = 7;
-  input1[3] = 7;
-  input2[0] = 5;
-  input2[1] = 6;
-  input2[2] = 9;
-  input2[3] = 3;
+  Vector input1{8, 3, 7, 7};
+  Vector input2{5, 6, 9, 3};
 
   Vector output(4);
 
   thrust::transform(input1.begin(), input1.end(), input2.begin(), output.begin(), thrust::minimum<T>());
 
-  ASSERT_EQUAL(output[0], 5);
-  ASSERT_EQUAL(output[1], 3);
-  ASSERT_EQUAL(output[2], 7);
-  ASSERT_EQUAL(output[3], 3);
+  Vector ref{5, 3, 7, 3};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestMinimumFunctional);
 
@@ -307,22 +267,14 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestNot1()
 {
   using T = typename Vector::value_type;
 
-  Vector input(5);
-  input[0] = 1;
-  input[1] = 0;
-  input[2] = 1;
-  input[3] = 1;
-  input[4] = 0;
+  Vector input{1, 0, 1, 1, 0};
 
   Vector output(5);
 
   thrust::transform(input.begin(), input.end(), output.begin(), thrust::not_fn(thrust::identity<T>()));
 
-  ASSERT_EQUAL(output[0], 0);
-  ASSERT_EQUAL(output[1], 1);
-  ASSERT_EQUAL(output[2], 0);
-  ASSERT_EQUAL(output[3], 0);
-  ASSERT_EQUAL(output[4], 1);
+  Vector ref{0, 1, 0, 0, 1};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestNot1);
 
@@ -340,28 +292,15 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestNot2()
 {
   using T = typename Vector::value_type;
 
-  Vector input1(5);
-  Vector input2(5);
-  input1[0] = 1;
-  input1[1] = 0;
-  input1[2] = 1;
-  input1[3] = 1;
-  input1[4] = 0;
-  input2[0] = 1;
-  input2[1] = 1;
-  input2[2] = 0;
-  input2[3] = 1;
-  input2[4] = 1;
+  Vector input1{1, 0, 1, 1, 0};
+  Vector input2{1, 1, 0, 1, 1};
 
   Vector output(5);
 
   thrust::transform(input1.begin(), input1.end(), input2.begin(), output.begin(), thrust::not_fn(thrust::equal_to<T>()));
 
-  ASSERT_EQUAL(output[0], 0);
-  ASSERT_EQUAL(output[1], 1);
-  ASSERT_EQUAL(output[2], 1);
-  ASSERT_EQUAL(output[3], 0);
-  ASSERT_EQUAL(output[4], 1);
+  Vector ref{0, 1, 1, 0, 1};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestNot2);
 

--- a/thrust/testing/gather.cu
+++ b/thrust/testing/gather.cu
@@ -15,23 +15,14 @@ _CCCL_DIAG_SUPPRESS_MSVC(4244 4267) // possible loss of data
 template <class Vector>
 void TestGatherSimple()
 {
-  Vector map(5); // gather indices
-  Vector src(8); // source vector
-  Vector dst(5); // destination vector
-
-  // clang-format off
-  map[0] = 6; map[1] = 2; map[2] = 1; map[3] = 7; map[4] = 2;
-  src[0] = 0; src[1] = 1; src[2] = 2; src[3] = 3; src[4] = 4; src[5] = 5; src[6] = 6; src[7] = 7;
-  dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0; dst[4] = 0;
-  // clang-format on
+  Vector map{6, 2, 1, 7, 2}; // gather indices
+  Vector src{0, 1, 2, 3, 4, 5, 6, 7}; // source vector
+  Vector dst(5, 0); // destination vector
 
   thrust::gather(map.begin(), map.end(), src.begin(), dst.begin());
 
-  ASSERT_EQUAL(dst[0], 6);
-  ASSERT_EQUAL(dst[1], 2);
-  ASSERT_EQUAL(dst[2], 1);
-  ASSERT_EQUAL(dst[3], 7);
-  ASSERT_EQUAL(dst[4], 2);
+  Vector ref{6, 2, 1, 7, 2};
+  ASSERT_EQUAL(dst, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestGatherSimple);
 
@@ -138,25 +129,15 @@ DECLARE_VARIABLE_UNITTEST(TestGatherToDiscardIterator);
 template <class Vector>
 void TestGatherIfSimple()
 {
-  Vector flg(5); // predicate array
-  Vector map(5); // gather indices
-  Vector src(8); // source vector
-  Vector dst(5); // destination vector
-
-  // clang-format off
-  flg[0] = 0; flg[1] = 1; flg[2] = 0; flg[3] = 1; flg[4] = 0;
-  map[0] = 6; map[1] = 2; map[2] = 1; map[3] = 7; map[4] = 2;
-  src[0] = 0; src[1] = 1; src[2] = 2; src[3] = 3; src[4] = 4; src[5] = 5; src[6] = 6; src[7] = 7;
-  dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0; dst[4] = 0;
-  // clang-format on
+  Vector flg{0, 1, 0, 1, 0}; // predicate array
+  Vector map{6, 2, 1, 7, 2}; // gather indices
+  Vector src{0, 1, 2, 3, 4, 5, 6, 7}; // source vector
+  Vector dst(5, 0); // destination vector
 
   thrust::gather_if(map.begin(), map.end(), flg.begin(), src.begin(), dst.begin());
 
-  ASSERT_EQUAL(dst[0], 0);
-  ASSERT_EQUAL(dst[1], 2);
-  ASSERT_EQUAL(dst[2], 0);
-  ASSERT_EQUAL(dst[3], 7);
-  ASSERT_EQUAL(dst[4], 0);
+  Vector ref{0, 2, 0, 7, 0};
+  ASSERT_EQUAL(dst, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestGatherIfSimple);
 

--- a/thrust/testing/generate.cu
+++ b/thrust/testing/generate.cu
@@ -36,11 +36,8 @@ void TestGenerateSimple()
 
   thrust::generate(result.begin(), result.end(), f);
 
-  ASSERT_EQUAL(result[0], value);
-  ASSERT_EQUAL(result[1], value);
-  ASSERT_EQUAL(result[2], value);
-  ASSERT_EQUAL(result[3], value);
-  ASSERT_EQUAL(result[4], value);
+  Vector ref(result.size(), value);
+  ASSERT_EQUAL(result, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestGenerateSimple);
 
@@ -122,11 +119,8 @@ void TestGenerateNSimple()
 
   thrust::generate_n(result.begin(), result.size(), f);
 
-  ASSERT_EQUAL(result[0], value);
-  ASSERT_EQUAL(result[1], value);
-  ASSERT_EQUAL(result[2], value);
-  ASSERT_EQUAL(result[3], value);
-  ASSERT_EQUAL(result[4], value);
+  Vector ref(result.size(), value);
+  ASSERT_EQUAL(result, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestGenerateNSimple);
 
@@ -196,12 +190,10 @@ void TestGenerateZipIterator()
                    thrust::make_zip_iterator(thrust::make_tuple(v1.end(), v2.end())),
                    return_value<thrust::tuple<T, T>>(thrust::tuple<T, T>(4, 7)));
 
-  ASSERT_EQUAL(v1[0], 4);
-  ASSERT_EQUAL(v1[1], 4);
-  ASSERT_EQUAL(v1[2], 4);
-  ASSERT_EQUAL(v2[0], 7);
-  ASSERT_EQUAL(v2[1], 7);
-  ASSERT_EQUAL(v2[2], 7);
+  Vector ref1(3, 4);
+  Vector ref2(3, 7);
+  ASSERT_EQUAL(v1, ref1);
+  ASSERT_EQUAL(v2, ref2);
 };
 DECLARE_VECTOR_UNITTEST(TestGenerateZipIterator);
 

--- a/thrust/testing/inner_product.cu
+++ b/thrust/testing/inner_product.cu
@@ -12,14 +12,8 @@ void TestInnerProductSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector v1(3);
-  Vector v2(3);
-  v1[0] = 1;
-  v1[1] = -2;
-  v1[2] = 3;
-  v2[0] = -4;
-  v2[1] = 5;
-  v2[2] = 6;
+  Vector v1{1, -2, 3};
+  Vector v2{-4, 5, 6};
 
   T init   = 3;
   T result = thrust::inner_product(v1.begin(), v1.end(), v2.begin(), init);
@@ -67,14 +61,8 @@ void TestInnerProductWithOperator()
 {
   using T = typename Vector::value_type;
 
-  Vector v1(3);
-  Vector v2(3);
-  v1[0] = 1;
-  v1[1] = -2;
-  v1[2] = 3;
-  v2[0] = -1;
-  v2[1] = 3;
-  v2[2] = 6;
+  Vector v1{1, -2, 3};
+  Vector v2{-1, 3, 6};
 
   // compute (v1 - v2) and perform a multiplies reduction
   T init   = 3;

--- a/thrust/testing/is_partitioned.cu
+++ b/thrust/testing/is_partitioned.cu
@@ -18,11 +18,7 @@ void TestIsPartitionedSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector v(4);
-  v[0] = 1;
-  v[1] = 1;
-  v[2] = 1;
-  v[3] = 0;
+  Vector v{1, 1, 1, 0};
 
   // empty partition
   ASSERT_EQUAL_QUIET(true, thrust::is_partitioned(v.begin(), v.begin(), thrust::identity<T>()));
@@ -39,10 +35,7 @@ void TestIsPartitionedSimple()
   // one element false partition
   ASSERT_EQUAL_QUIET(true, thrust::is_partitioned(v.begin() + 3, v.end(), thrust::identity<T>()));
 
-  v[0] = 1;
-  v[1] = 0;
-  v[2] = 1;
-  v[3] = 1;
+  v = {1, 0, 1, 1};
 
   // not partitioned
   ASSERT_EQUAL_QUIET(false, thrust::is_partitioned(v.begin(), v.end(), thrust::identity<T>()));

--- a/thrust/testing/is_sorted.cu
+++ b/thrust/testing/is_sorted.cu
@@ -8,11 +8,7 @@ void TestIsSortedSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector v(4);
-  v[0] = 0;
-  v[1] = 5;
-  v[2] = 8;
-  v[3] = 0;
+  Vector v{0, 5, 8, 0};
 
   ASSERT_EQUAL(thrust::is_sorted(v.begin(), v.begin() + 0), true);
   ASSERT_EQUAL(thrust::is_sorted(v.begin(), v.begin() + 1), true);
@@ -40,18 +36,7 @@ DECLARE_VECTOR_UNITTEST(TestIsSortedSimple);
 template <class Vector>
 void TestIsSortedRepeatedElements()
 {
-  Vector v(10);
-
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 1;
-  v[3] = 2;
-  v[4] = 3;
-  v[5] = 4;
-  v[6] = 5;
-  v[7] = 5;
-  v[8] = 5;
-  v[9] = 6;
+  Vector v{0, 1, 1, 2, 3, 4, 5, 5, 5, 6};
 
   ASSERT_EQUAL(true, thrust::is_sorted(v.begin(), v.end()));
 }

--- a/thrust/testing/is_sorted_until.cu
+++ b/thrust/testing/is_sorted_until.cu
@@ -9,11 +9,7 @@ void TestIsSortedUntilSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector v(4);
-  v[0] = 0;
-  v[1] = 5;
-  v[2] = 8;
-  v[3] = 0;
+  Vector v{0, 5, 8, 0};
 
   Iterator first = v.begin();
 
@@ -63,18 +59,7 @@ DECLARE_VECTOR_UNITTEST(TestIsSortedUntilSimple);
 template <typename Vector>
 void TestIsSortedUntilRepeatedElements()
 {
-  Vector v(10);
-
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 1;
-  v[3] = 2;
-  v[4] = 3;
-  v[5] = 4;
-  v[6] = 5;
-  v[7] = 5;
-  v[8] = 5;
-  v[9] = 6;
+  Vector v{0, 1, 1, 2, 3, 4, 5, 5, 5, 6};
 
   ASSERT_EQUAL_QUIET(v.end(), thrust::is_sorted_until(v.begin(), v.end()));
 }

--- a/thrust/testing/max_element.cu
+++ b/thrust/testing/max_element.cu
@@ -10,13 +10,7 @@ void TestMaxElementSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(6);
-  data[0] = 3;
-  data[1] = 5;
-  data[2] = 1;
-  data[3] = 2;
-  data[4] = 5;
-  data[5] = 1;
+  Vector data{3, 5, 1, 2, 5, 1};
 
   ASSERT_EQUAL(*thrust::max_element(data.begin(), data.end()), 5);
   ASSERT_EQUAL(thrust::max_element(data.begin(), data.end()) - data.begin(), 1);
@@ -31,13 +25,7 @@ void TestMaxElementWithTransform()
 {
   using T = typename Vector::value_type;
 
-  Vector data(6);
-  data[0] = 3;
-  data[1] = 5;
-  data[2] = 1;
-  data[3] = 2;
-  data[4] = 5;
-  data[5] = 1;
+  Vector data{3, 5, 1, 2, 5, 1};
 
   ASSERT_EQUAL(*thrust::max_element(thrust::make_transform_iterator(data.begin(), thrust::negate<T>()),
                                     thrust::make_transform_iterator(data.end(), thrust::negate<T>())),

--- a/thrust/testing/min_element.cu
+++ b/thrust/testing/min_element.cu
@@ -8,13 +8,7 @@ void TestMinElementSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(6);
-  data[0] = 3;
-  data[1] = 5;
-  data[2] = 1;
-  data[3] = 2;
-  data[4] = 5;
-  data[5] = 1;
+  Vector data{3, 5, 1, 2, 5, 1};
 
   ASSERT_EQUAL(*thrust::min_element(data.begin(), data.end()), 1);
   ASSERT_EQUAL(thrust::min_element(data.begin(), data.end()) - data.begin(), 2);
@@ -29,13 +23,7 @@ void TestMinElementWithTransform()
 {
   using T = typename Vector::value_type;
 
-  Vector data(6);
-  data[0] = 3;
-  data[1] = 5;
-  data[2] = 1;
-  data[3] = 2;
-  data[4] = 5;
-  data[5] = 1;
+  Vector data{3, 5, 1, 2, 5, 1};
 
   ASSERT_EQUAL(*thrust::min_element(thrust::make_transform_iterator(data.begin(), thrust::negate<T>()),
                                     thrust::make_transform_iterator(data.end(), thrust::negate<T>())),

--- a/thrust/testing/minmax_element.cu
+++ b/thrust/testing/minmax_element.cu
@@ -6,13 +6,7 @@
 template <class Vector>
 void TestMinMaxElementSimple()
 {
-  Vector data(6);
-  data[0] = 3;
-  data[1] = 5;
-  data[2] = 1;
-  data[3] = 2;
-  data[4] = 5;
-  data[5] = 1;
+  Vector data{3, 5, 1, 2, 5, 1};
 
   ASSERT_EQUAL(*thrust::minmax_element(data.begin(), data.end()).first, 1);
   ASSERT_EQUAL(*thrust::minmax_element(data.begin(), data.end()).second, 5);
@@ -26,13 +20,7 @@ void TestMinMaxElementWithTransform()
 {
   using T = typename Vector::value_type;
 
-  Vector data(6);
-  data[0] = 3;
-  data[1] = 5;
-  data[2] = 1;
-  data[3] = 2;
-  data[4] = 5;
-  data[5] = 1;
+  Vector data{3, 5, 1, 2, 5, 1};
 
   ASSERT_EQUAL(*thrust::minmax_element(thrust::make_transform_iterator(data.begin(), thrust::negate<T>()),
                                        thrust::make_transform_iterator(data.end(), thrust::negate<T>()))

--- a/thrust/testing/mismatch.cu
+++ b/thrust/testing/mismatch.cu
@@ -2,20 +2,11 @@
 #include <thrust/mismatch.h>
 
 #include <unittest/unittest.h>
-
 template <class Vector>
 void TestMismatchSimple()
 {
-  Vector a(4);
-  Vector b(4);
-  a[0] = 1;
-  b[0] = 1;
-  a[1] = 2;
-  b[1] = 2;
-  a[2] = 3;
-  b[2] = 4;
-  a[3] = 4;
-  b[3] = 3;
+  Vector a{1, 2, 3, 4};
+  Vector b{1, 2, 4, 3};
 
   ASSERT_EQUAL(thrust::mismatch(a.begin(), a.end(), b.begin()).first - a.begin(), 2);
   ASSERT_EQUAL(thrust::mismatch(a.begin(), a.end(), b.begin()).second - b.begin(), 2);

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -39,21 +39,11 @@ void TestPartitionSimple()
   }
 #endif
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 1;
-  data[4] = 2;
+  Vector data{1, 2, 1, 1, 2};
 
   Iterator iter = thrust::partition(data.begin(), data.end(), is_even<T>());
 
-  Vector ref(5);
-  ref[0] = 2;
-  ref[1] = 2;
-  ref[2] = 1;
-  ref[3] = 1;
-  ref[4] = 1;
+  Vector ref{2, 2, 1, 1, 1};
 
   ASSERT_EQUAL(iter - data.begin(), 2);
   ASSERT_EQUAL(data, ref);
@@ -66,28 +56,13 @@ void TestPartitionStencilSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector data(5);
-  data[0] = 0;
-  data[1] = 1;
-  data[2] = 0;
-  data[3] = 0;
-  data[4] = 1;
+  Vector data{0, 1, 0, 0, 1};
 
-  Vector stencil(5);
-  stencil[0] = 1;
-  stencil[1] = 2;
-  stencil[2] = 1;
-  stencil[3] = 1;
-  stencil[4] = 2;
+  Vector stencil{1, 2, 1, 1, 2};
 
   Iterator iter = thrust::partition(data.begin(), data.end(), stencil.begin(), is_even<T>());
 
-  Vector ref(5);
-  ref[0] = 1;
-  ref[1] = 1;
-  ref[2] = 0;
-  ref[3] = 0;
-  ref[4] = 0;
+  Vector ref{1, 1, 0, 0, 0};
 
   ASSERT_EQUAL(iter - data.begin(), 2);
   ASSERT_EQUAL(data, ref);
@@ -99,12 +74,7 @@ void TestPartitionCopySimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 1;
-  data[4] = 2;
+  Vector data{1, 2, 1, 1, 2};
 
   Vector true_results(2);
   Vector false_results(3);
@@ -112,14 +82,9 @@ void TestPartitionCopySimple()
   thrust::pair<typename Vector::iterator, typename Vector::iterator> ends =
     thrust::partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>());
 
-  Vector true_ref(2);
-  true_ref[0] = 2;
-  true_ref[1] = 2;
+  Vector true_ref(2, 2);
 
-  Vector false_ref(3);
-  false_ref[0] = 1;
-  false_ref[1] = 1;
-  false_ref[2] = 1;
+  Vector false_ref(3, 1);
 
   ASSERT_EQUAL(2, ends.first - true_results.begin());
   ASSERT_EQUAL(3, ends.second - false_results.begin());
@@ -133,19 +98,9 @@ void TestPartitionCopyStencilSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 0;
-  data[1] = 1;
-  data[2] = 0;
-  data[3] = 0;
-  data[4] = 1;
+  Vector data{0, 1, 0, 0, 1};
 
-  Vector stencil(5);
-  stencil[0] = 1;
-  stencil[1] = 2;
-  stencil[2] = 1;
-  stencil[3] = 1;
-  stencil[4] = 2;
+  Vector stencil{1, 2, 1, 1, 2};
 
   Vector true_results(2);
   Vector false_results(3);
@@ -153,14 +108,9 @@ void TestPartitionCopyStencilSimple()
   thrust::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::partition_copy(
     data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), is_even<T>());
 
-  Vector true_ref(2);
-  true_ref[0] = 1;
-  true_ref[1] = 1;
+  Vector true_ref(2, 1);
 
-  Vector false_ref(3);
-  false_ref[0] = 0;
-  false_ref[1] = 0;
-  false_ref[2] = 0;
+  Vector false_ref(3, 0);
 
   ASSERT_EQUAL(2, ends.first - true_results.begin());
   ASSERT_EQUAL(3, ends.second - false_results.begin());
@@ -175,21 +125,11 @@ void TestStablePartitionSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   Iterator iter = thrust::stable_partition(data.begin(), data.end(), is_even<T>());
 
-  Vector ref(5);
-  ref[0] = 2;
-  ref[1] = 2;
-  ref[2] = 1;
-  ref[3] = 1;
-  ref[4] = 3;
+  Vector ref{2, 2, 1, 1, 3};
 
   ASSERT_EQUAL(iter - data.begin(), 2);
   ASSERT_EQUAL(data, ref);
@@ -202,28 +142,13 @@ void TestStablePartitionStencilSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
-  Vector stencil(5);
-  stencil[0] = 0;
-  stencil[1] = 1;
-  stencil[2] = 0;
-  stencil[3] = 0;
-  stencil[4] = 1;
+  Vector stencil{0, 1, 0, 0, 1};
 
   Iterator iter = thrust::stable_partition(data.begin(), data.end(), stencil.begin(), thrust::identity<T>());
 
-  Vector ref(5);
-  ref[0] = 2;
-  ref[1] = 2;
-  ref[2] = 1;
-  ref[3] = 1;
-  ref[4] = 3;
+  Vector ref{2, 2, 1, 1, 3};
 
   ASSERT_EQUAL(iter - data.begin(), 2);
   ASSERT_EQUAL(data, ref);
@@ -235,12 +160,7 @@ void TestStablePartitionCopySimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 1;
-  data[4] = 2;
+  Vector data{1, 2, 1, 1, 2};
 
   Vector true_results(2);
   Vector false_results(3);
@@ -248,14 +168,9 @@ void TestStablePartitionCopySimple()
   thrust::pair<typename Vector::iterator, typename Vector::iterator> ends =
     thrust::stable_partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>());
 
-  Vector true_ref(2);
-  true_ref[0] = 2;
-  true_ref[1] = 2;
+  Vector true_ref(2, 2);
 
-  Vector false_ref(3);
-  false_ref[0] = 1;
-  false_ref[1] = 1;
-  false_ref[2] = 1;
+  Vector false_ref(3, 1);
 
   ASSERT_EQUAL(2, ends.first - true_results.begin());
   ASSERT_EQUAL(3, ends.second - false_results.begin());
@@ -269,19 +184,9 @@ void TestStablePartitionCopyStencilSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 1;
-  data[4] = 2;
+  Vector data{1, 2, 1, 1, 2};
 
-  Vector stencil(5);
-  stencil[0] = false;
-  stencil[1] = true;
-  stencil[2] = false;
-  stencil[3] = false;
-  stencil[4] = true;
+  Vector stencil{false, true, false, false, true};
 
   Vector true_results(2);
   Vector false_results(3);
@@ -289,14 +194,9 @@ void TestStablePartitionCopyStencilSimple()
   thrust::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::stable_partition_copy(
     data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), thrust::identity<T>());
 
-  Vector true_ref(2);
-  true_ref[0] = 2;
-  true_ref[1] = 2;
+  Vector true_ref(2, 2);
 
-  Vector false_ref(3);
-  false_ref[0] = 1;
-  false_ref[1] = 1;
-  false_ref[2] = 1;
+  Vector false_ref(3, 1);
 
   ASSERT_EQUAL(2, ends.first - true_results.begin());
   ASSERT_EQUAL(3, ends.second - false_results.begin());
@@ -937,19 +837,8 @@ struct is_ordered
 template <typename Vector>
 void TestPartitionZipIterator()
 {
-  Vector data1(5);
-  Vector data2(5);
-
-  data1[0] = 1;
-  data2[0] = 2;
-  data1[1] = 2;
-  data2[1] = 1;
-  data1[2] = 1;
-  data2[2] = 2;
-  data1[3] = 1;
-  data2[3] = 2;
-  data1[4] = 2;
-  data2[4] = 1;
+  Vector data1{1, 2, 1, 1, 2};
+  Vector data2{2, 1, 2, 2, 1};
 
   using Iterator      = typename Vector::iterator;
   using IteratorTuple = thrust::tuple<Iterator, Iterator>;
@@ -960,19 +849,8 @@ void TestPartitionZipIterator()
 
   ZipIterator iter = thrust::partition(begin, end, is_ordered());
 
-  Vector ref1(5);
-  Vector ref2(5);
-
-  ref1[0] = 1;
-  ref2[0] = 2;
-  ref1[1] = 1;
-  ref2[1] = 2;
-  ref1[2] = 1;
-  ref2[2] = 2;
-  ref1[3] = 2;
-  ref2[3] = 1;
-  ref1[4] = 2;
-  ref2[4] = 1;
+  Vector ref1{1, 1, 1, 2, 2};
+  Vector ref2{2, 2, 2, 1, 1};
 
   ASSERT_EQUAL(iter - begin, 3);
   ASSERT_EQUAL(data1, ref1);
@@ -983,26 +861,10 @@ DECLARE_VECTOR_UNITTEST(TestPartitionZipIterator);
 template <typename Vector>
 void TestPartitionStencilZipIterator()
 {
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 0;
-  data[2] = 1;
-  data[3] = 1;
-  data[4] = 0;
+  Vector data{1, 0, 1, 1, 0};
 
-  Vector stencil1(5);
-  Vector stencil2(5);
-
-  stencil1[0] = 1;
-  stencil2[0] = 2;
-  stencil1[1] = 2;
-  stencil2[1] = 1;
-  stencil1[2] = 1;
-  stencil2[2] = 2;
-  stencil1[3] = 1;
-  stencil2[3] = 2;
-  stencil1[4] = 2;
-  stencil2[4] = 1;
+  Vector stencil1{1, 2, 1, 1, 2};
+  Vector stencil2{2, 1, 2, 2, 1};
 
   using Iterator      = typename Vector::iterator;
   using IteratorTuple = thrust::tuple<Iterator, Iterator>;
@@ -1012,13 +874,7 @@ void TestPartitionStencilZipIterator()
 
   Iterator iter = thrust::partition(data.begin(), data.end(), stencil_begin, is_ordered());
 
-  Vector ref(5);
-
-  ref[0] = 1;
-  ref[1] = 1;
-  ref[2] = 1;
-  ref[3] = 0;
-  ref[4] = 0;
+  Vector ref{1, 1, 1, 0, 0};
 
   ASSERT_EQUAL(iter - data.begin(), 3);
   ASSERT_EQUAL(data, ref);
@@ -1028,19 +884,8 @@ DECLARE_VECTOR_UNITTEST(TestPartitionStencilZipIterator);
 template <typename Vector>
 void TestStablePartitionZipIterator()
 {
-  Vector data1(5);
-  Vector data2(5);
-
-  data1[0] = 1;
-  data2[0] = 2;
-  data1[1] = 2;
-  data2[1] = 0;
-  data1[2] = 1;
-  data2[2] = 3;
-  data1[3] = 1;
-  data2[3] = 2;
-  data1[4] = 2;
-  data2[4] = 1;
+  Vector data1{1, 2, 1, 1, 2};
+  Vector data2{2, 0, 3, 2, 1};
 
   using Iterator      = typename Vector::iterator;
   using IteratorTuple = thrust::tuple<Iterator, Iterator>;
@@ -1051,19 +896,8 @@ void TestStablePartitionZipIterator()
 
   ZipIterator iter = thrust::stable_partition(begin, end, is_ordered());
 
-  Vector ref1(5);
-  Vector ref2(5);
-
-  ref1[0] = 1;
-  ref2[0] = 2;
-  ref1[1] = 1;
-  ref2[1] = 3;
-  ref1[2] = 1;
-  ref2[2] = 2;
-  ref1[3] = 2;
-  ref2[3] = 0;
-  ref1[4] = 2;
-  ref2[4] = 1;
+  Vector ref1{1, 1, 1, 2, 2};
+  Vector ref2{2, 3, 2, 0, 1};
 
   ASSERT_EQUAL(data1, ref1);
   ASSERT_EQUAL(data2, ref2);
@@ -1074,26 +908,10 @@ DECLARE_VECTOR_UNITTEST(TestStablePartitionZipIterator);
 template <typename Vector>
 void TestStablePartitionStencilZipIterator()
 {
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 0;
-  data[2] = 1;
-  data[3] = 1;
-  data[4] = 0;
+  Vector data{1, 0, 1, 1, 0};
 
-  Vector stencil1(5);
-  Vector stencil2(5);
-
-  stencil1[0] = 1;
-  stencil2[0] = 2;
-  stencil1[1] = 2;
-  stencil2[1] = 0;
-  stencil1[2] = 1;
-  stencil2[2] = 3;
-  stencil1[3] = 1;
-  stencil2[3] = 2;
-  stencil1[4] = 2;
-  stencil2[4] = 1;
+  Vector stencil1{1, 2, 1, 1, 2};
+  Vector stencil2{2, 0, 3, 2, 1};
 
   using Iterator      = typename Vector::iterator;
   using IteratorTuple = thrust::tuple<Iterator, Iterator>;
@@ -1103,13 +921,7 @@ void TestStablePartitionStencilZipIterator()
 
   Iterator mid = thrust::stable_partition(data.begin(), data.end(), stencil_begin, is_ordered());
 
-  Vector ref(5);
-
-  ref[0] = 1;
-  ref[1] = 1;
-  ref[2] = 1;
-  ref[3] = 0;
-  ref[4] = 0;
+  Vector ref{1, 1, 1, 0, 0};
 
   ASSERT_EQUAL(ref, data);
   ASSERT_EQUAL(mid - data.begin(), 3);

--- a/thrust/testing/partition_point.cu
+++ b/thrust/testing/partition_point.cu
@@ -19,11 +19,7 @@ void TestPartitionPointSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector v(4);
-  v[0] = 1;
-  v[1] = 1;
-  v[2] = 1;
-  v[3] = 0;
+  Vector v{1, 1, 1, 0};
 
   Iterator first = v.begin();
 

--- a/thrust/testing/permutation_iterator.cu
+++ b/thrust/testing/permutation_iterator.cu
@@ -160,11 +160,6 @@ void TestPermutationIteratorHostDeviceGather()
   thrust::sequence(h_source.begin(), h_source.end(), 1);
   thrust::sequence(d_source.begin(), d_source.end(), 1);
 
-  // h_indices[0] = d_indices[0] = 3;
-  // h_indices[1] = d_indices[1] = 0;
-  // h_indices[2] = d_indices[2] = 5;
-  // h_indices[3] = d_indices[3] = 7;
-
   thrust::permutation_iterator<HostIterator, HostIterator> p_h_source(h_source.begin(), h_indices.begin());
   thrust::permutation_iterator<DeviceIterator, DeviceIterator> p_d_source(d_source.begin(), d_indices.begin());
 

--- a/thrust/testing/permutation_iterator.cu
+++ b/thrust/testing/permutation_iterator.cu
@@ -15,15 +15,10 @@ void TestPermutationIteratorSimple()
   using Iterator = typename Vector::iterator;
 
   Vector source(8);
-  Vector indices(4);
+  Vector indices{3, 0, 5, 7};
 
   // initialize input
   thrust::sequence(source.begin(), source.end(), 1);
-
-  indices[0] = 3;
-  indices[1] = 0;
-  indices[2] = 5;
-  indices[3] = 7;
 
   thrust::permutation_iterator<Iterator, Iterator> begin(source.begin(), indices.begin());
   thrust::permutation_iterator<Iterator, Iterator> end(source.begin(), indices.end());
@@ -45,14 +40,8 @@ void TestPermutationIteratorSimple()
   *begin = 10;
   *end   = 20;
 
-  ASSERT_EQUAL(source[0], 10);
-  ASSERT_EQUAL(source[1], 2);
-  ASSERT_EQUAL(source[2], 3);
-  ASSERT_EQUAL(source[3], 4);
-  ASSERT_EQUAL(source[4], 5);
-  ASSERT_EQUAL(source[5], 20);
-  ASSERT_EQUAL(source[6], 7);
-  ASSERT_EQUAL(source[7], 8);
+  Vector ref{10, 2, 3, 4, 5, 20, 7, 8};
+  ASSERT_EQUAL(source, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorSimple);
 static_assert(cuda::std::is_trivially_copy_constructible<thrust::permutation_iterator<int*, int*>>::value, "");
@@ -64,25 +53,18 @@ void TestPermutationIteratorGather()
   using Iterator = typename Vector::iterator;
 
   Vector source(8);
-  Vector indices(4);
+  Vector indices{3, 0, 5, 7};
   Vector output(4, 10);
 
   // initialize input
   thrust::sequence(source.begin(), source.end(), 1);
 
-  indices[0] = 3;
-  indices[1] = 0;
-  indices[2] = 5;
-  indices[3] = 7;
-
   thrust::permutation_iterator<Iterator, Iterator> p_source(source.begin(), indices.begin());
 
   thrust::copy(p_source, p_source + 4, output.begin());
 
-  ASSERT_EQUAL(output[0], 4);
-  ASSERT_EQUAL(output[1], 1);
-  ASSERT_EQUAL(output[2], 6);
-  ASSERT_EQUAL(output[3], 8);
+  Vector ref{4, 1, 6, 8};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorGather);
 
@@ -92,30 +74,19 @@ void TestPermutationIteratorScatter()
   using Iterator = typename Vector::iterator;
 
   Vector source(4, 10);
-  Vector indices(4);
+  Vector indices{3, 0, 5, 7};
   Vector output(8);
 
   // initialize output
   thrust::sequence(output.begin(), output.end(), 1);
-
-  indices[0] = 3;
-  indices[1] = 0;
-  indices[2] = 5;
-  indices[3] = 7;
 
   // construct transform_iterator
   thrust::permutation_iterator<Iterator, Iterator> p_output(output.begin(), indices.begin());
 
   thrust::copy(source.begin(), source.end(), p_output);
 
-  ASSERT_EQUAL(output[0], 10);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 3);
-  ASSERT_EQUAL(output[3], 10);
-  ASSERT_EQUAL(output[4], 5);
-  ASSERT_EQUAL(output[5], 10);
-  ASSERT_EQUAL(output[6], 7);
-  ASSERT_EQUAL(output[7], 10);
+  Vector ref{10, 2, 3, 10, 5, 10, 7, 10};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorScatter);
 
@@ -123,25 +94,18 @@ template <class Vector>
 void TestMakePermutationIterator()
 {
   Vector source(8);
-  Vector indices(4);
+  Vector indices{3, 0, 5, 7};
   Vector output(4, 10);
 
   // initialize input
   thrust::sequence(source.begin(), source.end(), 1);
 
-  indices[0] = 3;
-  indices[1] = 0;
-  indices[2] = 5;
-  indices[3] = 7;
-
   thrust::copy(thrust::make_permutation_iterator(source.begin(), indices.begin()),
                thrust::make_permutation_iterator(source.begin(), indices.begin()) + 4,
                output.begin());
 
-  ASSERT_EQUAL(output[0], 4);
-  ASSERT_EQUAL(output[1], 1);
-  ASSERT_EQUAL(output[2], 6);
-  ASSERT_EQUAL(output[3], 8);
+  Vector ref{4, 1, 6, 8};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestMakePermutationIterator);
 
@@ -152,16 +116,11 @@ void TestPermutationIteratorReduce()
   using Iterator = typename Vector::iterator;
 
   Vector source(8);
-  Vector indices(4);
+  Vector indices{3, 0, 5, 7};
   Vector output(4, 10);
 
   // initialize input
   thrust::sequence(source.begin(), source.end(), 1);
-
-  indices[0] = 3;
-  indices[1] = 0;
-  indices[2] = 5;
-  indices[3] = 7;
 
   // construct transform_iterator
   thrust::permutation_iterator<Iterator, Iterator> iter(source.begin(), indices.begin());
@@ -190,21 +149,21 @@ void TestPermutationIteratorHostDeviceGather()
   using DeviceIterator = DeviceVector::iterator;
 
   HostVector h_source(8);
-  HostVector h_indices(4);
+  HostVector h_indices{3, 0, 5, 7};
   HostVector h_output(4, 10);
 
   DeviceVector d_source(8);
-  DeviceVector d_indices(4);
+  DeviceVector d_indices(h_indices);
   DeviceVector d_output(4, 10);
 
   // initialize source
   thrust::sequence(h_source.begin(), h_source.end(), 1);
   thrust::sequence(d_source.begin(), d_source.end(), 1);
 
-  h_indices[0] = d_indices[0] = 3;
-  h_indices[1] = d_indices[1] = 0;
-  h_indices[2] = d_indices[2] = 5;
-  h_indices[3] = d_indices[3] = 7;
+  // h_indices[0] = d_indices[0] = 3;
+  // h_indices[1] = d_indices[1] = 0;
+  // h_indices[2] = d_indices[2] = 5;
+  // h_indices[3] = d_indices[3] = 7;
 
   thrust::permutation_iterator<HostIterator, HostIterator> p_h_source(h_source.begin(), h_indices.begin());
   thrust::permutation_iterator<DeviceIterator, DeviceIterator> p_d_source(d_source.begin(), d_indices.begin());
@@ -212,18 +171,14 @@ void TestPermutationIteratorHostDeviceGather()
   // gather host->device
   thrust::copy(p_h_source, p_h_source + 4, d_output.begin());
 
-  ASSERT_EQUAL(d_output[0], 4);
-  ASSERT_EQUAL(d_output[1], 1);
-  ASSERT_EQUAL(d_output[2], 6);
-  ASSERT_EQUAL(d_output[3], 8);
+  DeviceVector dref{4, 1, 6, 8};
+  ASSERT_EQUAL(d_output, dref);
 
   // gather device->host
   thrust::copy(p_d_source, p_d_source + 4, h_output.begin());
 
-  ASSERT_EQUAL(h_output[0], 4);
-  ASSERT_EQUAL(h_output[1], 1);
-  ASSERT_EQUAL(h_output[2], 6);
-  ASSERT_EQUAL(h_output[3], 8);
+  HostVector href{4, 1, 6, 8};
+  ASSERT_EQUAL(h_output, href);
 }
 DECLARE_UNITTEST(TestPermutationIteratorHostDeviceGather);
 
@@ -236,21 +191,16 @@ void TestPermutationIteratorHostDeviceScatter()
   using DeviceIterator = DeviceVector::iterator;
 
   HostVector h_source(4, 10);
-  HostVector h_indices(4);
+  HostVector h_indices{3, 0, 5, 7};
   HostVector h_output(8);
 
   DeviceVector d_source(4, 10);
-  DeviceVector d_indices(4);
+  DeviceVector d_indices(h_indices);
   DeviceVector d_output(8);
 
   // initialize source
   thrust::sequence(h_output.begin(), h_output.end(), 1);
   thrust::sequence(d_output.begin(), d_output.end(), 1);
-
-  h_indices[0] = d_indices[0] = 3;
-  h_indices[1] = d_indices[1] = 0;
-  h_indices[2] = d_indices[2] = 5;
-  h_indices[3] = d_indices[3] = 7;
 
   thrust::permutation_iterator<HostIterator, HostIterator> p_h_output(h_output.begin(), h_indices.begin());
   thrust::permutation_iterator<DeviceIterator, DeviceIterator> p_d_output(d_output.begin(), d_indices.begin());
@@ -258,26 +208,14 @@ void TestPermutationIteratorHostDeviceScatter()
   // scatter host->device
   thrust::copy(h_source.begin(), h_source.end(), p_d_output);
 
-  ASSERT_EQUAL(d_output[0], 10);
-  ASSERT_EQUAL(d_output[1], 2);
-  ASSERT_EQUAL(d_output[2], 3);
-  ASSERT_EQUAL(d_output[3], 10);
-  ASSERT_EQUAL(d_output[4], 5);
-  ASSERT_EQUAL(d_output[5], 10);
-  ASSERT_EQUAL(d_output[6], 7);
-  ASSERT_EQUAL(d_output[7], 10);
+  DeviceVector dref{10, 2, 3, 10, 5, 10, 7, 10};
+  ASSERT_EQUAL(d_output, dref);
 
   // scatter device->host
   thrust::copy(d_source.begin(), d_source.end(), p_h_output);
 
-  ASSERT_EQUAL(h_output[0], 10);
-  ASSERT_EQUAL(h_output[1], 2);
-  ASSERT_EQUAL(h_output[2], 3);
-  ASSERT_EQUAL(h_output[3], 10);
-  ASSERT_EQUAL(h_output[4], 5);
-  ASSERT_EQUAL(h_output[5], 10);
-  ASSERT_EQUAL(h_output[6], 7);
-  ASSERT_EQUAL(h_output[7], 10);
+  HostVector href(dref);
+  ASSERT_EQUAL(h_output, href);
 }
 DECLARE_UNITTEST(TestPermutationIteratorHostDeviceScatter);
 
@@ -298,10 +236,8 @@ void TestPermutationIteratorWithCountingIterator()
 
     thrust::copy(first, last, output.begin());
 
-    ASSERT_EQUAL(output[0], 0);
-    ASSERT_EQUAL(output[1], 1);
-    ASSERT_EQUAL(output[2], 2);
-    ASSERT_EQUAL(output[3], 3);
+    Vector ref{0, 1, 2, 3};
+    ASSERT_EQUAL(output, ref);
   }
 
   // test copy()
@@ -313,10 +249,8 @@ void TestPermutationIteratorWithCountingIterator()
                       output.begin(),
                       thrust::identity<T>());
 
-    ASSERT_EQUAL(output[0], 0);
-    ASSERT_EQUAL(output[1], 1);
-    ASSERT_EQUAL(output[2], 2);
-    ASSERT_EQUAL(output[3], 3);
+    Vector ref{0, 1, 2, 3};
+    ASSERT_EQUAL(output, ref);
   }
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestPermutationIteratorWithCountingIterator);

--- a/thrust/testing/reduce.cu
+++ b/thrust/testing/reduce.cu
@@ -30,10 +30,7 @@ void TestReduceSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector v(3);
-  v[0] = 1;
-  v[1] = -2;
-  v[2] = 3;
+  Vector v{1, -2, 3};
 
   // no initializer
   ASSERT_EQUAL(thrust::reduce(v.begin(), v.end()), 2);
@@ -99,17 +96,9 @@ template <class IntVector, class FloatVector>
 void TestReduceMixedTypes()
 {
   // make sure we get types for default args and operators correct
-  IntVector int_input(4);
-  int_input[0] = 1;
-  int_input[1] = 2;
-  int_input[2] = 3;
-  int_input[3] = 4;
+  IntVector int_input{1, 2, 3, 4};
 
-  FloatVector float_input(4);
-  float_input[0] = 1.5;
-  float_input[1] = 2.5;
-  float_input[2] = 3.5;
-  float_input[3] = 4.5;
+  FloatVector float_input{1.5, 2.5, 3.5, 4.5};
 
   // float -> int should use using plus<int> operator by default
   ASSERT_EQUAL(thrust::reduce(float_input.begin(), float_input.end(), (int) 0), 10);
@@ -167,22 +156,9 @@ void TestReduceWithIndirection()
   // add numbers modulo 3 with external lookup table
   using T = typename Vector::value_type;
 
-  Vector data(7);
-  data[0] = 0;
-  data[1] = 1;
-  data[2] = 2;
-  data[3] = 1;
-  data[4] = 2;
-  data[5] = 0;
-  data[6] = 1;
+  Vector data{0, 1, 2, 1, 2, 0, 1};
 
-  Vector table(6);
-  table[0] = 0;
-  table[1] = 1;
-  table[2] = 2;
-  table[3] = 0;
-  table[4] = 1;
-  table[5] = 2;
+  Vector table{0, 1, 2, 0, 1, 2};
 
   T result = thrust::reduce(data.begin(), data.end(), T(0), plus_mod3<T>(thrust::raw_pointer_cast(&table[0])));
 

--- a/thrust/testing/reduce_by_key.cu
+++ b/thrust/testing/reduce_by_key.cu
@@ -18,30 +18,14 @@ template <typename Vector>
 void initialize_keys(Vector& keys)
 {
   keys.resize(9);
-  keys[0] = 11;
-  keys[1] = 11;
-  keys[2] = 21;
-  keys[3] = 20;
-  keys[4] = 21;
-  keys[5] = 21;
-  keys[6] = 21;
-  keys[7] = 37;
-  keys[8] = 37;
+  keys = {11, 11, 21, 20, 21, 21, 21, 37, 37};
 }
 
 template <typename Vector>
 void initialize_values(Vector& values)
 {
   values.resize(9);
-  values[0] = 0;
-  values[1] = 1;
-  values[2] = 2;
-  values[3] = 3;
-  values[4] = 4;
-  values[5] = 5;
-  values[6] = 6;
-  values[7] = 7;
-  values[8] = 8;
+  values = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 }
 
 template <typename Vector>
@@ -65,18 +49,14 @@ void TestReduceByKeySimple()
     thrust::reduce_by_key(keys.begin(), keys.end(), values.begin(), output_keys.begin(), output_values.begin());
 
   ASSERT_EQUAL(new_last.first - output_keys.begin(), 5);
+  output_keys.resize(new_last.first - output_keys.begin());
   ASSERT_EQUAL(new_last.second - output_values.begin(), 5);
-  ASSERT_EQUAL(output_keys[0], 11);
-  ASSERT_EQUAL(output_keys[1], 21);
-  ASSERT_EQUAL(output_keys[2], 20);
-  ASSERT_EQUAL(output_keys[3], 21);
-  ASSERT_EQUAL(output_keys[4], 37);
+  output_values.resize(new_last.second - output_values.begin());
+  Vector ref_keys{11, 21, 20, 21, 37};
+  ASSERT_EQUAL(output_keys, ref_keys);
 
-  ASSERT_EQUAL(output_values[0], 1);
-  ASSERT_EQUAL(output_values[1], 2);
-  ASSERT_EQUAL(output_values[2], 3);
-  ASSERT_EQUAL(output_values[3], 15);
-  ASSERT_EQUAL(output_values[4], 15);
+  Vector ref_values{1, 2, 3, 15, 15};
+  ASSERT_EQUAL(output_values, ref_values);
 
   // test BinaryPredicate
   initialize_keys(keys);
@@ -86,18 +66,22 @@ void TestReduceByKeySimple()
     keys.begin(), keys.end(), values.begin(), output_keys.begin(), output_values.begin(), is_equal_div_10_reduce<T>());
 
   ASSERT_EQUAL(new_last.first - output_keys.begin(), 3);
+  output_keys.resize(new_last.first - output_keys.begin());
   ASSERT_EQUAL(new_last.second - output_values.begin(), 3);
-  ASSERT_EQUAL(output_keys[0], 11);
-  ASSERT_EQUAL(output_keys[1], 21);
-  ASSERT_EQUAL(output_keys[2], 37);
+  output_values.resize(new_last.second - output_values.begin());
 
-  ASSERT_EQUAL(output_values[0], 1);
-  ASSERT_EQUAL(output_values[1], 20);
-  ASSERT_EQUAL(output_values[2], 15);
+  ref_keys = {11, 21, 37};
+  ASSERT_EQUAL(output_keys, ref_keys);
+
+  ref_values = {1, 20, 15};
+  ASSERT_EQUAL(output_values, ref_values);
 
   // test BinaryFunction
   initialize_keys(keys);
   initialize_values(values);
+
+  output_keys.resize(keys.size());
+  output_values.resize(values.size());
 
   new_last = thrust::reduce_by_key(
     keys.begin(),
@@ -109,18 +93,15 @@ void TestReduceByKeySimple()
     thrust::plus<T>());
 
   ASSERT_EQUAL(new_last.first - output_keys.begin(), 5);
+  output_keys.resize(new_last.first - output_keys.begin());
   ASSERT_EQUAL(new_last.second - output_values.begin(), 5);
-  ASSERT_EQUAL(output_keys[0], 11);
-  ASSERT_EQUAL(output_keys[1], 21);
-  ASSERT_EQUAL(output_keys[2], 20);
-  ASSERT_EQUAL(output_keys[3], 21);
-  ASSERT_EQUAL(output_keys[4], 37);
+  output_values.resize(new_last.second - output_values.begin());
 
-  ASSERT_EQUAL(output_values[0], 1);
-  ASSERT_EQUAL(output_values[1], 2);
-  ASSERT_EQUAL(output_values[2], 3);
-  ASSERT_EQUAL(output_values[3], 15);
-  ASSERT_EQUAL(output_values[4], 15);
+  ref_keys = {11, 21, 20, 21, 37};
+  ASSERT_EQUAL(output_keys, ref_keys);
+
+  ref_values = {1, 2, 3, 15, 15};
+  ASSERT_EQUAL(output_values, ref_values);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestReduceByKeySimple);
 

--- a/thrust/testing/remove.cu
+++ b/thrust/testing/remove.cu
@@ -32,20 +32,15 @@ void TestRemoveSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   typename Vector::iterator end = thrust::remove(data.begin(), data.end(), (T) 2);
 
   ASSERT_EQUAL(end - data.begin(), 3);
+  data.resize(end - data.begin());
 
-  ASSERT_EQUAL(data[0], 1);
-  ASSERT_EQUAL(data[1], 1);
-  ASSERT_EQUAL(data[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(data, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestRemoveSimple);
 
@@ -89,22 +84,17 @@ void TestRemoveCopySimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   Vector result(5);
 
   typename Vector::iterator end = thrust::remove_copy(data.begin(), data.end(), result.begin(), (T) 2);
 
   ASSERT_EQUAL(end - result.begin(), 3);
+  result.resize(end - result.begin());
 
-  ASSERT_EQUAL(result[0], 1);
-  ASSERT_EQUAL(result[1], 1);
-  ASSERT_EQUAL(result[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(result, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestRemoveCopySimple);
 
@@ -149,20 +139,15 @@ void TestRemoveIfSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), is_even<T>());
 
   ASSERT_EQUAL(end - data.begin(), 3);
+  data.resize(end - data.begin());
 
-  ASSERT_EQUAL(data[0], 1);
-  ASSERT_EQUAL(data[1], 1);
-  ASSERT_EQUAL(data[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(data, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestRemoveIfSimple);
 
@@ -206,27 +191,17 @@ void TestRemoveIfStencilSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
-  Vector stencil(5);
-  stencil[0] = 0;
-  stencil[1] = 1;
-  stencil[2] = 0;
-  stencil[3] = 0;
-  stencil[4] = 1;
+  Vector stencil{0, 1, 0, 0, 1};
 
   typename Vector::iterator end = thrust::remove_if(data.begin(), data.end(), stencil.begin(), thrust::identity<T>());
 
   ASSERT_EQUAL(end - data.begin(), 3);
+  data.resize(end - data.begin());
 
-  ASSERT_EQUAL(data[0], 1);
-  ASSERT_EQUAL(data[1], 1);
-  ASSERT_EQUAL(data[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(data, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestRemoveIfStencilSimple);
 
@@ -271,22 +246,17 @@ void TestRemoveCopyIfSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   Vector result(5);
 
   typename Vector::iterator end = thrust::remove_copy_if(data.begin(), data.end(), result.begin(), is_even<T>());
 
   ASSERT_EQUAL(end - result.begin(), 3);
+  result.resize(end - result.begin());
 
-  ASSERT_EQUAL(result[0], 1);
-  ASSERT_EQUAL(result[1], 1);
-  ASSERT_EQUAL(result[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(result, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestRemoveCopyIfSimple);
 
@@ -331,19 +301,9 @@ void TestRemoveCopyIfStencilSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
-  Vector stencil(5);
-  stencil[0] = 0;
-  stencil[1] = 1;
-  stencil[2] = 0;
-  stencil[3] = 0;
-  stencil[4] = 1;
+  Vector stencil{0, 1, 0, 0, 1};
 
   Vector result(5);
 
@@ -351,10 +311,10 @@ void TestRemoveCopyIfStencilSimple()
     thrust::remove_copy_if(data.begin(), data.end(), stencil.begin(), result.begin(), thrust::identity<T>());
 
   ASSERT_EQUAL(end - result.begin(), 3);
+  result.resize(end - result.begin());
 
-  ASSERT_EQUAL(result[0], 1);
-  ASSERT_EQUAL(result[1], 1);
-  ASSERT_EQUAL(result[2], 3);
+  Vector ref{1, 1, 3};
+  ASSERT_EQUAL(result, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestRemoveCopyIfStencilSimple);
 

--- a/thrust/testing/replace.cu
+++ b/thrust/testing/replace.cu
@@ -28,22 +28,12 @@ void TestReplaceSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   thrust::replace(data.begin(), data.end(), (T) 1, (T) 4);
   thrust::replace(data.begin(), data.end(), (T) 2, (T) 5);
 
-  Vector result(5);
-  result[0] = 4;
-  result[1] = 5;
-  result[2] = 4;
-  result[3] = 3;
-  result[4] = 5;
+  Vector result{4, 5, 4, 3, 5};
 
   ASSERT_EQUAL(data, result);
 }
@@ -105,25 +95,14 @@ void TestReplaceCopySimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 1;
-  data[3] = 3;
-  data[4] = 2;
+  Vector data{1, 2, 1, 3, 2};
 
   Vector dest(5);
 
   thrust::replace_copy(data.begin(), data.end(), dest.begin(), (T) 1, (T) 4);
   thrust::replace_copy(dest.begin(), dest.end(), dest.begin(), (T) 2, (T) 5);
 
-  Vector result(5);
-  result[0] = 4;
-  result[1] = 5;
-  result[2] = 4;
-  result[3] = 3;
-  result[4] = 5;
-
+  Vector result{4, 5, 4, 3, 5};
   ASSERT_EQUAL(dest, result);
 }
 DECLARE_VECTOR_UNITTEST(TestReplaceCopySimple);
@@ -222,21 +201,11 @@ void TestReplaceIfSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 3;
-  data[2] = 4;
-  data[3] = 6;
-  data[4] = 5;
+  Vector data{1, 3, 4, 6, 5};
 
   thrust::replace_if(data.begin(), data.end(), less_than_five<T>(), (T) 0);
 
-  Vector result(5);
-  result[0] = 0;
-  result[1] = 0;
-  result[2] = 0;
-  result[3] = 6;
-  result[4] = 5;
+  Vector result{0, 0, 0, 6, 5};
 
   ASSERT_EQUAL(data, result);
 }
@@ -280,28 +249,12 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceIfStencilSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 3;
-  data[2] = 4;
-  data[3] = 6;
-  data[4] = 5;
+  Vector data{1, 3, 4, 6, 5};
 
-  Vector stencil(5);
-  stencil[0] = 5;
-  stencil[1] = 4;
-  stencil[2] = 6;
-  stencil[3] = 3;
-  stencil[4] = 7;
-
+  Vector stencil{5, 4, 6, 3, 7};
   thrust::replace_if(data.begin(), data.end(), stencil.begin(), less_than_five<T>(), (T) 0);
 
-  Vector result(5);
-  result[0] = 1;
-  result[1] = 0;
-  result[2] = 4;
-  result[3] = 0;
-  result[4] = 5;
+  Vector result{1, 0, 4, 0, 5};
 
   ASSERT_EQUAL(data, result);
 }
@@ -375,24 +328,13 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 3;
-  data[2] = 4;
-  data[3] = 6;
-  data[4] = 5;
+  Vector data{1, 3, 4, 6, 5};
 
   Vector dest(5);
 
   thrust::replace_copy_if(data.begin(), data.end(), dest.begin(), less_than_five<T>(), (T) 0);
 
-  Vector result(5);
-  result[0] = 0;
-  result[1] = 0;
-  result[2] = 0;
-  result[3] = 6;
-  result[4] = 5;
-
+  Vector result{0, 0, 0, 6, 5};
   ASSERT_EQUAL(dest, result);
 }
 DECLARE_VECTOR_UNITTEST(TestReplaceCopyIfSimple);
@@ -439,30 +381,14 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopyIfStencilSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 3;
-  data[2] = 4;
-  data[3] = 6;
-  data[4] = 5;
-
-  Vector stencil(5);
-  stencil[0] = 1;
-  stencil[1] = 5;
-  stencil[2] = 4;
-  stencil[3] = 7;
-  stencil[4] = 8;
+  Vector data{1, 3, 4, 6, 5};
+  Vector stencil{1, 5, 4, 7, 8};
 
   Vector dest(5);
 
   thrust::replace_copy_if(data.begin(), data.end(), stencil.begin(), dest.begin(), less_than_five<T>(), (T) 0);
 
-  Vector result(5);
-  result[0] = 0;
-  result[1] = 3;
-  result[2] = 0;
-  result[3] = 6;
-  result[4] = 5;
+  Vector result{0, 3, 0, 6, 5};
 
   ASSERT_EQUAL(dest, result);
 }

--- a/thrust/testing/replace.cu
+++ b/thrust/testing/replace.cu
@@ -91,7 +91,7 @@ DECLARE_VARIABLE_UNITTEST(TestReplace);
 #ifndef THRUST_GCC13_TBB_MISCOMPILE
 #  ifndef THRUST_GCC12_OMP_MISCOMPILE
 template <class Vector>
-void TestReplaceCopySimple()
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestReplaceCopySimple()
 {
   using T = typename Vector::value_type;
 

--- a/thrust/testing/reverse.cu
+++ b/thrust/testing/reverse.cu
@@ -68,6 +68,7 @@ void TestReverseCopySimple()
   Vector input{1, 2, 3, 4, 5};
   Vector output(5);
 
+  // arm gcc is complaining here
   Iterator iter = thrust::reverse_copy(input.begin(), input.end(), output.begin());
 
   Vector ref{5, 4, 3, 2, 1};

--- a/thrust/testing/reverse.cu
+++ b/thrust/testing/reverse.cu
@@ -9,21 +9,11 @@ using ReverseTypes = unittest::type_list<unittest::int8_t, unittest::int16_t, un
 template <typename Vector>
 void TestReverseSimple()
 {
-  Vector data(5);
-  data[0] = 1;
-  data[1] = 2;
-  data[2] = 3;
-  data[3] = 4;
-  data[4] = 5;
+  Vector data{1, 2, 3, 4, 5};
 
   thrust::reverse(data.begin(), data.end());
 
-  Vector ref(5);
-  ref[0] = 5;
-  ref[1] = 4;
-  ref[2] = 3;
-  ref[3] = 2;
-  ref[4] = 1;
+  Vector ref{5, 4, 3, 2, 1};
 
   ASSERT_EQUAL(ref, data);
 }
@@ -75,24 +65,12 @@ void TestReverseCopySimple()
 
   using Iterator = typename Vector::iterator;
 
-  Vector input(5);
-  input[0] = 1;
-  input[1] = 2;
-  input[2] = 3;
-  input[3] = 4;
-  input[4] = 5;
-
+  Vector input{1, 2, 3, 4, 5};
   Vector output(5);
 
   Iterator iter = thrust::reverse_copy(input.begin(), input.end(), output.begin());
 
-  Vector ref(5);
-  ref[0] = 5;
-  ref[1] = 4;
-  ref[2] = 3;
-  ref[3] = 2;
-  ref[4] = 1;
-
+  Vector ref{5, 4, 3, 2, 1};
   ASSERT_EQUAL(5, iter - output.begin());
   ASSERT_EQUAL(ref, output);
 }

--- a/thrust/testing/reverse.cu
+++ b/thrust/testing/reverse.cu
@@ -66,11 +66,11 @@ void TestReverseCopySimple()
   using Iterator = typename Vector::iterator;
 
   Vector input{1, 2, 3, 4, 5};
-  Vector output(5);
+  Vector output(8); // arm GCC is complaining about destination size
 
-  // arm gcc is complaining here
   Iterator iter = thrust::reverse_copy(input.begin(), input.end(), output.begin());
 
+  output.resize(5);
   Vector ref{5, 4, 3, 2, 1};
   ASSERT_EQUAL(5, iter - output.begin());
   ASSERT_EQUAL(ref, output);

--- a/thrust/testing/reverse_iterator.cu
+++ b/thrust/testing/reverse_iterator.cu
@@ -67,21 +67,15 @@ DECLARE_UNITTEST(TestReverseIteratorIncrement);
 template <typename Vector>
 void TestReverseIteratorCopy()
 {
-  Vector source(4);
-  source[0] = 10;
-  source[1] = 20;
-  source[2] = 30;
-  source[3] = 40;
+  Vector source{10, 20, 30, 40};
 
   Vector destination(4, 0);
 
   thrust::copy(
     thrust::make_reverse_iterator(source.end()), thrust::make_reverse_iterator(source.begin()), destination.begin());
 
-  ASSERT_EQUAL(destination[0], 40);
-  ASSERT_EQUAL(destination[1], 30);
-  ASSERT_EQUAL(destination[2], 20);
-  ASSERT_EQUAL(destination[3], 10);
+  Vector ref{40, 30, 20, 10};
+  ASSERT_EQUAL(destination, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestReverseIteratorCopy);
 

--- a/thrust/testing/reverse_iterator.cu
+++ b/thrust/testing/reverse_iterator.cu
@@ -69,12 +69,12 @@ void TestReverseIteratorCopy()
 {
   Vector source{10, 20, 30, 40};
 
-  Vector destination(4, 0);
+  Vector destination(8, 0); // arm gcc is complaining here
 
-  // arm gcc is complaining here
   thrust::copy(
     thrust::make_reverse_iterator(source.end()), thrust::make_reverse_iterator(source.begin()), destination.begin());
 
+  destination.resize(4);
   Vector ref{40, 30, 20, 10};
   ASSERT_EQUAL(destination, ref);
 }

--- a/thrust/testing/reverse_iterator.cu
+++ b/thrust/testing/reverse_iterator.cu
@@ -71,6 +71,7 @@ void TestReverseIteratorCopy()
 
   Vector destination(4, 0);
 
+  // arm gcc is complaining here
   thrust::copy(
     thrust::make_reverse_iterator(source.end()), thrust::make_reverse_iterator(source.begin()), destination.begin());
 

--- a/thrust/testing/scan_by_key.exclusive.cu
+++ b/thrust/testing/scan_by_key.exclusive.cu
@@ -13,63 +13,32 @@ void TestExclusiveScanByKeySimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector keys(7);
-  Vector vals(7);
-
+  Vector keys{0, 1, 1, 1, 2, 3, 3};
+  Vector vals{1, 2, 3, 4, 5, 6, 7};
   Vector output(7, 0);
-
-  // clang-format off
-  keys[0] = 0; vals[0] = 1;
-  keys[1] = 1; vals[1] = 2;
-  keys[2] = 1; vals[2] = 3;
-  keys[3] = 1; vals[3] = 4;
-  keys[4] = 2; vals[4] = 5;
-  keys[5] = 3; vals[5] = 6;
-  keys[6] = 3; vals[6] = 7;
-  // clang-format on
 
   Iterator iter = thrust::exclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin());
 
   ASSERT_EQUAL_QUIET(iter, output.end());
 
-  ASSERT_EQUAL(output[0], 0);
-  ASSERT_EQUAL(output[1], 0);
-  ASSERT_EQUAL(output[2], 2);
-  ASSERT_EQUAL(output[3], 5);
-  ASSERT_EQUAL(output[4], 0);
-  ASSERT_EQUAL(output[5], 0);
-  ASSERT_EQUAL(output[6], 6);
+  Vector ref{0, 0, 2, 5, 0, 0, 6};
+  ASSERT_EQUAL(output, ref);
 
   thrust::exclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin(), T(10));
 
-  ASSERT_EQUAL(output[0], 10);
-  ASSERT_EQUAL(output[1], 10);
-  ASSERT_EQUAL(output[2], 12);
-  ASSERT_EQUAL(output[3], 15);
-  ASSERT_EQUAL(output[4], 10);
-  ASSERT_EQUAL(output[5], 10);
-  ASSERT_EQUAL(output[6], 16);
+  ref = {10, 10, 12, 15, 10, 10, 16};
+  ASSERT_EQUAL(output, ref);
 
   thrust::exclusive_scan_by_key(
     keys.begin(), keys.end(), vals.begin(), output.begin(), T(10), thrust::equal_to<T>(), thrust::multiplies<T>());
 
-  ASSERT_EQUAL(output[0], 10);
-  ASSERT_EQUAL(output[1], 10);
-  ASSERT_EQUAL(output[2], 20);
-  ASSERT_EQUAL(output[3], 60);
-  ASSERT_EQUAL(output[4], 10);
-  ASSERT_EQUAL(output[5], 10);
-  ASSERT_EQUAL(output[6], 60);
+  ref = {10, 10, 20, 60, 10, 10, 60};
+  ASSERT_EQUAL(output, ref);
 
   thrust::exclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin(), T(10), thrust::equal_to<T>());
 
-  ASSERT_EQUAL(output[0], 10);
-  ASSERT_EQUAL(output[1], 10);
-  ASSERT_EQUAL(output[2], 12);
-  ASSERT_EQUAL(output[3], 15);
-  ASSERT_EQUAL(output[4], 10);
-  ASSERT_EQUAL(output[5], 10);
-  ASSERT_EQUAL(output[6], 16);
+  ref = {10, 10, 12, 15, 10, 10, 16};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestExclusiveScanByKeySimple);
 
@@ -127,61 +96,29 @@ void TestScanByKeyHeadFlags()
 {
   using T = typename Vector::value_type;
 
-  Vector keys(7);
-  Vector vals(7);
-
+  Vector keys{0, 1, 0, 0, 1, 1, 0};
+  Vector vals{1, 2, 3, 4, 5, 6, 7};
   Vector output(7, 0);
-
-  // clang-format off
-  keys[0] = 0; vals[0] = 1;
-  keys[1] = 1; vals[1] = 2;
-  keys[2] = 0; vals[2] = 3;
-  keys[3] = 0; vals[3] = 4;
-  keys[4] = 1; vals[4] = 5;
-  keys[5] = 1; vals[5] = 6;
-  keys[6] = 0; vals[6] = 7;
-  // clang-format on
 
   thrust::exclusive_scan_by_key(
     keys.begin(), keys.end(), vals.begin(), output.begin(), T(10), head_flag_predicate(), thrust::plus<T>());
 
-  ASSERT_EQUAL(output[0], 10);
-  ASSERT_EQUAL(output[1], 10);
-  ASSERT_EQUAL(output[2], 12);
-  ASSERT_EQUAL(output[3], 15);
-  ASSERT_EQUAL(output[4], 10);
-  ASSERT_EQUAL(output[5], 10);
-  ASSERT_EQUAL(output[6], 16);
+  Vector ref{10, 10, 12, 15, 10, 10, 16};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestScanByKeyHeadFlags);
 
 template <typename Vector>
 void TestScanByKeyReusedKeys()
 {
-  Vector keys(7);
-  Vector vals(7);
-
+  Vector keys{0, 1, 1, 1, 0, 1, 1};
+  Vector vals{1, 2, 3, 4, 5, 6, 7};
   Vector output(7, 0);
-
-  // clang-format off
-  keys[0] = 0; vals[0] = 1;
-  keys[1] = 1; vals[1] = 2;
-  keys[2] = 1; vals[2] = 3;
-  keys[3] = 1; vals[3] = 4;
-  keys[4] = 0; vals[4] = 5;
-  keys[5] = 1; vals[5] = 6;
-  keys[6] = 1; vals[6] = 7;
-  // clang-format on
 
   thrust::exclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin(), typename Vector::value_type(10));
 
-  ASSERT_EQUAL(output[0], 10);
-  ASSERT_EQUAL(output[1], 10);
-  ASSERT_EQUAL(output[2], 12);
-  ASSERT_EQUAL(output[3], 15);
-  ASSERT_EQUAL(output[4], 10);
-  ASSERT_EQUAL(output[5], 10);
-  ASSERT_EQUAL(output[6], 16);
+  Vector ref{10, 10, 12, 15, 10, 10, 16};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestScanByKeyReusedKeys);
 

--- a/thrust/testing/scan_by_key.inclusive.cu
+++ b/thrust/testing/scan_by_key.inclusive.cu
@@ -13,53 +13,27 @@ void TestInclusiveScanByKeySimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector keys(7);
-  Vector vals(7);
-
+  Vector keys{0, 1, 1, 1, 2, 3, 3};
+  Vector vals{1, 2, 3, 4, 5, 6, 7};
   Vector output(7, 0);
-
-  // clang-format off
-  keys[0] = 0; vals[0] = 1;
-  keys[1] = 1; vals[1] = 2;
-  keys[2] = 1; vals[2] = 3;
-  keys[3] = 1; vals[3] = 4;
-  keys[4] = 2; vals[4] = 5;
-  keys[5] = 3; vals[5] = 6;
-  keys[6] = 3; vals[6] = 7;
-  // clang-format on
 
   Iterator iter = thrust::inclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin());
 
   ASSERT_EQUAL_QUIET(iter, output.end());
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 5);
-  ASSERT_EQUAL(output[3], 9);
-  ASSERT_EQUAL(output[4], 5);
-  ASSERT_EQUAL(output[5], 6);
-  ASSERT_EQUAL(output[6], 13);
+  Vector ref{1, 2, 5, 9, 5, 6, 13};
+  ASSERT_EQUAL(output, ref);
 
   thrust::inclusive_scan_by_key(
     keys.begin(), keys.end(), vals.begin(), output.begin(), thrust::equal_to<T>(), thrust::multiplies<T>());
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 6);
-  ASSERT_EQUAL(output[3], 24);
-  ASSERT_EQUAL(output[4], 5);
-  ASSERT_EQUAL(output[5], 6);
-  ASSERT_EQUAL(output[6], 42);
+  ref = {1, 2, 6, 24, 5, 6, 42};
+  ASSERT_EQUAL(output, ref);
 
   thrust::inclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin(), thrust::equal_to<T>());
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 5);
-  ASSERT_EQUAL(output[3], 9);
-  ASSERT_EQUAL(output[4], 5);
-  ASSERT_EQUAL(output[5], 6);
-  ASSERT_EQUAL(output[6], 13);
+  ref = {1, 2, 5, 9, 5, 6, 13};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestInclusiveScanByKeySimple);
 
@@ -117,31 +91,16 @@ void TestScanByKeyHeadFlags()
 {
   using T = typename Vector::value_type;
 
-  Vector keys(7);
-  Vector vals(7);
+  Vector keys{0, 1, 0, 0, 1, 1, 0};
+  Vector vals{1, 2, 3, 4, 5, 6, 7};
 
   Vector output(7, 0);
-
-  // clang-format off
-  keys[0] = 0; vals[0] = 1;
-  keys[1] = 1; vals[1] = 2;
-  keys[2] = 0; vals[2] = 3;
-  keys[3] = 0; vals[3] = 4;
-  keys[4] = 1; vals[4] = 5;
-  keys[5] = 1; vals[5] = 6;
-  keys[6] = 0; vals[6] = 7;
-  // clang-format on
 
   thrust::inclusive_scan_by_key(
     keys.begin(), keys.end(), vals.begin(), output.begin(), head_flag_predicate(), thrust::plus<T>());
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 5);
-  ASSERT_EQUAL(output[3], 9);
-  ASSERT_EQUAL(output[4], 5);
-  ASSERT_EQUAL(output[5], 6);
-  ASSERT_EQUAL(output[6], 13);
+  Vector ref{1, 2, 5, 9, 5, 6, 13};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestScanByKeyHeadFlags);
 
@@ -150,61 +109,29 @@ void TestInclusiveScanByKeyTransformIterator()
 {
   using T = typename Vector::value_type;
 
-  Vector keys(7);
-  Vector vals(7);
-
+  Vector keys{0, 1, 1, 1, 2, 3, 3};
+  Vector vals{1, 2, 3, 4, 5, 6, 7};
   Vector output(7, 0);
-
-  // clang-format off
-  keys[0] = 0; vals[0] = 1;
-  keys[1] = 1; vals[1] = 2;
-  keys[2] = 1; vals[2] = 3;
-  keys[3] = 1; vals[3] = 4;
-  keys[4] = 2; vals[4] = 5;
-  keys[5] = 3; vals[5] = 6;
-  keys[6] = 3; vals[6] = 7;
-  // clang-format on
 
   thrust::inclusive_scan_by_key(
     keys.begin(), keys.end(), thrust::make_transform_iterator(vals.begin(), thrust::negate<T>()), output.begin());
 
-  ASSERT_EQUAL(output[0], -1);
-  ASSERT_EQUAL(output[1], -2);
-  ASSERT_EQUAL(output[2], -5);
-  ASSERT_EQUAL(output[3], -9);
-  ASSERT_EQUAL(output[4], -5);
-  ASSERT_EQUAL(output[5], -6);
-  ASSERT_EQUAL(output[6], -13);
+  Vector ref{-1, -2, -5, -9, -5, -6, -13};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestInclusiveScanByKeyTransformIterator);
 
 template <typename Vector>
 void TestScanByKeyReusedKeys()
 {
-  Vector keys(7);
-  Vector vals(7);
-
+  Vector keys{0, 1, 1, 1, 0, 1, 1};
+  Vector vals{1, 2, 3, 4, 5, 6, 7};
   Vector output(7, 0);
-
-  // clang-format off
-  keys[0] = 0; vals[0] = 1;
-  keys[1] = 1; vals[1] = 2;
-  keys[2] = 1; vals[2] = 3;
-  keys[3] = 1; vals[3] = 4;
-  keys[4] = 0; vals[4] = 5;
-  keys[5] = 1; vals[5] = 6;
-  keys[6] = 1; vals[6] = 7;
-  // clang-format on
 
   thrust::inclusive_scan_by_key(keys.begin(), keys.end(), vals.begin(), output.begin());
 
-  ASSERT_EQUAL(output[0], 1);
-  ASSERT_EQUAL(output[1], 2);
-  ASSERT_EQUAL(output[2], 5);
-  ASSERT_EQUAL(output[3], 9);
-  ASSERT_EQUAL(output[4], 5);
-  ASSERT_EQUAL(output[5], 6);
-  ASSERT_EQUAL(output[6], 13);
+  Vector ref{1, 2, 5, 9, 5, 6, 13};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestScanByKeyReusedKeys);
 

--- a/thrust/testing/scatter.cu
+++ b/thrust/testing/scatter.cu
@@ -12,26 +12,14 @@
 template <class Vector>
 void TestScatterSimple()
 {
-  Vector map(5); // scatter indices
-  Vector src(5); // source vector
-  Vector dst(8); // destination vector
-
-  // clang-format off
-  map[0] = 6; map[1] = 3; map[2] = 1; map[3] = 7; map[4] = 2;
-  src[0] = 0; src[1] = 1; src[2] = 2; src[3] = 3; src[4] = 4;
-  dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0; dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
-  // clang-format on
+  Vector map{6, 3, 1, 7, 2};
+  Vector src{0, 1, 2, 3, 4};
+  Vector dst(8, 0);
 
   thrust::scatter(src.begin(), src.end(), map.begin(), dst.begin());
 
-  ASSERT_EQUAL(dst[0], 0);
-  ASSERT_EQUAL(dst[1], 2);
-  ASSERT_EQUAL(dst[2], 4);
-  ASSERT_EQUAL(dst[3], 1);
-  ASSERT_EQUAL(dst[4], 0);
-  ASSERT_EQUAL(dst[5], 0);
-  ASSERT_EQUAL(dst[6], 0);
-  ASSERT_EQUAL(dst[7], 3);
+  Vector ref{0, 2, 4, 1, 0, 0, 0, 3};
+  ASSERT_EQUAL(dst, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestScatterSimple);
 
@@ -125,28 +113,15 @@ DECLARE_VARIABLE_UNITTEST(TestScatterToDiscardIterator);
 template <class Vector>
 void TestScatterIfSimple()
 {
-  Vector flg(5); // predicate array
-  Vector map(5); // scatter indices
-  Vector src(5); // source vector
-  Vector dst(8); // destination vector
-
-  // clang-format off
-  flg[0] = 0; flg[1] = 1; flg[2] = 0; flg[3] = 1; flg[4] = 0;
-  map[0] = 6; map[1] = 3; map[2] = 1; map[3] = 7; map[4] = 2;
-  src[0] = 0; src[1] = 1; src[2] = 2; src[3] = 3; src[4] = 4;
-  dst[0] = 0; dst[1] = 0; dst[2] = 0; dst[3] = 0; dst[4] = 0; dst[5] = 0; dst[6] = 0; dst[7] = 0;
-  // clang-format on
+  Vector flg{0, 1, 0, 1, 0};
+  Vector map{6, 3, 1, 7, 2};
+  Vector src{0, 1, 2, 3, 4};
+  Vector dst(8, 0);
 
   thrust::scatter_if(src.begin(), src.end(), map.begin(), flg.begin(), dst.begin());
 
-  ASSERT_EQUAL(dst[0], 0);
-  ASSERT_EQUAL(dst[1], 0);
-  ASSERT_EQUAL(dst[2], 0);
-  ASSERT_EQUAL(dst[3], 1);
-  ASSERT_EQUAL(dst[4], 0);
-  ASSERT_EQUAL(dst[5], 0);
-  ASSERT_EQUAL(dst[6], 0);
-  ASSERT_EQUAL(dst[7], 3);
+  Vector ref{0, 0, 0, 1, 0, 0, 0, 3};
+  ASSERT_EQUAL(dst, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestScatterIfSimple);
 

--- a/thrust/testing/sequence.cu
+++ b/thrust/testing/sequence.cu
@@ -45,27 +45,18 @@ void TestSequenceSimple()
 
   thrust::sequence(v.begin(), v.end());
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
-  ASSERT_EQUAL(v[3], 3);
-  ASSERT_EQUAL(v[4], 4);
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::sequence(v.begin(), v.end(), value_type{10});
 
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(v[1], 11);
-  ASSERT_EQUAL(v[2], 12);
-  ASSERT_EQUAL(v[3], 13);
-  ASSERT_EQUAL(v[4], 14);
+  ref = {10, 11, 12, 13, 14};
+  ASSERT_EQUAL(v, ref);
 
   thrust::sequence(v.begin(), v.end(), value_type{10}, value_type{2});
 
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(v[1], 12);
-  ASSERT_EQUAL(v[2], 14);
-  ASSERT_EQUAL(v[3], 16);
-  ASSERT_EQUAL(v[4], 18);
+  ref = {10, 12, 14, 16, 18};
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestSequenceSimple);
 

--- a/thrust/testing/set_difference.cu
+++ b/thrust/testing/set_difference.cu
@@ -53,22 +53,8 @@ void TestSetDifferenceSimple()
 {
   using Iterator = typename Vector::iterator;
 
-  Vector a(4), b(5);
-
-  a[0] = 0;
-  a[1] = 2;
-  a[2] = 4;
-  a[3] = 5;
-  b[0] = 0;
-  b[1] = 3;
-  b[2] = 3;
-  b[3] = 4;
-  b[4] = 6;
-
-  Vector ref(2);
-  ref[0] = 2;
-  ref[1] = 5;
-
+  Vector a{0, 2, 4, 5}, b{0, 3, 3, 4, 6};
+  Vector ref{2, 5};
   Vector result(2);
 
   Iterator end = thrust::set_difference(a.begin(), a.end(), b.begin(), b.end(), result.begin());

--- a/thrust/testing/set_difference_by_key.cu
+++ b/thrust/testing/set_difference_by_key.cu
@@ -82,16 +82,8 @@ void TestSetDifferenceByKeySimple()
 {
   using Iterator = typename Vector::iterator;
 
-  Vector a_key(4), b_key(5);
-  Vector a_val(4), b_val(5);
-
-  // clang-format off
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4; a_key[3] = 5;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0; a_val[3] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4; b_key[4] = 6;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1; b_val[4] = 1;
-  // clang-format on
+  Vector a_key{0, 2, 4, 5}, b_key{0, 3, 3, 4, 6};
+  Vector a_val(4, 0), b_val(5, 1);
 
   Vector ref_key(2), ref_val(2);
   ref_key[0] = 2;

--- a/thrust/testing/set_difference_by_key_descending.cu
+++ b/thrust/testing/set_difference_by_key_descending.cu
@@ -10,22 +10,10 @@ void TestSetDifferenceByKeyDescendingSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector a_key(4), a_val(4);
-  Vector b_key(5), b_val(5);
+  Vector a_key{5, 4, 2, 0}, a_val(4, 0);
+  Vector b_key{6, 4, 3, 3, 0}, b_val(5, 1);
 
-  // clang-format off
-  a_key[0] = 5; a_key[1] = 4; a_key[2] = 2; a_key[3] = 0;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0; a_val[3] = 0;
-
-  b_key[0] = 6; b_key[1] = 4; b_key[2] = 3; b_key[3] = 3; b_key[4] = 0;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1; b_val[4] = 1;
-  // clang-format on
-
-  Vector ref_key(2), ref_val(2);
-  ref_key[0] = 5;
-  ref_key[1] = 2;
-  ref_val[0] = 0;
-  ref_val[1] = 0;
+  Vector ref_key{5, 2}, ref_val{0, 0};
 
   Vector result_key(2), result_val(2);
 

--- a/thrust/testing/set_difference_descending.cu
+++ b/thrust/testing/set_difference_descending.cu
@@ -10,17 +10,9 @@ void TestSetDifferenceDescendingSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector a(4), b(5);
+  Vector a{5, 4, 2, 0}, b{6, 4, 3, 3, 0};
 
-  // clang-format off
-  a[0] = 5; a[1] = 4; a[2] = 2; a[3] = 0;
-  b[0] = 6; b[1] = 4; b[2] = 3; b[3] = 3; b[4] = 0;
-  // clang-format on
-
-  Vector ref(2);
-  ref[0] = 5;
-  ref[1] = 2;
-
+  Vector ref{5, 2};
   Vector result(2);
 
   Iterator end = thrust::set_difference(a.begin(), a.end(), b.begin(), b.end(), result.begin(), thrust::greater<T>());

--- a/thrust/testing/set_intersection.cu
+++ b/thrust/testing/set_intersection.cu
@@ -54,19 +54,8 @@ void TestSetIntersectionSimple()
 {
   using Iterator = typename Vector::iterator;
 
-  Vector a(3), b(4);
-
-  a[0] = 0;
-  a[1] = 2;
-  a[2] = 4;
-  b[0] = 0;
-  b[1] = 3;
-  b[2] = 3;
-  b[3] = 4;
-
-  Vector ref(2);
-  ref[0] = 0;
-  ref[1] = 4;
+  Vector a{0, 2, 4}, b{0, 3, 3, 4};
+  Vector ref{0, 4};
 
   Vector result(2);
 

--- a/thrust/testing/set_intersection_by_key.cu
+++ b/thrust/testing/set_intersection_by_key.cu
@@ -77,20 +77,10 @@ void TestSetIntersectionByKeySimple()
 {
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a_key(3), b_key(4);
-  Vector a_val(3);
+  Vector a_key{0, 2, 4}, b_key{0, 3, 3, 4};
+  Vector a_val(3, 0);
 
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4;
-
-  Vector ref_key(2), ref_val(2);
-  ref_key[0] = 0; ref_key[1] = 4;
-  ref_val[0] = 0; ref_val[1] = 0;
-  // clang-format on
-
+  Vector ref_key{0, 4}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
   thrust::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(

--- a/thrust/testing/set_intersection_by_key_descending.cu
+++ b/thrust/testing/set_intersection_by_key_descending.cu
@@ -10,20 +10,10 @@ void TestSetIntersectionByKeyDescendingSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a_key(3), b_key(4);
-  Vector a_val(3), b_val(4);
+  Vector a_key{4, 2, 0}, b_key{4, 3, 3, 0};
+  Vector a_val(3, 0);
 
-  a_key[0] = 4; a_key[1] = 2; a_key[2] = 0;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0;
-
-  b_key[0] = 4; b_key[1] = 3; b_key[2] = 3; b_key[3] = 0;
-
-  Vector ref_key(2), ref_val(2);
-  ref_key[0] = 4; ref_key[1] = 0;
-  ref_val[0] = 0; ref_val[1] = 0;
-  // clang-format on
-
+  Vector ref_key{4, 0}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
   thrust::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(

--- a/thrust/testing/set_intersection_descending.cu
+++ b/thrust/testing/set_intersection_descending.cu
@@ -10,19 +10,8 @@ void TestSetIntersectionDescendingSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector a(3), b(4);
-
-  a[0] = 4;
-  a[1] = 2;
-  a[2] = 0;
-  b[0] = 4;
-  b[1] = 3;
-  b[2] = 3;
-  b[3] = 0;
-
-  Vector ref(2);
-  ref[0] = 4;
-  ref[1] = 0;
+  Vector a{4, 2, 0}, b{4, 3, 3, 0};
+  Vector ref{4, 0};
 
   Vector result(2);
 

--- a/thrust/testing/set_symmetric_difference.cu
+++ b/thrust/testing/set_symmetric_difference.cu
@@ -53,16 +53,9 @@ void TestSetSymmetricDifferenceSimple()
 {
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a(4), b(5);
+  Vector a{0, 2, 4, 6}, b{0, 3, 3, 4, 7};
 
-  a[0] = 0; a[1] = 2; a[2] = 4; a[3] = 6;
-  b[0] = 0; b[1] = 3; b[2] = 3; b[3] = 4; b[4] = 7;
-
-  Vector ref(5);
-  ref[0] = 2; ref[1] = 3; ref[2] = 3; ref[3] = 6; ref[4] = 7;
-  // clang-format on
-
+  Vector ref{2, 3, 3, 6, 7};
   Vector result(5);
 
   Iterator end = thrust::set_symmetric_difference(a.begin(), a.end(), b.begin(), b.end(), result.begin());

--- a/thrust/testing/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/set_symmetric_difference_by_key.cu
@@ -82,21 +82,10 @@ void TestSetSymmetricDifferenceByKeySimple()
 {
   using Iterator = typename Vector::iterator;
 
-  Vector a_key(4), b_key(5);
-  Vector a_val(4), b_val(5);
+  Vector a_key{0, 2, 4, 6}, b_key{0, 3, 3, 4, 7};
+  Vector a_val(4, 0), b_val(5, 1);
 
-  // clang-format off
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4; a_key[3] = 6;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0; a_val[3] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4; b_key[4] = 7;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1; b_val[4] = 1;
-
-  Vector ref_key(5), ref_val(5);
-  ref_key[0] = 2; ref_key[1] = 3; ref_key[2] = 3; ref_key[3] = 6; ref_key[4] = 7;
-  ref_val[0] = 0; ref_val[1] = 1; ref_val[2] = 1; ref_val[3] = 0; ref_val[4] = 1;
-  // clang-format on
-
+  Vector ref_key{2, 3, 3, 6, 7}, ref_val{0, 1, 1, 0, 1};
   Vector result_key(5), result_val(5);
 
   thrust::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(

--- a/thrust/testing/set_symmetric_difference_by_key_descending.cu
+++ b/thrust/testing/set_symmetric_difference_by_key_descending.cu
@@ -10,21 +10,10 @@ void TestSetSymmetricDifferenceByKeyDescendingSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector a_key(4), b_key(5);
-  Vector a_val(4), b_val(5);
+  Vector a_key{6, 4, 2, 0}, b_key{7, 4, 3, 3, 0};
+  Vector a_val(4, 0), b_val(5, 1);
 
-  // clang-format off
-  a_key[0] = 6; a_key[1] = 4; a_key[2] = 2; a_key[3] = 0;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0; a_val[3] = 0;
-
-  b_key[0] = 7; b_key[1] = 4; b_key[2] = 3; b_key[3] = 3; b_key[4] = 0;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1; b_val[4] = 1;
-
-  Vector ref_key(5), ref_val(5);
-  ref_key[0] = 7; ref_key[1] = 6; ref_key[2] = 3; ref_key[3] = 3; ref_key[4] = 2;
-  ref_val[0] = 1; ref_val[1] = 0; ref_val[2] = 1; ref_val[3] = 1; ref_val[4] = 0;
-  // clang-format on
-
+  Vector ref_key{7, 6, 3, 3, 2}, ref_val{1, 0, 1, 1, 0};
   Vector result_key(5), result_val(5);
 
   thrust::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(

--- a/thrust/testing/set_symmetric_difference_descending.cu
+++ b/thrust/testing/set_symmetric_difference_descending.cu
@@ -10,16 +10,9 @@ void TestSetSymmetricDifferenceDescendingSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a(4), b(5);
+  Vector a{6, 4, 2, 0}, b{7, 4, 3, 3, 0};
 
-  a[0] = 6; a[1] = 4; a[2] = 2; a[3] = 0;
-  b[0] = 7; b[1] = 4; b[2] = 3; b[3] = 3; b[4] = 0;
-
-  Vector ref(5);
-  ref[0] = 7; ref[1] = 6; ref[2] = 3; ref[3] = 3; ref[4] = 2;
-  // clang-format on
-
+  Vector ref{7, 6, 3, 3, 2};
   Vector result(5);
 
   Iterator end =

--- a/thrust/testing/set_union.cu
+++ b/thrust/testing/set_union.cu
@@ -53,23 +53,9 @@ void TestSetUnionSimple()
 {
   using Iterator = typename Vector::iterator;
 
-  Vector a(3), b(4);
+  Vector a{0, 2, 4}, b{0, 3, 3, 4};
 
-  a[0] = 0;
-  a[1] = 2;
-  a[2] = 4;
-  b[0] = 0;
-  b[1] = 3;
-  b[2] = 3;
-  b[3] = 4;
-
-  Vector ref(5);
-  ref[0] = 0;
-  ref[1] = 2;
-  ref[2] = 3;
-  ref[3] = 3;
-  ref[4] = 4;
-
+  Vector ref{0, 2, 3, 3, 4};
   Vector result(5);
 
   Iterator end = thrust::set_union(a.begin(), a.end(), b.begin(), b.end(), result.begin());
@@ -84,24 +70,9 @@ void TestSetUnionWithEquivalentElementsSimple()
 {
   using Iterator = typename Vector::iterator;
 
-  Vector a(3), b(5);
+  Vector a{0, 2, 2}, b{0, 2, 2, 2, 3};
 
-  a[0] = 0;
-  a[1] = 2;
-  a[2] = 2;
-  b[0] = 0;
-  b[1] = 2;
-  b[2] = 2;
-  b[3] = 2;
-  b[4] = 3;
-
-  Vector ref(5);
-  ref[0] = 0;
-  ref[1] = 2;
-  ref[2] = 2;
-  ref[3] = 2;
-  ref[4] = 3;
-
+  Vector ref{0, 2, 2, 2, 3};
   Vector result(5);
 
   Iterator end = thrust::set_union(a.begin(), a.end(), b.begin(), b.end(), result.begin());

--- a/thrust/testing/set_union_by_key.cu
+++ b/thrust/testing/set_union_by_key.cu
@@ -82,21 +82,10 @@ void TestSetUnionByKeySimple()
 {
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector a_key(3), b_key(4);
-  Vector a_val(3), b_val(4);
+  Vector a_key{0, 2, 4}, b_key{0, 3, 3, 4};
+  Vector a_val(3, 0), b_val(4, 1);
 
-  a_key[0] = 0; a_key[1] = 2; a_key[2] = 4;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0;
-
-  b_key[0] = 0; b_key[1] = 3; b_key[2] = 3; b_key[3] = 4;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1;
-
-  Vector ref_key(5), ref_val(5);
-  ref_key[0] = 0; ref_key[1] = 2; ref_key[2] = 3; ref_key[3] = 3; ref_key[4] = 4;
-  ref_val[0] = 0; ref_val[1] = 0; ref_val[2] = 1; ref_val[3] = 1; ref_val[4] = 0;
-  // clang-format on
-
+  Vector ref_key{0, 2, 3, 3, 4}, ref_val{0, 0, 1, 1, 0};
   Vector result_key(5), result_val(5);
 
   thrust::pair<Iterator, Iterator> end = thrust::set_union_by_key(

--- a/thrust/testing/set_union_by_key_descending.cu
+++ b/thrust/testing/set_union_by_key_descending.cu
@@ -10,21 +10,10 @@ void TestSetUnionByKeyDescendingSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector a_key(3), b_key(4);
-  Vector a_val(3), b_val(4);
+  Vector a_key{4, 2, 0}, b_key{4, 3, 3, 0};
+  Vector a_val(3, 0), b_val(4, 1);
 
-  // clang-format off
-  a_key[0] = 4; a_key[1] = 2; a_key[2] = 0;
-  a_val[0] = 0; a_val[1] = 0; a_val[2] = 0;
-
-  b_key[0] = 4; b_key[1] = 3; b_key[2] = 3; b_key[3] = 0;
-  b_val[0] = 1; b_val[1] = 1; b_val[2] = 1; b_val[3] = 1;
-
-  Vector ref_key(5), ref_val(5);
-  ref_key[0] = 4; ref_key[1] = 3; ref_key[2] = 3; ref_key[3] = 2; ref_key[4] = 0;
-  ref_val[0] = 0; ref_val[1] = 1; ref_val[2] = 1; ref_val[3] = 0; ref_val[4] = 0;
-  // clang-format on
-
+  Vector ref_key{4, 3, 3, 2, 0}, ref_val{0, 1, 1, 0, 0};
   Vector result_key(5), result_val(5);
 
   thrust::pair<Iterator, Iterator> end = thrust::set_union_by_key(

--- a/thrust/testing/set_union_descending.cu
+++ b/thrust/testing/set_union_descending.cu
@@ -10,23 +10,9 @@ void TestSetUnionDescendingSimple()
   using T        = typename Vector::value_type;
   using Iterator = typename Vector::iterator;
 
-  Vector a(3), b(4);
+  Vector a{4, 2, 0}, b{4, 3, 3, 0};
 
-  a[0] = 4;
-  a[1] = 2;
-  a[2] = 0;
-  b[0] = 4;
-  b[1] = 3;
-  b[2] = 3;
-  b[3] = 0;
-
-  Vector ref(5);
-  ref[0] = 4;
-  ref[1] = 3;
-  ref[2] = 3;
-  ref[3] = 2;
-  ref[4] = 0;
-
+  Vector ref{4, 3, 3, 2, 0};
   Vector result(5);
 
   Iterator end = thrust::set_union(a.begin(), a.end(), b.begin(), b.end(), result.begin(), thrust::greater<T>());

--- a/thrust/testing/shuffle.cu
+++ b/thrust/testing/shuffle.cu
@@ -391,12 +391,7 @@ constexpr double CephesFunctions::C[];
 template <typename Vector>
 void TestShuffleSimple()
 {
-  Vector data(5);
-  data[0] = 0;
-  data[1] = 1;
-  data[2] = 2;
-  data[3] = 3;
-  data[4] = 4;
+  Vector data{0, 1, 2, 3, 4};
   Vector shuffled(data.begin(), data.end());
   thrust::default_random_engine g(2);
   thrust::shuffle(shuffled.begin(), shuffled.end(), g);
@@ -410,12 +405,7 @@ DECLARE_VECTOR_UNITTEST(TestShuffleSimple);
 template <typename Vector>
 void TestShuffleCopySimple()
 {
-  Vector data(5);
-  data[0] = 0;
-  data[1] = 1;
-  data[2] = 2;
-  data[3] = 3;
-  data[4] = 4;
+  Vector data{0, 1, 2, 3, 4};
   Vector shuffled(5);
   thrust::default_random_engine g(2);
   thrust::shuffle_copy(data.begin(), data.end(), shuffled.begin(), g);

--- a/thrust/testing/sort.cu
+++ b/thrust/testing/sort.cu
@@ -41,22 +41,10 @@ template <class Vector>
 void InitializeSimpleKeySortTest(Vector& unsorted_keys, Vector& sorted_keys)
 {
   unsorted_keys.resize(7);
-  unsorted_keys[0] = 1;
-  unsorted_keys[1] = 3;
-  unsorted_keys[2] = 6;
-  unsorted_keys[3] = 5;
-  unsorted_keys[4] = 2;
-  unsorted_keys[5] = 0;
-  unsorted_keys[6] = 4;
+  unsorted_keys = {1, 3, 6, 5, 2, 0, 4};
 
   sorted_keys.resize(7);
-  sorted_keys[0] = 0;
-  sorted_keys[1] = 1;
-  sorted_keys[2] = 2;
-  sorted_keys[3] = 3;
-  sorted_keys[4] = 4;
-  sorted_keys[5] = 5;
-  sorted_keys[6] = 6;
+  sorted_keys = {0, 1, 2, 3, 4, 5, 6};
 }
 
 template <class Vector>

--- a/thrust/testing/sort_by_key.cu
+++ b/thrust/testing/sort_by_key.cu
@@ -42,27 +42,15 @@ template <class Vector>
 void InitializeSimpleKeyValueSortTest(
   Vector& unsorted_keys, Vector& unsorted_values, Vector& sorted_keys, Vector& sorted_values)
 {
-  // clang-format off
   unsorted_keys.resize(7);
+  unsorted_keys = {1, 3, 6, 5, 2, 0, 4};
   unsorted_values.resize(7);
-  unsorted_keys[0] = 1;  unsorted_values[0] = 0;
-  unsorted_keys[1] = 3;  unsorted_values[1] = 1;
-  unsorted_keys[2] = 6;  unsorted_values[2] = 2;
-  unsorted_keys[3] = 5;  unsorted_values[3] = 3;
-  unsorted_keys[4] = 2;  unsorted_values[4] = 4;
-  unsorted_keys[5] = 0;  unsorted_values[5] = 5;
-  unsorted_keys[6] = 4;  unsorted_values[6] = 6;
+  unsorted_values = {0, 1, 2, 3, 4, 5, 6};
 
   sorted_keys.resize(7);
+  sorted_keys = {0, 1, 2, 3, 4, 5, 6};
   sorted_values.resize(7);
-  sorted_keys[0] = 0;  sorted_values[1] = 0;
-  sorted_keys[1] = 1;  sorted_values[3] = 1;
-  sorted_keys[2] = 2;  sorted_values[6] = 2;
-  sorted_keys[3] = 3;  sorted_values[5] = 3;
-  sorted_keys[4] = 4;  sorted_values[2] = 4;
-  sorted_keys[5] = 5;  sorted_values[0] = 5;
-  sorted_keys[6] = 6;  sorted_values[4] = 6;
-  // clang-format on
+  sorted_values = {5, 0, 4, 1, 6, 3, 2};
 }
 
 template <class Vector>

--- a/thrust/testing/sort_permutation_iterator.cu
+++ b/thrust/testing/sort_permutation_iterator.cu
@@ -61,32 +61,14 @@ void TestSortPermutationIterator()
 {
   using Iterator = typename Vector::iterator;
 
-  Vector A(10);
-  A[0] = 2;
-  A[1] = 9;
-  A[2] = 0;
-  A[3] = 1;
-  A[4] = 5;
-  A[5] = 3;
-  A[6] = 8;
-  A[7] = 6;
-  A[8] = 7;
-  A[9] = 4;
+  Vector A{2, 9, 0, 1, 5, 3, 8, 6, 7, 4};
 
   strided_range<Iterator> S(A.begin(), A.end(), 2);
 
   thrust::sort(S.begin(), S.end());
 
-  ASSERT_EQUAL(A[0], 0);
-  ASSERT_EQUAL(A[1], 9);
-  ASSERT_EQUAL(A[2], 2);
-  ASSERT_EQUAL(A[3], 1);
-  ASSERT_EQUAL(A[4], 5);
-  ASSERT_EQUAL(A[5], 3);
-  ASSERT_EQUAL(A[6], 7);
-  ASSERT_EQUAL(A[7], 6);
-  ASSERT_EQUAL(A[8], 8);
-  ASSERT_EQUAL(A[9], 4);
+  Vector ref{0, 9, 2, 1, 5, 3, 7, 6, 8, 4};
+  ASSERT_EQUAL(A, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestSortPermutationIterator);
 
@@ -95,32 +77,14 @@ void TestStableSortPermutationIterator()
 {
   using Iterator = typename Vector::iterator;
 
-  Vector A(10);
-  A[0] = 2;
-  A[1] = 9;
-  A[2] = 0;
-  A[3] = 1;
-  A[4] = 5;
-  A[5] = 3;
-  A[6] = 8;
-  A[7] = 6;
-  A[8] = 7;
-  A[9] = 4;
+  Vector A{2, 9, 0, 1, 5, 3, 8, 6, 7, 4};
 
   strided_range<Iterator> S(A.begin(), A.end(), 2);
 
   thrust::stable_sort(S.begin(), S.end());
 
-  ASSERT_EQUAL(A[0], 0);
-  ASSERT_EQUAL(A[1], 9);
-  ASSERT_EQUAL(A[2], 2);
-  ASSERT_EQUAL(A[3], 1);
-  ASSERT_EQUAL(A[4], 5);
-  ASSERT_EQUAL(A[5], 3);
-  ASSERT_EQUAL(A[6], 7);
-  ASSERT_EQUAL(A[7], 6);
-  ASSERT_EQUAL(A[8], 8);
-  ASSERT_EQUAL(A[9], 4);
+  Vector ref{0, 9, 2, 1, 5, 3, 7, 6, 8, 4};
+  ASSERT_EQUAL(A, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestStableSortPermutationIterator);
 
@@ -129,46 +93,19 @@ void TestSortByKeyPermutationIterator()
 {
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector A(10), B(10);
-  A[0] = 2; B[0] = 0;
-  A[1] = 9; B[1] = 1;
-  A[2] = 0; B[2] = 2;
-  A[3] = 1; B[3] = 3;
-  A[4] = 5; B[4] = 4;
-  A[5] = 3; B[5] = 5;
-  A[6] = 8; B[6] = 6;
-  A[7] = 6; B[7] = 7;
-  A[8] = 7; B[8] = 8;
-  A[9] = 4; B[9] = 9;
-  // clang-format on
+  Vector A{2, 9, 0, 1, 5, 3, 8, 6, 7, 4};
+  Vector B{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   strided_range<Iterator> S(A.begin(), A.end(), 2);
   strided_range<Iterator> T(B.begin(), B.end(), 2);
 
   thrust::sort_by_key(S.begin(), S.end(), T.begin());
 
-  ASSERT_EQUAL(A[0], 0);
-  ASSERT_EQUAL(A[1], 9);
-  ASSERT_EQUAL(A[2], 2);
-  ASSERT_EQUAL(A[3], 1);
-  ASSERT_EQUAL(A[4], 5);
-  ASSERT_EQUAL(A[5], 3);
-  ASSERT_EQUAL(A[6], 7);
-  ASSERT_EQUAL(A[7], 6);
-  ASSERT_EQUAL(A[8], 8);
-  ASSERT_EQUAL(A[9], 4);
+  Vector ref_A{0, 9, 2, 1, 5, 3, 7, 6, 8, 4};
+  ASSERT_EQUAL(A, ref_A);
 
-  ASSERT_EQUAL(B[0], 2);
-  ASSERT_EQUAL(B[1], 1);
-  ASSERT_EQUAL(B[2], 0);
-  ASSERT_EQUAL(B[3], 3);
-  ASSERT_EQUAL(B[4], 4);
-  ASSERT_EQUAL(B[5], 5);
-  ASSERT_EQUAL(B[6], 8);
-  ASSERT_EQUAL(B[7], 7);
-  ASSERT_EQUAL(B[8], 6);
-  ASSERT_EQUAL(B[9], 9);
+  Vector ref_B{2, 1, 0, 3, 4, 5, 8, 7, 6, 9};
+  ASSERT_EQUAL(B, ref_B);
 }
 DECLARE_VECTOR_UNITTEST(TestSortByKeyPermutationIterator);
 
@@ -177,45 +114,18 @@ void TestStableSortByKeyPermutationIterator()
 {
   using Iterator = typename Vector::iterator;
 
-  // clang-format off
-  Vector A(10), B(10);
-  A[0] = 2; B[0] = 0;
-  A[1] = 9; B[1] = 1;
-  A[2] = 0; B[2] = 2;
-  A[3] = 1; B[3] = 3;
-  A[4] = 5; B[4] = 4;
-  A[5] = 3; B[5] = 5;
-  A[6] = 8; B[6] = 6;
-  A[7] = 6; B[7] = 7;
-  A[8] = 7; B[8] = 8;
-  A[9] = 4; B[9] = 9;
-  // clang-format on
+  Vector A{2, 9, 0, 1, 5, 3, 8, 6, 7, 4};
+  Vector B{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   strided_range<Iterator> S(A.begin(), A.end(), 2);
   strided_range<Iterator> T(B.begin(), B.end(), 2);
 
   thrust::stable_sort_by_key(S.begin(), S.end(), T.begin());
 
-  ASSERT_EQUAL(A[0], 0);
-  ASSERT_EQUAL(A[1], 9);
-  ASSERT_EQUAL(A[2], 2);
-  ASSERT_EQUAL(A[3], 1);
-  ASSERT_EQUAL(A[4], 5);
-  ASSERT_EQUAL(A[5], 3);
-  ASSERT_EQUAL(A[6], 7);
-  ASSERT_EQUAL(A[7], 6);
-  ASSERT_EQUAL(A[8], 8);
-  ASSERT_EQUAL(A[9], 4);
+  Vector ref_A{0, 9, 2, 1, 5, 3, 7, 6, 8, 4};
+  ASSERT_EQUAL(A, ref_A);
 
-  ASSERT_EQUAL(B[0], 2);
-  ASSERT_EQUAL(B[1], 1);
-  ASSERT_EQUAL(B[2], 0);
-  ASSERT_EQUAL(B[3], 3);
-  ASSERT_EQUAL(B[4], 4);
-  ASSERT_EQUAL(B[5], 5);
-  ASSERT_EQUAL(B[6], 8);
-  ASSERT_EQUAL(B[7], 7);
-  ASSERT_EQUAL(B[8], 6);
-  ASSERT_EQUAL(B[9], 9);
+  Vector ref_B{2, 1, 0, 3, 4, 5, 8, 7, 6, 9};
+  ASSERT_EQUAL(B, ref_B);
 }
 DECLARE_VECTOR_UNITTEST(TestStableSortByKeyPermutationIterator);

--- a/thrust/testing/stable_sort.cu
+++ b/thrust/testing/stable_sort.cu
@@ -50,26 +50,10 @@ template <class Vector>
 void InitializeSimpleStableKeySortTest(Vector& unsorted_keys, Vector& sorted_keys)
 {
   unsorted_keys.resize(9);
-  unsorted_keys[0] = 25;
-  unsorted_keys[1] = 14;
-  unsorted_keys[2] = 35;
-  unsorted_keys[3] = 16;
-  unsorted_keys[4] = 26;
-  unsorted_keys[5] = 34;
-  unsorted_keys[6] = 36;
-  unsorted_keys[7] = 24;
-  unsorted_keys[8] = 15;
+  unsorted_keys = {25, 14, 35, 16, 26, 34, 36, 24, 15};
 
   sorted_keys.resize(9);
-  sorted_keys[0] = 14;
-  sorted_keys[1] = 16;
-  sorted_keys[2] = 15;
-  sorted_keys[3] = 25;
-  sorted_keys[4] = 26;
-  sorted_keys[5] = 24;
-  sorted_keys[6] = 35;
-  sorted_keys[7] = 34;
-  sorted_keys[8] = 36;
+  sorted_keys = {14, 16, 15, 25, 26, 24, 35, 34, 36};
 }
 
 template <class Vector>
@@ -142,31 +126,12 @@ void TestStableSortWithIndirection()
   // add numbers modulo 3 with external lookup table
   using T = typename Vector::value_type;
 
-  Vector data(7);
-  data[0] = 1;
-  data[1] = 3;
-  data[2] = 5;
-  data[3] = 3;
-  data[4] = 0;
-  data[5] = 2;
-  data[6] = 1;
-
-  Vector table(6);
-  table[0] = 0;
-  table[1] = 1;
-  table[2] = 2;
-  table[3] = 0;
-  table[4] = 1;
-  table[5] = 2;
+  Vector data{1, 3, 5, 3, 0, 2, 1};
+  Vector table{0, 1, 2, 0, 1, 2};
 
   thrust::stable_sort(data.begin(), data.end(), comp_mod3<T>(thrust::raw_pointer_cast(&table[0])));
 
-  ASSERT_EQUAL(data[0], T(3));
-  ASSERT_EQUAL(data[1], T(3));
-  ASSERT_EQUAL(data[2], T(0));
-  ASSERT_EQUAL(data[3], T(1));
-  ASSERT_EQUAL(data[4], T(1));
-  ASSERT_EQUAL(data[5], T(5));
-  ASSERT_EQUAL(data[6], T(2));
+  Vector ref{3, 3, 0, 1, 1, 5, 2};
+  ASSERT_EQUAL(data, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestStableSortWithIndirection);

--- a/thrust/testing/stable_sort_by_key.cu
+++ b/thrust/testing/stable_sort_by_key.cu
@@ -51,31 +51,15 @@ template <class Vector>
 void InitializeSimpleStableKeyValueSortTest(
   Vector& unsorted_keys, Vector& unsorted_values, Vector& sorted_keys, Vector& sorted_values)
 {
-  // clang-format off
   unsorted_keys.resize(9);
+  unsorted_keys = {25, 14, 35, 16, 26, 34, 36, 24, 15};
   unsorted_values.resize(9);
-  unsorted_keys[0] = 25;   unsorted_values[0] = 0;
-  unsorted_keys[1] = 14;   unsorted_values[1] = 1;
-  unsorted_keys[2] = 35;   unsorted_values[2] = 2;
-  unsorted_keys[3] = 16;   unsorted_values[3] = 3;
-  unsorted_keys[4] = 26;   unsorted_values[4] = 4;
-  unsorted_keys[5] = 34;   unsorted_values[5] = 5;
-  unsorted_keys[6] = 36;   unsorted_values[6] = 6;
-  unsorted_keys[7] = 24;   unsorted_values[7] = 7;
-  unsorted_keys[8] = 15;   unsorted_values[8] = 8;
+  unsorted_values = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 
   sorted_keys.resize(9);
+  sorted_keys = {14, 16, 15, 25, 26, 24, 35, 34, 36};
   sorted_values.resize(9);
-  sorted_keys[0] = 14;   sorted_values[0] = 1;
-  sorted_keys[1] = 16;   sorted_values[1] = 3;
-  sorted_keys[2] = 15;   sorted_values[2] = 8;
-  sorted_keys[3] = 25;   sorted_values[3] = 0;
-  sorted_keys[4] = 26;   sorted_values[4] = 4;
-  sorted_keys[5] = 24;   sorted_values[5] = 7;
-  sorted_keys[6] = 35;   sorted_values[6] = 2;
-  sorted_keys[7] = 34;   sorted_values[7] = 5;
-  sorted_keys[8] = 36;   sorted_values[8] = 6;
-  // clang-format on
+  sorted_values = {1, 3, 8, 0, 4, 7, 2, 5, 6};
 }
 
 template <class Vector>

--- a/thrust/testing/swap_ranges.cu
+++ b/thrust/testing/swap_ranges.cu
@@ -44,33 +44,16 @@ DECLARE_UNITTEST(TestSwapRangesDispatchImplicit);
 template <class Vector>
 void TestSwapRangesSimple()
 {
-  Vector v1(5);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
-  v1[3] = 3;
-  v1[4] = 4;
-
-  Vector v2(5);
-  v2[0] = 5;
-  v2[1] = 6;
-  v2[2] = 7;
-  v2[3] = 8;
-  v2[4] = 9;
+  Vector v1{0, 1, 2, 3, 4};
+  Vector v2{5, 6, 7, 8, 9};
 
   thrust::swap_ranges(v1.begin(), v1.end(), v2.begin());
 
-  ASSERT_EQUAL(v1[0], 5);
-  ASSERT_EQUAL(v1[1], 6);
-  ASSERT_EQUAL(v1[2], 7);
-  ASSERT_EQUAL(v1[3], 8);
-  ASSERT_EQUAL(v1[4], 9);
+  Vector ref1{5, 6, 7, 8, 9};
+  ASSERT_EQUAL(v1, ref1);
 
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
-  ASSERT_EQUAL(v2[3], 3);
-  ASSERT_EQUAL(v2[4], 4);
+  Vector ref2{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v2, ref2);
 }
 DECLARE_VECTOR_UNITTEST(TestSwapRangesSimple);
 

--- a/thrust/testing/tabulate.cu
+++ b/thrust/testing/tabulate.cu
@@ -48,27 +48,18 @@ void TestTabulateSimple()
 
   thrust::tabulate(v.begin(), v.end(), thrust::identity<T>());
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
-  ASSERT_EQUAL(v[3], 3);
-  ASSERT_EQUAL(v[4], 4);
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::tabulate(v.begin(), v.end(), -_1);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], -1);
-  ASSERT_EQUAL(v[2], -2);
-  ASSERT_EQUAL(v[3], -3);
-  ASSERT_EQUAL(v[4], -4);
+  ref = {0, -1, -2, -3, -4};
+  ASSERT_EQUAL(v, ref);
 
   thrust::tabulate(v.begin(), v.end(), _1 * _1 * _1);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 8);
-  ASSERT_EQUAL(v[3], 27);
-  ASSERT_EQUAL(v[4], 64);
+  ref = {0, 1, 8, 27, 64};
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestTabulateSimple);
 

--- a/thrust/testing/tabulate_output_iterator.cu
+++ b/thrust/testing/tabulate_output_iterator.cu
@@ -129,22 +129,16 @@ void TestTabulateOutputIterator()
   thrust::tabulate_output_iterator<op_t> tabulate_out_it{op_t{out.begin()}};
 
   tabulate_out_it[1] = 2;
-  ASSERT_EQUAL(out[0], 42);
-  ASSERT_EQUAL(out[1], 2);
-  ASSERT_EQUAL(out[2], 42);
-  ASSERT_EQUAL(out[3], 42);
+  vector_t ref{42, 2, 42, 42};
+  ASSERT_EQUAL(out, ref);
 
   tabulate_out_it[3] = 0;
-  ASSERT_EQUAL(out[0], 42);
-  ASSERT_EQUAL(out[1], 2);
-  ASSERT_EQUAL(out[2], 42);
-  ASSERT_EQUAL(out[3], 0);
+  ref                = {42, 2, 42, 0};
+  ASSERT_EQUAL(out, ref);
 
   tabulate_out_it[1] = 4;
-  ASSERT_EQUAL(out[0], 42);
-  ASSERT_EQUAL(out[1], 4);
-  ASSERT_EQUAL(out[2], 42);
-  ASSERT_EQUAL(out[3], 0);
+  ref                = {42, 4, 42, 0};
+  ASSERT_EQUAL(out, ref);
 }
 
 DECLARE_UNITTEST(TestTabulateOutputIterator);

--- a/thrust/testing/transform.cu
+++ b/thrust/testing/transform.cu
@@ -23,15 +23,9 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformUnarySimple()
 
   typename Vector::iterator iter;
 
-  Vector input(3);
+  Vector input{1, -2, 3};
   Vector output(3);
-  Vector result(3);
-  input[0]  = 1;
-  input[1]  = -2;
-  input[2]  = 3;
-  result[0] = -1;
-  result[1] = 2;
-  result[2] = -3;
+  Vector result{-1, 2, -3};
 
   iter = thrust::transform(input.begin(), input.end(), output.begin(), thrust::negate<T>());
 
@@ -83,15 +77,9 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfUnaryNoStencilSimple()
 
   typename Vector::iterator iter;
 
-  Vector input(3);
-  Vector output(3);
-  Vector result(3);
-
-  // clang-format off
-  input[0]   =  0; input[1]   = -2; input[2]   =  0;
-  output[0]  = -1; output[1]  = -2; output[2]  = -3;
-  result[0]  = -1; result[1]  =  2; result[2]  = -3;
-  // clang-format on
+  Vector input{0, -2, 0};
+  Vector output{-1, -2, -3};
+  Vector result{-1, 2, -3};
 
   iter = thrust::transform_if(input.begin(), input.end(), output.begin(), thrust::negate<T>(), thrust::identity<T>());
 
@@ -148,17 +136,10 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfUnarySimple()
 
   typename Vector::iterator iter;
 
-  Vector input(3);
-  Vector stencil(3);
-  Vector output(3);
-  Vector result(3);
-
-  // clang-format off
-  input[0]   =  1; input[1]   = -2; input[2]   =  3;
-  output[0]  =  1; output[1]  =  2; output[2]  =  3;
-  stencil[0] =  1; stencil[1] =  0; stencil[2] =  1;
-  result[0]  = -1; result[1]  =  2; result[2]  = -3;
-  // clang-format on
+  Vector input{1, -2, 3};
+  Vector stencil{1, 0, 1};
+  Vector output{1, 2, 3};
+  Vector result{-1, 2, -3};
 
   iter = thrust::transform_if(
     input.begin(), input.end(), stencil.begin(), output.begin(), thrust::negate<T>(), thrust::identity<T>());
@@ -223,16 +204,10 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformBinarySimple()
   // There is a strange gcc bug here where it belives we would write out of bounds.
   // It seems to go away if we add one more element that we leave untouched. Luckily 0 - 0 = 0 so all is fine.
   // Note that we still write the element, so it does not hide a functional thrust bug
-  Vector input1(4);
-  Vector input2(4);
-  Vector output(4);
-  Vector result(4);
-
-  // clang-format off
-  input1[0] =  1; input1[1] = -2; input1[2] =  3;
-  input2[0] = -4; input2[1] =  5; input2[2] =  6;
-  result[0] =  5; result[1] = -7; result[2] = -3;
-  // clang-format on
+  Vector input1{1, -2, 3};
+  Vector input2{-4, 5, 6};
+  Vector output(3);
+  Vector result{5, -7, -3};
 
   iter = thrust::transform(input1.begin(), input1.end(), input2.begin(), output.begin(), thrust::minus<T>());
 
@@ -289,19 +264,11 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformIfBinarySimple()
 
   typename Vector::iterator iter;
 
-  Vector input1(3);
-  Vector input2(3);
-  Vector stencil(3);
-  Vector output(3);
-  Vector result(3);
-
-  // clang-format off
-  input1[0]  =  1; input1[1]  = -2; input1[2]  =  3;
-  input2[0]  = -4; input2[1]  =  5; input2[2]  =  6;
-  stencil[0] =  0; stencil[1] =  1; stencil[2] =  0;
-  output[0]  =  1; output[1]  =  2; output[2]  =  3;
-  result[0]  =  5; result[1]  =  2; result[2]  = -3;
-  // clang-format on
+  Vector input1{1, -2, 3};
+  Vector input2{-4, 5, 6};
+  Vector stencil{0, 1, 0};
+  Vector output{1, 2, 3};
+  Vector result{5, 2, -3};
 
   thrust::identity<T> identity;
 
@@ -768,37 +735,16 @@ THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestTransformWithIndirection()
   // add numbers modulo 3 with external lookup table
   using T = typename Vector::value_type;
 
-  Vector input1(7);
-  Vector input2(7);
+  Vector input1{0, 1, 2, 1, 2, 0, 1};
+  Vector input2{2, 2, 2, 0, 2, 1, 0};
   Vector output(7, 0);
 
-  // clang-format off
-  input1[0] = 0;  input2[0] = 2;
-  input1[1] = 1;  input2[1] = 2;
-  input1[2] = 2;  input2[2] = 2;
-  input1[3] = 1;  input2[3] = 0;
-  input1[4] = 2;  input2[4] = 2;
-  input1[5] = 0;  input2[5] = 1;
-  input1[6] = 1;  input2[6] = 0;
-  // clang-format on
-
-  Vector table(6);
-  table[0] = 0;
-  table[1] = 1;
-  table[2] = 2;
-  table[3] = 0;
-  table[4] = 1;
-  table[5] = 2;
+  Vector table{0, 1, 2, 0, 1, 2};
 
   thrust::transform(
     input1.begin(), input1.end(), input2.begin(), output.begin(), plus_mod3<T>(thrust::raw_pointer_cast(&table[0])));
 
-  ASSERT_EQUAL(output[0], T(2));
-  ASSERT_EQUAL(output[1], T(0));
-  ASSERT_EQUAL(output[2], T(1));
-  ASSERT_EQUAL(output[3], T(1));
-  ASSERT_EQUAL(output[4], T(1));
-  ASSERT_EQUAL(output[5], T(1));
-  ASSERT_EQUAL(output[6], T(1));
+  Vector ref{2, 0, 1, 1, 1, 1, 1};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestTransformWithIndirection);

--- a/thrust/testing/transform_input_output_iterator.cu
+++ b/thrust/testing/transform_input_output_iterator.cu
@@ -30,22 +30,14 @@ void TestTransformInputOutputIterator()
   // transform_iter writes squared value
   thrust::copy(input.begin(), input.end(), transform_iter);
 
-  Vector gold_squared(4);
-  gold_squared[0] = 1;
-  gold_squared[1] = 4;
-  gold_squared[2] = 9;
-  gold_squared[3] = 16;
+  Vector gold_squared{1, 4, 9, 16};
 
   ASSERT_EQUAL(squared, gold_squared);
 
   // negated value read from transform_iter
   thrust::copy_n(transform_iter, squared.size(), negated.begin());
 
-  Vector gold_negated(4);
-  gold_negated[0] = -1;
-  gold_negated[1] = -4;
-  gold_negated[2] = -9;
-  gold_negated[3] = -16;
+  Vector gold_negated{-1, -4, -9, -16};
 
   ASSERT_EQUAL(negated, gold_negated);
 }
@@ -71,11 +63,7 @@ void TestMakeTransformInputOutputIterator()
                  input.size(),
                  negated.begin());
 
-  Vector gold_negated(4);
-  gold_negated[0] = -1;
-  gold_negated[1] = -2;
-  gold_negated[2] = -3;
-  gold_negated[3] = -4;
+  Vector gold_negated{-1, -2, -3, -4};
 
   ASSERT_EQUAL(negated, gold_negated);
 
@@ -84,11 +72,7 @@ void TestMakeTransformInputOutputIterator()
                negated.end(),
                thrust::make_transform_input_output_iterator(squared.begin(), InputFunction(), OutputFunction()));
 
-  Vector gold_squared(4);
-  gold_squared[0] = 1;
-  gold_squared[1] = 4;
-  gold_squared[2] = 9;
-  gold_squared[3] = 16;
+  Vector gold_squared{1, 4, 9, 16};
 
   ASSERT_EQUAL(squared, gold_squared);
 }

--- a/thrust/testing/transform_iterator.cu
+++ b/thrust/testing/transform_iterator.cu
@@ -29,10 +29,8 @@ void TestTransformIterator()
 
   thrust::copy(iter, iter + 4, output.begin());
 
-  ASSERT_EQUAL(output[0], -1);
-  ASSERT_EQUAL(output[1], -2);
-  ASSERT_EQUAL(output[2], -3);
-  ASSERT_EQUAL(output[3], -4);
+  Vector ref{-1, -2, -3, -4};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestTransformIterator);
 
@@ -57,10 +55,8 @@ void TestMakeTransformIterator()
                thrust::make_transform_iterator(input.end(), UnaryFunction()),
                output.begin());
 
-  ASSERT_EQUAL(output[0], -1);
-  ASSERT_EQUAL(output[1], -2);
-  ASSERT_EQUAL(output[2], -3);
-  ASSERT_EQUAL(output[3], -4);
+  Vector ref{-1, -2, -3, -4};
+  ASSERT_EQUAL(output, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestMakeTransformIterator);
 

--- a/thrust/testing/transform_output_iterator.cu
+++ b/thrust/testing/transform_output_iterator.cu
@@ -28,11 +28,7 @@ void TestTransformOutputIterator()
 
   thrust::copy(input.begin(), input.end(), output_iter);
 
-  Vector gold_output(4);
-  gold_output[0] = 1;
-  gold_output[1] = 4;
-  gold_output[2] = 9;
-  gold_output[3] = 16;
+  Vector gold_output{1, 4, 9, 16};
 
   ASSERT_EQUAL(output, gold_output);
 }
@@ -53,11 +49,7 @@ void TestMakeTransformOutputIterator()
 
   thrust::copy(input.begin(), input.end(), thrust::make_transform_output_iterator(output.begin(), UnaryFunction()));
 
-  Vector gold_output(4);
-  gold_output[0] = 1;
-  gold_output[1] = 4;
-  gold_output[2] = 9;
-  gold_output[3] = 16;
+  Vector gold_output{1, 4, 9, 16};
   ASSERT_EQUAL(output, gold_output);
 }
 DECLARE_VECTOR_UNITTEST(TestMakeTransformOutputIterator);

--- a/thrust/testing/transform_reduce.cu
+++ b/thrust/testing/transform_reduce.cu
@@ -46,10 +46,7 @@ void TestTransformReduceSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(3);
-  data[0] = 1;
-  data[1] = -2;
-  data[2] = 3;
+  Vector data{1, -2, 3};
 
   T init   = 10;
   T result = thrust::transform_reduce(data.begin(), data.end(), thrust::negate<T>(), init, thrust::plus<T>());

--- a/thrust/testing/trivial_sequence.cu
+++ b/thrust/testing/trivial_sequence.cu
@@ -33,32 +33,16 @@ void test(Iterator first, Iterator last)
 template <class Vector>
 void TestTrivialSequence()
 {
-  Vector A(5);
-  A[0] = 0;
-  A[1] = 2;
-  A[2] = 1;
-  A[3] = 0;
-  A[4] = 1;
-  Vector B(5);
-  B[0] = 11;
-  B[1] = 11;
-  B[2] = 13;
-  B[3] = 10;
-  B[4] = 12;
+  Vector A{0, 2, 1, 0, 1};
+  Vector B{11, 11, 13, 10, 12};
 
   test(thrust::make_zip_iterator(thrust::make_tuple(A.begin(), B.begin())),
        thrust::make_zip_iterator(thrust::make_tuple(A.end(), B.end())));
 
+  Vector refA{0, 2, 1, 0, 1};
+  ASSERT_EQUAL(A, refA);
   // ensure that values weren't modified
-  ASSERT_EQUAL(A[0], 0);
-  ASSERT_EQUAL(B[0], 11);
-  ASSERT_EQUAL(A[1], 2);
-  ASSERT_EQUAL(B[1], 11);
-  ASSERT_EQUAL(A[2], 1);
-  ASSERT_EQUAL(B[2], 13);
-  ASSERT_EQUAL(A[3], 0);
-  ASSERT_EQUAL(B[3], 10);
-  ASSERT_EQUAL(A[4], 1);
-  ASSERT_EQUAL(B[4], 12);
+  Vector refB{11, 11, 13, 10, 12};
+  ASSERT_EQUAL(B, refB);
 }
 DECLARE_VECTOR_UNITTEST(TestTrivialSequence);

--- a/thrust/testing/uninitialized_copy.cu
+++ b/thrust/testing/uninitialized_copy.cu
@@ -79,42 +79,26 @@ DECLARE_UNITTEST(TestUninitializedCopyNDispatchImplicit);
 template <class Vector>
 void TestUninitializedCopySimplePOD()
 {
-  Vector v1(5);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
-  v1[3] = 3;
-  v1[4] = 4;
+  Vector v1{0, 1, 2, 3, 4};
 
   // copy to Vector
   Vector v2(5);
   thrust::uninitialized_copy(v1.begin(), v1.end(), v2.begin());
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
-  ASSERT_EQUAL(v2[3], 3);
-  ASSERT_EQUAL(v2[4], 4);
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v2, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestUninitializedCopySimplePOD);
 
 template <typename Vector>
 void TestUninitializedCopyNSimplePOD()
 {
-  Vector v1(5);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
-  v1[3] = 3;
-  v1[4] = 4;
+  Vector v1{0, 1, 2, 3, 4};
 
   // copy to Vector
   Vector v2(5);
   thrust::uninitialized_copy_n(v1.begin(), v1.size(), v2.begin());
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
-  ASSERT_EQUAL(v2[3], 3);
-  ASSERT_EQUAL(v2[4], 4);
+  Vector ref{0, 1, 2, 3, 4};
+  ASSERT_EQUAL(v2, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestUninitializedCopyNSimplePOD);
 

--- a/thrust/testing/uninitialized_fill.cu
+++ b/thrust/testing/uninitialized_fill.cu
@@ -79,52 +79,35 @@ void TestUninitializedFillPOD()
 {
   using T = typename Vector::value_type;
 
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   T exemplar(7);
 
   thrust::uninitialized_fill(v.begin() + 1, v.begin() + 4, exemplar);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], exemplar);
-  ASSERT_EQUAL(v[2], exemplar);
-  ASSERT_EQUAL(v[3], exemplar);
-  ASSERT_EQUAL(v[4], 4);
+  Vector ref{0, exemplar, exemplar, exemplar, 4};
+  ASSERT_EQUAL(v, ref);
 
   exemplar = 8;
 
   thrust::uninitialized_fill(v.begin() + 0, v.begin() + 3, exemplar);
 
-  ASSERT_EQUAL(v[0], exemplar);
-  ASSERT_EQUAL(v[1], exemplar);
-  ASSERT_EQUAL(v[2], exemplar);
-  ASSERT_EQUAL(v[3], 7);
-  ASSERT_EQUAL(v[4], 4);
+  ref = {exemplar, exemplar, exemplar, 7, 4};
+  ASSERT_EQUAL(v, ref);
 
   exemplar = 9;
 
   thrust::uninitialized_fill(v.begin() + 2, v.end(), exemplar);
 
-  ASSERT_EQUAL(v[0], 8);
-  ASSERT_EQUAL(v[1], 8);
-  ASSERT_EQUAL(v[2], exemplar);
-  ASSERT_EQUAL(v[3], exemplar);
-  ASSERT_EQUAL(v[4], 9);
+  ref = {8, 8, exemplar, exemplar, 9};
+  ASSERT_EQUAL(v, ref);
 
   exemplar = 1;
 
   thrust::uninitialized_fill(v.begin(), v.end(), exemplar);
 
-  ASSERT_EQUAL(v[0], exemplar);
-  ASSERT_EQUAL(v[1], exemplar);
-  ASSERT_EQUAL(v[2], exemplar);
-  ASSERT_EQUAL(v[3], exemplar);
-  ASSERT_EQUAL(v[4], exemplar);
+  ref = {exemplar, exemplar, exemplar, exemplar, exemplar};
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestUninitializedFillPOD);
 
@@ -189,55 +172,34 @@ void TestUninitializedFillNPOD()
 {
   using T = typename Vector::value_type;
 
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   T exemplar(7);
 
   typename Vector::iterator iter = thrust::uninitialized_fill_n(v.begin() + 1, 3, exemplar);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], exemplar);
-  ASSERT_EQUAL(v[2], exemplar);
-  ASSERT_EQUAL(v[3], exemplar);
-  ASSERT_EQUAL(v[4], 4);
+  Vector ref{0, exemplar, exemplar, exemplar, 4};
   ASSERT_EQUAL_QUIET(v.begin() + 4, iter);
 
   exemplar = 8;
 
   iter = thrust::uninitialized_fill_n(v.begin() + 0, 3, exemplar);
 
-  ASSERT_EQUAL(v[0], exemplar);
-  ASSERT_EQUAL(v[1], exemplar);
-  ASSERT_EQUAL(v[2], exemplar);
-  ASSERT_EQUAL(v[3], 7);
-  ASSERT_EQUAL(v[4], 4);
+  ref = {exemplar, exemplar, exemplar, 7, 4};
   ASSERT_EQUAL_QUIET(v.begin() + 3, iter);
 
   exemplar = 9;
 
   iter = thrust::uninitialized_fill_n(v.begin() + 2, 3, exemplar);
 
-  ASSERT_EQUAL(v[0], 8);
-  ASSERT_EQUAL(v[1], 8);
-  ASSERT_EQUAL(v[2], exemplar);
-  ASSERT_EQUAL(v[3], exemplar);
-  ASSERT_EQUAL(v[4], 9);
+  ref = {8, 8, exemplar, exemplar, 9};
   ASSERT_EQUAL_QUIET(v.end(), iter);
 
   exemplar = 1;
 
   iter = thrust::uninitialized_fill_n(v.begin(), v.size(), exemplar);
 
-  ASSERT_EQUAL(v[0], exemplar);
-  ASSERT_EQUAL(v[1], exemplar);
-  ASSERT_EQUAL(v[2], exemplar);
-  ASSERT_EQUAL(v[3], exemplar);
-  ASSERT_EQUAL(v[4], exemplar);
+  ref = {exemplar, exemplar, exemplar, exemplar, exemplar};
   ASSERT_EQUAL_QUIET(v.end(), iter);
 }
 DECLARE_VECTOR_UNITTEST(TestUninitializedFillNPOD);

--- a/thrust/testing/unique.cu
+++ b/thrust/testing/unique.cu
@@ -125,37 +125,24 @@ void TestUniqueSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(10);
-  data[0] = 11;
-  data[1] = 11;
-  data[2] = 12;
-  data[3] = 20;
-  data[4] = 29;
-  data[5] = 21;
-  data[6] = 21;
-  data[7] = 31;
-  data[8] = 31;
-  data[9] = 37;
+  Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
   typename Vector::iterator new_last;
 
   new_last = thrust::unique(data.begin(), data.end());
 
   ASSERT_EQUAL(new_last - data.begin(), 7);
-  ASSERT_EQUAL(data[0], 11);
-  ASSERT_EQUAL(data[1], 12);
-  ASSERT_EQUAL(data[2], 20);
-  ASSERT_EQUAL(data[3], 29);
-  ASSERT_EQUAL(data[4], 21);
-  ASSERT_EQUAL(data[5], 31);
-  ASSERT_EQUAL(data[6], 37);
+  data.resize(7);
+  Vector ref{11, 12, 20, 29, 21, 31, 37};
+  ASSERT_EQUAL(data, ref);
 
   new_last = thrust::unique(data.begin(), new_last, is_equal_div_10_unique<T>());
 
   ASSERT_EQUAL(new_last - data.begin(), 3);
-  ASSERT_EQUAL(data[0], 11);
-  ASSERT_EQUAL(data[1], 20);
-  ASSERT_EQUAL(data[2], 31);
+  ref.resize(3);
+  data.resize(3);
+  ref = {11, 20, 31};
+  ASSERT_EQUAL(data, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestUniqueSimple);
 
@@ -188,18 +175,7 @@ void TestUniqueCopySimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(10);
-  data[0] = 11;
-  data[1] = 11;
-  data[2] = 12;
-  data[3] = 20;
-  data[4] = 29;
-  data[5] = 21;
-  data[6] = 21;
-  data[7] = 31;
-  data[8] = 31;
-  data[9] = 37;
-
+  Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
   Vector output(10, -1);
 
   typename Vector::iterator new_last;
@@ -207,20 +183,17 @@ void TestUniqueCopySimple()
   new_last = thrust::unique_copy(data.begin(), data.end(), output.begin());
 
   ASSERT_EQUAL(new_last - output.begin(), 7);
-  ASSERT_EQUAL(output[0], 11);
-  ASSERT_EQUAL(output[1], 12);
-  ASSERT_EQUAL(output[2], 20);
-  ASSERT_EQUAL(output[3], 29);
-  ASSERT_EQUAL(output[4], 21);
-  ASSERT_EQUAL(output[5], 31);
-  ASSERT_EQUAL(output[6], 37);
+  output.resize(7);
+  Vector ref{11, 12, 20, 29, 21, 31, 37};
+  ASSERT_EQUAL(output, ref);
 
   new_last = thrust::unique_copy(output.begin(), new_last, data.begin(), is_equal_div_10_unique<T>());
 
   ASSERT_EQUAL(new_last - data.begin(), 3);
-  ASSERT_EQUAL(data[0], 11);
-  ASSERT_EQUAL(data[1], 20);
-  ASSERT_EQUAL(data[2], 31);
+  ref.resize(3);
+  data.resize(3);
+  ref = {11, 20, 31};
+  ASSERT_EQUAL(data, ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestUniqueCopySimple);
 
@@ -284,17 +257,7 @@ void TestUniqueCountSimple()
 {
   using T = typename Vector::value_type;
 
-  Vector data(10);
-  data[0] = 11;
-  data[1] = 11;
-  data[2] = 12;
-  data[3] = 20;
-  data[4] = 29;
-  data[5] = 21;
-  data[6] = 21;
-  data[7] = 31;
-  data[8] = 31;
-  data[9] = 37;
+  Vector data{11, 11, 12, 20, 29, 21, 21, 31, 31, 37};
 
   int count = thrust::unique_count(data.begin(), data.end());
 

--- a/thrust/testing/unique_by_key.cu
+++ b/thrust/testing/unique_by_key.cu
@@ -120,30 +120,14 @@ template <typename Vector>
 void initialize_keys(Vector& keys)
 {
   keys.resize(9);
-  keys[0] = 11;
-  keys[1] = 11;
-  keys[2] = 21;
-  keys[3] = 20;
-  keys[4] = 21;
-  keys[5] = 21;
-  keys[6] = 21;
-  keys[7] = 37;
-  keys[8] = 37;
+  keys = {11, 11, 21, 20, 21, 21, 21, 37, 37};
 }
 
 template <typename Vector>
 void initialize_values(Vector& values)
 {
   values.resize(9);
-  values[0] = 0;
-  values[1] = 1;
-  values[2] = 2;
-  values[3] = 3;
-  values[4] = 4;
-  values[5] = 5;
-  values[6] = 6;
-  values[7] = 7;
-  values[8] = 8;
+  values = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 }
 
 template <typename Vector>
@@ -164,17 +148,13 @@ void TestUniqueByKeySimple()
 
   ASSERT_EQUAL(new_last.first - keys.begin(), 5);
   ASSERT_EQUAL(new_last.second - values.begin(), 5);
-  ASSERT_EQUAL(keys[0], 11);
-  ASSERT_EQUAL(keys[1], 21);
-  ASSERT_EQUAL(keys[2], 20);
-  ASSERT_EQUAL(keys[3], 21);
-  ASSERT_EQUAL(keys[4], 37);
+  keys.resize(5);
+  values.resize(5);
+  Vector keys_ref{11, 21, 20, 21, 37};
+  ASSERT_EQUAL(keys, keys_ref);
 
-  ASSERT_EQUAL(values[0], 0);
-  ASSERT_EQUAL(values[1], 2);
-  ASSERT_EQUAL(values[2], 3);
-  ASSERT_EQUAL(values[3], 4);
-  ASSERT_EQUAL(values[4], 7);
+  Vector values_ref{0, 2, 3, 4, 7};
+  ASSERT_EQUAL(values, values_ref);
 
   // test BinaryPredicate
   initialize_keys(keys);
@@ -184,13 +164,15 @@ void TestUniqueByKeySimple()
 
   ASSERT_EQUAL(new_last.first - keys.begin(), 3);
   ASSERT_EQUAL(new_last.second - values.begin(), 3);
-  ASSERT_EQUAL(keys[0], 11);
-  ASSERT_EQUAL(keys[1], 21);
-  ASSERT_EQUAL(keys[2], 37);
+  keys_ref.resize(3);
+  keys.resize(3);
+  keys_ref = {11, 21, 37};
+  ASSERT_EQUAL(keys, keys_ref);
 
-  ASSERT_EQUAL(values[0], 0);
-  ASSERT_EQUAL(values[1], 2);
-  ASSERT_EQUAL(values[2], 7);
+  values.resize(3);
+  values_ref.resize(3);
+  values_ref = {0, 2, 7};
+  ASSERT_EQUAL(values, values_ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestUniqueByKeySimple);
 
@@ -216,17 +198,13 @@ void TestUniqueCopyByKeySimple()
 
   ASSERT_EQUAL(new_last.first - output_keys.begin(), 5);
   ASSERT_EQUAL(new_last.second - output_values.begin(), 5);
-  ASSERT_EQUAL(output_keys[0], 11);
-  ASSERT_EQUAL(output_keys[1], 21);
-  ASSERT_EQUAL(output_keys[2], 20);
-  ASSERT_EQUAL(output_keys[3], 21);
-  ASSERT_EQUAL(output_keys[4], 37);
+  output_keys.resize(5);
+  output_values.resize(5);
+  Vector keys_ref{11, 21, 20, 21, 37};
+  ASSERT_EQUAL(output_keys, keys_ref);
 
-  ASSERT_EQUAL(output_values[0], 0);
-  ASSERT_EQUAL(output_values[1], 2);
-  ASSERT_EQUAL(output_values[2], 3);
-  ASSERT_EQUAL(output_values[3], 4);
-  ASSERT_EQUAL(output_values[4], 7);
+  Vector values_ref{0, 2, 3, 4, 7};
+  ASSERT_EQUAL(output_values, values_ref);
 
   // test BinaryPredicate
   initialize_keys(keys);
@@ -237,13 +215,14 @@ void TestUniqueCopyByKeySimple()
 
   ASSERT_EQUAL(new_last.first - output_keys.begin(), 3);
   ASSERT_EQUAL(new_last.second - output_values.begin(), 3);
-  ASSERT_EQUAL(output_keys[0], 11);
-  ASSERT_EQUAL(output_keys[1], 21);
-  ASSERT_EQUAL(output_keys[2], 37);
+  output_keys.resize(3);
+  output_values.resize(3);
+  keys_ref = {11, 21, 37};
+  ASSERT_EQUAL(output_keys, keys_ref);
 
-  ASSERT_EQUAL(output_values[0], 0);
-  ASSERT_EQUAL(output_values[1], 2);
-  ASSERT_EQUAL(output_values[2], 7);
+  values_ref.resize(3);
+  values_ref = {0, 2, 7};
+  ASSERT_EQUAL(output_values, values_ref);
 }
 DECLARE_INTEGRAL_VECTOR_UNITTEST(TestUniqueCopyByKeySimple);
 

--- a/thrust/testing/vector.cu
+++ b/thrust/testing/vector.cu
@@ -22,23 +22,13 @@ DECLARE_VECTOR_UNITTEST(TestVectorZeroSize);
 
 void TestVectorBool()
 {
-  thrust::host_vector<bool> h(3);
-  thrust::device_vector<bool> d(3);
+  thrust::host_vector<bool> h{true, false, true};
+  thrust::device_vector<bool> d{true, false, true};
 
-  h[0] = true;
-  h[1] = false;
-  h[2] = true;
-  d[0] = true;
-  d[1] = false;
-  d[2] = true;
-
-  ASSERT_EQUAL(h[0], true);
-  ASSERT_EQUAL(h[1], false);
-  ASSERT_EQUAL(h[2], true);
-
-  ASSERT_EQUAL(d[0], true);
-  ASSERT_EQUAL(d[1], false);
-  ASSERT_EQUAL(d[2], true);
+  thrust::host_vector<bool> h_ref{true, false, true};
+  thrust::device_vector<bool> d_ref{true, false, true};
+  ASSERT_EQUAL(h, h_ref);
+  ASSERT_EQUAL(d, d_ref);
 }
 DECLARE_UNITTEST(TestVectorBool);
 
@@ -47,23 +37,19 @@ void TestVectorInitializerList()
 {
   Vector v{1, 2, 3};
   ASSERT_EQUAL(v.size(), 3lu);
-  ASSERT_EQUAL(v[0], 1);
-  ASSERT_EQUAL(v[1], 2);
-  ASSERT_EQUAL(v[2], 3);
+  Vector ref{1, 2, 3};
+  ASSERT_EQUAL(v, ref);
 
   v = {1, 2, 3, 4};
   ASSERT_EQUAL(v.size(), 4lu);
-  ASSERT_EQUAL(v[0], 1);
-  ASSERT_EQUAL(v[1], 2);
-  ASSERT_EQUAL(v[2], 3);
-  ASSERT_EQUAL(v[3], 4);
+  Vector v_ref = {1, 2, 3, 4};
+  ASSERT_EQUAL(v, v_ref);
 
   const auto alloc = v.get_allocator();
   Vector v2{{1, 2, 3}, alloc};
   ASSERT_EQUAL(v2.size(), 3lu);
-  ASSERT_EQUAL(v2[0], 1);
-  ASSERT_EQUAL(v2[1], 2);
-  ASSERT_EQUAL(v2[2], 3);
+  Vector v2_ref = {1, 2, 3};
+  ASSERT_EQUAL(v2, v2_ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorInitializerList);
 
@@ -72,10 +58,7 @@ void TestVectorFrontBack()
 {
   using T = typename Vector::value_type;
 
-  Vector v(3);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
+  Vector v{0, 1, 2};
 
   ASSERT_EQUAL(v.front(), T(0));
   ASSERT_EQUAL(v.back(), T(2));
@@ -88,10 +71,7 @@ void TestVectorData()
   using PointerT      = typename Vector::pointer;
   using PointerConstT = typename Vector::const_pointer;
 
-  Vector v(3);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
+  Vector v{0, 1, 2};
 
   ASSERT_EQUAL(0, *v.data());
   ASSERT_EQUAL(1, *(v.data() + 1));
@@ -114,29 +94,16 @@ DECLARE_VECTOR_UNITTEST(TestVectorData);
 template <class Vector>
 void TestVectorElementAssignment()
 {
-  Vector v(3);
+  Vector v{0, 1, 2};
 
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
+  Vector ref{0, 1, 2};
+  ASSERT_EQUAL(v, ref);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
+  v   = {10, 11, 12};
+  ref = {10, 11, 12};
+  ASSERT_EQUAL(v, ref);
 
-  v[0] = 10;
-  v[1] = 11;
-  v[2] = 12;
-
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(v[1], 11);
-  ASSERT_EQUAL(v[2], 12);
-
-  Vector w(3);
-  w[0] = v[0];
-  w[1] = v[1];
-  w[2] = v[2];
-
+  Vector w = v;
   ASSERT_EQUAL(v, w);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorElementAssignment);
@@ -146,24 +113,18 @@ void TestVectorFromSTLVector()
 {
   using T = typename Vector::value_type;
 
-  std::vector<T> stl_vector(3);
-  stl_vector[0] = 0;
-  stl_vector[1] = 1;
-  stl_vector[2] = 2;
+  std::vector<T> stl_vector{0, 1, 2};
 
   thrust::host_vector<T> v(stl_vector);
 
   ASSERT_EQUAL(v.size(), 3lu);
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
+  thrust::host_vector<T> ref{0, 1, 2};
+  ASSERT_EQUAL(v, ref);
 
   v = stl_vector;
 
   ASSERT_EQUAL(v.size(), 3lu);
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorFromSTLVector);
 
@@ -176,9 +137,8 @@ void TestVectorFillAssign()
   v.assign(3, 13);
 
   ASSERT_EQUAL(v.size(), 3lu);
-  ASSERT_EQUAL(v[0], 13);
-  ASSERT_EQUAL(v[1], 13);
-  ASSERT_EQUAL(v[2], 13);
+  thrust::host_vector<T> ref{13, 13, 13};
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorFillAssign);
 
@@ -187,18 +147,14 @@ void TestVectorAssignFromSTLVector()
 {
   using T = typename Vector::value_type;
 
-  std::vector<T> stl_vector(3);
-  stl_vector[0] = 0;
-  stl_vector[1] = 1;
-  stl_vector[2] = 2;
+  std::vector<T> stl_vector{0, 1, 2};
 
   thrust::host_vector<T> v;
   v.assign(stl_vector.begin(), stl_vector.end());
 
   ASSERT_EQUAL(v.size(), 3lu);
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
+  thrust::host_vector<T> ref{0, 1, 2};
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorAssignFromSTLVector);
 
@@ -215,9 +171,8 @@ void TestVectorFromBiDirectionalIterator()
   Vector v(stl_list.begin(), stl_list.end());
 
   ASSERT_EQUAL(v.size(), 3lu);
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
+  Vector ref{0, 1, 2};
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorFromBiDirectionalIterator);
 
@@ -235,9 +190,8 @@ void TestVectorAssignFromBiDirectionalIterator()
   v.assign(stl_list.begin(), stl_list.end());
 
   ASSERT_EQUAL(v.size(), 3lu);
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
+  Vector ref{0, 1, 2};
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorAssignFromBiDirectionalIterator);
 
@@ -246,10 +200,7 @@ void TestVectorAssignFromHostVector()
 {
   using T = typename Vector::value_type;
 
-  thrust::host_vector<T> h(3);
-  h[0] = 0;
-  h[1] = 1;
-  h[2] = 2;
+  thrust::host_vector<T> h{0, 1, 2};
 
   Vector v;
   v.assign(h.begin(), h.end());
@@ -263,10 +214,7 @@ void TestVectorToAndFromHostVector()
 {
   using T = typename Vector::value_type;
 
-  thrust::host_vector<T> h(3);
-  h[0] = 0;
-  h[1] = 1;
-  h[2] = 2;
+  thrust::host_vector<T> h{0, 1, 2};
 
   Vector v(h);
 
@@ -279,16 +227,12 @@ void TestVectorToAndFromHostVector()
 
   ASSERT_EQUAL(v, h);
 
-  v[0] = 10;
-  v[1] = 11;
-  v[2] = 12;
+  v = {10, 11, 12};
+  Vector v_ref{10, 11, 12};
+  ASSERT_EQUAL(v, v_ref);
 
-  ASSERT_EQUAL(h[0], 0);
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(h[1], 1);
-  ASSERT_EQUAL(v[1], 11);
-  ASSERT_EQUAL(h[2], 2);
-  ASSERT_EQUAL(v[2], 12);
+  Vector h_ref{0, 1, 2};
+  ASSERT_EQUAL(h, h_ref);
 
   h = v;
 
@@ -307,10 +251,7 @@ void TestVectorAssignFromDeviceVector()
 {
   using T = typename Vector::value_type;
 
-  thrust::device_vector<T> d(3);
-  d[0] = 0;
-  d[1] = 1;
-  d[2] = 2;
+  thrust::device_vector<T> d{0, 1, 2};
 
   Vector v;
   v.assign(d.begin(), d.end());
@@ -324,10 +265,7 @@ void TestVectorToAndFromDeviceVector()
 {
   using T = typename Vector::value_type;
 
-  thrust::device_vector<T> h(3);
-  h[0] = 0;
-  h[1] = 1;
-  h[2] = 2;
+  thrust::device_vector<T> h{0, 1, 2};
 
   Vector v(h);
 
@@ -340,16 +278,12 @@ void TestVectorToAndFromDeviceVector()
 
   ASSERT_EQUAL(v, h);
 
-  v[0] = 10;
-  v[1] = 11;
-  v[2] = 12;
+  v = {10, 11, 12};
+  Vector v_ref{10, 11, 12};
+  ASSERT_EQUAL(v, v_ref);
 
-  ASSERT_EQUAL(h[0], 0);
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(h[1], 1);
-  ASSERT_EQUAL(v[1], 11);
-  ASSERT_EQUAL(h[2], 2);
-  ASSERT_EQUAL(v[2], 12);
+  Vector h_ref{0, 1, 2};
+  ASSERT_EQUAL(h, h_ref);
 
   h = v;
 
@@ -373,66 +307,49 @@ void TestVectorWithInitialValue()
   Vector v(3, init);
 
   ASSERT_EQUAL(v.size(), 3lu);
-  ASSERT_EQUAL(v[0], init);
-  ASSERT_EQUAL(v[1], init);
-  ASSERT_EQUAL(v[2], init);
+  Vector ref(3, init);
+  ASSERT_EQUAL(v, ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorWithInitialValue);
 
 template <class Vector>
 void TestVectorSwap()
 {
-  Vector v(3);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-
-  Vector u(3);
-  u[0] = 10;
-  u[1] = 11;
-  u[2] = 12;
+  Vector v{0, 1, 2};
+  Vector u{10, 11, 12};
 
   v.swap(u);
 
-  ASSERT_EQUAL(v[0], 10);
-  ASSERT_EQUAL(u[0], 0);
-  ASSERT_EQUAL(v[1], 11);
-  ASSERT_EQUAL(u[1], 1);
-  ASSERT_EQUAL(v[2], 12);
-  ASSERT_EQUAL(u[2], 2);
+  Vector u_ref{0, 1, 2};
+  ASSERT_EQUAL(u, u_ref);
+
+  Vector v_ref{10, 11, 12};
+  ASSERT_EQUAL(v, v_ref);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorSwap);
 
 template <class Vector>
 void TestVectorErasePosition()
 {
-  Vector v(5);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
+  Vector v{0, 1, 2, 3, 4};
 
   v.erase(v.begin() + 2);
 
   ASSERT_EQUAL(v.size(), 4lu);
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 3);
-  ASSERT_EQUAL(v[3], 4);
+  Vector ref{0, 1, 3, 4};
+  ASSERT_EQUAL(v, ref);
 
   v.erase(v.begin() + 0);
 
   ASSERT_EQUAL(v.size(), 3lu);
-  ASSERT_EQUAL(v[0], 1);
-  ASSERT_EQUAL(v[1], 3);
-  ASSERT_EQUAL(v[2], 4);
+  ref = {1, 3, 4};
+  ASSERT_EQUAL(v, ref);
 
   v.erase(v.begin() + 2);
 
   ASSERT_EQUAL(v.size(), 2lu);
-  ASSERT_EQUAL(v[0], 1);
-  ASSERT_EQUAL(v[1], 3);
+  ref = {1, 3};
+  ASSERT_EQUAL(v, ref);
 
   v.erase(v.begin() + 1);
 
@@ -448,27 +365,19 @@ DECLARE_VECTOR_UNITTEST(TestVectorErasePosition);
 template <class Vector>
 void TestVectorEraseRange()
 {
-  Vector v(6);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-  v[3] = 3;
-  v[4] = 4;
-  v[5] = 5;
+  Vector v{0, 1, 2, 3, 4, 5};
 
   v.erase(v.begin() + 1, v.begin() + 3);
 
   ASSERT_EQUAL(v.size(), 4lu);
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 3);
-  ASSERT_EQUAL(v[2], 4);
-  ASSERT_EQUAL(v[3], 5);
+  Vector ref{0, 3, 4, 5};
+  ASSERT_EQUAL(v, ref);
 
   v.erase(v.begin() + 2, v.end());
 
   ASSERT_EQUAL(v.size(), 2lu);
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 3);
+  ref = {0, 3};
+  ASSERT_EQUAL(v, ref);
 
   v.erase(v.begin() + 0, v.begin() + 1);
 
@@ -483,41 +392,17 @@ DECLARE_VECTOR_UNITTEST(TestVectorEraseRange);
 
 void TestVectorEquality()
 {
-  thrust::host_vector<int> h_a(3);
-  thrust::host_vector<int> h_b(3);
+  thrust::host_vector<int> h_a{0, 1, 2};
+  thrust::host_vector<int> h_b{0, 1, 3};
   thrust::host_vector<int> h_c(3);
-  h_a[0] = 0;
-  h_a[1] = 1;
-  h_a[2] = 2;
-  h_b[0] = 0;
-  h_b[1] = 1;
-  h_b[2] = 3;
-  h_b[0] = 0;
-  h_b[1] = 1;
 
-  thrust::device_vector<int> d_a(3);
-  thrust::device_vector<int> d_b(3);
+  thrust::device_vector<int> d_a{0, 1, 2};
+  thrust::device_vector<int> d_b{0, 1, 3};
   thrust::device_vector<int> d_c(3);
-  d_a[0] = 0;
-  d_a[1] = 1;
-  d_a[2] = 2;
-  d_b[0] = 0;
-  d_b[1] = 1;
-  d_b[2] = 3;
-  d_b[0] = 0;
-  d_b[1] = 1;
 
-  std::vector<int> s_a(3);
-  std::vector<int> s_b(3);
+  std::vector<int> s_a{0, 1, 2};
+  std::vector<int> s_b{0, 1, 3};
   std::vector<int> s_c(3);
-  s_a[0] = 0;
-  s_a[1] = 1;
-  s_a[2] = 2;
-  s_b[0] = 0;
-  s_b[1] = 1;
-  s_b[2] = 3;
-  s_b[0] = 0;
-  s_b[1] = 1;
 
   ASSERT_EQUAL((h_a == h_a), true);
   ASSERT_EQUAL((h_a == d_a), true);
@@ -605,41 +490,17 @@ DECLARE_UNITTEST(TestVectorEquality);
 
 void TestVectorInequality()
 {
-  thrust::host_vector<int> h_a(3);
-  thrust::host_vector<int> h_b(3);
+  thrust::host_vector<int> h_a{0, 1, 2};
+  thrust::host_vector<int> h_b{0, 1, 3};
   thrust::host_vector<int> h_c(3);
-  h_a[0] = 0;
-  h_a[1] = 1;
-  h_a[2] = 2;
-  h_b[0] = 0;
-  h_b[1] = 1;
-  h_b[2] = 3;
-  h_b[0] = 0;
-  h_b[1] = 1;
 
-  thrust::device_vector<int> d_a(3);
-  thrust::device_vector<int> d_b(3);
+  thrust::device_vector<int> d_a{0, 1, 2};
+  thrust::device_vector<int> d_b{0, 1, 3};
   thrust::device_vector<int> d_c(3);
-  d_a[0] = 0;
-  d_a[1] = 1;
-  d_a[2] = 2;
-  d_b[0] = 0;
-  d_b[1] = 1;
-  d_b[2] = 3;
-  d_b[0] = 0;
-  d_b[1] = 1;
 
-  std::vector<int> s_a(3);
-  std::vector<int> s_b(3);
+  std::vector<int> s_a{0, 1, 2};
+  std::vector<int> s_b{0, 1, 3};
   std::vector<int> s_c(3);
-  s_a[0] = 0;
-  s_a[1] = 1;
-  s_a[2] = 2;
-  s_b[0] = 0;
-  s_b[1] = 1;
-  s_b[2] = 3;
-  s_b[0] = 0;
-  s_b[1] = 1;
 
   ASSERT_EQUAL((h_a != h_a), false);
   ASSERT_EQUAL((h_a != d_a), false);
@@ -734,17 +595,13 @@ void TestVectorResizing()
 
   ASSERT_EQUAL(v.size(), 3lu);
 
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
-
+  v = {0, 1, 2};
   v.resize(5);
 
   ASSERT_EQUAL(v.size(), 5lu);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
+  Vector ref{0, 1, 2, v[3], v[4]};
+  ASSERT_EQUAL(v, ref);
 
   v[3] = 3;
   v[4] = 4;
@@ -753,10 +610,8 @@ void TestVectorResizing()
 
   ASSERT_EQUAL(v.size(), 4lu);
 
-  ASSERT_EQUAL(v[0], 0);
-  ASSERT_EQUAL(v[1], 1);
-  ASSERT_EQUAL(v[2], 2);
-  ASSERT_EQUAL(v[3], 3);
+  ref = {0, 1, 2, 3};
+  ASSERT_EQUAL(v, ref);
 
   v.resize(0);
 
@@ -912,10 +767,7 @@ DECLARE_UNITTEST(TestVectorContainingLargeType);
 template <typename Vector>
 void TestVectorReversed()
 {
-  Vector v(3);
-  v[0] = 0;
-  v[1] = 1;
-  v[2] = 2;
+  Vector v{0, 1, 2};
 
   ASSERT_EQUAL(3, v.rend() - v.rbegin());
   ASSERT_EQUAL(3, static_cast<const Vector&>(v).rend() - static_cast<const Vector&>(v).rbegin());
@@ -937,10 +789,7 @@ template <class Vector>
 void TestVectorMove()
 {
   // test move construction
-  Vector v1(3);
-  v1[0] = 0;
-  v1[1] = 1;
-  v1[2] = 2;
+  Vector v1{0, 1, 2};
 
   const auto ptr1  = v1.data();
   const auto size1 = v1.size();
@@ -953,19 +802,15 @@ void TestVectorMove()
   ASSERT_EQUAL(true, v1.empty());
 
   // ensure v2 received the data from before
-  ASSERT_EQUAL(v2[0], 0);
-  ASSERT_EQUAL(v2[1], 1);
-  ASSERT_EQUAL(v2[2], 2);
+  Vector ref{0, 1, 2};
+  ASSERT_EQUAL(v2, ref);
   ASSERT_EQUAL(size1, size2);
 
   // ensure v2 received the pointer from before
   ASSERT_EQUAL(ptr1, ptr2);
 
   // test move assignment
-  Vector v3(3);
-  v3[0] = 3;
-  v3[1] = 4;
-  v3[2] = 5;
+  Vector v3{3, 4, 5};
 
   const auto ptr3  = v3.data();
   const auto size3 = v3.size();
@@ -978,9 +823,8 @@ void TestVectorMove()
   ASSERT_EQUAL(true, v3.empty());
 
   // ensure v2 received the data from before
-  ASSERT_EQUAL(v2[0], 3);
-  ASSERT_EQUAL(v2[1], 4);
-  ASSERT_EQUAL(v2[2], 5);
+  ref = {3, 4, 5};
+  ASSERT_EQUAL(v2, ref);
   ASSERT_EQUAL(size3, size4);
 
   // ensure v2 received the pointer from before

--- a/thrust/testing/vector_insert.cu
+++ b/thrust/testing/vector_insert.cu
@@ -8,8 +8,6 @@ struct TestVectorRangeInsertSimple
 {
   void operator()(size_t)
   {
-    using T = typename Vector::value_type;
-
     Vector v1(5);
     thrust::sequence(v1.begin(), v1.end());
 
@@ -29,16 +27,8 @@ struct TestVectorRangeInsertSimple
 
     v2.insert(v2.begin() + 1, v1.begin(), v1.end());
 
-    ASSERT_EQUAL(T(0), v2[0]);
-
-    ASSERT_EQUAL(T(0), v2[1]);
-    ASSERT_EQUAL(T(1), v2[2]);
-    ASSERT_EQUAL(T(2), v2[3]);
-    ASSERT_EQUAL(T(3), v2[4]);
-    ASSERT_EQUAL(T(4), v2[5]);
-
-    ASSERT_EQUAL(T(1), v2[6]);
-    ASSERT_EQUAL(T(2), v2[7]);
+    Vector ref{0, 0, 1, 2, 3, 4, 1, 2};
+    ASSERT_EQUAL(ref, v2);
 
     ASSERT_EQUAL(8lu, v2.size());
     ASSERT_EQUAL(10lu, v2.capacity());
@@ -58,18 +48,8 @@ struct TestVectorRangeInsertSimple
     ASSERT_EQUAL(true, insertion_size == num_displaced);
 
     v3.insert(v3.begin(), v1.begin(), v1.end());
-
-    ASSERT_EQUAL(T(0), v3[0]);
-    ASSERT_EQUAL(T(1), v3[1]);
-    ASSERT_EQUAL(T(2), v3[2]);
-    ASSERT_EQUAL(T(3), v3[3]);
-    ASSERT_EQUAL(T(4), v3[4]);
-
-    ASSERT_EQUAL(T(0), v3[5]);
-    ASSERT_EQUAL(T(1), v3[6]);
-    ASSERT_EQUAL(T(2), v3[7]);
-    ASSERT_EQUAL(T(3), v3[8]);
-    ASSERT_EQUAL(T(4), v3[9]);
+    ref = {0, 1, 2, 3, 4, 0, 1, 2, 3, 4};
+    ASSERT_EQUAL(ref, v3);
 
     ASSERT_EQUAL(10lu, v3.size());
     ASSERT_EQUAL(10lu, v3.capacity());
@@ -90,16 +70,8 @@ struct TestVectorRangeInsertSimple
 
     v4.insert(v4.begin() + 1, v1.begin(), v1.begin() + 3);
 
-    ASSERT_EQUAL(T(0), v4[0]);
-
-    ASSERT_EQUAL(T(0), v4[1]);
-    ASSERT_EQUAL(T(1), v4[2]);
-    ASSERT_EQUAL(T(2), v4[3]);
-
-    ASSERT_EQUAL(T(1), v4[4]);
-    ASSERT_EQUAL(T(2), v4[5]);
-    ASSERT_EQUAL(T(3), v4[6]);
-    ASSERT_EQUAL(T(4), v4[7]);
+    ref = {0, 0, 1, 2, 1, 2, 3, 4};
+    ASSERT_EQUAL(ref, v4);
 
     ASSERT_EQUAL(8lu, v4.size());
     ASSERT_EQUAL(10lu, v4.capacity());
@@ -114,18 +86,8 @@ struct TestVectorRangeInsertSimple
 
     v5.insert(v5.begin() + 1, v1.begin(), v1.end());
 
-    ASSERT_EQUAL(T(0), v5[0]);
-
-    ASSERT_EQUAL(T(0), v5[1]);
-    ASSERT_EQUAL(T(1), v5[2]);
-    ASSERT_EQUAL(T(2), v5[3]);
-    ASSERT_EQUAL(T(3), v5[4]);
-    ASSERT_EQUAL(T(4), v5[5]);
-
-    ASSERT_EQUAL(T(1), v5[6]);
-    ASSERT_EQUAL(T(2), v5[7]);
-    ASSERT_EQUAL(T(3), v5[8]);
-    ASSERT_EQUAL(T(4), v5[9]);
+    ref = {0, 0, 1, 2, 3, 4, 1, 2, 3, 4};
+    ASSERT_EQUAL(ref, v5);
 
     ASSERT_EQUAL(10lu, v5.size());
   }
@@ -173,8 +135,6 @@ struct TestVectorFillInsertSimple
 {
   void operator()(size_t)
   {
-    using T = typename Vector::value_type;
-
     // test when insertion range fits inside capacity
     // and the size of the insertion is greater than the number
     // of displaced elements
@@ -191,16 +151,8 @@ struct TestVectorFillInsertSimple
 
     v1.insert(v1.begin() + 1, insertion_size, 13);
 
-    ASSERT_EQUAL(T(0), v1[0]);
-
-    ASSERT_EQUAL(T(13), v1[1]);
-    ASSERT_EQUAL(T(13), v1[2]);
-    ASSERT_EQUAL(T(13), v1[3]);
-    ASSERT_EQUAL(T(13), v1[4]);
-    ASSERT_EQUAL(T(13), v1[5]);
-
-    ASSERT_EQUAL(T(1), v1[6]);
-    ASSERT_EQUAL(T(2), v1[7]);
+    Vector ref{0, 13, 13, 13, 13, 13, 1, 2};
+    ASSERT_EQUAL(ref, v1);
 
     ASSERT_EQUAL(8lu, v1.size());
     ASSERT_EQUAL(10lu, v1.capacity());
@@ -221,17 +173,8 @@ struct TestVectorFillInsertSimple
 
     v2.insert(v2.begin(), insertion_size, 13);
 
-    ASSERT_EQUAL(T(13), v2[0]);
-    ASSERT_EQUAL(T(13), v2[1]);
-    ASSERT_EQUAL(T(13), v2[2]);
-    ASSERT_EQUAL(T(13), v2[3]);
-    ASSERT_EQUAL(T(13), v2[4]);
-
-    ASSERT_EQUAL(T(0), v2[5]);
-    ASSERT_EQUAL(T(1), v2[6]);
-    ASSERT_EQUAL(T(2), v2[7]);
-    ASSERT_EQUAL(T(3), v2[8]);
-    ASSERT_EQUAL(T(4), v2[9]);
+    ref = {13, 13, 13, 13, 13, 0, 1, 2, 3, 4};
+    ASSERT_EQUAL(ref, v2);
 
     ASSERT_EQUAL(10lu, v2.size());
     ASSERT_EQUAL(10lu, v2.capacity());
@@ -252,16 +195,8 @@ struct TestVectorFillInsertSimple
 
     v3.insert(v3.begin() + 1, insertion_size, 13);
 
-    ASSERT_EQUAL(T(0), v3[0]);
-
-    ASSERT_EQUAL(T(13), v3[1]);
-    ASSERT_EQUAL(T(13), v3[2]);
-    ASSERT_EQUAL(T(13), v3[3]);
-
-    ASSERT_EQUAL(T(1), v3[4]);
-    ASSERT_EQUAL(T(2), v3[5]);
-    ASSERT_EQUAL(T(3), v3[6]);
-    ASSERT_EQUAL(T(4), v3[7]);
+    ref = {0, 13, 13, 13, 1, 2, 3, 4};
+    ASSERT_EQUAL(ref, v3);
 
     ASSERT_EQUAL(8lu, v3.size());
     ASSERT_EQUAL(10lu, v3.capacity());
@@ -277,18 +212,8 @@ struct TestVectorFillInsertSimple
 
     v4.insert(v4.begin() + 1, insertion_size, 13);
 
-    ASSERT_EQUAL(T(0), v4[0]);
-
-    ASSERT_EQUAL(T(13), v4[1]);
-    ASSERT_EQUAL(T(13), v4[2]);
-    ASSERT_EQUAL(T(13), v4[3]);
-    ASSERT_EQUAL(T(13), v4[4]);
-    ASSERT_EQUAL(T(13), v4[5]);
-
-    ASSERT_EQUAL(T(1), v4[6]);
-    ASSERT_EQUAL(T(2), v4[7]);
-    ASSERT_EQUAL(T(3), v4[8]);
-    ASSERT_EQUAL(T(4), v4[9]);
+    ref = {0, 13, 13, 13, 13, 13, 1, 2, 3, 4};
+    ASSERT_EQUAL(ref, v4);
 
     ASSERT_EQUAL(10lu, v4.size());
   }


### PR DESCRIPTION
Resolves #2347. 

Changes the format in which we initialize inputs and assert outputs in our thrust tests using `initializer_list` and improves readability. I've all the tests under `testing/cuda`, will be adding the rest upcoming commits.

Any new thrust tests should conform to that format.

ping @miscco 

_final diff is **-2842** lines._