### PR TITLE
conditionally include `<crt/host_defines.h>` from `__cccl/execution_space.h` header

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -22,6 +22,16 @@
 #  pragma system_header
 #endif // no system header
 
+#ifndef __has_include
+#  define __has_include(x) 0
+#endif // !__has_include
+
+// Bring in the __host__ and __device__ macros:
+#if __has_include(<crt/host_defines.h>)
+#  define __CUDA_INCLUDE_COMPILER_INTERNAL_HEADERS__
+#  include <crt/host_defines.h>
+#endif
+
 #if defined(_CCCL_CUDA_COMPILER)
 #  define _CCCL_HOST        __host__
 #  define _CCCL_DEVICE      __device__


### PR DESCRIPTION
## Description

when `<cuda/std/detail/__config>` is included, a number of macros are defined that expand (in part) to `__host__` and/or `__device__`. these macros are not usable until `__host__` and `__device__` are themselves defined, which typically happens when users include `<cuda_runtime_api.h>`. many of libcudacxx's own headers include `__config` and use the `_CCCL*` and `_LIBCUDACXX*` macros without including `<cuda_runtime_api.h>`, leading to compile failures.

this pr conditionally includes `<crt/host_defines.h>` from `<cuda/std/__cccl/execution_space.h>`, where `_CCCL_HOST_DEVICE` and friends get defined.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
