### PR TITLE
Drop `cub::DeviceTransform` fallback to `cub::DeviceFor`

### DIFF
--- a/cub/benchmarks/bench/transform/babelstream.h
+++ b/cub/benchmarks/bench/transform/babelstream.h
@@ -21,11 +21,9 @@ struct policy_hub_t
     static constexpr int min_bif    = cub::detail::transform::arch_to_min_bytes_in_flight(__CUDA_ARCH_LIST__);
     static constexpr auto algorithm = static_cast<cub::detail::transform::Algorithm>(TUNE_ALGORITHM);
     using algo_policy =
-      ::cuda::std::_If<algorithm == cub::detail::transform::Algorithm::fallback_for,
-                       cub::detail::transform::fallback_for_policy,
-                       ::cuda::std::_If<algorithm == cub::detail::transform::Algorithm::prefetch,
-                                        cub::detail::transform::prefetch_policy_t<TUNE_THREADS>,
-                                        cub::detail::transform::async_copy_policy_t<TUNE_THREADS>>>;
+      ::cuda::std::_If<algorithm == cub::detail::transform::Algorithm::prefetch,
+                       cub::detail::transform::prefetch_policy_t<TUNE_THREADS>,
+                       cub::detail::transform::async_copy_policy_t<TUNE_THREADS>>;
   };
 };
 #endif

--- a/cub/benchmarks/bench/transform/babelstream1.cu
+++ b/cub/benchmarks/bench/transform/babelstream1.cu
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // %RANGE% TUNE_THREADS tpb 128:1024:128
-// %RANGE% TUNE_ALGORITHM alg 0:2:1
+// %RANGE% TUNE_ALGORITHM alg 0:1:1
 
 // keep checks at the top so compilation of discarded variants fails really fast
 #if !TUNE_BASE
-#  if TUNE_ALGORITHM == 2 && (__CUDA_ARCH_LIST__) < 900
+#  if TUNE_ALGORITHM == 1 && (__CUDA_ARCH_LIST__) < 900
 #    error "Cannot compile algorithm 4 (ublkcp) below sm90"
 #  endif
 
-#  if TUNE_ALGORITHM == 2 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
+#  if TUNE_ALGORITHM == 1 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
 #    error "Cannot tune for ublkcp algorithm, which is not provided by CUB (old CTK?)"
 #  endif
 #endif

--- a/cub/benchmarks/bench/transform/babelstream2.cu
+++ b/cub/benchmarks/bench/transform/babelstream2.cu
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // %RANGE% TUNE_THREADS tpb 128:1024:128
-// %RANGE% TUNE_ALGORITHM alg 0:2:1
+// %RANGE% TUNE_ALGORITHM alg 0:1:1
 
 // keep checks at the top so compilation of discarded variants fails really fast
 #if !TUNE_BASE
-#  if TUNE_ALGORITHM == 2 && (__CUDA_ARCH_LIST__) < 900
+#  if TUNE_ALGORITHM == 1 && (__CUDA_ARCH_LIST__) < 900
 #    error "Cannot compile algorithm 4 (ublkcp) below sm90"
 #  endif
 
-#  if TUNE_ALGORITHM == 2 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
+#  if TUNE_ALGORITHM == 1 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
 #    error "Cannot tune for ublkcp algorithm, which is not provided by CUB (old CTK?)"
 #  endif
 #endif

--- a/cub/benchmarks/bench/transform/babelstream3.cu
+++ b/cub/benchmarks/bench/transform/babelstream3.cu
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // %RANGE% TUNE_THREADS tpb 128:1024:128
-// %RANGE% TUNE_ALGORITHM alg 0:2:1
+// %RANGE% TUNE_ALGORITHM alg 0:1:1
 
 // keep checks at the top so compilation of discarded variants fails really fast
 #if !TUNE_BASE
-#  if TUNE_ALGORITHM == 2 && (__CUDA_ARCH_LIST__) < 900
+#  if TUNE_ALGORITHM == 1 && (__CUDA_ARCH_LIST__) < 900
 #    error "Cannot compile algorithm 4 (ublkcp) below sm90"
 #  endif
 
-#  if TUNE_ALGORITHM == 2 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
+#  if TUNE_ALGORITHM == 1 && !defined(_CUB_HAS_TRANSFORM_UBLKCP)
 #    error "Cannot tune for ublkcp algorithm, which is not provided by CUB (old CTK?)"
 #  endif
 #endif

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -32,11 +32,9 @@ struct policy_hub_for_alg
     static constexpr int min_bif         = 64 * 1024;
     static constexpr Algorithm algorithm = Alg;
     using algo_policy =
-      ::cuda::std::_If<Alg == Algorithm::fallback_for,
-                       cub::detail::transform::fallback_for_policy,
-                       ::cuda::std::_If<Alg == Algorithm::prefetch,
-                                        cub::detail::transform::prefetch_policy_t<256>,
-                                        cub::detail::transform::async_copy_policy_t<256>>>;
+      ::cuda::std::_If<Alg == Algorithm::prefetch,
+                       cub::detail::transform::prefetch_policy_t<256>,
+                       cub::detail::transform::async_copy_policy_t<256>>;
   };
 };
 
@@ -79,7 +77,6 @@ DECLARE_TMPL_LAUNCH_WRAPPER(transform_many_with_alg_entry_point,
 
 using algorithms =
   c2h::enum_type_list<Algorithm,
-                      Algorithm::fallback_for,
                       Algorithm::prefetch
 #ifdef _CUB_HAS_TRANSFORM_UBLKCP
                       ,


### PR DESCRIPTION
We previously had a fallback algorithm that would use cub::DeviceFor. Benchmarks (see #2396) showed that the prefetch algorithm is always superior to that fallback, so let's remove it.

Depends on:

- [x] Merge #2396