### PR TITLE
Guard inclusion of `cuda_runtime_api` by using a cuda compiler

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/async_memory_pool.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/async_memory_pool.cuh
@@ -24,10 +24,10 @@
 // cudaMallocAsync was introduced in CTK 11.2
 #if !defined(_CCCL_COMPILER_MSVC_2017) && !defined(_CCCL_CUDACC_BELOW_11_2)
 
-#  if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#  if defined(_CCCL_CUDA_COMPILER_CLANG)
 #    include <cuda_runtime.h>
 #    include <cuda_runtime_api.h>
-#  endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+#  endif // _CCCL_CUDA_COMPILER_CLANG
 
 #  include <cuda/__memory_resource/get_property.h>
 #  include <cuda/__memory_resource/properties.h>

--- a/cudax/include/cuda/experimental/__memory_resource/async_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/async_memory_resource.cuh
@@ -24,10 +24,10 @@
 // cudaMallocAsync was introduced in CTK 11.2
 #if !defined(_CCCL_COMPILER_MSVC_2017) && !defined(_CCCL_CUDACC_BELOW_11_2)
 
-#  if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#  if defined(_CCCL_CUDA_COMPILER_CLANG)
 #    include <cuda_runtime.h>
 #    include <cuda_runtime_api.h>
-#  endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+#  endif // _CCCL_CUDA_COMPILER_CLANG
 
 #  include <cuda/__memory_resource/get_property.h>
 #  include <cuda/__memory_resource/properties.h>

--- a/libcudacxx/include/cuda/__functional/get_device_address.h
+++ b/libcudacxx/include/cuda/__functional/get_device_address.h
@@ -21,10 +21,14 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda_runtime_api.h>
+#if defined(_CCCL_CUDA_COMPILER_CLANG)
+#  include <cuda_runtime_api.h>
+#endif // _CCCL_CUDA_COMPILER_CLANG
 
 #include <cuda/std/__cuda/api_wrapper.h>
 #include <cuda/std/__memory/addressof.h>
+
+#include <nv/target>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
@@ -34,6 +38,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 template <class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _Tp* get_device_address(_Tp& __device_object)
 {
+#if defined(_CCCL_CUDA_COMPILER)
   NV_IF_ELSE_TARGET(
     NV_IS_DEVICE,
     (return _CUDA_VSTD::addressof(__device_object);),
@@ -43,6 +48,9 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _Tp* get_device_address(_Tp& __device_
        &__device_ptr,
        __device_object);
      return static_cast<_Tp*>(__device_ptr);))
+#else // ^^^ _CCCL_CUDA_COMPILER ^^^ / vvv !_CCCL_CUDA_COMPILER vvv
+  return _CUDA_VSTD::addressof(__device_object);
+#endif // !_CCCL_CUDA_COMPILER
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__memory_resource/device_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/device_memory_resource.h
@@ -23,9 +23,9 @@
 
 #if !defined(_CCCL_COMPILER_MSVC_2017) && defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
 
-#  if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#  if defined(_CCCL_CUDA_COMPILER_CLANG)
 #    include <cuda_runtime_api.h>
-#  endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+#  endif // _CCCL_CUDA_COMPILER_CLANG
 
 #  include <cuda/__memory_resource/get_property.h>
 #  include <cuda/__memory_resource/properties.h>

--- a/libcudacxx/include/cuda/__memory_resource/managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/managed_memory_resource.h
@@ -23,9 +23,9 @@
 
 #if !defined(_CCCL_COMPILER_MSVC_2017) && defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
 
-#  if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#  if defined(_CCCL_CUDA_COMPILER_CLANG)
 #    include <cuda_runtime_api.h>
-#  endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+#  endif // _CCCL_CUDA_COMPILER_CLANG
 
 #  include <cuda/__memory_resource/get_property.h>
 #  include <cuda/__memory_resource/properties.h>

--- a/libcudacxx/include/cuda/__memory_resource/pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/pinned_memory_resource.h
@@ -23,10 +23,10 @@
 
 #if !defined(_CCCL_COMPILER_MSVC_2017) && defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
 
-#  if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#  if defined(_CCCL_CUDA_COMPILER_CLANG)
 #    include <cuda_runtime.h>
 #    include <cuda_runtime_api.h>
-#  endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+#  endif // _CCCL_CUDA_COMPILER_CLANG
 
 #  include <cuda/__memory_resource/get_property.h>
 #  include <cuda/__memory_resource/properties.h>

--- a/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
+++ b/libcudacxx/include/cuda/std/__cuda/api_wrapper.h
@@ -21,30 +21,35 @@
 #  pragma system_header
 #endif // no system header
 
-#if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#if defined(_CCCL_CUDA_COMPILER_CLANG)
 #  include <cuda_runtime_api.h>
-#endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+#endif // _CCCL_CUDA_COMPILER_CLANG
 
 #include <cuda/std/__exception/cuda_error.h>
 
-#define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)           \
-  {                                                    \
-    const ::cudaError_t __status = _NAME(__VA_ARGS__); \
-    switch (__status)                                  \
-    {                                                  \
-      case ::cudaSuccess:                              \
-        break;                                         \
-      default:                                         \
-        ::cudaGetLastError();                          \
-        ::cuda::__throw_cuda_error(__status, _MSG);    \
-    }                                                  \
-  }
+#if defined(_CCCL_CUDA_COMPILER)
+#  define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)           \
+    {                                                    \
+      const ::cudaError_t __status = _NAME(__VA_ARGS__); \
+      switch (__status)                                  \
+      {                                                  \
+        case ::cudaSuccess:                              \
+          break;                                         \
+        default:                                         \
+          ::cudaGetLastError();                          \
+          ::cuda::__throw_cuda_error(__status, _MSG);    \
+      }                                                  \
+    }
 
-#define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)        \
-  {                                                    \
-    const ::cudaError_t __status = _NAME(__VA_ARGS__); \
-    _CCCL_ASSERT(__status == cudaSuccess, _MSG);       \
-    (void) __status;                                   \
-  }
+#  define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)        \
+    {                                                    \
+      const ::cudaError_t __status = _NAME(__VA_ARGS__); \
+      _CCCL_ASSERT(__status == cudaSuccess, _MSG);       \
+      (void) __status;                                   \
+    }
+#else // ^^^ _CCCL_CUDA_COMPILER ^^^ / vvv !_CCCL_CUDA_COMPILER vvv
+#  define _CCCL_TRY_CUDA_API(_NAME, _MSG, ...)
+#  define _CCCL_ASSERT_CUDA_API(_NAME, _MSG, ...)
+#endif // !_CCCL_CUDA_COMPILER
 
 #endif //_CUDA__STD__CUDA_API_WRAPPER_H

--- a/libcudacxx/include/cuda/std/__cuda/ensure_current_device.h
+++ b/libcudacxx/include/cuda/std/__cuda/ensure_current_device.h
@@ -21,9 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
-#if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#if defined(_CCCL_CUDA_COMPILER_CLANG)
 #  include <cuda_runtime_api.h>
-#endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+#endif // _CCCL_CUDA_COMPILER_CLANG
 
 #include <cuda/std/__cuda/api_wrapper.h>
 #include <cuda/std/__exception/cuda_error.h>

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -22,9 +22,9 @@
 #  pragma system_header
 #endif // no system header
 
-#if !defined(_CCCL_CUDA_COMPILER_NVCC) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#if defined(_CCCL_CUDA_COMPILER_CLANG)
 #  include <cuda_runtime_api.h>
-#endif // !_CCCL_CUDA_COMPILER_NVCC && !_CCCL_CUDA_COMPILER_NVHPC
+#endif // _CCCL_CUDA_COMPILER_CLANG
 
 #include <cuda/std/__exception/terminate.h>
 


### PR DESCRIPTION
We want to be able to include libcu++ headers even if we are not building with a cuda compiler.

We are less strict when it comes to headers in the `cuda` folder but lets try and make them easily usable