### PR TITLE
Refactor away per-project TOPLEVEL flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,22 +57,6 @@ if (CCCL_TOPLEVEL_PROJECT)
   cccl_build_compiler_targets()
 endif()
 
-if (CCCL_ENABLE_LIBCUDACXX)
-  set(LIBCUDACXX_TOPLEVEL_PROJECT ${CCCL_TOPLEVEL_PROJECT})
-endif()
-
-if (CCCL_ENABLE_CUB)
-  set(CUB_TOPLEVEL_PROJECT ${CCCL_TOPLEVEL_PROJECT})
-endif()
-
-if (CCCL_ENABLE_THRUST)
-  set(THRUST_TOPLEVEL_PROJECT ${CCCL_TOPLEVEL_PROJECT})
-endif()
-
-if (CCCL_ENABLE_CUDAX)
-  set(cudax_TOPLEVEL_PROJECT ${CCCL_TOPLEVEL_PROJECT})
-endif()
-
 add_subdirectory(libcudacxx)
 add_subdirectory(cub)
 add_subdirectory(thrust)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,12 @@ option(CCCL_ENABLE_C "Enable CUDA C Core Library." OFF)
 option(CCCL_ENABLE_UNSTABLE "Enable targets and developer build options for unstable projects." OFF)
 
 if (CCCL_ENABLE_UNSTABLE)
-  option(CCCL_ENABLE_CUDAX "Enable the CUDA Experimental developer build." ON)
+  option(CCCL_ENABLE_CUDAX "Enable the CUDA Experimental developer build." ${CCCL_TOPLEVEL_PROJECT})
+else()
+  # Always off if unstable disabled:
+  # Note that this doesn't override the cache variable, but rather creates a new
+  # directory-scoped variable that shadows it. This is sufficient for our purposes.
+  set(CCCL_ENABLE_CUDAX OFF)
 endif()
 
 include(CTest)

--- a/cub/CMakeLists.txt
+++ b/cub/CMakeLists.txt
@@ -3,18 +3,12 @@
 # 3.27.5 is the minimum for MSVC build with RDC=true.
 cmake_minimum_required(VERSION 3.15)
 
-project(CUB LANGUAGES NONE)
-
-# Determine whether CUB is the top-level project or included into
-# another project via add_subdirectory().
-if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
-  set(CUB_TOPLEVEL_PROJECT ON)
-endif ()
-
 # This must be done before any languages are enabled:
-if (CUB_TOPLEVEL_PROJECT)
+if (CCCL_ENABLE_CUB)
   cmake_minimum_required(VERSION 3.21)
 endif()
+
+project(CUB LANGUAGES NONE)
 
 # This must appear before the installation rules, as it is required by the
 # GNUInstallDirs CMake module.
@@ -22,7 +16,7 @@ enable_language(CXX)
 
 # Support adding CUB to a parent project via add_subdirectory.
 # See examples/cmake/add_subdir/CMakeLists.txt for details.
-if (NOT CUB_TOPLEVEL_PROJECT)
+if (NOT CCCL_ENABLE_CUB)
   include(cmake/CubAddSubdir.cmake)
   return()
 endif()

--- a/cudax/CMakeLists.txt
+++ b/cudax/CMakeLists.txt
@@ -2,18 +2,14 @@
 # 3.21 is the minimum for the developer build.
 cmake_minimum_required(VERSION 3.15)
 
-if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
-  set(cudax_TOPLEVEL_PROJECT ON)
-endif()
-
 # This must be done before any languages are enabled:
-if (cudax_TOPLEVEL_PROJECT)
+if (CCCL_ENABLE_CUDAX)
   cmake_minimum_required(VERSION 3.21)
 endif()
 
 project(cudax LANGUAGES CUDA CXX)
 
-if (NOT cudax_TOPLEVEL_PROJECT)
+if (NOT CCCL_ENABLE_CUDAX)
   include(cmake/cudaxAddSubdir.cmake)
   return()
 endif()

--- a/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/CMakeLists.txt
@@ -3,13 +3,7 @@
 # 3.21 is the minimum for the developer build.
 cmake_minimum_required(VERSION 3.15)
 
-# Determine whether libcudacxx is the top-level project or included into
-# another project via add_subdirectory().
-if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
-  set(LIBCUDACXX_TOPLEVEL_PROJECT ON)
-endif()
-
-if (LIBCUDACXX_TOPLEVEL_PROJECT)
+if (CCCL_ENABLE_LIBCUDACXX)
   cmake_minimum_required(VERSION 3.21)
 endif()
 
@@ -18,7 +12,7 @@ set(PACKAGE_VERSION 11.0)
 set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
 project(libcudacxx LANGUAGES CXX)
 
-if (NOT LIBCUDACXX_TOPLEVEL_PROJECT)
+if (NOT CCCL_ENABLE_LIBCUDACXX)
   include(cmake/libcudacxxAddSubdir.cmake)
   return()
 endif()

--- a/thrust/CMakeLists.txt
+++ b/thrust/CMakeLists.txt
@@ -2,35 +2,12 @@
 # 3.21 is the minimum for the developer build.
 cmake_minimum_required(VERSION 3.15)
 
-project(Thrust LANGUAGES NONE)
-
-# Determine whether Thrust is the top-level project or included into
-# another project via add_subdirectory()
-if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
-  set(THRUST_TOPLEVEL_PROJECT ON)
-endif()
-
-## thrust_fix_clang_nvcc_build_for
-#
-# Modifies the given target to include a fix for the clang host compiler case.
-# The fix consists of force-including a header into each compilation unit.
-#
-function(thrust_fix_clang_nvcc_build_for target)
-  if (UNIX)
-    # Path to the header containing the fix for clang + nvcc < 11.6. For more info,
-    # check the content of this header.
-    set(clang_fix_header_path "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/testing/fix_clang_nvcc_11.5.h")
-
-    # Only affects host compiler
-    target_compile_options(${target} PRIVATE
-        "$<$<COMPILE_LANGUAGE:CUDA>:-include${clang_fix_header_path}>")
-  endif()
-endfunction()
-
 # This must be done before any languages are enabled:
-if (THRUST_TOPLEVEL_PROJECT)
+if (CCCL_ENABLE_THRUST)
   cmake_minimum_required(VERSION 3.21)
 endif()
+
+project(Thrust LANGUAGES NONE)
 
 # This must appear after our Compiler Hacks or else CMake will delete the cache
 # and reconfigure from scratch.
@@ -40,7 +17,7 @@ enable_language(CXX)
 
 # Support adding Thrust to a parent project via add_subdirectory.
 # See examples/cmake/add_subdir/CMakeLists.txt for details.
-if (NOT THRUST_TOPLEVEL_PROJECT)
+if (NOT CCCL_ENABLE_THRUST)
   include(cmake/ThrustAddSubdir.cmake)
   return()
 endif()
@@ -67,11 +44,13 @@ if (NOT (THRUST_ENABLE_HEADER_TESTING OR
   return()
 endif()
 
+#include first:
+include(cmake/ThrustUtilities.cmake)
+
 include(cmake/ThrustBuildCompilerTargets.cmake)
 include(cmake/ThrustBuildTargetList.cmake)
 include(cmake/ThrustFindThrust.cmake)
 include(cmake/ThrustMultiConfig.cmake)
-include(cmake/ThrustUtilities.cmake)
 
 # Add cache string options for CMAKE_BUILD_TYPE and default to RelWithDebInfo.
 if ("" STREQUAL "${CMAKE_BUILD_TYPE}")

--- a/thrust/cmake/ThrustUtilities.cmake
+++ b/thrust/cmake/ThrustUtilities.cmake
@@ -41,3 +41,20 @@ function(thrust_configure_cuda_target target_name)
       CUDA_SEPARABLE_COMPILATION OFF)
   endif()
 endfunction()
+
+## thrust_fix_clang_nvcc_build_for
+#
+# Modifies the given target to include a fix for the clang host compiler case.
+# The fix consists of force-including a header into each compilation unit.
+#
+function(thrust_fix_clang_nvcc_build_for target)
+  if (UNIX)
+    # Path to the header containing the fix for clang + nvcc < 11.6. For more info,
+    # check the content of this header.
+    set(clang_fix_header_path "${Thrust_SOURCE_DIR}/testing/fix_clang_nvcc_11.5.h")
+
+    # Only affects host compiler
+    target_compile_options(${target} PRIVATE
+        "$<$<COMPILE_LANGUAGE:CUDA>:-include${clang_fix_header_path}>")
+  endif()
+endfunction()


### PR DESCRIPTION
These will never be toplevel projects ever again now that we're a monorepo.
They're redundant with the `CCCL_ENABLE_<proj>` flags, and have been replace by them.

This also moves the `thrust_fix_clang_nvcc_build_for` function definition out of Thrust's main `CMakeLists.txt` and into the `ThrustUtilities.cmake` file.