### PR TITLE
Ignore more files when detecting CI changes.

### DIFF
--- a/ci/inspect_changes.sh
+++ b/ci/inspect_changes.sh
@@ -61,6 +61,39 @@ declare -A project_dirs=(
   [cccl_c_parallel]="c/parallel"
 )
 
+# Changes to files / directories listed here are ignored when checking if the
+# CCCL Infrastructure has been modified.
+# These are checked as regexes that match the beginning of the file path.
+ignore_paths=(
+  ".clang-format"
+  ".clangd"
+  ".devcontainer/README.md"
+  ".devcontainer/img"
+  ".git-blame-ignore-revs"
+  ".github/actions/docs-build"
+  ".github/ISSUE_TEMPLATE"
+  ".github/CODEOWNERS"
+  ".github/copy-pr-bot.yaml"
+  ".github/PULL_REQUEST_TEMPLATE.md"
+  ".github/workflows/backport-prs.yml"
+  ".github/workflows/build-docs.yml"
+  ".github/workflows/build-rapids.yml"
+  ".github/workflows/project_automation" # All project automation workflows
+  ".github/workflows/triage_rotation.yml"
+  ".github/workflows/update_branch_version.yml"
+  ".github/workflows/verify-devcontainers.yml"
+  ".gitignore"
+  ".pre-commit-config.yaml"
+  "ci-overview.md"
+  "CITATION.md"
+  "CODE_OF_CONDUCT.md"
+  "CONTRIBUTING.md"
+  "LICENSE"
+  "README.md"
+  "SECURITY.md"
+  "docs"
+)
+
 # Usage checks:
 for subproject in "${subprojects[@]}"; do
   # Check that the subproject directory exists
@@ -113,7 +146,7 @@ inspect_cccl() {
     done
 
     # Manual exclusions:
-    exclusions+=("docs")
+    exclusions+=("${ignore_paths[@]}")
 
     IFS="|"
     echo "^(${exclusions[*]})/"

--- a/ci/inspect_changes.sh
+++ b/ci/inspect_changes.sh
@@ -67,13 +67,13 @@ declare -A project_dirs=(
 ignore_paths=(
   ".clang-format"
   ".clangd"
-  ".devcontainer/README.md"
   ".devcontainer/img"
+  ".devcontainer/README.md"
   ".git-blame-ignore-revs"
   ".github/actions/docs-build"
-  ".github/ISSUE_TEMPLATE"
   ".github/CODEOWNERS"
   ".github/copy-pr-bot.yaml"
+  ".github/ISSUE_TEMPLATE"
   ".github/PULL_REQUEST_TEMPLATE.md"
   ".github/workflows/backport-prs.yml"
   ".github/workflows/build-docs.yml"
@@ -87,10 +87,10 @@ ignore_paths=(
   "CITATION.md"
   "CODE_OF_CONDUCT.md"
   "CONTRIBUTING.md"
+  "docs"
   "LICENSE"
   "README.md"
   "SECURITY.md"
-  "docs"
 )
 
 # Usage checks:

--- a/ci/inspect_changes.sh
+++ b/ci/inspect_changes.sh
@@ -83,7 +83,6 @@ ignore_paths=(
   ".github/workflows/update_branch_version.yml"
   ".github/workflows/verify-devcontainers.yml"
   ".gitignore"
-  ".pre-commit-config.yaml"
   "ci-overview.md"
   "CITATION.md"
   "CODE_OF_CONDUCT.md"


### PR DESCRIPTION
Changes to things like `README.md` shouldn't trigger any CI jobs.
