### PR TITLE
Ensure that we only use the inline variable trait when it is actually available

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -84,12 +84,6 @@
 #  define _CCCL_ELSE_IF_CONSTEXPR else if
 #endif // _CCCL_STD_VER <= 2014
 
-#if _CCCL_STD_VER >= 2017
-#  define _CCCL_TRAIT(__TRAIT, ...) __TRAIT##_v<__VA_ARGS__>
-#else // ^^^ C++17 ^^^ / vvv C++14 vvv
-#  define _CCCL_TRAIT(__TRAIT, ...) __TRAIT<__VA_ARGS__>::value
-#endif // _CCCL_STD_VER <= 2014
-
 // In nvcc prior to 11.3 global variables could not be marked constexpr
 #if defined(_CCCL_CUDACC_BELOW_11_3)
 #  define _CCCL_CONSTEXPR_GLOBAL const
@@ -109,6 +103,13 @@
 #if _CCCL_STD_VER <= 2011 || !defined(__cpp_variable_templates) || (__cpp_variable_templates < 201304L)
 #  define _CCCL_NO_VARIABLE_TEMPLATES
 #endif // _CCCL_STD_VER <= 2011
+
+// Variable templates are more efficient most of the time, so we want to use them rather than structs when possible
+#if defined(_CCCL_NO_VARIABLE_TEMPLATES)
+#  define _CCCL_TRAIT(__TRAIT, ...) __TRAIT<__VA_ARGS__>::value
+#else // ^^^ _CCCL_NO_VARIABLE_TEMPLATES ^^^ / vvv !_CCCL_NO_VARIABLE_TEMPLATES vvv
+#  define _CCCL_TRAIT(__TRAIT, ...) __TRAIT##_v<__VA_ARGS__>
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 // We need to treat host and device separately
 #if defined(__CUDA_ARCH__)

--- a/libcudacxx/include/cuda/std/__memory/allocator_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_traits.h
@@ -42,7 +42,7 @@ _CCCL_NV_DIAG_SUPPRESS(1215)
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER <= 2014
+#if defined(_CCCL_NO_VARIABLE_TEMPLATES)
 #  define _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(NAME, PROPERTY)   \
     template <class _Tp, class = void>                           \
     struct NAME : false_type                                     \
@@ -50,14 +50,13 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
     template <class _Tp>                                         \
     struct NAME<_Tp, void_t<typename _Tp::PROPERTY>> : true_type \
     {}
-
-#else // ^^^ _CCCL_STD_VER <= 2014 ^^^ / vvv _CCCL_STD_VER >= 2017 vvv
+#else // ^^^ _CCCL_NO_VARIABLE_TEMPLATES ^^^ / vvv !_CCCL_NO_VARIABLE_TEMPLATES vvv
 #  define _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(NAME, PROPERTY) \
     template <class _Tp, class = void>                         \
-    inline constexpr bool NAME##_v = false;                    \
+    _CCCL_INLINE_VAR constexpr bool NAME##_v = false;          \
     template <class _Tp>                                       \
-    inline constexpr bool NAME##_v<_Tp, void_t<typename _Tp::PROPERTY>> = true;
-#endif // _CCCL_STD_VER >= 2017
+    _CCCL_INLINE_VAR constexpr bool NAME##_v<_Tp, void_t<typename _Tp::PROPERTY>> = true;
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 // __pointer
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_pointer, pointer);

--- a/libcudacxx/include/cuda/std/__memory/uses_allocator.h
+++ b/libcudacxx/include/cuda/std/__memory/uses_allocator.h
@@ -28,7 +28,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER <= 2014
+#if defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp, class = void>
 struct __has_allocator_type : false_type
 {};
@@ -42,7 +42,7 @@ struct __uses_allocator : false_type
 template <class _Tp, class _Alloc>
 struct __uses_allocator<_Tp, _Alloc, true> : is_convertible<_Alloc, typename _Tp::allocator_type>
 {};
-#else // ^^^ _CCCL_STD_VER <= 2014 ^^^ / vvv _CCCL_STD_VER >= 2017 vvv
+#else // ^^^ _CCCL_NO_VARIABLE_TEMPLATES ^^^ / vvv !_CCCL_NO_VARIABLE_TEMPLATES vvv
 template <class _Tp, class = void>
 _CCCL_INLINE_VAR constexpr bool __has_allocator_type_v = false;
 template <class _Tp>
@@ -53,7 +53,7 @@ _CCCL_INLINE_VAR constexpr bool __uses_allocator_v = false;
 template <class _Tp, class _Alloc>
 _CCCL_INLINE_VAR constexpr bool __uses_allocator_v<_Tp, _Alloc, true> =
   is_convertible_v<_Alloc, typename _Tp::allocator_type>;
-#endif // _CCCL_STD_VER >= 2017
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 template <class _Tp, class _Alloc>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT uses_allocator


### PR DESCRIPTION
We were defining `_CCCL_TRAIT` solely based on the standard version, but guarded actually defining the inline variables by `__cpp_variable_templates`

We should use that as the condition