### PR TITLE
[STF] The cmake example for stf was not updated when moving to main branch

### DIFF
--- a/docs/cudax/stf.rst
+++ b/docs/cudax/stf.rst
@@ -134,7 +134,7 @@ As part of the CCCL project, CUDASTF uses CMake for its build and installation
 infrastructure, and is the recommended way of building applications that use
 CUDASTF.
 
-This is facilitated by the CMake Package Manager as illustrated in this simple example which is available `here <https://github.com/caugonnet/cccl/examples/cudax_stf>`_, and which is described in the next paragraph.
+This is facilitated by the CMake Package Manager as illustrated in this simple example which is available `here <https://github.com/NVIDIA/cccl/tree/main/examples/cudax_stf>`_, and which is described in the next paragraph.
 
 A simple example
 ^^^^^^^^^^^^^^^^

--- a/examples/cudax_stf/CMakeLists.txt
+++ b/examples/cudax_stf/CMakeLists.txt
@@ -24,9 +24,8 @@ include(cmake/CPM.cmake)
 # This will automatically clone CCCL from GitHub and make the exported cmake targets available
 CPMAddPackage(
   NAME CCCL
-  # TODO update later !
-  GITHUB_REPOSITORY "caugonnet/cccl"
-  GIT_TAG "cudastf"
+  GITHUB_REPOSITORY "nvidia/cccl"
+  GIT_TAG "main"
   # The following is required to make the `CCCL::cudax` target available:
   OPTIONS "CCCL_ENABLE_UNSTABLE ON"
 )


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

A url was pointing to the forked branch, and the cmake example was also referring to the cudastf that got merged to main, so we update both

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ x] The documentation is up to date with these changes.
