### PR TITLE
assert that `cuda::std::declval` is `noexcept`

### DIFF
--- a/libcudacxx/test/libcudacxx/std/utilities/utility/declval/declval.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/declval/declval.pass.cpp
@@ -25,6 +25,7 @@ class A
 int main(int, char**)
 {
   static_assert((cuda::std::is_same<decltype(cuda::std::declval<A>()), A&&>::value), "");
+  static_assert(noexcept(cuda::std::declval<A>()), "");
 
   return 0;
 }


### PR DESCRIPTION
## Description

`declval<T>()` has two jobs: have a `T&&` type and be `noexcept`. test both of them.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
