### PR TITLE
re-express the `cudax::__tupl::__apply` member to make nvc++ happy

### DIFF
--- a/cudax/include/cuda/experimental/__async/tuple.cuh
+++ b/cudax/include/cuda/experimental/__async/tuple.cuh
@@ -52,13 +52,12 @@ struct __tupl<__mindices<_Idx...>, _Ts...> : __box<_Idx, _Ts>...
 {
   template <class _Fn, class _Self, class... _Us>
   _CUDAX_ALWAYS_INLINE _CCCL_HOST_DEVICE static auto __apply(_Fn&& __fn, _Self&& __self, _Us&&... __us) //
-    noexcept(noexcept(static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)...,
-                                               static_cast<_Self&&>(__self).__box<_Idx, _Ts>::__value_...)))
-      -> decltype(static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)...,
-                                           static_cast<_Self&&>(__self).__box<_Idx, _Ts>::__value_...))
+    noexcept(__nothrow_callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>...>)
+      -> __call_result_t<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>...>
   {
-    return static_cast<_Fn&&>(
-      __fn)(static_cast<_Us&&>(__us)..., static_cast<_Self&&>(__self).__box<_Idx, _Ts>::__value_...);
+    return static_cast<_Fn&&>(__fn)( //
+      static_cast<_Us&&>(__us)...,
+      static_cast<_Self&&>(__self).__box<_Idx, _Ts>::__value_...);
   }
 
   template <class _Fn, class _Self, class... _Us>


### PR DESCRIPTION
## Description

In #1488, @miscco wants to add the nvhpc compiler to the test matrix, truly a noble ambition. he is blocked by a bit of metaprogramming in cudax that is causing nvc++ to choke. this pr simplifies the code so that nvc++ accepts it.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
