### PR TITLE
Make tests technically correct by initializing the barrier

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_ptx_compiles.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_ptx_compiles.pass.cpp
@@ -30,6 +30,10 @@ __global__ void test_bulk_tensor(CUtensorMap* map)
 {
   __shared__ int smem;
   __shared__ barrier* bar;
+  if (threadIdx.x == 0)
+  {
+    init(bar, blockDim.x);
+  }
 
   cde::cp_async_bulk_tensor_1d_global_to_shared(&smem, map, 0, *bar);
   cde::cp_async_bulk_tensor_2d_global_to_shared(&smem, map, 0, 0, *bar);
@@ -48,11 +52,16 @@ __global__ void test_bulk(void* gmem)
 {
   __shared__ int smem;
   __shared__ barrier* bar;
+  if (threadIdx.x == 0)
+  {
+    init(bar, blockDim.x);
+  }
+
   cde::cp_async_bulk_global_to_shared(&smem, gmem, 1024, *bar);
   cde::cp_async_bulk_shared_to_global(gmem, &smem, 1024);
 }
 
-__global__ void test_fences_async_group(void* gmem)
+__global__ void test_fences_async_group(void*)
 {
   cde::fence_proxy_async_shared_cta();
 


### PR DESCRIPTION
This was found in #2229

We should always initialize the barrier