### PR TITLE
Ensure that we treat `cuda::mr::host_accessible` differently

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -37,6 +37,7 @@
 #endif
 
 #include <cuda/__memory_resource/get_property.h>
+#include <cuda/__memory_resource/properties.h>
 #include <cuda/__memory_resource/resource.h>
 #include <cuda/__memory_resource/resource_ref.h>
 #include <cuda/std/__concepts/__concept_macros.h>
@@ -84,7 +85,7 @@ private:
   //! @brief Validates that a set of \c _OtherProperties... is a superset of \c _Properties... .
   template <class... _OtherProperties>
   static constexpr bool __properties_match =
-    _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>;
+    _CUDA_VMR::__is_valid_subset_v<_CUDA_VSTD::__make_type_set<_Properties...>, _OtherProperties...>;
 
   //! @brief Validates that a passed in \c _Resource satisfies the \c resource or \c async_resource concept respectively
   //! as well as all properties in \c _Properties... .

--- a/cudax/include/cuda/experimental/__memory_resource/async_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/async_memory_resource.cuh
@@ -265,40 +265,83 @@ public:
   _LIBCUDACXX_REQUIRES((_CUDA_VMR::__different_resource<async_memory_resource, _Resource>) )
   _CCCL_NODISCARD bool operator==(_Resource const& __rhs) const noexcept
   {
-    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource*>(this)}
-        == _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+    if constexpr (has_property<_Resource, _CUDA_VMR::device_accessible>)
+    {
+      return _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<async_memory_resource*>(this)}
+          == _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<_Resource&>(__rhs)};
+    }
+    else
+    {
+      return false;
+    }
   }
 #    else // ^^^ C++20 ^^^ / vvv C++17
   template <class _Resource>
   _CCCL_NODISCARD_FRIEND auto operator==(async_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>)
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>&&
+                                          has_property<_Resource, _CUDA_VMR::device_accessible>)
   {
-    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource&>(__lhs)}
-        == _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<async_memory_resource&>(__lhs)}
+        == _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator==(async_memory_resource const&, _Resource const&) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>
+                                        && !has_property<_Resource, _CUDA_VMR::device_accessible>)
+  {
+    return false;
   }
 
   template <class _Resource>
   _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __rhs, async_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>)
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>&&
+                                          has_property<_Resource, _CUDA_VMR::device_accessible>)
   {
-    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource&>(__lhs)}
-        == _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<async_memory_resource&>(__lhs)}
+        == _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const&, async_memory_resource const&) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>
+                                        && !has_property<_Resource, _CUDA_VMR::device_accessible>)
+  {
+    return false;
   }
 
   template <class _Resource>
   _CCCL_NODISCARD_FRIEND auto operator!=(async_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>)
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>&&
+                                          has_property<_Resource, _CUDA_VMR::device_accessible>)
   {
-    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource&>(__lhs)}
-        != _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<async_memory_resource&>(__lhs)}
+        != _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator!=(async_memory_resource const&, _Resource const&) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>
+                                        && !has_property<_Resource, _CUDA_VMR::device_accessible>)
+  {
+    return true;
   }
 
   template <class _Resource>
   _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __rhs, async_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>)
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>&&
+                                          has_property<_Resource, _CUDA_VMR::device_accessible>)
   {
-    return _CUDA_VMR::resource_ref<>{const_cast<async_memory_resource&>(__lhs)}
-        != _CUDA_VMR::resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<async_memory_resource&>(__lhs)}
+        != _CUDA_VMR::resource_ref<_CUDA_VMR::device_accessible>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const&, async_memory_resource const&) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(_CUDA_VMR::__different_resource<async_memory_resource, _Resource>
+                                        && !has_property<_Resource, _CUDA_VMR::device_accessible>)
+  {
+    return true;
   }
 #    endif // _CCCL_STD_VER <= 2017
 

--- a/cudax/test/containers/uninitialized_async_buffer.cu
+++ b/cudax/test/containers/uninitialized_async_buffer.cu
@@ -45,7 +45,8 @@ constexpr int get_property(const cuda::experimental::uninitialized_async_buffer<
 TEMPLATE_TEST_CASE(
   "uninitialized_async_buffer", "[container]", char, short, int, long, long long, float, double, do_not_construct)
 {
-  using uninitialized_async_buffer = cuda::experimental::uninitialized_async_buffer<TestType>;
+  using uninitialized_async_buffer =
+    cuda::experimental::uninitialized_async_buffer<TestType, cuda::mr::device_accessible>;
   static_assert(!cuda::std::is_default_constructible<uninitialized_async_buffer>::value, "");
   static_assert(!cuda::std::is_copy_constructible<uninitialized_async_buffer>::value, "");
   static_assert(!cuda::std::is_copy_assignable<uninitialized_async_buffer>::value, "");

--- a/cudax/test/memory_resource/async_memory_resource.cu
+++ b/cudax/test/memory_resource/async_memory_resource.cu
@@ -434,12 +434,12 @@ TEST_CASE("async_memory_resource comparison", "[memory_resource]")
     CHECK(!(second_ref != first));
   }
 
-  { // comparison against a async_memory_resource wrapped inside a resource_ref<>
+  { // comparison against a async_memory_resource wrapped inside a resource_ref<> is always false
     cuda::experimental::mr::async_memory_resource second{};
-    CHECK(first == cuda::mr::resource_ref<>{second});
-    CHECK(!(first != cuda::mr::resource_ref<>{second}));
-    CHECK(cuda::mr::resource_ref<>{second} == first);
-    CHECK(!(cuda::mr::resource_ref<>{second} != first));
+    CHECK(first != cuda::mr::resource_ref<>{second});
+    CHECK(!(first == cuda::mr::resource_ref<>{second}));
+    CHECK(cuda::mr::resource_ref<>{second} != first);
+    CHECK(!(cuda::mr::resource_ref<>{second} == first));
   }
 
   { // comparison against a async_memory_resource wrapped inside a async_resource_ref
@@ -454,10 +454,10 @@ TEST_CASE("async_memory_resource comparison", "[memory_resource]")
 
   { // comparison against a async_memory_resource wrapped inside a async_resource_ref<>
     cuda::experimental::mr::async_memory_resource second{};
-    CHECK(first == cuda::mr::async_resource_ref<>{second});
-    CHECK(!(first != cuda::mr::async_resource_ref<>{second}));
-    CHECK(cuda::mr::async_resource_ref<>{second} == first);
-    CHECK(!(cuda::mr::async_resource_ref<>{second} != first));
+    CHECK(first != cuda::mr::async_resource_ref<>{second});
+    CHECK(!(first == cuda::mr::async_resource_ref<>{second}));
+    CHECK(cuda::mr::async_resource_ref<>{second} != first);
+    CHECK(!(cuda::mr::async_resource_ref<>{second} == first));
   }
 
   { // comparison against a different resource through resource_ref

--- a/libcudacxx/include/cuda/__memory_resource/device_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/device_memory_resource.h
@@ -114,38 +114,86 @@ public:
   //! @return If the underlying types are equality comparable, returns the result of equality comparison of both
   //! resources. Otherwise, returns false.
   _LIBCUDACXX_TEMPLATE(class _Resource)
-  _LIBCUDACXX_REQUIRES(__different_resource<device_memory_resource, _Resource>)
+  _LIBCUDACXX_REQUIRES((__different_resource<device_memory_resource, _Resource>) )
   _CCCL_NODISCARD bool operator==(_Resource const& __rhs) const noexcept
   {
-    return resource_ref<>{const_cast<device_memory_resource*>(this)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
+    if constexpr (has_property<_Resource, device_accessible>)
+    {
+      return resource_ref<device_accessible>{const_cast<device_memory_resource*>(this)}
+          == resource_ref<device_accessible>{const_cast<_Resource&>(__rhs)};
+    }
+    else
+    {
+      return false;
+    }
   }
 #    else // ^^^ C++20 ^^^ / vvv C++17
   template <class _Resource>
   _CCCL_NODISCARD_FRIEND auto operator==(device_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>)
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(
+      __different_resource<device_memory_resource, _Resource>&& has_property<_Resource, device_accessible>)
   {
-    return resource_ref<>{const_cast<device_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<device_accessible>{const_cast<device_memory_resource&>(__lhs)}
+        == resource_ref<device_accessible>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator==(device_memory_resource const&, _Resource const&) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>
+                                        && !has_property<_Resource, device_accessible>)
+  {
+    return false;
   }
 
   template <class _Resource>
   _CCCL_NODISCARD_FRIEND auto operator==(_Resource const& __rhs, device_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>)
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(
+      __different_resource<device_memory_resource, _Resource>&& has_property<_Resource, device_accessible>)
   {
-    return resource_ref<>{const_cast<device_memory_resource&>(__lhs)} == resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<device_accessible>{const_cast<device_memory_resource&>(__lhs)}
+        == resource_ref<device_accessible>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator==(_Resource const&, device_memory_resource const&) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>
+                                        && !has_property<_Resource, device_accessible>)
+  {
+    return false;
   }
 
   template <class _Resource>
   _CCCL_NODISCARD_FRIEND auto operator!=(device_memory_resource const& __lhs, _Resource const& __rhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>)
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(
+      __different_resource<device_memory_resource, _Resource>&& has_property<_Resource, device_accessible>)
   {
-    return resource_ref<>{const_cast<device_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<device_accessible>{const_cast<device_memory_resource&>(__lhs)}
+        != resource_ref<device_accessible>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator!=(device_memory_resource const&, _Resource const&) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>
+                                        && !has_property<_Resource, device_accessible>)
+  {
+    return true;
   }
 
   template <class _Resource>
   _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const& __rhs, device_memory_resource const& __lhs) noexcept
-    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>)
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(
+      __different_resource<device_memory_resource, _Resource>&& has_property<_Resource, device_accessible>)
   {
-    return resource_ref<>{const_cast<device_memory_resource&>(__lhs)} != resource_ref<>{const_cast<_Resource&>(__rhs)};
+    return resource_ref<device_accessible>{const_cast<device_memory_resource&>(__lhs)}
+        != resource_ref<device_accessible>{const_cast<_Resource&>(__rhs)};
+  }
+
+  template <class _Resource>
+  _CCCL_NODISCARD_FRIEND auto operator!=(_Resource const&, device_memory_resource const&) noexcept
+    _LIBCUDACXX_TRAILING_REQUIRES(bool)(__different_resource<device_memory_resource, _Resource>
+                                        && !has_property<_Resource, device_accessible>)
+  {
+    return true;
   }
 #    endif // _CCCL_STD_VER <= 2017
 
@@ -169,4 +217,4 @@ _LIBCUDACXX_END_NAMESPACE_CUDA_MR
 
 #endif // !_CCCL_COMPILER_MSVC_2017 && LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
-#endif //_CUDA__MEMORY_RESOURCE_CUDA_MEMORY_RESOURCE_H
+#endif // _CUDA__MEMORY_RESOURCE_CUDA_MEMORY_RESOURCE_H

--- a/libcudacxx/include/cuda/__memory_resource/properties.h
+++ b/libcudacxx/include/cuda/__memory_resource/properties.h
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/type_set.h>
 #include <cuda/std/cstddef>
 
 #if !defined(_CCCL_COMPILER_MSVC_2017) && defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
@@ -42,6 +43,46 @@ struct device_accessible
 //! @brief The device_accessible property signals that the allocated memory is host accessible
 struct host_accessible
 {};
+
+//! @brief determines wether a set of properties signals host accessible memory.
+//! @note If a set of properties does not contain any execution space property it is implicitly marked host_accessible
+template <class... _Properties>
+_LIBCUDACXX_INLINE_VAR constexpr bool __is_host_accessible =
+  _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_Properties...>, host_accessible>
+  || !_CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_Properties...>, device_accessible>;
+
+//! @brief determines wether a set of properties signals device accessible memory.
+template <class... _Properties>
+_LIBCUDACXX_INLINE_VAR constexpr bool __is_device_accessible =
+  _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_Properties...>, device_accessible>;
+
+//! @brief determines wether a set of properties signals host device accessible memory.
+template <class... _Properties>
+_LIBCUDACXX_INLINE_VAR constexpr bool __is_host_device_accessible =
+  _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_Properties...>, host_accessible, device_accessible>;
+
+template <class _Set>
+struct __is_valid_subset;
+
+template <class... _Properties>
+struct __is_valid_subset<_CUDA_VSTD::__type_set<_Properties...>>
+{
+  //! @brief We need to add host_accessible to the respective type sets because a set without execution space properties
+  //! is host accessible. But we can only add that if neither of the sets is device_accessible
+  template <class... _OtherProperties>
+  static constexpr bool value =
+    __is_device_accessible<_Properties...>
+      ? _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>
+    : __is_device_accessible<_OtherProperties...>
+      ? false
+      : _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__set::__insert<host_accessible, _OtherProperties...>,
+                                        host_accessible,
+                                        _Properties...>;
+};
+
+template <class _Set, class... _OtherProperties>
+_LIBCUDACXX_INLINE_VAR constexpr bool __is_valid_subset_v =
+  __is_valid_subset<_Set>::template value<_OtherProperties...>;
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_MR
 

--- a/libcudacxx/include/cuda/__memory_resource/resource_ref.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource_ref.h
@@ -24,6 +24,7 @@
 #if !defined(_CCCL_COMPILER_MSVC_2017) && defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
 
 #  include <cuda/__memory_resource/get_property.h>
+#  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__memory_resource/resource.h>
 #  include <cuda/std/__concepts/__concept_macros.h>
 #  include <cuda/std/__concepts/_One_of.h>
@@ -502,9 +503,10 @@ private:
 
   using __vtable = _Filtered_vtable<_Properties...>;
 
+  //! @brief Checks whether \c _OtherProperties is a true superset of \c _Properties, accounting for host_accessible
   template <class... _OtherProperties>
   static constexpr bool __properties_match =
-    _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>;
+    __is_valid_subset_v<_CUDA_VSTD::__make_type_set<_Properties...>, _OtherProperties...>;
 
   //! @brief Constructs a \c basic_resource_ref from a void*, a resource vtable ptr, and a vtable
   //! for the properties. This is used to create a \c basic_resource_ref from a \c basic_any_resource.

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/device_memory_resource/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/device_memory_resource/equality.pass.cpp
@@ -93,9 +93,9 @@ void test()
     assert(!(second_ref != first));
   }
 
-  { // comparison against a device_memory_resource wrapped inside a resource_ref<>
+  { // comparison against a device_memory_resource wrapped inside a resource_ref<cuda::mr::device_accessible>
     cuda::mr::device_memory_resource second{};
-    cuda::mr::resource_ref<> second_ref{second};
+    cuda::mr::resource_ref<cuda::mr::device_accessible> second_ref{second};
     assert(first == second_ref);
     assert(!(first != second_ref));
     assert(second_ref == first);
@@ -116,11 +116,11 @@ void test()
     assert(device_resource != first);
   }
 
-  { // comparison against a different resource through resource_ref
+  { // comparison against a different resource through resource_ref<cuda::mr::device_accessible>
     async_resource<AccessibilityType::Host> host_async_resource{};
     async_resource<AccessibilityType::Device> device_async_resource{};
     cuda::mr::resource_ref<> host_ref{host_async_resource};
-    cuda::mr::resource_ref<> device_ref{device_async_resource};
+    cuda::mr::resource_ref<cuda::mr::device_accessible> device_ref{device_async_resource};
     assert(!(first == host_ref));
     assert(first != host_ref);
     assert(!(first == device_async_resource));

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/memory_resource.resource_ref/resource_ref.conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/memory_resource.resource_ref/resource_ref.conversion.pass.cpp
@@ -122,6 +122,26 @@ void test_conversion_from_resource_ref()
     ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
+
+  { // Ensure that we treat `cuda::mr::host_accessible` differently, because a resource without execution space
+    // properties is implicitly `cuda::mr::host_accessible`.
+
+    using with_host_accessible    = cuda::mr::resource_ref<cuda::mr::host_accessible, PropA, PropB>;
+    using without_host_accessible = cuda::mr::resource_ref<PropA, PropB>;
+
+    static_assert(cuda::std::is_constructible<with_host_accessible, without_host_accessible>::value, "");
+    static_assert(cuda::std::is_constructible<without_host_accessible, with_host_accessible>::value, "");
+  }
+
+  { // Ensure that a resource without execution space properties is not constructible from a device accessible one
+    using no_execution_space_property = cuda::mr::resource_ref<PropA, PropB>;
+    using with_device_accessible      = cuda::mr::resource_ref<cuda::mr::device_accessible, PropA, PropB>;
+    using with_host_device_accessible =
+      cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible, PropA, PropB>;
+
+    static_assert(!cuda::std::is_constructible<no_execution_space_property, with_device_accessible>::value, "");
+    static_assert(!cuda::std::is_constructible<no_execution_space_property, with_host_device_accessible>::value, "");
+  }
 }
 
 template <class PropA, class PropB>
@@ -164,6 +184,29 @@ void test_conversion_from_async_resource_ref()
     int expected_after_deallocate = 1337;
     ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
+  }
+
+  { // Ensure that we treat `cuda::mr::host_accessible` differently, because a resource without execution space
+    // properties is implicitly `cuda::mr::host_accessible`.
+
+    using with_host_accessible    = cuda::mr::resource_ref<cuda::mr::host_accessible, PropA, PropB>;
+    using without_host_accessible = cuda::mr::resource_ref<PropA, PropB>;
+
+    using async_with_host_accessible    = cuda::mr::async_resource_ref<cuda::mr::host_accessible, PropA, PropB>;
+    using async_without_host_accessible = cuda::mr::async_resource_ref<PropA, PropB>;
+
+    static_assert(cuda::std::is_constructible<with_host_accessible, async_without_host_accessible>::value, "");
+    static_assert(cuda::std::is_constructible<without_host_accessible, async_with_host_accessible>::value, "");
+  }
+
+  { // Ensure that a resource without execution space properties is not constructible from a device accessible one
+    using no_execution_space_property = cuda::mr::resource_ref<PropA, PropB>;
+    using with_device_accessible      = cuda::mr::async_resource_ref<cuda::mr::device_accessible, PropA, PropB>;
+    using with_host_device_accessible =
+      cuda::mr::async_resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible, PropA, PropB>;
+
+    static_assert(!cuda::std::is_constructible<no_execution_space_property, with_device_accessible>::value, "");
+    static_assert(!cuda::std::is_constructible<no_execution_space_property, with_host_device_accessible>::value, "");
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/properties/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/properties/properties.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11
+// UNSUPPORTED: msvc-19.16
+// UNSUPPORTED: nvrtc
+
+#include <cuda/memory_resource>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+// Verify that the properties exist
+static_assert(cuda::std::is_empty<cuda::mr::host_accessible>::value, "");
+static_assert(cuda::std::is_empty<cuda::mr::device_accessible>::value, "");
+
+// Verify that host accessible is the default if nothing is specified
+static_assert(cuda::mr::__is_host_accessible<>, "");
+static_assert(cuda::mr::__is_host_accessible<cuda::mr::host_accessible>, "");
+static_assert(!cuda::mr::__is_host_accessible<cuda::mr::device_accessible>, "");
+static_assert(cuda::mr::__is_host_accessible<cuda::mr::host_accessible, cuda::mr::device_accessible>, "");
+
+// Verify that device accessible needs to be explicitly specified
+static_assert(!cuda::mr::__is_device_accessible<>, "");
+static_assert(!cuda::mr::__is_device_accessible<cuda::mr::host_accessible>, "");
+static_assert(cuda::mr::__is_device_accessible<cuda::mr::device_accessible>, "");
+static_assert(cuda::mr::__is_device_accessible<cuda::mr::host_accessible, cuda::mr::device_accessible>, "");
+
+// Verify that host device accessible needs to be explicitly specified
+static_assert(!cuda::mr::__is_host_device_accessible<>, "");
+static_assert(!cuda::mr::__is_host_device_accessible<cuda::mr::host_accessible>, "");
+static_assert(!cuda::mr::__is_host_device_accessible<cuda::mr::device_accessible>, "");
+static_assert(cuda::mr::__is_host_device_accessible<cuda::mr::host_accessible, cuda::mr::device_accessible>, "");
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/properties/subsets.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/properties/subsets.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11
+// UNSUPPORTED: msvc-19.16
+// UNSUPPORTED: nvrtc
+
+#include <cuda/memory_resource>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+// Verify that we properly account for host_accessible being implict when nothing is specified
+static_assert(cuda::mr::__is_valid_subset_v<cuda::std::__type_set<>, cuda::mr::host_accessible>, "");
+static_assert(cuda::mr::__is_valid_subset_v<cuda::std::__type_set<cuda::mr::host_accessible>, int>, "");
+
+// Verify that we properly require device_accessible to be specified
+static_assert(!cuda::mr::__is_valid_subset_v<cuda::std::__type_set<>, cuda::mr::device_accessible>, "");
+static_assert(!cuda::mr::__is_valid_subset_v<cuda::std::__type_set<cuda::mr::device_accessible>, int>, "");
+
+// Verify that we properly allow subsets of execution space modifiers
+static_assert(
+  cuda::mr::__is_valid_subset_v<cuda::std::__type_set<cuda::mr::device_accessible>, cuda::mr::device_accessible>, "");
+static_assert(cuda::mr::__is_valid_subset_v<cuda::std::__type_set<cuda::mr::device_accessible>,
+                                            cuda::mr::host_accessible,
+                                            cuda::mr::device_accessible>,
+              "");
+static_assert(cuda::mr::__is_valid_subset_v<cuda::std::__type_set<cuda::mr::device_accessible>,
+                                            cuda::mr::host_accessible,
+                                            cuda::mr::device_accessible>,
+              "");
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
Currently we have an efficient and simple set of rules regarding properties.

We simply match two sets of properties to find out whether A is a subset of B.

However, that is not correct because we must treat `cuda::mr::host_accessible` differently because it is the implicit default, so `resource_ref<>` is equivalent to `resource_ref<cuda::mr::host_accessible>`

This requires us to do some complex determination whether we need to actually extent the passed in set of types

