### PR TITLE
fixes merge conflict for policz pruning

### DIFF
--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -694,7 +694,7 @@ private:
   template <int, typename FunctorT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t invoke_static(FunctorT&, ::cuda::std::false_type)
   {
-    _LIBCUDACXX_UNREACHABLE();
+    _CCCL_UNREACHABLE();
   }
 
   template <typename FunctorT>
@@ -706,7 +706,7 @@ private:
   template <typename FunctorT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t do_invoke(FunctorT&, ::cuda::std::false_type)
   {
-    _LIBCUDACXX_UNREACHABLE();
+    _CCCL_UNREACHABLE();
   }
 };
 
@@ -737,7 +737,7 @@ private:
   template <int, typename FunctorT>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t invoke_static(FunctorT&, ::cuda::std::false_type)
   {
-    _LIBCUDACXX_UNREACHABLE();
+    _CCCL_UNREACHABLE();
   }
 };
 


### PR DESCRIPTION
## Description

https://github.com/NVIDIA/cccl/pull/2154/files still was using the `_LIBCUDACXX_UNREACHABLE` that, since the PR's last CI run, was updated to `_CCCL_UNREACHABLE`. This PR fixes the that. 

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
