### PR TITLE
Drop remaining uses of `_LIBCUDACXX_COMPILER_*`

### DIFF
--- a/libcudacxx/include/cuda/std/__concepts/convertible_to.h
+++ b/libcudacxx/include/cuda/std/__concepts/convertible_to.h
@@ -35,9 +35,9 @@ concept convertible_to = is_convertible_v<_From, _To> && requires { static_cast<
 
 #elif _CCCL_STD_VER >= 2014 // ^^^ C++20 ^^^ / vvv C++14/17 vvv
 
-#  if defined(_LIBCUDACXX_COMPILER_MSVC)
+#  if defined(_CCCL_COMPILER_MSVC)
 _CCCL_NV_DIAG_SUPPRESS(1211) // nonstandard cast to array type ignored
-#  endif // _LIBCUDACXX_COMPILER_MSVC
+#  endif // _CCCL_COMPILER_MSVC
 _CCCL_NV_DIAG_SUPPRESS(171) // invalid type conversion, e.g. [with _From=int **, _To=const int *const *]
 
 // We cannot put this conversion check with the other constraint, as types with deleted operator will break here
@@ -55,9 +55,9 @@ _LIBCUDACXX_CONCEPT_FRAGMENT(
 template <class _From, class _To>
 _LIBCUDACXX_CONCEPT convertible_to = _LIBCUDACXX_FRAGMENT(__convertible_to_, _From, _To);
 
-#  if defined(_LIBCUDACXX_COMPILER_MSVC)
+#  if defined(_CCCL_COMPILER_MSVC)
 _CCCL_NV_DIAG_DEFAULT(1211) // nonstandard cast to array type ignored
-#  endif // _LIBCUDACXX_COMPILER_MSVC
+#  endif // _CCCL_COMPILER_MSVC
 _CCCL_NV_DIAG_DEFAULT(171) // invalid type conversion, e.g. [with _From=int **, _To=const int *const *]
 
 #endif // _CCCL_STD_VER >= 2014

--- a/libcudacxx/include/cuda/std/__concepts/swappable.h
+++ b/libcudacxx/include/cuda/std/__concepts/swappable.h
@@ -37,9 +37,9 @@
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
 
-#if defined(_LIBCUDACXX_COMPILER_MSVC)
+#if defined(_CCCL_COMPILER_MSVC)
 _CCCL_NV_DIAG_SUPPRESS(461) // nonstandard cast to array type ignored
-#endif // _LIBCUDACXX_COMPILER_MSVC
+#endif // _CCCL_COMPILER_MSVC
 
 #if _CCCL_STD_VER > 2011
 
@@ -200,8 +200,8 @@ _LIBCUDACXX_END_NAMESPACE_STD
 
 #endif // _CCCL_STD_VER > 2011
 
-#if defined(_LIBCUDACXX_COMPILER_MSVC)
+#if defined(_CCCL_COMPILER_MSVC)
 _CCCL_NV_DIAG_DEFAULT(461) // nonstandard cast to array type ignored
-#endif // _LIBCUDACXX_COMPILER_MSVC
+#endif // _CCCL_COMPILER_MSVC
 
 #endif // _LIBCUDACXX___CONCEPTS_SWAPPABLE_H

--- a/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
+++ b/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
@@ -639,7 +639,7 @@ template <class _Type>
 struct __allocator_has_trivial_move_construct<allocator<_Type>, _Type> : true_type
 {};
 
-#ifndef _LIBCUDACXX_COMPILER_GCC
+#ifndef _CCCL_COMPILER_GCC
 template <class _Alloc,
           class _Iter1,
           class _Iter2,
@@ -665,7 +665,7 @@ __uninitialized_allocator_move_if_noexcept(_Alloc&, _Iter1 __first1, _Iter1 __la
     return _CUDA_VSTD::move(__first1, __last1, __first2);
   }
 }
-#endif // _LIBCUDACXX_COMPILER_GCC
+#endif // _CCCL_COMPILER_GCC
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -21,43 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-#if defined(_CCCL_COMPILER_ICC)
-#  define _LIBCUDACXX_COMPILER_ICC
-#elif defined(_CCCL_COMPILER_NVHPC)
-#  define _LIBCUDACXX_COMPILER_NVHPC
-#elif defined(_CCCL_COMPILER_CLANG)
-#  define _LIBCUDACXX_COMPILER_CLANG
-#  ifndef __apple_build_version__
-#    define _LIBCUDACXX_CLANG_VER (__clang_major__ * 100 + __clang_minor__)
-#  endif
-#elif defined(_CCCL_COMPILER_GCC)
-#  define _LIBCUDACXX_COMPILER_GCC
-#elif defined(_CCCL_COMPILER_MSVC)
-#  define _LIBCUDACXX_COMPILER_MSVC
-#elif defined(_CCCL_COMPILER_NVRTC)
-#  define _LIBCUDACXX_COMPILER_NVRTC
-#endif
-
-#if defined(_CCCL_COMPILER_MSVC)
-#  if _MSC_VER < 1917
-#    define _LIBCUDACXX_COMPILER_MSVC_2017
-#  elif _MSC_VER < 1930
-#    define _LIBCUDACXX_COMPILER_MSVC_2019
-#  else
-#    define _LIBCUDACXX_COMPILER_MSVC_2022
-#  endif
-#endif // defined(_LIBCUDACXX_COMPILER_MSVC)
-
-#if defined(_CCCL_CUDA_COMPILER_NVCC)
-// This is not mutually exclusive with other compilers, as NVCC uses a host
-// compiler.
-#  define _LIBCUDACXX_COMPILER_NVCC
-#elif defined(_CCCL_CUDA_COMPILER_NVHPC)
-#  define _LIBCUDACXX_COMPILER_NVHPC_CUDA
-#elif defined(_CCCL_CUDA_COMPILER_CLANG)
-#  define _LIBCUDACXX_COMPILER_CLANG_CUDA
-#endif
-
 #ifdef __cplusplus
 
 // __config may be included in `extern "C"` contexts, switch back to include <nv/target>

--- a/libcudacxx/test/support/count_new.h
+++ b/libcudacxx/test/support/count_new.h
@@ -12,9 +12,9 @@
 #include <cuda/std/cassert>
 #include <cuda/std/cstdlib>
 
-#if !defined(_LIBCUDACXX_COMPILER_NVRTC)
+#if !defined(_CCCL_COMPILER_NVRTC)
 #  include <new>
-#endif // !_LIBCUDACXX_COMPILER_NVRTC
+#endif // !_CCCL_COMPILER_NVRTC
 
 #include "test_macros.h"
 

--- a/libcudacxx/test/support/test_macros.h
+++ b/libcudacxx/test/support/test_macros.h
@@ -82,16 +82,14 @@
 #  define TEST_COMPILER_EDG
 #endif
 
-#if defined(__NVCC__)
-// This is not mutually exclusive with other compilers, as NVCC uses a host
-// compiler.
+#if defined(_CCCL_CUDA_COMPILER_NVCC)
 #  define TEST_COMPILER_NVCC
 #  define TEST_COMPILER_EDG
-#elif defined(_NVHPC_CUDA)
+#elif defined(_CCCL_CUDA_COMPILER_NVHPC)
 #  define TEST_COMPILER_NVHPC_CUDA
-#elif defined(__CUDA__) && defined(_LIBCUDACXX_COMPILER_CLANG)
+#elif defined(_CCCL_CUDA_COMPILER_CLANG)
 #  define TEST_COMPILER_CLANG_CUDA
-#endif
+#endif // no cuda compiler
 
 #if defined(__apple_build_version__)
 #  define TEST_APPLE_CLANG_VER (__clang_major__ * 100) + __clang_minor__


### PR DESCRIPTION
This was breaking some other PR and we never use them anymore
