### PR TITLE
Add installation presets and update README with install steps

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,6 +29,29 @@
       }
     },
     {
+      "name": "install",
+      "displayName": "Installation / Packaging (only stable libraries)",
+      "inherits": "base",
+      "cacheVariables": {
+        "cudax_ENABLE_INSTALL_RULES": false
+      }
+    },
+    {
+      "name": "install-unstable",
+      "displayName": "Installation / Packaging (includes experimental libraries)",
+      "inherits": "base"
+    },
+    {
+      "name": "install-unstable-only",
+      "displayName": "Installation / Packaging (*only* experimental libraries)",
+      "inherits": "base",
+      "cacheVariables": {
+        "libcudacxx_ENABLE_INSTALL_RULES": false,
+        "CUB_ENABLE_INSTALL_RULES": false,
+        "Thrust_ENABLE_INSTALL_RULES": false
+      }
+    },
+    {
       "name": "all-dev",
       "inherits": "base",
       "cacheVariables": {

--- a/README.md
+++ b/README.md
@@ -138,6 +138,21 @@ nvcc -Icccl/thrust -Icccl/libcudacxx/include -Icccl/cub main.cu -o main
 > **Note**
 > Use `-I` and not `-isystem` to avoid collisions with the CCCL headers implicitly included by `nvcc` from the CUDA Toolkit. All CCCL headers use `#pragma system_header` to ensure warnings will still be silenced as if using `-isystem`, see https://github.com/NVIDIA/cccl/issues/527 for more information.
 
+##### Installation
+
+A minimal build that only generates installation rules can be configured using the `install` CMake preset:
+```bash
+git clone https://github.com/NVIDIA/cccl.git
+cd cccl
+cmake --preset install -DCMAKE_INSTALL_PREFIX=/usr/local/
+cd build/install
+ninja install
+```
+
+To include experimental libraries in the installation, use the `install-unstable` preset and build directory.
+
+To install **only** the experimental libraries, use the `install-unstable-only` preset and build directory.
+
 #### Conda
 
 CCCL also provides conda packages of each release via the `conda-forge` channel:

--- a/cmake/install/cudax.cmake
+++ b/cmake/install/cudax.cmake
@@ -1,4 +1,4 @@
-cccl_generate_install_rules(cudax ${CCCL_TOPLEVEL_PROJECT}
+cccl_generate_install_rules(cudax ${CCCL_ENABLE_CUDAX}
   HEADERS_SUBDIRS "include/cuda"
   HEADERS_INCLUDE "*.cuh"
   PACKAGE


### PR DESCRIPTION
##### Installation

A minimal build that only generates installation rules can be configured using the `install` CMake preset:
```bash
git clone https://github.com/NVIDIA/cccl.git
cd cccl
cmake --preset install -DCMAKE_INSTALL_PREFIX=/usr/local/
cd build/install
ninja install
```

To include experimental libraries in the installation, use the `install-unstable` preset and build directory.

To install **only** the experimental libraries, use the `install-unstable-only` preset and build directory.