### PR TITLE
Disable compiler extensions on CCCL targets.

### DIFF
--- a/cmake/CCCLConfigureTarget.cmake
+++ b/cmake/CCCLConfigureTarget.cmake
@@ -10,6 +10,13 @@ function(cccl_configure_target target_name)
 
   get_target_property(type ${target_name} TYPE)
 
+  set_target_properties(${target_name}
+    PROPERTIES
+      # Disable compiler extensions:
+      CXX_EXTENSIONS OFF
+      CUDA_EXTENSIONS OFF
+  )
+
   if (DEFINED CCT_DIALECT)
     set_target_properties(${target_name}
       PROPERTIES


### PR DESCRIPTION
Disable compiler extensions when building CCCL targets.