### PR TITLE
Add prefetching kernel as new fallback for `cub::DeviceTransform`

### DIFF
--- a/cub/benchmarks/bench/transform/babelstream.h
+++ b/cub/benchmarks/bench/transform/babelstream.h
@@ -23,7 +23,9 @@ struct policy_hub_t
     using algo_policy =
       ::cuda::std::_If<algorithm == cub::detail::transform::Algorithm::fallback_for,
                        cub::detail::transform::fallback_for_policy,
-                       cub::detail::transform::async_copy_policy_t<TUNE_THREADS>>;
+                       ::cuda::std::_If<algorithm == cub::detail::transform::Algorithm::prefetch,
+                                        cub::detail::transform::prefetch_policy_t<TUNE_THREADS>,
+                                        cub::detail::transform::async_copy_policy_t<TUNE_THREADS>>>;
   };
 };
 #endif

--- a/cub/benchmarks/bench/transform/babelstream1.cu
+++ b/cub/benchmarks/bench/transform/babelstream1.cu
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // %RANGE% TUNE_THREADS tpb 128:1024:128
-// %RANGE% TUNE_ALGORITHM alg 0:1:1
+// %RANGE% TUNE_ALGORITHM alg 0:2:1
 
 // keep checks at the top so compilation of discarded variants fails really fast
 #if !TUNE_BASE
-#  if TUNE_ALGORITHM == 1 && (__CUDA_ARCH_LIST__) < 900
+#  if TUNE_ALGORITHM == 2 && (__CUDA_ARCH_LIST__) < 900
 #    error "Cannot compile algorithm 4 (ublkcp) below sm90"
 #  endif
 
-#  if TUNE_ALGORITHM == 1 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
+#  if TUNE_ALGORITHM == 2 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
 #    error "Cannot tune for ublkcp algorithm, which is not provided by CUB (old CTK?)"
 #  endif
 #endif

--- a/cub/benchmarks/bench/transform/babelstream2.cu
+++ b/cub/benchmarks/bench/transform/babelstream2.cu
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // %RANGE% TUNE_THREADS tpb 128:1024:128
-// %RANGE% TUNE_ALGORITHM alg 0:1:1
+// %RANGE% TUNE_ALGORITHM alg 0:2:1
 
 // keep checks at the top so compilation of discarded variants fails really fast
 #if !TUNE_BASE
-#  if TUNE_ALGORITHM == 1 && (__CUDA_ARCH_LIST__) < 900
+#  if TUNE_ALGORITHM == 2 && (__CUDA_ARCH_LIST__) < 900
 #    error "Cannot compile algorithm 4 (ublkcp) below sm90"
 #  endif
 
-#  if TUNE_ALGORITHM == 1 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
+#  if TUNE_ALGORITHM == 2 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
 #    error "Cannot tune for ublkcp algorithm, which is not provided by CUB (old CTK?)"
 #  endif
 #endif

--- a/cub/benchmarks/bench/transform/babelstream3.cu
+++ b/cub/benchmarks/bench/transform/babelstream3.cu
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // %RANGE% TUNE_THREADS tpb 128:1024:128
-// %RANGE% TUNE_ALGORITHM alg 0:1:1
+// %RANGE% TUNE_ALGORITHM alg 0:2:1
 
 // keep checks at the top so compilation of discarded variants fails really fast
 #if !TUNE_BASE
-#  if TUNE_ALGORITHM == 1 && (__CUDA_ARCH_LIST__) < 900
+#  if TUNE_ALGORITHM == 2 && (__CUDA_ARCH_LIST__) < 900
 #    error "Cannot compile algorithm 4 (ublkcp) below sm90"
 #  endif
 
-#  if TUNE_ALGORITHM == 1 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
+#  if TUNE_ALGORITHM == 2 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
 #    error "Cannot tune for ublkcp algorithm, which is not provided by CUB (old CTK?)"
 #  endif
 #endif

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -89,6 +89,7 @@ _CCCL_HOST_DEVICE constexpr auto loaded_bytes_per_iteration() -> int
 enum class Algorithm
 {
   fallback_for,
+  prefetch,
 #ifdef _CUB_HAS_TRANSFORM_UBLKCP
   ublkcp,
 #endif // _CUB_HAS_TRANSFORM_UBLKCP
@@ -131,6 +132,90 @@ _CCCL_DEVICE void transform_kernel_impl(
   {
     agent_t{tile_base, op}.template consume_tile<false>(items_in_tile, block_threads);
   }
+}
+
+template <int BlockThreads>
+struct prefetch_policy_t
+{
+  static constexpr int block_threads = BlockThreads;
+  // items per tile are determined at runtime. these (inclusive) bounds allow overriding that value via a tuning policy
+  static constexpr int items_per_thread_no_input = 2; // when there are no input iterators, the kernel is just filling
+  static constexpr int min_items_per_thread      = 1;
+  static constexpr int max_items_per_thread      = 32;
+};
+
+// Prefetches (at least on Hopper) a 128 byte cache line. Prefetching out-of-bounds addresses has no side effects
+// TODO(bgruber): there is also the cp.async.bulk.prefetch instruction available on Hopper. May improve perf a tiny bit
+// as we need to create less instructions to prefetch the same amount of data.
+template <typename T>
+_CCCL_DEVICE _CCCL_FORCEINLINE void prefetch(const T* addr)
+{
+  assert(__isGlobal(addr));
+  // TODO(bgruber): prefetch to L1 may be even better
+  asm volatile("prefetch.global.L2 [%0];" : : "l"(addr) : "memory");
+}
+
+// overload for any iterator that is not a pointer, do nothing
+template <typename It, ::cuda::std::__enable_if_t<!::cuda::std::is_pointer<It>::value, int> = 0>
+_CCCL_DEVICE _CCCL_FORCEINLINE void prefetch(It)
+{}
+
+// this kernel guarantees stable addresses for the parameters of the user provided function
+template <typename PrefetchPolicy,
+          typename Offset,
+          typename F,
+          typename RandomAccessIteratorOut,
+          typename... RandomAccessIteratorIn>
+_CCCL_DEVICE void transform_kernel_impl(
+  ::cuda::std::integral_constant<Algorithm, Algorithm::prefetch>,
+  Offset num_items,
+  int num_elem_per_thread,
+  F f,
+  RandomAccessIteratorOut out,
+  RandomAccessIteratorIn... ins)
+{
+  constexpr int block_dim = PrefetchPolicy::block_threads;
+  const int tile_stride   = block_dim * num_elem_per_thread;
+  const Offset offset     = static_cast<Offset>(blockIdx.x) * tile_stride;
+  const int tile_size     = static_cast<int>(::cuda::std::min(num_items - offset, Offset{tile_stride}));
+
+  // move index and iterator domain to the block/thread index, to reduce arithmetic in the loops below
+  {
+    int dummy[] = {(ins += offset, 0)..., 0};
+    (void) &dummy;
+    out += offset;
+  }
+
+  for (int j = 0; j < num_elem_per_thread; ++j)
+  {
+    const int idx = j * block_dim + threadIdx.x;
+    // TODO(bgruber): replace by fold over comma in C++17
+    int dummy[] = {(prefetch(ins + idx), 0)..., 0}; // extra zero to handle empty packs
+    (void) &dummy; // nvcc 11.1 needs extra strong unused warning suppression
+  }
+
+#define PREFETCH_AGENT(full_tile)                                                                                  \
+  /* ahendriksen: various unrolling yields less <1% gains at much higher compile-time cost */                      \
+  /* TODO(bgruber): A6000 disagrees */                                                                             \
+  _Pragma("unroll 1") for (int j = 0; j < num_elem_per_thread; ++j)                                                \
+  {                                                                                                                \
+    const int idx = j * block_dim + threadIdx.x;                                                                   \
+    if (full_tile || idx < tile_size)                                                                              \
+    {                                                                                                              \
+      /* we have to unwrap Thrust's proxy references here for backward compatibility (try zip_iterator.cu test) */ \
+      out[idx] = f(THRUST_NS_QUALIFIER::raw_reference_cast(ins[idx])...);                                          \
+    }                                                                                                              \
+  }
+
+  if (tile_stride == tile_size)
+  {
+    PREFETCH_AGENT(true);
+  }
+  else
+  {
+    PREFETCH_AGENT(false);
+  }
+#undef PREFETCH_AGENT
 }
 
 template <int BlockThreads>
@@ -543,8 +628,8 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
   {
     static constexpr int min_bif = arch_to_min_bytes_in_flight(300);
     // TODO(bgruber): we don't need algo, because we can just detect the type of algo_policy
-    static constexpr auto algorithm = Algorithm::fallback_for;
-    using algo_policy               = fallback_for_policy;
+    static constexpr auto algorithm = Algorithm::prefetch;
+    using algo_policy               = prefetch_policy_t<256>;
   };
 
 #ifdef _CUB_HAS_TRANSFORM_UBLKCP
@@ -566,8 +651,8 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
 
     static constexpr bool use_fallback =
       RequiresStableAddress || !can_memcpy || no_input_streams || exhaust_smem || any_type_is_overalinged;
-    static constexpr auto algorithm = use_fallback ? Algorithm::fallback_for : Algorithm::ublkcp;
-    using algo_policy               = ::cuda::std::_If<use_fallback, fallback_for_policy, async_policy>;
+    static constexpr auto algorithm = use_fallback ? Algorithm::prefetch : Algorithm::ublkcp;
+    using algo_policy               = ::cuda::std::_If<use_fallback, prefetch_policy_t<256>, async_policy>;
   };
 
   using max_policy = policy900;
@@ -823,6 +908,38 @@ struct dispatch_t<RequiresStableAddress,
           CUB_DETAIL_TRANSFORM_KERNEL_PTR,
           num_items,
           items_per_thread,
+          op,
+          out,
+          make_iterator_kernel_arg(THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(::cuda::std::get<Is>(in)))...));
+  }
+
+  template <typename ActivePolicy, std::size_t... Is>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t
+  invoke_algorithm(cuda::std::index_sequence<Is...>, ::cuda::std::integral_constant<Algorithm, Algorithm::prefetch>)
+  {
+    using policy_t          = typename ActivePolicy::algo_policy;
+    constexpr int block_dim = policy_t::block_threads;
+    int max_occupancy       = 0;
+    const auto error        = CubDebug(MaxSmOccupancy(max_occupancy, CUB_DETAIL_TRANSFORM_KERNEL_PTR, block_dim, 0));
+    if (error != cudaSuccess)
+    {
+      return error;
+    }
+
+    const int items_per_thread =
+      loaded_bytes_per_iter == 0
+        ? +policy_t::items_per_thread_no_input
+        : ::cuda::ceil_div(ActivePolicy::min_bif, max_occupancy * block_dim * loaded_bytes_per_iter);
+    const int items_per_thread_clamped =
+      ::cuda::std::clamp(items_per_thread, +policy_t::min_items_per_thread, +policy_t::max_items_per_thread);
+    const int tile_size = block_dim * items_per_thread_clamped;
+    const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));
+    return CubDebug(
+      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(grid_dim, block_dim, 0, stream)
+        .doit(
+          CUB_DETAIL_TRANSFORM_KERNEL_PTR,
+          num_items,
+          items_per_thread_clamped,
           op,
           out,
           make_iterator_kernel_arg(THRUST_NS_QUALIFIER::try_unwrap_contiguous_iterator(::cuda::std::get<Is>(in)))...));

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -179,6 +179,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void prefetch_tile(const T* addr, int tile_size)
   }
 }
 
+// TODO(miscco): we should probably constrain It to not be a contiguous iterator in C++17 (and change the overload
+// above to accept any contiguous iterator)
 // overload for any iterator that is not a pointer, do nothing
 template <int, typename It, ::cuda::std::__enable_if_t<!::cuda::std::is_pointer<It>::value, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE void prefetch_tile(It, int)

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -34,7 +34,9 @@ struct policy_hub_for_alg
     using algo_policy =
       ::cuda::std::_If<Alg == Algorithm::fallback_for,
                        cub::detail::transform::fallback_for_policy,
-                       cub::detail::transform::async_copy_policy_t<256>>;
+                       ::cuda::std::_If<Alg == Algorithm::prefetch,
+                                        cub::detail::transform::prefetch_policy_t<256>,
+                                        cub::detail::transform::async_copy_policy_t<256>>>;
   };
 };
 

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -79,7 +79,8 @@ DECLARE_TMPL_LAUNCH_WRAPPER(transform_many_with_alg_entry_point,
 
 using algorithms =
   c2h::enum_type_list<Algorithm,
-                      Algorithm::fallback_for
+                      Algorithm::fallback_for,
+                      Algorithm::prefetch
 #ifdef _CUB_HAS_TRANSFORM_UBLKCP
                       ,
                       Algorithm::ublkcp


### PR DESCRIPTION
The new prefetching kernel tunes it's number of elements per thread at runtime to reach an architecture-specific number of bytes in flight. It is based on work by @ahendriksen and adapted in the following ways:

* Prefetch cachelines instead of elements
* Avoid maximizing bytes in flight for small problem sizes. Rather try to evenly spread the workload on all available SMs. This is needed to beat `cub::DeviceFor` for problem sizes around 2^16 elements.

The new prefetching kernel replaces the current fallback to `cub::DeviceFor` in the tuning policies (the fallback implementation is not yet removed. Will be done in a separate PR).

<details>
  <summary>Babelstream on H100 fallback_for vs prefetch</summary>
  
```
['/home/bgruber/babelstream_fallbackfor_H100/', '/home/bgruber/babelstream_prefetch_H100/']
# mul

## [0] NVIDIA H100 PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   5.019 us |       1.89% |   4.552 us |       2.29% |   -0.467 us |  -9.30% |   FAIL   |
|   I8    |      I32      |      2^20      |   7.974 us |       2.06% |  11.798 us |       1.68% |    3.824 us |  47.96% |   FAIL   |
|   I8    |      I32      |      2^24      |  52.438 us |       0.23% |  31.339 us |       0.82% |  -21.099 us | -40.24% |   FAIL   |
|   I8    |      I32      |      2^28      | 750.740 us |       0.03% | 332.620 us |       0.27% | -418.120 us | -55.69% |   FAIL   |
|   I8    |      I64      |      2^16      |   5.520 us |       2.64% |   5.062 us |       2.69% |   -0.458 us |  -8.29% |   FAIL   |
|   I8    |      I64      |      2^20      |   8.223 us |       1.73% |  11.915 us |       1.48% |    3.693 us |  44.91% |   FAIL   |
|   I8    |      I64      |      2^24      |  52.640 us |       0.27% |  31.395 us |       0.84% |  -21.246 us | -40.36% |   FAIL   |
|   I8    |      I64      |      2^28      | 752.238 us |       0.03% | 333.346 us |       0.27% | -418.892 us | -55.69% |   FAIL   |
|   I16   |      I32      |      2^16      |   5.514 us |       3.02% |   5.150 us |       2.76% |   -0.363 us |  -6.59% |   FAIL   |
|   I16   |      I32      |      2^20      |   8.966 us |       1.66% |   9.820 us |       2.06% |    0.855 us |   9.53% |   FAIL   |
|   I16   |      I32      |      2^24      |  57.333 us |       0.19% |  43.414 us |       0.71% |  -13.919 us | -24.28% |   FAIL   |
|   I16   |      I32      |      2^28      | 812.365 us |       0.02% | 595.944 us |       0.44% | -216.420 us | -26.64% |   FAIL   |
|   I16   |      I64      |      2^16      |   5.580 us |       3.13% |   5.267 us |       3.08% |   -0.313 us |  -5.62% |   FAIL   |
|   I16   |      I64      |      2^20      |   8.757 us |       1.79% |   9.809 us |       1.96% |    1.052 us |  12.01% |   FAIL   |
|   I16   |      I64      |      2^24      |  57.092 us |       0.22% |  43.752 us |       0.75% |  -13.340 us | -23.37% |   FAIL   |
|   I16   |      I64      |      2^28      | 809.144 us |       0.02% | 595.682 us |       0.43% | -213.462 us | -26.38% |   FAIL   |
|   F32   |      I32      |      2^16      |   5.654 us |       2.76% |   5.217 us |       2.76% |   -0.437 us |  -7.73% |   FAIL   |
|   F32   |      I32      |      2^20      |  10.595 us |       1.50% |  10.767 us |       2.22% |    0.172 us |   1.62% |   FAIL   |
|   F32   |      I32      |      2^24      |  87.013 us |       0.24% |  78.501 us |       0.91% |   -8.511 us |  -9.78% |   FAIL   |
|   F32   |      I32      |      2^28      |   1.273 ms |       0.08% |   1.177 ms |       0.26% |  -96.044 us |  -7.54% |   FAIL   |
|   F32   |      I64      |      2^16      |   5.720 us |       3.05% |   5.340 us |       3.28% |   -0.380 us |  -6.64% |   FAIL   |
|   F32   |      I64      |      2^20      |  10.589 us |       1.45% |  10.783 us |       2.10% |    0.195 us |   1.84% |   FAIL   |
|   F32   |      I64      |      2^24      |  86.935 us |       0.29% |  78.594 us |       1.18% |   -8.341 us |  -9.59% |   FAIL   |
|   F32   |      I64      |      2^28      |   1.273 ms |       0.08% |   1.177 ms |       0.26% |  -95.188 us |  -7.48% |   FAIL   |
|   F64   |      I32      |      2^16      |   5.930 us |       3.84% |   5.610 us |       4.69% |   -0.320 us |  -5.40% |   FAIL   |
|   F64   |      I32      |      2^20      |  15.202 us |       1.43% |  14.480 us |       2.05% |   -0.722 us |  -4.75% |   FAIL   |
|   F64   |      I32      |      2^24      | 152.854 us |       0.39% | 151.988 us |       0.41% |   -0.866 us |  -0.57% |   FAIL   |
|   F64   |      I32      |      2^28      |   2.333 ms |       0.03% |   2.329 ms |       0.14% |   -4.029 us |  -0.17% |   FAIL   |
|   F64   |      I64      |      2^16      |   6.003 us |       4.20% |   5.696 us |       4.58% |   -0.307 us |  -5.12% |   FAIL   |
|   F64   |      I64      |      2^20      |  15.176 us |       1.47% |  14.532 us |       1.93% |   -0.644 us |  -4.24% |   FAIL   |
|   F64   |      I64      |      2^24      | 152.804 us |       0.42% | 152.024 us |       0.39% |   -0.780 us |  -0.51% |   FAIL   |
|   F64   |      I64      |      2^28      |   2.333 ms |       0.04% |   2.329 ms |       0.16% |   -4.142 us |  -0.18% |   FAIL   |
|  I128   |      I32      |      2^16      |   6.703 us |       5.52% |   6.458 us |       5.17% |   -0.245 us |  -3.65% |   PASS   |
|  I128   |      I32      |      2^20      |  24.490 us |       1.04% |  23.172 us |       1.55% |   -1.318 us |  -5.38% |   FAIL   |
|  I128   |      I32      |      2^24      | 298.453 us |       0.25% | 295.902 us |       0.28% |   -2.550 us |  -0.85% |   FAIL   |
|  I128   |      I32      |      2^28      |   4.649 ms |       0.04% |   4.678 ms |       0.13% |   29.054 us |   0.63% |   FAIL   |
|  I128   |      I64      |      2^16      |   6.397 us |       3.07% |   6.271 us |       3.67% |   -0.126 us |  -1.96% |   PASS   |
|  I128   |      I64      |      2^20      |  24.597 us |       1.10% |  23.624 us |       1.57% |   -0.973 us |  -3.96% |   FAIL   |
|  I128   |      I64      |      2^24      | 302.222 us |       1.40% | 299.443 us |       1.44% |   -2.778 us |  -0.92% |   PASS   |
|  I128   |      I64      |      2^28      |   4.649 ms |       0.04% |   4.677 ms |       0.13% |   28.678 us |   0.62% |   FAIL   |

# add

## [0] NVIDIA H100 PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   4.943 us |       2.33% |   4.708 us |       2.38% |   -0.235 us |  -4.75% |   FAIL   |
|   I8    |      I32      |      2^20      |   8.560 us |       1.71% |   9.627 us |       1.80% |    1.067 us |  12.47% |   FAIL   |
|   I8    |      I32      |      2^24      |  58.620 us |       0.20% |  40.265 us |       0.51% |  -18.355 us | -31.31% |   FAIL   |
|   I8    |      I32      |      2^28      | 817.313 us |       0.03% | 483.184 us |       0.23% | -334.128 us | -40.88% |   FAIL   |
|   I8    |      I64      |      2^16      |   5.499 us |       2.82% |   5.271 us |       3.03% |   -0.228 us |  -4.15% |   FAIL   |
|   I8    |      I64      |      2^20      |   8.689 us |       1.65% |   9.749 us |       1.77% |    1.061 us |  12.21% |   FAIL   |
|   I8    |      I64      |      2^24      |  58.960 us |       0.24% |  40.282 us |       0.57% |  -18.677 us | -31.68% |   FAIL   |
|   I8    |      I64      |      2^28      | 822.444 us |       0.03% | 483.517 us |       0.24% | -338.927 us | -41.21% |   FAIL   |
|   I16   |      I32      |      2^16      |   5.587 us |       2.45% |   5.357 us |       2.85% |   -0.231 us |  -4.13% |   FAIL   |
|   I16   |      I32      |      2^20      |  10.294 us |       1.49% |  10.354 us |       2.03% |    0.060 us |   0.58% |   PASS   |
|   I16   |      I32      |      2^24      |  76.462 us |       0.16% |  60.624 us |       0.44% |  -15.838 us | -20.71% |   FAIL   |
|   I16   |      I32      |      2^28      |   1.019 ms |       0.02% | 865.096 us |       0.21% | -154.161 us | -15.12% |   FAIL   |
|   I16   |      I64      |      2^16      |   5.637 us |       2.79% |   5.441 us |       3.01% |   -0.196 us |  -3.48% |   FAIL   |
|   I16   |      I64      |      2^20      |  10.149 us |       1.46% |  10.405 us |       2.02% |    0.255 us |   2.52% |   FAIL   |
|   I16   |      I64      |      2^24      |  75.928 us |       0.16% |  60.759 us |       0.44% |  -15.169 us | -19.98% |   FAIL   |
|   I16   |      I64      |      2^28      |   1.014 ms |       0.02% | 865.537 us |       0.21% | -148.121 us | -14.61% |   FAIL   |
|   F32   |      I32      |      2^16      |   5.955 us |       3.38% |   5.597 us |       3.61% |   -0.358 us |  -6.01% |   FAIL   |
|   F32   |      I32      |      2^20      |  12.977 us |       1.25% |  12.877 us |       1.57% |   -0.100 us |  -0.77% |   PASS   |
|   F32   |      I32      |      2^24      | 121.529 us |       0.71% | 115.634 us |       0.57% |   -5.895 us |  -4.85% |   FAIL   |
|   F32   |      I32      |      2^28      |   1.798 ms |       0.07% |   1.703 ms |       0.17% |  -94.747 us |  -5.27% |   FAIL   |
|   F32   |      I64      |      2^16      |   5.995 us |       3.72% |   5.755 us |       4.56% |   -0.240 us |  -4.00% |   FAIL   |
|   F32   |      I64      |      2^20      |  12.936 us |       1.37% |  12.953 us |       1.61% |    0.017 us |   0.13% |   PASS   |
|   F32   |      I64      |      2^24      | 121.399 us |       0.65% | 115.690 us |       0.55% |   -5.710 us |  -4.70% |   FAIL   |
|   F32   |      I64      |      2^28      |   1.795 ms |       0.07% |   1.703 ms |       0.16% |  -92.254 us |  -5.14% |   FAIL   |
|   F64   |      I32      |      2^16      |   6.527 us |       4.58% |   6.371 us |       4.74% |   -0.157 us |  -2.40% |   PASS   |
|   F64   |      I32      |      2^20      |  20.354 us |       1.08% |  19.271 us |       1.38% |   -1.083 us |  -5.32% |   FAIL   |
|   F64   |      I32      |      2^24      | 220.761 us |       0.25% | 220.170 us |       0.25% |   -0.592 us |  -0.27% |   FAIL   |
|   F64   |      I32      |      2^28      |   3.389 ms |       0.05% |   3.431 ms |       0.11% |   41.806 us |   1.23% |   FAIL   |
|   F64   |      I64      |      2^16      |   6.627 us |       5.00% |   6.496 us |       4.82% |   -0.131 us |  -1.98% |   PASS   |
|   F64   |      I64      |      2^20      |  20.324 us |       1.13% |  19.376 us |       1.40% |   -0.948 us |  -4.66% |   FAIL   |
|   F64   |      I64      |      2^24      | 220.783 us |       0.25% | 220.195 us |       0.26% |   -0.588 us |  -0.27% |   FAIL   |
|   F64   |      I64      |      2^28      |   3.389 ms |       0.05% |   3.431 ms |       0.10% |   42.063 us |   1.24% |   FAIL   |
|  I128   |      I32      |      2^16      |   8.093 us |       5.43% |   7.685 us |       5.15% |   -0.408 us |  -5.04% |   PASS   |
|  I128   |      I32      |      2^20      |  34.111 us |       0.81% |  33.224 us |       0.81% |   -0.888 us |  -2.60% |   FAIL   |
|  I128   |      I32      |      2^24      | 432.087 us |       0.15% | 430.026 us |       0.25% |   -2.061 us |  -0.48% |   FAIL   |
|  I128   |      I32      |      2^28      |   6.790 ms |       0.04% |   6.759 ms |       0.03% |  -30.595 us |  -0.45% |   FAIL   |
|  I128   |      I64      |      2^16      |   7.499 us |       2.82% |   7.181 us |       2.74% |   -0.318 us |  -4.24% |   FAIL   |
|  I128   |      I64      |      2^20      |  34.568 us |       0.76% |  33.791 us |       0.92% |   -0.776 us |  -2.25% |   FAIL   |
|  I128   |      I64      |      2^24      | 438.079 us |       1.41% | 435.787 us |       1.43% |   -2.292 us |  -0.52% |   PASS   |
|  I128   |      I64      |      2^28      |   6.790 ms |       0.04% |   6.759 ms |       0.03% |  -31.077 us |  -0.46% |   FAIL   |

# triad

## [0] NVIDIA H100 PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   5.649 us |       3.66% |   5.340 us |       2.98% |   -0.309 us |  -5.47% |   FAIL   |
|   I8    |      I32      |      2^20      |   8.746 us |       1.90% |   9.625 us |       2.46% |    0.879 us |  10.05% |   FAIL   |
|   I8    |      I32      |      2^24      |  59.716 us |       0.24% |  40.237 us |       0.65% |  -19.478 us | -32.62% |   FAIL   |
|   I8    |      I32      |      2^28      | 820.635 us |       0.43% | 485.822 us |       0.95% | -334.814 us | -40.80% |   FAIL   |
|   I8    |      I64      |      2^16      |   5.612 us |       2.78% |   5.301 us |       2.64% |   -0.311 us |  -5.55% |   FAIL   |
|   I8    |      I64      |      2^20      |   8.686 us |       1.67% |   9.709 us |       1.84% |    1.023 us |  11.78% |   FAIL   |
|   I8    |      I64      |      2^24      |  59.393 us |       0.24% |  39.772 us |       0.55% |  -19.621 us | -33.04% |   FAIL   |
|   I8    |      I64      |      2^28      | 819.940 us |       0.03% | 481.645 us |       0.23% | -338.295 us | -41.26% |   FAIL   |
|   I16   |      I32      |      2^16      |   5.682 us |       2.81% |   5.370 us |       2.79% |   -0.312 us |  -5.49% |   FAIL   |
|   I16   |      I32      |      2^20      |  10.257 us |       1.54% |  10.303 us |       2.05% |    0.046 us |   0.45% |   PASS   |
|   I16   |      I32      |      2^24      |  76.557 us |       0.16% |  60.598 us |       0.48% |  -15.959 us | -20.85% |   FAIL   |
|   I16   |      I32      |      2^28      |   1.019 ms |       0.03% | 860.964 us |       0.17% | -157.600 us | -15.47% |   FAIL   |
|   I16   |      I64      |      2^16      |   5.680 us |       3.52% |   5.457 us |       3.15% |   -0.223 us |  -3.92% |   FAIL   |
|   I16   |      I64      |      2^20      |  10.242 us |       1.53% |  10.225 us |       1.88% |   -0.017 us |  -0.16% |   PASS   |
|   I16   |      I64      |      2^24      |  76.018 us |       0.19% |  60.683 us |       0.48% |  -15.336 us | -20.17% |   FAIL   |
|   I16   |      I64      |      2^28      |   1.013 ms |       0.03% | 861.393 us |       0.19% | -151.457 us | -14.95% |   FAIL   |
|   F32   |      I32      |      2^16      |   5.927 us |       3.08% |   5.608 us |       3.59% |   -0.318 us |  -5.37% |   FAIL   |
|   F32   |      I32      |      2^20      |  12.888 us |       1.35% |  12.970 us |       1.49% |    0.082 us |   0.64% |   PASS   |
|   F32   |      I32      |      2^24      | 121.555 us |       0.72% | 115.033 us |       0.55% |   -6.522 us |  -5.37% |   FAIL   |
|   F32   |      I32      |      2^28      |   1.796 ms |       0.06% |   1.703 ms |       0.17% |  -93.157 us |  -5.19% |   FAIL   |
|   F32   |      I64      |      2^16      |   5.948 us |       3.91% |   5.655 us |       4.10% |   -0.294 us |  -4.94% |   FAIL   |
|   F32   |      I64      |      2^20      |  12.892 us |       1.36% |  13.011 us |       1.54% |    0.119 us |   0.92% |   PASS   |
|   F32   |      I64      |      2^24      | 121.347 us |       0.69% | 115.109 us |       0.62% |   -6.238 us |  -5.14% |   FAIL   |
|   F32   |      I64      |      2^28      |   1.794 ms |       0.07% |   1.703 ms |       0.17% |  -91.036 us |  -5.08% |   FAIL   |
|   F64   |      I32      |      2^16      |   6.473 us |       4.75% |   6.267 us |       3.90% |   -0.206 us |  -3.18% |   PASS   |
|   F64   |      I32      |      2^20      |  20.763 us |       1.04% |  19.802 us |       1.25% |   -0.962 us |  -4.63% |   FAIL   |
|   F64   |      I32      |      2^24      | 221.277 us |       0.26% | 220.973 us |       0.31% |   -0.304 us |  -0.14% |   PASS   |
|   F64   |      I32      |      2^28      |   3.390 ms |       0.05% |   3.431 ms |       0.12% |   41.010 us |   1.21% |   FAIL   |
|   F64   |      I64      |      2^16      |   6.695 us |       5.73% |   6.438 us |       4.61% |   -0.257 us |  -3.84% |   PASS   |
|   F64   |      I64      |      2^20      |  20.777 us |       1.17% |  19.908 us |       1.29% |   -0.869 us |  -4.18% |   FAIL   |
|   F64   |      I64      |      2^24      | 221.180 us |       0.24% | 221.003 us |       0.30% |   -0.177 us |  -0.08% |   PASS   |
|   F64   |      I64      |      2^28      |   3.390 ms |       0.05% |   3.431 ms |       0.11% |   40.861 us |   1.21% |   FAIL   |
|  I128   |      I32      |      2^16      |   7.754 us |       5.27% |   7.236 us |       4.72% |   -0.518 us |  -6.68% |   FAIL   |
|  I128   |      I32      |      2^20      |  34.314 us |       0.69% |  33.583 us |       0.76% |   -0.731 us |  -2.13% |   FAIL   |
|  I128   |      I32      |      2^24      | 432.004 us |       0.15% | 429.729 us |       0.26% |   -2.275 us |  -0.53% |   FAIL   |
|  I128   |      I32      |      2^28      |   6.790 ms |       0.04% |   6.759 ms |       0.03% |  -30.655 us |  -0.45% |   FAIL   |
|  I128   |      I64      |      2^16      |   7.362 us |       3.47% |   6.915 us |       3.12% |   -0.447 us |  -6.07% |   FAIL   |
|  I128   |      I64      |      2^20      |  34.626 us |       0.81% |  33.817 us |       0.94% |   -0.809 us |  -2.34% |   FAIL   |
|  I128   |      I64      |      2^24      | 437.931 us |       1.39% | 435.455 us |       1.43% |   -2.476 us |  -0.57% |   PASS   |
|  I128   |      I64      |      2^28      |   6.790 ms |       0.04% |   6.759 ms |       0.03% |  -30.958 us |  -0.46% |   FAIL   |

# nstream

## [0] NVIDIA H100 PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  OverwriteInput  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |        1         |   5.204 us |       2.40% |   4.827 us |       2.23% |   -0.377 us |  -7.24% |   FAIL   |
|   I8    |      I32      |      2^20      |        1         |   9.560 us |       1.78% |   9.901 us |       1.81% |    0.340 us |   3.56% |   FAIL   |
|   I8    |      I32      |      2^24      |        1         |  65.895 us |       0.22% |  51.806 us |       0.56% |  -14.089 us | -21.38% |   FAIL   |
|   I8    |      I32      |      2^28      |        1         | 891.910 us |       0.03% | 654.394 us |       0.29% | -237.516 us | -26.63% |   FAIL   |
|   I8    |      I64      |      2^16      |        1         |   5.740 us |       2.42% |   5.315 us |       2.58% |   -0.424 us |  -7.39% |   FAIL   |
|   I8    |      I64      |      2^20      |        1         |   9.679 us |       1.79% |   9.979 us |       1.77% |    0.300 us |   3.10% |   FAIL   |
|   I8    |      I64      |      2^24      |        1         |  66.383 us |       0.25% |  51.817 us |       0.50% |  -14.567 us | -21.94% |   FAIL   |
|   I8    |      I64      |      2^28      |        1         | 899.463 us |       0.03% | 654.562 us |       0.30% | -244.901 us | -27.23% |   FAIL   |
|   I16   |      I32      |      2^16      |        1         |   5.806 us |       2.54% |   5.468 us |       2.53% |   -0.339 us |  -5.83% |   FAIL   |
|   I16   |      I32      |      2^20      |        1         |  11.720 us |       1.42% |  11.701 us |       2.15% |   -0.019 us |  -0.16% |   PASS   |
|   I16   |      I32      |      2^24      |        1         |  94.163 us |       0.14% |  79.849 us |       1.14% |  -14.314 us | -15.20% |   FAIL   |
|   I16   |      I32      |      2^28      |        1         |   1.313 ms |       0.11% |   1.216 ms |       0.18% |  -97.411 us |  -7.42% |   FAIL   |
|   I16   |      I64      |      2^16      |        1         |   5.875 us |       3.04% |   5.566 us |       3.22% |   -0.309 us |  -5.25% |   FAIL   |
|   I16   |      I64      |      2^20      |        1         |  11.729 us |       1.50% |  11.755 us |       2.02% |    0.026 us |   0.22% |   PASS   |
|   I16   |      I64      |      2^24      |        1         |  93.993 us |       0.15% |  80.006 us |       1.19% |  -13.987 us | -14.88% |   FAIL   |
|   I16   |      I64      |      2^28      |        1         |   1.311 ms |       0.11% |   1.216 ms |       0.18% |  -95.007 us |  -7.24% |   FAIL   |
|   F32   |      I32      |      2^16      |        1         |   6.131 us |       3.50% |   5.923 us |       3.30% |   -0.208 us |  -3.40% |   FAIL   |
|   F32   |      I32      |      2^20      |        1         |  15.139 us |       1.11% |  14.953 us |       1.30% |   -0.187 us |  -1.23% |   FAIL   |
|   F32   |      I32      |      2^24      |        1         | 153.994 us |       0.56% | 151.961 us |       0.39% |   -2.033 us |  -1.32% |   FAIL   |
|   F32   |      I32      |      2^28      |        1         |   2.342 ms |       0.06% |   2.288 ms |       0.04% |  -53.510 us |  -2.28% |   FAIL   |
|   F32   |      I64      |      2^16      |        1         |   6.254 us |       4.31% |   6.037 us |       3.75% |   -0.217 us |  -3.46% |   PASS   |
|   F32   |      I64      |      2^20      |        1         |  15.222 us |       1.13% |  15.006 us |       1.14% |   -0.216 us |  -1.42% |   FAIL   |
|   F32   |      I64      |      2^24      |        1         | 154.041 us |       0.53% | 152.052 us |       0.41% |   -1.988 us |  -1.29% |   FAIL   |
|   F32   |      I64      |      2^28      |        1         |   2.341 ms |       0.06% |   2.289 ms |       0.04% |  -51.752 us |  -2.21% |   FAIL   |
|   F64   |      I32      |      2^16      |        1         |   6.973 us |       5.01% |   6.500 us |       4.36% |   -0.473 us |  -6.79% |   FAIL   |
|   F64   |      I32      |      2^20      |        1         |  24.873 us |       0.86% |  24.380 us |       0.83% |   -0.493 us |  -1.98% |   FAIL   |
|   F64   |      I32      |      2^24      |        1         | 292.095 us |       0.17% | 292.004 us |       0.14% |   -0.091 us |  -0.03% |   PASS   |
|   F64   |      I32      |      2^28      |        1         |   4.491 ms |       0.02% |   4.498 ms |       0.02% |    6.589 us |   0.15% |   FAIL   |
|   F64   |      I64      |      2^16      |        1         |   7.093 us |       5.55% |   6.669 us |       4.86% |   -0.423 us |  -5.97% |   FAIL   |
|   F64   |      I64      |      2^20      |        1         |  24.897 us |       0.85% |  24.479 us |       0.81% |   -0.418 us |  -1.68% |   FAIL   |
|   F64   |      I64      |      2^24      |        1         | 292.136 us |       0.18% | 292.146 us |       0.15% |    0.010 us |   0.00% |   PASS   |
|   F64   |      I64      |      2^28      |        1         |   4.491 ms |       0.02% |   4.498 ms |       0.02% |    7.276 us |   0.16% |   FAIL   |
|  I128   |      I32      |      2^16      |        1         |   8.751 us |       5.69% |   8.296 us |       5.34% |   -0.455 us |  -5.20% |   PASS   |
|  I128   |      I32      |      2^20      |        1         |  42.849 us |       0.59% |  42.029 us |       0.56% |   -0.820 us |  -1.91% |   FAIL   |
|  I128   |      I32      |      2^24      |        1         | 570.422 us |       0.10% | 569.592 us |       0.07% |   -0.830 us |  -0.15% |   FAIL   |
|  I128   |      I32      |      2^28      |        1         |   8.945 ms |       0.01% |   8.937 ms |       0.01% |   -7.566 us |  -0.08% |   FAIL   |
|  I128   |      I64      |      2^16      |        1         |   8.189 us |       2.26% |   7.682 us |       2.36% |   -0.507 us |  -6.19% |   FAIL   |
|  I128   |      I64      |      2^20      |        1         |  42.851 us |       0.57% |  41.972 us |       0.56% |   -0.879 us |  -2.05% |   FAIL   |
|  I128   |      I64      |      2^24      |        1         | 570.468 us |       0.09% | 569.285 us |       0.07% |   -1.183 us |  -0.21% |   FAIL   |
|  I128   |      I64      |      2^28      |        1         |   8.945 ms |       0.01% |   8.930 ms |       0.01% |  -15.065 us |  -0.17% |   FAIL   |
```

</details>

Performance requirements:

- [x] no regressions of more than 15% compared to cub::DeviceFor
- [x] no regressions of more than 2% compared to cub::DeviceFor on 2^24+ problem sizes
- [x] peeling version outperforms cub::DeviceFor on 2^24+ problem sizes with average improvement of more than 5%

Average perf diff across all Babelstream kernels on 2^24+ problem sizes on H100

kernel | diff
-- | --
mul | -16.45%
add | -11.77%
triad | -11.99%
nstream | -7.47%

Fixes: #2363
