### PR TITLE
implement `make_integer_sequence` in terms of intrinsics whenever possible

### DIFF
--- a/libcudacxx/include/cuda/std/__utility/integer_sequence.h
+++ b/libcudacxx/include/cuda/std/__utility/integer_sequence.h
@@ -39,7 +39,19 @@ struct __integer_sequence
   using __to_tuple_indices = __tuple_indices<(_Values + _Sp)...>;
 };
 
-#ifndef _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ
+#if defined(_LIBCUDACXX_HAS_MAKE_INTEGER_SEQ)
+
+template <size_t _Ep, size_t _Sp>
+using __make_indices_imp =
+  typename __make_integer_seq<__integer_sequence, size_t, _Ep - _Sp>::template __to_tuple_indices<_Sp>;
+
+#elif __has_builtin(__integer_pack) // ^^^ _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ ^^^ / vvv __has_builtin(__integer_pack) vvv
+
+template <size_t _Ep, size_t _Sp>
+using __make_indices_imp =
+  typename __integer_sequence<size_t, __integer_pack(_Ep - _Sp)...>::template __to_tuple_indices<_Sp>;
+
+#else // ^^^ __has_builtin(__integer_pack) ^^^ / vvv !__has_builtin(__integer_pack) vvv
 
 namespace __detail
 {
@@ -170,13 +182,6 @@ struct __parity<7>
 
 } // namespace __detail
 
-#endif // !_LIBCUDACXX_HAS_MAKE_INTEGER_SEQ
-
-#ifdef _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ
-template <size_t _Ep, size_t _Sp>
-using __make_indices_imp =
-  typename __make_integer_seq<__integer_sequence, size_t, _Ep - _Sp>::template __to_tuple_indices<_Sp>;
-#else
 template <size_t _Ep, size_t _Sp>
 using __make_indices_imp = typename __detail::__make<_Ep - _Sp>::type::template __to_tuple_indices<_Sp>;
 
@@ -201,7 +206,12 @@ using index_sequence = integer_sequence<size_t, _Ip...>;
 template <class _Tp, _Tp _Ep>
 using __make_integer_sequence _LIBCUDACXX_NODEBUG_TYPE = __make_integer_seq<integer_sequence, _Tp, _Ep>;
 
-#else // _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ
+#elif __has_builtin(__integer_pack) // ^^^ _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ ^^^ / vvv __has_builtin(__integer_pack) vvv
+
+template <class _Tp, _Tp _Ep>
+using __make_integer_sequence _LIBCUDACXX_NODEBUG_TYPE = integer_sequence<_Tp, __integer_pack(_Ep)...>;
+
+#else // ^^^ __has_builtin(__integer_pack) ^^^ / vvv !__has_builtin(__integer_pack) vvv
 
 template <typename _Tp, _Tp _Np>
 using __make_integer_sequence_unchecked _LIBCUDACXX_NODEBUG_TYPE =

--- a/libcudacxx/include/cuda/std/__utility/integer_sequence.h
+++ b/libcudacxx/include/cuda/std/__utility/integer_sequence.h
@@ -33,25 +33,26 @@ template <class _IdxType, _IdxType... _Values>
 struct __integer_sequence
 {
   template <template <class _OIdxType, _OIdxType...> class _ToIndexSeq, class _ToIndexType>
-  using __convert = _ToIndexSeq<_ToIndexType, _Values...>;
+  using __convert _LIBCUDACXX_NODEBUG_TYPE = _ToIndexSeq<_ToIndexType, _Values...>;
 
   template <size_t _Sp>
-  using __to_tuple_indices = __tuple_indices<(_Values + _Sp)...>;
+  using __to_tuple_indices _LIBCUDACXX_NODEBUG_TYPE = __tuple_indices<(_Values + _Sp)...>;
 };
 
 #if defined(_LIBCUDACXX_HAS_MAKE_INTEGER_SEQ)
 
 template <size_t _Ep, size_t _Sp>
-using __make_indices_imp =
+using __make_indices_imp _LIBCUDACXX_NODEBUG_TYPE =
   typename __make_integer_seq<__integer_sequence, size_t, _Ep - _Sp>::template __to_tuple_indices<_Sp>;
 
-#elif __has_builtin(__integer_pack) // ^^^ _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ ^^^ / vvv __has_builtin(__integer_pack) vvv
+#elif defined(_LIBCUDACXX_HAS_INTEGER_PACK) // ^^^ _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ ^^^
+                                            // vvv _LIBCUDACXX_HAS_INTEGER_PACK vvv
 
 template <size_t _Ep, size_t _Sp>
-using __make_indices_imp =
+using __make_indices_imp _LIBCUDACXX_NODEBUG_TYPE =
   typename __integer_sequence<size_t, __integer_pack(_Ep - _Sp)...>::template __to_tuple_indices<_Sp>;
 
-#else // ^^^ __has_builtin(__integer_pack) ^^^ / vvv !__has_builtin(__integer_pack) vvv
+#else // ^^^ _LIBCUDACXX_HAS_INTEGER_PACK ^^^ / vvv !_LIBCUDACXX_HAS_INTEGER_PACK vvv
 
 namespace __detail
 {
@@ -77,6 +78,7 @@ struct __repeat<__integer_sequence<_Tp, _Np...>, _Extra...>
 
 template <size_t _Np>
 struct __parity;
+
 template <size_t _Np>
 struct __make : __parity<_Np % 8>::template __pmake<_Np>
 {};
@@ -183,7 +185,8 @@ struct __parity<7>
 } // namespace __detail
 
 template <size_t _Ep, size_t _Sp>
-using __make_indices_imp = typename __detail::__make<_Ep - _Sp>::type::template __to_tuple_indices<_Sp>;
+using __make_indices_imp _LIBCUDACXX_NODEBUG_TYPE =
+  typename __detail::__make<_Ep - _Sp>::type::template __to_tuple_indices<_Sp>;
 
 #endif
 
@@ -206,12 +209,13 @@ using index_sequence = integer_sequence<size_t, _Ip...>;
 template <class _Tp, _Tp _Ep>
 using __make_integer_sequence _LIBCUDACXX_NODEBUG_TYPE = __make_integer_seq<integer_sequence, _Tp, _Ep>;
 
-#elif __has_builtin(__integer_pack) // ^^^ _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ ^^^ / vvv __has_builtin(__integer_pack) vvv
+#elif defined(_LIBCUDACXX_HAS_INTEGER_PACK) // ^^^ _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ ^^^
+                                            // vvv _LIBCUDACXX_HAS_INTEGER_PACK vvv
 
 template <class _Tp, _Tp _Ep>
 using __make_integer_sequence _LIBCUDACXX_NODEBUG_TYPE = integer_sequence<_Tp, __integer_pack(_Ep)...>;
 
-#else // ^^^ __has_builtin(__integer_pack) ^^^ / vvv !__has_builtin(__integer_pack) vvv
+#else // ^^^ _LIBCUDACXX_HAS_INTEGER_PACK ^^^ / vvv !_LIBCUDACXX_HAS_INTEGER_PACK vvv
 
 template <typename _Tp, _Tp _Np>
 using __make_integer_sequence_unchecked _LIBCUDACXX_NODEBUG_TYPE =

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -1064,6 +1064,9 @@ typedef unsigned int char32_t;
 #        define _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ
 #      endif
 #    endif
+#    if __check_builtin(integer_pack)
+#      define _LIBCUDACXX_HAS_INTEGER_PACK
+#    endif
 #  endif
 
 #  ifdef _LIBCUDACXX_DEBUG

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -1056,8 +1056,14 @@ typedef unsigned int char32_t;
 #    define _LIBCUDACXX_HAS_NO_BUILTIN_OPERATOR_NEW_DELETE
 #  endif
 
-#  if __check_builtin(make_integer_seq) && !defined(_LIBCUDACXX_TESTING_FALLBACK_MAKE_INTEGER_SEQUENCE)
-#    define _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ
+#  if !defined(_LIBCUDACXX_TESTING_FALLBACK_MAKE_INTEGER_SEQUENCE)
+#    if __check_builtin(make_integer_seq)
+#      define _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ
+#    elif defined(_CCCL_COMPILER_MSVC)
+#      if _CCCL_MSVC_VERSION_FULL >= 190023918
+#        define _LIBCUDACXX_HAS_MAKE_INTEGER_SEQ
+#      endif
+#    endif
 #  endif
 
 #  ifdef _LIBCUDACXX_DEBUG


### PR DESCRIPTION
## Description

MSVC has the `__make_integer_seq` intrinsic, but our implementation of `make_integer_sequence` isn't using it. this PR corrects that.

additionally, it uses the `__integer_pack` intrinsic on gcc.

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
fixes #2367 

<!-- Provide a standalone description of changes in this PR. -->
this PR defines `_LIBCUDACXX_HAS_MAKE_INTEGER_SEQ` when `_CCCL_MSVC_VERSION_FULL >= 190023918` is `true`.

it also conditionally implements `make_integer_sequence` in terms of `__integer_pack` if such a builtin is available.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
