### PR TITLE
Move nightly time

### DIFF
--- a/.github/workflows/ci-workflow-nightly.yml
+++ b/.github/workflows/ci-workflow-nightly.yml
@@ -23,7 +23,7 @@ defaults:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * *' # 7AM UTC, 12AM PST, 3AM EST
+    - cron: '0 3 * * *' # 3AM UTC, 11PM EST, 8PM PST
 
 concurrency:
   group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}


### PR DESCRIPTION
## Description
CCCL nightlies currently run at 7am UTC / 3am EST / 12am PST. We schedule RAPIDS nightlies at [5am UTC / 1am EST / 10pm PST](https://github.com/rapidsai/workflows/blob/95fd62edf3ba10ef1fed88690ae1ef2ab496db7a/.github/workflows/nightly-pipeline-trigger.yaml#L6). I suspect that putting CCCL a few hours earlier would reduce overlap with EU/US workday times and the RAPIDS nightly queue. I propose moving CCCL to 3am UTC / 11pm EST / 8pm PST.

Hopefully with this change, the CCCL nightly queue could be mostly done by the time that RAPIDS launches.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
