### PR TITLE
address portability issues found while using the typelist/typeset utities

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -523,6 +523,34 @@ using __type_back = __type_at_c<_List::__size - 1, _List>;
 
 namespace __detail
 {
+#  if defined(_CCCL_COMPILER_MSVC) && _CCCL_MSVC_VERSION < 1938
+// A workaround for https://developercommunity.visualstudio.com/t/fatal-error-C1001:-Internal-compiler-err/10405847
+struct __type_concat_fn
+{
+  template <class... _Lists>
+  struct __trait
+  {};
+
+  template <class... _Ts, class... _Us, class... _Lists>
+  struct __trait<__type_list<_Ts...>, __type_list<_Us...>, _Lists...> : __trait<__type_list<_Ts..., _Us...>, _Lists...>
+  {};
+
+  template <class... _Ts>
+  struct __trait<__type_list<_Ts...>>
+  {
+    using type = __type_list<_Ts...>;
+  };
+
+  template <>
+  struct __trait<>
+  {
+    using type = __type_list<>;
+  };
+
+  template <class... _Lists>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = __type<__trait<_Lists...>>;
+};
+#  else
 template <size_t _Count>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_concat_fn
 {
@@ -582,6 +610,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_concat_fn
     __type_list_ptr<>{nullptr},
     __type_list_ptr<>{nullptr}));
 };
+#  endif
 } // namespace __detail
 
 //! \brief Concatenate a list of type lists into a single type list.
@@ -803,7 +832,7 @@ using __type_copy_if = __type_flatten<__type_transform<_List, __detail::__type_r
 
 //! \brief Remove all duplicate types from a type list
 template <class _List>
-using __type_unique = __type_concat<__type_call<_List, __type_quote<__make_type_set>>>;
+using __type_unique = __as_type_list<__type_call<_List, __type_quote<__make_type_set>>>;
 
 namespace __detail
 {

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -550,7 +550,7 @@ struct __type_concat_fn
   template <class... _Lists>
   using __call _LIBCUDACXX_NODEBUG_TYPE = __type<__trait<_Lists...>>;
 };
-#  else
+#  else // ^^^ _CCCL_COMPILER_MSVC < 19.38 ^^^ / vvv !(_CCCL_COMPILER_MSVC < 19.38) vvv
 template <size_t _Count>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_concat_fn
 {
@@ -610,7 +610,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_concat_fn
     __type_list_ptr<>{nullptr},
     __type_list_ptr<>{nullptr}));
 };
-#  endif
+#  endif // !(_CCCL_COMPILER_MSVC < 19.38)
 } // namespace __detail
 
 //! \brief Concatenate a list of type lists into a single type list.

--- a/libcudacxx/include/cuda/std/__type_traits/type_set.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_set.h
@@ -68,11 +68,11 @@ using __insert =
 struct __bulk_insert
 {
   template <class... _Ts>
-  _LIBCUDACXX_HIDE_FROM_ABI static auto __call(__tupl<_Ts...>*) -> __tupl<_Ts...>;
+  _LIBCUDACXX_HIDE_FROM_ABI static auto __call(__tupl<_Ts...>*, int) -> __tupl<_Ts...>;
 
   template <class _Ap, class... _Us, class... _Ts, class _SetInsert = __bulk_insert>
-  _LIBCUDACXX_HIDE_FROM_ABI static auto __call(__tupl<_Ts...>*)
-    -> decltype(_SetInsert::template __call<_Us...>(static_cast<__insert<_Ap, _Ts...>*>(nullptr)));
+  _LIBCUDACXX_HIDE_FROM_ABI static auto __call(__tupl<_Ts...>*, long)
+    -> decltype(_SetInsert::template __call<_Us...>(static_cast<__insert<_Ap, _Ts...>*>(nullptr), 0));
 };
 } // namespace __set
 
@@ -91,7 +91,7 @@ template <class... _Ts>
 using __type_set = __set::__tupl<_Ts...>;
 
 template <class _Set, class... _Ts>
-using __type_set_insert = decltype(__set::__bulk_insert::__call<_Ts...>(static_cast<_Set*>(nullptr)));
+using __type_set_insert = decltype(__set::__bulk_insert::__call<_Ts...>(static_cast<_Set*>(nullptr), 0));
 
 template <class... _Ts>
 using __make_type_set = __type_set_insert<__type_set<>, _Ts...>;

--- a/libcudacxx/include/cuda/std/__type_traits/type_set.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_set.h
@@ -30,6 +30,9 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+template <class...>
+struct __type_list;
+
 template <class _Set, class... _Ty>
 struct __type_set_contains : __fold_and<_CCCL_TRAIT(is_base_of, __type_identity<_Ty>, _Set)...>
 {};
@@ -81,9 +84,18 @@ struct __bulk_insert
 template <>
 struct __bulk_insert<false>
 {
+#if defined(_CCCL_COMPILER_MSVC) && _CCCL_MSVC_VERSION < 1920
+  template <class _Set, class _Ty, class... _Us>
+  _LIBCUDACXX_HIDE_FROM_ABI static auto __insert_fn(__type_list<_Ty, _Us...>*) ->
+    typename __bulk_insert<sizeof...(_Us) == 0>::template __call<typename _Set::template __maybe_insert<_Ty>, _Us...>;
+
+  template <class _Set, class... _Us>
+  using __call _LIBCUDACXX_NODEBUG_TYPE = decltype(__insert_fn<_Set>(static_cast<__type_list<_Us...>*>(nullptr)));
+#else
   template <class _Set, class _Ty, class... _Us>
   using __call _LIBCUDACXX_NODEBUG_TYPE =
     typename __bulk_insert<sizeof...(_Us) == 0>::template __call<typename _Set::template __maybe_insert<_Ty>, _Us...>;
+#endif
 };
 } // namespace __set
 


### PR DESCRIPTION
## Description

some more complicated uses of `__type_list` and `__type_set` exposed some portability issues with clang and msvc: this pr:

* gives older msvc a simpler-but-less-efficient implementation for `__type_concat`.
* gives older clang an assist disambiguating between overloads in `__type_set_insert`.

it also fixes a legit bug in the implementation of `__type_unique` where we were passing a `__set::__tupl` as a type list to `__type_concat`, which can only handle `__type_list` specializations.