### PR TITLE
CCCL_TOPLEVEL_PROJECT always needs to be defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 # Determine whether CCCL is the top-level project or included into
 # another project via add_subdirectory()
+set(CCCL_TOPLEVEL_PROJECT OFF)
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
   set(CCCL_TOPLEVEL_PROJECT ON)
 endif()


### PR DESCRIPTION
## Description

The `cccl_generate_install_rules` requires two arguments. When `CCCL_TOPLEVEL_PROJECT` doesn't exist all the existing calls will have `HEADERS_INCLUDE` or `NO_HEADERS` become the second argument.

Currently consuming projects need to explicitly define `CCCL_TOPLEVEL_PROJECT` to `OFF` so that valid install rules are generated.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
