### PR TITLE
nvrtc wants `integral_constant`'s functions host/device annotated

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/integral_constant.h
+++ b/libcudacxx/include/cuda/std/__type_traits/integral_constant.h
@@ -28,20 +28,24 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT integral_constant
   static constexpr const _Tp value = __v;
   typedef _Tp value_type;
   typedef integral_constant type;
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr operator value_type() const noexcept
+  _CCCL_HOST_DEVICE _LIBCUDACXX_HIDE_FROM_ABI constexpr operator value_type() const noexcept
   {
     return value;
   }
 #if _CCCL_STD_VER > 2011
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr value_type operator()() const noexcept
+  _CCCL_HOST_DEVICE _LIBCUDACXX_HIDE_FROM_ABI constexpr value_type operator()() const noexcept
   {
     return value;
   }
 #endif
 };
 
+// Before the addition of inline variables, it was necessary to
+// provide a definition for constexpr class static data members.
+#if _CCCL_STD_VER >= 2017 && defined(__cpp_inline_variables) && (__cpp_inline_variables >= 201606L)
 template <class _Tp, _Tp __v>
 constexpr const _Tp integral_constant<_Tp, __v>::value;
+#endif
 
 typedef integral_constant<bool, true> true_type;
 typedef integral_constant<bool, false> false_type;


### PR DESCRIPTION
## Description

in the CI runs of my `__type_list` pr, i'm seeing nvrtc failures such as:

```
  5: /home/coder/cccl/libcudacxx/include/cuda/std/__type_traits/integral_constant.h(31): 
error: A function without execution space annotations (__host__/__device__/__global__) is 
considered a host function, and host functions are not allowed in JIT mode. Consider using -
default-device flag to process unannotated functions as __device__ functions in JIT mode
  5:     _LIBCUDACXX_HIDE_FROM_ABI constexpr operator value_type() const noexcept
  5:                                         ^
  5:           detected during:
  5:             instantiation of class "cuda::std::__4::integral_constant<_Tp, __v> [with
_Tp=<error-type>, __v=<error-constant>]" at line 359 of
/home/coder/cccl/libcudacxx/include/cuda/std/__type_traits/type_list.h
```

this pr adds the missing host/device annotations. as a drive-by, it guards the redefinition of the `::value` class static with the appropriate feature test.


<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
