### PR TITLE
un-templatize CUDASTF's `callback_completion_kernel` per @robertmaynard

### DIFF
--- a/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
+++ b/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
@@ -320,8 +320,7 @@ inline void cudagraph_callback_dispatcher(void* userData)
 }
 
 // There is likely a more efficient way in the current implementation of callbacks !
-template <int = 0> // template to make this `inline` without using `inline`, which nvcc dislikes
-__global__ void callback_completion_kernel(int* completion_flag)
+__global__ static void callback_completion_kernel(int* completion_flag)
 {
   // Loop until *completion_flag == 1
   while (1 != (atomicCAS(completion_flag, 1, 1)))

--- a/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
+++ b/cudax/include/cuda/experimental/__stf/places/exec/host/callback_queues.cuh
@@ -513,7 +513,7 @@ inline _CCCL_HOST cudaError_t cudaGraphAddHostNodeWithQueue(
   // Submit completion kernel in the stream ...
   // callback_completion_kernel<<<1,1,0,stream>>>(data->completion_flag);
   cudaKernelNodeParams kernel_node_params;
-  kernel_node_params.func            = (void*) callback_completion_kernel<>;
+  kernel_node_params.func            = (void*) callback_completion_kernel;
   kernel_node_params.gridDim         = 1;
   kernel_node_params.blockDim        = 1;
   kernel_node_params.kernelParams    = new void*[1];


### PR DESCRIPTION
## Description

in #2641 i "fixed" a linker error in CUDASTF by making `callback_completion_kernel` a template. @robertmaynard has since informed me that doing that is Bad.

> That fix is wrong, it will lead to runtime launch errors. [...] Basically mark it static or place it into an unnamed namespace.

in this PR i obey Robert and make `callback_completion_kernel` a non-template function with internal linkage.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
