### PR TITLE
Fix nvbench helper compilation for clang-18

### DIFF
--- a/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -392,7 +392,7 @@ struct gen_t
     T min               = std::numeric_limits<T>::min,
     T max               = std::numeric_limits<T>::max()) const
   {
-    return {seed_t{}, elements, entropy, min, max};
+    return {{seed_t{}, elements, entropy}, min, max};
   }
 
   gen_uniform_t uniform{};


### PR DESCRIPTION
clang-18 suggested adding braces around the sub object initializer