### PR TITLE
[CUDAX] Enable passing hierarchy levels directly into make_config

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -141,6 +141,9 @@ struct can_stack_checker
   using can_stack = ::cuda::std::__fold_and<detail::can_stack_on_top<LevelsShifted, Levels>...>;
 };
 
+template <typename... Levels>
+using get_last_level = level_at_index<sizeof...(Levels) - 1, Levels...>;
+
 template <typename LUnit, typename L1, typename... Levels>
 _CCCL_INLINE_VAR constexpr bool __can_stack =
   can_stack_checker<__level_type_of<L1>,

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -767,7 +767,7 @@ constexpr auto _CCCL_HOST get_launch_dimensions(const hierarchy_dimensions<Level
  This could have been a single function with make_hierarchy and first template
  argument defauled, but then the above TODO would be impossible and the current
  name makes more sense */
-template <typename LUnit, typename L1, typename... Levels>
+template <typename LUnit = void, typename L1, typename... Levels>
 constexpr auto make_hierarchy_fragment(L1 l1, Levels... ls) noexcept
 {
   return detail::__make_hierarchy_fragment<LUnit>()(detail::__as_level(l1), detail::__as_level(ls)...);

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_levels.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_levels.cuh
@@ -80,6 +80,9 @@ struct allowed_levels
 
 namespace detail
 {
+template <typename LevelType>
+using __default_unit_below = typename LevelType::allowed_below::default_unit;
+
 template <typename QueryLevel, typename AllowedLevels>
 _CCCL_INLINE_VAR constexpr bool is_level_allowed = false;
 
@@ -93,7 +96,7 @@ _CCCL_INLINE_VAR constexpr bool can_stack_on_top =
 
 template <typename Unit, typename Level>
 _CCCL_INLINE_VAR constexpr bool legal_unit_for_level =
-  can_stack_on_top<Unit, Level> || legal_unit_for_level<Unit, typename Level::allowed_below::default_unit>;
+  can_stack_on_top<Unit, Level> || legal_unit_for_level<Unit, __default_unit_below<Level>>;
 
 template <typename Unit>
 _CCCL_INLINE_VAR constexpr bool legal_unit_for_level<Unit, void> = false;
@@ -278,7 +281,7 @@ template <typename Unit, typename Level>
   }
   else
   {
-    using SplitLevel = typename Level::allowed_below::default_unit;
+    using SplitLevel = detail::__default_unit_below<Level>;
     return dims_product<typename Level::product_type>(
       extents_impl<SplitLevel, Level>(), extents_impl<Unit, SplitLevel>());
   }
@@ -294,7 +297,7 @@ template <typename Unit, typename Level>
   }
   else
   {
-    using SplitLevel = typename Level::allowed_below::default_unit;
+    using SplitLevel = detail::__default_unit_below<Level>;
     return dims_sum<typename Level::product_type>(
       dims_product<typename Level::product_type>(index_impl<SplitLevel, Level>(), extents_impl<Unit, SplitLevel>()),
       index_impl<Unit, SplitLevel>());
@@ -392,7 +395,7 @@ _CCCL_DEVICE auto rank(const Unit&, const Level&)
   {
     /* Its interesting that there is a need for else here, but using the above in all cases would result in
         a different numbering scheme, where adjacent ranks in lower level would not be adjacent in this level */
-    using SplitLevel = typename Level::allowed_below::default_unit;
+    using SplitLevel = detail::__default_unit_below<Level>;
     return rank<SplitLevel, Level>() * count<Unit, SplitLevel>() + rank<Unit, SplitLevel>();
   }
 }

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -363,10 +363,10 @@ struct kernel_config
 
   constexpr kernel_config(const Dimensions& dims, const Options&... opts)
       : dims(dims)
-      , options(opts...){};
+      , options(opts...) {};
   constexpr kernel_config(const Dimensions& dims, const ::cuda::std::tuple<Options...>& opts)
       : dims(dims)
-      , options(opts){};
+      , options(opts) {};
 
   /**
    * @brief Add a new option to this configuration

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -14,6 +14,7 @@
 #include <cuda/std/span>
 #include <cuda/std/tuple>
 
+#include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/hierarchy.cuh>
 
 #if _CCCL_STD_VER >= 2017
@@ -86,6 +87,35 @@ inline constexpr bool no_duplicate_options = true;
 template <typename Option, typename... Rest>
 inline constexpr bool no_duplicate_options<Option, Rest...> =
   ((Option::kind != Rest::kind) && ...) && no_duplicate_options<Rest...>;
+
+template <typename... Prev>
+_CCCL_NODISCARD constexpr auto process_config_args(const ::cuda::std::tuple<Prev...>& previous)
+{
+  return kernel_config(::cuda::std::apply(make_hierarchy_fragment<void, const Prev&...>, previous));
+}
+
+template <typename... Prev, typename Arg, typename... Rest>
+_CCCL_NODISCARD constexpr auto
+process_config_args(const ::cuda::std::tuple<Prev...>& previous, const Arg& arg, const Rest&... rest)
+{
+  if constexpr (::cuda::std::is_base_of_v<detail::launch_option, Arg>)
+  {
+    static_assert((::cuda::std::is_base_of_v<detail::launch_option, Rest> && ...),
+                  "Hierarchy levels and launch options can't be mixed");
+    if constexpr (sizeof...(Prev) == 0)
+    {
+      return kernel_config(uninit_t{}, arg, rest...);
+    }
+    else
+    {
+      return kernel_config(::cuda::std::apply(make_hierarchy_fragment<void, const Prev&...>, previous), arg, rest...);
+    }
+  }
+  else
+  {
+    return process_config_args(::cuda::std::tuple_cat(previous, ::cuda::std::make_tuple(arg)), rest...);
+  }
+}
 
 } // namespace detail
 
@@ -333,10 +363,10 @@ struct kernel_config
 
   constexpr kernel_config(const Dimensions& dims, const Options&... opts)
       : dims(dims)
-      , options(opts...) {};
+      , options(opts...){};
   constexpr kernel_config(const Dimensions& dims, const ::cuda::std::tuple<Options...>& opts)
       : dims(dims)
-      , options(opts) {};
+      , options(opts){};
 
   /**
    * @brief Add a new option to this configuration
@@ -386,10 +416,18 @@ _CCCL_NODISCARD constexpr auto operator&(const hierarchy_dimensions<Levels...>& 
  * @param opts
  * Variadic number of launch configuration options to be included in the resulting kernel configuration object
  */
-template <typename... Levels, typename... Opts>
-_CCCL_NODISCARD constexpr auto make_config(const hierarchy_dimensions<Levels...>& dims, const Opts&... opts) noexcept
+template <typename BottomUnit, typename... Levels, typename... Opts>
+_CCCL_NODISCARD constexpr auto
+make_config(const hierarchy_dimensions_fragment<BottomUnit, Levels...>& dims, const Opts&... opts) noexcept
 {
-  return kernel_config<hierarchy_dimensions<Levels...>, Opts...>(dims, opts...);
+  return kernel_config<hierarchy_dimensions_fragment<BottomUnit, Levels...>, Opts...>(dims, opts...);
+}
+
+template <typename... Args>
+_CCCL_NODISCARD constexpr auto make_config(const Args&... args)
+{
+  static_assert(sizeof...(Args) != 0, "Configuration can't be empty");
+  return detail::process_config_args(::cuda::std::make_tuple(), args...);
 }
 
 namespace detail

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -41,7 +41,8 @@ template <typename Config, typename Kernel, typename... Args>
 _CCCL_NODISCARD cudaError_t
 launch_impl(::cuda::stream_ref stream, Config conf, const Kernel& kernel_fn, const Args&... args)
 {
-  static_assert(!::cuda::std::is_same_v<Config, uninit_t>, "Can't launch a configuration without hierarchy dimensions");
+  static_assert(!::cuda::std::is_same_v<decltype(conf.dims), uninit_t>,
+                "Can't launch a configuration without hierarchy dimensions");
   cudaLaunchConfig_t config{};
   cudaError_t status                      = cudaSuccess;
   constexpr bool has_cluster_level        = has_level<cluster_level, decltype(conf.dims)>;

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -41,6 +41,7 @@ template <typename Config, typename Kernel, typename... Args>
 _CCCL_NODISCARD cudaError_t
 launch_impl(::cuda::stream_ref stream, Config conf, const Kernel& kernel_fn, const Args&... args)
 {
+  static_assert(!::cuda::std::is_same_v<Config, uninit_t>, "Can't launch a configuration without hierarchy dimensions");
   cudaLaunchConfig_t config{};
   cudaError_t status                      = cudaSuccess;
   constexpr bool has_cluster_level        = has_level<cluster_level, decltype(conf.dims)>;

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -188,3 +188,18 @@ TEST_CASE("Launch configuration", "[launch]")
   CUDART(cudaStreamDestroy(stream));
   CUDAX_CHECK(replacementCalled);
 }
+
+TEST_CASE("Hierarchy construction in config", "[launch]")
+{
+  auto config = cudax::make_config(cudax::grid_dims<2>(), cudax::cooperative_launch());
+  static_assert(config.dims.count(cudax::block) == 2);
+
+  auto config_larger = cudax::make_config(cudax::grid_dims<2>(), cudax::block_dims(256), cudax::cooperative_launch());
+  CUDAX_REQUIRE(config_larger.dims.count(cudax::thread) == 512);
+
+  auto config_no_options = cudax::make_config(cudax::grid_dims(2), cudax::block_dims<128>());
+  CUDAX_REQUIRE(config_no_options.dims.count(cudax::thread) == 256);
+
+  [[maybe_unused]] auto config_no_dims = cudax::make_config(cudax::cooperative_launch());
+  static_assert(cuda::std::is_same_v<decltype(config_no_dims.dims), cudax::uninit_t>);
+}


### PR DESCRIPTION
Currently launching a kernel requires creating a thread hierarchy using `make_hierarchy` function. That hierarchy can be used to launch the kernel directly or can be combined with launch options using `make_config` function.

It would be more convenient to use `make_config` directly to construct final configuration object that includes both the hierarchy and launch options. This change adds a new `make_config` overload that accepts a list of levels and config options.
For ease of implementation I decided to require a strict separation of hierarchy levels which come first and launch options which come second. This is similar to the order in the current overload, where the hierarchy comes first.
In addition the hierarchy arguments follow the same restrictions as the current `make_hierarchy` function, so sorted either ascending or descending.

We could think about relaxing some of these requirements, but I don't consider it a priority.

This PR also does two small changes:
- Introduces `__default_unit_below` for easy access to a default unit for a level.
- It introduces an option to automatically deduce the bottom unit for `make_hierarchy_fragment` by providing `void` as unit and makes it the default if unit is not provided. This was needed to implement rest of the changes, but using this new mode is the same if the hierarchy was made with a chain of `operator&`