### PR TITLE
define `_CCCL_NO_RTTI` in device code; RTTI isn't available there

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/rtti.h
+++ b/libcudacxx/include/cuda/std/__cccl/rtti.h
@@ -28,7 +28,7 @@
 #ifndef _CCCL_NO_RTTI
 #  if defined(CCCL_DISABLE_RTTI) // Escape hatch for users to manually disable RTTI
 #    define _CCCL_NO_RTTI
-#  elif defined(_CCCL_CUDACC) && defined(__CUDA_ARCH__)
+#  elif defined(__CUDA_ARCH__)
 #    define _CCCL_NO_RTTI // No RTTI in CUDA device code
 #  elif defined(_CCCL_COMPILER_ICC)
 #    if __RTTI == 0 && __INTEL_RTTI__ == 0 && __GXX_RTTI == 0 && _CPPRTTI == 0
@@ -54,8 +54,8 @@
 #ifndef _CCCL_NO_TYPEID
 #  if defined(CCCL_DISABLE_RTTI) // CCCL_DISABLE_RTTI disables typeid also
 #    define _CCCL_NO_TYPEID
-#  elif defined(_CCCL_CUDACC) && defined(__CUDA_ARCH__)
-#    define _CCCL_NO_TYPEID // No RTTI in CUDA device code
+#  elif defined(__CUDA_ARCH__)
+#    define _CCCL_NO_TYPEID // No typeid in CUDA device code
 #  elif defined(_CCCL_COMPILER_ICC)
 // when emulating MSVC, typeid is available even when RTTI is disabled
 #    if !defined(_MSC_VER) && __RTTI == 0 && __INTEL_RTTI__ == 0 && __GXX_RTTI == 0 && _CPPRTTI == 0

--- a/libcudacxx/include/cuda/std/__cccl/rtti.h
+++ b/libcudacxx/include/cuda/std/__cccl/rtti.h
@@ -28,6 +28,8 @@
 #ifndef _CCCL_NO_RTTI
 #  if defined(CCCL_DISABLE_RTTI) // Escape hatch for users to manually disable RTTI
 #    define _CCCL_NO_RTTI
+#  elif defined(_CCCL_CUDACC) && defined(__CUDA_ARCH__)
+#    define _CCCL_NO_RTTI // No RTTI in CUDA device code
 #  elif defined(_CCCL_COMPILER_ICC)
 #    if __RTTI == 0 && __INTEL_RTTI__ == 0 && __GXX_RTTI == 0 && _CPPRTTI == 0
 #      define _CCCL_NO_RTTI
@@ -52,6 +54,8 @@
 #ifndef _CCCL_NO_TYPEID
 #  if defined(CCCL_DISABLE_RTTI) // CCCL_DISABLE_RTTI disables typeid also
 #    define _CCCL_NO_TYPEID
+#  elif defined(_CCCL_CUDACC) && defined(__CUDA_ARCH__)
+#    define _CCCL_NO_RTTI // No RTTI in CUDA device code
 #  elif defined(_CCCL_COMPILER_ICC)
 // when emulating MSVC, typeid is available even when RTTI is disabled
 #    if !defined(_MSC_VER) && __RTTI == 0 && __INTEL_RTTI__ == 0 && __GXX_RTTI == 0 && _CPPRTTI == 0

--- a/libcudacxx/include/cuda/std/__cccl/rtti.h
+++ b/libcudacxx/include/cuda/std/__cccl/rtti.h
@@ -55,7 +55,7 @@
 #  if defined(CCCL_DISABLE_RTTI) // CCCL_DISABLE_RTTI disables typeid also
 #    define _CCCL_NO_TYPEID
 #  elif defined(_CCCL_CUDACC) && defined(__CUDA_ARCH__)
-#    define _CCCL_NO_RTTI // No RTTI in CUDA device code
+#    define _CCCL_NO_TYPEID // No RTTI in CUDA device code
 #  elif defined(_CCCL_COMPILER_ICC)
 // when emulating MSVC, typeid is available even when RTTI is disabled
 #    if !defined(_MSC_VER) && __RTTI == 0 && __INTEL_RTTI__ == 0 && __GXX_RTTI == 0 && _CPPRTTI == 0


### PR DESCRIPTION
## Description

currently we are not defining `_CCCL_NO_RTTI` when compiling for device, but any attempt to use RTTI there will fail. this pr corrects an oversight i made in #2578 
