### PR TITLE
Shorten the git commit message in the ci scripts

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -131,7 +131,7 @@ print_environment_details() {
       TBB_ROOT
 
   echo "Current commit is:"
-  git log -1 || echo "Not a repository"
+  git log -1 --format=short || echo "Not a repository"
 
   if command -v nvidia-smi &> /dev/null; then
     nvidia-smi

--- a/ci/windows/build_common.psm1
+++ b/ci/windows/build_common.psm1
@@ -57,7 +57,7 @@ Write-Host "CMAKE_BUILD_PARALLEL_LEVEL=$env:CMAKE_BUILD_PARALLEL_LEVEL"
 Write-Host "CTEST_PARALLEL_LEVEL=$env:CTEST_PARALLEL_LEVEL"
 Write-Host "CCCL_BUILD_INFIX=$env:CCCL_BUILD_INFIX"
 Write-Host "Current commit is:"
-Write-Host "$(git log -1)"
+Write-Host "$(git log -1 --format=short)"
 Write-Host "========================================"
 
 cmake --version


### PR DESCRIPTION
Depending on the terminal this might need user interaction if the commit message is long.

We are mostly interested in the sha anyway, so use a short description
