### PR TITLE
Fix the example project which the documentation refers too

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ conda install -c conda-forge cccl
 CCCL uses [CMake](https://cmake.org/) for all build and installation infrastructure, including tests as well as targets to link against in other CMake projects.
 Therefore, CMake is the recommended way to integrate CCCL into another project.
 
-For a complete example of how to do this using CMake Package Manager see [our example project](examples/example_project).
+For a complete example of how to do this using CMake Package Manager see [our basic example project](examples/basic).
 
 Other build systems should work, but only CMake is tested.
 Contributions to simplify integrating CCCL into other build systems are welcome.


### PR DESCRIPTION
## Description

The url in the README.md section to illustrate how to use cmake in other projects was dangling

<!-- Provide a standalone description of changes in this PR. -->
I have pointed that the to basic example instead

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
