### PR TITLE
fix the forwarding of the receiver in the `just_from` algorithm

### DIFF
--- a/cudax/include/cuda/experimental/__async/env.cuh
+++ b/cudax/include/cuda/experimental/__async/env.cuh
@@ -40,6 +40,7 @@ _CCCL_DIAG_PUSH
 // suppress this warning rather than fix the code because defaulting or defining
 // the copy constructor would prevent aggregate initialization, which these types
 // depend on.
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunknown-warning-option")
 _CCCL_DIAG_SUPPRESS_CLANG("-Wdeprecated-copy")
 
 // warning #20012-D: __device__ annotation is ignored on a

--- a/cudax/include/cuda/experimental/__async/env.cuh
+++ b/cudax/include/cuda/experimental/__async/env.cuh
@@ -62,6 +62,8 @@ struct prop
   {
     return __value;
   }
+
+  prop& operator=(const prop&) = delete;
 };
 
 template <class... _Envs>
@@ -90,6 +92,8 @@ struct env
   {
     return __get_1st(__query).__query(__query);
   }
+
+  env& operator=(const env&) = delete;
 };
 
 // partial specialization for two environments
@@ -122,6 +126,8 @@ struct env<_Env0, _Env1>
   {
     return __get_1st(__query).__query(__query);
   }
+
+  env& operator=(const env&) = delete;
 };
 
 template <class... _Envs>

--- a/cudax/include/cuda/experimental/__async/env.cuh
+++ b/cudax/include/cuda/experimental/__async/env.cuh
@@ -33,6 +33,15 @@
 
 #include <cuda/experimental/__async/prologue.cuh>
 
+_CCCL_DIAG_PUSH
+
+// Suppress the warning: "definition of implicit copy constructor for 'env<>' is
+// deprecated because it has a user-declared copy assignment operator". We need to
+// suppress this warning rather than fix the code because defaulting or defining
+// the copy constructor would prevent aggregate initialization, which these types
+// depend on.
+_CCCL_DIAG_SUPPRESS_CLANG("-Wdeprecated-copy")
+
 // warning #20012-D: __device__ annotation is ignored on a
 // function("inplace_stop_source") that is explicitly defaulted on its first
 // declaration
@@ -192,6 +201,8 @@ using env_of_t = decltype(get_env(__declval<_Ty>()));
 } // namespace cuda::experimental::__async
 
 _CCCL_NV_DIAG_DEFAULT(20012)
+
+_CCCL_DIAG_POP
 
 #include <cuda/experimental/__async/epilogue.cuh>
 

--- a/cudax/include/cuda/experimental/__async/just_from.cuh
+++ b/cudax/include/cuda/experimental/__async/just_from.cuh
@@ -90,7 +90,7 @@ private:
     template <class... _Ts>
     _CCCL_HOST_DEVICE auto operator()(_Ts&&... __ts) const noexcept
     {
-      _SetTag()(static_cast<_Rcvr&>(__rcvr_), static_cast<_Ts&&>(__ts)...);
+      _SetTag()(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Ts&&>(__ts)...);
     }
   };
 


### PR DESCRIPTION
## Description

a typo in the `just_from` algorithm meant that a receiver is getting passed as an lvalue to a completion function. not all receivers have `.set_[value|error|stopped]()` members that are callable on lvalue object. this PR fixes the typo and correctly forwards the receiver.

as a drive-by, i also fix a conformance issue by making environments not move/copy assignable.


<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
