### PR TITLE
Remove obsolete ways to set iterator category in CUB

### DIFF
--- a/cub/cub/iterator/arg_index_input_iterator.cuh
+++ b/cub/cub/iterator/arg_index_input_iterator.cuh
@@ -46,16 +46,11 @@
 #include <cub/thread/thread_load.cuh>
 #include <cub/thread/thread_store.cuh>
 
+#include <thrust/iterator/iterator_facade.h>
+#include <thrust/iterator/iterator_traits.h>
 #include <thrust/version.h>
 
-#include <iostream>
-#include <iterator>
-
-#if (THRUST_VERSION >= 100700)
-// This iterator is compatible with Thrust API 1.7 and newer
-#  include <thrust/iterator/iterator_facade.h>
-#  include <thrust/iterator/iterator_traits.h>
-#endif // THRUST_VERSION
+#include <ostream>
 
 CUB_NAMESPACE_BEGIN
 
@@ -132,19 +127,12 @@ public:
   /// The type of a reference to an element the iterator can point to
   using reference = value_type;
 
-#if (THRUST_VERSION >= 100700)
-  // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
-
   /// The iterator category
   using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::any_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
     reference>::type;
-#else
-  /// The iterator category
-  using iterator_category = std::random_access_iterator_tag;
-#endif // THRUST_VERSION
 
 private:
   InputIteratorT itr;

--- a/cub/cub/iterator/cache_modified_input_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_input_iterator.cuh
@@ -43,21 +43,18 @@
 #  pragma system_header
 #endif // no system header
 
-#if !defined(_CCCL_COMPILER_NVRTC)
+#ifdef _CCCL_COMPILER_NVRTC
+#  include <cuda/std/iterator>
+#else // _CCCL_COMPILER_NVRTC
+#  include <thrust/iterator/iterator_facade.h>
+#  include <thrust/iterator/iterator_traits.h>
+
 #  include <iostream>
 #  include <iterator>
-#else
-#  include <cuda/std/iterator>
-#endif
+#endif // _CCCL_COMPILER_NVRTC
 
 #include <cub/thread/thread_load.cuh>
 #include <cub/thread/thread_store.cuh>
-
-#if (THRUST_VERSION >= 100700)
-// This iterator is compatible with Thrust API 1.7 and newer
-#  include <thrust/iterator/iterator_facade.h>
-#  include <thrust/iterator/iterator_traits.h>
-#endif // THRUST_VERSION
 
 CUB_NAMESPACE_BEGIN
 
@@ -126,20 +123,15 @@ public:
   /// The type of a reference to an element the iterator can point to
   using reference = ValueType;
 
-#if !defined(_CCCL_COMPILER_NVRTC)
-#  if (THRUST_VERSION >= 100700)
-  // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
+#ifdef _CCCL_COMPILER_NVRTC
+  using iterator_category = ::cuda::std::random_access_iterator_tag;
+#else // _CCCL_COMPILER_NVRTC
   using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::device_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
     reference>::type;
-#  else // THRUST_VERSION < 100700
-  using iterator_category = std::random_access_iterator_tag;
-#  endif // THRUST_VERSION
-#else // defined(_CCCL_COMPILER_NVRTC)
-  using iterator_category = ::cuda::std::random_access_iterator_tag;
-#endif // defined(_CCCL_COMPILER_NVRTC)
+#endif // _CCCL_COMPILER_NVRTC
 
 public:
   /// Wrapped native pointer

--- a/cub/cub/iterator/cache_modified_output_iterator.cuh
+++ b/cub/cub/iterator/cache_modified_output_iterator.cuh
@@ -46,14 +46,10 @@
 #include <cub/thread/thread_load.cuh>
 #include <cub/thread/thread_store.cuh>
 
-#include <iostream>
-#include <iterator>
+#include <thrust/iterator/iterator_facade.h>
+#include <thrust/iterator/iterator_traits.h>
 
-#if (THRUST_VERSION >= 100700)
-// This iterator is compatible with Thrust API 1.7 and newer
-#  include <thrust/iterator/iterator_facade.h>
-#  include <thrust/iterator/iterator_traits.h>
-#endif // THRUST_VERSION
+#include <iosfwd>
 
 CUB_NAMESPACE_BEGIN
 
@@ -143,19 +139,12 @@ public:
   /// The type of a reference to an element the iterator can point to
   using reference = Reference;
 
-#if (THRUST_VERSION >= 100700)
-  // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
-
   /// The iterator category
   using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::device_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
     reference>::type;
-#else
-  /// The iterator category
-  using iterator_category = std::random_access_iterator_tag;
-#endif // THRUST_VERSION
 
 private:
   ValueType* ptr;

--- a/cub/cub/iterator/constant_input_iterator.cuh
+++ b/cub/cub/iterator/constant_input_iterator.cuh
@@ -46,14 +46,10 @@
 #include <cub/thread/thread_load.cuh>
 #include <cub/thread/thread_store.cuh>
 
-#include <iostream>
-#include <iterator>
+#include <thrust/iterator/iterator_facade.h>
+#include <thrust/iterator/iterator_traits.h>
 
-#if (THRUST_VERSION >= 100700)
-// This iterator is compatible with Thrust API 1.7 and newer
-#  include <thrust/iterator/iterator_facade.h>
-#  include <thrust/iterator/iterator_traits.h>
-#endif // THRUST_VERSION
+#include <ostream>
 
 CUB_NAMESPACE_BEGIN
 
@@ -111,19 +107,12 @@ public:
   /// The type of a reference to an element the iterator can point to
   using reference = ValueType;
 
-#if (THRUST_VERSION >= 100700)
-  // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
-
   /// The iterator category
   using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::any_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
     reference>::type;
-#else
-  /// The iterator category
-  using iterator_category = std::random_access_iterator_tag;
-#endif // THRUST_VERSION
 
 private:
   ValueType val;

--- a/cub/cub/iterator/counting_input_iterator.cuh
+++ b/cub/cub/iterator/counting_input_iterator.cuh
@@ -46,20 +46,14 @@
 #include <cub/thread/thread_load.cuh>
 #include <cub/thread/thread_store.cuh>
 
-#if !defined(_CCCL_COMPILER_NVRTC)
-#  include <iostream>
-#  include <iterator>
-#else
-#  include <cuda/std/iterator>
-#endif
-
 #include <cuda/std/iterator>
 
-#if (THRUST_VERSION >= 100700)
-// This iterator is compatible with Thrust API 1.7 and newer
+#ifndef _CCCL_COMPILER_NVRTC
 #  include <thrust/iterator/iterator_facade.h>
 #  include <thrust/iterator/iterator_traits.h>
-#endif // THRUST_VERSION
+
+#  include <ostream>
+#endif // _CCCL_COMPILER_NVRTC
 
 CUB_NAMESPACE_BEGIN
 
@@ -116,20 +110,15 @@ public:
   /// The type of a reference to an element the iterator can point to
   using reference = ValueType;
 
-#if !defined(_CCCL_COMPILER_NVRTC)
-#  if (THRUST_VERSION >= 100700)
-  // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
+#ifdef _CCCL_COMPILER_NVRTC
+  using iterator_category = ::cuda::std::random_access_iterator_tag;
+#else // _CCCL_COMPILER_NVRTC
   using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::any_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
     reference>::type;
-#  else // THRUST_VERSION < 100700
-  using iterator_category = std::random_access_iterator_tag;
-#  endif // THRUST_VERSION
-#else // defined(_CCCL_COMPILER_NVRTC)
-  using iterator_category = ::cuda::std::random_access_iterator_tag;
-#endif // defined(_CCCL_COMPILER_NVRTC)
+#endif // _CCCL_COMPILER_NVRTC
 
 private:
   ValueType val;
@@ -228,13 +217,13 @@ public:
   }
 
   /// ostream operator
-#if !defined(_CCCL_COMPILER_NVRTC)
+#ifndef _CCCL_COMPILER_NVRTC
   friend std::ostream& operator<<(std::ostream& os, const self_type& itr)
   {
     os << "[" << itr.val << "]";
     return os;
   }
-#endif
+#endif // _CCCL_COMPILER_NVRTC
 };
 
 CUB_NAMESPACE_END

--- a/cub/cub/iterator/discard_output_iterator.cuh
+++ b/cub/cub/iterator/discard_output_iterator.cuh
@@ -43,14 +43,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <iostream>
-#include <iterator>
+#include <thrust/iterator/iterator_facade.h>
+#include <thrust/iterator/iterator_traits.h>
 
-#if (THRUST_VERSION >= 100700)
-// This iterator is compatible with Thrust API 1.7 and newer
-#  include <thrust/iterator/iterator_facade.h>
-#  include <thrust/iterator/iterator_traits.h>
-#endif // THRUST_VERSION
+#include <ostream>
 
 CUB_NAMESPACE_BEGIN
 
@@ -78,19 +74,12 @@ public:
   /// The type of a reference to an element the iterator can point to
   using reference = void;
 
-#if (THRUST_VERSION >= 100700)
-  // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
-
   /// The iterator category
   using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::any_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
     reference>::type;
-#else
-  /// The iterator category
-  using iterator_category = std::random_access_iterator_tag;
-#endif // THRUST_VERSION
 
 private:
   OffsetT offset;

--- a/cub/cub/iterator/tex_obj_input_iterator.cuh
+++ b/cub/cub/iterator/tex_obj_input_iterator.cuh
@@ -47,16 +47,12 @@
 #include <cub/thread/thread_store.cuh>
 #include <cub/util_debug.cuh>
 
-#include <iostream>
-#include <iterator>
+#include <thrust/iterator/iterator_facade.h>
+#include <thrust/iterator/iterator_traits.h>
+
+#include <ostream>
 
 #include <nv/target>
-
-#if (THRUST_VERSION >= 100700)
-// This iterator is compatible with Thrust API 1.7 and newer
-#  include <thrust/iterator/iterator_facade.h>
-#  include <thrust/iterator/iterator_traits.h>
-#endif // THRUST_VERSION
 
 CUB_NAMESPACE_BEGIN
 
@@ -128,19 +124,12 @@ public:
   /// The type of a reference to an element the iterator can point to
   using reference = T;
 
-#if (THRUST_VERSION >= 100700)
-  // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
-
   /// The iterator category
   using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::device_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
     reference>::type;
-#else
-  /// The iterator category
-  using iterator_category = std::random_access_iterator_tag;
-#endif // THRUST_VERSION
 
 private:
   // Largest texture word we can use in device

--- a/cub/cub/iterator/transform_input_iterator.cuh
+++ b/cub/cub/iterator/transform_input_iterator.cuh
@@ -46,14 +46,10 @@
 #include <cub/thread/thread_load.cuh>
 #include <cub/thread/thread_store.cuh>
 
-#include <iostream>
-#include <iterator>
+#include <thrust/iterator/iterator_facade.h>
+#include <thrust/iterator/iterator_traits.h>
 
-#if (THRUST_VERSION >= 100700)
-// This iterator is compatible with Thrust API 1.7 and newer
-#  include <thrust/iterator/iterator_facade.h>
-#  include <thrust/iterator/iterator_traits.h>
-#endif // THRUST_VERSION
+#include <iosfwd>
 
 CUB_NAMESPACE_BEGIN
 
@@ -134,19 +130,12 @@ public:
   /// The type of a reference to an element the iterator can point to
   using reference = ValueType;
 
-#if (THRUST_VERSION >= 100700)
-  // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
-
   /// The iterator category
   using iterator_category = typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
     THRUST_NS_QUALIFIER::any_system_tag,
     THRUST_NS_QUALIFIER::random_access_traversal_tag,
     value_type,
     reference>::type;
-#else
-  /// The iterator category
-  using iterator_category = std::random_access_iterator_tag;
-#endif // THRUST_VERSION
 
 private:
   ConversionOp conversion_op;


### PR DESCRIPTION
This PR removes the branches computing the iterator categories of CUB iterators for `THRUST_VERSION < 100700`.