### PR TITLE
Start reworking our math functions

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -146,6 +146,32 @@
 #  define _CCCL_BUILTIN_EXPECT(...) __builtin_expect(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_expect)
 
+#if _CCCL_CHECK_BUILTIN(builtin_fmax) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FMAXF(...) __builtin_fmaxf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMAX(...)  __builtin_fmax(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMAXL(...) __builtin_fmaxl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fmax)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_FMAXF
+#  undef _CCCL_BUILTIN_FMAX
+#  undef _CCCL_BUILTIN_FMAXL
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_fmin) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FMINF(...) __builtin_fminf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMIN(...)  __builtin_fmin(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FMINL(...) __builtin_fminl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fmin)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_FMINF
+#  undef _CCCL_BUILTIN_FMIN
+#  undef _CCCL_BUILTIN_FMINL
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
 #if _CCCL_HAS_BUILTIN(__builtin_FILE) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_FILE() __builtin_FILE()
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_FILE) ^^^ / vvv !_CCCL_HAS_BUILTIN(__builtin_FILE) vvv
@@ -202,7 +228,7 @@
 #  define _CCCL_BUILTIN_LINE() __LINE__
 #endif // _CCCL_CUDACC_BELOW(11, 3)
 
-#if _CCCL_CHECK_BUILTIN(builtin_log) || defined(_CCCL_COMPILER_GCC)
+#if _CCCL_CHECK_BUILTIN(builtin_log) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_LOGF(...) __builtin_logf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOG(...)  __builtin_log(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOGL(...) __builtin_logl(__VA_ARGS__)
@@ -216,7 +242,7 @@
 #  undef _CCCL_BUILTIN_LOGL
 #endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER_CLANG
 
-#if _CCCL_CHECK_BUILTIN(builtin_log10) || defined(_CCCL_COMPILER_GCC)
+#if _CCCL_CHECK_BUILTIN(builtin_log10) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_LOG10F(...) __builtin_log10f(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOG10(...)  __builtin_log10(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOG10L(...) __builtin_log10l(__VA_ARGS__)
@@ -229,7 +255,7 @@
 #  undef _CCCL_BUILTIN_LOG10L
 #endif // _CCCL_CUDACC_BELOW(11, 7)
 
-#if _CCCL_CHECK_BUILTIN(builtin_ilogb) || defined(_CCCL_COMPILER_GCC)
+#if _CCCL_CHECK_BUILTIN(builtin_ilogb) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_ILOGBF(...) __builtin_ilogbf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ILOGB(...)  __builtin_ilogb(__VA_ARGS__)
 #  define _CCCL_BUILTIN_ILOGBL(...) __builtin_ilogbl(__VA_ARGS__)
@@ -243,7 +269,7 @@
 #  undef _CCCL_BUILTIN_ILOGBL
 #endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER_CLANG
 
-#if _CCCL_CHECK_BUILTIN(builtin_log1p) || defined(_CCCL_COMPILER_GCC)
+#if _CCCL_CHECK_BUILTIN(builtin_log1p) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_LOG1PF(...) __builtin_log1pf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOG1P(...)  __builtin_log1p(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOG1PL(...) __builtin_log1pl(__VA_ARGS__)
@@ -257,7 +283,7 @@
 #  undef _CCCL_BUILTIN_LOG1PL
 #endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER_CLANG
 
-#if _CCCL_CHECK_BUILTIN(builtin_log2) || defined(_CCCL_COMPILER_GCC)
+#if _CCCL_CHECK_BUILTIN(builtin_log2) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_LOG2F(...) __builtin_log2f(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOG2(...)  __builtin_log2(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOG2L(...) __builtin_log2l(__VA_ARGS__)
@@ -270,7 +296,7 @@
 #  undef _CCCL_BUILTIN_LOG2L
 #endif // _CCCL_CUDACC_BELOW(11, 7)
 
-#if _CCCL_CHECK_BUILTIN(builtin_logb) || defined(_CCCL_COMPILER_GCC)
+#if _CCCL_CHECK_BUILTIN(builtin_logb) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_LOGBF(...) __builtin_logbf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOGB(...)  __builtin_logb(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOGBL(...) __builtin_logbl(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -202,6 +202,88 @@
 #  define _CCCL_BUILTIN_LINE() __LINE__
 #endif // _CCCL_CUDACC_BELOW(11, 3)
 
+#if _CCCL_CHECK_BUILTIN(builtin_log) || defined(_CCCL_COMPILER_GCC)
+#  define _CCCL_BUILTIN_LOGF(...) __builtin_logf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG(...)  __builtin_log(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOGL(...) __builtin_logl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "logf"
+#if _CCCL_CUDACC_BELOW(11, 7) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#  undef _CCCL_BUILTIN_LOGF
+#  undef _CCCL_BUILTIN_LOG
+#  undef _CCCL_BUILTIN_LOGL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER_CLANG
+
+#if _CCCL_CHECK_BUILTIN(builtin_log10) || defined(_CCCL_COMPILER_GCC)
+#  define _CCCL_BUILTIN_LOG10F(...) __builtin_log10f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG10(...)  __builtin_log10(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG10L(...) __builtin_log10l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log10)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_LOG10F
+#  undef _CCCL_BUILTIN_LOG10
+#  undef _CCCL_BUILTIN_LOG10L
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_ilogb) || defined(_CCCL_COMPILER_GCC)
+#  define _CCCL_BUILTIN_ILOGBF(...) __builtin_ilogbf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ILOGB(...)  __builtin_ilogb(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ILOGBL(...) __builtin_ilogbl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log10)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "ilogb"
+#if _CCCL_CUDACC_BELOW(11, 7) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#  undef _CCCL_BUILTIN_ILOGBF
+#  undef _CCCL_BUILTIN_ILOGB
+#  undef _CCCL_BUILTIN_ILOGBL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER_CLANG
+
+#if _CCCL_CHECK_BUILTIN(builtin_log1p) || defined(_CCCL_COMPILER_GCC)
+#  define _CCCL_BUILTIN_LOG1PF(...) __builtin_log1pf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG1P(...)  __builtin_log1p(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG1PL(...) __builtin_log1pl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log1p)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "log1p"
+#if _CCCL_CUDACC_BELOW(11, 7) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#  undef _CCCL_BUILTIN_LOG1PF
+#  undef _CCCL_BUILTIN_LOG1P
+#  undef _CCCL_BUILTIN_LOG1PL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER_CLANG
+
+#if _CCCL_CHECK_BUILTIN(builtin_log2) || defined(_CCCL_COMPILER_GCC)
+#  define _CCCL_BUILTIN_LOG2F(...) __builtin_log2f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG2(...)  __builtin_log2(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOG2L(...) __builtin_log2l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log1)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_LOG2F
+#  undef _CCCL_BUILTIN_LOG2
+#  undef _CCCL_BUILTIN_LOG2L
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_logb) || defined(_CCCL_COMPILER_GCC)
+#  define _CCCL_BUILTIN_LOGBF(...) __builtin_logbf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOGB(...)  __builtin_logb(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LOGBL(...) __builtin_logbl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_log1)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "logb"
+#if _CCCL_CUDACC_BELOW(11, 7) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#  undef _CCCL_BUILTIN_LOGBF
+#  undef _CCCL_BUILTIN_LOGB
+#  undef _CCCL_BUILTIN_LOGBL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER_CLANG
+
 #if _CCCL_CHECK_BUILTIN(__builtin_operator_new) && _CCCL_CHECK_BUILTIN(__builtin_operator_delete) \
   && defined(_CCCL_CUDA_COMPILER_CLANG)
 #  define _CCCL_BUILTIN_OPERATOR_DELETE(...) __builtin_operator_delete(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -206,7 +206,34 @@
 #  undef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
 #endif // _CCCL_STD_VER < 2014 && _CCCL_CUDA_COMPILER_NVCC
 
-#if _CCCL_CHECK_BUILTIN(builtin_launder) || _CCCL_COMPILER(GCC, >=, 7)
+#if _CCCL_CHECK_BUILTIN(builtin_isfinite) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(NVRTC)
+#  define _CCCL_BUILTIN_ISFINITE(...) __builtin_isfinite(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(isfinite)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_ISFINITE
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_isinf) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ISINF(...) __builtin_isinf(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(isinf)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_ISINF
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_isnan) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ISNAN(...) __builtin_isnan(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(isnan)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_ISNAN
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if (_CCCL_CHECK_BUILTIN(builtin_launder) || (_CCCL_COMPILER(GCC) && _CCCL_GCC_VERSION >= 70000))
 #  define _CCCL_BUILTIN_LAUNDER(...) __builtin_launder(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_launder) && gcc >= 7
 
@@ -315,6 +342,15 @@
 #  define _CCCL_BUILTIN_OPERATOR_DELETE(...) __builtin_operator_delete(__VA_ARGS__)
 #  define _CCCL_BUILTIN_OPERATOR_NEW(...)    __builtin_operator_new(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(__builtin_operator_new) && _CCCL_CHECK_BUILTIN(__builtin_operator_delete)
+
+#if _CCCL_CHECK_BUILTIN(builtin_signbit) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SIGNBIT(...) __builtin_signbit(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_signbit)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_SIGNBIT
+#endif // _CCCL_CUDACC_BELOW(11, 7)
 
 #if _CCCL_HAS_BUILTIN(__decay) && defined(_CCCL_CUDA_COMPILER_CLANG)
 #  define _CCCL_BUILTIN_DECAY(...) __decay(__VA_ARGS__)
@@ -578,18 +614,6 @@
 #if 0 // _CCCL_HAS_BUILTIN(__is_volatile)
 #  define _CCCL_BUILTIN_IS_VOLATILE(...) __is_volatile(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__is_volatile)
-
-#if _CCCL_CHECK_BUILTIN(isfinite)
-#  define _CCCL_BUILTIN_ISFINITE(...) __builtin_isfinite(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(isfinite)
-
-#if _CCCL_CHECK_BUILTIN(isinf)
-#  define _CCCL_BUILTIN_ISINF(...) __builtin_isinf(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(isinf)
-
-#if _CCCL_CHECK_BUILTIN(isnan)
-#  define _CCCL_BUILTIN_ISNAN(...) __builtin_isnan(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(isnan)
 
 #if _CCCL_CHECK_BUILTIN(make_integer_seq) || _CCCL_COMPILER(MSVC, >=, 19, 23)
 #  define _CCCL_BUILTIN_MAKE_INTEGER_SEQ(...) __make_integer_seq<__VA_ARGS__>

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -285,7 +285,8 @@
 #endif // _CCCL_CHECK_BUILTIN(builtin_log10)
 
 // Below 11.7 nvcc treats the builtin as a host only function
-#if _CCCL_CUDACC_BELOW(11, 7)
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "log10f"
+#if _CCCL_CUDACC_BELOW(11, 7) || defined(_CCCL_CUDA_COMPILER_CLANG)
 #  undef _CCCL_BUILTIN_LOG10F
 #  undef _CCCL_BUILTIN_LOG10
 #  undef _CCCL_BUILTIN_LOG10L
@@ -326,7 +327,8 @@
 #endif // _CCCL_CHECK_BUILTIN(builtin_log1)
 
 // Below 11.7 nvcc treats the builtin as a host only function
-#if _CCCL_CUDACC_BELOW(11, 7)
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "log2f"
+#if _CCCL_CUDACC_BELOW(11, 7) || defined(_CCCL_CUDA_COMPILER_CLANG)
 #  undef _CCCL_BUILTIN_LOG2F
 #  undef _CCCL_BUILTIN_LOG2
 #  undef _CCCL_BUILTIN_LOG2L

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -184,6 +184,15 @@
 #  define _CCCL_BUILTIN_FILE() __FILE__
 #endif // _CCCL_CUDACC_BELOW(11, 3)
 
+#if _CCCL_CHECK_BUILTIN(builtin_fpclassify) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FPCLASSIFY(...) __builtin_fpclassify(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_fpclassify)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_FPCLASSIFY
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
 #if _CCCL_HAS_BUILTIN(__builtin_FUNCTION) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_FUNCTION() __builtin_FUNCTION()
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_FUNCTION) ^^^ / vvv !_CCCL_HAS_BUILTIN(__builtin_FUNCTION) vvv

--- a/libcudacxx/include/cuda/std/__cmath/common.h
+++ b/libcudacxx/include/cuda/std/__cmath/common.h
@@ -1,0 +1,40 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_COMMON_H
+#define _LIBCUDACXX___CMATH_COMMON_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// MSVC and clang cuda need the host side functions included
+#if _CCCL_COMPILER(MSVC) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#  include <math.h>
+#endif // _CCCL_COMPILER(MSVC) || _CCCL_CUDA_COMPILER_CLANG
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+#  include <cuda_fp16.h>
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-function")
+#  include <cuda_bf16.h>
+_CCCL_DIAG_POP
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+#endif // _LIBCUDACXX___CMATH_COMMON_H

--- a/libcudacxx/include/cuda/std/__cmath/fpclassify.h
+++ b/libcudacxx/include/cuda/std/__cmath/fpclassify.h
@@ -1,0 +1,189 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_FPCLASSIFY_H
+#define _LIBCUDACXX___CMATH_FPCLASSIFY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__bit/bit_cast.h>
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_extended_floating_point.h>
+#include <cuda/std/__type_traits/is_integral.h>
+
+#if _CCCL_COMPILER(NVRTC)
+#  ifndef FP_NAN
+#    define FP_NAN 0
+#  endif // ! FP_NAN
+#  ifndef FP_INFINITE
+#    define FP_INFINITE 1
+#  endif // ! FP_INFINITE
+#  ifndef FP_ZERO
+#    define FP_ZERO 2
+#  endif // ! FP_ZERO
+#  ifndef FP_SUBNORMAL
+#    define FP_SUBNORMAL 3
+#  endif // ! FP_SUBNORMAL
+#  ifndef FP_NORMAL
+#    define FP_NORMAL 4
+#  endif // ! FP_NORMAL
+#else // ^^^ _CCCL_COMPILER(NVRTC) ^^^ ^/  vvv !_CCCL_COMPILER(NVRTC) vvv
+#  include <math.h>
+#endif // !_CCCL_COMPILER(NVRTC)
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+struct _CCCL_FLOAT_BITS
+{
+#if defined(_LIBCUDACXX_LITTLE_ENDIAN)
+  unsigned int man  : 23;
+  unsigned int exp  : 8;
+  unsigned int sign : 1;
+#else // ^^^ _LIBCUDACXX_LITTLE_ENDIAN ^^^ / vvv _LIBCUDACXX_BIG_ENDIAN vvv
+  unsigned int sign : 1;
+  unsigned int exp  : 8;
+  unsigned int man  : 23;
+#endif // _LIBCUDACXX_BIG_ENDIAN
+};
+
+struct _CCCL_DOUBLE_BITS
+{
+#if defined(_LIBCUDACXX_LITTLE_ENDIAN)
+  unsigned int manl : 32;
+  unsigned int manh : 20;
+  unsigned int exp  : 11;
+  unsigned int sign : 1;
+#else // ^^^ _LIBCUDACXX_LITTLE_ENDIAN ^^^ / vvv _LIBCUDACXX_BIG_ENDIAN vvv
+  unsigned int sign : 1;
+  unsigned int exp  : 11;
+  unsigned int manh : 20;
+  unsigned int manl : 32;
+#endif // _LIBCUDACXX_BIG_ENDIAN
+};
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+struct _CCCL_HALF_BITS
+{
+#  if defined(_LIBCUDACXX_LITTLE_ENDIAN)
+  unsigned short man  : 10;
+  unsigned short exp  : 5;
+  unsigned short sign : 1;
+#  else // ^^^ _LIBCUDACXX_LITTLE_ENDIAN ^^^ / vvv _LIBCUDACXX_BIG_ENDIAN vvv
+  unsigned short sign : 1;
+  unsigned short exp  : 5;
+  unsigned short man  : 10;
+#  endif // _LIBCUDACXX_BIG_ENDIAN
+};
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+struct _CCCL_NVBFLOAT_BITS
+{
+#  if defined(_LIBCUDACXX_LITTLE_ENDIAN)
+  unsigned short man  : 7;
+  unsigned short exp  : 8;
+  unsigned short sign : 1;
+#  else // ^^^ _LIBCUDACXX_LITTLE_ENDIAN ^^^ / vvv _LIBCUDACXX_BIG_ENDIAN vvv
+  unsigned short sign : 1;
+  unsigned short exp  : 8;
+  unsigned short man  : 7;
+#  endif // _LIBCUDACXX_BIG_ENDIAN
+};
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int fpclassify(float __x) noexcept
+{
+  _CCCL_FLOAT_BITS __bits = _CUDA_VSTD::bit_cast<_CCCL_FLOAT_BITS>(__x);
+  if (__bits.exp == 0)
+  {
+    return __bits.man == 0 ? FP_ZERO : FP_SUBNORMAL;
+  }
+  if (__bits.exp == 255)
+  {
+    return __bits.man == 0 ? FP_INFINITE : FP_NAN;
+  }
+  return (FP_NORMAL);
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int fpclassify(double __x) noexcept
+{
+  _CCCL_DOUBLE_BITS __bits = _CUDA_VSTD::bit_cast<_CCCL_DOUBLE_BITS>(__x);
+  if (__bits.exp == 0)
+  {
+    return (__bits.manl | __bits.manh) == 0 ? FP_ZERO : FP_SUBNORMAL;
+  }
+  if (__bits.exp == 2047)
+  {
+    return (__bits.manl | __bits.manh) == 0 ? FP_INFINITE : FP_NAN;
+  }
+  return (FP_NORMAL);
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int fpclassify(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FPCLASSIFY)
+  return _CCCL_BUILTIN_FPCLASSIFY(FP_NAN, FP_INFINITE, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, __x);
+#  else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
+  return ::fpclassify(__x);
+#  endif // !_CCCL_BUILTIN_SIGNBIT
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int fpclassify(__half __x) noexcept
+{
+  _CCCL_HALF_BITS __bits = _CUDA_VSTD::bit_cast<_CCCL_HALF_BITS>(__x);
+  if (__bits.exp == 0)
+  {
+    return __bits.man == 0 ? FP_ZERO : FP_SUBNORMAL;
+  }
+  if (__bits.exp == 31)
+  {
+    return __bits.man == 0 ? FP_INFINITE : FP_NAN;
+  }
+  return (FP_NORMAL);
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int fpclassify(__nv_bfloat16 __x) noexcept
+{
+  _CCCL_NVBFLOAT_BITS __bits = _CUDA_VSTD::bit_cast<_CCCL_NVBFLOAT_BITS>(__x);
+  if (__bits.exp == 0)
+  {
+    return __bits.man == 0 ? FP_ZERO : FP_SUBNORMAL;
+  }
+  if (__bits.exp == 255)
+  {
+    return __bits.man == 0 ? FP_INFINITE : FP_NAN;
+  }
+  return (FP_NORMAL);
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_integral, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int fpclassify(_A1 __x) noexcept
+{
+  return (__x == 0) ? FP_ZERO : FP_NORMAL;
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_FPCLASSIFY_H

--- a/libcudacxx/include/cuda/std/__cmath/lerp.h
+++ b/libcudacxx/include/cuda/std/__cmath/lerp.h
@@ -1,0 +1,102 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_LERP_H
+#define _LIBCUDACXX___CMATH_LERP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/promote.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <typename _Fp>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Fp __lerp(_Fp __a, _Fp __b, _Fp __t) noexcept
+{
+  if ((__a <= 0 && __b >= 0) || (__a >= 0 && __b <= 0))
+  {
+    return __t * __b + (1 - __t) * __a;
+  }
+
+  if (__t == 1)
+  {
+    return __b;
+  }
+  const _Fp __x = __a + __t * (__b - __a);
+  if ((__t > 1) == (__b > __a))
+  {
+    return __b < __x ? __x : __b;
+  }
+  else
+  {
+    return __x < __b ? __x : __b;
+  }
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 float lerp(float __a, float __b, float __t) noexcept
+{
+  return _CUDA_VSTD::__lerp(__a, __b, __t);
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 double lerp(double __a, double __b, double __t) noexcept
+{
+  return _CUDA_VSTD::__lerp(__a, __b, __t);
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 long double
+lerp(long double __a, long double __b, long double __t) noexcept
+{
+  return _CUDA_VSTD::__lerp(__a, __b, __t);
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half lerp(__half __a, __half __b, __half __t) noexcept
+{
+  return __float2half(_CUDA_VSTD::__lerp(__half2float(__a), __half2float(__b), __half2float(__t)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16
+lerp(__nv_bfloat16 __a, __nv_bfloat16 __b, __nv_bfloat16 __t) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::__lerp(__bfloat162float(__a), __bfloat162float(__b), __bfloat162float(__t)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _A1, class _A2, class _A3>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14
+enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2) && _CCCL_TRAIT(is_arithmetic, _A3),
+            __promote_t<_A1, _A2, _A3>>
+lerp(_A1 __a, _A2 __b, _A3 __t) noexcept
+{
+  using __result_type = __promote_t<_A1, _A2, _A3>;
+  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)
+                  && _CCCL_TRAIT(is_same, _A3, __result_type)),
+                "");
+  return _CUDA_VSTD::__lerp((__result_type) __a, (__result_type) __b, (__result_type) __t);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_LERP_H

--- a/libcudacxx/include/cuda/std/__cmath/logarithms.h
+++ b/libcudacxx/include/cuda/std/__cmath/logarithms.h
@@ -1,0 +1,494 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_LOGARITHMS_H
+#define _LIBCUDACXX___CMATH_LOGARITHMS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/cstdint>
+
+#include <nv/target>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// log
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float log(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOGF)
+  return _CCCL_BUILTIN_LOGF(__x);
+#else // ^^^ _CCCL_BUILTIN_LOGF ^^^ / vvv !_CCCL_BUILTIN_LOGF vvv
+  return ::logf(__x);
+#endif // !_CCCL_BUILTIN_LOGF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float logf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOGF)
+  return _CCCL_BUILTIN_LOGF(__x);
+#else // ^^^ _CCCL_BUILTIN_LOGF ^^^ / vvv !_CCCL_BUILTIN_LOGF vvv
+  return ::logf(__x);
+#endif // !_CCCL_BUILTIN_LOGF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double log(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG)
+  return _CCCL_BUILTIN_LOG(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG ^^^ / vvv !_CCCL_BUILTIN_LOG vvv
+  return ::log(__x);
+#endif // !_CCCL_BUILTIN_LOG
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double log(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOGL)
+  return _CCCL_BUILTIN_LOGL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOGL ^^^ / vvv !_CCCL_BUILTIN_LOGL vvv
+  return ::logl(__x);
+#  endif // !_CCCL_BUILTIN_LOGL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double logl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOGL)
+  return _CCCL_BUILTIN_LOGL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOGL ^^^ / vvv !_CCCL_BUILTIN_LOGL vvv
+  return ::logl(__x);
+#  endif // !_CCCL_BUILTIN_LOGL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half log(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53, (return ::hlog(__x);), ({
+                      float __vf            = __half2float(__x);
+                      __vf                  = _CUDA_VSTD::logf(__vf);
+                      __half_raw __ret_repr = ::__float2half_rn(__vf);
+
+                      _CUDA_VSTD::uint16_t __repr = __half_raw(__x).x;
+                      switch (__repr)
+                      {
+                        case 7544:
+                          __ret_repr.x -= 1;
+                          break;
+
+                        default:;
+                      }
+
+                      return __ret_repr;
+                    }))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 log(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hlog(__x);), (return __float2bfloat16(_CUDA_VSTD::logf(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double log(_Integer __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG)
+  return _CCCL_BUILTIN_LOG((double) __x);
+#else // ^^^ _CCCL_BUILTIN_LOG ^^^ / vvv !_CCCL_BUILTIN_LOG vvv
+  return ::log((double) __x);
+#endif // !_CCCL_BUILTIN_LOG
+}
+
+// log10
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float log10(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG10F)
+  return _CCCL_BUILTIN_LOG10F(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG10F ^^^ / vvv !_CCCL_BUILTIN_LOG10F vvv
+  return ::log10f(__x);
+#endif // !_CCCL_BUILTIN_LOG10F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float log10f(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG10F)
+  return _CCCL_BUILTIN_LOG10F(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG10F ^^^ / vvv !_CCCL_BUILTIN_LOG10F vvv
+  return ::log10f(__x);
+#endif // !_CCCL_BUILTIN_LOG10F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double log10(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG10)
+  return _CCCL_BUILTIN_LOG10(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG10 ^^^ / vvv !_CCCL_BUILTIN_LOG10 vvv
+  return ::log10(__x);
+#endif // !_CCCL_BUILTIN_LOG10
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double log10(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOG10L)
+  return _CCCL_BUILTIN_LOG10L(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOG10L ^^^ / vvv !_CCCL_BUILTIN_LOG10L vvv
+  return ::log10l(__x);
+#  endif // !_CCCL_BUILTIN_LOG10L
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double log10l(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOG10L)
+  return _CCCL_BUILTIN_LOG10L(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOG10L ^^^ / vvv !_CCCL_BUILTIN_LOG10L vvv
+  return ::log10l(__x);
+#  endif // !_CCCL_BUILTIN_LOG10L
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half log10(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_PROVIDES_SM_53, (return ::hlog10(__x);), (return __float2half(_CUDA_VSTD::log10f(__half2float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 log10(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hlog10(__x);), (return __float2bfloat16(_CUDA_VSTD::log10f(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double log10(_Integer __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG10)
+  return _CCCL_BUILTIN_LOG10((double) __x);
+#else // ^^^ _CCCL_BUILTIN_LOG10 ^^^ / vvv !_CCCL_BUILTIN_LOG10 vvv
+  return ::log10((double) __x);
+#endif // !_CCCL_BUILTIN_LOG10
+}
+
+// ilogb
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int ilogb(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ILOGBF)
+  return _CCCL_BUILTIN_ILOGBF(__x);
+#else // ^^^ _CCCL_BUILTIN_ILOGBF ^^^ / vvv !_CCCL_BUILTIN_ILOGBF vvv
+  return ::ilogbf(__x);
+#endif // !_CCCL_BUILTIN_ILOGBF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int ilogbf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ILOGBF)
+  return _CCCL_BUILTIN_ILOGBF(__x);
+#else // ^^^ _CCCL_BUILTIN_ILOGBF ^^^ / vvv !_CCCL_BUILTIN_ILOGBF vvv
+  return ::ilogbf(__x);
+#endif // !_CCCL_BUILTIN_ILOGBF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int ilogb(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ILOGB)
+  return _CCCL_BUILTIN_ILOGB(__x);
+#else // ^^^ _CCCL_BUILTIN_ILOGB ^^^ / vvv !_CCCL_BUILTIN_ILOGB vvv
+  return ::ilogb(__x);
+#endif // !_CCCL_BUILTIN_ILOGB
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int ilogb(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ILOGBL)
+  return _CCCL_BUILTIN_ILOGBL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ILOGBL ^^^ / vvv !_CCCL_BUILTIN_ILOGBL vvv
+  return ::ilogbl(__x);
+#  endif // !_CCCL_BUILTIN_ILOGBL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int ilogbl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ILOGBL)
+  return _CCCL_BUILTIN_ILOGBL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ILOGBL ^^^ / vvv !_CCCL_BUILTIN_ILOGBL vvv
+  return ::ilogbl(__x);
+#  endif // !_CCCL_BUILTIN_ILOGBL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int ilogb(__half __x) noexcept
+{
+  return _CUDA_VSTD::ilogbf(__half2float(__x));
+}
+#endif // defined(_LIBCUDACXX_HAS_NVFP16)
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int ilogb(__nv_bfloat16 __x) noexcept
+{
+  return _CUDA_VSTD::ilogbf(__bfloat162float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI int ilogb(_Integer __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ILOGB)
+  return _CCCL_BUILTIN_ILOGB((double) __x);
+#else // ^^^ _CCCL_BUILTIN_ILOGB ^^^ / vvv !_CCCL_BUILTIN_ILOGB vvv
+  return ::ilogb((double) __x);
+#endif // !_CCCL_BUILTIN_ILOGB
+}
+
+// log1p
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float log1p(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG1PF)
+  return _CCCL_BUILTIN_LOG1PF(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG1PF ^^^ / vvv !_CCCL_BUILTIN_LOG1PF vvv
+  return ::log1pf(__x);
+#endif // !_CCCL_BUILTIN_LOG1PF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float log1pf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG1PF)
+  return _CCCL_BUILTIN_LOG1PF(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG1PF ^^^ / vvv !_CCCL_BUILTIN_LOG1PF vvv
+  return ::log1pf(__x);
+#endif // !_CCCL_BUILTIN_LOG1PF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double log1p(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG1P)
+  return _CCCL_BUILTIN_LOG1P(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG1P ^^^ / vvv !_CCCL_BUILTIN_LOG1P vvv
+  return ::log1p(__x);
+#endif // !_CCCL_BUILTIN_LOG1P
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double log1p(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOG1PL)
+  return _CCCL_BUILTIN_LOG1PL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOG1PL ^^^ / vvv !_CCCL_BUILTIN_LOG1PL vvv
+  return ::log1pl(__x);
+#  endif // !_CCCL_BUILTIN_LOG1PL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double log1pl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOG1PL)
+  return _CCCL_BUILTIN_LOG1PL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOG1PL ^^^ / vvv !_CCCL_BUILTIN_LOG1PL vvv
+  return ::log1pl(__x);
+#  endif // !_CCCL_BUILTIN_LOG1PL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half log1p(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::log1pf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 log1p(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::log1pf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double log1p(_Integer __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG1P)
+  return _CCCL_BUILTIN_LOG1P((double) __x);
+#else // ^^^ _CCCL_BUILTIN_LOG1P ^^^ / vvv !_CCCL_BUILTIN_LOG1P vvv
+  return ::log1p((double) __x);
+#endif // !_CCCL_BUILTIN_LOG1P
+}
+
+// log2
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float log2(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG2F)
+  return _CCCL_BUILTIN_LOG2F(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG2F ^^^ / vvv !_CCCL_BUILTIN_LOG2F vvv
+  return ::log2f(__x);
+#endif // !_CCCL_BUILTIN_LOG2F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float log2f(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG2F)
+  return _CCCL_BUILTIN_LOG2F(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG2F ^^^ / vvv !_CCCL_BUILTIN_LOG2F vvv
+  return ::log2f(__x);
+#endif // !_CCCL_BUILTIN_LOG2F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double log2(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG2)
+  return _CCCL_BUILTIN_LOG2(__x);
+#else // ^^^ _CCCL_BUILTIN_LOG2 ^^^ / vvv !_CCCL_BUILTIN_LOG2 vvv
+  return ::log2(__x);
+#endif // !_CCCL_BUILTIN_LOG2
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double log2(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOG2L)
+  return _CCCL_BUILTIN_LOG2L(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOG2L ^^^ / vvv !_CCCL_BUILTIN_LOG2L vvv
+  return ::log2l(__x);
+#  endif // !_CCCL_BUILTIN_LOG2L
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double log2l(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOG2L)
+  return _CCCL_BUILTIN_LOG2L(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOG2L ^^^ / vvv !_CCCL_BUILTIN_LOG2L vvv
+  return ::log2l(__x);
+#  endif // !_CCCL_BUILTIN_LOG2L
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half log2(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_PROVIDES_SM_53, (return ::hlog2(__x);), (return __float2half(_CUDA_VSTD::log2f(__half2float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 log2(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hlog2(__x);), (return __float2bfloat16(_CUDA_VSTD::log2f(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double log2(_Integer __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOG2)
+  return _CCCL_BUILTIN_LOG2((double) __x);
+#else // ^^^ _CCCL_BUILTIN_LOG2 ^^^ / vvv !_CCCL_BUILTIN_LOG2 vvv
+  return ::log2((double) __x);
+#endif // !_CCCL_BUILTIN_LOG2
+}
+
+// logb
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float logb(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOGBF)
+  return _CCCL_BUILTIN_LOGBF(__x);
+#else // ^^^ _CCCL_BUILTIN_LOGBF ^^^ / vvv !_CCCL_BUILTIN_LOGBF vvv
+  return ::logbf(__x);
+#endif // !_CCCL_BUILTIN_LOGBF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float logbf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOGBF)
+  return _CCCL_BUILTIN_LOGBF(__x);
+#else // ^^^ _CCCL_BUILTIN_LOGBF ^^^ / vvv !_CCCL_BUILTIN_LOGBF vvv
+  return ::logbf(__x);
+#endif // !_CCCL_BUILTIN_LOGBF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double logb(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOGB)
+  return _CCCL_BUILTIN_LOGB(__x);
+#else // ^^^ _CCCL_BUILTIN_LOGB ^^^ / vvv !_CCCL_BUILTIN_LOGB vvv
+  return ::logb(__x);
+#endif // !_CCCL_BUILTIN_LOGB
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double logb(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOGBL)
+  return _CCCL_BUILTIN_LOGBL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOGBL ^^^ / vvv !_CCCL_BUILTIN_LOGBL vvv
+  return ::logbl(__x);
+#  endif // !_CCCL_BUILTIN_LOGBL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double logbl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LOGBL)
+  return _CCCL_BUILTIN_LOGBL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LOGBL ^^^ / vvv !_CCCL_BUILTIN_LOGBL vvv
+  return ::logbl(__x);
+#  endif // !_CCCL_BUILTIN_LOGBL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half logb(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::logbf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 logb(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::logbf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double logb(_Integer __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LOGB)
+  return _CCCL_BUILTIN_LOGB((double) __x);
+#else // ^^^ _CCCL_BUILTIN_LOGB ^^^ / vvv !_CCCL_BUILTIN_LOGB vvv
+  return ::logb((double) __x);
+#endif // !_CCCL_BUILTIN_LOGB
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_LOGARITHMS_H

--- a/libcudacxx/include/cuda/std/__cmath/min_max.h
+++ b/libcudacxx/include/cuda/std/__cmath/min_max.h
@@ -1,0 +1,227 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_MIN_MAX_H
+#define _LIBCUDACXX___CMATH_MIN_MAX_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/promote.h>
+
+#include <nv/target>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// fmax
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float fmax(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_FMAX)
+  return _CCCL_BUILTIN_FMAXF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_FMAX ^^^ / vvv !_CCCL_BUILTIN_FMAX vvv
+  return ::fmaxf(__x, __y);
+#endif // !_CCCL_BUILTIN_FMAX
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float fmaxf(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_FMAX)
+  return _CCCL_BUILTIN_FMAXF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_FMAX ^^^ / vvv !_CCCL_BUILTIN_FMAX vvv
+  return ::fmaxf(__x, __y);
+#endif // !_CCCL_BUILTIN_FMAX
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double fmax(double __x, double __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_FMAX)
+  return _CCCL_BUILTIN_FMAX(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_FMAX ^^^ / vvv !_CCCL_BUILTIN_FMAX vvv
+  return ::fmax(__x, __y);
+#endif // !_CCCL_BUILTIN_FMAX
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double fmax(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FMAX)
+  return _CCCL_BUILTIN_FMAXL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_FMAX ^^^ / vvv !_CCCL_BUILTIN_FMAX vvv
+  return ::fmaxl(__x, __y);
+#  endif // !_CCCL_BUILTIN_FMAX
+}
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double fmaxl(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FMAX)
+  return _CCCL_BUILTIN_FMAXL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_FMAX ^^^ / vvv !_CCCL_BUILTIN_FMAX vvv
+  return ::fmaxl(__x, __y);
+#  endif // !_CCCL_BUILTIN_FMAX
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half fmax(__half __x, __half __y) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE,
+                    (return ::__hmax(__x, __y);),
+                    (return __float2half(_CUDA_VSTD::fmaxf(__half2float(__x), __half2float(__y)));))
+}
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<float, _A1> fmax(__half __x, _A1 __y) noexcept
+{
+  return _CUDA_VSTD::fmaxf(__half2float(__x), __y);
+}
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, float> fmax(_A1 __x, __half __y) noexcept
+{
+  return _CUDA_VSTD::fmaxf(__x, __half2float(__y));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 fmax(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE,
+                    (return ::__hmax(__x, __y);),
+                    (return __float2bfloat16(_CUDA_VSTD::fmaxf(__bfloat162float(__x), __bfloat162float(__y)));))
+}
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<float, _A1> fmax(__nv_bfloat16 __x, _A1 __y) noexcept
+{
+  return _CUDA_VSTD::fmaxf(__bfloat162float(__x), __y);
+}
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, float> fmax(_A1 __x, __nv_bfloat16 __y) noexcept
+{
+  return _CUDA_VSTD::fmaxf(__x, __bfloat162float(__y));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, _A2> fmax(_A1 __x, _A2 __y) noexcept
+{
+  using __result_type = __promote_t<_A1, _A2>;
+  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  return _CUDA_VSTD::fmax((__result_type) __x, (__result_type) __y);
+}
+
+// fmin
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float fmin(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_FMIN)
+  return _CCCL_BUILTIN_FMINF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_FMIN ^^^ / vvv !_CCCL_BUILTIN_FMIN vvv
+  return ::fminf(__x, __y);
+#endif // !_CCCL_BUILTIN_FMIN
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float fminf(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_FMIN)
+  return _CCCL_BUILTIN_FMINF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_FMIN ^^^ / vvv !_CCCL_BUILTIN_FMIN vvv
+  return ::fminf(__x, __y);
+#endif // !_CCCL_BUILTIN_FMIN
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double fmin(double __x, double __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_FMIN)
+  return _CCCL_BUILTIN_FMIN(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_FMIN ^^^ / vvv !_CCCL_BUILTIN_FMIN vvv
+  return ::fmin(__x, __y);
+#endif // !_CCCL_BUILTIN_FMIN
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double fmin(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FMIN)
+  return _CCCL_BUILTIN_FMINL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_FMIN ^^^ / vvv !_CCCL_BUILTIN_FMIN vvv
+  return ::fminl(__x, __y);
+#  endif // !_CCCL_BUILTIN_FMIN
+}
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double fminl(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FMIN)
+  return _CCCL_BUILTIN_FMINL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_FMIN ^^^ / vvv !_CCCL_BUILTIN_FMIN vvv
+  return ::fminl(__x, __y);
+#  endif // !_CCCL_BUILTIN_FMIN
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half fmin(__half __x, __half __y) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE,
+                    (return ::__hmin(__x, __y);),
+                    (return __float2half(_CUDA_VSTD::fminf(__half2float(__x), __half2float(__y)));))
+}
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<float, _A1> fmin(__half __x, _A1 __y) noexcept
+{
+  return _CUDA_VSTD::fminf(__half2float(__x), __y);
+}
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, float> fmin(_A1 __x, __half __y) noexcept
+{
+  return _CUDA_VSTD::fminf(__x, __half2float(__y));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 fmin(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE,
+                    (return ::__hmin(__x, __y);),
+                    (return __float2bfloat16(_CUDA_VSTD::fminf(__bfloat162float(__x), __bfloat162float(__y)));))
+}
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<float, _A1> fmin(__nv_bfloat16 __x, _A1 __y) noexcept
+{
+  return _CUDA_VSTD::fminf(__bfloat162float(__x), __y);
+}
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, float> fmin(_A1 __x, __nv_bfloat16 __y) noexcept
+{
+  return _CUDA_VSTD::fminf(__x, __bfloat162float(__y));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, _A2> fmin(_A1 __x, _A2 __y) noexcept
+{
+  using __result_type = __promote_t<_A1, _A2>;
+  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  return _CUDA_VSTD::fmin((__result_type) __x, (__result_type) __y);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_MIN_MAX_H

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _LIBCUDACXX___CUDA_CMATH_NVBF16_H
-#define _LIBCUDACXX___CUDA_CMATH_NVBF16_H
+#ifndef _LIBCUDACXX___CMATH_NVBF16_H
+#define _LIBCUDACXX___CMATH_NVBF16_H
 
 #include <cuda/std/detail/__config>
 
@@ -155,4 +155,4 @@ _LIBCUDACXX_END_NAMESPACE_STD
 
 #endif /// _LIBCUDACXX_HAS_NVBF16
 
-#endif // _LIBCUDACXX___CUDA_CMATH_NVBF16_H
+#endif // _LIBCUDACXX___CMATH_NVBF16_H

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -93,7 +93,7 @@ _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isnan(__nv_bfloat16 __x) noexcept
 
 _LIBCUDACXX_HIDE_FROM_ABI bool isnan(__nv_bfloat16 __v)
 {
-  return __constexpr_isnan(__v);
+  return _CUDA_VSTD::__constexpr_isnan(__v);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isinf(__nv_bfloat16 __x) noexcept
@@ -108,17 +108,17 @@ _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isinf(__nv_bfloat16 __x) noexcept
 
 _LIBCUDACXX_HIDE_FROM_ABI bool isinf(__nv_bfloat16 __v)
 {
-  return __constexpr_isinf(__v);
+  return _CUDA_VSTD::__constexpr_isinf(__v);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isfinite(__nv_bfloat16 __x) noexcept
 {
-  return !__constexpr_isnan(__x) && !__constexpr_isinf(__x);
+  return !_CUDA_VSTD::__constexpr_isnan(__x) && !_CUDA_VSTD::__constexpr_isinf(__x);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI bool isfinite(__nv_bfloat16 __v)
 {
-  return __constexpr_isfinite(__v);
+  return _CUDA_VSTD::__constexpr_isfinite(__v);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 __constexpr_copysign(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
@@ -128,7 +128,7 @@ _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 __constexpr_copysign(__nv_bfloat16 __x, 
 
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 copysign(__nv_bfloat16 __x, __nv_bfloat16 __y)
 {
-  return __constexpr_copysign(__x, __y);
+  return _CUDA_VSTD::__constexpr_copysign(__x, __y);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 __constexpr_fabs(__nv_bfloat16 __x) noexcept
@@ -138,12 +138,12 @@ _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 __constexpr_fabs(__nv_bfloat16 __x) noex
 
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 fabs(__nv_bfloat16 __x)
 {
-  return __constexpr_fabs(__x);
+  return _CUDA_VSTD::__constexpr_fabs(__x);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 abs(__nv_bfloat16 __x)
 {
-  return __constexpr_fabs(__x);
+  return _CUDA_VSTD::__constexpr_fabs(__x);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 __constexpr_fmax(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -76,46 +76,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 sqrt(__nv_bfloat16 __x)
 }
 
 // floating point helper
-_LIBCUDACXX_HIDE_FROM_ABI bool signbit(__nv_bfloat16 __v)
-{
-  return ::signbit(::__bfloat162float(__v));
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isnan(__nv_bfloat16 __x) noexcept
-{
-  return ::__hisnan(__x);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool isnan(__nv_bfloat16 __v)
-{
-  return _CUDA_VSTD::__constexpr_isnan(__v);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isinf(__nv_bfloat16 __x) noexcept
-{
-#  if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
-  // this is a workaround for nvbug 4362808
-  return !::__hisnan(__x) && ::__hisnan(__x - __x);
-#  else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
-  return ::__hisinf(__x) != 0;
-#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_BELOW(12, 3)
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool isinf(__nv_bfloat16 __v)
-{
-  return _CUDA_VSTD::__constexpr_isinf(__v);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isfinite(__nv_bfloat16 __x) noexcept
-{
-  return !_CUDA_VSTD::__constexpr_isnan(__x) && !_CUDA_VSTD::__constexpr_isinf(__x);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool isfinite(__nv_bfloat16 __v)
-{
-  return _CUDA_VSTD::__constexpr_isfinite(__v);
-}
-
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 __constexpr_copysign(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
 {
   return __float2bfloat16(::copysignf(__bfloat162float(__x), __bfloat162float(__y)));

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -70,11 +70,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 atan2(__nv_bfloat16 __x, __nv_bfloat16 _
   return __float2bfloat16(::atan2f(__bfloat162float(__x), __bfloat162float(__y)));
 }
 
-_LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 log(__nv_bfloat16 __x)
-{
-  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hlog(__x);), (return __float2bfloat16(::logf(__bfloat162float(__x)));))
-}
-
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 sqrt(__nv_bfloat16 __x)
 {
   NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hsqrt(__x);), (return __float2bfloat16(::sqrtf(__bfloat162float(__x)));))

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -135,33 +135,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __half atan2(__half __x, __half __y)
   return __float2half(::atan2f(__half2float(__x), __half2float(__y)));
 }
 
-// clang-format off
-_LIBCUDACXX_HIDE_FROM_ABI  __half log(__half __x)
-{
-  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53, (
-    return ::hlog(__x);
-  ), (
-    {
-      float __vf            = __half2float(__x);
-      __vf                  = ::logf(__vf);
-      __half_raw __ret_repr = ::__float2half_rn(__vf);
-
-      uint16_t __repr = __half_raw(__x).x;
-      switch (__repr)
-      {
-        case 7544:
-          __ret_repr.x -= 1;
-          break;
-
-        default:;
-      }
-
-      return __ret_repr;
-    }
-  ))
-}
-// clang-format on
-
 _LIBCUDACXX_HIDE_FROM_ABI __half sqrt(__half __x)
 {
   NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hsqrt(__x);), (return __float2half(::sqrtf(__half2float(__x)));))

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -180,7 +180,7 @@ _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isnan(__half __x) noexcept
 
 _LIBCUDACXX_HIDE_FROM_ABI bool isnan(__half __v)
 {
-  return __constexpr_isnan(__v);
+  return _CUDA_VSTD::__constexpr_isnan(__v);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isinf(__half __x) noexcept
@@ -195,17 +195,17 @@ _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isinf(__half __x) noexcept
 
 _LIBCUDACXX_HIDE_FROM_ABI bool isinf(__half __v)
 {
-  return __constexpr_isinf(__v);
+  return _CUDA_VSTD::__constexpr_isinf(__v);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isfinite(__half __x) noexcept
 {
-  return !__constexpr_isnan(__x) && !__constexpr_isinf(__x);
+  return !_CUDA_VSTD::__constexpr_isnan(__x) && !_CUDA_VSTD::__constexpr_isinf(__x);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI bool isfinite(__half __v)
 {
-  return __constexpr_isfinite(__v);
+  return _CUDA_VSTD::__constexpr_isfinite(__v);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI __half __constexpr_copysign(__half __x, __half __y) noexcept
@@ -215,7 +215,7 @@ _LIBCUDACXX_HIDE_FROM_ABI __half __constexpr_copysign(__half __x, __half __y) no
 
 _LIBCUDACXX_HIDE_FROM_ABI __half copysign(__half __x, __half __y)
 {
-  return __constexpr_copysign(__x, __y);
+  return _CUDA_VSTD::__constexpr_copysign(__x, __y);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI __half __constexpr_fabs(__half __x) noexcept
@@ -225,12 +225,12 @@ _LIBCUDACXX_HIDE_FROM_ABI __half __constexpr_fabs(__half __x) noexcept
 
 _LIBCUDACXX_HIDE_FROM_ABI __half fabs(__half __x)
 {
-  return __constexpr_fabs(__x);
+  return _CUDA_VSTD::__constexpr_fabs(__x);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI __half abs(__half __x)
 {
-  return __constexpr_fabs(__x);
+  return _CUDA_VSTD::__constexpr_fabs(__x);
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI __half __constexpr_fmax(__half __x, __half __y) noexcept

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -141,46 +141,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __half sqrt(__half __x)
 }
 
 // floating point helper
-_LIBCUDACXX_HIDE_FROM_ABI bool signbit(__half __v)
-{
-  return ::signbit(::__half2float(__v));
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isnan(__half __x) noexcept
-{
-  return ::__hisnan(__x);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool isnan(__half __v)
-{
-  return _CUDA_VSTD::__constexpr_isnan(__v);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isinf(__half __x) noexcept
-{
-#  if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
-  // this is a workaround for nvbug 4362808
-  return !::__hisnan(__x) && ::__hisnan(__x - __x);
-#  else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
-  return ::__hisinf(__x) != 0;
-#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_BELOW(12, 3)
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool isinf(__half __v)
-{
-  return _CUDA_VSTD::__constexpr_isinf(__v);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isfinite(__half __x) noexcept
-{
-  return !_CUDA_VSTD::__constexpr_isnan(__x) && !_CUDA_VSTD::__constexpr_isinf(__x);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI bool isfinite(__half __v)
-{
-  return _CUDA_VSTD::__constexpr_isfinite(__v);
-}
-
 _LIBCUDACXX_HIDE_FROM_ABI __half __constexpr_copysign(__half __x, __half __y) noexcept
 {
   return __float2half(::copysignf(__half2float(__x), __half2float(__y)));

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _LIBCUDACXX___CUDA_CMATH_NVFP16_H
-#define _LIBCUDACXX___CUDA_CMATH_NVFP16_H
+#ifndef _LIBCUDACXX___CMATH_NVFP16_H
+#define _LIBCUDACXX___CMATH_NVFP16_H
 
 #include <cuda/std/detail/__config>
 
@@ -242,4 +242,4 @@ _LIBCUDACXX_END_NAMESPACE_STD
 
 #endif /// _LIBCUDACXX_HAS_NVFP16
 
-#endif // _LIBCUDACXX___CUDA_CMATH_NVFP16_H
+#endif // _LIBCUDACXX___CMATH_NVFP16_H

--- a/libcudacxx/include/cuda/std/__cmath/traits.h
+++ b/libcudacxx/include/cuda/std/__cmath/traits.h
@@ -1,0 +1,469 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_TRAITS_H
+#define _LIBCUDACXX___CMATH_TRAITS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/is_extended_floating_point.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/promote.h>
+
+#include <nv/target>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SIGNBIT)
+  return __builtin_signbit(__x);
+#else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
+  return ::signbit(__x);
+#endif // !_CCCL_BUILTIN_SIGNBIT
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SIGNBIT)
+  return __builtin_signbit(__x);
+#else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
+  return ::signbit(__x);
+#endif // !_CCCL_BUILTIN_SIGNBIT
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SIGNBIT)
+  return __builtin_signbit(__x);
+#  else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
+  return ::signbit(__x);
+#  endif // !_CCCL_BUILTIN_SIGNBIT
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(__half __x) noexcept
+{
+  return _CUDA_VSTD::signbit(__half2float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(__nv_bfloat16 __x) noexcept
+{
+  return _CUDA_VSTD::signbit(__bfloat162float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_integral, _A1) && _CCCL_TRAIT(is_signed, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(_A1 __x) noexcept
+{
+  return __x < 0;
+}
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_integral, _A1) && !_CCCL_TRAIT(is_signed, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(_A1) noexcept
+{
+  return false;
+}
+
+// isfinite
+
+#if defined(_CCCL_BUILTIN_ISFINITE) || (defined(_CCCL_BUILTIN_ISINF) && defined(_CCCL_BUILTIN_ISNAN))
+#  define _CCCL_CONSTEXPR_ISFINITE constexpr
+#else // ^^^ _CCCL_BUILTIN_ISFINITE ^^^ / vvv !_CCCL_BUILTIN_ISFINITE vvv
+#  define _CCCL_CONSTEXPR_ISFINITE
+#endif // !_CCCL_BUILTIN_ISFINITE
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_integral, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isfinite(_A1) noexcept
+{
+  return true;
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_ISFINITE bool isfinite(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ISFINITE)
+  return _CCCL_BUILTIN_ISFINITE(__x);
+#elif _CCCL_CUDACC_BELOW(11, 8)
+  return !::__isinf(__x) && !::__isnan(__x);
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv !_CCCL_CUDACC_BELOW(11, 8) vvv
+  return ::isfinite(__x);
+#endif // !_CCCL_CUDACC_BELOW(11, 8)
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_ISFINITE bool isfinite(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ISFINITE)
+  return _CCCL_BUILTIN_ISFINITE(__x);
+#elif _CCCL_CUDACC_BELOW(11, 8)
+  return !::__isinf(__x) && !::__isnan(__x);
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv !_CCCL_CUDACC_BELOW(11, 8) vvv
+  return ::isfinite(__x);
+#endif // !_CCCL_CUDACC_BELOW(11, 8)
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_ISFINITE bool isfinite(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ISFINITE)
+  return _CCCL_BUILTIN_ISFINITE(__x);
+#  elif _CCCL_CUDACC_BELOW(11, 8)
+  return !::__isinf(__x) && !::__isnan(__x);
+#  else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv !_CCCL_CUDACC_BELOW(11, 8) vvv
+  return ::isfinite(__x);
+#  endif // !_CCCL_CUDACC_BELOW(11, 8)
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isfinite(__half __x) noexcept
+{
+  return !::__hisnan(__x) && !::__hisinf(__x);
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isfinite(__nv_bfloat16 __x) noexcept
+{
+  return !::__hisnan(__x) && !::__hisinf(__x);
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+// isinf
+
+#if defined(_CCCL_BUILTIN_ISINF)
+#  define _CCCL_CONSTEXPR_ISINF constexpr
+#else // ^^^ _CCCL_BUILTIN_ISINF ^^^ / vvv !_CCCL_BUILTIN_ISINF vvv
+#  define _CCCL_CONSTEXPR_ISINF
+#endif // !_CCCL_BUILTIN_ISINF
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_integral, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isinf(_A1) noexcept
+{
+  return false;
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_ISINF bool isinf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ISINF)
+  return _CCCL_BUILTIN_ISINF(__x);
+#elif _CCCL_CUDACC_BELOW(11, 8)
+  return ::__isinf(__x);
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv !_CCCL_CUDACC_BELOW(11, 8) vvv
+  return ::isinf(__x);
+#endif // !_CCCL_CUDACC_BELOW(11, 8)
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_ISINF bool isinf(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ISINF)
+  return _CCCL_BUILTIN_ISINF(__x);
+#elif _CCCL_CUDACC_BELOW(11, 8)
+  return ::__isinf(__x);
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv !_CCCL_CUDACC_BELOW(11, 8) vvv
+  return ::isinf(__x);
+#endif // !_CCCL_CUDACC_BELOW(11, 8)
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_ISINF bool isinf(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ISINF)
+  return _CCCL_BUILTIN_ISINF(__x);
+#  elif _CCCL_CUDACC_BELOW(11, 8)
+  return ::__isinf(__x);
+#  else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv !_CCCL_CUDACC_BELOW(11, 8) vvv
+  return ::isinf(__x);
+#  endif // !_CCCL_CUDACC_BELOW(11, 8)
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isinf(__half __x) noexcept
+{
+#  if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
+  // this is a workaround for nvbug 4362808
+  return !::__hisnan(__x) && ::__hisnan(__x - __x);
+#  else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
+  return ::__hisinf(__x) != 0;
+#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_VER < 1203000
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isinf(__nv_bfloat16 __x) noexcept
+{
+#  if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
+  // this is a workaround for nvbug 4362808
+  return !::__hisnan(__x) && ::__hisnan(__x - __x);
+#  else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
+  return ::__hisinf(__x) != 0;
+#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_VER < 1203000
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+// isnan
+
+#if defined(_CCCL_BUILTIN_ISNAN)
+#  define _CCCL_CONSTEXPR_ISNAN constexpr
+#else // ^^^ _CCCL_BUILTIN_ISNAN ^^^ / vvv !_CCCL_BUILTIN_ISNAN vvv
+#  define _CCCL_CONSTEXPR_ISNAN
+#endif // !_CCCL_BUILTIN_ISNAN
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_integral, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool isnan(_A1) noexcept
+{
+  return false;
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_ISNAN bool isnan(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ISNAN)
+  return _CCCL_BUILTIN_ISNAN(__x);
+#elif _CCCL_CUDACC_BELOW(11, 8)
+  return ::__isnan(__x);
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv !_CCCL_CUDACC_BELOW(11, 8) vvv
+  return ::isnan(__x);
+#endif // !_CCCL_CUDACC_BELOW(11, 8)
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_ISNAN bool isnan(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ISNAN)
+  return _CCCL_BUILTIN_ISNAN(__x);
+#elif _CCCL_CUDACC_BELOW(11, 8)
+  return ::__isnan(__x);
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv !_CCCL_CUDACC_BELOW(11, 8) vvv
+  return ::isnan(__x);
+#endif // !_CCCL_CUDACC_BELOW(11, 8)
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_ISNAN bool isnan(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ISNAN)
+  return _CCCL_BUILTIN_ISNAN(__x);
+#  elif _CCCL_CUDACC_BELOW(11, 8)
+  return ::__isnan(__x);
+#  else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv !_CCCL_CUDACC_BELOW(11, 8) vvv
+  return ::isnan(__x);
+#  endif // !_CCCL_CUDACC_BELOW(11, 8)
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnan(__half __x) noexcept
+{
+  return ::__hisnan(__x);
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnan(__nv_bfloat16 __x) noexcept
+{
+  return ::__hisnan(__x);
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+// isnormal
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(is_integral, _A1), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(_A1 __x) noexcept
+{
+  return __x != 0;
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(float __x) noexcept
+{
+  return __x != 0 && _CUDA_VSTD::isfinite(__x);
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(double __x) noexcept
+{
+  return __x != 0 && _CUDA_VSTD::isfinite(__x);
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(long double __x) noexcept
+{
+  return __x != 0 && _CUDA_VSTD::isfinite(__x);
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(__half __x) noexcept
+{
+  return _CUDA_VSTD::isnormal(__half2float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(__nv_bfloat16 __x) noexcept
+{
+  return _CUDA_VSTD::isnormal(__bfloat162float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+// isgreater
+
+template <class _Tp>
+struct __is_extended_arithmetic
+{
+  static constexpr bool value = _CCCL_TRAIT(is_arithmetic, _Tp) || _CCCL_TRAIT(__is_extended_floating_point, _Tp);
+};
+
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr bool __is_extended_arithmetic_v =
+  is_arithmetic_v<_Tp> || __is_extended_floating_point_v<_Tp>;
+#endif // !_CCCL_NO_INLINE_VARIABLES
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_isgreater(_A1 __x, _A1 __y) noexcept
+{
+  if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
+  {
+    return false;
+  }
+  return __x > __y;
+}
+
+template <class _A1,
+          class _A2,
+          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isgreater(_A1 __x, _A2 __y) noexcept
+{
+  using type = __promote_t<_A1, _A2>;
+  NV_IF_ELSE_TARGET(NV_IS_HOST,
+                    (return ::isgreater((type) __x, (type) __y);),
+                    (return _CUDA_VSTD::__device_isgreater((type) __x, (type) __y);))
+}
+
+// isgreaterequal
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_isgreaterequal(_A1 __x, _A1 __y) noexcept
+{
+  if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
+  {
+    return false;
+  }
+  return __x >= __y;
+}
+
+template <class _A1,
+          class _A2,
+          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isgreaterequal(_A1 __x, _A2 __y) noexcept
+{
+  using type = __promote_t<_A1, _A2>;
+  NV_IF_ELSE_TARGET(NV_IS_HOST,
+                    (return ::isgreaterequal((type) __x, (type) __y);),
+                    (return _CUDA_VSTD::__device_isgreaterequal((type) __x, (type) __y);))
+}
+
+// isless
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_isless(_A1 __x, _A1 __y) noexcept
+{
+  if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
+  {
+    return false;
+  }
+  return __x < __y;
+}
+
+template <class _A1,
+          class _A2,
+          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isless(_A1 __x, _A2 __y) noexcept
+{
+  using type = __promote_t<_A1, _A2>;
+  NV_IF_ELSE_TARGET(NV_IS_HOST,
+                    (return ::isless((type) __x, (type) __y);),
+                    (return _CUDA_VSTD::__device_isless((type) __x, (type) __y);))
+}
+
+// islessequal
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_islessequal(_A1 __x, _A1 __y) noexcept
+{
+  if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
+  {
+    return false;
+  }
+  return __x <= __y;
+}
+
+template <class _A1,
+          class _A2,
+          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool islessequal(_A1 __x, _A2 __y) noexcept
+{
+  using type = __promote_t<_A1, _A2>;
+  NV_IF_ELSE_TARGET(NV_IS_HOST,
+                    (return ::islessequal((type) __x, (type) __y);),
+                    (return _CUDA_VSTD::__device_islessequal((type) __x, (type) __y);))
+}
+
+// islessgreater
+
+template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+_CCCL_NODISCARD _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_islessgreater(_A1 __x, _A1 __y) noexcept
+{
+  if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
+  {
+    return false;
+  }
+  return __x < __y || __x > __y;
+}
+
+template <class _A1,
+          class _A2,
+          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool islessgreater(_A1 __x, _A2 __y) noexcept
+{
+  using type = __promote_t<_A1, _A2>;
+  NV_IF_ELSE_TARGET(NV_IS_HOST,
+                    (return ::islessgreater((type) __x, (type) __y);),
+                    (return _CUDA_VSTD::__device_islessgreater((type) __x, (type) __y);))
+}
+
+// isunordered
+
+template <class _A1,
+          class _A2,
+          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isunordered(_A1 __x, _A2 __y) noexcept
+{
+  using type = __promote_t<_A1, _A2>;
+  return _CUDA_VSTD::isnan((type) __x) || _CUDA_VSTD::isnan((type) __y);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_TRAITS_H

--- a/libcudacxx/include/cuda/std/__cmath/traits.h
+++ b/libcudacxx/include/cuda/std/__cmath/traits.h
@@ -22,6 +22,7 @@
 #endif // no system header
 
 #include <cuda/std/__cmath/common.h>
+#include <cuda/std/__cmath/fpclassify.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_extended_floating_point.h>
@@ -297,18 +298,18 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(_A1 __x) noexcept
 
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(float __x) noexcept
 {
-  return __x != 0 && _CUDA_VSTD::isfinite(__x);
+  return _CUDA_VSTD::fpclassify(__x) == FP_NORMAL;
 }
 
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(double __x) noexcept
 {
-  return __x != 0 && _CUDA_VSTD::isfinite(__x);
+  return _CUDA_VSTD::fpclassify(__x) == FP_NORMAL;
 }
 
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool isnormal(long double __x) noexcept
 {
-  return __x != 0 && _CUDA_VSTD::isfinite(__x);
+  return _CUDA_VSTD::fpclassify(__x) == FP_NORMAL;
 }
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 

--- a/libcudacxx/include/cuda/std/__cmath/traits.h
+++ b/libcudacxx/include/cuda/std/__cmath/traits.h
@@ -37,7 +37,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(float __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_SIGNBIT)
-  return __builtin_signbit(__x);
+  return _CCCL_BUILTIN_SIGNBIT(__x);
 #else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
   return ::signbit(__x);
 #endif // !_CCCL_BUILTIN_SIGNBIT
@@ -46,7 +46,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(float __x) noexcept
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(double __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_SIGNBIT)
-  return __builtin_signbit(__x);
+  return _CCCL_BUILTIN_SIGNBIT(__x);
 #else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
   return ::signbit(__x);
 #endif // !_CCCL_BUILTIN_SIGNBIT
@@ -56,7 +56,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(double __x) noexcept
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI bool signbit(long double __x) noexcept
 {
 #  if defined(_CCCL_BUILTIN_SIGNBIT)
-  return __builtin_signbit(__x);
+  return _CCCL_BUILTIN_SIGNBIT(__x);
 #  else // ^^^ _CCCL_BUILTIN_SIGNBIT ^^^ / vvv !_CCCL_BUILTIN_SIGNBIT vvv
   return ::signbit(__x);
 #  endif // !_CCCL_BUILTIN_SIGNBIT

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -28,8 +28,8 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-function")
 #  include <cuda_bf16.h>
 _CCCL_DIAG_POP
 
+#  include <cuda/std/__cmath/nvbf16.h>
 #  include <cuda/std/__complex/vector_support.h>
-#  include <cuda/std/__cuda/cmath_nvbf16.h>
 #  include <cuda/std/__fwd/get.h>
 #  include <cuda/std/__type_traits/enable_if.h>
 #  include <cuda/std/__type_traits/integral_constant.h>

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -25,8 +25,8 @@
 
 #  include <cuda_fp16.h>
 
+#  include <cuda/std/__cmath/nvfp16.h>
 #  include <cuda/std/__complex/vector_support.h>
-#  include <cuda/std/__cuda/cmath_nvfp16.h>
 #  include <cuda/std/__fwd/get.h>
 #  include <cuda/std/__type_traits/enable_if.h>
 #  include <cuda/std/__type_traits/integral_constant.h>

--- a/libcudacxx/include/cuda/std/__type_traits/promote.h
+++ b/libcudacxx/include/cuda/std/__type_traits/promote.h
@@ -42,10 +42,10 @@ struct __numeric_type
 {
   _LIBCUDACXX_HIDE_FROM_ABI static void __test(...);
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  _LIBCUDACXX_HIDE_FROM_ABI static __half __test(__half);
+  _LIBCUDACXX_HIDE_FROM_ABI static float __test(__half);
 #endif // _LIBCUDACXX_HAS_NVBF16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  _LIBCUDACXX_HIDE_FROM_ABI static __nv_bfloat16 __test(__nv_bfloat16);
+  _LIBCUDACXX_HIDE_FROM_ABI static float __test(__nv_bfloat16);
 #endif // _LIBCUDACXX_HAS_NVFP16
   _LIBCUDACXX_HIDE_FROM_ABI static float __test(float);
   _LIBCUDACXX_HIDE_FROM_ABI static double __test(char);
@@ -68,10 +68,55 @@ struct __numeric_type<void>
   static const bool value = true;
 };
 
+template <class _A1, class _A2, class _A3>
+struct __is_mixed_extended_floating_point
+{
+  static constexpr bool value = false;
+};
+
+#if defined(_LIBCUDACXX_HAS_NVFP16) && defined(_LIBCUDACXX_HAS_NVBF16)
+template <class _A1>
+struct __is_mixed_extended_floating_point<_A1, __half, __nv_bfloat16>
+{
+  static constexpr bool value = true;
+};
+
+template <class _A1>
+struct __is_mixed_extended_floating_point<_A1, __nv_bfloat16, __half>
+{
+  static constexpr bool value = true;
+};
+
+template <class _A1>
+struct __is_mixed_extended_floating_point<__half, _A1, __nv_bfloat16>
+{
+  static constexpr bool value = true;
+};
+
+template <class _A1>
+struct __is_mixed_extended_floating_point<__nv_bfloat16, _A1, __half>
+{
+  static constexpr bool value = true;
+};
+
+template <class _A1>
+struct __is_mixed_extended_floating_point<__half, __nv_bfloat16, _A1>
+{
+  static constexpr bool value = true;
+};
+
+template <class _A1>
+struct __is_mixed_extended_floating_point<__nv_bfloat16, __half, _A1>
+{
+  static constexpr bool value = true;
+};
+#endif // _LIBCUDACXX_HAS_NVFP16 && _LIBCUDACXX_HAS_NVBF16
+
 template <class _A1,
           class _A2 = void,
           class _A3 = void,
-          bool      = __numeric_type<_A1>::value && __numeric_type<_A2>::value && __numeric_type<_A3>::value>
+          bool      = __numeric_type<_A1>::value && __numeric_type<_A2>::value && __numeric_type<_A3>::value
+              && !__is_mixed_extended_floating_point<_A1, _A2, _A3>::value>
 class __promote_imp
 {
 public:
@@ -95,8 +140,8 @@ template <class _A1, class _A2>
 class __promote_imp<_A1, _A2, void, true>
 {
 private:
-  typedef typename __promote_imp<_A1>::type __type1;
-  typedef typename __promote_imp<_A2>::type __type2;
+  using __type1 = typename __promote_imp<_A1>::type;
+  using __type2 = typename __promote_imp<_A2>::type;
 
 public:
   typedef decltype(__type1() + __type2()) type;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -588,16 +588,16 @@ using ::truncl;
 #if _CCCL_STD_VER > 2014 && !defined(__cuda_std__)
 _LIBCUDACXX_HIDE_FROM_ABI float hypot(float x, float y, float z)
 {
-  return sqrt(x * x + y * y + z * z);
+  return _CUDA_VSTD::sqrt(x * x + y * y + z * z);
 }
 _LIBCUDACXX_HIDE_FROM_ABI double hypot(double x, double y, double z)
 {
-  return sqrt(x * x + y * y + z * z);
+  return _CUDA_VSTD::sqrt(x * x + y * y + z * z);
 }
 #  ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
 _LIBCUDACXX_HIDE_FROM_ABI long double hypot(long double x, long double y, long double z)
 {
-  return sqrt(x * x + y * y + z * z);
+  return _CUDA_VSTD::sqrt(x * x + y * y + z * z);
 }
 #  endif
 
@@ -611,7 +611,7 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) noexcept
   static_assert(
     (!(is_same<_A1, __result_type>::value && is_same<_A2, __result_type>::value && is_same<_A3, __result_type>::value)),
     "");
-  return ::hypot((__result_type) __lcpp_x, (__result_type) __lcpp_y, (__result_type) __lcpp_z);
+  return _CUDA_VSTD::hypot((__result_type) __lcpp_x, (__result_type) __lcpp_y, (__result_type) __lcpp_z);
 }
 #endif
 
@@ -763,11 +763,11 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX float __constexpr_fmax(f
   if (_CCCL_BUILTIN_IS_CONSTANT_EVALUATED())
 #    endif // _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
   {
-    if (__constexpr_isnan(__x))
+    if (_CUDA_VSTD::__constexpr_isnan(__x))
     {
       return __y;
     }
-    if (__constexpr_isnan(__y))
+    if (_CUDA_VSTD::__constexpr_isnan(__y))
     {
       return __x;
     }
@@ -786,11 +786,11 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX double __constexpr_fmax(
   if (_CCCL_BUILTIN_IS_CONSTANT_EVALUATED())
 #    endif // _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
   {
-    if (__constexpr_isnan(__x))
+    if (_CUDA_VSTD::__constexpr_isnan(__x))
     {
       return __y;
     }
-    if (__constexpr_isnan(__y))
+    if (_CUDA_VSTD::__constexpr_isnan(__y))
     {
       return __x;
     }
@@ -810,11 +810,11 @@ __constexpr_fmax(long double __x, long double __y) noexcept
   if (_CCCL_BUILTIN_IS_CONSTANT_EVALUATED())
 #    endif // _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
   {
-    if (__constexpr_isnan(__x))
+    if (_CUDA_VSTD::__constexpr_isnan(__x))
     {
       return __y;
     }
-    if (__constexpr_isnan(__y))
+    if (_CUDA_VSTD::__constexpr_isnan(__y))
     {
       return __x;
     }
@@ -851,17 +851,17 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX _Tp __constexpr_logb(_Tp
       return -numeric_limits<_Tp>::infinity();
     }
 
-    if (__constexpr_isinf(__x))
+    if (_CUDA_VSTD::__constexpr_isinf(__x))
     {
       return numeric_limits<_Tp>::infinity();
     }
 
-    if (__constexpr_isnan(__x))
+    if (_CUDA_VSTD::__constexpr_isnan(__x))
     {
       return numeric_limits<_Tp>::quiet_NaN();
     }
 
-    __x                      = __constexpr_fabs(__x);
+    __x                      = _CUDA_VSTD::__constexpr_fabs(__x);
     unsigned long long __exp = 0;
     while (__x >= _Tp(numeric_limits<_Tp>::radix))
     {
@@ -913,7 +913,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX _Tp __constexpr_scalbn(_
       return __x;
     }
 
-    if (__constexpr_isinf(__x))
+    if (_CUDA_VSTD::__constexpr_isinf(__x))
     {
       return __x;
     }
@@ -923,7 +923,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX _Tp __constexpr_scalbn(_
       return __x;
     }
 
-    if (__constexpr_isnan(__x))
+    if (_CUDA_VSTD::__constexpr_isnan(__x))
     {
       return numeric_limits<_Tp>::quiet_NaN();
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -323,11 +323,11 @@ long double    truncl(long double x);
 #include <cuda/std/version>
 
 #ifdef _LIBCUDACXX_HAS_NVFP16
-#  include <cuda/std/__cuda/cmath_nvfp16.h>
+#  include <cuda/std/__cmath/nvfp16.h>
 #endif // _LIBCUDACXX_HAS_NVFP16
 
 #ifdef _LIBCUDACXX_HAS_NVBF16
-#  include <cuda/std/__cuda/cmath_nvbf16.h>
+#  include <cuda/std/__cmath/nvbf16.h>
 #endif // _LIBCUDACXX_HAS_NVBF16
 
 #if _CCCL_COMPILER(NVRTC)

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -319,6 +319,7 @@ long double    truncl(long double x);
 #endif // _CCCL_COMPILER(NVHPC)
 
 #include <cuda/std/__cmath/lerp.h>
+#include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/version>
@@ -387,9 +388,6 @@ using ::asinhf;
 using ::atanh;
 using ::atanhf;
 
-using ::log;
-using ::logf;
-
 using ::hypot;
 using ::hypotf;
 
@@ -425,11 +423,6 @@ using ::frexpf;
 using ::ldexp;
 using ::ldexpf;
 
-using ::log;
-using ::logf;
-
-using ::log10;
-using ::log10f;
 using ::modf;
 using ::modff;
 
@@ -477,20 +470,12 @@ using ::fmax;
 using ::fmaxf;
 using ::fmin;
 using ::fminf;
-using ::ilogb;
-using ::ilogbf;
 using ::lgamma;
 using ::lgammaf;
 using ::llrint;
 using ::llrintf;
 using ::llround;
 using ::llroundf;
-using ::log1p;
-using ::log1pf;
-using ::log2;
-using ::log2f;
-using ::logb;
-using ::logbf;
 using ::lrint;
 using ::lrintf;
 using ::lround;
@@ -535,8 +520,6 @@ using ::floorl;
 using ::fmodl;
 using ::frexpl;
 using ::ldexpl;
-using ::log10l;
-using ::logl;
 using ::modfl;
 using ::powl;
 using ::sinhl;
@@ -561,13 +544,9 @@ using ::fmal;
 using ::fmaxl;
 using ::fminl;
 using ::hypotl;
-using ::ilogbl;
 using ::lgammal;
 using ::llrintl;
 using ::llroundl;
-using ::log1pl;
-using ::log2l;
-using ::logbl;
 using ::lrintl;
 using ::lroundl;
 using ::nanl;
@@ -836,7 +815,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX __promote_t<_Tp, _Up> __
 template <class _A1>
 _LIBCUDACXX_HIDE_FROM_ABI _A1 __constexpr_logb(_A1 __x)
 {
-  return ::logb(__x);
+  return _CUDA_VSTD::logb(__x);
 }
 #else
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -320,6 +320,7 @@ long double    truncl(long double x);
 
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
+#include <cuda/std/__cmath/min_max.h>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/version>
@@ -466,10 +467,6 @@ using ::fdim;
 using ::fdimf;
 using ::fma;
 using ::fmaf;
-using ::fmax;
-using ::fmaxf;
-using ::fmin;
-using ::fminf;
 using ::lgamma;
 using ::lgammaf;
 using ::llrint;
@@ -541,8 +538,6 @@ using ::exp2l;
 using ::expm1l;
 using ::fdiml;
 using ::fmal;
-using ::fmaxl;
-using ::fminl;
 using ::hypotl;
 using ::lgammal;
 using ::llrintl;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -1001,45 +1001,6 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr long double lerp(long double __a, long doubl
 
 #endif // _CCCL_STD_VER > 2017
 
-template <class _IntT,
-          class _FloatT,
-          bool _FloatBigger = (numeric_limits<_FloatT>::digits > numeric_limits<_IntT>::digits),
-          int _Bits         = (numeric_limits<_IntT>::digits - numeric_limits<_FloatT>::digits)>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr _IntT __max_representable_int_for_float() noexcept
-{
-  static_assert(is_floating_point<_FloatT>::value, "must be a floating point type");
-  static_assert(is_integral<_IntT>::value, "must be an integral type");
-  static_assert(numeric_limits<_FloatT>::radix == 2, "FloatT has incorrect radix");
-#ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
-  static_assert(
-    (_IsSame<_FloatT, float>::value || _IsSame<_FloatT, double>::value || _IsSame<_FloatT, long double>::value),
-    "unsupported floating point type");
-#else
-  static_assert((_IsSame<_FloatT, float>::value || _IsSame<_FloatT, double>::value), "unsupported floating point type");
-#endif
-  return _FloatBigger ? numeric_limits<_IntT>::max() : (numeric_limits<_IntT>::max() >> _Bits << _Bits);
-}
-
-// Convert a floating point number to the specified integral type after
-// clamping to the integral types representable range.
-//
-// The behavior is undefined if `__r` is NaN.
-template <class _IntT, class _RealT>
-_LIBCUDACXX_HIDE_FROM_ABI _IntT __clamp_to_integral(_RealT __r) noexcept
-{
-  using _Lim          = _CUDA_VSTD::numeric_limits<_IntT>;
-  const _IntT _MaxVal = _CUDA_VSTD::__max_representable_int_for_float<_IntT, _RealT>();
-  if (__r >= ::nextafter(static_cast<_RealT>(_MaxVal), INFINITY))
-  {
-    return _Lim::max();
-  }
-  else if (__r <= _Lim::lowest())
-  {
-    return _Lim::min();
-  }
-  return static_cast<_IntT>(__r);
-}
-
 _LIBCUDACXX_END_NAMESPACE_STD
 
 _CCCL_POP_MACROS

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -318,6 +318,7 @@ long double    truncl(long double x);
 #  include <cmath>
 #endif // _CCCL_COMPILER(NVHPC)
 
+#include <cuda/std/__cmath/fpclassify.h>
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/min_max.h>
@@ -393,8 +394,6 @@ using ::abs;
 #endif
 
 #if !_CCCL_COMPILER(NVRTC)
-
-using ::fpclassify;
 
 using ::double_t;
 using ::float_t;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -318,6 +318,7 @@ long double    truncl(long double x);
 #  include <cmath>
 #endif // _CCCL_COMPILER(NVHPC)
 
+#include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/version>
@@ -959,47 +960,6 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX _Tp __constexpr_scalbn(_
   return __builtin_scalbn(__x, __exp);
 }
 #endif // !_CCCL_COMPILER(MSVC)
-
-#if _CCCL_STD_VER > 2017
-template <typename _Fp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr _Fp __lerp(_Fp __a, _Fp __b, _Fp __t) noexcept
-{
-  if ((__a <= 0 && __b >= 0) || (__a >= 0 && __b <= 0))
-  {
-    return __t * __b + (1 - __t) * __a;
-  }
-
-  if (__t == 1)
-  {
-    return __b;
-  }
-  const _Fp __x = __a + __t * (__b - __a);
-  if ((__t > 1) == (__b > __a))
-  {
-    return __b < __x ? __x : __b;
-  }
-  else
-  {
-    return __x < __b ? __x : __b;
-  }
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI constexpr float lerp(float __a, float __b, float __t) noexcept
-{
-  return __lerp(__a, __b, __t);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI constexpr double lerp(double __a, double __b, double __t) noexcept
-{
-  return __lerp(__a, __b, __t);
-}
-
-_LIBCUDACXX_HIDE_FROM_ABI constexpr long double lerp(long double __a, long double __b, long double __t) noexcept
-{
-  return __lerp(__a, __b, __t);
-}
-
-#endif // _CCCL_STD_VER > 2017
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -321,6 +321,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/min_max.h>
+#include <cuda/std/__cmath/traits.h>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/version>
@@ -342,11 +343,6 @@ long double    truncl(long double x);
 _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
-
-using ::isfinite;
-using ::isinf;
-using ::isnan;
-using ::signbit;
 
 using ::acos;
 using ::acosf;
@@ -399,14 +395,6 @@ using ::abs;
 #if !_CCCL_COMPILER(NVRTC)
 
 using ::fpclassify;
-using ::isgreater;
-using ::isgreaterequal;
-using ::isless;
-using ::islessequal;
-using ::islessgreater;
-using ::isnormal;
-
-using ::isunordered;
 
 using ::double_t;
 using ::float_t;
@@ -595,69 +583,6 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) noexcept
 #  define _CCCL_CONSTEXPR_CXX14_COMPLEX
 #endif // _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
 
-template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_A1>::value, bool>
-__constexpr_isnan(_A1 __lcpp_x) noexcept
-{
-#if _CCCL_CUDACC_BELOW(11, 8)
-  return __isnan(__lcpp_x);
-#elif defined(_CCCL_BUILTIN_ISNAN)
-  // nvcc at times has issues determining the type of __lcpp_x
-  return _CCCL_BUILTIN_ISNAN(static_cast<double>(__lcpp_x));
-#else // ^^^ _CCCL_BUILTIN_ISNAN ^^^ / vvv !_CCCL_BUILTIN_ISNAN vvv
-  return ::isnan(__lcpp_x);
-#endif // !_CCCL_BUILTIN_ISNAN
-}
-
-template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<!is_floating_point<_A1>::value, bool>
-__constexpr_isnan(_A1 __lcpp_x) noexcept
-{
-  return ::isnan(__lcpp_x);
-}
-
-template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_A1>::value, bool>
-__constexpr_isinf(_A1 __lcpp_x) noexcept
-{
-#if _CCCL_CUDACC_BELOW(11, 8)
-  return __isinf(__lcpp_x);
-#elif defined(_CCCL_BUILTIN_ISINF)
-  // nvcc at times has issues determining the type of __lcpp_x
-  return __builtin_isinf(static_cast<double>(__lcpp_x));
-#else // ^^^ _CCCL_BUILTIN_ISINF ^^^ / vvv !_CCCL_BUILTIN_ISINF vvv
-  return ::isinf(__lcpp_x);
-#endif // !_CCCL_BUILTIN_ISINF
-}
-
-template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<!is_floating_point<_A1>::value, bool>
-__constexpr_isinf(_A1 __lcpp_x) noexcept
-{
-  return ::isinf(__lcpp_x);
-}
-
-template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_A1>::value, bool>
-__constexpr_isfinite(_A1 __lcpp_x) noexcept
-{
-#if _CCCL_CUDACC_BELOW(11, 8)
-  return !__isinf(__lcpp_x) && !__isnan(__lcpp_x);
-#elif defined(_CCCL_BUILTIN_ISFINITE)
-  // nvcc at times has issues determining the type of __lcpp_x
-  return __builtin_isfinite(static_cast<double>(__lcpp_x));
-#else // ^^^ _CCCL_BUILTIN_ISFINITE ^^^ / vvv !_CCCL_BUILTIN_ISFINITE vvv
-  return ::isfinite(__lcpp_x);
-#endif // !_CCCL_BUILTIN_ISFINITE
-}
-
-template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<!is_floating_point<_A1>::value, bool>
-__constexpr_isfinite(_A1 __lcpp_x) noexcept
-{
-  return isfinite(__lcpp_x);
-}
-
 #if _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
 template <class _A1>
 _LIBCUDACXX_HIDE_FROM_ABI _A1 __constexpr_copysign(_A1 __x, _A1 __y) noexcept
@@ -675,11 +600,13 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 double __constexpr_copysign(doub
   return __builtin_copysign(__x, __y);
 }
 
+#  if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 long double
 __constexpr_copysign(long double __x, long double __y) noexcept
 {
   return __builtin_copysignl(__x, __y);
 }
+#  endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 template <class _A1, class _A2>
 _LIBCUDACXX_HIDE_FROM_ABI
@@ -709,10 +636,12 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 double __constexpr_fabs(double _
   return __builtin_fabs(__x);
 }
 
+#  if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 long double __constexpr_fabs(long double __x) noexcept
 {
   return __builtin_fabsl(__x);
 }
+#  endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 template <class _Tp, enable_if_t<is_integral<_Tp>::value, int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 double __constexpr_fabs(_Tp __x) noexcept
@@ -737,11 +666,11 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX float __constexpr_fmax(f
   if (_CCCL_BUILTIN_IS_CONSTANT_EVALUATED())
 #    endif // _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
   {
-    if (_CUDA_VSTD::__constexpr_isnan(__x))
+    if (_CUDA_VSTD::isnan(__x))
     {
       return __y;
     }
-    if (_CUDA_VSTD::__constexpr_isnan(__y))
+    if (_CUDA_VSTD::isnan(__y))
     {
       return __x;
     }
@@ -760,11 +689,11 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX double __constexpr_fmax(
   if (_CCCL_BUILTIN_IS_CONSTANT_EVALUATED())
 #    endif // _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
   {
-    if (_CUDA_VSTD::__constexpr_isnan(__x))
+    if (_CUDA_VSTD::isnan(__x))
     {
       return __y;
     }
-    if (_CUDA_VSTD::__constexpr_isnan(__y))
+    if (_CUDA_VSTD::isnan(__y))
     {
       return __x;
     }
@@ -774,29 +703,31 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX double __constexpr_fmax(
   return __builtin_fmax(__x, __y);
 }
 
+#  if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX long double
 __constexpr_fmax(long double __x, long double __y) noexcept
 {
-#  if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED) && !defined(_LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS)
-#    if _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
+#    if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED) && !defined(_LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS)
+#      if _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
   if (false)
-#    else // _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
+#      else // _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
   if (_CCCL_BUILTIN_IS_CONSTANT_EVALUATED())
-#    endif // _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
+#      endif // _CCCL_COMPILER(ICC) && _NV_ISEMPTY(_CCCL_CONSTEXPR_CXX14_COMPLEX)
   {
-    if (_CUDA_VSTD::__constexpr_isnan(__x))
+    if (_CUDA_VSTD::isnan(__x))
     {
       return __y;
     }
-    if (_CUDA_VSTD::__constexpr_isnan(__y))
+    if (_CUDA_VSTD::isnan(__y))
     {
       return __x;
     }
     return __x < __y ? __y : __x;
   }
-#  endif // defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
+#    endif // defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
   return __builtin_fmax(__x, __y);
 }
+#  endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 template <class _Tp, class _Up, enable_if_t<is_arithmetic<_Tp>::value && is_arithmetic<_Up>::value, int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX __promote_t<_Tp, _Up> __constexpr_fmax(_Tp __x, _Up __y) noexcept
@@ -825,12 +756,12 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX _Tp __constexpr_logb(_Tp
       return -numeric_limits<_Tp>::infinity();
     }
 
-    if (_CUDA_VSTD::__constexpr_isinf(__x))
+    if (_CUDA_VSTD::isinf(__x))
     {
       return numeric_limits<_Tp>::infinity();
     }
 
-    if (_CUDA_VSTD::__constexpr_isnan(__x))
+    if (_CUDA_VSTD::isnan(__x))
     {
       return numeric_limits<_Tp>::quiet_NaN();
     }
@@ -887,7 +818,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX _Tp __constexpr_scalbn(_
       return __x;
     }
 
-    if (_CUDA_VSTD::__constexpr_isinf(__x))
+    if (_CUDA_VSTD::isinf(__x))
     {
       return __x;
     }
@@ -897,7 +828,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX _Tp __constexpr_scalbn(_
       return __x;
     }
 
-    if (_CUDA_VSTD::__constexpr_isnan(__x))
+    if (_CUDA_VSTD::isnan(__x))
     {
       return numeric_limits<_Tp>::quiet_NaN();
     }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -513,16 +513,14 @@ operator*(const complex<_Tp>& __z, const complex<_Tp>& __w)
   {
     bool __z_zero = __a == _Tp(0) && __b == _Tp(0);
     bool __w_zero = __c == _Tp(0) && __d == _Tp(0);
-    bool __z_inf  = _CUDA_VSTD::__constexpr_isinf(__a) || _CUDA_VSTD::__constexpr_isinf(__b);
-    bool __w_inf  = _CUDA_VSTD::__constexpr_isinf(__c) || _CUDA_VSTD::__constexpr_isinf(__d);
+    bool __z_inf  = _CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b);
+    bool __w_inf  = _CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d);
     bool __z_nan  = !__z_inf
-                && ((_CUDA_VSTD::__constexpr_isnan(__a) && _CUDA_VSTD::__constexpr_isnan(__b))
-                    || (_CUDA_VSTD::__constexpr_isnan(__a) && __b == _Tp(0))
-                    || (__a == _Tp(0) && _CUDA_VSTD::__constexpr_isnan(__b)));
+                && ((_CUDA_VSTD::isnan(__a) && _CUDA_VSTD::isnan(__b)) || (_CUDA_VSTD::isnan(__a) && __b == _Tp(0))
+                    || (__a == _Tp(0) && _CUDA_VSTD::isnan(__b)));
     bool __w_nan = !__w_inf
-                && ((_CUDA_VSTD::__constexpr_isnan(__c) && _CUDA_VSTD::__constexpr_isnan(__d))
-                    || (_CUDA_VSTD::__constexpr_isnan(__c) && __d == _Tp(0))
-                    || (__c == _Tp(0) && _CUDA_VSTD::__constexpr_isnan(__d)));
+                && ((_CUDA_VSTD::isnan(__c) && _CUDA_VSTD::isnan(__d)) || (_CUDA_VSTD::isnan(__c) && __d == _Tp(0))
+                    || (__c == _Tp(0) && _CUDA_VSTD::isnan(__d)));
     if (__z_nan || __w_nan)
     {
       return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
@@ -535,10 +533,8 @@ operator*(const complex<_Tp>& __z, const complex<_Tp>& __w)
       }
       return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
     }
-    bool __z_nonzero_nan =
-      !__z_inf && !__z_nan && (_CUDA_VSTD::__constexpr_isnan(__a) || _CUDA_VSTD::__constexpr_isnan(__b));
-    bool __w_nonzero_nan =
-      !__w_inf && !__w_nan && (_CUDA_VSTD::__constexpr_isnan(__c) || _CUDA_VSTD::__constexpr_isnan(__d));
+    bool __z_nonzero_nan = !__z_inf && !__z_nan && (_CUDA_VSTD::isnan(__a) || _CUDA_VSTD::isnan(__b));
+    bool __w_nonzero_nan = !__w_inf && !__w_nan && (_CUDA_VSTD::isnan(__c) || _CUDA_VSTD::isnan(__d));
     if (__z_nonzero_nan || __w_nonzero_nan)
     {
       return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
@@ -551,54 +547,54 @@ operator*(const complex<_Tp>& __z, const complex<_Tp>& __w)
   _Tp __x = __partials.__ac - __partials.__bd;
   _Tp __y = __partials.__ad + __partials.__bc;
 #ifndef LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_MULTIPLICATION
-  if (_CUDA_VSTD::__constexpr_isnan(__x) && _CUDA_VSTD::__constexpr_isnan(__y))
+  if (_CUDA_VSTD::isnan(__x) && _CUDA_VSTD::isnan(__y))
   {
     bool __recalc = false;
-    if (_CUDA_VSTD::__constexpr_isinf(__a) || _CUDA_VSTD::__constexpr_isinf(__b))
+    if (_CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b))
     {
-      __a = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::__constexpr_isinf(__a) ? _Tp(1) : _Tp(0), __a);
-      __b = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::__constexpr_isinf(__b) ? _Tp(1) : _Tp(0), __b);
-      if (_CUDA_VSTD::__constexpr_isnan(__c))
+      __a = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__a) ? _Tp(1) : _Tp(0), __a);
+      __b = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__b) ? _Tp(1) : _Tp(0), __b);
+      if (_CUDA_VSTD::isnan(__c))
       {
         __c = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __c);
       }
-      if (_CUDA_VSTD::__constexpr_isnan(__d))
+      if (_CUDA_VSTD::isnan(__d))
       {
         __d = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __d);
       }
       __recalc = true;
     }
-    if (_CUDA_VSTD::__constexpr_isinf(__c) || _CUDA_VSTD::__constexpr_isinf(__d))
+    if (_CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d))
     {
-      __c = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::__constexpr_isinf(__c) ? _Tp(1) : _Tp(0), __c);
-      __d = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::__constexpr_isinf(__d) ? _Tp(1) : _Tp(0), __d);
-      if (_CUDA_VSTD::__constexpr_isnan(__a))
+      __c = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__c) ? _Tp(1) : _Tp(0), __c);
+      __d = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__d) ? _Tp(1) : _Tp(0), __d);
+      if (_CUDA_VSTD::isnan(__a))
       {
         __a = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __a);
       }
-      if (_CUDA_VSTD::__constexpr_isnan(__b))
+      if (_CUDA_VSTD::isnan(__b))
       {
         __b = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __b);
       }
       __recalc = true;
     }
     if (!__recalc
-        && (_CUDA_VSTD::__constexpr_isinf(__partials.__ac) || _CUDA_VSTD::__constexpr_isinf(__partials.__bd)
-            || _CUDA_VSTD::__constexpr_isinf(__partials.__ad) || _CUDA_VSTD::__constexpr_isinf(__partials.__bc)))
+        && (_CUDA_VSTD::isinf(__partials.__ac) || _CUDA_VSTD::isinf(__partials.__bd)
+            || _CUDA_VSTD::isinf(__partials.__ad) || _CUDA_VSTD::isinf(__partials.__bc)))
     {
-      if (_CUDA_VSTD::__constexpr_isnan(__a))
+      if (_CUDA_VSTD::isnan(__a))
       {
         __a = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __a);
       }
-      if (_CUDA_VSTD::__constexpr_isnan(__b))
+      if (_CUDA_VSTD::isnan(__b))
       {
         __b = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __b);
       }
-      if (_CUDA_VSTD::__constexpr_isnan(__c))
+      if (_CUDA_VSTD::isnan(__c))
       {
         __c = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __c);
       }
-      if (_CUDA_VSTD::__constexpr_isnan(__d))
+      if (_CUDA_VSTD::isnan(__d))
       {
         __d = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __d);
       }
@@ -643,7 +639,7 @@ operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
   _Tp __d      = __w.imag();
   _Tp __logbw  = _CUDA_VSTD::__constexpr_logb(
     _CUDA_VSTD::__constexpr_fmax(_CUDA_VSTD::__constexpr_fabs(__c), _CUDA_VSTD::__constexpr_fabs(__d)));
-  if (_CUDA_VSTD::__constexpr_isfinite(__logbw))
+  if (_CUDA_VSTD::isfinite(__logbw))
   {
     __ilogbw = static_cast<int>(__logbw);
     __c      = _CUDA_VSTD::__constexpr_scalbn(__c, -__ilogbw);
@@ -656,24 +652,20 @@ operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
   {
     bool __z_zero = __a == _Tp(0) && __b == _Tp(0);
     bool __w_zero = __c == _Tp(0) && __d == _Tp(0);
-    bool __z_inf  = _CUDA_VSTD::__constexpr_isinf(__a) || _CUDA_VSTD::__constexpr_isinf(__b);
-    bool __w_inf  = _CUDA_VSTD::__constexpr_isinf(__c) || _CUDA_VSTD::__constexpr_isinf(__d);
+    bool __z_inf  = _CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b);
+    bool __w_inf  = _CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d);
     bool __z_nan  = !__z_inf
-                && ((_CUDA_VSTD::__constexpr_isnan(__a) && _CUDA_VSTD::__constexpr_isnan(__b))
-                    || (_CUDA_VSTD::__constexpr_isnan(__a) && __b == _Tp(0))
-                    || (__a == _Tp(0) && _CUDA_VSTD::__constexpr_isnan(__b)));
+                && ((_CUDA_VSTD::isnan(__a) && _CUDA_VSTD::isnan(__b)) || (_CUDA_VSTD::isnan(__a) && __b == _Tp(0))
+                    || (__a == _Tp(0) && _CUDA_VSTD::isnan(__b)));
     bool __w_nan = !__w_inf
-                && ((_CUDA_VSTD::__constexpr_isnan(__c) && _CUDA_VSTD::__constexpr_isnan(__d))
-                    || (_CUDA_VSTD::__constexpr_isnan(__c) && __d == _Tp(0))
-                    || (__c == _Tp(0) && _CUDA_VSTD::__constexpr_isnan(__d)));
+                && ((_CUDA_VSTD::isnan(__c) && _CUDA_VSTD::isnan(__d)) || (_CUDA_VSTD::isnan(__c) && __d == _Tp(0))
+                    || (__c == _Tp(0) && _CUDA_VSTD::isnan(__d)));
     if ((__z_nan || __w_nan) || (__z_inf && __w_inf))
     {
       return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
     }
-    bool __z_nonzero_nan =
-      !__z_inf && !__z_nan && (_CUDA_VSTD::__constexpr_isnan(__a) || _CUDA_VSTD::__constexpr_isnan(__b));
-    bool __w_nonzero_nan =
-      !__w_inf && !__w_nan && (_CUDA_VSTD::__constexpr_isnan(__c) || _CUDA_VSTD::__constexpr_isnan(__d));
+    bool __z_nonzero_nan = !__z_inf && !__z_nan && (_CUDA_VSTD::isnan(__a) || _CUDA_VSTD::isnan(__b));
+    bool __w_nonzero_nan = !__w_inf && !__w_nan && (_CUDA_VSTD::isnan(__c) || _CUDA_VSTD::isnan(__d));
     if (__z_nonzero_nan || __w_nonzero_nan)
     {
       if (__w_zero)
@@ -708,26 +700,25 @@ operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
   _Tp __x     = _CUDA_VSTD::__constexpr_scalbn((__partials.__ac + __partials.__bd) / __denom, -__ilogbw);
   _Tp __y     = _CUDA_VSTD::__constexpr_scalbn((__partials.__bc - __partials.__ad) / __denom, -__ilogbw);
 #ifndef LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_DIVISION
-  if (_CUDA_VSTD::__constexpr_isnan(__x) && _CUDA_VSTD::__constexpr_isnan(__y))
+  if (_CUDA_VSTD::isnan(__x) && _CUDA_VSTD::isnan(__y))
   {
-    if ((__denom == _Tp(0)) && (!_CUDA_VSTD::__constexpr_isnan(__a) || !_CUDA_VSTD::__constexpr_isnan(__b)))
+    if ((__denom == _Tp(0)) && (!_CUDA_VSTD::isnan(__a) || !_CUDA_VSTD::isnan(__b)))
     {
       __x = _CUDA_VSTD::__constexpr_copysign(_Tp(INFINITY), __c) * __a;
       __y = _CUDA_VSTD::__constexpr_copysign(_Tp(INFINITY), __c) * __b;
     }
-    else if ((_CUDA_VSTD::__constexpr_isinf(__a) || _CUDA_VSTD::__constexpr_isinf(__b))
-             && _CUDA_VSTD::__constexpr_isfinite(__c) && _CUDA_VSTD::__constexpr_isfinite(__d))
+    else if ((_CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b)) && _CUDA_VSTD::isfinite(__c)
+             && _CUDA_VSTD::isfinite(__d))
     {
-      __a = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::__constexpr_isinf(__a) ? _Tp(1) : _Tp(0), __a);
-      __b = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::__constexpr_isinf(__b) ? _Tp(1) : _Tp(0), __b);
+      __a = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__a) ? _Tp(1) : _Tp(0), __a);
+      __b = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__b) ? _Tp(1) : _Tp(0), __b);
       __x = _Tp(INFINITY) * (__a * __c + __b * __d);
       __y = _Tp(INFINITY) * (__b * __c - __a * __d);
     }
-    else if (_CUDA_VSTD::__constexpr_isinf(__logbw) && __logbw > _Tp(0) && _CUDA_VSTD::__constexpr_isfinite(__a)
-             && _CUDA_VSTD::__constexpr_isfinite(__b))
+    else if (_CUDA_VSTD::isinf(__logbw) && __logbw > _Tp(0) && _CUDA_VSTD::isfinite(__a) && _CUDA_VSTD::isfinite(__b))
     {
-      __c = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::__constexpr_isinf(__c) ? _Tp(1) : _Tp(0), __c);
-      __d = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::__constexpr_isinf(__d) ? _Tp(1) : _Tp(0), __d);
+      __c = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__c) ? _Tp(1) : _Tp(0), __c);
+      __d = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__d) ? _Tp(1) : _Tp(0), __d);
       __x = _Tp(0) * (__a * __c + __b * __d);
       __y = _Tp(0) * (__b * __c - __a * __d);
     }
@@ -928,11 +919,11 @@ _LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_same<_Tp, float>::value, float> arg(_Tp
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp norm(const complex<_Tp>& __c)
 {
-  if (_CUDA_VSTD::__constexpr_isinf(__c.real()))
+  if (_CUDA_VSTD::isinf(__c.real()))
   {
     return _CUDA_VSTD::abs(__c.real());
   }
-  if (_CUDA_VSTD::__constexpr_isinf(__c.imag()))
+  if (_CUDA_VSTD::isinf(__c.imag()))
   {
     return _CUDA_VSTD::abs(__c.imag());
   }
@@ -965,7 +956,7 @@ template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> proj(const complex<_Tp>& __c)
 {
   complex<_Tp> __r = __c;
-  if (_CUDA_VSTD::__constexpr_isinf(__c.real()) || _CUDA_VSTD::__constexpr_isinf(__c.imag()))
+  if (_CUDA_VSTD::isinf(__c.real()) || _CUDA_VSTD::isinf(__c.imag()))
   {
     __r = complex<_Tp>(INFINITY, __constexpr_copysign(_Tp(0), __c.imag()));
   }
@@ -975,7 +966,7 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> proj(const complex<_Tp>& __c)
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI enable_if_t<__is_complex_float<_Tp>::value, __libcpp_complex_complex_type<_Tp>> proj(_Tp __re)
 {
-  if (_CUDA_VSTD::__constexpr_isinf(__re))
+  if (_CUDA_VSTD::isinf(__re))
   {
     __re = _CUDA_VSTD::abs(__re);
   }
@@ -993,33 +984,33 @@ _LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value, __libcpp_complex_
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> polar(const _Tp& __rho, const _Tp& __theta = _Tp())
 {
-  if (_CUDA_VSTD::__constexpr_isnan(__rho) || _CUDA_VSTD::signbit(__rho))
+  if (_CUDA_VSTD::isnan(__rho) || _CUDA_VSTD::signbit(__rho))
   {
     return complex<_Tp>(_Tp(NAN), _Tp(NAN));
   }
-  if (_CUDA_VSTD::__constexpr_isnan(__theta))
+  if (_CUDA_VSTD::isnan(__theta))
   {
-    if (_CUDA_VSTD::__constexpr_isinf(__rho))
+    if (_CUDA_VSTD::isinf(__rho))
     {
       return complex<_Tp>(__rho, __theta);
     }
     return complex<_Tp>(__theta, __theta);
   }
-  if (_CUDA_VSTD::__constexpr_isinf(__theta))
+  if (_CUDA_VSTD::isinf(__theta))
   {
-    if (_CUDA_VSTD::__constexpr_isinf(__rho))
+    if (_CUDA_VSTD::isinf(__rho))
     {
       return complex<_Tp>(__rho, _Tp(NAN));
     }
     return complex<_Tp>(_Tp(NAN), _Tp(NAN));
   }
   _Tp __x = __rho * _CUDA_VSTD::cos(__theta);
-  if (_CUDA_VSTD::__constexpr_isnan(__x))
+  if (_CUDA_VSTD::isnan(__x))
   {
     __x = 0;
   }
   _Tp __y = __rho * _CUDA_VSTD::sin(__theta);
-  if (_CUDA_VSTD::__constexpr_isnan(__y))
+  if (_CUDA_VSTD::isnan(__y))
   {
     __y = 0;
   }
@@ -1047,18 +1038,18 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> log10(const complex<_Tp>& __x)
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> sqrt(const complex<_Tp>& __x)
 {
-  if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+  if (_CUDA_VSTD::isinf(__x.imag()))
   {
     return complex<_Tp>(_Tp(INFINITY), __x.imag());
   }
-  if (_CUDA_VSTD::__constexpr_isinf(__x.real()))
+  if (_CUDA_VSTD::isinf(__x.real()))
   {
     if (__x.real() > _Tp(0))
     {
-      return complex<_Tp>(
-        __x.real(), _CUDA_VSTD::__constexpr_isnan(__x.imag()) ? __x.imag() : __constexpr_copysign(_Tp(0), __x.imag()));
+      return complex<_Tp>(__x.real(),
+                          _CUDA_VSTD::isnan(__x.imag()) ? __x.imag() : __constexpr_copysign(_Tp(0), __x.imag()));
     }
-    return complex<_Tp>(_CUDA_VSTD::__constexpr_isnan(__x.imag()) ? __x.imag() : _Tp(0),
+    return complex<_Tp>(_CUDA_VSTD::isnan(__x.imag()) ? __x.imag() : _Tp(0),
                         __constexpr_copysign(__x.real(), __x.imag()));
   }
   return _CUDA_VSTD::polar(_CUDA_VSTD::sqrt(_CUDA_VSTD::abs(__x)), _CUDA_VSTD::arg(__x) / _Tp(2));
@@ -1074,18 +1065,18 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> exp(const complex<_Tp>& __x)
   {
     return complex<_Tp>(_CUDA_VSTD::exp(__x.real()), __constexpr_copysign(_Tp(0), __x.imag()));
   }
-  if (_CUDA_VSTD::__constexpr_isinf(__x.real()))
+  if (_CUDA_VSTD::isinf(__x.real()))
   {
     if (__x.real() < _Tp(0))
     {
-      if (!_CUDA_VSTD::__constexpr_isfinite(__i))
+      if (!_CUDA_VSTD::isfinite(__i))
       {
         __i = _Tp(1);
       }
     }
-    else if (__i == _Tp(0) || !_CUDA_VSTD::__constexpr_isfinite(__i))
+    else if (__i == _Tp(0) || !_CUDA_VSTD::isfinite(__i))
     {
-      if (_CUDA_VSTD::__constexpr_isinf(__i))
+      if (_CUDA_VSTD::isinf(__i))
       {
         __i = _Tp(NAN);
       }
@@ -1144,21 +1135,21 @@ template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> asinh(const complex<_Tp>& __x)
 {
   const _Tp __pi(static_cast<_Tp>(atan2(+0., -0.)));
-  if (_CUDA_VSTD::__constexpr_isinf(__x.real()))
+  if (_CUDA_VSTD::isinf(__x.real()))
   {
-    if (_CUDA_VSTD::__constexpr_isnan(__x.imag()))
+    if (_CUDA_VSTD::isnan(__x.imag()))
     {
       return __x;
     }
-    if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+    if (_CUDA_VSTD::isinf(__x.imag()))
     {
       return complex<_Tp>(__x.real(), __constexpr_copysign(__pi * _Tp(0.25), __x.imag()));
     }
     return complex<_Tp>(__x.real(), __constexpr_copysign(_Tp(0), __x.imag()));
   }
-  if (_CUDA_VSTD::__constexpr_isnan(__x.real()))
+  if (_CUDA_VSTD::isnan(__x.real()))
   {
-    if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+    if (_CUDA_VSTD::isinf(__x.imag()))
     {
       return complex<_Tp>(__x.imag(), __x.real());
     }
@@ -1168,7 +1159,7 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> asinh(const complex<_Tp>& __x)
     }
     return complex<_Tp>(__x.real(), __x.real());
   }
-  if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+  if (_CUDA_VSTD::isinf(__x.imag()))
   {
     return complex<_Tp>(__constexpr_copysign(__x.imag(), __x.real()), __constexpr_copysign(__pi / _Tp(2), __x.imag()));
   }
@@ -1182,13 +1173,13 @@ template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> acosh(const complex<_Tp>& __x)
 {
   const _Tp __pi(static_cast<_Tp>(atan2(+0., -0.)));
-  if (_CUDA_VSTD::__constexpr_isinf(__x.real()))
+  if (_CUDA_VSTD::isinf(__x.real()))
   {
-    if (_CUDA_VSTD::__constexpr_isnan(__x.imag()))
+    if (_CUDA_VSTD::isnan(__x.imag()))
     {
       return complex<_Tp>(_CUDA_VSTD::abs(__x.real()), __x.imag());
     }
-    if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+    if (_CUDA_VSTD::isinf(__x.imag()))
     {
       if (__x.real() > _Tp(0))
       {
@@ -1205,15 +1196,15 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> acosh(const complex<_Tp>& __x)
     }
     return complex<_Tp>(__x.real(), __constexpr_copysign(_Tp(0), __x.imag()));
   }
-  if (_CUDA_VSTD::__constexpr_isnan(__x.real()))
+  if (_CUDA_VSTD::isnan(__x.real()))
   {
-    if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+    if (_CUDA_VSTD::isinf(__x.imag()))
     {
       return complex<_Tp>(_CUDA_VSTD::abs(__x.imag()), __x.real());
     }
     return complex<_Tp>(__x.real(), __x.real());
   }
-  if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+  if (_CUDA_VSTD::isinf(__x.imag()))
   {
     return complex<_Tp>(_CUDA_VSTD::abs(__x.imag()), __constexpr_copysign(__pi / _Tp(2), __x.imag()));
   }
@@ -1227,23 +1218,23 @@ template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> atanh(const complex<_Tp>& __x)
 {
   const _Tp __pi(static_cast<_Tp>(atan2(+0., -0.)));
-  if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+  if (_CUDA_VSTD::isinf(__x.imag()))
   {
     return complex<_Tp>(__constexpr_copysign(_Tp(0), __x.real()), __constexpr_copysign(__pi / _Tp(2), __x.imag()));
   }
-  if (_CUDA_VSTD::__constexpr_isnan(__x.imag()))
+  if (_CUDA_VSTD::isnan(__x.imag()))
   {
-    if (_CUDA_VSTD::__constexpr_isinf(__x.real()) || __x.real() == _Tp(0))
+    if (_CUDA_VSTD::isinf(__x.real()) || __x.real() == _Tp(0))
     {
       return complex<_Tp>(__constexpr_copysign(_Tp(0), __x.real()), __x.imag());
     }
     return complex<_Tp>(__x.imag(), __x.imag());
   }
-  if (_CUDA_VSTD::__constexpr_isnan(__x.real()))
+  if (_CUDA_VSTD::isnan(__x.real()))
   {
     return complex<_Tp>(__x.real(), __x.real());
   }
-  if (_CUDA_VSTD::__constexpr_isinf(__x.real()))
+  if (_CUDA_VSTD::isinf(__x.real()))
   {
     return complex<_Tp>(__constexpr_copysign(_Tp(0), __x.real()), __constexpr_copysign(__pi / _Tp(2), __x.imag()));
   }
@@ -1260,15 +1251,15 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> atanh(const complex<_Tp>& __x)
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> sinh(const complex<_Tp>& __x)
 {
-  if (_CUDA_VSTD::__constexpr_isinf(__x.real()) && !_CUDA_VSTD::__constexpr_isfinite(__x.imag()))
+  if (_CUDA_VSTD::isinf(__x.real()) && !_CUDA_VSTD::isfinite(__x.imag()))
   {
     return complex<_Tp>(__x.real(), _Tp(NAN));
   }
-  if (__x.real() == _Tp(0) && !_CUDA_VSTD::__constexpr_isfinite(__x.imag()))
+  if (__x.real() == _Tp(0) && !_CUDA_VSTD::isfinite(__x.imag()))
   {
     return complex<_Tp>(__x.real(), _Tp(NAN));
   }
-  if (__x.imag() == _Tp(0) && !_CUDA_VSTD::__constexpr_isfinite(__x.real()))
+  if (__x.imag() == _Tp(0) && !_CUDA_VSTD::isfinite(__x.real()))
   {
     return __x;
   }
@@ -1281,11 +1272,11 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> sinh(const complex<_Tp>& __x)
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> cosh(const complex<_Tp>& __x)
 {
-  if (_CUDA_VSTD::__constexpr_isinf(__x.real()) && !_CUDA_VSTD::__constexpr_isfinite(__x.imag()))
+  if (_CUDA_VSTD::isinf(__x.real()) && !_CUDA_VSTD::isfinite(__x.imag()))
   {
     return complex<_Tp>(_CUDA_VSTD::abs(__x.real()), _Tp(NAN));
   }
-  if (__x.real() == _Tp(0) && !_CUDA_VSTD::__constexpr_isfinite(__x.imag()))
+  if (__x.real() == _Tp(0) && !_CUDA_VSTD::isfinite(__x.imag()))
   {
     return complex<_Tp>(_Tp(NAN), __x.real());
   }
@@ -1293,7 +1284,7 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> cosh(const complex<_Tp>& __x)
   {
     return complex<_Tp>(_Tp(1), __x.imag());
   }
-  if (__x.imag() == _Tp(0) && !_CUDA_VSTD::__constexpr_isfinite(__x.real()))
+  if (__x.imag() == _Tp(0) && !_CUDA_VSTD::isfinite(__x.real()))
   {
     return complex<_Tp>(_CUDA_VSTD::abs(__x.real()), __x.imag());
   }
@@ -1306,16 +1297,16 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> cosh(const complex<_Tp>& __x)
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> tanh(const complex<_Tp>& __x)
 {
-  if (_CUDA_VSTD::__constexpr_isinf(__x.real()))
+  if (_CUDA_VSTD::isinf(__x.real()))
   {
-    if (!_CUDA_VSTD::__constexpr_isfinite(__x.imag()))
+    if (!_CUDA_VSTD::isfinite(__x.imag()))
     {
       return complex<_Tp>(__constexpr_copysign(_Tp(1), __x.real()), _Tp(0));
     }
     return complex<_Tp>(__constexpr_copysign(_Tp(1), __x.real()),
                         __constexpr_copysign(_Tp(0), _CUDA_VSTD::sin(_Tp(2) * __x.imag())));
   }
-  if (_CUDA_VSTD::__constexpr_isnan(__x.real()) && __x.imag() == _Tp(0))
+  if (_CUDA_VSTD::isnan(__x.real()) && __x.imag() == _Tp(0))
   {
     return __x;
   }
@@ -1323,7 +1314,7 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> tanh(const complex<_Tp>& __x)
   _Tp __2i(_Tp(2) * __x.imag());
   _Tp __d(_CUDA_VSTD::cosh(__2r) + _CUDA_VSTD::cos(__2i));
   _Tp __2rsh(_CUDA_VSTD::sinh(__2r));
-  if (_CUDA_VSTD::__constexpr_isinf(__2rsh) && _CUDA_VSTD::__constexpr_isinf(__d))
+  if (_CUDA_VSTD::isinf(__2rsh) && _CUDA_VSTD::isinf(__d))
   {
     return complex<_Tp>(__2rsh > _Tp(0) ? _Tp(1) : _Tp(-1), __2i > _Tp(0) ? _Tp(0) : _Tp(-0.));
   }
@@ -1345,13 +1336,13 @@ template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> acos(const complex<_Tp>& __x)
 {
   const _Tp __pi(static_cast<_Tp>(atan2(+0., -0.)));
-  if (_CUDA_VSTD::__constexpr_isinf(__x.real()))
+  if (_CUDA_VSTD::isinf(__x.real()))
   {
-    if (_CUDA_VSTD::__constexpr_isnan(__x.imag()))
+    if (_CUDA_VSTD::isnan(__x.imag()))
     {
       return complex<_Tp>(__x.imag(), __x.real());
     }
-    if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+    if (_CUDA_VSTD::isinf(__x.imag()))
     {
       if (__x.real() < _Tp(0))
       {
@@ -1365,15 +1356,15 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> acos(const complex<_Tp>& __x)
     }
     return complex<_Tp>(_Tp(0), _CUDA_VSTD::signbit(__x.imag()) ? __x.real() : -__x.real());
   }
-  if (_CUDA_VSTD::__constexpr_isnan(__x.real()))
+  if (_CUDA_VSTD::isnan(__x.real()))
   {
-    if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+    if (_CUDA_VSTD::isinf(__x.imag()))
     {
       return complex<_Tp>(__x.real(), -__x.imag());
     }
     return complex<_Tp>(__x.real(), __x.real());
   }
-  if (_CUDA_VSTD::__constexpr_isinf(__x.imag()))
+  if (_CUDA_VSTD::isinf(__x.imag()))
   {
     return complex<_Tp>(__pi / _Tp(2), -__x.imag());
   }

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_min_max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_min_max.pass.cpp
@@ -16,28 +16,28 @@
 #include "test_macros.h"
 
 template <class T>
-__host__ __device__ void test_fmax()
+__host__ __device__ void test_fmax(T value)
 {
   static_assert((cuda::std::is_same<decltype(cuda::std::fmax((T) 0, (T) 0)), T>::value), "");
   static_assert(
     (cuda::std::is_same<decltype(cuda::std::fmax((float) 0, (T) 0)), cuda::std::__promote_t<float, T>>::value), "");
   static_assert(
     (cuda::std::is_same<decltype(cuda::std::fmax((double) 0, (T) 0)), cuda::std::__promote_t<double, T>>::value), "");
-  assert(cuda::std::fmax((T) 1, (T) 0) == T(1));
+  assert(cuda::std::fmax(value, (T) 0) == value);
 }
 
-__host__ __device__ void test_fmax()
+__host__ __device__ void test_fmax(float value)
 {
-  test_fmax<float>();
-  test_fmax<double>();
+  test_fmax<float>(value);
+  test_fmax<double>(value);
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  test_fmax<long double>();
+  test_fmax<long double>(value);
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  test_fmax<__half>();
+  test_fmax<__half>(__float2half(value));
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  test_fmax<__nv_bfloat16>();
+  test_fmax<__nv_bfloat16>(__float2bfloat16(value));
 #endif // _LIBCUDACXX_HAS_NVBF16
 
   static_assert((cuda::std::is_same<decltype(cuda::std::fmax((int) 0, (int) 0)), double>::value), "");
@@ -58,28 +58,28 @@ __host__ __device__ void test_fmax()
 }
 
 template <class T>
-__host__ __device__ void test_fmin()
+__host__ __device__ void test_fmin(T value)
 {
   static_assert((cuda::std::is_same<decltype(cuda::std::fmin((T) 0, (T) 0)), T>::value), "");
   static_assert(
     (cuda::std::is_same<decltype(cuda::std::fmin((float) 0, (T) 0)), cuda::std::__promote_t<float, T>>::value), "");
   static_assert(
     (cuda::std::is_same<decltype(cuda::std::fmin((double) 0, (T) 0)), cuda::std::__promote_t<double, T>>::value), "");
-  assert(cuda::std::fmin((T) 1, (T) 0) == T(0));
+  assert(cuda::std::fmin(value, (T) 0) == T(0));
 }
 
-__host__ __device__ void test_fmin()
+__host__ __device__ void test_fmin(float value)
 {
-  test_fmax<float>();
-  test_fmax<double>();
+  test_fmax<float>(value);
+  test_fmax<double>(value);
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  test_fmax<long double>();
+  test_fmax<long double>(value);
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  test_fmax<__half>();
+  test_fmax<__half>(__float2half(value));
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  test_fmax<__nv_bfloat16>();
+  test_fmax<__nv_bfloat16>(__float2bfloat16(value));
 #endif // _LIBCUDACXX_HAS_NVBF16
 
   static_assert((cuda::std::is_same<decltype(cuda::std::fmin((int) 0, (int) 0)), double>::value), "");
@@ -99,19 +99,20 @@ __host__ __device__ void test_fmin()
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 }
 
-__host__ __device__ void test()
+__host__ __device__ void test(float value)
 {
-  test_fmax();
-  test_fmin();
+  test_fmax(value);
+  test_fmin(value);
 }
 
-__global__ void test_global_kernel()
+__global__ void test_global_kernel(float* value)
 {
-  test();
+  test(*value);
 }
 
 int main(int, char**)
 {
-  test();
+  volatile float value = 1.0f;
+  test(value);
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_min_max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_min_max.pass.cpp
@@ -1,0 +1,117 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+template <class T>
+__host__ __device__ void test_fmax()
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((T) 0, (T) 0)), T>::value), "");
+  static_assert(
+    (cuda::std::is_same<decltype(cuda::std::fmax((float) 0, (T) 0)), cuda::std::__promote_t<float, T>>::value), "");
+  static_assert(
+    (cuda::std::is_same<decltype(cuda::std::fmax((double) 0, (T) 0)), cuda::std::__promote_t<double, T>>::value), "");
+  assert(cuda::std::fmax((T) 1, (T) 0) == T(1));
+}
+
+__host__ __device__ void test_fmax()
+{
+  test_fmax<float>();
+  test_fmax<double>();
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test_fmax<long double>();
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test_fmax<__half>();
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test_fmax<__nv_bfloat16>();
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((int) 0, (int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((int) 0, (long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((int) 0, (unsigned long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((float) 0, (unsigned int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((double) 0, (long) 0)), double>::value), "");
+
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((bool) 0, (float) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((unsigned short) 0, (double) 0)), double>::value), "");
+
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmaxf(0, 0)), float>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmax((long double) 0, (unsigned long) 0)), long double>::value),
+                "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmaxl(0, 0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <class T>
+__host__ __device__ void test_fmin()
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((T) 0, (T) 0)), T>::value), "");
+  static_assert(
+    (cuda::std::is_same<decltype(cuda::std::fmin((float) 0, (T) 0)), cuda::std::__promote_t<float, T>>::value), "");
+  static_assert(
+    (cuda::std::is_same<decltype(cuda::std::fmin((double) 0, (T) 0)), cuda::std::__promote_t<double, T>>::value), "");
+  assert(cuda::std::fmin((T) 1, (T) 0) == T(0));
+}
+
+__host__ __device__ void test_fmin()
+{
+  test_fmax<float>();
+  test_fmax<double>();
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test_fmax<long double>();
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test_fmax<__half>();
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test_fmax<__nv_bfloat16>();
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((int) 0, (int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((int) 0, (long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((int) 0, (unsigned long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((float) 0, (unsigned int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((double) 0, (long) 0)), double>::value), "");
+
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((bool) 0, (float) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((unsigned short) 0, (double) 0)), double>::value), "");
+
+  static_assert((cuda::std::is_same<decltype(cuda::std::fminf(0, 0)), float>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::fmin((long double) 0, (unsigned long) 0)), long double>::value),
+                "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fminl(0, 0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+__host__ __device__ void test()
+{
+  test_fmax();
+  test_fmin();
+}
+
+__global__ void test_global_kernel()
+{
+  test();
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits.pass.cpp
@@ -1,0 +1,410 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "fp_compare.h"
+#include "test_macros.h"
+
+template <class T>
+__host__ __device__ void test_signbit(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::signbit((T) 0)), bool>::value), "");
+  assert(cuda::std::signbit(T(val)) == false);
+  assert(cuda::std::signbit(T(-1.0)) == true);
+  assert(cuda::std::signbit(T(0.0)) == false);
+}
+
+__host__ __device__ void test_signbit(float val)
+{
+  test_signbit<float>(val);
+  test_signbit<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test_signbit<long double>(val);
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test_signbit<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test_signbit<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  assert(cuda::std::signbit(0u) == false);
+  assert(cuda::std::signbit(cuda::std::numeric_limits<unsigned>::max()) == false);
+  assert(cuda::std::signbit(1) == false);
+  assert(cuda::std::signbit(-1) == true);
+  assert(cuda::std::signbit(cuda::std::numeric_limits<int>::max()) == false);
+  assert(cuda::std::signbit(cuda::std::numeric_limits<int>::min()) == true);
+}
+
+template <class T>
+__host__ __device__ void test_isfinite(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::isfinite((T) 0)), bool>::value), "");
+  assert(cuda::std::isfinite(T(val)) == true);
+  assert(cuda::std::isfinite(T(-1.0f)) == true);
+  assert(cuda::std::isfinite(T(1.0f)) == true);
+  assert(cuda::std::isfinite(T(NAN)) == false);
+  assert(cuda::std::isfinite(T(INFINITY)) == false);
+  assert(cuda::std::isfinite(-T(INFINITY)) == false);
+}
+
+__host__ __device__ void test_isfinite(float val)
+{
+  test_isfinite<float>(val);
+  test_isfinite<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test_isfinite<long double>();
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test_isfinite<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test_isfinite<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  assert(cuda::std::isfinite(0) == true);
+  assert(cuda::std::isfinite(1) == true);
+  assert(cuda::std::isfinite(-1) == true);
+  assert(cuda::std::isfinite(cuda::std::numeric_limits<int>::max()) == true);
+  assert(cuda::std::isfinite(cuda::std::numeric_limits<int>::min()) == true);
+}
+
+__host__ __device__ _CCCL_CONSTEXPR_ISFINITE bool test_constexpr_isfinite(float val)
+{
+  return cuda::std::isfinite(val);
+}
+
+template <class T>
+__host__ __device__ void test_isnormal(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::isnormal((T) 0)), bool>::value), "");
+  assert(cuda::std::isnormal(T(val)) == false);
+  assert(cuda::std::isnormal(T(-1.0f)) == true);
+  assert(cuda::std::isnormal(T(1.0f)) == true);
+  assert(cuda::std::isnormal(T(0.0f)) == false);
+  assert(cuda::std::isnormal(T(NAN)) == false);
+  assert(cuda::std::isnormal(T(INFINITY)) == false);
+  assert(cuda::std::isnormal(-T(INFINITY)) == false);
+}
+
+__host__ __device__ void test_isnormal(float val)
+{
+  test_isnormal<float>(val);
+  test_isnormal<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test_isnormal<long double>();
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test_isnormal<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test_isnormal<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  assert(cuda::std::isnormal(0) == false);
+  assert(cuda::std::isnormal(1) == true);
+  assert(cuda::std::isnormal(-1) == true);
+  assert(cuda::std::isnormal(cuda::std::numeric_limits<int>::max()) == true);
+  assert(cuda::std::isnormal(cuda::std::numeric_limits<int>::min()) == true);
+}
+
+__host__ __device__ void test_isgreater(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((float) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((float) 0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((float) 0, (long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater(0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((double) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((long double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((long double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((long double) 0, (long double) 0)), bool>::value),
+                "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__half) 0, (__half) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__half) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__half) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value),
+                "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__nv_bfloat16) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreater((__nv_bfloat16) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::isgreater(-1.0, 0.F) == false);
+}
+
+__host__ __device__ void test_isgreaterequal(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((float) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((float) 0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((float) 0, (long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal(0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((double) 0, (long double) 0)), bool>::value),
+                "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((long double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((long double) 0, (double) 0)), bool>::value),
+                "");
+  static_assert(
+    (cuda::std::is_same<decltype(cuda::std::isgreaterequal((long double) 0, (long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__half) 0, (__half) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__half) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__half) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert(
+    (cuda::std::is_same<decltype(cuda::std::isgreaterequal((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__nv_bfloat16) 0, (float) 0)), bool>::value),
+                "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isgreaterequal((__nv_bfloat16) 0, (double) 0)), bool>::value),
+                "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::isgreaterequal(-1.0, 0.F) == false);
+}
+
+__host__ __device__ void test_isinf(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::isinf((float) 0)), bool>::value), "");
+
+  typedef decltype(cuda::std::isinf((double) 0)) DoubleRetType;
+  static_assert((cuda::std::is_same<DoubleRetType, bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isinf(0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isinf((long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isinf((__half) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isinf((__nv_bfloat16) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::isinf(-1.0) == false);
+  assert(cuda::std::isinf(0) == false);
+  assert(cuda::std::isinf(1) == false);
+  assert(cuda::std::isinf(-1) == false);
+  assert(cuda::std::isinf(cuda::std::numeric_limits<int>::max()) == false);
+  assert(cuda::std::isinf(cuda::std::numeric_limits<int>::min()) == false);
+}
+
+__host__ __device__ _CCCL_CONSTEXPR_ISINF bool test_constexpr_isinf(float val)
+{
+  return cuda::std::isinf(val);
+}
+
+__host__ __device__ void test_isless(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((float) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((float) 0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((float) 0, (long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless(0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((double) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((long double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((long double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((long double) 0, (long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__half) 0, (__half) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__half) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__half) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value),
+                "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__nv_bfloat16) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isless((__nv_bfloat16) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::isless(-1.0, 0.F) == true);
+}
+
+__host__ __device__ void test_islessequal(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((float) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((float) 0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((float) 0, (long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal(0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((double) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((long double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((long double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((long double) 0, (long double) 0)), bool>::value),
+                "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__half) 0, (__half) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__half) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__half) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert(
+    (cuda::std::is_same<decltype(cuda::std::islessequal((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__nv_bfloat16) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessequal((__nv_bfloat16) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::islessequal(-1.0, 0.F) == true);
+}
+
+__host__ __device__ void test_islessgreater(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((float) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((float) 0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((float) 0, (long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater(0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((double) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((long double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((long double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((long double) 0, (long double) 0)), bool>::value),
+                "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__half) 0, (__half) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__half) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__half) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert(
+    (cuda::std::is_same<decltype(cuda::std::islessgreater((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__nv_bfloat16) 0, (float) 0)), bool>::value),
+                "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::islessgreater((__nv_bfloat16) 0, (double) 0)), bool>::value),
+                "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::islessgreater(-1.0, 0.F) == true);
+}
+
+__host__ __device__ void test_isnan(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::isnan((float) 0)), bool>::value), "");
+
+  typedef decltype(cuda::std::isnan((double) 0)) DoubleRetType;
+  static_assert((cuda::std::is_same<DoubleRetType, bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isnan(0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isnan((long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isnan((__half) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isnan((__nv_bfloat16) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::isnan(-1.0) == false);
+  assert(cuda::std::isnan(0) == false);
+  assert(cuda::std::isnan(1) == false);
+  assert(cuda::std::isnan(-1) == false);
+  assert(cuda::std::isnan(cuda::std::numeric_limits<int>::max()) == false);
+  assert(cuda::std::isnan(cuda::std::numeric_limits<int>::min()) == false);
+}
+
+__host__ __device__ _CCCL_CONSTEXPR_ISNAN bool test_constexpr_isnan(float val)
+{
+  return cuda::std::isnan(val);
+}
+
+__host__ __device__ void test_isunordered(float val)
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((float) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((float) 0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((float) 0, (long double) 0)), bool>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered(0, (double) 0)), bool>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((double) 0, (long double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((long double) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((long double) 0, (double) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((long double) 0, (long double) 0)), bool>::value),
+                "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__half) 0, (__half) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__half) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__half) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert(
+    (cuda::std::is_same<decltype(cuda::std::isunordered((__nv_bfloat16) 0, (__nv_bfloat16) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__nv_bfloat16) 0, (float) 0)), bool>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::isunordered((__nv_bfloat16) 0, (double) 0)), bool>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::isunordered(-1.0, 0.F) == false);
+}
+
+__host__ __device__ void test(float val)
+{
+  test_signbit(val);
+  test_isfinite(val);
+  test_isnormal(val);
+  test_isgreater(val);
+  test_isgreaterequal(val);
+  test_isinf(val);
+  test_isless(val);
+  test_islessequal(val);
+  test_islessgreater(val);
+  test_isnan(val);
+  test_isunordered(val);
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 0.0f;
+  test(val);
+
+#if defined(_CCCL_BUILTIN_ISNAN)
+  static_assert(!test_constexpr_isnan(0.0f), "");
+#endif // _CCCL_BUILTIN_ISNAN
+
+#if defined(_CCCL_BUILTIN_ISINF)
+  static_assert(!test_constexpr_isinf(0.0f), "");
+#endif // _CCCL_BUILTIN_ISINF
+
+#if defined(_CCCL_BUILTIN_ISFINITE) || (defined(_CCCL_BUILTIN_ISINF) && defined(_CCCL_BUILTIN_ISNAN))
+  static_assert(test_constexpr_isfinite(0.0f), "");
+#endif // _CCCL_BUILTIN_ISFINITE|| (_CCCL_BUILTIN_ISINF && _CCCL_BUILTIN_ISNAN)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_traits.pass.cpp
@@ -20,12 +20,12 @@
 template <class T>
 __host__ __device__ void test_fpclassify(float val)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::fpclassify(val)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::fpclassify(T(val))), int>::value), "");
   assert(cuda::std::fpclassify(T(val)) == FP_NORMAL);
   assert(cuda::std::fpclassify(T(1.0)) == FP_NORMAL);
   assert(cuda::std::fpclassify(T(0.0)) == FP_ZERO);
   assert(cuda::std::fpclassify(T(-1.0)) == FP_NORMAL);
-  assert(cuda::std::fpclassify(T(0.0)) == FP_ZERO);
+  assert(cuda::std::fpclassify(T(-0.0)) == FP_ZERO);
   // extended floating point types have issues here
   if (!cuda::std::__is_extended_floating_point<T>::value)
   {

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/lerp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/lerp.pass.cpp
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+// constexpr float lerp(float a, float b, float t) noexcept;
+// constexpr double lerp(double a, double b, double t) noexcept;
+// constexpr long double lerp(long double a, long double b, long double t) noexcept;
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "fp_compare.h"
+#include "test_macros.h"
+
+template <typename T>
+__host__ __device__ TEST_CONSTEXPR_CXX14 bool constexpr_test()
+{
+  return cuda::std::lerp(T(0.0), T(12), T(0.0)) == T(0.0) && cuda::std::lerp(T(12), T(0.0), T(0.5)) == T(6)
+      && cuda::std::lerp(T(0.0), T(12), T(2)) == T(24);
+}
+
+template <typename T>
+__host__ __device__ void test()
+{
+  ASSERT_SAME_TYPE(T, decltype(cuda::std::lerp(T(), T(), T())));
+  static_assert(noexcept(cuda::std::lerp(T(), T(), T())), "");
+
+  //     constexpr T minV = cuda::std::numeric_limits<T>::min();
+  const T maxV = cuda::std::numeric_limits<T>::max();
+  const T inf  = cuda::std::numeric_limits<T>::infinity();
+
+  //  Things that can be compared exactly
+  assert((cuda::std::lerp(T(0.0), T(12), T(0.0)) == T(0.0)));
+  assert((cuda::std::lerp(T(0.0), T(12), T(1)) == T(12)));
+  assert((cuda::std::lerp(T(12), T(0.0), T(0.0)) == T(12)));
+  assert((cuda::std::lerp(T(12), T(0.0), T(1)) == T(0.0)));
+
+  assert((cuda::std::lerp(T(0.0), T(12), T(0.5)) == T(6)));
+  assert((cuda::std::lerp(T(12), T(0.0), T(0.5)) == T(6)));
+  assert((cuda::std::lerp(T(0.0), T(12), T(2)) == T(24)));
+  assert((cuda::std::lerp(T(12), T(0.0), T(2)) == T(-12)));
+
+  assert((cuda::std::lerp(maxV, maxV / T(10), T(0.0)) == maxV));
+  assert((cuda::std::lerp(maxV / T(10), maxV, T(1)) == maxV));
+
+  assert((cuda::std::lerp(T(2.3), T(2.3), inf) == T(2.3)));
+
+  assert(cuda::std::lerp(T(0.0), T(0.0), T(23)) == T(0.0));
+
+  // __half and __nvbfloat have precision issues here
+  if (!cuda::std::__is_extended_floating_point<T>::value)
+  {
+    assert(cuda::std::isnan(cuda::std::lerp(T(0.0), T(0.0), inf)));
+  }
+}
+
+int main(int, char**)
+{
+  test<float>();
+  test<double>();
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  // test<__half>();
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>();
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+#if TEST_STD_VER >= 2014
+  static_assert(constexpr_test<float>(), "");
+  static_assert(constexpr_test<double>(), "");
+#endif // TEST_STD_VER >= 2014
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/lerp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/lerp.pass.cpp
@@ -34,7 +34,6 @@ __host__ __device__ void test()
   ASSERT_SAME_TYPE(T, decltype(cuda::std::lerp(T(), T(), T())));
   static_assert(noexcept(cuda::std::lerp(T(), T(), T())), "");
 
-  //     constexpr T minV = cuda::std::numeric_limits<T>::min();
   const T maxV = cuda::std::numeric_limits<T>::max();
   const T inf  = cuda::std::numeric_limits<T>::infinity();
 
@@ -59,7 +58,7 @@ __host__ __device__ void test()
   // __half and __nvbfloat have precision issues here
   if (!cuda::std::__is_extended_floating_point<T>::value)
   {
-    assert(cuda::std::isnan(cuda::std::lerp(T(0.0), T(0.0), inf)));
+    assert(cuda::std::isnan(cuda::std::lerp(T(0.0), T(0.0), T(inf))));
   }
 }
 
@@ -72,7 +71,7 @@ int main(int, char**)
 #endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  // test<__half>();
+  test<__half>();
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
   test<__nv_bfloat16>();

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
@@ -15,191 +15,96 @@
 
 #include "test_macros.h"
 
-__host__ __device__ void test_log()
+template <class T>
+__host__ __device__ void test_log(T value)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((float) 0)), float>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((bool) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((unsigned short) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((unsigned int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((unsigned long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((unsigned long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((double) 0)), double>::value), "");
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::log(value)), ret>::value, "");
+  assert(cuda::std::log(value) == ret{0});
+}
+
+template <class T>
+__host__ __device__ void test_log10(T value)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::log10(value)), ret>::value, "");
+  assert(cuda::std::log10(value) == ret{0});
+}
+
+template <class T>
+__host__ __device__ void test_ilogb(T value)
+{
+  static_assert(cuda::std::is_same<decltype(cuda::std::ilogb(value)), int>::value, "");
+  assert(cuda::std::ilogb(value) == 0);
+}
+
+template <class T>
+__host__ __device__ void test_log1p(T value)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::log1p(value)), ret>::value, "");
+  assert(cuda::std::log1p(value - value) == ret{0});
+}
+
+template <class T>
+__host__ __device__ void test_log2(T value)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::log2(value)), ret>::value, "");
+  assert(cuda::std::log2(value) == ret{0});
+}
+
+template <class T>
+__host__ __device__ void test_logb(T value)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::logb(value)), ret>::value, "");
+  assert(cuda::std::logb(value) == ret{0});
+}
+
+template <class T>
+__host__ __device__ void test(T value)
+{
+  test_log<T>(value);
+  test_log10<T>(value);
+  test_ilogb<T>(value);
+  test_log1p<T>(value);
+  test_log2<T>(value);
+  test_logb<T>(value);
+}
+
+__host__ __device__ void test(float value)
+{
+  test<float>(value);
+  test<double>(value);
 #if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((long double) 0)), long double>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::logf(0)), float>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((long double) 0)), long double>::value), "");
+  test<long double>(value);
 #endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((__half) 0)), __half>::value), "");
+  test<__half>(__float2half(value));
 #endif // _LIBCUDACXX_HAS_NVFP16
 #ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::log((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
+  test<__nv_bfloat16>(__float2bfloat16(value));
 #endif // _LIBCUDACXX_HAS_NVBF16
-  assert(cuda::std::log(1) == 0);
+
+  test<unsigned short>(value);
+  test<int>(value);
+  test<unsigned int>(value);
+  test<long>(value);
+  test<long long>(value);
+  test<int>(value);
+  test<unsigned long long>(value);
+  test<int>(value);
 }
 
-__host__ __device__ void test_log10()
+__global__ void test_global_kernel(float* value)
 {
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((float) 0)), float>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((bool) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((unsigned short) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((unsigned int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((unsigned long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((unsigned long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((double) 0)), double>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((long double) 0)), long double>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10f(0)), float>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10l((long double) 0)), long double>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((__half) 0)), __half>::value), "");
-#endif // _LIBCUDACXX_HAS_NVFP16
-#ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::log10((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
-#endif // _LIBCUDACXX_HAS_NVBF16
-  assert(cuda::std::log10(1) == 0);
-}
-
-__host__ __device__ void test_ilogb()
-{
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((float) 0)), int>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((bool) 0)), int>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((unsigned short) 0)), int>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((int) 0)), int>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((unsigned int) 0)), int>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((long) 0)), int>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((unsigned long) 0)), int>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((long long) 0)), int>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((unsigned long long) 0)), int>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((double) 0)), int>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((long double) 0)), int>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogbf(0)), int>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogbl(0)), int>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((__half) 0)), int>::value), "");
-#endif // _LIBCUDACXX_HAS_NVFP16
-#ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((__nv_bfloat16) 0)), int>::value), "");
-#endif // _LIBCUDACXX_HAS_NVBF16
-  assert(cuda::std::ilogb(1) == 0);
-}
-
-__host__ __device__ void test_log1p()
-{
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((float) 0)), float>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((bool) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((unsigned short) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((unsigned int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((unsigned long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((unsigned long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((double) 0)), double>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((long double) 0)), long double>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1pf(0)), float>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1pl(0)), long double>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((__half) 0)), __half>::value), "");
-#endif // _LIBCUDACXX_HAS_NVFP16
-#ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
-#endif // _LIBCUDACXX_HAS_NVBF16
-  assert(cuda::std::log1p(0) == 0);
-}
-
-__host__ __device__ void test_log2()
-{
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((float) 0)), float>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((bool) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((unsigned short) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((unsigned int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((unsigned long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((unsigned long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((double) 0)), double>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((long double) 0)), long double>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2f(0)), float>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2l(0)), long double>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((__half) 0)), __half>::value), "");
-#endif // _LIBCUDACXX_HAS_NVFP16
-#ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::log2((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
-#endif // _LIBCUDACXX_HAS_NVBF16
-  assert(cuda::std::log2(1) == 0);
-}
-
-__host__ __device__ void test_logb()
-{
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((float) 0)), float>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((bool) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((unsigned short) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((unsigned int) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((unsigned long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((unsigned long long) 0)), double>::value), "");
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((double) 0)), double>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((long double) 0)), long double>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-  static_assert((cuda::std::is_same<decltype(cuda::std::logbf(0)), float>::value), "");
-#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
-  static_assert((cuda::std::is_same<decltype(cuda::std::logbl(0)), long double>::value), "");
-#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#ifdef _LIBCUDACXX_HAS_NVFP16
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((__half) 0)), __half>::value), "");
-#endif // _LIBCUDACXX_HAS_NVFP16
-#ifdef _LIBCUDACXX_HAS_NVBF16
-  static_assert((cuda::std::is_same<decltype(cuda::std::logb((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
-#endif // _LIBCUDACXX_HAS_NVBF16
-  assert(cuda::std::logb(1) == 0);
-}
-
-__host__ __device__ void test()
-{
-  test_log();
-  test_log10();
-  test_ilogb();
-  test_log1p();
-  test_log2();
-  test_logb();
-}
-
-__global__ void test_global_kernel()
-{
-  test();
+  test(*value);
 }
 
 int main(int, char**)
 {
-  test();
+  volatile float value = 1.0f;
+  test(value);
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
@@ -1,0 +1,205 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+__host__ __device__ void test_log()
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((float) 0)), float>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((bool) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((unsigned short) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((unsigned int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((unsigned long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((unsigned long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((double) 0)), double>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((long double) 0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::logf(0)), float>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((long double) 0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((__half) 0)), __half>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::log((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::log(1) == 0);
+}
+
+__host__ __device__ void test_log10()
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((float) 0)), float>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((bool) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((unsigned short) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((unsigned int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((unsigned long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((unsigned long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((double) 0)), double>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((long double) 0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10f(0)), float>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10l((long double) 0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((__half) 0)), __half>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::log10((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::log10(1) == 0);
+}
+
+__host__ __device__ void test_ilogb()
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((float) 0)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((bool) 0)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((unsigned short) 0)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((int) 0)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((unsigned int) 0)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((long) 0)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((unsigned long) 0)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((long long) 0)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((unsigned long long) 0)), int>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((double) 0)), int>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((long double) 0)), int>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogbf(0)), int>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogbl(0)), int>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((__half) 0)), int>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::ilogb((__nv_bfloat16) 0)), int>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::ilogb(1) == 0);
+}
+
+__host__ __device__ void test_log1p()
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((float) 0)), float>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((bool) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((unsigned short) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((unsigned int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((unsigned long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((unsigned long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((double) 0)), double>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((long double) 0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1pf(0)), float>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1pl(0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((__half) 0)), __half>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::log1p((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::log1p(0) == 0);
+}
+
+__host__ __device__ void test_log2()
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((float) 0)), float>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((bool) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((unsigned short) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((unsigned int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((unsigned long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((unsigned long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((double) 0)), double>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((long double) 0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2f(0)), float>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2l(0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((__half) 0)), __half>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::log2((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::log2(1) == 0);
+}
+
+__host__ __device__ void test_logb()
+{
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((float) 0)), float>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((bool) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((unsigned short) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((unsigned int) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((unsigned long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((unsigned long long) 0)), double>::value), "");
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((double) 0)), double>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((long double) 0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  static_assert((cuda::std::is_same<decltype(cuda::std::logbf(0)), float>::value), "");
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  static_assert((cuda::std::is_same<decltype(cuda::std::logbl(0)), long double>::value), "");
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((__half) 0)), __half>::value), "");
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  static_assert((cuda::std::is_same<decltype(cuda::std::logb((__nv_bfloat16) 0)), __nv_bfloat16>::value), "");
+#endif // _LIBCUDACXX_HAS_NVBF16
+  assert(cuda::std::logb(1) == 0);
+}
+
+__host__ __device__ void test()
+{
+  test_log();
+  test_log10();
+  test_ilogb();
+  test_log1p();
+  test_log2();
+  test_logb();
+}
+
+__global__ void test_global_kernel()
+{
+  test();
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/logarithms.pass.cpp
@@ -87,14 +87,13 @@ __host__ __device__ void test(float value)
   test<__nv_bfloat16>(__float2bfloat16(value));
 #endif // _LIBCUDACXX_HAS_NVBF16
 
-  test<unsigned short>(value);
-  test<int>(value);
-  test<unsigned int>(value);
-  test<long>(value);
-  test<long long>(value);
-  test<int>(value);
-  test<unsigned long long>(value);
-  test<int>(value);
+  test<unsigned short>(static_cast<unsigned short>(value));
+  test<int>(static_cast<int>(value));
+  test<unsigned int>(static_cast<unsigned int>(value));
+  test<long>(static_cast<long>(value));
+  test<unsigned long>(static_cast<unsigned long>(value));
+  test<long long>(static_cast<long long>(value));
+  test<unsigned long long>(static_cast<unsigned long long>(value));
 }
 
 __global__ void test_global_kernel(float* value)


### PR DESCRIPTION
We lack a lot of coverage for extended floating point types. This leads to a lot of the cmath functions being undefined for `__half` and `__nv_bfloat16`

Even worse, it turns out a ton of our machinery doesnt even work properly because we do pull in host only functions. That leads to a ton of error messages like:
```
error #20014-D: calling a __host__ function from a __host__ __device__ function is not allowed
    cuda::std::fmax(1, 0);
```

This starts moving towards using our own implementations of basic math functions, that use a builtin when available but fall back to the host definition otherwise.

For device we use functions from the CRT or implement them ourself