### PR TITLE
Allow `thrust::identity` to forward value category

### DIFF
--- a/thrust/thrust/iterator/detail/transform_input_output_iterator.inl
+++ b/thrust/thrust/iterator/detail/transform_input_output_iterator.inl
@@ -56,7 +56,7 @@ public:
   transform_input_output_iterator_proxy(const transform_input_output_iterator_proxy&) = default;
 
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_HOST_DEVICE operator Value const() const
+  _CCCL_HOST_DEVICE operator Value() const
   {
     return input_function(*io);
   }


### PR DESCRIPTION
This PR adds more overloads to `thrust::identity` to allow it to forward mutable references and temporary values. This is necessary for some refactorings around `thrust::transform_iterator` which will enable #2006 at some point. Also, and more importantly, it makes `thrust::identity<T>` (with non-`void` T) behave more like `cuda::std::identity`, which should replace it at some point.