### PR TITLE
Use a default initialization for CUDA graph mem alloc nodes

### DIFF
--- a/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
@@ -162,7 +162,7 @@ private:
 
     // Parameter structure for cudaGraphAddMemAllocNode - most values are constants.
     static cudaMemAllocNodeParams params = [] {
-      cudaMemAllocNodeParams result;
+      cudaMemAllocNodeParams result {};
       result.poolProps.allocType               = cudaMemAllocationTypePinned;
       result.poolProps.handleTypes             = cudaMemHandleTypeNone;
       result.poolProps.location                = {.type = cudaMemLocationTypeDevice, .id = 0};

--- a/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
@@ -162,7 +162,7 @@ private:
 
     // Parameter structure for cudaGraphAddMemAllocNode - most values are constants.
     static cudaMemAllocNodeParams params = [] {
-      cudaMemAllocNodeParams result {};
+      cudaMemAllocNodeParams result{};
       result.poolProps.allocType               = cudaMemAllocationTypePinned;
       result.poolProps.handleTypes             = cudaMemHandleTypeNone;
       result.poolProps.location                = {.type = cudaMemLocationTypeDevice, .id = 0};


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

This initializes all fields of the configuration of the memory nodes in the CUDA graph API : this API has changed across CUDA releases, and we might miss some fields which are improperly initialized, resulting in failing tests

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
