### PR TITLE
Drop implementation of `thrust::pair` and `thrust::tuple`

### DIFF
--- a/docs/thrust/api_docs/utility/pair.rst
+++ b/docs/thrust/api_docs/utility/pair.rst
@@ -3,11 +3,12 @@
 Pair
 ----
 
-  - :cpp:struct:`thrust::pair <thrust::pair>`
+Thrust provides an implementations of `std::pair`, that is pulled in from `libcu++`.
+
+It is recommended to replace `thrust::pair` and `thrust::make_pair` with `cuda::std::pair` and `cuda::std::make_pair`.
 
 .. toctree::
    :glob:
    :maxdepth: 1
 
-   ${repo_docs_api_path}/*struct*pair*
-   ${repo_docs_api_path}/*function_group__pair*
+   ${repo_docs_api_path}/*typedef*pair*

--- a/docs/thrust/api_docs/utility/tuple.rst
+++ b/docs/thrust/api_docs/utility/tuple.rst
@@ -3,10 +3,12 @@
 Tuple
 ------
 
-  - :cpp:struct:`thrust::tuple <thrust::tuple>`
+Thrust provides an implementations of `std::tuple`, that is pulled in from `libcu++`.
+
+It is recommended to replace `thrust::tuple` with `cuda::std::tuple`.
 
 .. toctree::
    :glob:
    :maxdepth: 1
 
-   ${repo_docs_api_path}/*function_group__tuple*
+   ${repo_docs_api_path}/*typedef*tuple*

--- a/docs/thrust/api_docs/utility/tuple.rst
+++ b/docs/thrust/api_docs/utility/tuple.rst
@@ -3,7 +3,7 @@
 Tuple
 ------
 
-Thrust provides an implementations of `std::tuple`, that is pulled in from `libcu++`.
+Thrust provides an implementation of `std::tuple`, that is pulled in from `libcu++`.
 
 It is recommended to replace `thrust::tuple` with `cuda::std::tuple`.
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -194,6 +194,10 @@ _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+template <class>
+struct __is_tuple_of_iterator_references : _CUDA_VSTD::false_type
+{};
+
 // __tuple_leaf
 struct __tuple_leaf_default_constructor_tag
 {};
@@ -853,6 +857,15 @@ public:
     _If<__tuple_like_with_size<_Tuple, sizeof...(_Tp)>::value,
         typename __tuple_constraints<_Tp...>::template __tuple_like_constraints<_Tuple>,
         __invalid_tuple_constraints>;
+
+  // Horrible hack to make tuple_of_iterator_references work
+  template <class _TupleOfIteratorReferences,
+            __enable_if_t<__is_tuple_of_iterator_references<_TupleOfIteratorReferences>::value, int> = 0,
+            __enable_if_t<(tuple_size<_TupleOfIteratorReferences>::value == sizeof...(_Tp)), int>    = 0>
+  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 tuple(_TupleOfIteratorReferences&& __t)
+      : tuple(_CUDA_VSTD::forward<_TupleOfIteratorReferences>(__t).template __to_tuple<_Tp...>(
+          __make_tuple_indices_t<sizeof...(_Tp)>()))
+  {}
 
   template <class _Tuple,
             class _Constraints                                            = __tuple_like_constraints<_Tuple>,

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -67,7 +67,9 @@ public:
   using super_t = thrust::tuple<Ts...>;
   using super_t::super_t;
 
-  tuple_of_iterator_references() = default;
+  inline _CCCL_HOST_DEVICE tuple_of_iterator_references()
+      : super_t()
+  {}
 
   // allow implicit construction from tuple<refs>
   inline _CCCL_HOST_DEVICE tuple_of_iterator_references(const super_t& other)
@@ -136,14 +138,13 @@ public:
 
 } // namespace detail
 
-template <class... Ts>
-struct __is_tuple_of_iterator_references<THRUST_NS_QUALIFIER::detail::tuple_of_iterator_references<Ts...>>
-    : _CUDA_VSTD::true_type
-{};
-
 THRUST_NAMESPACE_END
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class... Ts>
+struct __is_tuple_of_iterator_references<THRUST_NS_QUALIFIER::detail::tuple_of_iterator_references<Ts...>> : true_type
+{};
 
 // define tuple_size, tuple_element, etc.
 template <class... Ts>

--- a/thrust/thrust/pair.h
+++ b/thrust/thrust/pair.h
@@ -49,7 +49,12 @@ THRUST_NAMESPACE_BEGIN
  *  \tparam N This parameter selects the member of interest.
  *  \tparam T A \c pair type of interest.
  */
+#ifdef DOXYGEN_SHOULD_SKIP_THIS // Provide a fake alias for doxygen
+template <size_t N, class T>
+using tuple_element = _CUDA_VSTD::tuple_element<N, T>;
+#else // ^^^ DOXYGEN_SHOULD_SKIP_THIS ^^^ / vvv !DOXYGEN_SHOULD_SKIP_THIS vvv
 using _CUDA_VSTD::tuple_element;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /*! This convenience metafunction is included for compatibility with
  *  \p tuple. It returns \c 2, the number of elements of a \p pair,
@@ -57,7 +62,12 @@ using _CUDA_VSTD::tuple_element;
  *
  *  \tparam Pair A \c pair type of interest.
  */
+#ifdef DOXYGEN_SHOULD_SKIP_THIS // Provide a fake alias for doxygen
+template <class T>
+using tuple_size = _CUDA_VSTD::tuple_size<T>;
+#else // ^^^ DOXYGEN_SHOULD_SKIP_THIS ^^^ / vvv !DOXYGEN_SHOULD_SKIP_THIS vvv
 using _CUDA_VSTD::tuple_size;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /*! \p pair is a generic data structure encapsulating a heterogeneous
  *  pair of values.
@@ -70,9 +80,15 @@ using _CUDA_VSTD::tuple_size;
  *          requirements on the type of \p T2. <tt>T2</tt>'s type is
  *          provided by <tt>pair::second_type</tt>.
  */
+#ifdef DOXYGEN_SHOULD_SKIP_THIS // Provide a fake alias for doxygen
+template <class T, class U>
+using pair = _CUDA_VSTD::pair<T, U>;
+#else // ^^^ DOXYGEN_SHOULD_SKIP_THIS ^^^ / vvv !DOXYGEN_SHOULD_SKIP_THIS vvv
+using _CUDA_VSTD::pair;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
 using _CUDA_VSTD::get;
 using _CUDA_VSTD::make_pair;
-using _CUDA_VSTD::pair;
 
 /*! \endcond
  */

--- a/thrust/thrust/pair.h
+++ b/thrust/thrust/pair.h
@@ -30,9 +30,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/type_traits/is_trivially_relocatable.h>
-
-#include <cuda/std/__type_traits/conjunction.h>
 #include <cuda/std/utility>
 
 THRUST_NAMESPACE_BEGIN
@@ -52,8 +49,7 @@ THRUST_NAMESPACE_BEGIN
  *  \tparam N This parameter selects the member of interest.
  *  \tparam T A \c pair type of interest.
  */
-template <size_t N, class T>
-using tuple_element = _CUDA_VSTD::tuple_element<N, T>;
+using _CUDA_VSTD::tuple_element;
 
 /*! This convenience metafunction is included for compatibility with
  *  \p tuple. It returns \c 2, the number of elements of a \p pair,
@@ -61,8 +57,7 @@ using tuple_element = _CUDA_VSTD::tuple_element<N, T>;
  *
  *  \tparam Pair A \c pair type of interest.
  */
-template <class T>
-using tuple_size = _CUDA_VSTD::tuple_size<T>;
+using _CUDA_VSTD::tuple_size;
 
 /*! \p pair is a generic data structure encapsulating a heterogeneous
  *  pair of values.
@@ -75,55 +70,9 @@ using tuple_size = _CUDA_VSTD::tuple_size<T>;
  *          requirements on the type of \p T2. <tt>T2</tt>'s type is
  *          provided by <tt>pair::second_type</tt>.
  */
-template <class T, class U>
-struct pair : public _CUDA_VSTD::pair<T, U>
-{
-  using super_t = _CUDA_VSTD::pair<T, U>;
-  using super_t::super_t;
-
-#if (defined(_CCCL_COMPILER_GCC) && __GNUC__ < 9) || (defined(_CCCL_COMPILER_CLANG) && __clang_major__ < 12)
-  // For whatever reason nvcc complains about that constructor being used before being defined in a constexpr variable
-  constexpr pair() = default;
-
-  template <class _U1          = T,
-            class _U2          = U,
-            class _Constraints = typename _CUDA_VSTD::__pair_constraints<T, U>::template __constructible<_U1, _U2>,
-            _CUDA_VSTD::__enable_if_t<_Constraints::__implicit_constructible, int> = 0>
-  _CCCL_HOST_DEVICE constexpr pair(_U1&& __u1, _U2&& __u2)
-      : super_t(_CUDA_VSTD::forward<_U1>(__u1), _CUDA_VSTD::forward<_U2>(__u2))
-  {}
-#endif // _CCCL_COMPILER_GCC < 9 || _CCCL_COMPILER_CLANG < 12
-};
-
-#if _CCCL_STD_VER >= 2017
-template <class _T1, class _T2>
-_CCCL_HOST_DEVICE pair(_T1, _T2) -> pair<_T1, _T2>;
-#endif // _CCCL_STD_VER >= 2017
-
-template <class T1, class T2>
-inline _CCCL_HOST_DEVICE
-_CUDA_VSTD::__enable_if_t<_CUDA_VSTD::__is_swappable<T1>::value && _CUDA_VSTD::__is_swappable<T2>::value, void>
-swap(pair<T1, T2>& lhs, pair<T1, T2>& rhs) noexcept(
-  (_CUDA_VSTD::__is_nothrow_swappable<T1>::value && _CUDA_VSTD::__is_nothrow_swappable<T2>::value))
-{
-  lhs.swap(rhs);
-}
-
-template <class T1, class T2>
-inline _CCCL_HOST_DEVICE
-pair<typename _CUDA_VSTD::__unwrap_ref_decay<T1>::type, typename _CUDA_VSTD::__unwrap_ref_decay<T2>::type>
-make_pair(T1&& t1, T2&& t2)
-{
-  return pair<typename _CUDA_VSTD::__unwrap_ref_decay<T1>::type, typename _CUDA_VSTD::__unwrap_ref_decay<T2>::type>(
-    _CUDA_VSTD::forward<T1>(t1), _CUDA_VSTD::forward<T2>(t2));
-}
-
 using _CUDA_VSTD::get;
-
-template <typename T, typename U>
-struct proclaim_trivially_relocatable<pair<T, U>>
-    : ::cuda::std::conjunction<is_trivially_relocatable<T>, is_trivially_relocatable<U>>
-{};
+using _CUDA_VSTD::make_pair;
+using _CUDA_VSTD::pair;
 
 /*! \endcond
  */
@@ -135,38 +84,3 @@ struct proclaim_trivially_relocatable<pair<T, U>>
  */
 
 THRUST_NAMESPACE_END
-
-_LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-template <class T1, class T2>
-struct tuple_size<THRUST_NS_QUALIFIER::pair<T1, T2>> : tuple_size<pair<T1, T2>>
-{};
-
-template <size_t Id, class T1, class T2>
-struct tuple_element<Id, THRUST_NS_QUALIFIER::pair<T1, T2>> : tuple_element<Id, pair<T1, T2>>
-{};
-
-template <class T1, class T2>
-struct __tuple_like_ext<THRUST_NS_QUALIFIER::pair<T1, T2>> : true_type
-{};
-
-_LIBCUDACXX_END_NAMESPACE_STD
-
-// This is a workaround for the fact that structured bindings require that the specializations of
-// `tuple_size` and `tuple_element` reside in namespace std (https://eel.is/c++draft/dcl.struct.bind#4).
-// See https://github.com/NVIDIA/libcudacxx/issues/316 for a short discussion
-#if _CCCL_STD_VER >= 2017
-
-#  include <utility>
-
-namespace std
-{
-template <class T1, class T2>
-struct tuple_size<THRUST_NS_QUALIFIER::pair<T1, T2>> : tuple_size<pair<T1, T2>>
-{};
-
-template <size_t Id, class T1, class T2>
-struct tuple_element<Id, THRUST_NS_QUALIFIER::pair<T1, T2>> : tuple_element<Id, pair<T1, T2>>
-{};
-} // namespace std
-#endif // _CCCL_STD_VER >= 2017

--- a/thrust/thrust/tuple.h
+++ b/thrust/thrust/tuple.h
@@ -94,7 +94,12 @@ _CCCL_HOST_DEVICE inline bool operator>(const null_type&, const null_type&)
  *  \see pair
  *  \see tuple
  */
+#ifdef DOXYGEN_SHOULD_SKIP_THIS // Provide a fake alias for doxygen
+template <size_t N, class T>
+using tuple_element = _CUDA_VSTD::tuple_element<N, T>;
+#else // ^^^ DOXYGEN_SHOULD_SKIP_THIS ^^^ / vvv !DOXYGEN_SHOULD_SKIP_THIS vvv
 using _CUDA_VSTD::tuple_element;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /*! This metafunction returns the number of elements
  *  of a \p tuple type of interest.
@@ -104,16 +109,19 @@ using _CUDA_VSTD::tuple_element;
  *  \see pair
  *  \see tuple
  */
+#ifdef DOXYGEN_SHOULD_SKIP_THIS // Provide a fake alias for doxygen
+template <class T>
+using tuple_size = _CUDA_VSTD::tuple_size<T>;
+#else // ^^^ DOXYGEN_SHOULD_SKIP_THIS ^^^ / vvv !DOXYGEN_SHOULD_SKIP_THIS vvv
 using _CUDA_VSTD::tuple_size;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
-/*! \brief \p tuple is a class template that can be instantiated with up to ten
- *  arguments. Each template argument specifies the type of element in the \p
- *  tuple. Consequently, tuples are heterogeneous, fixed-size collections of
- *  values. An instantiation of \p tuple with two arguments is similar to an
+/*! \brief \p tuple is a heterogeneous, fixed-size collection of values.
+ *  An instantiation of \p tuple with two arguments is similar to an
  *  instantiation of \p pair with the same two arguments. Individual elements
  *  of a \p tuple may be accessed with the \p get function.
  *
- *  \tparam TN The type of the <tt>N</tt> \c tuple element. Thrust's \p tuple
+ *  \tparam Ts The type of the <tt>N</tt> \c tuple element. Thrust's \p tuple
  *          type currently supports up to ten elements.
  *
  *  The following code snippet demonstrates how to create a new \p tuple object
@@ -145,10 +153,16 @@ using _CUDA_VSTD::tuple_size;
  *  \see tuple_size
  *  \see tie
  */
+#ifdef DOXYGEN_SHOULD_SKIP_THIS // Provide a fake alias for doxygen
+template <class... Ts>
+using tuple = _CUDA_VSTD::tuple<T...>;
+#else // ^^^ DOXYGEN_SHOULD_SKIP_THIS ^^^ / vvv !DOXYGEN_SHOULD_SKIP_THIS vvv
+using _CUDA_VSTD::tuple;
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
 using _CUDA_VSTD::get;
 using _CUDA_VSTD::make_tuple;
 using _CUDA_VSTD::tie;
-using _CUDA_VSTD::tuple;
 
 /*! \endcond
  */

--- a/thrust/thrust/tuple.h
+++ b/thrust/thrust/tuple.h
@@ -39,13 +39,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/type_traits/is_trivially_relocatable.h>
-
 #include <cuda/std/tuple>
-#include <cuda/std/type_traits>
-#include <cuda/std/utility>
-
-#include <tuple>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -100,8 +94,7 @@ _CCCL_HOST_DEVICE inline bool operator>(const null_type&, const null_type&)
  *  \see pair
  *  \see tuple
  */
-template <size_t N, class T>
-using tuple_element = _CUDA_VSTD::tuple_element<N, T>;
+using _CUDA_VSTD::tuple_element;
 
 /*! This metafunction returns the number of elements
  *  of a \p tuple type of interest.
@@ -111,12 +104,7 @@ using tuple_element = _CUDA_VSTD::tuple_element<N, T>;
  *  \see pair
  *  \see tuple
  */
-template <class T>
-using tuple_size = _CUDA_VSTD::tuple_size<T>;
-
-template <class>
-struct __is_tuple_of_iterator_references : _CUDA_VSTD::false_type
-{};
+using _CUDA_VSTD::tuple_size;
 
 /*! \brief \p tuple is a class template that can be instantiated with up to ten
  *  arguments. Each template argument specifies the type of element in the \p
@@ -157,86 +145,10 @@ struct __is_tuple_of_iterator_references : _CUDA_VSTD::false_type
  *  \see tuple_size
  *  \see tie
  */
-template <class... Ts>
-struct tuple : public _CUDA_VSTD::tuple<Ts...>
-{
-  using super_t = _CUDA_VSTD::tuple<Ts...>;
-  using super_t::super_t;
-
-  tuple() = default;
-
-  template <class _TupleOfIteratorReferences,
-            _CUDA_VSTD::__enable_if_t<__is_tuple_of_iterator_references<_TupleOfIteratorReferences>::value, int> = 0,
-            _CUDA_VSTD::__enable_if_t<(tuple_size<_TupleOfIteratorReferences>::value == sizeof...(Ts)), int>     = 0>
-  _CCCL_HOST_DEVICE tuple(_TupleOfIteratorReferences&& tup)
-      : tuple(_CUDA_VSTD::forward<_TupleOfIteratorReferences>(tup).template __to_tuple<Ts...>(
-          _CUDA_VSTD::__make_tuple_indices_t<sizeof...(Ts)>()))
-  {}
-
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class TupleLike,
-            _CUDA_VSTD::__enable_if_t<_CUDA_VSTD::__tuple_assignable<TupleLike, super_t>::value, int> = 0>
-  _CCCL_HOST_DEVICE tuple& operator=(TupleLike&& other)
-  {
-    super_t::operator=(_CUDA_VSTD::forward<TupleLike>(other));
-    return *this;
-  }
-
-#if defined(_CCCL_COMPILER_MSVC_2017)
-  // MSVC2017 needs some help to convert tuples
-  template <class... Us,
-            _CUDA_VSTD::__enable_if_t<!_CUDA_VSTD::is_same<tuple<Us...>, tuple>::value, int> = 0,
-            _CUDA_VSTD::__enable_if_t<_CUDA_VSTD::__tuple_convertible<_CUDA_VSTD::tuple<Us...>, super_t>::value, int> = 0>
-  _CCCL_HOST_DEVICE constexpr operator tuple<Us...>()
-  {
-    return __to_tuple<Us...>(typename _CUDA_VSTD::__make_tuple_indices<sizeof...(Ts)>::type{});
-  }
-
-  template <class... Us, size_t... Id>
-  _CCCL_HOST_DEVICE constexpr tuple<Us...> __to_tuple(_CUDA_VSTD::__tuple_indices<Id...>) const
-  {
-    return tuple<Us...>{_CUDA_VSTD::get<Id>(*this)...};
-  }
-#endif // _CCCL_COMPILER_MSVC_2017
-};
-
-#if _CCCL_STD_VER >= 2017
-template <class... Ts>
-_CCCL_HOST_DEVICE tuple(Ts...) -> tuple<Ts...>;
-
-template <class T1, class T2>
-struct pair;
-
-template <class T1, class T2>
-_CCCL_HOST_DEVICE tuple(pair<T1, T2>) -> tuple<T1, T2>;
-#endif // _CCCL_STD_VER >= 2017
-
-template <class... Ts>
-inline
-  _CCCL_HOST_DEVICE _CUDA_VSTD::__enable_if_t<_CUDA_VSTD::__all<_CUDA_VSTD::__is_swappable<Ts>::value...>::value, void>
-  swap(tuple<Ts...>& __x,
-       tuple<Ts...>& __y) noexcept((_CUDA_VSTD::__all<_CUDA_VSTD::__is_nothrow_swappable<Ts>::value...>::value))
-{
-  __x.swap(__y);
-}
-
-template <class... Ts>
-inline _CCCL_HOST_DEVICE tuple<typename _CUDA_VSTD::__unwrap_ref_decay<Ts>::type...> make_tuple(Ts&&... __t)
-{
-  return tuple<typename _CUDA_VSTD::__unwrap_ref_decay<Ts>::type...>(_CUDA_VSTD::forward<Ts>(__t)...);
-}
-
-template <class... Ts>
-inline _CCCL_HOST_DEVICE tuple<Ts&...> tie(Ts&... ts) noexcept
-{
-  return tuple<Ts&...>(ts...);
-}
-
 using _CUDA_VSTD::get;
-
-template <typename... Ts>
-struct proclaim_trivially_relocatable<tuple<Ts...>> : ::cuda::std::conjunction<is_trivially_relocatable<Ts>...>
-{};
+using _CUDA_VSTD::make_tuple;
+using _CUDA_VSTD::tie;
+using _CUDA_VSTD::tuple;
 
 /*! \endcond
  */
@@ -250,18 +162,6 @@ struct proclaim_trivially_relocatable<tuple<Ts...>> : ::cuda::std::conjunction<i
 THRUST_NAMESPACE_END
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-template <class... Ts>
-struct tuple_size<THRUST_NS_QUALIFIER::tuple<Ts...>> : tuple_size<tuple<Ts...>>
-{};
-
-template <size_t Id, class... Ts>
-struct tuple_element<Id, THRUST_NS_QUALIFIER::tuple<Ts...>> : tuple_element<Id, tuple<Ts...>>
-{};
-
-template <class... Ts>
-struct __tuple_like_ext<THRUST_NS_QUALIFIER::tuple<Ts...>> : true_type
-{};
 
 template <>
 struct tuple_size<tuple<THRUST_NS_QUALIFIER::null_type,
@@ -371,19 +271,3 @@ struct tuple_size<tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, THRUST_NS_QUALIFIER:
 {};
 
 _LIBCUDACXX_END_NAMESPACE_STD
-
-// This is a workaround for the fact that structured bindings require that the specializations of
-// `tuple_size` and `tuple_element` reside in namespace std (https://eel.is/c++draft/dcl.struct.bind#4).
-// See https://github.com/NVIDIA/libcudacxx/issues/316 for a short discussion
-#if _CCCL_STD_VER >= 2017
-namespace std
-{
-template <class... Ts>
-struct tuple_size<THRUST_NS_QUALIFIER::tuple<Ts...>> : tuple_size<tuple<Ts...>>
-{};
-
-template <size_t Id, class... Ts>
-struct tuple_element<Id, THRUST_NS_QUALIFIER::tuple<Ts...>> : tuple_element<Id, tuple<Ts...>>
-{};
-} // namespace std
-#endif // _CCCL_STD_VER >= 2017


### PR DESCRIPTION
We previously moved them back to proper class definitions, as using alias declarations broke CTAD.

Thanks to @bernhardmgruber who realized that instead of making them an alias we can just pull them in and be done with it.
