### PR TITLE
add `__is_callable_v` variable template when possible

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/is_callable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_callable.h
@@ -34,6 +34,11 @@ template <class _Func, class... _Args>
 struct __is_callable : decltype(__is_callable_helper<_Func, _Args...>(0))
 {};
 
+#ifndef _CCCL_NO_VARIABLE_TEMPLATES
+template <class _Func, class... _Args>
+_CCCL_INLINE_VAR constexpr bool __is_callable_v = decltype(__is_callable_helper<_Func, _Args...>(0))::value;
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
+
 _LIBCUDACXX_END_NAMESPACE_STD
 
 #endif // _LIBCUDACXX___TYPE_TRAITS_IS_CALLABLE_H


### PR DESCRIPTION
## Description

i want to be able to check callability without instantiating a class template. i will be using this in an upcoming PR.
