### PR TITLE
add new type-list algorithms `copy_if`, `remove_if`, `find_if`, and `unique`

### DIFF
--- a/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
@@ -103,7 +103,7 @@ private:
   _CCCL_NODISCARD_FRIEND _CUDA_VSTD::span<_Tp>
   __cudax_launch_transform(::cuda::stream_ref, uninitialized_async_buffer& __self) noexcept
   {
-    static_assert(_CUDA_VSTD::__is_included_in<_CUDA_VMR::device_accessible, _Properties...>,
+    static_assert(_CUDA_VSTD::__is_included_in_v<_CUDA_VMR::device_accessible, _Properties...>,
                   "The buffer must be device accessible to be passed to `launch`");
     return {__self.__get_data(), __self.size()};
   }
@@ -113,7 +113,7 @@ private:
   _CCCL_NODISCARD_FRIEND _CUDA_VSTD::span<const _Tp>
   __cudax_launch_transform(::cuda::stream_ref, const uninitialized_async_buffer& __self) noexcept
   {
-    static_assert(_CUDA_VSTD::__is_included_in<_CUDA_VMR::device_accessible, _Properties...>,
+    static_assert(_CUDA_VSTD::__is_included_in_v<_CUDA_VMR::device_accessible, _Properties...>,
                   "The buffer must be device accessible to be passed to `launch`");
     return {__self.__get_data(), __self.size()};
   }
@@ -252,7 +252,7 @@ public:
   //! @brief Forwards the passed properties
   _LIBCUDACXX_TEMPLATE(class _Property)
   _LIBCUDACXX_REQUIRES(
-    (!property_with_value<_Property>) _LIBCUDACXX_AND _CUDA_VSTD::__is_included_in<_Property, _Properties...>)
+    (!property_with_value<_Property>) _LIBCUDACXX_AND _CUDA_VSTD::__is_included_in_v<_Property, _Properties...>)
   friend constexpr void get_property(const uninitialized_async_buffer&, _Property) noexcept {}
 #  endif // DOXYGEN_SHOULD_SKIP_THIS
 };

--- a/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
@@ -93,7 +93,7 @@ private:
   _CCCL_NODISCARD_FRIEND _CUDA_VSTD::span<_Tp>
   __cudax_launch_transform(::cuda::stream_ref, uninitialized_buffer& __self) noexcept
   {
-    static_assert(_CUDA_VSTD::__is_included_in<_CUDA_VMR::device_accessible, _Properties...>,
+    static_assert(_CUDA_VSTD::__is_included_in_v<_CUDA_VMR::device_accessible, _Properties...>,
                   "The buffer must be device accessible to be passed to `launch`");
     return {__self.__get_data(), __self.size()};
   }
@@ -103,7 +103,7 @@ private:
   _CCCL_NODISCARD_FRIEND _CUDA_VSTD::span<const _Tp>
   __cudax_launch_transform(::cuda::stream_ref, const uninitialized_buffer& __self) noexcept
   {
-    static_assert(_CUDA_VSTD::__is_included_in<_CUDA_VMR::device_accessible, _Properties...>,
+    static_assert(_CUDA_VSTD::__is_included_in_v<_CUDA_VMR::device_accessible, _Properties...>,
                   "The buffer must be device accessible to be passed to `launch`");
     return {__self.__get_data(), __self.size()};
   }
@@ -220,7 +220,7 @@ public:
   //! @brief Forwards the passed Properties
   _LIBCUDACXX_TEMPLATE(class _Property)
   _LIBCUDACXX_REQUIRES(
-    (!property_with_value<_Property>) _LIBCUDACXX_AND _CUDA_VSTD::__is_included_in<_Property, _Properties...>)
+    (!property_with_value<_Property>) _LIBCUDACXX_AND _CUDA_VSTD::__is_included_in_v<_Property, _Properties...>)
   friend constexpr void get_property(const uninitialized_buffer&, _Property) noexcept {}
 #  endif // DOXYGEN_SHOULD_SKIP_THIS
 };

--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -87,7 +87,7 @@ private:
   //! @brief Validates that a set of \c _OtherProperties... is a superset of \c _Properties... .
   template <class... _OtherProperties>
   static constexpr bool __properties_match =
-    _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>;
+    _CUDA_VSTD::__type_set_contains_v<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>;
 
   //! @brief Validates that a passed in \c _Resource satisfies the \c resource or \c async_resource concept respectively
   //! as well as all properties in \c _Properties... .
@@ -218,8 +218,8 @@ public:
   //! @return The \c resource_ref to this resource.
   _LIBCUDACXX_TEMPLATE(_CUDA_VMR::_AllocType _OtherAllocType, class... _OtherProperties)
   _LIBCUDACXX_REQUIRES(
-    (_OtherAllocType == _CUDA_VMR::_AllocType::_Default || _OtherAllocType == _Alloc_type)
-      _LIBCUDACXX_AND(_CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_Properties...>, _OtherProperties...>))
+    (_OtherAllocType == _CUDA_VMR::_AllocType::_Default || _OtherAllocType == _Alloc_type) _LIBCUDACXX_AND(
+      _CUDA_VSTD::__type_set_contains_v<_CUDA_VSTD::__make_type_set<_Properties...>, _OtherProperties...>))
   operator _CUDA_VMR::basic_resource_ref<_OtherAllocType, _OtherProperties...>() noexcept
   {
     return _CUDA_VMR::_Resource_ref_helper::_Construct<_Alloc_type, _OtherProperties...>(
@@ -263,13 +263,13 @@ public:
   //! @brief Forwards the stateless properties
   _LIBCUDACXX_TEMPLATE(class _Property)
   _LIBCUDACXX_REQUIRES(
-    (!property_with_value<_Property>) _LIBCUDACXX_AND(_CUDA_VSTD::__is_included_in<_Property, _Properties...>))
+    (!property_with_value<_Property>) _LIBCUDACXX_AND(_CUDA_VSTD::__is_included_in_v<_Property, _Properties...>))
   friend void get_property(const basic_any_resource&, _Property) noexcept {}
 
   //! @brief Forwards the stateful properties
   _LIBCUDACXX_TEMPLATE(class _Property)
   _LIBCUDACXX_REQUIRES(
-    property_with_value<_Property> _LIBCUDACXX_AND(_CUDA_VSTD::__is_included_in<_Property, _Properties...>))
+    property_with_value<_Property> _LIBCUDACXX_AND(_CUDA_VSTD::__is_included_in_v<_Property, _Properties...>))
   _CCCL_NODISCARD_FRIEND __property_value_t<_Property> get_property(const basic_any_resource& __res, _Property) noexcept
   {
     _CUDA_VMR::_Property_vtable<_Property> const& __prop = __res;

--- a/libcudacxx/include/cuda/__memory_resource/properties.h
+++ b/libcudacxx/include/cuda/__memory_resource/properties.h
@@ -47,17 +47,17 @@ struct host_accessible
 //! @brief determines wether a set of properties signals host accessible memory.
 template <class... _Properties>
 _CCCL_INLINE_VAR constexpr bool __is_host_accessible =
-  _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_Properties...>, host_accessible>;
+  _CUDA_VSTD::__type_set_contains_v<_CUDA_VSTD::__make_type_set<_Properties...>, host_accessible>;
 
 //! @brief determines wether a set of properties signals device accessible memory.
 template <class... _Properties>
 _CCCL_INLINE_VAR constexpr bool __is_device_accessible =
-  _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_Properties...>, device_accessible>;
+  _CUDA_VSTD::__type_set_contains_v<_CUDA_VSTD::__make_type_set<_Properties...>, device_accessible>;
 
 //! @brief determines wether a set of properties signals host device accessible memory.
 template <class... _Properties>
 _CCCL_INLINE_VAR constexpr bool __is_host_device_accessible =
-  _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_Properties...>, host_accessible, device_accessible>;
+  _CUDA_VSTD::__type_set_contains_v<_CUDA_VSTD::__make_type_set<_Properties...>, host_accessible, device_accessible>;
 
 //! @brief verifies that a set of properties contains at least one execution space property
 template <class... _Properties>

--- a/libcudacxx/include/cuda/__memory_resource/resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource.h
@@ -84,9 +84,9 @@ _LIBCUDACXX_CONCEPT async_resource = _LIBCUDACXX_REQUIRES_EXPR(
 template <class _Resource, class... _Properties>
 _LIBCUDACXX_CONCEPT resource_with =
 #    if defined(_CCCL_COMPILER_NVHPC)
-  resource<_Resource> && _CUDA_VSTD::__fold_and<__has_property_impl<_Resource, _Properties>::value...>;
+  resource<_Resource> && _CUDA_VSTD::__fold_and_v<__has_property_impl<_Resource, _Properties>::value...>;
 #    else // ^^^ _CCCL_COMPILER_NVHPC ^^^ / vvv !_CCCL_COMPILER_NVHPC vvv
-  resource<_Resource> && _CUDA_VSTD::__fold_and<has_property<_Resource, _Properties>...>;
+  resource<_Resource> && _CUDA_VSTD::__fold_and_v<has_property<_Resource, _Properties>...>;
 #    endif // !_CCCL_COMPILER_NVHPC
 
 //! @brief The \c async_resource_with concept verifies that a type Resource satisfies the `async_resource`
@@ -96,9 +96,9 @@ _LIBCUDACXX_CONCEPT resource_with =
 template <class _Resource, class... _Properties>
 _LIBCUDACXX_CONCEPT async_resource_with =
 #    if defined(_CCCL_COMPILER_NVHPC)
-  async_resource<_Resource> && _CUDA_VSTD::__fold_and<__has_property_impl<_Resource, _Properties>::value...>;
+  async_resource<_Resource> && _CUDA_VSTD::__fold_and_v<__has_property_impl<_Resource, _Properties>::value...>;
 #    else // ^^^ _CCCL_COMPILER_NVHPC ^^^ / vvv !_CCCL_COMPILER_NVHPC vvv
-  async_resource<_Resource> && _CUDA_VSTD::__fold_and<has_property<_Resource, _Properties>...>;
+  async_resource<_Resource> && _CUDA_VSTD::__fold_and_v<has_property<_Resource, _Properties>...>;
 #    endif // !_CCCL_COMPILER_NVHPC
 
 template <bool _Convertible>

--- a/libcudacxx/include/cuda/__memory_resource/resource_ref.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource_ref.h
@@ -348,7 +348,7 @@ template <class _Property, class... _Properties>
 struct _Filtered<_Property, _Properties...>
 {
   using _Filtered_vtable = typename _Property_filter<
-    property_with_value<_Property> && !_CUDA_VSTD::__is_included_in<_Property, _Properties...>>::
+    property_with_value<_Property> && !_CUDA_VSTD::__is_included_in_v<_Property, _Properties...>>::
     template _Filtered_properties<_Property, _Properties...>;
 
   template <class _OtherPropery>
@@ -507,7 +507,7 @@ private:
   //! @brief Checks whether \c _OtherProperties is a true superset of \c _Properties, accounting for host_accessible
   template <class... _OtherProperties>
   static constexpr bool __properties_match =
-    _CUDA_VSTD::__type_set_contains<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>;
+    _CUDA_VSTD::__type_set_contains_v<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>;
 
   //! @brief Constructs a \c basic_resource_ref from a void*, a resource vtable ptr, and a vtable
   //! for the properties. This is used to create a \c basic_resource_ref from a \c basic_any_resource.
@@ -615,13 +615,13 @@ public:
   //! @brief Forwards the stateless properties
   _LIBCUDACXX_TEMPLATE(class _Property)
   _LIBCUDACXX_REQUIRES(
-    (!property_with_value<_Property>) _LIBCUDACXX_AND _CUDA_VSTD::__is_included_in<_Property, _Properties...>)
+    (!property_with_value<_Property>) _LIBCUDACXX_AND _CUDA_VSTD::__is_included_in_v<_Property, _Properties...>)
   friend void get_property(const basic_resource_ref&, _Property) noexcept {}
 
   //! @brief Forwards the stateful properties
   _LIBCUDACXX_TEMPLATE(class _Property)
   _LIBCUDACXX_REQUIRES(
-    property_with_value<_Property> _LIBCUDACXX_AND _CUDA_VSTD::__is_included_in<_Property, _Properties...>)
+    property_with_value<_Property> _LIBCUDACXX_AND _CUDA_VSTD::__is_included_in_v<_Property, _Properties...>)
   _CCCL_NODISCARD_FRIEND __property_value_t<_Property> get_property(const basic_resource_ref& __res, _Property) noexcept
   {
     return __res._Property_vtable<_Property>::__property_fn(__res.__object);

--- a/libcudacxx/include/cuda/std/__type_traits/fold.h
+++ b/libcudacxx/include/cuda/std/__type_traits/fold.h
@@ -37,10 +37,10 @@ template <bool... _Preds>
 _CCCL_INLINE_VAR constexpr bool __fold_or_v = (_Preds || ...);
 
 template <bool... _Preds>
-using __fold_and = bool_constant<(_Preds && ...)>;
+using __fold_and = bool_constant<bool((_Preds && ...))>; // cast to bool to avoid error from gcc < 8
 
 template <bool... _Preds>
-using __fold_or = bool_constant<(_Preds || ...)>;
+using __fold_or = bool_constant<bool((_Preds || ...))>; // cast to bool to avoid error from gcc < 8
 
 #else // ^^^ !_LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS / _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS vvv
 

--- a/libcudacxx/include/cuda/std/__type_traits/fold.h
+++ b/libcudacxx/include/cuda/std/__type_traits/fold.h
@@ -20,29 +20,62 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/negation.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if _CCCL_STD_VER >= 2017
+
+// In C++17 and later, we can use fold expressions to implement __fold_and_v and __fold_or_v.
 template <bool... _Preds>
-_CCCL_INLINE_VAR constexpr bool __fold_and = (_Preds && ...);
+_CCCL_INLINE_VAR constexpr bool __fold_and_v = (_Preds && ...);
 
 template <bool... _Preds>
-_CCCL_INLINE_VAR constexpr bool __fold_or = (_Preds || ...);
+_CCCL_INLINE_VAR constexpr bool __fold_or_v = (_Preds || ...);
+
+template <bool... _Preds>
+using __fold_and = bool_constant<__fold_and_v<_Preds...>>;
+
+template <bool... _Preds>
+using __fold_or = bool_constant<__fold_or_v<_Preds...>>;
 
 #elif _CCCL_STD_VER >= 2014
+
+// In C++14, we can use a helper class to implement __fold_and_v and __fold_or_v.
 template <bool... _Preds>
 struct __fold_helper;
 
 template <bool... _Preds>
-_CCCL_INLINE_VAR constexpr bool __fold_and =
+_CCCL_INLINE_VAR constexpr bool __fold_and_v =
   _IsSame<__fold_helper<true, _Preds...>, __fold_helper<_Preds..., true>>::value;
 
 template <bool... _Preds>
-_CCCL_INLINE_VAR constexpr bool __fold_or =
+_CCCL_INLINE_VAR constexpr bool __fold_or_v =
   !_IsSame<__fold_helper<false, _Preds...>, __fold_helper<_Preds..., false>>::value;
-#endif // _CCCL_STD_VER >= 2014
+
+template <bool... _Preds>
+using __fold_and = bool_constant<__fold_and_v<_Preds...>>;
+
+template <bool... _Preds>
+using __fold_or = bool_constant<__fold_or_v<_Preds...>>;
+
+#else // ^^^ _CCCL_STD_VER >= 2014 / _CCCL_STD_VER < 2014 vvv
+
+// Otherwise, we cannot define __fold_and_v and __fold_or_v since C++11 does not
+// have variable templates. Instead we provide just __fold_and and __fold_or type
+// aliases.
+template <bool... _Preds>
+struct __fold_helper;
+
+template <bool... _Preds>
+using __fold_and = _IsSame<__fold_helper<true, _Preds...>, __fold_helper<_Preds..., true>>;
+
+template <bool... _Preds>
+using __fold_or = _Not<_IsSame<__fold_helper<false, _Preds...>, __fold_helper<_Preds..., false>>>;
+
+#endif // _CCCL_STD_VER < 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/fold.h
+++ b/libcudacxx/include/cuda/std/__type_traits/fold.h
@@ -31,10 +31,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // Use fold expressions when possible to implement __fold_and[_v] and
 // __fold_or[_v].
 template <bool... _Preds>
-_CCCL_GLOBAL_CONSTANT bool __fold_and_v = (_Preds && ...);
+_CCCL_INLINE_VAR constexpr bool __fold_and_v = (_Preds && ...);
 
 template <bool... _Preds>
-_CCCL_GLOBAL_CONSTANT bool __fold_or_v = (_Preds || ...);
+_CCCL_INLINE_VAR constexpr bool __fold_or_v = (_Preds || ...);
 
 template <bool... _Preds>
 using __fold_and = bool_constant<(_Preds && ...)>;
@@ -56,10 +56,10 @@ using __fold_or = _Not<_IsSame<__fold_helper<false, _Preds...>, __fold_helper<_P
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <bool... _Preds>
-_CCCL_GLOBAL_CONSTANT bool __fold_and_v = __fold_and<_Preds...>::value;
+_CCCL_INLINE_VAR constexpr bool __fold_and_v = __fold_and<_Preds...>::value;
 
 template <bool... _Preds>
-_CCCL_GLOBAL_CONSTANT bool __fold_or_v = __fold_or<_Preds...>::value;
+_CCCL_INLINE_VAR constexpr bool __fold_or_v = __fold_or<_Preds...>::value;
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 #endif // _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS

--- a/libcudacxx/include/cuda/std/__type_traits/fold.h
+++ b/libcudacxx/include/cuda/std/__type_traits/fold.h
@@ -26,46 +26,25 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER >= 2017
+#if !defined(_LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS)
 
-// In C++17 and later, we can use fold expressions to implement __fold_and_v and __fold_or_v.
+// Use fold expressions when possible to implement __fold_and[_v] and
+// __fold_or[_v].
 template <bool... _Preds>
-_CCCL_INLINE_VAR constexpr bool __fold_and_v = (_Preds && ...);
-
-template <bool... _Preds>
-_CCCL_INLINE_VAR constexpr bool __fold_or_v = (_Preds || ...);
+_CCCL_GLOBAL_CONSTANT bool __fold_and_v = (_Preds && ...);
 
 template <bool... _Preds>
-using __fold_and = bool_constant<__fold_and_v<_Preds...>>;
+_CCCL_GLOBAL_CONSTANT bool __fold_or_v = (_Preds || ...);
 
 template <bool... _Preds>
-using __fold_or = bool_constant<__fold_or_v<_Preds...>>;
-
-#elif _CCCL_STD_VER >= 2014
-
-// In C++14, we can use a helper class to implement __fold_and_v and __fold_or_v.
-template <bool... _Preds>
-struct __fold_helper;
+using __fold_and = bool_constant<(_Preds && ...)>;
 
 template <bool... _Preds>
-_CCCL_INLINE_VAR constexpr bool __fold_and_v =
-  _IsSame<__fold_helper<true, _Preds...>, __fold_helper<_Preds..., true>>::value;
+using __fold_or = bool_constant<(_Preds || ...)>;
 
-template <bool... _Preds>
-_CCCL_INLINE_VAR constexpr bool __fold_or_v =
-  !_IsSame<__fold_helper<false, _Preds...>, __fold_helper<_Preds..., false>>::value;
+#else // ^^^ !_LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS / _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS vvv
 
-template <bool... _Preds>
-using __fold_and = bool_constant<__fold_and_v<_Preds...>>;
-
-template <bool... _Preds>
-using __fold_or = bool_constant<__fold_or_v<_Preds...>>;
-
-#else // ^^^ _CCCL_STD_VER >= 2014 / _CCCL_STD_VER < 2014 vvv
-
-// Otherwise, we cannot define __fold_and_v and __fold_or_v since C++11 does not
-// have variable templates. Instead we provide just __fold_and and __fold_or type
-// aliases.
+// Otherwise, we can use a helper class to implement __fold_and and __fold_or.
 template <bool... _Preds>
 struct __fold_helper;
 
@@ -75,7 +54,15 @@ using __fold_and = _IsSame<__fold_helper<true, _Preds...>, __fold_helper<_Preds.
 template <bool... _Preds>
 using __fold_or = _Not<_IsSame<__fold_helper<false, _Preds...>, __fold_helper<_Preds..., false>>>;
 
-#endif // _CCCL_STD_VER < 2014
+#  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
+template <bool... _Preds>
+_CCCL_GLOBAL_CONSTANT bool __fold_and_v = __fold_and<_Preds...>::value;
+
+template <bool... _Preds>
+_CCCL_GLOBAL_CONSTANT bool __fold_or_v = __fold_or<_Preds...>::value;
+#  endif // !_CCCL_NO_VARIABLE_TEMPLATES
+
+#endif // _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -181,14 +181,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_always
 //! \note The AND operation is not short-circuiting.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_and
 {
-#  ifndef _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ts::value && ...)>;
-#  else
-  template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<_CCCL_TRAIT(
-    is_same, integer_sequence<bool, true, _Ts::value...>, integer_sequence<bool, _Ts::value..., true>)>;
-#  endif
+  using __call _LIBCUDACXX_NODEBUG_TYPE = __fold_and<_Ts::value...>;
 };
 
 //! \brief Perform a logical OR operation on a list of Boolean types.
@@ -196,14 +190,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_and
 //! \note The OR operation is not short-circuiting.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_or
 {
-#  ifndef _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ts::value || ...)>;
-#  else
-  template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<!_CCCL_TRAIT(
-    is_same, integer_sequence<bool, false, _Ts::value...>, integer_sequence<bool, _Ts::value..., false>)>;
-#  endif
+  using __call _LIBCUDACXX_NODEBUG_TYPE = __fold_or<_Ts::value...>;
 };
 
 //! \brief Perform a logical NOT operation on a Boolean type.
@@ -371,6 +359,15 @@ template <class _Fn, class... _Ts>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_defer
     : __type_call<__detail::__type_defer_fn<__type_callable<_Fn, _Ts...>::value>, _Fn, _Ts...>
 {};
+
+//! \brief Defer the instantiation of a template with a list of arguments.
+//!
+//! Given a variadic template and a list of arguments, return a trait type \c T
+//! where \c T::type is the result of instantiating the template with the
+//! arguments, or if the template cannot be instantiated with the arguments, a
+//! class type without a nested \c ::type type alias.
+template <template <class...> class _Fn, class... _Ts>
+using __type_defer_quote = __type_defer<__type_quote<_Fn>, _Ts...>;
 
 //! \brief A composition of two meta-callables that will attempt to call the
 //! first, and if that fails, call the second.

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -25,6 +25,7 @@
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/type_identity.h>
+#include <cuda/std/__type_traits/type_set.h>
 #include <cuda/std/__type_traits/void_t.h>
 #include <cuda/std/__utility/integer_sequence.h>
 
@@ -46,8 +47,8 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class... _Ts>
 struct __type_list;
 
-template <class _Tp>
-using __type = typename _Tp::type;
+template <class _Ty>
+using __type = typename _Ty::type;
 
 //! \brief Evaluate a meta-callable with the given arguments
 template <class _Fn, class... _Ts>
@@ -175,6 +176,101 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_always
   using __call _LIBCUDACXX_NODEBUG_TYPE = _Ty;
 };
 
+//! \brief Perform a logical AND operation on a list of Boolean types.
+//!
+//! \note The AND operation is not short-circuiting.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_and
+{
+#  ifndef _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS
+  template <class... _Ts>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ts::value && ...)>;
+#  else
+  template <class... _Ts>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<_CCCL_TRAIT(
+    is_same, integer_sequence<bool, true, _Ts::value...>, integer_sequence<bool, _Ts::value..., true>)>;
+#  endif
+};
+
+//! \brief Perform a logical OR operation on a list of Boolean types.
+//!
+//! \note The OR operation is not short-circuiting.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_or
+{
+#  ifndef _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS
+  template <class... _Ts>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ts::value || ...)>;
+#  else
+  template <class... _Ts>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<!_CCCL_TRAIT(
+    is_same, integer_sequence<bool, false, _Ts::value...>, integer_sequence<bool, _Ts::value..., false>)>;
+#  endif
+};
+
+//! \brief Perform a logical NOT operation on a Boolean type.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_not
+{
+  template <class _Ty>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(!_Ty::value)>;
+};
+
+//! \brief Test whether two integral constants are equal.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_equal
+{
+  template <class _Ty, class _Uy>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value == _Uy::value)>;
+};
+
+//! \brief Test whether two integral constants are not equal.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_not_equal
+{
+  template <class _Ty, class _Uy>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value != _Uy::value)>;
+};
+
+//! \brief Test whether one integral constant is less than another.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_less
+{
+  template <class _Ty, class _Uy>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value < _Uy::value)>;
+};
+
+//! \brief Test whether one integral constant is less than or equal to another.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_less_equal
+{
+  template <class _Ty, class _Uy>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value <= _Uy::value)>;
+};
+
+//! \brief Test whether one integral constant is greater than another.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_greater
+{
+  template <class _Ty, class _Uy>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value > _Uy::value)>;
+};
+
+//! \brief Test whether one integral constant is greater than or equal to another.
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_greater_equal
+{
+  template <class _Ty, class _Uy>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value >= _Uy::value)>;
+};
+
+//! \brief A functional adaptor that negates a unary predicate
+template <class _Fn>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_negate1
+{
+  template <class _Ty>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call1<__type_not, __type_call1<_Fn, _Ty>>;
+};
+
+//! \brief A functional adaptor that negates a binary predicate
+template <class _Fn>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_negate2
+{
+  template <class _Ty, class _Uy>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call1<__type_not, __type_call2<_Fn, _Ty, _Uy>>;
+};
+
 //! \brief A type list
 template <class... _Ts>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_list
@@ -210,6 +306,25 @@ using __type_push_back = __type_call<_List, __type_quote<__type_list>, _Ts...>;
 //! \brief Given a type list and a list of types, prepend the types to the list.
 template <class _List, class... _Ts>
 using __type_push_front = __type_call1<_List, __type_bind_front<__type_quote<__type_list>, _Ts...>>;
+
+namespace __detail
+{
+template <template <class...> class _Fn, class... _Ts>
+_LIBCUDACXX_HIDE_FROM_ABI auto __as_type_list_fn(_Fn<_Ts...>*) -> __type_list<_Ts...>;
+
+template <template <class _Ty, _Ty...> class _Fn, class _Ty, _Ty... _Us>
+_LIBCUDACXX_HIDE_FROM_ABI auto __as_type_list_fn(_Fn<_Ty, _Us...>*) -> __type_list<integral_constant<_Ty, _Us>...>;
+} // namespace __detail
+
+//! \brief Given a type that is a specialization of a class template, return a
+//! type list of the template arguments.
+template <class _List>
+using __as_type_list = decltype(__detail::__as_type_list_fn(static_cast<_List*>(nullptr)));
+
+//! \brief Given a type that is a specialization of a class template and a
+//! meta-callable, invoke the callable with the template arguments.
+template <class _Fn, class _List>
+using __type_apply = __type_call<__as_type_list<_List>, _Fn>;
 
 namespace __detail
 {
@@ -256,6 +371,22 @@ template <class _Fn, class... _Ts>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_defer
     : __type_call<__detail::__type_defer_fn<__type_callable<_Fn, _Ts...>::value>, _Fn, _Ts...>
 {};
+
+//! \brief A composition of two meta-callables that will attempt to call the
+//! first, and if that fails, call the second.
+//!
+//! Compose two meta-callables, \c _TryFn and \c _CatchFn, into a new
+//! meta-callable. Given arguments \c _Ts... , \c __type_try_catch will try to
+//! evaluate `__type_call<_TryFn, _Ts...>`. If this type is well-formed, it will
+//! be the result of the composition. Otherwise, the result will be
+//! `__type_call<_CatchFn, _Ts...>`.
+template <class _TryFn, class _CatchFn>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_try_catch
+{
+  template <class... _Ts>
+  using __call _LIBCUDACXX_NODEBUG_TYPE =
+    __type_call<_If<__type_callable<_TryFn, _Ts...>::value, _TryFn, _CatchFn>, _Ts...>;
+};
 
 // Implementation for indexing into a list of types:
 #  if defined(__cpp_pack_indexing) && !defined(_CCCL_CUDA_COMPILER_NVCC)
@@ -471,13 +602,28 @@ using __type_flatten = __type_call1<_ListOfLists, __type_quote<__type_concat>>;
 namespace __detail
 {
 template <bool _IsEmpty>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_find_if_fn;
+
+template <bool _Found>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_find_if_found
+{
+  template <class _Fn, class _Head, class... _Tail>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_list<_Head, _Tail...>;
+};
+
+template <>
+struct __type_find_if_found<false>
+{
+  template <class _Fn, class _Head, class... _Tail>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call<__type_maybe_find_if_fn<sizeof...(_Tail) == 0>, _Fn, _Tail...>;
+};
+
+template <bool _IsEmpty>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_find_if_fn // Type list is not empty
 {
   template <class _Fn, class _Head, class... _Tail>
   using __call _LIBCUDACXX_NODEBUG_TYPE =
-    _If<__type_call1<_Fn, _Head>::value,
-        __type_list<_Head, _Tail...>,
-        __type_call<__type_maybe_find_if_fn<sizeof...(_Tail) == 0>, _Fn, _Tail...>>;
+    __type_call<__type_find_if_found<__type_call1<_Fn, _Head>::value>, _Fn, _Head, _Tail...>;
 };
 
 template <>
@@ -493,16 +639,31 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_find_if_fn
   template <class... _Ts>
   using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call<__type_maybe_find_if_fn<sizeof...(_Ts) == 0>, _Fn, _Ts...>;
 };
+
+template <class _Ty>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_same_as
+{
+  template <class _Uy>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<_CCCL_TRAIT(is_same, _Ty, _Uy)>;
+};
 } // namespace __detail
 
-//! \brief Given a type list and a predicate, find the first type in a list that
-//! satisfies a predicate. It returns a type list containing the first type that
-//! satisfies the predicate and all the types after it.
+//! \brief Given a type list and a predicate, find the first type in the list
+//! that satisfies the predicate. It returns a type list containing the first
+//! type that satisfies the predicate and all the types after it.
 //!
-//! If no type in the list satisfies the predicate, \c __type_find_if
-//! returns an empty type list.
+//! If no type in the list satisfies the predicate, \c __type_find_if returns an
+//! empty type list.
 template <class _List, class _Fn>
 using __type_find_if = __type_call1<_List, __detail::__type_find_if_fn<_Fn>>;
+
+//! \brief Given a type list and type, find the first occurrance of the type in
+//! the list. It returns a type list containing the type and all the types after
+//! it.
+//!
+//! If the type is not in the list, \c __type_find returns an empty type list.
+template <class _List, class _Ty>
+using __type_find = __type_find_if<_List, __detail::__type_same_as<_Ty>>;
 
 namespace __detail
 {
@@ -627,6 +788,28 @@ using __type_remove = __type_flatten<__type_transform<_List, __detail::__type_re
 
 namespace __detail
 {
+template <class _Fn>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_remove_if_fn
+{
+  template <class _Uy>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = _If<__type_call1<_Fn, _Uy>::value, __type_list<>, __type_list<_Uy>>;
+};
+} // namespace __detail
+
+//! \brief Remove all types satisfying a unary predicate from a type list
+template <class _List, class _Fn>
+using __type_remove_if = __type_flatten<__type_transform<_List, __detail::__type_remove_if_fn<_Fn>>>;
+
+//! \brief Remove all types not satisfying a unary predicate from a type list
+template <class _List, class _Fn>
+using __type_copy_if = __type_flatten<__type_transform<_List, __detail::__type_remove_if_fn<__type_negate1<_Fn>>>>;
+
+//! \brief Remove all duplicate types from a type list
+template <class _List>
+using __type_unique = __type_concat<__type_call<_List, __type_quote<__make_type_set>>>;
+
+namespace __detail
+{
 // _State is the list of type lists being built by the __type_fold_left
 template <class _State, class _List>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_cartesian_product_fn
@@ -662,87 +845,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_sizeof
 {
   template <class _Ty>
   using __call _LIBCUDACXX_NODEBUG_TYPE = integral_constant<size_t, sizeof(_Ty)>;
-};
-
-//! \brief Perform a logical AND operation on a list of Boolean types.
-//!
-//! \note The AND operation is not short-circuiting.
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_and
-{
-#  ifndef _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS
-  template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ts::value && ...)>;
-#  else
-  template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<_CCCL_TRAIT(
-    is_same, integer_sequence<bool, true, _Ts::value...>, integer_sequence<bool, _Ts::value..., true>)>;
-#  endif
-};
-
-//! \brief Perform a logical OR operation on a list of Boolean types.
-//!
-//! \note The OR operation is not short-circuiting.
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_or
-{
-#  ifndef _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS
-  template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ts::value || ...)>;
-#  else
-  template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<!_CCCL_TRAIT(
-    is_same, integer_sequence<bool, false, _Ts::value...>, integer_sequence<bool, _Ts::value..., false>)>;
-#  endif
-};
-
-//! \brief Perform a logical NOT operation on a Boolean type.
-//!
-//! \note The AND operation is not short-circuiting.
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_not
-{
-  template <class _Ty>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(!_Ty::value)>;
-};
-
-//! \brief Test whether two integral constants are equal.
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_equal
-{
-  template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value == _Uy::value)>;
-};
-
-//! \brief Test whether two integral constants are not equal.
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_not_equal
-{
-  template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value != _Uy::value)>;
-};
-
-//! \brief Test whether one integral constant is less than another.
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_less
-{
-  template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value < _Uy::value)>;
-};
-
-//! \brief Test whether one integral constant is less than or equal to another.
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_less_equal
-{
-  template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value <= _Uy::value)>;
-};
-
-//! \brief Test whether one integral constant is greater than another.
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_greater
-{
-  template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value > _Uy::value)>;
-};
-
-//! \brief Test whether one integral constant is greater than or equal to another.
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_greater_equal
-{
-  template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value >= _Uy::value)>;
 };
 
 //! \brief A pair of types

--- a/libcudacxx/include/cuda/std/__type_traits/type_set.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_set.h
@@ -36,7 +36,7 @@ struct __type_set_contains : __fold_and<_CCCL_TRAIT(is_base_of, __type_identity<
 
 #ifndef _CCCL_NO_VARIABLE_TEMPLATES
 template <class _Set, class... _Ty>
-_CCCL_GLOBAL_CONSTANT bool __type_set_contains_v = __fold_and_v<is_base_of_v<__type_identity<_Ty>, _Set>...>;
+_CCCL_INLINE_VAR constexpr bool __type_set_contains_v = __fold_and_v<is_base_of_v<__type_identity<_Ty>, _Set>...>;
 #endif // _CCCL_NO_VARIABLE_TEMPLATES
 
 namespace __set
@@ -84,7 +84,7 @@ using __type_set_eq =
 
 #ifndef _CCCL_NO_VARIABLE_TEMPLATES
 template <class _ExpectedSet, class... _Ts>
-_CCCL_GLOBAL_CONSTANT bool __type_set_eq_v = __type_set_eq<_ExpectedSet, _Ts...>::value;
+_CCCL_INLINE_VAR constexpr bool __type_set_eq_v = __type_set_eq<_ExpectedSet, _Ts...>::value;
 #endif // _CCCL_NO_VARIABLE_TEMPLATES
 
 template <class... _Ts>
@@ -102,7 +102,7 @@ struct __is_included_in : __fold_or<_CCCL_TRAIT(is_same, _Ty, _Ts)...>
 
 #ifndef _CCCL_NO_VARIABLE_TEMPLATES
 template <class _Ty, class... _Ts>
-_CCCL_GLOBAL_CONSTANT bool __is_included_in_v = __fold_or_v<is_same_v<_Ty, _Ts>...>;
+_CCCL_INLINE_VAR constexpr bool __is_included_in_v = __fold_or_v<is_same_v<_Ty, _Ts>...>;
 #endif // _CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__type_traits/type_set.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_set.h
@@ -44,7 +44,7 @@ namespace __set
 template <class... _Ts>
 struct __tupl
 {
-  static constexpr size_t __size() noexcept
+  _LIBCUDACXX_HIDE_FROM_ABI static constexpr size_t __size() noexcept
   {
     return 0;
   }
@@ -55,7 +55,7 @@ struct __tupl<_Ty, _Ts...>
     : __type_identity<_Ty>
     , __tupl<_Ts...>
 {
-  static constexpr size_t __size() noexcept
+  _LIBCUDACXX_HIDE_FROM_ABI static constexpr size_t __size() noexcept
   {
     return sizeof...(_Ts) + 1;
   }
@@ -68,10 +68,10 @@ using __insert =
 struct __bulk_insert
 {
   template <class... _Ts>
-  static auto __call(__tupl<_Ts...>*) -> __tupl<_Ts...>;
+  _LIBCUDACXX_HIDE_FROM_ABI static auto __call(__tupl<_Ts...>*) -> __tupl<_Ts...>;
 
   template <class _Ap, class... _Us, class... _Ts, class _SetInsert = __bulk_insert>
-  static auto __call(__tupl<_Ts...>*)
+  _LIBCUDACXX_HIDE_FROM_ABI static auto __call(__tupl<_Ts...>*)
     -> decltype(_SetInsert::template __call<_Us...>(static_cast<__insert<_Ap, _Ts...>*>(nullptr)));
 };
 } // namespace __set

--- a/libcudacxx/include/cuda/std/__type_traits/type_set.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_set.h
@@ -30,19 +30,13 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+template <class _Set, class... _Ty>
+struct __type_set_contains : __fold_and<_CCCL_TRAIT(is_base_of, __type_identity<_Ty>, _Set)...>
+{};
+
 #ifndef _CCCL_NO_VARIABLE_TEMPLATES
-
 template <class _Set, class... _Ty>
-_CCCL_INLINE_VAR constexpr bool __type_set_contains_v = __fold_and_v<is_base_of_v<__type_identity<_Ty>, _Set>...>;
-
-template <class _Set, class... _Ty>
-using __type_set_contains = bool_constant<__type_set_contains_v<_Set, _Ty...>>;
-
-#else // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES ^^^ / vvv _CCCL_NO_VARIABLE_TEMPLATES vvv
-
-template <class _Set, class... _Ty>
-using __type_set_contains = __fold_and<is_base_of<__type_identity<_Ty>, _Set>::value...>;
-
+_CCCL_GLOBAL_CONSTANT bool __type_set_contains_v = __fold_and_v<is_base_of_v<__type_identity<_Ty>, _Set>...>;
 #endif // _CCCL_NO_VARIABLE_TEMPLATES
 
 namespace __set
@@ -90,7 +84,7 @@ using __type_set_eq =
 
 #ifndef _CCCL_NO_VARIABLE_TEMPLATES
 template <class _ExpectedSet, class... _Ts>
-_CCCL_INLINE_VAR constexpr bool __type_set_eq_v = __type_set_eq<_ExpectedSet, _Ts...>::value;
+_CCCL_GLOBAL_CONSTANT bool __type_set_eq_v = __type_set_eq<_ExpectedSet, _Ts...>::value;
 #endif // _CCCL_NO_VARIABLE_TEMPLATES
 
 template <class... _Ts>
@@ -102,15 +96,13 @@ using __type_set_insert = decltype(__set::__bulk_insert::__call<_Ts...>(static_c
 template <class... _Ts>
 using __make_type_set = __type_set_insert<__type_set<>, _Ts...>;
 
+template <class _Ty, class... _Ts>
+struct __is_included_in : __fold_or<_CCCL_TRAIT(is_same, _Ty, _Ts)...>
+{};
+
 #ifndef _CCCL_NO_VARIABLE_TEMPLATES
 template <class _Ty, class... _Ts>
-_CCCL_INLINE_VAR constexpr bool __is_included_in_v = __fold_or_v<is_same_v<_Ty, _Ts>...>;
-
-template <class _Ty, class... _Ts>
-using __is_included_in = bool_constant<__is_included_in_v<_Ty, _Ts...>>;
-#else // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES ^^^ / vvv _CCCL_NO_VARIABLE_TEMPLATES vvv
-template <class _Ty, class... _Ts>
-using __is_included_in = __fold_or<is_same<_Ty, _Ts>::value...>;
+_CCCL_GLOBAL_CONSTANT bool __is_included_in_v = __fold_or_v<is_same_v<_Ty, _Ts>...>;
 #endif // _CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/inheritance.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/inheritance.pass.cpp
@@ -43,11 +43,11 @@ struct async_resource_base
 
   _LIBCUDACXX_TEMPLATE(class Property)
   _LIBCUDACXX_REQUIRES((!cuda::property_with_value<Property>)
-                       && _CUDA_VSTD::__is_included_in<Property, Properties...>) //
+                       && _CUDA_VSTD::__is_included_in_v<Property, Properties...>) //
   friend void get_property(const async_resource_base&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  _LIBCUDACXX_REQUIRES(cuda::property_with_value<Property>&& _CUDA_VSTD::__is_included_in<Property, Properties...>) //
+  _LIBCUDACXX_REQUIRES(cuda::property_with_value<Property>&& _CUDA_VSTD::__is_included_in_v<Property, Properties...>) //
   friend typename Property::value_type get_property(const async_resource_base& res, Property) noexcept
   {
     return 42;

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/types.h
@@ -59,11 +59,11 @@ struct async_resource
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  _LIBCUDACXX_REQUIRES((!cuda::property_with_value<Property>) && _CUDA_VSTD::__is_included_in<Property, Properties...>)
+  _LIBCUDACXX_REQUIRES((!cuda::property_with_value<Property>) && _CUDA_VSTD::__is_included_in_v<Property, Properties...>)
   friend void get_property(const async_resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  _LIBCUDACXX_REQUIRES(cuda::property_with_value<Property>&& _CUDA_VSTD::__is_included_in<Property, Properties...>)
+  _LIBCUDACXX_REQUIRES(cuda::property_with_value<Property>&& _CUDA_VSTD::__is_included_in_v<Property, Properties...>)
   friend typename Property::value_type get_property(const async_resource& res, Property) noexcept
   {
     return static_cast<typename Property::value_type>(res._val);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/inheritance.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/inheritance.pass.cpp
@@ -39,11 +39,11 @@ struct resource_base
 
   _LIBCUDACXX_TEMPLATE(class Property)
   _LIBCUDACXX_REQUIRES((!cuda::property_with_value<Property>)
-                       && _CUDA_VSTD::__is_included_in<Property, Properties...>) //
+                       && _CUDA_VSTD::__is_included_in_v<Property, Properties...>) //
   friend void get_property(const resource_base&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  _LIBCUDACXX_REQUIRES(cuda::property_with_value<Property>&& _CUDA_VSTD::__is_included_in<Property, Properties...>) //
+  _LIBCUDACXX_REQUIRES(cuda::property_with_value<Property>&& _CUDA_VSTD::__is_included_in_v<Property, Properties...>) //
   friend typename Property::value_type get_property(const resource_base& res, Property) noexcept
   {
     return 42;

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/types.h
@@ -59,11 +59,11 @@ struct resource
   int _val = 0;
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  _LIBCUDACXX_REQUIRES((!cuda::property_with_value<Property>) && _CUDA_VSTD::__is_included_in<Property, Properties...>)
+  _LIBCUDACXX_REQUIRES((!cuda::property_with_value<Property>) && _CUDA_VSTD::__is_included_in_v<Property, Properties...>)
   friend void get_property(const resource&, Property) noexcept {}
 
   _LIBCUDACXX_TEMPLATE(class Property)
-  _LIBCUDACXX_REQUIRES(cuda::property_with_value<Property>&& _CUDA_VSTD::__is_included_in<Property, Properties...>)
+  _LIBCUDACXX_REQUIRES(cuda::property_with_value<Property>&& _CUDA_VSTD::__is_included_in_v<Property, Properties...>)
   friend typename Property::value_type get_property(const resource& res, Property) noexcept
   {
     return static_cast<typename Property::value_type>(res._val);

--- a/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
@@ -719,6 +719,26 @@ static_assert(::cuda::std::is_same<::cuda::std::__type_remove<::cuda::std::__typ
                                    ::cuda::std::__type_list<short, int*>>::value,
               "");
 
+// __type_remove_if
+static_assert(::cuda::std::is_same<::cuda::std::__type_remove_if<::cuda::std::__type_list<>, BiggerThanFour>,
+                                   ::cuda::std::__type_list<>>::value,
+              "");
+static_assert(
+  ::cuda::std::is_same<
+    ::cuda::std::__type_remove_if<::cuda::std::__type_list<char[0], char[8], char[4], char[3], char[5]>, BiggerThanFour>,
+    ::cuda::std::__type_list<char[0], char[4], char[3]>>::value,
+  "");
+
+// __type_copy_if
+static_assert(::cuda::std::is_same<::cuda::std::__type_remove_if<::cuda::std::__type_list<>, BiggerThanFour>,
+                                   ::cuda::std::__type_list<>>::value,
+              "");
+static_assert(
+  ::cuda::std::is_same<
+    ::cuda::std::__type_copy_if<::cuda::std::__type_list<char[0], char[8], char[4], char[3], char[5]>, BiggerThanFour>,
+    ::cuda::std::__type_list<char[8], char[5]>>::value,
+  "");
+
 // __type_cartesian_product
 static_assert(
   ::cuda::std::is_same<::cuda::std::__type_cartesian_product<::cuda::std::__type_list<>, ::cuda::std::__type_list<>>,

--- a/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
@@ -725,8 +725,8 @@ static_assert(::cuda::std::is_same<::cuda::std::__type_remove_if<::cuda::std::__
               "");
 static_assert(
   ::cuda::std::is_same<
-    ::cuda::std::__type_remove_if<::cuda::std::__type_list<char[0], char[8], char[4], char[3], char[5]>, BiggerThanFour>,
-    ::cuda::std::__type_list<char[0], char[4], char[3]>>::value,
+    ::cuda::std::__type_remove_if<::cuda::std::__type_list<char[1], char[8], char[4], char[3], char[5]>, BiggerThanFour>,
+    ::cuda::std::__type_list<char[1], char[4], char[3]>>::value,
   "");
 
 // __type_copy_if
@@ -735,7 +735,7 @@ static_assert(::cuda::std::is_same<::cuda::std::__type_remove_if<::cuda::std::__
               "");
 static_assert(
   ::cuda::std::is_same<
-    ::cuda::std::__type_copy_if<::cuda::std::__type_list<char[0], char[8], char[4], char[3], char[5]>, BiggerThanFour>,
+    ::cuda::std::__type_copy_if<::cuda::std::__type_list<char[1], char[8], char[4], char[3], char[5]>, BiggerThanFour>,
     ::cuda::std::__type_list<char[8], char[5]>>::value,
   "");
 


### PR DESCRIPTION
also, make the type-set facility portable to c++11

## Description

this PR factors the type-list/type-set changes out of #2633. it adds the above mentioned type-list algorithms and makes the new `__fold_and`/`__fold_or` utilities available on C++11 as well as `__type_set`. it also adds a way to turn a template specialization `C<Ts...>` to a type-list `__type_list<Ts...>`, and a `__type_apply` metafunction for evaluating a metafunction with the types in a type-list.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
