### PR TITLE
Make `any_resource` emplacable

### DIFF
--- a/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
@@ -72,7 +72,7 @@ template <class _Tp, class... _Properties>
 class uninitialized_async_buffer
 {
 private:
-  using __async_resource = ::cuda::experimental::mr::async_any_resource<_Properties...>;
+  using __async_resource = ::cuda::experimental::mr::any_async_resource<_Properties...>;
   __async_resource __mr_;
   ::cuda::stream_ref __stream_ = {};
   size_t __count_              = 0;

--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -42,11 +42,15 @@
 #include <cuda/std/__concepts/__concept_macros.h>
 #include <cuda/std/__concepts/_One_of.h>
 #include <cuda/std/__concepts/all_of.h>
+#include <cuda/std/__new_>
+#include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__type_traits/type_set.h>
 #include <cuda/std/__utility/exchange.h>
 #include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/in_place.h>
 
 namespace cuda::experimental::mr
 {
@@ -77,19 +81,25 @@ private:
 
   using __vtable = _CUDA_VMR::_Filtered_vtable<_Properties...>;
 
+  //! @brief Validates that a set of \c _OtherProperties... is a superset of \c _Properties... .
   template <class... _OtherProperties>
   static constexpr bool __properties_match =
     _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>;
+
+  //! @brief Validates that a passed in \c _Resource satisfies the \c resource or \c async_resource concept respectively
+  //! as well as all properties in \c _Properties... .
+  template <class _Resource>
+  static constexpr bool __valid_resource =
+    _Alloc_type == _CUDA_VMR::_AllocType::_Async
+      ? _CUDA_VMR::async_resource_with<_Resource, _Properties...>
+      : _CUDA_VMR::resource_with<_Resource, _Properties...>;
 
 public:
   //! @brief Constructs a \c basic_any_resource from a type that satisfies the \c resource or \c async_resource
   //! concept as well as all properties.
   //! @param __res The resource to be wrapped within the \c basic_any_resource.
   _LIBCUDACXX_TEMPLATE(class _Resource, class __resource_t = _CUDA_VSTD::remove_cvref_t<_Resource>)
-  _LIBCUDACXX_REQUIRES(
-    (!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND(_CUDA_VMR::resource_with<__resource_t, _Properties...>)
-      _LIBCUDACXX_AND(_Alloc_type != _CUDA_VMR::_AllocType::_Async
-                      || (_CUDA_VMR::async_resource_with<__resource_t, _Properties...>) ))
+  _LIBCUDACXX_REQUIRES((!__is_basic_any_resource<_Resource>) _LIBCUDACXX_AND __valid_resource<__resource_t>)
   basic_any_resource(_Resource&& __res) noexcept
       : _CUDA_VMR::_Resource_base<_Alloc_type, _CUDA_VMR::_WrapperType::_Owning>(
           nullptr, &_CUDA_VMR::__alloc_vtable<_Alloc_type, _CUDA_VMR::_WrapperType::_Owning, __resource_t>)
@@ -102,6 +112,29 @@ public:
     else
     {
       this->__object.__ptr_ = new __resource_t(_CUDA_VSTD::forward<_Resource>(__res));
+    }
+  }
+
+  //! @brief Constructs a \c basic_any_resource wrapping an object of type \c _Resource that
+  //! is constructed from \c __args... . \c _Resource must satisfy the  \c resource or \c async_resource
+  //! concept, and it must provide all properties in \c _Properties... .
+  //! @param __args The arguments used to construct the instance of \c _Resource to be wrapped within the
+  //! \c basic_any_resource.
+  _LIBCUDACXX_TEMPLATE(class _Resource, class... _Args)
+  _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _Resource, _Args...)
+                         _LIBCUDACXX_AND __valid_resource<_Resource>)
+  basic_any_resource(_CUDA_VSTD::in_place_type_t<_Resource>, _Args&&... __args) noexcept
+      : _CUDA_VMR::_Resource_base<_Alloc_type, _CUDA_VMR::_WrapperType::_Owning>(
+          nullptr, &_CUDA_VMR::__alloc_vtable<_Alloc_type, _CUDA_VMR::_WrapperType::_Owning, _Resource>)
+      , __vtable(__vtable::template _Create<_Resource>())
+  {
+    if constexpr (_CUDA_VMR::_IsSmall<_Resource>())
+    {
+      ::new (static_cast<void*>(this->__object.__buf_)) _Resource(_CUDA_VSTD::forward<_Args>(__args)...);
+    }
+    else
+    {
+      this->__object.__ptr_ = new _Resource(_CUDA_VSTD::forward<_Args>(__args)...);
     }
   }
 
@@ -273,6 +306,51 @@ using any_resource = basic_any_resource<_CUDA_VMR::_AllocType::_Default, _Proper
 //! @endrst
 template <class... _Properties>
 using any_async_resource = basic_any_resource<_CUDA_VMR::_AllocType::_Async, _Properties...>;
+
+//! @rst
+//! .. _cudax-memory-resource-make-any-resource:
+//!
+//! Factory function for `any_resource` objects
+//! -------------------------------------------
+//!
+//! ``make_any_resource`` constructs an :ref:`any_resource <cudax-memory-resource-any-resource>` object that wraps a
+//! newly constructed instance of the given resource type. The resource type must satisfy the ``cuda::mr::resource``
+//! concept and provide all of the properties specified in the template parameter pack.
+//!
+//! @param __args The arguments used to construct the instance of the resource type.
+//!
+//! @endrst
+template <class _Resource, class... _Properties, class... _Args>
+auto make_any_resource(_Args&&... __args) -> any_resource<_Properties...>
+{
+  static_assert(_CUDA_VMR::resource<_Resource>, "_Resource does not satisfy the cuda::mr::resource concept");
+  static_assert(_CUDA_VMR::resource_with<_Resource, _Properties...>,
+                "Resource does not satisfy the required properties");
+  return any_resource<_Properties...>{_CUDA_VSTD::in_place_type<_Resource>, _CUDA_VSTD::forward<_Args>(__args)...};
+}
+
+//! @rst
+//! .. _cudax-memory-resource-make-any-async-resource:
+//!
+//! Factory function for `any_async_resource` objects
+//! -------------------------------------------------
+//!
+//! ``make_any_async_resource`` constructs an :ref:`any_async_resource <cudax-memory-resource-any-async-resource>`
+//! object that wraps a newly constructed instance of the given resource type. The resource type must satisfy the
+//! ``cuda::mr::async_resource`` concept and provide all of the properties specified in the template parameter pack.
+//!
+//! @param __args The arguments used to construct the instance of the resource type.
+//!
+//! @endrst
+template <class _Resource, class... _Properties, class... _Args>
+auto make_any_async_resource(_Args&&... __args) -> any_async_resource<_Properties...>
+{
+  static_assert(_CUDA_VMR::async_resource<_Resource>,
+                "_Resource does not satisfy the cuda::mr::async_resource concept");
+  static_assert(_CUDA_VMR::async_resource_with<_Resource, _Properties...>,
+                "Resource does not satisfy the required properties");
+  return any_async_resource<_Properties...>{_CUDA_VSTD::in_place_type<_Resource>, _CUDA_VSTD::forward<_Args>(__args)...};
+}
 
 } // namespace cuda::experimental::mr
 

--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -106,7 +106,7 @@ public:
   }
 
   //! @brief Conversion from a \c basic_any_resource with the same set of properties but in a different order.
-  //! This constructor also handles conversion from \c async_any_resource to \c any_resource
+  //! This constructor also handles conversion from \c any_async_resource to \c any_resource
   //! @param __other The other \c basic_any_resource.
   _LIBCUDACXX_TEMPLATE(_CUDA_VMR::_AllocType _OtherAllocType, class... _OtherProperties)
   _LIBCUDACXX_REQUIRES(
@@ -260,19 +260,19 @@ template <class... _Properties>
 using any_resource = basic_any_resource<_CUDA_VMR::_AllocType::_Default, _Properties...>;
 
 //! @rst
-//! .. _cudax-memory-resource-async-any-resource:
+//! .. _cudax-memory-resource-any-async-resource:
 //!
 //! Type erased wrapper around an `async_resource`
 //! -----------------------------------------------
 //!
-//! ``async_any_resource`` wraps any given :ref:`async resource <libcudacxx-extended-api-memory-resources-resource>`
+//! ``any_async_resource`` wraps any given :ref:`async resource <libcudacxx-extended-api-memory-resources-resource>`
 //! that satisfies the required properties. It owns the contained resource, taking care of construction / destruction.
 //! This makes it especially suited for use in e.g. container types that need to ensure that the lifetime of the
 //! container exceeds the lifetime of the memory resource used to allocate the storage
 //!
 //! @endrst
 template <class... _Properties>
-using async_any_resource = basic_any_resource<_CUDA_VMR::_AllocType::_Async, _Properties...>;
+using any_async_resource = basic_any_resource<_CUDA_VMR::_AllocType::_Async, _Properties...>;
 
 } // namespace cuda::experimental::mr
 

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -92,6 +92,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   )
 
   cudax_add_catch2_test(test_target memory_resource ${cn_target}
+    memory_resource/any_async_resource.cu
     memory_resource/any_resource.cu
     memory_resource/async_memory_pool.cu
     memory_resource/async_memory_resource.cu

--- a/cudax/test/memory_resource/any_resource.cu
+++ b/cudax/test/memory_resource/any_resource.cu
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "cuda/std/detail/libcxx/include/cstddef"
 #include <catch2/catch.hpp>
 #include <testing.cuh>
 

--- a/cudax/test/memory_resource/any_resource.cu
+++ b/cudax/test/memory_resource/any_resource.cu
@@ -303,4 +303,21 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
 
   // Reset the counters:
   this->counts = Counts();
+
+  SECTION("make_any_resource")
+  {
+    Counts expected{};
+    CHECK(this->counts == expected);
+    {
+      cudax::mr::any_resource<> mr = cudax::mr::make_any_resource<TestResource>(42, this);
+      expected.new_count += is_big;
+      ++expected.object_count;
+      CHECK(this->counts == expected);
+    }
+    expected.delete_count += is_big;
+    --expected.object_count;
+    CHECK(this->counts == expected);
+  }
+  // Reset the counters:
+  this->counts = Counts();
 }

--- a/cudax/test/memory_resource/test_resource.h
+++ b/cudax/test/memory_resource/test_resource.h
@@ -1,0 +1,206 @@
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include <catch2/catch.hpp>
+#include <testing.cuh>
+
+using std::size_t;
+using std::uintptr_t;
+
+struct Counts
+{
+  int object_count           = 0;
+  int move_count             = 0;
+  int copy_count             = 0;
+  int allocate_count         = 0;
+  int deallocate_count       = 0;
+  int allocate_async_count   = 0;
+  int deallocate_async_count = 0;
+  int equal_to_count         = 0;
+  int new_count              = 0;
+  int delete_count           = 0;
+
+  friend std::ostream& operator<<(std::ostream& os, const Counts& counts)
+  {
+    return os
+        << "object: " << counts.object_count << ", " //
+        << "move: " << counts.move_count << ", " //
+        << "copy: " << counts.copy_count << ", " //
+        << "allocate: " << counts.allocate_count << ", " //
+        << "deallocate: " << counts.deallocate_count << ", " //
+        << "allocate_async: " << counts.allocate_async_count << ", " //
+        << "deallocate_async: " << counts.deallocate_async_count << ", " //
+        << "equal_to: " << counts.equal_to_count << ", " //
+        << "new: " << counts.new_count << ", " //
+        << "delete: " << counts.delete_count;
+  }
+
+  friend bool operator==(const Counts& lhs, const Counts& rhs) noexcept
+  {
+    return lhs.object_count == rhs.object_count && //
+           lhs.move_count == rhs.move_count && //
+           lhs.copy_count == rhs.copy_count && //
+           lhs.allocate_count == rhs.allocate_count && //
+           lhs.deallocate_count == rhs.deallocate_count && //
+           lhs.allocate_async_count == rhs.allocate_async_count && //
+           lhs.deallocate_async_count == rhs.deallocate_async_count && //
+           lhs.equal_to_count == rhs.equal_to_count && //
+           lhs.new_count == rhs.new_count && //
+           lhs.delete_count == rhs.delete_count; //
+  }
+
+  friend bool operator!=(const Counts& lhs, const Counts& rhs) noexcept
+  {
+    return !(lhs == rhs);
+  }
+};
+
+struct test_fixture_
+{
+  Counts counts;
+  size_t bytes_ = 0;
+  size_t align_ = 0;
+  static thread_local Counts* counts_;
+
+  test_fixture_() noexcept
+      : counts()
+  {
+    counts_ = &counts;
+  }
+
+  size_t bytes(size_t sz) noexcept
+  {
+    bytes_ = sz;
+    return bytes_;
+  }
+
+  size_t align(size_t align) noexcept
+  {
+    align_ = align;
+    return align_;
+  }
+};
+
+inline thread_local Counts* test_fixture_::counts_ = nullptr;
+
+template <class>
+using test_fixture = test_fixture_;
+
+template <class T>
+struct test_resource
+{
+  int data;
+  test_fixture_* fixture;
+  T cookie[2] = {0xDEADBEEF, 0xDEADBEEF};
+
+  explicit test_resource(int i, test_fixture_* fix) noexcept
+      : data(i)
+      , fixture(fix)
+  {
+    ++fixture->counts.object_count;
+  }
+
+  test_resource(test_resource&& other) noexcept
+      : data(other.data)
+      , fixture(other.fixture)
+  {
+    other._assert_valid();
+    ++fixture->counts.move_count;
+    ++fixture->counts.object_count;
+    other.cookie[0] = other.cookie[1] = 0x0C07FEFE;
+  }
+
+  test_resource(const test_resource& other) noexcept
+      : data(other.data)
+      , fixture(other.fixture)
+  {
+    other._assert_valid();
+    ++fixture->counts.copy_count;
+    ++fixture->counts.object_count;
+  }
+
+  ~test_resource()
+  {
+    --fixture->counts.object_count;
+  }
+
+  void* allocate(std::size_t bytes, std::size_t align)
+  {
+    _assert_valid();
+    CHECK(bytes == fixture->bytes_);
+    CHECK(align == fixture->align_);
+    ++fixture->counts.allocate_count;
+    return fixture;
+  }
+
+  void deallocate(void* ptr, std::size_t bytes, std::size_t align) noexcept
+  {
+    _assert_valid();
+    CHECK(ptr == fixture);
+    CHECK(bytes == fixture->bytes_);
+    CHECK(align == fixture->align_);
+    ++fixture->counts.deallocate_count;
+    return;
+  }
+
+  void* allocate_async(std::size_t bytes, std::size_t align, ::cuda::stream_ref)
+  {
+    _assert_valid();
+    CHECK(bytes == fixture->bytes_);
+    CHECK(align == fixture->align_);
+    ++fixture->counts.allocate_async_count;
+    return fixture;
+  }
+
+  void deallocate_async(void* ptr, std::size_t bytes, std::size_t align, ::cuda::stream_ref) noexcept
+  {
+    _assert_valid();
+    CHECK(ptr == fixture);
+    CHECK(bytes == fixture->bytes_);
+    CHECK(align == fixture->align_);
+    ++fixture->counts.deallocate_async_count;
+    return;
+  }
+
+  friend bool operator==(const test_resource& lhs, const test_resource& rhs)
+  {
+    lhs._assert_valid();
+    rhs._assert_valid();
+    ++lhs.fixture->counts.equal_to_count;
+    return lhs.data == rhs.data;
+  }
+
+  friend bool operator!=(const test_resource& lhs, const test_resource& rhs)
+  {
+    FAIL("any_resource should only be calling operator==");
+    return lhs.data != rhs.data;
+  }
+
+  void _assert_valid() const noexcept
+  {
+    REQUIRE(cookie[0] == 0xDEADBEEF);
+    REQUIRE(cookie[1] == 0xDEADBEEF);
+  }
+
+  static void* operator new(::cuda::std::size_t size)
+  {
+    ++test_fixture_::counts_->new_count;
+    return ::operator new(size);
+  }
+
+  static void operator delete(void* pv) noexcept
+  {
+    ++test_fixture_::counts_->delete_count;
+    return ::operator delete(pv);
+  }
+};
+
+using big_resource   = test_resource<uintptr_t>;
+using small_resource = test_resource<unsigned int>;
+
+static_assert(sizeof(big_resource) > sizeof(cuda::mr::_AnyResourceStorage));
+static_assert(sizeof(small_resource) <= sizeof(cuda::mr::_AnyResourceStorage));

--- a/docs/cudax/index.rst
+++ b/docs/cudax/index.rst
@@ -16,7 +16,7 @@ However, any feature within this library has important use cases and we encourag
 
 Specifically, ``cudax`` provides:
    - :ref:`uninitialized storage <cudax-containers-uninitialized-buffer>`
-   - :ref:`an owning type erased memory resource <cudax-memory-resource-async-any-resource>`
+   - :ref:`an owning type erased memory resource <cudax-memory-resource-any-async-resource>`
    - :ref:`stream-ordered memory resources <cudax-memory-resource-async>`
    - dimensions description functionality
 

--- a/docs/cudax/memory_resource.rst
+++ b/docs/cudax/memory_resource.rst
@@ -15,7 +15,7 @@ Memory Resources
 
 The ``<cuda/experimental/memory_resource.cuh>`` header provides:
    -  :ref:`any_resource <cudax-memory-resource-any-resource>` and
-      :ref:`async_any_resource <cudax-memory-resource-async-any-resource>` type erased memory resources similar to
+      :ref:`any_async_resource <cudax-memory-resource-any-async-resource>` type erased memory resources similar to
       ``std::any``. In contrast to :ref:`resource_ref <libcudacxx-extended-api-memory-resources-resource-ref>` they
       own the contained resource.
    -  :ref:`async_memory_resource <cudax-memory-resource-async>` A standard C++ interface for *heterogeneous*,


### PR DESCRIPTION
We want to be able to directly emplace a resource inside an `any_resource`

This adds a constructor that takes a tag type and convenience functions `make_any_resource`

While we are at it also add tests for any_async_resource