### PR TITLE
[BACKPORT]: Rework `head_flags` so that we do not rely on the tuple being unevaluated (#2619)

### DIFF
--- a/thrust/testing/unique.cu
+++ b/thrust/testing/unique.cu
@@ -3,6 +3,8 @@
 #include <thrust/iterator/retag.h>
 #include <thrust/unique.h>
 
+#include <cuda/std/array>
+
 #include <unittest/unittest.h>
 
 template <typename ForwardIterator>
@@ -324,3 +326,14 @@ struct TestUniqueCount
   }
 };
 VariableUnitTest<TestUniqueCount, IntegralTypes> TestUniqueCountInstance;
+
+template <typename T>
+struct TestUniqueMemoryAccess
+{
+  void operator()(void)
+  {
+    thrust::device_vector<cuda::std::array<T, 100>> v(10);
+    thrust::unique(v.begin(), v.end());
+  }
+};
+SimpleUnitTest<TestUniqueMemoryAccess, unittest::type_list<int>> TestUniqueMemoryAccessInstance;

--- a/thrust/thrust/detail/range/head_flags.h
+++ b/thrust/thrust/detail/range/head_flags.h
@@ -25,10 +25,10 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
-#include <thrust/iterator/zip_iterator.h>
 #include <thrust/tuple.h>
 
 THRUST_NAMESPACE_BEGIN
@@ -39,151 +39,41 @@ template <typename RandomAccessIterator,
           typename BinaryPredicate = thrust::equal_to<typename thrust::iterator_value<RandomAccessIterator>::type>,
           typename ValueType       = bool,
           typename IndexType       = typename thrust::iterator_difference<RandomAccessIterator>::type>
-class head_flags_with_init
-{
-  using init_type = typename thrust::iterator_value<RandomAccessIterator>::type;
-
-  // XXX WAR cudafe issue
-  // private:
-
-public:
-  struct head_flag_functor
-  {
-    BinaryPredicate binary_pred; // this must be the first member for performance reasons
-    init_type init;
-    IndexType n;
-
-    using result_type = ValueType;
-
-    _CCCL_HOST_DEVICE head_flag_functor(init_type init, IndexType n)
-        : binary_pred()
-        , init(init)
-        , n(n)
-    {}
-
-    _CCCL_HOST_DEVICE head_flag_functor(init_type init, IndexType n, BinaryPredicate binary_pred)
-        : binary_pred(binary_pred)
-        , init(init)
-        , n(n)
-    {}
-
-    template <typename Tuple>
-    _CCCL_HOST_DEVICE _CCCL_FORCEINLINE result_type operator()(const Tuple& t)
-    {
-      const IndexType i = thrust::get<0>(t);
-
-      if (i == 0)
-      {
-        return !binary_pred(init, thrust::get<1>(t));
-      }
-
-      return !binary_pred(thrust::get<1>(t), thrust::get<2>(t));
-    }
-  };
-
-  using counting_iterator = thrust::counting_iterator<IndexType>;
-
-public:
-  using iterator = thrust::transform_iterator<
-    head_flag_functor,
-    thrust::zip_iterator<thrust::tuple<counting_iterator, RandomAccessIterator, RandomAccessIterator>>>;
-
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_HOST_DEVICE head_flags_with_init(RandomAccessIterator first, RandomAccessIterator last, init_type init)
-      : m_begin(thrust::make_transform_iterator(
-          thrust::make_zip_iterator(thrust::make_tuple(thrust::counting_iterator<IndexType>(0), first, first - 1)),
-          head_flag_functor(init, last - first)))
-      , m_end(m_begin + (last - first))
-  {}
-
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_HOST_DEVICE head_flags_with_init(
-    RandomAccessIterator first, RandomAccessIterator last, init_type init, BinaryPredicate binary_pred)
-      : m_begin(thrust::make_transform_iterator(
-          thrust::make_zip_iterator(thrust::make_tuple(thrust::counting_iterator<IndexType>(0), first, first - 1)),
-          head_flag_functor(init, last - first, binary_pred)))
-      , m_end(m_begin + (last - first))
-  {}
-
-  _CCCL_HOST_DEVICE iterator begin() const
-  {
-    return m_begin;
-  }
-
-  _CCCL_HOST_DEVICE iterator end() const
-  {
-    return m_end;
-  }
-
-  template <typename OtherIndex>
-  _CCCL_HOST_DEVICE typename iterator::reference operator[](OtherIndex i)
-  {
-    return *(begin() + i);
-  }
-
-  _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(head_flags_with_init, iterator);
-
-private:
-  iterator m_begin, m_end;
-};
-
-template <typename RandomAccessIterator,
-          typename BinaryPredicate = thrust::equal_to<typename thrust::iterator_value<RandomAccessIterator>::type>,
-          typename ValueType       = bool,
-          typename IndexType       = typename thrust::iterator_difference<RandomAccessIterator>::type>
 class head_flags
 {
-  // XXX WAR cudafe issue
-  // private:
-
 public:
   struct head_flag_functor
   {
     BinaryPredicate binary_pred; // this must be the first member for performance reasons
-    IndexType n;
+    RandomAccessIterator iter;
 
     using result_type = ValueType;
 
-    _CCCL_HOST_DEVICE head_flag_functor(IndexType n)
-        : binary_pred()
-        , n(n)
-    {}
-
-    _CCCL_HOST_DEVICE head_flag_functor(IndexType n, BinaryPredicate binary_pred)
+    _CCCL_HOST_DEVICE head_flag_functor(RandomAccessIterator iter, BinaryPredicate binary_pred = {})
         : binary_pred(binary_pred)
-        , n(n)
+        , iter(iter)
     {}
 
-    template <typename Tuple>
-    _CCCL_HOST_DEVICE _CCCL_FORCEINLINE result_type operator()(const Tuple& t)
+    _CCCL_HOST_DEVICE _CCCL_FORCEINLINE result_type operator()(const IndexType i)
     {
-      const IndexType i = thrust::get<0>(t);
-
-      // note that we do not dereference the tuple's 2nd element when i <= 0
+      // note that we do not dereference the iterators i <= 0
       // and therefore do not dereference a bad location at the boundary
-      return (i == 0 || !binary_pred(thrust::get<1>(t), thrust::get<2>(t)));
+      if (i <= 0)
+      {
+        return true;
+      }
+
+      return !binary_pred(thrust::raw_reference_cast(iter[i]), thrust::raw_reference_cast(iter[i - 1]));
     }
   };
 
-  using counting_iterator = thrust::counting_iterator<IndexType>;
-
 public:
-  using iterator = thrust::transform_iterator<
-    head_flag_functor,
-    thrust::zip_iterator<thrust::tuple<counting_iterator, RandomAccessIterator, RandomAccessIterator>>>;
+  using iterator = thrust::transform_iterator<head_flag_functor, thrust::counting_iterator<IndexType>>;
 
-  _CCCL_HOST_DEVICE head_flags(RandomAccessIterator first, RandomAccessIterator last)
+  _CCCL_HOST_DEVICE head_flags(RandomAccessIterator first, RandomAccessIterator last, BinaryPredicate binary_pred = {})
       : m_begin(thrust::make_transform_iterator(
-          thrust::make_zip_iterator(thrust::make_tuple(thrust::counting_iterator<IndexType>(0), first, first - 1)),
-          head_flag_functor(last - first)))
-      , m_end(m_begin + (last - first))
-  {}
-
-  _CCCL_HOST_DEVICE head_flags(RandomAccessIterator first, RandomAccessIterator last, BinaryPredicate binary_pred)
-      : m_begin(thrust::make_transform_iterator(
-          thrust::make_zip_iterator(thrust::make_tuple(thrust::counting_iterator<IndexType>(0), first, first - 1)),
-          head_flag_functor(last - first, binary_pred)))
-      , m_end(m_begin + (last - first))
+          thrust::counting_iterator<IndexType>(0), head_flag_functor(first, binary_pred)))
+      , m_count(last - first)
   {}
 
   _CCCL_HOST_DEVICE iterator begin() const
@@ -193,7 +83,7 @@ public:
 
   _CCCL_HOST_DEVICE iterator end() const
   {
-    return m_end;
+    return m_begin + m_count;
   }
 
   template <typename OtherIndex>
@@ -205,7 +95,8 @@ public:
   _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(head_flags, iterator);
 
 private:
-  iterator m_begin, m_end;
+  iterator m_begin;
+  IndexType m_count;
 };
 
 template <typename RandomAccessIterator, typename BinaryPredicate>


### PR DESCRIPTION
We were relying on no accessing all elements of a thrust::tuple in `head_flags`

However, the way this works with `tuple_of_iterator_references`
means that the memory will always be accessed when dereferencing the `zip_iterator`

Fix this by simplifying the `head_flag` implementation to effectively be a counting_iterator
and store the pointer into the stencil array in the operator it self.

That way we never get into the situation where would dereference an invalid memory location
