### PR TITLE
Tell ninja to keep compiling after error

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -220,7 +220,7 @@ function build_preset() {
     source "./sccache_stats.sh" "start"
 
     pushd .. > /dev/null
-    run_command "$GROUP_NAME" cmake --build --preset=$PRESET -v
+    run_command "$GROUP_NAME" cmake --build --preset=$PRESET -v -- -k 0
     status=$?
     popd > /dev/null
 


### PR DESCRIPTION
We want to gather as much information as possible, so ltest pass `-k 0` to ninja which ensure that we continue compilation
