### PR TITLE
`uninitialized_buffer::get_resource` returns a ref to an `any_resource` that can be copied

### DIFF
--- a/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
@@ -188,13 +188,14 @@ public:
   }
 
   //! @rst
-  //! Returns a :ref:`resource_ref <libcudacxx-extended-api-memory-resources-resource-ref>` to the resource used to
-  //! allocate the buffer
+  //! Returns a \c const reference to the :ref:`any_resource <cudax-memory-resource-any-resource>`
+  //! that holds the memory resource used to allocate the buffer
   //! @endrst
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_NODISCARD _CCCL_HOST_DEVICE _CUDA_VMR::resource_ref<_Properties...> get_resource() const noexcept
+  _CCCL_NODISCARD _CCCL_HOST_DEVICE const ::cuda::experimental::mr::any_resource<_Properties...>&
+  get_resource() const noexcept
   {
-    return _CUDA_VMR::resource_ref<_Properties...>{const_cast<uninitialized_buffer*>(this)->__mr_};
+    return __mr_;
   }
 
   //! @brief Swaps the contents with those of another \c uninitialized_buffer


### PR DESCRIPTION

## Description

cudax `uninitialized_buffer::get_resource` returns a `resource_ref` that refers (in a non-owning way) to the memory resource owned by the buffer. if the returned `resource_ref` is then used to construct another `uninitialized_buffer`, the new buffer will be left with a dangling reference once the first is destroyed.

See issue #2430 for an example of code that looks reasonable and will compile, but will crash at runtime due to a dangling reference.

closes #2430 

<!-- Provide a standalone description of changes in this PR. -->

this PR changes `uninitialized_buffer::get_resource` to return a `const any_resource&` instead of a `resource_ref`. that way, if the result is used to construct a new `uninitialized_buffer`, the buffer will own a copy of the resource.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
