### PR TITLE
Rename cudax test targets to match CCCL conventions.

### DIFF
--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(catch2_main PUBLIC Catch2::Catch2)
 function(cudax_add_catch2_test target_name_var test_name cn_target) # ARGN=test sources
   cudax_get_target_property(config_prefix ${cn_target} PREFIX)
 
-  set(test_target ${config_prefix}.${test_name})
+  set(test_target ${config_prefix}.test.${test_name})
   set(test_sources ${ARGN})
 
   add_executable(${test_target} ${test_sources})
@@ -62,34 +62,34 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   add_dependencies(${config_prefix}.all ${config_meta_target})
 
   # Add tests:
-  cudax_add_catch2_test(test_target hierarchy_tests ${cn_target}
+  cudax_add_catch2_test(test_target hierarchy ${cn_target}
     hierarchy/hierarchy_smoke.cu
     hierarchy/hierarchy_custom_types.cu
   )
 
-  cudax_add_catch2_test(test_target launch_tests ${cn_target}
+  cudax_add_catch2_test(test_target launch ${cn_target}
     launch/launch_smoke.cu
     launch/configuration.cu
   )
 
-  cudax_add_catch2_test(test_target device_tests ${cn_target}
+  cudax_add_catch2_test(test_target device ${cn_target}
     device/device_smoke.cu
     device/arch_traits.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-relaxed-constexpr>)
 
-  cudax_add_catch2_test(test_target event_tests ${cn_target}
+  cudax_add_catch2_test(test_target event ${cn_target}
     event/event_smoke.cu
   )
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
 
-  cudax_add_catch2_test(test_target stream_tests ${cn_target}
+  cudax_add_catch2_test(test_target stream ${cn_target}
     stream/get_stream.cu
     stream/stream_smoke.cu
   )
 
-  cudax_add_catch2_test(test_target misc_tests ${cn_target}
+  cudax_add_catch2_test(test_target misc ${cn_target}
     utility/driver_api.cu
     utility/ensure_current_device.cu
   )
@@ -107,7 +107,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     memory_resource/shared_resource.cu
   )
 
-  cudax_add_catch2_test(test_target async_tests ${cn_target}
+  cudax_add_catch2_test(test_target async ${cn_target}
     async/test_conditional.cu
     async/test_continue_on.cu
     async/test_just.cu


### PR DESCRIPTION
<project>.<dialect>.test.<testname>
instead of
<project>.<dialect>.<testname>_tests
