### PR TITLE
Default ctor of device_ptr and normal_iterator

### DIFF
--- a/thrust/thrust/device_ptr.h
+++ b/thrust/thrust/device_ptr.h
@@ -77,7 +77,7 @@ private:
   using super_t = thrust::pointer<T, thrust::device_system_tag, thrust::device_reference<T>, thrust::device_ptr<T>>;
 
 public:
-  device_ptr() = default;
+  _CCCL_HIDE_FROM_ABI device_ptr() = default;
 
   /*! \brief Construct a null \c device_ptr.
    *

--- a/thrust/thrust/device_ptr.h
+++ b/thrust/thrust/device_ptr.h
@@ -77,13 +77,7 @@ private:
   using super_t = thrust::pointer<T, thrust::device_system_tag, thrust::device_reference<T>, thrust::device_ptr<T>>;
 
 public:
-  /*! \brief Construct a null \c device_ptr.
-   *
-   *  \post <tt>get() == nullptr</tt>.
-   */
-  _CCCL_HOST_DEVICE device_ptr()
-      : super_t()
-  {}
+  device_ptr() = default;
 
   /*! \brief Construct a null \c device_ptr.
    *

--- a/thrust/thrust/iterator/detail/normal_iterator.h
+++ b/thrust/thrust/iterator/detail/normal_iterator.h
@@ -45,7 +45,7 @@ class normal_iterator : public iterator_adaptor<normal_iterator<Pointer>, Pointe
   using super_t = iterator_adaptor<normal_iterator<Pointer>, Pointer>;
 
 public:
-  normal_iterator() = default;
+  _CCCL_HIDE_FROM_ABI normal_iterator() = default;
 
   _CCCL_HOST_DEVICE normal_iterator(Pointer p)
       : super_t(p)

--- a/thrust/thrust/iterator/detail/normal_iterator.h
+++ b/thrust/thrust/iterator/detail/normal_iterator.h
@@ -45,7 +45,7 @@ class normal_iterator : public iterator_adaptor<normal_iterator<Pointer>, Pointe
   using super_t = iterator_adaptor<normal_iterator<Pointer>, Pointer>;
 
 public:
-  _CCCL_HOST_DEVICE normal_iterator() {}
+  normal_iterator() = default;
 
   _CCCL_HOST_DEVICE normal_iterator(Pointer p)
       : super_t(p)


### PR DESCRIPTION
I was tracking a failing static assertion and applied defaulted two constructors on my way.