### PR TITLE
Check for missing `inline` on functions in public headers.

### DIFF
--- a/cmake/CCCLGenerateHeaderTests.cmake
+++ b/cmake/CCCLGenerateHeaderTests.cmake
@@ -112,9 +112,13 @@ function(cccl_generate_header_tests target_name project_include_path)
   set(link_target ${target_name}.link_check)
   add_library(${link_target} SHARED)
   cccl_configure_target(${link_target} ${cccl_configure_target_options})
+  set_target_properties(${link_target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
   # Linking both ${target_name} and $<TARGET_OBJECTS:${target_name}> forces CMake to
   # link the same objects twice. The compiler will complain about duplicate symbols if
   # any functions are missing inline markup.
-  target_link_libraries(${link_target} PRIVATE ${target_name} $<TARGET_OBJECTS:${target_name}>)
+  target_link_libraries(${link_target} PRIVATE
+    ${target_name}
+    $<TARGET_OBJECTS:${target_name}>
+  )
 
 endfunction()

--- a/cmake/CCCLGenerateHeaderTests.cmake
+++ b/cmake/CCCLGenerateHeaderTests.cmake
@@ -108,4 +108,13 @@ function(cccl_generate_header_tests target_name project_include_path)
   add_library(${target_name} OBJECT ${header_srcs})
   cccl_configure_target(${target_name} ${cccl_configure_target_options})
 
+  # Check that all functions in headers are either template functions or inline:
+  set(link_target ${target_name}.link_check)
+  add_library(${link_target} SHARED)
+  cccl_configure_target(${link_target} ${cccl_configure_target_options})
+  # Linking both ${target_name} and $<TARGET_OBJECTS:${target_name}> forces CMake to
+  # link the same objects twice. The compiler will complain about duplicate symbols if
+  # any functions are missing inline markup.
+  target_link_libraries(${link_target} PRIVATE ${target_name} $<TARGET_OBJECTS:${target_name}>)
+
 endfunction()

--- a/cmake/CCCLGenerateHeaderTests.cmake
+++ b/cmake/CCCLGenerateHeaderTests.cmake
@@ -110,9 +110,8 @@ function(cccl_generate_header_tests target_name project_include_path)
 
   # Check that all functions in headers are either template functions or inline:
   set(link_target ${target_name}.link_check)
-  add_library(${link_target} SHARED)
+  add_executable(${link_target} "${CCCL_SOURCE_DIR}/cmake/link_check_main.cpp")
   cccl_configure_target(${link_target} ${cccl_configure_target_options})
-  set_target_properties(${link_target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
   # Linking both ${target_name} and $<TARGET_OBJECTS:${target_name}> forces CMake to
   # link the same objects twice. The compiler will complain about duplicate symbols if
   # any functions are missing inline markup.

--- a/cmake/link_check_main.cpp
+++ b/cmake/link_check_main.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}


### PR DESCRIPTION
We can test for missing `inline` markup by linking the header objects into the same target twice. By default CMake will eliminate duplicate link targets, but linking both the target and the $<TARGET_OBJECTS:target> bypasses the duplicate checks.