### PR TITLE
fix linker errors about multiply defined symbols in STF

### DIFF
--- a/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
+++ b/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
@@ -514,7 +514,7 @@ inline _CCCL_HOST cudaError_t cudaGraphAddHostNodeWithQueue(
   // Submit completion kernel in the stream ...
   // callback_completion_kernel<<<1,1,0,stream>>>(data->completion_flag);
   cudaKernelNodeParams kernel_node_params;
-  kernel_node_params.func            = (void*) callback_completion_kernel;
+  kernel_node_params.func            = (void*) callback_completion_kernel<>;
   kernel_node_params.gridDim         = 1;
   kernel_node_params.blockDim        = 1;
   kernel_node_params.kernelParams    = new void*[1];

--- a/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
+++ b/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
@@ -320,6 +320,7 @@ inline void cudagraph_callback_dispatcher(void* userData)
 }
 
 // There is likely a more efficient way in the current implementation of callbacks !
+template <int = 0> // template to make this `inline` without using `inline`, which nvcc dislikes
 __global__ void callback_completion_kernel(int* completion_flag)
 {
   // Loop until *completion_flag == 1
@@ -341,7 +342,7 @@ inline class cb* get_current_cb()
   return cudaCallbackStateCtx::instance().get_current_cb();
 }
 
-cudaError_t cudaCallbackSetStatus(int step, void* private_ptr)
+inline cudaError_t cudaCallbackSetStatus(int step, void* private_ptr)
 {
   class cb* current_cb = get_current_cb();
   assert(current_cb);
@@ -350,7 +351,7 @@ cudaError_t cudaCallbackSetStatus(int step, void* private_ptr)
   return cudaSuccess;
 }
 
-cudaError_t cudaCallbackGetStatus(int* step, void** private_ptr)
+inline cudaError_t cudaCallbackGetStatus(int* step, void** private_ptr)
 {
   class cb* current_cb = get_current_cb();
   assert(current_cb);


### PR DESCRIPTION
## Description

my pr's are failing CI with errors like this:

```
/usr/bin/ld: cudax/CMakeFiles/cudax.cpp17.headers.basic.stf.dir/./headers/cudax.cpp17.headers.basic.stf/cuda/experimental/__stf/places/exec/host/callback_queues.cuh.cu.o: in function `cuda::experimental::stf::callback_completion_kernel(int*)':
  tmpxft_00006f23_00000000-6_callback_queues.cuh.compute_80.cudafe1.cpp:(.text+0x10): multiple definition of `cuda::experimental::stf::callback_completion_kernel(int*)'; cudax/CMakeFiles/cudax.cpp17.headers.basic.stf.dir/headers/cudax.cpp17.headers.basic.stf/cuda/experimental/__stf/places/exec/host/callback_queues.cuh.cu.o:tmpxft_00006f23_00000000-6_callback_queues.cuh.compute_80.cudafe1.cpp:(.text+0x10): first defined here
  /usr/bin/ld: cudax/CMakeFiles/cudax.cpp17.headers.basic.stf.dir/./headers/cudax.cpp17.headers.basic.stf/cuda/experimental/__stf/places/exec/host/callback_queues.cuh.cu.o: in function `cuda::experimental::stf::cudaCallbackSetStatus(int, void*)':
  tmpxft_00006f23_00000000-6_callback_queues.cuh.compute_80.cudafe1.cpp:(.text+0xc0): multiple definition of `cuda::experimental::stf::cudaCallbackSetStatus(int, void*)'; cudax/CMakeFiles/cudax.cpp17.headers.basic.stf.dir/headers/cudax.cpp17.headers.basic.stf/cuda/experimental/__stf/places/exec/host/callback_queues.cuh.cu.o:tmpxft_00006f23_00000000-6_callback_queues.cuh.compute_80.cudafe1.cpp:(.text+0xc0): first defined here
  /usr/bin/ld: cudax/CMakeFiles/cudax.cpp17.headers.basic.stf.dir/./headers/cudax.cpp17.headers.basic.stf/cuda/experimental/__stf/places/exec/host/callback_queues.cuh.cu.o: in function `cuda::experimental::stf::cudaCallbackGetStatus(int*, void**)':
  tmpxft_00006f23_00000000-6_callback_queues.cuh.compute_80.cudafe1.cpp:(.text+0x150): multiple definition of `cuda::experimental::stf::cudaCallbackGetStatus(int*, void**)'; cudax/CMakeFiles/cudax.cpp17.headers.basic.stf.dir/headers/cudax.cpp17.headers.basic.stf/cuda/experimental/__stf/places/exec/host/callback_queues.cuh.cu.o:tmpxft_00006f23_00000000-6_callback_queues.cuh.compute_80.cudafe1.cpp:(.text+0x150): first defined here
  /usr/bin/ld: cudax/CMakeFiles/cudax.cpp17.headers.basic.stf.dir/./headers/cudax.cpp17.headers.basic.stf/cuda/experimental/__stf/places/exec/host/callback_queues.cuh.cu.o: in function `__device_stub__ZN4cuda12experimental3stf26callback_completion_kernelEPi(int*)':
  tmpxft_00006f23_00000000-6_callback_queues.cuh.compute_80.cudafe1.cpp:(.text+0x1f0): multiple definition of `__device_stub__ZN4cuda12experimental3stf26callback_completion_kernelEPi(int*)'; cudax/CMakeFiles/cudax.cpp17.headers.basic.stf.dir/headers/cudax.cpp17.headers.basic.stf/cuda/experimental/__stf/places/exec/host/callback_queues.cuh.cu.o:tmpxft_00006f23_00000000-6_callback_queues.cuh.compute_80.cudafe1.cpp:(.text+0x1f0): first defined here
  collect2: error: ld returned 1 exit status
```


this is caused by function definition in headers without `inline`. there's also a multiply-defined symbols error about a cuda kernel. i'm not sure what is the right way to handle kernels in headers, so i just made it a template. i would be happy to learn the right way to do this.