### PR TITLE
[on hold] Automatic address stability detection for `thrust::transform`

### DIFF
--- a/libcudacxx/include/cuda/__functional/address_stability.h
+++ b/libcudacxx/include/cuda/__functional/address_stability.h
@@ -23,20 +23,77 @@
 #include <cuda/std/__functional/not_fn.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__functional/ranges_operations.h>
+#include <cuda/std/__type_traits/conjunction.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_class.h>
 #include <cuda/std/__type_traits/is_enum.h>
 #include <cuda/std/__type_traits/is_void.h>
+#include <cuda/std/__type_traits/is_function.h>
+#include <cuda/std/__type_traits/is_reference.h>
+#include <cuda/std/__type_traits/negation.h>
+#include <cuda/std/__type_traits/remove_pointer.h>
+#include <cuda/std/__type_traits/void_t.h>
+#include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+template <typename _FuncPtr>
+struct __all_parameters_by_value_fptr : _CUDA_VSTD::false_type
+{};
+
+// TODO(bgruber): does the reference detection even work for proxy references? If a callable takes a
+// thrust::device_reference<T> or a std::reference_wrapper<T>, allowing a copy would be wrong
+
+template <typename R, typename... Args>
+struct __all_parameters_by_value_fptr<R (*)(Args...)>
+    : _CUDA_VSTD::conjunction<_CUDA_VSTD::_Not<_CUDA_VSTD::is_reference<Args>>...>
+{};
+
+template <typename R, typename C, typename... Args>
+struct __all_parameters_by_value_fptr<R (C::*)(Args...)>
+    : _CUDA_VSTD::conjunction<_CUDA_VSTD::_Not<_CUDA_VSTD::is_reference<Args>>...>
+{};
+
+template <typename R, typename C, typename... Args>
+struct __all_parameters_by_value_fptr<R (C::*)(Args...) const>
+    : _CUDA_VSTD::conjunction<_CUDA_VSTD::_Not<_CUDA_VSTD::is_reference<Args>>...>
+{};
+
+// case for when we cannot address the call target
+template <typename _F, typename _SFINAE = void>
+struct __all_parameters_by_value : _CUDA_VSTD::false_type
+{};
+
+// case for function pointers
+template <typename _FP>
+struct __all_parameters_by_value<
+  _FP,
+  _CUDA_VSTD::__enable_if_t<_CUDA_VSTD::is_pointer<_FP>::value
+                            && _CUDA_VSTD::is_function<_CUDA_VSTD::__remove_pointer_t<_FP>>::value>>
+    : __all_parameters_by_value_fptr<_FP>
+{};
+
+// case for function objects
+template <typename _F>
+struct __all_parameters_by_value<_F, _CUDA_VSTD::void_t<decltype(&_F::operator())>>
+    : __all_parameters_by_value_fptr<decltype(&_F::operator())>
+{};
+
+// case for functions
+template <typename _F>
+struct __all_parameters_by_value<_F, _CUDA_VSTD::__enable_if_t<_CUDA_VSTD::is_function<_F>::value>>
+    : __all_parameters_by_value_fptr<decltype(&::cuda::std::declval<_F>())>
+{};
 
 //! Trait telling whether a function object type F does not rely on the memory addresses of its arguments. The nested
 //! value is true when the addresses of the arguments do not matter and arguments can be provided from arbitrary copies
 //! of the respective sources. This trait can be specialized for custom function objects types.
 //! @see proclaim_copyable_arguments
+// TODO(bgruber): if we ever get something like declcall (https://wg21.link/P2825), we should use it here to inspect the
+// signature of the function that overload resolution chose
 template <typename F, typename SFINAE = void>
-struct proclaims_copyable_arguments : _CUDA_VSTD::false_type
+struct proclaims_copyable_arguments : _CUDA_VSTD::conjunction<__all_parameters_by_value<F>>
 {};
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
@@ -45,10 +102,29 @@ _CCCL_INLINE_VAR constexpr bool proclaims_copyable_arguments_v = proclaims_copya
 #endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 // Wrapper for a callable to mark it as permitting copied arguments
-template <typename F>
-struct __callable_permitting_copied_arguments : F
+template <typename _F, typename _SFINAE = void>
+struct __callable_permitting_copied_arguments : _F
 {
-  using F::operator();
+  using _F::operator();
+};
+
+// TODO(bgruber): maybe just provide one implementation that stores the callable as a member
+template <typename _FP>
+struct __callable_permitting_copied_arguments<
+  _FP,
+  _CUDA_VSTD::__enable_if_t<_CUDA_VSTD::is_pointer<_FP>::value
+                            && _CUDA_VSTD::is_function<_CUDA_VSTD::__remove_pointer_t<_FP>>::value>>
+{
+  _FP __fp;
+
+  // TODO(bgruber): we may just use ::cuda::std::invoke() here
+  template <typename... _Args>
+  auto operator()(_Args&&... args) const -> decltype(__fp(_CUDA_VSTD::forward<_Args>(args)...))
+  {
+    return __fp(_CUDA_VSTD::forward<_Args>(args)...);
+  }
+
+  static constexpr bool allows_copied_arguments = true;
 };
 
 template <typename F>

--- a/thrust/testing/address_stability.cu
+++ b/thrust/testing/address_stability.cu
@@ -1,4 +1,4 @@
-#include <cuda/__functional/address_stability.h>
+#include <cuda/functional>
 
 #include <unittest/unittest.h>
 
@@ -59,13 +59,44 @@ struct my_plus
   }
 };
 
+struct pathological_plus
+{
+  // can copy
+  _CCCL_HOST_DEVICE auto operator()(int a, int b) const -> int
+  {
+    return a + b;
+  }
+
+  // cannot copy
+  _CCCL_HOST_DEVICE auto operator()(const float& a, const float& b) const -> float
+  {
+    return a + b;
+  }
+};
+
+#define MY_GENERIC_PLUS(suffix, param)                             \
+  struct my_generic_plus##suffix                                   \
+  {                                                                \
+    template <typename T>                                          \
+    _CCCL_HOST_DEVICE auto operator()(param a, param b) const -> T \
+    {                                                              \
+      return a + b;                                                \
+    }                                                              \
+  }
+
+MY_GENERIC_PLUS(, T);
+MY_GENERIC_PLUS(_lref, T&);
+MY_GENERIC_PLUS(_rref, T&&);
+MY_GENERIC_PLUS(_clref, const T&);
+MY_GENERIC_PLUS(_crref, const T&&);
+
 void TestAddressStabilityUserDefinedFunctionObject()
 {
   using ::cuda::proclaim_copyable_arguments;
   using ::cuda::proclaims_copyable_arguments;
 
   // by-value overload
-  static_assert(!proclaims_copyable_arguments<my_plus<int>>::value, "");
+  static_assert(proclaims_copyable_arguments<my_plus<int>>::value, "");
 
   // by-value overload with opt-in
   static_assert(proclaims_copyable_arguments<decltype(proclaim_copyable_arguments(my_plus<int>{}))>::value, "");
@@ -81,5 +112,74 @@ void TestAddressStabilityUserDefinedFunctionObject()
   static_assert(proclaims_copyable_arguments<decltype(proclaim_copyable_arguments(my_plus<const int&>{}))>::value, "");
   static_assert(proclaims_copyable_arguments<decltype(proclaim_copyable_arguments(my_plus<int&&>{}))>::value, "");
   static_assert(proclaims_copyable_arguments<decltype(proclaim_copyable_arguments(my_plus<const int&&>{}))>::value, "");
+
+  // pathological overloaded set
+  static_assert(!proclaims_copyable_arguments<pathological_plus>::value, "");
+
+  // call operator is a template
+  static_assert(!proclaims_copyable_arguments<my_generic_plus>::value, ""); // may be solvable if we know T
+  static_assert(!proclaims_copyable_arguments<my_generic_plus_lref>::value, "");
+  static_assert(!proclaims_copyable_arguments<my_generic_plus_rref>::value, "");
+  static_assert(!proclaims_copyable_arguments<my_generic_plus_clref>::value, "");
+  static_assert(!proclaims_copyable_arguments<my_generic_plus_crref>::value, "");
 }
 DECLARE_UNITTEST(TestAddressStabilityUserDefinedFunctionObject);
+
+_CCCL_HOST_DEVICE auto my_plus_func(int a, int b) -> int
+{
+  return a + b;
+}
+
+_CCCL_HOST_DEVICE auto my_plus_func_ref(const int& a, const int& b) -> int
+{
+  return a + b;
+}
+
+void TestAddressStabilityUserDefinedFunctions()
+{
+  using ::cuda::proclaim_copyable_arguments;
+  using ::cuda::proclaims_copyable_arguments;
+
+  // user-defined function types
+  static_assert(proclaims_copyable_arguments<int(int, int)>::value, "");
+  static_assert(!proclaims_copyable_arguments<int(const int&, const int&)>::value, "");
+
+  static_assert(proclaims_copyable_arguments<decltype(my_plus_func)>::value, "");
+  static_assert(!proclaims_copyable_arguments<decltype(my_plus_func_ref)>::value, "");
+  static_assert(proclaims_copyable_arguments<decltype(proclaim_copyable_arguments(my_plus_func_ref))>::value, "");
+
+  // user-defined function pointer types
+  static_assert(proclaims_copyable_arguments<int (*)(int, int)>::value, "");
+  static_assert(!proclaims_copyable_arguments<int (*)(const int&, const int&)>::value, "");
+
+  static_assert(proclaims_copyable_arguments<decltype(&my_plus_func)>::value, "");
+  static_assert(!proclaims_copyable_arguments<decltype(&my_plus_func_ref)>::value, "");
+  static_assert(proclaims_copyable_arguments<decltype(proclaim_copyable_arguments(&my_plus_func_ref))>::value, "");
+
+  // TODO(bgruber): test user-defined function reference types?
+}
+DECLARE_UNITTEST(TestAddressStabilityUserDefinedFunctions);
+
+struct my_plus_proxy_ref
+{
+  int* a_ptr;
+
+  // has a by-value argument
+  auto operator()(::cuda::std::reference_wrapper<int> a, ::cuda::std::reference_wrapper<int> b) const -> int
+  {
+    int* address = &a.get(); // allows to recover the address of the argument
+    ASSERT_EQUAL(address, a_ptr);
+    return a + b;
+  }
+};
+
+void TestAddressStabilityProxyReferences()
+{
+  using ::cuda::proclaims_copyable_arguments;
+
+  int a = 1;
+  int b = 2;
+  ASSERT_EQUAL(my_plus_proxy_ref{&a}(a, b), 3);
+  static_assert(!proclaims_copyable_arguments<my_plus_proxy_ref>::value, "");
+}
+DECLARE_UNITTEST(TestAddressStabilityProxyReferences);


### PR DESCRIPTION
This PR extendes the automatic detection of function objects for which arguments can savely be copied before passing them to the function object.

Fixes: #2403

Merge before:

- [x] #2263 
- [x] #2719