### PR TITLE
Avoid including `yvals.h` when the compiler is not MSVC.

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/assert.h
+++ b/libcudacxx/include/cuda/std/__cccl/assert.h
@@ -62,7 +62,7 @@
 //! _CCCL_ASSERT_IMPL_HOST should never be used directly
 #if defined(_CCCL_COMPILER_NVRTC) // There is no host standard library in nvrtc
 #  define _CCCL_ASSERT_IMPL_HOST(expression, message) ((void) 0)
-#elif __has_include(<yvals_core.h>) && defined(_CCCL_COMPILER_MSVC) // MSVC uses _STL_VERIFY from <yvals.h>
+#elif __has_include(<yvals.h>) && defined(_CCCL_COMPILER_MSVC) // MSVC uses _STL_VERIFY from <yvals.h>
 #  include <yvals.h>
 #  define _CCCL_ASSERT_IMPL_HOST(expression, message) _STL_VERIFY(expression, message)
 #else // ^^^ MSVC STL ^^^ / vvv !MSVC STL vvv

--- a/libcudacxx/include/cuda/std/__cccl/assert.h
+++ b/libcudacxx/include/cuda/std/__cccl/assert.h
@@ -62,7 +62,7 @@
 //! _CCCL_ASSERT_IMPL_HOST should never be used directly
 #if defined(_CCCL_COMPILER_NVRTC) // There is no host standard library in nvrtc
 #  define _CCCL_ASSERT_IMPL_HOST(expression, message) ((void) 0)
-#elif __has_include(<yvals_core.h>) // MSVC uses _STL_VERIFY from <yvals.h>
+#elif __has_include(<yvals_core.h>) && defined(_CCCL_COMPILER_MSVC) // MSVC uses _STL_VERIFY from <yvals.h>
 #  include <yvals.h>
 #  define _CCCL_ASSERT_IMPL_HOST(expression, message) _STL_VERIFY(expression, message)
 #else // ^^^ MSVC STL ^^^ / vvv !MSVC STL vvv


### PR DESCRIPTION
## Description

closes nvbug/4902968

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
