### PR TITLE
abide by CCCL config macro naming conventions for `_CCCL_PRETTY_FUNCTION` and `_CCCL_NO_BUILTIN_STRLEN`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -521,8 +521,10 @@
 // GCC's builtin_strlen isn't reliable at constexpr time
 // MSVC does not expose builtin_strlen before C++17
 // NVRTC does not expose builtin_strlen
+// clang's builtin_strlen is host-only
 #if !defined(_CCCL_COMPILER_GCC) && !defined(_CCCL_COMPILER_NVRTC) \
-  && !(defined(_CCCL_COMPILER_MSVC) && _CCCL_STD_VER < 2017)
+  && !(defined(_CCCL_COMPILER_MSVC) && _CCCL_STD_VER < 2017)       \
+  && !(defined(_CCCL_COMPILER_CLANG) && defined(__CUDA_ARCH__))
 #  define _CCCL_BUILTIN_STRLEN(...) __builtin_strlen(__VA_ARGS__)
 #endif
 

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -524,7 +524,7 @@
 // clang's builtin_strlen is host-only
 #if !defined(_CCCL_COMPILER_GCC) && !defined(_CCCL_COMPILER_NVRTC) \
   && !(defined(_CCCL_COMPILER_MSVC) && _CCCL_STD_VER < 2017)       \
-  && !(defined(_CCCL_COMPILER_CLANG) && defined(_CCCL_CUDA_COMPILER_NVCC) && defined(__CUDA_ARCH__))
+  && !(defined(_CCCL_COMPILER_CLANG) && defined(__CUDA_ARCH__))
 #  define _CCCL_BUILTIN_STRLEN(...) __builtin_strlen(__VA_ARGS__)
 #endif
 

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -521,10 +521,8 @@
 // GCC's builtin_strlen isn't reliable at constexpr time
 // MSVC does not expose builtin_strlen before C++17
 // NVRTC does not expose builtin_strlen
-// clang's builtin_strlen is host-only
 #if !defined(_CCCL_COMPILER_GCC) && !defined(_CCCL_COMPILER_NVRTC) \
-  && !(defined(_CCCL_COMPILER_MSVC) && _CCCL_STD_VER < 2017)       \
-  && !(defined(_CCCL_COMPILER_CLANG) && defined(__CUDA_ARCH__))
+  && !(defined(_CCCL_COMPILER_MSVC) && _CCCL_STD_VER < 2017)
 #  define _CCCL_BUILTIN_STRLEN(...) __builtin_strlen(__VA_ARGS__)
 #endif
 

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -510,20 +510,20 @@
 
 #if defined(_CCCL_COMPILER_MSVC)
 #  if _CCCL_MSVC_VERSION >= 1935
-#    define _CCCL_PRETTY_FUNCTION __builtin_FUNCSIG()
+#    define _CCCL_BUILTIN_PRETTY_FUNCTION() __builtin_FUNCSIG()
 #  else // ^^^ _CCCL_MSVC_VERSION >= 1935 ^^^ / vvv _CCCL_MSVC_VERSION < 1935 vvv
-#    define _CCCL_PRETTY_FUNCTION __FUNCSIG__
+#    define _CCCL_BUILTIN_PRETTY_FUNCTION() __FUNCSIG__
 #  endif // _CCCL_MSVC_VERSION < 1935
 #else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
-#  define _CCCL_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#  define _CCCL_BUILTIN_PRETTY_FUNCTION() __PRETTY_FUNCTION__
 #endif // !_CCCL_COMPILER_MSVC
 
 // GCC's builtin_strlen isn't reliable at constexpr time
 // MSVC does not expose builtin_strlen before C++17
 // NVRTC does not expose builtin_strlen
-#if defined(_CCCL_COMPILER_GCC) || defined(_CCCL_COMPILER_NVRTC) \
-  || (defined(_CCCL_COMPILER_MSVC) && _CCCL_STD_VER < 2017)
-#  define _CCCL_HAS_NO_BUILTIN_STRLEN
+#if !defined(_CCCL_COMPILER_GCC) && !defined(_CCCL_COMPILER_NVRTC) \
+  && !(defined(_CCCL_COMPILER_MSVC) && _CCCL_STD_VER < 2017)
+#  define _CCCL_BUILTIN_STRLEN(...) __builtin_strlen(__VA_ARGS__)
 #endif
 
 #endif // __CCCL_BUILTIN_H

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -524,7 +524,7 @@
 // clang's builtin_strlen is host-only
 #if !defined(_CCCL_COMPILER_GCC) && !defined(_CCCL_COMPILER_NVRTC) \
   && !(defined(_CCCL_COMPILER_MSVC) && _CCCL_STD_VER < 2017)       \
-  && !(defined(_CCCL_COMPILER_CLANG) && defined(__CUDA_ARCH__))
+  && !(defined(_CCCL_COMPILER_CLANG) && defined(_CCCL_CUDA_COMPILER_NVCC) && defined(__CUDA_ARCH__))
 #  define _CCCL_BUILTIN_STRLEN(...) __builtin_strlen(__VA_ARGS__)
 #endif
 

--- a/libcudacxx/include/cuda/std/__string/string_view.h
+++ b/libcudacxx/include/cuda/std/__string/string_view.h
@@ -294,10 +294,10 @@ private:
 
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr size_t __strlen_(char const* __str) noexcept
   {
-#ifndef _CCCL_HAS_NO_BUILTIN_STRLEN
-    return __builtin_strlen(__str);
+#ifdef _CCCL_BUILTIN_STRLEN
+    return _CCCL_BUILTIN_STRLEN(__str);
 #elif _CCCL_STD_VER >= 2014
-    return std::char_traits<char>::length(__str);
+    return _CUDA_VSTD::char_traits<char>::length(__str);
 #else
     return __strlen_0x_(__str, 0);
 #endif

--- a/libcudacxx/include/cuda/std/__string/string_view.h
+++ b/libcudacxx/include/cuda/std/__string/string_view.h
@@ -294,9 +294,7 @@ private:
 
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr size_t __strlen_(char const* __str) noexcept
   {
-#ifdef _CCCL_BUILTIN_STRLEN
-    return _CCCL_BUILTIN_STRLEN(__str);
-#elif _CCCL_STD_VER >= 2014
+#if _CCCL_STD_VER >= 2014
     return _CUDA_VSTD::char_traits<char>::length(__str);
 #else
     return __strlen_0x_(__str, 0);

--- a/libcudacxx/include/cuda/std/__utility/typeid.h
+++ b/libcudacxx/include/cuda/std/__utility/typeid.h
@@ -123,7 +123,7 @@ template <class _Tp, size_t _Np>
 _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr auto __make_pretty_name(integral_constant<size_t, _Np>) noexcept //
   -> __enable_if_t<_Np == size_t(-1), __string_view>
 {
-  using _TpName = __static_nameof<_Tp, sizeof(_CCCL_PRETTY_FUNCTION)>;
+  using _TpName = __static_nameof<_Tp, sizeof(_CCCL_BUILTIN_PRETTY_FUNCTION())>;
   return __string_view(_TpName::value.__str_, _TpName::value.__len_);
 }
 
@@ -131,7 +131,7 @@ template <class _Tp, size_t _Np>
 _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr auto __make_pretty_name(integral_constant<size_t, _Np>) noexcept //
   -> __enable_if_t<_Np != size_t(-1), __sstring<_Np>>
 {
-  return _CUDA_VSTD::__make_pretty_name_impl<_Np>(_CCCL_PRETTY_FUNCTION, make_index_sequence<_Np>{});
+  return _CUDA_VSTD::__make_pretty_name_impl<_Np>(_CCCL_BUILTIN_PRETTY_FUNCTION(), make_index_sequence<_Np>{});
 }
 
 // TODO: class statics cannot be accessed from device code, so we need to use
@@ -177,7 +177,7 @@ _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __string_view __
 #if defined(_CCCL_COMPILER_GCC) && _CCCL_GCC_VERSION < 90000 && !defined(__CUDA_ARCH__)
   return _CUDA_VSTD::__find_pretty_name(_CUDA_VSTD::__make_pretty_name<_Tp>(integral_constant<size_t, size_t(-1)>{}));
 #else // ^^^ gcc < 9 ^^^^/ vvv other compiler vvv
-  return _CUDA_VSTD::__find_pretty_name(_CUDA_VSTD::__string_view(_CCCL_PRETTY_FUNCTION));
+  return _CUDA_VSTD::__find_pretty_name(_CUDA_VSTD::__string_view(_CCCL_BUILTIN_PRETTY_FUNCTION()));
 #endif // not gcc < 9
 }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -258,17 +258,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char>
   _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept;
 
-  // Define a fallback _CCCL_BUILTIN_STRLEN function using parens to prevent
-  // macro expansion.
-  _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 size_t(_CCCL_BUILTIN_STRLEN)(const char_type* __s) noexcept
-  {
-    size_t __len = 0;
-    for (; !eq(*__s, char(0)); ++__s)
-    {
-      ++__len;
-    }
-    return __len;
-  }
   _LIBCUDACXX_HIDE_FROM_ABI static size_t _CCCL_CONSTEXPR_CXX14 length(const char_type* __s) noexcept
   {
 #if defined(_CCCL_COMPILER_GCC) && _CCCL_GCC_VERSION < 130000
@@ -276,10 +265,18 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char>
     if (__libcpp_is_constant_evaluated())
       ;
 #endif
-    // On device, this will always use the fallback function above. On host,
-    // this will use __builtin_strlen if it is available; otherwise, it will
-    // call the fallback function above.
-    NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return (_CCCL_BUILTIN_STRLEN) (__s);), (return _CCCL_BUILTIN_STRLEN(__s);))
+#if defined(_CCCL_BUILTIN_STRLEN)
+    NV_IF_ELSE_TARGET(NV_IS_DEVICE,
+                      (size_t __len = 0; for (; !eq(*__s, char(0)); ++__s)++ __len; return __len;),
+                      (return _CCCL_BUILTIN_STRLEN(__s);))
+#else
+    size_t __len = 0;
+    for (; !eq(*__s, char(0)); ++__s)
+    {
+      ++__len;
+    }
+    return __len;
+#endif
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 const char_type*

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -69,6 +69,7 @@ template <> struct char_traits<char8_t>;  // c++20
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__algorithm/search.h>
 #include <cuda/std/__fwd/string.h>
+#include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/detail/libcxx/include/iosfwd>
 
 _CCCL_PUSH_MACROS
@@ -268,14 +269,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char>
   }
   _LIBCUDACXX_HIDE_FROM_ABI static size_t _CCCL_CONSTEXPR_CXX14 length(const char_type* __s) noexcept
   {
+#if defined(_CCCL_COMPILER_GCC) && _CCCL_GCC_VERSION < 130000
+    // absurd workaround for GCC "internal compiler error: in cxx_eval_array_reference"
     if (__libcpp_is_constant_evaluated())
-    {
-      return (_CCCL_BUILTIN_STRLEN) (__s);
-    }
-    // In device code, always call the above _CCCL_BUILTIN_STRLEN function. In
-    // host code, call __builtin_strlen if available; otherwise, call the
-    // fallback function.
-    NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return (_CCCL_BUILTIN_STRLEN) (__s);), (return _CCCL_BUILTIN_STRLEN(__s);))
+      ;
+#endif
+    // This will use __builtin_strlen if it is available; otherwise, it will
+    // call the fallback function above.
+    return _CCCL_BUILTIN_STRLEN(__s);
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 const char_type*

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -256,24 +256,16 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char>
   compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept;
   _LIBCUDACXX_HIDE_FROM_ABI static size_t _CCCL_CONSTEXPR_CXX14 length(const char_type* __s) noexcept
   {
-#ifdef _CCCL_HAS_NO_BUILTIN_STRLEN
-#  ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED // is_constant_evaluated only exists since GCC 9
-    if (__libcpp_is_constant_evaluated())
-#  endif // defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
+#ifdef _CCCL_BUILTIN_STRLEN
+    return _CCCL_BUILTIN_STRLEN(__s);
+#else // ^^^ _CCCL_BUILTIN_STRLEN ^^^ / vvv !_CCCL_BUILTIN_STRLEN vvv
+    size_t __len = 0;
+    for (; !eq(*__s, char(0)); ++__s)
     {
-      size_t __len = 0;
-      for (; !eq(*__s, char(0)); ++__s)
-      {
-        ++__len;
-      }
-      return __len;
+      ++__len;
     }
-#endif // defined(_CCCL_HAS_NO_BUILTIN_STRLEN)
-#if !defined(_CCCL_HAS_NO_BUILTIN_STRLEN) || defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
-    NV_IF_ELSE_TARGET(NV_IS_DEVICE,
-                      (size_t __len = 0; for (; !eq(*__s, char(0)); ++__s)++ __len; return __len;),
-                      (return __builtin_strlen(__s);))
-#endif // !defined(_CCCL_HAS_NO_BUILTIN_STRLEN) || defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
+    return __len;
+#endif // !_CCCL_BUILTIN_STRLEN
   }
   _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 const char_type*
   find(const char_type* __s, size_t __n, const char_type& __a) noexcept;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -72,6 +72,8 @@ template <> struct char_traits<char8_t>;  // c++20
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/detail/libcxx/include/iosfwd>
 
+#include <nv/target>
+
 _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
@@ -274,9 +276,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char>
     if (__libcpp_is_constant_evaluated())
       ;
 #endif
-    // This will use __builtin_strlen if it is available; otherwise, it will
+    // On device, this will always use the fallback function above. On host,
+    // this will use __builtin_strlen if it is available; otherwise, it will
     // call the fallback function above.
-    return _CCCL_BUILTIN_STRLEN(__s);
+    NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return (_CCCL_BUILTIN_STRLEN) (__s);), (return _CCCL_BUILTIN_STRLEN(__s);))
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 const char_type*

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -254,19 +254,30 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char>
 
   _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept;
-  _LIBCUDACXX_HIDE_FROM_ABI static size_t _CCCL_CONSTEXPR_CXX14 length(const char_type* __s) noexcept
+
+  // Define a fallback _CCCL_BUILTIN_STRLEN function using parens to prevent
+  // macro expansion.
+  _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 size_t(_CCCL_BUILTIN_STRLEN)(const char_type* __s) noexcept
   {
-#ifdef _CCCL_BUILTIN_STRLEN
-    return _CCCL_BUILTIN_STRLEN(__s);
-#else // ^^^ _CCCL_BUILTIN_STRLEN ^^^ / vvv !_CCCL_BUILTIN_STRLEN vvv
     size_t __len = 0;
     for (; !eq(*__s, char(0)); ++__s)
     {
       ++__len;
     }
     return __len;
-#endif // !_CCCL_BUILTIN_STRLEN
   }
+  _LIBCUDACXX_HIDE_FROM_ABI static size_t _CCCL_CONSTEXPR_CXX14 length(const char_type* __s) noexcept
+  {
+    if (__libcpp_is_constant_evaluated())
+    {
+      return (_CCCL_BUILTIN_STRLEN) (__s);
+    }
+    // In device code, always call the above _CCCL_BUILTIN_STRLEN function. In
+    // host code, call __builtin_strlen if available; otherwise, call the
+    // fallback function.
+    NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return (_CCCL_BUILTIN_STRLEN) (__s);), (return _CCCL_BUILTIN_STRLEN(__s);))
+  }
+
   _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 const char_type*
   find(const char_type* __s, size_t __n, const char_type& __a) noexcept;
   _LIBCUDACXX_HIDE_FROM_ABI static char_type* move(char_type* __s1, const char_type* __s2, size_t __n) noexcept


### PR DESCRIPTION
## Description

some CCCL config macros i touched recently (`_CCCL_PRETTY_FUNCTION` and `CCCL_BUILTIN_NO_STRLEN`) don't follow the established naming conventions for such things. this PR:

- renames `_CCCL_PRETTY_FUNCTION` to `_CCCL_BUILTIN_PRETTY_FUNCTION` and makes it a function-like macro, following the lead of #2628.
- replaces `_CCCL_NO_BUILTIN_STRLEN` with `_CCCL_BUILTIN_STRLEN(str)`, which is not defined if there is no such builtin.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
