### PR TITLE
Do not read uninitialized memory for OOB elements.

### DIFF
--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -926,7 +926,7 @@ struct ScanTileState<T, false>
     {
       value = ThreadLoad<LOAD_CG>(d_tile_partial + TILE_STATUS_PADDING + tile_idx);
     }
-    else
+    else if (status == StatusWord(SCAN_TILE_INCLUSIVE))
     {
       value = ThreadLoad<LOAD_CG>(d_tile_inclusive + TILE_STATUS_PADDING + tile_idx);
     }


### PR DESCRIPTION
When the scan status is `SCAN_TILE_OOB`, uninitialized memory was ready from `d_tile_inclusive`.

This adds a check that the status is actually `SCAN_TILE_INCLUSIVE` before reading from `d_tile_inclusive`.

Fixes #1891.