### PR TITLE
[DO_NOT_MERGE] disable system header escape hatch

### DIFF
--- a/cmake/CCCLBuildCompilerTargets.cmake
+++ b/cmake/CCCLBuildCompilerTargets.cmake
@@ -50,9 +50,6 @@ function(cccl_build_compiler_targets)
   list(APPEND cuda_compile_definitions "-Xcudafe=--promote_warnings")
   list(APPEND cuda_compile_definitions "-Wno-deprecated-gpu-targets")
 
-  # Ensure that we build our tests without treating ourself as system header
-  list(APPEND cxx_compile_definitions "_CCCL_NO_SYSTEM_HEADER")
-
   if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     list(APPEND cuda_compile_options "--use-local-env")
     list(APPEND cxx_compile_options "/bigobj")

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -640,7 +640,6 @@ class Configuration(object):
         # Configure extra flags
         compile_flags_str = self.get_lit_conf('compile_flags', '')
         self.cxx.compile_flags += shlex.split(compile_flags_str)
-        self.cxx.compile_flags += ['-D_CCCL_NO_SYSTEM_HEADER']
         if self.is_windows:
             # FIXME: Can we remove this?
             self.cxx.compile_flags += ['-D_CRT_SECURE_NO_WARNINGS']

--- a/thrust/testing/CMakeLists.txt
+++ b/thrust/testing/CMakeLists.txt
@@ -79,9 +79,6 @@ function(thrust_add_test target_name_var test_name test_src thrust_target)
     target_compile_definitions(${test_target} PRIVATE THRUST_TEST_DEVICE_SIDE)
   endif()
 
-  # Ensure that we build our tests without treating ourself as system header
-  target_compile_definitions(${test_target} PRIVATE "_CCCL_NO_SYSTEM_HEADER")
-
   thrust_fix_clang_nvcc_build_for(${test_target})
 
   # Add to the active configuration's meta target


### PR DESCRIPTION
This temporarily disables the `_CCCL_NO_SYSTEM_HEADER` escape hatch due to nvbug4867473 

We need to establish how much is broken