### PR TITLE
Limit Linux CI parallel jobs for each PR.

### DIFF
--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -78,6 +78,7 @@ jobs:
       id-token: write
       contents: read
     strategy:
+      max-parallel: 4
       fail-fast: false
       matrix:
         name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys'] }}
@@ -112,6 +113,7 @@ jobs:
       id-token: write
       contents: read
     strategy:
+      max-parallel: 4
       fail-fast: false
       matrix:
         name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys'] }}

--- a/.github/workflows/workflow-dispatch-standalone-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-linux.yml
@@ -16,6 +16,7 @@ jobs:
   run-jobs:
     name: "${{ matrix.name }}"
     strategy:
+      max-parallel: 4
       fail-fast: false
       matrix:
         include: ${{ fromJSON(inputs.job-array) }}

--- a/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
@@ -19,6 +19,7 @@ jobs:
       id-token: write
       contents: read
     strategy:
+      max-parallel: 4
       fail-fast: false
       matrix:
         include: ${{ fromJSON(inputs.pc-array) }}

--- a/.github/workflows/workflow-dispatch-two-stage-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-linux.yml
@@ -56,6 +56,7 @@ jobs:
       env:
         NVIDIA_VISIBLE_DEVICES: ${{env.NVIDIA_VISIBLE_DEVICES}}
     strategy:
+      max-parallel: 4
       fail-fast: false
       matrix:
         include: ${{ fromJSON(inputs.consumers) }}


### PR DESCRIPTION
## Description
Due to changes in the CI queueing system, CCCL is consuming more of the shared CI resources than before (it is not limited by org). This PR adds limits to parallel jobs launched by Linux CI.


## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
