### PR TITLE
Introduce `_CCCL_PRAGMA` to CCCL

### DIFF
--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -385,7 +385,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 #  define UBLKCP_AGENT(full_tile)                                                                                    \
     _CCCL_PRAGMA(unroll 1) /* Unroll 1 tends to improve performance, especially for smaller data types (confirmed by \
                               benchmark) */                                                                          \
-      for (int j = 0; j < num_elem_per_thread; ++j)                                                                  \
+    for (int j = 0; j < num_elem_per_thread; ++j)                                                                    \
     {                                                                                                                \
       const int idx = j * block_dim + threadIdx.x;                                                                   \
       if (full_tile || idx < tile_size)                                                                              \

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -382,22 +382,22 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
   // note: I tried expressing the UBLKCP_AGENT as a function object but it adds a lot of code to handle the variadics
   // TODO(bgruber): use a polymorphic lambda in C++14
-#  define UBLKCP_AGENT(full_tile)                                                                                 \
-    _Pragma("unroll 1") /* Unroll 1 tends to improve performance, especially for smaller data types (confirmed by \
-                             benchmark) */                                                                        \
-      for (int j = 0; j < num_elem_per_thread; ++j)                                                               \
-    {                                                                                                             \
-      const int idx = j * block_dim + threadIdx.x;                                                                \
-      if (full_tile || idx < tile_size)                                                                           \
-      {                                                                                                           \
-        int smem_offset = 0;                                                                                      \
-        /* need to expand into a tuple for guaranteed order of evaluation*/                                       \
-        out[idx] = poor_apply(                                                                                    \
-          [&](const InTs&... values) {                                                                            \
-            return f(values...);                                                                                  \
-          },                                                                                                      \
-          ::cuda::std::tuple<InTs...>{fetch_operand(tile_stride, smem, smem_offset, idx, aligned_ptrs)...});      \
-      }                                                                                                           \
+#  define UBLKCP_AGENT(full_tile)                                                                                    \
+    _CCCL_PRAGMA(unroll 1) /* Unroll 1 tends to improve performance, especially for smaller data types (confirmed by \
+                              benchmark) */                                                                          \
+      for (int j = 0; j < num_elem_per_thread; ++j)                                                                  \
+    {                                                                                                                \
+      const int idx = j * block_dim + threadIdx.x;                                                                   \
+      if (full_tile || idx < tile_size)                                                                              \
+      {                                                                                                              \
+        int smem_offset = 0;                                                                                         \
+        /* need to expand into a tuple for guaranteed order of evaluation*/                                          \
+        out[idx] = poor_apply(                                                                                       \
+          [&](const InTs&... values) {                                                                               \
+            return f(values...);                                                                                     \
+          },                                                                                                         \
+          ::cuda::std::tuple<InTs...>{fetch_operand(tile_stride, smem, smem_offset, idx, aligned_ptrs)...});         \
+      }                                                                                                              \
     }
   if (tile_stride == tile_size)
   {

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -382,22 +382,22 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
   // note: I tried expressing the UBLKCP_AGENT as a function object but it adds a lot of code to handle the variadics
   // TODO(bgruber): use a polymorphic lambda in C++14
-#  define UBLKCP_AGENT(full_tile)                                                                                    \
-    _CCCL_PRAGMA(unroll 1) /* Unroll 1 tends to improve performance, especially for smaller data types (confirmed by \
-                              benchmark) */                                                                          \
-    for (int j = 0; j < num_elem_per_thread; ++j)                                                                    \
-    {                                                                                                                \
-      const int idx = j * block_dim + threadIdx.x;                                                                   \
-      if (full_tile || idx < tile_size)                                                                              \
-      {                                                                                                              \
-        int smem_offset = 0;                                                                                         \
-        /* need to expand into a tuple for guaranteed order of evaluation*/                                          \
-        out[idx] = poor_apply(                                                                                       \
-          [&](const InTs&... values) {                                                                               \
-            return f(values...);                                                                                     \
-          },                                                                                                         \
-          ::cuda::std::tuple<InTs...>{fetch_operand(tile_stride, smem, smem_offset, idx, aligned_ptrs)...});         \
-      }                                                                                                              \
+#  define UBLKCP_AGENT(full_tile)                                                                            \
+    /* Unroll 1 tends to improve performance, especially for smaller data types (confirmed by benchmark) */  \
+    _CCCL_PRAGMA(unroll 1)                                                                                   \
+    for (int j = 0; j < num_elem_per_thread; ++j)                                                            \
+    {                                                                                                        \
+      const int idx = j * block_dim + threadIdx.x;                                                           \
+      if (full_tile || idx < tile_size)                                                                      \
+      {                                                                                                      \
+        int smem_offset = 0;                                                                                 \
+        /* need to expand into a tuple for guaranteed order of evaluation*/                                  \
+        out[idx] = poor_apply(                                                                               \
+          [&](const InTs&... values) {                                                                       \
+            return f(values...);                                                                             \
+          },                                                                                                 \
+          ::cuda::std::tuple<InTs...>{fetch_operand(tile_stride, smem, smem_offset, idx, aligned_ptrs)...}); \
+      }                                                                                                      \
     }
   if (tile_stride == tile_size)
   {

--- a/cub/cub/util_cpp_dialect.cuh
+++ b/cub/cub/util_cpp_dialect.cuh
@@ -81,7 +81,7 @@
 
 // Define CUB_COMPILER_DEPRECATION macro:
 #  if defined(_CCCL_COMPILER_MSVC)
-#    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TOSTRING(__LINE__) ": warning: " #msg))
+#    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TO_STRING(__LINE__) ": warning: " #msg))
 #  else // clang / gcc:
 #    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(GCC warning #msg)
 #  endif

--- a/cub/cub/util_cpp_dialect.cuh
+++ b/cub/cub/util_cpp_dialect.cuh
@@ -83,7 +83,7 @@
 #  if defined(_CCCL_COMPILER_MSVC)
 #    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TOSTRING(__LINE__) ": warning: " #msg))
 #  else // clang / gcc:
-#    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(GCC warning _CCCL_TOSTRING(msg))
+#    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(GCC warning #msg)
 #  endif
 
 #  define CUB_COMPILER_DEPRECATION(REQ) \

--- a/cub/cub/util_cpp_dialect.cuh
+++ b/cub/cub/util_cpp_dialect.cuh
@@ -81,13 +81,9 @@
 
 // Define CUB_COMPILER_DEPRECATION macro:
 #  if defined(_CCCL_COMPILER_MSVC)
-#    define CUB_COMP_DEPR_IMPL(msg) __pragma(message(__FILE__ ":" CUB_COMP_DEPR_IMPL0(__LINE__) ": warning: " #msg))
-#    define CUB_COMP_DEPR_IMPL0(x)  CUB_COMP_DEPR_IMPL1(x)
-#    define CUB_COMP_DEPR_IMPL1(x)  #x
+#    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TOSTRING(__LINE__) ": warning: " #msg))
 #  else // clang / gcc:
-#    define CUB_COMP_DEPR_IMPL(msg)   CUB_COMP_DEPR_IMPL0(GCC warning #msg)
-#    define CUB_COMP_DEPR_IMPL0(expr) _Pragma(#expr)
-#    define CUB_COMP_DEPR_IMPL1       /* intentionally blank */
+#    define CUB_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(GCC warning _CCCL_TOSTRING(msg))
 #  endif
 
 #  define CUB_COMPILER_DEPRECATION(REQ) \

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -100,4 +100,15 @@
 #  define _CCCL_CUDACC_BELOW_12_3
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
 
+// Enable us to selectively silence host compiler warnings
+#define _CCCL_TOSTRING2(_STR) #_STR
+#define _CCCL_TOSTRING(_STR)  _CCCL_TOSTRING2(_STR)
+
+// Define the pragma for the host compiler
+#if defined(_CCCL_COMPILER_MSVC)
+#  define _CCCL_PRAGMA(x) __pragma(x)
+#else
+#  define _CCCL_PRAGMA(x) _Pragma(_CCCL_TOSTRING(x))
+#endif // defined(_CCCL_COMPILER_MSVC)
+
 #endif // __CCCL_COMPILER_H

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -100,15 +100,15 @@
 #  define _CCCL_CUDACC_BELOW_12_3
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
 
-// Enable us to selectively silence host compiler warnings
-#define _CCCL_TOSTRING2(_STR) #_STR
-#define _CCCL_TOSTRING(_STR)  _CCCL_TOSTRING2(_STR)
+// Convert parameter to string
+#define _CCCL_TO_STRING2(_STR) #_STR
+#define _CCCL_TO_STRING(_STR)  _CCCL_TO_STRING2(_STR)
 
 // Define the pragma for the host compiler
 #if defined(_CCCL_COMPILER_MSVC)
 #  define _CCCL_PRAGMA(x) __pragma(x)
 #else
-#  define _CCCL_PRAGMA(x) _Pragma(_CCCL_TOSTRING(x))
+#  define _CCCL_PRAGMA(x) _Pragma(_CCCL_TO_STRING(x))
 #endif // defined(_CCCL_COMPILER_MSVC)
 
 #endif // __CCCL_COMPILER_H

--- a/libcudacxx/include/cuda/std/__cccl/diagnostic.h
+++ b/libcudacxx/include/cuda/std/__cccl/diagnostic.h
@@ -31,36 +31,36 @@
 #  define _CCCL_DIAG_SUPPRESS_MSVC(str)
 #  define _CCCL_DIAG_SUPPRESS_ICC(str)
 #elif defined(_CCCL_COMPILER_GCC)
-#  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(GCC diagnostic push)
-#  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(GCC diagnostic pop)
+#  define _CCCL_DIAG_PUSH _CCCL_PRAGMA(GCC diagnostic push)
+#  define _CCCL_DIAG_POP  _CCCL_PRAGMA(GCC diagnostic pop)
 #  define _CCCL_DIAG_SUPPRESS_CLANG(str)
-#  define _CCCL_DIAG_SUPPRESS_GCC(str)   _CCCL_PRAGMA(GCC diagnostic ignored str)
+#  define _CCCL_DIAG_SUPPRESS_GCC(str) _CCCL_PRAGMA(GCC diagnostic ignored str)
 #  define _CCCL_DIAG_SUPPRESS_NVHPC(str)
 #  define _CCCL_DIAG_SUPPRESS_MSVC(str)
 #  define _CCCL_DIAG_SUPPRESS_ICC(str)
 #elif defined(_CCCL_COMPILER_ICC)
-#  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(GCC diagnostic push)
-#  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(GCC diagnostic pop)
+#  define _CCCL_DIAG_PUSH _CCCL_PRAGMA(GCC diagnostic push)
+#  define _CCCL_DIAG_POP  _CCCL_PRAGMA(GCC diagnostic pop)
 #  define _CCCL_DIAG_SUPPRESS_CLANG(str)
-#  define _CCCL_DIAG_SUPPRESS_GCC(str)   _CCCL_PRAGMA(GCC diagnostic ignored str)
+#  define _CCCL_DIAG_SUPPRESS_GCC(str) _CCCL_PRAGMA(GCC diagnostic ignored str)
 #  define _CCCL_DIAG_SUPPRESS_NVHPC(str)
 #  define _CCCL_DIAG_SUPPRESS_MSVC(str)
-#  define _CCCL_DIAG_SUPPRESS_ICC(str)   _CCCL_PRAGMA(warning disable str)
+#  define _CCCL_DIAG_SUPPRESS_ICC(str) _CCCL_PRAGMA(warning disable str)
 #elif defined(_CCCL_COMPILER_NVHPC)
-#  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(diagnostic push)
-#  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(diagnostic pop)
+#  define _CCCL_DIAG_PUSH _CCCL_PRAGMA(diagnostic push)
+#  define _CCCL_DIAG_POP  _CCCL_PRAGMA(diagnostic pop)
 #  define _CCCL_DIAG_SUPPRESS_CLANG(str)
 #  define _CCCL_DIAG_SUPPRESS_GCC(str)
 #  define _CCCL_DIAG_SUPPRESS_NVHPC(str) _CCCL_PRAGMA(diag_suppress str)
 #  define _CCCL_DIAG_SUPPRESS_MSVC(str)
 #  define _CCCL_DIAG_SUPPRESS_ICC(str)
 #elif defined(_CCCL_COMPILER_MSVC)
-#  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(warning(push))
-#  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(warning(pop))
+#  define _CCCL_DIAG_PUSH _CCCL_PRAGMA(warning(push))
+#  define _CCCL_DIAG_POP  _CCCL_PRAGMA(warning(pop))
 #  define _CCCL_DIAG_SUPPRESS_CLANG(str)
 #  define _CCCL_DIAG_SUPPRESS_GCC(str)
 #  define _CCCL_DIAG_SUPPRESS_NVHPC(str)
-#  define _CCCL_DIAG_SUPPRESS_MSVC(str)  _CCCL_PRAGMA(warning(disable : str))
+#  define _CCCL_DIAG_SUPPRESS_MSVC(str) _CCCL_PRAGMA(warning(disable : str))
 #  define _CCCL_DIAG_SUPPRESS_ICC(str)
 #else
 #  define _CCCL_DIAG_PUSH
@@ -105,14 +105,12 @@
 #      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _CCCL_PRAGMA(nv_diag_suppress _WARNING)
 #      define _CCCL_NV_DIAG_DEFAULT(_WARNING)  _CCCL_PRAGMA(nv_diag_default _WARNING)
 #    else // ^^^ _CCCL_COMPILER_{MSVC,ICC}^^^ / vvv !_CCCL_COMPILER_{MSVC,ICC} vvv
-#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) \
-        _CCCL_PRAGMA(nv_diagnostic push) _CCCL_PRAGMA(nv_diag_suppress _WARNING)
-#      define _CCCL_NV_DIAG_DEFAULT(_WARNING) _CCCL_PRAGMA(nv_diagnostic pop)
+#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _CCCL_PRAGMA(nv_diagnostic push) _CCCL_PRAGMA(nv_diag_suppress _WARNING)
+#      define _CCCL_NV_DIAG_DEFAULT(_WARNING)  _CCCL_PRAGMA(nv_diagnostic pop)
 #    endif // !_CCCL_COMPILER_MSVC
 #  elif defined(_CCCL_COMPILER_NVHPC)
-#    define _CCCL_NV_DIAG_SUPPRESS(_WARNING) \
-      _CCCL_PRAGMA(diagnostic push) _CCCL_PRAGMA(diag_suppress _WARNING)
-#    define _CCCL_NV_DIAG_DEFAULT(_WARNING) _CCCL_PRAGMA(diagnostic pop)
+#    define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _CCCL_PRAGMA(diagnostic push) _CCCL_PRAGMA(diag_suppress _WARNING)
+#    define _CCCL_NV_DIAG_DEFAULT(_WARNING)  _CCCL_PRAGMA(diagnostic pop)
 #  else // ^^^ __NVCC_DIAG_PRAGMA_SUPPORT__ ^^^ / vvv !__NVCC_DIAG_PRAGMA_SUPPORT__ vvv
 #    if defined(_CCCL_COMPILER_MSVC_2017) // MSVC 2017 has issues with restoring the warning
 #      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _CCCL_PRAGMA(diag_suppress _WARNING)
@@ -146,9 +144,9 @@
 // warning C4800: 'boo': forcing value to bool 'true' or 'false' (performance warning)
 // warning C4996: 'meow': was declared deprecated
 #  define _CCCL_MSVC_DISABLED_WARNINGS 4100 4127 4180 4197 4296 4324 4455 4503 4522 4668 4800 4996 /**/
-#  define _CCCL_MSVC_WARNINGS_PUSH     \
-     _CCCL_PRAGMA(warning(push)) _CCCL_PRAGMA(warning(disable : _CCCL_MSVC_DISABLED_WARNINGS))
-#  define _CCCL_MSVC_WARNINGS_POP      _CCCL_PRAGMA(warning(pop))
+#  define _CCCL_MSVC_WARNINGS_PUSH \
+    _CCCL_PRAGMA(warning(push)) _CCCL_PRAGMA(warning(disable : _CCCL_MSVC_DISABLED_WARNINGS))
+#  define _CCCL_MSVC_WARNINGS_POP _CCCL_PRAGMA(warning(pop))
 #else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
 #  define _CCCL_MSVC_WARNINGS_PUSH
 #  define _CCCL_MSVC_WARNINGS_POP

--- a/libcudacxx/include/cuda/std/__cccl/diagnostic.h
+++ b/libcudacxx/include/cuda/std/__cccl/diagnostic.h
@@ -22,6 +22,7 @@
 #  pragma system_header
 #endif // no system header
 
+// Enable us to selectively silence host compiler warnings
 #ifdef _CCCL_COMPILER_CLANG
 #  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(clang diagnostic push)
 #  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(clang diagnostic pop)

--- a/libcudacxx/include/cuda/std/__cccl/diagnostic.h
+++ b/libcudacxx/include/cuda/std/__cccl/diagnostic.h
@@ -22,48 +22,45 @@
 #  pragma system_header
 #endif // no system header
 
-// Enable us to selectively silence host compiler warnings
-#define _CCCL_TOSTRING2(_STR) #_STR
-#define _CCCL_TOSTRING(_STR)  _CCCL_TOSTRING2(_STR)
 #ifdef _CCCL_COMPILER_CLANG
-#  define _CCCL_DIAG_PUSH                _Pragma("clang diagnostic push")
-#  define _CCCL_DIAG_POP                 _Pragma("clang diagnostic pop")
-#  define _CCCL_DIAG_SUPPRESS_CLANG(str) _Pragma(_CCCL_TOSTRING(clang diagnostic ignored str))
+#  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(clang diagnostic push)
+#  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(clang diagnostic pop)
+#  define _CCCL_DIAG_SUPPRESS_CLANG(str) _CCCL_PRAGMA(clang diagnostic ignored str)
 #  define _CCCL_DIAG_SUPPRESS_GCC(str)
 #  define _CCCL_DIAG_SUPPRESS_NVHPC(str)
 #  define _CCCL_DIAG_SUPPRESS_MSVC(str)
 #  define _CCCL_DIAG_SUPPRESS_ICC(str)
 #elif defined(_CCCL_COMPILER_GCC)
-#  define _CCCL_DIAG_PUSH _Pragma("GCC diagnostic push")
-#  define _CCCL_DIAG_POP  _Pragma("GCC diagnostic pop")
+#  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(GCC diagnostic push)
+#  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(GCC diagnostic pop)
 #  define _CCCL_DIAG_SUPPRESS_CLANG(str)
-#  define _CCCL_DIAG_SUPPRESS_GCC(str) _Pragma(_CCCL_TOSTRING(GCC diagnostic ignored str))
+#  define _CCCL_DIAG_SUPPRESS_GCC(str)   _CCCL_PRAGMA(GCC diagnostic ignored str)
 #  define _CCCL_DIAG_SUPPRESS_NVHPC(str)
 #  define _CCCL_DIAG_SUPPRESS_MSVC(str)
 #  define _CCCL_DIAG_SUPPRESS_ICC(str)
 #elif defined(_CCCL_COMPILER_ICC)
-#  define _CCCL_DIAG_PUSH _Pragma("GCC diagnostic push")
-#  define _CCCL_DIAG_POP  _Pragma("GCC diagnostic pop")
+#  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(GCC diagnostic push)
+#  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(GCC diagnostic pop)
 #  define _CCCL_DIAG_SUPPRESS_CLANG(str)
-#  define _CCCL_DIAG_SUPPRESS_GCC(str) _Pragma(_CCCL_TOSTRING(GCC diagnostic ignored str))
+#  define _CCCL_DIAG_SUPPRESS_GCC(str)   _CCCL_PRAGMA(GCC diagnostic ignored str)
 #  define _CCCL_DIAG_SUPPRESS_NVHPC(str)
 #  define _CCCL_DIAG_SUPPRESS_MSVC(str)
-#  define _CCCL_DIAG_SUPPRESS_ICC(str) _Pragma(_CCCL_TOSTRING(warning disable str))
+#  define _CCCL_DIAG_SUPPRESS_ICC(str)   _CCCL_PRAGMA(warning disable str)
 #elif defined(_CCCL_COMPILER_NVHPC)
-#  define _CCCL_DIAG_PUSH _Pragma("diagnostic push")
-#  define _CCCL_DIAG_POP  _Pragma("diagnostic pop")
+#  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(diagnostic push)
+#  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(diagnostic pop)
 #  define _CCCL_DIAG_SUPPRESS_CLANG(str)
 #  define _CCCL_DIAG_SUPPRESS_GCC(str)
-#  define _CCCL_DIAG_SUPPRESS_NVHPC(str) _Pragma(_CCCL_TOSTRING(diag_suppress str))
+#  define _CCCL_DIAG_SUPPRESS_NVHPC(str) _CCCL_PRAGMA(diag_suppress str)
 #  define _CCCL_DIAG_SUPPRESS_MSVC(str)
 #  define _CCCL_DIAG_SUPPRESS_ICC(str)
 #elif defined(_CCCL_COMPILER_MSVC)
-#  define _CCCL_DIAG_PUSH __pragma(warning(push))
-#  define _CCCL_DIAG_POP  __pragma(warning(pop))
+#  define _CCCL_DIAG_PUSH                _CCCL_PRAGMA(warning(push))
+#  define _CCCL_DIAG_POP                 _CCCL_PRAGMA(warning(pop))
 #  define _CCCL_DIAG_SUPPRESS_CLANG(str)
 #  define _CCCL_DIAG_SUPPRESS_GCC(str)
 #  define _CCCL_DIAG_SUPPRESS_NVHPC(str)
-#  define _CCCL_DIAG_SUPPRESS_MSVC(str) __pragma(warning(disable : str))
+#  define _CCCL_DIAG_SUPPRESS_MSVC(str)  _CCCL_PRAGMA(warning(disable : str))
 #  define _CCCL_DIAG_SUPPRESS_ICC(str)
 #else
 #  define _CCCL_DIAG_PUSH
@@ -103,33 +100,27 @@
 #  if defined(_CCCL_CUDA_COMPILER_CLANG)
 #    define _CCCL_NV_DIAG_SUPPRESS(_WARNING)
 #    define _CCCL_NV_DIAG_DEFAULT(_WARNING)
-#  elif defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
+#  elif defined(__NVCC_DIAG_PRAGMA_SUPPORT__) || defined(_CCCL_COMPILER_ICC)
 #    if defined(_CCCL_COMPILER_MSVC)
-#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) __pragma(_CCCL_TOSTRING(nv_diag_suppress _WARNING))
-#      define _CCCL_NV_DIAG_DEFAULT(_WARNING)  __pragma(_CCCL_TOSTRING(nv_diag_default _WARNING))
-#    elif defined(_CCCL_COMPILER_ICC) // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv _CCCL_COMPILER_ICCvvv
-#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _Pragma(_CCCL_TOSTRING(nv_diag_suppress _WARNING))
-#      define _CCCL_NV_DIAG_DEFAULT(_WARNING)  _Pragma(_CCCL_TOSTRING(nv_diag_default _WARNING))
-#    else // ^^^ _CCCL_COMPILER_ICC^^^ / vvv !_CCCL_COMPILER_{MSVC,ICC} vvv
+#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _CCCL_PRAGMA(nv_diag_suppress _WARNING)
+#      define _CCCL_NV_DIAG_DEFAULT(_WARNING)  _CCCL_PRAGMA(nv_diag_default _WARNING)
+#    else // ^^^ _CCCL_COMPILER_{MSVC,ICC}^^^ / vvv !_CCCL_COMPILER_{MSVC,ICC} vvv
 #      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) \
-        _Pragma(_CCCL_TOSTRING(nv_diagnostic push)) _Pragma(_CCCL_TOSTRING(nv_diag_suppress _WARNING))
-#      define _CCCL_NV_DIAG_DEFAULT(_WARNING) _Pragma(_CCCL_TOSTRING(nv_diagnostic pop))
+        _CCCL_PRAGMA(nv_diagnostic push) _CCCL_PRAGMA(nv_diag_suppress _WARNING)
+#      define _CCCL_NV_DIAG_DEFAULT(_WARNING) _CCCL_PRAGMA(nv_diagnostic pop)
 #    endif // !_CCCL_COMPILER_MSVC
 #  elif defined(_CCCL_COMPILER_NVHPC)
 #    define _CCCL_NV_DIAG_SUPPRESS(_WARNING) \
-      _Pragma(_CCCL_TOSTRING(diagnostic push)) _Pragma(_CCCL_TOSTRING(diag_suppress _WARNING))
-#    define _CCCL_NV_DIAG_DEFAULT(_WARNING) _Pragma(_CCCL_TOSTRING(diagnostic pop))
+      _CCCL_PRAGMA(diagnostic push) _CCCL_PRAGMA(diag_suppress _WARNING)
+#    define _CCCL_NV_DIAG_DEFAULT(_WARNING) _CCCL_PRAGMA(diagnostic pop)
 #  else // ^^^ __NVCC_DIAG_PRAGMA_SUPPORT__ ^^^ / vvv !__NVCC_DIAG_PRAGMA_SUPPORT__ vvv
 #    if defined(_CCCL_COMPILER_MSVC_2017) // MSVC 2017 has issues with restoring the warning
-#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) __pragma(_CCCL_TOSTRING(diag_suppress _WARNING))
+#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _CCCL_PRAGMA(diag_suppress _WARNING)
 #      define _CCCL_NV_DIAG_DEFAULT(_WARNING)
-#    elif defined(_CCCL_COMPILER_MSVC)
-#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) __pragma(_CCCL_TOSTRING(diag_suppress _WARNING))
-#      define _CCCL_NV_DIAG_DEFAULT(_WARNING)  __pragma(_CCCL_TOSTRING(diag_default _WARNING))
-#    else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
-#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _Pragma(_CCCL_TOSTRING(diag_suppress _WARNING))
-#      define _CCCL_NV_DIAG_DEFAULT(_WARNING)  _Pragma(_CCCL_TOSTRING(diag_default _WARNING))
-#    endif // !_CCCL_COMPILER_MSVC
+#    else // ^^^ _CCCL_COMPILER_MSVC_2017 ^^^ / vvv !_CCCL_COMPILER_MSVC_2017 vvv
+#      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _CCCL_PRAGMA(diag_suppress _WARNING)
+#      define _CCCL_NV_DIAG_DEFAULT(_WARNING)  _CCCL_PRAGMA(diag_default _WARNING)
+#    endif // !_CCCL_COMPILER_MSVC_2017
 #  endif // !__NVCC_DIAG_PRAGMA_SUPPORT__
 #else // ^^^ _CCCL_CUDA_COMPILER ^^^ / vvv !_CCCL_CUDA_COMPILER vvv
 #  define _CCCL_NV_DIAG_SUPPRESS(_WARNING)
@@ -155,8 +146,9 @@
 // warning C4800: 'boo': forcing value to bool 'true' or 'false' (performance warning)
 // warning C4996: 'meow': was declared deprecated
 #  define _CCCL_MSVC_DISABLED_WARNINGS 4100 4127 4180 4197 4296 4324 4455 4503 4522 4668 4800 4996 /**/
-#  define _CCCL_MSVC_WARNINGS_PUSH     __pragma(warning(push)) __pragma(warning(disable : _CCCL_MSVC_DISABLED_WARNINGS))
-#  define _CCCL_MSVC_WARNINGS_POP      __pragma(warning(pop))
+#  define _CCCL_MSVC_WARNINGS_PUSH     \
+     _CCCL_PRAGMA(warning(push)) _CCCL_PRAGMA(warning(disable : _CCCL_MSVC_DISABLED_WARNINGS))
+#  define _CCCL_MSVC_WARNINGS_POP      _CCCL_PRAGMA(warning(pop))
 #else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
 #  define _CCCL_MSVC_WARNINGS_PUSH
 #  define _CCCL_MSVC_WARNINGS_POP
@@ -172,13 +164,9 @@
 #  define _CCCL_PUSH_MACROS _CCCL_MSVC_WARNINGS_PUSH
 #  define _CCCL_POP_MACROS  _CCCL_MSVC_WARNINGS_POP
 #else // ^^^ _CCCL_HAS_NO_PRAGMA_PUSH_POP_MACRO ^^^ / vvv !_CCCL_HAS_NO_PRAGMA_PUSH_POP_MACRO vvv
-#  if defined(_CCCL_COMPILER_MSVC)
-#    define _CCCL_PUSH_MACROS __pragma(push_macro("min")) __pragma(push_macro("max")) _CCCL_MSVC_WARNINGS_PUSH
-#    define _CCCL_POP_MACROS  __pragma(pop_macro("min")) __pragma(pop_macro("max")) _CCCL_MSVC_WARNINGS_POP
-#  else
-#    define _CCCL_PUSH_MACROS _Pragma("push_macro(\"min\")") _Pragma("push_macro(\"max\")")
-#    define _CCCL_POP_MACROS  _Pragma("pop_macro(\"min\")") _Pragma("pop_macro(\"max\")")
-#  endif
+#  define _CCCL_PUSH_MACROS _CCCL_PRAGMA(push_macro("min")) _CCCL_PRAGMA(push_macro("max")) _CCCL_MSVC_WARNINGS_PUSH
+#  define _CCCL_POP_MACROS  _CCCL_PRAGMA(pop_macro("min")) _CCCL_PRAGMA(pop_macro("max")) _CCCL_MSVC_WARNINGS_POP
+
 #endif // !_CCCL_HAS_NO_PRAGMA_PUSH_POP_MACRO
 
 #endif // __CCCL_DIAGNOSTIC_H

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -50,11 +50,7 @@
 
 #if !defined(_CCCL_EXEC_CHECK_DISABLE)
 #  if defined(_CCCL_CUDA_COMPILER_NVCC)
-#    if defined(_CCCL_COMPILER_MSVC)
-#      define _CCCL_EXEC_CHECK_DISABLE __pragma("nv_exec_check_disable")
-#    else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
-#      define _CCCL_EXEC_CHECK_DISABLE _Pragma("nv_exec_check_disable")
-#    endif // !_CCCL_COMPILER_MSVC
+#    define _CCCL_EXEC_CHECK_DISABLE _CCCL_PRAGMA(nv_exec_check_disable)
 #  else
 #    define _CCCL_EXEC_CHECK_DISABLE
 #  endif // _CCCL_CUDA_COMPILER_NVCC

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -405,8 +405,7 @@ typedef __char32_t char32_t;
 
 #  elif defined(_CCCL_COMPILER_MSVC)
 
-#    define _LIBCUDACXX_WARNING(x) \
-       _CCCL_PRAGMA(message(__FILE__ "(" _CCCL_TOSTRING(__LINE__) ") : warning note: " x))
+#    define _LIBCUDACXX_WARNING(x) _CCCL_PRAGMA(message(__FILE__ "(" _CCCL_TOSTRING(__LINE__) ") : warning note: " x))
 
 #    if _MSC_VER < 1900
 #      error "MSVC versions prior to Visual Studio 2015 are not supported"

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -405,7 +405,7 @@ typedef __char32_t char32_t;
 
 #  elif defined(_CCCL_COMPILER_MSVC)
 
-#    define _LIBCUDACXX_WARNING(x) _CCCL_PRAGMA(message(__FILE__ "(" _CCCL_TOSTRING(__LINE__) ") : warning note: " x))
+#    define _LIBCUDACXX_WARNING(x) _CCCL_PRAGMA(message(__FILE__ "(" _CCCL_TO_STRING(__LINE__) ") : warning note: " x))
 
 #    if _MSC_VER < 1900
 #      error "MSVC versions prior to Visual Studio 2015 are not supported"

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -319,17 +319,10 @@ extern "C++" {
 #    define _CCCL_ALIGNAS(x)      __attribute__((__aligned__(x)))
 #  endif // !_CCCL_COMPILER_MSVC && !_CCCL_HAS_FEATURE(cxx_alignas)
 
-#  define _LIBCUDACXX_TOSTRING2(_STR) #_STR
-#  define _LIBCUDACXX_TOSTRING(_STR)  _LIBCUDACXX_TOSTRING2(_STR)
-
 // This is wrapped in __CUDA_ARCH__ to prevent error: "ignoring '#pragma unroll'
 // [-Werror=unknown-pragmas]"
 #  if defined(__CUDA_ARCH__)
-#    if defined(_CCCL_COMPILER_MSVC)
-#      define _LIBCUDACXX_PRAGMA_UNROLL(_N) __pragma(_LIBCUDACXX_TOSTRING(unroll _N))
-#    else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
-#      define _LIBCUDACXX_PRAGMA_UNROLL(_N) _Pragma(_LIBCUDACXX_TOSTRING(unroll _N))
-#    endif // !_CCCL_COMPILER_MSVC
+#    define _LIBCUDACXX_PRAGMA_UNROLL(_N) _CCCL_PRAGMA(unroll _N)
 #  else // ^^^ __CUDA_ARCH__ ^^^ / vvv !__CUDA_ARCH__ vvv
 #    define _LIBCUDACXX_PRAGMA_UNROLL(_N)
 #  endif // !__CUDA_ARCH__
@@ -412,7 +405,8 @@ typedef __char32_t char32_t;
 
 #  elif defined(_CCCL_COMPILER_MSVC)
 
-#    define _LIBCUDACXX_WARNING(x) __pragma(message(__FILE__ "(" _LIBCUDACXX_TOSTRING(__LINE__) ") : warning note: " x))
+#    define _LIBCUDACXX_WARNING(x) \
+       _CCCL_PRAGMA(message(__FILE__ "(" _CCCL_TOSTRING(__LINE__) ") : warning note: " x))
 
 #    if _MSC_VER < 1900
 #      error "MSVC versions prior to Visual Studio 2015 are not supported"

--- a/libcudacxx/test/support/rapid-cxx-test.h
+++ b/libcudacxx/test/support/rapid-cxx-test.h
@@ -84,12 +84,12 @@
     {                                                                                                      \
       Name();                                                                                              \
     }                                                                                                      \
-    _Pragma("clang diagnostic push")                                                                       \
-      _Pragma("clang diagnostic ignored \"-Wglobal-constructors\"") static ::rapid_cxx_test::registrar     \
+    _CCCL_PRAGMA(clang diagnostic push)                                                                    \
+      _CCCL_PRAGMA(clang diagnostic ignored "-Wglobal-constructors") static ::rapid_cxx_test::registrar    \
         RAPID_CXX_TEST_PP_CAT(rapid_cxx_test_registrar_, Name)(                                            \
           get_test_suite(),                                                                                \
           ::rapid_cxx_test::test_case(__FILE__, #Name, __LINE__, &RAPID_CXX_TEST_PP_CAT(Name, _invoker))); \
-    _Pragma("clang diagnostic pop") void Name()
+    _CCCL_PRAGMA(clang diagnostic pop) void Name()
 #
 #endif /* !defined(__clang__) */
 

--- a/libcudacxx/test/support/rapid-cxx-test.h
+++ b/libcudacxx/test/support/rapid-cxx-test.h
@@ -78,17 +78,17 @@
 #
 #else /* __clang__ */
 #
-#  define TEST_CASE(Name)                                                                                  \
-    void Name();                                                                                           \
-    static void RAPID_CXX_TEST_PP_CAT(Name, _invoker)()                                                    \
-    {                                                                                                      \
-      Name();                                                                                              \
-    }                                                                                                      \
-    _CCCL_PRAGMA(clang diagnostic push)                                                                    \
-      _CCCL_PRAGMA(clang diagnostic ignored "-Wglobal-constructors") static ::rapid_cxx_test::registrar    \
-        RAPID_CXX_TEST_PP_CAT(rapid_cxx_test_registrar_, Name)(                                            \
-          get_test_suite(),                                                                                \
-          ::rapid_cxx_test::test_case(__FILE__, #Name, __LINE__, &RAPID_CXX_TEST_PP_CAT(Name, _invoker))); \
+#  define TEST_CASE(Name)                                                                              \
+    void Name();                                                                                       \
+    static void RAPID_CXX_TEST_PP_CAT(Name, _invoker)()                                                \
+    {                                                                                                  \
+      Name();                                                                                          \
+    }                                                                                                  \
+    _CCCL_PRAGMA(clang diagnostic push)                                                                \
+    _CCCL_PRAGMA(clang diagnostic ignored "-Wglobal-constructors")                                     \
+    static ::rapid_cxx_test::registrar RAPID_CXX_TEST_PP_CAT(rapid_cxx_test_registrar_, Name)(         \
+      get_test_suite(),                                                                                \
+      ::rapid_cxx_test::test_case(__FILE__, #Name, __LINE__, &RAPID_CXX_TEST_PP_CAT(Name, _invoker))); \
     _CCCL_PRAGMA(clang diagnostic pop) void Name()
 #
 #endif /* !defined(__clang__) */

--- a/libcudacxx/test/support/test_macros.h
+++ b/libcudacxx/test/support/test_macros.h
@@ -443,17 +443,9 @@ __host__ __device__ constexpr bool unused(T&&...)
 #if defined(TEST_COMPILER_CLANG_CUDA)
 #  define TEST_NV_DIAG_SUPPRESS(WARNING)
 #elif defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
-#  if defined(TEST_COMPILER_MSVC)
-#    define TEST_NV_DIAG_SUPPRESS(WARNING) __pragma(_TEST_TOSTRING(nv_diag_suppress WARNING))
-#  else // ^^^ MSVC ^^^ / vvv not MSVC vvv
-#    define TEST_NV_DIAG_SUPPRESS(WARNING) _Pragma(_TEST_TOSTRING(nv_diag_suppress WARNING))
-#  endif // not MSVC
+#  define TEST_NV_DIAG_SUPPRESS(WARNING) _CCCL_PRAGMA(nv_diag_suppress WARNING)
 #else // ^^^ __NVCC_DIAG_PRAGMA_SUPPORT__ ^^^ / vvv !__NVCC_DIAG_PRAGMA_SUPPORT__ vvv
-#  if defined(TEST_COMPILER_MSVC)
-#    define TEST_NV_DIAG_SUPPRESS(WARNING) __pragma(_TEST_TOSTRING(diag_suppress WARNING))
-#  else // ^^^ MSVC ^^^ / vvv not MSVC vvv
-#    define TEST_NV_DIAG_SUPPRESS(WARNING) _Pragma(_TEST_TOSTRING(diag_suppress WARNING))
-#  endif // not MSVC
+#  define TEST_NV_DIAG_SUPPRESS(WARNING) _CCCL_PRAGMA(diag_suppress WARNING)
 #endif
 
 #define TEST_CONSTEXPR_GLOBAL _CCCL_CONSTEXPR_GLOBAL

--- a/thrust/thrust/detail/config/cpp_dialect.h
+++ b/thrust/thrust/detail/config/cpp_dialect.h
@@ -69,13 +69,9 @@
 
 // Define THRUST_COMPILER_DEPRECATION macro:
 #if defined(_CCCL_COMPILER_MSVC)
-#  define THRUST_COMP_DEPR_IMPL(msg) __pragma(message(__FILE__ ":" THRUST_COMP_DEPR_IMPL0(__LINE__) ": warning: " #msg))
-#  define THRUST_COMP_DEPR_IMPL0(x)  THRUST_COMP_DEPR_IMPL1(x)
-#  define THRUST_COMP_DEPR_IMPL1(x)  #x
+#  define THRUST_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TOSTRING(__LINE__) ": warning: " #msg))
 #else // clang / gcc:
-#  define THRUST_COMP_DEPR_IMPL(msg)   THRUST_COMP_DEPR_IMPL0(GCC warning #msg)
-#  define THRUST_COMP_DEPR_IMPL0(expr) _Pragma(#expr)
-#  define THRUST_COMP_DEPR_IMPL1       /* intentionally blank */
+#  define THRUST_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(GCC warning #msg)
 #endif
 
 #define THRUST_COMPILER_DEPRECATION(REQ) \

--- a/thrust/thrust/detail/config/cpp_dialect.h
+++ b/thrust/thrust/detail/config/cpp_dialect.h
@@ -69,7 +69,7 @@
 
 // Define THRUST_COMPILER_DEPRECATION macro:
 #if defined(_CCCL_COMPILER_MSVC)
-#  define THRUST_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TOSTRING(__LINE__) ": warning: " #msg))
+#  define THRUST_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(message(__FILE__ ":" _CCCL_TO_STRING(__LINE__) ": warning: " #msg))
 #else // clang / gcc:
 #  define THRUST_COMP_DEPR_IMPL(msg) _CCCL_PRAGMA(GCC warning #msg)
 #endif

--- a/thrust/thrust/system/omp/detail/pragma_omp.h
+++ b/thrust/thrust/system/omp/detail/pragma_omp.h
@@ -37,16 +37,6 @@
 #  pragma system_header
 #endif // no system header
 
-#if defined(_CCCL_COMPILER_MSVC)
-// MSVC ICEs when using the standard C++11 `_Pragma` operator with OpenMP
-// directives.
-// WAR this by using the MSVC-extension `__pragma`. See this link for more info:
-// https://developercommunity.visualstudio.com/t/Using-C11s-_Pragma-with-OpenMP-dire/1590628
-#  define THRUST_PRAGMA_OMP_IMPL(directive) __pragma(directive)
-#else // Not MSVC:
-#  define THRUST_PRAGMA_OMP_IMPL(directive) _Pragma(#directive)
-#endif
-
 // For internal use only -- THRUST_PRAGMA_OMP is used to switch between
 // different flavors of openmp pragmas. Pragmas are not emitted when OpenMP is
 // not available.
@@ -56,9 +46,9 @@
 //   With   : THRUST_PRAGMA_OMP(parallel for)
 //
 #if defined(_NVHPC_STDPAR_OPENMP) && _NVHPC_STDPAR_OPENMP == 1
-#  define THRUST_PRAGMA_OMP(directive) THRUST_PRAGMA_OMP_IMPL(omp_stdpar directive)
+#  define THRUST_PRAGMA_OMP(directive) _CCCL_PRAGMA(omp_stdpar directive)
 #elif defined(_OPENMP)
-#  define THRUST_PRAGMA_OMP(directive) THRUST_PRAGMA_OMP_IMPL(omp directive)
+#  define THRUST_PRAGMA_OMP(directive) _CCCL_PRAGMA(omp directive)
 #else
 #  define THRUST_PRAGMA_OMP(directive)
 #endif


### PR DESCRIPTION
## Description

Closes #2601.

This PR simplifies using pragmas in macros independent on current compiler. The macro `_CCCL_PRAGMA` is defined in the `libcudacxx/include/cuda/std/__cccl/compiler.h` module.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines]().
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
