### PR TITLE
cudax: rename ustdex's `__query` member function to `query`

### DIFF
--- a/cudax/include/cuda/experimental/__async/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/continue_on.cuh
@@ -244,7 +244,7 @@ struct continue_on_t::__sndr_t
     _CUDAX_API auto query(_Query) const //
       -> __query_result_t<_Query, env_of_t<_Sndr>>
     {
-      return __async::get_env(__sndr->__sndr).__query(_Query{});
+      return __async::get_env(__sndr->__sndr).query(_Query{});
     }
   };
 

--- a/cudax/include/cuda/experimental/__async/env.cuh
+++ b/cudax/include/cuda/experimental/__async/env.cuh
@@ -100,7 +100,7 @@ struct env
     noexcept(__nothrow_queryable<__1st_env_t<_Query>, _Query>) //
     -> __query_result_t<__1st_env_t<_Query>, _Query>
   {
-    return __get_1st(__query).__query(__query);
+    return __get_1st(__query).query(__query);
   }
 
   env& operator=(const env&) = delete;
@@ -134,7 +134,7 @@ struct env<_Env0, _Env1>
     noexcept(__nothrow_queryable<__1st_env_t<_Query>, _Query>) //
     -> __query_result_t<__1st_env_t<_Query>, _Query>
   {
-    return __get_1st(__query).__query(__query);
+    return __get_1st(__query).query(__query);
   }
 
   env& operator=(const env&) = delete;

--- a/cudax/include/cuda/experimental/__async/queries.cuh
+++ b/cudax/include/cuda/experimental/__async/queries.cuh
@@ -35,7 +35,7 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 namespace cuda::experimental::__async
 {
 template <class _Ty, class _Query>
-auto __query_result_() -> decltype(__declval<_Ty>().__query(_Query()));
+auto __query_result_() -> decltype(__declval<_Ty>().query(_Query()));
 
 template <class _Ty, class _Query>
 using __query_result_t = decltype(__query_result_<_Ty, _Query>());
@@ -48,7 +48,7 @@ template <class _Ty, class _Query>
 inline constexpr bool __nothrow_queryable = true;
 #else
 template <class _Ty, class _Query>
-using __nothrow_queryable_ = __mif<noexcept(__declval<_Ty>().__query(_Query()))>;
+using __nothrow_queryable_ = __mif<noexcept(__declval<_Ty>().query(_Query()))>;
 
 template <class _Ty, class _Query>
 inline constexpr bool __nothrow_queryable = __mvalid_q<__nothrow_queryable_, _Ty, _Query>;
@@ -58,10 +58,10 @@ _CCCL_GLOBAL_CONSTANT struct get_allocator_t
 {
   template <class _Env>
   _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.__query(*this))
+    -> decltype(__env.query(*this))
   {
-    static_assert(noexcept(__env.__query(*this)));
-    return __env.__query(*this);
+    static_assert(noexcept(__env.query(*this)));
+    return __env.query(*this);
   }
 
   _CUDAX_API auto operator()(__ignore) const noexcept -> _CUDA_VSTD::allocator<void>
@@ -74,10 +74,10 @@ _CCCL_GLOBAL_CONSTANT struct get_stop_token_t
 {
   template <class _Env>
   _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.__query(*this))
+    -> decltype(__env.query(*this))
   {
-    static_assert(noexcept(__env.__query(*this)));
-    return __env.__query(*this);
+    static_assert(noexcept(__env.query(*this)));
+    return __env.query(*this);
   }
 
   _CUDAX_API auto operator()(__ignore) const noexcept -> never_stop_token
@@ -94,10 +94,10 @@ struct get_completion_scheduler_t
 {
   template <class _Env>
   _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.__query(*this))
+    -> decltype(__env.query(*this))
   {
-    static_assert(noexcept(__env.__query(*this)));
-    return __env.__query(*this);
+    static_assert(noexcept(__env.query(*this)));
+    return __env.query(*this);
   }
 };
 
@@ -108,10 +108,10 @@ _CCCL_GLOBAL_CONSTANT struct get_scheduler_t
 {
   template <class _Env>
   _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.__query(*this))
+    -> decltype(__env.query(*this))
   {
-    static_assert(noexcept(__env.__query(*this)));
-    return __env.__query(*this);
+    static_assert(noexcept(__env.query(*this)));
+    return __env.query(*this);
   }
 } get_scheduler{};
 
@@ -119,10 +119,10 @@ _CCCL_GLOBAL_CONSTANT struct get_delegatee_scheduler_t
 {
   template <class _Env>
   _CUDAX_API auto operator()(const _Env& __env) const noexcept //
-    -> decltype(__env.__query(*this))
+    -> decltype(__env.query(*this))
   {
-    static_assert(noexcept(__env.__query(*this)));
-    return __env.__query(*this);
+    static_assert(noexcept(__env.query(*this)));
+    return __env.query(*this);
   }
 } get_delegatee_scheduler{};
 
@@ -137,10 +137,10 @@ _CCCL_GLOBAL_CONSTANT struct get_forward_progress_guarantee_t
 {
   template <class _Sch>
   _CUDAX_API auto operator()(const _Sch& __sch) const noexcept //
-    -> decltype(__async::__decay_copy(__sch.__query(*this)))
+    -> decltype(__async::__decay_copy(__sch.query(*this)))
   {
-    static_assert(noexcept(__sch.__query(*this)));
-    return __sch.__query(*this);
+    static_assert(noexcept(__sch.query(*this)));
+    return __sch.query(*this);
   }
 
   _CUDAX_API auto operator()(__ignore) const noexcept -> forward_progress_guarantee
@@ -153,7 +153,7 @@ _CCCL_GLOBAL_CONSTANT struct get_domain_t
 {
   template <class _Sch>
   _CUDAX_API constexpr auto operator()(const _Sch& __sch) const noexcept //
-    -> decltype(__async::__decay_copy(__sch.__query(*this)))
+    -> decltype(__async::__decay_copy(__sch.query(*this)))
   {
     return {};
   }

--- a/cudax/include/cuda/experimental/__async/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__async/rcvr_with_env.cuh
@@ -69,7 +69,7 @@ struct __rcvr_with_env_t : _Rcvr
     noexcept(__nothrow_queryable<_1st_env_t<_Query>, _Query>) //
     -> __query_result_t<_1st_env_t<_Query>, _Query>
   {
-    return __get_1st(__query).__query(__query);
+    return __get_1st(__query).query(__query);
   }
 
   _Env __env_;
@@ -128,7 +128,7 @@ struct __rcvr_with_env_t<_Rcvr*, _Env>
     noexcept(__nothrow_queryable<_1st_env_t<_Query>, _Query>) //
     -> __query_result_t<_1st_env_t<_Query>, _Query>
   {
-    return __get_1st(__query).__query(__query);
+    return __get_1st(__query).query(__query);
   }
 
   _Rcvr* __rcvr_;

--- a/cudax/include/cuda/experimental/__async/start_on.cuh
+++ b/cudax/include/cuda/experimental/__async/start_on.cuh
@@ -38,7 +38,7 @@ struct __sch_env_t
 {
   _Sch __sch_;
 
-  _Sch __query(get_scheduler_t) const noexcept
+  _Sch query(get_scheduler_t) const noexcept
   {
     return __sch_;
   }

--- a/cudax/include/cuda/experimental/__async/when_all.cuh
+++ b/cudax/include/cuda/experimental/__async/when_all.cuh
@@ -301,7 +301,7 @@ struct __env_t
 
   __state_t& __state_;
 
-  _CUDAX_API inplace_stop_token __query(get_stop_token_t) const noexcept
+  _CUDAX_API inplace_stop_token query(get_stop_token_t) const noexcept
   {
     return __state_.__stop_token_;
   }
@@ -309,7 +309,7 @@ struct __env_t
   template <class _Tag>
   _CUDAX_API auto query(_Tag) const noexcept -> __query_result_t<_Tag, env_of_t<__rcvr_t>>
   {
-    return __async::get_env(__state_.__rcvr_).__query(_Tag());
+    return __async::get_env(__state_.__rcvr_).query(_Tag());
   }
 };
 


### PR DESCRIPTION
## Description

now that [P3325](https://wg21.link/P3325), "A Utility for Creating Execution Environments", has passed LEWG electronic polling for C++26, it feels like the right time to rename the `__query` member function to `query`. this brings cudax's std::execution bits closer in line with the standard.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
