### PR TITLE
Add `cccl_add_ctest`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ if (CCCL_TOPLEVEL_PROJECT)
   include(cmake/AppendOptionIfAvailable.cmake)
   include(cmake/CCCLUtilities.cmake) # include this before other CCCL helpers
 
+  include(cmake/CCCLAddCTest.cmake)
   include(cmake/CCCLBuildCompilerTargets.cmake)
   include(cmake/CCCLClangdCompileInfo.cmake)
   include(cmake/CCCLConfigureTarget.cmake)

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,6 +8,10 @@ workflows:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'llvm16']}
   #
   override:
+    - {jobs: ['infra'], project: 'cccl', ctk: '11.1', cxx: ['gcc6',  'clang9']}
+    - {jobs: ['infra'], project: 'cccl', ctk: '12.0', cxx: ['gcc12', 'clang14']}
+    - {jobs: ['infra'], project: 'cccl', ctk: 'curr', cxx: ['gcc',   'clang']}
+    - {jobs: ['test'], project: 'pycuda', ctk: ['12.5']}
 
   pull_request:
     # Old CTK

--- a/cmake/CCCLAddCTest.cmake
+++ b/cmake/CCCLAddCTest.cmake
@@ -45,27 +45,27 @@ function(cccl_add_ctest test_name)
   set_property(TEST ${test_name} PROPERTY LABELS "${labels}")
 endfunction()
 
-# Extract a label path from a target name. `marker` is the last label before the test name.
+# Extract a label path from a target name. `marker` is the last label used.
 #
 # cccl_get_label_path(label_path cub.cpp17.test.reduce.foo.bar.baz "test")
-# will set`label_path` to `cub.cpp17.test.reduce`.
+# will set`label_path` to `cub.cpp17.test`.
 #
 # If `lid_[0-9]` appears after the test name, it will be appended to the label path:
 # cccl_get_label_path(label_path cub.cpp17.test.reduce.foo.bar.lid_2.baz "test")
-# will set `label_path` to `cub.cpp17.test.reduce.lid_2`.
+# will set `label_path` to `cub.cpp17.test.lid_2`.
 #
 # If the target name starts with `thrust.<host>.<device>.cpp<dialect>....`, the host/device
 # strings will be combined to form a single "<host>_<device>" label:
 # cccl_get_label_path(label_path thrust.cpp.cuda.cpp17.test.reduce.foo.bar.lid_2.baz "test")
-# will set `label_path` to `thrust.cpp_cuda.cpp17.test.reduce.lid_2`.
+# will set `label_path` to `thrust.cpp_cuda.cpp17.test.lid_2`.
 function(cccl_get_label_path label_path_var test_name marker)
   # Combine thrust host/device to a single label, if present:
-  if (test_name MATCHES "^thrust\.[^\.]+\.[^\.]+\.cpp.+$")
-    string(REGEX REPLACE "^(thrust\.[^\.]+)\.(.+)$" "\\1_\\2" test_name ${test_name})
+  if (test_name MATCHES "^thrust\\.[^.]+\\.[^.]+\\.cpp.+$")
+    string(REGEX REPLACE "^(thrust\\.[^.]+)\\.(.+)$" "\\1_\\2" test_name ${test_name})
   endif()
 
   # Truncate the label path to only include a single label after 'test.':
-  string(REGEX MATCH ".+\.${marker}\.[^.]+" label_path ${test_name})
+  string(REGEX MATCH ".+\\.${marker}" label_path ${test_name})
 
   # Append any `lid_X` options:
   string(REGEX MATCH "lid_[0-9]+" launcher_id_str ${test_name})

--- a/cmake/CCCLAddCTest.cmake
+++ b/cmake/CCCLAddCTest.cmake
@@ -12,9 +12,8 @@
 # LABEL_PATH: A set of heirarchical labels delimited by periods. Each label will include all
 #   previous labels. For example, `LABEL_PATH thrust.cpp_cuda.cpp17.test` will add the labels
 #   `thrust`, `thrust.cpp_cuda`, `thrust.cpp_cuda.cpp17`, and `thrust.cpp_cuda.cpp17.test`.
-# LABEL_MARKER: The last label before the test name. Defaults to "test". See cccl_get_label_path
-#   for more information.
-# LABEL_NAME: If set, the test name will be directly used as the label.
+# LABEL_MARKER: See cccl_get_label_path docs for usage and examples.
+# LABEL_NAME: If set, the test name will be directly used as the label_path.
 function(cccl_add_ctest test_name)
   set(options LABEL_NAME)
   set(oneValueArgs LABEL_PATH LABEL_MARKER)

--- a/cmake/CCCLAddCTest.cmake
+++ b/cmake/CCCLAddCTest.cmake
@@ -51,12 +51,12 @@ endfunction()
 # will set`label_path` to `cub.cpp17.test.reduce`.
 #
 # If `lid_[0-9]` appears after the test name, it will be appended to the label path:
-# cccl_get_label_path_with_launcher_id(label_path cub.cpp17.test.reduce.foo.bar.lid_2.baz "test")
+# cccl_get_label_path(label_path cub.cpp17.test.reduce.foo.bar.lid_2.baz "test")
 # will set `label_path` to `cub.cpp17.test.reduce.lid_2`.
 #
 # If the target name starts with `thrust.<host>.<device>.cpp<dialect>....`, the host/device
 # strings will be combined to form a single "<host>_<device>" label:
-# cccl_get_label_path_with_launcher_id(label_path thrust.cpp.cuda.cpp17.test.reduce.foo.bar.lid_2.baz "test")
+# cccl_get_label_path(label_path thrust.cpp.cuda.cpp17.test.reduce.foo.bar.lid_2.baz "test")
 # will set `label_path` to `thrust.cpp_cuda.cpp17.test.reduce.lid_2`.
 function(cccl_get_label_path label_path_var test_name marker)
   # Combine thrust host/device to a single label, if present:

--- a/cmake/CCCLAddCTest.cmake
+++ b/cmake/CCCLAddCTest.cmake
@@ -1,0 +1,78 @@
+# Usage:
+# cccl_add_ctest(test_name
+#                [LABEL_PATH label1.label2.label3]
+#                [LABEL_MARKER marker]
+#                [LABEL_NAME]
+#                [add_test options]
+# )
+#
+# Options:
+# test_name: The name of the test that will be used by CTest.
+# add_test options: Additional options to pass to add_test.
+# LABEL_PATH: A set of heirarchical labels delimited by periods. Each label will include all
+#   previous labels. For example, `LABEL_PATH thrust.cpp_cuda.cpp17.test` will add the labels
+#   `thrust`, `thrust.cpp_cuda`, `thrust.cpp_cuda.cpp17`, and `thrust.cpp_cuda.cpp17.test`.
+# LABEL_MARKER: The last label before the test name. Defaults to "test". See cccl_get_label_path
+#   for more information.
+# LABEL_NAME: If set, the test name will be directly used as the label.
+function(cccl_add_ctest test_name)
+  set(options LABEL_NAME)
+  set(oneValueArgs LABEL_PATH LABEL_MARKER)
+  set(multiValueArgs)
+  cmake_parse_arguments(CACT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  set(add_test_opts ${CACT_UNPARSED_ARGUMENTS})
+
+  if (DEFINED CACT_LABEL_NAME)
+    set(CACT_LABEL_PATH ${test_name})
+  endif()
+
+  if (DEFINED CACT_LABEL_MARKER)
+    cccl_get_label_path(CACT_LABEL_PATH ${test_name} ${CACT_LABEL_MARKER})
+  endif()
+
+  set(labels)
+  if (DEFINED CACT_LABEL_PATH)
+    set(label_tmp)
+    string(REPLACE "." ";" label_list ${CACT_LABEL_PATH})
+    foreach (label IN LISTS label_list)
+      list(APPEND label_tmp "${label}")
+      string(REPLACE ";" "." label_str "${label_tmp}")
+      list(APPEND labels "${label_str}")
+    endforeach()
+  endif()
+
+  add_test(NAME ${test_name} ${add_test_opts})
+  set_property(TEST ${test_name} PROPERTY LABELS "${labels}")
+endfunction()
+
+# Extract a label path from a target name. `marker` is the last label before the test name.
+#
+# cccl_get_label_path(label_path cub.cpp17.test.reduce.foo.bar.baz "test")
+# will set`label_path` to `cub.cpp17.test.reduce`.
+#
+# If `lid_[0-9]` appears after the test name, it will be appended to the label path:
+# cccl_get_label_path_with_launcher_id(label_path cub.cpp17.test.reduce.foo.bar.lid_2.baz "test")
+# will set `label_path` to `cub.cpp17.test.reduce.lid_2`.
+#
+# If the target name starts with `thrust.<host>.<device>.cpp<dialect>....`, the host/device
+# strings will be combined to form a single "<host>_<device>" label:
+# cccl_get_label_path_with_launcher_id(label_path thrust.cpp.cuda.cpp17.test.reduce.foo.bar.lid_2.baz "test")
+# will set `label_path` to `thrust.cpp_cuda.cpp17.test.reduce.lid_2`.
+function(cccl_get_label_path label_path_var test_name marker)
+  # Combine thrust host/device to a single label, if present:
+  if (test_name MATCHES "^thrust\.[^\.]+\.[^\.]+\.cpp.+$")
+    string(REGEX REPLACE "^(thrust\.[^\.]+)\.(.+)$" "\\1_\\2" test_name ${test_name})
+  endif()
+
+  # Truncate the label path to only include a single label after 'test.':
+  string(REGEX MATCH ".+\.${marker}\.[^.]+" label_path ${test_name})
+
+  # Append any `lid_X` options:
+  string(REGEX MATCH "lid_[0-9]+" launcher_id_str ${test_name})
+  if (launcher_id_str)
+    string(APPEND label_path ".${launcher_id_str}")
+  endif()
+
+  set(${label_path_var} ${label_path} PARENT_SCOPE)
+endfunction()

--- a/cmake/CCCLUtilities.cmake
+++ b/cmake/CCCLUtilities.cmake
@@ -55,7 +55,7 @@ function(cccl_add_compile_test full_test_name_var name_prefix subdir test_id)
   set(test_name ${name_prefix}.${subdir}.${test_id})
   set(src_dir "${CMAKE_CURRENT_SOURCE_DIR}/${subdir}")
   set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/${subdir}/${test_id}")
-  add_test(NAME ${test_name}
+  cccl_add_ctest(${test_name}
     COMMAND "${CMAKE_CTEST_COMMAND}"
       --build-and-test "${src_dir}" "${build_dir}"
       --build-generator "${CMAKE_GENERATOR}"

--- a/cub/examples/CMakeLists.txt
+++ b/cub/examples/CMakeLists.txt
@@ -44,7 +44,8 @@ function(cub_add_example target_name_var example_name example_src cub_target)
   endif()
   add_dependencies(${example_meta_target} ${example_target})
 
-  add_test(NAME ${example_target}
+  cccl_add_ctest(${example_target}
+    LABEL_MARKER example
     COMMAND "$<TARGET_FILE:${example_target}>"
   )
 endfunction()

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -201,7 +201,10 @@ function(cub_add_test target_name_var test_name test_src cub_target launcher_id)
       target_link_libraries(${test_target} PRIVATE ${catch2_main_objects})
       add_dependencies(${config_meta_target} ${test_target})
 
-      add_test(NAME ${test_target} COMMAND "$<TARGET_FILE:${test_target}>")
+      cccl_add_ctest(${test_target}
+        LABEL_MARKER test
+        COMMAND "$<TARGET_FILE:${test_target}>"
+      )
     else() # Not CUB_SEPARATE_CATCH2
       # Per config catch2 runner
       set(config_c2run_target ${config_prefix}.catch2_test.lid_${launcher_id})
@@ -221,7 +224,8 @@ function(cub_add_test target_name_var test_name test_src cub_target launcher_id)
           target_link_options(${config_c2run_target} PRIVATE "-cuda")
         endif()
 
-        add_test(NAME ${config_c2run_target}
+        cccl_add_ctest(NAME ${config_c2run_target}
+          LABEL_NAME
           COMMAND "$<TARGET_FILE:${config_c2run_target}>"
         )
       endif() # per config catch2 runner
@@ -279,10 +283,10 @@ function(cub_add_test target_name_var test_name test_src cub_target launcher_id)
     if (is_fail_test)
       set_target_properties(${test_target} PROPERTIES EXCLUDE_FROM_ALL true
                                            EXCLUDE_FROM_DEFAULT_BUILD true)
-      add_test(NAME ${test_target}
-               COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}"
-                                        --target ${test_target}
-                                        --config $<CONFIGURATION>)
+      cccl_add_ctest(${test_target}
+        COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}"
+                                 --target ${test_target}
+                                 --config $<CONFIGURATION>)
       string(REGEX MATCH "err_([0-9]+)" MATCH_RESULT "${test_name}")
       file(READ ${test_src} test_content)
       if(MATCH_RESULT)
@@ -312,7 +316,10 @@ function(cub_add_test target_name_var test_name test_src cub_target launcher_id)
       endif()
       add_dependencies(${test_meta_target} ${test_target})
 
-      add_test(NAME ${test_target} COMMAND "$<TARGET_FILE:${test_target}>")
+      cccl_add_ctest(${test_target}
+        LABEL_MARKER test
+        COMMAND "$<TARGET_FILE:${test_target}>"
+      )
     endif()
   endif() # Not catch2 test
 endfunction()

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -278,12 +278,16 @@ function(cub_add_test target_name_var test_name test_src cub_target launcher_id)
       target_link_libraries(${test_target} nvtx3-cpp)
     endif()
 
-
     _cub_is_fail_test(is_fail_test "${test_src}")
     if (is_fail_test)
       set_target_properties(${test_target} PROPERTIES EXCLUDE_FROM_ALL true
                                            EXCLUDE_FROM_DEFAULT_BUILD true)
+
+      # The name of the test without the config_prefix or .err_X suffix:
+      string(REGEX REPLACE ".+\\.([^.]+)\\.err_[0-9]+" "\\1" base_name ${test_target})
+
       cccl_add_ctest(${test_target}
+        LABEL_MARKER ${base_name}
         COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}"
                                  --target ${test_target}
                                  --config $<CONFIGURATION>)

--- a/cub/test/cmake/CMakeLists.txt
+++ b/cub/test/cmake/CMakeLists.txt
@@ -1,6 +1,5 @@
 # Check source code for issues that can be found by pattern matching:
-add_test(
-  NAME cub.test.cmake.check_source_files
+cccl_add_ctest(cub.test.cmake.check_source_files
   COMMAND
     "${CMAKE_COMMAND}"
       -D "CUB_SOURCE_DIR=${CUB_SOURCE_DIR}"

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(catch2_main PUBLIC Catch2::Catch2)
 function(cudax_add_catch2_test target_name_var test_name cn_target) # ARGN=test sources
   cudax_get_target_property(config_prefix ${cn_target} PREFIX)
 
-  set(test_target ${config_prefix}.${test_name})
+  set(test_target ${config_prefix}.test.${test_name})
   set(test_sources ${ARGN})
 
   add_executable(${test_target} ${test_sources})
@@ -47,7 +47,10 @@ function(cudax_add_catch2_test target_name_var test_name cn_target) # ARGN=test 
   set(config_meta_target ${config_prefix}.tests)
   add_dependencies(${config_meta_target} ${test_target})
 
-  add_test(NAME ${test_target} COMMAND "$<TARGET_FILE:${test_target}>")
+  cccl_add_ctest(${test_target}
+    LABEL_MARKER test
+    COMMAND "$<TARGET_FILE:${test_target}>"
+  )
 
   set(${target_name_var} ${test_target} PARENT_SCOPE)
 endfunction()
@@ -62,34 +65,34 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   add_dependencies(${config_prefix}.all ${config_meta_target})
 
   # Add tests:
-  cudax_add_catch2_test(test_target hierarchy_tests ${cn_target}
+  cudax_add_catch2_test(test_target hierarchy ${cn_target}
     hierarchy/hierarchy_smoke.cu
     hierarchy/hierarchy_custom_types.cu
   )
 
-  cudax_add_catch2_test(test_target launch_tests ${cn_target}
+  cudax_add_catch2_test(test_target launch ${cn_target}
     launch/launch_smoke.cu
     launch/configuration.cu
   )
 
-  cudax_add_catch2_test(test_target device_tests ${cn_target}
+  cudax_add_catch2_test(test_target device ${cn_target}
     device/device_smoke.cu
     device/arch_traits.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-relaxed-constexpr>)
 
-  cudax_add_catch2_test(test_target event_tests ${cn_target}
+  cudax_add_catch2_test(test_target event ${cn_target}
     event/event_smoke.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
 
-  cudax_add_catch2_test(test_target stream_tests ${cn_target}
+  cudax_add_catch2_test(test_target stream ${cn_target}
     stream/get_stream.cu
     stream/stream_smoke.cu
   )
 
-  cudax_add_catch2_test(test_target misc_tests ${cn_target}
+  cudax_add_catch2_test(test_target misc ${cn_target}
     utility/driver_api.cu
     utility/ensure_current_device.cu
   )
@@ -107,7 +110,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     memory_resource/shared_resource.cu
   )
 
-  cudax_add_catch2_test(test_target async_tests ${cn_target}
+  cudax_add_catch2_test(test_target async ${cn_target}
     async/test_conditional.cu
     async/test_continue_on.cu
     async/test_just.cu

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -32,6 +32,8 @@ set(cmake_cpm_opts
   -D "CCCL_TAG=${CCCL_EXAMPLE_CPM_TAG}"
 )
 
+message(STATUS "Example options:\n${cmake_opts}\n${cmake_cpm_opts}")
+
 cccl_add_compile_test(test_name
   cccl.example
   basic

--- a/libcudacxx/codegen/CMakeLists.txt
+++ b/libcudacxx/codegen/CMakeLists.txt
@@ -32,9 +32,11 @@ add_custom_target(
     BYPRODUCTS "${atomic_install_location}/cuda_ptx_generated.h"
 )
 
-add_test(
-    NAME libcudacxx.test.atomics.codegen.diff
-    COMMAND ${CMAKE_COMMAND} -E compare_files "${atomic_install_location}/cuda_ptx_generated.h" "${atomic_generated_output}"
+cccl_add_ctest(libcudacxx.test.atomics.codegen.diff
+  LABEL_NAME
+  COMMAND
+    ${CMAKE_COMMAND} -E compare_files
+      "${atomic_install_location}/cuda_ptx_generated.h" "${atomic_generated_output}"
 )
 
 set_tests_properties(

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -128,11 +128,13 @@ set(libcudacxx_LIT_PARALLEL_LEVEL 8 CACHE STRING
 "Parallelism used to run libcudacxx's lit test suite."
 )
 
-add_test(NAME libcudacxx.test.lit COMMAND
-  "${CMAKE_COMMAND}" -E env
-    "LIBCUDACXX_SITE_CONFIG=${lit_site_cfg_path}"
-  "${libcudacxx_LIT}" -vv --no-progress-bar --time-tests ${libcudacxx_LIT_FLAGS}
-    -j "${libcudacxx_LIT_PARALLEL_LEVEL}" "${libcudacxx_SOURCE_DIR}/test/libcudacxx"
+cccl_add_ctest(libcudacxx.test.lit
+  LABEL_NAME
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "LIBCUDACXX_SITE_CONFIG=${lit_site_cfg_path}"
+    "${libcudacxx_LIT}" -vv --no-progress-bar --time-tests ${libcudacxx_LIT_FLAGS}
+      -j "${libcudacxx_LIT_PARALLEL_LEVEL}" "${libcudacxx_SOURCE_DIR}/test/libcudacxx"
 )
 
 set_tests_properties(libcudacxx.test.lit PROPERTIES

--- a/test/cmake/CMakeLists.txt
+++ b/test/cmake/CMakeLists.txt
@@ -49,7 +49,8 @@ endforeach() # root_type
 
 ################################################################################
 # Install tree fixtures
-add_test(NAME cccl.test.cmake.install_tree.install
+cccl_add_ctest(cccl.test.cmake.install_tree.install
+  LABEL_NAME
   COMMAND "${CMAKE_COMMAND}"
     --install "${CCCL_BINARY_DIR}"
     --prefix "${tmp_install_prefix}"
@@ -58,7 +59,8 @@ set_tests_properties(cccl.test.cmake.install_tree.install PROPERTIES
   FIXTURES_SETUP install_tree
 )
 
-add_test(NAME cccl.test.cmake.install_tree.cleanup
+cccl_add_ctest(cccl.test.cmake.install_tree.cleanup
+  LABEL_NAME
   COMMAND "${CMAKE_COMMAND}" -E rm -rf "${tmp_install_prefix}"
 )
 set_tests_properties(cccl.test.cmake.install_tree.cleanup PROPERTIES

--- a/thrust/examples/CMakeLists.txt
+++ b/thrust/examples/CMakeLists.txt
@@ -113,7 +113,8 @@ function(thrust_add_example target_name_var example_name example_src thrust_targ
     "${example_target}.filecheck"
   )
 
-  add_test(NAME ${example_target}
+  cccl_add_ctest(${example_target}
+    LABEL_MARKER example
     COMMAND "${CMAKE_COMMAND}"
     "-DEXAMPLE_EXECUTABLE=$<TARGET_FILE:${example_target}>"
     "-DFILECHECK_ENABLED=${THRUST_ENABLE_EXAMPLE_FILECHECK}"

--- a/thrust/testing/CMakeLists.txt
+++ b/thrust/testing/CMakeLists.txt
@@ -90,7 +90,8 @@ function(thrust_add_test target_name_var test_name test_src thrust_target)
   endif()
   add_dependencies(${test_meta_target} ${test_target})
 
-  add_test(NAME ${test_target}
+  cccl_add_ctest(${test_target}
+    LABEL_MARKER test
     COMMAND "${CMAKE_COMMAND}"
     "-DTHRUST_BINARY=$<TARGET_FILE:${test_target}>"
     "-DTHRUST_SOURCE=${Thrust_SOURCE_DIR}"

--- a/thrust/testing/cmake/CMakeLists.txt
+++ b/thrust/testing/cmake/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Check source code for issues that can be found by pattern matching:
-add_test(
-  NAME thrust.test.cmake.check_source_files
+cccl_add_ctest(thrust.test.cmake.check_source_files
+  LABEL_NAME
   COMMAND
     "${CMAKE_COMMAND}"
       -D "Thrust_SOURCE_DIR=${Thrust_SOURCE_DIR}"


### PR DESCRIPTION
This wraps all `add_test` calls in CCCL and can be used for project-wide configuration.

It currently adds CTest labels that are used to produce timing breakdowns in the CTest output.