### PR TITLE
Try to use the same redefinition of `__assert_fail` as pytorch has

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/assert.h
+++ b/libcudacxx/include/cuda/std/__cccl/assert.h
@@ -71,7 +71,7 @@
 // Reintroduce the __assert_fail declaration
 extern "C" {
 _CCCL_HOST_DEVICE void
-__assert_fail(const char* __assertion, const char* __file, unsigned int __line, const char* __function) __THROW
+__assert_fail(const char* __assertion, const char* __file, unsigned int __line, const char* __function) noexcept
   __attribute__((__noreturn__));
 }
 #  endif // NDEBUG

--- a/libcudacxx/include/cuda/std/__cccl/assert.h
+++ b/libcudacxx/include/cuda/std/__cccl/assert.h
@@ -24,6 +24,7 @@
 
 #include <cuda/std/__cccl/attributes.h>
 #include <cuda/std/__cccl/builtin.h>
+#include <cuda/std/__cccl/execution_space.h>
 
 #if !defined(_CCCL_COMPILER_NVRTC)
 #  include <assert.h>
@@ -68,9 +69,11 @@
 #else // ^^^ MSVC STL ^^^ / vvv !MSVC STL vvv
 #  ifdef NDEBUG
 // Reintroduce the __assert_fail declaration
-extern void
+extern "C" {
+_CCCL_HOST_DEVICE void
 __assert_fail(const char* __assertion, const char* __file, unsigned int __line, const char* __function) __THROW
   __attribute__((__noreturn__));
+}
 #  endif // NDEBUG
 // ICC cannot deal with `__builtin_expect` in the constexpr evaluator, so just drop it
 #  if defined(_CCCL_COMPILER_ICC)

--- a/libcudacxx/include/cuda/std/__cccl/assert.h
+++ b/libcudacxx/include/cuda/std/__cccl/assert.h
@@ -70,7 +70,10 @@
 #  ifdef NDEBUG
 // Reintroduce the __assert_fail declaration
 extern "C" {
-_CCCL_HOST_DEVICE void
+#    if !defined(_CCCL_CUDA_COMPILER_CLANG)
+_CCCL_HOST_DEVICE
+#    endif // !_CCCL_CUDA_COMPILER_CLANG
+void
 __assert_fail(const char* __assertion, const char* __file, unsigned int __line, const char* __function) noexcept
   __attribute__((__noreturn__));
 }


### PR DESCRIPTION
We do not want to break them and that definition is actually fine.

Fixes #2571