### PR TITLE
fix portability bug in libcu++'s implementation of `char_traits`

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -285,16 +285,16 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char>
   find(const char_type* __s, size_t __n, const char_type& __a) noexcept;
   _LIBCUDACXX_HIDE_FROM_ABI static char_type* move(char_type* __s1, const char_type* __s2, size_t __n) noexcept
   {
-    return __n == 0 ? __s1 : (char_type*) __copy<_ClassicAlgPolicy>(__s2, __s2 + __n, __s1).first - __n;
+    return __n == 0 ? __s1 : const_cast<char_type*>(__copy<_ClassicAlgPolicy>(__s2, __s2 + __n, __s1).first) - __n;
   }
   _LIBCUDACXX_HIDE_FROM_ABI static char_type* copy(char_type* __s1, const char_type* __s2, size_t __n) noexcept
   {
     _CCCL_ASSERT(__s2 < __s1 || __s2 >= __s1 + __n, "char_traits::copy overlapped range");
-    return __n == 0 ? __s1 : (char_type*) memcpy(__s1, __s2, __n);
+    return __n == 0 ? __s1 : static_cast<char_type*>(memcpy(__s1, __s2, __n));
   }
   _LIBCUDACXX_HIDE_FROM_ABI static char_type* assign(char_type* __s, size_t __n, char_type __a) noexcept
   {
-    return __n == 0 ? __s : (char_type*) memset(__s, to_int_type(__a), __n);
+    return __n == 0 ? __s : static_cast<char_type*>(memset(__s, to_int_type(__a), __n));
   }
 
 #ifndef __cuda_std__
@@ -556,18 +556,18 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char8_t>
 
   _LIBCUDACXX_HIDE_FROM_ABI static char_type* move(char_type* __s1, const char_type* __s2, size_t __n) noexcept
   {
-    return __n == 0 ? __s1 : (char_type*) __copy<_ClassicAlgPolicy>(__s2, __s2 + __n, __s1).first - __n;
+    return __n == 0 ? __s1 : const_cast<char_type*>(__copy<_ClassicAlgPolicy>(__s2, __s2 + __n, __s1).first) - __n;
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI static char_type* copy(char_type* __s1, const char_type* __s2, size_t __n) noexcept
   {
     _CCCL_ASSERT(__s2 < __s1 || __s2 >= __s1 + __n, "char_traits::copy overlapped range");
-    return __n == 0 ? __s1 : (char_type*) memcpy(__s1, __s2, __n);
+    return __n == 0 ? __s1 : static_cast<char_type*>(memcpy(__s1, __s2, __n));
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI static char_type* assign(char_type* __s, size_t __n, char_type __a) noexcept
   {
-    return __n == 0 ? __s : (char_type*) memset(__s, to_int_type(__a), __n);
+    return __n == 0 ? __s : static_cast<char_type*>(memset(__s, to_int_type(__a), __n));
   }
 
 #  ifndef __cuda_std__


### PR DESCRIPTION
## Description

nvcc isn't very keen on using C-style casts to drop `const` qualifiers. as a result, `<cuda/std/detail/libcxx/include/__string>` was failing to compile. this PR makes nvcc happy by using C++-style casts (`const_cast`) for removing const-ness.

as a drive-by, i replace a few C-style casts from `void*` to use `static_cast` instead.
