### PR TITLE
Clean up CUB thread operators

### DIFF
--- a/cub/benchmarks/bench/adjacent_difference/subtract_left.cu
+++ b/cub/benchmarks/bench/adjacent_difference/subtract_left.cu
@@ -57,7 +57,7 @@ void left(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 
   using input_it_t      = const T*;
   using output_it_t     = T*;
-  using difference_op_t = cub::Difference;
+  using difference_op_t = ::cuda::std::minus<>;
   using offset_t        = cub::detail::choose_offset_t<OffsetT>;
 
 #if !TUNE_BASE

--- a/cub/benchmarks/bench/reduce/by_key.cu
+++ b/cub/benchmarks/bench/reduce/by_key.cu
@@ -76,8 +76,8 @@ static void reduce(nvbench::state& state, nvbench::type_list<KeyT, ValueT, Offse
   using vals_input_it_t            = const ValueT*;
   using aggregate_output_it_t      = ValueT*;
   using num_runs_output_iterator_t = OffsetT*;
-  using equality_op_t              = cub::Equality;
-  using reduction_op_t             = cub::Sum;
+  using equality_op_t              = ::cuda::std::equal_to<>;
+  using reduction_op_t             = ::cuda::std::plus<>;
   using accum_t                    = ValueT;
   using offset_t                   = OffsetT;
 

--- a/cub/benchmarks/bench/reduce/min.cu
+++ b/cub/benchmarks/bench/reduce/min.cu
@@ -25,7 +25,7 @@
  *
  ******************************************************************************/
 // NOTE: this benchmark is intented to cover DPX instructions on Hopper+ architectures.
-//       It specifically uses cub::Min instead of a user-defined operator.
+//       It specifically uses cuda::minimum<> instead of a user-defined operator.
 #define TUNE_T int16_t
 #include <nvbench_helper.cuh>
 
@@ -33,5 +33,5 @@
 // %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
 // %RANGE% TUNE_ITEMS_PER_VEC_LOAD_POW2 ipv 1:2:1
 
-using op_t = cub::Min;
+using op_t = ::cuda::minimum<>;
 #include "base.cuh"

--- a/cub/benchmarks/bench/reduce/sum.cu
+++ b/cub/benchmarks/bench/reduce/sum.cu
@@ -31,5 +31,5 @@
 // %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
 // %RANGE% TUNE_ITEMS_PER_VEC_LOAD_POW2 ipv 1:2:1
 
-using op_t = cub::Sum;
+using op_t = ::cuda::std::plus<>;
 #include "base.cuh"

--- a/cub/benchmarks/bench/run_length_encode/encode.cu
+++ b/cub/benchmarks/bench/run_length_encode/encode.cu
@@ -77,8 +77,8 @@ static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using vals_input_it_t            = cub::ConstantInputIterator<offset_t, OffsetT>;
   using aggregate_output_it_t      = offset_t*;
   using num_runs_output_iterator_t = offset_t*;
-  using equality_op_t              = cub::Equality;
-  using reduction_op_t             = cub::Sum;
+  using equality_op_t              = ::cuda::std::equal_to<>;
+  using reduction_op_t             = ::cuda::std::plus<>;
   using accum_t                    = offset_t;
 
 #if !TUNE_BASE

--- a/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
+++ b/cub/benchmarks/bench/run_length_encode/non_trivial_runs.cu
@@ -78,7 +78,7 @@ static void rle(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using offset_output_it_t         = offset_t*;
   using length_output_it_t         = offset_t*;
   using num_runs_output_iterator_t = offset_t*;
-  using equality_op_t              = cub::Equality;
+  using equality_op_t              = ::cuda::std::equal_to<>;
   using accum_t                    = offset_t;
 
 #if !TUNE_BASE

--- a/cub/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/cub/benchmarks/bench/scan/exclusive/by_key.cu
@@ -76,12 +76,12 @@ template <typename KeyT, typename ValueT, typename OffsetT>
 static void scan(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
 {
   using init_value_t    = ValueT;
-  using op_t            = cub::Sum;
+  using op_t            = ::cuda::std::plus<>;
   using accum_t         = ::cuda::std::__accumulator_t<op_t, ValueT, init_value_t>;
   using key_input_it_t  = const KeyT*;
   using val_input_it_t  = const ValueT*;
   using val_output_it_t = ValueT*;
-  using equality_op_t   = cub::Equality;
+  using equality_op_t   = ::cuda::std::equal_to<>;
   using offset_t        = OffsetT;
 
 #if !TUNE_BASE

--- a/cub/benchmarks/bench/scan/exclusive/sum.cu
+++ b/cub/benchmarks/bench/scan/exclusive/sum.cu
@@ -35,5 +35,5 @@
 // %RANGE% TUNE_TRANSPOSE trp 0:1:1
 // %RANGE% TUNE_LOAD ld 0:2:1
 
-using op_t = cub::Sum;
+using op_t = ::cuda::std::plus<>;
 #include "base.cuh"

--- a/cub/benchmarks/bench/select/unique.cu
+++ b/cub/benchmarks/bench/select/unique.cu
@@ -62,7 +62,7 @@ static void unique(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlace
   using output_it_t        = T*;
   using num_selected_it_t  = OffsetT*;
   using select_op_t        = cub::NullType;
-  using equality_op_t      = cub::Equality;
+  using equality_op_t      = ::cuda::std::equal_to<>;
   using offset_t           = OffsetT;
   constexpr bool may_alias = InPlaceAlgT::value;
 

--- a/cub/benchmarks/bench/select/unique_by_key.cu
+++ b/cub/benchmarks/bench/select/unique_by_key.cu
@@ -76,7 +76,7 @@ static void select(nvbench::state& state, nvbench::type_list<KeyT, ValueT, Offse
   using vals_input_it_t            = const ValueT*;
   using vals_output_it_t           = ValueT*;
   using num_runs_output_iterator_t = OffsetT*;
-  using equality_op_t              = cub::Equality;
+  using equality_op_t              = ::cuda::std::equal_to<>;
   using offset_t                   = OffsetT;
 
 #if !TUNE_BASE

--- a/cub/benchmarks/bench/transform_reduce/sum.cu
+++ b/cub/benchmarks/bench/transform_reduce/sum.cu
@@ -86,7 +86,7 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using offset_t       = cub::detail::choose_offset_t<OffsetT>;
   using output_t       = T;
   using init_t         = T;
-  using reduction_op_t = cub::Sum;
+  using reduction_op_t = ::cuda::std::plus<>;
   using transform_op_t = square_t<T>;
 
 #  if !TUNE_BASE
@@ -139,7 +139,7 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using offset_t       = cub::detail::choose_offset_t<OffsetT>;
   using output_t       = T;
   using init_t         = T;
-  using reduction_op_t = cub::Sum;
+  using reduction_op_t = ::cuda::std::plus<>;
   using transform_op_t = square_t<T>;
 
 #  if !TUNE_BASE

--- a/cub/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/cub/agent/agent_batch_memcpy.cuh
@@ -638,14 +638,14 @@ private:
 
   using BLevBuffScanPrefixCallbackOpT =
     TilePrefixCallbackOp<BufferOffsetT,
-                         Sum,
+                         ::cuda::std::plus<>,
                          BLevBufferOffsetTileState,
                          0,
                          typename AgentMemcpySmallBuffersPolicyT::buff_delay_constructor>;
 
   using BLevBlockScanPrefixCallbackOpT =
     TilePrefixCallbackOp<BlockOffsetT,
-                         Sum,
+                         ::cuda::std::plus<>,
                          BLevBlockOffsetTileState,
                          0,
                          typename AgentMemcpySmallBuffersPolicyT::block_delay_constructor>;
@@ -830,7 +830,7 @@ private:
     else
     {
       BLevBlockScanPrefixCallbackOpT blev_tile_prefix_op(
-        blev_block_scan_state, temp_storage.staged.blev.block_scan_callback, Sum(), tile_id);
+        blev_block_scan_state, temp_storage.staged.blev.block_scan_callback, ::cuda::std::plus<>{}, tile_id);
       BlockBLevTileCountScanT(temp_storage.staged.blev.block_scan_storage)
         .ExclusiveSum(block_offset, block_offset, blev_tile_prefix_op);
     }
@@ -1062,7 +1062,7 @@ public:
     else
     {
       BLevBuffScanPrefixCallbackOpT blev_buffer_prefix_op(
-        blev_buffer_scan_state, temp_storage.buffer_scan_callback, Sum(), tile_id);
+        blev_buffer_scan_state, temp_storage.buffer_scan_callback, ::cuda::std::plus<>{}, tile_id);
 
       // Signal our partial prefix and wait for the inclusive prefix of previous tiles
       if (threadIdx.x < CUB_PTX_WARP_THREADS)

--- a/cub/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/cub/agent/agent_radix_sort_histogram.cuh
@@ -223,7 +223,7 @@ struct AgentRadixSortHistogram
 #pragma unroll
       for (int pass = 0; pass < num_passes; ++pass)
       {
-        OffsetT count = internal::ThreadReduce(s.bins[pass][bin], Sum());
+        OffsetT count = internal::ThreadReduce(s.bins[pass][bin], ::cuda::std::plus<>{});
         if (count > 0)
         {
           // Using cuda::atomic<> here would also require using it in

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -223,7 +223,8 @@ struct AgentReduceByKey
 
   // Whether or not the scan operation has a zero-valued identity value (true
   // if we're performing addition on a primitive type)
-  static constexpr int HAS_IDENTITY_ZERO = (std::is_same<ReductionOpT, cub::Sum>::value) && (Traits<AccumT>::PRIMITIVE);
+  static constexpr int HAS_IDENTITY_ZERO =
+    (std::is_same<ReductionOpT, ::cuda::std::plus<>>::value) && (Traits<AccumT>::PRIMITIVE);
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier)
   // for keys Wrap the native input pointer with

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -248,7 +248,7 @@ struct AgentRle
   using WarpScanPairs = WarpScan<LengthOffsetPair>;
 
   // Reduce-length-by-run scan operator
-  using ReduceBySegmentOpT = ReduceBySegmentOp<cub::Sum>;
+  using ReduceBySegmentOpT = ReduceBySegmentOp<::cuda::std::plus<>>;
 
   // Callback type for obtaining tile prefix during block scan
   using DelayConstructorT = typename AgentRlePolicyT::detail::delay_constructor_t;
@@ -359,7 +359,7 @@ struct AgentRle
       , d_offsets_out(d_offsets_out)
       , d_lengths_out(d_lengths_out)
       , equality_op(equality_op)
-      , scan_op(cub::Sum())
+      , scan_op(::cuda::std::plus<>{})
       , num_items(num_items)
   {}
 
@@ -866,7 +866,8 @@ struct AgentRle
         tile_aggregate, warp_aggregate, warp_exclusive_in_tile, thread_exclusive_in_warp, lengths_and_num_runs);
 
       // First warp computes tile prefix in lane 0
-      TilePrefixCallbackOpT prefix_op(tile_status, temp_storage.aliasable.scan_storage.prefix, Sum(), tile_idx);
+      TilePrefixCallbackOpT prefix_op(
+        tile_status, temp_storage.aliasable.scan_storage.prefix, ::cuda::std::plus<>{}, tile_idx);
       unsigned int warp_id = ((WARPS == 1) ? 0 : threadIdx.x / WARP_THREADS);
       if (warp_id == 0)
       {

--- a/cub/cub/agent/agent_segment_fixup.cuh
+++ b/cub/cub/agent/agent_segment_fixup.cuh
@@ -167,7 +167,7 @@ struct AgentSegmentFixup
 
     // Whether or not the scan operation has a zero-valued identity value
     // (true if we're performing addition on a primitive type)
-    HAS_IDENTITY_ZERO = (std::is_same<ReductionOpT, cub::Sum>::value) && (Traits<ValueT>::PRIMITIVE),
+    HAS_IDENTITY_ZERO = (std::is_same<ReductionOpT, ::cuda::std::plus<>>::value) && (Traits<ValueT>::PRIMITIVE),
   };
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier) for keys
@@ -187,7 +187,7 @@ struct AgentSegmentFixup
                      AggregatesOutputIteratorT>;
 
   // Reduce-value-by-segment scan operator
-  using ReduceBySegmentOpT = ReduceByKeyOp<cub::Sum>;
+  using ReduceBySegmentOpT = ReduceByKeyOp<::cuda::std::plus<>>;
 
   // Parameterized BlockLoad type for pairs
   using BlockLoadPairs =

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -270,8 +270,9 @@ struct AgentSelectIf
   using BlockScanT = BlockScan<OffsetT, BLOCK_THREADS, AgentSelectIfPolicyT::SCAN_ALGORITHM>;
 
   // Callback type for obtaining tile prefix during block scan
-  using DelayConstructorT     = typename AgentSelectIfPolicyT::detail::delay_constructor_t;
-  using TilePrefixCallbackOpT = TilePrefixCallbackOp<OffsetT, cub::Sum, MemoryOrderedTileStateT, 0, DelayConstructorT>;
+  using DelayConstructorT = typename AgentSelectIfPolicyT::detail::delay_constructor_t;
+  using TilePrefixCallbackOpT =
+    TilePrefixCallbackOp<OffsetT, ::cuda::std::plus<>, MemoryOrderedTileStateT, 0, DelayConstructorT>;
 
   // Item exchange type
   using ItemExchangeT = InputT[TILE_ITEMS];
@@ -896,7 +897,8 @@ struct AgentSelectIf
     CTA_SYNC();
 
     // Exclusive scan of values and selection_flags
-    TilePrefixCallbackOpT prefix_op(tile_state_wrapper, temp_storage.scan_storage.prefix, cub::Sum(), tile_idx);
+    TilePrefixCallbackOpT prefix_op(
+      tile_state_wrapper, temp_storage.scan_storage.prefix, ::cuda::std::plus<>{}, tile_idx);
     BlockScanT(temp_storage.scan_storage.scan).ExclusiveSum(selection_flags, selection_indices, prefix_op);
 
     OffsetT num_tile_selections   = prefix_op.GetBlockAggregate();

--- a/cub/cub/agent/agent_spmv_orig.cuh
+++ b/cub/cub/agent/agent_spmv_orig.cuh
@@ -247,7 +247,7 @@ struct AgentSpmv
   using KeyValuePairT = KeyValuePair<OffsetT, ValueT>;
 
   // Reduce-value-by-segment scan operator
-  using ReduceBySegmentOpT = ReduceByKeyOp<cub::Sum>;
+  using ReduceBySegmentOpT = ReduceByKeyOp<::cuda::std::plus<>>;
 
   // BlockReduce specialization
   using BlockReduceT = BlockReduce<ValueT, BLOCK_THREADS, BLOCK_REDUCE_WARP_REDUCTIONS>;

--- a/cub/cub/agent/agent_three_way_partition.cuh
+++ b/cub/cub/agent/agent_three_way_partition.cuh
@@ -208,8 +208,9 @@ struct AgentThreeWayPartition
   using BlockScanT = cub::BlockScan<AccumPackT, BLOCK_THREADS, PolicyT::SCAN_ALGORITHM>;
 
   // Callback type for obtaining tile prefix during block scan
-  using DelayConstructorT     = typename PolicyT::detail::delay_constructor_t;
-  using TilePrefixCallbackOpT = cub::TilePrefixCallbackOp<AccumPackT, cub::Sum, ScanTileStateT, 0, DelayConstructorT>;
+  using DelayConstructorT = typename PolicyT::detail::delay_constructor_t;
+  using TilePrefixCallbackOpT =
+    cub::TilePrefixCallbackOp<AccumPackT, ::cuda::std::plus<>, ScanTileStateT, 0, DelayConstructorT>;
 
   // Item exchange type
   using ItemExchangeT = InputT[TILE_ITEMS];
@@ -475,7 +476,7 @@ struct AgentThreeWayPartition
     CTA_SYNC();
 
     // Exclusive scan of values and selection_flags
-    TilePrefixCallbackOpT prefix_op(tile_state, temp_storage.scan_storage.prefix, cub::Sum(), tile_idx);
+    TilePrefixCallbackOpT prefix_op(tile_state, temp_storage.scan_storage.prefix, ::cuda::std::plus<>{}, tile_idx);
 
     BlockScanT(temp_storage.scan_storage.scan).ExclusiveSum(items_selected_flags, items_selected_indices, prefix_op);
 

--- a/cub/cub/agent/agent_unique_by_key.cuh
+++ b/cub/cub/agent/agent_unique_by_key.cuh
@@ -174,8 +174,9 @@ struct AgentUniqueByKey
   using BlockScanT = cub::BlockScan<OffsetT, BLOCK_THREADS, AgentUniqueByKeyPolicyT::SCAN_ALGORITHM>;
 
   // Parameterized BlockDiscontinuity type for items
-  using DelayConstructorT  = typename AgentUniqueByKeyPolicyT::detail::delay_constructor_t;
-  using TilePrefixCallback = cub::TilePrefixCallbackOp<OffsetT, cub::Sum, ScanTileStateT, 0, DelayConstructorT>;
+  using DelayConstructorT = typename AgentUniqueByKeyPolicyT::detail::delay_constructor_t;
+  using TilePrefixCallback =
+    cub::TilePrefixCallbackOp<OffsetT, ::cuda::std::plus<>, ScanTileStateT, 0, DelayConstructorT>;
 
   // Key exchange type
   using KeyExchangeT = KeyT[ITEMS_PER_TILE];
@@ -490,7 +491,7 @@ struct AgentUniqueByKey
     OffsetT num_selections        = 0;
     OffsetT num_selections_prefix = 0;
 
-    TilePrefixCallback prefix_cb(tile_state, temp_storage.scan_storage.prefix, cub::Sum(), tile_idx);
+    TilePrefixCallback prefix_cb(tile_state, temp_storage.scan_storage.prefix, ::cuda::std::plus<>{}, tile_idx);
     BlockScanT(temp_storage.scan_storage.scan).ExclusiveSum(selection_flags, selection_idx, prefix_cb);
 
     num_selections        = prefix_cb.GetInclusivePrefix();

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -319,7 +319,7 @@ private:
       raking_ptr = smem_raking_ptr;
     }
 
-    return internal::ThreadReduce<RAKING_SEGMENT>(raking_ptr, Sum());
+    return internal::ThreadReduce<RAKING_SEGMENT>(raking_ptr, ::cuda::std::plus<>{});
   }
 
   /// Performs exclusive downsweep raking scan
@@ -330,7 +330,7 @@ private:
     PackedCounter* raking_ptr = (MEMOIZE_OUTER_SCAN) ? cached_segment : smem_raking_ptr;
 
     // Exclusive raking downsweep scan
-    internal::ThreadScanExclusive<RAKING_SEGMENT>(raking_ptr, raking_ptr, Sum(), raking_partial);
+    internal::ThreadScanExclusive<RAKING_SEGMENT>(raking_ptr, raking_ptr, ::cuda::std::plus<>{}, raking_partial);
 
     if (MEMOIZE_OUTER_SCAN)
     {
@@ -1000,7 +1000,7 @@ struct BlockRadixRankMatchEarlyCounts
         for (int u = 0; u < WARP_BINS_PER_THREAD; ++u)
         {
           int bin = lane + u * WARP_THREADS;
-          bins[u] = internal::ThreadReduce(warp_histograms[bin], Sum());
+          bins[u] = internal::ThreadReduce(warp_histograms[bin], ::cuda::std::plus<>{});
         }
         CTA_SYNC();
 

--- a/cub/cub/block/block_reduce.cuh
+++ b/cub/cub/block/block_reduce.cuh
@@ -338,7 +338,7 @@ public:
   //!        ...
   //!
   //!        // Compute the block-wide max for thread0
-  //!        int aggregate = BlockReduce(temp_storage).Reduce(thread_data, cub::Max());
+  //!        int aggregate = BlockReduce(temp_storage).Reduce(thread_data, cuda::maximum<>{});
   //!
   //! @endrst
   //!
@@ -388,7 +388,7 @@ public:
   //!        ...
   //!
   //!        // Compute the block-wide max for thread0
-  //!        int aggregate = BlockReduce(temp_storage).Reduce(thread_data, cub::Max());
+  //!        int aggregate = BlockReduce(temp_storage).Reduce(thread_data, cuda::maximum<>{});
   //!
   //! @endrst
   //!
@@ -442,7 +442,7 @@ public:
   //!        if (threadIdx.x < num_valid) thread_data = ...
   //!
   //!        // Compute the block-wide max for thread0
-  //!        int aggregate = BlockReduce(temp_storage).Reduce(thread_data, cub::Max(), num_valid);
+  //!        int aggregate = BlockReduce(temp_storage).Reduce(thread_data, cuda::maximum<>{}, num_valid);
   //!
   //! @endrst
   //!
@@ -562,7 +562,7 @@ public:
   _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T (&inputs)[ITEMS_PER_THREAD])
   {
     // Reduce partials
-    T partial = internal::ThreadReduce(inputs, cub::Sum());
+    T partial = internal::ThreadReduce(inputs, ::cuda::std::plus<>{});
     return Sum(partial);
   }
 

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -350,7 +350,7 @@ public:
   {
     T initial_value{};
 
-    ExclusiveScan(input, output, initial_value, cub::Sum());
+    ExclusiveScan(input, output, initial_value, ::cuda::std::plus<>{});
   }
 
   //! @rst
@@ -407,7 +407,7 @@ public:
   {
     T initial_value{};
 
-    ExclusiveScan(input, output, initial_value, cub::Sum(), block_aggregate);
+    ExclusiveScan(input, output, initial_value, ::cuda::std::plus<>{}, block_aggregate);
   }
 
   //! @rst
@@ -506,7 +506,7 @@ public:
   template <typename BlockPrefixCallbackOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveSum(T input, T& output, BlockPrefixCallbackOp& block_prefix_callback_op)
   {
-    ExclusiveScan(input, output, cub::Sum(), block_prefix_callback_op);
+    ExclusiveScan(input, output, ::cuda::std::plus<>{}, block_prefix_callback_op);
   }
 
   //! @} end member group
@@ -569,7 +569,7 @@ public:
   {
     T initial_value{};
 
-    ExclusiveScan(input, output, initial_value, cub::Sum());
+    ExclusiveScan(input, output, initial_value, ::cuda::std::plus<>{});
   }
 
   //! @rst
@@ -636,7 +636,7 @@ public:
     // Reduce consecutive thread items in registers
     T initial_value{};
 
-    ExclusiveScan(input, output, initial_value, cub::Sum(), block_aggregate);
+    ExclusiveScan(input, output, initial_value, ::cuda::std::plus<>{}, block_aggregate);
   }
 
   //! @rst
@@ -755,7 +755,7 @@ public:
   _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveSum(
     T (&input)[ITEMS_PER_THREAD], T (&output)[ITEMS_PER_THREAD], BlockPrefixCallbackOp& block_prefix_callback_op)
   {
-    ExclusiveScan(input, output, cub::Sum(), block_prefix_callback_op);
+    ExclusiveScan(input, output, ::cuda::std::plus<>{}, block_prefix_callback_op);
   }
 
   //! @} end member group // Exclusive prefix sums
@@ -793,7 +793,7 @@ public:
   //!        ...
   //!
   //!        // Collectively compute the block-wide exclusive prefix max scan
-  //!        BlockScan(temp_storage).ExclusiveScan(thread_data, thread_data, INT_MIN, cub::Max());
+  //!        BlockScan(temp_storage).ExclusiveScan(thread_data, thread_data, INT_MIN, cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is ``0, -1, 2, -3, ..., 126, -127``.
   //! The corresponding output ``thread_data`` in those threads will be ``INT_MIN, 0, 0, 2, ..., 124, 126``.
@@ -855,7 +855,8 @@ public:
   //!
   //!        // Collectively compute the block-wide exclusive prefix max scan
   //!        int block_aggregate;
-  //!        BlockScan(temp_storage).ExclusiveScan(thread_data, thread_data, INT_MIN, cub::Max(), block_aggregate);
+  //!        BlockScan(temp_storage).ExclusiveScan(thread_data, thread_data, INT_MIN, cuda::maximum<>{},
+  //!        block_aggregate);
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is ``0, -1, 2, -3, ..., 126, -127``.
   //! The corresponding output ``thread_data`` in those threads will be ``INT_MIN, 0, 0, 2, ..., 124, 126``.
@@ -955,7 +956,7 @@ public:
   //!
   //!            // Collectively compute the block-wide exclusive prefix max scan
   //!            BlockScan(temp_storage).ExclusiveScan(
-  //!                thread_data, thread_data, INT_MIN, cub::Max(), prefix_op);
+  //!                thread_data, thread_data, INT_MIN, cuda::maximum<>{}, prefix_op);
   //!            CTA_SYNC();
   //!
   //!            // Store scanned items to output segment
@@ -1032,7 +1033,7 @@ public:
   //!        ...
   //!
   //!        // Collectively compute the block-wide exclusive prefix max scan
-  //!        BlockScan(temp_storage).ExclusiveScan(thread_data, thread_data, INT_MIN, cub::Max());
+  //!        BlockScan(temp_storage).ExclusiveScan(thread_data, thread_data, INT_MIN, cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{ [0,-1,2,-3], [4,-5,6,-7], ..., [508,-509,510,-511] }``.
@@ -1110,7 +1111,8 @@ public:
   //!
   //!        // Collectively compute the block-wide exclusive prefix max scan
   //!        int block_aggregate;
-  //!        BlockScan(temp_storage).ExclusiveScan(thread_data, thread_data, INT_MIN, cub::Max(), block_aggregate);
+  //!        BlockScan(temp_storage).ExclusiveScan(thread_data, thread_data, INT_MIN, cuda::maximum<>{},
+  //!        block_aggregate);
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{ [0,-1,2,-3], [4,-5,6,-7], ..., [508,-509,510,-511] }``.
@@ -1232,7 +1234,7 @@ public:
   //!
   //!            // Collectively compute the block-wide exclusive prefix max scan
   //!            BlockScan(temp_storage.scan).ExclusiveScan(
-  //!                thread_data, thread_data, INT_MIN, cub::Max(), prefix_op);
+  //!                thread_data, thread_data, INT_MIN, cuda::maximum<>{}, prefix_op);
   //!            CTA_SYNC();
   //!
   //!            // Store scanned items to output segment
@@ -1492,7 +1494,7 @@ public:
   //!   Calling thread's output item (may be aliased to `input`)
   _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveSum(T input, T& output)
   {
-    InclusiveScan(input, output, cub::Sum());
+    InclusiveScan(input, output, ::cuda::std::plus<>{});
   }
 
   //! @rst
@@ -1545,7 +1547,7 @@ public:
   //!   block-wide aggregate reduction of input items
   _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveSum(T input, T& output, T& block_aggregate)
   {
-    InclusiveScan(input, output, cub::Sum(), block_aggregate);
+    InclusiveScan(input, output, ::cuda::std::plus<>{}, block_aggregate);
   }
 
   //! @rst
@@ -1645,7 +1647,7 @@ public:
   template <typename BlockPrefixCallbackOp>
   _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveSum(T input, T& output, BlockPrefixCallbackOp& block_prefix_callback_op)
   {
-    InclusiveScan(input, output, cub::Sum(), block_prefix_callback_op);
+    InclusiveScan(input, output, ::cuda::std::plus<>{}, block_prefix_callback_op);
   }
 
   //! @}  end member group
@@ -1710,7 +1712,7 @@ public:
     else
     {
       // Reduce consecutive thread items in registers
-      Sum scan_op;
+      ::cuda::std::plus<> scan_op;
       T thread_prefix = internal::ThreadReduce(input, scan_op);
 
       // Exclusive thread block-scan
@@ -1768,9 +1770,6 @@ public:
   //! @tparam ITEMS_PER_THREAD
   //!   **[inferred]** The number of consecutive items partitioned onto each thread.
   //!
-  //! @tparam ScanOp
-  //!   **[inferred]** Binary scan functor type having member `T operator()(const T &a, const T &b)`
-  //!
   //! @param[in] input
   //!   Calling thread's input items
   //!
@@ -1790,7 +1789,7 @@ public:
     else
     {
       // Reduce consecutive thread items in registers
-      Sum scan_op;
+      ::cuda::std::plus<> scan_op;
       T thread_prefix = internal::ThreadReduce(input, scan_op);
 
       // Exclusive thread block-scan
@@ -1922,7 +1921,7 @@ public:
     else
     {
       // Reduce consecutive thread items in registers
-      Sum scan_op;
+      ::cuda::std::plus<> scan_op;
       T thread_prefix = internal::ThreadReduce(input, scan_op);
 
       // Exclusive thread block-scan
@@ -1968,7 +1967,7 @@ public:
   //!        ...
   //!
   //!        // Collectively compute the block-wide inclusive prefix max scan
-  //!        BlockScan(temp_storage).InclusiveScan(thread_data, thread_data, cub::Max());
+  //!        BlockScan(temp_storage).InclusiveScan(thread_data, thread_data, cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``0, -1, 2, -3, ..., 126, -127``. The corresponding output ``thread_data``
@@ -2026,7 +2025,7 @@ public:
   //!
   //!        // Collectively compute the block-wide inclusive prefix max scan
   //!        int block_aggregate;
-  //!        BlockScan(temp_storage).InclusiveScan(thread_data, thread_data, cub::Max(), block_aggregate);
+  //!        BlockScan(temp_storage).InclusiveScan(thread_data, thread_data, cuda::maximum<>{}, block_aggregate);
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``0, -1, 2, -3, ..., 126, -127``. The corresponding output ``thread_data``
@@ -2123,7 +2122,7 @@ public:
   //!
   //!            // Collectively compute the block-wide inclusive prefix max scan
   //!            BlockScan(temp_storage).InclusiveScan(
-  //!                thread_data, thread_data, cub::Max(), prefix_op);
+  //!                thread_data, thread_data, cuda::maximum<>{}, prefix_op);
   //!            CTA_SYNC();
   //!
   //!            // Store scanned items to output segment
@@ -2201,7 +2200,7 @@ public:
   //!        ...
   //!
   //!        // Collectively compute the block-wide inclusive prefix max scan
-  //!        BlockScan(temp_storage).InclusiveScan(thread_data, thread_data, cub::Max());
+  //!        BlockScan(temp_storage).InclusiveScan(thread_data, thread_data, cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{ [0,-1,2,-3], [4,-5,6,-7], ..., [508,-509,510,-511] }``.
@@ -2336,7 +2335,7 @@ public:
   //!
   //!        // Collectively compute the block-wide inclusive prefix max scan
   //!        int block_aggregate;
-  //!        BlockScan(temp_storage).InclusiveScan(thread_data, thread_data, cub::Max(), block_aggregate);
+  //!        BlockScan(temp_storage).InclusiveScan(thread_data, thread_data, cuda::maximum<>{}, block_aggregate);
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{ [0,-1,2,-3], [4,-5,6,-7], ..., [508,-509,510,-511] }``.
@@ -2521,7 +2520,7 @@ public:
   //!
   //!            // Collectively compute the block-wide inclusive prefix max scan
   //!            BlockScan(temp_storage.scan).InclusiveScan(
-  //!                thread_data, thread_data, cub::Max(), prefix_op);
+  //!                thread_data, thread_data, cuda::maximum<>{}, prefix_op);
   //!            CTA_SYNC();
   //!
   //!            // Store scanned items to output segment

--- a/cub/cub/block/specializations/block_reduce_raking.cuh
+++ b/cub/cub/block/specializations/block_reduce_raking.cuh
@@ -252,7 +252,7 @@ struct BlockReduceRaking
   template <bool IS_FULL_TILE>
   _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T partial, int num_valid)
   {
-    cub::Sum reduction_op;
+    ::cuda::std::plus<> reduction_op;
 
     return Reduce<IS_FULL_TILE>(partial, num_valid, reduction_op);
   }

--- a/cub/cub/block/specializations/block_reduce_raking_commutative_only.cuh
+++ b/cub/cub/block/specializations/block_reduce_raking_commutative_only.cuh
@@ -174,7 +174,7 @@ struct BlockReduceRakingCommutativeOnly
       {
         // Raking reduction in grid
         T* raking_segment = BlockRakingLayout::RakingPtr(temp_storage.default_storage.raking_grid, linear_tid);
-        partial           = internal::ThreadReduce<SEGMENT_LENGTH>(raking_segment, cub::Sum(), partial);
+        partial           = internal::ThreadReduce<SEGMENT_LENGTH>(raking_segment, ::cuda::std::plus<>{}, partial);
 
         // Warp reduction
         partial = WarpReduce(temp_storage.default_storage.warp_storage).Sum(partial);

--- a/cub/cub/device/device_adjacent_difference.cuh
+++ b/cub/cub/device/device_adjacent_difference.cuh
@@ -247,7 +247,7 @@ public:
   //!   @endrst
   template <typename InputIteratorT,
             typename OutputIteratorT,
-            typename DifferenceOpT = cub::Difference,
+            typename DifferenceOpT = ::cuda::std::minus<>,
             typename NumItemsT     = std::uint32_t>
   static CUB_RUNTIME_FUNCTION cudaError_t SubtractLeftCopy(
     void* d_temp_storage,
@@ -378,7 +378,9 @@ public:
   //!   @rst
   //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
   //!   @endrst
-  template <typename RandomAccessIteratorT, typename DifferenceOpT = cub::Difference, typename NumItemsT = std::uint32_t>
+  template <typename RandomAccessIteratorT,
+            typename DifferenceOpT = ::cuda::std::minus<>,
+            typename NumItemsT     = std::uint32_t>
   static CUB_RUNTIME_FUNCTION cudaError_t SubtractLeft(
     void* d_temp_storage,
     std::size_t& temp_storage_bytes,
@@ -523,7 +525,7 @@ public:
   //!   @endrst
   template <typename InputIteratorT,
             typename OutputIteratorT,
-            typename DifferenceOpT = cub::Difference,
+            typename DifferenceOpT = ::cuda::std::minus<>,
             typename NumItemsT     = std::uint32_t>
   static CUB_RUNTIME_FUNCTION cudaError_t SubtractRightCopy(
     void* d_temp_storage,
@@ -643,7 +645,9 @@ public:
   //!   @rst
   //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
   //!   @endrst
-  template <typename RandomAccessIteratorT, typename DifferenceOpT = cub::Difference, typename NumItemsT = std::uint32_t>
+  template <typename RandomAccessIteratorT,
+            typename DifferenceOpT = ::cuda::std::minus<>,
+            typename NumItemsT     = std::uint32_t>
   static CUB_RUNTIME_FUNCTION cudaError_t SubtractRight(
     void* d_temp_storage,
     std::size_t& temp_storage_bytes,

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -319,13 +319,13 @@ struct DeviceReduce
 
     using InitT = OutputT;
 
-    return DispatchReduce<InputIteratorT, OutputIteratorT, OffsetT, cub::Sum, InitT>::Dispatch(
+    return DispatchReduce<InputIteratorT, OutputIteratorT, OffsetT, ::cuda::std::plus<>, InitT>::Dispatch(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
       d_out,
       static_cast<OffsetT>(num_items),
-      cub::Sum(),
+      ::cuda::std::plus<>{},
       InitT{}, // zero-initialize
       stream);
   }
@@ -442,13 +442,13 @@ struct DeviceReduce
 
     using InitT = InputT;
 
-    return DispatchReduce<InputIteratorT, OutputIteratorT, OffsetT, cub::Min, InitT>::Dispatch(
+    return DispatchReduce<InputIteratorT, OutputIteratorT, OffsetT, ::cuda::minimum<>, InitT>::Dispatch(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
       d_out,
       static_cast<OffsetT>(num_items),
-      cub::Min(),
+      ::cuda::minimum<>{},
       // replace with
       // std::numeric_limits<T>::max() when
       // C++11 support is more prevalent
@@ -700,13 +700,13 @@ struct DeviceReduce
 
     using InitT = InputT;
 
-    return DispatchReduce<InputIteratorT, OutputIteratorT, OffsetT, cub::Max, InitT>::Dispatch(
+    return DispatchReduce<InputIteratorT, OutputIteratorT, OffsetT, ::cuda::maximum<>, InitT>::Dispatch(
       d_temp_storage,
       temp_storage_bytes,
       d_in,
       d_out,
       static_cast<OffsetT>(num_items),
-      cub::Max(),
+      ::cuda::maximum<>{},
       // replace with
       // std::numeric_limits<T>::lowest()
       // when C++11 support is more
@@ -908,7 +908,7 @@ struct DeviceReduce
   //!      in.begin(),
   //!      out.begin(),
   //!      in.size(),
-  //!      cub::Sum{},
+  //!      cuda::std::plus<>{},
   //!      square_t{},
   //!      init);
   //!
@@ -921,7 +921,7 @@ struct DeviceReduce
   //!      in.begin(),
   //!      out.begin(),
   //!      in.size(),
-  //!      cub::Sum{},
+  //!      cuda::std::plus<>{},
   //!      square_t{},
   //!      init);
   //!
@@ -1172,7 +1172,7 @@ struct DeviceReduce
     // Selection op (not used)
 
     // Default == operator
-    using EqualityOp = Equality;
+    using EqualityOp = ::cuda::std::equal_to<>;
 
     return DispatchReduceByKey<
       KeysInputIteratorT,

--- a/cub/cub/device/device_run_length_encode.cuh
+++ b/cub/cub/device/device_run_length_encode.cuh
@@ -193,8 +193,8 @@ struct DeviceRunLengthEncode
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceRunLengthEncode::Encode");
 
     using offset_t     = int; // Signed integer type for global offsets
-    using equality_op  = Equality; // Default == operator
-    using reduction_op = cub::Sum; // Value reduction operator
+    using equality_op  = ::cuda::std::equal_to<>; // Default == operator
+    using reduction_op = ::cuda::std::plus<>; // Value reduction operator
 
     // The lengths output value type
     using length_t = cub::detail::non_void_value_t<LengthsOutputIteratorT, offset_t>;
@@ -367,7 +367,7 @@ struct DeviceRunLengthEncode
     CUB_DETAIL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceRunLengthEncode::NonTrivialRuns");
 
     using OffsetT    = int; // Signed integer type for global offsets
-    using EqualityOp = Equality; // Default == operator
+    using EqualityOp = ::cuda::std::equal_to<>; // Default == operator
 
     return DeviceRleDispatch<
       InputIteratorT,

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -197,8 +197,15 @@ struct DeviceScan
     // Initial value
     InitT init_value{};
 
-    return DispatchScan<InputIteratorT, OutputIteratorT, Sum, detail::InputValue<InitT>, OffsetT>::Dispatch(
-      d_temp_storage, temp_storage_bytes, d_in, d_out, Sum(), detail::InputValue<InitT>(init_value), num_items, stream);
+    return DispatchScan<InputIteratorT, OutputIteratorT, ::cuda::std::plus<>, detail::InputValue<InitT>, OffsetT>::
+      Dispatch(d_temp_storage,
+               temp_storage_bytes,
+               d_in,
+               d_out,
+               ::cuda::std::plus<>{},
+               detail::InputValue<InitT>(init_value),
+               num_items,
+               stream);
   }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
@@ -380,7 +387,7 @@ struct DeviceScan
   //! @tparam OutputIteratorT
   //!   **[inferred]** Random-access output iterator type for writing scan outputs @iterator
   //!
-  //! @tparam ScanOp
+  //! @tparam ScanOpT
   //!   **[inferred]** Binary scan functor type having member `T operator()(const T &a, const T &b)`
   //!
   //! @tparam InitValueT
@@ -526,7 +533,7 @@ struct DeviceScan
   //! @tparam IteratorT
   //!   **[inferred]** Random-access input iterator type for reading scan inputs and writing scan outputs
   //!
-  //! @tparam ScanOp
+  //! @tparam ScanOpT
   //!   **[inferred]** Binary scan functor type having member `T operator()(const T &a, const T &b)`
   //!
   //! @tparam InitValueT
@@ -664,7 +671,7 @@ struct DeviceScan
   //! @tparam OutputIteratorT
   //!   **[inferred]** Random-access output iterator type for writing scan outputs @iterator
   //!
-  //! @tparam ScanOp
+  //! @tparam ScanOpT
   //!   **[inferred]** Binary scan functor type having member `T operator()(const T &a, const T &b)`
   //!
   //! @tparam InitValueT
@@ -823,7 +830,7 @@ struct DeviceScan
   //! @tparam IteratorT
   //!   **[inferred]** Random-access input iterator type for reading scan inputs and writing scan outputs
   //!
-  //! @tparam ScanOp
+  //! @tparam ScanOpT
   //!   **[inferred]** Binary scan functor type having member `T operator()(const T &a, const T &b)`
   //!
   //! @tparam InitValueT
@@ -992,8 +999,8 @@ struct DeviceScan
     // Unsigned integer type for global offsets
     using OffsetT = detail::choose_offset_t<NumItemsT>;
 
-    return DispatchScan<InputIteratorT, OutputIteratorT, Sum, NullType, OffsetT>::Dispatch(
-      d_temp_storage, temp_storage_bytes, d_in, d_out, Sum(), NullType(), num_items, stream);
+    return DispatchScan<InputIteratorT, OutputIteratorT, ::cuda::std::plus<>, NullType, OffsetT>::Dispatch(
+      d_temp_storage, temp_storage_bytes, d_in, d_out, ::cuda::std::plus<>{}, NullType{}, num_items, stream);
   }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
@@ -1172,7 +1179,7 @@ struct DeviceScan
   //! @tparam OutputIteratorT
   //!   **[inferred]** Random-access output iterator type for writing scan outputs @iterator
   //!
-  //! @tparam ScanOp
+  //! @tparam ScanOpT
   //!   **[inferred]** Binary scan functor type having member `T operator()(const T &a, const T &b)`
   //!
   //! @tparam NumItemsT
@@ -1405,7 +1412,7 @@ struct DeviceScan
   //! @tparam IteratorT
   //!   **[inferred]** Random-access input iterator type for reading scan inputs and writing scan outputs
   //!
-  //! @tparam ScanOp
+  //! @tparam ScanOpT
   //!   **[inferred]** Binary scan functor type having member `T operator()(const T &a, const T &b)`
   //!
   //! @tparam NumItemsT
@@ -1552,7 +1559,7 @@ struct DeviceScan
   //!
   //! @param[in] equality_op
   //!   Binary functor that defines the equality of keys.
-  //!   Default is cub::Equality().
+  //!   Default is cuda::std::equal_to<>{}.
   //!
   //! @param[in] stream
   //!   @rst
@@ -1561,7 +1568,7 @@ struct DeviceScan
   template <typename KeysInputIteratorT,
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
-            typename EqualityOpT = Equality,
+            typename EqualityOpT = ::cuda::std::equal_to<>,
             typename NumItemsT   = std::uint32_t>
   CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveSumByKey(
     void* d_temp_storage,
@@ -1587,7 +1594,7 @@ struct DeviceScan
       ValuesInputIteratorT,
       ValuesOutputIteratorT,
       EqualityOpT,
-      Sum,
+      ::cuda::std::plus<>,
       InitT,
       OffsetT>::Dispatch(d_temp_storage,
                          temp_storage_bytes,
@@ -1595,7 +1602,7 @@ struct DeviceScan
                          d_values_in,
                          d_values_out,
                          equality_op,
-                         Sum(),
+                         ::cuda::std::plus<>{},
                          init_value,
                          num_items,
                          stream);
@@ -1605,7 +1612,7 @@ struct DeviceScan
   template <typename KeysInputIteratorT,
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
-            typename EqualityOpT = Equality,
+            typename EqualityOpT = ::cuda::std::equal_to<>,
             typename NumItemsT   = std::uint32_t>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveSumByKey(
     void* d_temp_storage,
@@ -1715,7 +1722,7 @@ struct DeviceScan
   //! @tparam ValuesOutputIteratorT
   //!   **[inferred]** Random-access output iterator type for writing scan values outputs @iterator
   //!
-  //! @tparam ScanOp
+  //! @tparam ScanOpT
   //!   **[inferred]** Binary scan functor type having member `T operator()(const T &a, const T &b)`
   //!
   //! @tparam InitValueT
@@ -1758,7 +1765,7 @@ struct DeviceScan
   //!
   //!  @param[in] equality_op
   //!    Binary functor that defines the equality of keys.
-  //!    Default is cub::Equality().
+  //!    Default is cuda::std::equal_to<>{}.
   //!
   //!  @param[in] stream
   //!    @rst
@@ -1769,7 +1776,7 @@ struct DeviceScan
             typename ValuesOutputIteratorT,
             typename ScanOpT,
             typename InitValueT,
-            typename EqualityOpT = Equality,
+            typename EqualityOpT = ::cuda::std::equal_to<>,
             typename NumItemsT   = std::uint32_t>
   CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScanByKey(
     void* d_temp_storage,
@@ -1813,7 +1820,7 @@ struct DeviceScan
             typename ValuesOutputIteratorT,
             typename ScanOpT,
             typename InitValueT,
-            typename EqualityOpT = Equality,
+            typename EqualityOpT = ::cuda::std::equal_to<>,
             typename NumItemsT   = std::uint32_t>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScanByKey(
     void* d_temp_storage,
@@ -1938,7 +1945,7 @@ struct DeviceScan
   //!
   //!  @param[in] equality_op
   //!    Binary functor that defines the equality of keys.
-  //!    Default is cub::Equality().
+  //!    Default is cuda::std::equal_to<>{}.
   //!
   //!  @param[in] stream
   //!    @rst
@@ -1947,7 +1954,7 @@ struct DeviceScan
   template <typename KeysInputIteratorT,
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
-            typename EqualityOpT = Equality,
+            typename EqualityOpT = ::cuda::std::equal_to<>,
             typename NumItemsT   = std::uint32_t>
   CUB_RUNTIME_FUNCTION static cudaError_t InclusiveSumByKey(
     void* d_temp_storage,
@@ -1969,7 +1976,7 @@ struct DeviceScan
       ValuesInputIteratorT,
       ValuesOutputIteratorT,
       EqualityOpT,
-      Sum,
+      ::cuda::std::plus<>,
       NullType,
       OffsetT>::Dispatch(d_temp_storage,
                          temp_storage_bytes,
@@ -1977,8 +1984,8 @@ struct DeviceScan
                          d_values_in,
                          d_values_out,
                          equality_op,
-                         Sum(),
-                         NullType(),
+                         ::cuda::std::plus<>{},
+                         NullType{},
                          num_items,
                          stream);
   }
@@ -1987,7 +1994,7 @@ struct DeviceScan
   template <typename KeysInputIteratorT,
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
-            typename EqualityOpT = Equality,
+            typename EqualityOpT = ::cuda::std::equal_to<>,
             typename NumItemsT   = std::uint32_t>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION static cudaError_t InclusiveSumByKey(
     void* d_temp_storage,
@@ -2092,7 +2099,7 @@ struct DeviceScan
   //! @tparam ValuesOutputIteratorT
   //!   **[inferred]** Random-access output iterator type for writing scan values outputs @iterator
   //!
-  //! @tparam ScanOp
+  //! @tparam ScanOpT
   //!   **[inferred]** Binary scan functor type having member `T operator()(const T &a, const T &b)`
   //!
   //! @tparam EqualityOpT
@@ -2126,7 +2133,7 @@ struct DeviceScan
   //!
   //!  @param[in] equality_op
   //!    Binary functor that defines the equality of keys.
-  //!    Default is cub::Equality().
+  //!    Default is cuda::std::equal_to<>{}.
   //!
   //!  @param[in] stream
   //!    @rst
@@ -2136,7 +2143,7 @@ struct DeviceScan
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
             typename ScanOpT,
-            typename EqualityOpT = Equality,
+            typename EqualityOpT = ::cuda::std::equal_to<>,
             typename NumItemsT   = std::uint32_t>
   CUB_RUNTIME_FUNCTION static cudaError_t InclusiveScanByKey(
     void* d_temp_storage,
@@ -2178,7 +2185,7 @@ struct DeviceScan
             typename ValuesInputIteratorT,
             typename ValuesOutputIteratorT,
             typename ScanOpT,
-            typename EqualityOpT = Equality,
+            typename EqualityOpT = ::cuda::std::equal_to<>,
             typename NumItemsT   = std::uint32_t>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED CUB_RUNTIME_FUNCTION static cudaError_t InclusiveScanByKey(
     void* d_temp_storage,

--- a/cub/cub/device/device_segmented_reduce.cuh
+++ b/cub/cub/device/device_segmented_reduce.cuh
@@ -407,7 +407,12 @@ public:
 
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");
 
-    return segmented_reduce<InputIteratorT, OutputIteratorT, BeginOffsetIteratorT, EndOffsetIteratorT, OffsetT, cub::Sum>(
+    return segmented_reduce<InputIteratorT,
+                            OutputIteratorT,
+                            BeginOffsetIteratorT,
+                            EndOffsetIteratorT,
+                            OffsetT,
+                            ::cuda::std::plus<>>(
       integral_offset_check{},
       d_temp_storage,
       temp_storage_bytes,
@@ -416,7 +421,7 @@ public:
       num_segments,
       d_begin_offsets,
       d_end_offsets,
-      cub::Sum(),
+      ::cuda::std::plus<>{},
       OutputT(), // zero-initialize
       stream);
   }
@@ -545,7 +550,12 @@ public:
 
     static_assert(integral_offset_check::value, "Offset iterator value type should be integral.");
 
-    return segmented_reduce<InputIteratorT, OutputIteratorT, BeginOffsetIteratorT, EndOffsetIteratorT, OffsetT, cub::Min>(
+    return segmented_reduce<InputIteratorT,
+                            OutputIteratorT,
+                            BeginOffsetIteratorT,
+                            EndOffsetIteratorT,
+                            OffsetT,
+                            ::cuda::minimum<>>(
       integral_offset_check{},
       d_temp_storage,
       temp_storage_bytes,
@@ -554,7 +564,7 @@ public:
       num_segments,
       d_begin_offsets,
       d_end_offsets,
-      cub::Min(),
+      ::cuda::minimum<>{},
       Traits<InputT>::Max(), // replace with
                              // std::numeric_limits<T>::max()
                              // when C++11 support is
@@ -859,7 +869,7 @@ public:
       num_segments,
       d_begin_offsets,
       d_end_offsets,
-      cub::Max(),
+      ::cuda::maximum<>{},
       Traits<InputT>::Lowest(), // replace with
                                 // std::numeric_limits<T>::lowest()
                                 // when C++11 support is

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -989,7 +989,7 @@ struct DeviceSelect
     using OffsetT      = ::cuda::std::int64_t;
     using FlagIterator = NullType*; // FlagT iterator type (not used)
     using SelectOp     = NullType; // Selection op (not used)
-    using EqualityOp   = Equality; // Default == operator
+    using EqualityOp   = ::cuda::std::equal_to<>; // Default == operator
 
     return DispatchSelectIf<
       InputIteratorT,
@@ -1326,7 +1326,7 @@ struct DeviceSelect
       d_values_out,
       d_num_selected_out,
       num_items,
-      Equality{},
+      ::cuda::std::equal_to<>{},
       stream);
   }
 

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -190,17 +190,23 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanPolicy::BLOCK_THREADS), 
 {
   // Parameterize the AgentScan type for the current configuration
   using AgentScanT =
-    AgentScan<typename ChainedPolicyT::ActivePolicy::ScanPolicy, OffsetT*, OffsetT*, cub::Sum, OffsetT, OffsetT, OffsetT>;
+    AgentScan<typename ChainedPolicyT::ActivePolicy::ScanPolicy,
+              OffsetT*,
+              OffsetT*,
+              ::cuda::std::plus<>,
+              OffsetT,
+              OffsetT,
+              OffsetT>;
 
   // Shared memory storage
   __shared__ typename AgentScanT::TempStorage temp_storage;
 
   // Block scan instance
-  AgentScanT block_scan(temp_storage, d_spine, d_spine, cub::Sum(), OffsetT(0));
+  AgentScanT block_scan(temp_storage, d_spine, d_spine, ::cuda::std::plus<>{}, OffsetT(0));
 
   // Process full input tiles
   int block_offset = 0;
-  BlockScanRunningPrefixOp<OffsetT, Sum> prefix_op(0, Sum());
+  BlockScanRunningPrefixOp<OffsetT, ::cuda::std::plus<>> prefix_op(0, ::cuda::std::plus<>{});
   while (block_offset + AgentScanT::TILE_ITEMS <= num_counts)
   {
     block_scan.template ConsumeTile<false, false>(block_offset, prefix_op);

--- a/cub/cub/device/dispatch/dispatch_spmv_orig.cuh
+++ b/cub/cub/device/dispatch/dispatch_spmv_orig.cuh
@@ -317,15 +317,15 @@ __launch_bounds__(int(AgentSegmentFixupPolicyT::BLOCK_THREADS))
     AgentSegmentFixup<AgentSegmentFixupPolicyT,
                       PairsInputIteratorT,
                       AggregatesOutputIteratorT,
-                      cub::Equality,
-                      cub::Sum,
+                      ::cuda::std::equal_to<>,
+                      ::cuda::std::plus<>,
                       OffsetT>;
 
   // Shared memory for AgentSegmentFixup
   __shared__ typename AgentSegmentFixupT::TempStorage temp_storage;
 
   // Process tiles
-  AgentSegmentFixupT(temp_storage, d_pairs_in, d_aggregates_out, cub::Equality(), cub::Sum())
+  AgentSegmentFixupT(temp_storage, d_pairs_in, d_aggregates_out, ::cuda::std::equal_to<>{}, ::cuda::std::plus<>{})
     .ConsumeRange(num_items, num_tiles, tile_state);
 }
 

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -263,7 +263,7 @@ struct sm80_tuning<__uint128_t, primitive_op::yes, primitive_accum::no, accum_si
 } // namespace scan
 } // namespace detail
 
-template <typename AccumT, typename ScanOpT = Sum>
+template <typename AccumT, typename ScanOpT = ::cuda::std::plus<>>
 struct DeviceScanPolicy
 {
   // For large values, use timesliced loads/stores to fit shared memory.

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -1039,7 +1039,7 @@ struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size
 } // namespace scan_by_key
 } // namespace detail
 
-template <typename KeysInputIteratorT, typename AccumT, typename ValueT = AccumT, typename ScanOpT = Sum>
+template <typename KeysInputIteratorT, typename AccumT, typename ValueT = AccumT, typename ScanOpT = ::cuda::std::plus<>>
 struct DeviceScanByKeyPolicy
 {
   using KeyT = cub::detail::value_t<KeysInputIteratorT>;

--- a/cub/cub/thread/thread_reduce.cuh
+++ b/cub/cub/thread/thread_reduce.cuh
@@ -84,10 +84,10 @@ constexpr bool enable_dpx_reduction()
   using T = decltype(::cuda::std::declval<Input>()[0]);
   // TODO: use constexpr variable in C++14+
   using Length = ::cuda::std::integral_constant<int, detail::static_size<Input>()>;
-  return ((Length{} >= 9 && detail::are_same<ReductionOp, cub::Sum/*, std::plus<T>*/>()) || Length{} >= 10)
+  return ((Length{} >= 9 && detail::are_same<ReductionOp, ::cuda::std::plus<>/*, std::plus<T>*/>()) || Length{} >= 10)
             && detail::are_same<T, AccumT>()
             && detail::is_one_of<T, int16_t, uint16_t>()
-            && detail::is_one_of<ReductionOp, cub::Min, cub::Max, cub::Sum/*, std::plus<T>*/>();
+            && detail::is_one_of<ReductionOp,::cuda::minimum<>, ::cuda::maximum<>, ::cuda::std::plus<>/*, std::plus<T>*/>();
 }
 // clang-format on
 

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -240,7 +240,7 @@ struct Int2Type
  *     temp_storage_bytes,
  *     d_in,
  *     d_out,
- *     cub::Sum(),
+ *     cuda::std::plus<>{},
  *     init_value,
  *     num_items);
  * allocator.DeviceFree(d_intermediate_result);

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -145,7 +145,8 @@ struct WarpScanShfl
    * @param[in] offset
    *   Up-offset to pull from
    */
-  _CCCL_DEVICE _CCCL_FORCEINLINE int InclusiveScanStep(int input, cub::Sum /*scan_op*/, int first_lane, int offset)
+  _CCCL_DEVICE _CCCL_FORCEINLINE int
+  InclusiveScanStep(int input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     int output;
     int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
@@ -181,7 +182,7 @@ struct WarpScanShfl
    *   Up-offset to pull from
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int
-  InclusiveScanStep(unsigned int input, cub::Sum /*scan_op*/, int first_lane, int offset)
+  InclusiveScanStep(unsigned int input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     unsigned int output;
     int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
@@ -216,7 +217,8 @@ struct WarpScanShfl
    * @param[in] offset
    *   Up-offset to pull from
    */
-  _CCCL_DEVICE _CCCL_FORCEINLINE float InclusiveScanStep(float input, cub::Sum /*scan_op*/, int first_lane, int offset)
+  _CCCL_DEVICE _CCCL_FORCEINLINE float
+  InclusiveScanStep(float input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     float output;
     int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
@@ -252,7 +254,7 @@ struct WarpScanShfl
    *   Up-offset to pull from
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE unsigned long long
-  InclusiveScanStep(unsigned long long input, cub::Sum /*scan_op*/, int first_lane, int offset)
+  InclusiveScanStep(unsigned long long input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     unsigned long long output;
     int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
@@ -293,7 +295,7 @@ struct WarpScanShfl
    *   Up-offset to pull from
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE long long
-  InclusiveScanStep(long long input, cub::Sum /*scan_op*/, int first_lane, int offset)
+  InclusiveScanStep(long long input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     long long output;
     int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
@@ -333,7 +335,8 @@ struct WarpScanShfl
    * @param[in] offset
    *   Up-offset to pull from
    */
-  _CCCL_DEVICE _CCCL_FORCEINLINE double InclusiveScanStep(double input, cub::Sum /*scan_op*/, int first_lane, int offset)
+  _CCCL_DEVICE _CCCL_FORCEINLINE double
+  InclusiveScanStep(double input, ::cuda::std::plus<> /*scan_op*/, int first_lane, int offset)
   {
     double output;
     int shfl_c = first_lane | SHFL_C; // Shuffle control (mask and first-lane)
@@ -359,25 +362,26 @@ struct WarpScanShfl
   }
 
   /*
-      /// Inclusive prefix scan (specialized for ReduceBySegmentOp<cub::Sum> across KeyValuePair<OffsetT, Value> types)
-      template <typename Value, typename OffsetT>
-      _CCCL_DEVICE _CCCL_FORCEINLINE KeyValuePair<OffsetT, Value>InclusiveScanStep(
-          KeyValuePair<OffsetT, Value>    input,              ///< [in] Calling thread's input item.
-          ReduceBySegmentOp<cub::Sum>     scan_op,            ///< [in] Binary scan operator
-          int                             first_lane,         ///< [in] Index of first lane in segment
-          int                             offset)             ///< [in] Up-offset to pull from
-      {
-          KeyValuePair<OffsetT, Value> output;
+  /// Inclusive prefix scan (specialized for ReduceBySegmentOp<::cuda::std::plus<>> across KeyValuePair<OffsetT, Value>
+  /// types)
+  template <typename Value, typename OffsetT>
+  _CCCL_DEVICE _CCCL_FORCEINLINE KeyValuePair<OffsetT, Value> InclusiveScanStep(
+    KeyValuePair<OffsetT, Value> input, ///< [in] Calling thread's input item.
+    ReduceBySegmentOp<::cuda::std::plus<>> scan_op, ///< [in] Binary scan operator
+    int first_lane, ///< [in] Index of first lane in segment
+    int offset) ///< [in] Up-offset to pull from
+  {
+    KeyValuePair<OffsetT, Value> output;
+    output.value = InclusiveScanStep(
+      input.value, ::cuda::std::plus<>{}, first_lane, offset, Int2Type<IntegerTraits<Value>::IS_SMALL_UNSIGNED>());
+    output.key = InclusiveScanStep(
+      input.key, ::cuda::std::plus<>{}, first_lane, offset, Int2Type<IntegerTraits<OffsetT>::IS_SMALL_UNSIGNED>());
 
-          output.value = InclusiveScanStep(input.value, cub::Sum(), first_lane, offset,
-     Int2Type<IntegerTraits<Value>::IS_SMALL_UNSIGNED>()); output.key = InclusiveScanStep(input.key, cub::Sum(),
-     first_lane, offset, Int2Type<IntegerTraits<OffsetT>::IS_SMALL_UNSIGNED>());
+    if (input.key > 0)
+      output.value = input.value;
 
-          if (input.key > 0)
-              output.value = input.value;
-
-          return output;
-      }
+    return output;
+  }
   */
 
   /**
@@ -611,7 +615,7 @@ struct WarpScanShfl
    *        integer types)
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE void
-  Update(T input, T& inclusive, T& exclusive, cub::Sum /*scan_op*/, Int2Type<true> /*is_integer*/)
+  Update(T input, T& inclusive, T& exclusive, ::cuda::std::plus<> /*scan_op*/, Int2Type<true> /*is_integer*/)
   {
     // initial value presumed 0
     exclusive = inclusive - input;
@@ -638,8 +642,8 @@ struct WarpScanShfl
    * @brief Update inclusive and exclusive using initial value using input and inclusive
    *        (specialized for summation of integer types)
    */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  Update(T input, T& inclusive, T& exclusive, cub::Sum scan_op, T initial_value, Int2Type<true> /*is_integer*/)
+  _CCCL_DEVICE _CCCL_FORCEINLINE void Update(
+    T input, T& inclusive, T& exclusive, ::cuda::std::plus<> scan_op, T initial_value, Int2Type<true> /*is_integer*/)
   {
     inclusive = scan_op(initial_value, inclusive);
     exclusive = inclusive - input;

--- a/cub/cub/warp/specializations/warp_scan_smem.cuh
+++ b/cub/cub/warp/specializations/warp_scan_smem.cuh
@@ -165,7 +165,8 @@ struct WarpScanSmem
    * @param[in]
    *   Marker type indicating whether T is primitive type
    */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveScan(T input, T& output, Sum scan_op, Int2Type<true> /*is_primitive*/)
+  _CCCL_DEVICE _CCCL_FORCEINLINE void
+  InclusiveScan(T input, T& output, ::cuda::std::plus<> scan_op, Int2Type<true> /*is_primitive*/)
   {
     T identity = 0;
     ThreadStore<STORE_VOLATILE>(&temp_storage[lane_id], (CellT) identity);
@@ -316,7 +317,7 @@ struct WarpScanSmem
    *        integer types)
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE void
-  Update(T input, T& inclusive, T& exclusive, cub::Sum /*scan_op*/, Int2Type<true> /*is_integer*/)
+  Update(T input, T& inclusive, T& exclusive, ::cuda::std::plus<> /*scan_op*/, Int2Type<true> /*is_integer*/)
   {
     // initial value presumed 0
     exclusive = inclusive - input;
@@ -346,8 +347,8 @@ struct WarpScanSmem
    * @brief Update inclusive and exclusive using initial value using input and inclusive
    *        (specialized for summation of integer types)
    */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  Update(T input, T& inclusive, T& exclusive, cub::Sum scan_op, T initial_value, Int2Type<true> /*is_integer*/)
+  _CCCL_DEVICE _CCCL_FORCEINLINE void Update(
+    T input, T& inclusive, T& exclusive, ::cuda::std::plus<> scan_op, T initial_value, Int2Type<true> /*is_integer*/)
   {
     inclusive = scan_op(initial_value, inclusive);
     exclusive = inclusive - input;
@@ -373,8 +374,13 @@ struct WarpScanSmem
    * @brief Update inclusive, exclusive, and warp aggregate using input and inclusive (specialized
    *        for summation of integer types)
    */
-  _CCCL_DEVICE _CCCL_FORCEINLINE void
-  Update(T input, T& inclusive, T& exclusive, T& warp_aggregate, cub::Sum /*scan_o*/, Int2Type<true> /*is_integer*/)
+  _CCCL_DEVICE _CCCL_FORCEINLINE void Update(
+    T input,
+    T& inclusive,
+    T& exclusive,
+    T& warp_aggregate,
+    ::cuda::std::plus<> /*scan_o*/,
+    Int2Type<true> /*is_integer*/)
   {
     // Initial value presumed to be unknown or identity (either way our padding is correct)
     ThreadStore<STORE_VOLATILE>(&temp_storage[HALF_WARP_THREADS + lane_id], (CellT) inclusive);

--- a/cub/cub/warp/warp_reduce.cuh
+++ b/cub/cub/warp/warp_reduce.cuh
@@ -256,7 +256,7 @@ public:
   //! @param[in] input Calling thread's input
   _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T input)
   {
-    return InternalWarpReduce(temp_storage).template Reduce<true>(input, LOGICAL_WARP_THREADS, cub::Sum());
+    return InternalWarpReduce(temp_storage).template Reduce<true>(input, LOGICAL_WARP_THREADS, ::cuda::std::plus<>{});
   }
 
   //! @rst
@@ -309,7 +309,7 @@ public:
   _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(T input, int valid_items)
   {
     // Determine if we don't need bounds checking
-    return InternalWarpReduce(temp_storage).template Reduce<false>(input, valid_items, cub::Sum());
+    return InternalWarpReduce(temp_storage).template Reduce<false>(input, valid_items, ::cuda::std::plus<>{});
   }
 
   //! @rst
@@ -363,7 +363,7 @@ public:
   template <typename FlagT>
   _CCCL_DEVICE _CCCL_FORCEINLINE T HeadSegmentedSum(T input, FlagT head_flag)
   {
-    return HeadSegmentedReduce(input, head_flag, cub::Sum());
+    return HeadSegmentedReduce(input, head_flag, ::cuda::std::plus<>{});
   }
 
   //! @rst
@@ -417,7 +417,7 @@ public:
   template <typename FlagT>
   _CCCL_DEVICE _CCCL_FORCEINLINE T TailSegmentedSum(T input, FlagT tail_flag)
   {
-    return TailSegmentedReduce(input, tail_flag, cub::Sum());
+    return TailSegmentedReduce(input, tail_flag, ::cuda::std::plus<>{});
   }
 
   //! @}  end member group
@@ -456,7 +456,7 @@ public:
   //!        // Return the warp-wide reductions to each lane0
   //!        int warp_id = threadIdx.x / 32;
   //!        int aggregate = WarpReduce(temp_storage[warp_id]).Reduce(
-  //!            thread_data, cub::Max());
+  //!            thread_data, cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{0, 1, 2, 3, ..., 127}``. The corresponding output ``aggregate`` in threads 0, 32, 64, and
@@ -515,7 +515,7 @@ public:
   //!
   //!        // Return the warp-wide reductions to each lane0
   //!        int aggregate = WarpReduce(temp_storage).Reduce(
-  //!            thread_data, cub::Max(), valid_items);
+  //!            thread_data, cuda::maximum<>{}, valid_items);
   //!
   //! Suppose the input ``d_data`` is ``{0, 1, 2, 3, 4, ... }`` and ``valid_items``
   //! is ``4``. The corresponding output ``aggregate`` in thread0 is ``3`` (and is
@@ -574,7 +574,7 @@ public:
   //!
   //!        // Return the warp-wide reductions to each lane0
   //!        int aggregate = WarpReduce(temp_storage).HeadSegmentedReduce(
-  //!            thread_data, head_flag, cub::Max());
+  //!            thread_data, head_flag, cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` and ``head_flag`` across the block of threads
   //! is ``{0, 1, 2, 3, ..., 31}`` and is ``{1, 0, 0, 0, 1, 0, 0, 0, ..., 1, 0, 0, 0}``,
@@ -633,7 +633,7 @@ public:
   //!
   //!        // Return the warp-wide reductions to each lane0
   //!        int aggregate = WarpReduce(temp_storage).TailSegmentedReduce(
-  //!            thread_data, tail_flag, cub::Max());
+  //!            thread_data, tail_flag, cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` and ``tail_flag`` across the block of threads
   //! is ``{0, 1, 2, 3, ..., 31}`` and is ``{0, 0, 0, 1, 0, 0, 0, 1, ..., 0, 0, 0, 1}``,

--- a/cub/cub/warp/warp_scan.cuh
+++ b/cub/cub/warp/warp_scan.cuh
@@ -261,7 +261,7 @@ public:
   //!   Calling thread's output item. May be aliased with `input`.
   _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveSum(T input, T& inclusive_output)
   {
-    InclusiveScan(input, inclusive_output, cub::Sum());
+    InclusiveScan(input, inclusive_output, ::cuda::std::plus<>{});
   }
 
   //! @rst
@@ -314,7 +314,7 @@ public:
   //!   Warp-wide aggregate reduction of input items
   _CCCL_DEVICE _CCCL_FORCEINLINE void InclusiveSum(T input, T& inclusive_output, T& warp_aggregate)
   {
-    InclusiveScan(input, inclusive_output, cub::Sum(), warp_aggregate);
+    InclusiveScan(input, inclusive_output, ::cuda::std::plus<>{}, warp_aggregate);
   }
 
   //! @}  end member group
@@ -366,7 +366,7 @@ public:
   _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveSum(T input, T& exclusive_output)
   {
     T initial_value{};
-    ExclusiveScan(input, exclusive_output, initial_value, cub::Sum());
+    ExclusiveScan(input, exclusive_output, initial_value, ::cuda::std::plus<>{});
   }
 
   //! @rst
@@ -423,7 +423,7 @@ public:
   _CCCL_DEVICE _CCCL_FORCEINLINE void ExclusiveSum(T input, T& exclusive_output, T& warp_aggregate)
   {
     T initial_value{};
-    ExclusiveScan(input, exclusive_output, initial_value, cub::Sum(), warp_aggregate);
+    ExclusiveScan(input, exclusive_output, initial_value, ::cuda::std::plus<>{}, warp_aggregate);
   }
 
   //! @}  end member group
@@ -459,7 +459,7 @@ public:
   //!
   //!        // Compute inclusive warp-wide prefix max scans
   //!        int warp_id = threadIdx.x / 32;
-  //!        WarpScan(temp_storage[warp_id]).InclusiveScan(thread_data, thread_data, cub::Max());
+  //!        WarpScan(temp_storage[warp_id]).InclusiveScan(thread_data, thread_data, cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
@@ -568,7 +568,7 @@ public:
   //!        int warp_aggregate;
   //!        int warp_id = threadIdx.x / 32;
   //!        WarpScan(temp_storage[warp_id]).InclusiveScan(
-  //!            thread_data, thread_data, cub::Max(), warp_aggregate);
+  //!            thread_data, thread_data, cuda::maximum<>{}, warp_aggregate);
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
@@ -693,7 +693,7 @@ public:
   //!
   //!        // Compute exclusive warp-wide prefix max scans
   //!        int warp_id = threadIdx.x / 32;
-  //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, thread_data, cub::Max());
+  //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, thread_data, cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
@@ -757,7 +757,7 @@ public:
   //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data,
   //!                                                      thread_data,
   //!                                                      INT_MIN,
-  //!                                                      cub::Max());
+  //!                                                      cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
@@ -825,7 +825,7 @@ public:
   //!        int warp_id = threadIdx.x / 32;
   //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data,
   //!                                                      thread_data,
-  //!                                                      cub::Max(),
+  //!                                                      cuda::maximum<>{},
   //!                                                      warp_aggregate);
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
@@ -896,7 +896,7 @@ public:
   //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data,
   //!                                                      thread_data,
   //!                                                      INT_MIN,
-  //!                                                      cub::Max(),
+  //!                                                      cuda::maximum<>{},
   //!                                                      warp_aggregate);
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
@@ -975,7 +975,7 @@ public:
   //!        WarpScan(temp_storage[warp_id]).Scan(thread_data,
   //!                                             inclusive_partial,
   //!                                             exclusive_partial,
-  //!                                             cub::Max());
+  //!                                             cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``inclusive_partial`` in the
@@ -1045,7 +1045,7 @@ public:
   //!                                             inclusive_partial,
   //!                                             exclusive_partial,
   //!                                             INT_MIN,
-  //!                                             cub::Max());
+  //!                                             cuda::maximum<>{});
   //!
   //! Suppose the set of input ``thread_data`` across the block of threads is
   //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``inclusive_partial`` in the

--- a/cub/examples/device/example_device_decoupled_look_back.cu
+++ b/cub/examples/device/example_device_decoupled_look_back.cu
@@ -40,7 +40,7 @@ __global__ void init_kernel(ScanTileStateT tile_state, int blocks_in_grid)
 template <class MessageT>
 __global__ void decoupled_look_back_kernel(cub::ScanTileState<MessageT> tile_state)
 {
-  using scan_op_t         = cub::Sum;
+  using scan_op_t         = ::cuda::std::plus<>;
   using scan_tile_state_t = cub::ScanTileState<MessageT>;
   using tile_prefix_op    = cub::TilePrefixCallbackOp<MessageT, scan_op_t, scan_tile_state_t>;
   using temp_storage_t    = typename tile_prefix_op::TempStorage;

--- a/cub/test/catch2_test_block_reduce.cu
+++ b/cub/test/catch2_test_block_reduce.cu
@@ -109,7 +109,7 @@ struct max_partial_tile_op_t
   template <int ItemsPerThread, class BlockReduceT, class T>
   __device__ T operator()(BlockReduceT& reduce, T (&thread_data)[ItemsPerThread], int valid_items) const
   {
-    return reduce.Reduce(thread_data[0], cub::Max{}, valid_items);
+    return reduce.Reduce(thread_data[0], ::cuda::maximum<>{}, valid_items);
   }
 };
 
@@ -118,7 +118,7 @@ struct max_full_tile_op_t
   template <int ItemsPerThread, class BlockReduceT, class T>
   __device__ T operator()(BlockReduceT& reduce, T (&thread_data)[ItemsPerThread], int /* valid_items */) const
   {
-    return reduce.Reduce(thread_data, cub::Max{});
+    return reduce.Reduce(thread_data, ::cuda::maximum<>{});
   }
 };
 

--- a/cub/test/catch2_test_block_scan.cu
+++ b/cub/test/catch2_test_block_scan.cu
@@ -118,11 +118,11 @@ struct min_init_value_op_t
   {
     _CCCL_IF_CONSTEXPR (Mode == scan_mode::exclusive)
     {
-      scan.ExclusiveScan(thread_data, thread_data, initial_value, cub::Min{});
+      scan.ExclusiveScan(thread_data, thread_data, initial_value, ::cuda::minimum<>{});
     }
     else
     {
-      scan.InclusiveScan(thread_data, thread_data, initial_value, cub::Min{});
+      scan.InclusiveScan(thread_data, thread_data, initial_value, ::cuda::minimum<>{});
     }
   }
 };
@@ -135,11 +135,11 @@ struct min_op_t
   {
     if (Mode == scan_mode::exclusive)
     {
-      scan.ExclusiveScan(thread_data, thread_data, cub::Min{});
+      scan.ExclusiveScan(thread_data, thread_data, ::cuda::minimum<>{});
     }
     else
     {
-      scan.InclusiveScan(thread_data, thread_data, cub::Min{});
+      scan.InclusiveScan(thread_data, thread_data, ::cuda::minimum<>{});
     }
   }
 };
@@ -158,11 +158,11 @@ struct min_init_value_aggregate_op_t
 
     _CCCL_IF_CONSTEXPR (Mode == scan_mode::exclusive)
     {
-      scan.ExclusiveScan(thread_data, thread_data, initial_value, cub::Min{}, block_aggregate);
+      scan.ExclusiveScan(thread_data, thread_data, initial_value, ::cuda::minimum<>{}, block_aggregate);
     }
     else
     {
-      scan.InclusiveScan(thread_data, thread_data, initial_value, cub::Min{}, block_aggregate);
+      scan.InclusiveScan(thread_data, thread_data, initial_value, ::cuda::minimum<>{}, block_aggregate);
     }
 
     const int tid = cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z);
@@ -262,7 +262,7 @@ struct min_prefix_op_t
     __device__ T operator()(T block_aggregate)
     {
       T retval = (linear_tid == 0) ? prefix : min_identity;
-      prefix   = cub::Min{}(prefix, block_aggregate);
+      prefix   = ::cuda::minimum<>{}(prefix, block_aggregate);
       return retval;
     }
   };
@@ -275,11 +275,11 @@ struct min_prefix_op_t
 
     if (Mode == scan_mode::exclusive)
     {
-      scan.ExclusiveScan(thread_data, thread_data, cub::Min{}, prefix_op);
+      scan.ExclusiveScan(thread_data, thread_data, ::cuda::minimum<>{}, prefix_op);
     }
     else
     {
-      scan.InclusiveScan(thread_data, thread_data, cub::Min{}, prefix_op);
+      scan.InclusiveScan(thread_data, thread_data, ::cuda::minimum<>{}, prefix_op);
     }
   }
 };

--- a/cub/test/catch2_test_block_scan_api.cu
+++ b/cub/test/catch2_test_block_scan_api.cu
@@ -56,7 +56,7 @@ __global__ void InclusiveBlockScanKernel(int* output)
   //  input: {[0, -1], [2, -3],[4, -5], ... [126, -127]}
 
   // Collectively compute the block-wide inclusive scan max
-  block_scan_t(temp_storage).InclusiveScan(thread_data, thread_data, initial_value, cub::Max());
+  block_scan_t(temp_storage).InclusiveScan(thread_data, thread_data, initial_value, ::cuda::maximum<>{});
 
   // output: {[1, 1], [2, 2],[3, 3], ... [126, 126]}
   // ...
@@ -107,7 +107,8 @@ __global__ void InclusiveBlockScanKernelAggregate(int* output, int* d_block_aggr
 
   // Collectively compute the block-wide inclusive scan max
   int block_aggregate;
-  block_scan_t(temp_storage).InclusiveScan(thread_data, thread_data, initial_value, cub::Max(), block_aggregate);
+  block_scan_t(temp_storage)
+    .InclusiveScan(thread_data, thread_data, initial_value, ::cuda::maximum<>{}, block_aggregate);
 
   // output: {[1, 1], [2, 2],[3, 3], ... [126, 126]}
   // block_aggregate = 126;

--- a/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
@@ -61,7 +61,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft can run with empty input", "[de
   constexpr int num_items = 0;
   c2h::device_vector<type> in(num_items);
 
-  adjacent_difference_subtract_left(in.begin(), num_items, cub::Difference{});
+  adjacent_difference_subtract_left(in.begin(), num_items, ::cuda::std::minus<>{});
 }
 
 C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can run with empty input", "[device][adjacent_difference]", types)
@@ -72,7 +72,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy can run with empty input", 
   c2h::device_vector<type> in(num_items);
   c2h::device_vector<type> out(num_items);
 
-  adjacent_difference_subtract_left_copy(in.begin(), out.begin(), num_items, cub::Difference{});
+  adjacent_difference_subtract_left_copy(in.begin(), out.begin(), num_items, ::cuda::std::minus<>{});
 }
 
 C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy does not change the input", "[device][adjacent_difference]", types)
@@ -84,7 +84,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy does not change the input",
   c2h::gen(C2H_SEED(2), in);
 
   c2h::device_vector<type> reference = in;
-  adjacent_difference_subtract_left_copy(in.begin(), thrust::discard_iterator<>(), num_items, cub::Difference{});
+  adjacent_difference_subtract_left_copy(in.begin(), thrust::discard_iterator<>(), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == in);
 }
@@ -101,7 +101,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with iterators", "[device
   c2h::host_vector<type> reference(num_items);
   std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
 
-  adjacent_difference_subtract_left(in.begin(), num_items, cub::Difference{});
+  adjacent_difference_subtract_left(in.begin(), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == in);
 }
@@ -119,7 +119,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with iterators", "[de
   c2h::host_vector<type> reference(num_items);
   std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
 
-  adjacent_difference_subtract_left_copy(in.begin(), out.begin(), num_items, cub::Difference{});
+  adjacent_difference_subtract_left_copy(in.begin(), out.begin(), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == out);
 }
@@ -136,7 +136,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeft works with pointers", "[device]
   c2h::host_vector<type> reference(num_items);
   std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
 
-  adjacent_difference_subtract_left(thrust::raw_pointer_cast(in.data()), num_items, cub::Difference{});
+  adjacent_difference_subtract_left(thrust::raw_pointer_cast(in.data()), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == in);
 }
@@ -155,7 +155,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with pointers", "[dev
   std::adjacent_difference(h_in.begin(), h_in.end(), reference.begin(), std::minus<type>{});
 
   adjacent_difference_subtract_left_copy(
-    thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), num_items, cub::Difference{});
+    thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == out);
 }

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -61,7 +61,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight can run with empty input", "[d
   constexpr int num_items = 0;
   c2h::device_vector<type> in(num_items);
 
-  adjacent_difference_subtract_right(in.begin(), num_items, cub::Difference{});
+  adjacent_difference_subtract_right(in.begin(), num_items, ::cuda::std::minus<>{});
 }
 
 C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy can run with empty input", "[device][adjacent_difference]", types)
@@ -72,7 +72,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy can run with empty input",
   c2h::device_vector<type> in(num_items);
   c2h::device_vector<type> out(num_items);
 
-  adjacent_difference_subtract_right_copy(in.begin(), out.begin(), num_items, cub::Difference{});
+  adjacent_difference_subtract_right_copy(in.begin(), out.begin(), num_items, ::cuda::std::minus<>{});
 }
 
 C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy does not change the input", "[device][adjacent_difference]", types)
@@ -84,7 +84,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy does not change the input"
   c2h::gen(C2H_SEED(2), in);
 
   c2h::device_vector<type> reference = in;
-  adjacent_difference_subtract_right_copy(in.begin(), thrust::discard_iterator<>(), num_items, cub::Difference{});
+  adjacent_difference_subtract_right_copy(in.begin(), thrust::discard_iterator<>(), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == in);
 }
@@ -129,7 +129,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight works with iterators", "[devic
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 
-  adjacent_difference_subtract_right(in.begin(), num_items, cub::Difference{});
+  adjacent_difference_subtract_right(in.begin(), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == in);
 }
@@ -149,7 +149,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with iterators", "[d
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 
-  adjacent_difference_subtract_right_copy(in.begin(), out.begin(), num_items, cub::Difference{});
+  adjacent_difference_subtract_right_copy(in.begin(), out.begin(), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == out);
 }
@@ -168,7 +168,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRight works with pointers", "[device
   std::rotate(reference.begin(), reference.begin() + 1, reference.end());
   reference.back() = h_in.back();
 
-  adjacent_difference_subtract_right(thrust::raw_pointer_cast(in.data()), num_items, cub::Difference{});
+  adjacent_difference_subtract_right(thrust::raw_pointer_cast(in.data()), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == in);
 }
@@ -189,7 +189,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy works with pointers", "[de
   reference.back() = h_in.back();
 
   adjacent_difference_subtract_right_copy(
-    thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), num_items, cub::Difference{});
+    thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), num_items, ::cuda::std::minus<>{});
 
   REQUIRE(reference == out);
 }

--- a/cub/test/catch2_test_device_decoupled_look_back.cu
+++ b/cub/test/catch2_test_device_decoupled_look_back.cu
@@ -44,7 +44,7 @@ __global__ void init_kernel(ScanTileStateT tile_state, int blocks_in_grid)
 template <class MessageT>
 __global__ void decoupled_look_back_kernel(cub::ScanTileState<MessageT> tile_state, MessageT* tile_data)
 {
-  using scan_op_t         = cub::Sum;
+  using scan_op_t         = ::cuda::std::plus<>;
   using scan_tile_state_t = cub::ScanTileState<MessageT>;
   using tile_prefix_op    = cub::TilePrefixCallbackOp<MessageT, scan_op_t, scan_tile_state_t>;
   using temp_storage_t    = typename tile_prefix_op::TempStorage;

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -130,7 +130,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
 #if TEST_TYPES != 4
   SECTION("reduce")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Binary reduction operator
     auto reduction_op = unwrap_op(reference_extended_fp(d_in_it), op_t{});
@@ -156,7 +156,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
 #if TEST_TYPES != 3
   SECTION("sum")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, item_t, output_t>;
 
     // Prepare verification data

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -33,6 +33,9 @@
 
 #include <thrust/iterator/constant_iterator.h>
 
+#include <cuda/__functional/maximum.h>
+#include <cuda/__functional/minimum.h>
+
 #include <iostream>
 #include <numeric>
 #include <type_traits>
@@ -43,18 +46,35 @@
 #include <c2h/test_util_vec.cuh>
 #include <nv/target>
 
-CUB_NAMESPACE_BEGIN
-
 #if TEST_HALF_T
 // Half support is provided by SM53+. We currently test against a few older architectures.
 // The specializations below can be removed once we drop these architectures.
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
 template <>
-__host__ __device__ __forceinline__ //
-  __half
-  Min::operator()(__half& a, __half& b) const
+_LIBCUDACXX_HIDE_FROM_ABI __half minimum<void>::operator()<__half, __half>(const __half& a, const __half& b) const
 {
+#  if defined(__CUDA_NO_HALF_OPERATORS__)
+  return CUB_MIN(__half2float(a), __half2float(b));
+#  else // ^^^ __CUDA_NO_HALF_OPERATORS__ ^^^ / vvv !__CUDA_NO_HALF_OPERATORS__ vvv
   NV_IF_TARGET(NV_PROVIDES_SM_53, (return CUB_MIN(a, b);), (return CUB_MIN(__half2float(a), __half2float(b));));
+#  endif // !__CUDA_NO_HALF_OPERATORS__
 }
+
+template <>
+_LIBCUDACXX_HIDE_FROM_ABI __half maximum<void>::operator()<__half, __half>(const __half& a, const __half& b) const
+{
+#  if defined(__CUDA_NO_HALF_OPERATORS__)
+  return CUB_MAX(__half2float(a), __half2float(b));
+#  else // ^^^ __CUDA_NO_HALF_OPERATORS__ ^^^ / vvv !__CUDA_NO_HALF_OPERATORS__ vvv
+  NV_IF_TARGET(NV_PROVIDES_SM_53, (return CUB_MAX(a, b);), (return CUB_MAX(__half2float(a), __half2float(b));));
+#  endif // !__CUDA_NO_HALF_OPERATORS__
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+CUB_NAMESPACE_BEGIN
 
 template <>
 __host__ __device__ __forceinline__ //
@@ -70,14 +90,6 @@ __host__ __device__ __forceinline__ //
   }
 
   return a;
-}
-
-template <>
-__host__ __device__ __forceinline__ //
-  __half
-  Max::operator()(__half& a, __half& b) const
-{
-  NV_IF_TARGET(NV_PROVIDES_SM_53, (return CUB_MAX(a, b);), (return CUB_MAX(__half2float(a), __half2float(b));));
 }
 
 template <>
@@ -225,7 +237,7 @@ std::integral_constant<bool, !std::is_same<WrappedItT, ItT>::value> //
   return {};
 }
 
-inline ExtendedFloatSum unwrap_op(std::true_type /* extended float */, cub::Sum) //
+inline ExtendedFloatSum unwrap_op(std::true_type /* extended float */, ::cuda::std::plus<>) //
 {
   return {};
 }

--- a/cub/test/catch2_test_device_reduce_by_key.cu
+++ b/cub/test/catch2_test_device_reduce_by_key.cu
@@ -110,7 +110,7 @@ C2H_TEST("Device reduce-by-key works", "[by_key][reduce][device]", full_type_lis
 
   SECTION("sum")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Binary reduction operator
     auto reduction_op = unwrap_op(reference_extended_fp(d_values_it), op_t{});
@@ -144,7 +144,7 @@ C2H_TEST("Device reduce-by-key works", "[by_key][reduce][device]", full_type_lis
 
   SECTION("min")
   {
-    using op_t = cub::Min;
+    using op_t = ::cuda::minimum<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_segments);

--- a/cub/test/catch2_test_device_reduce_by_key_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_by_key_iterators.cu
@@ -87,7 +87,7 @@ C2H_TEST("Device reduce-by-key works with iterators", "[by_key][reduce][device]"
   init_default_constant(default_constant);
   auto value_it = thrust::make_constant_iterator(default_constant);
 
-  using op_t = cub::Sum;
+  using op_t = ::cuda::std::plus<>;
 
   // Prepare verification data
   using accum_t = ::cuda::std::__accumulator_t<op_t, value_t, output_t>;

--- a/cub/test/catch2_test_device_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_reduce_iterators.cu
@@ -97,7 +97,7 @@ C2H_TEST("Device reduce works with fancy input iterators", "[reduce][device]", i
   init_default_constant(default_constant);
   auto in_it = thrust::make_constant_iterator(default_constant);
 
-  using op_t   = cub::Sum;
+  using op_t   = ::cuda::std::plus<>;
   using init_t = output_t;
 
   // Binary reduction operator
@@ -136,7 +136,7 @@ C2H_TEST("Device reduce compiles with discard output iterator", "[reduce][device
   init_default_constant(default_constant);
   auto in_it = thrust::make_constant_iterator(default_constant);
 
-  using op_t   = cub::Sum;
+  using op_t   = ::cuda::std::plus<>;
   using init_t = output_t;
 
   // Binary reduction operator

--- a/cub/test/catch2_test_device_run_length_encode_non_trivial_runs.cu
+++ b/cub/test/catch2_test_device_run_length_encode_non_trivial_runs.cu
@@ -285,7 +285,7 @@ struct CustomDeviceRunLengthEncode
     cudaStream_t stream = 0)
   {
     using OffsetT    = int; // Signed integer type for global offsets
-    using EqualityOp = cub::Equality; // Default == operator
+    using EqualityOp = ::cuda::std::equal_to<>; // Default == operator
 
     return cub::DeviceRleDispatch<InputIteratorT,
                                   OffsetsOutputIteratorT,

--- a/cub/test/catch2_test_device_scan.cu
+++ b/cub/test/catch2_test_device_scan.cu
@@ -126,7 +126,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
 #if TEST_TYPES != 3
   SECTION("inclusive sum")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Prepare verification data
@@ -154,7 +154,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
 
   SECTION("exclusive sum")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Prepare verification data
@@ -183,7 +183,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
 
   SECTION("inclusive scan")
   {
-    using op_t    = cub::Min;
+    using op_t    = ::cuda::minimum<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Prepare verification data
@@ -212,7 +212,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
 
   SECTION("inclusive scan with init value")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Scan operator
@@ -247,7 +247,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
 
   SECTION("exclusive scan")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Scan operator
@@ -280,7 +280,7 @@ C2H_TEST("Device scan works with all device interfaces", "[scan][device]", full_
 
   SECTION("exclusive scan with future-init value")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Scan operator

--- a/cub/test/catch2_test_device_scan.cuh
+++ b/cub/test/catch2_test_device_scan.cuh
@@ -36,7 +36,10 @@
  * @brief Helper class template to facilitate specifying input/output type pairs along with the key
  * type for *-by-key algorithms, and an equality operator type.
  */
-template <typename InputT, typename OutputT = InputT, typename KeyT = std::int32_t, typename EqualityOpT = cub::Equality>
+template <typename InputT,
+          typename OutputT     = InputT,
+          typename KeyT        = std::int32_t,
+          typename EqualityOpT = ::cuda::std::equal_to<>>
 struct type_quad
 {
   using input_t  = InputT;

--- a/cub/test/catch2_test_device_scan_api.cu
+++ b/cub/test/catch2_test_device_scan_api.cu
@@ -42,7 +42,7 @@ C2H_TEST("Device inclusive scan works", "[scan][device]")
   size_t temp_storage_bytes{};
 
   cub::DeviceScan::InclusiveScanInit(
-    nullptr, temp_storage_bytes, input.begin(), out.begin(), cub::Max{}, init, static_cast<int>(input.size()));
+    nullptr, temp_storage_bytes, input.begin(), out.begin(), ::cuda::maximum<>{}, init, static_cast<int>(input.size()));
 
   // Allocate temporary storage for inclusive scan
   thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
@@ -53,7 +53,7 @@ C2H_TEST("Device inclusive scan works", "[scan][device]")
     temp_storage_bytes,
     input.begin(),
     out.begin(),
-    cub::Max{},
+    ::cuda::maximum<>{},
     init,
     static_cast<int>(input.size()));
 

--- a/cub/test/catch2_test_device_scan_by_key.cu
+++ b/cub/test/catch2_test_device_scan_by_key.cu
@@ -56,7 +56,7 @@ using custom_t =
                      c2h::lexicographical_greater_comparable_t>;
 
 // type_quad's parameters and defaults:
-// type_quad<value_in_t, value_out_t=value_in_t, key_t=int32_t, equality_op_t=cub::Equality>
+// type_quad<value_in_t, value_out_t=value_in_t, key_t=int32_t, equality_op_t=::cuda::std::equal_to<>>
 #if TEST_TYPES == 0
 using full_type_list = c2h::type_list<type_quad<std::uint8_t, std::int32_t, float>,
                                       type_quad<std::int8_t, std::int8_t, std::int32_t, Mod2Equality>>;
@@ -125,7 +125,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
 #if TEST_TYPES != 3
   SECTION("inclusive sum")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
@@ -155,7 +155,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
 
   SECTION("exclusive sum")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
@@ -187,7 +187,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
 
   SECTION("inclusive scan")
   {
-    using op_t = cub::Min;
+    using op_t = ::cuda::minimum<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
@@ -219,7 +219,7 @@ C2H_TEST("Device scan works with all device interfaces", "[by_key][scan][device]
 
   SECTION("exclusive scan")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Scan operator
     auto scan_op = unwrap_op(reference_extended_fp(d_values_it), op_t{});
@@ -307,15 +307,16 @@ C2H_TEST("Device scan works when memory for keys and results alias one another",
 
   SECTION("inclusive sum")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
-    compute_inclusive_scan_by_key_reference(in_values, segment_keys, expected_result.begin(), op_t{}, cub::Equality{});
+    compute_inclusive_scan_by_key_reference(
+      in_values, segment_keys, expected_result.begin(), op_t{}, ::cuda::std::equal_to<>{});
 
     // Run test
     auto d_values_out_it = d_keys_it;
-    device_inclusive_sum_by_key(d_keys_it, d_values_it, d_values_out_it, num_items, cub::Equality{});
+    device_inclusive_sum_by_key(d_keys_it, d_values_it, d_values_out_it, num_items, ::cuda::std::equal_to<>{});
 
     // Verify result
     REQUIRE(expected_result == segment_keys);
@@ -323,16 +324,16 @@ C2H_TEST("Device scan works when memory for keys and results alias one another",
 
   SECTION("exclusive sum")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
     compute_exclusive_scan_by_key_reference(
-      in_values, segment_keys, expected_result.begin(), op_t{}, cub::Equality{}, output_t{});
+      in_values, segment_keys, expected_result.begin(), op_t{}, ::cuda::std::equal_to<>{}, output_t{});
 
     // Run test
     auto d_values_out_it = d_keys_it;
-    device_exclusive_sum_by_key(d_keys_it, d_values_it, d_values_out_it, num_items, cub::Equality{});
+    device_exclusive_sum_by_key(d_keys_it, d_values_it, d_values_out_it, num_items, ::cuda::std::equal_to<>{});
 
     // Verify result
     REQUIRE(expected_result == segment_keys);
@@ -340,15 +341,16 @@ C2H_TEST("Device scan works when memory for keys and results alias one another",
 
   SECTION("inclusive scan")
   {
-    using op_t = cub::Min;
+    using op_t = ::cuda::minimum<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
-    compute_inclusive_scan_by_key_reference(in_values, segment_keys, expected_result.begin(), op_t{}, cub::Equality{});
+    compute_inclusive_scan_by_key_reference(
+      in_values, segment_keys, expected_result.begin(), op_t{}, ::cuda::std::equal_to<>{});
 
     // Run test
     auto d_values_out_it = d_keys_it;
-    device_inclusive_scan_by_key(d_keys_it, d_values_it, d_values_out_it, op_t{}, num_items, cub::Equality{});
+    device_inclusive_scan_by_key(d_keys_it, d_values_it, d_values_out_it, op_t{}, num_items, ::cuda::std::equal_to<>{});
 
     // Verify result
     REQUIRE(expected_result == segment_keys);
@@ -356,7 +358,7 @@ C2H_TEST("Device scan works when memory for keys and results alias one another",
 
   SECTION("exclusive scan")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Scan operator
     auto scan_op = op_t{};
@@ -364,12 +366,13 @@ C2H_TEST("Device scan works when memory for keys and results alias one another",
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
     compute_exclusive_scan_by_key_reference(
-      in_values, segment_keys, expected_result.begin(), scan_op, cub::Equality{}, output_t{});
+      in_values, segment_keys, expected_result.begin(), scan_op, ::cuda::std::equal_to<>{}, output_t{});
 
     // Run test
     auto d_values_out_it = d_keys_it;
     using init_t         = value_t;
-    device_exclusive_scan_by_key(d_keys_it, d_values_it, d_values_out_it, scan_op, init_t{}, num_items, cub::Equality{});
+    device_exclusive_scan_by_key(
+      d_keys_it, d_values_it, d_values_out_it, scan_op, init_t{}, num_items, ::cuda::std::equal_to<>{});
 
     // Verify result
     REQUIRE(expected_result == segment_keys);

--- a/cub/test/catch2_test_device_scan_by_key_iterators.cu
+++ b/cub/test/catch2_test_device_scan_by_key_iterators.cu
@@ -55,7 +55,7 @@ using custom_t =
                      c2h::lexicographical_greater_comparable_t>;
 
 // type_quad's parameters and defaults:
-// type_quad<value_in_t, value_out_t=value_in_t, key_t=int32_t, equality_op_t=cub::Equality>
+// type_quad<value_in_t, value_out_t=value_in_t, key_t=int32_t, equality_op_t=::cuda::std::equal_to<>>
 #if TEST_TYPES == 0
 using full_type_list = c2h::type_list<type_quad<std::uint8_t, std::int32_t, float>,
                                       type_quad<std::int8_t, std::int8_t, std::int32_t, Mod2Equality>>;
@@ -122,7 +122,7 @@ C2H_TEST("Device scan works with fancy iterators", "[by_key][scan][device]", ful
 
   SECTION("inclusive sum")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
@@ -139,7 +139,7 @@ C2H_TEST("Device scan works with fancy iterators", "[by_key][scan][device]", ful
 
   SECTION("exclusive sum")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
@@ -156,7 +156,7 @@ C2H_TEST("Device scan works with fancy iterators", "[by_key][scan][device]", ful
 
   SECTION("inclusive scan")
   {
-    using op_t = cub::Min;
+    using op_t = ::cuda::minimum<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_items);
@@ -173,7 +173,7 @@ C2H_TEST("Device scan works with fancy iterators", "[by_key][scan][device]", ful
 
   SECTION("exclusive scan")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Scan operator
     auto scan_op = op_t{};

--- a/cub/test/catch2_test_device_scan_by_key_large_offsets.cu
+++ b/cub/test/catch2_test_device_scan_by_key_large_offsets.cu
@@ -97,7 +97,7 @@ struct div_op
 C2H_TEST("DeviceScan::ScanByKey works for very large number of items", "[by_key][scan][device]", offset_types)
 try
 {
-  using op_t     = cub::Sum;
+  using op_t     = ::cuda::std::plus<>;
   using item_t   = std::uint32_t;
   using key_t    = std::uint64_t;
   using index_t  = std::uint64_t;
@@ -130,7 +130,8 @@ try
   {
     constexpr bool is_exclusive = true;
     auto initial_value          = item_t{42};
-    device_exclusive_scan_by_key(keys_it, items_it, d_items_out_it, op_t{}, initial_value, num_items, cub::Equality{});
+    device_exclusive_scan_by_key(
+      keys_it, items_it, d_items_out_it, op_t{}, initial_value, num_items, ::cuda::std::equal_to<>{});
 
     // Ensure that we created the correct output
     auto expected_out_it = thrust::make_transform_iterator(
@@ -142,7 +143,7 @@ try
   {
     constexpr bool is_exclusive = false;
     auto initial_value          = item_t{0};
-    device_inclusive_scan_by_key(keys_it, items_it, d_items_out_it, op_t{}, num_items, cub::Equality{});
+    device_inclusive_scan_by_key(keys_it, items_it, d_items_out_it, op_t{}, num_items, ::cuda::std::equal_to<>{});
 
     // Ensure that we created the correct output
     auto expected_out_it = thrust::make_transform_iterator(

--- a/cub/test/catch2_test_device_scan_iterators.cu
+++ b/cub/test/catch2_test_device_scan_iterators.cu
@@ -83,7 +83,7 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
 
   SECTION("inclusive sum")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Prepare verification data
@@ -101,7 +101,7 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
 
   SECTION("exclusive sum")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Prepare verification data
@@ -119,7 +119,7 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
 
   SECTION("inclusive scan")
   {
-    using op_t    = cub::Min;
+    using op_t    = ::cuda::minimum<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Prepare verification data
@@ -138,7 +138,7 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
 
   SECTION("exclusive scan")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Prepare verification data
@@ -156,7 +156,7 @@ C2H_TEST("Device scan works with iterators", "[scan][device]", iterator_type_lis
 
   SECTION("exclusive scan with future-init value")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, input_t>;
 
     // Prepare verification data
@@ -303,7 +303,7 @@ C2H_TEST("Device scan works complex accumulator types", "[scan][device]")
 
   auto d_in_it  = thrust::raw_pointer_cast(d_input.data());
   auto d_out_it = thrust::raw_pointer_cast(d_output.data());
-  device_exclusive_scan(d_in_it, d_out_it, cub::Sum{}, init, num_items);
+  device_exclusive_scan(d_in_it, d_out_it, ::cuda::std::plus<>{}, init, num_items);
 
   REQUIRE(d_ok_count[0] == num_items);
 }

--- a/cub/test/catch2_test_device_scan_large_offsets.cu
+++ b/cub/test/catch2_test_device_scan_large_offsets.cu
@@ -73,7 +73,7 @@ struct mod_op
 C2H_TEST("DeviceScan works for very large number of items", "[scan][device]", offset_types)
 try
 {
-  using op_t     = cub::Sum;
+  using op_t     = ::cuda::std::plus<>;
   using item_t   = std::uint32_t;
   using index_t  = std::uint64_t;
   using offset_t = typename c2h::get<0, TestType>;

--- a/cub/test/catch2_test_device_segmented_reduce.cu
+++ b/cub/test/catch2_test_device_segmented_reduce.cu
@@ -115,7 +115,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][
 
   SECTION("reduce")
   {
-    using op_t = cub::Sum;
+    using op_t = ::cuda::std::plus<>;
 
     // Binary reduction operator
     auto reduction_op = unwrap_op(reference_extended_fp(d_in_it), op_t{});
@@ -141,7 +141,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][
 #if TEST_TYPES != 3
   SECTION("sum")
   {
-    using op_t    = cub::Sum;
+    using op_t    = ::cuda::std::plus<>;
     using accum_t = ::cuda::std::__accumulator_t<op_t, input_t, output_t>;
 
     // Prepare verification data
@@ -160,7 +160,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][
 
   SECTION("min")
   {
-    using op_t = cub::Min;
+    using op_t = ::cuda::minimum<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_segments);
@@ -178,7 +178,7 @@ C2H_TEST("Device reduce works with all device interfaces", "[segmented][reduce][
 
   SECTION("max")
   {
-    using op_t = cub::Max;
+    using op_t = ::cuda::maximum<>;
 
     // Prepare verification data
     c2h::host_vector<output_t> expected_result(num_segments);

--- a/cub/test/catch2_test_device_segmented_reduce_iterators.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_iterators.cu
@@ -86,7 +86,7 @@ C2H_TEST("Device segmented reduce works with fancy input iterators", "[reduce][d
   init_default_constant(default_constant);
   auto in_it = thrust::make_constant_iterator(default_constant);
 
-  using op_t   = cub::Sum;
+  using op_t   = ::cuda::std::plus<>;
   using init_t = output_t;
 
   // Binary reduction operator

--- a/cub/test/catch2_test_device_segmented_reduce_iterators_64bit.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_iterators_64bit.cu
@@ -49,7 +49,7 @@ using offsets = c2h::type_list<std::ptrdiff_t, std::size_t>;
 C2H_TEST("Device segmented reduce works with fancy input iterators and 64-bit offsets", "[reduce][device]", offsets)
 {
   using offset_t = typename c2h::get<0, TestType>;
-  using op_t     = cub::Sum;
+  using op_t     = ::cuda::std::plus<>;
 
   constexpr offset_t offset_zero           = 0;
   constexpr offset_t offset_one            = 1;

--- a/cub/test/catch2_test_device_select_unique_by_key.cu
+++ b/cub/test/catch2_test_device_select_unique_by_key.cu
@@ -280,7 +280,8 @@ C2H_TEST("DeviceSelect::UniqueByKey works with iterators", "[device][select_uniq
   c2h::host_vector<val_type> reference_vals = vals_in;
   const auto zip_begin                      = thrust::make_zip_iterator(reference_keys.begin(), reference_vals.begin());
   const auto zip_end                        = thrust::make_zip_iterator(reference_keys.end(), reference_vals.end());
-  const auto boundary = std::unique(zip_begin, zip_end, project_first<cub::Equality>{cub::Equality{}});
+  const auto boundary =
+    std::unique(zip_begin, zip_end, project_first<::cuda::std::equal_to<>>{::cuda::std::equal_to<>{}});
   REQUIRE((boundary - zip_begin) == num_selected_out[0]);
 
   keys_out.resize(num_selected_out[0]);
@@ -321,7 +322,8 @@ C2H_TEST("DeviceSelect::UniqueByKey works with pointers", "[device][select_uniqu
   c2h::host_vector<val_type> reference_vals = vals_in;
   const auto zip_begin                      = thrust::make_zip_iterator(reference_keys.begin(), reference_vals.begin());
   const auto zip_end                        = thrust::make_zip_iterator(reference_keys.end(), reference_vals.end());
-  const auto boundary = std::unique(zip_begin, zip_end, project_first<cub::Equality>{cub::Equality{}});
+  const auto boundary =
+    std::unique(zip_begin, zip_end, project_first<::cuda::std::equal_to<>>{::cuda::std::equal_to<>{}});
   REQUIRE((boundary - zip_begin) == num_selected_out[0]);
 
   keys_out.resize(num_selected_out[0]);
@@ -377,7 +379,8 @@ C2H_TEST("DeviceSelect::UniqueByKey works with a different output type", "[devic
   c2h::host_vector<val_type> reference_vals = vals_in;
   const auto zip_begin                      = thrust::make_zip_iterator(reference_keys.begin(), reference_vals.begin());
   const auto zip_end                        = thrust::make_zip_iterator(reference_keys.end(), reference_vals.end());
-  const auto boundary = std::unique(zip_begin, zip_end, project_first<cub::Equality>{cub::Equality{}});
+  const auto boundary =
+    std::unique(zip_begin, zip_end, project_first<::cuda::std::equal_to<>>{::cuda::std::equal_to<>{}});
   REQUIRE((boundary - zip_begin) == num_selected_out[0]);
 
   keys_out.resize(num_selected_out[0]);
@@ -423,7 +426,8 @@ C2H_TEST("DeviceSelect::UniqueByKey works and uses vsmem for large types",
 
   const auto zip_begin = thrust::make_zip_iterator(reference_keys.begin(), reference_vals.begin());
   const auto zip_end   = thrust::make_zip_iterator(reference_keys.end(), reference_vals.end());
-  const auto boundary  = std::unique(zip_begin, zip_end, project_first<cub::Equality>{cub::Equality{}});
+  const auto boundary =
+    std::unique(zip_begin, zip_end, project_first<::cuda::std::equal_to<>>{::cuda::std::equal_to<>{}});
   REQUIRE((boundary - zip_begin) == num_selected_out[0]);
 
   keys_out.resize(num_selected_out[0]);

--- a/cub/test/catch2_test_device_transform_reduce.cu
+++ b/cub/test/catch2_test_device_transform_reduce.cu
@@ -58,7 +58,7 @@ C2H_TEST("Device transform reduce works with pointers", "[reduce][device]", type
   using item_t         = c2h::get<0, TestType>;
   using init_t         = item_t;
   using offset_t       = std::int32_t;
-  using reduction_op_t = cub::Sum;
+  using reduction_op_t = ::cuda::std::plus<>;
   using transform_op_t = square_t<item_t>;
 
   constexpr int max_items = 5000000;
@@ -105,7 +105,7 @@ C2H_TEST("Device transform reduce works with iterators", "[reduce][device]", typ
   using item_t         = c2h::get<0, TestType>;
   using init_t         = item_t;
   using offset_t       = std::int32_t;
-  using reduction_op_t = cub::Sum;
+  using reduction_op_t = ::cuda::std::plus<>;
   using transform_op_t = square_t<item_t>;
 
   constexpr int max_items = 5000000;

--- a/cub/test/catch2_test_thread_operators.cu
+++ b/cub/test/catch2_test_thread_operators.cu
@@ -81,49 +81,12 @@ public:
     }                                                  \
   }
 
-//                  NAME  RT    OP  CONVERTABLE
 CUSTOM_TYPE_FACTORY(Eq, bool, ==, false);
-CUSTOM_TYPE_FACTORY(Ineq, bool, !=, false);
-CUSTOM_TYPE_FACTORY(Sum, int, +, false);
-CUSTOM_TYPE_FACTORY(Diff, int, -, false);
-CUSTOM_TYPE_FACTORY(Div, int, /, false);
-CUSTOM_TYPE_FACTORY(Gt, bool, >, true);
-CUSTOM_TYPE_FACTORY(Lt, bool, <, true);
-
-C2H_TEST("Equality", "[thread_operator]")
-{
-  cub::Equality op{};
-
-  constexpr int const_magic_val = 42;
-  int magic_val                 = const_magic_val;
-
-  CHECK(op(const_magic_val, const_magic_val) == true);
-  CHECK(op(const_magic_val, magic_val) == true);
-  CHECK(op(const_magic_val, magic_val + 1) == false);
-
-  CHECK(op(Make<CustomEqT>(magic_val), magic_val) == true);
-  CHECK(op(Make<CustomEqT>(magic_val), magic_val + 1) == false);
-}
-
-C2H_TEST("Inequality", "[thread_operator]")
-{
-  cub::Inequality op{};
-
-  constexpr int const_magic_val = 42;
-  int magic_val                 = const_magic_val;
-
-  CHECK(op(const_magic_val, const_magic_val) == false);
-  CHECK(op(const_magic_val, magic_val) == false);
-  CHECK(op(const_magic_val, magic_val + 1) == true);
-
-  CHECK(op(Make<CustomIneqT>(magic_val), magic_val) == false);
-  CHECK(op(Make<CustomIneqT>(magic_val), magic_val + 1) == true);
-}
 
 C2H_TEST("InequalityWrapper", "[thread_operator]")
 {
-  cub::Equality wrapped_op{};
-  cub::InequalityWrapper<cub::Equality> op{wrapped_op};
+  ::cuda::std::equal_to<> wrapped_op{};
+  cub::InequalityWrapper<::cuda::std::equal_to<>> op{wrapped_op};
 
   constexpr int const_magic_val = 42;
   int magic_val                 = const_magic_val;
@@ -134,116 +97,4 @@ C2H_TEST("InequalityWrapper", "[thread_operator]")
 
   CHECK(op(Make<CustomEqT>(magic_val), magic_val) == false);
   CHECK(op(Make<CustomEqT>(magic_val), magic_val + 1) == true);
-}
-
-#define CUSTOM_SYNC_T(NAME, RT, OP)               \
-  struct Custom##NAME##Sink                       \
-  {                                               \
-    template <class T>                            \
-    __host__ __device__ RT operator OP(T&&) const \
-    {                                             \
-      return RT{};                                \
-    }                                             \
-  }
-
-CUSTOM_SYNC_T(SumInt, int, +);
-CUSTOM_SYNC_T(SumCustomInt, CustomSumIntSink, +);
-
-CUSTOM_SYNC_T(DiffInt, int, -);
-CUSTOM_SYNC_T(DiffCustomInt, CustomDiffIntSink, -);
-
-CUSTOM_SYNC_T(DivInt, int, /);
-CUSTOM_SYNC_T(DivCustomInt, CustomDivIntSink, /);
-
-template <class ExpectedT, class ActualT>
-void StaticSame()
-{
-  STATIC_REQUIRE(std::is_same<ExpectedT, ActualT>::value);
-}
-
-C2H_TEST("Sum", "[thread_operator]")
-{
-  cub::Sum op{};
-
-  constexpr int const_magic_val = 40;
-  int magic_val                 = const_magic_val;
-
-  CHECK(op(const_magic_val, 2) == 42);
-  CHECK(op(magic_val, 2) == 42);
-  CHECK(op(Make<CustomSumT>(magic_val), 2) == 42);
-
-  StaticSame<decltype(op(42, 42)), int>();
-  StaticSame<decltype(op(1, 1.0)), double>();
-  StaticSame<decltype(op(CustomSumIntSink{}, 1.0)), int>();
-  StaticSame<decltype(op(CustomSumCustomIntSink{}, 1.0)), CustomSumIntSink>();
-}
-
-C2H_TEST("Difference", "[thread_operator]")
-{
-  cub::Difference op{};
-
-  constexpr int const_magic_val = 44;
-  int magic_val                 = const_magic_val;
-
-  CHECK(op(const_magic_val, 2) == 42);
-  CHECK(op(magic_val, 2) == 42);
-
-  CHECK(op(Make<CustomDiffT>(magic_val), 2) == 42);
-
-  StaticSame<decltype(op(42, 42)), int>();
-  StaticSame<decltype(op(1, 1.0)), double>();
-  StaticSame<decltype(op(CustomDiffIntSink{}, 1.0)), int>();
-  StaticSame<decltype(op(CustomDiffCustomIntSink{}, 1.0)), CustomDiffIntSink>();
-}
-
-C2H_TEST("Division", "[thread_operator]")
-{
-  cub::Division op{};
-
-  constexpr int const_magic_val = 44;
-  int magic_val                 = const_magic_val;
-
-  CHECK(op(const_magic_val, 2) == 22);
-  CHECK(op(magic_val, 2) == 22);
-
-  CHECK(op(Make<CustomDivT>(magic_val), 2) == 22);
-
-  StaticSame<decltype(op(42, 42)), int>();
-  StaticSame<decltype(op(1, 1.0)), double>();
-  StaticSame<decltype(op(CustomDivIntSink{}, 1.0)), int>();
-  StaticSame<decltype(op(CustomDivCustomIntSink{}, 1.0)), CustomDivIntSink>();
-}
-
-C2H_TEST("Max", "[thread_operator]")
-{
-  cub::Max op{};
-
-  constexpr int const_magic_val = 42;
-  int magic_val                 = const_magic_val;
-
-  CHECK(op(const_magic_val, 2) == 42);
-  CHECK(op(magic_val, 2) == 42);
-
-  CHECK(op(2, Make<CustomGtT>(magic_val)) == 42);
-
-  StaticSame<decltype(op(42, 42)), int>();
-  StaticSame<decltype(op(1, 1.0)), double>();
-  StaticSame<decltype(op(1, Make<CustomGtT>(magic_val))), int>();
-}
-
-C2H_TEST("Min", "[thread_operator]")
-{
-  cub::Min op{};
-
-  constexpr int const_magic_val = 42;
-  int magic_val                 = const_magic_val;
-
-  CHECK(op(const_magic_val, 2) == 2);
-  CHECK(op(magic_val, 2) == 2);
-
-  CHECK(op(2, Make<CustomLtT>(magic_val)) == 2);
-
-  StaticSame<decltype(op(42, 42)), int>();
-  StaticSame<decltype(op(1, 1.0)), double>();
-  StaticSame<decltype(op(1, Make<CustomLtT>(magic_val))), int>();
 }

--- a/cub/test/catch2_test_warp_reduce.cu
+++ b/cub/test/catch2_test_warp_reduce.cu
@@ -373,7 +373,7 @@ C2H_TEST("Warp reduce works", "[reduce][warp]", builtin_type_list, logical_warp_
 {
   using params   = params_t<TestType>;
   using type     = typename params::type;
-  using red_op_t = cub::Min;
+  using red_op_t = ::cuda::minimum<>;
 
   // Prepare test data
   c2h::device_vector<type> d_in(params::tile_size);
@@ -438,7 +438,7 @@ C2H_TEST("Warp reduce on partial warp works", "[reduce][warp]", builtin_type_lis
 {
   using params   = params_t<TestType>;
   using type     = typename params::type;
-  using red_op_t = cub::Min;
+  using red_op_t = ::cuda::minimum<>;
 
   // Prepare test data
   c2h::device_vector<type> d_in(params::tile_size);
@@ -515,7 +515,7 @@ C2H_TEST("Warp segmented reduction works", "[reduce][warp]", builtin_type_list, 
 {
   using params   = params_t<TestType>;
   using type     = typename params::type;
-  using red_op_t = cub::Min;
+  using red_op_t = ::cuda::minimum<>;
 
   constexpr auto segmented_mod = c2h::get<2, TestType>::value;
   static_assert(segmented_mod == reduce_mode::tail_flags || segmented_mod == reduce_mode::head_flags,

--- a/cub/test/catch2_test_warp_scan.cu
+++ b/cub/test/catch2_test_warp_scan.cu
@@ -160,11 +160,11 @@ struct min_op_t
   {
     _CCCL_IF_CONSTEXPR (Mode == scan_mode::exclusive)
     {
-      scan.ExclusiveScan(thread_data, thread_data, cub::Min{});
+      scan.ExclusiveScan(thread_data, thread_data, ::cuda::minimum<>{});
     }
     else
     {
-      scan.InclusiveScan(thread_data, thread_data, cub::Min{});
+      scan.InclusiveScan(thread_data, thread_data, ::cuda::minimum<>{});
     }
   }
 };
@@ -182,11 +182,11 @@ struct min_aggregate_op_t
 
     _CCCL_IF_CONSTEXPR (Mode == scan_mode::exclusive)
     {
-      scan.ExclusiveScan(thread_data, thread_data, cub::Min{}, warp_aggregate);
+      scan.ExclusiveScan(thread_data, thread_data, ::cuda::minimum<>{}, warp_aggregate);
     }
     else
     {
-      scan.InclusiveScan(thread_data, thread_data, cub::Min{}, warp_aggregate);
+      scan.InclusiveScan(thread_data, thread_data, ::cuda::minimum<>{}, warp_aggregate);
     }
 
     const int tid = cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z);
@@ -207,11 +207,11 @@ struct min_init_value_op_t
   {
     _CCCL_IF_CONSTEXPR (Mode == scan_mode::exclusive)
     {
-      scan.ExclusiveScan(thread_data, thread_data, initial_value, cub::Min{});
+      scan.ExclusiveScan(thread_data, thread_data, initial_value, ::cuda::minimum<>{});
     }
     else
     {
-      scan.InclusiveScan(thread_data, thread_data, initial_value, cub::Min{});
+      scan.InclusiveScan(thread_data, thread_data, initial_value, ::cuda::minimum<>{});
     }
   }
 };
@@ -230,11 +230,11 @@ struct min_init_value_aggregate_op_t
 
     _CCCL_IF_CONSTEXPR (Mode == scan_mode::exclusive)
     {
-      scan.ExclusiveScan(thread_data, thread_data, initial_value, cub::Min{}, warp_aggregate);
+      scan.ExclusiveScan(thread_data, thread_data, initial_value, ::cuda::minimum<>{}, warp_aggregate);
     }
     else
     {
-      scan.InclusiveScan(thread_data, thread_data, initial_value, cub::Min{}, warp_aggregate);
+      scan.InclusiveScan(thread_data, thread_data, initial_value, ::cuda::minimum<>{}, warp_aggregate);
     }
 
     const int tid = cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z);
@@ -251,7 +251,7 @@ struct min_scan_op_t
   template <class T, class WarpScanT>
   __device__ void operator()(WarpScanT& scan, T& thread_data, T& inclusive_output, T& exclusive_output) const
   {
-    scan.Scan(thread_data, inclusive_output, exclusive_output, cub::Min{});
+    scan.Scan(thread_data, inclusive_output, exclusive_output, ::cuda::minimum<>{});
   }
 };
 
@@ -262,7 +262,7 @@ struct min_init_value_scan_op_t
   template <class WarpScanT>
   __device__ void operator()(WarpScanT& scan, T& thread_data, T& inclusive_output, T& exclusive_output) const
   {
-    scan.Scan(thread_data, inclusive_output, exclusive_output, initial_value, cub::Min{});
+    scan.Scan(thread_data, inclusive_output, exclusive_output, initial_value, ::cuda::minimum<>{});
   }
 };
 

--- a/cub/test/catch2_test_warp_scan_api.cu
+++ b/cub/test/catch2_test_warp_scan_api.cu
@@ -73,7 +73,7 @@ __global__ void InclusiveWarpScanKernel(int* output)
   // warp #4 input: {3, 4, 5, 6, ..., 34}
 
   // Collectively compute the warp-wide inclusive prefix max scan
-  warp_scan_t(temp_storage[warp_id]).InclusiveScan(thread_data, thread_data, initial_value, cub::Max());
+  warp_scan_t(temp_storage[warp_id]).InclusiveScan(thread_data, thread_data, initial_value, ::cuda::maximum<>{});
 
   // initial value = 3 (for each warp)
   // warp #0 output: {3, 3, 3, 3, ..., 31}
@@ -127,7 +127,8 @@ __global__ void InclusiveWarpScanKernelAggr(int* output, int* d_warp_aggregate)
   // warp #4 input: {1, 1, 1, 1, ..., 1}
 
   // Collectively compute the warp-wide inclusive prefix max scan
-  warp_scan_t(temp_storage[warp_id]).InclusiveScan(thread_data, thread_data, initial_value, cub::Sum(), warp_aggregate);
+  warp_scan_t(temp_storage[warp_id])
+    .InclusiveScan(thread_data, thread_data, initial_value, ::cuda::std::plus<>{}, warp_aggregate);
 
   // warp #1 output: {4, 5, 6, 7, ..., 35} - warp aggregate: 32
   // warp #2 output: {4, 5, 6, 7, ..., 35} - warp aggregate: 32

--- a/cub/test/test_device_segmented_reduce_offset_type_fail.cu
+++ b/cub/test/test_device_segmented_reduce_offset_type_fail.cu
@@ -41,7 +41,7 @@ int main()
 #if TEST_ERR == 0
   // expected-error {{"Offset iterator type should be integral."}}
   cub::DeviceSegmentedReduce::Reduce(
-    d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1, cub::Min(), 0);
+    d_temp_storage, temp_storage_bytes, d_in, d_out, 0, d_offsets, d_offsets + 1, ::cuda::minimum<>{}, 0);
 
 #elif TEST_ERR == 1
   // expected-error {{"Offset iterator type should be integral."}}

--- a/docs/cub/developer_overview.rst
+++ b/docs/cub/developer_overview.rst
@@ -255,7 +255,7 @@ and algorithm implementation look like:
 
     __device__ __forceinline__ T Sum(T input, int valid_items) {
       return InternalWarpReduce(temp_storage)
-          .Reduce(input, valid_items, cub::Sum());
+          .Reduce(input, valid_items, ::cuda::std::plus<>{});
     }
 
 Due to ``LEGACY_PTX_ARCH`` issues described above,
@@ -282,15 +282,15 @@ we can't specialize on the PTX version.
                               std::is_same<unsigned int, U>::value,
                               T>::type
         ReduceImpl(T input,
-                  int,      // valid_items
-                  cub::Sum) // reduction_op
+                  int,               // valid_items
+                  ::cuda::std::plus<>) // reduction_op
     {
       T output = input;
 
       NV_IF_TARGET(NV_PROVIDES_SM_80,
                   (output = __reduce_add_sync(member_mask, input);),
-                  (output = ReduceImpl<cub::Sum>(
-                        input, LOGICAL_WARP_THREADS, cub::Sum{});));
+                  (output = ReduceImpl<::cuda::std::plus<>>(
+                        input, LOGICAL_WARP_THREADS, ::cuda::std::plus<>{});));
 
       return output;
     }

--- a/thrust/thrust/system/cuda/detail/async/exclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/exclusive_scan.h
@@ -54,9 +54,6 @@
 #    include <type_traits>
 
 // TODO specialize for thrust::plus to use e.g. ExclusiveSum instead of ExcScan
-//  - Note that thrust::plus<> is transparent, cub::Sum is not. This should be
-//    fixed in CUB first).
-//  - Need to check if CUB actually optimizes for sums before putting in effort
 
 THRUST_NAMESPACE_BEGIN
 namespace system

--- a/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
@@ -54,9 +54,6 @@
 #    include <type_traits>
 
 // TODO specialize for thrust::plus to use e.g. InclusiveSum instead of IncScan
-//  - Note that thrust::plus<> is transparent, cub::Sum is not. This should be
-//    fixed in CUB first).
-//  - Need to check if CUB actually optimizes for sums before putting in effort
 
 THRUST_NAMESPACE_BEGIN
 namespace system

--- a/thrust/thrust/system/cuda/detail/set_operations.h
+++ b/thrust/thrust/system/cuda/detail/set_operations.h
@@ -318,7 +318,7 @@ struct SetOpAgent
     using BlockLoadValues1 = typename core::BlockLoad<PtxPlan, ValuesLoadIt1>::type;
     using BlockLoadValues2 = typename core::BlockLoad<PtxPlan, ValuesLoadIt2>::type;
 
-    using TilePrefixCallback = cub::TilePrefixCallbackOp<Size, cub::Sum, ScanTileState, Arch::ver>;
+    using TilePrefixCallback = cub::TilePrefixCallbackOp<Size, ::cuda::std::plus<>, ScanTileState, Arch::ver>;
 
     using BlockScan = cub::BlockScan<Size, PtxPlan::BLOCK_THREADS, PtxPlan::SCAN_ALGORITHM, 1, 1, Arch::ver>;
 
@@ -599,7 +599,7 @@ struct SetOpAgent
       }
       else
       {
-        TilePrefixCallback prefix_cb(tile_state, storage.scan_storage.prefix, cub::Sum(), tile_idx);
+        TilePrefixCallback prefix_cb(tile_state, storage.scan_storage.prefix, ::cuda::std::plus<>{}, tile_idx);
 
         BlockScan(storage.scan_storage.scan).ExclusiveSum(thread_output_count, thread_output_prefix, prefix_cb);
         tile_output_count  = prefix_cb.GetBlockAggregate();

--- a/thrust/thrust/system/cuda/detail/unique.h
+++ b/thrust/thrust/system/cuda/detail/unique.h
@@ -186,7 +186,7 @@ struct UniqueAgent
 
     using BlockDiscontinuityItems = cub::BlockDiscontinuity<item_type, PtxPlan::BLOCK_THREADS, 1, 1, Arch::ver>;
 
-    using TilePrefixCallback = cub::TilePrefixCallbackOp<Size, cub::Sum, ScanTileState, Arch::ver>;
+    using TilePrefixCallback = cub::TilePrefixCallbackOp<Size, ::cuda::std::plus<>, ScanTileState, Arch::ver>;
     using BlockScan          = cub::BlockScan<Size, PtxPlan::BLOCK_THREADS, PtxPlan::SCAN_ALGORITHM, 1, 1, Arch::ver>;
 
     using shared_items_t = core::uninitialized_array<item_type, PtxPlan::ITEMS_PER_TILE>;
@@ -353,7 +353,7 @@ struct UniqueAgent
       }
       else
       {
-        TilePrefixCallback prefix_cb(tile_state, temp_storage.scan_storage.prefix, cub::Sum(), tile_idx);
+        TilePrefixCallback prefix_cb(tile_state, temp_storage.scan_storage.prefix, ::cuda::std::plus<>{}, tile_idx);
         BlockScan(temp_storage.scan_storage.scan).ExclusiveSum(selection_flags, selection_idx, prefix_cb);
 
         num_selections        = prefix_cb.GetInclusivePrefix();


### PR DESCRIPTION
* Replace CUB thread operators by libcu++ ones where possible
* Alias cub::[Min|Max] to cuda::[minimum|maximum]
* Make aliases available in C++11
* Deprecate all CUB aliases to libcu++
* Remove obsolete unit tests