### PR TITLE
Found out that gcc and clang define __builtin_FILE(), __builtin_LINE(…

### DIFF
--- a/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
@@ -110,7 +110,7 @@ public:
    * @param loc location of the call, defaulted
    */
   template <typename T>
-  cuda_exception(const T status, const source_location loc = ::cuda::experimental::stf::source_location::current())
+  cuda_exception(const T status, const source_location loc = source_location::current())
   {
     // All "success" statuses are zero
     static_assert(cudaSuccess == 0 && CUDA_SUCCESS == 0
@@ -277,7 +277,7 @@ UNITTEST("first_param")
  * @snippet this cuda_safe_call
  */
 template <typename T>
-void cuda_safe_call(const T status, const source_location loc = ::cuda::experimental::stf::source_location::current())
+void cuda_safe_call(const T status, const source_location loc = source_location::current())
 {
   // Common early exit test for all cases
   if (status == 0)
@@ -318,7 +318,7 @@ UNITTEST("cuda_safe_call")
  * @snippet this cuda_try1
  */
 template <typename Status>
-void cuda_try(Status status, const source_location loc = ::cuda::experimental::stf::source_location::current())
+void cuda_try(Status status, const source_location loc = source_location::current())
 {
   if (status)
   {

--- a/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/cuda_safe_call.cuh
@@ -110,7 +110,7 @@ public:
    * @param loc location of the call, defaulted
    */
   template <typename T>
-  cuda_exception(const T status, const source_location loc = RESERVED_STF_SOURCE_LOCATION())
+  cuda_exception(const T status, const source_location loc = ::cuda::experimental::stf::source_location::current())
   {
     // All "success" statuses are zero
     static_assert(cudaSuccess == 0 && CUDA_SUCCESS == 0
@@ -277,7 +277,7 @@ UNITTEST("first_param")
  * @snippet this cuda_safe_call
  */
 template <typename T>
-void cuda_safe_call(const T status, const source_location loc = RESERVED_STF_SOURCE_LOCATION())
+void cuda_safe_call(const T status, const source_location loc = ::cuda::experimental::stf::source_location::current())
 {
   // Common early exit test for all cases
   if (status == 0)
@@ -318,7 +318,7 @@ UNITTEST("cuda_safe_call")
  * @snippet this cuda_try1
  */
 template <typename Status>
-void cuda_try(Status status, const source_location loc = RESERVED_STF_SOURCE_LOCATION())
+void cuda_try(Status status, const source_location loc = ::cuda::experimental::stf::source_location::current())
 {
   if (status)
   {

--- a/cudax/include/cuda/experimental/__stf/utility/memory.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/memory.cuh
@@ -124,8 +124,7 @@ inline void* allocateManagedMemory(size_t sz)
  * @param sz size in bytes
  * @param loc location of the call, defaulted
  */
-inline void
-deallocateHostMemory(void* p, size_t sz, source_location loc = ::cuda::experimental::stf::source_location::current())
+inline void deallocateHostMemory(void* p, size_t sz, source_location loc = source_location::current())
 {
   ::std::ignore = loc;
   assert([&] {
@@ -150,8 +149,7 @@ deallocateHostMemory(void* p, size_t sz, source_location loc = ::cuda::experimen
  * @param sz size in bytes
  * @param loc location of the call, defaulted
  */
-inline void
-deallocateManagedMemory(void* p, size_t sz, source_location loc = ::cuda::experimental::stf::source_location::current())
+inline void deallocateManagedMemory(void* p, size_t sz, source_location loc = source_location::current())
 {
   ::std::ignore = loc;
   assert([&] {

--- a/cudax/include/cuda/experimental/__stf/utility/memory.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/memory.cuh
@@ -124,7 +124,8 @@ inline void* allocateManagedMemory(size_t sz)
  * @param sz size in bytes
  * @param loc location of the call, defaulted
  */
-inline void deallocateHostMemory(void* p, size_t sz, source_location loc = ::cuda::experimental::stf::source_location::current())
+inline void
+deallocateHostMemory(void* p, size_t sz, source_location loc = ::cuda::experimental::stf::source_location::current())
 {
   ::std::ignore = loc;
   assert([&] {
@@ -149,7 +150,8 @@ inline void deallocateHostMemory(void* p, size_t sz, source_location loc = ::cud
  * @param sz size in bytes
  * @param loc location of the call, defaulted
  */
-inline void deallocateManagedMemory(void* p, size_t sz, source_location loc = ::cuda::experimental::stf::source_location::current())
+inline void
+deallocateManagedMemory(void* p, size_t sz, source_location loc = ::cuda::experimental::stf::source_location::current())
 {
   ::std::ignore = loc;
   assert([&] {

--- a/cudax/include/cuda/experimental/__stf/utility/memory.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/memory.cuh
@@ -124,7 +124,7 @@ inline void* allocateManagedMemory(size_t sz)
  * @param sz size in bytes
  * @param loc location of the call, defaulted
  */
-inline void deallocateHostMemory(void* p, size_t sz, source_location loc = RESERVED_STF_SOURCE_LOCATION())
+inline void deallocateHostMemory(void* p, size_t sz, source_location loc = ::cuda::experimental::stf::source_location::current())
 {
   ::std::ignore = loc;
   assert([&] {
@@ -149,7 +149,7 @@ inline void deallocateHostMemory(void* p, size_t sz, source_location loc = RESER
  * @param sz size in bytes
  * @param loc location of the call, defaulted
  */
-inline void deallocateManagedMemory(void* p, size_t sz, source_location loc = RESERVED_STF_SOURCE_LOCATION())
+inline void deallocateManagedMemory(void* p, size_t sz, source_location loc = ::cuda::experimental::stf::source_location::current())
 {
   ::std::ignore = loc;
   assert([&] {

--- a/cudax/include/cuda/experimental/__stf/utility/source_location.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/source_location.cuh
@@ -86,5 +86,5 @@ private:
 } // end namespace cuda::experimental::stf
 
 #  define RESERVED_STF_SOURCE_LOCATION() \
-    ::cuda::experimental::stf::source_location::current(__FILE__, __LINE__, __func__)
+    ::cuda::experimental::stf::source_location::current(__builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION())
 #endif

--- a/cudax/include/cuda/experimental/__stf/utility/source_location.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/source_location.cuh
@@ -68,24 +68,28 @@ public:
     return func_;
   }
 
-  static constexpr source_location
-  current(const char* file = __builtin_FILE(), ::std::uint_least32_t line = __builtin_LINE(), ::std::uint_least32_t column = __builtin_COLUMN(), const char* func = __builtin_FUNCTION()) noexcept
+  static constexpr source_location current(
+    const char* file             = __builtin_FILE(),
+    ::std::uint_least32_t line   = __builtin_LINE(),
+    ::std::uint_least32_t column = __builtin_COLUMN(),
+    const char* func             = __builtin_FUNCTION()) noexcept
   {
     return source_location(file, line, column, func);
   }
 
 private:
-  constexpr source_location(const char* file, ::std::uint_least32_t line, ::std::uint_least32_t column, const char* func) noexcept
+  constexpr source_location(
+    const char* file, ::std::uint_least32_t line, ::std::uint_least32_t column, const char* func) noexcept
       : file_(file)
       , line_(line)
       , column(_column)
       , func_(func)
   {}
 
-  const char* file_ = "";
-  ::std::uint_least32_t line_ = 0;
+  const char* file_             = "";
+  ::std::uint_least32_t line_   = 0;
   ::std::uint_least32_t column_ = 0;
-  const char* func_ = "";
+  const char* func_             = "";
 };
 
 } // end namespace cuda::experimental::stf

--- a/cudax/include/cuda/experimental/__stf/utility/source_location.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/source_location.cuh
@@ -34,7 +34,6 @@ namespace cuda::experimental::stf
 {
 using source_location = ::std::source_location;
 }
-#  define RESERVED_STF_SOURCE_LOCATION() ::cuda::experimental::stf::source_location::current()
 
 #elif __has_include(<experimental/source_location>)
 #  include <experimental/source_location>
@@ -43,8 +42,6 @@ namespace cuda::experimental::stf
 using source_location = ::std::experimental::source_location;
 }
 
-#  define RESERVED_STF_SOURCE_LOCATION() ::cuda::experimental::stf::source_location::current()
-
 #else
 // Custom implementation for C++17 or earlier
 namespace cuda::experimental::stf
@@ -52,20 +49,19 @@ namespace cuda::experimental::stf
 class source_location
 {
 public:
-  constexpr source_location(
-    const char* file = "unknown file", int line = 0, const char* func = "unknown function") noexcept
-      : file_(file)
-      , line_(line)
-      , func_(func)
-  {}
+  constexpr source_location() noexcept = default;
 
   constexpr const char* file_name() const noexcept
   {
     return file_;
   }
-  constexpr int line() const noexcept
+  constexpr ::std::uint_least32_t line() const noexcept
   {
     return line_;
+  }
+  constexpr ::std::uint_least32_t column() const noexcept
+  {
+    return column_;
   }
   constexpr const char* function_name() const noexcept
   {
@@ -73,18 +69,25 @@ public:
   }
 
   static constexpr source_location
-  current(const char* file = __FILE__, int line = __LINE__, const char* func = __func__) noexcept
+  current(const char* file = __builtin_FILE(), ::std::uint_least32_t line = __builtin_LINE(), ::std::uint_least32_t column = __builtin_COLUMN(), const char* func = __builtin_FUNCTION()) noexcept
   {
-    return source_location(file, line, func);
+    return source_location(file, line, column, func);
   }
 
 private:
-  const char* file_;
-  int line_;
-  const char* func_;
+  constexpr source_location(const char* file, ::std::uint_least32_t line, ::std::uint_least32_t column, const char* func) noexcept
+      : file_(file)
+      , line_(line)
+      , column(_column)
+      , func_(func)
+  {}
+
+  const char* file_ = "";
+  ::std::uint_least32_t line_ = 0;
+  ::std::uint_least32_t column_ = 0;
+  const char* func_ = "";
 };
+
 } // end namespace cuda::experimental::stf
 
-#  define RESERVED_STF_SOURCE_LOCATION() \
-    ::cuda::experimental::stf::source_location::current(__builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION())
 #endif

--- a/cudax/include/cuda/experimental/__stf/utility/threads.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/threads.cuh
@@ -55,8 +55,7 @@ public:
 
 #ifndef NDEBUG
 
-  explicit single_threaded_section(mutex_type& m,
-                                   source_location loc = ::cuda::experimental::stf::source_location::current())
+  explicit single_threaded_section(mutex_type& m, source_location loc = source_location::current())
       : mutex(m)
   {
     if (mutex.try_lock())

--- a/cudax/include/cuda/experimental/__stf/utility/threads.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/threads.cuh
@@ -55,7 +55,7 @@ public:
 
 #ifndef NDEBUG
 
-  explicit single_threaded_section(mutex_type& m, source_location loc = RESERVED_STF_SOURCE_LOCATION())
+  explicit single_threaded_section(mutex_type& m, source_location loc = ::cuda::experimental::stf::source_location::current())
       : mutex(m)
   {
     if (mutex.try_lock())

--- a/cudax/include/cuda/experimental/__stf/utility/threads.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/threads.cuh
@@ -55,7 +55,8 @@ public:
 
 #ifndef NDEBUG
 
-  explicit single_threaded_section(mutex_type& m, source_location loc = ::cuda::experimental::stf::source_location::current())
+  explicit single_threaded_section(mutex_type& m,
+                                   source_location loc = ::cuda::experimental::stf::source_location::current())
       : mutex(m)
   {
     if (mutex.try_lock())

--- a/cudax/include/cuda/experimental/__stf/utility/unittest.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/unittest.cuh
@@ -78,7 +78,7 @@
  */
 #  define EXPECT(...)                              \
     ::cuda::experimental::stf::expecter::validate( \
-      RESERVED_STF_SOURCE_LOCATION(), ::cuda::experimental::stf::expecter()->*__VA_ARGS__)
+      ::cuda::experimental::stf::source_location::current(), ::cuda::experimental::stf::expecter()->*__VA_ARGS__)
 
 namespace cuda::experimental::stf
 {
@@ -492,12 +492,12 @@ int main()
 #    ifdef STF_HAS_UNITTEST_WITH_ARGS
 #      define UNITTEST(name, ...)                                                                                     \
         [[maybe_unused]] static const auto CUDASTF_UNIQUE_NAME(unittest) =                                            \
-          ::cuda::experimental::stf::unittest<>::make(name, RESERVED_STF_SOURCE_LOCATION() __VA_OPT__(, __VA_ARGS__)) \
+          ::cuda::experimental::stf::unittest<>::make(name, ::cuda::experimental::stf::source_location::current() __VA_OPT__(, __VA_ARGS__)) \
             ->*[]([[maybe_unused]] const char* unittest_name __VA_OPT__(, [[maybe_unused]] auto&& unittest_param))
 #    else
 #      define UNITTEST(name)                                                                    \
         [[maybe_unused]] static const auto CUDASTF_UNIQUE_NAME(unittest) =                      \
-          ::cuda::experimental::stf::unittest<>::make(name, RESERVED_STF_SOURCE_LOCATION())->*[ \
+          ::cuda::experimental::stf::unittest<>::make(name, ::cuda::experimental::stf::source_location::current())->*[ \
           ]([[maybe_unused]] const char* unittest_name)
 #    endif
 
@@ -692,7 +692,7 @@ UNITTEST("shuffled_array_tuple")
 
 UNITTEST("source_location")
 {
-  auto test_func = [](::cuda::experimental::stf::source_location loc = RESERVED_STF_SOURCE_LOCATION()) {
+  auto test_func = [](::cuda::experimental::stf::source_location loc = ::cuda::experimental::stf::source_location::current()) {
     // Check the source location metadata
     EXPECT(loc.line() > 0); // The line number should be positive
     EXPECT(loc.file_name() != nullptr); // File name should not be null

--- a/cudax/include/cuda/experimental/__stf/utility/unittest.cuh
+++ b/cudax/include/cuda/experimental/__stf/utility/unittest.cuh
@@ -490,13 +490,14 @@ int main()
 }
 
 #    ifdef STF_HAS_UNITTEST_WITH_ARGS
-#      define UNITTEST(name, ...)                                                                                     \
-        [[maybe_unused]] static const auto CUDASTF_UNIQUE_NAME(unittest) =                                            \
-          ::cuda::experimental::stf::unittest<>::make(name, ::cuda::experimental::stf::source_location::current() __VA_OPT__(, __VA_ARGS__)) \
+#      define UNITTEST(name, ...)                                                                  \
+        [[maybe_unused]] static const auto CUDASTF_UNIQUE_NAME(unittest) =                         \
+          ::cuda::experimental::stf::unittest<>::make(                                             \
+            name, ::cuda::experimental::stf::source_location::current() __VA_OPT__(, __VA_ARGS__)) \
             ->*[]([[maybe_unused]] const char* unittest_name __VA_OPT__(, [[maybe_unused]] auto&& unittest_param))
 #    else
-#      define UNITTEST(name)                                                                    \
-        [[maybe_unused]] static const auto CUDASTF_UNIQUE_NAME(unittest) =                      \
+#      define UNITTEST(name)                                                                                           \
+        [[maybe_unused]] static const auto CUDASTF_UNIQUE_NAME(unittest) =                                             \
           ::cuda::experimental::stf::unittest<>::make(name, ::cuda::experimental::stf::source_location::current())->*[ \
           ]([[maybe_unused]] const char* unittest_name)
 #    endif
@@ -692,12 +693,13 @@ UNITTEST("shuffled_array_tuple")
 
 UNITTEST("source_location")
 {
-  auto test_func = [](::cuda::experimental::stf::source_location loc = ::cuda::experimental::stf::source_location::current()) {
-    // Check the source location metadata
-    EXPECT(loc.line() > 0); // The line number should be positive
-    EXPECT(loc.file_name() != nullptr); // File name should not be null
-    EXPECT(loc.function_name() != nullptr); // Function name should not be null
-  };
+  auto test_func =
+    [](::cuda::experimental::stf::source_location loc = ::cuda::experimental::stf::source_location::current()) {
+      // Check the source location metadata
+      EXPECT(loc.line() > 0); // The line number should be positive
+      EXPECT(loc.file_name() != nullptr); // File name should not be null
+      EXPECT(loc.function_name() != nullptr); // Function name should not be null
+    };
 
   // Call the test function and validate the source location information
   test_func();


### PR DESCRIPTION
…), __builtin_FUNCTION(), let us put them to test

Currently the macro `RESERVED_STF_SOURCE_LOCATION` does not really work. This PR takes advantage of the builtins `__builtin_FILE(),` `__builtin_LINE()`, `__builtin_FUNCTION()`. I speculate they work even for olden gcc implementations that don't support `source_location`.