### PR TITLE
test for exceptions support on msvc with the `_CPPUNWIND` macro

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/exceptions.h
+++ b/libcudacxx/include/cuda/std/__cccl/exceptions.h
@@ -25,7 +25,7 @@
 #ifndef _CCCL_NO_EXCEPTIONS
 #  if defined(CCCL_DISABLE_EXCEPTIONS) // Escape hatch for users to manually disable exceptions
 #    define _CCCL_NO_EXCEPTIONS
-#  elif defined(_CCCL_COMPILER_NVRTC) || (defined(_CCCL_COMPILER_MSVC) && _HAS_EXCEPTIONS == 0) \
+#  elif defined(_CCCL_COMPILER_NVRTC) || (defined(_CCCL_COMPILER_MSVC) && _CPPUNWIND == 0) \
     || (!defined(_CCCL_COMPILER_MSVC) && !__EXCEPTIONS) // Catches all non msvc based compilers
 #    define _CCCL_NO_EXCEPTIONS
 #  endif


### PR DESCRIPTION
## Description

According to [MSDN](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170), `_CPPUNWIND` is the correct macro to use when detecting whether the compiler supports exceptions.

It looks like `_HAS_EXCEPTIONS` is used to control whether Microsoft's STL uses exceptions, which isn't what we want to be testing here.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
