### PR TITLE
avoid gcc optimizer bug by not force inlining part of `thrust::transform`

### DIFF
--- a/thrust/thrust/system/cuda/detail/transform.h
+++ b/thrust/thrust/system/cuda/detail/transform.h
@@ -178,8 +178,10 @@ struct binary_transform_f<InputIt1, InputIt2, OutputIt, no_stencil_tag, Transfor
   }
 }; // struct binary_transform_f
 
+// EAN 2024-10-04: when force-inlined, gcc's optimizer will generate bad code
+// for this function:
 template <class Policy, class InputIt, class Size, class OutputIt, class StencilIt, class TransformOp, class Predicate>
-OutputIt THRUST_FUNCTION unary(
+OutputIt _CCCL_HOST_DEVICE inline unary(
   Policy& policy,
   InputIt items,
   OutputIt result,
@@ -200,6 +202,8 @@ OutputIt THRUST_FUNCTION unary(
   return result + num_items;
 }
 
+// EAN 2024-10-04: when force-inlined, gcc's optimizer will generate bad code
+// for this function:
 template <class Policy,
           class InputIt1,
           class InputIt2,
@@ -208,7 +212,7 @@ template <class Policy,
           class StencilIt,
           class TransformOp,
           class Predicate>
-OutputIt THRUST_FUNCTION binary(
+OutputIt _CCCL_HOST_DEVICE inline binary(
   Policy& policy,
   InputIt1 items1,
   InputIt2 items2,


### PR DESCRIPTION
## Description

in #2439, the `_CCCL_FORCEINLINE` macro was changed to actually force-inline functions whether compiling for CUDA or not. the addition of the force-inline attribute on some functions exposed a gcc optimizer bug, causing build errors such as:

```
  /home/coder/cccl/thrust/thrust/cmake/../../thrust/detail/internal_functional.h:226:21: 
error: writing 8 bytes into a region of size 5 [-Werror=stringop-overflow=]
    226 |     thrust::get<1>(t) = f(thrust::get<0>(t));
        |     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~ 
```

for example, see [this CI job](https://github.com/NVIDIA/cccl/actions/runs/10967082905/job/30507674109?pr=2439).

the CUDA toolkit build is currently broken with a failure such as this (see nvbug#4893064).

i have tracked down the two functions (part of `thrust::transform`'s implementation) the force-inlining of which is the root cause of this build failure. this PR removes the force-inline attribute for these two functions.

## Validation

since the problem is not actively repro-ing on `main`, i confirmed the fix by checking out [b12665877d9924a7dafb33b76a10052cb4c29ab4], repro-ing the problem there, making the change, and verifying that it avoids the error.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
