### PR TITLE
Fixes `cub::DeviceMemcpy::Batched` to be able to copy from `const` source pointers

### DIFF
--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -455,7 +455,7 @@ struct DispatchBatchMemcpy : SelectedPolicy
     // The number of thread blocks (or tiles) required to process all of the given buffers
     BlockOffsetT num_tiles = ::cuda::ceil_div(num_buffers, TILE_SIZE);
 
-    using BlevBufferSrcsOutT          = ::cuda::std::_If<IsMemcpy, void*, cub::detail::value_t<InputBufferIt>>;
+    using BlevBufferSrcsOutT          = ::cuda::std::_If<IsMemcpy, const void*, cub::detail::value_t<InputBufferIt>>;
     using BlevBufferDstOutT           = ::cuda::std::_If<IsMemcpy, void*, cub::detail::value_t<OutputBufferIt>>;
     using BlevBufferSrcsOutItT        = BlevBufferSrcsOutT*;
     using BlevBufferDstsOutItT        = BlevBufferDstOutT*;

--- a/cub/test/test_device_batch_memcpy.cu
+++ b/cub/test/test_device_batch_memcpy.cu
@@ -216,7 +216,8 @@ void RunTest(BufferOffsetT num_buffers,
 {
   try
   {
-    using SrcPtrT = uint8_t*;
+    using SrcPtrT = const uint8_t*;
+    using DstPtrT = uint8_t*;
 
     // Buffer segment data (their offsets and sizes)
     c2h::host_vector<BufferSizeT> h_buffer_sizes(num_buffers);
@@ -286,8 +287,8 @@ void RunTest(BufferOffsetT num_buffers,
       thrust::raw_pointer_cast(d_buffer_src_offsets.data()), src_transform_op);
 
     // Prepare d_buffer_dsts
-    OffsetToPtrOp<SrcPtrT> dst_transform_op{static_cast<SrcPtrT>(thrust::raw_pointer_cast(d_out.data()))};
-    cub::TransformInputIterator<SrcPtrT, OffsetToPtrOp<SrcPtrT>, ByteOffsetT*> d_buffer_dsts(
+    OffsetToPtrOp<DstPtrT> dst_transform_op{static_cast<DstPtrT>(thrust::raw_pointer_cast(d_out.data()))};
+    cub::TransformInputIterator<DstPtrT, OffsetToPtrOp<DstPtrT>, ByteOffsetT*> d_buffer_dsts(
       thrust::raw_pointer_cast(d_buffer_dst_offsets.data()), dst_transform_op);
 
     // Get temporary storage requirements


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes https://github.com/NVIDIA/cccl/issues/586 <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
