### PR TITLE
Alias `cuda::std::identity` to `__identity`

### DIFF
--- a/libcudacxx/include/cuda/std/__functional/identity.h
+++ b/libcudacxx/include/cuda/std/__functional/identity.h
@@ -54,26 +54,7 @@ struct __is_identity<reference_wrapper<const __identity>> : true_type
 
 #if _CCCL_STD_VER > 2011
 
-struct identity
-{
-  template <class _Tp>
-  _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp&& operator()(_Tp&& __t) const noexcept
-  {
-    return _CUDA_VSTD::forward<_Tp>(__t);
-  }
-
-  using is_transparent = void;
-};
-
-template <>
-struct __is_identity<identity> : true_type
-{};
-template <>
-struct __is_identity<reference_wrapper<identity>> : true_type
-{};
-template <>
-struct __is_identity<reference_wrapper<const identity>> : true_type
-{};
+using identity = __identity;
 
 #endif // _CCCL_STD_VER > 2011
 


### PR DESCRIPTION
This makes both names refer to the same type. This also makes `thrust::identity<void>` refer to that same type, so any proclamations in Thrust will also apply to libcu++.

Alternatively, we could have made `cuda::std::identity` available in C++11 and replace `__identity` by it, but that would require a far bigger change.