### PR TITLE
Fix miscellaneous bugs in cub/iterator documentation.

### DIFF
--- a/cub/cub/iterator/arg_index_input_iterator.cuh
+++ b/cub/cub/iterator/arg_index_input_iterator.cuh
@@ -64,8 +64,8 @@ CUB_NAMESPACE_BEGIN
  *        indices (forming \p KeyValuePair tuples).
  *
  * @par Overview
- * - ArgIndexInputIteratorTwraps a random access input iterator @p itr of type @p InputIteratorT.
- *   Dereferencing an ArgIndexInputIteratorTat offset @p i produces a @p KeyValuePair value whose
+ * - ArgIndexInputIterator wraps a random access input iterator @p itr of type @p InputIteratorT.
+ *   Dereferencing an ArgIndexInputIterator at offset @p i produces a @p KeyValuePair value whose
  *   @p key field is @p i and whose @p value field is <tt>itr[i]</tt>.
  * - Can be used with any data type.
  * - Can be constructed, manipulated, and exchanged within and between host and device
@@ -74,7 +74,7 @@ CUB_NAMESPACE_BEGIN
  * - Compatible with Thrust API v1.7 or newer.
  *
  * @par Snippet
- * The code snippet below illustrates the use of @p ArgIndexInputIteratorTto
+ * The code snippet below illustrates the use of @p ArgIndexInputIterator to
  * dereference an array of doubles
  * @par
  * @code
@@ -87,17 +87,16 @@ CUB_NAMESPACE_BEGIN
  * cub::ArgIndexInputIterator<double*> itr(d_in);
  *
  * // Within device code:
- * using Tuple = typename cub::ArgIndexInputIterator<double*>::value_type;
- * Tuple item_offset_pair.key = *itr;
- * printf("%f @ %d\n",
- *   item_offset_pair.value,
- *   item_offset_pair.key);   // 8.0 @ 0
+ * cub::ArgIndexInputIterator<double*>::value_type tup = *itr;
+ * printf("%f @ %ld\n",
+ *   tup.value,
+ *   tup.key);   // 8.0 @ 0
  *
  * itr = itr + 6;
- * item_offset_pair.key = *itr;
- * printf("%f @ %d\n",
- *   item_offset_pair.value,
- *   item_offset_pair.key);   // 9.0 @ 6
+ * tup = *itr;
+ * printf("%f @ %ld\n",
+ *   tup.value,
+ *   tup.key);   // 9.0 @ 6
  *
  * @endcode
  *

--- a/cub/cub/iterator/constant_input_iterator.cuh
+++ b/cub/cub/iterator/constant_input_iterator.cuh
@@ -61,7 +61,7 @@ CUB_NAMESPACE_BEGIN
  * @brief A random-access input generator for dereferencing a sequence of homogeneous values
  *
  * @par Overview
- * - Read references to a ConstantInputIteratorTiterator always return the supplied constant
+ * - Read references to a ConstantInputIterator always return the supplied constant
  *   of type @p ValueType.
  * - Can be used with any data type.
  * - Can be constructed, manipulated, dereferenced, and exchanged within and between host and device
@@ -69,7 +69,7 @@ CUB_NAMESPACE_BEGIN
  * - Compatible with Thrust API v1.7 or newer.
  *
  * @par Snippet
- * The code snippet below illustrates the use of @p ConstantInputIteratorTto
+ * The code snippet below illustrates the use of @p ConstantInputIterator to
  * dereference a sequence of homogeneous doubles.
  * @par
  * @code

--- a/cub/cub/iterator/counting_input_iterator.cuh
+++ b/cub/cub/iterator/counting_input_iterator.cuh
@@ -67,14 +67,14 @@ CUB_NAMESPACE_BEGIN
  * @brief A random-access input generator for dereferencing a sequence of incrementing integer values.
  *
  * @par Overview
- * - After initializing a CountingInputIteratorTto a certain integer @p base, read references
+ * - After initializing a CountingInputIterator to a certain integer @p base, read references
  *   at @p offset will return the value @p base + @p offset.
  * - Can be constructed, manipulated, dereferenced, and exchanged within and between host and device
  *   functions.
  * - Compatible with Thrust API v1.7 or newer.
  *
  * @par Snippet
- * The code snippet below illustrates the use of @p CountingInputIteratorTto
+ * The code snippet below illustrates the use of @p CountingInputIterator to
  * dereference a sequence of incrementing integers.
  * @par
  * @code

--- a/cub/cub/iterator/transform_input_iterator.cuh
+++ b/cub/cub/iterator/transform_input_iterator.cuh
@@ -61,7 +61,7 @@ CUB_NAMESPACE_BEGIN
  * @brief A random-access input wrapper for transforming dereferenced values.
  *
  * @par Overview
- * - TransformInputIteratorTwraps a unary conversion functor of type
+ * - TransformInputIterator wraps a unary conversion functor of type
  *   @p ConversionOp and a random-access input iterator of type <tt>InputIteratorT</tt>,
  *   using the former to produce references of type @p ValueType from the latter.
  * - Can be used with any data type.
@@ -71,7 +71,7 @@ CUB_NAMESPACE_BEGIN
  * - Compatible with Thrust API v1.7 or newer.
  *
  * @par Snippet
- * The code snippet below illustrates the use of @p TransformInputIteratorTto
+ * The code snippet below illustrates the use of @p TransformInputIterator to
  * dereference an array of integers, tripling the values and converting them to doubles.
  * @par
  * @code


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
<!-- closes --><!-- Link issue here -->
Noticed while working through cub/iterator files.

The cub/cub/iterator/arg_index_input_iterator.cuh documentation has this very confusing bug:

* `Tuple item_offset_pair.key = *itr;` must be `Tuple item_offset_pair = *itr;`

Also incorrect in the same file:

* `%d` must be `%ld`

The other changes are more minor fixes or enhancements.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
