### PR TITLE
add a config macro for testing support for inline variables

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -101,6 +101,7 @@
 #if _CCCL_STD_VER >= 2017 && defined(__cpp_inline_variables) && (__cpp_inline_variables >= 201606L)
 #  define _CCCL_INLINE_VAR inline
 #else // ^^^ C++14 ^^^ / vvv C++17 vvv
+#  define _CCCL_NO_INLINE_VARIABLES
 #  define _CCCL_INLINE_VAR
 #endif // _CCCL_STD_VER <= 2014
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_extended_floating_point.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_extended_floating_point.h
@@ -28,7 +28,7 @@ template <class _Tp>
 struct __is_extended_floating_point : false_type
 {};
 
-#if _CCCL_STD_VER >= 2017 && defined(__cpp_inline_variables) && (__cpp_inline_variables >= 201606L)
+#ifndef _LIBCUDACXX_HAS_NO_INLINE_VARIABLES
 template <class _Tp>
 _LIBCUDACXX_INLINE_VAR constexpr bool __is_extended_floating_point_v = false;
 #elif _CCCL_STD_VER >= 2014 && !defined(_LIBCUDACXX_HAS_NO_VARIABLE_TEMPLATES)
@@ -43,7 +43,7 @@ template <>
 struct __is_extended_floating_point<__half> : true_type
 {};
 
-#  if _CCCL_STD_VER >= 2017 && defined(__cpp_inline_variables) && (__cpp_inline_variables >= 201606L)
+#  ifndef _LIBCUDACXX_HAS_NO_INLINE_VARIABLES
 template <>
 _LIBCUDACXX_INLINE_VAR constexpr bool __is_extended_floating_point_v<__half> = true;
 #  endif // _CCCL_STD_VER >= 2014
@@ -59,7 +59,7 @@ template <>
 struct __is_extended_floating_point<__nv_bfloat16> : true_type
 {};
 
-#  if _CCCL_STD_VER >= 2017 && defined(__cpp_inline_variables) && (__cpp_inline_variables >= 201606L)
+#  ifndef _LIBCUDACXX_HAS_NO_INLINE_VARIABLES
 template <>
 _LIBCUDACXX_INLINE_VAR constexpr bool __is_extended_floating_point_v<__nv_bfloat16> = true;
 #  endif // _CCCL_STD_VER >= 2014

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -190,7 +190,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_list
 
 // Before the addition of inline variables, it was necessary to
 // provide a definition for constexpr class static data members.
-#  if _CCCL_STD_VER >= 2017 && defined(__cpp_inline_variables) && (__cpp_inline_variables >= 201606L)
+#  ifndef _LIBCUDACXX_HAS_NO_INLINE_VARIABLES
 template <class... _Ts>
 constexpr size_t const __type_list<_Ts...>::__size;
 #  endif

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -723,10 +723,9 @@ typedef unsigned int char32_t;
 #    define _LIBCUDACXX_DEPRECATED_IN_CXX20
 #  endif
 
-#  if _CCCL_STD_VER > 2014 && defined(__cpp_inline_variables) && (__cpp_inline_variables >= 201606L)
-#    define _LIBCUDACXX_INLINE_VAR inline
-#  else
-#    define _LIBCUDACXX_INLINE_VAR
+#  define _LIBCUDACXX_INLINE_VAR _CCCL_INLINE_VAR
+#  if defined(_CCCL_NO_INLINE_VARIABLES)
+#    define _LIBCUDACXX_HAS_NO_INLINE_VARIABLES
 #  endif
 
 #  ifdef _LIBCUDACXX_HAS_NO_RVALUE_REFERENCES


### PR DESCRIPTION
## Description

We have feature tests for `__cpp_inline_variables` smeared out all over. We should have a single config macro for that.

This PR adds a `_CCCL_NO_INLINE_VARIABLES` config macro. It also defines `_LIBCUDACXX_HAS_NO_INLINE_VARIABLES` in terms of it and used that instead of directly testing for `defined(__cpp_inline_variables)` elsewhere.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
