### PR TITLE
Make `get_stream` work with queries

### DIFF
--- a/cudax/include/cuda/experimental/__stream/get_stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/get_stream.cuh
@@ -26,13 +26,12 @@
 #include <cuda/std/__concepts/__concept_macros.h>
 #include <cuda/std/__concepts/convertible_to.h>
 #include <cuda/std/__cuda/api_wrapper.h>
+#include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/stream_ref>
 
 #include <cuda/experimental/__stream/stream.cuh>
 
 namespace cuda::experimental
-{
-namespace __get_stream
 {
 
 template <class _Tp>
@@ -48,11 +47,11 @@ template <class _Tp>
 _LIBCUDACXX_CONCEPT __has_member_get_stream = _LIBCUDACXX_FRAGMENT(__has_member_get_stream_, _Tp);
 
 //! @brief `get_stream` is a customization point object that queries a type `T` for an associated stream
-struct __fn
+struct get_stream_t
 {
   _LIBCUDACXX_TEMPLATE(class _Tp)
   _LIBCUDACXX_REQUIRES(__convertible_to_stream_ref<_Tp>)
-  _CCCL_NODISCARD constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
     noexcept(noexcept(static_cast<::cuda::stream_ref>(__t)))
   {
     return static_cast<::cuda::stream_ref>(__t);
@@ -60,18 +59,23 @@ struct __fn
 
   _LIBCUDACXX_TEMPLATE(class _Tp)
   _LIBCUDACXX_REQUIRES(__has_member_get_stream<_Tp>)
-  _CCCL_NODISCARD constexpr ::cuda::stream_ref operator()(const _Tp& __t) const noexcept(noexcept(__t.get_stream()))
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
+    noexcept(noexcept(__t.get_stream()))
   {
     return __t.get_stream();
   }
+
+  _LIBCUDACXX_TEMPLATE(
+    class _Env, class _Ret = decltype(_CUDA_VSTD::declval<const _Env&>().query(_CUDA_VSTD::declval<get_stream_t>())))
+  _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Ret, ::cuda::stream_ref))
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Env& __env) const noexcept
+  {
+    static_assert(noexcept(__env.query(*this)), "");
+    return __env.query(*this);
+  }
 }; // namespace cuda::experimental
 
-} // namespace __get_stream
-
-inline namespace __cpo
-{
-_CCCL_GLOBAL_CONSTANT auto get_stream = __get_stream::__fn{};
-} // namespace __cpo
+_CCCL_GLOBAL_CONSTANT auto get_stream = get_stream_t{};
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__stream/get_stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/get_stream.cuh
@@ -73,7 +73,7 @@ struct get_stream_t
     static_assert(noexcept(__env.query(*this)), "");
     return __env.query(*this);
   }
-}; // namespace cuda::experimental
+};
 
 _CCCL_GLOBAL_CONSTANT auto get_stream = get_stream_t{};
 

--- a/cudax/test/stream/get_stream.cu
+++ b/cudax/test/stream/get_stream.cu
@@ -70,7 +70,7 @@ struct get_stream_wrong_return
 };
 TEST_CASE("The get_stream method must return a cuda::stream_ref", "[stream]")
 {
-  static_assert(!::cuda::std::is_invocable_v<::cuda::experimental::get_stream_t, const get_stream_wrong_return&>);
+  STATIC_REQUIRE(!::cuda::std::is_invocable_v<::cuda::experimental::get_stream_t, const get_stream_wrong_return&>);
 }
 
 struct env_with_query

--- a/cudax/test/stream/get_stream.cu
+++ b/cudax/test/stream/get_stream.cu
@@ -56,7 +56,7 @@ struct non_const_get_stream
 
 TEST_CASE("The get_stream method must be const qualified", "[stream]")
 {
-  static_assert(!::cuda::std::is_invocable_v<::cuda::experimental::get_stream_t, const non_const_get_stream&>);
+  STATIC_REQUIRE(!::cuda::std::is_invocable_v<::cuda::experimental::get_stream_t, const non_const_get_stream&>);
 }
 
 struct get_stream_wrong_return
@@ -130,6 +130,6 @@ struct env_with_query_that_returns_wrong_type
 };
 TEST_CASE("Queries require a proper return type", "[stream]")
 {
-  static_assert(
+  STATIC_REQUIRE(
     !::cuda::std::is_invocable_v<::cuda::experimental::get_stream_t, const env_with_query_that_returns_wrong_type&>);
 }

--- a/cudax/test/stream/get_stream.cu
+++ b/cudax/test/stream/get_stream.cu
@@ -56,7 +56,7 @@ struct non_const_get_stream
 
 TEST_CASE("The get_stream method must be const qualified", "[stream]")
 {
-  static_assert(!::cuda::std::is_invocable_v<decltype(::cuda::experimental::get_stream), const non_const_get_stream&>);
+  static_assert(!::cuda::std::is_invocable_v<::cuda::experimental::get_stream_t, const non_const_get_stream&>);
 }
 
 struct get_stream_wrong_return
@@ -70,6 +70,66 @@ struct get_stream_wrong_return
 };
 TEST_CASE("The get_stream method must return a cuda::stream_ref", "[stream]")
 {
+  static_assert(!::cuda::std::is_invocable_v<::cuda::experimental::get_stream_t, const get_stream_wrong_return&>);
+}
+
+struct env_with_query
+{
+  cudax::stream stream_{};
+
+  ::cuda::stream_ref query(::cuda::experimental::get_stream_t) const noexcept
+  {
+    return ::cuda::stream_ref{stream_.get()};
+  }
+};
+TEST_CASE("Works with queries", "[stream]")
+{
+  env_with_query env;
+  ::cuda::stream_ref ref = ::cuda::experimental::get_stream(env);
+  CUDAX_CHECK(ref == env.stream_);
+}
+
+struct env_with_query_that_returns_cudastream
+{
+  cudax::stream stream_{};
+
+  ::cudaStream_t query(::cuda::experimental::get_stream_t) const noexcept
+  {
+    return stream_.get();
+  }
+};
+TEST_CASE("Works with queries that return cudastream", "[stream]")
+{
+  env_with_query_that_returns_cudastream env;
+  ::cuda::stream_ref ref = ::cuda::experimental::get_stream(env);
+  CUDAX_CHECK(ref == env.stream_);
+}
+
+struct env_with_query_that_returns_stream
+{
+  cudax::stream stream_{};
+
+  const cudax::stream& query(::cuda::experimental::get_stream_t) const noexcept
+  {
+    return stream_;
+  }
+};
+TEST_CASE("Works with queries that return stream", "[stream]")
+{
+  env_with_query_that_returns_stream env;
+  ::cuda::stream_ref ref = ::cuda::experimental::get_stream(env);
+  CUDAX_CHECK(ref == env.stream_);
+}
+
+struct env_with_query_that_returns_wrong_type
+{
+  float query(::cuda::experimental::get_stream_t) const noexcept
+  {
+    return 42;
+  }
+};
+TEST_CASE("Queries require a proper return type", "[stream]")
+{
   static_assert(
-    !::cuda::std::is_invocable_v<decltype(::cuda::experimental::get_stream), const get_stream_wrong_return&>);
+    !::cuda::std::is_invocable_v<::cuda::experimental::get_stream_t, const env_with_query_that_returns_wrong_type&>);
 }


### PR DESCRIPTION
This lets `cuda::experimental::get_stream` handle sender style queries