### PR TITLE
Fix race condition in block_reduce_raking.

### DIFF
--- a/cub/cub/block/specializations/block_reduce_raking.cuh
+++ b/cub/cub/block/specializations/block_reduce_raking.cuh
@@ -225,6 +225,9 @@ struct BlockReduceRaking
 
         int valid_raking_threads = (IS_FULL_TILE) ? RAKING_THREADS : (num_valid + SEGMENT_LENGTH - 1) / SEGMENT_LENGTH;
 
+        // sync before re-using shmem (warp_storage/raking_grid are aliased)
+        CTA_SYNC();
+
         partial = WarpReduce(temp_storage.warp_storage)
                     .template Reduce<(IS_FULL_TILE && RAKING_UNGUARDED)>(partial, valid_raking_threads, reduction_op);
       }

--- a/cub/cub/block/specializations/block_reduce_raking.cuh
+++ b/cub/cub/block/specializations/block_reduce_raking.cuh
@@ -226,7 +226,9 @@ struct BlockReduceRaking
         int valid_raking_threads = (IS_FULL_TILE) ? RAKING_THREADS : (num_valid + SEGMENT_LENGTH - 1) / SEGMENT_LENGTH;
 
         // sync before re-using shmem (warp_storage/raking_grid are aliased)
-        CTA_SYNC();
+        static_assert(RAKING_THREADS <= CUB_PTX_WARP_THREADS, "RAKING_THREADS must be <= warp size.");
+        unsigned int mask = static_cast<unsigned int>((1ull << RAKING_THREADS) - 1);
+        WARP_SYNC(mask);
 
         partial = WarpReduce(temp_storage.warp_storage)
                     .template Reduce<(IS_FULL_TILE && RAKING_UNGUARDED)>(partial, valid_raking_threads, reduction_op);

--- a/cub/cub/thread/thread_reduce.cuh
+++ b/cub/cub/thread/thread_reduce.cuh
@@ -83,8 +83,8 @@ constexpr bool enable_dpx_reduction()
 {
   using T = decltype(::cuda::std::declval<Input>()[0]);
   // TODO: use constexpr variable in C++14+
-  using Lenght = ::cuda::std::integral_constant<int, detail::static_size<Input>()>;
-  return ((Lenght{} >= 9 && detail::are_same<ReductionOp, cub::Sum/*, std::plus<T>*/>()) || Lenght{} >= 10)
+  using Length = ::cuda::std::integral_constant<int, detail::static_size<Input>()>;
+  return ((Length{} >= 9 && detail::are_same<ReductionOp, cub::Sum/*, std::plus<T>*/>()) || Length{} >= 10)
             && detail::are_same<T, AccumT>()
             && detail::is_one_of<T, int16_t, uint16_t>()
             && detail::is_one_of<ReductionOp, cub::Min, cub::Max, cub::Sum/*, std::plus<T>*/>();


### PR DESCRIPTION
`temp_storage.raking_grid` and `temp_storage.warp_storage` are aliased.
We need to sync between using shmem to compute partials via `RakingReduction` and `WarpReduce`-ing those partial.

Fixes #1902.
