### PR TITLE
Deprecate `thrust::cuda_cub::identity`

### DIFF
--- a/thrust/thrust/system/cuda/detail/gather.h
+++ b/thrust/thrust/system/cuda/detail/gather.h
@@ -40,6 +40,8 @@
 #  include <thrust/iterator/permutation_iterator.h>
 #  include <thrust/system/cuda/detail/transform.h>
 
+#  include <cuda/std/__functional/identity.h>
+
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
@@ -53,7 +55,7 @@ gather(execution_policy<Derived>& policy, MapIt map_first, MapIt map_last, Items
     thrust::make_permutation_iterator(items, map_first),
     thrust::make_permutation_iterator(items, map_last),
     result,
-    identity());
+    ::cuda::std::__identity{});
 }
 
 template <class Derived, class MapIt, class StencilIt, class ItemsIt, class ResultIt, class Predicate>
@@ -72,7 +74,7 @@ ResultIt _CCCL_HOST_DEVICE gather_if(
     thrust::make_permutation_iterator(items, map_last),
     stencil,
     result,
-    identity(),
+    ::cuda::std::__identity{},
     predicate);
 }
 
@@ -80,7 +82,7 @@ template <class Derived, class MapIt, class StencilIt, class ItemsIt, class Resu
 ResultIt _CCCL_HOST_DEVICE gather_if(
   execution_policy<Derived>& policy, MapIt map_first, MapIt map_last, StencilIt stencil, ItemsIt items, ResultIt result)
 {
-  return cuda_cub::gather_if(policy, map_first, map_last, stencil, items, result, identity());
+  return cuda_cub::gather_if(policy, map_first, map_last, stencil, items, result, ::cuda::std::__identity{});
 }
 
 } // namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/mismatch.h
+++ b/thrust/thrust/system/cuda/detail/mismatch.h
@@ -43,6 +43,8 @@
 #  include <thrust/pair.h>
 #  include <thrust/system/cuda/detail/execution_policy.h>
 
+#  include <cuda/std/__functional/identity.h>
+
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
@@ -71,8 +73,8 @@ mismatch(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, Inp
 
   transform_t transform_first = transform_t(first1, first2, binary_pred);
 
-  transform_t result =
-    cuda_cub::find_if_not(policy, transform_first, transform_first + thrust::distance(first1, last1), identity());
+  transform_t result = cuda_cub::find_if_not(
+    policy, transform_first, transform_first + thrust::distance(first1, last1), ::cuda::std::__identity{});
 
   return thrust::make_pair(first1 + thrust::distance(transform_first, result),
                            first2 + thrust::distance(transform_first, result));

--- a/thrust/thrust/system/cuda/detail/scatter.h
+++ b/thrust/thrust/system/cuda/detail/scatter.h
@@ -40,6 +40,8 @@
 #  include <thrust/iterator/permutation_iterator.h>
 #  include <thrust/system/cuda/detail/transform.h>
 
+#  include <cuda/std/__functional/identity.h>
+
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
@@ -48,7 +50,7 @@ template <class Derived, class ItemsIt, class MapIt, class ResultIt>
 void _CCCL_HOST_DEVICE
 scatter(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, MapIt map, ResultIt result)
 {
-  cuda_cub::transform(policy, first, last, thrust::make_permutation_iterator(result, map), identity());
+  cuda_cub::transform(policy, first, last, thrust::make_permutation_iterator(result, map), ::cuda::std::__identity{});
 }
 
 template <class Derived, class ItemsIt, class MapIt, class StencilIt, class ResultIt, class Predicate>
@@ -62,14 +64,14 @@ void _CCCL_HOST_DEVICE scatter_if(
   Predicate predicate)
 {
   cuda_cub::transform_if(
-    policy, first, last, stencil, thrust::make_permutation_iterator(result, map), identity(), predicate);
+    policy, first, last, stencil, thrust::make_permutation_iterator(result, map), ::cuda::std::__identity{}, predicate);
 }
 
 template <class Derived, class ItemsIt, class MapIt, class StencilIt, class ResultIt, class Predicate>
 void _CCCL_HOST_DEVICE scatter_if(
   execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, MapIt map, StencilIt stencil, ResultIt result)
 {
-  cuda_cub::scatter_if(policy, first, last, map, stencil, result, identity());
+  cuda_cub::scatter_if(policy, first, last, map, stencil, result, ::cuda::std::__identity{});
 }
 
 } // namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/util.h
+++ b/thrust/thrust/system/cuda/detail/util.h
@@ -472,7 +472,8 @@ struct transform_pair_of_input_iterators_t
 
 }; // struct transform_pair_of_input_iterators_t
 
-struct identity
+// deprecated [Since 2.8]
+struct THRUST_DEPRECATED_BECAUSE("Use cuda::std::identity") identity
 {
   template <class T>
   _CCCL_HOST_DEVICE T const& operator()(T const& t) const


### PR DESCRIPTION
And use `cuda::std::__identity` instead of it.