### PR TITLE
Remove ninja stats from CI scripts. 

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -234,16 +234,6 @@ function build_preset() {
         echo "${minimal_sccache_stats}"
         sccache -s
         end_group
-
-        begin_group "🥷 ninja build times"
-        echo "The "weighted" time is the elapsed time of each build step divided by the number
-              of tasks that were running in parallel. This makes it an excellent approximation
-              of how "important" a slow step was. A link that is entirely or mostly serialized
-              will have a weighted time that is the same or similar to its elapsed time. A
-              compile that runs in parallel with 999 other compiles will have a weighted time
-              that is tiny."
-        ./ninja_summary.py -C ${BUILD_DIR}/${PRESET} || echo "Warning: ninja_summary.py failed to execute properly."
-        end_group
     else
       echo $minimal_sccache_stats
     fi


### PR DESCRIPTION
## Description

The ninja_summary script doesn't work with the latest version of ninja anymore. The `ninja_summary` script looks to be unmaintained now and not really worth the effort to try and fix it.

We can roll our own script later if we want, but removing this for now to reduce noise in the log. 

