### PR TITLE
avoid using nvcc's `__type_pack_element` before 12.2

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -549,10 +549,10 @@
 #  define _CCCL_BUILTIN_TYPE_PACK_ELEMENT(...) __type_pack_element<__VA_ARGS__>
 #endif // _CCCL_HAS_BUILTIN(__type_pack_element)
 
-// NVCC prior to 12.0 have trouble with pack expansion into __type_pack_element in an alias template
-#if defined(_CCCL_CUDACC_BELOW_12_0)
+// NVCC prior to 12.2 have trouble with pack expansion into __type_pack_element in an alias template
+#if defined(_CCCL_CUDACC_BELOW_12_2)
 #  undef _CCCL_BUILTIN_TYPE_PACK_ELEMENT
-#endif // _CCCL_CUDACC_BELOW_12_0
+#endif // _CCCL_CUDACC_BELOW_12_2
 
 #if _CCCL_CHECK_BUILTIN(underlying_type) || (defined(_CCCL_COMPILER_GCC) && _CCCL_GCC_VERSION >= 40700) \
   || defined(_CCCL_COMPILER_MSVC) || defined(_CCCL_COMPILER_NVRTC)


### PR DESCRIPTION
## Description

the following code causes nvcc 12.1 to crash:

```c++
template <class Fn, class... Ts>
using type_call = typename Fn::template call<Ts...>;

template <class... Ts>
struct type_list
{
  template <class Fn>
  using call = type_call<Fn, Ts...>;
};

template <class _Fn, 
          class... _Ts, 
          template <class...> class _Fn2 = _Fn::template call, 
          class = _Fn2<_Ts...>>
void type_callable_fn(int)
{}

template <class...>
void type_callable_fn(long)
{}

template <size_t _Ip>
struct type_at_fn
{
  template <class... _Ts>
  using call = __type_pack_element<_Ip, _Ts...>;
};

struct type_front
{
  template <class List>
  using call = type_call<List, type_at_fn<0>>;
};

int main()
{
  type_callable_fn<type_front, type_list<>>(0);
}
```

The problem is with the use of `__type_pack_element`, as indicated by the diagnostic:

```
Internal error: assertion failed at: "templates.c", line 9063 in instantiate_type_pack_element

1 catastrophic error detected in the compilation of "test.cpp".
Compilation aborted.
Aborted (core dumped)
```

we already avoid `__type_pack_element` prior to 12.0. this bumps the minimum version of nvcc to 12.2.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
