### PR TITLE
fix `cuda::std::bit_width()` return type

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -65,10 +65,10 @@ bit_ceil(_Tp __t) noexcept
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
 bit_width(_Tp __t) noexcept
 {
-  return __t == 0 ? 0 : static_cast<_Tp>(__bit_log2(__t) + 1);
+  return __t == 0 ? 0 : static_cast<int>(__bit_log2(__t) + 1);
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/test/libcudacxx/std/numerics/bit/bit.pow.two/bit_width.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/bit/bit.pow.two/bit_width.pass.cpp
@@ -45,7 +45,7 @@ __host__ __device__ constexpr bool constexpr_test()
 template <typename T>
 __host__ __device__ void runtime_test()
 {
-  ASSERT_SAME_TYPE(T, decltype(cuda::std::bit_width(T(0))));
+  ASSERT_SAME_TYPE(int, decltype(cuda::std::bit_width(T(0))));
   ASSERT_NOEXCEPT(cuda::std::bit_width(T(0)));
 
   assert(cuda::std::bit_width(T(0)) == T(0));


### PR DESCRIPTION
Fixes #2744

## Description

Fix `cuda:;std::bit_width()` return type