### PR TITLE
[cuda.cooperative] Add missing overloads to block.reduce and block.sum

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -206,7 +206,9 @@ class Array(Pointer):
         super().__init__(value_dtype, is_output)
 
     def __repr__(self) -> str:
-        return f"Array(dtype={self.value_dtype}, size={self.size}, out={self.is_output})"
+        return (
+            f"Array(dtype={self.value_dtype}, size={self.size}, out={self.is_output})"
+        )
 
     def cpp_decl(self, name):
         return f"{numba_type_to_cpp(self.value_dtype)} (&{name})[{self.size}]"

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -206,7 +206,7 @@ class Array(Pointer):
         super().__init__(value_dtype, is_output)
 
     def __repr__(self) -> str:
-        return f"Array(dtype={self.value_dtype}, out={self.is_output})"
+        return f"Array(dtype={self.value_dtype}, size={self.size}, out={self.is_output})"
 
     def cpp_decl(self, name):
         return f"{numba_type_to_cpp(self.value_dtype)} (&{name})[{self.size}]"
@@ -780,7 +780,7 @@ class Algorithm:
                             )
                             types.append(ir.PointerType(ir.IntType(8)))
                             arguments.append(void_ptr)
-                        if isinstance(param, Reference):
+                        elif isinstance(param, Reference):
                             if param.is_output:
                                 ptr = cgutils.alloca_once(
                                     builder, context.get_value_type(dtype)

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
@@ -76,9 +76,9 @@ def reduce(dtype, threads_in_block, binary_op, items_per_thread=1, methods=None)
                 DependentOperator(
                     Dependency("T"),
                     [Dependency("T"), Dependency("T")],
-                    Dependency("Op")
+                    Dependency("Op"),
                 ),
-                DependentReference(Dependency("T"), True)
+                DependentReference(Dependency("T"), True),
             ],
             # T Reduce(T&, Op);
             [
@@ -98,16 +98,21 @@ def reduce(dtype, threads_in_block, binary_op, items_per_thread=1, methods=None)
                 DependentOperator(
                     Dependency("T"),
                     [Dependency("T"), Dependency("T")],
-                    Dependency("Op")
+                    Dependency("Op"),
                 ),
                 Value(numba.int32),
-                DependentReference(Dependency("T"), True)
-            ]
+                DependentReference(Dependency("T"), True),
+            ],
         ],
         type_definitions=[numba_type_to_wrapper(dtype, methods=methods)],
     )
     specialization = template.specialize(
-        {"T": dtype, "BLOCK_DIM_X": threads_in_block, "ITEMS_PER_THREAD": items_per_thread, "Op": binary_op}
+        {
+            "T": dtype,
+            "BLOCK_DIM_X": threads_in_block,
+            "ITEMS_PER_THREAD": items_per_thread,
+            "Op": binary_op,
+        }
     )
 
     return Invocable(
@@ -173,7 +178,7 @@ def sum(dtype, threads_in_block, items_per_thread=1, methods=None):
             [
                 Pointer(numba.uint8),
                 DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
-                DependentReference(Dependency("T"), True)
+                DependentReference(Dependency("T"), True),
             ],
             # T Sum(T&);
             [
@@ -187,11 +192,17 @@ def sum(dtype, threads_in_block, items_per_thread=1, methods=None):
                 DependentReference(Dependency("T")),
                 Value(numba.int32),
                 DependentReference(Dependency("T"), True),
-            ]
+            ],
         ],
         type_definitions=[numba_type_to_wrapper(dtype, methods=methods)],
     )
-    specialization = template.specialize({"T": dtype, "BLOCK_DIM_X": threads_in_block, "ITEMS_PER_THREAD": items_per_thread})
+    specialization = template.specialize(
+        {
+            "T": dtype,
+            "BLOCK_DIM_X": threads_in_block,
+            "ITEMS_PER_THREAD": items_per_thread,
+        }
+    )
     return Invocable(
         temp_files=[
             make_binary_tempfile(ltoir, ".ltoir")

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
@@ -38,6 +38,7 @@ def reduce(dtype, threads_in_block, binary_op, items_per_thread=1, methods=None)
         threads_in_block: The number of threads in a block
         binary_op: Binary reduction function
         items_per_thread: The number of items each thread contributes to the reduction
+        methods: A dict of methods for user-defined types
 
     Warning:
         The return value is undefined in threads other than thread\ :sub:`0`.
@@ -143,6 +144,7 @@ def sum(dtype, threads_in_block, items_per_thread=1, methods=None):
         dtype: Data type being reduced
         threads_in_block: The number of threads in a block
         items_per_thread: The number of items each thread owns
+        methods: A dict of methods for user-defined types
 
     Warning:
         The return value is undefined in threads other than thread\ :sub:`0`.

--- a/python/cuda_cooperative/tests/test_block_reduce.py
+++ b/python/cuda_cooperative/tests/test_block_reduce.py
@@ -216,6 +216,130 @@ def test_block_reduction_of_integral_type(T, threads_in_block):
 
 @pytest.mark.parametrize("T", [types.uint32, types.uint64])
 @pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
+def test_block_reduction_valid(T, threads_in_block):
+    def op(a, b):
+        return a if a < b else b
+
+    block_reduce = cudax.block.reduce(
+        dtype=T, binary_op=op, threads_in_block=threads_in_block
+    )
+    temp_storage_bytes = block_reduce.temp_storage_bytes
+
+    @cuda.jit(link=block_reduce.files)
+    def kernel(input, output):
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
+        block_output = block_reduce(temp_storage, input[cuda.threadIdx.x], threads_in_block / 2)
+
+        if cuda.threadIdx.x == 0:
+            output[0] = block_output
+
+    dtype = NUMBA_TYPES_TO_NP[T]
+    h_input = random_int(threads_in_block, dtype)
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(1, dtype=dtype)
+    kernel[1, threads_in_block](d_input, d_output)
+    cuda.synchronize()
+    h_output = d_output.copy_to_host()
+    h_expected = np.min(h_input[: threads_in_block // 2])
+
+    assert h_output[0] == h_expected
+
+    sig = (T[::1], T[::1])
+    sass = kernel.inspect_sass(sig)
+
+    assert "LDL" not in sass
+    assert "STL" not in sass
+
+
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 128, 512, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 2, 4])
+def test_block_reduction_array_local(T, threads_in_block, items_per_thread):
+    def op(a, b):
+        return a if a < b else b
+
+    block_reduce = cudax.block.reduce(
+        dtype=T, binary_op=op, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+    )
+    temp_storage_bytes = block_reduce.temp_storage_bytes
+
+    @cuda.jit(link=block_reduce.files)
+    def kernel(input, output):
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
+        thread_items = cuda.local.array(shape=items_per_thread, dtype=T)
+
+        for i in range(items_per_thread):
+            thread_items[i] = input[i * threads_in_block + cuda.threadIdx.x]
+
+        block_output = block_reduce(temp_storage, thread_items)
+
+        if cuda.threadIdx.x == 0:
+            output[0] = block_output
+
+    dtype = NUMBA_TYPES_TO_NP[T]
+    h_input = random_int(items_per_thread * threads_in_block, dtype)
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(1, dtype=dtype)
+    kernel[1, threads_in_block](d_input, d_output)
+    cuda.synchronize()
+    h_output = d_output.copy_to_host()
+    h_expected = np.min(h_input)
+
+    assert h_output[0] == h_expected
+
+    sig = (T[::1], T[::1])
+    sass = kernel.inspect_sass(sig)
+
+    assert "LDL" not in sass
+    assert "STL" not in sass
+
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 128, 512, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 2, 4])
+def test_block_reduction_array_global(T, threads_in_block, items_per_thread):
+    def op(a, b):
+        return a if a < b else b
+
+    block_reduce = cudax.block.reduce(
+        dtype=T, binary_op=op, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+    )
+    temp_storage_bytes = block_reduce.temp_storage_bytes
+
+    @cuda.jit(link=block_reduce.files)
+    def kernel(input, output):
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
+
+        # If a scalar (e.g. input[x]) is passed here, the reference overload
+        # will be selected and only one element will be loaded, instead of the
+        # statically sized array overload. This is very subtle and should be
+        # fixed.
+        block_output = block_reduce(
+            temp_storage, input[items_per_thread * cuda.threadIdx.x:]
+        )
+
+        if cuda.threadIdx.x == 0:
+            output[0] = block_output
+
+    dtype = NUMBA_TYPES_TO_NP[T]
+    h_input = random_int(items_per_thread * threads_in_block, dtype)
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(1, dtype=dtype)
+    kernel[1, threads_in_block](d_input, d_output)
+    cuda.synchronize()
+    h_output = d_output.copy_to_host()
+    h_expected = np.min(h_input)
+
+    assert h_output[0] == h_expected
+
+    sig = (T[::1], T[::1])
+    sass = kernel.inspect_sass(sig)
+
+    assert "LDL" not in sass
+    assert "STL" not in sass
+
+
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
 def test_block_sum(T, threads_in_block):
     block_reduce = cudax.block.sum(dtype=T, threads_in_block=threads_in_block)
     temp_storage_bytes = block_reduce.temp_storage_bytes
@@ -248,7 +372,7 @@ def test_block_sum(T, threads_in_block):
 
 @pytest.mark.parametrize("T", [types.uint32, types.uint64])
 @pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
-def test_block_valid_sum(T, threads_in_block):
+def test_block_sum_valid(T, threads_in_block):
     block_reduce = cudax.block.sum(dtype=T, threads_in_block=threads_in_block)
     temp_storage_bytes = block_reduce.temp_storage_bytes
 
@@ -270,6 +394,84 @@ def test_block_valid_sum(T, threads_in_block):
     cuda.synchronize()
     h_output = d_output.copy_to_host()
     h_expected = np.sum(h_input[: threads_in_block // 2])
+
+    assert h_output[0] == h_expected
+
+    sig = (T[::1], T[::1])
+    sass = kernel.inspect_sass(sig)
+
+    assert "LDL" not in sass
+    assert "STL" not in sass
+
+
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 128, 512, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 2, 4])
+def test_block_sum_array_local(T, threads_in_block, items_per_thread):
+    block_reduce = cudax.block.sum(dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread)
+    temp_storage_bytes = block_reduce.temp_storage_bytes
+
+    @cuda.jit(link=block_reduce.files)
+    def kernel(input, output):
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
+        thread_items = cuda.local.array(shape=items_per_thread, dtype=T)
+
+        for i in range(items_per_thread):
+            thread_items[i] = input[i * threads_in_block + cuda.threadIdx.x]
+
+        block_output = block_reduce(temp_storage, thread_items)
+
+        if cuda.threadIdx.x == 0:
+            output[0] = block_output
+
+    dtype = NUMBA_TYPES_TO_NP[T]
+    h_input = random_int(items_per_thread * threads_in_block, dtype)
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(1, dtype=dtype)
+    kernel[1, threads_in_block](d_input, d_output)
+    cuda.synchronize()
+    h_output = d_output.copy_to_host()
+    h_expected = np.sum(h_input)
+
+    assert h_output[0] == h_expected
+
+    sig = (T[::1], T[::1])
+    sass = kernel.inspect_sass(sig)
+
+    assert "LDL" not in sass
+    assert "STL" not in sass
+
+
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 128, 512, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 2, 4])
+def test_block_sum_array_global(T, threads_in_block, items_per_thread):
+    block_reduce = cudax.block.sum(dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread)
+    temp_storage_bytes = block_reduce.temp_storage_bytes
+
+    @cuda.jit(link=block_reduce.files)
+    def kernel(input, output):
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
+
+        # If a scalar (e.g. input[x]) is passed here, the reference overload
+        # will be selected and only one element will be loaded, instead of the
+        # statically sized array overload. This is very subtle and should be
+        # fixed.
+        block_output = block_reduce(
+            temp_storage, input[items_per_thread * cuda.threadIdx.x:]
+        )
+
+        if cuda.threadIdx.x == 0:
+            output[0] = block_output
+
+    dtype = NUMBA_TYPES_TO_NP[T]
+    h_input = random_int(items_per_thread * threads_in_block, dtype)
+    d_input = cuda.to_device(h_input)
+    d_output = cuda.device_array(1, dtype=dtype)
+    kernel[1, threads_in_block](d_input, d_output)
+    cuda.synchronize()
+    h_output = d_output.copy_to_host()
+    h_expected = np.sum(h_input)
 
     assert h_output[0] == h_expected
 

--- a/python/cuda_cooperative/tests/test_block_reduce.py
+++ b/python/cuda_cooperative/tests/test_block_reduce.py
@@ -228,7 +228,9 @@ def test_block_reduction_valid(T, threads_in_block):
     @cuda.jit(link=block_reduce.files)
     def kernel(input, output):
         temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
-        block_output = block_reduce(temp_storage, input[cuda.threadIdx.x], threads_in_block / 2)
+        block_output = block_reduce(
+            temp_storage, input[cuda.threadIdx.x], threads_in_block / 2
+        )
 
         if cuda.threadIdx.x == 0:
             output[0] = block_output
@@ -259,7 +261,10 @@ def test_block_reduction_array_local(T, threads_in_block, items_per_thread):
         return a if a < b else b
 
     block_reduce = cudax.block.reduce(
-        dtype=T, binary_op=op, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+        dtype=T,
+        binary_op=op,
+        threads_in_block=threads_in_block,
+        items_per_thread=items_per_thread,
     )
     temp_storage_bytes = block_reduce.temp_storage_bytes
 
@@ -293,6 +298,7 @@ def test_block_reduction_array_local(T, threads_in_block, items_per_thread):
     assert "LDL" not in sass
     assert "STL" not in sass
 
+
 @pytest.mark.parametrize("T", [types.uint32, types.uint64])
 @pytest.mark.parametrize("threads_in_block", [32, 128, 512, 1024])
 @pytest.mark.parametrize("items_per_thread", [1, 2, 4])
@@ -301,7 +307,10 @@ def test_block_reduction_array_global(T, threads_in_block, items_per_thread):
         return a if a < b else b
 
     block_reduce = cudax.block.reduce(
-        dtype=T, binary_op=op, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+        dtype=T,
+        binary_op=op,
+        threads_in_block=threads_in_block,
+        items_per_thread=items_per_thread,
     )
     temp_storage_bytes = block_reduce.temp_storage_bytes
 
@@ -314,7 +323,7 @@ def test_block_reduction_array_global(T, threads_in_block, items_per_thread):
         # statically sized array overload. This is very subtle and should be
         # fixed.
         block_output = block_reduce(
-            temp_storage, input[items_per_thread * cuda.threadIdx.x:]
+            temp_storage, input[items_per_thread * cuda.threadIdx.x :]
         )
 
         if cuda.threadIdx.x == 0:
@@ -408,7 +417,9 @@ def test_block_sum_valid(T, threads_in_block):
 @pytest.mark.parametrize("threads_in_block", [32, 128, 512, 1024])
 @pytest.mark.parametrize("items_per_thread", [1, 2, 4])
 def test_block_sum_array_local(T, threads_in_block, items_per_thread):
-    block_reduce = cudax.block.sum(dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread)
+    block_reduce = cudax.block.sum(
+        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+    )
     temp_storage_bytes = block_reduce.temp_storage_bytes
 
     @cuda.jit(link=block_reduce.files)
@@ -446,7 +457,9 @@ def test_block_sum_array_local(T, threads_in_block, items_per_thread):
 @pytest.mark.parametrize("threads_in_block", [32, 128, 512, 1024])
 @pytest.mark.parametrize("items_per_thread", [1, 2, 4])
 def test_block_sum_array_global(T, threads_in_block, items_per_thread):
-    block_reduce = cudax.block.sum(dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread)
+    block_reduce = cudax.block.sum(
+        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+    )
     temp_storage_bytes = block_reduce.temp_storage_bytes
 
     @cuda.jit(link=block_reduce.files)
@@ -458,7 +471,7 @@ def test_block_sum_array_global(T, threads_in_block, items_per_thread):
         # statically sized array overload. This is very subtle and should be
         # fixed.
         block_output = block_reduce(
-            temp_storage, input[items_per_thread * cuda.threadIdx.x:]
+            temp_storage, input[items_per_thread * cuda.threadIdx.x :]
         )
 
         if cuda.threadIdx.x == 0:

--- a/python/cuda_cooperative/tests/test_block_reduce.py
+++ b/python/cuda_cooperative/tests/test_block_reduce.py
@@ -237,6 +237,7 @@ def test_block_reduction_valid(T, threads_in_block):
 
     dtype = NUMBA_TYPES_TO_NP[T]
     h_input = random_int(threads_in_block, dtype)
+    h_input[-1] = 0
     d_input = cuda.to_device(h_input)
     d_output = cuda.device_array(1, dtype=dtype)
     kernel[1, threads_in_block](d_input, d_output)
@@ -397,6 +398,7 @@ def test_block_sum_valid(T, threads_in_block):
 
     dtype = NUMBA_TYPES_TO_NP[T]
     h_input = random_int(threads_in_block, dtype)
+    h_input[-1] = 0
     d_input = cuda.to_device(h_input)
     d_output = cuda.device_array(1, dtype=dtype)
     kernel[1, threads_in_block](d_input, d_output)

--- a/python/cuda_cooperative/tests/test_block_reduce_api.py
+++ b/python/cuda_cooperative/tests/test_block_reduce_api.py
@@ -2,25 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# example-begin imports
 import numba
 import numpy as np
 from numba import cuda
 from pynvjitlink import patch
+patch.patch_numba_linker(lto=True)
 
 import cuda.cooperative.experimental as cudax
+# example-end imports
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
-# example-begin imports
-patch.patch_numba_linker(lto=True)
-# example-end imports
-
-
 def test_block_reduction():
+    # example-begin reduce
     def op(a, b):
         return a if a > b else b
 
-    # example-begin reduce
     threads_in_block = 128
     block_reduce = cudax.block.reduce(numba.int32, threads_in_block, op)
 

--- a/python/cuda_cooperative/tests/test_block_reduce_api.py
+++ b/python/cuda_cooperative/tests/test_block_reduce_api.py
@@ -7,12 +7,14 @@ import numba
 import numpy as np
 from numba import cuda
 from pynvjitlink import patch
-patch.patch_numba_linker(lto=True)
 
 import cuda.cooperative.experimental as cudax
+
+patch.patch_numba_linker(lto=True)
 # example-end imports
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+
 
 def test_block_reduction():
     # example-begin reduce


### PR DESCRIPTION
## Description

[`cub::BlockReduce` cooperative methods have the following overloads](https://nvidia.github.io/cccl/cub/api/classcub_1_1BlockReduce.html), but not all were exposed in `cuda.cooperative`.

- `T Reduce(T, Op);`
- `T Reduce(T, Op, int num_valid);` (added in this PR)
- `T Reduce(T(&)[ITEMS_PER_THREAD], Op);` (added in this PR)
- `T Sum(T, );`
- `T Sum(T, int num_valid);`
- `T Sum(T(&)[ITEMS_PER_THREAD]);` (added in this PR)

This PR fixes that.

`cub::BlockReduce` doesn't take a class-level items-per-thread template parameter, but the array overloads do. So, I had to add an items-per-thread parameter to `block.reduce` and `block.sum`. I gave it a default of 1. I recall having a bug at one point where I forgot to add items-per-thread and I think it led to elements in the input arrays being silently ignored.

## Checklist

- [x] Add tests.
- [x] Check what happens if you call the array overloads with an array larger than the specify items-per-thread; if this silently ignores elements, we should strive for a diagnostic and consider the implications of having items-per-thread defaulted to 1.
- [x] Update the `cuda.cooperative` documentation to list the cooperative overloads of all algorithms; currently none are listed (this is not an issue for just reduce).
