### PR TITLE
portability fixes for `_CCCL_BUILTIN_PRETTY_FUNCTION` and `_CCCL_TYPEID`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -560,10 +560,12 @@
 #endif // _CCCL_CHECK_BUILTIN(underlying_type) && gcc >= 4.7
 
 #if defined(_CCCL_COMPILER_MSVC)
-#  if _CCCL_MSVC_VERSION >= 1935
+#  // To use __builtin_FUNCSIG(), both MSVC and nvcc need to support it
+#  if _CCCL_MSVC_VERSION >= 1935 && (!defined(_CCCL_CUDACC) || _CCCL_CUDACC_VER >= 1203000)
 #    define _CCCL_BUILTIN_PRETTY_FUNCTION() __builtin_FUNCSIG()
 #  else // ^^^ _CCCL_MSVC_VERSION >= 1935 ^^^ / vvv _CCCL_MSVC_VERSION < 1935 vvv
 #    define _CCCL_BUILTIN_PRETTY_FUNCTION() __FUNCSIG__
+#    define _CCCL_BROKEN_MSVC_FUNCSIG
 #  endif // _CCCL_MSVC_VERSION < 1935
 #else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
 #  define _CCCL_BUILTIN_PRETTY_FUNCTION() __PRETTY_FUNCTION__

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -561,7 +561,7 @@
 
 #if defined(_CCCL_COMPILER_MSVC)
 #  // To use __builtin_FUNCSIG(), both MSVC and nvcc need to support it
-#  if _CCCL_MSVC_VERSION >= 1935 && (!defined(_CCCL_CUDACC) || _CCCL_CUDACC_VER >= 1203000)
+#  if _CCCL_MSVC_VERSION >= 1935 && !defined(_CCCL_CUDACC_BELOW_12_3)
 #    define _CCCL_BUILTIN_PRETTY_FUNCTION() __builtin_FUNCSIG()
 #  else // ^^^ _CCCL_MSVC_VERSION >= 1935 ^^^ / vvv _CCCL_MSVC_VERSION < 1935 vvv
 #    define _CCCL_BUILTIN_PRETTY_FUNCTION() __FUNCSIG__

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -87,22 +87,28 @@
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1103000
 #if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1104000)
 #  define _CCCL_CUDACC_BELOW_11_4
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 11074000
+#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1104000
 #if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1107000)
 #  define _CCCL_CUDACC_BELOW_11_7
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1104000
+#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1107000
 #if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000)
 #  define _CCCL_CUDACC_BELOW_11_8
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000
 #if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1200000)
 #  define _CCCL_CUDACC_BELOW_12_0
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
+#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1200000
 #if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1202000)
 #  define _CCCL_CUDACC_BELOW_12_2
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
+#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1202000
 #if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000)
 #  define _CCCL_CUDACC_BELOW_12_3
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
+#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1204000)
+#  define _CCCL_CUDACC_BELOW_12_4
+#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1204000
+#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1205000)
+#  define _CCCL_CUDACC_BELOW_12_5
+#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1205000
 
 // Convert parameter to string
 #define _CCCL_TO_STRING2(_STR) #_STR
@@ -110,9 +116,9 @@
 
 // Define the pragma for the host compiler
 #if defined(_CCCL_COMPILER_MSVC)
-#  define _CCCL_PRAGMA(x) __pragma(x)
+#  define _CCCL_PRAGMA(_ARG) __pragma(_ARG)
 #else
-#  define _CCCL_PRAGMA(x) _Pragma(_CCCL_TO_STRING(x))
+#  define _CCCL_PRAGMA(_ARG) _Pragma(_CCCL_TO_STRING(_ARG))
 #endif // defined(_CCCL_COMPILER_MSVC)
 
 #endif // __CCCL_COMPILER_H

--- a/libcudacxx/include/cuda/std/__utility/typeid.h
+++ b/libcudacxx/include/cuda/std/__utility/typeid.h
@@ -52,6 +52,8 @@
 #  include <typeinfo>
 #endif
 
+// _CCCL_MSVC_BROKEN_FUNCSIG:
+//
 // When using MSVC as the host compiler, there is a bug in the EDG front-end of
 // cudafe++ that causes the __FUNCSIG__ predefined macro to be expanded too
 // early in the compilation process. The result is that within a function
@@ -62,11 +64,6 @@
 // available and can be used in place of __FUNCSIG__, resolving the issue. For
 // older versions of MSVC, we fall back to using the built-in typeid feature,
 // which is always available on MSVC, even when RTTI is disabled.
-
-#if defined(_CCCL_COMPILER_MSVC) && (_CCCL_MSVC_VERSION < 1935) && defined(_CCCL_CUDA_COMPILER_NVCC) \
-  && !defined(__CUDA_ARCH__)
-#  define _CCCL_BROKEN_MSVC_FUNCSIG
-#endif
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
@@ -442,7 +439,7 @@ _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr __type_info const& __typeid() noex
 #endif // !defined(__CUDA_ARCH__) && !_CCCL_BROKEN_MSVC_FUNCSIG
 
 // if `__pretty_nameof` is constexpr _CCCL_TYPEID_FALLBACK is also constexpr.
-#if !defined(_CCCL_NO_CONSTEXPR_PRETTY_NAMEOF) && !defined(_CCCL_BROKEN_MSVC_FUNCSIG)
+#if !defined(_CCCL_NO_CONSTEXPR_PRETTY_NAMEOF) && (!defined(_CCCL_BROKEN_MSVC_FUNCSIG) || defined(__CUDA_ARCH__))
 #  define _CCCL_TYPEOF_CONSTEXPR _CCCL_TYPEOF_FALLBACK
 #endif
 


### PR DESCRIPTION
## Description

`_CCCL_TYPEID` depends on `_CCCL_BUILTIN_PRETTY_FUNCTION`. on msvc, `_CCCL_BUILTIN_PRETTY_FUNCTION` expands to either `__FUNCSIG__` or `__builtin_FUNCSIG()` depending on the compiler version. but whether msvc as a host compiler can use `__builtin_FUNCSIG()` _also_ depends on the version of `nvcc`, which needs to recognize it as a builtin.

this PR changes the definition of `_CCCL_BUILTIN_PRETTY_FUNCTION` to test the version of `nvcc` in addition to that of msvc before using `__builtin_FUNCSIG()`.

it also changes the definition of `_CCCL_TYPEID` in accordance with the change to `_CCCL_BUILTIN_PRETTY_FUNCTION`.

finally, it addresses some minor issues in `cuda/std/__cccl/compiler.h` wrt incorrect comments and code formatting, while also adding the convenience macros `_CCCL_CUDACC_BELOW_12_4` and `_CCCL_CUDACC_BELOW_12_4`. the latter change is not strictly necessary and can be backed out if folks would prefer that.