### PR TITLE
Add -Wmissing-field-initializers to cudax

### DIFF
--- a/cudax/cmake/cudaxBuildCompilerTargets.cmake
+++ b/cudax/cmake/cudaxBuildCompilerTargets.cmake
@@ -65,6 +65,8 @@ function(cudax_build_compiler_targets)
 
     # GCC 7.3 complains about name mangling changes due to `noexcept`
     append_option_if_available("-Wno-noexcept-type" cxx_compile_options)
+
+    append_option_if_available("-Wmissing-field-initializers" cxx_compile_options)
   endif()
 
   if ("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -41,7 +41,7 @@ template <typename Config, typename Kernel, typename... Args>
 _CCCL_NODISCARD cudaError_t
 launch_impl(::cuda::stream_ref stream, Config conf, const Kernel& kernel_fn, const Args&... args)
 {
-  cudaLaunchConfig_t config               = {0};
+  cudaLaunchConfig_t config{};
   cudaError_t status                      = cudaSuccess;
   constexpr bool has_cluster_level        = has_level<cluster_level, decltype(conf.dims)>;
   constexpr unsigned int num_attrs_needed = detail::kernel_config_count_attr_space(conf) + has_cluster_level;

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -103,7 +103,7 @@ auto configuration_test(
   ::cuda::stream_ref stream, const dim3& grid_dims, const dim3& block_dims, const dim3& cluster_dims = dim3())
 {
   auto dims             = make_test_dims<HasCluster>(grid_dims, block_dims, cluster_dims);
-  expectedConfig        = {0};
+  expectedConfig        = {};
   expectedConfig.stream = stream.get();
   if constexpr (HasCluster)
   {


### PR DESCRIPTION
Fixes #2357 

Add the new flag to cudax build to make sure it works.
Change cudaLaunchConfig_t init to make the build work with the new flag