### PR TITLE
consistent use of `_CUDAX` function attributes in the cudax `__async/` directory

### DIFF
--- a/cudax/include/cuda/experimental/__async/basic_sender.cuh
+++ b/cudax/include/cuda/experimental/__async/basic_sender.cuh
@@ -105,7 +105,7 @@ struct basic_receiver
 };
 
 template <class _Rcvr>
-_CCCL_INLINE_VAR constexpr bool has_no_environment = _CUDA_VSTD::is_same_v<_Rcvr, receiver_archetype>;
+inline constexpr bool has_no_environment = _CUDA_VSTD::is_same_v<_Rcvr, receiver_archetype>;
 
 template <bool _HasStopped, class _Data, class _Rcvr>
 struct __mk_completions
@@ -172,7 +172,7 @@ struct __basic_opstate
                                     __traits_t::template __set_error_t,
                                     typename __traits_t::__set_stopped_t>;
 
-  _CCCL_HOST_DEVICE __basic_opstate(_Sndr&& __sndr, _Data __data, _Rcvr __rcvr)
+  _CUDAX_API __basic_opstate(_Sndr&& __sndr, _Data __data, _Rcvr __rcvr)
       : __state_{static_cast<_Data&&>(__data), static_cast<_Rcvr&&>(__rcvr)}
       , __op_(__async::connect(static_cast<_Sndr&&>(__sndr), __rcvr_t{__state_}))
   {}

--- a/cudax/include/cuda/experimental/__async/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__async/completion_signatures.cuh
@@ -37,16 +37,16 @@ struct completion_signatures
 
 // A metafunction to determine if a type is a completion signature
 template <class>
-_CCCL_INLINE_VAR constexpr bool __is_valid_signature = false;
+inline constexpr bool __is_valid_signature = false;
 
 template <class... _Ts>
-_CCCL_INLINE_VAR constexpr bool __is_valid_signature<set_value_t(_Ts...)> = true;
+inline constexpr bool __is_valid_signature<set_value_t(_Ts...)> = true;
 
 template <class _Error>
-_CCCL_INLINE_VAR constexpr bool __is_valid_signature<set_error_t(_Error)> = true;
+inline constexpr bool __is_valid_signature<set_error_t(_Error)> = true;
 
 template <>
-_CCCL_INLINE_VAR constexpr bool __is_valid_signature<set_stopped_t()> = true;
+inline constexpr bool __is_valid_signature<set_stopped_t()> = true;
 
 // The implementation of transform_completion_signatures starts here
 template <class _Sig, template <class...> class _Vy, template <class...> class _Ey, class _Sy>
@@ -264,11 +264,11 @@ template <class _Sndr, class _Rcvr, template <class...> class _Variant>
 using error_types_of_t = __error_types<completion_signatures_of_t<_Sndr, _Rcvr>, _Variant>;
 
 template <class _Sigs>
-_CCCL_INLINE_VAR constexpr bool __sends_stopped = //
+inline constexpr bool __sends_stopped = //
   __transform_completion_signatures<_Sigs, __malways<__mfalse>::__f, __malways<__mfalse>::__f, __mtrue, __mor>::__value;
 
 template <class _Sndr, class _Rcvr = receiver_archetype>
-_CCCL_INLINE_VAR constexpr bool sends_stopped = //
+inline constexpr bool sends_stopped = //
   __sends_stopped<completion_signatures_of_t<_Sndr, _Rcvr>>;
 
 using __eptr_completion = completion_signatures<set_error_t(::std::exception_ptr)>;
@@ -277,17 +277,17 @@ template <bool _NoExcept>
 using __eptr_completion_if = _CUDA_VSTD::_If<_NoExcept, completion_signatures<>, __eptr_completion>;
 
 template <class>
-_CCCL_INLINE_VAR constexpr bool __is_completion_signatures = false;
+inline constexpr bool __is_completion_signatures = false;
 
 template <class... _Sigs>
-_CCCL_INLINE_VAR constexpr bool __is_completion_signatures<completion_signatures<_Sigs...>> = true;
+inline constexpr bool __is_completion_signatures<completion_signatures<_Sigs...>> = true;
 
 template <class _Sndr>
 using __is_non_dependent_detail_ = //
   __mif<__is_completion_signatures<completion_signatures_of_t<_Sndr>>>;
 
 template <class _Sndr>
-_CCCL_INLINE_VAR constexpr bool __is_non_dependent_sender = __mvalid_q<__is_non_dependent_detail_, _Sndr>;
+inline constexpr bool __is_non_dependent_sender = __mvalid_q<__is_non_dependent_detail_, _Sndr>;
 
 namespace __csig
 {

--- a/cudax/include/cuda/experimental/__async/conditional.cuh
+++ b/cudax/include/cuda/experimental/__async/conditional.cuh
@@ -60,7 +60,7 @@ struct __cond_t
   {
     using operation_state_concept = operation_state_t;
 
-    _CCCL_HOST_DEVICE friend env_of_t<_Rcvr> get_env(const __opstate* __self) noexcept
+    _CUDAX_API friend env_of_t<_Rcvr> get_env(const __opstate* __self) noexcept
     {
       return get_env(__self->__rcvr_);
     }
@@ -83,19 +83,19 @@ struct __cond_t
     using completion_signatures = //
       transform_completion_signatures_of<_Sndr, __opstate*, __async::completion_signatures<>, __value_t>;
 
-    _CCCL_HOST_DEVICE __opstate(_Sndr&& __sndr, _Rcvr&& __rcvr, __data<_Pred, _Then, _Else>&& __data)
+    _CUDAX_API __opstate(_Sndr&& __sndr, _Rcvr&& __rcvr, __data<_Pred, _Then, _Else>&& __data)
         : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
         , __data_{static_cast<__cond_t::__data<_Pred, _Then, _Else>>(__data)}
         , __op_{__async::connect(static_cast<_Sndr&&>(__sndr), this)}
     {}
 
-    _CCCL_HOST_DEVICE void start() noexcept
+    _CUDAX_API void start() noexcept
     {
       __async::start(__op_);
     }
 
     template <class... _Args>
-    _CCCL_HOST_DEVICE void set_value(_Args&&... __args) noexcept
+    _CUDAX_API void set_value(_Args&&... __args) noexcept
     {
       if (static_cast<_Pred&&>(__data_.__pred_)(__args...))
       {
@@ -116,12 +116,12 @@ struct __cond_t
     }
 
     template <class _Error>
-    _CCCL_HOST_DEVICE void set_error(_Error&& __error) noexcept
+    _CUDAX_API void set_error(_Error&& __error) noexcept
     {
       __async::set_error(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Error&&>(__error));
     }
 
-    _CCCL_HOST_DEVICE void set_stopped() noexcept
+    _CUDAX_API void set_stopped() noexcept
     {
       __async::set_stopped(static_cast<_Rcvr&&>(__rcvr_));
     }
@@ -179,7 +179,7 @@ struct __cond_t::__sndr_t
   _Sndr __sndr_;
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) && -> __opstate<_Sndr, _Rcvr, _Pred, _Then, _Else>
+  _CUDAX_API auto connect(_Rcvr __rcvr) && -> __opstate<_Sndr, _Rcvr, _Pred, _Then, _Else>
   {
     return {static_cast<_Sndr&&>(__sndr_),
             static_cast<_Rcvr&&>(__rcvr),
@@ -187,12 +187,12 @@ struct __cond_t::__sndr_t
   }
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) const& -> __opstate<_Sndr const&, _Rcvr, _Pred, _Then, _Else>
+  _CUDAX_API auto connect(_Rcvr __rcvr) const& -> __opstate<_Sndr const&, _Rcvr, _Pred, _Then, _Else>
   {
     return {__sndr_, static_cast<_Rcvr&&>(__rcvr), static_cast<__cond_t::__data<_Pred, _Then, _Else>&&>(__data_)};
   }
 
-  _CCCL_HOST_DEVICE env_of_t<_Sndr> get_env() const noexcept
+  _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
   {
     return __async::get_env(__sndr_);
   }

--- a/cudax/include/cuda/experimental/__async/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/continue_on.cuh
@@ -73,13 +73,13 @@ private:
     __complete_fn __complete_;
 
     template <class _Tag, class... _As>
-    _CCCL_HOST_DEVICE void operator()(_Tag, _As&... __as) noexcept
+    _CUDAX_API void operator()(_Tag, _As&... __as) noexcept
     {
       _Tag()(static_cast<_Rcvr&&>(__rcvr_), static_cast<_As&&>(__as)...);
     }
 
     template <class _Tag, class... _As>
-    _CCCL_HOST_DEVICE void __set_result(_Tag, _As&&... __as) noexcept
+    _CUDAX_API void __set_result(_Tag, _As&&... __as) noexcept
     {
       using __tupl_t = __tuple<_Tag, __decay_t<_As>...>;
       if constexpr (__nothrow_decay_copyable<_As...>)
@@ -104,23 +104,23 @@ private:
       };
     }
 
-    _CCCL_HOST_DEVICE void set_value() noexcept
+    _CUDAX_API void set_value() noexcept
     {
       __complete_(this);
     }
 
     template <class _Error>
-    _CCCL_HOST_DEVICE void set_error(_Error&& __error) noexcept
+    _CUDAX_API void set_error(_Error&& __error) noexcept
     {
       __async::set_error(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Error&&>(__error));
     }
 
-    _CCCL_HOST_DEVICE void set_stopped() noexcept
+    _CUDAX_API void set_stopped() noexcept
     {
       __async::set_stopped(static_cast<_Rcvr&&>(__rcvr_));
     }
 
-    _CCCL_HOST_DEVICE env_of_t<_Rcvr> get_env() const noexcept
+    _CUDAX_API env_of_t<_Rcvr> get_env() const noexcept
     {
       return __async::get_env(__rcvr_);
     }
@@ -129,7 +129,7 @@ private:
   template <class _Rcvr, class _CvSndr, class _Sch>
   struct __opstate_t
   {
-    _CCCL_HOST_DEVICE friend auto get_env(const __opstate_t* __self) noexcept -> env_of_t<_Rcvr>
+    _CUDAX_API friend auto get_env(const __opstate_t* __self) noexcept -> env_of_t<_Rcvr>
     {
       return __async::get_env(__self->__rcvr_.__rcvr);
     }
@@ -162,7 +162,7 @@ private:
     connect_result_t<_CvSndr, __opstate_t*> __opstate1_;
     connect_result_t<schedule_result_t<_Sch>, __rcvr_t<_Rcvr, __result_t>*> __opstate2_;
 
-    _CCCL_HOST_DEVICE __opstate_t(_CvSndr&& __sndr, _Sch __sch, _Rcvr __rcvr)
+    _CUDAX_API __opstate_t(_CvSndr&& __sndr, _Sch __sch, _Rcvr __rcvr)
         : __rcvr_{static_cast<_Rcvr&&>(__rcvr), {}, nullptr}
         , __opstate1_{__async::connect(static_cast<_CvSndr&&>(__sndr), this)}
         , __opstate2_{__async::connect(schedule(__sch), &__rcvr_)}
@@ -170,26 +170,26 @@ private:
 
     _CUDAX_IMMOVABLE(__opstate_t);
 
-    _CCCL_HOST_DEVICE void start() noexcept
+    _CUDAX_API void start() noexcept
     {
       __async::start(__opstate1_);
     }
 
     template <class... _As>
-    _CCCL_HOST_DEVICE void set_value(_As&&... __as) noexcept
+    _CUDAX_API void set_value(_As&&... __as) noexcept
     {
       __rcvr_.__set_result(set_value_t(), static_cast<_As&&>(__as)...);
       __async::start(__opstate2_);
     }
 
     template <class _Error>
-    _CCCL_HOST_DEVICE void set_error(_Error&& __error) noexcept
+    _CUDAX_API void set_error(_Error&& __error) noexcept
     {
       __rcvr_.__set_result(set_error_t(), static_cast<_Error&&>(__error));
       __async::start(__opstate2_);
     }
 
-    _CCCL_HOST_DEVICE void set_stopped() noexcept
+    _CUDAX_API void set_stopped() noexcept
     {
       __rcvr_.__set_result(set_stopped_t());
       __async::start(__opstate2_);
@@ -204,7 +204,7 @@ private:
 
 public:
   template <class _Sndr, class _Sch>
-  _CCCL_HOST_DEVICE __sndr_t<_Sndr, _Sch> operator()(_Sndr __sndr, _Sch __sch) const noexcept;
+  _CUDAX_API __sndr_t<_Sndr, _Sch> operator()(_Sndr __sndr, _Sch __sch) const noexcept;
 
   template <class _Sch>
   _CUDAX_TRIVIAL_API __closure_t<_Sch> operator()(_Sch __sch) const noexcept;
@@ -235,13 +235,13 @@ struct continue_on_t::__sndr_t
     __sndr_t* __sndr;
 
     template <class _SetTag>
-    _CCCL_HOST_DEVICE auto query(get_completion_scheduler_t<_SetTag>) const noexcept
+    _CUDAX_API auto query(get_completion_scheduler_t<_SetTag>) const noexcept
     {
       return __sndr->__sch;
     }
 
     template <class _Query>
-    _CCCL_HOST_DEVICE auto query(_Query) const //
+    _CUDAX_API auto query(_Query) const //
       -> __query_result_t<_Query, env_of_t<_Sndr>>
     {
       return __async::get_env(__sndr->__sndr).__query(_Query{});
@@ -249,25 +249,25 @@ struct continue_on_t::__sndr_t
   };
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE __opstate_t<_Rcvr, _Sndr, _Sch> connect(_Rcvr __rcvr) &&
+  _CUDAX_API __opstate_t<_Rcvr, _Sndr, _Sch> connect(_Rcvr __rcvr) &&
   {
     return {static_cast<_Sndr&&>(__sndr), __sch, static_cast<_Rcvr&&>(__rcvr)};
   }
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE __opstate_t<_Rcvr, const _Sndr&, _Sch> connect(_Rcvr __rcvr) const&
+  _CUDAX_API __opstate_t<_Rcvr, const _Sndr&, _Sch> connect(_Rcvr __rcvr) const&
   {
     return {__sndr, __sch, static_cast<_Rcvr&&>(__rcvr)};
   }
 
-  _CCCL_HOST_DEVICE __attrs_t get_env() const noexcept
+  _CUDAX_API __attrs_t get_env() const noexcept
   {
     return __attrs_t{this};
   }
 };
 
 template <class _Sndr, class _Sch>
-_CCCL_HOST_DEVICE auto
+_CUDAX_API auto
 continue_on_t::operator()(_Sndr __sndr, _Sch __sch) const noexcept -> continue_on_t::__sndr_t<_Sndr, _Sch>
 {
   return __sndr_t<_Sndr, _Sch>{{}, __sch, static_cast<_Sndr&&>(__sndr)};

--- a/cudax/include/cuda/experimental/__async/cpos.cuh
+++ b/cudax/include/cuda/experimental/__async/cpos.cuh
@@ -53,13 +53,13 @@ template <class _Ty>
 using __scheduler_concept_t = typename __remove_ref_t<_Ty>::scheduler_concept;
 
 template <class _Ty>
-_CCCL_INLINE_VAR constexpr bool __is_sender = __mvalid_q<__sender_concept_t, _Ty>;
+inline constexpr bool __is_sender = __mvalid_q<__sender_concept_t, _Ty>;
 
 template <class _Ty>
-_CCCL_INLINE_VAR constexpr bool __is_receiver = __mvalid_q<__receiver_concept_t, _Ty>;
+inline constexpr bool __is_receiver = __mvalid_q<__receiver_concept_t, _Ty>;
 
 template <class _Ty>
-_CCCL_INLINE_VAR constexpr bool __is_scheduler = __mvalid_q<__scheduler_concept_t, _Ty>;
+inline constexpr bool __is_scheduler = __mvalid_q<__scheduler_concept_t, _Ty>;
 
 _CCCL_GLOBAL_CONSTANT struct set_value_t
 {
@@ -190,7 +190,7 @@ template <class _Sch>
 using schedule_result_t = decltype(schedule(__declval<_Sch>()));
 
 template <class _Sndr, class _Rcvr>
-_CCCL_INLINE_VAR constexpr bool __nothrow_connectable = noexcept(connect(__declval<_Sndr>(), __declval<_Rcvr>()));
+inline constexpr bool __nothrow_connectable = noexcept(connect(__declval<_Sndr>(), __declval<_Rcvr>()));
 
 // handy enumerations for keeping type names readable
 enum __disposition_t

--- a/cudax/include/cuda/experimental/__async/env.cuh
+++ b/cudax/include/cuda/experimental/__async/env.cuh
@@ -141,7 +141,7 @@ struct env<_Env0, _Env1>
 };
 
 template <class... _Envs>
-_CCCL_HOST_DEVICE env(_Envs...) -> env<__unwrap_reference_t<_Envs>...>;
+_CUDAX_API env(_Envs...) -> env<__unwrap_reference_t<_Envs>...>;
 
 using empty_env = env<>;
 

--- a/cudax/include/cuda/experimental/__async/fwd_rcvr.cuh
+++ b/cudax/include/cuda/experimental/__async/fwd_rcvr.cuh
@@ -30,7 +30,7 @@ namespace cuda::experimental::__async
 template <class _Rcvr>
 struct __fwd_rcvr : _Rcvr
 {
-  _CCCL_HOST_DEVICE decltype(auto) get_env() const noexcept
+  _CUDAX_API decltype(auto) get_env() const noexcept
   {
     // TODO: only forward the "forwarding" queries:
     return __async::get_env(static_cast<_Rcvr const&>(*this));
@@ -60,7 +60,7 @@ struct __fwd_rcvr<_Rcvr*>
     __async::set_stopped(__rcvr_);
   }
 
-  _CCCL_HOST_DEVICE decltype(auto) get_env() const noexcept
+  _CUDAX_API decltype(auto) get_env() const noexcept
   {
     // TODO: only forward the "forwarding" queries:
     return __async::get_env(__rcvr_);

--- a/cudax/include/cuda/experimental/__async/just.cuh
+++ b/cudax/include/cuda/experimental/__async/just.cuh
@@ -72,13 +72,13 @@ private:
     {
       __opstate_t* __self_;
 
-      _CCCL_HOST_DEVICE void operator()(_Ts&... __ts) const noexcept
+      _CUDAX_API void operator()(_Ts&... __ts) const noexcept
       {
         _SetTag()(static_cast<_Rcvr&&>(__self_->__rcvr_), static_cast<_Ts&&>(__ts)...);
       }
     };
 
-    _CCCL_HOST_DEVICE void start() & noexcept
+    _CUDAX_API void start() & noexcept
     {
       __values_.__apply(__complete_fn{this}, __values_);
     }
@@ -94,14 +94,14 @@ private:
     __tuple<_Ts...> __values_;
 
     template <class _Rcvr>
-    _CCCL_HOST_DEVICE __opstate_t<_Rcvr, _Ts...> connect(_Rcvr __rcvr) && //
+    _CUDAX_API __opstate_t<_Rcvr, _Ts...> connect(_Rcvr __rcvr) && //
       noexcept(__nothrow_decay_copyable<_Rcvr, _Ts...>)
     {
       return __opstate_t<_Rcvr, _Ts...>{static_cast<_Rcvr&&>(__rcvr), static_cast<__tuple<_Ts...>&&>(__values_)};
     }
 
     template <class _Rcvr>
-    _CCCL_HOST_DEVICE __opstate_t<_Rcvr, _Ts...> connect(_Rcvr __rcvr) const& //
+    _CUDAX_API __opstate_t<_Rcvr, _Ts...> connect(_Rcvr __rcvr) const& //
       noexcept(__nothrow_decay_copyable<_Rcvr, _Ts const&...>)
     {
       return __opstate_t<_Rcvr, _Ts...>{static_cast<_Rcvr&&>(__rcvr), __values_};

--- a/cudax/include/cuda/experimental/__async/just_from.cuh
+++ b/cudax/include/cuda/experimental/__async/just_from.cuh
@@ -88,7 +88,7 @@ private:
     _Rcvr& __rcvr_;
 
     template <class... _Ts>
-    _CCCL_HOST_DEVICE auto operator()(_Ts&&... __ts) const noexcept
+    _CUDAX_API auto operator()(_Ts&&... __ts) const noexcept
     {
       _SetTag()(static_cast<_Rcvr&&>(__rcvr_), static_cast<_Ts&&>(__ts)...);
     }
@@ -104,7 +104,7 @@ private:
     _Rcvr __rcvr_;
     _Fn __fn_;
 
-    _CCCL_HOST_DEVICE void start() & noexcept
+    _CUDAX_API void start() & noexcept
     {
       static_cast<_Fn&&>(__fn_)(__complete_fn<_Rcvr>{__rcvr_});
     }
@@ -119,14 +119,14 @@ private:
     _Fn __fn_;
 
     template <class _Rcvr>
-    _CCCL_HOST_DEVICE __opstate<_Rcvr, _Fn> connect(_Rcvr __rcvr) && //
+    _CUDAX_API __opstate<_Rcvr, _Fn> connect(_Rcvr __rcvr) && //
       noexcept(__nothrow_decay_copyable<_Rcvr, _Fn>)
     {
       return __opstate<_Rcvr, _Fn>{static_cast<_Rcvr&&>(__rcvr), static_cast<_Fn&&>(__fn_)};
     }
 
     template <class _Rcvr>
-    _CCCL_HOST_DEVICE __opstate<_Rcvr, _Fn> connect(_Rcvr __rcvr) const& //
+    _CUDAX_API __opstate<_Rcvr, _Fn> connect(_Rcvr __rcvr) const& //
       noexcept(__nothrow_decay_copyable<_Rcvr, _Fn const&>)
     {
       return __opstate<_Rcvr, _Fn>{static_cast<_Rcvr&&>(__rcvr), __fn_};

--- a/cudax/include/cuda/experimental/__async/lazy.cuh
+++ b/cudax/include/cuda/experimental/__async/lazy.cuh
@@ -37,26 +37,26 @@ namespace cuda::experimental::__async
 template <class _Ty>
 struct __lazy
 {
-  _CCCL_HOST_DEVICE __lazy() noexcept {}
+  _CUDAX_API __lazy() noexcept {}
 
-  _CCCL_HOST_DEVICE ~__lazy() {}
+  _CUDAX_API ~__lazy() {}
 
   template <class... _Ts>
-  _CCCL_HOST_DEVICE _Ty& construct(_Ts&&... __ts) noexcept(__nothrow_constructible<_Ty, _Ts...>)
+  _CUDAX_API _Ty& construct(_Ts&&... __ts) noexcept(__nothrow_constructible<_Ty, _Ts...>)
   {
     _Ty* __value_ = ::new (static_cast<void*>(_CUDA_VSTD::addressof(__value_))) _Ty{static_cast<_Ts&&>(__ts)...};
     return *_CUDA_VSTD::launder(__value_);
   }
 
   template <class _Fn, class... _Ts>
-  _CCCL_HOST_DEVICE _Ty& construct_from(_Fn&& __fn, _Ts&&... __ts) noexcept(__nothrow_callable<_Fn, _Ts...>)
+  _CUDAX_API _Ty& construct_from(_Fn&& __fn, _Ts&&... __ts) noexcept(__nothrow_callable<_Fn, _Ts...>)
   {
     _Ty* __value_ = ::new (static_cast<void*>(_CUDA_VSTD::addressof(__value_)))
       _Ty{static_cast<_Fn&&>(__fn)(static_cast<_Ts&&>(__ts)...)};
     return *_CUDA_VSTD::launder(__value_);
   }
 
-  _CCCL_HOST_DEVICE void destroy() noexcept
+  _CUDAX_API void destroy() noexcept
   {
     _CUDA_VSTD::destroy_at(&__value_);
   }
@@ -102,7 +102,7 @@ struct __lazy_tupl<__mindices<_Idx...>, _Ts...> : __detail::__lazy_box<_Idx, _Ts
 
   _CUDAX_TRIVIAL_API __lazy_tupl() noexcept {}
 
-  _CCCL_HOST_DEVICE ~__lazy_tupl()
+  _CUDAX_API ~__lazy_tupl()
   {
     ((__engaged_[_Idx] ? _CUDA_VSTD::destroy_at(__get<_Idx, _Ts>()) : void(0)), ...);
   }

--- a/cudax/include/cuda/experimental/__async/let_value.cuh
+++ b/cudax/include/cuda/experimental/__async/let_value.cuh
@@ -147,7 +147,7 @@ private:
   template <class _Rcvr, class _CvSndr, class _Fn>
   struct __opstate_t
   {
-    _CCCL_HOST_DEVICE friend env_of_t<_Rcvr> get_env(const __opstate_t* __self) noexcept
+    _CUDAX_API friend env_of_t<_Rcvr> get_env(const __opstate_t* __self) noexcept
     {
       return __async::get_env(__self->__rcvr_);
     }
@@ -168,20 +168,20 @@ private:
     connect_result_t<_CvSndr, __opstate_t*> __opstate1_;
     __opstate_variant_t __opstate2_;
 
-    _CCCL_HOST_DEVICE __opstate_t(_CvSndr&& __sndr, _Fn __fn, _Rcvr __rcvr) noexcept(
+    _CUDAX_API __opstate_t(_CvSndr&& __sndr, _Fn __fn, _Rcvr __rcvr) noexcept(
       __nothrow_decay_copyable<_Fn, _Rcvr> && __nothrow_connectable<_CvSndr, __opstate_t*>)
         : __rcvr_(static_cast<_Rcvr&&>(__rcvr))
         , __fn_(static_cast<_Fn&&>(__fn))
         , __opstate1_(__async::connect(static_cast<_CvSndr&&>(__sndr), this))
     {}
 
-    _CCCL_HOST_DEVICE void start() noexcept
+    _CUDAX_API void start() noexcept
     {
       __async::start(__opstate1_);
     }
 
     template <class _Tag, class... _As>
-    _CCCL_HOST_DEVICE void __complete(_Tag, _As&&... __as) noexcept
+    _CUDAX_API void __complete(_Tag, _As&&... __as) noexcept
     {
       if constexpr (_CUDA_VSTD::is_same_v<_Tag, _SetTag>)
       {
@@ -242,7 +242,7 @@ private:
     _Sndr __sndr_;
 
     template <class _Rcvr>
-    _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) && noexcept(
+    _CUDAX_API auto connect(_Rcvr __rcvr) && noexcept(
       __nothrow_constructible<__opstate_t<_Rcvr, _Sndr, _Fn>, _Sndr, _Fn, _Rcvr>) -> __opstate_t<_Rcvr, _Sndr, _Fn>
     {
       return __opstate_t<_Rcvr, _Sndr, _Fn>(
@@ -250,7 +250,7 @@ private:
     }
 
     template <class _Rcvr>
-    _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) const& noexcept( //
+    _CUDAX_API auto connect(_Rcvr __rcvr) const& noexcept( //
       __nothrow_constructible<__opstate_t<_Rcvr, const _Sndr&, _Fn>,
                               const _Sndr&,
                               const _Fn&,
@@ -260,7 +260,7 @@ private:
       return __opstate_t<_Rcvr, const _Sndr&, _Fn>(__sndr_, __fn_, static_cast<_Rcvr&&>(__rcvr));
     }
 
-    _CCCL_HOST_DEVICE env_of_t<_Sndr> get_env() const noexcept
+    _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
     {
       return __async::get_env(__sndr_);
     }
@@ -289,7 +289,7 @@ private:
 
 public:
   template <class _Sndr, class _Fn>
-  _CCCL_HOST_DEVICE __sndr_t<_Sndr, _Fn> operator()(_Sndr __sndr, _Fn __fn) const
+  _CUDAX_API __sndr_t<_Sndr, _Fn> operator()(_Sndr __sndr, _Fn __fn) const
   {
     // If the incoming sender is non-dependent, we can check the completion
     // signatures of the composed sender immediately.

--- a/cudax/include/cuda/experimental/__async/meta.cuh
+++ b/cudax/include/cuda/experimental/__async/meta.cuh
@@ -282,17 +282,17 @@ constexpr bool __ustdex_unhandled_error(...) noexcept
 }
 
 template <class _Ty>
-_CCCL_INLINE_VAR constexpr bool __is_error = false;
+inline constexpr bool __is_error = false;
 
 template <class... _What>
-_CCCL_INLINE_VAR constexpr bool __is_error<_ERROR<_What...>> = true;
+inline constexpr bool __is_error<_ERROR<_What...>> = true;
 
 template <class... _What>
-_CCCL_INLINE_VAR constexpr bool __is_error<_ERROR<_What...>&> = true;
+inline constexpr bool __is_error<_ERROR<_What...>&> = true;
 
 // True if any of the types in _Ts... are errors; false otherwise.
 template <class... _Ts>
-_CCCL_INLINE_VAR constexpr bool __contains_error =
+inline constexpr bool __contains_error =
 #if defined(_CCCL_COMPILER_MSVC)
   (__is_error<_Ts> || ...);
 #else
@@ -327,28 +327,28 @@ template <class _Ty, class...>
 using __mfront = _Ty;
 
 template <template <class...> class _Fn, class _List, class _Enable = void>
-_CCCL_INLINE_VAR constexpr bool __mvalid_ = false;
+inline constexpr bool __mvalid_ = false;
 
 template <template <class...> class _Fn, class... _Ts>
-_CCCL_INLINE_VAR constexpr bool __mvalid_<_Fn, __mlist<_Ts...>, __mvoid<_Fn<_Ts...>>> = true;
+inline constexpr bool __mvalid_<_Fn, __mlist<_Ts...>, __mvoid<_Fn<_Ts...>>> = true;
 
 template <template <class...> class _Fn, class... _Ts>
-_CCCL_INLINE_VAR constexpr bool __mvalid_q = __mvalid_<_Fn, __mlist<_Ts...>>;
+inline constexpr bool __mvalid_q = __mvalid_<_Fn, __mlist<_Ts...>>;
 
 template <class _Fn, class... _Ts>
-_CCCL_INLINE_VAR constexpr bool __mvalid = __mvalid_<_Fn::template __f, __mlist<_Ts...>>;
+inline constexpr bool __mvalid = __mvalid_<_Fn::template __f, __mlist<_Ts...>>;
 
 template <class _Tp>
-_CCCL_INLINE_VAR constexpr auto __v = _Tp::__value;
+inline constexpr auto __v = _Tp::__value;
 
 template <auto _Value>
-_CCCL_INLINE_VAR constexpr auto __v<__mvalue<_Value>> = _Value;
+inline constexpr auto __v<__mvalue<_Value>> = _Value;
 
 template <bool _Value>
-_CCCL_INLINE_VAR constexpr auto __v<__mbool<_Value>> = _Value;
+inline constexpr auto __v<__mbool<_Value>> = _Value;
 
 template <class _Tp, _Tp _Value>
-_CCCL_INLINE_VAR constexpr auto __v<_CUDA_VSTD::integral_constant<_Tp, _Value>> = _Value;
+inline constexpr auto __v<_CUDA_VSTD::integral_constant<_Tp, _Value>> = _Value;
 
 struct __midentity
 {
@@ -676,7 +676,7 @@ struct __mconcat_into_q
 
 // The following must be super-fast to compile, so use an intrinsic directly if it is available
 template <class _Set, class... _Ty>
-_CCCL_INLINE_VAR constexpr bool __mset_contains = (_CUDA_VSTD::is_base_of_v<__mtype<_Ty>, _Set> && ...);
+inline constexpr bool __mset_contains = (_CUDA_VSTD::is_base_of_v<__mtype<_Ty>, _Set> && ...);
 
 namespace __set
 {
@@ -720,7 +720,7 @@ template <class... _Ts>
 using __mmake_set = __mset_insert<__mset<>, _Ts...>;
 
 template <class _Set1, class _Set2>
-_CCCL_INLINE_VAR constexpr bool __mset_eq = __v<__mapply<__set::__eq<_Set1>, _Set2>>;
+inline constexpr bool __mset_eq = __v<__mapply<__set::__eq<_Set1>, _Set2>>;
 
 template <class _Fn>
 struct __munique

--- a/cudax/include/cuda/experimental/__async/queries.cuh
+++ b/cudax/include/cuda/experimental/__async/queries.cuh
@@ -41,30 +41,30 @@ template <class _Ty, class _Query>
 using __query_result_t = decltype(__query_result_<_Ty, _Query>());
 
 template <class _Ty, class _Query>
-_CCCL_INLINE_VAR constexpr bool __queryable = __mvalid_q<__query_result_t, _Ty, _Query>;
+inline constexpr bool __queryable = __mvalid_q<__query_result_t, _Ty, _Query>;
 
 #if defined(__CUDA_ARCH__)
 template <class _Ty, class _Query>
-_CCCL_INLINE_VAR constexpr bool __nothrow_queryable = true;
+inline constexpr bool __nothrow_queryable = true;
 #else
 template <class _Ty, class _Query>
 using __nothrow_queryable_ = __mif<noexcept(__declval<_Ty>().__query(_Query()))>;
 
 template <class _Ty, class _Query>
-_CCCL_INLINE_VAR constexpr bool __nothrow_queryable = __mvalid_q<__nothrow_queryable_, _Ty, _Query>;
+inline constexpr bool __nothrow_queryable = __mvalid_q<__nothrow_queryable_, _Ty, _Query>;
 #endif
 
 _CCCL_GLOBAL_CONSTANT struct get_allocator_t
 {
   template <class _Env>
-  _CCCL_HOST_DEVICE auto operator()(const _Env& __env) const noexcept //
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
     -> decltype(__env.__query(*this))
   {
     static_assert(noexcept(__env.__query(*this)));
     return __env.__query(*this);
   }
 
-  _CCCL_HOST_DEVICE auto operator()(__ignore) const noexcept -> _CUDA_VSTD::allocator<void>
+  _CUDAX_API auto operator()(__ignore) const noexcept -> _CUDA_VSTD::allocator<void>
   {
     return {};
   }
@@ -73,14 +73,14 @@ _CCCL_GLOBAL_CONSTANT struct get_allocator_t
 _CCCL_GLOBAL_CONSTANT struct get_stop_token_t
 {
   template <class _Env>
-  _CCCL_HOST_DEVICE auto operator()(const _Env& __env) const noexcept //
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
     -> decltype(__env.__query(*this))
   {
     static_assert(noexcept(__env.__query(*this)));
     return __env.__query(*this);
   }
 
-  _CCCL_HOST_DEVICE auto operator()(__ignore) const noexcept -> never_stop_token
+  _CUDAX_API auto operator()(__ignore) const noexcept -> never_stop_token
   {
     return {};
   }
@@ -93,7 +93,7 @@ template <class _Tag>
 struct get_completion_scheduler_t
 {
   template <class _Env>
-  _CCCL_HOST_DEVICE auto operator()(const _Env& __env) const noexcept //
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
     -> decltype(__env.__query(*this))
   {
     static_assert(noexcept(__env.__query(*this)));
@@ -107,7 +107,7 @@ _CCCL_GLOBAL_CONSTANT get_completion_scheduler_t<_Tag> get_completion_scheduler{
 _CCCL_GLOBAL_CONSTANT struct get_scheduler_t
 {
   template <class _Env>
-  _CCCL_HOST_DEVICE auto operator()(const _Env& __env) const noexcept //
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
     -> decltype(__env.__query(*this))
   {
     static_assert(noexcept(__env.__query(*this)));
@@ -118,7 +118,7 @@ _CCCL_GLOBAL_CONSTANT struct get_scheduler_t
 _CCCL_GLOBAL_CONSTANT struct get_delegatee_scheduler_t
 {
   template <class _Env>
-  _CCCL_HOST_DEVICE auto operator()(const _Env& __env) const noexcept //
+  _CUDAX_API auto operator()(const _Env& __env) const noexcept //
     -> decltype(__env.__query(*this))
   {
     static_assert(noexcept(__env.__query(*this)));
@@ -136,14 +136,14 @@ enum class forward_progress_guarantee
 _CCCL_GLOBAL_CONSTANT struct get_forward_progress_guarantee_t
 {
   template <class _Sch>
-  _CCCL_HOST_DEVICE auto operator()(const _Sch& __sch) const noexcept //
+  _CUDAX_API auto operator()(const _Sch& __sch) const noexcept //
     -> decltype(__async::__decay_copy(__sch.__query(*this)))
   {
     static_assert(noexcept(__sch.__query(*this)));
     return __sch.__query(*this);
   }
 
-  _CCCL_HOST_DEVICE auto operator()(__ignore) const noexcept -> forward_progress_guarantee
+  _CUDAX_API auto operator()(__ignore) const noexcept -> forward_progress_guarantee
   {
     return forward_progress_guarantee::weakly_parallel;
   }
@@ -152,7 +152,7 @@ _CCCL_GLOBAL_CONSTANT struct get_forward_progress_guarantee_t
 _CCCL_GLOBAL_CONSTANT struct get_domain_t
 {
   template <class _Sch>
-  _CCCL_HOST_DEVICE constexpr auto operator()(const _Sch& __sch) const noexcept //
+  _CUDAX_API constexpr auto operator()(const _Sch& __sch) const noexcept //
     -> decltype(__async::__decay_copy(__sch.__query(*this)))
   {
     return {};

--- a/cudax/include/cuda/experimental/__async/read_env.cuh
+++ b/cudax/include/cuda/experimental/__async/read_env.cuh
@@ -72,13 +72,13 @@ private:
 
     _Rcvr __rcvr_;
 
-    _CCCL_HOST_DEVICE explicit __opstate_t(_Rcvr __rcvr)
+    _CUDAX_API explicit __opstate_t(_Rcvr __rcvr)
         : __rcvr_(static_cast<_Rcvr&&>(__rcvr))
     {}
 
     _CUDAX_IMMOVABLE(__opstate_t);
 
-    _CCCL_HOST_DEVICE void start() noexcept
+    _CUDAX_API void start() noexcept
     {
       // If the query invocation is noexcept, call it directly. Otherwise,
       // wrap it in a try-catch block and forward the exception to the
@@ -110,8 +110,8 @@ private:
   {
     using operation_state_concept = operation_state_t;
     using completion_signatures   = dependent_completions;
-    _CCCL_HOST_DEVICE explicit __opstate_t(receiver_archetype);
-    _CCCL_HOST_DEVICE void start() noexcept;
+    _CUDAX_API explicit __opstate_t(receiver_archetype);
+    _CUDAX_API void start() noexcept;
   };
 
   template <class _Query>
@@ -133,7 +133,7 @@ struct read_env_t::__sndr_t
   _CCCL_NO_UNIQUE_ADDRESS _Query __query;
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) const noexcept(__nothrow_movable<_Rcvr>) -> __opstate_t<_Rcvr, _Query>
+  _CUDAX_API auto connect(_Rcvr __rcvr) const noexcept(__nothrow_movable<_Rcvr>) -> __opstate_t<_Rcvr, _Query>
   {
     return __opstate_t<_Rcvr, _Query>{static_cast<_Rcvr&&>(__rcvr)};
   }

--- a/cudax/include/cuda/experimental/__async/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__async/run_loop.cuh
@@ -47,12 +47,12 @@ struct __task : __immovable
 
   __task() = default;
 
-  _CCCL_HOST_DEVICE explicit __task(__task* __next, __task* __tail) noexcept
+  _CUDAX_API explicit __task(__task* __next, __task* __tail) noexcept
       : __next_{__next}
       , __tail_{__tail}
   {}
 
-  _CCCL_HOST_DEVICE explicit __task(__task* __next, __execute_fn_t* __execute) noexcept
+  _CUDAX_API explicit __task(__task* __next, __execute_fn_t* __execute) noexcept
       : __next_{__next}
       , __execute_fn_{__execute}
   {}
@@ -65,7 +65,7 @@ struct __task : __immovable
     __execute_fn_t* __execute_fn_;
   };
 
-  _CCCL_HOST_DEVICE void __execute() noexcept
+  _CUDAX_API void __execute() noexcept
   {
     (*__execute_fn_)(this);
   }
@@ -80,7 +80,7 @@ struct __operation : __task
   using completion_signatures = //
     __async::completion_signatures<set_value_t(), set_error_t(::std::exception_ptr), set_stopped_t()>;
 
-  _CCCL_HOST_DEVICE static void __execute_impl(__task* __p) noexcept
+  _CUDAX_API static void __execute_impl(__task* __p) noexcept
   {
     auto& __rcvr = static_cast<__operation*>(__p)->__rcvr_;
     _CUDAX_TRY( //
@@ -100,17 +100,17 @@ struct __operation : __task
         }))
   }
 
-  _CCCL_HOST_DEVICE explicit __operation(__task* __tail_) noexcept
+  _CUDAX_API explicit __operation(__task* __tail_) noexcept
       : __task{this, __tail_}
   {}
 
-  _CCCL_HOST_DEVICE __operation(__task* __next_, run_loop* __loop, _Rcvr __rcvr)
+  _CUDAX_API __operation(__task* __next_, run_loop* __loop, _Rcvr __rcvr)
       : __task{__next_, &__execute_impl}
       , __loop_{__loop}
       , __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
   {}
 
-  _CCCL_HOST_DEVICE void start() & noexcept;
+  _CUDAX_API void start() & noexcept;
 };
 
 class run_loop
@@ -136,7 +136,7 @@ public:
       using sender_concept = sender_t;
 
       template <class _Rcvr>
-      _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) const noexcept -> __operation<_Rcvr>
+      _CUDAX_API auto connect(_Rcvr __rcvr) const noexcept -> __operation<_Rcvr>
       {
         return {&__loop_->__head, __loop_, static_cast<_Rcvr&&>(__rcvr)};
       }
@@ -149,18 +149,18 @@ public:
         run_loop* __loop_;
 
         template <class _Tag>
-        _CCCL_HOST_DEVICE auto query(get_completion_scheduler_t<_Tag>) const noexcept -> __scheduler
+        _CUDAX_API auto query(get_completion_scheduler_t<_Tag>) const noexcept -> __scheduler
         {
           return __loop_->get_scheduler();
         }
       };
 
-      _CCCL_HOST_DEVICE auto get_env() const noexcept -> __env
+      _CUDAX_API auto get_env() const noexcept -> __env
       {
         return __env{__loop_};
       }
 
-      _CCCL_HOST_DEVICE explicit __schedule_task(run_loop* __loop) noexcept
+      _CUDAX_API explicit __schedule_task(run_loop* __loop) noexcept
           : __loop_(__loop)
       {}
 
@@ -169,11 +169,11 @@ public:
 
     friend run_loop;
 
-    _CCCL_HOST_DEVICE explicit __scheduler(run_loop* __loop) noexcept
+    _CUDAX_API explicit __scheduler(run_loop* __loop) noexcept
         : __loop_(__loop)
     {}
 
-    _CCCL_HOST_DEVICE auto query(get_forward_progress_guarantee_t) const noexcept -> forward_progress_guarantee
+    _CUDAX_API auto query(get_forward_progress_guarantee_t) const noexcept -> forward_progress_guarantee
     {
       return forward_progress_guarantee::parallel;
     }
@@ -183,34 +183,34 @@ public:
   public:
     using scheduler_concept = scheduler_t;
 
-    [[nodiscard]] _CCCL_HOST_DEVICE auto schedule() const noexcept -> __schedule_task
+    [[nodiscard]] _CUDAX_API auto schedule() const noexcept -> __schedule_task
     {
       return __schedule_task{__loop_};
     }
 
-    _CCCL_HOST_DEVICE friend bool operator==(const __scheduler& __a, const __scheduler& __b) noexcept
+    _CUDAX_API friend bool operator==(const __scheduler& __a, const __scheduler& __b) noexcept
     {
       return __a.__loop_ == __b.__loop_;
     }
 
-    _CCCL_HOST_DEVICE friend bool operator!=(const __scheduler& __a, const __scheduler& __b) noexcept
+    _CUDAX_API friend bool operator!=(const __scheduler& __a, const __scheduler& __b) noexcept
     {
       return __a.__loop_ != __b.__loop_;
     }
   };
 
-  _CCCL_HOST_DEVICE auto get_scheduler() noexcept -> __scheduler
+  _CUDAX_API auto get_scheduler() noexcept -> __scheduler
   {
     return __scheduler{this};
   }
 
-  _CCCL_HOST_DEVICE void run();
+  _CUDAX_API void run();
 
-  _CCCL_HOST_DEVICE void finish();
+  _CUDAX_API void finish();
 
 private:
-  _CCCL_HOST_DEVICE void __push_back(__task* __tsk);
-  _CCCL_HOST_DEVICE auto __pop_front() -> __task*;
+  _CUDAX_API void __push_back(__task* __tsk);
+  _CUDAX_API auto __pop_front() -> __task*;
 
   ::std::mutex __mutex{};
   ::std::condition_variable __cv{};
@@ -219,7 +219,7 @@ private:
 };
 
 template <class _Rcvr>
-_CCCL_HOST_DEVICE inline void __operation<_Rcvr>::start() & noexcept {
+_CUDAX_API inline void __operation<_Rcvr>::start() & noexcept {
   _CUDAX_TRY( //
     ({ //
       __loop_->__push_back(this); //
@@ -230,7 +230,7 @@ _CCCL_HOST_DEVICE inline void __operation<_Rcvr>::start() & noexcept {
       })) //
 }
 
-_CCCL_HOST_DEVICE inline void run_loop::run()
+_CUDAX_API inline void run_loop::run()
 {
   for (__task* __tsk = __pop_front(); __tsk != &__head; __tsk = __pop_front())
   {
@@ -238,14 +238,14 @@ _CCCL_HOST_DEVICE inline void run_loop::run()
   }
 }
 
-_CCCL_HOST_DEVICE inline void run_loop::finish()
+_CUDAX_API inline void run_loop::finish()
 {
   ::std::unique_lock __lock{__mutex};
   __stop = true;
   __cv.notify_all();
 }
 
-_CCCL_HOST_DEVICE inline void run_loop::__push_back(__task* __tsk)
+_CUDAX_API inline void run_loop::__push_back(__task* __tsk)
 {
   ::std::unique_lock __lock{__mutex};
   __tsk->__next_ = &__head;
@@ -253,7 +253,7 @@ _CCCL_HOST_DEVICE inline void run_loop::__push_back(__task* __tsk)
   __cv.notify_one();
 }
 
-_CCCL_HOST_DEVICE inline auto run_loop::__pop_front() -> __task*
+_CUDAX_API inline auto run_loop::__pop_front() -> __task*
 {
   ::std::unique_lock __lock{__mutex};
   __cv.wait(__lock, [this] {

--- a/cudax/include/cuda/experimental/__async/sequence.cuh
+++ b/cudax/include/cuda/experimental/__async/sequence.cuh
@@ -59,7 +59,7 @@ struct __seq
         completion_signatures_of_t<__sndr2_t, __rcvr_ref_t<__rcvr_t&>>,
         __malways<__async::completion_signatures<>>::__f>; // swallow the first sender's value completions
 
-    _CCCL_HOST_DEVICE friend env_of_t<__rcvr_t> get_env(const __opstate* __self) noexcept
+    _CUDAX_API friend env_of_t<__rcvr_t> get_env(const __opstate* __self) noexcept
     {
       return __async::get_env(__self->__rcvr_);
     }
@@ -68,30 +68,30 @@ struct __seq
     connect_result_t<__sndr1_t, __opstate*> __opstate1_;
     connect_result_t<__sndr2_t, __rcvr_ref_t<__rcvr_t&>> __opstate2_;
 
-    _CCCL_HOST_DEVICE __opstate(__sndr1_t&& __sndr1, __sndr2_t&& __sndr2, __rcvr_t&& __rcvr)
+    _CUDAX_API __opstate(__sndr1_t&& __sndr1, __sndr2_t&& __sndr2, __rcvr_t&& __rcvr)
         : __rcvr_(static_cast<__rcvr_t&&>(__rcvr))
         , __opstate1_(__async::connect(static_cast<__sndr1_t&&>(__sndr1), this))
         , __opstate2_(__async::connect(static_cast<__sndr2_t&&>(__sndr2), __rcvr_ref(__rcvr_)))
     {}
 
-    _CCCL_HOST_DEVICE void start() noexcept
+    _CUDAX_API void start() noexcept
     {
       __async::start(__opstate1_);
     }
 
     template <class... _Values>
-    _CCCL_HOST_DEVICE void set_value(_Values&&...) && noexcept
+    _CUDAX_API void set_value(_Values&&...) && noexcept
     {
       __async::start(__opstate2_);
     }
 
     template <class _Error>
-    _CCCL_HOST_DEVICE void set_error(_Error&& __error) && noexcept
+    _CUDAX_API void set_error(_Error&& __error) && noexcept
     {
       __async::set_error(static_cast<__rcvr_t&&>(__rcvr_), static_cast<_Error&&>(__error));
     }
 
-    _CCCL_HOST_DEVICE void set_stopped() && noexcept
+    _CUDAX_API void set_stopped() && noexcept
     {
       __async::set_stopped(static_cast<__rcvr_t&&>(__rcvr_));
     }
@@ -101,7 +101,7 @@ struct __seq
   struct __sndr_t;
 
   template <class _Sndr1, class _Sndr2>
-  _CCCL_HOST_DEVICE auto operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>;
+  _CUDAX_API auto operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>;
 };
 
 template <class _Sndr1, class _Sndr2>
@@ -112,20 +112,20 @@ struct __seq::__sndr_t
   using __sndr2_t      = _Sndr2;
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) &&
+  _CUDAX_API auto connect(_Rcvr __rcvr) &&
   {
     using __opstate_t = __opstate<__zip<__args<_Rcvr, _Sndr1, _Sndr2>>>;
     return __opstate_t{static_cast<_Sndr1&&>(__sndr1_), static_cast<_Sndr2>(__sndr2_), static_cast<_Rcvr&&>(__rcvr)};
   }
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) const&
+  _CUDAX_API auto connect(_Rcvr __rcvr) const&
   {
     using __opstate_t = __opstate<__zip<__args<_Rcvr, const _Sndr1&, const _Sndr2&>>>;
     return __opstate_t{__sndr1_, __sndr2_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
-  _CCCL_HOST_DEVICE env_of_t<_Sndr2> get_env() const noexcept
+  _CUDAX_API env_of_t<_Sndr2> get_env() const noexcept
   {
     return __async::get_env(__sndr2_);
   }
@@ -137,7 +137,7 @@ struct __seq::__sndr_t
 };
 
 template <class _Sndr1, class _Sndr2>
-_CCCL_HOST_DEVICE auto __seq::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>
+_CUDAX_API auto __seq::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const -> __sndr_t<_Sndr1, _Sndr2>
 {
   return __sndr_t<_Sndr1, _Sndr2>{{}, {}, static_cast<_Sndr1&&>(__sndr1), static_cast<_Sndr2&&>(__sndr2)};
 }

--- a/cudax/include/cuda/experimental/__async/start_detached.cuh
+++ b/cudax/include/cuda/experimental/__async/start_detached.cuh
@@ -76,11 +76,11 @@ private:
       delete static_cast<__opstate_t*>(__ptr);
     }
 
-    _CCCL_HOST_DEVICE explicit __opstate_t(_Sndr&& __sndr)
+    _CUDAX_API explicit __opstate_t(_Sndr&& __sndr)
         : __opstate_(__async::connect(static_cast<_Sndr&&>(__sndr), __rcvr_t{this, &__destroy}))
     {}
 
-    _CCCL_HOST_DEVICE void start() & noexcept
+    _CUDAX_API void start() & noexcept
     {
       __async::start(__opstate_);
     }

--- a/cudax/include/cuda/experimental/__async/start_on.cuh
+++ b/cudax/include/cuda/experimental/__async/start_on.cuh
@@ -54,7 +54,7 @@ private:
   template <class _Rcvr, class _Sch, class _CvSndr>
   struct __opstate_t
   {
-    _CCCL_HOST_DEVICE friend env_of_t<_Rcvr> get_env(const __opstate_t* __self) noexcept
+    _CUDAX_API friend env_of_t<_Rcvr> get_env(const __opstate_t* __self) noexcept
     {
       return __async::get_env(__self->__env_rcvr_.__rcvr());
     }
@@ -72,7 +72,7 @@ private:
     connect_result_t<schedule_result_t<_Sch>, __opstate_t*> __opstate1_;
     connect_result_t<_CvSndr, __rcvr_with_env_t<_Rcvr, __sch_env_t<_Sch>>*> __opstate2_;
 
-    _CCCL_HOST_DEVICE __opstate_t(_Sch __sch, _Rcvr __rcvr, _CvSndr&& __sndr)
+    _CUDAX_API __opstate_t(_Sch __sch, _Rcvr __rcvr, _CvSndr&& __sndr)
         : __env_rcvr_{static_cast<_Rcvr&&>(__rcvr), {__sch}}
         , __opstate1_{connect(schedule(__env_rcvr_.__env_.__sch_), this)}
         , __opstate2_{connect(static_cast<_CvSndr&&>(__sndr), &__env_rcvr_)}
@@ -80,23 +80,23 @@ private:
 
     _CUDAX_IMMOVABLE(__opstate_t);
 
-    _CCCL_HOST_DEVICE void start() noexcept
+    _CUDAX_API void start() noexcept
     {
       __async::start(__opstate1_);
     }
 
-    _CCCL_HOST_DEVICE void set_value() noexcept
+    _CUDAX_API void set_value() noexcept
     {
       __async::start(__opstate2_);
     }
 
     template <class _Error>
-    _CCCL_HOST_DEVICE void set_error(_Error&& __error) noexcept
+    _CUDAX_API void set_error(_Error&& __error) noexcept
     {
       __async::set_error(static_cast<_Rcvr&&>(__env_rcvr_.__rcvr()), static_cast<_Error&&>(__error));
     }
 
-    _CCCL_HOST_DEVICE void set_stopped() noexcept
+    _CUDAX_API void set_stopped() noexcept
     {
       __async::set_stopped(static_cast<_Rcvr&&>(__env_rcvr_.__rcvr()));
     }
@@ -107,7 +107,7 @@ private:
 
 public:
   template <class _Sch, class _Sndr>
-  _CCCL_HOST_DEVICE auto operator()(_Sch __sch, _Sndr __sndr) const noexcept //
+  _CUDAX_API auto operator()(_Sch __sch, _Sndr __sndr) const noexcept //
     -> __sndr_t<_Sch, _Sndr>;
 } start_on{};
 
@@ -120,26 +120,25 @@ struct start_on_t::__sndr_t
   _Sndr __sndr_;
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sch, _Sndr>
+  _CUDAX_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sch, _Sndr>
   {
     return __opstate_t<_Rcvr, _Sch, _Sndr>{__sch_, static_cast<_Rcvr&&>(__rcvr), static_cast<_Sndr&&>(__sndr_)};
   }
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Rcvr, _Sch, const _Sndr&>
+  _CUDAX_API auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Rcvr, _Sch, const _Sndr&>
   {
     return __opstate_t<_Rcvr, _Sch, const _Sndr&>{__sch_, static_cast<_Rcvr&&>(__rcvr), __sndr_};
   }
 
-  _CCCL_HOST_DEVICE env_of_t<_Sndr> get_env() const noexcept
+  _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
   {
     return __async::get_env(__sndr_);
   }
 };
 
 template <class _Sch, class _Sndr>
-_CCCL_HOST_DEVICE auto
-start_on_t::operator()(_Sch __sch, _Sndr __sndr) const noexcept -> start_on_t::__sndr_t<_Sch, _Sndr>
+_CUDAX_API auto start_on_t::operator()(_Sch __sch, _Sndr __sndr) const noexcept -> start_on_t::__sndr_t<_Sch, _Sndr>
 {
   return __sndr_t<_Sch, _Sndr>{{}, __sch, __sndr};
 }

--- a/cudax/include/cuda/experimental/__async/stop_token.cuh
+++ b/cudax/include/cuda/experimental/__async/stop_token.cuh
@@ -56,7 +56,7 @@ namespace __stok
 {
 struct __inplace_stop_callback_base
 {
-  _CCCL_HOST_DEVICE void __execute() noexcept
+  _CUDAX_API void __execute() noexcept
   {
     this->__execute_fn_(this);
   }
@@ -64,14 +64,14 @@ struct __inplace_stop_callback_base
 protected:
   using __execute_fn_t = void(__inplace_stop_callback_base*) noexcept;
 
-  _CCCL_HOST_DEVICE explicit __inplace_stop_callback_base( //
+  _CUDAX_API explicit __inplace_stop_callback_base( //
     const inplace_stop_source* __source, //
     __execute_fn_t* __execute) noexcept
       : __source_(__source)
       , __execute_fn_(__execute)
   {}
 
-  _CCCL_HOST_DEVICE void __register_callback() noexcept;
+  _CUDAX_API void __register_callback() noexcept;
 
   friend inplace_stop_source;
 
@@ -87,7 +87,7 @@ struct __spin_wait
 {
   __spin_wait() noexcept = default;
 
-  _CCCL_HOST_DEVICE void __wait() noexcept
+  _CUDAX_API void __wait() noexcept
   {
     if (__count_ == 0)
     {
@@ -115,29 +115,29 @@ struct never_stop_token
 private:
   struct __callback_type
   {
-    _CCCL_HOST_DEVICE explicit __callback_type(never_stop_token, __ignore) noexcept {}
+    _CUDAX_API explicit __callback_type(never_stop_token, __ignore) noexcept {}
   };
 
 public:
   template <class>
   using callback_type = __callback_type;
 
-  _CCCL_HOST_DEVICE static constexpr auto stop_requested() noexcept -> bool
+  _CUDAX_API static constexpr auto stop_requested() noexcept -> bool
   {
     return false;
   }
 
-  _CCCL_HOST_DEVICE static constexpr auto stop_possible() noexcept -> bool
+  _CUDAX_API static constexpr auto stop_possible() noexcept -> bool
   {
     return false;
   }
 
-  _CCCL_HOST_DEVICE friend constexpr bool operator==(const never_stop_token&, const never_stop_token&) noexcept
+  _CUDAX_API friend constexpr bool operator==(const never_stop_token&, const never_stop_token&) noexcept
   {
     return true;
   }
 
-  _CCCL_HOST_DEVICE friend constexpr bool operator!=(const never_stop_token&, const never_stop_token&) noexcept
+  _CUDAX_API friend constexpr bool operator!=(const never_stop_token&, const never_stop_token&) noexcept
   {
     return false;
   }
@@ -150,15 +150,15 @@ class inplace_stop_callback;
 class inplace_stop_source
 {
 public:
-  _CCCL_HOST_DEVICE inplace_stop_source() noexcept = default;
-  _CCCL_HOST_DEVICE ~inplace_stop_source();
+  _CUDAX_API inplace_stop_source() noexcept = default;
+  _CUDAX_API ~inplace_stop_source();
   _CUDAX_IMMOVABLE(inplace_stop_source);
 
-  _CCCL_HOST_DEVICE auto get_token() const noexcept -> inplace_stop_token;
+  _CUDAX_API auto get_token() const noexcept -> inplace_stop_token;
 
-  _CCCL_HOST_DEVICE auto request_stop() noexcept -> bool;
+  _CUDAX_API auto request_stop() noexcept -> bool;
 
-  _CCCL_HOST_DEVICE auto stop_requested() const noexcept -> bool
+  _CUDAX_API auto stop_requested() const noexcept -> bool
   {
     return (__state_.load(_CUDA_VSTD::memory_order_acquire) & __stop_requested_flag) != 0;
   }
@@ -169,14 +169,14 @@ private:
   template <class>
   friend class inplace_stop_callback;
 
-  _CCCL_HOST_DEVICE auto __lock() const noexcept -> uint8_t;
-  _CCCL_HOST_DEVICE void __unlock(uint8_t) const noexcept;
+  _CUDAX_API auto __lock() const noexcept -> uint8_t;
+  _CUDAX_API void __unlock(uint8_t) const noexcept;
 
-  _CCCL_HOST_DEVICE auto __try_lock_unless_stop_requested(bool) const noexcept -> bool;
+  _CUDAX_API auto __try_lock_unless_stop_requested(bool) const noexcept -> bool;
 
-  _CCCL_HOST_DEVICE auto __try_add_callback(__stok::__inplace_stop_callback_base*) const noexcept -> bool;
+  _CUDAX_API auto __try_add_callback(__stok::__inplace_stop_callback_base*) const noexcept -> bool;
 
-  _CCCL_HOST_DEVICE void __remove_callback(__stok::__inplace_stop_callback_base*) const noexcept;
+  _CUDAX_API void __remove_callback(__stok::__inplace_stop_callback_base*) const noexcept;
 
   static constexpr uint8_t __stop_requested_flag = 1;
   static constexpr uint8_t __locked_flag         = 2;
@@ -193,45 +193,45 @@ public:
   template <class _Fun>
   using callback_type = inplace_stop_callback<_Fun>;
 
-  _CCCL_HOST_DEVICE inplace_stop_token() noexcept
+  _CUDAX_API inplace_stop_token() noexcept
       : __source_(nullptr)
   {}
 
   inplace_stop_token(const inplace_stop_token& __other) noexcept = default;
 
-  _CCCL_HOST_DEVICE inplace_stop_token(inplace_stop_token&& __other) noexcept
+  _CUDAX_API inplace_stop_token(inplace_stop_token&& __other) noexcept
       : __source_(__async::__exchange(__other.__source_, {}))
   {}
 
   auto operator=(const inplace_stop_token& __other) noexcept -> inplace_stop_token& = default;
 
-  _CCCL_HOST_DEVICE auto operator=(inplace_stop_token&& __other) noexcept -> inplace_stop_token&
+  _CUDAX_API auto operator=(inplace_stop_token&& __other) noexcept -> inplace_stop_token&
   {
     __source_ = __async::__exchange(__other.__source_, nullptr);
     return *this;
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE auto stop_requested() const noexcept -> bool
+  [[nodiscard]] _CUDAX_API auto stop_requested() const noexcept -> bool
   {
     return __source_ != nullptr && __source_->stop_requested();
   }
 
-  [[nodiscard]] _CCCL_HOST_DEVICE auto stop_possible() const noexcept -> bool
+  [[nodiscard]] _CUDAX_API auto stop_possible() const noexcept -> bool
   {
     return __source_ != nullptr;
   }
 
-  _CCCL_HOST_DEVICE void swap(inplace_stop_token& __other) noexcept
+  _CUDAX_API void swap(inplace_stop_token& __other) noexcept
   {
     __async::__swap(__source_, __other.__source_);
   }
 
-  _CCCL_HOST_DEVICE friend bool operator==(const inplace_stop_token& __a, const inplace_stop_token& __b) noexcept
+  _CUDAX_API friend bool operator==(const inplace_stop_token& __a, const inplace_stop_token& __b) noexcept
   {
     return __a.__source_ == __b.__source_;
   }
 
-  _CCCL_HOST_DEVICE friend bool operator!=(const inplace_stop_token& __a, const inplace_stop_token& __b) noexcept
+  _CUDAX_API friend bool operator!=(const inplace_stop_token& __a, const inplace_stop_token& __b) noexcept
   {
     return __a.__source_ != __b.__source_;
   }
@@ -241,14 +241,14 @@ private:
   template <class>
   friend class inplace_stop_callback;
 
-  _CCCL_HOST_DEVICE explicit inplace_stop_token(const inplace_stop_source* __source) noexcept
+  _CUDAX_API explicit inplace_stop_token(const inplace_stop_source* __source) noexcept
       : __source_(__source)
   {}
 
   const inplace_stop_source* __source_;
 };
 
-_CCCL_HOST_DEVICE inline auto inplace_stop_source::get_token() const noexcept -> inplace_stop_token
+_CUDAX_API inline auto inplace_stop_source::get_token() const noexcept -> inplace_stop_token
 {
   return inplace_stop_token{this};
 }
@@ -259,15 +259,15 @@ class inplace_stop_callback : __stok::__inplace_stop_callback_base
 {
 public:
   template <class _Fun2>
-  _CCCL_HOST_DEVICE explicit inplace_stop_callback(inplace_stop_token __token, _Fun2&& __fun) noexcept(
-    _CUDA_VSTD::is_nothrow_constructible_v<_Fun, _Fun2>)
+  _CUDAX_API explicit inplace_stop_callback(inplace_stop_token __token,
+                                            _Fun2&& __fun) noexcept(_CUDA_VSTD::is_nothrow_constructible_v<_Fun, _Fun2>)
       : __stok::__inplace_stop_callback_base(__token.__source_, &inplace_stop_callback::__execute_impl)
       , __fun(static_cast<_Fun2&&>(__fun))
   {
     __register_callback();
   }
 
-  _CCCL_HOST_DEVICE ~inplace_stop_callback()
+  _CUDAX_API ~inplace_stop_callback()
   {
     if (__source_ != nullptr)
     {
@@ -276,7 +276,7 @@ public:
   }
 
 private:
-  _CCCL_HOST_DEVICE static void __execute_impl(__stok::__inplace_stop_callback_base* __cb) noexcept
+  _CUDAX_API static void __execute_impl(__stok::__inplace_stop_callback_base* __cb) noexcept
   {
     static_cast<_Fun&&>(static_cast<inplace_stop_callback*>(__cb)->__fun)();
   }
@@ -286,7 +286,7 @@ private:
 
 namespace __stok
 {
-_CCCL_HOST_DEVICE inline void __inplace_stop_callback_base::__register_callback() noexcept
+_CUDAX_API inline void __inplace_stop_callback_base::__register_callback() noexcept
 {
   if (__source_ != nullptr)
   {
@@ -301,13 +301,13 @@ _CCCL_HOST_DEVICE inline void __inplace_stop_callback_base::__register_callback(
 }
 } // namespace __stok
 
-_CCCL_HOST_DEVICE inline inplace_stop_source::~inplace_stop_source()
+_CUDAX_API inline inplace_stop_source::~inplace_stop_source()
 {
   _CCCL_ASSERT((__state_.load(_CUDA_VSTD::memory_order_relaxed) & __locked_flag) == 0, "");
   _CCCL_ASSERT(__callbacks_ == nullptr, "");
 }
 
-_CCCL_HOST_DEVICE inline auto inplace_stop_source::request_stop() noexcept -> bool
+_CUDAX_API inline auto inplace_stop_source::request_stop() noexcept -> bool
 {
   if (!__try_lock_unless_stop_requested(true))
   {
@@ -347,7 +347,7 @@ _CCCL_HOST_DEVICE inline auto inplace_stop_source::request_stop() noexcept -> bo
   return false;
 }
 
-_CCCL_HOST_DEVICE inline auto inplace_stop_source::__lock() const noexcept -> uint8_t
+_CUDAX_API inline auto inplace_stop_source::__lock() const noexcept -> uint8_t
 {
   __stok::__spin_wait __spin;
   auto __old_state = __state_.load(_CUDA_VSTD::memory_order_relaxed);
@@ -364,12 +364,12 @@ _CCCL_HOST_DEVICE inline auto inplace_stop_source::__lock() const noexcept -> ui
   return __old_state;
 }
 
-_CCCL_HOST_DEVICE inline void inplace_stop_source::__unlock(uint8_t __old_state) const noexcept
+_CUDAX_API inline void inplace_stop_source::__unlock(uint8_t __old_state) const noexcept
 {
   (void) __state_.store(__old_state, _CUDA_VSTD::memory_order_release);
 }
 
-_CCCL_HOST_DEVICE inline auto
+_CUDAX_API inline auto
 inplace_stop_source::__try_lock_unless_stop_requested(bool __set_stop_requested) const noexcept -> bool
 {
   __stok::__spin_wait __spin;
@@ -403,7 +403,7 @@ inplace_stop_source::__try_lock_unless_stop_requested(bool __set_stop_requested)
   return true;
 }
 
-_CCCL_HOST_DEVICE inline auto
+_CUDAX_API inline auto
 inplace_stop_source::__try_add_callback(__stok::__inplace_stop_callback_base* __callbk) const noexcept -> bool
 {
   if (!__try_lock_unless_stop_requested(false))
@@ -424,7 +424,7 @@ inplace_stop_source::__try_add_callback(__stok::__inplace_stop_callback_base* __
   return true;
 }
 
-_CCCL_HOST_DEVICE inline void
+_CUDAX_API inline void
 inplace_stop_source::__remove_callback(__stok::__inplace_stop_callback_base* __callbk) const noexcept
 {
   auto __old_state = __lock();
@@ -471,7 +471,7 @@ struct __on_stop_request
 {
   inplace_stop_source& __source_;
 
-  _CCCL_HOST_DEVICE void operator()() const noexcept
+  _CUDAX_API void operator()() const noexcept
   {
     __source_.request_stop();
   }

--- a/cudax/include/cuda/experimental/__async/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__async/sync_wait.cuh
@@ -52,12 +52,12 @@ private:
   {
     run_loop* __loop_;
 
-    _CCCL_HOST_DEVICE auto query(get_scheduler_t) const noexcept
+    _CUDAX_API auto query(get_scheduler_t) const noexcept
     {
       return __loop_->get_scheduler();
     }
 
-    _CCCL_HOST_DEVICE auto query(get_delegatee_scheduler_t) const noexcept
+    _CUDAX_API auto query(get_delegatee_scheduler_t) const noexcept
     {
       return __loop_->get_scheduler();
     }
@@ -72,7 +72,7 @@ private:
       __state_t* __state_;
 
       template <class... _As>
-      _CCCL_HOST_DEVICE void set_value(_As&&... __as) noexcept
+      _CUDAX_API void set_value(_As&&... __as) noexcept
       {
         _CUDAX_TRY( //
           ({ //
@@ -86,7 +86,7 @@ private:
       }
 
       template <class _Error>
-      _CCCL_HOST_DEVICE void set_error(_Error __err) noexcept
+      _CUDAX_API void set_error(_Error __err) noexcept
       {
         if constexpr (_CUDA_VSTD::is_same_v<_Error, ::std::exception_ptr>)
         {
@@ -103,7 +103,7 @@ private:
         __state_->__loop_.finish();
       }
 
-      _CCCL_HOST_DEVICE void set_stopped() noexcept
+      _CUDAX_API void set_stopped() noexcept
       {
         __state_->__loop_.finish();
       }

--- a/cudax/include/cuda/experimental/__async/then.cuh
+++ b/cudax/include/cuda/experimental/__async/then.cuh
@@ -125,7 +125,7 @@ private:
   template <class _Rcvr, class _CvSndr, class _Fn>
   struct __opstate_t
   {
-    _CCCL_HOST_DEVICE friend env_of_t<_Rcvr> get_env(const __opstate_t* __self) noexcept
+    _CUDAX_API friend env_of_t<_Rcvr> get_env(const __opstate_t* __self) noexcept
     {
       return __async::get_env(__self->__rcvr_);
     }
@@ -137,7 +137,7 @@ private:
     _Fn __fn_;
     connect_result_t<_CvSndr, __opstate_t*> __opstate_;
 
-    _CCCL_HOST_DEVICE __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, _Fn __fn)
+    _CUDAX_API __opstate_t(_CvSndr&& __sndr, _Rcvr __rcvr, _Fn __fn)
         : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
         , __fn_{static_cast<_Fn&&>(__fn)}
         , __opstate_{__async::connect(static_cast<_CvSndr&&>(__sndr), this)}
@@ -145,13 +145,13 @@ private:
 
     _CUDAX_IMMOVABLE(__opstate_t);
 
-    _CCCL_HOST_DEVICE void start() & noexcept
+    _CUDAX_API void start() & noexcept
     {
       __async::start(__opstate_);
     }
 
     template <bool _CanThrow = false, class... _Ts>
-    _CCCL_HOST_DEVICE void __set(_Ts&&... __ts) noexcept(!_CanThrow)
+    _CUDAX_API void __set(_Ts&&... __ts) noexcept(!_CanThrow)
     {
       if constexpr (_CanThrow || __nothrow_callable<_Fn, _Ts...>)
       {
@@ -192,18 +192,18 @@ private:
     }
 
     template <class... _Ts>
-    _CCCL_HOST_DEVICE void set_value(_Ts&&... __ts) noexcept
+    _CUDAX_API void set_value(_Ts&&... __ts) noexcept
     {
       __complete(set_value_t(), static_cast<_Ts&&>(__ts)...);
     }
 
     template <class _Error>
-    _CCCL_HOST_DEVICE void set_error(_Error&& __error) noexcept
+    _CUDAX_API void set_error(_Error&& __error) noexcept
     {
       __complete(set_error_t(), static_cast<_Error&&>(__error));
     }
 
-    _CCCL_HOST_DEVICE void set_stopped() noexcept
+    _CUDAX_API void set_stopped() noexcept
     {
       __complete(set_stopped_t());
     }
@@ -218,7 +218,7 @@ private:
     _Sndr __sndr_;
 
     template <class _Rcvr>
-    _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) && //
+    _CUDAX_API auto connect(_Rcvr __rcvr) && //
       noexcept(__nothrow_constructible<__opstate_t<_Rcvr, _Sndr, _Fn>, _Sndr, _Rcvr, _Fn>) //
       -> __opstate_t<_Rcvr, _Sndr, _Fn>
     {
@@ -227,7 +227,7 @@ private:
     }
 
     template <class _Rcvr>
-    _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) const& //
+    _CUDAX_API auto connect(_Rcvr __rcvr) const& //
       noexcept(__nothrow_constructible<__opstate_t<_Rcvr, const _Sndr&, _Fn>,
                                        const _Sndr&,
                                        _Rcvr,
@@ -237,7 +237,7 @@ private:
       return __opstate_t<_Rcvr, const _Sndr&, _Fn>{__sndr_, static_cast<_Rcvr&&>(__rcvr), __fn_};
     }
 
-    _CCCL_HOST_DEVICE env_of_t<_Sndr> get_env() const noexcept
+    _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
     {
       return __async::get_env(__sndr_);
     }

--- a/cudax/include/cuda/experimental/__async/thread.cuh
+++ b/cudax/include/cuda/experimental/__async/thread.cuh
@@ -45,23 +45,23 @@ struct __thread_id
     int __device_;
   };
 
-  _CCCL_HOST_DEVICE __thread_id() noexcept
+  _CUDAX_API __thread_id() noexcept
       : __host_()
   {}
-  _CCCL_HOST_DEVICE __thread_id(::std::thread::id __host) noexcept
+  _CUDAX_API __thread_id(::std::thread::id __host) noexcept
       : __host_(__host)
   {}
-  _CCCL_HOST_DEVICE __thread_id(int __device) noexcept
+  _CUDAX_API __thread_id(int __device) noexcept
       : __device_(__device)
   {}
 
-  _CCCL_HOST_DEVICE friend bool operator==(const __thread_id& __self, const __thread_id& __other) noexcept
+  _CUDAX_API friend bool operator==(const __thread_id& __self, const __thread_id& __other) noexcept
   {
     _CUDAX_FOR_HOST_OR_DEVICE((return __self.__host_ == __other.__host_;),
                               (return __self.__device_ == __other.__device_;))
   }
 
-  _CCCL_HOST_DEVICE friend bool operator!=(const __thread_id& __self, const __thread_id& __other) noexcept
+  _CUDAX_API friend bool operator!=(const __thread_id& __self, const __thread_id& __other) noexcept
   {
     return !(__self == __other);
   }
@@ -70,13 +70,13 @@ struct __thread_id
 using __thread_id = ::std::thread::id;
 #endif
 
-inline _CCCL_HOST_DEVICE __thread_id __this_thread_id() noexcept
+inline _CUDAX_API __thread_id __this_thread_id() noexcept
 {
   _CUDAX_FOR_HOST_OR_DEVICE((return ::std::this_thread::get_id();),
                             (return static_cast<int>(threadIdx.x + blockIdx.x * blockDim.x);))
 }
 
-inline _CCCL_HOST_DEVICE void __this_thread_yield() noexcept
+inline _CUDAX_API void __this_thread_yield() noexcept
 {
   _CUDAX_FOR_HOST_OR_DEVICE((::std::this_thread::yield();), (void();))
 }

--- a/cudax/include/cuda/experimental/__async/tuple.cuh
+++ b/cudax/include/cuda/experimental/__async/tuple.cuh
@@ -72,7 +72,7 @@ struct __tupl<__mindices<_Idx...>, _Ts...> : __box<_Idx, _Ts>...
 };
 
 template <class... _Ts>
-_CCCL_HOST_DEVICE __tupl(_Ts...) //
+_CUDAX_API __tupl(_Ts...) //
   -> __tupl<__mmake_indices<sizeof...(_Ts)>, _Ts...>;
 
 template <class _Fn, class _Tupl, class... _Us>

--- a/cudax/include/cuda/experimental/__async/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__async/type_traits.cuh
@@ -190,53 +190,53 @@ template <class _Fn, class... _As>
 using __call_result_t = decltype(__declval<_Fn>()(__declval<_As>()...));
 
 template <class _Fn, class... _As>
-_CCCL_INLINE_VAR constexpr bool __callable = __mvalid_q<__call_result_t, _Fn, _As...>;
+inline constexpr bool __callable = __mvalid_q<__call_result_t, _Fn, _As...>;
 
 #if defined(__CUDA_ARCH__)
 template <class _Fn, class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_callable = true;
+inline constexpr bool __nothrow_callable = true;
 
 template <class _Ty, class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_constructible = true;
+inline constexpr bool __nothrow_constructible = true;
 
 template <class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_decay_copyable = true;
+inline constexpr bool __nothrow_decay_copyable = true;
 
 template <class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_movable = true;
+inline constexpr bool __nothrow_movable = true;
 
 template <class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_copyable = true;
+inline constexpr bool __nothrow_copyable = true;
 #else
 template <class _Fn, class... _As>
 using __nothrow_callable_ = __mif<noexcept(__declval<_Fn>()(__declval<_As>()...))>;
 
 template <class _Fn, class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_callable = __mvalid_q<__nothrow_callable_, _Fn, _As...>;
+inline constexpr bool __nothrow_callable = __mvalid_q<__nothrow_callable_, _Fn, _As...>;
 
 template <class _Ty, class... _As>
 using __nothrow_constructible_ = __mif<noexcept(_Ty{__declval<_As>()...})>;
 
 template <class _Ty, class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_constructible = __mvalid_q<__nothrow_constructible_, _Ty, _As...>;
+inline constexpr bool __nothrow_constructible = __mvalid_q<__nothrow_constructible_, _Ty, _As...>;
 
 template <class _Ty>
 using __nothrow_decay_copyable_ = __mif<noexcept(__decay_t<_Ty>(__declval<_Ty>()))>;
 
 template <class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_decay_copyable = (__mvalid_q<__nothrow_decay_copyable_, _As> && ...);
+inline constexpr bool __nothrow_decay_copyable = (__mvalid_q<__nothrow_decay_copyable_, _As> && ...);
 
 template <class _Ty>
 using __nothrow_movable_ = __mif<noexcept(_Ty(__declval<_Ty>()))>;
 
 template <class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_movable = (__mvalid_q<__nothrow_movable_, _As> && ...);
+inline constexpr bool __nothrow_movable = (__mvalid_q<__nothrow_movable_, _As> && ...);
 
 template <class _Ty>
 using __nothrow_copyable_ = __mif<noexcept(_Ty(__declval<const _Ty&>()))>;
 
 template <class... _As>
-_CCCL_INLINE_VAR constexpr bool __nothrow_copyable = (__mvalid_q<__nothrow_copyable_, _As> && ...);
+inline constexpr bool __nothrow_copyable = (__mvalid_q<__nothrow_copyable_, _As> && ...);
 #endif
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/utility.cuh
+++ b/cudax/include/cuda/experimental/__async/utility.cuh
@@ -37,7 +37,7 @@ _CCCL_GLOBAL_CONSTANT size_t __npos = static_cast<size_t>(-1);
 struct __ignore
 {
   template <class... _As>
-  _CCCL_HOST_DEVICE constexpr __ignore(_As&&...) noexcept {};
+  _CUDAX_API constexpr __ignore(_As&&...) noexcept {};
 };
 
 template <class...>
@@ -58,7 +58,7 @@ struct __immovable
   _CUDAX_IMMOVABLE(__immovable);
 };
 
-_CCCL_HOST_DEVICE constexpr size_t __maximum(_CUDA_VSTD::initializer_list<size_t> __il) noexcept
+_CUDAX_API constexpr size_t __maximum(_CUDA_VSTD::initializer_list<size_t> __il) noexcept
 {
   size_t __max = 0;
   for (auto i : __il)
@@ -71,7 +71,7 @@ _CCCL_HOST_DEVICE constexpr size_t __maximum(_CUDA_VSTD::initializer_list<size_t
   return __max;
 }
 
-_CCCL_HOST_DEVICE constexpr size_t __find_pos(bool const* const __begin, bool const* const __end) noexcept
+_CUDAX_API constexpr size_t __find_pos(bool const* const __begin, bool const* const __end) noexcept
 {
   for (bool const* __where = __begin; __where != __end; ++__where)
   {
@@ -84,14 +84,14 @@ _CCCL_HOST_DEVICE constexpr size_t __find_pos(bool const* const __begin, bool co
 }
 
 template <class _Ty, class... _Ts>
-_CCCL_HOST_DEVICE constexpr size_t __index_of() noexcept
+_CUDAX_API constexpr size_t __index_of() noexcept
 {
   constexpr bool __same[] = {_CUDA_VSTD::is_same_v<_Ty, _Ts>...};
   return __async::__find_pos(__same, __same + sizeof...(_Ts));
 }
 
 template <class _Ty, class _Uy = _Ty>
-_CCCL_HOST_DEVICE constexpr _Ty __exchange(_Ty& __obj, _Uy&& __new_value) noexcept
+_CUDAX_API constexpr _Ty __exchange(_Ty& __obj, _Uy&& __new_value) noexcept
 {
   constexpr bool __is_nothrow = //
     noexcept(_Ty(static_cast<_Ty&&>(__obj))) && //
@@ -104,7 +104,7 @@ _CCCL_HOST_DEVICE constexpr _Ty __exchange(_Ty& __obj, _Uy&& __new_value) noexce
 }
 
 template <class _Ty>
-_CCCL_HOST_DEVICE constexpr void __swap(_Ty& __left, _Ty& __right) noexcept
+_CUDAX_API constexpr void __swap(_Ty& __left, _Ty& __right) noexcept
 {
   constexpr bool __is_nothrow = //
     noexcept(_Ty(static_cast<_Ty&&>(__left))) && //
@@ -117,7 +117,7 @@ _CCCL_HOST_DEVICE constexpr void __swap(_Ty& __left, _Ty& __right) noexcept
 }
 
 template <class _Ty>
-_CCCL_HOST_DEVICE constexpr _Ty __decay_copy(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>)
+_CUDAX_API constexpr _Ty __decay_copy(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>)
 {
   return static_cast<_Ty&&>(__ty);
 }

--- a/cudax/include/cuda/experimental/__async/variant.cuh
+++ b/cudax/include/cuda/experimental/__async/variant.cuh
@@ -49,7 +49,7 @@ class __variant_impl<__mindices<>>
 {
 public:
   template <class _Fn, class... _Us>
-  _CCCL_HOST_DEVICE void __visit(_Fn&&, _Us&&...) const noexcept
+  _CUDAX_API void __visit(_Fn&&, _Us&&...) const noexcept
   {}
 };
 
@@ -64,7 +64,7 @@ class __variant_impl<__mindices<_Idx...>, _Ts...>
   template <size_t _Ny>
   using __at = __m_at_c<_Ny, _Ts...>;
 
-  _CCCL_HOST_DEVICE void __destroy() noexcept
+  _CUDAX_API void __destroy() noexcept
   {
     if (__index_ != __npos)
     {
@@ -77,9 +77,9 @@ class __variant_impl<__mindices<_Idx...>, _Ts...>
 public:
   _CUDAX_IMMOVABLE(__variant_impl);
 
-  _CCCL_HOST_DEVICE __variant_impl() noexcept {}
+  _CUDAX_API __variant_impl() noexcept {}
 
-  _CCCL_HOST_DEVICE ~__variant_impl()
+  _CUDAX_API ~__variant_impl()
   {
     __destroy();
   }
@@ -95,7 +95,7 @@ public:
   }
 
   template <class _Ty, class... _As>
-  _CCCL_HOST_DEVICE _Ty& __emplace(_As&&... __as) //
+  _CUDAX_API _Ty& __emplace(_As&&... __as) //
     noexcept(__nothrow_constructible<_Ty, _As...>)
   {
     constexpr size_t __new_index = __async::__index_of<_Ty, _Ts...>();
@@ -108,7 +108,7 @@ public:
   }
 
   template <size_t _Ny, class... _As>
-  _CCCL_HOST_DEVICE __at<_Ny>& __emplace_at(_As&&... __as) //
+  _CUDAX_API __at<_Ny>& __emplace_at(_As&&... __as) //
     noexcept(__nothrow_constructible<__at<_Ny>, _As...>)
   {
     static_assert(_Ny < sizeof...(_Ts), "variant index is too large");
@@ -120,7 +120,7 @@ public:
   }
 
   template <class _Fn, class... _As>
-  _CCCL_HOST_DEVICE auto __emplace_from(_Fn&& __fn, _As&&... __as) //
+  _CUDAX_API auto __emplace_from(_Fn&& __fn, _As&&... __as) //
     noexcept(__nothrow_callable<_Fn, _As...>) -> __call_result_t<_Fn, _As...>&
   {
     using __result_t             = __call_result_t<_Fn, _As...>;
@@ -134,7 +134,7 @@ public:
   }
 
   template <class _Fn, class _Self, class... _As>
-  _CCCL_HOST_DEVICE static void __visit(_Fn&& __fn, _Self&& __self, _As&&... __as) //
+  _CUDAX_API static void __visit(_Fn&& __fn, _Self&& __self, _As&&... __as) //
     noexcept((__nothrow_callable<_Fn, _As..., __copy_cvref_t<_Self, _Ts>> && ...))
   {
     // make this local in case destroying the sub-object destroys *this
@@ -147,21 +147,21 @@ public:
   }
 
   template <size_t _Ny>
-  _CCCL_HOST_DEVICE __at<_Ny>&& __get() && noexcept
+  _CUDAX_API __at<_Ny>&& __get() && noexcept
   {
     _CCCL_ASSERT(_Ny == __index_, "");
     return static_cast<__at<_Ny>&&>(*static_cast<__at<_Ny>*>(__ptr()));
   }
 
   template <size_t _Ny>
-  _CCCL_HOST_DEVICE __at<_Ny>& __get() & noexcept
+  _CUDAX_API __at<_Ny>& __get() & noexcept
   {
     _CCCL_ASSERT(_Ny == __index_, "");
     return *static_cast<__at<_Ny>*>(__ptr());
   }
 
   template <size_t _Ny>
-  _CCCL_HOST_DEVICE const __at<_Ny>& __get() const& noexcept
+  _CUDAX_API const __at<_Ny>& __get() const& noexcept
   {
     _CCCL_ASSERT(_Ny == __index_, "");
     return *static_cast<const __at<_Ny>*>(__ptr());

--- a/cudax/include/cuda/experimental/__async/when_all.cuh
+++ b/cudax/include/cuda/experimental/__async/when_all.cuh
@@ -239,7 +239,7 @@ _CCCL_NV_DIAG_SUPPRESS(expr_has_no_effect)
 _CCCL_DIAG_SUPPRESS_NVHPC(expr_has_no_effect)
 
 template <size_t... _Offsets>
-_CCCL_INLINE_VAR constexpr size_t __last_offset = (0, ..., _Offsets);
+inline constexpr size_t __last_offset = (0, ..., _Offsets);
 
 _CCCL_NV_DIAG_DEFAULT(expr_has_no_effect)
 _CCCL_DIAG_POP
@@ -301,13 +301,13 @@ struct __env_t
 
   __state_t& __state_;
 
-  _CCCL_HOST_DEVICE inplace_stop_token __query(get_stop_token_t) const noexcept
+  _CUDAX_API inplace_stop_token __query(get_stop_token_t) const noexcept
   {
     return __state_.__stop_token_;
   }
 
   template <class _Tag>
-  _CCCL_HOST_DEVICE auto query(_Tag) const noexcept -> __query_result_t<_Tag, env_of_t<__rcvr_t>>
+  _CUDAX_API auto query(_Tag) const noexcept -> __query_result_t<_Tag, env_of_t<__rcvr_t>>
   {
     return __async::get_env(__state_.__rcvr_).__query(_Tag());
   }
@@ -336,13 +336,13 @@ struct __rcvr_t
     __state_.__arrive();
   }
 
-  _CCCL_HOST_DEVICE void set_stopped() noexcept
+  _CUDAX_API void set_stopped() noexcept
   {
     __state_.__set_stopped();
     __state_.__arrive();
   }
 
-  _CCCL_HOST_DEVICE auto get_env() const noexcept -> __env_t<_StateZip>
+  _CUDAX_API auto get_env() const noexcept -> __env_t<_StateZip>
   {
     return {__state_};
   }
@@ -388,7 +388,7 @@ struct __state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
   using __stop_tok_t      = stop_token_of_t<env_of_t<_Rcvr>>;
   using __stop_callback_t = stop_callback_for_t<__stop_tok_t, __on_stop_request>;
 
-  _CCCL_HOST_DEVICE explicit __state_t(_Rcvr __rcvr, size_t __count)
+  _CUDAX_API explicit __state_t(_Rcvr __rcvr, size_t __count)
       : __rcvr_{static_cast<_Rcvr&&>(__rcvr)}
       , __count_{__count}
       , __stop_source_{}
@@ -407,7 +407,7 @@ struct __state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
   }
 
   template <size_t _Index, size_t... _Jdx, class... _Ts>
-  _CCCL_HOST_DEVICE void __set_value(__mindices<_Jdx...>, [[maybe_unused]] _Ts&&... __ts) noexcept
+  _CUDAX_API void __set_value(__mindices<_Jdx...>, [[maybe_unused]] _Ts&&... __ts) noexcept
   {
     [[maybe_unused]] constexpr size_t _Offset = __offset_for<_Index>(static_cast<__offsets_t*>(nullptr));
     if constexpr (!_CUDA_VSTD::is_same_v<__values_t, __nil>)
@@ -431,7 +431,7 @@ struct __state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
   }
 
   template <class _Error>
-  _CCCL_HOST_DEVICE void __set_error(_Error&& __err) noexcept
+  _CUDAX_API void __set_error(_Error&& __err) noexcept
   {
     // TODO: Use weaker memory orders
     if (__error != __state_.exchange(__error))
@@ -457,7 +457,7 @@ struct __state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
     }
   }
 
-  _CCCL_HOST_DEVICE void __set_stopped() noexcept
+  _CUDAX_API void __set_stopped() noexcept
   {
     _CUDA_VSTD::underlying_type_t<__estate_t> __expected = __started;
     // Transition to the "stopped" state if and only if we're in the
@@ -469,7 +469,7 @@ struct __state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
     }
   }
 
-  _CCCL_HOST_DEVICE void __arrive() noexcept
+  _CUDAX_API void __arrive() noexcept
   {
     if (0 == --__count_)
     {
@@ -477,7 +477,7 @@ struct __state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
     }
   }
 
-  _CCCL_HOST_DEVICE void __complete() noexcept
+  _CUDAX_API void __complete() noexcept
   {
     // Stop callback is no longer needed. Destroy it.
     __on_stop_.destroy();
@@ -529,7 +529,7 @@ struct __opstate_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
   struct __connect_subs_fn
   {
     template <class... _CvSndrs>
-    _CCCL_HOST_DEVICE auto operator()(__state_t& __state, _CvSndrs&&... __sndrs_) const
+    _CUDAX_API auto operator()(__state_t& __state, _CvSndrs&&... __sndrs_) const
     {
       using __state_ref_t = __zip<__state_t>;
       if constexpr (_CUDA_VSTD::is_same_v<__offsets_t, __moffsets<>>)
@@ -556,7 +556,7 @@ struct __opstate_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
 
   /// Initialize the data member, connect all the sub-operations and
   /// save the resulting operation states in __sub_ops_.
-  _CCCL_HOST_DEVICE __opstate_t(__sndrs_t&& __sndrs_, _Rcvr __rcvr)
+  _CUDAX_API __opstate_t(__sndrs_t&& __sndrs_, _Rcvr __rcvr)
       : __state_{static_cast<_Rcvr&&>(__rcvr), sizeof...(_Sndrs)}
       , __sub_ops_{__sndrs_.__apply(__connect_subs_fn(), static_cast<__sndrs_t&&>(__sndrs_), __state_)}
   {}
@@ -564,7 +564,7 @@ struct __opstate_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
   _CUDAX_IMMOVABLE(__opstate_t);
 
   /// Start all the sub-operations.
-  _CCCL_HOST_DEVICE void start() & noexcept
+  _CUDAX_API void start() & noexcept
   {
     // register stop callback:
     __state_.__on_stop_.construct(
@@ -601,7 +601,7 @@ struct __sndr_t;
 struct when_all_t
 {
   template <class... _Sndrs>
-  _CCCL_HOST_DEVICE __when_all::__sndr_t<_Sndrs...> operator()(_Sndrs... __sndrs_) const;
+  _CUDAX_API __when_all::__sndr_t<_Sndrs...> operator()(_Sndrs... __sndrs_) const;
 };
 
 // The sender for when_all
@@ -616,13 +616,13 @@ struct __when_all::__sndr_t
   __sndrs_t __sndrs_;
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, __cp, __sndrs_t>
+  _CUDAX_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, __cp, __sndrs_t>
   {
     return __opstate_t<_Rcvr, __cp, __sndrs_t>(static_cast<__sndrs_t&&>(__sndrs_), static_cast<_Rcvr&&>(__rcvr));
   }
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) const& //
+  _CUDAX_API auto connect(_Rcvr __rcvr) const& //
     -> __opstate_t<_Rcvr, __cpclr, __sndrs_t>
   {
     return __opstate_t<_Rcvr, __cpclr, __sndrs_t>(__sndrs_, static_cast<_Rcvr&&>(__rcvr));
@@ -630,7 +630,7 @@ struct __when_all::__sndr_t
 };
 
 template <class... _Sndrs>
-_CCCL_HOST_DEVICE __when_all::__sndr_t<_Sndrs...> when_all_t::operator()(_Sndrs... __sndrs_) const
+_CUDAX_API __when_all::__sndr_t<_Sndrs...> when_all_t::operator()(_Sndrs... __sndrs_) const
 {
   // If the incoming sender is non-dependent, we can check the completion
   // signatures of the composed sender immediately.

--- a/cudax/include/cuda/experimental/__async/write_env.cuh
+++ b/cudax/include/cuda/experimental/__async/write_env.cuh
@@ -50,14 +50,14 @@ private:
     __rcvr_with_env_t<_Rcvr, _Env> __env_rcvr_;
     connect_result_t<_Sndr, __rcvr_with_env_t<_Rcvr, _Env>*> __opstate_;
 
-    _CCCL_HOST_DEVICE explicit __opstate_t(_Sndr&& __sndr, _Env __env, _Rcvr __rcvr)
+    _CUDAX_API explicit __opstate_t(_Sndr&& __sndr, _Env __env, _Rcvr __rcvr)
         : __env_rcvr_(static_cast<_Env&&>(__env), static_cast<_Rcvr&&>(__rcvr))
         , __opstate_(__async::connect(static_cast<_Sndr&&>(__sndr), &__env_rcvr_))
     {}
 
     _CUDAX_IMMOVABLE(__opstate_t);
 
-    _CCCL_HOST_DEVICE void start() noexcept
+    _CUDAX_API void start() noexcept
     {
       __async::start(__opstate_);
     }
@@ -83,20 +83,20 @@ struct write_env_t::__sndr_t
   _Sndr __sndr_;
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sndr, _Env>
+  _CUDAX_API auto connect(_Rcvr __rcvr) && -> __opstate_t<_Rcvr, _Sndr, _Env>
   {
     return __opstate_t<_Rcvr, _Sndr, _Env>{
       static_cast<_Sndr&&>(__sndr_), static_cast<_Env&&>(__env_), static_cast<_Rcvr&&>(__rcvr)};
   }
 
   template <class _Rcvr>
-  _CCCL_HOST_DEVICE auto connect(_Rcvr __rcvr) const& //
+  _CUDAX_API auto connect(_Rcvr __rcvr) const& //
     -> __opstate_t<_Rcvr, const _Sndr&, _Env>
   {
     return __opstate_t<_Rcvr, const _Sndr&, _Env>{__sndr_, __env_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
-  _CCCL_HOST_DEVICE env_of_t<_Sndr> get_env() const noexcept
+  _CUDAX_API env_of_t<_Sndr> get_env() const noexcept
   {
     return __async::get_env(__sndr_);
   }


### PR DESCRIPTION
## Description

this is a bit of cudax house cleaning. with #2638, cudax got a config header and config macros. this pr applies the cudax `_CUDAX_[TRIVIAL_]API` macros to just the `__async/` directory for now. future prs will do the same for other subdirectories.

while i was working with the attributes, i noticed that `_CCCL_INLINE_VAR` was getting used needlessly. cudax is C++17. we can assume that inline variables are always available. 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
