### PR TITLE
[CUDAX] Add get_name to device_ref

### DIFF
--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -25,6 +25,7 @@
 
 #include <cuda/experimental/__utility/driver_api.cuh>
 
+#include <string>
 #include <vector>
 
 namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__device/device_ref.cuh
+++ b/cudax/include/cuda/experimental/__device/device_ref.cuh
@@ -23,6 +23,8 @@
 
 #include <cuda/std/__cuda/api_wrapper.h>
 
+#include <cuda/experimental/__utility/driver_api.cuh>
+
 #include <vector>
 
 namespace cuda::experimental
@@ -104,6 +106,16 @@ public:
   _CCCL_NODISCARD auto attr() const
   {
     return attr(detail::__dev_attr<_Attr>());
+  }
+
+  _CCCL_NODISCARD ::std::string get_name() const
+  {
+    constexpr int __max_name_length = 256;
+    ::std::string __name(256, 0);
+
+    // For some reason there is no separate name query in CUDA runtime
+    detail::driver::getName(__name.data(), __max_name_length, get());
+    return __name;
   }
 
   const arch_traits_t& arch_traits() const;

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -102,6 +102,15 @@ inline CUdevice deviceGet(int ordinal)
   return result;
 }
 
+inline void getName(char* __out, int __len, int __ordinal)
+{
+  static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDeviceGetName);
+
+  // TODO CUdevice is just an int, we probably could just cast, but for now do the safe thing
+  CUdevice __dev = deviceGet(__ordinal);
+  call_driver_fn(driver_fn, "Failed to query the name of a device", __out, __len, __dev);
+}
+
 inline CUcontext primaryCtxRetain(CUdevice dev)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRetain);

--- a/cudax/include/cuda/experimental/__utility/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__utility/driver_api.cuh
@@ -102,13 +102,13 @@ inline CUdevice deviceGet(int ordinal)
   return result;
 }
 
-inline void getName(char* __out, int __len, int __ordinal)
+inline void getName(char* __name_out, int __len, int __ordinal)
 {
   static auto driver_fn = CUDAX_GET_DRIVER_FUNCTION(cuDeviceGetName);
 
   // TODO CUdevice is just an int, we probably could just cast, but for now do the safe thing
   CUdevice __dev = deviceGet(__ordinal);
-  call_driver_fn(driver_fn, "Failed to query the name of a device", __out, __len, __dev);
+  call_driver_fn(driver_fn, "Failed to query the name of a device", __name_out, __len, __dev);
 }
 
 inline CUcontext primaryCtxRetain(CUdevice dev)

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -278,6 +278,11 @@ TEST_CASE("Smoke", "[device]")
       CUDAX_REQUIRE(compute_cap == 100 * compute_cap_major + 10 * compute_cap_minor);
     }
   }
+  SECTION("Name")
+  {
+    std::string name = device_ref(0).get_name();
+    CUDAX_REQUIRE(name.length() != 0);
+  }
 }
 
 TEST_CASE("global devices vector", "[device]")

--- a/cudax/test/device/device_smoke.cu
+++ b/cudax/test/device/device_smoke.cu
@@ -282,6 +282,7 @@ TEST_CASE("Smoke", "[device]")
   {
     std::string name = device_ref(0).get_name();
     CUDAX_REQUIRE(name.length() != 0);
+    CUDAX_REQUIRE(name[0] != 0);
   }
 }
 


### PR DESCRIPTION
Its a simple API to return a string with device name, lowers to Driver API, because in CUDART it seems to only be available in a heavy properties struct