### PR TITLE
Remove an unused variable

### DIFF
--- a/thrust/testing/unique.cu
+++ b/thrust/testing/unique.cu
@@ -239,7 +239,6 @@ struct TestUniqueCopyToDiscardIterator
 
     thrust::discard_iterator<> reference(h_unique.size());
 
-    typename thrust::host_vector<T>::iterator h_new_last;
     typename thrust::device_vector<T>::iterator d_new_last;
 
     thrust::discard_iterator<> h_result =


### PR DESCRIPTION
I got sudden unrelated CI errors due to an unused variable. See e.g. https://github.com/NVIDIA/cccl/actions/runs/11664801417/job/32476514609?pr=2389. This PR removes the unused variable.