### PR TITLE
[CUDAX] Add placeholder green context type and logical device that can hold both a green ctx and a device

### DIFF
--- a/cudax/include/cuda/experimental/__device/device_ref_v2.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref_v2.cuh
@@ -1,0 +1,134 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__DEVICE_DEVICE_REF_V2
+#define _CUDAX__DEVICE_DEVICE_REF_V2
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__device/all_devices.cuh>
+#include <cuda/experimental/__green_context/green_ctx.cuh>
+
+namespace cuda::experimental
+{
+
+//! @brief A non-owning representation of a CUDA device
+class device_ref_v2
+{
+  friend struct stream_ref;
+  // This might be a CUdevice as well
+  int __dev_id    = 0;
+  CUcontext __ctx = nullptr;
+
+public:
+  //! @brief Retrieve the native ordinal of the `device_ref`
+  //!
+  //! @return int The native device ordinal held by the `device_ref` object
+  _CCCL_NODISCARD constexpr CUcontext context() const noexcept
+  {
+    return __ctx;
+  }
+
+  _CCCL_NODISCARD constexpr device_ref device() const noexcept
+  {
+    return __dev_id;
+  }
+
+  explicit device_ref_v2(int __id)
+      : __dev_id(__id)
+      , __ctx(devices[__id].primary_context())
+  {}
+
+  device_ref_v2(device_ref __dev)
+      : device_ref_v2(__dev.get())
+  {}
+
+  device_ref_v2(const ::cuda::experimental::device& __dev)
+      : __dev_id(__dev.get())
+      , __ctx(__dev.primary_context())
+  {}
+
+#if CUDART_VERSION >= 12050
+  device_ref_v2(const green_context& __gctx)
+      : __dev_id(__gctx.__dev_id)
+      , __ctx(__gctx.__transformed)
+  {}
+#endif
+
+  //! @brief Compares two `device_ref`s for equality
+  //!
+  //! @note Allows comparison with `int` due to implicit conversion to
+  //! `device_ref`.
+  //!
+  //! @param __lhs The first `device_ref` to compare
+  //! @param __rhs The second `device_ref` to compare
+  //! @return true if `lhs` and `rhs` refer to the same device ordinal
+  _CCCL_NODISCARD_FRIEND bool operator==(device_ref_v2 __lhs, device_ref_v2 __rhs) noexcept
+  {
+    return __lhs.__dev_id == __rhs.__dev_id && __lhs.__ctx == __rhs.__ctx;
+  }
+
+#if _CCCL_STD_VER <= 2017
+  //! @brief Compares two `device_ref`s for inequality
+  //!
+  //! @note Allows comparison with `int` due to implicit conversion to
+  //! `device_ref`.
+  //!
+  //! @param __lhs The first `device_ref` to compare
+  //! @param __rhs The second `device_ref` to compare
+  //! @return true if `lhs` and `rhs` refer to different device ordinal
+  _CCCL_NODISCARD_FRIEND bool operator!=(device_ref_v2 __lhs, device_ref_v2 __rhs) noexcept
+  {
+    return __lhs.__dev_id != __rhs.__dev_id || __lhs.__ctx != __rhs.__ctx;
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+  /*
+    //! @brief Retrieve the specified attribute for the device
+    //!
+    //! @param __attr The attribute to query. See `device::attrs` for the available
+    //!        attributes.
+    //!
+    //! @throws cuda_error if the attribute query fails
+    //!
+    //! @sa device::attrs
+    template <typename _Attr>
+    _CCCL_NODISCARD auto attr(_Attr __attr) const
+    {
+      return __attr(*this);
+    }
+
+    //! @overload
+    template <::cudaDeviceAttr _Attr>
+    _CCCL_NODISCARD auto attr() const
+    {
+      return attr(detail::__dev_attr<_Attr>());
+    }
+
+    const arch_traits_t& arch_traits() const;*/
+
+private:
+  device_ref_v2(int __id, CUcontext __context)
+      : __dev_id(__id)
+      , __ctx(__context)
+  {}
+};
+
+} // namespace cuda::experimental
+
+#endif // _CUDAX__DEVICE_DEVICE_REF

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -26,6 +26,10 @@
 
 namespace cuda::experimental
 {
+namespace detail
+{
+struct logical_device_access;
+}
 
 //! @brief A non-owning representation of a CUDA device or a green context
 struct logical_device
@@ -110,7 +114,7 @@ struct logical_device
 #endif // _CCCL_STD_VER <= 2017
 
 private:
-  friend struct ::cuda::experimental::stream_ref;
+  friend detail::logical_device_access;
   // This might be a CUdevice as well
   int __dev_id    = 0;
   CUcontext __ctx = nullptr;
@@ -123,6 +127,17 @@ private:
       , __kind(__k)
   {}
 };
+
+namespace detail
+{
+struct logical_device_access
+{
+  static logical_device make_logical_device(int __id, CUcontext __context, logical_device::kinds __k)
+  {
+    return logical_device(__id, __context, __k);
+  }
+};
+} // namespace detail
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -62,6 +62,8 @@ public:
   }
 
   //! @brief Construct logical_device from a device ordinal
+  //!
+  //! Constructing a logical_device for a given device ordinal has a side effect of initializing that device
   explicit logical_device(int __id)
       : __dev_id(__id)
       , __kind(kinds::device)
@@ -69,11 +71,15 @@ public:
   {}
 
   //! @brief Construct logical_device from a device_ref
+  //!
+  //! Constructing a logical_device for a given device_ref has a side effect of initializing that device
   explicit logical_device(device_ref __dev)
       : logical_device(__dev.get())
   {}
 
   // More of a micro-optimization, we can also remove this (depending if we keep device_ref)
+  //!
+  //! Constructing a logical_device for a given device has a side effect of initializing that device
   logical_device(const ::cuda::experimental::device& __dev)
       : __dev_id(__dev.get())
       , __kind(kinds::device)

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -26,14 +26,12 @@
 
 namespace cuda::experimental
 {
-namespace detail
-{
-struct logical_device_access;
-}
+struct __logical_device_access;
 
 //! @brief A non-owning representation of a CUDA device or a green context
 class logical_device
 {
+public:
   //! @brief Enum to indicate the kind of logical device stored
   enum class kinds
   {
@@ -51,7 +49,7 @@ class logical_device
   }
 
   //! @brief Retrieve the device on which this logical device resides
-  _CCCL_NODISCARD constexpr device_ref underlying_device() const noexcept
+  _CCCL_NODISCARD constexpr device_ref get_underlying_device() const noexcept
   {
     return __dev_id;
   }
@@ -66,8 +64,8 @@ class logical_device
   //! @brief Construct logical_device from a device ordinal
   explicit logical_device(int __id)
       : __dev_id(__id)
-      , __ctx(devices[__id].primary_context())
       , __kind(kinds::device)
+      , __ctx(devices[__id].primary_context())
   {}
 
   //! @brief Construct logical_device from a device_ref
@@ -78,16 +76,16 @@ class logical_device
   // More of a micro-optimization, we can also remove this (depending if we keep device_ref)
   logical_device(const ::cuda::experimental::device& __dev)
       : __dev_id(__dev.get())
-      , __ctx(__dev.primary_context())
       , __kind(kinds::device)
+      , __ctx(__dev.primary_context())
   {}
 
 #if CUDART_VERSION >= 12050
   //! @brief Construct logical_device from a green_context
   logical_device(const green_context& __gctx)
       : __dev_id(__gctx.__dev_id)
-      , __ctx(__gctx.__transformed)
       , __kind(kinds::green_context)
+      , __ctx(__gctx.__transformed)
   {}
 #endif // CUDART_VERSION >= 12050
 
@@ -114,29 +112,26 @@ class logical_device
 #endif // _CCCL_STD_VER <= 2017
 
 private:
-  friend detail::logical_device_access;
+  friend __logical_device_access;
   // This might be a CUdevice as well
-  int __dev_id    = 0;
+  int __dev_id = 0;
   kinds __kind;
   CUcontext __ctx = nullptr;
 
   logical_device(int __id, CUcontext __context, kinds __k)
       : __dev_id(__id)
-      , __ctx(__context)
       , __kind(__k)
+      , __ctx(__context)
   {}
 };
 
-namespace detail
-{
-struct logical_device_access
+struct __logical_device_access
 {
   static logical_device make_logical_device(int __id, CUcontext __context, logical_device::kinds __k)
   {
     return logical_device(__id, __context, __k);
   }
 };
-} // namespace detail
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDAX__DEVICE_DEVICE_REF_V2
-#define _CUDAX__DEVICE_DEVICE_REF_V2
+#ifndef _CUDAX__DEVICE_LOGICAL_DEVICE
+#define _CUDAX__DEVICE_LOGICAL_DEVICE
 
 #include <cuda/__cccl_config>
 
@@ -28,7 +28,7 @@ namespace cuda::experimental
 {
 
 //! @brief A non-owning representation of a CUDA device
-class device_ref_v2
+class logical_device
 {
   friend struct stream_ref;
   // This might be a CUdevice as well
@@ -49,22 +49,22 @@ public:
     return __dev_id;
   }
 
-  explicit device_ref_v2(int __id)
+  explicit logical_device(int __id)
       : __dev_id(__id)
       , __ctx(devices[__id].primary_context())
   {}
 
-  device_ref_v2(device_ref __dev)
-      : device_ref_v2(__dev.get())
+  logical_device(device_ref __dev)
+      : logical_device(__dev.get())
   {}
 
-  device_ref_v2(const ::cuda::experimental::device& __dev)
+  logical_device(const ::cuda::experimental::device& __dev)
       : __dev_id(__dev.get())
       , __ctx(__dev.primary_context())
   {}
 
 #if CUDART_VERSION >= 12050
-  device_ref_v2(const green_context& __gctx)
+  logical_device(const green_context& __gctx)
       : __dev_id(__gctx.__dev_id)
       , __ctx(__gctx.__transformed)
   {}
@@ -78,7 +78,7 @@ public:
   //! @param __lhs The first `device_ref` to compare
   //! @param __rhs The second `device_ref` to compare
   //! @return true if `lhs` and `rhs` refer to the same device ordinal
-  _CCCL_NODISCARD_FRIEND bool operator==(device_ref_v2 __lhs, device_ref_v2 __rhs) noexcept
+  _CCCL_NODISCARD_FRIEND bool operator==(logical_device __lhs, logical_device __rhs) noexcept
   {
     return __lhs.__dev_id == __rhs.__dev_id && __lhs.__ctx == __rhs.__ctx;
   }
@@ -92,7 +92,7 @@ public:
   //! @param __lhs The first `device_ref` to compare
   //! @param __rhs The second `device_ref` to compare
   //! @return true if `lhs` and `rhs` refer to different device ordinal
-  _CCCL_NODISCARD_FRIEND bool operator!=(device_ref_v2 __lhs, device_ref_v2 __rhs) noexcept
+  _CCCL_NODISCARD_FRIEND bool operator!=(logical_device __lhs, logical_device __rhs) noexcept
   {
     return __lhs.__dev_id != __rhs.__dev_id || __lhs.__ctx != __rhs.__ctx;
   }
@@ -123,7 +123,7 @@ public:
     const arch_traits_t& arch_traits() const;*/
 
 private:
-  device_ref_v2(int __id, CUcontext __context)
+  logical_device(int __id, CUcontext __context)
       : __dev_id(__id)
       , __ctx(__context)
   {}

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -32,9 +32,9 @@ struct logical_device_access;
 }
 
 //! @brief A non-owning representation of a CUDA device or a green context
-struct logical_device
+class logical_device
 {
-  // Enum to indicate kind of logical device stored
+  //! @brief Enum to indicate the kind of logical device stored
   enum class kinds
   {
     // Indicates logical device is a full device
@@ -58,7 +58,7 @@ struct logical_device
 
   //! @brief Retrieve the kind of logical device stored in this object
   //! The kind indicates if this logical_device holds a device or green_context
-  _CCCL_NODISCARD constexpr kinds kind() const noexcept
+  _CCCL_NODISCARD constexpr kinds get_kind() const noexcept
   {
     return __kind;
   }
@@ -89,7 +89,7 @@ struct logical_device
       , __ctx(__gctx.__transformed)
       , __kind(kinds::green_context)
   {}
-#endif
+#endif // CUDART_VERSION >= 12050
 
   //! @brief Compares two logical_devices for equality
   //!
@@ -117,9 +117,8 @@ private:
   friend detail::logical_device_access;
   // This might be a CUdevice as well
   int __dev_id    = 0;
-  CUcontext __ctx = nullptr;
-  // If we ever move to a variant instead of CUcontext we can probably remove the kind member
   kinds __kind;
+  CUcontext __ctx = nullptr;
 
   logical_device(int __id, CUcontext __context, kinds __k)
       : __dev_id(__id)

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -30,40 +30,48 @@ namespace cuda::experimental
 //! @brief A non-owning representation of a CUDA device or a green context
 struct logical_device
 {
+  // Enum to indicate kind of logical device stored
   enum class kinds
   {
+    // Indicates logical device is a full device
     device,
+    // Indicated logical device is a green context
     green_context
   };
 
-  //! @brief Retrieve the native ordinal of the `device_ref`
-  //!
-  //! @return int The native device ordinal held by the `device_ref` object
+  // We might want to make this private depending on how this type ends up looking like long term,
+  // not documenting it for now
   _CCCL_NODISCARD constexpr CUcontext context() const noexcept
   {
     return __ctx;
   }
 
+  //! @brief Retrieve the device on which this logical device resides
   _CCCL_NODISCARD constexpr device_ref underlying_device() const noexcept
   {
     return __dev_id;
   }
 
+  //! @brief Retrieve the kind of logical device stored in this object
+  //! The kind indicates if this logical_device holds a device or green_context
   _CCCL_NODISCARD constexpr kinds kind() const noexcept
   {
     return __kind;
   }
 
+  //! @brief Construct logical_device from a device ordinal
   explicit logical_device(int __id)
       : __dev_id(__id)
       , __ctx(devices[__id].primary_context())
       , __kind(kinds::device)
   {}
 
+  //! @brief Construct logical_device from a device_ref
   explicit logical_device(device_ref __dev)
       : logical_device(__dev.get())
   {}
 
+  // More of a micro-optimization, we can also remove this (depending if we keep device_ref)
   logical_device(const ::cuda::experimental::device& __dev)
       : __dev_id(__dev.get())
       , __ctx(__dev.primary_context())
@@ -71,6 +79,7 @@ struct logical_device
   {}
 
 #if CUDART_VERSION >= 12050
+  //! @brief Construct logical_device from a green_context
   logical_device(const green_context& __gctx)
       : __dev_id(__gctx.__dev_id)
       , __ctx(__gctx.__transformed)
@@ -78,28 +87,25 @@ struct logical_device
   {}
 #endif
 
-  //! @brief Compares two `device_ref`s for equality
+  //! @brief Compares two logical_devices for equality
   //!
-  //! @note Allows comparison with `int` due to implicit conversion to
-  //! `device_ref`.
-  //!
-  //! @param __lhs The first `device_ref` to compare
-  //! @param __rhs The second `device_ref` to compare
-  //! @return true if `lhs` and `rhs` refer to the same device ordinal
+  //! @param __lhs The first `logical_device` to compare
+  //! @param __rhs The second `logical_device` to compare
+  //! @return true if `lhs` and `rhs` refer to the same logical device
   _CCCL_NODISCARD_FRIEND bool operator==(logical_device __lhs, logical_device __rhs) noexcept
   {
     return __lhs.__ctx == __rhs.__ctx;
   }
 
 #if _CCCL_STD_VER <= 2017
-  //! @brief Compares two `device_ref`s for inequality
+  //! @brief Compares two logical_devices for inequality
   //!
   //! @note Allows comparison with `int` due to implicit conversion to
   //! `device_ref`.
   //!
-  //! @param __lhs The first `device_ref` to compare
-  //! @param __rhs The second `device_ref` to compare
-  //! @return true if `lhs` and `rhs` refer to different device ordinal
+  //! @param __lhs The first `logical_device` to compare
+  //! @param __rhs The second `logical_device` to compare
+  //! @return true if `lhs` and `rhs` refer to the different logical device
   _CCCL_NODISCARD_FRIEND bool operator!=(logical_device __lhs, logical_device __rhs) noexcept
   {
     return __lhs.__ctx != __rhs.__ctx;

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -100,9 +100,6 @@ struct logical_device
 #if _CCCL_STD_VER <= 2017
   //! @brief Compares two logical_devices for inequality
   //!
-  //! @note Allows comparison with `int` due to implicit conversion to
-  //! `device_ref`.
-  //!
   //! @param __lhs The first `logical_device` to compare
   //! @param __rhs The second `logical_device` to compare
   //! @return true if `lhs` and `rhs` refer to the different logical device

--- a/cudax/include/cuda/experimental/__device/logical_device.cuh
+++ b/cudax/include/cuda/experimental/__device/logical_device.cuh
@@ -110,7 +110,7 @@ struct logical_device
 #endif // _CCCL_STD_VER <= 2017
 
 private:
-  friend struct stream_ref;
+  friend struct ::cuda::experimental::stream_ref;
   // This might be a CUdevice as well
   int __dev_id    = 0;
   CUcontext __ctx = nullptr;

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -46,6 +46,9 @@ struct green_context
     __transformed     = detail::driver::ctxFromGreenCtx(__green_ctx);
   }
 
+  green_context(const device&)            = delete;
+  green_context& operator=(const device&) = delete;
+
   // TODO this probably should be the runtime equivalent once available
   _CCCL_NODISCARD static green_context from_native_handle(CUgreenCtx __gctx)
   {

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -46,8 +46,8 @@ struct green_context
     __transformed     = detail::driver::ctxFromGreenCtx(__green_ctx);
   }
 
-  green_context(const device&)            = delete;
-  green_context& operator=(const device&) = delete;
+  green_context(const green_context&)            = delete;
+  green_context& operator=(const green_context&) = delete;
 
   // TODO this probably should be the runtime equivalent once available
   _CCCL_NODISCARD static green_context from_native_handle(CUgreenCtx __gctx)

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/std/utility>
 
 #include <cuda/experimental/__device/all_devices.cuh>
 #include <cuda/experimental/__utility/driver_api.cuh>
@@ -33,9 +34,9 @@ struct device_ref;
 
 struct green_context
 {
-  int __dev_id;
-  CUgreenCtx __green_ctx;
-  CUcontext __transformed;
+  int __dev_id            = -1;
+  CUgreenCtx __green_ctx  = nullptr;
+  CUcontext __transformed = nullptr;
 
   explicit green_context(const device& __device)
       : __dev_id(__device.get())

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -37,7 +37,7 @@ struct green_context
   CUgreenCtx __green_ctx;
   CUcontext __transformed;
 
-  green_context(const device& __device)
+  explicit green_context(const device& __device)
       : __dev_id(__device.get())
   {
     // TODO get CUdevice from device
@@ -60,7 +60,7 @@ struct green_context
     return green_context(__id, __gctx, __transformed);
   }
 
-  CUgreenCtx release()
+  _CCCL_NODISCARD CUgreenCtx release() noexcept
   {
     __transformed = nullptr;
     __dev_id      = -1;
@@ -76,12 +76,12 @@ struct green_context
   }
 
 private:
-  green_context(int __id, CUgreenCtx __gctx, CUcontext __ctx)
+  explicit green_context(int __id, CUgreenCtx __gctx, CUcontext __ctx)
       : __dev_id(__id)
       , __green_ctx(__gctx)
       , __transformed(__ctx)
   {}
 };
 } // namespace cuda::experimental
-#endif
-#endif
+#endif // CUDART_VERSION >= 12050
+#endif // _CUDAX__GREEN_CONTEXT_GREEN_CTX

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__GREEN_CONTEXT_GREEN_CTX
+#define _CUDAX__GREEN_CONTEXT_GREEN_CTX
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cuda/api_wrapper.h>
+
+#include <cuda/experimental/__device/all_devices.cuh>
+#include <cuda/experimental/__utility/driver_api.cuh>
+
+#if CUDART_VERSION >= 12050
+namespace cuda::experimental
+{
+struct device_ref;
+
+struct green_context
+{
+  int __dev_id;
+  CUgreenCtx __green_ctx;
+  CUcontext __transformed;
+
+  green_context(const device& __device)
+      : __dev_id(__device.get())
+  {
+    // TODO get CUdevice from device
+    __green_ctx   = detail::driver::greenCtxCreate((CUdevice) __dev_id);
+    __transformed = detail::driver::ctxFromGreenCtx(__green_ctx);
+  }
+
+  // TODO this probably should be the runtime equivalent once available
+  _CCCL_NODISCARD static green_context from_native_handle(CUgreenCtx __gctx)
+  {
+    int __id;
+    CUcontext __transformed = detail::driver::ctxFromGreenCtx(__gctx);
+    detail::driver::ctxPush(__transformed);
+    _CCCL_TRY_CUDA_API(cudaGetDevice, "Failed to get device ordinal from a green context", &__id);
+    detail::driver::ctxPop();
+    return green_context(__id, __gctx, __transformed);
+  }
+
+  CUgreenCtx release()
+  {
+    __transformed = nullptr;
+    __dev_id      = -1;
+    return _CUDA_VSTD::exchange(__green_ctx, nullptr);
+  }
+
+  ~green_context()
+  {
+    if (__green_ctx)
+    {
+      [[maybe_unused]] cudaError_t __status = detail::driver::greenCtxDestroy(__green_ctx);
+    }
+  }
+
+private:
+  green_context(int __id, CUgreenCtx __gctx, CUcontext __ctx)
+      : __dev_id(__id)
+      , __green_ctx(__gctx)
+      , __transformed(__ctx)
+  {}
+};
+} // namespace cuda::experimental
+#endif
+#endif

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -41,8 +41,9 @@ struct green_context
       : __dev_id(__device.get())
   {
     // TODO get CUdevice from device
-    __green_ctx   = detail::driver::greenCtxCreate((CUdevice) __dev_id);
-    __transformed = detail::driver::ctxFromGreenCtx(__green_ctx);
+    auto __dev_handle = detail::driver::deviceGet(__dev_id);
+    __green_ctx       = detail::driver::greenCtxCreate(__dev_handle);
+    __transformed     = detail::driver::ctxFromGreenCtx(__green_ctx);
   }
 
   // TODO this probably should be the runtime equivalent once available

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -25,7 +25,7 @@
 #include <cuda/std/__cuda/api_wrapper.h>
 
 #include <cuda/experimental/__device/device_ref.cuh>
-#include <cuda/experimental/__device/device_ref_v2.cuh>
+#include <cuda/experimental/__device/logical_device.cuh>
 #include <cuda/experimental/__stream/stream_ref.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
 
@@ -51,7 +51,7 @@ struct stream : stream_ref
       ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamDefault, __priority);
   }
 
-  explicit stream(device_ref_v2 __dev, int __priority = default_priority)
+  explicit stream(::cuda::experimental::logical_device __dev, int __priority = default_priority)
       : stream_ref(detail::__invalid_stream)
   {
     [[maybe_unused]] __ensure_current_device __dev_setter(__dev);

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -51,6 +51,11 @@ struct stream : stream_ref
       ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamDefault, __priority);
   }
 
+  //! @brief Constructs a stream on a specified logical device and with specified priority
+  //!
+  //! Priority is defaulted to stream::default_priority
+  //!
+  //! @throws cuda_error if stream creation fails
   explicit stream(::cuda::experimental::logical_device __dev, int __priority = default_priority)
       : stream_ref(detail::__invalid_stream)
   {

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -25,6 +25,7 @@
 #include <cuda/std/__cuda/api_wrapper.h>
 
 #include <cuda/experimental/__device/device_ref.cuh>
+#include <cuda/experimental/__device/device_ref_v2.cuh>
 #include <cuda/experimental/__stream/stream_ref.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
 
@@ -43,6 +44,14 @@ struct stream : stream_ref
   //!
   //! @throws cuda_error if stream creation fails
   explicit stream(device_ref __dev, int __priority = default_priority)
+      : stream_ref(detail::__invalid_stream)
+  {
+    [[maybe_unused]] __ensure_current_device __dev_setter(__dev);
+    _CCCL_TRY_CUDA_API(
+      ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamDefault, __priority);
+  }
+
+  explicit stream(device_ref_v2 __dev, int __priority = default_priority)
       : stream_ref(detail::__invalid_stream)
   {
     [[maybe_unused]] __ensure_current_device __dev_setter(__dev);

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -96,6 +96,9 @@ struct stream_ref : ::cuda::stream_ref
     wait(__tmp);
   }
 
+  //! @brief Get the logical device under which this stream was created
+  //! Compared to `device()` member function the returned logical_device will hold a green context for streams
+  //! created under one.
   logical_device logical_device() const
   {
     CUcontext __stream_ctx;
@@ -104,12 +107,12 @@ struct stream_ref : ::cuda::stream_ref
     auto __ctx = detail::driver::streamGetCtx_v2(__stream);
     if (cuda::std::holds_alternative<CUgreenCtx>(__ctx))
     {
-      __stream_ctx = detail::driver::ctxFromGreenCtx(cuda::std::get<CUgreenCtx>(__ctx));
+      __stream_ctx = detail::driver::ctxFromGreenCtx(::cuda::std::get<CUgreenCtx>(__ctx));
       __ctx_kind   = ::cuda::experimental::logical_device::kinds::green_context;
     }
     else
     {
-      __stream_ctx = cuda::std::get<CUcontext>(__ctx);
+      __stream_ctx = ::cuda::std::get<CUcontext>(__ctx);
       __ctx_kind   = ::cuda::experimental::logical_device::kinds::device;
     }
 #else
@@ -124,6 +127,9 @@ struct stream_ref : ::cuda::stream_ref
   }
 
   //! @brief Get device under which this stream was created.
+  //!
+  //! Note: In case of a stream created under a `green_context` the device on which that `green_context` was created is
+  //! returned
   //!
   //! @throws cuda_error if device check fails
   device_ref device() const

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -99,15 +99,18 @@ struct stream_ref : ::cuda::stream_ref
   logical_device logical_device() const
   {
     CUcontext __stream_ctx;
+    ::cuda::experimental::logical_device::kinds __ctx_kind = ::cuda::experimental::logical_device::kinds::device;
 #if CUDART_VERSION >= 12050
     auto __ctx = detail::driver::streamGetCtx_v2(__stream);
     if (cuda::std::holds_alternative<CUgreenCtx>(__ctx))
     {
       __stream_ctx = detail::driver::ctxFromGreenCtx(cuda::std::get<CUgreenCtx>(__ctx));
+      __ctx_kind   = ::cuda::experimental::logical_device::kinds::green_context;
     }
     else
     {
       __stream_ctx = cuda::std::get<CUcontext>(__ctx);
+      __ctx_kind   = ::cuda::experimental::logical_device::kinds::device;
     }
 #else
     __stream_ctx = detail::driver::streamGetCtx(__stream);
@@ -117,7 +120,7 @@ struct stream_ref : ::cuda::stream_ref
     __ensure_current_device __setter(__stream_ctx);
     int __id;
     _CCCL_TRY_CUDA_API(cudaGetDevice, "Could not get device from a stream", &__id);
-    return ::cuda::experimental::logical_device(__id, __stream_ctx);
+    return ::cuda::experimental::logical_device(__id, __stream_ctx, __ctx_kind);
   }
 
   //! @brief Get device under which this stream was created.

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -26,7 +26,7 @@
 #include <cuda/stream_ref>
 
 #include <cuda/experimental/__device/all_devices.cuh>
-#include <cuda/experimental/__device/device_ref_v2.cuh>
+#include <cuda/experimental/__device/logical_device.cuh>
 #include <cuda/experimental/__event/timed_event.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
 
@@ -96,7 +96,7 @@ struct stream_ref : ::cuda::stream_ref
     wait(__tmp);
   }
 
-  device_ref_v2 get_device_ref_v2() const
+  logical_device logical_device() const
   {
     CUcontext __stream_ctx;
 #if CUDART_VERSION >= 12050
@@ -117,7 +117,7 @@ struct stream_ref : ::cuda::stream_ref
     __ensure_current_device __setter(__stream_ctx);
     int __id;
     _CCCL_TRY_CUDA_API(cudaGetDevice, "Could not get device from a stream", &__id);
-    return device_ref_v2(__id, __stream_ctx);
+    return ::cuda::experimental::logical_device(__id, __stream_ctx);
   }
 
   //! @brief Get device under which this stream was created.
@@ -125,7 +125,7 @@ struct stream_ref : ::cuda::stream_ref
   //! @throws cuda_error if device check fails
   device_ref device() const
   {
-    return get_device_ref_v2().__dev_id;
+    return logical_device().__dev_id;
   }
 };
 

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -123,7 +123,7 @@ struct stream_ref : ::cuda::stream_ref
     __ensure_current_device __setter(__stream_ctx);
     int __id;
     _CCCL_TRY_CUDA_API(cudaGetDevice, "Could not get device from a stream", &__id);
-    return ::cuda::experimental::logical_device(__id, __stream_ctx, __ctx_kind);
+    return detail::logical_device_access::make_logical_device(__id, __stream_ctx, __ctx_kind);
   }
 
   //! @brief Get device under which this stream was created.
@@ -134,7 +134,7 @@ struct stream_ref : ::cuda::stream_ref
   //! @throws cuda_error if device check fails
   device_ref device() const
   {
-    return logical_device().__dev_id;
+    return logical_device().underlying_device();
   }
 };
 

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -149,7 +149,7 @@ inline cuda::std::variant<CUcontext, CUgreenCtx> streamGetCtx_v2(CUstream stream
     return ctx;
   }
 }
-#endif
+#endif // CUDART_VERSION >= 12050
 
 inline void streamWaitEvent(CUstream stream, CUevent event)
 {
@@ -199,7 +199,7 @@ inline CUcontext ctxFromGreenCtx(CUgreenCtx green_ctx)
   call_driver_fn(driver_fn, "Failed to convert a green context", &result, green_ctx);
   return result;
 }
-#endif
+#endif // CUDART_VERSION >= 12050
 } // namespace cuda::experimental::detail::driver
 
 #undef CUDAX_GET_DRIVER_FUNCTION

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -24,7 +24,9 @@
 
 namespace cuda::experimental::detail::driver
 {
-// For minor version compatibility request the 12.0 version of everything for now, unless requested otherwise
+//! @brief Get a driver function pointer for a given API name and optionally specific CUDA version
+//!
+//! For minor version compatibility request the 12.0 version of everything for now, unless requested otherwise
 inline void* get_driver_entry_point(const char* name, [[maybe_unused]] int version = 12000)
 {
   void* fn;

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -166,6 +166,7 @@ inline cudaError_t eventDestroy(CUevent event)
 }
 
 #if CUDART_VERSION >= 12050
+// Add actual resource description input once exposure is ready
 inline CUgreenCtx greenCtxCreate(CUdevice dev)
 {
   CUgreenCtx result;

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -60,6 +60,17 @@ inline void call_driver_fn(Fn fn, const char* err_msg, Args... args)
   }
 }
 
+inline int getVersion()
+{
+  static int version = []() {
+    int v;
+    auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDriverGetVersion);
+    call_driver_fn(driver_fn, "Failed to check CUDA driver version", &v);
+    return v;
+  }();
+  return version;
+}
+
 inline void ctxPush(CUcontext ctx)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuCtxPushCurrent);

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -132,6 +132,7 @@ inline CUcontext streamGetCtx(CUstream stream)
   return result;
 }
 
+#if CUDART_VERSION >= 12050
 struct __ctx_from_stream
 {
   enum class __kind
@@ -148,7 +149,6 @@ struct __ctx_from_stream
   } __ctx_ptr;
 };
 
-#if CUDART_VERSION >= 12050
 inline __ctx_from_stream streamGetCtx_v2(CUstream stream)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetCtx, cuStreamGetCtx_v2, 12050);

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -24,7 +24,7 @@
 #include <cuda/stream_ref>
 
 #include <cuda/experimental/__device/all_devices.cuh>
-#include <cuda/experimental/__device/device_ref_v2.cuh>
+#include <cuda/experimental/__device/logical_device.cuh>
 #include <cuda/experimental/__utility/driver_api.cuh>
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
@@ -48,7 +48,7 @@ struct [[maybe_unused]] __ensure_current_device
     detail::driver::ctxPush(ctx);
   }
 
-  explicit __ensure_current_device(device_ref_v2 new_device)
+  explicit __ensure_current_device(logical_device new_device)
   {
     detail::driver::ctxPush(new_device.context());
   }

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -31,6 +31,9 @@
 
 namespace cuda::experimental
 {
+//! TODO we might want to change the comments to indicate it operates on contexts for certains differences
+//! with green context, but it depends on how exactly green context internals end up being
+
 //! @brief RAII helper which on construction sets the current device to the specified one or one a
 //! stream was created under. It sets the state back on destruction.
 //!
@@ -42,17 +45,28 @@ struct [[maybe_unused]] __ensure_current_device
   //! @param new_device The device to switch to
   //!
   //! @throws cuda_error if the device switch fails
-  explicit __ensure_current_device(device_ref new_device)
+  explicit __ensure_current_device(device_ref __new_device)
   {
-    auto ctx = devices[new_device.get()].primary_context();
-    detail::driver::ctxPush(ctx);
+    auto __ctx = devices[__new_device.get()].primary_context();
+    detail::driver::ctxPush(__ctx);
   }
 
-  explicit __ensure_current_device(logical_device new_device)
+  //! @brief Construct a new `__ensure_current_device` object and switch to the specified
+  //!        device.
+  //!
+  //! Note: if this logical device contains a green_context the device under which the green
+  //! context was created will be set to current
+  //!
+  //! @param new_device The device to switch to
+  //!
+  //! @throws cuda_error if the device switch fails
+  explicit __ensure_current_device(logical_device __new_device)
   {
-    detail::driver::ctxPush(new_device.context());
+    detail::driver::ctxPush(__new_device.context());
   }
 
+  // Doesn't really fit into the type description, we might consider changing it once
+  // green ctx design is more finalized
   explicit __ensure_current_device(CUcontext __ctx)
   {
     detail::driver::ctxPush(__ctx);
@@ -64,10 +78,10 @@ struct [[maybe_unused]] __ensure_current_device
   //! @param stream Stream indicating the device to switch to
   //!
   //! @throws cuda_error if the device switch fails
-  explicit __ensure_current_device(stream_ref stream)
+  explicit __ensure_current_device(stream_ref __stream)
   {
-    auto ctx = detail::driver::streamGetCtx(stream.get());
-    detail::driver::ctxPush(ctx);
+    auto __ctx = detail::driver::streamGetCtx(__stream.get());
+    detail::driver::ctxPush(__ctx);
   }
 
   __ensure_current_device(__ensure_current_device&&)                 = delete;

--- a/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
+++ b/cudax/include/cuda/experimental/__utility/ensure_current_device.cuh
@@ -24,6 +24,7 @@
 #include <cuda/stream_ref>
 
 #include <cuda/experimental/__device/all_devices.cuh>
+#include <cuda/experimental/__device/device_ref_v2.cuh>
 #include <cuda/experimental/__utility/driver_api.cuh>
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
@@ -45,6 +46,16 @@ struct [[maybe_unused]] __ensure_current_device
   {
     auto ctx = devices[new_device.get()].primary_context();
     detail::driver::ctxPush(ctx);
+  }
+
+  explicit __ensure_current_device(device_ref_v2 new_device)
+  {
+    detail::driver::ctxPush(new_device.context());
+  }
+
+  explicit __ensure_current_device(CUcontext __ctx)
+  {
+    detail::driver::ctxPush(__ctx);
   }
 
   //! @brief Construct a new `__ensure_current_device` object and switch to the device

--- a/cudax/include/cuda/experimental/green_context.cuh
+++ b/cudax/include/cuda/experimental/green_context.cuh
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_GREEN_CONTEXT__
+#define __CUDAX_GREEN_CONTEXT__
+
+#include <cuda/experimental/__green_context/green_ctx.cuh>
+
+#endif // __CUDAX_GREEN_CONTEXT__

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -110,7 +110,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-relaxed-constexpr>)
 
   cudax_add_catch2_test(test_target green_context ${cn_target}
-  green_context/green_ctx_smoke.cu
+    green_context/green_ctx_smoke.cu
   )
 
 endforeach()

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -109,4 +109,8 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-relaxed-constexpr>)
 
+  cudax_add_catch2_test(test_target green_context ${cn_target}
+  green_context/green_ctx_smoke.cu
+  )
+
 endforeach()

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -146,6 +146,13 @@ inline void empty_driver_stack()
   }
 }
 
+inline int cuda_driver_version()
+{
+  int version;
+  CUDART(cudaDriverGetVersion(&version));
+  return version;
+}
+
 } // namespace test
 } // namespace
 #endif // __COMMON_UTILITY_H__

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -148,9 +148,7 @@ inline void empty_driver_stack()
 
 inline int cuda_driver_version()
 {
-  int version;
-  CUDART(cudaDriverGetVersion(&version));
-  return version;
+  return cudax::detail::driver::getVersion();
 }
 
 } // namespace test

--- a/cudax/test/green_context/green_ctx_smoke.cu
+++ b/cudax/test/green_context/green_ctx_smoke.cu
@@ -12,30 +12,48 @@
 #include <cuda/experimental/stream.cuh>
 
 #include <catch2/catch.hpp>
-#include <testing.cuh>
+#include <utility.cuh>
 
 #if CUDART_VERSION >= 12050
-TEST_CASE("Can create a green context", "[green_context]")
+TEST_CASE("Green context", "[green_context]")
 {
+  if (test::cuda_driver_version() <= 12050)
   {
-    [[maybe_unused]] cudax::green_context ctx(cudax::devices[0]);
+    SUCCEED("Driver is too old for green context tests");
   }
+  else
   {
-    cudax::green_context ctx(cudax::devices[0]);
-    auto handle     = ctx.release();
-    auto new_object = cudax::green_context::from_native_handle(handle);
-  }
-  cudax::green_context green_ctx_dev0(cudax::devices[0]);
-  cudax::stream stream_under_green_ctx(green_ctx_dev0);
-  CUDAX_REQUIRE(stream_under_green_ctx.device() == 0);
-  if (cudax::devices.size() > 1)
-  {
-    cudax::green_context green_ctx_dev1(cudax::devices[1]);
-    cudax::stream stream_dev1(green_ctx_dev1);
-    CUDAX_REQUIRE(stream_dev1.device() == 1);
-    auto dev_ref_v2 = stream_dev1.logical_device();
-    cudax::stream another_stream_dev1(dev_ref_v2);
-    CUDAX_REQUIRE(another_stream_dev1.device() == 1);
+    INFO("Can create a green context")
+    {
+      {
+        [[maybe_unused]] cudax::green_context ctx(cudax::devices[0]);
+      }
+      {
+        cudax::green_context ctx(cudax::devices[0]);
+        auto handle     = ctx.release();
+        auto new_object = cudax::green_context::from_native_handle(handle);
+      }
+    }
+
+    INFO("Can create streams under green context")
+    {
+      cudax::green_context green_ctx_dev0(cudax::devices[0]);
+      cudax::stream stream_under_green_ctx(green_ctx_dev0);
+      CUDAX_REQUIRE(stream_under_green_ctx.device() == 0);
+      if (cudax::devices.size() > 1)
+      {
+        cudax::green_context green_ctx_dev1(cudax::devices[1]);
+        cudax::stream stream_dev1(green_ctx_dev1);
+        CUDAX_REQUIRE(stream_dev1.device() == 1);
+      }
+      auto ldev1 = stream_under_green_ctx.logical_device();
+      CUDAX_REQUIRE(ldev1.kind() == cudax::logical_device::kinds::green_context);
+      cudax::stream side_stream(ldev1);
+      CUDAX_REQUIRE(side_stream.device() == 0);
+      auto ldev2 = side_stream.logical_device();
+      CUDAX_REQUIRE(ldev2.kind() == cudax::logical_device::kinds::green_context);
+      CUDAX_REQUIRE(ldev1 == ldev2);
+    }
   }
 }
 #endif

--- a/cudax/test/green_context/green_ctx_smoke.cu
+++ b/cudax/test/green_context/green_ctx_smoke.cu
@@ -46,13 +46,17 @@ TEST_CASE("Green context", "[green_context]")
         cudax::stream stream_dev1(green_ctx_dev1);
         CUDAX_REQUIRE(stream_dev1.device() == 1);
       }
-      auto ldev1 = stream_under_green_ctx.logical_device();
-      CUDAX_REQUIRE(ldev1.kind() == cudax::logical_device::kinds::green_context);
-      cudax::stream side_stream(ldev1);
-      CUDAX_REQUIRE(side_stream.device() == 0);
-      auto ldev2 = side_stream.logical_device();
-      CUDAX_REQUIRE(ldev2.kind() == cudax::logical_device::kinds::green_context);
-      CUDAX_REQUIRE(ldev1 == ldev2);
+
+      INFO("Can create a side stream")
+      {
+        auto ldev1 = stream_under_green_ctx.logical_device();
+        CUDAX_REQUIRE(ldev1.kind() == cudax::logical_device::kinds::green_context);
+        cudax::stream side_stream(ldev1);
+        CUDAX_REQUIRE(side_stream.device() == 0);
+        auto ldev2 = side_stream.logical_device();
+        CUDAX_REQUIRE(ldev2.kind() == cudax::logical_device::kinds::green_context);
+        CUDAX_REQUIRE(ldev1 == ldev2);
+      }
     }
   }
 }

--- a/cudax/test/green_context/green_ctx_smoke.cu
+++ b/cudax/test/green_context/green_ctx_smoke.cu
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/experimental/green_context.cuh>
+#include <cuda/experimental/stream.cuh>
+
+#include <catch2/catch.hpp>
+#include <testing.cuh>
+
+#if CUDART_VERSION >= 12050
+TEST_CASE("Can create a green context", "[green_context]")
+{
+  {
+    [[maybe_unused]] cudax::green_context ctx(cudax::devices[0]);
+  }
+  {
+    cudax::green_context ctx(cudax::devices[0]);
+    auto handle     = ctx.release();
+    auto new_object = cudax::green_context::from_native_handle(handle);
+  }
+  cudax::green_context green_ctx_dev0(cudax::devices[0]);
+  cudax::stream stream_under_green_ctx(green_ctx_dev0);
+  CUDAX_REQUIRE(stream_under_green_ctx.device() == 0);
+  if (cudax::devices.size() > 1)
+  {
+    cudax::green_context green_ctx_dev1(cudax::devices[1]);
+    cudax::stream stream_dev1(green_ctx_dev1);
+    CUDAX_REQUIRE(stream_dev1.device() == 1);
+    auto dev_ref_v2 = stream_dev1.get_device_ref_v2();
+    cudax::stream another_stream_dev1(dev_ref_v2);
+    CUDAX_REQUIRE(another_stream_dev1.device() == 1);
+  }
+}
+#endif

--- a/cudax/test/green_context/green_ctx_smoke.cu
+++ b/cudax/test/green_context/green_ctx_smoke.cu
@@ -60,4 +60,4 @@ TEST_CASE("Green context", "[green_context]")
     }
   }
 }
-#endif
+#endif // CUDART_VERSION >= 12050

--- a/cudax/test/green_context/green_ctx_smoke.cu
+++ b/cudax/test/green_context/green_ctx_smoke.cu
@@ -50,11 +50,11 @@ TEST_CASE("Green context", "[green_context]")
       INFO("Can create a side stream")
       {
         auto ldev1 = stream_under_green_ctx.logical_device();
-        CUDAX_REQUIRE(ldev1.kind() == cudax::logical_device::kinds::green_context);
+        CUDAX_REQUIRE(ldev1.get_kind() == cudax::logical_device::kinds::green_context);
         cudax::stream side_stream(ldev1);
         CUDAX_REQUIRE(side_stream.device() == 0);
         auto ldev2 = side_stream.logical_device();
-        CUDAX_REQUIRE(ldev2.kind() == cudax::logical_device::kinds::green_context);
+        CUDAX_REQUIRE(ldev2.get_kind() == cudax::logical_device::kinds::green_context);
         CUDAX_REQUIRE(ldev1 == ldev2);
       }
     }

--- a/cudax/test/green_context/green_ctx_smoke.cu
+++ b/cudax/test/green_context/green_ctx_smoke.cu
@@ -33,7 +33,7 @@ TEST_CASE("Can create a green context", "[green_context]")
     cudax::green_context green_ctx_dev1(cudax::devices[1]);
     cudax::stream stream_dev1(green_ctx_dev1);
     CUDAX_REQUIRE(stream_dev1.device() == 1);
-    auto dev_ref_v2 = stream_dev1.get_device_ref_v2();
+    auto dev_ref_v2 = stream_dev1.logical_device();
     cudax::stream another_stream_dev1(dev_ref_v2);
     CUDAX_REQUIRE(another_stream_dev1.device() == 1);
   }

--- a/cudax/test/green_context/green_ctx_smoke.cu
+++ b/cudax/test/green_context/green_ctx_smoke.cu
@@ -17,7 +17,7 @@
 #if CUDART_VERSION >= 12050
 TEST_CASE("Green context", "[green_context]")
 {
-  if (test::cuda_driver_version() <= 12050)
+  if (test::cuda_driver_version() < 12050)
   {
     SUCCEED("Driver is too old for green context tests");
   }

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -127,7 +127,7 @@ TEST_CASE("Stream get device", "[stream]")
     if (test::cuda_driver_version() >= 12050)
     {
       auto ldev = dev0_stream.logical_device();
-      CUDAX_REQUIRE(ldev.kind() == cudax::logical_device::kinds::device);
+      CUDAX_REQUIRE(ldev.get_kind() == cudax::logical_device::kinds::device);
       cudax::stream side_stream(ldev);
       CUDAX_REQUIRE(side_stream.device() == dev0_stream.device());
     }

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -125,6 +125,7 @@ TEST_CASE("Stream get device", "[stream]")
   INFO("Can create a side stream using logical device")
   {
     auto ldev = dev0_stream.logical_device();
+    CUDAX_REQUIRE(ldev.kind() == cudax::logical_device::kinds::device);
     cudax::stream side_stream(ldev);
     CUDAX_REQUIRE(side_stream.device() == dev0_stream.device());
   }

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -124,9 +124,12 @@ TEST_CASE("Stream get device", "[stream]")
 
   INFO("Can create a side stream using logical device")
   {
-    auto ldev = dev0_stream.logical_device();
-    CUDAX_REQUIRE(ldev.kind() == cudax::logical_device::kinds::device);
-    cudax::stream side_stream(ldev);
-    CUDAX_REQUIRE(side_stream.device() == dev0_stream.device());
+    if (test::cuda_driver_version() >= 12050)
+    {
+      auto ldev = dev0_stream.logical_device();
+      CUDAX_REQUIRE(ldev.kind() == cudax::logical_device::kinds::device);
+      cudax::stream side_stream(ldev);
+      CUDAX_REQUIRE(side_stream.device() == dev0_stream.device());
+    }
   }
 }

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -121,4 +121,11 @@ TEST_CASE("Stream get device", "[stream]")
   CUDAX_REQUIRE(stream_cudart.device() == *std::prev(cudax::devices.end()));
   auto stream_ref_cudart = cudax::stream_ref(stream_handle);
   CUDAX_REQUIRE(stream_ref_cudart.device() == *std::prev(cudax::devices.end()));
+
+  INFO("Can create a side stream using logical device")
+  {
+    auto ldev = dev0_stream.logical_device();
+    cudax::stream side_stream(ldev);
+    CUDAX_REQUIRE(side_stream.device() == dev0_stream.device());
+  }
 }


### PR DESCRIPTION
There are cases where we would like to handle both green context and a device. One example is creating a side stream for a given stream, where the stream was passed into a function (for example into a library function).

```
auto ldev = stream.logical_device();
cudax::stream side_stream(ldev);
```

This PR adds `logical_device` type that can hold both a device and a green context and a stream constructor for it.
It also adds a minimal placeholder green context type, so the `logical_device` can be tested with something beyond just a device.

There are probably more APIs that will return or take a `logical_device` in follow-up changes.
We should also consider removing `device_ref` if we think `logical_device` can replace it.

Finally we should consider if `logical_device` should be used to access device attributes, for now we have a clear separation and you need to call `ldev.underlying_device()` to access attributes.

Final note: It would be nice to come up with a name for this type that does not have a device in it