### PR TITLE
Make `thrust::transform` use `cub::DeviceTransform`

### DIFF
--- a/docs/libcudacxx/extended_api/functional.rst
+++ b/docs/libcudacxx/extended_api/functional.rst
@@ -18,6 +18,10 @@ Function wrapper
      - Creates a forwarding call wrapper that proclaims return type
      - libcu++ 1.9.0 / CCCL 2.0.0 / CUDA 11.8
 
+   * - ``cuda::proclaim_copyable_arguments``
+     - Creates a forwarding call wrapper that proclaims that arguments can be freely copied before an invocation of the wrapped callable
+     - CCCL 2.8.0
+
    * - :ref:`cuda::get_device_address <libcudacxx-extended-api-functional-get-device-address>`
      - Returns a valid address to a device object
      - CCCL 2.8.0

--- a/libcudacxx/include/cuda/__functional/address_stability.h
+++ b/libcudacxx/include/cuda/__functional/address_stability.h
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___FUNCTIONAL_ADDRESS_STABILITY_H
+#define _CUDA___FUNCTIONAL_ADDRESS_STABILITY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__utility/move.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+//! Trait telling whether a function object type F does not rely on the memory addresses of its arguments. The nested
+//! value is true when the addresses of the arguments do not matter and arguments can be provided from arbitrary copies
+//! of the respective sources. This trait can be specialized for custom function objects types.
+//! @see proclaim_copyable_arguments
+template <typename F, typename SFINAE = void>
+struct proclaims_copyable_arguments : _CUDA_VSTD::false_type
+{};
+
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
+template <typename F, typename... Args>
+_CCCL_INLINE_VAR constexpr bool proclaims_copyable_arguments_v = proclaims_copyable_arguments<F, Args...>::value;
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
+
+// Wrapper for a callable to mark it as permitting copied arguments
+template <typename F>
+struct __callable_permitting_copied_arguments : F
+{
+  using F::operator();
+};
+
+template <typename F>
+struct proclaims_copyable_arguments<__callable_permitting_copied_arguments<F>> : _CUDA_VSTD::true_type
+{};
+
+//! Creates a new function object from an existing one, which is marked as permitting its arguments to be copies of
+//! whatever source they come from. This implies that the addresses of the arguments are irrelevant to the function
+//! object.
+//! @see proclaims_copyable_arguments
+template <typename F>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr auto
+proclaim_copyable_arguments(F f) -> __callable_permitting_copied_arguments<F>
+{
+  return __callable_permitting_copied_arguments<F>{_CUDA_VSTD::move(f)};
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CUDA___FUNCTIONAL_ADDRESS_STABILITY_H

--- a/libcudacxx/include/cuda/functional
+++ b/libcudacxx/include/cuda/functional
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__functional/address_stability.h>
 #include <cuda/__functional/get_device_address.h>
 #include <cuda/__functional/maximum.h>
 #include <cuda/__functional/minimum.h>

--- a/thrust/benchmarks/bench/transform/basic.cu
+++ b/thrust/benchmarks/bench/transform/basic.cu
@@ -33,6 +33,8 @@
 #include <thrust/transform.h>
 #include <thrust/zip_function.h>
 
+#include <cuda/__functional/address_stability.h>
+
 #include <nvbench_helper.cuh>
 
 template <class InT, class OutT>
@@ -121,9 +123,10 @@ static void mul(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch&) {
     const T scalar = startScalar;
-    thrust::transform(c.begin(), c.end(), b.begin(), [=] __device__ __host__(const T& ci) {
-      return ci * scalar;
-    });
+    thrust::transform(
+      c.begin(), c.end(), b.begin(), cuda::proclaim_copyable_arguments([=] __device__ __host__(const T& ci) {
+        return ci * scalar;
+      }));
   });
 }
 
@@ -145,9 +148,14 @@ static void add(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_writes<T>(n);
 
   state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch&) {
-    thrust::transform(a.begin(), a.end(), b.begin(), c.begin(), [] __device__ __host__(const T& ai, const T& bi) {
-      return ai + bi;
-    });
+    thrust::transform(
+      a.begin(),
+      a.end(),
+      b.begin(),
+      c.begin(),
+      cuda::proclaim_copyable_arguments([] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
+        return ai + bi;
+      }));
   });
 }
 
@@ -170,9 +178,14 @@ static void triad(nvbench::state& state, nvbench::type_list<T>)
 
   state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch&) {
     const T scalar = startScalar;
-    thrust::transform(b.begin(), b.end(), c.begin(), a.begin(), [=] __device__ __host__(const T& bi, const T& ci) {
-      return bi + scalar * ci;
-    });
+    thrust::transform(
+      b.begin(),
+      b.end(),
+      c.begin(),
+      a.begin(),
+      cuda::proclaim_copyable_arguments([=] _CCCL_DEVICE(const T& bi, const T& ci) {
+        return bi + scalar * ci;
+      }));
   });
 }
 
@@ -199,9 +212,11 @@ static void nstream(nvbench::state& state, nvbench::type_list<T>)
       thrust::make_zip_iterator(a.begin(), b.begin(), c.begin()),
       thrust::make_zip_iterator(a.end(), b.end(), c.end()),
       a.begin(),
-      thrust::make_zip_function([=] __device__ __host__(const T& ai, const T& bi, const T& ci) {
-        return ai + bi + scalar * ci;
-      }));
+
+      thrust::make_zip_function(
+        cuda::proclaim_copyable_arguments([=] _CCCL_DEVICE(const T& ai, const T& bi, const T& ci) {
+          return ai + bi + scalar * ci;
+        })));
   });
 }
 

--- a/thrust/benchmarks/bench/transform/basic.cu
+++ b/thrust/benchmarks/bench/transform/basic.cu
@@ -106,7 +106,7 @@ constexpr auto startC      = 3; // BabelStream: 0.1
 constexpr auto startScalar = 4; // BabelStream: 0.4
 
 using element_types    = nvbench::type_list<std::int8_t, std::int16_t, float, double, __int128>;
-auto array_size_powers = std::vector<std::int64_t>{25};
+auto array_size_powers = std::vector<std::int64_t>{25}; // BabelStream uses 2^25, H200 can fit 2^31
 
 template <typename T>
 static void mul(nvbench::state& state, nvbench::type_list<T>)
@@ -207,6 +207,37 @@ static void nstream(nvbench::state& state, nvbench::type_list<T>)
 
 NVBENCH_BENCH_TYPES(nstream, NVBENCH_TYPE_AXES(element_types))
   .set_name("nstream")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", array_size_powers);
+
+// variation of nstream requiring a stable parameter address because it recovers the element index
+template <typename T>
+static void nstream_stable(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto n = static_cast<std::size_t>(state.get_int64("Elements"));
+  thrust::device_vector<T> a(n, startA);
+  thrust::device_vector<T> b(n, startB);
+  thrust::device_vector<T> c(n, startC);
+
+  const T* a_start = thrust::raw_pointer_cast(a.data());
+  const T* b_start = thrust::raw_pointer_cast(b.data());
+  const T* c_start = thrust::raw_pointer_cast(c.data());
+
+  state.add_element_count(n);
+  state.add_global_memory_reads<T>(3 * n);
+  state.add_global_memory_writes<T>(n);
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch&) {
+    const T scalar = startScalar;
+    thrust::transform(a.begin(), a.end(), a.begin(), [=] _CCCL_DEVICE(const T& ai) {
+      const auto i = &ai - a_start;
+      return ai + b_start[i] + scalar * c_start[i];
+    });
+  });
+}
+
+NVBENCH_BENCH_TYPES(nstream_stable, NVBENCH_TYPE_AXES(element_types))
+  .set_name("nstream_stable")
   .set_type_axes_names({"T{ct}"})
   .add_int64_power_of_two_axis("Elements", array_size_powers);
 } // namespace babelstream

--- a/thrust/testing/address_stability.cu
+++ b/thrust/testing/address_stability.cu
@@ -1,0 +1,24 @@
+#include <cuda/__functional/address_stability.h>
+
+#include <unittest/unittest.h>
+
+struct my_plus
+{
+  _CCCL_HOST_DEVICE auto operator()(int a, int b) const -> int
+  {
+    return a + b;
+  }
+};
+
+void TestAddressStability()
+{
+  using ::cuda::proclaim_copyable_arguments;
+  using ::cuda::proclaims_copyable_arguments;
+
+  static_assert(!proclaims_copyable_arguments<thrust::plus<int>>::value, "");
+  static_assert(proclaims_copyable_arguments<decltype(proclaim_copyable_arguments(thrust::plus<int>{}))>::value, "");
+
+  static_assert(!proclaims_copyable_arguments<my_plus>::value, "");
+  static_assert(proclaims_copyable_arguments<decltype(proclaim_copyable_arguments(my_plus{}))>::value, "");
+}
+DECLARE_UNITTEST(TestAddressStability);

--- a/thrust/testing/cuda/transform.cu
+++ b/thrust/testing/cuda/transform.cu
@@ -344,3 +344,80 @@ void TestTransformBinaryCudaStreams()
   cudaStreamDestroy(s);
 }
 DECLARE_UNITTEST(TestTransformBinaryCudaStreams);
+
+struct sum_five
+{
+  _CCCL_HOST_DEVICE auto
+  operator()(std::int8_t a, std::int16_t b, std::int32_t c, std::int64_t d, float e) const -> double
+  {
+    return a + b + c + d + e;
+  }
+};
+
+// The following test cannot be compiled because of a bug in the conversion of thrust::tuple on MSVC 2017
+#ifndef _CCCL_COMPILER_MSVC_2017
+// we specialize zip_function for sum_five, but do nothing in the call operator so the test below would fail if the
+// zip_function is actually called (and not unwrapped)
+THRUST_NAMESPACE_BEGIN
+template <>
+class zip_function<sum_five>
+{
+public:
+  _CCCL_HOST_DEVICE zip_function(sum_five func)
+      : func(func)
+  {}
+
+  _CCCL_HOST_DEVICE sum_five& underlying_function() const
+  {
+    return func;
+  }
+
+  template <typename Tuple>
+  _CCCL_HOST_DEVICE auto
+  operator()(Tuple&& t) const -> decltype(detail::zip_detail::apply(std::declval<sum_five>(), THRUST_FWD(t)))
+  {
+    // not calling func, so we would get a wrong result if we were called
+    return {};
+  }
+
+private:
+  mutable sum_five func;
+};
+THRUST_NAMESPACE_END
+
+// test that the cuda_cub backend of Thrust unwraps zip_iterators/zip_functions into their input streams
+void TestTransformZipIteratorUnwrapping()
+{
+  constexpr int num_items = 100;
+  thrust::device_vector<std::int8_t> a(num_items, 1);
+  thrust::device_vector<std::int16_t> b(num_items, 2);
+  thrust::device_vector<std::int32_t> c(num_items, 3);
+  thrust::device_vector<std::int64_t> d(num_items, 4);
+  thrust::device_vector<float> e(num_items, 5);
+
+  thrust::device_vector<double> result(num_items);
+  // SECTION("once") // TODO(bgruber): enable sections when we migrate to Catch2
+  {
+    const auto z = thrust::make_zip_iterator(a.begin(), b.begin(), c.begin(), d.begin(), e.begin());
+    thrust::transform(z, z + num_items, result.begin(), thrust::make_zip_function(sum_five{}));
+
+    // compute reference and verify
+    thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
+    ASSERT_EQUAL(reference, result);
+  }
+  // SECTION("trice")
+  {
+    const auto z = thrust::make_zip_iterator(
+      thrust::make_zip_iterator(thrust::make_zip_iterator(a.begin(), b.begin(), c.begin(), d.begin(), e.begin())));
+    thrust::transform(z,
+                      z + num_items,
+                      result.begin(),
+                      thrust::make_zip_function(thrust::make_zip_function(thrust::make_zip_function(sum_five{}))));
+
+    // compute reference and verify
+    thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
+    ASSERT_EQUAL(reference, result);
+  }
+}
+DECLARE_UNITTEST(TestTransformZipIteratorUnwrapping);
+#endif // !_CCCL_COMPILER_MSVC_2017

--- a/thrust/thrust/system/cuda/detail/internal/copy_device_to_device.h
+++ b/thrust/thrust/system/cuda/detail/internal/copy_device_to_device.h
@@ -50,6 +50,10 @@
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
+// Need a forward declaration here to work around a cyclic include, since "cuda/detail/transform.h" includes this header
+template <class Derived, class InputIt, class OutputIt, class TransformOp>
+OutputIt THRUST_FUNCTION
+transform(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result, TransformOp transform_op);
 
 namespace __copy
 {


### PR DESCRIPTION
This PR makes `thrust::transform` use `cub::DeviceTransform` for the CUDA backend.

It also:
* Introduces address stability detection and opt-in in libcu++
* Mark lambdas in Thrust BabelStream benchmark address oblivious
* Adds an optimization to the `cub::DeviceTransform` prefetch algorithm for small problem sizes

<details>
  <summary>Benchmark on H100</summary>

```
# base

## [0] NVIDIA H100 NVL

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   U32   |    2^16    |  10.367 us |       3.40% |   9.172 us |       3.05% | -1.195 us | -11.53% |   FAIL   |
|   U32   |    2^20    |  15.435 us |       4.07% |  16.118 us |       2.96% |  0.683 us |   4.43% |   FAIL   |
|   U32   |    2^24    |  96.316 us |       0.49% |  98.619 us |       0.30% |  2.303 us |   2.39% |   FAIL   |
|   U32   |    2^28    |   1.378 ms |       0.12% |   1.392 ms |       0.04% | 13.307 us |   0.97% |   FAIL   |
|   U64   |    2^16    |  12.335 us |      14.19% |   9.878 us |       3.00% | -2.457 us | -19.92% |   FAIL   |
|   U64   |    2^20    |  16.956 us |       5.22% |  17.244 us |       2.56% |  0.288 us |   1.70% |   PASS   |
|   U64   |    2^24    | 116.436 us |       0.32% | 112.155 us |       0.43% | -4.281 us |  -3.68% |   FAIL   |
|   U64   |    2^28    |   1.777 ms |       2.54% |   1.815 ms |       2.98% | 37.387 us |   2.10% |   PASS   |

# mul

## [0] NVIDIA H100 NVL

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^25    |  86.886 us |       2.14% |  34.495 us |       2.99% | -52.392 us | -60.30% |   FAIL   |
|   I16   |    2^25    |  94.903 us |       0.72% |  50.397 us |       1.35% | -44.506 us | -46.90% |   FAIL   |
|   F32   |    2^25    | 112.067 us |       0.55% |  87.791 us |       0.80% | -24.275 us | -21.66% |   FAIL   |
|   F64   |    2^25    | 172.552 us |       0.41% | 162.959 us |       0.54% |  -9.592 us |  -5.56% |   FAIL   |
|  I128   |    2^25    | 313.923 us |       0.56% | 316.735 us |       0.46% |   2.812 us |   0.90% |   FAIL   |

# add

## [0] NVIDIA H100 NVL

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^25    |  93.893 us |       1.08% |  45.065 us |       1.88% | -48.828 us | -52.00% |   FAIL   |
|   I16   |    2^25    | 105.996 us |       0.28% |  70.617 us |       0.80% | -35.378 us | -33.38% |   FAIL   |
|   F32   |    2^25    | 142.256 us |       0.37% | 124.355 us |       0.51% | -17.901 us | -12.58% |   FAIL   |
|   F64   |    2^25    | 234.508 us |       0.31% | 233.388 us |       0.32% |  -1.121 us |  -0.48% |   FAIL   |
|  I128   |    2^25    | 455.391 us |       0.59% | 453.136 us |       0.58% |  -2.254 us |  -0.50% |   PASS   |

# triad

## [0] NVIDIA H100 NVL

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^25    |  95.942 us |       0.98% |  44.766 us |       1.78% | -51.176 us | -53.34% |   FAIL   |
|   I16   |    2^25    | 106.412 us |       0.39% |  70.679 us |       1.00% | -35.733 us | -33.58% |   FAIL   |
|   F32   |    2^25    | 142.654 us |       0.40% | 124.903 us |       0.53% | -17.751 us | -12.44% |   FAIL   |
|   F64   |    2^25    | 234.775 us |       0.31% | 233.577 us |       0.30% |  -1.198 us |  -0.51% |   FAIL   |
|  I128   |    2^25    | 455.983 us |       0.57% | 453.968 us |       0.52% |  -2.015 us |  -0.44% |   PASS   |

# nstream

## [0] NVIDIA H100 NVL

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^25    | 102.062 us |       1.36% |  55.360 us |       2.87% | -46.702 us | -45.76% |   FAIL   |
|   I16   |    2^25    | 119.080 us |       0.29% |  89.179 us |       0.57% | -29.901 us | -25.11% |   FAIL   |
|   F32   |    2^25    | 172.130 us |       0.29% | 160.601 us |       0.41% | -11.529 us |  -6.70% |   FAIL   |
|   F64   |    2^25    | 305.508 us |       0.19% | 304.931 us |       0.25% |  -0.578 us |  -0.19% |   PASS   |
|  I128   |    2^25    | 595.518 us |       0.30% | 594.329 us |       0.28% |  -1.189 us |  -0.20% |   PASS   |

# nstream_stable

## [0] NVIDIA H100 NVL

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |    2^25    | 102.602 us |       1.36% |  99.178 us |       1.61% | -3.424 us |  -3.34% |   FAIL   |
|   I16   |    2^25    | 119.544 us |       0.40% | 114.715 us |       0.37% | -4.829 us |  -4.04% |   FAIL   |
|   F32   |    2^25    | 172.225 us |       0.32% | 167.925 us |       0.30% | -4.300 us |  -2.50% |   FAIL   |
|   F64   |    2^25    | 305.132 us |       0.17% | 305.411 us |       0.16% |  0.280 us |   0.09% |   PASS   |
|  I128   |    2^25    | 595.308 us |       0.29% | 595.591 us |       0.33% |  0.283 us |   0.05% |   PASS   |
```

</details>

<details>
  <summary>Benchmark on H200</summary>

```
# base

## [0] NVIDIA H200

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   U32   |    2^16    |  12.166 us |       4.54% |  11.492 us |       6.80% |  -0.674 us |  -5.54% |   FAIL   |
|   U32   |    2^20    |  16.644 us |       2.42% |  17.449 us |       2.59% |   0.805 us |   4.83% |   FAIL   |
|   U32   |    2^24    |  88.994 us |       0.57% |  90.992 us |       0.59% |   1.998 us |   2.25% |   FAIL   |
|   U32   |    2^28    |   1.242 ms |       3.31% |   1.254 ms |       0.94% |  11.856 us |   0.95% |   FAIL   |
|   U64   |    2^16    |  12.668 us |       5.41% |  11.867 us |       4.50% |  -0.801 us |  -6.32% |   FAIL   |
|   U64   |    2^20    |  17.953 us |       3.47% |  18.353 us |       2.51% |   0.400 us |   2.23% |   PASS   |
|   U64   |    2^24    | 105.728 us |       0.47% | 102.073 us |       0.63% |  -3.655 us |  -3.46% |   FAIL   |
|   U64   |    2^28    |   1.509 ms |       0.13% |   1.445 ms |       0.45% | -64.508 us |  -4.27% |   FAIL   |

# mul

## [0] NVIDIA H200

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^25    |  79.274 us |       1.54% |  32.089 us |       2.77% | -47.185 us | -59.52% |   FAIL   |
|   I16   |    2^25    |  87.026 us |       0.78% |  46.222 us |       2.37% | -40.803 us | -46.89% |   FAIL   |
|   F32   |    2^25    | 101.086 us |       0.89% |  76.642 us |       1.22% | -24.444 us | -24.18% |   FAIL   |
|   F64   |    2^25    | 149.348 us |       0.71% | 139.039 us |       0.69% | -10.309 us |  -6.90% |   FAIL   |
|  I128   |    2^25    | 264.865 us |       0.32% | 269.614 us |       0.37% |   4.749 us |   1.79% |   FAIL   |

# add

## [0] NVIDIA H200

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^25    |  86.340 us |       0.63% |  41.636 us |       1.54% | -44.704 us | -51.78% |   FAIL   |
|   I16   |    2^25    |  97.559 us |       0.50% |  62.541 us |       1.21% | -35.017 us | -35.89% |   FAIL   |
|   F32   |    2^25    | 124.967 us |       0.44% | 106.734 us |       0.45% | -18.233 us | -14.59% |   FAIL   |
|   F64   |    2^25    | 198.089 us |       0.28% | 197.965 us |       6.21% |  -0.124 us |  -0.06% |   PASS   |
|  I128   |    2^25    | 382.959 us |       2.94% | 379.519 us |       0.24% |  -3.439 us |  -0.90% |   FAIL   |

# triad

## [0] NVIDIA H200

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^25    |  88.292 us |       0.76% |  41.519 us |       2.03% | -46.773 us | -52.98% |   FAIL   |
|   I16   |    2^25    |  96.488 us |       0.53% |  62.454 us |       1.28% | -34.034 us | -35.27% |   FAIL   |
|   F32   |    2^25    | 125.204 us |       0.44% | 106.697 us |       0.48% | -18.507 us | -14.78% |   FAIL   |
|   F64   |    2^25    | 198.454 us |       0.25% | 196.966 us |       0.34% |  -1.489 us |  -0.75% |   FAIL   |
|  I128   |    2^25    | 381.363 us |       0.37% | 377.733 us |       0.36% |  -3.631 us |  -0.95% |   FAIL   |

# nstream

## [0] NVIDIA H200

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^25    |  92.025 us |       0.47% |  48.296 us |       1.49% | -43.729 us | -47.52% |   FAIL   |
|   I16   |    2^25    | 106.494 us |       0.33% |  75.618 us |       1.02% | -30.876 us | -28.99% |   FAIL   |
|   F32   |    2^25    | 146.526 us |       0.56% | 134.765 us |       0.61% | -11.761 us |  -8.03% |   FAIL   |
|   F64   |    2^25    | 254.879 us |       0.36% | 254.521 us |       0.37% |  -0.358 us |  -0.14% |   PASS   |
|  I128   |    2^25    | 499.487 us |       0.36% | 494.593 us |       0.28% |  -4.894 us |  -0.98% |   FAIL   |

# nstream_stable

## [0] NVIDIA H200

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |    2^25    |  92.382 us |       0.52% |  88.861 us |       0.56% | -3.521 us |  -3.81% |   FAIL   |
|   I16   |    2^25    | 106.623 us |       0.45% | 100.466 us |       0.46% | -6.157 us |  -5.77% |   FAIL   |
|   F32   |    2^25    | 146.150 us |       0.56% | 142.722 us |       0.58% | -3.428 us |  -2.35% |   FAIL   |
|   F64   |    2^25    | 254.607 us |       0.47% | 254.666 us |       0.36% |  0.059 us |   0.02% |   PASS   |
|  I128   |    2^25    | 499.203 us |       0.16% | 496.988 us |       0.17% | -2.215 us |  -0.44% |   FAIL   |
```

</details>

Resolve before:

- [x] #2086 
- [x] #2396 (optional, but big gains)
- [x] #2664
- [x] #2402
- [x] no regressions of more than 15% compared to previous implementation (`cub::DeviceFor`)
- [x] no regressions of more than 2.5% compared to previous implementation on 2^24+ problem sizes
- [x] new implementation outperforms old implementation on 2^24+ problem sizes with average improvement of more than 5%
