### PR TITLE
Avoid C++17 extension in c++11 tests

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch.fail.cpp
@@ -19,7 +19,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_max.pass.cpp
@@ -21,7 +21,7 @@
 
 template <class T,
           template <typename, typename>
-          typename Selector,
+          class Selector,
           cuda::thread_scope ThreadScope,
           bool Signed = cuda::std::is_signed<T>::value>
 struct TestFn
@@ -65,7 +65,7 @@ struct TestFn
   }
 };
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope ThreadScope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope ThreadScope>
 struct TestFn<T, Selector, ThreadScope, true>
 {
   __host__ __device__ void operator()() const
@@ -109,7 +109,7 @@ struct TestFn<T, Selector, ThreadScope, true>
   }
 };
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope ThreadScope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope ThreadScope>
 struct TestFnDispatch
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/atomics/atomic.ext/atomic_fetch_min.pass.cpp
@@ -21,7 +21,7 @@
 
 template <class T,
           template <typename, typename>
-          typename Selector,
+          class Selector,
           cuda::thread_scope ThreadScope,
           bool Signed = cuda::std::is_signed<T>::value>
 struct TestFn
@@ -65,7 +65,7 @@ struct TestFn
   }
 };
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope ThreadScope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope ThreadScope>
 struct TestFn<T, Selector, ThreadScope, true>
 {
   __host__ __device__ void operator()() const
@@ -109,7 +109,7 @@ struct TestFn<T, Selector, ThreadScope, true>
   }
 };
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope ThreadScope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope ThreadScope>
 struct TestFnDispatch
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/cuda/bad_atomic_alignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/bad_atomic_alignment.pass.cpp
@@ -21,7 +21,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <template <typename, typename> typename Selector>
+template <template <typename, typename> class Selector>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/heterogeneous/barrier.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/barrier.pass.cpp
@@ -33,7 +33,7 @@ struct barrier_and_token
   {}
 };
 
-template <template <typename> typename Barrier>
+template <template <typename> class Barrier>
 struct barrier_and_token_with_completion
 {
   struct completion_t

--- a/libcudacxx/test/libcudacxx/heterogeneous/barrier_abi_v2.pass.cpp
+++ b/libcudacxx/test/libcudacxx/heterogeneous/barrier_abi_v2.pass.cpp
@@ -38,7 +38,7 @@ struct barrier_and_token
   {}
 };
 
-template <template <typename> typename Barrier>
+template <template <typename> class Barrier>
 struct barrier_and_token_with_completion
 {
   struct completion_t

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/bool.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/bool.pass.cpp
@@ -62,7 +62,7 @@
 #endif
 #include "cuda_space_selector.h"
 
-template <template <cuda::thread_scope> typename Atomic,
+template <template <cuda::thread_scope> class Atomic,
           cuda::thread_scope Scope,
           template <typename, typename>
           class Selector>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point.pass.cpp
@@ -146,7 +146,7 @@ __host__ __device__ __noinline__ void test()
   do_test<volatile A, T, Selector>();
 }
 
-template <template <typename, cuda::thread_scope> typename Atomic,
+template <template <typename, cuda::thread_scope> class Atomic,
           cuda::thread_scope Scope,
           template <typename, typename>
           class Selector>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point_ref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point_ref.pass.cpp
@@ -142,7 +142,7 @@ __host__ __device__ __noinline__ void test()
   do_test<A, T, Selector>();
 }
 
-template <template <typename, cuda::thread_scope> typename Atomic,
+template <template <typename, cuda::thread_scope> class Atomic,
           cuda::thread_scope Scope,
           template <typename, typename>
           class Selector>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point_ref_constness.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/floating_point_ref_constness.pass.cpp
@@ -82,7 +82,7 @@ __host__ __device__ __noinline__ void test()
   do_test<A, T, Selector>();
 }
 
-template <template <typename, cuda::thread_scope> typename Atomic,
+template <template <typename, cuda::thread_scope> class Atomic,
           cuda::thread_scope Scope,
           template <typename, typename>
           class Selector>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral.pass.cpp
@@ -166,7 +166,7 @@ __host__ __device__ __noinline__ void test()
   do_test<volatile A, T, Selector>();
 }
 
-template <template <typename, cuda::thread_scope> typename Atomic,
+template <template <typename, cuda::thread_scope> class Atomic,
           cuda::thread_scope Scope,
           template <typename, typename>
           class Selector>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_ref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_ref.pass.cpp
@@ -162,7 +162,7 @@ __host__ __device__ __noinline__ void test()
   do_test<A, T, Selector>();
 }
 
-template <template <typename, cuda::thread_scope> typename Atomic,
+template <template <typename, cuda::thread_scope> class Atomic,
           cuda::thread_scope Scope,
           template <typename, typename>
           class Selector>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_ref_constness.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.generic/integral_ref_constness.pass.cpp
@@ -162,7 +162,7 @@ __host__ __device__ __noinline__ void test()
   do_test<A, T, Selector>();
 }
 
-template <template <typename, cuda::thread_scope> typename Atomic,
+template <template <typename, cuda::thread_scope> class Atomic,
           cuda::thread_scope Scope,
           template <typename, typename>
           class Selector>

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_strong.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_strong.pass.cpp
@@ -28,7 +28,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_strong_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_strong_explicit.pass.cpp
@@ -31,7 +31,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_weak.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_weak.pass.cpp
@@ -29,7 +29,7 @@
 #include "test_macros.h"
 #include <cmpxchg_loop.h>
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_weak_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_compare_exchange_weak_explicit.pass.cpp
@@ -32,7 +32,7 @@
 #include "test_macros.h"
 #include <cmpxchg_loop.h>
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_exchange.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_exchange.pass.cpp
@@ -28,7 +28,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_exchange_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_exchange_explicit.pass.cpp
@@ -28,7 +28,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add.pass.cpp
@@ -36,7 +36,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const
@@ -60,7 +60,7 @@ struct TestFn
   }
 };
 
-template <class T, template <typename, typename> typename Selector>
+template <class T, template <typename, typename> class Selector>
 __host__ __device__ void testp()
 {
   {

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.pass.cpp
@@ -36,7 +36,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const
@@ -60,7 +60,7 @@ struct TestFn
   }
 };
 
-template <class T, template <typename, typename> typename Selector>
+template <class T, template <typename, typename> class Selector>
 __host__ __device__ void testp()
 {
   {

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and.pass.cpp
@@ -27,7 +27,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and_explicit.pass.cpp
@@ -27,7 +27,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or.pass.cpp
@@ -27,7 +27,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or_explicit.pass.cpp
@@ -27,7 +27,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.pass.cpp
@@ -36,7 +36,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const
@@ -60,7 +60,7 @@ struct TestFn
   }
 };
 
-template <class T, template <typename, typename> typename Selector>
+template <class T, template <typename, typename> class Selector>
 __host__ __device__ void testp()
 {
   {

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub_explicit.pass.cpp
@@ -37,7 +37,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const
@@ -61,7 +61,7 @@ struct TestFn
   }
 };
 
-template <class T, template <typename, typename> typename Selector>
+template <class T, template <typename, typename> class Selector>
 __host__ __device__ void testp()
 {
   {

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor.pass.cpp
@@ -27,7 +27,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_xor_explicit.pass.cpp
@@ -27,7 +27,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_init.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_init.pass.cpp
@@ -28,7 +28,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_is_lock_free.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_is_lock_free.pass.cpp
@@ -26,7 +26,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename, cuda::thread_scope>
+template <class T, template <typename, typename> class, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_load.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_load.pass.cpp
@@ -28,7 +28,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_load_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_load_explicit.pass.cpp
@@ -28,7 +28,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store.pass.cpp
@@ -27,7 +27,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_explicit.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_store_explicit.pass.cpp
@@ -27,7 +27,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_ref_member_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_ref_member_wait.pass.cpp
@@ -21,7 +21,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope Scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope Scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_wait.pass.cpp
@@ -21,7 +21,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <class T, template <typename, typename> typename Selector, cuda::thread_scope Scope>
+template <class T, template <typename, typename> class Selector, cuda::thread_scope Scope>
 struct TestFn
 {
   __host__ __device__ void operator()() const

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Barrier, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Barrier, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Barrier, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive_and_drop.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive_and_drop.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Barrier, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Barrier, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Barrier, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive_and_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/arrive_and_wait.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Barrier, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Barrier, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Barrier, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/completion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/completion.pass.cpp
@@ -22,9 +22,9 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <template <typename> typename Barrier,
+template <template <typename> class Barrier,
           template <typename, typename>
-          typename Selector,
+          class Selector,
           typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_for.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_for.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Barrier, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Barrier, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test(bool add_delay = false)
 {
   Selector<Barrier, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_parity_for.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_parity_for.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Barrier, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Barrier, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test(bool add_delay = false)
 {
   Selector<Barrier, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_parity_until.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_parity_until.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Barrier, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Barrier, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test(bool add_delay = false)
 {
   Selector<Barrier, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_until.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.barrier/try_wait_until.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Barrier, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Barrier, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test(bool add_delay = false)
 {
   Selector<Barrier, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/arrive_and_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/arrive_and_wait.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Latch, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Latch, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Latch, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/count_down.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/count_down.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Latch, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Latch, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Latch, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.latch/try_wait.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.latch/try_wait.pass.cpp
@@ -17,7 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Latch, template <typename, typename> typename Selector, typename Initializer = constructor_initializer>
+template <typename Latch, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Latch, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/acquire.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/acquire.pass.cpp
@@ -17,10 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Semaphore,
-          template <typename, typename>
-          typename Selector,
-          typename Initializer = constructor_initializer>
+template <typename Semaphore, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Semaphore, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/release.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/release.pass.cpp
@@ -17,10 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Semaphore,
-          template <typename, typename>
-          typename Selector,
-          typename Initializer = constructor_initializer>
+template <typename Semaphore, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Semaphore, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/timed.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/timed.pass.cpp
@@ -18,10 +18,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Semaphore,
-          template <typename, typename>
-          typename Selector,
-          typename Initializer = constructor_initializer>
+template <typename Semaphore, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Semaphore, Initializer> sel;

--- a/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/try_acquire.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/thread/thread.semaphore/try_acquire.pass.cpp
@@ -17,10 +17,7 @@
 #include "cuda_space_selector.h"
 #include "test_macros.h"
 
-template <typename Semaphore,
-          template <typename, typename>
-          typename Selector,
-          typename Initializer = constructor_initializer>
+template <typename Semaphore, template <typename, typename> class Selector, typename Initializer = constructor_initializer>
 __host__ __device__ void test()
 {
   Selector<Semaphore, Initializer> sel;

--- a/libcudacxx/test/support/cuda_space_selector.h
+++ b/libcudacxx/test/support/cuda_space_selector.h
@@ -130,7 +130,7 @@ struct default_initializer
 
 template <typename T,
           template <typename, cuda::std::size_t>
-          typename Provider,
+          class Provider,
           typename Initializer           = constructor_initializer,
           cuda::std::size_t SharedOffset = 0>
 class memory_selector


### PR DESCRIPTION
Using typename in a template template parameter is a C++17 extension and clang warns about that as a cuda compiler
