### PR TITLE
Refactor `cuda::ceil_div` to take two different types

### DIFF
--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -242,7 +242,7 @@ struct AgentRadixSortHistogram
     // Within a portion, avoid overflowing (u)int32 counters.
     // Between portions, accumulate results in global memory.
     constexpr OffsetT MAX_PORTION_SIZE = 1 << 30;
-    OffsetT num_portions               = cub::DivideAndRoundUp(num_items, MAX_PORTION_SIZE);
+    OffsetT num_portions               = ::cuda::ceil_div(num_items, MAX_PORTION_SIZE);
     for (OffsetT portion = 0; portion < num_portions; ++portion)
     {
       // Reset the counters.

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -154,7 +154,7 @@ private:
 
     if (is_aligned<typename wrapped_op_t::vector_t>(unwrapped_first))
     { // Vectorize loads
-      const OffsetT num_vec_items = cub::DivideAndRoundUp(num_items, wrapped_op_t::vec_size);
+      const OffsetT num_vec_items = ::cuda::ceil_div(num_items, wrapped_op_t::vec_size);
 
       return detail::for_each::dispatch_t<OffsetT, wrapped_op_t>::dispatch(
         num_vec_items,

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -205,7 +205,7 @@ struct DispatchAdjacentDifference : public SelectedPolicy
     do
     {
       constexpr int tile_size = AdjacentDifferencePolicyT::ITEMS_PER_TILE;
-      const int num_tiles     = static_cast<int>(DivideAndRoundUp(num_items, tile_size));
+      const int num_tiles     = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
 
       std::size_t first_tile_previous_size = MayAlias * num_tiles * sizeof(InputT);
 
@@ -244,7 +244,7 @@ struct DispatchAdjacentDifference : public SelectedPolicy
         using AgentDifferenceInitT = AgentDifferenceInit<InputIteratorT, InputT, OffsetT, ReadLeft>;
 
         constexpr int init_block_size = AgentDifferenceInitT::BLOCK_THREADS;
-        const int init_grid_size      = DivideAndRoundUp(num_tiles, init_block_size);
+        const int init_grid_size      = ::cuda::ceil_div(num_tiles, init_block_size);
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
         _CubLog("Invoking DeviceAdjacentDifferenceInitKernel"

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -453,7 +453,7 @@ struct DispatchBatchMemcpy : SelectedPolicy
                                  * ActivePolicyT::AgentSmallBufferPolicyT::BUFFERS_PER_THREAD;
 
     // The number of thread blocks (or tiles) required to process all of the given buffers
-    BlockOffsetT num_tiles = DivideAndRoundUp(num_buffers, TILE_SIZE);
+    BlockOffsetT num_tiles = ::cuda::ceil_div(num_buffers, TILE_SIZE);
 
     using BlevBufferSrcsOutT          = ::cuda::std::_If<IsMemcpy, void*, cub::detail::value_t<InputBufferIt>>;
     using BlevBufferDstOutT           = ::cuda::std::_If<IsMemcpy, void*, cub::detail::value_t<OutputBufferIt>>;
@@ -528,7 +528,7 @@ struct DispatchBatchMemcpy : SelectedPolicy
     BlevBufferTileOffsetsOutItT d_blev_block_offsets = blev_buffer_block_alloc.get();
 
     // Kernels' grid sizes
-    BlockOffsetT init_grid_size         = DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS);
+    BlockOffsetT init_grid_size         = ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS);
     BlockOffsetT batch_memcpy_grid_size = num_tiles;
 
     // Kernels

--- a/cub/cub/device/dispatch/dispatch_for.cuh
+++ b/cub/cub/device/dispatch/dispatch_for.cuh
@@ -99,7 +99,7 @@ struct dispatch_t : PolicyHubT
     constexpr int items_per_thread = ActivePolicyT::for_policy_t::items_per_thread;
 
     const auto tile_size = static_cast<OffsetT>(block_threads * items_per_thread);
-    const auto num_tiles = cub::DivideAndRoundUp(num_items, tile_size);
+    const auto num_tiles = ::cuda::ceil_div(num_items, tile_size);
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
     _CubLog("Invoking detail::for_each::dynamic_kernel<<<%d, %d, 0, %lld>>>(), "
@@ -144,7 +144,7 @@ struct dispatch_t : PolicyHubT
     constexpr int items_per_thread = ActivePolicyT::for_policy_t::items_per_thread;
 
     const auto tile_size = static_cast<OffsetT>(block_threads * items_per_thread);
-    const auto num_tiles = cub::DivideAndRoundUp(num_items, tile_size);
+    const auto num_tiles = ::cuda::ceil_div(num_items, tile_size);
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
     _CubLog("Invoking detail::for_each::static_kernel<<<%d, %d, 0, %lld>>>(), "

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -361,7 +361,7 @@ struct dispatch_histogram
 
       // Get grid dimensions, trying to keep total blocks ~histogram_sweep_occupancy
       int pixels_per_tile = block_threads * pixels_per_thread;
-      int tiles_per_row   = static_cast<int>(cub::DivideAndRoundUp(num_row_pixels, pixels_per_tile));
+      int tiles_per_row   = static_cast<int>(::cuda::ceil_div(num_row_pixels, pixels_per_tile));
       int blocks_per_row  = CUB_MIN(histogram_sweep_occupancy, tiles_per_row);
       int blocks_per_col =
         (blocks_per_row > 0) ? int(CUB_MIN(histogram_sweep_occupancy / blocks_per_row, num_rows)) : 0;

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -238,7 +238,7 @@ struct dispatch_t
       typename choose_merge_agent<merge_policy_t, KeyIt1, ValueIt1, KeyIt2, ValueIt2, KeyIt3, ValueIt3, Offset, CompareOp>::
         type;
 
-    const auto num_tiles = cub::DivideAndRoundUp(num_items1 + num_items2, agent_t::policy::ITEMS_PER_TILE);
+    const auto num_tiles = ::cuda::ceil_div(num_items1 + num_items2, agent_t::policy::ITEMS_PER_TILE);
     void* allocations[2] = {nullptr, nullptr};
     {
       const std::size_t merge_partitions_size      = (1 + num_tiles) * sizeof(Offset);
@@ -263,8 +263,7 @@ struct dispatch_t
     {
       const Offset num_partitions               = num_tiles + 1;
       constexpr int threads_per_partition_block = 256; // TODO(bgruber): no policy?
-      const int partition_grid_size =
-        static_cast<int>(cub::DivideAndRoundUp(num_partitions, threads_per_partition_block));
+      const int partition_grid_size = static_cast<int>(::cuda::ceil_div(num_partitions, threads_per_partition_block));
 
       auto error = CubDebug(
         THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -508,7 +508,7 @@ struct DispatchMergeSort : SelectedPolicy
     do
     {
       constexpr auto tile_size = merge_sort_helper_t::policy_t::ITEMS_PER_TILE;
-      const auto num_tiles     = cub::DivideAndRoundUp(num_items, tile_size);
+      const auto num_tiles     = ::cuda::ceil_div(num_items, tile_size);
 
       const auto merge_partitions_size         = static_cast<std::size_t>(1 + num_tiles) * sizeof(OffsetT);
       const auto temporary_keys_storage_size   = static_cast<std::size_t>(num_items * sizeof(KeyT));
@@ -597,8 +597,7 @@ struct DispatchMergeSort : SelectedPolicy
 
       const OffsetT num_partitions              = num_tiles + 1;
       constexpr int threads_per_partition_block = 256;
-      const int partition_grid_size =
-        static_cast<int>(cub::DivideAndRoundUp(num_partitions, threads_per_partition_block));
+      const int partition_grid_size = static_cast<int>(::cuda::ceil_div(num_partitions, threads_per_partition_block));
 
       error = CubDebug(detail::DebugSyncStream(stream));
       if (cudaSuccess != error)

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -2091,10 +2091,10 @@ struct DispatchRadixSort : SelectedPolicy
     // portions handle inputs with >=2**30 elements, due to the way lookback works
     // for testing purposes, one portion is <= 2**28 elements
     constexpr PortionOffsetT PORTION_SIZE = ((1 << 28) - 1) / ONESWEEP_TILE_ITEMS * ONESWEEP_TILE_ITEMS;
-    int num_passes                        = cub::DivideAndRoundUp(end_bit - begin_bit, RADIX_BITS);
-    OffsetT num_portions                  = static_cast<OffsetT>(cub::DivideAndRoundUp(num_items, PORTION_SIZE));
-    PortionOffsetT max_num_blocks         = cub::DivideAndRoundUp(
-      static_cast<int>(CUB_MIN(num_items, static_cast<OffsetT>(PORTION_SIZE))), ONESWEEP_TILE_ITEMS);
+    int num_passes                        = ::cuda::ceil_div(end_bit - begin_bit, RADIX_BITS);
+    OffsetT num_portions                  = static_cast<OffsetT>(::cuda::ceil_div(num_items, PORTION_SIZE));
+    PortionOffsetT max_num_blocks =
+      ::cuda::ceil_div(static_cast<int>(CUB_MIN(num_items, static_cast<OffsetT>(PORTION_SIZE))), ONESWEEP_TILE_ITEMS);
 
     size_t value_size         = KEYS_ONLY ? 0 : sizeof(ValueT);
     size_t allocation_sizes[] = {
@@ -2237,7 +2237,7 @@ struct DispatchRadixSort : SelectedPolicy
           PortionOffsetT portion_num_items = static_cast<PortionOffsetT>(
             CUB_MIN(num_items - portion * PORTION_SIZE, static_cast<OffsetT>(PORTION_SIZE)));
 
-          PortionOffsetT num_blocks = cub::DivideAndRoundUp(portion_num_items, ONESWEEP_TILE_ITEMS);
+          PortionOffsetT num_blocks = ::cuda::ceil_div(portion_num_items, ONESWEEP_TILE_ITEMS);
 
           error = CubDebug(cudaMemsetAsync(d_lookback, 0, num_blocks * RADIX_DIGITS * sizeof(AtomicOffsetT), stream));
           if (cudaSuccess != error)
@@ -2429,7 +2429,7 @@ struct DispatchRadixSort : SelectedPolicy
       // Pass planning.  Run passes of the alternate digit-size configuration until we have an even multiple of our
       // preferred digit size
       int num_bits           = end_bit - begin_bit;
-      int num_passes         = cub::DivideAndRoundUp(num_bits, pass_config.radix_bits);
+      int num_passes         = ::cuda::ceil_div(num_bits, pass_config.radix_bits);
       bool is_num_passes_odd = num_passes & 1;
       int max_alt_passes     = (num_passes * pass_config.radix_bits) - num_bits;
       int alt_end_bit        = CUB_MIN(end_bit, begin_bit + (max_alt_passes * alt_pass_config.radix_bits));

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -3055,7 +3055,7 @@ struct DispatchSegmentedRadixSort : SelectedPolicy
       int radix_bits         = ActivePolicyT::SegmentedPolicy::RADIX_BITS;
       int alt_radix_bits     = ActivePolicyT::AltSegmentedPolicy::RADIX_BITS;
       int num_bits           = end_bit - begin_bit;
-      int num_passes         = CUB_MAX(DivideAndRoundUp(num_bits, radix_bits), 1);
+      int num_passes         = CUB_MAX(::cuda::ceil_div(num_bits, radix_bits), 1);
       bool is_num_passes_odd = num_passes & 1;
       int max_alt_passes     = (num_passes * radix_bits) - num_bits;
       int alt_end_bit        = CUB_MIN(end_bit, begin_bit + (max_alt_passes * alt_radix_bits));

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -308,7 +308,7 @@ struct DispatchReduceByKey
 
       // Number of input tiles
       int tile_size = block_threads * items_per_thread;
-      int num_tiles = static_cast<int>(cub::DivideAndRoundUp(num_items, tile_size));
+      int num_tiles = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
 
       // Specify temporary storage allocation requirements
       size_t allocation_sizes[1];
@@ -344,7 +344,7 @@ struct DispatchReduceByKey
       }
 
       // Log init_kernel configuration
-      int init_grid_size = CUB_MAX(1, cub::DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS));
+      int init_grid_size = CUB_MAX(1, ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS));
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
       _CubLog("Invoking init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, INIT_KERNEL_THREADS, (long long) stream);

--- a/cub/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle.cuh
@@ -312,7 +312,7 @@ struct DeviceRleDispatch
 
       // Number of input tiles
       int tile_size = block_threads * items_per_thread;
-      int num_tiles = static_cast<int>(cub::DivideAndRoundUp(num_items, tile_size));
+      int num_tiles = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
 
       // Specify temporary storage allocation requirements
       size_t allocation_sizes[1];
@@ -347,7 +347,7 @@ struct DeviceRleDispatch
       }
 
       // Log device_scan_init_kernel configuration
-      int init_grid_size = CUB_MAX(1, cub::DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS));
+      int init_grid_size = CUB_MAX(1, ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS));
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
       _CubLog("Invoking device_scan_init_kernel<<<%d, %d, 0, %lld>>>()\n",
@@ -401,7 +401,7 @@ struct DeviceRleDispatch
       // Get grid size for scanning tiles
       dim3 scan_grid_size;
       scan_grid_size.z = 1;
-      scan_grid_size.y = cub::DivideAndRoundUp(num_tiles, max_dim_x);
+      scan_grid_size.y = ::cuda::ceil_div(num_tiles, max_dim_x);
       scan_grid_size.x = CUB_MIN(num_tiles, max_dim_x);
 
 // Log device_rle_sweep_kernel configuration

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -382,7 +382,7 @@ struct DispatchScan : SelectedPolicy
 
       // Number of input tiles
       int tile_size = Policy::BLOCK_THREADS * Policy::ITEMS_PER_THREAD;
-      int num_tiles = static_cast<int>(cub::DivideAndRoundUp(num_items, tile_size));
+      int num_tiles = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
 
       // Specify temporary storage allocation requirements
       size_t allocation_sizes[1];
@@ -424,7 +424,7 @@ struct DispatchScan : SelectedPolicy
       }
 
       // Log init_kernel configuration
-      int init_grid_size = cub::DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS);
+      int init_grid_size = ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS);
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
       _CubLog("Invoking init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, INIT_KERNEL_THREADS, (long long) stream);

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -389,7 +389,7 @@ struct DispatchScanByKey : SelectedPolicy
 
       // Number of input tiles
       int tile_size = Policy::BLOCK_THREADS * Policy::ITEMS_PER_THREAD;
-      int num_tiles = static_cast<int>(cub::DivideAndRoundUp(num_items, tile_size));
+      int num_tiles = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
 
       // Specify temporary storage allocation requirements
       size_t allocation_sizes[2];
@@ -435,7 +435,7 @@ struct DispatchScanByKey : SelectedPolicy
       }
 
       // Log init_kernel configuration
-      int init_grid_size = cub::DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS);
+      int init_grid_size = ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS);
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
       _CubLog("Invoking init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, INIT_KERNEL_THREADS, (long long) stream);
 #endif // CUB_DETAIL_DEBUG_ENABLE_LOG

--- a/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_sort.cuh
@@ -581,10 +581,10 @@ CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN cudaError_t DeviceSegmentedSortCont
   const unsigned int small_segments  = group_sizes[1];
   const unsigned int medium_segments = static_cast<unsigned int>(num_segments) - (large_segments + small_segments);
 
-  const unsigned int small_blocks = DivideAndRoundUp(small_segments, SmallAndMediumPolicyT::SEGMENTS_PER_SMALL_BLOCK);
+  const unsigned int small_blocks = ::cuda::ceil_div(small_segments, SmallAndMediumPolicyT::SEGMENTS_PER_SMALL_BLOCK);
 
   const unsigned int medium_blocks =
-    DivideAndRoundUp(medium_segments, SmallAndMediumPolicyT::SEGMENTS_PER_MEDIUM_BLOCK);
+    ::cuda::ceil_div(medium_segments, SmallAndMediumPolicyT::SEGMENTS_PER_MEDIUM_BLOCK);
 
   const unsigned int small_and_medium_blocks_in_grid = small_blocks + medium_blocks;
 
@@ -1311,7 +1311,7 @@ struct DispatchSegmentedSort : SelectedPolicy
        * To avoid these issues, we have to use extra memory. The extra memory
        * holds temporary storage for writing intermediate results of each stage.
        * Since we iterate over digits in keys, we potentially need:
-       * `sizeof(KeyT) * num_items * DivideAndRoundUp(sizeof(KeyT),RADIX_BITS)`
+       * `sizeof(KeyT) * num_items * cuda::ceil_div(sizeof(KeyT),RADIX_BITS)`
        * auxiliary memory bytes. To reduce the auxiliary memory storage
        * requirements, the algorithm relies on a double buffer facility. The
        * idea behind it is in swapping destination and source buffers at each
@@ -1476,7 +1476,7 @@ private:
   {
     constexpr int byte_size = 8;
     constexpr int num_bits  = sizeof(KeyT) * byte_size;
-    const int num_passes    = DivideAndRoundUp(num_bits, radix_bits);
+    const int num_passes    = ::cuda::ceil_div(num_bits, radix_bits);
     return num_passes;
   }
 

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -415,7 +415,7 @@ struct DispatchSelectIf : SelectedPolicy
     constexpr auto block_threads    = VsmemHelperT::agent_policy_t::BLOCK_THREADS;
     constexpr auto items_per_thread = VsmemHelperT::agent_policy_t::ITEMS_PER_THREAD;
     constexpr int tile_size         = block_threads * items_per_thread;
-    int num_tiles                   = static_cast<int>(cub::DivideAndRoundUp(num_items, tile_size));
+    int num_tiles                   = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
     const auto vsmem_size           = num_tiles * VsmemHelperT::vsmem_per_block;
 
     do
@@ -462,7 +462,7 @@ struct DispatchSelectIf : SelectedPolicy
       }
 
       // Log scan_init_kernel configuration
-      int init_grid_size = CUB_MAX(1, cub::DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS));
+      int init_grid_size = CUB_MAX(1, ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS));
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
       _CubLog(
@@ -504,7 +504,7 @@ struct DispatchSelectIf : SelectedPolicy
       // Get grid size for scanning tiles
       dim3 scan_grid_size;
       scan_grid_size.z = 1;
-      scan_grid_size.y = cub::DivideAndRoundUp(num_tiles, max_dim_x);
+      scan_grid_size.y = ::cuda::ceil_div(num_tiles, max_dim_x);
       scan_grid_size.x = CUB_MIN(num_tiles, max_dim_x);
 
 // Log select_if_kernel configuration

--- a/cub/cub/device/dispatch/dispatch_spmv_orig.cuh
+++ b/cub/cub/device/dispatch/dispatch_spmv_orig.cuh
@@ -624,7 +624,7 @@ struct DispatchSpmv
         }
 
         constexpr int threads_in_block = EMPTY_MATRIX_KERNEL_THREADS;
-        const int blocks_in_grid       = cub::DivideAndRoundUp(spmv_params.num_rows, threads_in_block);
+        const int blocks_in_grid       = ::cuda::ceil_div(spmv_params.num_rows, threads_in_block);
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
         _CubLog("Invoking spmv_empty_matrix_kernel<<<%d, %d, 0, %lld>>>()\n",
@@ -661,7 +661,7 @@ struct DispatchSpmv
 
         // Get search/init grid dims
         int degen_col_kernel_block_size = INIT_KERNEL_THREADS;
-        int degen_col_kernel_grid_size  = cub::DivideAndRoundUp(spmv_params.num_rows, degen_col_kernel_block_size);
+        int degen_col_kernel_grid_size  = ::cuda::ceil_div(spmv_params.num_rows, degen_col_kernel_block_size);
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
         _CubLog("Invoking spmv_1col_kernel<<<%d, %d, 0, %lld>>>()\n",
@@ -720,8 +720,8 @@ struct DispatchSpmv
       int segment_fixup_tile_size = segment_fixup_config.block_threads * segment_fixup_config.items_per_thread;
 
       // Number of tiles for kernels
-      int num_merge_tiles         = cub::DivideAndRoundUp(num_merge_items, merge_tile_size);
-      int num_segment_fixup_tiles = cub::DivideAndRoundUp(num_merge_tiles, segment_fixup_tile_size);
+      int num_merge_tiles         = ::cuda::ceil_div(num_merge_items, merge_tile_size);
+      int num_segment_fixup_tiles = ::cuda::ceil_div(num_merge_tiles, segment_fixup_tile_size);
 
       // Get SM occupancy for kernels
       int spmv_sm_occupancy;
@@ -738,10 +738,10 @@ struct DispatchSpmv
       }
 
       // Get grid dimensions
-      dim3 spmv_grid_size(CUB_MIN(num_merge_tiles, max_dim_x), cub::DivideAndRoundUp(num_merge_tiles, max_dim_x), 1);
+      dim3 spmv_grid_size(CUB_MIN(num_merge_tiles, max_dim_x), ::cuda::ceil_div(num_merge_tiles, max_dim_x), 1);
 
       dim3 segment_fixup_grid_size(
-        CUB_MIN(num_segment_fixup_tiles, max_dim_x), cub::DivideAndRoundUp(num_segment_fixup_tiles, max_dim_x), 1);
+        CUB_MIN(num_segment_fixup_tiles, max_dim_x), ::cuda::ceil_div(num_segment_fixup_tiles, max_dim_x), 1);
 
       // Get the temporary storage allocation requirements
       size_t allocation_sizes[3];
@@ -777,7 +777,7 @@ struct DispatchSpmv
 
       // Get search/init grid dims
       int search_block_size = INIT_KERNEL_THREADS;
-      int search_grid_size  = cub::DivideAndRoundUp(num_merge_tiles + 1, search_block_size);
+      int search_grid_size  = ::cuda::ceil_div(num_merge_tiles + 1, search_block_size);
 
       if (search_grid_size < sm_count)
       //            if (num_merge_tiles < spmv_sm_occupancy * sm_count)

--- a/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -237,7 +237,7 @@ struct DispatchThreeWayPartitionIf
 
       // Number of input tiles
       int tile_size = block_threads * items_per_thread;
-      int num_tiles = static_cast<int>(DivideAndRoundUp(num_items, tile_size));
+      int num_tiles = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
 
       // Specify temporary storage allocation requirements
       size_t allocation_sizes[1]; // bytes needed for tile status descriptors
@@ -281,7 +281,7 @@ struct DispatchThreeWayPartitionIf
       }
 
       // Log three_way_partition_init_kernel configuration
-      int init_grid_size = CUB_MAX(1, DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS));
+      int init_grid_size = CUB_MAX(1, ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS));
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
       _CubLog("Invoking three_way_partition_init_kernel<<<%d, %d, 0, %lld>>>()\n",
@@ -319,7 +319,7 @@ struct DispatchThreeWayPartitionIf
       // Get grid size for scanning tiles
       dim3 scan_grid_size;
       scan_grid_size.z = 1;
-      scan_grid_size.y = DivideAndRoundUp(num_tiles, max_dim_x);
+      scan_grid_size.y = ::cuda::ceil_div(num_tiles, max_dim_x);
       scan_grid_size.x = CUB_MIN(num_tiles, max_dim_x);
 
 // Log select_if_kernel configuration

--- a/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -385,7 +385,7 @@ struct DispatchUniqueByKey : SelectedPolicy
       constexpr auto block_threads    = VsmemHelperT::agent_policy_t::BLOCK_THREADS;
       constexpr auto items_per_thread = VsmemHelperT::agent_policy_t::ITEMS_PER_THREAD;
       int tile_size                   = block_threads * items_per_thread;
-      int num_tiles                   = static_cast<int>(cub::DivideAndRoundUp(num_items, tile_size));
+      int num_tiles                   = static_cast<int>(::cuda::ceil_div(num_items, tile_size));
       const auto vsmem_size           = num_tiles * VsmemHelperT::vsmem_per_block;
 
       // Specify temporary storage allocation requirements
@@ -423,7 +423,7 @@ struct DispatchUniqueByKey : SelectedPolicy
 
       // Log init_kernel configuration
       num_tiles          = CUB_MAX(1, num_tiles);
-      int init_grid_size = cub::DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS);
+      int init_grid_size = ::cuda::ceil_div(num_tiles, INIT_KERNEL_THREADS);
 
 #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
       _CubLog("Invoking init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, INIT_KERNEL_THREADS, (long long) stream);
@@ -464,7 +464,7 @@ struct DispatchUniqueByKey : SelectedPolicy
       // Get grid size for scanning tiles
       dim3 scan_grid_size;
       scan_grid_size.z = 1;
-      scan_grid_size.y = cub::DivideAndRoundUp(num_tiles, max_dim_x);
+      scan_grid_size.y = ::cuda::ceil_div(num_tiles, max_dim_x);
       scan_grid_size.x = CUB_MIN(num_tiles, max_dim_x);
 
 // Log select_if_kernel configuration

--- a/cub/cub/grid/grid_even_share.cuh
+++ b/cub/cub/grid/grid_even_share.cuh
@@ -130,7 +130,7 @@ public:
     this->block_offset      = num_items_; // Initialize past-the-end
     this->block_end         = num_items_; // Initialize past-the-end
     this->num_items         = num_items_;
-    this->total_tiles       = static_cast<int>(cub::DivideAndRoundUp(num_items_, tile_items));
+    this->total_tiles       = static_cast<int>(::cuda::ceil_div(num_items_, tile_items));
     this->grid_size         = CUB_MIN(total_tiles, max_grid_size);
     int avg_tiles_per_block = total_tiles / grid_size;
     // leftover grains go to big blocks:

--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -77,6 +77,7 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT safe_add_bound_to_max(OffsetT lhs, O
  *
  * Effectively performs `(n + d - 1) / d`, but is robust against the case where
  * `(n + d - 1)` would overflow.
+ * deprecated [Since 2.8.0] `cub::DivideAndRoundUp` is deprecated. Use `cuda::ceil_div` instead.
  */
 template <typename NumeratorT, typename DenominatorT>
 CUB_DEPRECATED_BECAUSE("Use cuda::ceil_div instead")

--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -42,6 +42,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/cmath>
 #include <cuda/std/type_traits>
 
 CUB_NAMESPACE_BEGIN
@@ -78,15 +79,13 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE OffsetT safe_add_bound_to_max(OffsetT lhs, O
  * `(n + d - 1)` would overflow.
  */
 template <typename NumeratorT, typename DenominatorT>
+CUB_DEPRECATED_BECAUSE("Use cuda::ceil_div instead")
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr NumeratorT DivideAndRoundUp(NumeratorT n, DenominatorT d)
 {
-  // TODO(bgruber): implement using ::cuda::ceil_div
   static_assert(
     cub::detail::is_integral_or_enum<NumeratorT>::value && cub::detail::is_integral_or_enum<DenominatorT>::value,
     "DivideAndRoundUp is only intended for integral types.");
-
-  // Static cast to undo integral promotion.
-  return static_cast<NumeratorT>(n / d + (n % d != 0 ? 1 : 0));
+  return ::cuda::ceil_div(n, d);
 }
 
 constexpr _CCCL_HOST_DEVICE int Nominal4BItemsToItemsCombined(int nominal_4b_items_per_thread, int combined_bytes)

--- a/cub/examples/device/example_device_decoupled_look_back.cu
+++ b/cub/examples/device/example_device_decoupled_look_back.cu
@@ -105,7 +105,7 @@ void decoupled_look_back_example(int blocks_in_grid)
   scan_tile_state_t tile_status;
   tile_status.Init(blocks_in_grid, d_temp_storage, temp_storage_bytes);
   constexpr unsigned int threads_in_init_block = 256;
-  const unsigned int blocks_in_init_grid       = cub::DivideAndRoundUp(blocks_in_grid, threads_in_init_block);
+  const unsigned int blocks_in_init_grid       = ::cuda::ceil_div(blocks_in_grid, threads_in_init_block);
   init_kernel<<<blocks_in_init_grid, threads_in_init_block>>>(tile_status, blocks_in_grid);
 
   // Launch decoupled look-back

--- a/cub/test/catch2_large_array_sort_helper.cuh
+++ b/cub/test/catch2_large_array_sort_helper.cuh
@@ -398,7 +398,7 @@ private:
     using summary_t = detail::summary<KeyType>;
 
     const std::size_t max_summary_mem = num_items * (sizeof(KeyType) + sizeof(ValueType));
-    const std::size_t max_summaries   = cub::DivideAndRoundUp(max_summary_mem, sizeof(summary_t));
+    const std::size_t max_summaries   = ::cuda::ceil_div(max_summary_mem, sizeof(summary_t));
     return max_summaries;
   }
 

--- a/cub/test/catch2_radix_sort_helper.cuh
+++ b/cub/test/catch2_radix_sort_helper.cuh
@@ -461,7 +461,7 @@ template <class OffsetT>
 void generate_segment_offsets(c2h::seed_t seed, c2h::device_vector<OffsetT>& offsets, std::size_t num_items)
 {
   const std::size_t num_segments        = offsets.size() - 1;
-  const OffsetT expected_segment_length = static_cast<OffsetT>(cub::DivideAndRoundUp(num_items, num_segments));
+  const OffsetT expected_segment_length = static_cast<OffsetT>(::cuda::ceil_div(num_items, num_segments));
   const OffsetT max_segment_length      = (expected_segment_length * 2) + 1;
   c2h::gen(seed, offsets, OffsetT{0}, max_segment_length);
   thrust::exclusive_scan(

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -1374,7 +1374,7 @@ inline c2h::device_vector<int>
 generate_random_offsets(c2h::seed_t seed, int max_items, int max_segment, int num_segments)
 {
   C2H_TIME_SCOPE("generate_random_offsets");
-  const int expected_segment_length = cub::DivideAndRoundUp(max_items, num_segments);
+  const int expected_segment_length = ::cuda::ceil_div(max_items, num_segments);
   const int max_segment_length      = CUB_MIN(max_segment, (expected_segment_length * 2) + 1);
 
   c2h::device_vector<int> offsets(num_segments + 1);

--- a/cub/test/catch2_test_device_decoupled_look_back.cu
+++ b/cub/test/catch2_test_device_decoupled_look_back.cu
@@ -147,7 +147,7 @@ CUB_TEST("Decoupled look-back works with various message types", "[decoupled loo
   REQUIRE(status == cudaSuccess);
 
   constexpr unsigned int threads_in_init_block = 256;
-  const unsigned int blocks_in_init_grid       = cub::DivideAndRoundUp(num_tiles, threads_in_init_block);
+  const unsigned int blocks_in_init_grid       = ::cuda::ceil_div(num_tiles, threads_in_init_block);
   init_kernel<<<blocks_in_init_grid, threads_in_init_block>>>(tile_status, num_tiles);
   REQUIRE(cudaSuccess == cudaPeekAtLastError());
   REQUIRE(cudaSuccess == cudaDeviceSynchronize());

--- a/cub/test/catch2_test_vsmem.cu
+++ b/cub/test/catch2_test_vsmem.cu
@@ -302,7 +302,7 @@ struct dispatch_dummy_algorithm_t : SelectedPolicy
     constexpr auto block_threads    = vsmem_helper_t::agent_policy_t::BLOCK_THREADS;
     constexpr auto items_per_thread = vsmem_helper_t::agent_policy_t::ITEMS_PER_THREAD;
     constexpr auto tile_size        = block_threads * items_per_thread;
-    const auto num_tiles            = cub::DivideAndRoundUp(num_items, tile_size);
+    const auto num_tiles            = ::cuda::ceil_div(num_items, tile_size);
     const auto total_vsmem          = num_tiles * vsmem_helper_t::vsmem_per_block;
 
     // Get device ordinal

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -1392,7 +1392,7 @@ void InitializeSegments(OffsetT num_items, int num_segments, OffsetT* h_segment_
     return;
   }
 
-  OffsetT expected_segment_length = CUB_NS_QUALIFIER::DivideAndRoundUp(num_items, OffsetT(num_segments));
+  OffsetT expected_segment_length = ::cuda::ceil_div(num_items, OffsetT(num_segments));
   OffsetT offset                  = 0;
   for (int i = 0; i < num_segments; ++i)
   {

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -13,8 +13,6 @@
 
 #include <cuda/std/detail/__config>
 
-#include <cstdlib>
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -25,6 +25,7 @@
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_enum.h>
 #include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/__type_traits/make_unsigned.h>
 #include <cuda/std/__type_traits/underlying_type.h>
@@ -40,25 +41,32 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! @pre \p __b must be positive
 template <class _Tp,
           class _Up,
-          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,
-          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0,
-          class _UCommon = _CUDA_VSTD::__make_unsigned_t<_CUDA_VSTD::__common_type_t<_Tp, _Up>>>
+          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_unsigned, _Tp), int> = 0,
+          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
 {
-  _LIBCUDACXX_DEBUG_ASSERT(_CCCL_TRAIT(_CUDA_VSTD::is_unsigned, _Tp) || __a >= _Tp(0),
-                           "cuda::ceil_div: a must be non negative");
   _LIBCUDACXX_DEBUG_ASSERT(__b > _Tp(0), "cuda::ceil_div: b must be positive");
+  using _UCommon   = _CUDA_VSTD::__make_unsigned_t<_CUDA_VSTD::__common_type_t<_Tp, _Up>>;
+  const auto __res = static_cast<_UCommon>(__a) / static_cast<_UCommon>(__b);
+  return static_cast<_Tp>(__res + (__res * static_cast<_UCommon>(__b) != static_cast<_UCommon>(__a)));
+}
 
-  _CCCL_IF_CONSTEXPR (_CCCL_TRAIT(_CUDA_VSTD::is_unsigned, _Tp))
-  {
-    const auto __res = static_cast<_UCommon>(__a) / static_cast<_UCommon>(__b);
-    return static_cast<_Tp>(__res + (__res * static_cast<_UCommon>(__b) != static_cast<_UCommon>(__a)));
-  }
-  else
-  { // Due to the precondition `__a >= 0` we can safely cast to unsigned without danger of overflowing
-    return static_cast<_Tp>((static_cast<_UCommon>(__a) + static_cast<_UCommon>(__b) - 1) / static_cast<_UCommon>(__b));
-  }
-  _LIBCUDACXX_UNREACHABLE();
+//! @brief Divides two numbers \p __a and \p __b, rounding up if there is a remainder
+//! @param __a The dividend
+//! @param __b The divisor
+//! @pre \p __a must be non-negative
+//! @pre \p __b must be positive
+template <class _Tp,
+          class _Up,
+          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp), int>   = 0,
+          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
+{
+  _LIBCUDACXX_DEBUG_ASSERT(__a >= _Tp(0), "cuda::ceil_div: a must be non negative");
+  _LIBCUDACXX_DEBUG_ASSERT(__b > _Tp(0), "cuda::ceil_div: b must be positive");
+  using _UCommon = _CUDA_VSTD::__make_unsigned_t<_CUDA_VSTD::__common_type_t<_Tp, _Up>>;
+  // Due to the precondition `__a >= 0` we can safely cast to unsigned without danger of overflowing
+  return static_cast<_Tp>((static_cast<_UCommon>(__a) + static_cast<_UCommon>(__b) - 1) / static_cast<_UCommon>(__b));
 }
 
 //! @brief Divides two numbers \p __a and \p __b, rounding up if there is a remainder
@@ -68,12 +76,10 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(con
 template <class _Tp,
           class _Up,
           _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,
-          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up), int>     = 0,
-          class _UCommon =
-            _CUDA_VSTD::__make_unsigned_t<_CUDA_VSTD::__common_type_t<_Tp, _CUDA_VSTD::__underlying_type_t<_Up>>>>
+          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up), int>     = 0>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
 {
-  return ::cuda::ceil_div(__a, static_cast<_UCommon>(__b));
+  return ::cuda::ceil_div(__a, static_cast<_CUDA_VSTD::__underlying_type_t<_Up>>(__b));
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -29,7 +29,6 @@
 #include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/__type_traits/make_unsigned.h>
 #include <cuda/std/__type_traits/underlying_type.h>
-#include <cuda/std/cstdlib>
 #include <cuda/std/detail/libcxx/include/__debug>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
@@ -69,10 +68,11 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(con
   return static_cast<_Tp>((static_cast<_UCommon>(__a) + static_cast<_UCommon>(__b) - 1) / static_cast<_UCommon>(__b));
 }
 
-//! @brief Divides two numbers \p __a and \p __b, rounding up if there is a remainder
+//! @brief Divides two numbers \p __a and \p __b, rounding up if there is a remainder, \p __b is an enum
 //! @param __a The dividend
 //! @param __b The divisor
 //! @pre \p __a must be non-negative
+//! @pre \p __b must be positive
 template <class _Tp,
           class _Up,
           _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -37,6 +37,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! @param __a The dividend
 //! @param __b The divisor
 //! @pre \p __a must be non-negative
+//! @pre \p __b must be positive
 template <class _Tp,
           class _Up,
           _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -13,6 +13,8 @@
 
 #include <cuda/std/detail/__config>
 
+#include <cstdlib>
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -23,7 +25,12 @@
 
 #include <cuda/std/__type_traits/common_type.h>
 #include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_enum.h>
 #include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_unsigned.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
+#include <cuda/std/__type_traits/underlying_type.h>
+#include <cuda/std/cstdlib>
 #include <cuda/std/detail/libcxx/include/__debug>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
@@ -32,13 +39,34 @@ template <class _Tp,
           class _Up,
           _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,
           _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0,
-          class _Common = _CUDA_VSTD::__common_type_t<_Tp, _Up>>
+          class _UCommon = _CUDA_VSTD::__make_unsigned_t<_CUDA_VSTD::__common_type_t<_Tp, _Up>>>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
 {
-  _LIBCUDACXX_DEBUG_ASSERT(__a >= _Tp(0), "cuda::ceil_div: a must be non negative");
+  _LIBCUDACXX_DEBUG_ASSERT(_CCCL_TRAIT(_CUDA_VSTD::is_unsigned, _Tp) || __a >= _Tp(0),
+                           "cuda::ceil_div: a must be non negative");
   _LIBCUDACXX_DEBUG_ASSERT(__b > _Tp(0), "cuda::ceil_div: b must be positive");
-  const auto __res = static_cast<_Common>(__a) / static_cast<_Common>(__b);
-  return static_cast<_Tp>(__res + (__res * static_cast<_Common>(__b) != static_cast<_Common>(__a)));
+
+  _CCCL_IF_CONSTEXPR (_CCCL_TRAIT(_CUDA_VSTD::is_unsigned, _Tp))
+  {
+    const auto __res = static_cast<_UCommon>(__a) / static_cast<_UCommon>(__b);
+    return static_cast<_Tp>(__res + (__res * static_cast<_UCommon>(__b) != static_cast<_UCommon>(__a)));
+  }
+  else
+  { // Due to the precondition `__a >= 0` we can safely cast to unsigned without danger of overflowing
+    return static_cast<_Tp>((static_cast<_UCommon>(__a) + static_cast<_UCommon>(__b) - 1) / static_cast<_UCommon>(__b));
+  }
+  _LIBCUDACXX_UNREACHABLE();
+}
+
+template <class _Tp,
+          class _Up,
+          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,
+          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up), int>     = 0,
+          class _UCommon =
+            _CUDA_VSTD::__make_unsigned_t<_CUDA_VSTD::__common_type_t<_Tp, _CUDA_VSTD::__underlying_type_t<_Up>>>>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
+{
+  return ::cuda::ceil_div(__a, static_cast<_UCommon>(__b));
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___CMATH_CEIL_DIV_H
+#define _CUDA___CMATH_CEIL_DIV_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/common_type.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/detail/libcxx/include/__debug>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+template <class _Tp,
+          class _Up,
+          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,
+          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0,
+          class _Common                                                             = __common_type_t<_Tp, _Up>>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
+{
+  _LIBCUDACXX_DEBUG_ASSERT(__a >= _Tp(0), "cuda::ceil_div: a must be non negative");
+  _LIBCUDACXX_DEBUG_ASSERT(__b > _Tp(0), "cuda::ceil_div: b must be positive");
+  const auto __res = static_cast<_Common>(__a) / static_cast<_Common>(__b);
+  return static_cast<_Tp>(__res + (__res * static_cast<_Common>(__b) != static_cast<_Common>(__a)));
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CUDA___CMATH_CEIL_DIV_H

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -35,6 +35,10 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
+//! @brief Divides two numbers \p __a and \p __b, rounding up if there is a remainder
+//! @param __a The dividend
+//! @param __b The divisor
+//! @pre \p __a must be non-negative
 template <class _Tp,
           class _Up,
           _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,
@@ -58,6 +62,10 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(con
   _LIBCUDACXX_UNREACHABLE();
 }
 
+//! @brief Divides two numbers \p __a and \p __b, rounding up if there is a remainder
+//! @param __a The dividend
+//! @param __b The divisor
+//! @pre \p __a must be non-negative
 template <class _Tp,
           class _Up,
           _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -32,7 +32,7 @@ template <class _Tp,
           class _Up,
           _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,
           _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0,
-          class _Common                                                             = __common_type_t<_Tp, _Up>>
+          class _Common = _CUDA_VSTD::__common_type_t<_Tp, _Up>>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
 {
   _LIBCUDACXX_DEBUG_ASSERT(__a >= _Tp(0), "cuda::ceil_div: a must be non negative");

--- a/libcudacxx/include/cuda/cmath
+++ b/libcudacxx/include/cuda/cmath
@@ -21,22 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__cmath/ceil_div.h>
 #include <cuda/std/cmath>
-#include <cuda/std/detail/libcxx/include/__debug>
-
-_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
-
-template <class _Tp, _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Tp __b) noexcept
-{
-  _LIBCUDACXX_DEBUG_ASSERT(__a >= _Tp(0), "cuda::ceil_div: a must be non negative");
-  _LIBCUDACXX_DEBUG_ASSERT(__b > _Tp(0), "cuda::ceil_div: b must be positive");
-  const _Tp __res = static_cast<_Tp>(__a / __b);
-  return static_cast<_Tp>(__res + (__res * __b != __a));
-}
-
-_LIBCUDACXX_END_NAMESPACE_CUDA
 
 #endif // _CUDA_CMATH

--- a/libcudacxx/include/cuda/cmath
+++ b/libcudacxx/include/cuda/cmath
@@ -21,7 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__cmath/ceil_div.h>
+#include <cuda/__cmath/ceil_div.h>
 #include <cuda/std/cmath>
 
 #endif // _CUDA_CMATH

--- a/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
@@ -43,6 +43,9 @@ template <class _Tp>
 struct underlying_type : __underlying_type_impl<_Tp, is_enum<_Tp>::value>
 {};
 
+template <class _Tp>
+using __underlying_type_t = typename underlying_type<_Tp>::type;
+
 #  if _CCCL_STD_VER > 2011
 template <class _Tp>
 using underlying_type_t = typename underlying_type<_Tp>::type;

--- a/libcudacxx/test/libcudacxx/cuda/cmath.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath.pass.cpp
@@ -25,7 +25,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
   constexpr T maxv = cuda::std::numeric_limits<T>::max();
 
   // ensure that we return the right type
-  static_assert(cuda::std::is_same_v<decltype(cuda::ceil_div(T(0), U(1))), T>::value, "");
+  static_assert(cuda::std::is_same<decltype(cuda::ceil_div(T(0), U(1))), T>::value, "");
 
   assert(cuda::ceil_div(T(0), U(1)) == T(0));
   assert(cuda::ceil_div(T(1), U(1)) == T(1));

--- a/libcudacxx/test/libcudacxx/cuda/cmath.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath.pass.cpp
@@ -19,18 +19,65 @@
 #  include <cstdint>
 #endif // !TEST_COMPILER_NVRTC
 
-template <class T>
+template <class T, class U>
 __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
 {
   constexpr T maxv = cuda::std::numeric_limits<T>::max();
 
-  assert(cuda::ceil_div(T(0), T(1)) == T(0));
-  assert(cuda::ceil_div(T(1), T(1)) == T(1));
-  assert(cuda::ceil_div(T(126), T(64)) == T(2));
+  // ensure that we return the right type
+  static_assert(cuda::std::is_same_v<decltype(cuda::ceil_div(T(0), U(1))), T>::value, "");
+
+  assert(cuda::ceil_div(T(0), U(1)) == T(0));
+  assert(cuda::ceil_div(T(1), U(1)) == T(1));
+  assert(cuda::ceil_div(T(126), U(64)) == T(2));
 
   // ensure that we are resilient against overflow
-  assert(cuda::ceil_div(maxv, T(1)) == maxv);
+  assert(cuda::ceil_div(maxv, U(1)) == maxv);
   assert(cuda::ceil_div(maxv, maxv) == T(1));
+}
+
+template <class T>
+__host__ __device__ TEST_CONSTEXPR_CXX14 void test()
+{
+  // Builtin integer types:
+  test<T, char>();
+  test<T, signed char>();
+  test<T, unsigned char>();
+
+  test<T, short>();
+  test<T, unsigned short>();
+
+  test<T, int>();
+  test<T, unsigned int>();
+
+  test<T, long>();
+  test<T, unsigned long>();
+
+  test<T, long long>();
+  test<T, unsigned long long>();
+
+#if !defined(TEST_COMPILER_NVRTC)
+  // cstdint types:
+  test<T, std::size_t>();
+  test<T, std::ptrdiff_t>();
+  test<T, std::intptr_t>();
+  test<T, std::uintptr_t>();
+
+  test<T, std::int8_t>();
+  test<T, std::int16_t>();
+  test<T, std::int32_t>();
+  test<T, std::int64_t>();
+
+  test<T, std::uint8_t>();
+  test<T, std::uint16_t>();
+  test<T, std::uint32_t>();
+  test<T, std::uint64_t>();
+#endif // !TEST_COMPILER_NVRTC
+
+#if !defined(TEST_HAS_NO_INT128_T)
+  test<T, __int128_t>();
+  test<T, __uint128_t>();
+#endif // !TEST_HAS_NO_INT128_T
 }
 
 __host__ __device__ TEST_CONSTEXPR_CXX14 bool test()

--- a/thrust/thrust/system/cuda/detail/extrema.h
+++ b/thrust/thrust/system/cuda/detail/extrema.h
@@ -273,7 +273,7 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
     else if (reduce_plan.grid_mapping == cub::GRID_MAPPING_DYNAMIC)
     {
       // Work is distributed dynamically
-      size_t num_tiles = cub::DivideAndRoundUp(num_items, reduce_plan.items_per_tile);
+      size_t num_tiles = ::cuda::ceil_div(num_items, reduce_plan.items_per_tile);
 
       // if not enough to fill the device with threadblocks
       // then fill the device with threadblocks

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -713,7 +713,7 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
     else if (reduce_plan.grid_mapping == cub::GRID_MAPPING_DYNAMIC)
     {
       // Work is distributed dynamically
-      size_t num_tiles = cub::DivideAndRoundUp(num_items, reduce_plan.items_per_tile);
+      size_t num_tiles = ::cuda::ceil_div(num_items, reduce_plan.items_per_tile);
 
       // if not enough to fill the device with threadblocks
       // then fill the device with threadblocks

--- a/thrust/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/thrust/system/cuda/detail/reduce_by_key.h
@@ -808,7 +808,7 @@ THRUST_RUNTIME_FUNCTION cudaError_t doit_step(
 
   // Number of input tiles
   int tile_size  = reduce_by_key_plan.items_per_tile;
-  Size num_tiles = cub::DivideAndRoundUp(num_items, tile_size);
+  Size num_tiles = ::cuda::ceil_div(num_items, tile_size);
 
   size_t vshmem_size = core::vshmem_size(reduce_by_key_plan.shared_memory_size, num_tiles);
 

--- a/thrust/thrust/system/cuda/detail/unique.h
+++ b/thrust/thrust/system/cuda/detail/unique.h
@@ -509,7 +509,7 @@ static cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   typename get_plan<unique_agent>::type unique_plan = unique_agent::get_plan(stream);
 
   int tile_size    = unique_plan.items_per_tile;
-  size_t num_tiles = cub::DivideAndRoundUp(num_items, tile_size);
+  size_t num_tiles = ::cuda::ceil_div(num_items, tile_size);
 
   size_t vshmem_size = core::vshmem_size(unique_plan.shared_memory_size, num_tiles);
 


### PR DESCRIPTION
We already use a similar function in cub.

Deprecate that and replace it with `cuda::ceil_div`