### PR TITLE
Fix issues with `__host__` and `__device__` definitions

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -58,6 +58,11 @@
 #  define _CCCL_CUDA_COMPILER
 #endif // cuda compiler available
 
+// We need to ensure that we not only compile with a cuda compiler but also compile cuda source files
+#if defined(_CCCL_CUDA_COMPILER) && defined(__CUDACC__)
+#  define _CCCL_CUDA_COMPILATION
+#endif // _CCCL_CUDA_COMPILER && __CUDACC__
+
 // clang-cuda does not define __CUDACC_VER_MAJOR__ and friends. They are instead retrieved from the CUDA_VERSION macro
 // defined in "cuda.h". clang-cuda automatically pre-includes "__clang_cuda_runtime_wrapper.h" which includes "cuda.h"
 #if defined(_CCCL_CUDA_COMPILER_CLANG)
@@ -72,7 +77,7 @@
 #  define _CCCL_CUDACC_VER_MINOR __CUDACC_VER_MINOR__
 #  define _CCCL_CUDACC_VER_BUILD __CUDACC_VER_BUILD__
 #  define _CCCL_CUDACC_VER       _CCCL_CUDACC_VER_MAJOR * 100000 + _CCCL_CUDACC_VER_MINOR * 1000 + _CCCL_CUDACC_VER_BUILD
-#endif // __CUDACC__ || _CCCL_CUDA_COMPILER_NVHPC
+#endif // _CCCL_CUDA_COMPILER
 
 // Some convenience macros to filter CUDACC versions
 #if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1102000)

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -58,11 +58,6 @@
 #  define _CCCL_CUDA_COMPILER
 #endif // cuda compiler available
 
-// We need to ensure that we not only compile with a cuda compiler but also compile cuda source files
-#if defined(_CCCL_CUDA_COMPILER) && defined(__CUDACC__)
-#  define _CCCL_CUDA_COMPILATION
-#endif // _CCCL_CUDA_COMPILER && __CUDACC__
-
 // clang-cuda does not define __CUDACC_VER_MAJOR__ and friends. They are instead retrieved from the CUDA_VERSION macro
 // defined in "cuda.h". clang-cuda automatically pre-includes "__clang_cuda_runtime_wrapper.h" which includes "cuda.h"
 #if defined(_CCCL_CUDA_COMPILER_CLANG)

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -22,27 +22,17 @@
 #  pragma system_header
 #endif // no system header
 
-#ifndef __has_include
-#  define __has_include(x) 0
-#endif // !__has_include
-
-// Bring in the __host__ and __device__ macros:
-#if __has_include(<crt/host_defines.h>)
-#  define __CUDA_INCLUDE_COMPILER_INTERNAL_HEADERS__
-#  include <crt/host_defines.h>
-#endif
-
-#if defined(_CCCL_CUDA_COMPILER)
+#if defined(_CCCL_CUDA_COMPILATION)
 #  define _CCCL_HOST        __host__
 #  define _CCCL_DEVICE      __device__
 #  define _CCCL_HOST_DEVICE __host__ __device__
 #  define _CCCL_FORCEINLINE __forceinline__
-#else // ^^^ _CCCL_CUDA_COMPILER ^^^ / vvv !_CCCL_CUDA_COMPILER
+#else // ^^^ _CCCL_CUDA_COMPILATION ^^^ / vvv !_CCCL_CUDA_COMPILATION
 #  define _CCCL_HOST
 #  define _CCCL_DEVICE
 #  define _CCCL_HOST_DEVICE
 #  define _CCCL_FORCEINLINE inline
-#endif // !_CCCL_CUDA_COMPILER
+#endif // !_CCCL_CUDA_COMPILATION
 
 #if !defined(_CCCL_EXEC_CHECK_DISABLE)
 #  if defined(_CCCL_CUDA_COMPILER_NVCC)

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -22,12 +22,13 @@
 #  pragma system_header
 #endif // no system header
 
-#if defined(_CCCL_CUDA_COMPILATION)
+// We need to ensure that we not only compile with a cuda compiler but also compile cuda source files
+#if defined(_CCCL_CUDA_COMPILER) && (defined(__CUDACC__) || defined(_NVHPC_CUDA))
 #  define _CCCL_HOST        __host__
 #  define _CCCL_DEVICE      __device__
 #  define _CCCL_HOST_DEVICE __host__ __device__
 #  define _CCCL_FORCEINLINE __forceinline__
-#else // ^^^ _CCCL_CUDA_COMPILATION ^^^ / vvv !_CCCL_CUDA_COMPILATION
+#else // ^^^ _CCCL_CUDA_COMPILATION ^^^ / vvv !_CCCL_CUDA_COMPILATION vvv
 #  define _CCCL_HOST
 #  define _CCCL_DEVICE
 #  define _CCCL_HOST_DEVICE


### PR DESCRIPTION
We currently only checked whether we are compiling with a cuda compiler, but not whether we are actually compiling in cuda mode.

That meant that certain macros werent properly defined.
