### PR TITLE
revert config macros `_CCCL_CUDACC_BELOW_XX_X` to their original semantics

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -79,28 +79,28 @@
 #endif // _CCCL_CUDA_COMPILER
 
 // Some convenience macros to filter CUDACC versions
-#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1102000)
+#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1102000
 #  define _CCCL_CUDACC_BELOW_11_2
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1102000
-#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1103000)
+#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1103000
 #  define _CCCL_CUDACC_BELOW_11_3
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1103000
-#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1104000)
+#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1104000
 #  define _CCCL_CUDACC_BELOW_11_4
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 11074000
-#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1107000)
-#  define _CCCL_CUDACC_BELOW_11_7
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1104000
-#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000)
+#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1107000
+#  define _CCCL_CUDACC_BELOW_11_7
+#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1107000
+#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000
 #  define _CCCL_CUDACC_BELOW_11_8
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000
-#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1200000)
+#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1200000
 #  define _CCCL_CUDACC_BELOW_12_0
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
-#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1202000)
+#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1200000
+#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1202000
 #  define _CCCL_CUDACC_BELOW_12_2
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
-#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000)
+#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1202000
+#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
 #  define _CCCL_CUDACC_BELOW_12_3
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
 


### PR DESCRIPTION
## Description

in PR #1831, the definitions of the `_CCCL_CUDACC_BELOW_XX_X` macros were changed as follows:

```diff
 // Some convenience macros to filter CUDACC versions
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1102000
+#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1102000)
 #  define _CCCL_CUDACC_BELOW_11_2
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1102000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1103000
+#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1103000)
 #  define _CCCL_CUDACC_BELOW_11_3
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1103000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000
+#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000)
 #  define _CCCL_CUDACC_BELOW_11_8
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1202000
+#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1202000)
 #  define _CCCL_CUDACC_BELOW_12_2
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
+#if !defined(_CCCL_CUDA_COMPILER) || (defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000)
 #  define _CCCL_CUDACC_BELOW_12_3
 #endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
```

before the change, a macro like `_CCCL_CUDACC_BELOW_12_3` was defined if and only if we are compiling for CUDA _and_ the CUDA version is < 12.3. after the change, `_CCCL_CUDACC_BELOW_12_3` is additionally defined when not compiling for CUDA at all.

i couldn't find any rationale for the change, and it is objectively causing problems (see #2686). this pr rolls back the change and restores the `_CCCL_CUDACC_BELOW_XX_X` macros to their original semantics.


<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #2686

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
