### PR TITLE
removes superfluous template keyword in call to Dereference

### DIFF
--- a/cub/cub/thread/thread_store.cuh
+++ b/cub/cub/thread/thread_store.cuh
@@ -305,7 +305,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void ThreadStoreVolatilePtr(T* ptr, T val, Int2Ty
     reinterpret_cast<ShuffleWord*>(words)[i] = reinterpret_cast<ShuffleWord*>(&val)[i];
   }
 
-  IterateThreadStore<0, VOLATILE_MULTIPLE>::template Dereference(reinterpret_cast<volatile VolatileWord*>(ptr), words);
+  IterateThreadStore<0, VOLATILE_MULTIPLE>::Dereference(reinterpret_cast<volatile VolatileWord*>(ptr), words);
 }
 
 /**


### PR DESCRIPTION
## Description

This PR proposes to removes a superfluous template keyword for a call to function `Dereference` that triggers a warning/error with clang-19+CUDA compilation.   I encountered this using the pre-cccl version of CUB but this particular line is the same in the current trunk vs. the version I'm using.

```
thread_store.cuh:349:56: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  349 |     IterateThreadStore<0, VOLATILE_MULTIPLE>::template Dereference(
      |                                                        ^
1 error generated when compiling for sm_80.
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](). 
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
