### PR TITLE
Enable type trait aliases in all standard modes

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -193,11 +193,11 @@ auto BitwiseEqualsRange(const Range& range) -> CustomEqualsRangeMatcher<Range, b
 #include <cuda/std/tuple>
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <size_t N, typename... T>
-__enable_if_t<(N == sizeof...(T))> print_elem(::std::ostream&, const tuple<T...>&)
+enable_if_t<(N == sizeof...(T))> print_elem(::std::ostream&, const tuple<T...>&)
 {}
 
 template <size_t N, typename... T>
-__enable_if_t<(N < sizeof...(T))> print_elem(::std::ostream& os, const tuple<T...>& tup)
+enable_if_t<(N < sizeof...(T))> print_elem(::std::ostream& os, const tuple<T...>& tup)
 {
   _CCCL_IF_CONSTEXPR (N != 0)
   {

--- a/cub/benchmarks/bench/transform/babelstream.h
+++ b/cub/benchmarks/bench/transform/babelstream.h
@@ -91,7 +91,7 @@ struct narrowing_error : std::runtime_error
 
 // from C++ GSL
 // implementation insipired by: https://github.com/microsoft/GSL/blob/main/include/gsl/narrow
-template <typename DstT, typename SrcT, ::cuda::std::__enable_if_t<::cuda::std::is_arithmetic<SrcT>::value, int> = 0>
+template <typename DstT, typename SrcT, ::cuda::std::enable_if_t<::cuda::std::is_arithmetic<SrcT>::value, int> = 0>
 constexpr DstT narrow(SrcT value)
 {
   constexpr bool is_different_signedness = ::cuda::std::is_signed<SrcT>::value != ::cuda::std::is_signed<DstT>::value;

--- a/cub/cub/detail/choose_offset.cuh
+++ b/cub/cub/detail/choose_offset.cuh
@@ -148,7 +148,7 @@ using choose_signed_offset_t = typename choose_signed_offset<NumItemsT>::type;
 template <typename... Iter>
 struct common_iterator_value
 {
-  using type = ::cuda::std::__common_type_t<::cuda::std::__iter_value_type<Iter>...>;
+  using type = ::cuda::std::common_type_t<::cuda::std::__iter_value_type<Iter>...>;
 };
 template <typename... Iter>
 using common_iterator_value_t = typename common_iterator_value<Iter...>::type;

--- a/cub/cub/detail/type_traits.cuh
+++ b/cub/cub/detail/type_traits.cuh
@@ -50,7 +50,7 @@ _CCCL_SUPPRESS_DEPRECATED_PUSH
 _CCCL_SUPPRESS_DEPRECATED_POP
 #include <cuda/std/type_traits>
 
-#define _CUB_TEMPLATE_REQUIRES(...) ::cuda::std::__enable_if_t<(__VA_ARGS__)>* = nullptr
+#define _CUB_TEMPLATE_REQUIRES(...) ::cuda::std::enable_if_t<(__VA_ARGS__)>* = nullptr
 
 CUB_NAMESPACE_BEGIN
 namespace detail

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -40,7 +40,7 @@ class choose_merge_agent
                                     && sizeof(typename fallback_agent_t::TempStorage) <= max_smem_per_block;
 
 public:
-  using type = ::cuda::std::__conditional_t<use_fallback, fallback_agent_t, default_agent_t>;
+  using type = ::cuda::std::conditional_t<use_fallback, fallback_agent_t, default_agent_t>;
 };
 
 // Computes the merge path intersections at equally wide intervals. The approach is outlined in the paper:

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -147,7 +147,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE void prefetch_tile(const T* addr, int tile_size)
 // TODO(miscco): we should probably constrain It to not be a contiguous iterator in C++17 (and change the overload
 // above to accept any contiguous iterator)
 // overload for any iterator that is not a pointer, do nothing
-template <int, typename It, ::cuda::std::__enable_if_t<!::cuda::std::is_pointer<It>::value, int> = 0>
+template <int, typename It, ::cuda::std::enable_if_t<!::cuda::std::is_pointer<It>::value, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE void prefetch_tile(It, int)
 {}
 
@@ -232,12 +232,12 @@ _CCCL_DEVICE _CCCL_FORCEINLINE auto poor_apply(F&& f, Tuple&& t)
   -> decltype(poor_apply_impl(
     ::cuda::std::forward<F>(f),
     ::cuda::std::forward<Tuple>(t),
-    ::cuda::std::make_index_sequence<::cuda::std::tuple_size<::cuda::std::__libcpp_remove_reference_t<Tuple>>::value>{}))
+    ::cuda::std::make_index_sequence<::cuda::std::tuple_size<::cuda::std::remove_reference_t<Tuple>>::value>{}))
 {
   return poor_apply_impl(
     ::cuda::std::forward<F>(f),
     ::cuda::std::forward<Tuple>(t),
-    ::cuda::std::make_index_sequence<::cuda::std::tuple_size<::cuda::std::__libcpp_remove_reference_t<Tuple>>::value>{});
+    ::cuda::std::make_index_sequence<::cuda::std::tuple_size<::cuda::std::remove_reference_t<Tuple>>::value>{});
 }
 
 // mult must be a power of 2
@@ -245,7 +245,7 @@ template <typename Integral>
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE constexpr auto round_up_to_po2_multiple(Integral x, Integral mult) -> Integral
 {
 #if _CCCL_STD_VER > 2011
-  _CCCL_ASSERT(::cuda::std::has_single_bit(static_cast<::cuda::std::__make_unsigned_t<Integral>>(mult)), "");
+  _CCCL_ASSERT(::cuda::std::has_single_bit(static_cast<::cuda::std::make_unsigned_t<Integral>>(mult)), "");
 #endif // _CCCL_STD_VER > 2011
   return (x + mult - 1) & ~(mult - 1);
 }
@@ -544,7 +544,7 @@ using needs_aligned_ptr_t =
                              >;
 
 #ifdef _CUB_HAS_TRANSFORM_UBLKCP
-template <Algorithm Alg, typename It, ::cuda::std::__enable_if_t<needs_aligned_ptr_t<Alg>::value, int> = 0>
+template <Algorithm Alg, typename It, ::cuda::std::enable_if_t<needs_aligned_ptr_t<Alg>::value, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE auto select_kernel_arg(
   ::cuda::std::integral_constant<Algorithm, Alg>, kernel_arg<It>&& arg) -> aligned_base_ptr<value_t<It>>&&
 {
@@ -552,7 +552,7 @@ _CCCL_DEVICE _CCCL_FORCEINLINE auto select_kernel_arg(
 }
 #endif // _CUB_HAS_TRANSFORM_UBLKCP
 
-template <Algorithm Alg, typename It, ::cuda::std::__enable_if_t<!needs_aligned_ptr_t<Alg>::value, int> = 0>
+template <Algorithm Alg, typename It, ::cuda::std::enable_if_t<!needs_aligned_ptr_t<Alg>::value, int> = 0>
 _CCCL_DEVICE _CCCL_FORCEINLINE auto
 select_kernel_arg(::cuda::std::integral_constant<Algorithm, Alg>, kernel_arg<It>&& arg) -> It&&
 {

--- a/cub/cub/thread/thread_reduce.cuh
+++ b/cub/cub/thread/thread_reduce.cuh
@@ -131,9 +131,9 @@ ThreadReduceSequential(const Input& input, ReductionOp reduction_op)
 /// Specialization for DPX reduction
 template <typename Input, typename ReductionOp>
 _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE auto
-ThreadReduceDpx(const Input& input, ReductionOp reduction_op) -> ::cuda::std::__remove_cvref_t<decltype(input[0])>
+ThreadReduceDpx(const Input& input, ReductionOp reduction_op) -> ::cuda::std::remove_cvref_t<decltype(input[0])>
 {
-  using T              = ::cuda::std::__remove_cvref_t<decltype(input[0])>;
+  using T              = ::cuda::std::remove_cvref_t<decltype(input[0])>;
   constexpr int length = detail::static_size<Input>();
   T array[length];
 #  pragma unroll
@@ -153,7 +153,7 @@ ThreadReduceDpx(const Input& input, ReductionOp reduction_op) -> ::cuda::std::__
 // DPX/Sequential dispatch
 template <typename Input,
           typename ReductionOp,
-          typename ValueT = ::cuda::std::__remove_cvref_t<decltype(::cuda::std::declval<Input>()[0])>,
+          typename ValueT = ::cuda::std::remove_cvref_t<decltype(::cuda::std::declval<Input>()[0])>,
           typename AccumT = ::cuda::std::__accumulator_t<ReductionOp, ValueT>,
           _CUB_TEMPLATE_REQUIRES(enable_dpx_reduction<Input, ReductionOp, AccumT>())>
 _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE AccumT ThreadReduce(const Input& input, ReductionOp reduction_op)
@@ -170,7 +170,7 @@ _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE AccumT ThreadReduce(const Input& 
 
 template <typename Input,
           typename ReductionOp,
-          typename ValueT = ::cuda::std::__remove_cvref_t<decltype(::cuda::std::declval<Input>()[0])>,
+          typename ValueT = ::cuda::std::remove_cvref_t<decltype(::cuda::std::declval<Input>()[0])>,
           typename AccumT = ::cuda::std::__accumulator_t<ReductionOp, ValueT>,
           _CUB_TEMPLATE_REQUIRES(!enable_dpx_reduction<Input, ReductionOp, AccumT>())>
 _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE AccumT ThreadReduce(const Input& input, ReductionOp reduction_op)
@@ -213,7 +213,7 @@ template <typename Input,
           typename ReductionOp,
           typename PrefixT,
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
-          typename ValueT = ::cuda::std::__remove_cvref_t<decltype(::cuda::std::declval<Input>()[0])>,
+          typename ValueT = ::cuda::std::remove_cvref_t<decltype(::cuda::std::declval<Input>()[0])>,
 #endif // !DOXYGEN_SHOULD_SKIP_THIS
           typename AccumT = ::cuda::std::__accumulator_t<ReductionOp, ValueT, PrefixT>>
 _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE AccumT

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -100,7 +100,7 @@ using value_t =
   typename std::iterator_traits<Iterator>::value_type;
 #  endif // defined(_CCCL_COMPILER_NVRTC)
 
-template <typename It, typename FallbackT, bool = ::cuda::std::is_void<::cuda::std::__remove_pointer_t<It>>::value>
+template <typename It, typename FallbackT, bool = ::cuda::std::is_void<::cuda::std::remove_pointer_t<It>>::value>
 struct non_void_value_impl
 {
   using type = FallbackT;

--- a/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_left.cu
@@ -163,7 +163,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractLeftCopy works with pointers", "[dev
 template <class T>
 struct cust_diff
 {
-  template <class T2, cuda::std::__enable_if_t<cuda::std::is_same<T, T2>::value, int> = 0>
+  template <class T2, cuda::std::enable_if_t<cuda::std::is_same<T, T2>::value, int> = 0>
   __host__ __device__ constexpr T2 operator()(const T2& lhs, const T2& rhs) const noexcept
   {
     return lhs - rhs;

--- a/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
+++ b/cub/test/catch2_test_device_adjacent_difference_substract_right.cu
@@ -92,7 +92,7 @@ C2H_TEST("DeviceAdjacentDifference::SubtractRightCopy does not change the input"
 template <class T>
 struct ref_diff
 {
-  template <class T2, cuda::std::__enable_if_t<cuda::std::is_same<T, T2>::value, int> = 0>
+  template <class T2, cuda::std::enable_if_t<cuda::std::is_same<T, T2>::value, int> = 0>
   __host__ __device__ constexpr T2 operator()(const T2& lhs, const T2& rhs) const noexcept
   {
     return rhs - lhs;

--- a/cudax/include/cuda/experimental/__async/cpos.cuh
+++ b/cudax/include/cuda/experimental/__async/cpos.cuh
@@ -44,13 +44,13 @@ struct scheduler_t
 {};
 
 template <class _Ty>
-using __sender_concept_t = typename __remove_ref_t<_Ty>::sender_concept;
+using __sender_concept_t = typename _CUDA_VSTD::remove_reference_t<_Ty>::sender_concept;
 
 template <class _Ty>
-using __receiver_concept_t = typename __remove_ref_t<_Ty>::receiver_concept;
+using __receiver_concept_t = typename _CUDA_VSTD::remove_reference_t<_Ty>::receiver_concept;
 
 template <class _Ty>
-using __scheduler_concept_t = typename __remove_ref_t<_Ty>::scheduler_concept;
+using __scheduler_concept_t = typename _CUDA_VSTD::remove_reference_t<_Ty>::scheduler_concept;
 
 template <class _Ty>
 inline constexpr bool __is_sender = __type_valid_v<__sender_concept_t, _Ty>;

--- a/cudax/include/cuda/experimental/__async/meta.cuh
+++ b/cudax/include/cuda/experimental/__async/meta.cuh
@@ -94,7 +94,7 @@ template <class... _What>
 struct _ERROR : __merror_base
 {
   template <class...>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _ERROR;
+  using __call _CCCL_NODEBUG_ALIAS = _ERROR;
 
   _ERROR operator+();
 
@@ -138,14 +138,14 @@ template <bool _Error>
 struct __type_self_or_error_with_
 {
   template <class _Ty, class... _With>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Ty;
+  using __call _CCCL_NODEBUG_ALIAS = _Ty;
 };
 
 template <>
 struct __type_self_or_error_with_<true>
 {
   template <class _Ty, class... _With>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = decltype(__declval<_Ty&>().with(__declval<_ERROR<_With...>&>()));
+  using __call _CCCL_NODEBUG_ALIAS = decltype(__declval<_Ty&>().with(__declval<_ERROR<_With...>&>()));
 };
 
 template <class _Ty, class... _With>
@@ -162,7 +162,7 @@ struct __type_try__<false>
   using __call_q = _Fn<_Ts...>;
 
   template <class _Fn, class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = typename _Fn::template __call<_Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = typename _Fn::template __call<_Ts...>;
 };
 
 template <>
@@ -172,7 +172,7 @@ struct __type_try__<true>
   using __call_q = __type_find_error<_Ts...>;
 
   template <class _Fn, class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_find_error<_Fn, _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_find_error<_Fn, _Ts...>;
 };
 
 template <class _Fn, class... _Ts>
@@ -187,7 +187,7 @@ template <class _Fn>
 struct __type_try
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_try_call<_Fn, _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_try_call<_Fn, _Ts...>;
 };
 
 template <template <class...> class _Fn, class... _Default>
@@ -198,7 +198,7 @@ template <template <class...> class _Fn>
 struct __type_try_quote<_Fn>
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
+  using __call _CCCL_NODEBUG_ALIAS =
     typename __type_try__<__type_contains_error<_Ts...>>::template __call_q<_Fn, _Ts...>;
 };
 
@@ -207,7 +207,7 @@ template <template <class...> class _Fn, class _Default>
 struct __type_try_quote<_Fn, _Default>
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
+  using __call _CCCL_NODEBUG_ALIAS =
     typename _CUDA_VSTD::_If<__type_valid_v<_Fn, _Ts...>, //
                              __type_try_quote<_Fn>,
                              _CUDA_VSTD::__type_always<_Default>>::template __call<_Ts...>;
@@ -230,20 +230,20 @@ template <template <class...> class _Second, template <class...> class _First>
 struct __type_compose_quote
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Second<_First<_Ts...>>;
+  using __call _CCCL_NODEBUG_ALIAS = _Second<_First<_Ts...>>;
 };
 
 struct __type_count
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Ts)>;
+  using __call _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Ts)>;
 };
 
 template <template <class...> class _Continuation>
 struct __type_concat_into_quote
 {
   template <class... _Args>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
+  using __call _CCCL_NODEBUG_ALIAS =
     _CUDA_VSTD::__type_call1<_CUDA_VSTD::__type_concat<_CUDA_VSTD::__as_type_list<_Args>...>,
                              _CUDA_VSTD::__type_quote<_Continuation>>;
 };
@@ -252,7 +252,7 @@ template <class _Ty>
 struct __type_self_or
 {
   template <class _Uy = _Ty>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Uy;
+  using __call _CCCL_NODEBUG_ALIAS = _Uy;
 };
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__async/type_traits.cuh
@@ -35,9 +35,6 @@
 namespace cuda::experimental::__async
 {
 
-template <class _Ty>
-using __remove_ref_t = _CUDA_VSTD::__libcpp_remove_reference_t<_Ty>;
-
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // __decay_t: An efficient implementation for ::std::decay
 #if defined(_CCCL_BUILTIN_DECAY)

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -125,12 +125,12 @@ struct get_level_helper
 
 template <typename QueryLevel, typename Hierarchy>
 _CCCL_INLINE_VAR constexpr bool has_level =
-  detail::has_level_helper<QueryLevel, ::cuda::std::__remove_cvref_t<Hierarchy>>::value;
+  detail::has_level_helper<QueryLevel, ::cuda::std::remove_cvref_t<Hierarchy>>::value;
 
 template <typename QueryLevel, typename Hierarchy>
 _CCCL_INLINE_VAR constexpr bool has_level_or_unit =
-  detail::has_level_helper<QueryLevel, ::cuda::std::__remove_cvref_t<Hierarchy>>::value
-  || detail::has_unit<QueryLevel, ::cuda::std::__remove_cvref_t<Hierarchy>>::value;
+  detail::has_level_helper<QueryLevel, ::cuda::std::remove_cvref_t<Hierarchy>>::value
+  || detail::has_unit<QueryLevel, ::cuda::std::remove_cvref_t<Hierarchy>>::value;
 
 namespace detail
 {

--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -436,7 +436,7 @@ doxygen_predefined = [
   "_LIBCUDACXX_AND=&&",
   "_LIBCUDACXX_EAT_REST(x)=",
   "_LIBCUDACXX_GLOBAL_CONSTANT=inline",
-  "_LIBCUDACXX_REQUIRES(x)= ::cuda::std::__enable_if_t<x, int> = 0>",
+  "_LIBCUDACXX_REQUIRES(x)= ::cuda::std::enable_if_t<x, int> = 0>",
   "_LIBCUDACXX_TEMPLATE(x)=template<x, ",
   "_LIBCUDACXX_TRAILING_REQUIRES(x)=-> x _LIBCUDACXX_EAT_REST",
   "LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE=",

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -39,12 +39,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! @pre \p __b must be positive
 template <class _Tp,
           class _Up,
-          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_unsigned, _Tp), int> = 0,
-          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0>
+          _CUDA_VSTD::enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_unsigned, _Tp), int> = 0,
+          _CUDA_VSTD::enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
 {
   _CCCL_ASSERT(__b > _Up(0), "cuda::ceil_div: b must be positive");
-  using _UCommon   = _CUDA_VSTD::__make_unsigned_t<_CUDA_VSTD::__common_type_t<_Tp, _Up>>;
+  using _UCommon   = _CUDA_VSTD::make_unsigned_t<_CUDA_VSTD::common_type_t<_Tp, _Up>>;
   const auto __res = static_cast<_UCommon>(__a) / static_cast<_UCommon>(__b);
   return static_cast<_Tp>(__res + (__res * static_cast<_UCommon>(__b) != static_cast<_UCommon>(__a)));
 }
@@ -56,13 +56,13 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(con
 //! @pre \p __b must be positive
 template <class _Tp,
           class _Up,
-          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp), int>   = 0,
-          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0>
+          _CUDA_VSTD::enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp), int>   = 0,
+          _CUDA_VSTD::enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up), int> = 0>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
 {
   _CCCL_ASSERT(__a >= _Tp(0), "cuda::ceil_div: a must be non negative");
   _CCCL_ASSERT(__b > _Up(0), "cuda::ceil_div: b must be positive");
-  using _UCommon = _CUDA_VSTD::__make_unsigned_t<_CUDA_VSTD::__common_type_t<_Tp, _Up>>;
+  using _UCommon = _CUDA_VSTD::make_unsigned_t<_CUDA_VSTD::common_type_t<_Tp, _Up>>;
   // Due to the precondition `__a >= 0` we can safely cast to unsigned without danger of overflowing
   return static_cast<_Tp>((static_cast<_UCommon>(__a) + static_cast<_UCommon>(__b) - 1) / static_cast<_UCommon>(__b));
 }
@@ -74,11 +74,11 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(con
 //! @pre \p __b must be positive
 template <class _Tp,
           class _Up,
-          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,
-          _CUDA_VSTD::__enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up), int>     = 0>
+          _CUDA_VSTD::enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp), int> = 0,
+          _CUDA_VSTD::enable_if_t<_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up), int>     = 0>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp ceil_div(const _Tp __a, const _Up __b) noexcept
 {
-  return ::cuda::ceil_div(__a, static_cast<_CUDA_VSTD::__underlying_type_t<_Up>>(__b));
+  return ::cuda::ceil_div(__a, static_cast<_CUDA_VSTD::underlying_type_t<_Up>>(__b));
 }
 
 _LIBCUDACXX_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__functional/maximum.h
+++ b/libcudacxx/include/cuda/__functional/maximum.h
@@ -42,7 +42,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT maximum<void>
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _T1, class _T2>
-  _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _CUDA_VSTD::__common_type_t<_T1, _T2>
+  _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _CUDA_VSTD::common_type_t<_T1, _T2>
   operator()(const _T1& __lhs, const _T2& __rhs) const noexcept(noexcept((__lhs < __rhs) ? __rhs : __lhs))
   {
     return (__lhs < __rhs) ? __rhs : __lhs;

--- a/libcudacxx/include/cuda/__functional/minimum.h
+++ b/libcudacxx/include/cuda/__functional/minimum.h
@@ -42,7 +42,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT minimum<void>
 {
   _CCCL_EXEC_CHECK_DISABLE
   template <class _T1, class _T2>
-  _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _CUDA_VSTD::__common_type_t<_T1, _T2>
+  _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _CUDA_VSTD::common_type_t<_T1, _T2>
   operator()(const _T1& __lhs, const _T2& __rhs) const noexcept(noexcept((__lhs < __rhs) ? __lhs : __rhs))
   {
     return (__lhs < __rhs) ? __lhs : __rhs;

--- a/libcudacxx/include/cuda/__functional/proclaim_return_type.h
+++ b/libcudacxx/include/cuda/__functional/proclaim_return_type.h
@@ -41,8 +41,7 @@ private:
 public:
   __return_type_wrapper() = delete;
 
-  template <class _Fn,
-            class = _CUDA_VSTD::__enable_if_t<_CUDA_VSTD::is_same<_CUDA_VSTD::__decay_t<_Fn>, _DecayFn>::value>>
+  template <class _Fn, class = _CUDA_VSTD::enable_if_t<_CUDA_VSTD::is_same<_CUDA_VSTD::decay_t<_Fn>, _DecayFn>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 explicit __return_type_wrapper(_Fn&& __fn) noexcept
       : __fn_(_CUDA_VSTD::forward<_Fn>(__fn))
   {}
@@ -95,10 +94,10 @@ public:
 } // namespace __detail
 
 template <class _Ret, class _Fn>
-_LIBCUDACXX_HIDE_FROM_ABI __detail::__return_type_wrapper<_Ret, _CUDA_VSTD::__decay_t<_Fn>>
+_LIBCUDACXX_HIDE_FROM_ABI __detail::__return_type_wrapper<_Ret, _CUDA_VSTD::decay_t<_Fn>>
 proclaim_return_type(_Fn&& __fn) noexcept
 {
-  return __detail::__return_type_wrapper<_Ret, _CUDA_VSTD::__decay_t<_Fn>>(_CUDA_VSTD::forward<_Fn>(__fn));
+  return __detail::__return_type_wrapper<_Ret, _CUDA_VSTD::decay_t<_Fn>>(_CUDA_VSTD::forward<_Fn>(__fn));
 }
 _LIBCUDACXX_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -103,8 +103,8 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool __constexpr_tail_overlap(_T
 template <class _AlgPolicy,
           class _Tp,
           class _Up,
-          __enable_if_t<_CCCL_TRAIT(is_same, __remove_const_t<_Tp>, _Up), int> = 0,
-          __enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>          = 0>
+          enable_if_t<_CCCL_TRAIT(is_same, remove_const_t<_Tp>, _Up), int> = 0,
+          enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>        = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair<_Tp*, _Up*> __copy(_Tp* __first, _Tp* __last, _Up* __result)
 {
   const ptrdiff_t __n = __last - __first;

--- a/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
@@ -42,8 +42,8 @@ __copy_backward(_BidirectionalIterator __first, _BidirectionalIterator __last, _
 
 template <class _Tp,
           class _Up,
-          __enable_if_t<_CCCL_TRAIT(is_same, __remove_const_t<_Tp>, _Up), int> = 0,
-          __enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>          = 0>
+          enable_if_t<_CCCL_TRAIT(is_same, remove_const_t<_Tp>, _Up), int> = 0,
+          enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>        = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _Up* __copy_backward(_Tp* __first, _Tp* __last, _Up* __result)
 {
   const ptrdiff_t __n = __last - __first;

--- a/libcudacxx/include/cuda/std/__algorithm/copy_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy_n.h
@@ -30,8 +30,8 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _InputIterator,
           class _Size,
           class _OutputIterator,
-          __enable_if_t<__is_cpp17_input_iterator<_InputIterator>::value, int>          = 0,
-          __enable_if_t<!__is_cpp17_random_access_iterator<_InputIterator>::value, int> = 0>
+          enable_if_t<__is_cpp17_input_iterator<_InputIterator>::value, int>          = 0,
+          enable_if_t<!__is_cpp17_random_access_iterator<_InputIterator>::value, int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _OutputIterator
 copy_n(_InputIterator __first, _Size __orig_n, _OutputIterator __result)
 {
@@ -54,7 +54,7 @@ copy_n(_InputIterator __first, _Size __orig_n, _OutputIterator __result)
 template <class _InputIterator,
           class _Size,
           class _OutputIterator,
-          __enable_if_t<__is_cpp17_random_access_iterator<_InputIterator>::value, int> = 0>
+          enable_if_t<__is_cpp17_random_access_iterator<_InputIterator>::value, int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _OutputIterator
 copy_n(_InputIterator __first, _Size __orig_n, _OutputIterator __result)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/equal.h
+++ b/libcudacxx/include/cuda/std/__algorithm/equal.h
@@ -84,7 +84,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool __equal(
   {
     return false;
   }
-  return _CUDA_VSTD::equal<_RandomAccessIterator1, _RandomAccessIterator2, __add_lvalue_reference_t<_BinaryPredicate>>(
+  return _CUDA_VSTD::equal<_RandomAccessIterator1, _RandomAccessIterator2, add_lvalue_reference_t<_BinaryPredicate>>(
     __first1, __last1, __first2, __pred);
 }
 
@@ -96,7 +96,7 @@ equal(_InputIterator1 __first1,
       _InputIterator2 __last2,
       _BinaryPredicate __pred)
 {
-  return _CUDA_VSTD::__equal<__add_lvalue_reference_t<_BinaryPredicate>>(
+  return _CUDA_VSTD::__equal<add_lvalue_reference_t<_BinaryPredicate>>(
     __first1,
     __last1,
     __first2,

--- a/libcudacxx/include/cuda/std/__algorithm/find_end.h
+++ b/libcudacxx/include/cuda/std/__algorithm/find_end.h
@@ -196,7 +196,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _ForwardIterator
   _ForwardIterator2 __last2,
   _BinaryPredicate __pred)
 {
-  return _CUDA_VSTD::__find_end<__add_lvalue_reference_t<_BinaryPredicate>>(
+  return _CUDA_VSTD::__find_end<add_lvalue_reference_t<_BinaryPredicate>>(
     __first1,
     __last1,
     __first2,

--- a/libcudacxx/include/cuda/std/__algorithm/half_positive.h
+++ b/libcudacxx/include/cuda/std/__algorithm/half_positive.h
@@ -28,13 +28,13 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // Perform division by two quickly for positive integers (llvm.org/PR39129)
 
-template <class _Integral, __enable_if_t<_CCCL_TRAIT(is_integral, _Integral), int> = 0>
+template <class _Integral, enable_if_t<_CCCL_TRAIT(is_integral, _Integral), int> = 0>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Integral __half_positive(_Integral __value)
 {
-  return static_cast<_Integral>(static_cast<__make_unsigned_t<_Integral>>(__value) / 2);
+  return static_cast<_Integral>(static_cast<make_unsigned_t<_Integral>>(__value) / 2);
 }
 
-template <class _Tp, __enable_if_t<!_CCCL_TRAIT(is_integral, _Tp), int> = 0>
+template <class _Tp, enable_if_t<!_CCCL_TRAIT(is_integral, _Tp), int> = 0>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __half_positive(_Tp __value)
 {
   return __value / 2;

--- a/libcudacxx/include/cuda/std/__algorithm/is_permutation.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_permutation.h
@@ -205,7 +205,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool __is_permut
     return false;
   }
   return _CUDA_VSTD::
-    is_permutation<_RandomAccessIterator1, _RandomAccessIterator2, __add_lvalue_reference_t<_BinaryPredicate>>(
+    is_permutation<_RandomAccessIterator1, _RandomAccessIterator2, add_lvalue_reference_t<_BinaryPredicate>>(
       __first1, __last1, __first2, __pred);
 }
 
@@ -217,7 +217,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool is_permutat
   _ForwardIterator2 __last2,
   _BinaryPredicate __pred)
 {
-  return _CUDA_VSTD::__is_permutation<__add_lvalue_reference_t<_BinaryPredicate>>(
+  return _CUDA_VSTD::__is_permutation<add_lvalue_reference_t<_BinaryPredicate>>(
     __first1,
     __last1,
     __first2,

--- a/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
+++ b/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
@@ -111,14 +111,14 @@ struct _IterOps<_ClassicAlgPolicy>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 static void __validate_iter_reference()
   {
     static_assert(
-      is_same<__deref_t<_Iter>, typename iterator_traits<__remove_cvref_t<_Iter>>::reference>::value,
+      is_same<__deref_t<_Iter>, typename iterator_traits<remove_cvref_t<_Iter>>::reference>::value,
       "It looks like your iterator's `iterator_traits<It>::reference` does not match the return type of "
       "dereferencing the iterator, i.e., calling `*it`. This is undefined behavior according to [input.iterators] "
       "and can lead to dangling reference issues at runtime, so we are flagging this.");
   }
 
   // iter_move
-  template <class _Iter, __enable_if_t<is_reference<__deref_t<_Iter>>::value, int> = 0>
+  template <class _Iter, enable_if_t<is_reference<__deref_t<_Iter>>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 static
     // If the result of dereferencing `_Iter` is a reference type, deduce the result of calling `_CUDA_VSTD::move` on
     // it. Note that the C++03 mode doesn't support `decltype(auto)` as the return type.
@@ -130,7 +130,7 @@ struct _IterOps<_ClassicAlgPolicy>
     return _CUDA_VSTD::move(*_CUDA_VSTD::forward<_Iter>(__i));
   }
 
-  template <class _Iter, __enable_if_t<!is_reference<__deref_t<_Iter>>::value, int> = 0>
+  template <class _Iter, enable_if_t<!is_reference<__deref_t<_Iter>>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 static
     // If the result of dereferencing `_Iter` is a value type, deduce the return value of this function to also be a
     // value -- otherwise, after `operator*` returns a temporary, this function would return a dangling reference to
@@ -158,16 +158,16 @@ struct _IterOps<_ClassicAlgPolicy>
   }
 
   template <class _Iter>
-  _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 __remove_cvref_t<_Iter>
-  next(_Iter&& __it, __difference_type<__remove_cvref_t<_Iter>> __n = 1)
+  _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 remove_cvref_t<_Iter>
+  next(_Iter&& __it, __difference_type<remove_cvref_t<_Iter>> __n = 1)
   {
     return _CUDA_VSTD::next(_CUDA_VSTD::forward<_Iter>(__it), __n);
   }
 
   // prev
   template <class _Iter>
-  _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 __remove_cvref_t<_Iter>
-  prev(_Iter&& __iter, __difference_type<__remove_cvref_t<_Iter>> __n = 1)
+  _LIBCUDACXX_HIDE_FROM_ABI static _CCCL_CONSTEXPR_CXX14 remove_cvref_t<_Iter>
+  prev(_Iter&& __iter, __difference_type<remove_cvref_t<_Iter>> __n = 1)
   {
     return _CUDA_VSTD::prev(_CUDA_VSTD::forward<_Iter>(__iter), __n);
   }

--- a/libcudacxx/include/cuda/std/__algorithm/make_projected.h
+++ b/libcudacxx/include/cuda/std/__algorithm/make_projected.h
@@ -68,10 +68,9 @@ struct _ProjectedPred
   }
 };
 
-template <
-  class _Pred,
-  class _Proj,
-  __enable_if_t<!(!is_member_pointer<__decay_t<_Pred>>::value && __is_identity<__decay_t<_Proj>>::value), int> = 0>
+template <class _Pred,
+          class _Proj,
+          enable_if_t<!(!is_member_pointer<decay_t<_Pred>>::value && __is_identity<decay_t<_Proj>>::value), int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _ProjectedPred<_Pred, _Proj> __make_projected(_Pred& __pred, _Proj& __proj)
 {
   return _ProjectedPred<_Pred, _Proj>(__pred, __proj);
@@ -82,7 +81,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr _ProjectedPred<_Pred, _Proj> __make_projecte
 // the call stack when the comparator is invoked, even in an unoptimized build.
 template <class _Pred,
           class _Proj,
-          __enable_if_t<!is_member_pointer<__decay_t<_Pred>>::value && __is_identity<__decay_t<_Proj>>::value, int> = 0>
+          enable_if_t<!is_member_pointer<decay_t<_Pred>>::value && __is_identity<decay_t<_Proj>>::value, int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr _Pred& __make_projected(_Pred& __pred, _Proj&)
 {
   return __pred;

--- a/libcudacxx/include/cuda/std/__algorithm/move.h
+++ b/libcudacxx/include/cuda/std/__algorithm/move.h
@@ -45,8 +45,8 @@ __move(_InputIterator __first, _InputIterator __last, _OutputIterator __result)
 template <class _AlgPolicy,
           class _Tp,
           class _Up,
-          __enable_if_t<_CCCL_TRAIT(is_same, __remove_const_t<_Tp>, _Up), int> = 0,
-          __enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>          = 0>
+          enable_if_t<_CCCL_TRAIT(is_same, remove_const_t<_Tp>, _Up), int> = 0,
+          enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>        = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair<_Tp*, _Up*> __move(_Tp* __first, _Tp* __last, _Up* __result)
 {
   const ptrdiff_t __n = __last - __first;

--- a/libcudacxx/include/cuda/std/__algorithm/move_backward.h
+++ b/libcudacxx/include/cuda/std/__algorithm/move_backward.h
@@ -44,8 +44,8 @@ __move_backward(_BidirectionalIterator __first, _BidirectionalIterator __last, _
 template <class _AlgPolicy,
           class _Tp,
           class _Up,
-          __enable_if_t<_CCCL_TRAIT(is_same, __remove_const_t<_Tp>, _Up), int> = 0,
-          __enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>          = 0>
+          enable_if_t<_CCCL_TRAIT(is_same, remove_const_t<_Tp>, _Up), int> = 0,
+          enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>        = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair<_Tp*, _Up*>
 __move_backward(_Tp* __first, _Tp* __last, _Up* __result)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/partition.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partition.h
@@ -94,7 +94,7 @@ template <class _AlgPolicy, class _ForwardIterator, class _Sentinel, class _Pred
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair<_ForwardIterator, _ForwardIterator>
 __partition(_ForwardIterator __first, _Sentinel __last, _Predicate&& __pred, _IterCategory __iter_category)
 {
-  return _CUDA_VSTD::__partition_impl<__remove_cvref_t<_Predicate>&, _AlgPolicy>(
+  return _CUDA_VSTD::__partition_impl<remove_cvref_t<_Predicate>&, _AlgPolicy>(
     _CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __pred, __iter_category);
 }
 

--- a/libcudacxx/include/cuda/std/__algorithm/ranges_iterator_concept.h
+++ b/libcudacxx/include/cuda/std/__algorithm/ranges_iterator_concept.h
@@ -31,7 +31,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 template <class _IterMaybeQualified>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr auto __get_iterator_concept()
 {
-  using _Iter = __remove_cvref_t<_IterMaybeQualified>;
+  using _Iter = remove_cvref_t<_IterMaybeQualified>;
 
   if constexpr (contiguous_iterator<_Iter>)
   {

--- a/libcudacxx/include/cuda/std/__algorithm/remove_if.h
+++ b/libcudacxx/include/cuda/std/__algorithm/remove_if.h
@@ -30,7 +30,7 @@ template <class _ForwardIterator, class _Predicate>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _ForwardIterator
 remove_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
-  __first = _CUDA_VSTD::find_if<_ForwardIterator, __add_lvalue_reference_t<_Predicate>>(__first, __last, __pred);
+  __first = _CUDA_VSTD::find_if<_ForwardIterator, add_lvalue_reference_t<_Predicate>>(__first, __last, __pred);
   if (__first != __last)
   {
     _ForwardIterator __i = __first;

--- a/libcudacxx/include/cuda/std/__algorithm/search.h
+++ b/libcudacxx/include/cuda/std/__algorithm/search.h
@@ -149,7 +149,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _ForwardIterator
   _ForwardIterator2 __last2,
   _BinaryPredicate __pred)
 {
-  return _CUDA_VSTD::__search<__add_lvalue_reference_t<_BinaryPredicate>>(
+  return _CUDA_VSTD::__search<add_lvalue_reference_t<_BinaryPredicate>>(
            __first1,
            __last1,
            __first2,

--- a/libcudacxx/include/cuda/std/__algorithm/search_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/search_n.h
@@ -136,7 +136,7 @@ template <class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _ForwardIterator
 search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value_, _BinaryPredicate __pred)
 {
-  return _CUDA_VSTD::__search_n<__add_lvalue_reference_t<_BinaryPredicate>>(
+  return _CUDA_VSTD::__search_n<add_lvalue_reference_t<_BinaryPredicate>>(
     __first,
     __last,
     __convert_to_integral(__count),

--- a/libcudacxx/include/cuda/std/__algorithm/set_difference.h
+++ b/libcudacxx/include/cuda/std/__algorithm/set_difference.h
@@ -34,7 +34,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Comp, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair<__remove_cvref_t<_InIter1>, __remove_cvref_t<_OutIter>>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair<remove_cvref_t<_InIter1>, remove_cvref_t<_OutIter>>
 __set_difference(
   _InIter1&& __first1, _Sent1&& __last1, _InIter2&& __first2, _Sent2&& __last2, _OutIter&& __result, _Comp&& __comp)
 {

--- a/libcudacxx/include/cuda/std/__algorithm/unique_copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unique_copy.h
@@ -122,13 +122,13 @@ template <class _InputIterator, class _OutputIterator, class _BinaryPredicate>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _OutputIterator
 unique_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryPredicate __pred)
 {
-  using __algo_tag = __conditional_t<
+  using __algo_tag = conditional_t<
     _CCCL_TRAIT(is_base_of, forward_iterator_tag, __iterator_category_type<_InputIterator>),
     __unique_copy_tags::__reread_from_input_tag,
-    __conditional_t<_CCCL_TRAIT(is_base_of, forward_iterator_tag, __iterator_category_type<_OutputIterator>)
-                      && _CCCL_TRAIT(is_same, __iter_value_type<_InputIterator>, __iter_value_type<_OutputIterator>),
-                    __unique_copy_tags::__reread_from_output_tag,
-                    __unique_copy_tags::__read_from_tmp_value_tag>>;
+    conditional_t<_CCCL_TRAIT(is_base_of, forward_iterator_tag, __iterator_category_type<_OutputIterator>)
+                    && _CCCL_TRAIT(is_same, __iter_value_type<_InputIterator>, __iter_value_type<_OutputIterator>),
+                  __unique_copy_tags::__reread_from_output_tag,
+                  __unique_copy_tags::__read_from_tmp_value_tag>>;
   return _CUDA_VSTD::__unique_copy<_ClassicAlgPolicy>(
            _CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), _CUDA_VSTD::move(__result), __pred, __algo_tag())
     .second;

--- a/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
@@ -69,9 +69,7 @@ struct __unwrap_iter_impl<_Iter, true>
   }
 };
 
-template <class _Iter,
-          class _Impl                                             = __unwrap_iter_impl<_Iter>,
-          __enable_if_t<is_copy_constructible<_Iter>::value, int> = 0>
+template <class _Iter, class _Impl = __unwrap_iter_impl<_Iter>, enable_if_t<is_copy_constructible<_Iter>::value, int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 decltype(_Impl::__unwrap(_CUDA_VSTD::declval<_Iter>()))
 __unwrap_iter(_Iter __i) noexcept
 {

--- a/libcudacxx/include/cuda/std/__atomic/functions/common.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/common.h
@@ -47,7 +47,7 @@ struct __atomic_ptr_skip<_Tp[n]>
 {};
 
 template <typename _Tp>
-using __atomic_ptr_skip_t = __atomic_ptr_skip<__remove_cvref_t<_Tp>>;
+using __atomic_ptr_skip_t = __atomic_ptr_skip<remove_cvref_t<_Tp>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
@@ -33,19 +33,19 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Operand>
 using __cuda_atomic_enable_non_native_arithmetic =
-  __enable_if_t<_Operand::__size <= 16 || _Operand::__op == __atomic_cuda_operand::_f, bool>;
+  enable_if_t<_Operand::__size <= 16 || _Operand::__op == __atomic_cuda_operand::_f, bool>;
 
 template <class _Operand>
-using __cuda_atomic_enable_non_native_bitwise = __enable_if_t<_Operand::__size <= 16, bool>;
+using __cuda_atomic_enable_non_native_bitwise = enable_if_t<_Operand::__size <= 16, bool>;
 
 template <class _Operand>
-using __cuda_atomic_enable_native_bitwise = __enable_if_t<_Operand::__size >= 32, bool>;
+using __cuda_atomic_enable_native_bitwise = enable_if_t<_Operand::__size >= 32, bool>;
 
 template <class _Operand>
-using __cuda_atomic_enable_non_native_ld_st = __enable_if_t<_Operand::__size <= 8, bool>;
+using __cuda_atomic_enable_non_native_ld_st = enable_if_t<_Operand::__size <= 8, bool>;
 
 template <class _Operand>
-using __cuda_atomic_enable_native_ld_st = __enable_if_t<_Operand::__size >= 16, bool>;
+using __cuda_atomic_enable_native_ld_st = enable_if_t<_Operand::__size >= 16, bool>;
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_ld_st<_Operand> = 0>
 static inline _CCCL_DEVICE void

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated_helper.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated_helper.h
@@ -170,13 +170,13 @@ template <class _Type>
 using __atomic_enable_if_native_bitwise = bool;
 
 template <class _Type>
-using __atomic_enable_if_native_arithmetic = __enable_if_t<_CCCL_TRAIT(is_scalar, _Type), bool>;
+using __atomic_enable_if_native_arithmetic = enable_if_t<_CCCL_TRAIT(is_scalar, _Type), bool>;
 
 template <class _Type>
-using __atomic_enable_if_native_minmax = __enable_if_t<_CCCL_TRAIT(is_integral, _Type), bool>;
+using __atomic_enable_if_native_minmax = enable_if_t<_CCCL_TRAIT(is_integral, _Type), bool>;
 
 template <class _Type>
-using __atomic_enable_if_not_native_minmax = __enable_if_t<!_CCCL_TRAIT(is_integral, _Type), bool>;
+using __atomic_enable_if_not_native_minmax = enable_if_t<!_CCCL_TRAIT(is_integral, _Type), bool>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__atomic/functions/host.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/host.h
@@ -45,7 +45,7 @@ template <typename _Tp>
 __atomic_alignment_wrapper<_Tp>* __atomic_force_align_host(_Tp* __a)
 {
   __atomic_alignment_wrapper<_Tp>* __w =
-    reinterpret_cast<__atomic_alignment_wrapper<_Tp>*>(const_cast<__remove_cv_t<_Tp>*>(__a));
+    reinterpret_cast<__atomic_alignment_wrapper<_Tp>*>(const_cast<remove_cv_t<_Tp>*>(__a));
   return __w;
 }
 
@@ -67,17 +67,17 @@ inline void __atomic_store_host(_Tp* __a, _Up __val, memory_order __order)
 }
 
 template <typename _Tp>
-inline auto __atomic_load_host(_Tp* __a, memory_order __order) -> __remove_cv_t<_Tp>
+inline auto __atomic_load_host(_Tp* __a, memory_order __order) -> remove_cv_t<_Tp>
 {
-  __remove_cv_t<_Tp> __ret;
+  remove_cv_t<_Tp> __ret;
   __atomic_load(&__atomic_force_align_host(__a)->__atom, &__ret, __atomic_order_to_int(__order));
   return __ret;
 }
 
 template <typename _Tp, typename _Up>
-inline auto __atomic_exchange_host(_Tp* __a, _Up __val, memory_order __order) -> __remove_cv_t<_Tp>
+inline auto __atomic_exchange_host(_Tp* __a, _Up __val, memory_order __order) -> remove_cv_t<_Tp>
 {
-  __remove_cv_t<_Tp> __ret;
+  remove_cv_t<_Tp> __ret;
   __atomic_exchange(&__atomic_force_align_host(__a)->__atom, &__val, &__ret, __atomic_order_to_int(__order));
   return __ret;
 }
@@ -110,15 +110,15 @@ inline bool __atomic_compare_exchange_weak_host(
     __atomic_failure_order_to_int(__failure));
 }
 
-template <typename _Tp, typename _Td, __enable_if_t<!is_floating_point<_Tp>::value, int> = 0>
-inline __remove_cv_t<_Tp> __atomic_fetch_add_host(_Tp* __a, _Td __delta, memory_order __order)
+template <typename _Tp, typename _Td, enable_if_t<!is_floating_point<_Tp>::value, int> = 0>
+inline remove_cv_t<_Tp> __atomic_fetch_add_host(_Tp* __a, _Td __delta, memory_order __order)
 {
   constexpr auto __skip_v = __atomic_ptr_skip_t<_Tp>::__skip;
   return __atomic_fetch_add(__a, __delta * __skip_v, __atomic_order_to_int(__order));
 }
 
-template <typename _Tp, typename _Td, __enable_if_t<is_floating_point<_Tp>::value, int> = 0>
-inline __remove_cv_t<_Tp> __atomic_fetch_add_host(_Tp* __a, _Td __delta, memory_order __order)
+template <typename _Tp, typename _Td, enable_if_t<is_floating_point<_Tp>::value, int> = 0>
+inline remove_cv_t<_Tp> __atomic_fetch_add_host(_Tp* __a, _Td __delta, memory_order __order)
 {
   auto __expected = __atomic_load_host(__a, memory_order_relaxed);
   auto __desired  = __expected + __delta;
@@ -131,15 +131,15 @@ inline __remove_cv_t<_Tp> __atomic_fetch_add_host(_Tp* __a, _Td __delta, memory_
   return __expected;
 }
 
-template <typename _Tp, typename _Td, __enable_if_t<!is_floating_point<_Tp>::value, int> = 0>
-inline __remove_cv_t<_Tp> __atomic_fetch_sub_host(_Tp* __a, _Td __delta, memory_order __order)
+template <typename _Tp, typename _Td, enable_if_t<!is_floating_point<_Tp>::value, int> = 0>
+inline remove_cv_t<_Tp> __atomic_fetch_sub_host(_Tp* __a, _Td __delta, memory_order __order)
 {
   constexpr auto __skip_v = __atomic_ptr_skip_t<_Tp>::__skip;
   return __atomic_fetch_sub(__a, __delta * __skip_v, __atomic_order_to_int(__order));
 }
 
-template <typename _Tp, typename _Td, __enable_if_t<is_floating_point<_Tp>::value, int> = 0>
-inline __remove_cv_t<_Tp> __atomic_fetch_sub_host(_Tp* __a, _Td __delta, memory_order __order)
+template <typename _Tp, typename _Td, enable_if_t<is_floating_point<_Tp>::value, int> = 0>
+inline remove_cv_t<_Tp> __atomic_fetch_sub_host(_Tp* __a, _Td __delta, memory_order __order)
 {
   auto __expected = __atomic_load_host(__a, memory_order_relaxed);
   auto __desired  = __expected - __delta;
@@ -153,25 +153,25 @@ inline __remove_cv_t<_Tp> __atomic_fetch_sub_host(_Tp* __a, _Td __delta, memory_
 }
 
 template <typename _Tp, typename _Td>
-inline __remove_cv_t<_Tp> __atomic_fetch_and_host(_Tp* __a, _Td __pattern, memory_order __order)
+inline remove_cv_t<_Tp> __atomic_fetch_and_host(_Tp* __a, _Td __pattern, memory_order __order)
 {
   return __atomic_fetch_and(__a, __pattern, __atomic_order_to_int(__order));
 }
 
 template <typename _Tp, typename _Td>
-inline __remove_cv_t<_Tp> __atomic_fetch_or_host(_Tp* __a, _Td __pattern, memory_order __order)
+inline remove_cv_t<_Tp> __atomic_fetch_or_host(_Tp* __a, _Td __pattern, memory_order __order)
 {
   return __atomic_fetch_or(__a, __pattern, __atomic_order_to_int(__order));
 }
 
 template <typename _Tp, typename _Td>
-inline __remove_cv_t<_Tp> __atomic_fetch_xor_host(_Tp* __a, _Td __pattern, memory_order __order)
+inline remove_cv_t<_Tp> __atomic_fetch_xor_host(_Tp* __a, _Td __pattern, memory_order __order)
 {
   return __atomic_fetch_xor(__a, __pattern, __atomic_order_to_int(__order));
 }
 
 template <typename _Tp, typename _Td>
-inline __remove_cv_t<_Tp> __atomic_fetch_max_host(_Tp* __a, _Td __val, memory_order __order)
+inline remove_cv_t<_Tp> __atomic_fetch_max_host(_Tp* __a, _Td __val, memory_order __order)
 {
   auto __expected = __atomic_load_host(__a, memory_order_relaxed);
   auto __desired  = __expected > __val ? __expected : __val;
@@ -185,7 +185,7 @@ inline __remove_cv_t<_Tp> __atomic_fetch_max_host(_Tp* __a, _Td __val, memory_or
 }
 
 template <typename _Tp, typename _Td>
-inline __remove_cv_t<_Tp> __atomic_fetch_min_host(_Tp* __a, _Td __val, memory_order __order)
+inline remove_cv_t<_Tp> __atomic_fetch_min_host(_Tp* __a, _Td __val, memory_order __order)
 {
   auto __expected = __atomic_load_host(__a, memory_order_relaxed);
   auto __desired  = __expected < __val ? __expected : __val;

--- a/libcudacxx/include/cuda/std/__atomic/platform/msvc_to_builtins.h
+++ b/libcudacxx/include/cuda/std/__atomic/platform/msvc_to_builtins.h
@@ -72,7 +72,7 @@ static inline void __atomic_thread_fence(int __memorder)
 }
 
 template <typename _Type, size_t _Size>
-using __enable_if_sized_as = __enable_if_t<sizeof(_Type) == _Size, int>;
+using __enable_if_sized_as = enable_if_t<sizeof(_Type) == _Size, int>;
 
 template <class _Type, __enable_if_sized_as<_Type, 1> = 0>
 void __atomic_load_relaxed(const volatile _Type* __ptr, _Type* __ret)

--- a/libcudacxx/include/cuda/std/__atomic/types/common.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/common.h
@@ -38,30 +38,29 @@ enum class __atomic_tag
 
 // Helpers to SFINAE on the tag inside the storage object
 template <typename _Sto>
-using __atomic_storage_is_base = __enable_if_t<__atomic_tag::__atomic_base_tag == __remove_cvref_t<_Sto>::__tag, int>;
+using __atomic_storage_is_base = enable_if_t<__atomic_tag::__atomic_base_tag == remove_cvref_t<_Sto>::__tag, int>;
 template <typename _Sto>
-using __atomic_storage_is_locked =
-  __enable_if_t<__atomic_tag::__atomic_locked_tag == __remove_cvref_t<_Sto>::__tag, int>;
+using __atomic_storage_is_locked = enable_if_t<__atomic_tag::__atomic_locked_tag == remove_cvref_t<_Sto>::__tag, int>;
 template <typename _Sto>
-using __atomic_storage_is_small = __enable_if_t<__atomic_tag::__atomic_small_tag == __remove_cvref_t<_Sto>::__tag, int>;
+using __atomic_storage_is_small = enable_if_t<__atomic_tag::__atomic_small_tag == remove_cvref_t<_Sto>::__tag, int>;
 
 template <typename _Tp>
 using __atomic_underlying_t = typename _Tp::__underlying_t;
 template <typename _Tp>
-using __atomic_underlying_remove_cv_t = __remove_cv_t<typename _Tp::__underlying_t>;
+using __atomic_underlying_remove_cv_t = remove_cv_t<typename _Tp::__underlying_t>;
 
 // [atomics.types.generic]p1 guarantees _Tp is trivially copyable. Because
 // the default operator= in an object is not volatile, a byte-by-byte copy
 // is required.
 template <typename _Tp, typename _Tv>
-_CCCL_HOST_DEVICE __enable_if_t<_CCCL_TRAIT(is_assignable, _Tp&, _Tv)>
+_CCCL_HOST_DEVICE enable_if_t<_CCCL_TRAIT(is_assignable, _Tp&, _Tv)>
 __atomic_assign_volatile(_Tp* __a_value, _Tv const& __val)
 {
   *__a_value = __val;
 }
 
 template <typename _Tp, typename _Tv>
-_CCCL_HOST_DEVICE __enable_if_t<_CCCL_TRAIT(is_assignable, _Tp&, _Tv)>
+_CCCL_HOST_DEVICE enable_if_t<_CCCL_TRAIT(is_assignable, _Tp&, _Tv)>
 __atomic_assign_volatile(_Tp volatile* __a_value, _Tv volatile const& __val)
 {
   volatile char* __to         = reinterpret_cast<volatile char*>(__a_value);

--- a/libcudacxx/include/cuda/std/__atomic/types/small.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/small.h
@@ -36,20 +36,20 @@ template <typename _Tp>
 using __atomic_small_proxy_t = _If<_CCCL_TRAIT(is_signed, _Tp), int32_t, uint32_t>;
 
 // Arithmetic conversions to/from proxy types
-template <class _Tp, __enable_if_t<_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
+template <class _Tp, enable_if_t<_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
 _CCCL_HOST_DEVICE constexpr __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __val)
 {
   return static_cast<__atomic_small_proxy_t<_Tp>>(__val);
 }
 
-template <class _Tp, __enable_if_t<_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
+template <class _Tp, enable_if_t<_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
 _CCCL_HOST_DEVICE constexpr inline _Tp __atomic_small_from_32(__atomic_small_proxy_t<_Tp> __val)
 {
   return static_cast<_Tp>(__val);
 }
 
 // Non-arithmetic conversion to/from proxy types
-template <class _Tp, __enable_if_t<!_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
+template <class _Tp, enable_if_t<!_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
 _CCCL_HOST_DEVICE inline __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __val)
 {
   __atomic_small_proxy_t<_Tp> __temp{};
@@ -57,7 +57,7 @@ _CCCL_HOST_DEVICE inline __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __
   return __temp;
 }
 
-template <class _Tp, __enable_if_t<!_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
+template <class _Tp, enable_if_t<!_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
 _CCCL_HOST_DEVICE inline _Tp __atomic_small_from_32(__atomic_small_proxy_t<_Tp> __val)
 {
   _Tp __temp{};

--- a/libcudacxx/include/cuda/std/__bit/bit_cast.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_cast.h
@@ -43,9 +43,9 @@ _CCCL_DIAG_SUPPRESS_GCC("-Wclass-memaccess")
 template <
   class _To,
   class _From,
-  __enable_if_t<(sizeof(_To) == sizeof(_From)), int>                                                                = 0,
-  __enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _To) || _CCCL_TRAIT(__is_extended_floating_point, _To), int>     = 0,
-  __enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _From) || _CCCL_TRAIT(__is_extended_floating_point, _From), int> = 0>
+  enable_if_t<(sizeof(_To) == sizeof(_From)), int>                                                                = 0,
+  enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _To) || _CCCL_TRAIT(__is_extended_floating_point, _To), int>     = 0,
+  enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _From) || _CCCL_TRAIT(__is_extended_floating_point, _From), int> = 0>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _LIBCUDACXX_CONSTEXPR_BIT_CAST _To bit_cast(const _From& __from) noexcept
 {
 #if defined(_CCCL_BUILTIN_BIT_CAST)

--- a/libcudacxx/include/cuda/std/__bit/countl.h
+++ b/libcudacxx/include/cuda/std/__bit/countl.h
@@ -35,14 +35,14 @@ template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr int __countl_zero(_Tp __t) noexcept;
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
 __countl_zero_dispatch(_Tp __t) noexcept
 {
   return __libcpp_clz(static_cast<uint32_t>(__t)) - (numeric_limits<uint32_t>::digits - numeric_limits<_Tp>::digits);
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
 __countl_zero_dispatch(_Tp __t) noexcept
 {
   return __libcpp_clz(static_cast<uint64_t>(__t)) - (numeric_limits<uint64_t>::digits - numeric_limits<_Tp>::digits);
@@ -81,7 +81,7 @@ struct __countl_zero_rotl_impl<_Tp, 1>
 };
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
 __countl_zero_dispatch(_Tp __t) noexcept
 {
   return __countl_zero_rotl_impl<_Tp>::__count(__t);
@@ -102,14 +102,14 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int __countl_one(_Tp __t) noexcept
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
 countl_zero(_Tp __t) noexcept
 {
   return __countl_zero(__t);
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
 countl_one(_Tp __t) noexcept
 {
   return __countl_one(__t);

--- a/libcudacxx/include/cuda/std/__bit/countr.h
+++ b/libcudacxx/include/cuda/std/__bit/countr.h
@@ -34,14 +34,14 @@ template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr int __countr_zero(_Tp __t) noexcept;
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
 __countr_zero_dispatch(_Tp __t) noexcept
 {
   return __libcpp_ctz(static_cast<uint32_t>(__t));
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
 __countr_zero_dispatch(_Tp __t) noexcept
 {
   return __libcpp_ctz(static_cast<uint64_t>(__t));
@@ -74,7 +74,7 @@ struct __countr_zero_rsh_impl<_Tp, 1>
 };
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
 __countr_zero_dispatch(_Tp __t) noexcept
 {
   return __countr_zero_rsh_impl<_Tp>::__count(__t, 0);
@@ -96,14 +96,14 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int __countr_one(_Tp __t) noexcept
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
 countr_zero(_Tp __t) noexcept
 {
   return __countr_zero(__t);
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
 countr_one(_Tp __t) noexcept
 {
   return __countr_one(__t);

--- a/libcudacxx/include/cuda/std/__bit/has_single_bit.h
+++ b/libcudacxx/include/cuda/std/__bit/has_single_bit.h
@@ -34,7 +34,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr bool __has_single_bit(_Tp __t) noexcept
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, bool>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, bool>
 has_single_bit(_Tp __t) noexcept
 {
   return __has_single_bit(__t);

--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -37,13 +37,13 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr uint32_t __bit_log2(_Tp __t) noexcept
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<sizeof(_Tp) >= sizeof(uint32_t), _Tp> __ceil2(_Tp __t) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<sizeof(_Tp) >= sizeof(uint32_t), _Tp> __ceil2(_Tp __t) noexcept
 {
   return _Tp{1} << (numeric_limits<_Tp>::digits - __countl_zero((_Tp) (__t - 1u)));
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<sizeof(_Tp) < sizeof(uint32_t), _Tp> __ceil2(_Tp __t) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<sizeof(_Tp) < sizeof(uint32_t), _Tp> __ceil2(_Tp __t) noexcept
 {
   return (_Tp) ((1u << ((numeric_limits<_Tp>::digits - __countl_zero((_Tp) (__t - 1u)))
                         + (numeric_limits<unsigned>::digits - numeric_limits<_Tp>::digits)))
@@ -51,21 +51,20 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<sizeof(_Tp) < sizeof(uint32_t)
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
 bit_floor(_Tp __t) noexcept
 {
   return __t == 0 ? 0 : static_cast<_Tp>(_Tp{1} << __bit_log2(__t));
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
-bit_ceil(_Tp __t) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp> bit_ceil(_Tp __t) noexcept
 {
   return (__t < 2) ? 1 : static_cast<_Tp>(__ceil2(__t));
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
 bit_width(_Tp __t) noexcept
 {
   return __t == 0 ? 0 : static_cast<int>(__bit_log2(__t) + 1);

--- a/libcudacxx/include/cuda/std/__bit/popcount.h
+++ b/libcudacxx/include/cuda/std/__bit/popcount.h
@@ -30,14 +30,14 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<sizeof(_Tp) <= sizeof(uint32_t), int>
 __popcount_dispatch(_Tp __t) noexcept
 {
   return __libcpp_popc(static_cast<uint32_t>(__t));
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<sizeof(_Tp) == sizeof(uint64_t), int>
 __popcount_dispatch(_Tp __t) noexcept
 {
   return __libcpp_popc(static_cast<uint64_t>(__t));
@@ -63,7 +63,7 @@ struct __popcount_rsh_impl<_Tp, 1>
 };
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<(sizeof(_Tp) > sizeof(uint64_t)), int>
 __popcount_dispatch(_Tp __t) noexcept
 {
   return __popcount_rsh_impl<_Tp>::__count(__t);
@@ -78,8 +78,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr int __popcount(_Tp __t) noexcept
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int>
-popcount(_Tp __t) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, int> popcount(_Tp __t) noexcept
 {
   return __popcount(__t);
 }

--- a/libcudacxx/include/cuda/std/__bit/reference.h
+++ b/libcudacxx/include/cuda/std/__bit/reference.h
@@ -1048,13 +1048,13 @@ public:
   using difference_type   = typename _Cp::difference_type;
   using value_type        = bool;
   using pointer           = __bit_iterator;
-  using reference         = __conditional_t<_IsConst, __bit_const_reference<_Cp>, __bit_reference<_Cp>>;
+  using reference         = conditional_t<_IsConst, __bit_const_reference<_Cp>, __bit_reference<_Cp>>;
   using iterator_category = random_access_iterator_tag;
 
 private:
   using __storage_type = typename _Cp::__storage_type;
   using __storage_pointer =
-    __conditional_t<_IsConst, typename _Cp::__const_storage_pointer, typename _Cp::__storage_pointer>;
+    conditional_t<_IsConst, typename _Cp::__const_storage_pointer, typename _Cp::__storage_pointer>;
 
   static const unsigned __bits_per_word = _Cp::__bits_per_word;
 
@@ -1069,7 +1069,7 @@ public:
 
   _CCCL_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __bit_iterator(const __bit_iterator<_Cp, _IsConst>& __it) = default;
 
-  template <bool _OtherIsConst, class = __enable_if_t<_IsConst == true && _OtherIsConst == false>>
+  template <bool _OtherIsConst, class = enable_if_t<_IsConst == true && _OtherIsConst == false>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __bit_iterator(const __bit_iterator<_Cp, _OtherIsConst>& __it) noexcept
       : __seg_(__it.__seg_)
       , __ctz_(__it.__ctz_)

--- a/libcudacxx/include/cuda/std/__bit/rotate.h
+++ b/libcudacxx/include/cuda/std/__bit/rotate.h
@@ -50,7 +50,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp __rotr(_Tp __t, unsigned
 }
 
 template <class _Tp>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
 rotl(_Tp __t, unsigned int __cnt) noexcept
 {
   return __rotl(__t, __cnt);
@@ -58,7 +58,7 @@ rotl(_Tp __t, unsigned int __cnt) noexcept
 
 // rotr
 template <class _Tp>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__libcpp_is_unsigned_integer<_Tp>::value, _Tp>
 rotr(_Tp __t, unsigned int __cnt) noexcept
 {
   return __rotr(__t, __cnt);

--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -51,6 +51,13 @@
 #  define _CCCL_FALLTHROUGH() ((void) 0)
 #endif
 
+// The nodebug attribute flattens aliases down to the actual type rather typename meow<T>::type
+#if _CCCL_HAS_ATTRIBUTE(__nodebug__) && defined(_CCCL_CUDA_COMPILER_CLANG)
+#  define _CCCL_NODEBUG_ALIAS __attribute__((nodebug))
+#else
+#  define _CCCL_NODEBUG_ALIAS
+#endif
+
 #if _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_unique_address)
 // MSVC implements [[no_unique_address]] as a silent no-op currently.
 // (If/when MSVC breaks its C++ ABI, it will be changed to work as intended.)

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -119,14 +119,14 @@ public:
       : __repr_(__re, __im)
   {}
 
-  template <class _Up, __enable_if_t<__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0>
+  template <class _Up, enable_if_t<__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI complex(const complex<_Up>& __c)
       : __repr_(__convert_to_bfloat16(__c.real()), __convert_to_bfloat16(__c.imag()))
   {}
 
   template <class _Up,
-            __enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0,
-            __enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Up), int>                           = 0>
+            enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0,
+            enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Up), int>                           = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit complex(const complex<_Up>& __c)
       : __repr_(__convert_to_bfloat16(__c.real()), __convert_to_bfloat16(__c.imag()))
   {}

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -116,14 +116,14 @@ public:
       : __repr_(__re, __im)
   {}
 
-  template <class _Up, __enable_if_t<__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0>
+  template <class _Up, enable_if_t<__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI complex(const complex<_Up>& __c)
       : __repr_(__convert_to_half(__c.real()), __convert_to_half(__c.imag()))
   {}
 
   template <class _Up,
-            __enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0,
-            __enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Up), int>                           = 0>
+            enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0,
+            enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Up), int>                           = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit complex(const complex<_Up>& __c)
       : __repr_(__convert_to_half(__c.real()), __convert_to_half(__c.imag()))
   {}

--- a/libcudacxx/include/cuda/std/__complex/vector_support.h
+++ b/libcudacxx/include/cuda/std/__complex/vector_support.h
@@ -84,14 +84,14 @@ struct __ab_results
   _Tp __b;
 };
 
-template <class _Tp, typename = __enable_if_t<!__has_vector_type<_Tp>::value>>
+template <class _Tp, typename = enable_if_t<!__has_vector_type<_Tp>::value>>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __abcd_results<_Tp>
 __complex_calculate_partials(_Tp __a, _Tp __b, _Tp __c, _Tp __d) noexcept
 {
   return {__a * __c, __b * __d, __a * __d, __b * __c};
 }
 
-template <class _Tp, typename = __enable_if_t<!__has_vector_type<_Tp>::value>>
+template <class _Tp, typename = enable_if_t<!__has_vector_type<_Tp>::value>>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __ab_results<_Tp>
 __complex_piecewise_mul(_Tp __x1, _Tp __y1, _Tp __x2, _Tp __y2) noexcept
 {
@@ -99,7 +99,7 @@ __complex_piecewise_mul(_Tp __x1, _Tp __y1, _Tp __x2, _Tp __y2) noexcept
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __enable_if_t<__has_vector_type<_Tp>::value, __abcd_results<_Tp>>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<__has_vector_type<_Tp>::value, __abcd_results<_Tp>>
 __complex_calculate_partials(_Tp __a, _Tp __b, _Tp __c, _Tp __d) noexcept
 {
   __abcd_results<_Tp> __ret;
@@ -122,7 +122,7 @@ __complex_calculate_partials(_Tp __a, _Tp __b, _Tp __c, _Tp __d) noexcept
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __enable_if_t<__has_vector_type<_Tp>::value, __ab_results<_Tp>>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<__has_vector_type<_Tp>::value, __ab_results<_Tp>>
 __complex_piecewise_mul(_Tp __x1, _Tp __y1, _Tp __x2, _Tp __y2) noexcept
 {
   __ab_results<_Tp> __ret;

--- a/libcudacxx/include/cuda/std/__concepts/destructible.h
+++ b/libcudacxx/include/cuda/std/__concepts/destructible.h
@@ -44,9 +44,9 @@ _CCCL_INLINE_VAR constexpr bool __destructible_impl = false;
 
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool __destructible_impl<_Tp,
-                                                    __enable_if_t<_CCCL_TRAIT(is_object, _Tp)>,
+                                                    enable_if_t<_CCCL_TRAIT(is_object, _Tp)>,
 #    if defined(_CCCL_COMPILER_GCC)
-                                                    __enable_if_t<_CCCL_TRAIT(is_destructible, _Tp)>>
+                                                    enable_if_t<_CCCL_TRAIT(is_destructible, _Tp)>>
 #    else // ^^^ _CCCL_COMPILER_GCC ^^^ / vvv !_CCCL_COMPILER_GCC vvv
                                                     void_t<decltype(_CUDA_VSTD::declval<_Tp>().~_Tp())>>
 #    endif // !_CCCL_COMPILER_GCC

--- a/libcudacxx/include/cuda/std/__concepts/invocable.h
+++ b/libcudacxx/include/cuda/std/__concepts/invocable.h
@@ -64,7 +64,7 @@ _LIBCUDACXX_CONCEPT regular_invocable = invocable<_Fn, _Args...>;
 template <class _Fun, class... _Args>
 _LIBCUDACXX_CONCEPT_FRAGMENT(
   __invoke_constructible_,
-  requires(_Fun&& __fun, _Args&&... __args)((static_cast<__remove_cvref_t<invoke_result_t<_Fun, _Args...>>>(
+  requires(_Fun&& __fun, _Args&&... __args)((static_cast<remove_cvref_t<invoke_result_t<_Fun, _Args...>>>(
     _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fun>(__fun), _CUDA_VSTD::forward<_Args>(__args)...)))));
 template <class _Fun, class... _Args>
 _LIBCUDACXX_CONCEPT __invoke_constructible = _LIBCUDACXX_FRAGMENT(__invoke_constructible_, _Fun, _Args...);

--- a/libcudacxx/include/cuda/std/__expected/expected.h
+++ b/libcudacxx/include/cuda/std/__expected/expected.h
@@ -74,8 +74,8 @@ namespace __expected
 template <class _Tp, class _Err>
 _CCCL_INLINE_VAR constexpr bool __valid_expected =
   !_CCCL_TRAIT(is_reference, _Tp) && !_CCCL_TRAIT(is_function, _Tp)
-  && !_CCCL_TRAIT(is_same, __remove_cv_t<_Tp>, in_place_t) && !_CCCL_TRAIT(is_same, __remove_cv_t<_Tp>, unexpect_t)
-  && !__unexpected::__is_unexpected<__remove_cv_t<_Tp>> && __unexpected::__valid_unexpected<_Err>;
+  && !_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, in_place_t) && !_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, unexpect_t)
+  && !__unexpected::__is_unexpected<remove_cv_t<_Tp>> && __unexpected::__valid_unexpected<_Err>;
 
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool __is_expected = false;
@@ -227,8 +227,8 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Up = _Tp)
-  _LIBCUDACXX_REQUIRES((!_CCCL_TRAIT(is_same, __remove_cvref_t<_Up>, in_place_t)) _LIBCUDACXX_AND(!_CCCL_TRAIT(
-    is_same, expected, __remove_cvref_t<_Up>)) _LIBCUDACXX_AND(!__unexpected::__is_unexpected<__remove_cvref_t<_Up>>)
+  _LIBCUDACXX_REQUIRES((!_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, in_place_t)) _LIBCUDACXX_AND(!_CCCL_TRAIT(
+    is_same, expected, remove_cvref_t<_Up>)) _LIBCUDACXX_AND(!__unexpected::__is_unexpected<remove_cvref_t<_Up>>)
                          _LIBCUDACXX_AND _CCCL_TRAIT(is_constructible, _Tp, _Up)
                            _LIBCUDACXX_AND _CCCL_TRAIT(is_convertible, _Up, _Tp))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr expected(_Up&& __u) noexcept(
@@ -237,8 +237,8 @@ public:
   {}
 
   _LIBCUDACXX_TEMPLATE(class _Up = _Tp)
-  _LIBCUDACXX_REQUIRES((!_CCCL_TRAIT(is_same, __remove_cvref_t<_Up>, in_place_t)) _LIBCUDACXX_AND(!_CCCL_TRAIT(
-    is_same, expected, __remove_cvref_t<_Up>)) _LIBCUDACXX_AND(!__unexpected::__is_unexpected<__remove_cvref_t<_Up>>)
+  _LIBCUDACXX_REQUIRES((!_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, in_place_t)) _LIBCUDACXX_AND(!_CCCL_TRAIT(
+    is_same, expected, remove_cvref_t<_Up>)) _LIBCUDACXX_AND(!__unexpected::__is_unexpected<remove_cvref_t<_Up>>)
                          _LIBCUDACXX_AND _CCCL_TRAIT(is_constructible, _Tp, _Up)
                            _LIBCUDACXX_AND(!_CCCL_TRAIT(is_convertible, _Up, _Tp)))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit expected(_Up&& __u) noexcept(
@@ -345,8 +345,8 @@ public:
   // [expected.object.assign], assignment
   _LIBCUDACXX_TEMPLATE(class _Up = _Tp)
   _LIBCUDACXX_REQUIRES(
-    (!_CCCL_TRAIT(is_same, expected, __remove_cvref_t<_Up>))
-      _LIBCUDACXX_AND(!__unexpected::__is_unexpected<__remove_cvref_t<_Up>>)
+    (!_CCCL_TRAIT(is_same, expected, remove_cvref_t<_Up>))
+      _LIBCUDACXX_AND(!__unexpected::__is_unexpected<remove_cvref_t<_Up>>)
         _LIBCUDACXX_AND _CCCL_TRAIT(is_constructible, _Tp, _Up) _LIBCUDACXX_AND _CCCL_TRAIT(is_assignable, _Tp&, _Up)
           _LIBCUDACXX_AND(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up)
                           || _CCCL_TRAIT(is_nothrow_move_constructible, _Tp)
@@ -621,7 +621,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto and_then(_Fun&& __fun) &
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Tp&>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, _Tp&>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
     static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
@@ -641,7 +641,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto and_then(_Fun&& __fun) const&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Tp&>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Tp&>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
     static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
@@ -661,7 +661,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto and_then(_Fun&& __fun) &&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Tp>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, _Tp>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
     static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
@@ -681,7 +681,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto and_then(_Fun&& __fun) const&&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Tp>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Tp>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
     static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
@@ -701,7 +701,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp2, _Tp2&))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto or_else(_Fun&& __fun) &
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Err&>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, _Err&>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
@@ -722,7 +722,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto or_else(_Fun&& __fun) const&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Err&>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Err&>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
@@ -743,7 +743,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto or_else(_Fun&& __fun) &&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Err>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, _Err>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
@@ -764,7 +764,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp2, const _Tp2))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto or_else(_Fun&& __fun) const&&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Err>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Err>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
@@ -783,11 +783,11 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&)
-                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void))
+                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun, _Tp&>, "std::expected::transform requires that F must be invocable with T.");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, _Tp&>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, _Tp&>>;
 
     if (this->__has_val_)
     {
@@ -802,11 +802,11 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&)
-                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void)))
+                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun, _Tp&>, "std::expected::transform requires that F must be invocable with T.");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, _Tp&>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, _Tp&>>;
 
     static_assert(__invoke_constructible<_Fun, _Tp&>,
                   "std::expected::transform requires that the return type of F is constructible with the result of "
@@ -828,11 +828,11 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2)
-                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void))
+                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) const&
   {
     static_assert(invocable<_Fun, const _Tp&>, "std::expected::transform requires that F must be invocable with T.");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, const _Tp&>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, const _Tp&>>;
 
     if (this->__has_val_)
     {
@@ -846,12 +846,12 @@ public:
   }
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-  _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2) _LIBCUDACXX_AND(
-    !_CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void)))
+  _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2)
+                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) const&
   {
     static_assert(invocable<_Fun, const _Tp&>, "std::expected::transform requires that F must be invocable with T");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, const _Tp&>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, const _Tp&>>;
 
     static_assert(__invoke_constructible<_Fun, const _Tp&>,
                   "std::expected::transform requires that the return type of F is constructible with the result of "
@@ -873,11 +873,11 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2)
-                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void))
+                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun, _Tp>, "std::expected::transform requires that F must be invocable with T.");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, _Tp>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, _Tp>>;
 
     if (this->__has_val_)
     {
@@ -891,11 +891,11 @@ public:
   }
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2)
-                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void)))
+                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun, _Tp>, "std::expected::transform requires that F must be invocable with T");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, _Tp>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, _Tp>>;
 
     static_assert(__invoke_constructible<_Fun, _Tp>,
                   "std::expected::transform requires that the return type of F is constructible with the result of "
@@ -920,11 +920,11 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2)
-                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void))
+                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) const&&
   {
     static_assert(invocable<_Fun, const _Tp>, "std::expected::transform requires that F must be invocable with T.");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, const _Tp>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, const _Tp>>;
 
     if (this->__has_val_)
     {
@@ -939,11 +939,11 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2)
-                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void)))
+                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) const&&
   {
     static_assert(invocable<_Fun, const _Tp>, "std::expected::transform requires that F must be invocable with T");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, const _Tp>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, const _Tp>>;
 
     static_assert(__invoke_constructible<_Fun, const _Tp>,
                   "std::expected::transform requires that the return type of F is constructible with the result of "
@@ -971,7 +971,7 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform_error(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun, _Err&>, "std::expected::transform_error requires that F must be invocable with E");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, _Err&>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, _Err&>>;
 
     static_assert(__invoke_constructible<_Fun, _Err&>,
                   "std::expected::transform_error requires that the return type of F is constructible with the result "
@@ -997,7 +997,7 @@ public:
   {
     static_assert(invocable<_Fun, const _Err&>,
                   "std::expected::transform_error requires that F must be invocable with E");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, const _Err&>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, const _Err&>>;
 
     static_assert(__invoke_constructible<_Fun, const _Err&>,
                   "std::expected::transform_error requires that the return type of F is constructible with the result "
@@ -1022,7 +1022,7 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform_error(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun, _Err>, "std::expected::transform_error requires that F must be invocable with E");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, _Err>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, _Err>>;
 
     static_assert(__invoke_constructible<_Fun, _Err>,
                   "std::expected::transform_error requires that the return type of F is constructible with the result "
@@ -1051,7 +1051,7 @@ public:
   {
     static_assert(invocable<_Fun, const _Err>,
                   "std::expected::transform_error requires that F must be invocable with E");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, const _Err>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, const _Err>>;
 
     static_assert(__invoke_constructible<_Fun, const _Err>,
                   "std::expected::transform_error requires that the return type of F is constructible with the result "
@@ -1486,7 +1486,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto and_then(_Fun&& __fun) &
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
     static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
@@ -1506,7 +1506,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto and_then(_Fun&& __fun) const&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
     static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
@@ -1526,7 +1526,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto and_then(_Fun&& __fun) &&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
     static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
@@ -1546,7 +1546,7 @@ public:
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto and_then(_Fun&& __fun) const&&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
     static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
@@ -1565,7 +1565,7 @@ public:
   template <class _Fun>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto or_else(_Fun&& __fun) &
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Err&>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, _Err&>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
@@ -1585,7 +1585,7 @@ public:
   template <class _Fun>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto or_else(_Fun&& __fun) const&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Err&>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Err&>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
@@ -1605,7 +1605,7 @@ public:
   template <class _Fun>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto or_else(_Fun&& __fun) &&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, _Err>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, _Err>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
@@ -1625,7 +1625,7 @@ public:
   template <class _Fun>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto or_else(_Fun&& __fun) const&&
   {
-    using _Res = __remove_cvref_t<invoke_result_t<_Fun, const _Err>>;
+    using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Err>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
@@ -1644,7 +1644,7 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&)
-                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void))
+                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
@@ -1661,11 +1661,11 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&)
-                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void)))
+                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun>>;
 
     static_assert(__invoke_constructible<_Fun>,
                   "std::expected::transform requires that the return type of F is constructible with the result of "
@@ -1686,7 +1686,7 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2)
-                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void))
+                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) const&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
@@ -1703,11 +1703,11 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2)
-                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void)))
+                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) const&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun>>;
 
     static_assert(__invoke_constructible<_Fun>,
                   "std::expected::transform requires that the return type of F is constructible with the result of "
@@ -1728,7 +1728,7 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2)
-                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void))
+                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
@@ -1744,11 +1744,11 @@ public:
   }
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2)
-                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void)))
+                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun>>;
 
     static_assert(__invoke_constructible<_Fun>,
                   "std::expected::transform requires that the return type of F is constructible with the result of "
@@ -1769,7 +1769,7 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2)
-                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void))
+                         _LIBCUDACXX_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) const&&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
@@ -1786,11 +1786,11 @@ public:
 
   _LIBCUDACXX_TEMPLATE(class _Fun, class _Err2 = _Err)
   _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2)
-                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, __remove_cv_t<invoke_result_t<_Fun>>, void)))
+                         _LIBCUDACXX_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void)))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform(_Fun&& __fun) const&&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun>>;
 
     static_assert(__invoke_constructible<_Fun>,
                   "std::expected::transform requires that the return type of F is constructible with the result of "
@@ -1813,7 +1813,7 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform_error(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun, _Err&>, "std::expected::transform_error requires that F must be invocable with E");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, _Err&>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, _Err&>>;
 
     static_assert(__invoke_constructible<_Fun, _Err&>,
                   "std::expected::transform_error requires that the return type of F is constructible with the result "
@@ -1838,7 +1838,7 @@ public:
   {
     static_assert(invocable<_Fun, const _Err&>,
                   "std::expected::transform_error requires that F must be invocable with E");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, const _Err&>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, const _Err&>>;
 
     static_assert(__invoke_constructible<_Fun, const _Err&>,
                   "std::expected::transform_error requires that the return type of F is constructible with the result "
@@ -1862,7 +1862,7 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI constexpr auto transform_error(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun, _Err>, "std::expected::transform_error requires that F must be invocable with E");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, _Err>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, _Err>>;
 
     static_assert(__invoke_constructible<_Fun, _Err>,
                   "std::expected::transform_error requires that the return type of F is constructible with the result "
@@ -1890,7 +1890,7 @@ public:
   {
     static_assert(invocable<_Fun, const _Err>,
                   "std::expected::transform_error requires that F must be invocable with E");
-    using _Res = __remove_cv_t<invoke_result_t<_Fun, const _Err>>;
+    using _Res = remove_cv_t<invoke_result_t<_Fun, const _Err>>;
 
     static_assert(__invoke_constructible<_Fun, const _Err>,
                   "std::expected::transform_error requires that the return type of F is constructible with the result "

--- a/libcudacxx/include/cuda/std/__functional/bind.h
+++ b/libcudacxx/include/cuda/std/__functional/bind.h
@@ -50,7 +50,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct is_bind_expression
-    : _If<_IsSame<_Tp, __remove_cvref_t<_Tp>>::value, false_type, is_bind_expression<__remove_cvref_t<_Tp>>>
+    : _If<_IsSame<_Tp, remove_cvref_t<_Tp>>::value, false_type, is_bind_expression<remove_cvref_t<_Tp>>>
 {};
 
 #  if _CCCL_STD_VER > 2014
@@ -60,7 +60,7 @@ inline constexpr size_t is_bind_expression_v = is_bind_expression<_Tp>::value;
 
 template <class _Tp>
 struct is_placeholder
-    : _If<_IsSame<_Tp, __remove_cvref_t<_Tp>>::value, integral_constant<int, 0>, is_placeholder<__remove_cvref_t<_Tp>>>
+    : _If<_IsSame<_Tp, remove_cvref_t<_Tp>>::value, integral_constant<int, 0>, is_placeholder<remove_cvref_t<_Tp>>>
 {};
 
 #  if _CCCL_STD_VER > 2014
@@ -119,7 +119,7 @@ __mu_expand(_Ti& __ti, tuple<_Uj...>& __uj, __tuple_indices<_Indx...>)
 }
 
 template <class _Ti, class... _Uj>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_bind_expression<_Ti>::value, __invoke_of<_Ti&, _Uj...>>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_bind_expression<_Ti>::value, __invoke_of<_Ti&, _Uj...>>
 __mu(_Ti& __ti, tuple<_Uj...>& __uj)
 {
   typedef __make_tuple_indices_t<sizeof...(_Uj)> __indices;
@@ -138,7 +138,7 @@ struct __mu_return2<true, _Ti, _Uj>
 
 template <class _Ti, class _Uj>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<0 < is_placeholder<_Ti>::value, typename __mu_return2<0 < is_placeholder<_Ti>::value, _Ti, _Uj>::type>
+enable_if_t<0 < is_placeholder<_Ti>::value, typename __mu_return2<0 < is_placeholder<_Ti>::value, _Ti, _Uj>::type>
 __mu(_Ti&, _Uj& __uj)
 {
   const size_t _Indx = is_placeholder<_Ti>::value - 1;
@@ -147,8 +147,8 @@ __mu(_Ti&, _Uj& __uj)
 
 template <class _Ti, class _Uj>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<!is_bind_expression<_Ti>::value && is_placeholder<_Ti>::value == 0 && !__is_reference_wrapper<_Ti>::value,
-              _Ti&>
+enable_if_t<!is_bind_expression<_Ti>::value && is_placeholder<_Ti>::value == 0 && !__is_reference_wrapper<_Ti>::value,
+            _Ti&>
 __mu(_Ti& __ti, _Uj&)
 {
   return __ti;
@@ -246,11 +246,11 @@ __apply_functor(_Fp& __f, _BoundArgs& __bound_args, __tuple_indices<_Indx...>, _
 }
 
 template <class _Fp, class... _BoundArgs>
-class __bind : public __weak_result_type<__decay_t<_Fp>>
+class __bind : public __weak_result_type<decay_t<_Fp>>
 {
 protected:
-  typedef __decay_t<_Fp> _Fd;
-  typedef tuple<__decay_t<_BoundArgs>...> _Td;
+  typedef decay_t<_Fp> _Fd;
+  typedef tuple<decay_t<_BoundArgs>...> _Td;
 
 private:
   _Fd __f_;
@@ -261,8 +261,7 @@ private:
 public:
   template <class _Gp,
             class... _BA,
-            class = __enable_if_t<is_constructible<_Fd, _Gp>::value
-                                  && !is_same<__libcpp_remove_reference_t<_Gp>, __bind>::value>>
+            class = enable_if_t<is_constructible<_Fd, _Gp>::value && !is_same<remove_reference_t<_Gp>, __bind>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 explicit __bind(_Gp&& __f, _BA&&... __bound_args)
       : __f_(_CUDA_VSTD::forward<_Gp>(__f))
       , __bound_args_(_CUDA_VSTD::forward<_BA>(__bound_args)...)
@@ -301,16 +300,15 @@ public:
 
   template <class _Gp,
             class... _BA,
-            class = __enable_if_t<is_constructible<_Fd, _Gp>::value
-                                  && !is_same<__libcpp_remove_reference_t<_Gp>, __bind_r>::value>>
+            class = enable_if_t<is_constructible<_Fd, _Gp>::value && !is_same<remove_reference_t<_Gp>, __bind_r>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 explicit __bind_r(_Gp&& __f, _BA&&... __bound_args)
       : base(_CUDA_VSTD::forward<_Gp>(__f), _CUDA_VSTD::forward<_BA>(__bound_args)...)
   {}
 
   template <class... _Args>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20
-  __enable_if_t<is_convertible<__bind_return_t<_Fd, _Td, tuple<_Args&&...>>, result_type>::value || is_void<_Rp>::value,
-                result_type>
+  enable_if_t<is_convertible<__bind_return_t<_Fd, _Td, tuple<_Args&&...>>, result_type>::value || is_void<_Rp>::value,
+              result_type>
   operator()(_Args&&... __args)
   {
     typedef __invoke_void_return_wrapper<_Rp> _Invoker;
@@ -318,7 +316,7 @@ public:
   }
 
   template <class... _Args>
-  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 __enable_if_t<
+  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 enable_if_t<
     is_convertible<__bind_return_t<const _Fd, const _Td, tuple<_Args&&...>>, result_type>::value || is_void<_Rp>::value,
     result_type>
   operator()(_Args&&... __args) const

--- a/libcudacxx/include/cuda/std/__functional/function.h
+++ b/libcudacxx/include/cuda/std/__functional/function.h
@@ -136,8 +136,8 @@ class __alloc_func<_Fp, _Ap, _Rp(_ArgTypes...)>
   __compressed_pair<_Fp, _Ap> __f_;
 
 public:
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Fp _Target;
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Ap _Alloc;
+  typedef _CCCL_NODEBUG_ALIAS _Fp _Target;
+  typedef _CCCL_NODEBUG_ALIAS _Ap _Alloc;
 
   _LIBCUDACXX_HIDE_FROM_ABI const _Target& __target() const
   {
@@ -206,7 +206,7 @@ class __default_alloc_func<_Fp, _Rp(_ArgTypes...)>
   _Fp __f_;
 
 public:
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Fp _Target;
+  typedef _CCCL_NODEBUG_ALIAS _Fp _Target;
 
   _LIBCUDACXX_HIDE_FROM_ABI const _Target& __target() const
   {
@@ -419,7 +419,7 @@ public:
     }
   }
 
-  template <class _Fp, class = __enable_if_t<!is_same<__decay_t<_Fp>, __value_func>::value>>
+  template <class _Fp, class = enable_if_t<!is_same<decay_t<_Fp>, __value_func>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI explicit __value_func(_Fp&& __f)
       : __value_func(_CUDA_VSTD::forward<_Fp>(__f), allocator<_Fp>())
   {}
@@ -687,7 +687,7 @@ private:
 // Used to choose between perfect forwarding or pass-by-value. Pass-by-value is
 // faster for types that can be passed in registers.
 template <typename _Tp>
-using __fast_forward = __conditional_t<is_scalar<_Tp>::value, _Tp, _Tp&&>;
+using __fast_forward = conditional_t<is_scalar<_Tp>::value, _Tp, _Tp&&>;
 
 // __policy_invoker calls an instance of __alloc_func held in __policy_storage.
 
@@ -786,7 +786,7 @@ public:
     }
   }
 
-  template <class _Fp, class = __enable_if_t<!is_same<__decay_t<_Fp>, __policy_func>::value>>
+  template <class _Fp, class = enable_if_t<!is_same<decay_t<_Fp>, __policy_func>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI explicit __policy_func(_Fp&& __f)
       : __policy_(__policy::__create_empty())
   {
@@ -997,7 +997,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT function<_Rp(_ArgTypes...)>
 
   __func __f_;
 
-  template <class _Fp, bool = _And<_IsNotSame<__remove_cvref_t<_Fp>, function>, __invokable<_Fp, _ArgTypes...>>::value>
+  template <class _Fp, bool = _And<_IsNotSame<remove_cvref_t<_Fp>, function>, __invokable<_Fp, _ArgTypes...>>::value>
   struct __callable;
   template <class _Fp>
   struct __callable<_Fp, true>
@@ -1012,7 +1012,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT function<_Rp(_ArgTypes...)>
   };
 
   template <class _Fp>
-  using _EnableIfLValueCallable = __enable_if_t<__callable<_Fp&>::value>;
+  using _EnableIfLValueCallable = enable_if_t<__callable<_Fp&>::value>;
 
 public:
   typedef _Rp result_type;
@@ -1043,7 +1043,7 @@ public:
   function& operator=(const function&);
   function& operator=(function&&) noexcept;
   function& operator=(nullptr_t) noexcept;
-  template <class _Fp, class = _EnableIfLValueCallable<__decay_t<_Fp>>>
+  template <class _Fp, class = _EnableIfLValueCallable<decay_t<_Fp>>>
   function& operator=(_Fp&&);
 
   ~function();

--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -647,25 +647,25 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<nullptr_t> : public __unary_function<n
 #  endif
 
 template <class _Key, class _Hash>
-using __check_hash_requirements _LIBCUDACXX_NODEBUG_TYPE =
+using __check_hash_requirements _CCCL_NODEBUG_ALIAS =
   integral_constant<bool,
                     is_copy_constructible<_Hash>::value && is_move_constructible<_Hash>::value
                       && __invokable_r<size_t, _Hash, _Key const&>::value>;
 
 template <class _Key, class _Hash = hash<_Key>>
-using __has_enabled_hash _LIBCUDACXX_NODEBUG_TYPE =
+using __has_enabled_hash _CCCL_NODEBUG_ALIAS =
   integral_constant<bool, __check_hash_requirements<_Key, _Hash>::value && is_default_constructible<_Hash>::value>;
 
 #  if _CCCL_STD_VER > 2014
 template <class _Type, class>
-using __enable_hash_helper_imp _LIBCUDACXX_NODEBUG_TYPE = _Type;
+using __enable_hash_helper_imp _CCCL_NODEBUG_ALIAS = _Type;
 
 template <class _Type, class... _Keys>
-using __enable_hash_helper _LIBCUDACXX_NODEBUG_TYPE =
-  __enable_hash_helper_imp<_Type, __enable_if_t<__all<__has_enabled_hash<_Keys>::value...>::value>>;
+using __enable_hash_helper _CCCL_NODEBUG_ALIAS =
+  __enable_hash_helper_imp<_Type, enable_if_t<__all<__has_enabled_hash<_Keys>::value...>::value>>;
 #  else
 template <class _Type, class...>
-using __enable_hash_helper _LIBCUDACXX_NODEBUG_TYPE = _Type;
+using __enable_hash_helper _CCCL_NODEBUG_ALIAS = _Type;
 #  endif
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/__functional/invoke.h
@@ -253,7 +253,7 @@ struct __member_pointer_traits_imp<_Rp _Class::*, false, true>
 
 template <class _MP>
 struct __member_pointer_traits
-    : public __member_pointer_traits_imp<__remove_cv_t<_MP>,
+    : public __member_pointer_traits_imp<remove_cv_t<_MP>,
                                          is_member_function_pointer<_MP>::value,
                                          is_member_object_pointer<_MP>::value>
 {
@@ -274,45 +274,45 @@ struct __member_pointer_class_type<_Ret _ClassType::*>
 
 template <class _Fp,
           class _A0,
-          class _DecayFp = __decay_t<_Fp>,
+          class _DecayFp = decay_t<_Fp>,
           class _DecayA0 = typename decay<_A0>::type,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet1 =
-  __enable_if_t<is_member_function_pointer<_DecayFp>::value && is_base_of<_ClassT, _DecayA0>::value>;
+  enable_if_t<is_member_function_pointer<_DecayFp>::value && is_base_of<_ClassT, _DecayA0>::value>;
 
-template <class _Fp, class _A0, class _DecayFp = __decay_t<_Fp>, class _DecayA0 = typename decay<_A0>::type>
+template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>, class _DecayA0 = typename decay<_A0>::type>
 using __enable_if_bullet2 =
-  __enable_if_t<is_member_function_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
+  enable_if_t<is_member_function_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
 
 template <class _Fp,
           class _A0,
-          class _DecayFp = __decay_t<_Fp>,
+          class _DecayFp = decay_t<_Fp>,
           class _DecayA0 = typename decay<_A0>::type,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet3 =
-  __enable_if_t<is_member_function_pointer<_DecayFp>::value && !is_base_of<_ClassT, _DecayA0>::value
-                && !__is_reference_wrapper<_DecayA0>::value>;
+  enable_if_t<is_member_function_pointer<_DecayFp>::value && !is_base_of<_ClassT, _DecayA0>::value
+              && !__is_reference_wrapper<_DecayA0>::value>;
 
 template <class _Fp,
           class _A0,
-          class _DecayFp = __decay_t<_Fp>,
+          class _DecayFp = decay_t<_Fp>,
           class _DecayA0 = typename decay<_A0>::type,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet4 =
-  __enable_if_t<is_member_object_pointer<_DecayFp>::value && is_base_of<_ClassT, _DecayA0>::value>;
+  enable_if_t<is_member_object_pointer<_DecayFp>::value && is_base_of<_ClassT, _DecayA0>::value>;
 
-template <class _Fp, class _A0, class _DecayFp = __decay_t<_Fp>, class _DecayA0 = typename decay<_A0>::type>
+template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>, class _DecayA0 = typename decay<_A0>::type>
 using __enable_if_bullet5 =
-  __enable_if_t<is_member_object_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
+  enable_if_t<is_member_object_pointer<_DecayFp>::value && __is_reference_wrapper<_DecayA0>::value>;
 
 template <class _Fp,
           class _A0,
-          class _DecayFp = __decay_t<_Fp>,
+          class _DecayFp = decay_t<_Fp>,
           class _DecayA0 = typename decay<_A0>::type,
           class _ClassT  = typename __member_pointer_class_type<_DecayFp>::type>
 using __enable_if_bullet6 =
-  __enable_if_t<is_member_object_pointer<_DecayFp>::value && !is_base_of<_ClassT, _DecayA0>::value
-                && !__is_reference_wrapper<_DecayA0>::value>;
+  enable_if_t<is_member_object_pointer<_DecayFp>::value && !is_base_of<_ClassT, _DecayA0>::value
+              && !__is_reference_wrapper<_DecayA0>::value>;
 
 // __invoke forward declarations
 
@@ -406,9 +406,9 @@ struct __invokable_r
   // or incomplete array types as required by the standard.
   using _Result = decltype(__try_call<_Fp, _Args...>(0));
 
-  using type              = __conditional_t<_IsNotSame<_Result, __nat>::value,
-                                            __conditional_t<is_void<_Ret>::value, true_type, __is_core_convertible<_Result, _Ret>>,
-                                            false_type>;
+  using type              = conditional_t<_IsNotSame<_Result, __nat>::value,
+                                          conditional_t<is_void<_Ret>::value, true_type, __is_core_convertible<_Result, _Ret>>,
+                                          false_type>;
   static const bool value = type::value;
 };
 template <class _Fp, class... _Args>

--- a/libcudacxx/include/cuda/std/__functional/not_fn.h
+++ b/libcudacxx/include/cuda/std/__functional/not_fn.h
@@ -52,7 +52,7 @@ struct __not_fn_t : __perfect_forward<__not_fn_op, _Fn>
   _CCCL_HIDE_FROM_ABI constexpr __not_fn_t() noexcept = default;
 
   _LIBCUDACXX_TEMPLATE(class _OrigFn)
-  _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_same, _Fn, __decay_t<_OrigFn>))
+  _LIBCUDACXX_REQUIRES(_CCCL_TRAIT(is_same, _Fn, decay_t<_OrigFn>))
   _LIBCUDACXX_HIDE_FROM_ABI constexpr __not_fn_t(_OrigFn&& __fn) noexcept(
     noexcept(__base(_CUDA_VSTD::declval<_OrigFn>())))
       : __base(_CUDA_VSTD::forward<_OrigFn>(__fn))

--- a/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
@@ -45,7 +45,7 @@ private:
 
 public:
   template <class _Up,
-            class = __enable_if_t<!__is_same_uncvref<_Up, reference_wrapper>::value, decltype(__fun(declval<_Up>()))>>
+            class = enable_if_t<!__is_same_uncvref<_Up, reference_wrapper>::value, decltype(__fun(declval<_Up>()))>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 reference_wrapper(_Up&& __u) noexcept(noexcept(__fun(declval<_Up>())))
   {
     type& __f = static_cast<_Up&&>(__u);

--- a/libcudacxx/include/cuda/std/__functional/unwrap_ref.h
+++ b/libcudacxx/include/cuda/std/__functional/unwrap_ref.h
@@ -25,7 +25,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct __unwrap_reference
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 
 template <class _Tp>
@@ -34,7 +34,7 @@ class reference_wrapper;
 template <class _Tp>
 struct __unwrap_reference<reference_wrapper<_Tp>>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp& type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp& type;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__functional/weak_result_type.h
+++ b/libcudacxx/include/cuda/std/__functional/weak_result_type.h
@@ -105,7 +105,7 @@ struct __weak_result_type_imp // bool is true
     , public __maybe_derive_from_binary_function<_Tp>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = typename _Tp::result_type;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = typename _Tp::result_type;
 #endif
 };
 
@@ -125,7 +125,7 @@ template <class _Rp>
 struct __weak_result_type<_Rp()>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 
@@ -133,7 +133,7 @@ template <class _Rp>
 struct __weak_result_type<_Rp (&)()>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 
@@ -141,7 +141,7 @@ template <class _Rp>
 struct __weak_result_type<_Rp (*)()>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 
@@ -211,7 +211,7 @@ template <class _Rp, class _A1, class _A2, class _A3, class... _A4>
 struct __weak_result_type<_Rp(_A1, _A2, _A3, _A4...)>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 
@@ -219,7 +219,7 @@ template <class _Rp, class _A1, class _A2, class _A3, class... _A4>
 struct __weak_result_type<_Rp (&)(_A1, _A2, _A3, _A4...)>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 
@@ -227,7 +227,7 @@ template <class _Rp, class _A1, class _A2, class _A3, class... _A4>
 struct __weak_result_type<_Rp (*)(_A1, _A2, _A3, _A4...)>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 
@@ -235,7 +235,7 @@ template <class _Rp, class _Cp, class _A1, class _A2, class... _A3>
 struct __weak_result_type<_Rp (_Cp::*)(_A1, _A2, _A3...)>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 
@@ -243,7 +243,7 @@ template <class _Rp, class _Cp, class _A1, class _A2, class... _A3>
 struct __weak_result_type<_Rp (_Cp::*)(_A1, _A2, _A3...) const>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 
@@ -251,7 +251,7 @@ template <class _Rp, class _Cp, class _A1, class _A2, class... _A3>
 struct __weak_result_type<_Rp (_Cp::*)(_A1, _A2, _A3...) volatile>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 
@@ -259,7 +259,7 @@ template <class _Rp, class _Cp, class _A1, class _A2, class... _A3>
 struct __weak_result_type<_Rp (_Cp::*)(_A1, _A2, _A3...) const volatile>
 {
 #if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  using result_type _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
+  using result_type _CCCL_NODEBUG_ALIAS _LIBCUDACXX_DEPRECATED_IN_CXX17 = _Rp;
 #endif
 };
 

--- a/libcudacxx/include/cuda/std/__iterator/advance.h
+++ b/libcudacxx/include/cuda/std/__iterator/advance.h
@@ -71,7 +71,7 @@ __advance(_RandIter& __i, typename iterator_traits<_RandIter>::difference_type _
 template <class _InputIter,
           class _Distance,
           class _IntegralDistance = decltype(_CUDA_VSTD::__convert_to_integral(_CUDA_VSTD::declval<_Distance>())),
-          class                   = __enable_if_t<is_integral<_IntegralDistance>::value>>
+          class                   = enable_if_t<is_integral<_IntegralDistance>::value>>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 void advance(_InputIter& __i, _Distance __orig_n)
 {
   typedef typename iterator_traits<_InputIter>::difference_type _Difference;

--- a/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
+++ b/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
@@ -39,7 +39,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // Arithmetic operations are allowed and the bounds of the resulting iterator
 // are not checked. Hence, it is possible to create an iterator pointing outside
 // its range, but it is not possible to dereference it.
-template <class _Iterator, class = __enable_if_t<__is_cpp17_contiguous_iterator<_Iterator>::value>>
+template <class _Iterator, class = enable_if_t<__is_cpp17_contiguous_iterator<_Iterator>::value>>
 struct __bounded_iter
 {
   using value_type        = typename iterator_traits<_Iterator>::value_type;
@@ -60,7 +60,7 @@ struct __bounded_iter
   _CCCL_HIDE_FROM_ABI __bounded_iter(__bounded_iter const&) = default;
   _CCCL_HIDE_FROM_ABI __bounded_iter(__bounded_iter&&)      = default;
 
-  template <class _OtherIterator, class = __enable_if_t<is_convertible<_OtherIterator, _Iterator>::value>>
+  template <class _OtherIterator, class = enable_if_t<is_convertible<_OtherIterator, _Iterator>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr __bounded_iter(__bounded_iter<_OtherIterator> const& __other) noexcept
       : __current_(__other.__current_)
       , __begin_(__other.__begin_)

--- a/libcudacxx/include/cuda/std/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_swap.h
@@ -153,7 +153,7 @@ template <class _I1, class _I2 = _I1, class = void>
 _CCCL_INLINE_VAR constexpr bool __noexcept_swappable = false;
 
 template <class _I1, class _I2>
-_CCCL_INLINE_VAR constexpr bool __noexcept_swappable<_I1, _I2, __enable_if_t<indirectly_swappable<_I1, _I2>>> =
+_CCCL_INLINE_VAR constexpr bool __noexcept_swappable<_I1, _I2, enable_if_t<indirectly_swappable<_I1, _I2>>> =
   noexcept(_CUDA_VRANGES::iter_swap(_CUDA_VSTD::declval<_I1&>(), _CUDA_VSTD::declval<_I2&>()));
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -178,7 +178,7 @@ struct __iter_concept_category_test
 struct __iter_concept_random_fallback
 {
   template <class _Iter>
-  using _Apply = __enable_if_t<__is_primary_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
+  using _Apply = enable_if_t<__is_primary_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
 };
 
 template <class _Iter, class _Tester>
@@ -811,7 +811,7 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits<_Tp*>
 {
   typedef ptrdiff_t difference_type;
-  typedef __remove_cv_t<_Tp> value_type;
+  typedef remove_cv_t<_Tp> value_type;
   typedef _Tp* pointer;
   typedef typename add_lvalue_reference<_Tp>::type reference;
   typedef random_access_iterator_tag iterator_category;

--- a/libcudacxx/include/cuda/std/__iterator/move_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/move_iterator.h
@@ -160,8 +160,7 @@ public:
   typedef typename iterator_traits<iterator_type>::difference_type difference_type;
   typedef iterator_type pointer;
   typedef typename iterator_traits<iterator_type>::reference __reference;
-  typedef __conditional_t<is_reference<__reference>::value, __libcpp_remove_reference_t<__reference>&&, __reference>
-    reference;
+  typedef conditional_t<is_reference<__reference>::value, remove_reference_t<__reference>&&, __reference> reference;
 #endif // _CCCL_STD_VER < 2017
 
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 explicit move_iterator(_Iter __i)
@@ -246,14 +245,14 @@ public:
       : __current_()
   {}
 
-  template <class _Up, class = __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<const _Up&, _Iter>::value>>
+  template <class _Up, class = enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<const _Up&, _Iter>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 move_iterator(const move_iterator<_Up>& __u)
       : __current_(__u.base())
   {}
 
   template <class _Up,
-            class = __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<const _Up&, _Iter>::value
-                                  && is_assignable<_Iter&, const _Up&>::value>>
+            class = enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<const _Up&, _Iter>::value
+                                && is_assignable<_Iter&, const _Up&>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 move_iterator& operator=(const move_iterator<_Up>& __u)
   {
     __current_ = __u.base();

--- a/libcudacxx/include/cuda/std/__iterator/next.h
+++ b/libcudacxx/include/cuda/std/__iterator/next.h
@@ -30,7 +30,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _InputIter>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __enable_if_t<__is_cpp17_input_iterator<_InputIter>::value, _InputIter>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<__is_cpp17_input_iterator<_InputIter>::value, _InputIter>
 next(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n = 1)
 {
   _CCCL_ASSERT(__n >= 0 || __is_cpp17_bidirectional_iterator<_InputIter>::value,

--- a/libcudacxx/include/cuda/std/__iterator/prev.h
+++ b/libcudacxx/include/cuda/std/__iterator/prev.h
@@ -30,7 +30,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _InputIter>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __enable_if_t<__is_cpp17_input_iterator<_InputIter>::value, _InputIter>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<__is_cpp17_input_iterator<_InputIter>::value, _InputIter>
 prev(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n = 1)
 {
   _CCCL_ASSERT(__n <= 0 || __is_cpp17_bidirectional_iterator<_InputIter>::value,

--- a/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
@@ -128,15 +128,15 @@ public:
       , current(__x)
   {}
 
-  template <class _Up, class = __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value>>
+  template <class _Up, class = enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 reverse_iterator(const reverse_iterator<_Up>& __u)
       : __t_(__u.base())
       , current(__u.base())
   {}
 
   template <class _Up,
-            class = __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value
-                                  && is_assignable<_Iter&, _Up const&>::value>>
+            class = enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value
+                                && is_assignable<_Iter&, _Up const&>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 reverse_iterator& operator=(const reverse_iterator<_Up>& __u)
   {
     __t_ = current = __u.base();
@@ -151,14 +151,14 @@ public:
       : current(__x)
   {}
 
-  template <class _Up, class = __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value>>
+  template <class _Up, class = enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 reverse_iterator(const reverse_iterator<_Up>& __u)
       : current(__u.base())
   {}
 
   template <class _Up,
-            class = __enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value
-                                  && is_assignable<_Iter&, _Up const&>::value>>
+            class = enable_if_t<!is_same<_Up, _Iter>::value && is_convertible<_Up const&, _Iter>::value
+                                && is_assignable<_Iter&, _Up const&>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 reverse_iterator& operator=(const reverse_iterator<_Up>& __u)
   {
     current = __u.base();

--- a/libcudacxx/include/cuda/std/__mdspan/standard_layout_static_array.h
+++ b/libcudacxx/include/cuda/std/__mdspan/standard_layout_static_array.h
@@ -628,7 +628,7 @@ struct __partially_static_sizes_tagged
   using __psa_impl_t =
     __standard_layout_psa<_Tag, T, _static_t, _CUDA_VSTD::integer_sequence<_static_t, __values_or_sentinals...>>;
 #    if defined(_CCCL_COMPILER_NVRTC) || defined(_CCCL_CUDACC_BELOW_11_3)
-  template <class... _Args, __enable_if_t<_CCCL_TRAIT(is_constructible, __psa_impl_t, _Args...), int> = 0>
+  template <class... _Args, enable_if_t<_CCCL_TRAIT(is_constructible, __psa_impl_t, _Args...), int> = 0>
   __MDSPAN_FORCE_INLINE_FUNCTION constexpr __partially_static_sizes_tagged(_Args&&... __args) noexcept(
     noexcept(__psa_impl_t(_CUDA_VSTD::declval<_Args>()...)))
       : __psa_impl_t(_CUDA_VSTD::forward<_Args>(__args)...)
@@ -681,7 +681,7 @@ private:
 
 public:
 #    if defined(_CCCL_COMPILER_NVRTC) || defined(_CCCL_CUDACC_BELOW_11_3)
-  template <class... _Args, __enable_if_t<_CCCL_TRAIT(is_constructible, __base_t, _Args...), int> = 0>
+  template <class... _Args, enable_if_t<_CCCL_TRAIT(is_constructible, __base_t, _Args...), int> = 0>
   __MDSPAN_FORCE_INLINE_FUNCTION constexpr __partially_static_sizes(_Args&&... __args) noexcept(
     noexcept(__base_t(_CUDA_VSTD::declval<_Args>()...)))
       : __base_t(_CUDA_VSTD::forward<_Args>(__args)...)

--- a/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
@@ -42,7 +42,7 @@ _CCCL_INLINE_VAR constexpr allocator_arg_t allocator_arg = allocator_arg_t();
 template <class _Tp, class _Alloc, class... _Args>
 struct __uses_alloc_ctor_imp
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __remove_cvref_t<_Alloc> _RawAlloc;
+  typedef _CCCL_NODEBUG_ALIAS remove_cvref_t<_Alloc> _RawAlloc;
   static const bool __ua = uses_allocator<_Tp, _RawAlloc>::value;
   static const bool __ic = is_constructible<_Tp, allocator_arg_t, _Alloc, _Args...>::value;
   static const int value = __ua ? 2 - __ic : 0;

--- a/libcudacxx/include/cuda/std/__memory/allocator_destructor.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_destructor.h
@@ -29,11 +29,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Alloc>
 class __allocator_destructor
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE allocator_traits<_Alloc> __alloc_traits;
+  typedef _CCCL_NODEBUG_ALIAS allocator_traits<_Alloc> __alloc_traits;
 
 public:
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename __alloc_traits::pointer pointer;
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename __alloc_traits::size_type size_type;
+  typedef _CCCL_NODEBUG_ALIAS typename __alloc_traits::pointer pointer;
+  typedef _CCCL_NODEBUG_ALIAS typename __alloc_traits::size_type size_type;
 
 private:
   _Alloc& __alloc_;

--- a/libcudacxx/include/cuda/std/__memory/allocator_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_traits.h
@@ -62,16 +62,16 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_pointer, pointer);
 template <class _Tp,
           class _Alloc,
-          class _RawAlloc = __libcpp_remove_reference_t<_Alloc>,
+          class _RawAlloc = remove_reference_t<_Alloc>,
           bool            = _CCCL_TRAIT(__has_pointer, _RawAlloc)>
 struct __pointer
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _RawAlloc::pointer;
+  using type _CCCL_NODEBUG_ALIAS = typename _RawAlloc::pointer;
 };
 template <class _Tp, class _Alloc, class _RawAlloc>
 struct __pointer<_Tp, _Alloc, _RawAlloc, false>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _Tp*;
+  using type _CCCL_NODEBUG_ALIAS = _Tp*;
 };
 
 // __const_pointer
@@ -79,12 +79,12 @@ _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_const_pointer, const_pointer);
 template <class _Tp, class _Ptr, class _Alloc, bool = _CCCL_TRAIT(__has_const_pointer, _Alloc)>
 struct __const_pointer
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc::const_pointer;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc::const_pointer;
 };
 template <class _Tp, class _Ptr, class _Alloc>
 struct __const_pointer<_Tp, _Ptr, _Alloc, false>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename pointer_traits<_Ptr>::template rebind<const _Tp>;
+  using type _CCCL_NODEBUG_ALIAS = typename pointer_traits<_Ptr>::template rebind<const _Tp>;
 };
 
 // __void_pointer
@@ -92,12 +92,12 @@ _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_void_pointer, void_pointer);
 template <class _Ptr, class _Alloc, bool = _CCCL_TRAIT(__has_void_pointer, _Alloc)>
 struct __void_pointer
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc::void_pointer;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc::void_pointer;
 };
 template <class _Ptr, class _Alloc>
 struct __void_pointer<_Ptr, _Alloc, false>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename pointer_traits<_Ptr>::template rebind<void>;
+  using type _CCCL_NODEBUG_ALIAS = typename pointer_traits<_Ptr>::template rebind<void>;
 };
 
 // __const_void_pointer
@@ -105,12 +105,12 @@ _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_const_void_pointer, const_void_pointe
 template <class _Ptr, class _Alloc, bool = _CCCL_TRAIT(__has_const_void_pointer, _Alloc)>
 struct __const_void_pointer
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc::const_void_pointer;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc::const_void_pointer;
 };
 template <class _Ptr, class _Alloc>
 struct __const_void_pointer<_Ptr, _Alloc, false>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename pointer_traits<_Ptr>::template rebind<const void>;
+  using type _CCCL_NODEBUG_ALIAS = typename pointer_traits<_Ptr>::template rebind<const void>;
 };
 
 // __size_type
@@ -121,7 +121,7 @@ struct __size_type : make_unsigned<_DiffType>
 template <class _Alloc, class _DiffType>
 struct __size_type<_Alloc, _DiffType, true>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc::size_type;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc::size_type;
 };
 
 // __alloc_traits_difference_type
@@ -129,12 +129,12 @@ _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_alloc_traits_difference_type, differe
 template <class _Alloc, class _Ptr, bool = _CCCL_TRAIT(__has_alloc_traits_difference_type, _Alloc)>
 struct __alloc_traits_difference_type
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename pointer_traits<_Ptr>::difference_type;
+  using type _CCCL_NODEBUG_ALIAS = typename pointer_traits<_Ptr>::difference_type;
 };
 template <class _Alloc, class _Ptr>
 struct __alloc_traits_difference_type<_Alloc, _Ptr, true>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc::difference_type;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc::difference_type;
 };
 
 // __propagate_on_container_copy_assignment
@@ -146,7 +146,7 @@ struct __propagate_on_container_copy_assignment : false_type
 template <class _Alloc>
 struct __propagate_on_container_copy_assignment<_Alloc, true>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc::propagate_on_container_copy_assignment;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc::propagate_on_container_copy_assignment;
 };
 
 // __propagate_on_container_move_assignment
@@ -158,7 +158,7 @@ struct __propagate_on_container_move_assignment : false_type
 template <class _Alloc>
 struct __propagate_on_container_move_assignment<_Alloc, true>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc::propagate_on_container_move_assignment;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc::propagate_on_container_move_assignment;
 };
 
 // __propagate_on_container_swap
@@ -169,7 +169,7 @@ struct __propagate_on_container_swap : false_type
 template <class _Alloc>
 struct __propagate_on_container_swap<_Alloc, true>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc::propagate_on_container_swap;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc::propagate_on_container_swap;
 };
 
 // __is_always_equal
@@ -180,7 +180,7 @@ struct __is_always_equal : is_empty<_Alloc>
 template <class _Alloc>
 struct __is_always_equal<_Alloc, true>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc::is_always_equal;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc::is_always_equal;
 };
 
 // __allocator_traits_rebind
@@ -196,17 +196,17 @@ template <class _Tp, class _Up, bool = __has_rebind_other<_Tp, _Up>::value>
 struct __allocator_traits_rebind
 {
   static_assert(__has_rebind_other<_Tp, _Up>::value, "This allocator has to implement rebind");
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Tp::template rebind<_Up>::other;
+  using type _CCCL_NODEBUG_ALIAS = typename _Tp::template rebind<_Up>::other;
 };
 template <template <class, class...> class _Alloc, class _Tp, class... _Args, class _Up>
 struct __allocator_traits_rebind<_Alloc<_Tp, _Args...>, _Up, true>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = typename _Alloc<_Tp, _Args...>::template rebind<_Up>::other;
+  using type _CCCL_NODEBUG_ALIAS = typename _Alloc<_Tp, _Args...>::template rebind<_Up>::other;
 };
 template <template <class, class...> class _Alloc, class _Tp, class... _Args, class _Up>
 struct __allocator_traits_rebind<_Alloc<_Tp, _Args...>, _Up, false>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _Alloc<_Up, _Args...>;
+  using type _CCCL_NODEBUG_ALIAS = _Alloc<_Up, _Args...>;
 };
 _CCCL_SUPPRESS_DEPRECATED_POP
 
@@ -323,8 +323,8 @@ struct __is_cpp17_move_insertable : is_move_constructible<typename _Alloc::value
 template <class _Alloc>
 struct __is_cpp17_move_insertable<
   _Alloc,
-  __enable_if_t<!__is_default_allocator<_Alloc>::value
-                && __has_construct<_Alloc, typename _Alloc::value_type*, typename _Alloc::value_type&&>::value>>
+  enable_if_t<!__is_default_allocator<_Alloc>::value
+              && __has_construct<_Alloc, typename _Alloc::value_type*, typename _Alloc::value_type&&>::value>>
     : true_type
 {};
 
@@ -339,8 +339,8 @@ struct __is_cpp17_copy_insertable
 template <class _Alloc>
 struct __is_cpp17_copy_insertable<
   _Alloc,
-  __enable_if_t<!__is_default_allocator<_Alloc>::value
-                && __has_construct<_Alloc, typename _Alloc::value_type*, const typename _Alloc::value_type&>::value>>
+  enable_if_t<!__is_default_allocator<_Alloc>::value
+              && __has_construct<_Alloc, typename _Alloc::value_type*, const typename _Alloc::value_type&>::value>>
     : __is_cpp17_move_insertable<_Alloc>
 {};
 
@@ -373,7 +373,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
     return __a.allocate(__n);
   }
 
-  template <class _Ap = _Alloc, __enable_if_t<__has_allocate_hint<_Ap, size_type, const_void_pointer>::value, int> = 0>
+  template <class _Ap = _Alloc, enable_if_t<__has_allocate_hint<_Ap, size_type, const_void_pointer>::value, int> = 0>
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static pointer
   allocate(allocator_type& __a, size_type __n, const_void_pointer __hint)
   {
@@ -381,9 +381,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
     return __a.allocate(__n, __hint);
     _CCCL_SUPPRESS_DEPRECATED_POP
   }
-  template <class _Ap                                                                           = _Alloc,
-            class                                                                               = void,
-            __enable_if_t<!__has_allocate_hint<_Ap, size_type, const_void_pointer>::value, int> = 0>
+  template <class _Ap                                                                         = _Alloc,
+            class                                                                             = void,
+            enable_if_t<!__has_allocate_hint<_Ap, size_type, const_void_pointer>::value, int> = 0>
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static pointer
   allocate(allocator_type& __a, size_type __n, const_void_pointer)
   {
@@ -396,7 +396,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
     __a.deallocate(__p, __n);
   }
 
-  template <class _Tp, class... _Args, __enable_if_t<__has_construct<allocator_type, _Tp*, _Args...>::value, int> = 0>
+  template <class _Tp, class... _Args, enable_if_t<__has_construct<allocator_type, _Tp*, _Args...>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static void construct(allocator_type& __a, _Tp* __p, _Args&&... __args)
   {
     _CCCL_SUPPRESS_DEPRECATED_PUSH
@@ -405,8 +405,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
   }
   template <class _Tp,
             class... _Args,
-            class                                                                       = void,
-            __enable_if_t<!__has_construct<allocator_type, _Tp*, _Args...>::value, int> = 0>
+            class                                                                     = void,
+            enable_if_t<!__has_construct<allocator_type, _Tp*, _Args...>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static void construct(allocator_type&, _Tp* __p, _Args&&... __args)
   {
 #if _CCCL_STD_VER >= 2020
@@ -416,14 +416,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
 #endif
   }
 
-  template <class _Tp, __enable_if_t<__has_destroy<allocator_type, _Tp*>::value, int> = 0>
+  template <class _Tp, enable_if_t<__has_destroy<allocator_type, _Tp*>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static void destroy(allocator_type& __a, _Tp* __p) noexcept
   {
     _CCCL_SUPPRESS_DEPRECATED_PUSH
     __a.destroy(__p);
     _CCCL_SUPPRESS_DEPRECATED_POP
   }
-  template <class _Tp, class = void, __enable_if_t<!__has_destroy<allocator_type, _Tp*>::value, int> = 0>
+  template <class _Tp, class = void, enable_if_t<!__has_destroy<allocator_type, _Tp*>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static void destroy(allocator_type&, _Tp* __p) noexcept
   {
 #if _CCCL_STD_VER >= 2020
@@ -434,27 +434,27 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
   }
 
   _CCCL_SUPPRESS_DEPRECATED_PUSH
-  template <class _Ap = _Alloc, __enable_if_t<__has_max_size<const _Ap>::value, int> = 0>
+  template <class _Ap = _Alloc, enable_if_t<__has_max_size<const _Ap>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static size_type max_size(const allocator_type& __a) noexcept
   {
     return __a.max_size();
   }
   _CCCL_SUPPRESS_DEPRECATED_POP
-  template <class _Ap = _Alloc, class = void, __enable_if_t<!__has_max_size<const _Ap>::value, int> = 0>
+  template <class _Ap = _Alloc, class = void, enable_if_t<!__has_max_size<const _Ap>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static size_type max_size(const allocator_type&) noexcept
   {
     return numeric_limits<size_type>::max() / sizeof(value_type);
   }
 
-  template <class _Ap = _Alloc, __enable_if_t<__has_select_on_container_copy_construction<const _Ap>::value, int> = 0>
+  template <class _Ap = _Alloc, enable_if_t<__has_select_on_container_copy_construction<const _Ap>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static allocator_type
   select_on_container_copy_construction(const allocator_type& __a)
   {
     return __a.select_on_container_copy_construction();
   }
-  template <class _Ap                                                                          = _Alloc,
-            class                                                                              = void,
-            __enable_if_t<!__has_select_on_container_copy_construction<const _Ap>::value, int> = 0>
+  template <class _Ap                                                                        = _Alloc,
+            class                                                                            = void,
+            enable_if_t<!__has_select_on_container_copy_construction<const _Ap>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static allocator_type
   select_on_container_copy_construction(const allocator_type& __a)
   {
@@ -481,7 +481,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
   }
 
   template <class _Tp>
-  _LIBCUDACXX_HIDE_FROM_ABI static __enable_if_t<
+  _LIBCUDACXX_HIDE_FROM_ABI static enable_if_t<
     (__is_default_allocator<allocator_type>::value || !__has_construct<allocator_type, _Tp*, _Tp>::value)
       && is_trivially_move_constructible<_Tp>::value,
     void>
@@ -507,9 +507,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
 
   template <class _SourceTp,
             class _DestTp,
-            class _RawSourceTp = __remove_const_t<_SourceTp>,
-            class _RawDestTp   = __remove_const_t<_DestTp>>
-  _LIBCUDACXX_HIDE_FROM_ABI static __enable_if_t<
+            class _RawSourceTp = remove_const_t<_SourceTp>,
+            class _RawDestTp   = remove_const_t<_DestTp>>
+  _LIBCUDACXX_HIDE_FROM_ABI static enable_if_t<
     is_trivially_move_constructible<_DestTp>::value && is_same<_RawSourceTp, _RawDestTp>::value
       && (__is_default_allocator<allocator_type>::value || !__has_construct<allocator_type, _DestTp*, _SourceTp&>::value),
     void>
@@ -544,7 +544,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
   }
 
   template <class _Tp>
-  _LIBCUDACXX_HIDE_FROM_ABI static __enable_if_t<
+  _LIBCUDACXX_HIDE_FROM_ABI static enable_if_t<
     (__is_default_allocator<allocator_type>::value || !__has_construct<allocator_type, _Tp*, _Tp>::value)
       && is_trivially_move_constructible<_Tp>::value,
     void>
@@ -560,12 +560,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
 };
 
 template <class _Traits, class _Tp>
-using __rebind_alloc _LIBCUDACXX_NODEBUG_TYPE = typename _Traits::template rebind_alloc<_Tp>;
+using __rebind_alloc _CCCL_NODEBUG_ALIAS = typename _Traits::template rebind_alloc<_Tp>;
 
 template <class _Traits, class _Tp>
 struct __rebind_alloc_helper
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename _Traits::template rebind_alloc<_Tp> type;
+  typedef _CCCL_NODEBUG_ALIAS typename _Traits::template rebind_alloc<_Tp> type;
 };
 
 // ASan choices

--- a/libcudacxx/include/cuda/std/__memory/builtin_new_allocator.h
+++ b/libcudacxx/include/cuda/std/__memory/builtin_new_allocator.h
@@ -66,13 +66,13 @@ struct __builtin_new_allocator
   }
 
   template <class _Tp>
-  _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_HIDE_FROM_ABI static __holder_t __allocate_type(size_t __n)
+  _CCCL_NODEBUG_ALIAS _LIBCUDACXX_HIDE_FROM_ABI static __holder_t __allocate_type(size_t __n)
   {
     return __allocate_bytes(__n * sizeof(_Tp), _LIBCUDACXX_ALIGNOF(_Tp));
   }
 
   template <class _Tp>
-  _LIBCUDACXX_NODEBUG_TYPE _LIBCUDACXX_HIDE_FROM_ABI static void __deallocate_type(void* __p, size_t __n) noexcept
+  _CCCL_NODEBUG_ALIAS _LIBCUDACXX_HIDE_FROM_ABI static void __deallocate_type(void* __p, size_t __n) noexcept
   {
     __deallocate_bytes(__p, __n * sizeof(_Tp), _LIBCUDACXX_ALIGNOF(_Tp));
   }

--- a/libcudacxx/include/cuda/std/__memory/compressed_pair.h
+++ b/libcudacxx/include/cuda/std/__memory/compressed_pair.h
@@ -48,7 +48,7 @@ struct __default_init_tag
 struct __value_init_tag
 {};
 
-template <class _Tp, int _Idx, bool _CanBeEmptyBase = _CCCL_TRAIT(is_empty, _Tp) && !__libcpp_is_final<_Tp>::value>
+template <class _Tp, int _Idx, bool _CanBeEmptyBase = _CCCL_TRAIT(is_empty, _Tp) && !_CCCL_TRAIT(is_final, _Tp)>
 struct __compressed_pair_elem
 {
   using _ParamT         = _Tp;
@@ -63,7 +63,7 @@ struct __compressed_pair_elem
       : __value_()
   {}
 
-  template <class _Up, __enable_if_t<!_CCCL_TRAIT(is_same, __compressed_pair_elem, __decay_t<_Up>), int> = 0>
+  template <class _Up, enable_if_t<!_CCCL_TRAIT(is_same, __compressed_pair_elem, decay_t<_Up>), int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit __compressed_pair_elem(_Up&& __u) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up))
       : __value_(_CUDA_VSTD::forward<_Up>(__u))
@@ -108,7 +108,7 @@ struct __compressed_pair_elem<_Tp, _Idx, true> : private _Tp
       : __value_type()
   {}
 
-  template <class _Up, __enable_if_t<!_CCCL_TRAIT(is_same, __compressed_pair_elem, __decay_t<_Up>), int> = 0>
+  template <class _Up, enable_if_t<!_CCCL_TRAIT(is_same, __compressed_pair_elem, decay_t<_Up>), int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit __compressed_pair_elem(_Up&& __u) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up))
       : __value_type(_CUDA_VSTD::forward<_Up>(__u))
@@ -147,12 +147,12 @@ public:
                 "The current implementation is NOT ABI-compatible with the previous implementation for this "
                 "configuration");
 
-  using _Base1 _LIBCUDACXX_NODEBUG_TYPE = __compressed_pair_elem<_T1, 0>;
-  using _Base2 _LIBCUDACXX_NODEBUG_TYPE = __compressed_pair_elem<_T2, 1>;
+  using _Base1 _CCCL_NODEBUG_ALIAS = __compressed_pair_elem<_T1, 0>;
+  using _Base2 _CCCL_NODEBUG_ALIAS = __compressed_pair_elem<_T2, 1>;
 
   template <bool _Dummy = true,
-            class       = __enable_if_t<__dependent_type<is_default_constructible<_T1>, _Dummy>::value
-                                        && __dependent_type<is_default_constructible<_T2>, _Dummy>::value>>
+            class       = enable_if_t<__dependent_type<is_default_constructible<_T1>, _Dummy>::value
+                                      && __dependent_type<is_default_constructible<_T2>, _Dummy>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit __compressed_pair() noexcept(
     _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
       : _Base1(__value_init_tag())

--- a/libcudacxx/include/cuda/std/__memory/construct_at.h
+++ b/libcudacxx/include/cuda/std/__memory/construct_at.h
@@ -109,7 +109,7 @@ template <class _Tp,
           class... _Args,
           class = decltype(::new(_CUDA_VSTD::declval<void*>()) _Tp(_CUDA_VSTD::declval<_Args>()...))>
 _LIBCUDACXX_HIDE_FROM_ABI
-_CCCL_CONSTEXPR_CXX20 __enable_if_t<!__detail::__can_optimize_construct_at<_Tp, _Args...>::value, _Tp*>
+_CCCL_CONSTEXPR_CXX20 enable_if_t<!__detail::__can_optimize_construct_at<_Tp, _Args...>::value, _Tp*>
 construct_at(_Tp* __location, _Args&&... __args)
 {
   _CCCL_ASSERT(__location != nullptr, "null pointer given to construct_at");
@@ -126,7 +126,7 @@ template <class _Tp,
           class... _Args,
           class = decltype(::new(_CUDA_VSTD::declval<void*>()) _Tp(_CUDA_VSTD::declval<_Args>()...))>
 _LIBCUDACXX_HIDE_FROM_ABI
-_CCCL_CONSTEXPR_CXX20 __enable_if_t<__detail::__can_optimize_construct_at<_Tp, _Args...>::value, _Tp*>
+_CCCL_CONSTEXPR_CXX20 enable_if_t<__detail::__can_optimize_construct_at<_Tp, _Args...>::value, _Tp*>
 construct_at(_Tp* __location, _Args&&... __args)
 {
   _CCCL_ASSERT(__location != nullptr, "null pointer given to construct_at");
@@ -144,7 +144,7 @@ construct_at(_Tp* __location, _Args&&... __args)
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class... _Args>
 _LIBCUDACXX_HIDE_FROM_ABI
-_CCCL_CONSTEXPR_CXX20 __enable_if_t<!__detail::__can_optimize_construct_at<_Tp, _Args...>::value, _Tp*>
+_CCCL_CONSTEXPR_CXX20 enable_if_t<!__detail::__can_optimize_construct_at<_Tp, _Args...>::value, _Tp*>
 __construct_at(_Tp* __location, _Args&&... __args)
 {
   _CCCL_ASSERT(__location != nullptr, "null pointer given to construct_at");
@@ -161,7 +161,7 @@ __construct_at(_Tp* __location, _Args&&... __args)
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class... _Args>
 _LIBCUDACXX_HIDE_FROM_ABI
-_CCCL_CONSTEXPR_CXX20 __enable_if_t<__detail::__can_optimize_construct_at<_Tp, _Args...>::value, _Tp*>
+_CCCL_CONSTEXPR_CXX20 enable_if_t<__detail::__can_optimize_construct_at<_Tp, _Args...>::value, _Tp*>
 __construct_at(_Tp* __location, _Args&&... __args)
 {
   _CCCL_ASSERT(__location != nullptr, "null pointer given to construct_at");
@@ -185,8 +185,8 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _ForwardIterator __destroy(_Forw
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp,
-          __enable_if_t<!_CCCL_TRAIT(is_array, _Tp), int>                  = 0,
-          __enable_if_t<!_CCCL_TRAIT(is_trivially_destructible, _Tp), int> = 0>
+          enable_if_t<!_CCCL_TRAIT(is_array, _Tp), int>                  = 0,
+          enable_if_t<!_CCCL_TRAIT(is_trivially_destructible, _Tp), int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 void __destroy_at(_Tp* __loc)
 {
   _CCCL_ASSERT(__loc != nullptr, "null pointer given to destroy_at");
@@ -195,15 +195,15 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 void __destroy_at(_Tp* __loc)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp,
-          __enable_if_t<!_CCCL_TRAIT(is_array, _Tp), int>                 = 0,
-          __enable_if_t<_CCCL_TRAIT(is_trivially_destructible, _Tp), int> = 0>
+          enable_if_t<!_CCCL_TRAIT(is_array, _Tp), int>                 = 0,
+          enable_if_t<_CCCL_TRAIT(is_trivially_destructible, _Tp), int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 void __destroy_at(_Tp* __loc)
 {
   _CCCL_ASSERT(__loc != nullptr, "null pointer given to destroy_at");
   (void) __loc;
 }
 
-template <class _Tp, __enable_if_t<_CCCL_TRAIT(is_array, _Tp), int> = 0>
+template <class _Tp, enable_if_t<_CCCL_TRAIT(is_array, _Tp), int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 void __destroy_at(_Tp* __loc)
 {
   _CCCL_ASSERT(__loc != nullptr, "null pointer given to destroy_at");
@@ -233,14 +233,14 @@ __reverse_destroy(_BidirectionalIterator __first, _BidirectionalIterator __last)
   return __last;
 }
 
-template <class _Tp, __enable_if_t<!_CCCL_TRAIT(is_array, _Tp), int> = 0>
+template <class _Tp, enable_if_t<!_CCCL_TRAIT(is_array, _Tp), int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 void destroy_at(_Tp* __loc)
 {
   _CCCL_ASSERT(__loc != nullptr, "null pointer given to destroy_at");
   __loc->~_Tp();
 }
 
-template <class _Tp, __enable_if_t<_CCCL_TRAIT(is_array, _Tp), int> = 0>
+template <class _Tp, enable_if_t<_CCCL_TRAIT(is_array, _Tp), int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 void destroy_at(_Tp* __loc)
 {
   _CUDA_VSTD::__destroy_at(__loc);

--- a/libcudacxx/include/cuda/std/__memory/pointer_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/pointer_traits.h
@@ -49,7 +49,7 @@ struct __pointer_traits_element_type;
 template <class _Ptr>
 struct __pointer_traits_element_type<_Ptr, true>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename _Ptr::element_type type;
+  typedef _CCCL_NODEBUG_ALIAS typename _Ptr::element_type type;
 };
 
 #ifndef _LIBCUDACXX_HAS_NO_VARIADICS
@@ -57,13 +57,13 @@ struct __pointer_traits_element_type<_Ptr, true>
 template <template <class, class...> class _Sp, class _Tp, class... _Args>
 struct __pointer_traits_element_type<_Sp<_Tp, _Args...>, true>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename _Sp<_Tp, _Args...>::element_type type;
+  typedef _CCCL_NODEBUG_ALIAS typename _Sp<_Tp, _Args...>::element_type type;
 };
 
 template <template <class, class...> class _Sp, class _Tp, class... _Args>
 struct __pointer_traits_element_type<_Sp<_Tp, _Args...>, false>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 
 #else // _LIBCUDACXX_HAS_NO_VARIADICS
@@ -129,13 +129,13 @@ struct __has_difference_type<_Tp, void_t<typename _Tp::difference_type>> : true_
 template <class _Ptr, bool = __has_difference_type<_Ptr>::value>
 struct __pointer_traits_difference_type
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE ptrdiff_t type;
+  typedef _CCCL_NODEBUG_ALIAS ptrdiff_t type;
 };
 
 template <class _Ptr>
 struct __pointer_traits_difference_type<_Ptr, true>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename _Ptr::difference_type type;
+  typedef _CCCL_NODEBUG_ALIAS typename _Ptr::difference_type type;
 };
 
 template <class _Tp, class _Up>
@@ -156,7 +156,7 @@ public:
 template <class _Tp, class _Up, bool = __has_rebind<_Tp, _Up>::value>
 struct __pointer_traits_rebind
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename _Tp::template rebind<_Up> type;
+  typedef _CCCL_NODEBUG_ALIAS typename _Tp::template rebind<_Up> type;
 };
 
 #ifndef _LIBCUDACXX_HAS_NO_VARIADICS
@@ -164,7 +164,7 @@ struct __pointer_traits_rebind
 template <template <class, class...> class _Sp, class _Tp, class... _Args, class _Up>
 struct __pointer_traits_rebind<_Sp<_Tp, _Args...>, _Up, true>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename _Sp<_Tp, _Args...>::template rebind<_Up> type;
+  typedef _CCCL_NODEBUG_ALIAS typename _Sp<_Tp, _Args...>::template rebind<_Up> type;
 };
 
 template <template <class, class...> class _Sp, class _Tp, class... _Args, class _Up>
@@ -241,7 +241,7 @@ private:
 
 public:
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static pointer
-  pointer_to(__conditional_t<is_void<element_type>::value, __nat, element_type>& __r)
+  pointer_to(conditional_t<is_void<element_type>::value, __nat, element_type>& __r)
   {
     return pointer::pointer_to(__r);
   }
@@ -263,7 +263,7 @@ private:
 
 public:
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 static pointer
-  pointer_to(__conditional_t<is_void<element_type>::value, __nat, element_type>& __r) noexcept
+  pointer_to(conditional_t<is_void<element_type>::value, __nat, element_type>& __r) noexcept
   {
     return _CUDA_VSTD::addressof(__r);
   }
@@ -311,8 +311,8 @@ struct _IsFancyPointer
 };
 
 // enable_if is needed here to avoid instantiating checks for fancy pointers on raw pointers
-template <class _Pointer, class = __enable_if_t<_And<is_class<_Pointer>, _IsFancyPointer<_Pointer>>::value>>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __decay_t<decltype(__to_address_helper<_Pointer>::__call(declval<const _Pointer&>()))>
+template <class _Pointer, class = enable_if_t<_And<is_class<_Pointer>, _IsFancyPointer<_Pointer>>::value>>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr decay_t<decltype(__to_address_helper<_Pointer>::__call(declval<const _Pointer&>()))>
 __to_address(const _Pointer& __p) noexcept
 {
   return __to_address_helper<_Pointer>::__call(__p);

--- a/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
+++ b/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
@@ -334,7 +334,7 @@ uninitialized_move_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __ofir
 //
 // This function assumes that destructors do not throw, and that the allocator is bound to
 // the correct type.
-template <class _Alloc, class _BidirIter, __enable_if_t<__is_cpp17_bidirectional_iterator<_BidirIter>::value, int> = 0>
+template <class _Alloc, class _BidirIter, enable_if_t<__is_cpp17_bidirectional_iterator<_BidirIter>::value, int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 void
 __allocator_destroy_multidimensional(_Alloc& __alloc, _BidirIter __first, _BidirIter __last) noexcept
 {
@@ -352,7 +352,7 @@ __allocator_destroy_multidimensional(_Alloc& __alloc, _BidirIter __first, _Bidir
     static_assert(!__libcpp_is_unbounded_array<_ValueType>::value,
                   "arrays of unbounded arrays don't exist, but if they did we would mess up here");
 
-    using _Element = __remove_extent_t<_ValueType>;
+    using _Element = remove_extent_t<_ValueType>;
     __allocator_traits_rebind_t<_Alloc, _Element> __elem_alloc(__alloc);
     do
     {
@@ -387,7 +387,7 @@ __allocator_construct_at_multidimensional(_Alloc& __alloc, _Tp* __loc)
 
   _CCCL_IF_CONSTEXPR (_CCCL_TRAIT(is_array, _Tp))
   {
-    using _Element = __remove_extent_t<_Tp>;
+    using _Element = remove_extent_t<_Tp>;
     __allocator_traits_rebind_t<_Alloc, _Element> __elem_alloc(__alloc);
     size_t __i   = 0;
     _Tp& __array = *__loc;
@@ -432,7 +432,7 @@ __allocator_construct_at_multidimensional(_Alloc& __alloc, _Tp* __loc, _Arg cons
                   "Provided non-array initialization argument to __allocator_construct_at_multidimensional when "
                   "trying to construct an array.");
 
-    using _Element = __remove_extent_t<_Tp>;
+    using _Element = remove_extent_t<_Tp>;
     __allocator_traits_rebind_t<_Alloc, _Element> __elem_alloc(__alloc);
     size_t __i   = 0;
     _Tp& __array = *__loc;
@@ -566,12 +566,12 @@ struct __allocator_has_trivial_copy_construct<allocator<_Type>, _Type> : true_ty
 template <
   class _Alloc,
   class _In,
-  class _RawTypeIn = __remove_const_t<_In>,
+  class _RawTypeIn = remove_const_t<_In>,
   class _Out,
-  __enable_if_t<
+  enable_if_t<
     // using _RawTypeIn because of the allocator<T const> extension
     _CCCL_TRAIT(is_trivially_copy_constructible, _RawTypeIn) && _CCCL_TRAIT(is_trivially_copy_assignable, _RawTypeIn)
-    && _CCCL_TRAIT(is_same, __remove_const_t<_In>, __remove_const_t<_Out>)
+    && _CCCL_TRAIT(is_same, remove_const_t<_In>, remove_const_t<_Out>)
     && __allocator_has_trivial_copy_construct<_Alloc, _RawTypeIn>::value>* = nullptr>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _Out*
 __uninitialized_allocator_copy_impl(_Alloc&, _In* __first1, _In* __last1, _Out* __first2)
@@ -644,9 +644,9 @@ template <class _Alloc,
           class _Iter1,
           class _Iter2,
           class _Type = typename iterator_traits<_Iter1>::value_type,
-          class       = __enable_if_t<_CCCL_TRAIT(is_trivially_move_constructible, _Type)
-                                      && _CCCL_TRAIT(is_trivially_move_assignable, _Type)
-                                      && __allocator_has_trivial_move_construct<_Alloc, _Type>::value>>
+          class       = enable_if_t<_CCCL_TRAIT(is_trivially_move_constructible, _Type)
+                                    && _CCCL_TRAIT(is_trivially_move_assignable, _Type)
+                                    && __allocator_has_trivial_move_construct<_Alloc, _Type>::value>>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _Iter2
 __uninitialized_allocator_move_if_noexcept(_Alloc&, _Iter1 __first1, _Iter1 __last1, _Iter2 __first2)
 {

--- a/libcudacxx/include/cuda/std/__memory/unique_ptr.h
+++ b/libcudacxx/include/cuda/std/__memory/unique_ptr.h
@@ -63,7 +63,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete
 
   template <class _Up>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20
-  default_delete(const default_delete<_Up>&, __enable_if_t<_CCCL_TRAIT(is_convertible, _Up*, _Tp*), int> = 0) noexcept
+  default_delete(const default_delete<_Up>&, enable_if_t<_CCCL_TRAIT(is_convertible, _Up*, _Tp*), int> = 0) noexcept
   {}
 
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 void operator()(_Tp* __ptr) const noexcept
@@ -81,11 +81,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete<_Tp[]>
 
   template <class _Up>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 default_delete(
-    const default_delete<_Up[]>&, __enable_if_t<_CCCL_TRAIT(is_convertible, _Up (*)[], _Tp (*)[]), int> = 0) noexcept
+    const default_delete<_Up[]>&, enable_if_t<_CCCL_TRAIT(is_convertible, _Up (*)[], _Tp (*)[]), int> = 0) noexcept
   {}
 
   template <class _Up>
-  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 __enable_if_t<_CCCL_TRAIT(is_convertible, _Up (*)[], _Tp (*)[]), void>
+  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 enable_if_t<_CCCL_TRAIT(is_convertible, _Up (*)[], _Tp (*)[]), void>
   operator()(_Up* __ptr) const noexcept
   {
     static_assert(sizeof(_Up) >= 0, "cannot delete an incomplete type");
@@ -130,7 +130,7 @@ class _LIBCUDACXX_UNIQUE_PTR_TRIVIAL_ABI _CCCL_TYPE_VISIBILITY_DEFAULT unique_pt
 public:
   typedef _Tp element_type;
   typedef _Dp deleter_type;
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename __pointer<_Tp, deleter_type>::type pointer;
+  typedef _CCCL_NODEBUG_ALIAS typename __pointer<_Tp, deleter_type>::type pointer;
 
   static_assert(!_CCCL_TRAIT(is_rvalue_reference, deleter_type),
                 "the specified deleter type cannot be an rvalue reference");
@@ -143,33 +143,31 @@ private:
     int __for_bool_;
   };
 
-  typedef _LIBCUDACXX_NODEBUG_TYPE __unique_ptr_deleter_sfinae<_Dp> _DeleterSFINAE;
+  typedef _CCCL_NODEBUG_ALIAS __unique_ptr_deleter_sfinae<_Dp> _DeleterSFINAE;
 
   template <bool _Dummy>
-  using _LValRefType _LIBCUDACXX_NODEBUG_TYPE = typename __dependent_type<_DeleterSFINAE, _Dummy>::__lval_ref_type;
+  using _LValRefType _CCCL_NODEBUG_ALIAS = typename __dependent_type<_DeleterSFINAE, _Dummy>::__lval_ref_type;
 
   template <bool _Dummy>
-  using _GoodRValRefType _LIBCUDACXX_NODEBUG_TYPE =
-    typename __dependent_type<_DeleterSFINAE, _Dummy>::__good_rval_ref_type;
+  using _GoodRValRefType _CCCL_NODEBUG_ALIAS = typename __dependent_type<_DeleterSFINAE, _Dummy>::__good_rval_ref_type;
 
   template <bool _Dummy>
-  using _BadRValRefType _LIBCUDACXX_NODEBUG_TYPE =
-    typename __dependent_type<_DeleterSFINAE, _Dummy>::__bad_rval_ref_type;
+  using _BadRValRefType _CCCL_NODEBUG_ALIAS = typename __dependent_type<_DeleterSFINAE, _Dummy>::__bad_rval_ref_type;
 
-  template <bool _Dummy, class _Deleter = typename __dependent_type<__type_identity<deleter_type>, _Dummy>::type>
-  using _EnableIfDeleterDefaultConstructible _LIBCUDACXX_NODEBUG_TYPE =
+  template <bool _Dummy, class _Deleter = typename __dependent_type<type_identity<deleter_type>, _Dummy>::type>
+  using _EnableIfDeleterDefaultConstructible _CCCL_NODEBUG_ALIAS =
     typename enable_if<is_default_constructible<_Deleter>::value && !is_pointer<_Deleter>::value>::type;
 
   template <class _ArgType>
-  using _EnableIfDeleterConstructible _LIBCUDACXX_NODEBUG_TYPE =
+  using _EnableIfDeleterConstructible _CCCL_NODEBUG_ALIAS =
     typename enable_if<is_constructible<deleter_type, _ArgType>::value>::type;
 
   template <class _UPtr, class _Up>
-  using _EnableIfMoveConvertible _LIBCUDACXX_NODEBUG_TYPE =
+  using _EnableIfMoveConvertible _CCCL_NODEBUG_ALIAS =
     typename enable_if<is_convertible<typename _UPtr::pointer, pointer>::value && !is_array<_Up>::value>::type;
 
   template <class _UDel>
-  using _EnableIfDeleterConvertible _LIBCUDACXX_NODEBUG_TYPE =
+  using _EnableIfDeleterConvertible _CCCL_NODEBUG_ALIAS =
     typename enable_if<(is_reference<_Dp>::value && is_same<_Dp, _UDel>::value)
                        || (!is_reference<_Dp>::value && is_convertible<_UDel, _Dp>::value)>::type;
 
@@ -251,7 +249,7 @@ public:
     return *this;
   }
 
-  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 __add_lvalue_reference_t<_Tp> operator*() const
+  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 add_lvalue_reference_t<_Tp> operator*() const
   {
     return *__ptr_.first();
   }
@@ -325,41 +323,38 @@ private:
   typedef __unique_ptr_deleter_sfinae<_Dp> _DeleterSFINAE;
 
   template <bool _Dummy>
-  using _LValRefType _LIBCUDACXX_NODEBUG_TYPE = typename __dependent_type<_DeleterSFINAE, _Dummy>::__lval_ref_type;
+  using _LValRefType _CCCL_NODEBUG_ALIAS = typename __dependent_type<_DeleterSFINAE, _Dummy>::__lval_ref_type;
 
   template <bool _Dummy>
-  using _GoodRValRefType _LIBCUDACXX_NODEBUG_TYPE =
-    typename __dependent_type<_DeleterSFINAE, _Dummy>::__good_rval_ref_type;
+  using _GoodRValRefType _CCCL_NODEBUG_ALIAS = typename __dependent_type<_DeleterSFINAE, _Dummy>::__good_rval_ref_type;
 
   template <bool _Dummy>
-  using _BadRValRefType _LIBCUDACXX_NODEBUG_TYPE =
-    typename __dependent_type<_DeleterSFINAE, _Dummy>::__bad_rval_ref_type;
+  using _BadRValRefType _CCCL_NODEBUG_ALIAS = typename __dependent_type<_DeleterSFINAE, _Dummy>::__bad_rval_ref_type;
 
-  template <bool _Dummy, class _Deleter = typename __dependent_type<__type_identity<deleter_type>, _Dummy>::type>
-  using _EnableIfDeleterDefaultConstructible _LIBCUDACXX_NODEBUG_TYPE =
+  template <bool _Dummy, class _Deleter = typename __dependent_type<type_identity<deleter_type>, _Dummy>::type>
+  using _EnableIfDeleterDefaultConstructible _CCCL_NODEBUG_ALIAS =
     typename enable_if<is_default_constructible<_Deleter>::value && !is_pointer<_Deleter>::value>::type;
 
   template <class _ArgType>
-  using _EnableIfDeleterConstructible _LIBCUDACXX_NODEBUG_TYPE =
+  using _EnableIfDeleterConstructible _CCCL_NODEBUG_ALIAS =
     typename enable_if<is_constructible<deleter_type, _ArgType>::value>::type;
 
   template <class _Pp>
-  using _EnableIfPointerConvertible _LIBCUDACXX_NODEBUG_TYPE =
+  using _EnableIfPointerConvertible _CCCL_NODEBUG_ALIAS =
     typename enable_if<_CheckArrayPointerConversion<_Pp>::value>::type;
 
   template <class _UPtr, class _Up, class _ElemT = typename _UPtr::element_type>
-  using _EnableIfMoveConvertible _LIBCUDACXX_NODEBUG_TYPE = typename enable_if<
+  using _EnableIfMoveConvertible _CCCL_NODEBUG_ALIAS = typename enable_if<
     is_array<_Up>::value && is_same<pointer, element_type*>::value && is_same<typename _UPtr::pointer, _ElemT*>::value
     && is_convertible<_ElemT (*)[], element_type (*)[]>::value>::type;
 
   template <class _UDel>
-  using _EnableIfDeleterConvertible _LIBCUDACXX_NODEBUG_TYPE =
+  using _EnableIfDeleterConvertible _CCCL_NODEBUG_ALIAS =
     typename enable_if<(is_reference<_Dp>::value && is_same<_Dp, _UDel>::value)
                        || (!is_reference<_Dp>::value && is_convertible<_UDel, _Dp>::value)>::type;
 
   template <class _UDel>
-  using _EnableIfDeleterAssignable _LIBCUDACXX_NODEBUG_TYPE =
-    typename enable_if<is_assignable<_Dp&, _UDel&&>::value>::type;
+  using _EnableIfDeleterAssignable _CCCL_NODEBUG_ALIAS = typename enable_if<is_assignable<_Dp&, _UDel&&>::value>::type;
 
 public:
   template <bool _Dummy = true, class = _EnableIfDeleterDefaultConstructible<_Dummy>>
@@ -458,7 +453,7 @@ public:
     return *this;
   }
 
-  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 __add_lvalue_reference_t<_Tp> operator[](size_t __i) const
+  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 add_lvalue_reference_t<_Tp> operator[](size_t __i) const
   {
     return __ptr_.first()[__i];
   }
@@ -488,7 +483,7 @@ public:
     return __t;
   }
 
-  template <class _Pp, __enable_if_t<_CheckArrayPointerConversion<_Pp>::value, int> = 0>
+  template <class _Pp, enable_if_t<_CheckArrayPointerConversion<_Pp>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 void reset(_Pp __p) noexcept
   {
     pointer __tmp  = __ptr_.first();
@@ -516,7 +511,7 @@ public:
 };
 
 template <class _Tp, class _Dp>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 __enable_if_t<__is_swappable<_Dp>::value, void>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 enable_if_t<__is_swappable<_Dp>::value, void>
 swap(unique_ptr<_Tp, _Dp>& __x, unique_ptr<_Tp, _Dp>& __y) noexcept
 {
   __x.swap(__y);
@@ -717,7 +712,7 @@ template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_array_unknown_bound
 make_unique(size_t __n)
 {
-  typedef __remove_extent_t<_Tp> _Up;
+  typedef remove_extent_t<_Tp> _Up;
   return unique_ptr<_Tp>(new _Up[__n]());
 }
 
@@ -734,7 +729,7 @@ template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 typename __unique_if<_Tp>::__unique_array_unknown_bound
 make_unique_for_overwrite(size_t __n)
 {
-  return unique_ptr<_Tp>(new __remove_extent_t<_Tp>[__n]);
+  return unique_ptr<_Tp>(new remove_extent_t<_Tp>[__n]);
 }
 
 template <class _Tp, class... _Args>

--- a/libcudacxx/include/cuda/std/__new/launder.h
+++ b/libcudacxx/include/cuda/std/__new/launder.h
@@ -32,7 +32,7 @@ template <class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp* launder(_Tp* __p) noexcept
 {
   static_assert(!_CCCL_TRAIT(is_function, _Tp), "can't launder functions");
-  static_assert(!_CCCL_TRAIT(is_same, void, __remove_cv_t<_Tp>), "can't launder cv-void");
+  static_assert(!_CCCL_TRAIT(is_same, void, remove_cv_t<_Tp>), "can't launder cv-void");
 #if defined(_CCCL_BUILTIN_LAUNDER)
   return _CCCL_BUILTIN_LAUNDER(__p);
 #else

--- a/libcudacxx/include/cuda/std/__numeric/gcd_lcm.h
+++ b/libcudacxx/include/cuda/std/__numeric/gcd_lcm.h
@@ -73,31 +73,31 @@ _CCCL_CONSTEXPR_CXX14 _LIBCUDACXX_HIDE_FROM_ABI _Tp __gcd(_Tp __m, _Tp __n)
 }
 
 template <class _Tp, class _Up>
-_CCCL_CONSTEXPR_CXX14 _LIBCUDACXX_HIDE_FROM_ABI __common_type_t<_Tp, _Up> gcd(_Tp __m, _Up __n)
+_CCCL_CONSTEXPR_CXX14 _LIBCUDACXX_HIDE_FROM_ABI common_type_t<_Tp, _Up> gcd(_Tp __m, _Up __n)
 {
   static_assert((_CCCL_TRAIT(is_integral, _Tp) && _CCCL_TRAIT(is_integral, _Up)),
                 "Arguments to gcd must be integer types");
-  static_assert((!_CCCL_TRAIT(is_same, __remove_cv_t<_Tp>, bool)), "First argument to gcd cannot be bool");
-  static_assert((!_CCCL_TRAIT(is_same, __remove_cv_t<_Up>, bool)), "Second argument to gcd cannot be bool");
-  using _Rp = __common_type_t<_Tp, _Up>;
-  using _Wp = __make_unsigned_t<_Rp>;
+  static_assert((!_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, bool)), "First argument to gcd cannot be bool");
+  static_assert((!_CCCL_TRAIT(is_same, remove_cv_t<_Up>, bool)), "Second argument to gcd cannot be bool");
+  using _Rp = common_type_t<_Tp, _Up>;
+  using _Wp = make_unsigned_t<_Rp>;
   return static_cast<_Rp>(
     _CUDA_VSTD::__gcd(static_cast<_Wp>(__ct_abs<_Rp, _Tp>()(__m)), static_cast<_Wp>(__ct_abs<_Rp, _Up>()(__n))));
 }
 
 template <class _Tp, class _Up>
-_CCCL_CONSTEXPR_CXX14 _LIBCUDACXX_HIDE_FROM_ABI __common_type_t<_Tp, _Up> lcm(_Tp __m, _Up __n)
+_CCCL_CONSTEXPR_CXX14 _LIBCUDACXX_HIDE_FROM_ABI common_type_t<_Tp, _Up> lcm(_Tp __m, _Up __n)
 {
   static_assert((_CCCL_TRAIT(is_integral, _Tp) && _CCCL_TRAIT(is_integral, _Up)),
                 "Arguments to lcm must be integer types");
-  static_assert((!_CCCL_TRAIT(is_same, __remove_cv_t<_Tp>, bool)), "First argument to lcm cannot be bool");
-  static_assert((!_CCCL_TRAIT(is_same, __remove_cv_t<_Up>, bool)), "Second argument to lcm cannot be bool");
+  static_assert((!_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, bool)), "First argument to lcm cannot be bool");
+  static_assert((!_CCCL_TRAIT(is_same, remove_cv_t<_Up>, bool)), "Second argument to lcm cannot be bool");
   if (__m == 0 || __n == 0)
   {
     return 0;
   }
 
-  using _Rp  = __common_type_t<_Tp, _Up>;
+  using _Rp  = common_type_t<_Tp, _Up>;
   _Rp __val1 = __ct_abs<_Rp, _Tp>()(__m) / _CUDA_VSTD::gcd(__m, __n);
   _Rp __val2 = __ct_abs<_Rp, _Up>()(__n);
   _CCCL_ASSERT((numeric_limits<_Rp>::max() / __val1 > __val2), "Overflow in lcm");

--- a/libcudacxx/include/cuda/std/__numeric/midpoint.h
+++ b/libcudacxx/include/cuda/std/__numeric/midpoint.h
@@ -39,11 +39,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14
-__enable_if_t<_CCCL_TRAIT(is_integral, _Tp) && !_CCCL_TRAIT(is_same, bool, _Tp) && !_CCCL_TRAIT(is_null_pointer, _Tp),
-              _Tp>
+enable_if_t<_CCCL_TRAIT(is_integral, _Tp) && !_CCCL_TRAIT(is_same, bool, _Tp) && !_CCCL_TRAIT(is_null_pointer, _Tp), _Tp>
 midpoint(_Tp __a, _Tp __b) noexcept
 {
-  using _Up = __make_unsigned_t<_Tp>;
+  using _Up = make_unsigned_t<_Tp>;
 
   if (__a > __b)
   {
@@ -58,7 +57,7 @@ midpoint(_Tp __a, _Tp __b) noexcept
 }
 
 template <class _Tp,
-          __enable_if_t<_CCCL_TRAIT(is_object, _Tp) && !_CCCL_TRAIT(is_void, _Tp) && (sizeof(_Tp) > 0), int> = 0>
+          enable_if_t<_CCCL_TRAIT(is_object, _Tp) && !_CCCL_TRAIT(is_void, _Tp) && (sizeof(_Tp) > 0), int> = 0>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Tp* midpoint(_Tp* __a, _Tp* __b) noexcept
 {
   return __a + _CUDA_VSTD::midpoint(ptrdiff_t(0), __b - __a);
@@ -77,7 +76,7 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _Fp __fp_abs(_Fp
 }
 
 template <class _Fp>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __enable_if_t<_CCCL_TRAIT(is_floating_point, _Fp), _Fp>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<_CCCL_TRAIT(is_floating_point, _Fp), _Fp>
 midpoint(_Fp __a, _Fp __b) noexcept
 {
   _CCCL_CONSTEXPR_CXX14 _Fp __lo = numeric_limits<_Fp>::min() * 2;

--- a/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
@@ -49,7 +49,7 @@ struct __make_tuple_types_flat<_Tuple<_Types...>, __tuple_indices<_Idx...>>
 
   // Specialization for pair, tuple, and __tuple_types
   template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>
-  using __apply_quals _LIBCUDACXX_NODEBUG_TYPE =
+  using __apply_quals _CCCL_NODEBUG_ALIAS =
     __tuple_types<__type_call<_ApplyFn, __type_at_c<_Idx, __tuple_types_list>>...>;
 };
 
@@ -63,13 +63,13 @@ struct __make_tuple_types_flat<array<_Vt, _Np>, __tuple_indices<_Idx...>>
 };
 
 template <class _Tp,
-          size_t _Ep     = tuple_size<__libcpp_remove_reference_t<_Tp>>::value,
+          size_t _Ep     = tuple_size<remove_reference_t<_Tp>>::value,
           size_t _Sp     = 0,
-          bool _SameSize = (_Ep == tuple_size<__libcpp_remove_reference_t<_Tp>>::value)>
+          bool _SameSize = (_Ep == tuple_size<remove_reference_t<_Tp>>::value)>
 struct __make_tuple_types
 {
   static_assert(_Sp <= _Ep, "__make_tuple_types input error");
-  using _RawTp = __remove_cv_t<__libcpp_remove_reference_t<_Tp>>;
+  using _RawTp = remove_cv_t<remove_reference_t<_Tp>>;
   using _Maker = __make_tuple_types_flat<_RawTp, __make_tuple_indices_t<_Ep, _Sp>>;
   using type   = typename _Maker::template __apply_quals<_Tp>;
 };
@@ -77,16 +77,16 @@ struct __make_tuple_types
 template <class... _Types, size_t _Ep>
 struct __make_tuple_types<tuple<_Types...>, _Ep, 0, true>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_types<_Types...> type;
+  typedef _CCCL_NODEBUG_ALIAS __tuple_types<_Types...> type;
 };
 
 template <class... _Types, size_t _Ep>
 struct __make_tuple_types<__tuple_types<_Types...>, _Ep, 0, true>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_types<_Types...> type;
+  typedef _CCCL_NODEBUG_ALIAS __tuple_types<_Types...> type;
 };
 
-template <class _Tp, size_t _Ep = tuple_size<__libcpp_remove_reference_t<_Tp>>::value, size_t _Sp = 0>
+template <class _Tp, size_t _Ep = tuple_size<remove_reference_t<_Tp>>::value, size_t _Sp = 0>
 using __make_tuple_types_t = typename __make_tuple_types<_Tp, _Ep, _Sp>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
@@ -77,7 +77,7 @@ struct __tuple_sfinae_base
 
 template <class _Tp,
           class _Up,
-          bool = __tuple_like_ext<__libcpp_remove_reference_t<_Tp>>::value,
+          bool = __tuple_like_ext<remove_reference_t<_Tp>>::value,
           bool = __tuple_like_ext<_Up>::value>
 struct __tuple_convertible : public false_type
 {};
@@ -91,7 +91,7 @@ struct __tuple_convertible<_Tp, _Up, true, true>
 
 template <class _Tp,
           class _Up,
-          bool = __tuple_like_ext<__libcpp_remove_reference_t<_Tp>>::value,
+          bool = __tuple_like_ext<remove_reference_t<_Tp>>::value,
           bool = __tuple_like_ext<_Up>::value>
 struct __tuple_constructible : public false_type
 {};
@@ -105,7 +105,7 @@ struct __tuple_constructible<_Tp, _Up, true, true>
 
 template <class _Tp,
           class _Up,
-          bool = __tuple_like_ext<__libcpp_remove_reference_t<_Tp>>::value,
+          bool = __tuple_like_ext<remove_reference_t<_Tp>>::value,
           bool = __tuple_like_ext<_Up>::value>
 struct __tuple_assignable : public false_type
 {};
@@ -118,7 +118,7 @@ struct __tuple_assignable<_Tp, _Up, true, true>
 template <size_t _Ip, class... _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, tuple<_Tp...>>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_element_t<_Ip, __tuple_types<_Tp...>> type;
+  typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, __tuple_types<_Tp...>> type;
 };
 
 template <bool _IsTuple, class _SizeTrait, size_t _Expected>
@@ -129,8 +129,8 @@ template <class _SizeTrait, size_t _Expected>
 struct __tuple_like_with_size_imp<true, _SizeTrait, _Expected> : integral_constant<bool, _SizeTrait::value == _Expected>
 {};
 
-template <class _Tuple, size_t _ExpectedSize, class _RawTuple = __remove_cvref_t<_Tuple>>
-using __tuple_like_with_size _LIBCUDACXX_NODEBUG_TYPE =
+template <class _Tuple, size_t _ExpectedSize, class _RawTuple = remove_cvref_t<_Tuple>>
+using __tuple_like_with_size _CCCL_NODEBUG_ALIAS =
   __tuple_like_with_size_imp<__tuple_like_ext<_RawTuple>::value, tuple_size<_RawTuple>, _ExpectedSize>;
 
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __check_tuple_constructor_fail

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_element.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_element.h
@@ -34,36 +34,36 @@ template <size_t _Ip, class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element;
 
 template <size_t _Ip, class... _Tp>
-using __tuple_element_t _LIBCUDACXX_NODEBUG_TYPE = typename tuple_element<_Ip, _Tp...>::type;
+using __tuple_element_t _CCCL_NODEBUG_ALIAS = typename tuple_element<_Ip, _Tp...>::type;
 
 template <size_t _Ip, class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, const _Tp>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename add_const<__tuple_element_t<_Ip, _Tp>>::type type;
+  typedef _CCCL_NODEBUG_ALIAS typename add_const<__tuple_element_t<_Ip, _Tp>>::type type;
 };
 
 template <size_t _Ip, class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, volatile _Tp>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename add_volatile<__tuple_element_t<_Ip, _Tp>>::type type;
+  typedef _CCCL_NODEBUG_ALIAS typename add_volatile<__tuple_element_t<_Ip, _Tp>>::type type;
 };
 
 template <size_t _Ip, class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, const volatile _Tp>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename add_cv<__tuple_element_t<_Ip, _Tp>>::type type;
+  typedef _CCCL_NODEBUG_ALIAS typename add_cv<__tuple_element_t<_Ip, _Tp>>::type type;
 };
 
 template <size_t _Ip, class... _Types>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, __tuple_types<_Types...>>
 {
   static_assert(_Ip < sizeof...(_Types), "tuple_element index out of range");
-  typedef _LIBCUDACXX_NODEBUG_TYPE __type_index_c<_Ip, _Types...> type;
+  typedef _CCCL_NODEBUG_ALIAS __type_index_c<_Ip, _Types...> type;
 };
 
 #if _CCCL_STD_VER > 2011
 template <size_t _Ip, class... _Tp>
-using tuple_element_t _LIBCUDACXX_NODEBUG_TYPE = typename tuple_element<_Ip, _Tp...>::type;
+using tuple_element_t _CCCL_NODEBUG_ALIAS = typename tuple_element<_Ip, _Tp...>::type;
 #endif
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_size.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_size.h
@@ -39,7 +39,7 @@ using __enable_if_tuple_size_imp = _Tp;
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
 tuple_size<__enable_if_tuple_size_imp<const _Tp,
-                                      __enable_if_t<!is_volatile<_Tp>::value>,
+                                      enable_if_t<!is_volatile<_Tp>::value>,
                                       integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value>
 {};
@@ -47,7 +47,7 @@ tuple_size<__enable_if_tuple_size_imp<const _Tp,
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
 tuple_size<__enable_if_tuple_size_imp<volatile _Tp,
-                                      __enable_if_t<!is_const<_Tp>::value>,
+                                      enable_if_t<!is_const<_Tp>::value>,
                                       integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value>
 {};

--- a/libcudacxx/include/cuda/std/__type_traits/add_const.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_const.h
@@ -25,13 +25,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT add_const
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE const _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS const _Tp type;
 };
 
-#if _CCCL_STD_VER > 2011
 template <class _Tp>
-using add_const_t = typename add_const<_Tp>::type;
-#endif
+using add_const_t _CCCL_NODEBUG_ALIAS = typename add_const<_Tp>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_cv.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_cv.h
@@ -25,13 +25,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT add_cv
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE const volatile _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS const volatile _Tp type;
 };
 
-#if _CCCL_STD_VER > 2011
 template <class _Tp>
-using add_cv_t = typename add_cv<_Tp>::type;
-#endif
+using add_cv_t _CCCL_NODEBUG_ALIAS = typename add_cv<_Tp>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
@@ -27,36 +27,31 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_ADD_LVALUE_REFERENCE) && !defined(_LIBCUDACXX_USE_ADD_LVALUE_REFERENCE_FALLBACK)
 
 template <class _Tp>
-using __add_lvalue_reference_t = _CCCL_BUILTIN_ADD_LVALUE_REFERENCE(_Tp);
+using add_lvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_LVALUE_REFERENCE(_Tp);
 
 #else // ^^^ _CCCL_BUILTIN_ADD_LVALUE_REFERENCE ^^^ / vvv !_CCCL_BUILTIN_ADD_LVALUE_REFERENCE vvv
 
 template <class _Tp, bool = __libcpp_is_referenceable<_Tp>::value>
 struct __add_lvalue_reference_impl
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 template <class _Tp>
 struct __add_lvalue_reference_impl<_Tp, true>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp& type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp& type;
 };
 
 template <class _Tp>
-using __add_lvalue_reference_t = typename __add_lvalue_reference_impl<_Tp>::type;
+using add_lvalue_reference_t _CCCL_NODEBUG_ALIAS = typename __add_lvalue_reference_impl<_Tp>::type;
 
 #endif // !_CCCL_BUILTIN_ADD_LVALUE_REFERENCE
 
 template <class _Tp>
 struct add_lvalue_reference
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __add_lvalue_reference_t<_Tp>;
+  using type _CCCL_NODEBUG_ALIAS = add_lvalue_reference_t<_Tp>;
 };
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using add_lvalue_reference_t = __add_lvalue_reference_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
@@ -31,35 +31,30 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_ADD_POINTER) && !defined(_LIBCUDACXX_USE_ADD_POINTER_FALLBACK)
 
 template <class _Tp>
-using __add_pointer_t = _CCCL_BUILTIN_ADD_POINTER(_Tp);
+using add_pointer_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_POINTER(_Tp);
 
 #else // ^^^ _CCCL_BUILTIN_ADD_POINTER ^^^ / vvv !_CCCL_BUILTIN_ADD_POINTER vvv
 template <class _Tp, bool = __libcpp_is_referenceable<_Tp>::value || is_void<_Tp>::value>
 struct __add_pointer_impl
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tp>* type;
+  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tp>* type;
 };
 template <class _Tp>
 struct __add_pointer_impl<_Tp, false>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 
 template <class _Tp>
-using __add_pointer_t = typename __add_pointer_impl<_Tp>::type;
+using add_pointer_t _CCCL_NODEBUG_ALIAS = typename __add_pointer_impl<_Tp>::type;
 
 #endif // !_CCCL_BUILTIN_ADD_POINTER
 
 template <class _Tp>
 struct add_pointer
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __add_pointer_t<_Tp>;
+  using type _CCCL_NODEBUG_ALIAS = add_pointer_t<_Tp>;
 };
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using add_pointer_t = __add_pointer_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
@@ -27,36 +27,31 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_ADD_RVALUE_REFERENCE) && !defined(_LIBCUDACXX_USE_ADD_RVALUE_REFERENCE_FALLBACK)
 
 template <class _Tp>
-using __add_rvalue_reference_t = _CCCL_BUILTIN_ADD_RVALUE_REFERENCE(_Tp);
+using add_rvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_RVALUE_REFERENCE(_Tp);
 
 #else // ^^^ _CCCL_BUILTIN_ADD_RVALUE_REFERENCE ^^^ / vvv !_CCCL_BUILTIN_ADD_RVALUE_REFERENCE vvv
 
 template <class _Tp, bool = __libcpp_is_referenceable<_Tp>::value>
 struct __add_rvalue_reference_impl
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 template <class _Tp>
 struct __add_rvalue_reference_impl<_Tp, true>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp&& type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp&& type;
 };
 
 template <class _Tp>
-using __add_rvalue_reference_t = typename __add_rvalue_reference_impl<_Tp>::type;
+using add_rvalue_reference_t _CCCL_NODEBUG_ALIAS = typename __add_rvalue_reference_impl<_Tp>::type;
 
 #endif // _CCCL_BUILTIN_ADD_RVALUE_REFERENCE
 
 template <class _Tp>
 struct add_rvalue_reference
 {
-  using type = __add_rvalue_reference_t<_Tp>;
+  using type = add_rvalue_reference_t<_Tp>;
 };
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using add_rvalue_reference_t = __add_rvalue_reference_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/add_volatile.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_volatile.h
@@ -25,13 +25,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT add_volatile
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE volatile _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS volatile _Tp type;
 };
 
-#if _CCCL_STD_VER > 2011
 template <class _Tp>
-using add_volatile_t = typename add_volatile<_Tp>::type;
-#endif
+using add_volatile_t _CCCL_NODEBUG_ALIAS = typename add_volatile<_Tp>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/aligned_storage.h
+++ b/libcudacxx/include/cuda/std/__type_traits/aligned_storage.h
@@ -106,10 +106,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT aligned_storage
   };
 };
 
-#if _CCCL_STD_VER > 2011
 template <size_t _Len, size_t _Align = __find_max_align<__all_types, _Len>::value>
-using aligned_storage_t = typename aligned_storage<_Len, _Align>::type;
-#endif
+using aligned_storage_t _CCCL_NODEBUG_ALIAS = typename aligned_storage<_Len, _Align>::type;
 
 #define _CREATE_ALIGNED_STORAGE_SPECIALIZATION(n)               \
   template <size_t _Len>                                        \

--- a/libcudacxx/include/cuda/std/__type_traits/aligned_union.h
+++ b/libcudacxx/include/cuda/std/__type_traits/aligned_union.h
@@ -50,10 +50,8 @@ struct aligned_union
   typedef typename aligned_storage<__len, alignment_value>::type type;
 };
 
-#if _CCCL_STD_VER > 2011
 template <size_t _Len, class... _Types>
-using aligned_union_t = typename aligned_union<_Len, _Types...>::type;
-#endif
+using aligned_union_t _CCCL_NODEBUG_ALIAS = typename aligned_union<_Len, _Types...>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/can_extract_key.h
+++ b/libcudacxx/include/cuda/std/__type_traits/can_extract_key.h
@@ -39,12 +39,12 @@ struct __extract_key_first_tag
 
 template <class _ValTy, class _Key, class _RawValTy = __remove_const_ref_t<_ValTy>>
 struct __can_extract_key
-    : __conditional_t<_IsSame<_RawValTy, _Key>::value, __extract_key_self_tag, __extract_key_fail_tag>
+    : conditional_t<_IsSame<_RawValTy, _Key>::value, __extract_key_self_tag, __extract_key_fail_tag>
 {};
 
 template <class _Pair, class _Key, class _First, class _Second>
 struct __can_extract_key<_Pair, _Key, pair<_First, _Second>>
-    : __conditional_t<_IsSame<__remove_const_t<_First>, _Key>::value, __extract_key_first_tag, __extract_key_fail_tag>
+    : conditional_t<_IsSame<remove_const_t<_First>, _Key>::value, __extract_key_first_tag, __extract_key_fail_tag>
 {};
 
 // __can_extract_map_key uses true_type/false_type instead of the tags.

--- a/libcudacxx/include/cuda/std/__type_traits/common_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/common_type.h
@@ -35,7 +35,7 @@ template <class... _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT common_type;
 
 template <class... _Tp>
-using __common_type_t = typename common_type<_Tp...>::type;
+using common_type_t _CCCL_NODEBUG_ALIAS = typename common_type<_Tp...>::type;
 
 // Let COND_RES(X, Y) be:
 template <class _Tp, class _Up>
@@ -50,23 +50,22 @@ struct __common_type_extended_floating_point
 #if !defined(__CUDA_NO_HALF_CONVERSIONS__) && !defined(__CUDA_NO_HALF_OPERATORS__) \
   && !defined(__CUDA_NO_BFLOAT16_CONVERSIONS__) && !defined(__CUDA_NO_BFLOAT16_OPERATORS__)
 template <class _Tp, class _Up>
-struct __common_type_extended_floating_point<
-  _Tp,
-  _Up,
-  __enable_if_t<_CCCL_TRAIT(__is_extended_floating_point, __remove_cvref_t<_Tp>)
-                && _CCCL_TRAIT(is_arithmetic, __remove_cvref_t<_Up>)>>
+struct __common_type_extended_floating_point<_Tp,
+                                             _Up,
+                                             enable_if_t<_CCCL_TRAIT(__is_extended_floating_point, remove_cvref_t<_Tp>)
+                                                         && _CCCL_TRAIT(is_arithmetic, remove_cvref_t<_Up>)>>
 {
-  using type = __common_type_t<__copy_cvref_t<_Tp, float>, _Up>;
+  using type = common_type_t<__copy_cvref_t<_Tp, float>, _Up>;
 };
 
 template <class _Tp, class _Up>
 struct __common_type_extended_floating_point<
   _Tp,
   _Up,
-  __enable_if_t<_CCCL_TRAIT(is_arithmetic, __remove_cvref_t<_Tp>)
-                && _CCCL_TRAIT(__is_extended_floating_point, __remove_cvref_t<_Up>)>>
+  enable_if_t<_CCCL_TRAIT(is_arithmetic, remove_cvref_t<_Tp>)
+              && _CCCL_TRAIT(__is_extended_floating_point, remove_cvref_t<_Up>)>>
 {
-  using type = __common_type_t<_Tp, __copy_cvref_t<_Up, float>>;
+  using type = common_type_t<_Tp, __copy_cvref_t<_Up, float>>;
 };
 #endif // extended floating point as arithmetic type
 
@@ -92,7 +91,7 @@ struct __common_type2_imp : __common_type3<_Tp, _Up>
 template <class _Tp, class _Up>
 using __msvc_declval_workaround =
 #if defined(_CCCL_COMPILER_MSVC)
-  __enable_if_t<_CCCL_TRAIT(is_same, __cond_type<_Tp, _Up>, __cond_type<_Up, _Tp>)>;
+  enable_if_t<_CCCL_TRAIT(is_same, __cond_type<_Tp, _Up>, __cond_type<_Up, _Tp>)>;
 #else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
   void;
 #endif // !_CCCL_COMPILER_MSVC
@@ -101,7 +100,7 @@ using __msvc_declval_workaround =
 template <class _Tp, class _Up>
 struct __common_type2_imp<_Tp, _Up, void_t<__cond_type<_Tp, _Up>, __msvc_declval_workaround<_Tp, _Up>>>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __decay_t<__cond_type<_Tp, _Up>> type;
+  typedef _CCCL_NODEBUG_ALIAS decay_t<__cond_type<_Tp, _Up>> type;
 };
 
 template <class, class = void>
@@ -112,14 +111,14 @@ template <class... _Tp>
 struct __common_types;
 
 template <class _Tp, class _Up>
-struct __common_type_impl<__common_types<_Tp, _Up>, void_t<__common_type_t<_Tp, _Up>>>
+struct __common_type_impl<__common_types<_Tp, _Up>, void_t<common_type_t<_Tp, _Up>>>
 {
-  typedef __common_type_t<_Tp, _Up> type;
+  typedef common_type_t<_Tp, _Up> type;
 };
 
 template <class _Tp, class _Up, class _Vp, class... _Rest>
-struct __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...>, void_t<__common_type_t<_Tp, _Up>>>
-    : __common_type_impl<__common_types<__common_type_t<_Tp, _Up>, _Vp, _Rest...>>
+struct __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...>, void_t<common_type_t<_Tp, _Up>>>
+    : __common_type_impl<__common_types<common_type_t<_Tp, _Up>, _Vp, _Rest...>>
 {};
 
 // bullet 1 - sizeof...(Tp) == 0
@@ -137,7 +136,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT common_type<_Tp> : public common_type<_Tp, 
 // bullet 3 - sizeof...(Tp) == 2
 
 // sub-bullet 1 - "If is_same_v<T1, D1> is false or ..."
-template <class _Tp, class _Up, class _D1 = __decay_t<_Tp>, class _D2 = __decay_t<_Up>>
+template <class _Tp, class _Up, class _D1 = decay_t<_Tp>, class _D2 = decay_t<_Up>>
 struct __common_type2 : common_type<_D1, _D2>
 {};
 
@@ -156,16 +155,16 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT common_type<_Tp, _Up, _Vp, _Rest...>
     : __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...>>
 {};
 
-#if _CCCL_STD_VER >= 2014
 template <class... _Tp>
-using common_type_t = typename common_type<_Tp...>::type;
+using common_type_t _CCCL_NODEBUG_ALIAS = typename common_type<_Tp...>::type;
 
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class, class, class = void>
 _CCCL_INLINE_VAR constexpr bool __has_common_type = false;
 
 template <class _Tp, class _Up>
 _CCCL_INLINE_VAR constexpr bool __has_common_type<_Tp, _Up, void_t<common_type_t<_Tp, _Up>>> = true;
-#endif // _CCCL_STD_VER >= 2014
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/conditional.h
+++ b/libcudacxx/include/cuda/std/__type_traits/conditional.h
@@ -29,18 +29,18 @@ template <>
 struct _IfImpl<true>
 {
   template <class _IfRes, class _ElseRes>
-  using _Select _LIBCUDACXX_NODEBUG_TYPE = _IfRes;
+  using _Select _CCCL_NODEBUG_ALIAS = _IfRes;
 };
 
 template <>
 struct _IfImpl<false>
 {
   template <class _IfRes, class _ElseRes>
-  using _Select _LIBCUDACXX_NODEBUG_TYPE = _ElseRes;
+  using _Select _CCCL_NODEBUG_ALIAS = _ElseRes;
 };
 
 template <bool _Cond, class _IfRes, class _ElseRes>
-using _If _LIBCUDACXX_NODEBUG_TYPE = typename _IfImpl<_Cond>::template _Select<_IfRes, _ElseRes>;
+using _If _CCCL_NODEBUG_ALIAS = typename _IfImpl<_Cond>::template _Select<_IfRes, _ElseRes>;
 
 template <bool _Bp, class _If, class _Then>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional
@@ -53,14 +53,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional<false, _If, _Then>
   typedef _Then type;
 };
 
-#if _CCCL_STD_VER > 2011
-template <bool _Bp, class _IfRes, class _ElseRes>
-using conditional_t = typename conditional<_Bp, _IfRes, _ElseRes>::type;
-#endif
-
-// Helper so we can use "conditional_t" in all language versions.
 template <bool _Bp, class _If, class _Then>
-using __conditional_t = typename conditional<_Bp, _If, _Then>::type;
+using conditional_t _CCCL_NODEBUG_ALIAS = typename conditional<_Bp, _If, _Then>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/conjunction.h
+++ b/libcudacxx/include/cuda/std/__type_traits/conjunction.h
@@ -30,7 +30,7 @@ template <class...>
 using __expand_to_true = true_type;
 
 template <class... _Pred>
-_CCCL_HOST_DEVICE __expand_to_true<__enable_if_t<_Pred::value>...> __and_helper(int);
+_CCCL_HOST_DEVICE __expand_to_true<enable_if_t<_Pred::value>...> __and_helper(int);
 
 template <class...>
 _CCCL_HOST_DEVICE false_type __and_helper(...);
@@ -41,7 +41,7 @@ _CCCL_HOST_DEVICE false_type __and_helper(...);
 // be instantiated) since it is an alias, unlike `conjunction<_Pred...>`, which is a struct.
 // If you want to defer the evaluation of `_And<_Pred...>` itself, use `_Lazy<_And, _Pred...>`.
 template <class... _Pred>
-using _And _LIBCUDACXX_NODEBUG_TYPE = decltype(__and_helper<_Pred...>(0));
+using _And _CCCL_NODEBUG_ALIAS = decltype(__and_helper<_Pred...>(0));
 
 template <class...>
 struct conjunction : true_type

--- a/libcudacxx/include/cuda/std/__type_traits/copy_cv.h
+++ b/libcudacxx/include/cuda/std/__type_traits/copy_cv.h
@@ -42,36 +42,30 @@ using __apply_cv_fn = decltype(__apply_cv<_Tp>);
 template <class>
 struct __apply_cv
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_;
 };
 template <class _Tp>
 struct __apply_cv<const _Tp>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_c;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_c;
 };
 template <class _Tp>
 struct __apply_cv<volatile _Tp>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_v;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_v;
 };
 template <class _Tp>
 struct __apply_cv<const volatile _Tp>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_cv;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_cv;
 };
 
 template <class _Tp>
-using __apply_cv_fn _LIBCUDACXX_NODEBUG_TYPE = typename __apply_cv<_Tp>::type;
+using __apply_cv_fn _CCCL_NODEBUG_ALIAS = typename __apply_cv<_Tp>::type;
 #endif // _CCCL_NO_VARIABLE_TEMPLATES
 
 template <class _From, class _To>
 using __copy_cv_t = typename __apply_cv_fn<_From>::template __call<_To>;
-
-template <class _From, class _To>
-struct __copy_cv
-{
-  using type _LIBCUDACXX_NODEBUG_TYPE = __copy_cv_t<_From, _To>;
-};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/copy_cvref.h
+++ b/libcudacxx/include/cuda/std/__type_traits/copy_cvref.h
@@ -24,8 +24,8 @@
 #include <cuda/std/__type_traits/add_rvalue_reference.h>
 
 #if defined(_CCCL_COMPILER_GCC) && _CCCL_GCC_VERSION < 70000
-#  define _CCCL_ADD_LVALUE_REFERENCE_WAR(_Tp) __add_lvalue_reference_t<_Tp>
-#  define _CCCL_ADD_RVALUE_REFERENCE_WAR(_Tp) __add_rvalue_reference_t<_Tp>
+#  define _CCCL_ADD_LVALUE_REFERENCE_WAR(_Tp) add_lvalue_reference_t<_Tp>
+#  define _CCCL_ADD_RVALUE_REFERENCE_WAR(_Tp) add_rvalue_reference_t<_Tp>
 #else
 #  define _CCCL_ADD_LVALUE_REFERENCE_WAR(_Tp) _Tp&
 #  define _CCCL_ADD_RVALUE_REFERENCE_WAR(_Tp) _Tp&&
@@ -36,73 +36,73 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 struct __apply_cvref_
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Tp;
+  using __call _CCCL_NODEBUG_ALIAS = _Tp;
 };
 
 struct __apply_cvref_c
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = const _Tp;
+  using __call _CCCL_NODEBUG_ALIAS = const _Tp;
 };
 
 struct __apply_cvref_v
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = volatile _Tp;
+  using __call _CCCL_NODEBUG_ALIAS = volatile _Tp;
 };
 
 struct __apply_cvref_cv
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = const volatile _Tp;
+  using __call _CCCL_NODEBUG_ALIAS = const volatile _Tp;
 };
 
 struct __apply_cvref_lr
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_ADD_LVALUE_REFERENCE_WAR(_Tp);
+  using __call _CCCL_NODEBUG_ALIAS = _CCCL_ADD_LVALUE_REFERENCE_WAR(_Tp);
 };
 
 struct __apply_cvref_clr
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_ADD_LVALUE_REFERENCE_WAR(const _Tp);
+  using __call _CCCL_NODEBUG_ALIAS = _CCCL_ADD_LVALUE_REFERENCE_WAR(const _Tp);
 };
 
 struct __apply_cvref_vlr
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_ADD_LVALUE_REFERENCE_WAR(volatile _Tp);
+  using __call _CCCL_NODEBUG_ALIAS = _CCCL_ADD_LVALUE_REFERENCE_WAR(volatile _Tp);
 };
 
 struct __apply_cvref_cvlr
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_ADD_LVALUE_REFERENCE_WAR(const volatile _Tp);
+  using __call _CCCL_NODEBUG_ALIAS = _CCCL_ADD_LVALUE_REFERENCE_WAR(const volatile _Tp);
 };
 
 struct __apply_cvref_rr
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_ADD_RVALUE_REFERENCE_WAR(_Tp);
+  using __call _CCCL_NODEBUG_ALIAS = _CCCL_ADD_RVALUE_REFERENCE_WAR(_Tp);
 };
 
 struct __apply_cvref_crr
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_ADD_RVALUE_REFERENCE_WAR(const _Tp);
+  using __call _CCCL_NODEBUG_ALIAS = _CCCL_ADD_RVALUE_REFERENCE_WAR(const _Tp);
 };
 
 struct __apply_cvref_vrr
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_ADD_RVALUE_REFERENCE_WAR(volatile _Tp);
+  using __call _CCCL_NODEBUG_ALIAS = _CCCL_ADD_RVALUE_REFERENCE_WAR(volatile _Tp);
 };
 
 struct __apply_cvref_cvrr
 {
   template <class _Tp>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_ADD_RVALUE_REFERENCE_WAR(const volatile _Tp);
+  using __call _CCCL_NODEBUG_ALIAS = _CCCL_ADD_RVALUE_REFERENCE_WAR(const volatile _Tp);
 };
 
 #ifndef _CCCL_NO_VARIABLE_TEMPLATES
@@ -137,76 +137,70 @@ using __apply_cvref_fn = decltype(__apply_cvref<_Tp>);
 template <class>
 struct __apply_cvref
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_;
 };
 template <class _Tp>
 struct __apply_cvref<const _Tp>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_c;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_c;
 };
 template <class _Tp>
 struct __apply_cvref<volatile _Tp>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_v;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_v;
 };
 template <class _Tp>
 struct __apply_cvref<const volatile _Tp>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_cv;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_cv;
 };
 template <class _Tp>
 struct __apply_cvref<_Tp&>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_lr;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_lr;
 };
 template <class _Tp>
 struct __apply_cvref<const _Tp&>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_clr;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_clr;
 };
 template <class _Tp>
 struct __apply_cvref<volatile _Tp&>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_vlr;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_vlr;
 };
 template <class _Tp>
 struct __apply_cvref<const volatile _Tp&>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_cvlr;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_cvlr;
 };
 template <class _Tp>
 struct __apply_cvref<_Tp&&>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_rr;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_rr;
 };
 template <class _Tp>
 struct __apply_cvref<const _Tp&&>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_crr;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_crr;
 };
 template <class _Tp>
 struct __apply_cvref<volatile _Tp&&>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_vrr;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_vrr;
 };
 template <class _Tp>
 struct __apply_cvref<const volatile _Tp&&>
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __apply_cvref_cvrr;
+  using type _CCCL_NODEBUG_ALIAS = __apply_cvref_cvrr;
 };
 
 template <class _Tp>
-using __apply_cvref_fn _LIBCUDACXX_NODEBUG_TYPE = typename __apply_cvref<_Tp>::type;
+using __apply_cvref_fn _CCCL_NODEBUG_ALIAS = typename __apply_cvref<_Tp>::type;
 #endif // _CCCL_NO_VARIABLE_TEMPLATES
 
 template <class _From, class _To>
 using __copy_cvref_t = typename __apply_cvref_fn<_From>::template __call<_To>;
-
-template <class _From, class _To>
-struct __copy_cvref
-{
-  using type _LIBCUDACXX_NODEBUG_TYPE = __copy_cvref_t<_From, _To>;
-};
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/decay.h
+++ b/libcudacxx/include/cuda/std/__type_traits/decay.h
@@ -35,46 +35,44 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct decay
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_DECAY(_Tp);
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_DECAY(_Tp);
 };
 
-#else
+template <class _Tp>
+using decay_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_DECAY(_Tp);
+
+#else // ^^^ _CCCL_BUILTIN_DECAY ^^^ / vvv !_CCCL_BUILTIN_DECAY vvv
 
 template <class _Up, bool>
 struct __decay_impl
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __remove_cv_t<_Up> type;
+  typedef _CCCL_NODEBUG_ALIAS remove_cv_t<_Up> type;
 };
 
 template <class _Up>
 struct __decay_impl<_Up, true>
 {
 public:
-  typedef _LIBCUDACXX_NODEBUG_TYPE
-    __conditional_t<is_array<_Up>::value,
-                    __remove_extent_t<_Up>*,
-                    __conditional_t<is_function<_Up>::value, __add_pointer_t<_Up>, __remove_cv_t<_Up>>>
-      type;
+  typedef _CCCL_NODEBUG_ALIAS conditional_t<is_array<_Up>::value,
+                                            remove_extent_t<_Up>*,
+                                            conditional_t<is_function<_Up>::value, add_pointer_t<_Up>, remove_cv_t<_Up>>>
+    type;
 };
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT decay
 {
 private:
-  typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tp> _Up;
+  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tp> _Up;
 
 public:
-  typedef _LIBCUDACXX_NODEBUG_TYPE typename __decay_impl<_Up, __libcpp_is_referenceable<_Up>::value>::type type;
+  typedef _CCCL_NODEBUG_ALIAS typename __decay_impl<_Up, __libcpp_is_referenceable<_Up>::value>::type type;
 };
-#endif // defined(_CCCL_BUILTIN_DECAY) && !defined(_LIBCUDACXX_USE_DECAY_FALLBACK)
 
 template <class _Tp>
-using __decay_t = typename decay<_Tp>::type;
+using decay_t _CCCL_NODEBUG_ALIAS = typename decay<_Tp>::type;
 
-#if _CCCL_STD_VER >= 2014
-template <class _Tp>
-using decay_t = typename decay<_Tp>::type;
-#endif // _CCCL_STD_VER >= 2014
+#endif // !_CCCL_BUILTIN_DECAY
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/disjunction.h
+++ b/libcudacxx/include/cuda/std/__type_traits/disjunction.h
@@ -31,7 +31,7 @@ template <>
 struct _OrImpl<true>
 {
   template <class _Res, class _First, class... _Rest>
-  using _Result _LIBCUDACXX_NODEBUG_TYPE =
+  using _Result _CCCL_NODEBUG_ALIAS =
     typename _OrImpl<!bool(_First::value) && sizeof...(_Rest) != 0>::template _Result<_First, _Rest...>;
 };
 
@@ -49,7 +49,7 @@ struct _OrImpl<false>
 // If you want to defer the evaluation of `_Or<_Pred...>` itself, use `_Lazy<_Or, _Pred...>`
 // or `disjunction<_Pred...>` directly.
 template <class... _Args>
-using _Or _LIBCUDACXX_NODEBUG_TYPE = typename _OrImpl<sizeof...(_Args) != 0>::template _Result<false_type, _Args...>;
+using _Or _CCCL_NODEBUG_ALIAS = typename _OrImpl<sizeof...(_Args) != 0>::template _Result<false_type, _Args...>;
 
 #ifdef _CCCL_COMPILER_MSVC
 template <class... _Args>

--- a/libcudacxx/include/cuda/std/__type_traits/enable_if.h
+++ b/libcudacxx/include/cuda/std/__type_traits/enable_if.h
@@ -32,12 +32,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT enable_if<true, _Tp>
 };
 
 template <bool _Bp, class _Tp = void>
-using __enable_if_t _LIBCUDACXX_NODEBUG_TYPE = typename enable_if<_Bp, _Tp>::type;
-
-#if _CCCL_STD_VER > 2011
-template <bool _Bp, class _Tp = void>
-using enable_if_t = typename enable_if<_Bp, _Tp>::type;
-#endif
+using enable_if_t _CCCL_NODEBUG_ALIAS = typename enable_if<_Bp, _Tp>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/has_unique_object_representation.h
+++ b/libcudacxx/include/cuda/std/__type_traits/has_unique_object_representation.h
@@ -26,7 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011 && defined(_CCCL_BUILTIN_HAS_UNIQUE_OBJECT_REPRESENTATIONS)
+#if defined(_CCCL_BUILTIN_HAS_UNIQUE_OBJECT_REPRESENTATIONS)
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT has_unique_object_representations
@@ -38,7 +38,7 @@ template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool has_unique_object_representations_v = has_unique_object_representations<_Tp>::value;
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
-#endif
+#endif // _CCCL_BUILTIN_HAS_UNIQUE_OBJECT_REPRESENTATIONS
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/integral_constant.h
+++ b/libcudacxx/include/cuda/std/__type_traits/integral_constant.h
@@ -32,12 +32,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT integral_constant
   {
     return value;
   }
-#if _CCCL_STD_VER > 2011
   _LIBCUDACXX_HIDE_FROM_ABI constexpr value_type operator()() const noexcept
   {
     return value;
   }
-#endif
 };
 
 template <class _Tp, _Tp __v>
@@ -47,7 +45,7 @@ typedef integral_constant<bool, true> true_type;
 typedef integral_constant<bool, false> false_type;
 
 template <bool _Val>
-using _BoolConstant _LIBCUDACXX_DEPRECATED _LIBCUDACXX_NODEBUG_TYPE = integral_constant<bool, _Val>;
+using _BoolConstant _LIBCUDACXX_DEPRECATED _CCCL_NODEBUG_ALIAS = integral_constant<bool, _Val>;
 
 template <bool __b>
 using bool_constant = integral_constant<bool, __b>;

--- a/libcudacxx/include/cuda/std/__type_traits/is_aggregate.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_aggregate.h
@@ -24,7 +24,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011 && defined(_CCCL_BUILTIN_IS_AGGREGATE)
+#if defined(_CCCL_BUILTIN_IS_AGGREGATE)
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_aggregate : public integral_constant<bool, _CCCL_BUILTIN_IS_AGGREGATE(_Tp)>
@@ -35,7 +35,7 @@ template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_aggregate_v = _CCCL_BUILTIN_IS_AGGREGATE(_Tp);
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
-#endif // _CCCL_STD_VER > 2011 && defined(_CCCL_BUILTIN_IS_AGGREGATE)
+#endif // defined(_CCCL_BUILTIN_IS_AGGREGATE)
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_assignable.h
@@ -29,7 +29,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <typename, typename _Tp>
 struct __select_2nd
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 
 #if defined(_CCCL_BUILTIN_IS_ASSIGNABLE) && !defined(_LIBCUDACXX_USE_IS_ASSIGNABLE_FALLBACK)

--- a/libcudacxx/include/cuda/std/__type_traits/is_bounded_array.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_bounded_array.h
@@ -32,8 +32,6 @@ template <class _Tp, size_t _Np>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __libcpp_is_bounded_array<_Tp[_Np]> : true_type
 {};
 
-#if _CCCL_STD_VER > 2011
-
 template <class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_bounded_array : false_type
 {};
@@ -41,10 +39,10 @@ template <class _Tp, size_t _Np>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_bounded_array<_Tp[_Np]> : true_type
 {};
 
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_bounded_array_v = is_bounded_array<_Tp>::value;
-
-#endif
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_constructible.h
@@ -51,8 +51,8 @@ template <class _To, class _From>
 struct __is_invalid_base_to_derived_cast
 {
   static_assert(is_reference<_To>::value, "Wrong specialization");
-  using _RawFrom = __remove_cvref_t<_From>;
-  using _RawTo   = __remove_cvref_t<_To>;
+  using _RawFrom = remove_cvref_t<_From>;
+  using _RawTo   = remove_cvref_t<_To>;
   static const bool value =
     _And<_IsNotSame<_RawFrom, _RawTo>, is_base_of<_RawFrom, _RawTo>, _Not<__libcpp_is_constructible<_RawTo, _From>>>::
       value;
@@ -67,8 +67,8 @@ struct __is_invalid_lvalue_to_rvalue_cast : false_type
 template <class _ToRef, class _FromRef>
 struct __is_invalid_lvalue_to_rvalue_cast<_ToRef&&, _FromRef&>
 {
-  using _RawFrom = __remove_cvref_t<_FromRef>;
-  using _RawTo   = __remove_cvref_t<_ToRef>;
+  using _RawFrom = remove_cvref_t<_FromRef>;
+  using _RawTo   = remove_cvref_t<_ToRef>;
   static const bool value =
     _And<_Not<is_function<_RawTo>>, _Or<_IsSame<_RawFrom, _RawTo>, is_base_of<_RawTo, _RawFrom>>>::value;
 };
@@ -119,7 +119,7 @@ struct __is_default_constructible<_Tp[], false> : false_type
 {};
 
 template <class _Tp, size_t _Nx>
-struct __is_default_constructible<_Tp[_Nx], false> : __is_default_constructible<__remove_all_extents_t<_Tp>>
+struct __is_default_constructible<_Tp[_Nx], false> : __is_default_constructible<remove_all_extents_t<_Tp>>
 {};
 
 template <class _Tp, class... _Args>

--- a/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
@@ -136,8 +136,7 @@ struct __is_array_function_or_void<_Tp, false, false, true>
 };
 } // namespace __is_convertible_imp
 
-template <class _Tp,
-          unsigned = __is_convertible_imp::__is_array_function_or_void<__libcpp_remove_reference_t<_Tp>>::value>
+template <class _Tp, unsigned = __is_convertible_imp::__is_array_function_or_void<remove_reference_t<_Tp>>::value>
 struct __is_convertible_check
 {
   static const size_t __v = 0;

--- a/libcudacxx/include/cuda/std/__type_traits/is_copy_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_copy_assignable.h
@@ -28,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_copy_assignable
-    : public is_assignable<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<typename add_const<_Tp>::type>>
+    : public is_assignable<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>>
 {};
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_copy_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_copy_constructible.h
@@ -28,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_copy_constructible
-    : public is_constructible<_Tp, __add_lvalue_reference_t<typename add_const<_Tp>::type>>
+    : public is_constructible<_Tp, add_lvalue_reference_t<typename add_const<_Tp>::type>>
 {};
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_destructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_destructible.h
@@ -73,7 +73,7 @@ struct __destructible_imp;
 
 template <class _Tp>
 struct __destructible_imp<_Tp, false>
-    : public integral_constant<bool, __is_destructor_wellformed<__remove_all_extents_t<_Tp>>::value>
+    : public integral_constant<bool, __is_destructor_wellformed<remove_all_extents_t<_Tp>>::value>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_final.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_final.h
@@ -27,38 +27,26 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_IS_FINAL)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __libcpp_is_final : public integral_constant<bool, _CCCL_BUILTIN_IS_FINAL(_Tp)>
-{};
-
-#  if _CCCL_STD_VER > 2011
-template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_final : public integral_constant<bool, _CCCL_BUILTIN_IS_FINAL(_Tp)>
 {};
-#  endif
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_final_v = _CCCL_BUILTIN_IS_FINAL(_Tp);
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
-#else
+#else // ^^^ _CCCL_BUILTIN_IS_FINAL ^^^ / vvv !_CCCL_BUILTIN_IS_FINAL vvv
 
-template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __libcpp_is_final : public false_type
-{};
-
-#  if _CCCL_STD_VER > 2011
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_final : public false_type
 {};
-#  endif
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_final_v = false;
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
-#endif // defined(_CCCL_BUILTIN_IS_FINAL)
+#endif // !_CCCL_BUILTIN_IS_FINAL
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_floating_point.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_floating_point.h
@@ -39,7 +39,7 @@ struct __libcpp_is_floating_point<long double> : public true_type
 {};
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_floating_point : public __libcpp_is_floating_point<__remove_cv_t<_Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_floating_point : public __libcpp_is_floating_point<remove_cv_t<_Tp>>
 {};
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_integral.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_integral.h
@@ -104,7 +104,7 @@ struct __libcpp_is_integral<__uint128_t> : public true_type
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_integral
-    : public integral_constant<bool, __libcpp_is_integral<__remove_cv_t<_Tp>>::value>
+    : public integral_constant<bool, __libcpp_is_integral<remove_cv_t<_Tp>>::value>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_literal_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_literal_type.h
@@ -43,8 +43,8 @@ _LIBCUDACXX_DEPRECATED_IN_CXX17 _CCCL_INLINE_VAR constexpr bool is_literal_type_
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT _LIBCUDACXX_DEPRECATED_IN_CXX17 is_literal_type
     : public integral_constant<bool,
-                               is_scalar<__remove_all_extents_t<_Tp>>::value
-                                 || is_reference<__remove_all_extents_t<_Tp>>::value>
+                               is_scalar<remove_all_extents_t<_Tp>>::value
+                                 || is_reference<remove_all_extents_t<_Tp>>::value>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_member_function_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_member_function_pointer.h
@@ -64,7 +64,7 @@ _CCCL_INLINE_VAR constexpr bool is_member_function_pointer_v = _CCCL_BUILTIN_IS_
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_member_function_pointer
-    : public integral_constant<bool, __libcpp_is_member_pointer<__remove_cv_t<_Tp>>::__is_func>
+    : public integral_constant<bool, __libcpp_is_member_pointer<remove_cv_t<_Tp>>::__is_func>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_member_object_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_member_object_pointer.h
@@ -42,7 +42,7 @@ _CCCL_INLINE_VAR constexpr bool is_member_object_pointer_v = _CCCL_BUILTIN_IS_ME
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_member_object_pointer
-    : public integral_constant<bool, __libcpp_is_member_pointer<__remove_cv_t<_Tp>>::__is_obj>
+    : public integral_constant<bool, __libcpp_is_member_pointer<remove_cv_t<_Tp>>::__is_obj>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_member_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_member_pointer.h
@@ -42,7 +42,7 @@ _CCCL_INLINE_VAR constexpr bool is_member_pointer_v = _CCCL_BUILTIN_IS_MEMBER_PO
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_member_pointer
-    : public integral_constant<bool, __libcpp_is_member_pointer<__remove_cv_t<_Tp>>::__is_member>
+    : public integral_constant<bool, __libcpp_is_member_pointer<remove_cv_t<_Tp>>::__is_member>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_move_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_move_assignable.h
@@ -28,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_move_assignable
-    : public is_assignable<__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>>
+    : public is_assignable<add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>>
 {};
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_move_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_move_constructible.h
@@ -27,7 +27,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_move_constructible : public is_constructible<_Tp, __add_rvalue_reference_t<_Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_move_constructible : public is_constructible<_Tp, add_rvalue_reference_t<_Tp>>
 {};
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_convertible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_convertible.h
@@ -30,8 +30,6 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011
-
 template <typename _Tp>
 _CCCL_HOST_DEVICE static void __test_noexcept(_Tp) noexcept;
 
@@ -49,10 +47,10 @@ struct is_nothrow_convertible
           _Lazy<_And, is_convertible<_Fm, _To>, __is_nothrow_convertible_helper<_Fm, _To>>>::type
 {};
 
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <typename _Fm, typename _To>
 _CCCL_INLINE_VAR constexpr bool is_nothrow_convertible_v = is_nothrow_convertible<_Fm, _To>::value;
-
-#endif // _CCCL_STD_VER > 2011
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_assignable.h
@@ -32,20 +32,20 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_copy_assignable
     : public integral_constant<bool,
                                _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(
-                                 __add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<typename add_const<_Tp>::type>)>
+                                 add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>)>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_nothrow_copy_assignable_v = _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(
-  __add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<typename add_const<_Tp>::type>);
+  add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>);
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 #else
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_copy_assignable
-    : public is_nothrow_assignable<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<typename add_const<_Tp>::type>>
+    : public is_nothrow_assignable<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_copy_constructible.h
@@ -28,7 +28,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_copy_constructible
-    : public is_nothrow_constructible<_Tp, __add_lvalue_reference_t<typename add_const<_Tp>::type>>
+    : public is_nothrow_constructible<_Tp, add_lvalue_reference_t<typename add_const<_Tp>::type>>
 {};
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_destructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_destructible.h
@@ -73,7 +73,7 @@ struct __libcpp_nothrow_destructor : public integral_constant<bool, is_scalar<_T
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_destructible
-    : public __libcpp_nothrow_destructor<__remove_all_extents_t<_Tp>>
+    : public __libcpp_nothrow_destructor<remove_all_extents_t<_Tp>>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_assignable.h
@@ -32,20 +32,20 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_move_assignable
     : public integral_constant<
         bool,
-        _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)>
+        _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>)>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_nothrow_move_assignable_v =
-  _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>);
+  _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>);
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 #else
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_move_assignable
-    : public is_nothrow_assignable<__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>>
+    : public is_nothrow_assignable<add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_move_constructible.h
@@ -27,7 +27,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_move_constructible
-    : public is_nothrow_constructible<_Tp, __add_rvalue_reference_t<_Tp>>
+    : public is_nothrow_constructible<_Tp, add_rvalue_reference_t<_Tp>>
 {};
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_null_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_null_pointer.h
@@ -34,11 +34,11 @@ struct __is_nullptr_t_impl<nullptr_t> : public true_type
 {};
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __is_nullptr_t : public __is_nullptr_t_impl<__remove_cv_t<_Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __is_nullptr_t : public __is_nullptr_t_impl<remove_cv_t<_Tp>>
 {};
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_null_pointer : public __is_nullptr_t_impl<__remove_cv_t<_Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_null_pointer : public __is_nullptr_t_impl<remove_cv_t<_Tp>>
 {};
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_pointer.h
@@ -46,7 +46,7 @@ struct __libcpp_is_pointer<_Tp*> : public true_type
 {};
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_pointer : public __libcpp_is_pointer<__remove_cv_t<_Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_pointer : public __libcpp_is_pointer<remove_cv_t<_Tp>>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_polymorphic.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_polymorphic.h
@@ -42,7 +42,7 @@ _CCCL_INLINE_VAR constexpr bool is_polymorphic_v = _CCCL_BUILTIN_IS_POLYMORPHIC(
 
 template <typename _Tp>
 _CCCL_HOST_DEVICE char& __is_polymorphic_impl(
-  __enable_if_t<sizeof((_Tp*) dynamic_cast<const volatile void*>(_CUDA_VSTD::declval<_Tp*>())) != 0, int>);
+  enable_if_t<sizeof((_Tp*) dynamic_cast<const volatile void*>(_CUDA_VSTD::declval<_Tp*>())) != 0, int>);
 template <typename _Tp>
 _CCCL_HOST_DEVICE __two& __is_polymorphic_impl(...);
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -40,7 +40,7 @@ struct __is_primary_template<_Tp, void_t<typename _Tp::__primary_template>>
 #else // ^^^ _CCCL_COMPILER_MSVC ^^^ / vvv !_CCCL_COMPILER_MSVC vvv
 
 template <class _Tp>
-using __test_for_primary_template = __enable_if_t<_IsSame<_Tp, typename _Tp::__primary_template>::value>;
+using __test_for_primary_template = enable_if_t<_IsSame<_Tp, typename _Tp::__primary_template>::value>;
 template <class _Tp>
 using __is_primary_template = _IsValidExpansion<__test_for_primary_template, _Tp>;
 #endif // !_CCCL_COMPILER_MSVC

--- a/libcudacxx/include/cuda/std/__type_traits/is_reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_reference_wrapper.h
@@ -35,7 +35,7 @@ template <class _Tp>
 struct __is_reference_wrapper_impl<reference_wrapper<_Tp>> : public true_type
 {};
 template <class _Tp>
-struct __is_reference_wrapper : public __is_reference_wrapper_impl<__remove_cv_t<_Tp>>
+struct __is_reference_wrapper : public __is_reference_wrapper_impl<remove_cv_t<_Tp>>
 {};
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__type_traits/is_standard_layout.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_standard_layout.h
@@ -42,7 +42,7 @@ _CCCL_INLINE_VAR constexpr bool is_standard_layout_v = _CCCL_BUILTIN_IS_STANDARD
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_standard_layout
-    : integral_constant<bool, is_scalar<__remove_all_extents_t<_Tp>>::value>
+    : integral_constant<bool, is_scalar<remove_all_extents_t<_Tp>>::value>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
@@ -96,9 +96,9 @@ template <class _Tp>
 struct __is_nothrow_swappable;
 
 template <class _Tp>
-using __swap_result_t =
-  __enable_if_t<__detect_adl_swap::__can_define_swap<_Tp>::value && _CCCL_TRAIT(is_move_constructible, _Tp)
-                && _CCCL_TRAIT(is_move_assignable, _Tp)>;
+using __swap_result_t _CCCL_NODEBUG_ALIAS =
+  enable_if_t<__detect_adl_swap::__can_define_swap<_Tp>::value && _CCCL_TRAIT(is_move_constructible, _Tp)
+              && _CCCL_TRAIT(is_move_assignable, _Tp)>;
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __swap_result_t<_Tp> swap(_Tp& __x, _Tp& __y) noexcept(
@@ -106,7 +106,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __swap_result_t<_Tp> swap(_Tp& _
 
 template <class _Tp, size_t _Np>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14
-__enable_if_t<__detect_adl_swap::__has_no_adl_swap_array<_Tp, _Np>::value && __is_swappable<_Tp>::value>
+enable_if_t<__detect_adl_swap::__has_no_adl_swap_array<_Tp, _Np>::value && __is_swappable<_Tp>::value>
   swap(_Tp (&__a)[_Np], _Tp (&__b)[_Np]) noexcept(__is_nothrow_swappable<_Tp>::value);
 
 namespace __detail
@@ -154,7 +154,7 @@ template <class _Tp>
 struct __is_nothrow_swappable : public integral_constant<bool, __detail::__nothrow_swappable_with<_Tp&>::value>
 {};
 
-#if _CCCL_STD_VER > 2011
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 
 template <class _Tp, class _Up>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_swappable_with
@@ -163,9 +163,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT is_swappable_with
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_swappable
-    : public __conditional_t<__libcpp_is_referenceable<_Tp>::value,
-                             is_swappable_with<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<_Tp>>,
-                             false_type>
+    : public conditional_t<__libcpp_is_referenceable<_Tp>::value,
+                           is_swappable_with<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<_Tp>>,
+                           false_type>
 {};
 
 template <class _Tp, class _Up>
@@ -175,9 +175,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_swappable_with
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_swappable
-    : public __conditional_t<__libcpp_is_referenceable<_Tp>::value,
-                             is_nothrow_swappable_with<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<_Tp>>,
-                             false_type>
+    : public conditional_t<__libcpp_is_referenceable<_Tp>::value,
+                           is_nothrow_swappable_with<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<_Tp>>,
+                           false_type>
 {};
 
 template <class _Tp, class _Up>
@@ -192,7 +192,7 @@ _CCCL_INLINE_VAR constexpr bool is_nothrow_swappable_with_v = is_nothrow_swappab
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_nothrow_swappable_v = is_nothrow_swappable<_Tp>::value;
 
-#endif // _CCCL_STD_VER > 2011
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_trivially_copy_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_trivially_copy_assignable.h
@@ -32,21 +32,20 @@ template <class _Tp>
 struct is_trivially_copy_assignable
     : public integral_constant<bool,
                                _CCCL_BUILTIN_IS_TRIVIALLY_ASSIGNABLE(
-                                 __add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<typename add_const<_Tp>::type>)>
+                                 add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>)>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_trivially_copy_assignable_v = _CCCL_BUILTIN_IS_TRIVIALLY_ASSIGNABLE(
-  __add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<typename add_const<_Tp>::type>);
+  add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>);
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 #else
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_trivially_copy_assignable
-    : public is_trivially_assignable<__add_lvalue_reference_t<_Tp>,
-                                     __add_lvalue_reference_t<typename add_const<_Tp>::type>>
+    : public is_trivially_assignable<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<typename add_const<_Tp>::type>>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_trivially_copy_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_trivially_copy_constructible.h
@@ -32,20 +32,20 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_trivially_copy_constructible
     : public integral_constant<
         bool,
-        _CCCL_BUILTIN_IS_TRIVIALLY_CONSTRUCTIBLE(_Tp, __add_lvalue_reference_t<typename add_const<_Tp>::type>)>
+        _CCCL_BUILTIN_IS_TRIVIALLY_CONSTRUCTIBLE(_Tp, add_lvalue_reference_t<typename add_const<_Tp>::type>)>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_trivially_copy_constructible_v =
-  _CCCL_BUILTIN_IS_TRIVIALLY_CONSTRUCTIBLE(_Tp, __add_lvalue_reference_t<typename add_const<_Tp>::type>);
+  _CCCL_BUILTIN_IS_TRIVIALLY_CONSTRUCTIBLE(_Tp, add_lvalue_reference_t<typename add_const<_Tp>::type>);
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 #else
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_trivially_copy_constructible
-    : public is_trivially_constructible<_Tp, __add_lvalue_reference_t<typename add_const<_Tp>::type>>
+    : public is_trivially_constructible<_Tp, add_lvalue_reference_t<typename add_const<_Tp>::type>>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_trivially_copyable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_trivially_copyable.h
@@ -42,7 +42,7 @@ _CCCL_INLINE_VAR constexpr bool is_trivially_copyable_v = _CCCL_BUILTIN_IS_TRIVI
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_trivially_copyable
-    : integral_constant<bool, is_scalar<__remove_all_extents_t<_Tp>>::value>
+    : integral_constant<bool, is_scalar<remove_all_extents_t<_Tp>>::value>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_trivially_destructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_trivially_destructible.h
@@ -52,7 +52,7 @@ struct __libcpp_trivial_destructor : public integral_constant<bool, is_scalar<_T
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_trivially_destructible
-    : public __libcpp_trivial_destructor<__remove_all_extents_t<_Tp>>
+    : public __libcpp_trivial_destructor<remove_all_extents_t<_Tp>>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_trivially_move_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_trivially_move_assignable.h
@@ -32,20 +32,20 @@ template <class _Tp>
 struct is_trivially_move_assignable
     : public integral_constant<
         bool,
-        _CCCL_BUILTIN_IS_TRIVIALLY_ASSIGNABLE(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)>
+        _CCCL_BUILTIN_IS_TRIVIALLY_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>)>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_trivially_move_assignable_v =
-  _CCCL_BUILTIN_IS_TRIVIALLY_ASSIGNABLE(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>);
+  _CCCL_BUILTIN_IS_TRIVIALLY_ASSIGNABLE(add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>);
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 #else
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_trivially_move_assignable
-    : public is_trivially_assignable<__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>>
+    : public is_trivially_assignable<add_lvalue_reference_t<_Tp>, add_rvalue_reference_t<_Tp>>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_trivially_move_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_trivially_move_constructible.h
@@ -29,20 +29,20 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_trivially_move_constructible
-    : public integral_constant<bool, _CCCL_BUILTIN_IS_TRIVIALLY_CONSTRUCTIBLE(_Tp, __add_rvalue_reference_t<_Tp>)>
+    : public integral_constant<bool, _CCCL_BUILTIN_IS_TRIVIALLY_CONSTRUCTIBLE(_Tp, add_rvalue_reference_t<_Tp>)>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_trivially_move_constructible_v =
-  _CCCL_BUILTIN_IS_TRIVIALLY_CONSTRUCTIBLE(_Tp, __add_rvalue_reference_t<_Tp>);
+  _CCCL_BUILTIN_IS_TRIVIALLY_CONSTRUCTIBLE(_Tp, add_rvalue_reference_t<_Tp>);
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 #else
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_trivially_move_constructible
-    : public is_trivially_constructible<_Tp, __add_rvalue_reference_t<_Tp>>
+    : public is_trivially_constructible<_Tp, add_rvalue_reference_t<_Tp>>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_unbounded_array.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_unbounded_array.h
@@ -31,8 +31,6 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __libcpp_is_unbounded_array<_Tp[]> : true_type
 {};
 
-#if _CCCL_STD_VER > 2011
-
 template <class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_unbounded_array : false_type
 {};
@@ -40,9 +38,10 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_unbounded_array<_Tp[]> : true_type
 {};
 
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_unbounded_array_v = is_unbounded_array<_Tp>::value;
-#endif
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_union.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_union.h
@@ -42,7 +42,7 @@ template <class _Tp>
 struct __libcpp_union : public false_type
 {};
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_union : public __libcpp_union<__remove_cv_t<_Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_union : public __libcpp_union<remove_cv_t<_Tp>>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/is_valid_expansion.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_valid_expansion.h
@@ -30,7 +30,7 @@ template <template <class...> class, class...>
 _LIBCUDACXX_HIDE_FROM_ABI false_type __sfinae_test_impl(...);
 
 template <template <class...> class _Templ, class... _Args>
-using _IsValidExpansion _LIBCUDACXX_NODEBUG_TYPE = decltype(_CUDA_VSTD::__sfinae_test_impl<_Templ, _Args...>(0));
+using _IsValidExpansion _CCCL_NODEBUG_ALIAS = decltype(_CUDA_VSTD::__sfinae_test_impl<_Templ, _Args...>(0));
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_void.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_void.h
@@ -40,7 +40,7 @@ _CCCL_INLINE_VAR constexpr bool is_void_v = __is_void(_Tp);
 #else
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_void : public is_same<__remove_cv_t<_Tp>, void>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_void : public is_same<remove_cv_t<_Tp>, void>
 {};
 
 #  if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/__type_traits/make_32_64_or_128_bit.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_32_64_or_128_bit.h
@@ -36,20 +36,20 @@ template <class _Tp>
 #if _CCCL_STD_VER > 2017
   requires(is_signed_v<_Tp> || is_unsigned_v<_Tp> || is_same_v<_Tp, char>)
 #endif
-using __make_32_64_or_128_bit_t =
+using __make_32_64_or_128_bit_t _CCCL_NODEBUG_ALIAS =
   __copy_unsigned_t<_Tp,
-                    __conditional_t<sizeof(_Tp) <= sizeof(int32_t),
-                                    int32_t,
-                                    __conditional_t<sizeof(_Tp) <= sizeof(int64_t),
-                                                    int64_t,
+                    conditional_t<sizeof(_Tp) <= sizeof(int32_t),
+                                  int32_t,
+                                  conditional_t<sizeof(_Tp) <= sizeof(int64_t),
+                                                int64_t,
 #ifndef _LIBCUDACXX_HAS_NO_INT128
-                                                    __conditional_t<sizeof(_Tp) <= sizeof(__int128_t),
-                                                                    __int128_t,
-                                                                    /* else */ void>
+                                                conditional_t<sizeof(_Tp) <= sizeof(__int128_t),
+                                                              __int128_t,
+                                                              /* else */ void>
 #else
-                                                    /* else */ void
+                                                /* else */ void
 #endif
-                                                    >>>;
+                                                >>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/make_const_lvalue_ref.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_const_lvalue_ref.h
@@ -25,7 +25,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-using __make_const_lvalue_ref = const __libcpp_remove_reference_t<_Tp>&;
+using __make_const_lvalue_ref = const remove_reference_t<_Tp>&;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/make_signed.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_signed.h
@@ -33,7 +33,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_MAKE_SIGNED) && !defined(_LIBCUDACXX_USE_MAKE_SIGNED_FALLBACK)
 
 template <class _Tp>
-using __make_signed_t = _CCCL_BUILTIN_MAKE_SIGNED(_Tp);
+using make_signed_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_MAKE_SIGNED(_Tp);
 
 #else
 typedef __type_list<signed char,
@@ -118,23 +118,18 @@ struct __make_signed_impl<__uint128_t, true>
 {
   typedef __int128_t type;
 };
-#  endif
+#  endif // !_LIBCUDACXX_HAS_NO_INT128
 
 template <class _Tp>
-using __make_signed_t = __copy_cvref_t<_Tp, typename __make_signed_impl<__remove_cv_t<_Tp>>::type>;
+using make_signed_t _CCCL_NODEBUG_ALIAS = __copy_cvref_t<_Tp, typename __make_signed_impl<remove_cv_t<_Tp>>::type>;
 
 #endif // defined(_CCCL_BUILTIN_MAKE_SIGNED) && !defined(_LIBCUDACXX_USE_MAKE_SIGNED_FALLBACK)
 
 template <class _Tp>
 struct make_signed
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __make_signed_t<_Tp>;
+  using type _CCCL_NODEBUG_ALIAS = make_signed_t<_Tp>;
 };
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using make_signed_t = __make_signed_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/make_unsigned.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_unsigned.h
@@ -35,7 +35,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_MAKE_UNSIGNED) && !defined(_LIBCUDACXX_USE_MAKE_UNSIGNED_FALLBACK)
 
 template <class _Tp>
-using __make_unsigned_t = _CCCL_BUILTIN_MAKE_UNSIGNED(_Tp);
+using make_unsigned_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_MAKE_UNSIGNED(_Tp);
 
 #else
 typedef __type_list<unsigned char,
@@ -120,32 +120,27 @@ struct __make_unsigned_impl<__uint128_t, true>
 {
   typedef __uint128_t type;
 };
-#  endif
+#  endif // !_LIBCUDACXX_HAS_NO_INT128
 
 template <class _Tp>
-using __make_unsigned_t = __copy_cvref_t<_Tp, typename __make_unsigned_impl<__remove_cv_t<_Tp>>::type>;
+using make_unsigned_t _CCCL_NODEBUG_ALIAS = __copy_cvref_t<_Tp, typename __make_unsigned_impl<remove_cv_t<_Tp>>::type>;
 
 #endif // defined(_CCCL_BUILTIN_MAKE_UNSIGNED) && !defined(_LIBCUDACXX_USE_MAKE_UNSIGNED_FALLBACK)
 
 template <class _Tp>
 struct make_unsigned
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __make_unsigned_t<_Tp>;
+  using type _CCCL_NODEBUG_ALIAS = make_unsigned_t<_Tp>;
 };
 
-#if _CCCL_STD_VER > 2011
 template <class _Tp>
-using make_unsigned_t = __make_unsigned_t<_Tp>;
-#endif
-
-template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __make_unsigned_t<_Tp> __to_unsigned_like(_Tp __x) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI constexpr make_unsigned_t<_Tp> __to_unsigned_like(_Tp __x) noexcept
 {
-  return static_cast<__make_unsigned_t<_Tp>>(__x);
+  return static_cast<make_unsigned_t<_Tp>>(__x);
 }
 
 template <class _Tp, class _Up>
-using __copy_unsigned_t = __conditional_t<is_unsigned<_Tp>::value, __make_unsigned_t<_Up>, _Up>;
+using __copy_unsigned_t _CCCL_NODEBUG_ALIAS = conditional_t<_CCCL_TRAIT(is_unsigned, _Tp), make_unsigned_t<_Up>, _Up>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/maybe_const.h
+++ b/libcudacxx/include/cuda/std/__type_traits/maybe_const.h
@@ -25,7 +25,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <bool _Const, class _Tp>
-using __maybe_const = __conditional_t<_Const, const _Tp, _Tp>;
+using __maybe_const = conditional_t<_Const, const _Tp, _Tp>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/negation.h
+++ b/libcudacxx/include/cuda/std/__type_traits/negation.h
@@ -31,10 +31,11 @@ struct _Not : bool_constant<!_Pred::value>
 template <class _Tp>
 struct negation : _Not<_Tp>
 {};
-#if _CCCL_STD_VER >= 2014
+
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool negation_v = !_Tp::value;
-#endif // _CCCL_STD_VER >= 2014
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/promote.h
+++ b/libcudacxx/include/cuda/std/__type_traits/promote.h
@@ -116,7 +116,7 @@ class __promote : public __promote_imp<_A1, _A2, _A3>
 {};
 
 template <class _A1, class _A2 = void, class _A3 = void>
-using __promote_t = typename __promote<_A1, _A2, _A3>::type;
+using __promote_t _CCCL_NODEBUG_ALIAS = typename __promote<_A1, _A2, _A3>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_all_extents.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_all_extents.h
@@ -28,11 +28,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct remove_all_extents
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_REMOVE_ALL_EXTENTS(_Tp);
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_ALL_EXTENTS(_Tp);
 };
 
 template <class _Tp>
-using __remove_all_extents_t = _CCCL_BUILTIN_REMOVE_ALL_EXTENTS(_Tp);
+using remove_all_extents_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_ALL_EXTENTS(_Tp);
 
 #else
 
@@ -53,14 +53,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_all_extents<_Tp[_Np]>
 };
 
 template <class _Tp>
-using __remove_all_extents_t = typename remove_all_extents<_Tp>::type;
+using remove_all_extents_t _CCCL_NODEBUG_ALIAS = typename remove_all_extents<_Tp>::type;
 
 #endif // defined(_CCCL_BUILTIN_REMOVE_ALL_EXTENTS) && !defined(_LIBCUDACXX_USE_REMOVE_ALL_EXTENTS_FALLBACK)
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using remove_all_extents_t = __remove_all_extents_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_const.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_const.h
@@ -26,11 +26,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct remove_const
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_REMOVE_CONST(_Tp);
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CONST(_Tp);
 };
 
 template <class _Tp>
-using __remove_const_t = _CCCL_BUILTIN_REMOVE_CONST(_Tp);
+using remove_const_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CONST(_Tp);
 
 #else
 
@@ -46,14 +46,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_const<const _Tp>
 };
 
 template <class _Tp>
-using __remove_const_t = typename remove_const<_Tp>::type;
+using remove_const_t _CCCL_NODEBUG_ALIAS = typename remove_const<_Tp>::type;
 
 #endif // defined(_CCCL_BUILTIN_REMOVE_CONST) && !defined(_LIBCUDACXX_USE_REMOVE_CONST_FALLBACK)
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using remove_const_t = __remove_const_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_const_ref.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_const_ref.h
@@ -26,7 +26,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-using __remove_const_ref_t = __remove_const_t<__libcpp_remove_reference_t<_Tp>>;
+using __remove_const_ref_t _CCCL_NODEBUG_ALIAS = remove_const_t<remove_reference_t<_Tp>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
@@ -29,29 +29,24 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct remove_cv
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_REMOVE_CV(_Tp);
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CV(_Tp);
 };
 
 template <class _Tp>
-using __remove_cv_t = _CCCL_BUILTIN_REMOVE_CV(_Tp);
+using remove_cv_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CV(_Tp);
 
 #else
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_cv
 {
-  typedef __remove_volatile_t<__remove_const_t<_Tp>> type;
+  typedef remove_volatile_t<remove_const_t<_Tp>> type;
 };
 
 template <class _Tp>
-using __remove_cv_t = __remove_volatile_t<__remove_const_t<_Tp>>;
+using remove_cv_t _CCCL_NODEBUG_ALIAS = remove_volatile_t<remove_const_t<_Tp>>;
 
 #endif // defined(_CCCL_BUILTIN_REMOVE_CV) && !defined(_LIBCUDACXX_USE_REMOVE_CV_FALLBACK)
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using remove_cv_t = __remove_cv_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cvref.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cvref.h
@@ -29,29 +29,24 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #if defined(_CCCL_BUILTIN_REMOVE_CVREF) && !defined(_LIBCUDACXX_USE_REMOVE_CVREF_FALLBACK)
 
 template <class _Tp>
-using __remove_cvref_t _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_REMOVE_CVREF(_Tp);
+using remove_cvref_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CVREF(_Tp);
 
 #else
 
 template <class _Tp>
-using __remove_cvref_t _LIBCUDACXX_NODEBUG_TYPE = __remove_cv_t<__libcpp_remove_reference_t<_Tp>>;
+using remove_cvref_t _CCCL_NODEBUG_ALIAS = remove_cv_t<remove_reference_t<_Tp>>;
 
 #endif // defined(_CCCL_BUILTIN_REMOVE_CVREF) && !defined(_LIBCUDACXX_USE_REMOVE_CVREF_FALLBACK)
 
 template <class _Tp, class _Up>
-struct __is_same_uncvref : _IsSame<__remove_cvref_t<_Tp>, __remove_cvref_t<_Up>>
+struct __is_same_uncvref : _IsSame<remove_cvref_t<_Tp>, remove_cvref_t<_Up>>
 {};
 
-#if _CCCL_STD_VER > 2011
 template <class _Tp>
 struct remove_cvref
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = __remove_cvref_t<_Tp>;
+  using type _CCCL_NODEBUG_ALIAS = remove_cvref_t<_Tp>;
 };
-
-template <class _Tp>
-using remove_cvref_t = __remove_cvref_t<_Tp>;
-#endif // _CCCL_STD_VER > 2011
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_extent.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_extent.h
@@ -28,11 +28,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct remove_extent
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_REMOVE_EXTENT(_Tp);
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_EXTENT(_Tp);
 };
 
 template <class _Tp>
-using __remove_extent_t = _CCCL_BUILTIN_REMOVE_EXTENT(_Tp);
+using remove_extent_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_EXTENT(_Tp);
 
 #else
 template <class _Tp>
@@ -52,14 +52,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_extent<_Tp[_Np]>
 };
 
 template <class _Tp>
-using __remove_extent_t = typename remove_extent<_Tp>::type;
+using remove_extent_t _CCCL_NODEBUG_ALIAS = typename remove_extent<_Tp>::type;
 
 #endif // defined(_CCCL_BUILTIN_REMOVE_EXTENT) && !defined(_LIBCUDACXX_USE_REMOVE_EXTENT_FALLBACK)
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using remove_extent_t = __remove_extent_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_pointer.h
@@ -26,48 +26,43 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct remove_pointer
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_REMOVE_POINTER(_Tp);
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_POINTER(_Tp);
 };
 
 template <class _Tp>
-using __remove_pointer_t = _CCCL_BUILTIN_REMOVE_POINTER(_Tp);
+using remove_pointer_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_POINTER(_Tp);
 
 #else
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer<_Tp*>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer<_Tp* const>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer<_Tp* volatile>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer<_Tp* const volatile>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 
 template <class _Tp>
-using __remove_pointer_t = typename remove_pointer<_Tp>::type;
+using remove_pointer_t _CCCL_NODEBUG_ALIAS = typename remove_pointer<_Tp>::type;
 
 #endif // defined(_CCCL_BUILTIN_REMOVE_POINTER) && !defined(_LIBCUDACXX_USE_REMOVE_POINTER_FALLBACK)
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using remove_pointer_t = __remove_pointer_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_reference.h
@@ -28,16 +28,16 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct remove_reference
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_REMOVE_REFERENCE_T(_Tp);
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_REFERENCE_T(_Tp);
 };
 
 #  if defined(_CCCL_COMPILER_GCC)
 // error: use of built-in trait in function signature; use library traits instead
 template <class _Tp>
-using __libcpp_remove_reference_t = typename remove_reference<_Tp>::type;
+using remove_reference_t _CCCL_NODEBUG_ALIAS = typename remove_reference<_Tp>::type;
 #  else // ^^^ _CCCL_COMPILER_GCC ^^^^/  vvv !_CCCL_COMPILER_GCC
 template <class _Tp>
-using __libcpp_remove_reference_t = _CCCL_BUILTIN_REMOVE_REFERENCE_T(_Tp);
+using remove_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_REFERENCE_T(_Tp);
 #  endif // !_CCCL_COMPILER_GCC
 
 #else // ^^^ _CCCL_BUILTIN_REMOVE_REFERENCE_T ^^^ / vvv !_CCCL_BUILTIN_REMOVE_REFERENCE_T vvv
@@ -45,28 +45,23 @@ using __libcpp_remove_reference_t = _CCCL_BUILTIN_REMOVE_REFERENCE_T(_Tp);
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_reference
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_reference<_Tp&>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_reference<_Tp&&>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _Tp type;
+  typedef _CCCL_NODEBUG_ALIAS _Tp type;
 };
 
 template <class _Tp>
-using __libcpp_remove_reference_t = typename remove_reference<_Tp>::type;
+using remove_reference_t _CCCL_NODEBUG_ALIAS = typename remove_reference<_Tp>::type;
 
 #endif // !_CCCL_BUILTIN_REMOVE_REFERENCE_T
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using remove_reference_t = __libcpp_remove_reference_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_volatile.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_volatile.h
@@ -26,11 +26,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct remove_volatile
 {
-  using type _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_REMOVE_VOLATILE(_Tp);
+  using type _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_VOLATILE(_Tp);
 };
 
 template <class _Tp>
-using __remove_volatile_t = _CCCL_BUILTIN_REMOVE_VOLATILE(_Tp);
+using remove_volatile_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_VOLATILE(_Tp);
 
 #else
 template <class _Tp>
@@ -45,14 +45,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_volatile<volatile _Tp>
 };
 
 template <class _Tp>
-using __remove_volatile_t = typename remove_volatile<_Tp>::type;
+using remove_volatile_t _CCCL_NODEBUG_ALIAS = typename remove_volatile<_Tp>::type;
 
 #endif // defined(_CCCL_BUILTIN_REMOVE_VOLATILE) && !defined(_LIBCUDACXX_USE_REMOVE_VOLATILE_FALLBACK)
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
-using remove_volatile_t = __remove_volatile_t<_Tp>;
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/result_of.h
+++ b/libcudacxx/include/cuda/std/__type_traits/result_of.h
@@ -35,10 +35,8 @@ class _LIBCUDACXX_DEPRECATED_IN_CXX17
 _CCCL_TYPE_VISIBILITY_DEFAULT result_of<_Fp(_Args...)> : public __invoke_of<_Fp, _Args...>
 {};
 
-#  if _CCCL_STD_VER > 2011
 template <class _Tp>
 using result_of_t _LIBCUDACXX_DEPRECATED_IN_CXX17 = typename result_of<_Tp>::type;
-#  endif // _CCCL_STD_VER > 2011
 #endif // _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_TYPE_TRAITS)
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__type_traits/type_identity.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_identity.h
@@ -23,23 +23,13 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct __type_identity
-{
-  typedef _Tp type;
-};
-
-template <class _Tp>
-using __type_identity_t _LIBCUDACXX_NODEBUG_TYPE = typename __type_identity<_Tp>::type;
-
-#if _CCCL_STD_VER > 2011
-template <class _Tp>
 struct type_identity
 {
   typedef _Tp type;
 };
+
 template <class _Tp>
-using type_identity_t = typename type_identity<_Tp>::type;
-#endif
+using type_identity_t _CCCL_NODEBUG_ALIAS = typename type_identity<_Tp>::type;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -68,7 +68,7 @@ template <size_t _DependentValue>
 struct __type_call_indirect_fn
 {
   template <template <class...> class _Fn, class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Fn<_Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = _Fn<_Ts...>;
 };
 } // namespace __detail
 
@@ -84,7 +84,7 @@ template <template <class...> class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_quote
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Fn<_Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = _Fn<_Ts...>;
 };
 
 //! \brief Turns a unary class or alias template into a meta-callable
@@ -92,7 +92,7 @@ template <template <class> class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_quote1
 {
   template <class _Ty>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Fn<_Ty>;
+  using __call _CCCL_NODEBUG_ALIAS = _Fn<_Ty>;
 };
 
 //! \brief Turns a binary class or alias template into a meta-callable
@@ -100,7 +100,7 @@ template <template <class, class> class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_quote2
 {
   template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Fn<_Ty, _Uy>;
+  using __call _CCCL_NODEBUG_ALIAS = _Fn<_Ty, _Uy>;
 };
 
 //! \brief Turns a trait class template \c _Fn into a meta-callable \c
@@ -110,7 +110,7 @@ template <template <class...> class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_quote_trait
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type<_Fn<_Ts...>>;
+  using __call _CCCL_NODEBUG_ALIAS = __type<_Fn<_Ts...>>;
 };
 
 //! \brief Turns a unary trait class template \c _Fn into a meta-callable
@@ -120,7 +120,7 @@ template <template <class> class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_quote_trait1
 {
   template <class _Ty>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type<_Fn<_Ty>>;
+  using __call _CCCL_NODEBUG_ALIAS = __type<_Fn<_Ty>>;
 };
 
 //! \brief Turns a binary trait class template \c _Fn into a meta-callable
@@ -130,7 +130,7 @@ template <template <class, class> class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_quote_trait2
 {
   template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type<_Fn<_Ty, _Uy>>;
+  using __call _CCCL_NODEBUG_ALIAS = __type<_Fn<_Ty, _Uy>>;
 };
 
 //! \brief Adds an indirection to a meta-callable to avoid the dreaded "pack
@@ -139,7 +139,7 @@ template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_indirect
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = typename __detail::__type_call_indirect_fn<sizeof(
+  using __call _CCCL_NODEBUG_ALIAS = typename __detail::__type_call_indirect_fn<sizeof(
     __type_list<_Ts...>*)>::template __call<_Fn::template __call, _Ts...>;
 };
 
@@ -150,7 +150,7 @@ template <template <class...> class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_indirect_quote
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
+  using __call _CCCL_NODEBUG_ALIAS =
     typename __detail::__type_call_indirect_fn<sizeof(__type_list<_Ts...>*)>::template __call<_Fn, _Ts...>;
 };
 
@@ -159,14 +159,14 @@ template <class _Fn1, class _Fn2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_compose
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call1<_Fn1, __type_call<_Fn2, _Ts...>>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call1<_Fn1, __type_call<_Fn2, _Ts...>>;
 };
 
 template <template <class...> class _Fn, class... _Ts>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_bind_front_quote
 {
   template <class... _Us>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Fn<_Ts..., _Us...>;
+  using __call _CCCL_NODEBUG_ALIAS = _Fn<_Ts..., _Us...>;
 };
 
 //! \brief A meta-callable that binds the front arguments to a meta-callable
@@ -178,7 +178,7 @@ template <template <class...> class _Fn, class... _Ts>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_bind_back_quote
 {
   template <class... _Us>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Fn<_Us..., _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = _Fn<_Us..., _Ts...>;
 };
 
 //! \brief A meta-callable that binds the back arguments to a meta-callable
@@ -191,18 +191,18 @@ template <class _Ty>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_always
 {
   template <class...>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Ty;
+  using __call _CCCL_NODEBUG_ALIAS = _Ty;
 };
 
 //! \brief A unary meta-callable that returns its argument unmodified.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_self
 {
   template <class _Ty>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Ty;
+  using __call _CCCL_NODEBUG_ALIAS = _Ty;
 };
 
 template <class _Ty>
-using __type_self_t _LIBCUDACXX_NODEBUG_TYPE = _Ty;
+using __type_self_t _CCCL_NODEBUG_ALIAS = _Ty;
 
 //! \brief Perform a logical AND operation on a list of Boolean types.
 //!
@@ -210,7 +210,7 @@ using __type_self_t _LIBCUDACXX_NODEBUG_TYPE = _Ty;
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_and
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __fold_and<_Ts::value...>;
+  using __call _CCCL_NODEBUG_ALIAS = __fold_and<_Ts::value...>;
 };
 
 //! \brief Perform a logical OR operation on a list of Boolean types.
@@ -219,56 +219,56 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_and
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_strict_or
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __fold_or<_Ts::value...>;
+  using __call _CCCL_NODEBUG_ALIAS = __fold_or<_Ts::value...>;
 };
 
 //! \brief Perform a logical NOT operation on a Boolean type.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_not
 {
   template <class _Ty>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(!_Ty::value)>;
+  using __call _CCCL_NODEBUG_ALIAS = bool_constant<(!_Ty::value)>;
 };
 
 //! \brief Test whether two integral constants are equal.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_equal
 {
   template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value == _Uy::value)>;
+  using __call _CCCL_NODEBUG_ALIAS = bool_constant<(_Ty::value == _Uy::value)>;
 };
 
 //! \brief Test whether two integral constants are not equal.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_not_equal
 {
   template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value != _Uy::value)>;
+  using __call _CCCL_NODEBUG_ALIAS = bool_constant<(_Ty::value != _Uy::value)>;
 };
 
 //! \brief Test whether one integral constant is less than another.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_less
 {
   template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value < _Uy::value)>;
+  using __call _CCCL_NODEBUG_ALIAS = bool_constant<(_Ty::value < _Uy::value)>;
 };
 
 //! \brief Test whether one integral constant is less than or equal to another.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_less_equal
 {
   template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value <= _Uy::value)>;
+  using __call _CCCL_NODEBUG_ALIAS = bool_constant<(_Ty::value <= _Uy::value)>;
 };
 
 //! \brief Test whether one integral constant is greater than another.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_greater
 {
   template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value > _Uy::value)>;
+  using __call _CCCL_NODEBUG_ALIAS = bool_constant<(_Ty::value > _Uy::value)>;
 };
 
 //! \brief Test whether one integral constant is greater than or equal to another.
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_greater_equal
 {
   template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<(_Ty::value >= _Uy::value)>;
+  using __call _CCCL_NODEBUG_ALIAS = bool_constant<(_Ty::value >= _Uy::value)>;
 };
 
 //! \brief A functional adaptor that negates a unary predicate
@@ -276,7 +276,7 @@ template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_negate1
 {
   template <class _Ty>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call1<__type_not, __type_call1<_Fn, _Ty>>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call1<__type_not, __type_call1<_Fn, _Ty>>;
 };
 
 //! \brief A functional adaptor that negates a binary predicate
@@ -284,7 +284,7 @@ template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_negate2
 {
   template <class _Ty, class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call1<__type_not, __type_call2<_Fn, _Ty, _Uy>>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call1<__type_not, __type_call2<_Fn, _Ty, _Uy>>;
 };
 
 //! \brief A type list
@@ -297,7 +297,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_list
   // that takes a meta-callable and applies the
   // elements of the list to it.
   template <class _Fn, class... _Us>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call<_Fn, _Ts..., _Us...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call<_Fn, _Ts..., _Us...>;
 };
 
 // Before the addition of inline variables, it was necessary to
@@ -366,14 +366,14 @@ template <bool _IsCallable>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_defer_fn
 {
   template <class, class...>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_defer_fn;
+  using __call _CCCL_NODEBUG_ALIAS = __type_defer_fn;
 };
 
 template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_defer_fn<true>
 {
   template <class _Fn, class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_identity<__type_call<_Fn, _Ts...>>;
+  using __call _CCCL_NODEBUG_ALIAS = type_identity<__type_call<_Fn, _Ts...>>;
 };
 } // namespace __detail
 
@@ -409,8 +409,7 @@ template <class _TryFn, class _CatchFn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_try_catch
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
-    __type_call<_If<__type_callable<_TryFn, _Ts...>::value, _TryFn, _CatchFn>, _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call<_If<__type_callable<_TryFn, _Ts...>::value, _TryFn, _CatchFn>, _Ts...>;
 };
 
 // Implementation for indexing into a list of types:
@@ -440,7 +439,7 @@ template <size_t _Ip>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_index_fn
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_TYPE_PACK_ELEMENT(_Ip, _Ts...);
+  using __call _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_TYPE_PACK_ELEMENT(_Ip, _Ts...);
 };
 } // namespace __detail
 
@@ -477,7 +476,7 @@ template <size_t... _Is>
 struct __type_index_large_size_fn<index_sequence<_Is...>>
 {
   template <class _Ip, class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = //
+  using __call _CCCL_NODEBUG_ALIAS = //
     __type<decltype(__detail::__type_index_get<_Ip::value>(
       static_cast<__inherit_flat<__type_index_leaf<_Is, _Ts>...>*>(nullptr)))>;
 };
@@ -491,7 +490,7 @@ struct __type_index_small_size_fn;
       struct __type_index_small_size_fn<_N>                     \
       {                                                         \
         template <_CCCL_PP_REPEAT(_N, _M0) class _Ty, class...> \
-        using __call _LIBCUDACXX_NODEBUG_TYPE = _Ty;            \
+        using __call _CCCL_NODEBUG_ALIAS = _Ty;                 \
       };
 
 _CCCL_PP_REPEAT_REVERSE(16, _M1)
@@ -503,7 +502,7 @@ template <bool _IsSmall>
 struct __type_index_select_fn // Default for larger indices
 {
   template <class _Ip, class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
+  using __call _CCCL_NODEBUG_ALIAS =
     __type_call<__type_index_large_size_fn<make_index_sequence<sizeof...(_Ts)>>, _Ip, _Ts...>;
 };
 
@@ -511,7 +510,7 @@ template <>
 struct __type_index_select_fn<true> // Fast implementation for smaller indices
 {
   template <class _Ip, class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call_indirect<__type_index_small_size_fn<_Ip::value>, _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call_indirect<__type_index_small_size_fn<_Ip::value>, _Ts...>;
 };
 } // namespace __detail
 
@@ -529,7 +528,7 @@ template <size_t _Ip>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_at_fn
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_index_c<_Ip, _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_index_c<_Ip, _Ts...>;
 };
 } // namespace __detail
 
@@ -576,13 +575,13 @@ struct __type_concat_fn
   };
 
   template <class... _Lists>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type<__trait<_Lists...>>;
+  using __call _CCCL_NODEBUG_ALIAS = __type<__trait<_Lists...>>;
 };
 #  else // ^^^ _CCCL_COMPILER_MSVC < 19.38 ^^^ / vvv !(_CCCL_COMPILER_MSVC < 19.38) vvv
 template <size_t _Count>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_concat_fn
 {
-  using __next_t = __type_maybe_concat_fn<(_Count < 8 ? 0 : _Count - 8)>;
+  using __next_t _CCCL_NODEBUG_ALIAS = __type_maybe_concat_fn<(_Count < 8 ? 0 : _Count - 8)>;
 
   template <class... _Ts,
             class... _As,
@@ -627,7 +626,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_concat_fn<0>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_concat_fn
 {
   template <class... _Lists>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = decltype(__type_maybe_concat_fn<sizeof...(_Lists)>::__fn(
+  using __call _CCCL_NODEBUG_ALIAS = decltype(__type_maybe_concat_fn<sizeof...(_Lists)>::__fn(
     __type_list_ptr<>{nullptr},
     static_cast<_Lists*>(nullptr)...,
     __type_list_ptr<>{nullptr},
@@ -662,21 +661,21 @@ template <bool _Found>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_find_if_found
 {
   template <class _Fn, class _Head, class... _Tail>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_list<_Head, _Tail...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_list<_Head, _Tail...>;
 };
 
 template <>
 struct __type_find_if_found<false>
 {
   template <class _Fn, class _Head, class... _Tail>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call<__type_maybe_find_if_fn<sizeof...(_Tail) == 0>, _Fn, _Tail...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call<__type_maybe_find_if_fn<sizeof...(_Tail) == 0>, _Fn, _Tail...>;
 };
 
 template <bool _IsEmpty>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_find_if_fn // Type list is not empty
 {
   template <class _Fn, class _Head, class... _Tail>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
+  using __call _CCCL_NODEBUG_ALIAS =
     __type_call<__type_find_if_found<__type_call1<_Fn, _Head>::value>, _Fn, _Head, _Tail...>;
 };
 
@@ -684,21 +683,21 @@ template <>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_maybe_find_if_fn<true> // Type list is empty
 {
   template <class, class... _None>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_list<>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_list<>;
 };
 
 template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_find_if_fn
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call<__type_maybe_find_if_fn<sizeof...(_Ts) == 0>, _Fn, _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call<__type_maybe_find_if_fn<sizeof...(_Ts) == 0>, _Fn, _Ts...>;
 };
 
 template <class _Ty>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_same_as
 {
   template <class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = bool_constant<_CCCL_TRAIT(is_same, _Ty, _Uy)>;
+  using __call _CCCL_NODEBUG_ALIAS = bool_constant<_CCCL_TRAIT(is_same, _Ty, _Uy)>;
 };
 } // namespace __detail
 
@@ -725,7 +724,7 @@ template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_transform_fn
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_list<__type_call1<_Fn, _Ts>...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_list<__type_call1<_Fn, _Ts>...>;
 };
 } // namespace __detail
 
@@ -748,12 +747,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_fold_left_fn;
 #  define _M3(_N) _M2(_N) >
 #  define _M4(_N) _M2(_CCCL_PP_DEC(_N)) >
 
-#  define _LIBCUDACXX_TYPE_LIST_FOLD_RIGHT(_N)                                                          \
-    template <>                                                                                         \
-    struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_fold_right_fn<_N>                                       \
-    {                                                                                                   \
-      template <class _Fn, class _State _CCCL_PP_REPEAT(_N, _M0)>                                       \
-      using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_PP_REPEAT(_N, _M1) _State _CCCL_PP_REPEAT(_N, _M3); \
+#  define _LIBCUDACXX_TYPE_LIST_FOLD_RIGHT(_N)                                                     \
+    template <>                                                                                    \
+    struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_fold_right_fn<_N>                                  \
+    {                                                                                              \
+      template <class _Fn, class _State _CCCL_PP_REPEAT(_N, _M0)>                                  \
+      using __call _CCCL_NODEBUG_ALIAS = _CCCL_PP_REPEAT(_N, _M1) _State _CCCL_PP_REPEAT(_N, _M3); \
     };
 
 _CCCL_PP_REPEAT_REVERSE(17, _LIBCUDACXX_TYPE_LIST_FOLD_RIGHT)
@@ -762,7 +761,7 @@ template <size_t _Np>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_fold_right_fn
 {
   template <class _Fn, class _State _CCCL_PP_REPEAT(16, _M0), class... _Rest>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
+  using __call _CCCL_NODEBUG_ALIAS =
     __type_call_indirect<__type_fold_right_fn<_Np - 16>,
                          _Fn,
                          __type_call<__type_fold_right_fn<16>, _Fn, _State _CCCL_PP_REPEAT(16, _M2)>,
@@ -773,17 +772,15 @@ template <class _Init, class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_fold_right_select_fn
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
-    __type_call_indirect<__type_fold_right_fn<sizeof...(_Ts)>, _Fn, _Init, _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call_indirect<__type_fold_right_fn<sizeof...(_Ts)>, _Fn, _Init, _Ts...>;
 };
 
-#  define _LIBCUDACXX_TYPE_FOLD_LEFT(_N)                                      \
-    template <>                                                               \
-    struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_fold_left_fn<_N>              \
-    {                                                                         \
-      template <class _Fn, class _State _CCCL_PP_REPEAT(_N, _M0)>             \
-      using __call _LIBCUDACXX_NODEBUG_TYPE = _CCCL_PP_REPEAT(_N, _M1) _State \
-        _CCCL_PP_REPEAT(_N, _M4, _N, _CCCL_PP_DEC);                           \
+#  define _LIBCUDACXX_TYPE_FOLD_LEFT(_N)                                                                             \
+    template <>                                                                                                      \
+    struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_fold_left_fn<_N>                                                     \
+    {                                                                                                                \
+      template <class _Fn, class _State _CCCL_PP_REPEAT(_N, _M0)>                                                    \
+      using __call _CCCL_NODEBUG_ALIAS = _CCCL_PP_REPEAT(_N, _M1) _State _CCCL_PP_REPEAT(_N, _M4, _N, _CCCL_PP_DEC); \
     };
 
 _CCCL_PP_REPEAT_REVERSE(17, _LIBCUDACXX_TYPE_FOLD_LEFT)
@@ -792,7 +789,7 @@ template <size_t _Np>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_fold_left_fn
 {
   template <class _Fn, class _State _CCCL_PP_REPEAT(16, _M0), class... _Rest>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
+  using __call _CCCL_NODEBUG_ALIAS =
     __type_call<__type_fold_left_fn<16>,
                 _Fn,
                 __type_call_indirect<__type_fold_left_fn<_Np - 16>, _Fn, _State, _Rest...> //
@@ -803,7 +800,7 @@ template <class _Init, class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_fold_left_select_fn
 {
   template <class... _Ts>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_call_indirect<__type_fold_left_fn<sizeof...(_Ts)>, _Fn, _Init, _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS = __type_call_indirect<__type_fold_left_fn<sizeof...(_Ts)>, _Fn, _Init, _Ts...>;
 };
 
 #  undef _LIBCUDACXX_TYPE_FOLD_LEFT
@@ -832,7 +829,7 @@ template <class _Ty>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_remove_fn
 {
   template <class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _If<_CCCL_TRAIT(is_same, _Ty, _Uy), __type_list<>, __type_list<_Uy>>;
+  using __call _CCCL_NODEBUG_ALIAS = _If<_CCCL_TRAIT(is_same, _Ty, _Uy), __type_list<>, __type_list<_Uy>>;
 };
 } // namespace __detail
 
@@ -846,7 +843,7 @@ template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_remove_if_fn
 {
   template <class _Uy>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _If<__type_call1<_Fn, _Uy>::value, __type_list<>, __type_list<_Uy>>;
+  using __call _CCCL_NODEBUG_ALIAS = _If<__type_call1<_Fn, _Uy>::value, __type_list<>, __type_list<_Uy>>;
 };
 } // namespace __detail
 
@@ -872,12 +869,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_cartesian_product_fn
   struct __lambda0
   {
     template <class _List2>
-    using __lambda1 _LIBCUDACXX_NODEBUG_TYPE = __type_list<__type_push_front<_List2, _Ty>>;
+    using __lambda1 _CCCL_NODEBUG_ALIAS = __type_list<__type_push_front<_List2, _Ty>>;
 
-    using type _LIBCUDACXX_NODEBUG_TYPE = __type_flatten<__type_transform<_State, __type_quote1<__lambda1>>>;
+    using type _CCCL_NODEBUG_ALIAS = __type_flatten<__type_transform<_State, __type_quote1<__lambda1>>>;
   };
 
-  using type _LIBCUDACXX_NODEBUG_TYPE = __type_flatten<__type_transform<_List, __type_quote_trait1<__lambda0>>>;
+  using type _CCCL_NODEBUG_ALIAS = __type_flatten<__type_transform<_List, __type_quote_trait1<__lambda0>>>;
 };
 } // namespace __detail
 /// \endcond
@@ -898,15 +895,15 @@ using __type_cartesian_product =
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_sizeof
 {
   template <class _Ty>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = integral_constant<size_t, sizeof(_Ty)>;
+  using __call _CCCL_NODEBUG_ALIAS = integral_constant<size_t, sizeof(_Ty)>;
 };
 
 //! \brief A pair of types
 template <class _First, class _Second>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_pair
 {
-  using __first _LIBCUDACXX_NODEBUG_TYPE  = _First;
-  using __second _LIBCUDACXX_NODEBUG_TYPE = _Second;
+  using __first _CCCL_NODEBUG_ALIAS  = _First;
+  using __second _CCCL_NODEBUG_ALIAS = _Second;
 };
 
 //! \brief Retreive the first of a pair of types
@@ -925,7 +922,7 @@ using __type_pair_second = typename _Pair::__second;
 template <class _Ty, _Ty... _Values>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_value_list : __type_list<integral_constant<_Ty, _Values>...>
 {
-  using __type _LIBCUDACXX_NODEBUG_TYPE = _Ty;
+  using __type _CCCL_NODEBUG_ALIAS = _Ty;
 };
 
 namespace __detail

--- a/libcudacxx/include/cuda/std/__type_traits/type_set.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_set.h
@@ -34,12 +34,12 @@ template <class...>
 struct __type_list;
 
 template <class _Set, class... _Ty>
-struct __type_set_contains : __fold_and<_CCCL_TRAIT(is_base_of, __type_identity<_Ty>, _Set)...>
+struct __type_set_contains : __fold_and<_CCCL_TRAIT(is_base_of, type_identity<_Ty>, _Set)...>
 {};
 
 #ifndef _CCCL_NO_VARIABLE_TEMPLATES
 template <class _Set, class... _Ty>
-_CCCL_INLINE_VAR constexpr bool __type_set_contains_v = __fold_and_v<is_base_of_v<__type_identity<_Ty>, _Set>...>;
+_CCCL_INLINE_VAR constexpr bool __type_set_contains_v = __fold_and_v<is_base_of_v<type_identity<_Ty>, _Set>...>;
 #endif // _CCCL_NO_VARIABLE_TEMPLATES
 
 namespace __set
@@ -51,7 +51,7 @@ template <>
 struct __tupl<>
 {
   template <class _Ty>
-  using __maybe_insert _LIBCUDACXX_NODEBUG_TYPE = __tupl<_Ty>;
+  using __maybe_insert _CCCL_NODEBUG_ALIAS = __tupl<_Ty>;
 
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr size_t __size() noexcept
   {
@@ -61,11 +61,11 @@ struct __tupl<>
 
 template <class _Ty, class... _Ts>
 struct __tupl<_Ty, _Ts...>
-    : __type_identity<_Ty>
+    : type_identity<_Ty>
     , __tupl<_Ts...>
 {
   template <class _Uy>
-  using __maybe_insert _LIBCUDACXX_NODEBUG_TYPE =
+  using __maybe_insert _CCCL_NODEBUG_ALIAS =
     _If<_CCCL_TRAIT(__type_set_contains, __tupl, _Uy), __tupl, __tupl<_Uy, _Ty, _Ts...>>;
 
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr size_t __size() noexcept
@@ -78,7 +78,7 @@ template <bool _Empty>
 struct __bulk_insert
 {
   template <class _Set, class...>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = _Set;
+  using __call _CCCL_NODEBUG_ALIAS = _Set;
 };
 
 template <>
@@ -90,10 +90,10 @@ struct __bulk_insert<false>
     typename __bulk_insert<sizeof...(_Us) == 0>::template __call<typename _Set::template __maybe_insert<_Ty>, _Us...>;
 
   template <class _Set, class... _Us>
-  using __call _LIBCUDACXX_NODEBUG_TYPE = decltype(__insert_fn<_Set>(static_cast<__type_list<_Us...>*>(nullptr)));
+  using __call _CCCL_NODEBUG_ALIAS = decltype(__insert_fn<_Set>(static_cast<__type_list<_Us...>*>(nullptr)));
 #else
   template <class _Set, class _Ty, class... _Us>
-  using __call _LIBCUDACXX_NODEBUG_TYPE =
+  using __call _CCCL_NODEBUG_ALIAS =
     typename __bulk_insert<sizeof...(_Us) == 0>::template __call<typename _Set::template __maybe_insert<_Ty>, _Us...>;
 #endif
 };

--- a/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
@@ -44,14 +44,9 @@ struct underlying_type : __underlying_type_impl<_Tp, is_enum<_Tp>::value>
 {};
 
 template <class _Tp>
-using __underlying_type_t = typename underlying_type<_Tp>::type;
+using underlying_type_t _CCCL_NODEBUG_ALIAS = typename underlying_type<_Tp>::type;
 
-#  if _CCCL_STD_VER > 2011
-template <class _Tp>
-using underlying_type_t = typename underlying_type<_Tp>::type;
-#  endif
-
-#else
+#else // ^^^ _CCCL_BUILTIN_UNDERLYING_TYPE ^^^ / vvv !_CCCL_BUILTIN_UNDERLYING_TYPE vvv
 
 template <class _Tp, bool _Support = false>
 struct underlying_type
@@ -62,7 +57,7 @@ struct underlying_type
                 "libc++ does not know how to use it.");
 };
 
-#endif // defined(_CCCL_BUILTIN_UNDERLYING_TYPE) && !defined(_LIBCUDACXX_USE_UNDERLYING_TYPE_FALLBACK)
+#endif // !_CCCL_BUILTIN_UNDERLYING_TYPE
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__utility/convert_to_integral.h
+++ b/libcudacxx/include/cuda/std/__utility/convert_to_integral.h
@@ -58,7 +58,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr unsigned long long __convert_to_integral(uns
 }
 
 template <typename _Fp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_floating_point<_Fp>::value, long long>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_Fp>::value, long long>
 __convert_to_integral(_Fp __val)
 {
   return __val;

--- a/libcudacxx/include/cuda/std/__utility/declval.h
+++ b/libcudacxx/include/cuda/std/__utility/declval.h
@@ -34,7 +34,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
   && !(defined(_CCCL_COMPILER_MSVC) && _CCCL_MSVC_VERSION < 1939)
 
 template <class _Tp>
-using __identity_t _LIBCUDACXX_NODEBUG_TYPE = _Tp;
+using __identity_t _CCCL_NODEBUG_ALIAS = _Tp;
 
 template <class _Tp, class = void>
 extern __identity_t<void (*)() noexcept> declval;

--- a/libcudacxx/include/cuda/std/__utility/exception_guard.h
+++ b/libcudacxx/include/cuda/std/__utility/exception_guard.h
@@ -109,11 +109,10 @@ template <class _Rollback>
 struct __exception_guard_noexceptions
 {
   __exception_guard_noexceptions() = delete;
-  _LIBCUDACXX_HIDE_FROM_ABI
-  _CCCL_CONSTEXPR_CXX20 _LIBCUDACXX_NODEBUG_TYPE explicit __exception_guard_noexceptions(_Rollback)
+  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _CCCL_NODEBUG_ALIAS explicit __exception_guard_noexceptions(_Rollback)
   {}
 
-  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _LIBCUDACXX_NODEBUG_TYPE __exception_guard_noexceptions(
+  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _CCCL_NODEBUG_ALIAS __exception_guard_noexceptions(
     __exception_guard_noexceptions&& __other) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Rollback))
       : __completed_(__other.__completed_)
   {
@@ -124,12 +123,12 @@ struct __exception_guard_noexceptions
   __exception_guard_noexceptions& operator=(__exception_guard_noexceptions const&) = delete;
   __exception_guard_noexceptions& operator=(__exception_guard_noexceptions&&)      = delete;
 
-  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _LIBCUDACXX_NODEBUG_TYPE void __complete() noexcept
+  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _CCCL_NODEBUG_ALIAS void __complete() noexcept
   {
     __completed_ = true;
   }
 
-  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _LIBCUDACXX_NODEBUG_TYPE ~__exception_guard_noexceptions()
+  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 _CCCL_NODEBUG_ALIAS ~__exception_guard_noexceptions()
   {
     _CCCL_ASSERT(__completed_, "__exception_guard not completed with exceptions disabled");
   }

--- a/libcudacxx/include/cuda/std/__utility/forward.h
+++ b/libcudacxx/include/cuda/std/__utility/forward.h
@@ -28,13 +28,13 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp&& forward(__libcpp_remove_reference_t<_Tp>& __t) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp&& forward(remove_reference_t<_Tp>& __t) noexcept
 {
   return static_cast<_Tp&&>(__t);
 }
 
 template <class _Tp>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp&& forward(__libcpp_remove_reference_t<_Tp>&& __t) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp&& forward(remove_reference_t<_Tp>&& __t) noexcept
 {
   static_assert(!is_lvalue_reference<_Tp>::value, "cannot forward an rvalue as an lvalue");
   return static_cast<_Tp&&>(__t);

--- a/libcudacxx/include/cuda/std/__utility/in_place.h
+++ b/libcudacxx/include/cuda/std/__utility/in_place.h
@@ -58,7 +58,7 @@ struct __is_inplace_type_imp<in_place_type_t<_Tp>> : true_type
 {};
 
 template <class _Tp>
-using __is_inplace_type = __is_inplace_type_imp<__remove_cvref_t<_Tp>>;
+using __is_inplace_type = __is_inplace_type_imp<remove_cvref_t<_Tp>>;
 
 template <class _Tp>
 struct __is_inplace_index_imp : false_type
@@ -68,7 +68,7 @@ struct __is_inplace_index_imp<in_place_index_t<_Idx>> : true_type
 {};
 
 template <class _Tp>
-using __is_inplace_index = __is_inplace_index_imp<__remove_cvref_t<_Tp>>;
+using __is_inplace_index = __is_inplace_index_imp<remove_cvref_t<_Tp>>;
 
 #endif // _CCCL_STD_VER > 2011
 

--- a/libcudacxx/include/cuda/std/__utility/integer_sequence.h
+++ b/libcudacxx/include/cuda/std/__utility/integer_sequence.h
@@ -33,22 +33,22 @@ template <class _IdxType, _IdxType... _Values>
 struct __integer_sequence
 {
   template <template <class _OIdxType, _OIdxType...> class _ToIndexSeq, class _ToIndexType>
-  using __convert _LIBCUDACXX_NODEBUG_TYPE = _ToIndexSeq<_ToIndexType, _Values...>;
+  using __convert _CCCL_NODEBUG_ALIAS = _ToIndexSeq<_ToIndexType, _Values...>;
 
   template <size_t _Sp>
-  using __to_tuple_indices _LIBCUDACXX_NODEBUG_TYPE = __tuple_indices<(_Values + _Sp)...>;
+  using __to_tuple_indices _CCCL_NODEBUG_ALIAS = __tuple_indices<(_Values + _Sp)...>;
 };
 
 #if defined(_CCCL_BUILTIN_MAKE_INTEGER_SEQ)
 
 template <size_t _Ep, size_t _Sp>
-using __make_indices_imp _LIBCUDACXX_NODEBUG_TYPE =
+using __make_indices_imp _CCCL_NODEBUG_ALIAS =
   typename _CCCL_BUILTIN_MAKE_INTEGER_SEQ(__integer_sequence, size_t, _Ep - _Sp)::template __to_tuple_indices<_Sp>;
 
 #elif defined(_CCCL_BUILTIN_INTEGER_PACK)
 
 template <size_t _Ep, size_t _Sp>
-using __make_indices_imp _LIBCUDACXX_NODEBUG_TYPE =
+using __make_indices_imp _CCCL_NODEBUG_ALIAS =
   typename __integer_sequence<size_t, _CCCL_BUILTIN_INTEGER_PACK(_Ep - _Sp)...>::template __to_tuple_indices<_Sp>;
 
 #else // ^^^ _CCCL_BUILTIN_INTEGER_PACK ^^^ / vvv !_CCCL_BUILTIN_INTEGER_PACK vvv
@@ -61,7 +61,7 @@ struct __repeat;
 template <typename _Tp, _Tp... _Np, size_t... _Extra>
 struct __repeat<__integer_sequence<_Tp, _Np...>, _Extra...>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __integer_sequence<
+  typedef _CCCL_NODEBUG_ALIAS __integer_sequence<
     _Tp,
     _Np...,
     sizeof...(_Np) + _Np...,
@@ -184,7 +184,7 @@ struct __parity<7>
 } // namespace __detail
 
 template <size_t _Ep, size_t _Sp>
-using __make_indices_imp _LIBCUDACXX_NODEBUG_TYPE =
+using __make_indices_imp _CCCL_NODEBUG_ALIAS =
   typename __detail::__make<_Ep - _Sp>::type::template __to_tuple_indices<_Sp>;
 
 #endif // !_CCCL_BUILTIN_INTEGER_PACK
@@ -206,17 +206,17 @@ using index_sequence = integer_sequence<size_t, _Ip...>;
 #if defined(_CCCL_BUILTIN_MAKE_INTEGER_SEQ)
 
 template <class _Tp, _Tp _Ep>
-using __make_integer_sequence _LIBCUDACXX_NODEBUG_TYPE = _CCCL_BUILTIN_MAKE_INTEGER_SEQ(integer_sequence, _Tp, _Ep);
+using __make_integer_sequence _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_MAKE_INTEGER_SEQ(integer_sequence, _Tp, _Ep);
 
 #elif defined(_CCCL_BUILTIN_INTEGER_PACK)
 
 template <class _Tp, _Tp _Ep>
-using __make_integer_sequence _LIBCUDACXX_NODEBUG_TYPE = integer_sequence<_Tp, __integer_pack(_Ep)...>;
+using __make_integer_sequence _CCCL_NODEBUG_ALIAS = integer_sequence<_Tp, __integer_pack(_Ep)...>;
 
 #else // ^^^ _CCCL_BUILTIN_INTEGER_PACK ^^^ / vvv !_CCCL_BUILTIN_INTEGER_PACK vvv
 
 template <typename _Tp, _Tp _Np>
-using __make_integer_sequence_unchecked _LIBCUDACXX_NODEBUG_TYPE =
+using __make_integer_sequence_unchecked _CCCL_NODEBUG_ALIAS =
   typename __detail::__make<_Np>::type::template __convert<integer_sequence, _Tp>;
 
 template <class _Tp, _Tp _Ep>
@@ -226,11 +226,11 @@ struct __make_integer_sequence_checked
   static_assert(0 <= _Ep, "std::make_integer_sequence must have a non-negative sequence length");
   // Workaround GCC bug by preventing bad installations when 0 <= _Ep
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68929
-  typedef _LIBCUDACXX_NODEBUG_TYPE __make_integer_sequence_unchecked<_Tp, 0 <= _Ep ? _Ep : 0> type;
+  typedef _CCCL_NODEBUG_ALIAS __make_integer_sequence_unchecked<_Tp, 0 <= _Ep ? _Ep : 0> type;
 };
 
 template <class _Tp, _Tp _Ep>
-using __make_integer_sequence _LIBCUDACXX_NODEBUG_TYPE = typename __make_integer_sequence_checked<_Tp, _Ep>::type;
+using __make_integer_sequence _CCCL_NODEBUG_ALIAS = typename __make_integer_sequence_checked<_Tp, _Ep>::type;
 
 #endif // !_CCCL_BUILTIN_INTEGER_PACK
 

--- a/libcudacxx/include/cuda/std/__utility/move.h
+++ b/libcudacxx/include/cuda/std/__utility/move.h
@@ -29,15 +29,15 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr __libcpp_remove_reference_t<_Tp>&& move(_Tp&& __t) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr remove_reference_t<_Tp>&& move(_Tp&& __t) noexcept
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tp> _Up;
+  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tp> _Up;
   return static_cast<_Up&&>(__t);
 }
 
 template <class _Tp>
 using __move_if_noexcept_result_t =
-  __conditional_t<!is_nothrow_move_constructible<_Tp>::value && is_copy_constructible<_Tp>::value, const _Tp&, _Tp&&>;
+  conditional_t<!is_nothrow_move_constructible<_Tp>::value && is_copy_constructible<_Tp>::value, const _Tp&, _Tp&&>;
 
 template <class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __move_if_noexcept_result_t<_Tp>

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -124,16 +124,16 @@ struct __pair_base
   _T1 first;
   _T2 second;
 
-  template <class _Constraints                                                 = __pair_constraints<_T1, _T2>,
-            __enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
+  template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
+            enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr __pair_base() noexcept(
     _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
       : first()
       , second()
   {}
 
-  template <class _Constraints                                                 = __pair_constraints<_T1, _T2>,
-            __enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
+  template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
+            enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr __pair_base() noexcept(
     _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
       : first()
@@ -163,16 +163,16 @@ struct __pair_base<_T1, _T2, true>
   _T1 first;
   _T2 second;
 
-  template <class _Constraints                                                 = __pair_constraints<_T1, _T2>,
-            __enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
+  template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
+            enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr __pair_base() noexcept(
     _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
       : first()
       , second()
   {}
 
-  template <class _Constraints                                                 = __pair_constraints<_T1, _T2>,
-            __enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
+  template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
+            enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr __pair_base() noexcept(
     _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
       : first()
@@ -184,10 +184,8 @@ struct __pair_base<_T1, _T2, true>
 
   // We need to ensure that a reference type, which would inhibit the implicit copy assignment still works
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __pair_base& operator=(
-    __conditional_t<_CCCL_TRAIT(is_copy_assignable, _T1) && _CCCL_TRAIT(is_copy_assignable, _T2),
-                    __pair_base,
-                    __nat> const& __p) noexcept(_CCCL_TRAIT(is_nothrow_copy_assignable, _T1)
-                                                && _CCCL_TRAIT(is_nothrow_copy_assignable, _T2))
+    conditional_t<_CCCL_TRAIT(is_copy_assignable, _T1) && _CCCL_TRAIT(is_copy_assignable, _T2), __pair_base, __nat> const&
+      __p) noexcept(_CCCL_TRAIT(is_nothrow_copy_assignable, _T1) && _CCCL_TRAIT(is_nothrow_copy_assignable, _T2))
   {
     first  = __p.first;
     second = __p.second;
@@ -196,7 +194,7 @@ struct __pair_base<_T1, _T2, true>
 
   // We need to ensure that a reference type, which would inhibit the implicit move assignment still works
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __pair_base& operator=(
-    __conditional_t<_CCCL_TRAIT(is_move_assignable, _T1) && _CCCL_TRAIT(is_move_assignable, _T2), __pair_base, __nat>&&
+    conditional_t<_CCCL_TRAIT(is_move_assignable, _T1) && _CCCL_TRAIT(is_move_assignable, _T2), __pair_base, __nat>&&
       __p) noexcept(_CCCL_TRAIT(is_nothrow_move_assignable, _T1) && _CCCL_TRAIT(is_nothrow_move_assignable, _T2))
   {
     first  = _CUDA_VSTD::forward<_T1>(__p.first);
@@ -229,30 +227,30 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   typedef _T1 first_type;
   typedef _T2 second_type;
 
-  template <class _Constraints                                                 = __pair_constraints<_T1, _T2>,
-            __enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
+  template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
+            enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr pair() noexcept(
     _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
       : __base()
   {}
 
-  template <class _Constraints                                                 = __pair_constraints<_T1, _T2>,
-            __enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
+  template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
+            enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr pair() noexcept(
     _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
       : __base()
   {}
 
   // element wise constructors
-  template <class _Constraints                                                       = __pair_constraints<_T1, _T2>,
-            __enable_if_t<_Constraints::__explicit_constructible_from_elements, int> = 0>
+  template <class _Constraints                                                     = __pair_constraints<_T1, _T2>,
+            enable_if_t<_Constraints::__explicit_constructible_from_elements, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
     _CCCL_TRAIT(is_nothrow_copy_constructible, _T1) && _CCCL_TRAIT(is_nothrow_copy_constructible, _T2))
       : __base(__t1, __t2)
   {}
 
-  template <class _Constraints                                                       = __pair_constraints<_T1, _T2>,
-            __enable_if_t<_Constraints::__implicit_constructible_from_elements, int> = 0>
+  template <class _Constraints                                                     = __pair_constraints<_T1, _T2>,
+            enable_if_t<_Constraints::__implicit_constructible_from_elements, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
     _CCCL_TRAIT(is_nothrow_copy_constructible, _T1) && _CCCL_TRAIT(is_nothrow_copy_constructible, _T2))
       : __base(__t1, __t2)
@@ -261,19 +259,19 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   template <class _U1, class _U2>
   using __pair_constructible = typename __pair_constraints<_T1, _T2>::template __constructible<_U1, _U2>;
 
-  template <class _U1                                                  = _T1,
-            class _U2                                                  = _T2,
-            class _Constraints                                         = __pair_constructible<_U1, _U2>,
-            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  template <class _U1                                                = _T1,
+            class _U2                                                = _T2,
+            class _Constraints                                       = __pair_constructible<_U1, _U2>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
       : __base(_CUDA_VSTD::forward<_U1>(__u1), _CUDA_VSTD::forward<_U2>(__u2))
   {}
 
-  template <class _U1                                                  = _T1,
-            class _U2                                                  = _T2,
-            class _Constraints                                         = __pair_constructible<_U1, _U2>,
-            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  template <class _U1                                                = _T1,
+            class _U2                                                = _T2,
+            class _Constraints                                       = __pair_constructible<_U1, _U2>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
       : __base(_CUDA_VSTD::forward<_U1>(__u1), _CUDA_VSTD::forward<_U2>(__u2))
@@ -294,38 +292,38 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   _CCCL_HIDE_FROM_ABI pair(pair const&) = default;
   _CCCL_HIDE_FROM_ABI pair(pair&&)      = default;
 
-  template <class _U1                                                  = _T1,
-            class _U2                                                  = _T2,
-            class _Constraints                                         = __pair_constructible<const _U1&, const _U2&>,
-            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  template <class _U1                                                = _T1,
+            class _U2                                                = _T2,
+            class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit _CCCL_CONSTEXPR_CXX14 pair(const pair<_U1, _U2>& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_constructible, _T2, const _U2&))
       : __base(__p.first, __p.second)
   {}
 
-  template <class _U1                                                  = _T1,
-            class _U2                                                  = _T2,
-            class _Constraints                                         = __pair_constructible<const _U1&, const _U2&>,
-            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  template <class _U1                                                = _T1,
+            class _U2                                                = _T2,
+            class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair(const pair<_U1, _U2>& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_constructible, _T2, const _U2&))
       : __base(__p.first, __p.second)
   {}
 
   // move constructors
-  template <class _U1                                                  = _T1,
-            class _U2                                                  = _T2,
-            class _Constraints                                         = __pair_constructible<_U1, _U2>,
-            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+  template <class _U1                                                = _T1,
+            class _U2                                                = _T2,
+            class _Constraints                                       = __pair_constructible<_U1, _U2>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit _CCCL_CONSTEXPR_CXX14 pair(pair<_U1, _U2>&& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
       : __base(_CUDA_VSTD::forward<_U1>(__p.first), _CUDA_VSTD::forward<_U2>(__p.second))
   {}
 
-  template <class _U1                                                  = _T1,
-            class _U2                                                  = _T2,
-            class _Constraints                                         = __pair_constructible<_U1, _U2>,
-            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+  template <class _U1                                                = _T1,
+            class _U2                                                = _T2,
+            class _Constraints                                       = __pair_constructible<_U1, _U2>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair(pair<_U1, _U2>&& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
       : __base(_CUDA_VSTD::forward<_U1>(__p.first), _CUDA_VSTD::forward<_U2>(__p.second))
@@ -335,8 +333,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if !defined(_CCCL_COMPILER_NVRTC)
   template <class _U1,
             class _U2,
-            class _Constraints                                         = __pair_constructible<const _U1&, const _U2&>,
-            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+            class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _CCCL_HOST _LIBCUDACXX_HIDE_FROM_ABI explicit _CCCL_CONSTEXPR_CXX14 pair(const ::std::pair<_U1, _U2>& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_constructible, _T2, const _U2&))
       : __base(__p.first, __p.second)
@@ -344,8 +342,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraints                                         = __pair_constructible<const _U1&, const _U2&>,
-            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+            class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _CCCL_HOST _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair(const ::std::pair<_U1, _U2>& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_constructible, _T2, const _U2&))
       : __base(__p.first, __p.second)
@@ -353,8 +351,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraints                                         = __pair_constructible<_U1, _U2>,
-            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+            class _Constraints                                       = __pair_constructible<_U1, _U2>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _CCCL_HOST _LIBCUDACXX_HIDE_FROM_ABI explicit _CCCL_CONSTEXPR_CXX14 pair(::std::pair<_U1, _U2>&& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
       : __base(_CUDA_VSTD::forward<_U1>(__p.first), _CUDA_VSTD::forward<_U2>(__p.second))
@@ -362,8 +360,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _U1,
             class _U2,
-            class _Constraints                                         = __pair_constructible<_U1, _U2>,
-            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+            class _Constraints                                       = __pair_constructible<_U1, _U2>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _CCCL_HOST _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair(::std::pair<_U1, _U2>&& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
       : __base(_CUDA_VSTD::forward<_U1>(__p.first), _CUDA_VSTD::forward<_U2>(__p.second))
@@ -377,7 +375,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   template <class _U1,
             class _U2,
             class _Constraints = typename __pair_constraints<_T1, _T2>::template __assignable<const _U1&, const _U2&>,
-            __enable_if_t<_Constraints::__enable_assign, int> = 0>
+            enable_if_t<_Constraints::__enable_assign, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair& operator=(const pair<_U1, _U2>& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_assignable, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_assignable, _T2, const _U2&))
   {
@@ -389,7 +387,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   template <class _U1,
             class _U2,
             class _Constraints = typename __pair_constraints<_T1, _T2>::template __assignable<_U1, _U2>,
-            __enable_if_t<_Constraints::__enable_assign, int> = 0>
+            enable_if_t<_Constraints::__enable_assign, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 pair& operator=(pair<_U1, _U2>&& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_assignable, _T1, _U1) && _CCCL_TRAIT(is_nothrow_assignable, _T2, _U2))
   {
@@ -400,7 +398,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   // std assignments
 #if !defined(_CCCL_COMPILER_NVRTC)
-  template <class _UT1 = _T1, __enable_if_t<is_copy_assignable<_UT1>::value && is_copy_assignable<_T2>::value, int> = 0>
+  template <class _UT1 = _T1, enable_if_t<is_copy_assignable<_UT1>::value && is_copy_assignable<_T2>::value, int> = 0>
   _CCCL_HOST _CCCL_CONSTEXPR_CXX14 pair& operator=(::std::pair<_T1, _T2> const& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_copy_assignable, _T1) && _CCCL_TRAIT(is_nothrow_copy_assignable, _T2))
   {
@@ -409,7 +407,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
     return *this;
   }
 
-  template <class _UT1 = _T1, __enable_if_t<is_move_assignable<_UT1>::value && is_move_assignable<_T2>::value, int> = 0>
+  template <class _UT1 = _T1, enable_if_t<is_move_assignable<_UT1>::value && is_move_assignable<_T2>::value, int> = 0>
   _CCCL_HOST _CCCL_CONSTEXPR_CXX14 pair& operator=(::std::pair<_T1, _T2>&& __p) noexcept(
     _CCCL_TRAIT(is_nothrow_copy_assignable, _T1) && _CCCL_TRAIT(is_nothrow_copy_assignable, _T2))
   {
@@ -608,7 +606,7 @@ struct common_type<pair<_T1, _T2>, pair<_U1, _U2>>
 
 template <class _T1, class _T2>
 _LIBCUDACXX_HIDE_FROM_ABI
-_CCCL_CONSTEXPR_CXX20 __enable_if_t<__is_swappable<_T1>::value && __is_swappable<_T2>::value, void>
+_CCCL_CONSTEXPR_CXX20 enable_if_t<__is_swappable<_T1>::value && __is_swappable<_T2>::value, void>
 swap(pair<_T1, _T2>& __x,
      pair<_T1, _T2>& __y) noexcept((__is_nothrow_swappable<_T1>::value && __is_nothrow_swappable<_T2>::value))
 {
@@ -647,13 +645,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, pair<_T1, _T2>>
 template <class _T1, class _T2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<0, pair<_T1, _T2>>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _T1 type;
+  typedef _CCCL_NODEBUG_ALIAS _T1 type;
 };
 
 template <class _T1, class _T2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<1, pair<_T1, _T2>>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE _T2 type;
+  typedef _CCCL_NODEBUG_ALIAS _T2 type;
 };
 
 template <size_t _Ip>

--- a/libcudacxx/include/cuda/std/__utility/swap.h
+++ b/libcudacxx/include/cuda/std/__utility/swap.h
@@ -44,7 +44,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __swap_result_t<_Tp> swap(_Tp& _
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, size_t _Np>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14
-__enable_if_t<__detect_adl_swap::__has_no_adl_swap_array<_Tp, _Np>::value && __is_swappable<_Tp>::value>
+enable_if_t<__detect_adl_swap::__has_no_adl_swap_array<_Tp, _Np>::value && __is_swappable<_Tp>::value>
 swap(_Tp (&__a)[_Np], _Tp (&__b)[_Np]) noexcept(__is_nothrow_swappable<_Tp>::value)
 {
   for (size_t __i = 0; __i != _Np; ++__i)

--- a/libcudacxx/include/cuda/std/__utility/typeid.h
+++ b/libcudacxx/include/cuda/std/__utility/typeid.h
@@ -118,7 +118,7 @@ __make_pretty_name_impl(char const (&__s)[_Mp], index_sequence<_Is...>) noexcept
 
 template <class _Tp, size_t _Np>
 _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr auto __make_pretty_name(integral_constant<size_t, _Np>) noexcept //
-  -> __enable_if_t<_Np == size_t(-1), __string_view>
+  -> enable_if_t<_Np == size_t(-1), __string_view>
 {
   using _TpName = __static_nameof<_Tp, sizeof(_CCCL_BUILTIN_PRETTY_FUNCTION())>;
   return __string_view(_TpName::value.__str_, _TpName::value.__len_);
@@ -126,7 +126,7 @@ _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr auto __make_pretty_name(integral
 
 template <class _Tp, size_t _Np>
 _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr auto __make_pretty_name(integral_constant<size_t, _Np>) noexcept //
-  -> __enable_if_t<_Np != size_t(-1), __sstring<_Np>>
+  -> enable_if_t<_Np != size_t(-1), __sstring<_Np>>
 {
   return _CUDA_VSTD::__make_pretty_name_impl<_Np>(_CCCL_BUILTIN_PRETTY_FUNCTION(), make_index_sequence<_Np>{});
 }
@@ -325,7 +325,7 @@ using __type_info_ref = __type_info_ref_;
 #  endif // defined(_CCCL_NO_TYPEID) || defined(_CCCL_USE_TYPEID_FALLBACK)
 
 #  define _CCCL_TYPEID_FALLBACK(...) \
-    _CUDA_VSTD::__type_info_ref(&_CUDA_VSTD::__type_info::__get_ti_for<_CUDA_VSTD::__remove_cv_t<__VA_ARGS__>>)
+    _CUDA_VSTD::__type_info_ref(&_CUDA_VSTD::__type_info::__get_ti_for<_CUDA_VSTD::remove_cv_t<__VA_ARGS__>>)
 
 #elif defined(_CCCL_BROKEN_MSVC_FUNCSIG) // ^^^ defined(__CUDA_ARCH__) ^^^
 
@@ -409,7 +409,7 @@ _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr __type_info const& __typeid() noex
   return __typeid_v<_Tp>;
 }
 
-#    define _CCCL_TYPEID_FALLBACK(...) _CUDA_VSTD::__typeid<_CUDA_VSTD::__remove_cv_t<__VA_ARGS__>>()
+#    define _CCCL_TYPEID_FALLBACK(...) _CUDA_VSTD::__typeid<_CUDA_VSTD::remove_cv_t<__VA_ARGS__>>()
 
 #  else // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES ^^^ / vvv _CCCL_NO_VARIABLE_TEMPLATES vvv
 
@@ -432,7 +432,7 @@ _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr __type_info const& __typeid() noex
   return __typeid_value<_Tp>::value;
 }
 
-#    define _CCCL_TYPEID_FALLBACK(...) _CUDA_VSTD::__typeid<_CUDA_VSTD::__remove_cv_t<__VA_ARGS__>>()
+#    define _CCCL_TYPEID_FALLBACK(...) _CUDA_VSTD::__typeid<_CUDA_VSTD::remove_cv_t<__VA_ARGS__>>()
 
 #  endif // _CCCL_NO_VARIABLE_TEMPLATES
 

--- a/libcudacxx/include/cuda/std/atomic
+++ b/libcudacxx/include/cuda/std/atomic
@@ -358,7 +358,7 @@ _LIBCUDACXX_HIDE_FROM_ABI void atomic_notify_all(atomic<_Tp>* __o) noexcept
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
+enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
 atomic_fetch_add(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_add(__op);
@@ -366,7 +366,7 @@ atomic_fetch_add(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
+enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
 atomic_fetch_add(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_add(__op);
@@ -388,7 +388,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _Tp* atomic_fetch_add(atomic<_Tp*>* __o, ptrdiff_t __o
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
+enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
 atomic_fetch_add_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_add(__op, __m);
@@ -396,7 +396,7 @@ atomic_fetch_add_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m)
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
+enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
 atomic_fetch_add_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_add(__op, __m);
@@ -419,7 +419,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _Tp* atomic_fetch_add_explicit(atomic<_Tp*>* __o, ptrd
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
+enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
 atomic_fetch_sub(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_sub(__op);
@@ -427,7 +427,7 @@ atomic_fetch_sub(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
+enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
 atomic_fetch_sub(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_sub(__op);
@@ -449,7 +449,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _Tp* atomic_fetch_sub(atomic<_Tp*>* __o, ptrdiff_t __o
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
+enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
 atomic_fetch_sub_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_sub(__op, __m);
@@ -457,7 +457,7 @@ atomic_fetch_sub_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m)
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
+enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value, _Tp>
 atomic_fetch_sub_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_sub(__op, __m);
@@ -479,14 +479,14 @@ _LIBCUDACXX_HIDE_FROM_ABI _Tp* atomic_fetch_sub_explicit(atomic<_Tp*>* __o, ptrd
 // atomic_fetch_and
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_and(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_and(__op);
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_and(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_and(__op);
@@ -495,14 +495,14 @@ atomic_fetch_and(atomic<_Tp>* __o, _Tp __op) noexcept
 // atomic_fetch_and_explicit
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_and_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_and(__op, __m);
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_and_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_and(__op, __m);
@@ -511,14 +511,14 @@ atomic_fetch_and_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 // atomic_fetch_or
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_or(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_or(__op);
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_or(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_or(__op);
@@ -527,14 +527,14 @@ atomic_fetch_or(atomic<_Tp>* __o, _Tp __op) noexcept
 // atomic_fetch_or_explicit
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_or_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_or(__op, __m);
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_or_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_or(__op, __m);
@@ -543,14 +543,14 @@ atomic_fetch_or_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 // atomic_fetch_xor
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_xor(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_xor(__op);
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_xor(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_xor(__op);
@@ -559,14 +559,14 @@ atomic_fetch_xor(atomic<_Tp>* __o, _Tp __op) noexcept
 // atomic_fetch_xor_explicit
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_xor_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_xor(__op, __m);
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
 atomic_fetch_xor_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_xor(__op, __m);

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -53,13 +53,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Int>
 struct __avoid_promotions
 {
-  using __base = __conditional_t<(sizeof(_Int) >= sizeof(int)),
-                                 _Int,
-                                 __conditional_t<is_unsigned<_Int>::value, unsigned int, signed int>>;
+  using __base =
+    conditional_t<(sizeof(_Int) >= sizeof(int)), _Int, conditional_t<is_unsigned<_Int>::value, unsigned int, signed int>>;
 
   _CCCL_HIDE_FROM_ABI constexpr __avoid_promotions() = default;
 
-  template <class _Tp, typename = __enable_if_t<_CCCL_TRAIT(is_integral, _Tp)>>
+  template <class _Tp, typename = enable_if_t<_CCCL_TRAIT(is_integral, _Tp)>>
   _CCCL_HOST_DEVICE constexpr __avoid_promotions(_Tp __i)
       : __data(static_cast<_Int>(__i))
   {}
@@ -439,7 +438,7 @@ class __bitset<1, _Size>
 public:
   typedef ptrdiff_t difference_type;
   typedef size_t size_type;
-  typedef __avoid_promotions<__conditional_t<_Size <= 8, uint8_t, __conditional_t<_Size <= 16, uint16_t, uint32_t>>>
+  typedef __avoid_promotions<conditional_t<_Size <= 8, uint8_t, conditional_t<_Size <= 16, uint16_t, uint32_t>>>
     __storage_type;
 
 protected:
@@ -674,7 +673,7 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI constexpr bitset(unsigned long long __v) noexcept
       : base(__v)
   {}
-  template <class _CharT, class = __enable_if_t<_IsCharLikeType<_CharT>::value>>
+  template <class _CharT, class = enable_if_t<_IsCharLikeType<_CharT>::value>>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 explicit bitset(
     const _CharT* __str, size_t __n = static_cast<size_t>(-1), _CharT __zero = _CharT('0'), _CharT __one = _CharT('1'))
   {

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -90,10 +90,6 @@ extern "C++" {
 #    define _LIBCUDACXX_ABI_REGEX_CONSTANTS_NONZERO
 #  endif
 
-#  ifndef _CCCL_HAS_ATTRIBUTE
-#    define _CCCL_HAS_ATTRIBUTE(__x) 0
-#  endif
-
 #  ifndef __has_extension
 #    define __has_extension(__x) 0
 #  endif
@@ -510,16 +506,6 @@ typedef __char32_t char32_t;
 #    define _LIBCUDACXX_HAS_NO_WCHAR_H
 #  endif // _LIBCUDACXX_HAS_NO_WCHAR_H
 
-#  ifndef _LIBCUDACXX_NODEBUG_TYPE
-#    if defined(__cuda_std__)
-#      define _LIBCUDACXX_NODEBUG_TYPE
-#    elif _CCCL_HAS_ATTRIBUTE(__nodebug__) && (defined(_CCCL_COMPILER_CLANG) && _LIBCUDACXX_CLANG_VER >= 1210)
-#      define _LIBCUDACXX_NODEBUG_TYPE __attribute__((nodebug))
-#    else
-#      define _LIBCUDACXX_NODEBUG_TYPE
-#    endif
-#  endif // !_LIBCUDACXX_NODEBUG_TYPE
-
 #  define _LIBCUDACXX_CONCAT1(_LIBCUDACXX_X, _LIBCUDACXX_Y) _LIBCUDACXX_X##_LIBCUDACXX_Y
 #  define _LIBCUDACXX_CONCAT(_LIBCUDACXX_X, _LIBCUDACXX_Y)  _LIBCUDACXX_CONCAT1(_LIBCUDACXX_X, _LIBCUDACXX_Y)
 
@@ -907,13 +893,13 @@ __sanitizer_annotate_contiguous_container(const void*, const void*, const void*,
 // NVRTC has a bug that prevented the use of delegated constructors, as it did not accept execution space annotations.
 // This creates a whole lot of boilerplate that we can avoid through a macro (see nvbug3961621)
 #  if defined(_CCCL_COMPILER_NVRTC) || (defined(_CCCL_CUDACC_BELOW_11_3) && defined(_CCCL_COMPILER_CLANG))
-#    define _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__class, __baseclass, ...)                                 \
-      using __base = __baseclass<__VA_ARGS__>;                                                           \
-      template <class... _Args, __enable_if_t<_CCCL_TRAIT(is_constructible, __base, _Args...), int> = 0> \
-      _LIBCUDACXX_HIDE_FROM_ABI constexpr __class(_Args&&... __args) noexcept(                           \
-        _CCCL_TRAIT(is_nothrow_constructible, __base, _Args...))                                         \
-          : __base(_CUDA_VSTD::forward<_Args>(__args)...)                                                \
-      {}                                                                                                 \
+#    define _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__class, __baseclass, ...)                               \
+      using __base = __baseclass<__VA_ARGS__>;                                                         \
+      template <class... _Args, enable_if_t<_CCCL_TRAIT(is_constructible, __base, _Args...), int> = 0> \
+      _LIBCUDACXX_HIDE_FROM_ABI constexpr __class(_Args&&... __args) noexcept(                         \
+        _CCCL_TRAIT(is_nothrow_constructible, __base, _Args...))                                       \
+          : __base(_CUDA_VSTD::forward<_Args>(__args)...)                                              \
+      {}                                                                                               \
       _CCCL_HIDE_FROM_ABI constexpr __class() noexcept = default;
 #  else // ^^^ _CCCL_COMPILER_NVRTC || nvcc < 11.3 ^^^ / vvv !_CCCL_COMPILER_NVRTC || nvcc >= 11.3 vvv
 #    define _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__class, __baseclass, ...) \

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
@@ -826,7 +826,7 @@ public:
 
 private:
   typedef typename _Engine::result_type _Engine_result_type;
-  typedef __conditional_t<sizeof(_Engine_result_type) <= sizeof(result_type), result_type, _Engine_result_type>
+  typedef conditional_t<sizeof(_Engine_result_type) <= sizeof(result_type), result_type, _Engine_result_type>
     _Working_result_type;
 
   _Engine& __e_;
@@ -1058,7 +1058,7 @@ template <class _URNG>
 typename uniform_int_distribution<_IntType>::result_type uniform_int_distribution<_IntType>::operator()(
   _URNG& __g, const param_type& __p) _LIBCUDACXX_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK
 {
-  typedef __conditional_t<sizeof(result_type) <= sizeof(uint32_t), uint32_t, uint64_t> _UIntType;
+  typedef conditional_t<sizeof(result_type) <= sizeof(uint32_t), uint32_t, uint64_t> _UIntType;
   const _UIntType _Rp = _UIntType(__p.b()) - _UIntType(__p.a()) + _UIntType(1);
   if (_Rp == 1)
   {
@@ -1256,7 +1256,7 @@ _CCCL_HOST_DEVICE _ForwardIterator __stable_partition(
   // recurse on [__first, __m), *__first know to be false
   // F?????????????????
   // f       m         l
-  typedef __add_lvalue_reference_t<_Predicate> _PredRef;
+  typedef add_lvalue_reference_t<_Predicate> _PredRef;
   _ForwardIterator __first_false = __stable_partition<_PredRef>(__first, __m, __pred, __len2, __p, __fit);
   // TTTFFFFF??????????
   // f  ff   m         l
@@ -1313,7 +1313,7 @@ __stable_partition(_ForwardIterator __first, _ForwardIterator __last, _Predicate
     __p = _CUDA_VSTD::get_temporary_buffer<value_type>(__len);
     __h.reset(__p.first);
   }
-  return __stable_partition<__add_lvalue_reference_t<_Predicate>>(
+  return __stable_partition<add_lvalue_reference_t<_Predicate>>(
     __first, __last, __pred, __len, __p, forward_iterator_tag());
 }
 
@@ -1406,7 +1406,7 @@ _CCCL_HOST_DEVICE _BidirectionalIterator __stable_partition(
   }
   // F???TFFF?????????T
   // f   m1  m        l
-  typedef __add_lvalue_reference_t<_Predicate> _PredRef;
+  typedef add_lvalue_reference_t<_Predicate> _PredRef;
   __first_false = __stable_partition<_PredRef>(__first, __m1, __pred, __len_half, __p, __bit);
 __first_half_done:
   // TTTFFFFF?????????T
@@ -1476,7 +1476,7 @@ _CCCL_HOST_DEVICE _BidirectionalIterator __stable_partition(
     __p = _CUDA_VSTD::get_temporary_buffer<value_type>(__len);
     __h.reset(__p.first);
   }
-  return __stable_partition<__add_lvalue_reference_t<_Predicate>>(
+  return __stable_partition<add_lvalue_reference_t<_Predicate>>(
     __first, __last, __pred, __len, __p, bidirectional_iterator_tag());
 }
 
@@ -1484,7 +1484,7 @@ template <class _ForwardIterator, class _Predicate>
 _LIBCUDACXX_HIDE_FROM_ABI _ForwardIterator
 stable_partition(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
-  return __stable_partition<__add_lvalue_reference_t<_Predicate>>(
+  return __stable_partition<add_lvalue_reference_t<_Predicate>>(
     __first, __last, __pred, typename iterator_traits<_ForwardIterator>::iterator_category());
 }
 
@@ -1596,7 +1596,7 @@ _CCCL_HOST_DEVICE void __selection_sort(_BirdirectionalIterator __first, _Birdir
   for (--__lm1; __first != __lm1; ++__first)
   {
     _BirdirectionalIterator __i =
-      _CUDA_VSTD::min_element<_BirdirectionalIterator, __add_lvalue_reference_t<_Compare>>(__first, __last, __comp);
+      _CUDA_VSTD::min_element<_BirdirectionalIterator, add_lvalue_reference_t<_Compare>>(__first, __last, __comp);
     if (__i != __first)
     {
       swap(*__first, *__i);
@@ -1979,7 +1979,7 @@ _LIBCUDACXX_HIDE_FROM_ABI void sort(__wrap_iter<_Tp*> __first, __wrap_iter<_Tp*>
 template <class _Tp, class _Compare>
 _LIBCUDACXX_HIDE_FROM_ABI void sort(__wrap_iter<_Tp*> __first, __wrap_iter<_Tp*> __last, _Compare __comp)
 {
-  typedef __add_lvalue_reference_t<_Compare> _Comp_ref;
+  typedef add_lvalue_reference_t<_Compare> _Comp_ref;
   _CUDA_VSTD::sort<_Tp*, _Comp_ref>(__first.base(), __last.base(), __comp);
 }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/array
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/array
@@ -334,7 +334,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT array<_Tp, 0>
   typedef _CUDA_VSTD::reverse_iterator<iterator> reverse_iterator;
   typedef _CUDA_VSTD::reverse_iterator<const_iterator> const_reverse_iterator;
 
-  typedef __conditional_t<is_const<_Tp>::value, const char, char> _CharType;
+  typedef conditional_t<is_const<_Tp>::value, const char, char> _CharType;
 
   struct _ArrayInStructT
   {
@@ -488,7 +488,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT array<_Tp, 0>
 };
 
 #if _CCCL_STD_VER >= 2017
-template <class _Tp, class... _Args, class = __enable_if_t<(is_same_v<_Tp, _Args> && ...)>>
+template <class _Tp, class... _Args, class = enable_if_t<(is_same_v<_Tp, _Args> && ...)>>
 _CCCL_HOST_DEVICE array(_Tp, _Args...) -> array<_Tp, 1 + sizeof...(_Args)>;
 #endif // _CCCL_STD_VER >= 2017
 
@@ -535,7 +535,7 @@ operator>=(const array<_Tp, _Size>& __x, const array<_Tp, _Size>& __y)
 }
 
 template <class _Tp, size_t _Size>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __enable_if_t<_Size == 0 || __is_swappable<_Tp>::value, void>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<_Size == 0 || __is_swappable<_Tp>::value, void>
 swap(array<_Tp, _Size>& __x, array<_Tp, _Size>& __y) noexcept(noexcept(__x.swap(__y)))
 {
   __x.swap(__y);

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -966,7 +966,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, false, false>
 };
 
 template <class _ToDuration, class _Rep, class _Period>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__is_duration<_ToDuration>::value, _ToDuration>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__is_duration<_ToDuration>::value, _ToDuration>
 duration_cast(const duration<_Rep, _Period>& __fd)
 {
   return __duration_cast<duration<_Rep, _Period>, _ToDuration>()(__fd);
@@ -1001,7 +1001,7 @@ public:
 
 #if _CCCL_STD_VER > 2011
 template <class _ToDuration, class _Rep, class _Period>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __enable_if_t<__is_duration<_ToDuration>::value, _ToDuration>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<__is_duration<_ToDuration>::value, _ToDuration>
 floor(const duration<_Rep, _Period>& __d)
 {
   _ToDuration __t = duration_cast<_ToDuration>(__d);
@@ -1013,7 +1013,7 @@ floor(const duration<_Rep, _Period>& __d)
 }
 
 template <class _ToDuration, class _Rep, class _Period>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __enable_if_t<__is_duration<_ToDuration>::value, _ToDuration>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<__is_duration<_ToDuration>::value, _ToDuration>
 ceil(const duration<_Rep, _Period>& __d)
 {
   _ToDuration __t = duration_cast<_ToDuration>(__d);
@@ -1025,7 +1025,7 @@ ceil(const duration<_Rep, _Period>& __d)
 }
 
 template <class _ToDuration, class _Rep, class _Period>
-_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __enable_if_t<__is_duration<_ToDuration>::value, _ToDuration>
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<__is_duration<_ToDuration>::value, _ToDuration>
 round(const duration<_Rep, _Period>& __d)
 {
   _ToDuration __lower = floor<_ToDuration>(__d);
@@ -1095,8 +1095,8 @@ public:
   template <class _Rep2>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit duration(
     const _Rep2& __r,
-    __enable_if_t<is_convertible<_Rep2, rep>::value
-                  && (treat_as_floating_point<rep>::value || !treat_as_floating_point<_Rep2>::value)>* = 0)
+    enable_if_t<is_convertible<_Rep2, rep>::value
+                && (treat_as_floating_point<rep>::value || !treat_as_floating_point<_Rep2>::value)>* = 0)
       : __rep_(static_cast<rep>(__r))
   {}
 
@@ -1104,9 +1104,9 @@ public:
   template <class _Rep2, class _Period2>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr duration(
     const duration<_Rep2, _Period2>& __d,
-    __enable_if_t<__no_overflow<_Period2, period>::value
-                  && (treat_as_floating_point<rep>::value
-                      || (__no_overflow<_Period2, period>::type::den == 1 && !treat_as_floating_point<_Rep2>::value))>* =
+    enable_if_t<__no_overflow<_Period2, period>::value
+                && (treat_as_floating_point<rep>::value
+                    || (__no_overflow<_Period2, period>::type::den == 1 && !treat_as_floating_point<_Rep2>::value))>* =
       0)
       : __rep_(_CUDA_VSTD::chrono::duration_cast<duration>(__d).count())
   {}
@@ -1322,8 +1322,8 @@ operator-(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 // Duration *
 
 template <class _Rep1, class _Period, class _Rep2>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_convertible<_Rep2, typename common_type<_Rep1, _Rep2>::type>::value,
-                                                  duration<typename common_type<_Rep1, _Rep2>::type, _Period>>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_convertible<_Rep2, typename common_type<_Rep1, _Rep2>::type>::value,
+                                                duration<typename common_type<_Rep1, _Rep2>::type, _Period>>
 operator*(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
 {
   typedef typename common_type<_Rep1, _Rep2>::type _Cr;
@@ -1332,8 +1332,8 @@ operator*(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
 }
 
 template <class _Rep1, class _Period, class _Rep2>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_convertible<_Rep1, typename common_type<_Rep1, _Rep2>::type>::value,
-                                                  duration<typename common_type<_Rep1, _Rep2>::type, _Period>>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_convertible<_Rep1, typename common_type<_Rep1, _Rep2>::type>::value,
+                                                duration<typename common_type<_Rep1, _Rep2>::type, _Period>>
 operator*(const _Rep1& __s, const duration<_Rep2, _Period>& __d)
 {
   return __d * __s;
@@ -1342,7 +1342,7 @@ operator*(const _Rep1& __s, const duration<_Rep2, _Period>& __d)
 // Duration /
 
 template <class _Rep1, class _Period, class _Rep2>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   !__is_duration<_Rep2>::value && is_convertible<_Rep2, typename common_type<_Rep1, _Rep2>::type>::value,
   duration<typename common_type<_Rep1, _Rep2>::type, _Period>>
 operator/(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
@@ -1363,7 +1363,7 @@ operator/(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 // Duration %
 
 template <class _Rep1, class _Period, class _Rep2>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   !__is_duration<_Rep2>::value && is_convertible<_Rep2, typename common_type<_Rep1, _Rep2>::type>::value,
   duration<typename common_type<_Rep1, _Rep2>::type, _Period>>
 operator%(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
@@ -1412,7 +1412,7 @@ public:
   // conversions
   template <class _Duration2>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14
-  time_point(const time_point<clock, _Duration2>& t, __enable_if_t<is_convertible<_Duration2, duration>::value>* = 0)
+  time_point(const time_point<clock, _Duration2>& t, enable_if_t<is_convertible<_Duration2, duration>::value>* = 0)
       : __d_(t.time_since_epoch())
   {}
 
@@ -1469,28 +1469,28 @@ time_point_cast(const time_point<_Clock, _Duration>& __t)
 
 #if _CCCL_STD_VER > 2011
 template <class _ToDuration, class _Clock, class _Duration>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__is_duration<_ToDuration>::value, time_point<_Clock, _ToDuration>>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__is_duration<_ToDuration>::value, time_point<_Clock, _ToDuration>>
 floor(const time_point<_Clock, _Duration>& __t)
 {
   return time_point<_Clock, _ToDuration>{floor<_ToDuration>(__t.time_since_epoch())};
 }
 
 template <class _ToDuration, class _Clock, class _Duration>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__is_duration<_ToDuration>::value, time_point<_Clock, _ToDuration>>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__is_duration<_ToDuration>::value, time_point<_Clock, _ToDuration>>
 ceil(const time_point<_Clock, _Duration>& __t)
 {
   return time_point<_Clock, _ToDuration>{ceil<_ToDuration>(__t.time_since_epoch())};
 }
 
 template <class _ToDuration, class _Clock, class _Duration>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<__is_duration<_ToDuration>::value, time_point<_Clock, _ToDuration>>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<__is_duration<_ToDuration>::value, time_point<_Clock, _ToDuration>>
 round(const time_point<_Clock, _Duration>& __t)
 {
   return time_point<_Clock, _ToDuration>{round<_ToDuration>(__t.time_since_epoch())};
 }
 
 template <class _Rep, class _Period>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<numeric_limits<_Rep>::is_signed, duration<_Rep, _Period>>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<numeric_limits<_Rep>::is_signed, duration<_Rep, _Period>>
 abs(duration<_Rep, _Period> __d)
 {
   return __d >= __d.zero() ? +__d : -__d;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -602,8 +602,8 @@ _LIBCUDACXX_HIDE_FROM_ABI long double hypot(long double x, long double y, long d
 
 template <class _A1, class _A2, class _A3>
 _LIBCUDACXX_HIDE_FROM_ABI
-__enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value && is_arithmetic<_A3>::value,
-              __promote_t<_A1, _A2, _A3>>
+enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value && is_arithmetic<_A3>::value,
+            __promote_t<_A1, _A2, _A3>>
 hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) noexcept
 {
   using __result_type = __promote_t<_A1, _A2, _A3>;
@@ -621,7 +621,7 @@ hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) noexcept
 #endif // _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
 
 template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_floating_point<_A1>::value, bool>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isnan(_A1 __lcpp_x) noexcept
 {
 #if defined(_CCCL_CUDACC_BELOW_11_8)
@@ -635,14 +635,14 @@ __constexpr_isnan(_A1 __lcpp_x) noexcept
 }
 
 template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<!is_floating_point<_A1>::value, bool>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<!is_floating_point<_A1>::value, bool>
 __constexpr_isnan(_A1 __lcpp_x) noexcept
 {
   return ::isnan(__lcpp_x);
 }
 
 template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_floating_point<_A1>::value, bool>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isinf(_A1 __lcpp_x) noexcept
 {
 #if defined(_CCCL_CUDACC_BELOW_11_8)
@@ -656,14 +656,14 @@ __constexpr_isinf(_A1 __lcpp_x) noexcept
 }
 
 template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<!is_floating_point<_A1>::value, bool>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<!is_floating_point<_A1>::value, bool>
 __constexpr_isinf(_A1 __lcpp_x) noexcept
 {
   return ::isinf(__lcpp_x);
 }
 
 template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_floating_point<_A1>::value, bool>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isfinite(_A1 __lcpp_x) noexcept
 {
 #if defined(_CCCL_CUDACC_BELOW_11_8)
@@ -677,7 +677,7 @@ __constexpr_isfinite(_A1 __lcpp_x) noexcept
 }
 
 template <class _A1>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<!is_floating_point<_A1>::value, bool>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<!is_floating_point<_A1>::value, bool>
 __constexpr_isfinite(_A1 __lcpp_x) noexcept
 {
   return isfinite(__lcpp_x);
@@ -708,7 +708,7 @@ __constexpr_copysign(long double __x, long double __y) noexcept
 
 template <class _A1, class _A2>
 _LIBCUDACXX_HIDE_FROM_ABI
-_CCCL_CONSTEXPR_CXX14 __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, __promote_t<_A1, _A2>>
+_CCCL_CONSTEXPR_CXX14 enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, __promote_t<_A1, _A2>>
 __constexpr_copysign(_A1 __x, _A2 __y) noexcept
 {
   using __result_type = __promote_t<_A1, _A2>;
@@ -739,7 +739,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 long double __constexpr_fabs(lon
   return __builtin_fabsl(__x);
 }
 
-template <class _Tp, __enable_if_t<is_integral<_Tp>::value, int> = 0>
+template <class _Tp, enable_if_t<is_integral<_Tp>::value, int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 double __constexpr_fabs(_Tp __x) noexcept
 {
   return __builtin_fabs(static_cast<double>(__x));
@@ -823,7 +823,7 @@ __constexpr_fmax(long double __x, long double __y) noexcept
   return __builtin_fmax(__x, __y);
 }
 
-template <class _Tp, class _Up, __enable_if_t<is_arithmetic<_Tp>::value && is_arithmetic<_Up>::value, int> = 0>
+template <class _Tp, class _Up, enable_if_t<is_arithmetic<_Tp>::value && is_arithmetic<_Up>::value, int> = 0>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14_COMPLEX __promote_t<_Tp, _Up> __constexpr_fmax(_Tp __x, _Up __y) noexcept
 {
   using __result_type = __promote_t<_Tp, _Up>;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -295,15 +295,15 @@ public:
       , __im_(__im)
   {}
 
-  template <class _Up, __enable_if_t<__cccl_internal::__is_non_narrowing_convertible<_Tp, _Up>::value, int> = 0>
+  template <class _Up, enable_if_t<__cccl_internal::__is_non_narrowing_convertible<_Tp, _Up>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr complex(const complex<_Up>& __c)
       : __re_(static_cast<_Tp>(__c.real()))
       , __im_(static_cast<_Tp>(__c.imag()))
   {}
 
   template <class _Up,
-            __enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<_Tp, _Up>::value, int> = 0,
-            __enable_if_t<_CCCL_TRAIT(is_constructible, _Tp, _Up), int>                           = 0>
+            enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<_Tp, _Up>::value, int> = 0,
+            enable_if_t<_CCCL_TRAIT(is_constructible, _Tp, _Up), int>                           = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr complex(const complex<_Up>& __c)
       : __re_(static_cast<_Tp>(__c.real()))
       , __im_(static_cast<_Tp>(__c.imag()))
@@ -898,21 +898,21 @@ _LIBCUDACXX_HIDE_FROM_ABI _Tp arg(const complex<_Tp>& __c)
 
 #ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_same<_Tp, long double>::value, long double> arg(_Tp __re)
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_same<_Tp, long double>::value, long double> arg(_Tp __re)
 {
   return _CUDA_VSTD::atan2l(0.L, __re);
 }
 #endif // _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value || is_same<_Tp, double>::value, double> arg(_Tp __re)
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value || is_same<_Tp, double>::value, double> arg(_Tp __re)
 {
   // integrals need to be promoted to double
   return _CUDA_VSTD::atan2(0., static_cast<double>(__re));
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_same<_Tp, float>::value, float> arg(_Tp __re)
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_same<_Tp, float>::value, float> arg(_Tp __re)
 {
   return _CUDA_VSTD::atan2f(0.F, __re);
 }
@@ -967,8 +967,7 @@ _LIBCUDACXX_HIDE_FROM_ABI complex<_Tp> proj(const complex<_Tp>& __c)
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<__is_complex_float<_Tp>::value, __libcpp_complex_complex_type<_Tp>>
-proj(_Tp __re)
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<__is_complex_float<_Tp>::value, __libcpp_complex_complex_type<_Tp>> proj(_Tp __re)
 {
   if (_CUDA_VSTD::__constexpr_isinf(__re))
   {
@@ -978,7 +977,7 @@ proj(_Tp __re)
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<is_integral<_Tp>::value, __libcpp_complex_complex_type<_Tp>> proj(_Tp __re)
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_integral<_Tp>::value, __libcpp_complex_complex_type<_Tp>> proj(_Tp __re)
 {
   return __libcpp_complex_complex_type<_Tp>(__re);
 }
@@ -1103,23 +1102,23 @@ _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_MSVC(4244)
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI complex<__common_type_t<_Tp, _Up>> pow(const complex<_Tp>& __x, const complex<_Up>& __y)
+_LIBCUDACXX_HIDE_FROM_ABI complex<common_type_t<_Tp, _Up>> pow(const complex<_Tp>& __x, const complex<_Up>& __y)
 {
-  using __result_type = complex<__common_type_t<_Tp, _Up>>;
+  using __result_type = complex<common_type_t<_Tp, _Up>>;
   return _CUDA_VSTD::pow(__result_type(__x), __result_type(__y));
 }
 
-template <class _Tp, class _Up, __enable_if_t<!__is_complex<_Up>::value, int> = 0>
-_LIBCUDACXX_HIDE_FROM_ABI complex<__common_type_t<_Tp, _Up>> pow(const complex<_Tp>& __x, const _Up& __y)
+template <class _Tp, class _Up, enable_if_t<!__is_complex<_Up>::value, int> = 0>
+_LIBCUDACXX_HIDE_FROM_ABI complex<common_type_t<_Tp, _Up>> pow(const complex<_Tp>& __x, const _Up& __y)
 {
-  using __result_type = complex<__common_type_t<_Tp, _Up>>;
+  using __result_type = complex<common_type_t<_Tp, _Up>>;
   return _CUDA_VSTD::pow(__result_type(__x), __result_type(__y));
 }
 
-template <class _Tp, class _Up, __enable_if_t<!__is_complex<_Tp>::value, int> = 0>
-_LIBCUDACXX_HIDE_FROM_ABI complex<__common_type_t<_Tp, _Up>> pow(const _Tp& __x, const complex<_Up>& __y)
+template <class _Tp, class _Up, enable_if_t<!__is_complex<_Tp>::value, int> = 0>
+_LIBCUDACXX_HIDE_FROM_ABI complex<common_type_t<_Tp, _Up>> pow(const _Tp& __x, const complex<_Up>& __y)
 {
-  using __result_type = complex<__common_type_t<_Tp, _Up>>;
+  using __result_type = complex<common_type_t<_Tp, _Up>>;
   return _CUDA_VSTD::pow(__result_type(__x, 0), __result_type(__y));
 }
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cstddef
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cstddef
@@ -115,35 +115,35 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr byte operator~(byte __b) noexcept
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_integral_v<_Integer>, byte>&
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, byte>&
 operator<<=(byte& __lhs, _Integer __shift) noexcept
 {
   return __lhs = __lhs << __shift;
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_integral_v<_Integer>, byte>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, byte>
 operator<<(byte __lhs, _Integer __shift) noexcept
 {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) << __shift));
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_integral_v<_Integer>, byte>&
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, byte>&
 operator>>=(byte& __lhs, _Integer __shift) noexcept
 {
   return __lhs = __lhs >> __shift;
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_integral_v<_Integer>, byte>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, byte>
 operator>>(byte __lhs, _Integer __shift) noexcept
 {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) >> __shift));
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<is_integral_v<_Integer>, _Integer> to_integer(byte __b) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, _Integer> to_integer(byte __b) noexcept
 {
   return static_cast<_Integer>(__b);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/limits
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/limits
@@ -634,9 +634,9 @@ protected:
 };
 
 template <class _Tp>
-class _CCCL_TYPE_VISIBILITY_DEFAULT numeric_limits : private __libcpp_numeric_limits<__remove_cv_t<_Tp>>
+class _CCCL_TYPE_VISIBILITY_DEFAULT numeric_limits : private __libcpp_numeric_limits<remove_cv_t<_Tp>>
 {
-  typedef __libcpp_numeric_limits<__remove_cv_t<_Tp>> __base;
+  typedef __libcpp_numeric_limits<remove_cv_t<_Tp>> __base;
   typedef typename __base::type type;
 
 public:

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -278,7 +278,7 @@ struct __optional_destruct_base<_Tp, false>
   union
   {
     char __null_state_;
-    __remove_cv_t<value_type> __val_;
+    remove_cv_t<value_type> __val_;
   };
   bool __engaged_;
 
@@ -329,7 +329,7 @@ struct __optional_destruct_base<_Tp, true>
   union
   {
     char __null_state_;
-    __remove_cv_t<value_type> __val_;
+    remove_cv_t<value_type> __val_;
   };
   bool __engaged_;
 
@@ -642,8 +642,7 @@ _CCCL_INLINE_VAR constexpr bool __opt_is_explictly_constructible =
 
 template <class _Tp, class _Up>
 _CCCL_INLINE_VAR constexpr bool __opt_is_constructible_from_U =
-  !_CCCL_TRAIT(is_same, __remove_cvref_t<_Up>, in_place_t)
-  && !_CCCL_TRAIT(is_same, __remove_cvref_t<_Up>, optional<_Tp>);
+  !_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, in_place_t) && !_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, optional<_Tp>);
 
 template <class _Tp, class _Up>
 _CCCL_INLINE_VAR constexpr bool __opt_is_constructible_from_opt =
@@ -655,8 +654,8 @@ _CCCL_INLINE_VAR constexpr bool __opt_is_assignable =
 
 template <class _Tp, class _Up>
 _CCCL_INLINE_VAR constexpr bool __opt_is_assignable_from_U =
-  !_CCCL_TRAIT(is_same, __remove_cvref_t<_Up>, optional<_Tp>)
-  && (!_CCCL_TRAIT(is_same, __remove_cvref_t<_Up>, _Tp) || !_CCCL_TRAIT(is_scalar, _Tp));
+  !_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, optional<_Tp>)
+  && (!_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, _Tp) || !_CCCL_TRAIT(is_scalar, _Tp));
 
 template <class _Tp, class _Up>
 _CCCL_INLINE_VAR constexpr bool __opt_is_assignable_from_opt =
@@ -676,9 +675,9 @@ public:
 
 private:
   // Disable the reference extension using this static assert.
-  static_assert(!_CCCL_TRAIT(is_same, __remove_cvref_t<value_type>, in_place_t),
+  static_assert(!_CCCL_TRAIT(is_same, remove_cvref_t<value_type>, in_place_t),
                 "instantiation of optional with in_place_t is ill-formed");
-  static_assert(!_CCCL_TRAIT(is_same, __remove_cvref_t<value_type>, nullopt_t),
+  static_assert(!_CCCL_TRAIT(is_same, remove_cvref_t<value_type>, nullopt_t),
                 "instantiation of optional with nullopt_t is ill-formed");
   static_assert(!_CCCL_TRAIT(is_reference, value_type),
                 "instantiation of optional with a reference type is ill-formed");
@@ -800,7 +799,7 @@ public:
     return *this;
   }
 
-  template <class... _Args, __enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Args...), int> = 0>
+  template <class... _Args, enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Args...), int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp& emplace(_Args&&... __args)
   {
     reset();
@@ -810,7 +809,7 @@ public:
 
   template <class _Up,
             class... _Args,
-            __enable_if_t<_CCCL_TRAIT(is_constructible, value_type, initializer_list<_Up>&, _Args...), int> = 0>
+            enable_if_t<_CCCL_TRAIT(is_constructible, value_type, initializer_list<_Up>&, _Args...), int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp& emplace(initializer_list<_Up> __il, _Args&&... __args)
   {
     reset();
@@ -1096,7 +1095,7 @@ _CCCL_HOST_DEVICE optional(_Tp) -> optional<_Tp>;
 
 // Comparisons between optionals
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() == declval<const _Up&>()), bool),
   bool>
 operator==(const optional<_Tp>& __x, const optional<_Up>& __y)
@@ -1113,7 +1112,7 @@ operator==(const optional<_Tp>& __x, const optional<_Up>& __y)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() != declval<const _Up&>()), bool),
   bool>
 operator!=(const optional<_Tp>& __x, const optional<_Up>& __y)
@@ -1130,7 +1129,7 @@ operator!=(const optional<_Tp>& __x, const optional<_Up>& __y)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() < declval<const _Up&>()), bool),
   bool>
 operator<(const optional<_Tp>& __x, const optional<_Up>& __y)
@@ -1147,7 +1146,7 @@ operator<(const optional<_Tp>& __x, const optional<_Up>& __y)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() > declval<const _Up&>()), bool),
   bool>
 operator>(const optional<_Tp>& __x, const optional<_Up>& __y)
@@ -1164,7 +1163,7 @@ operator>(const optional<_Tp>& __x, const optional<_Up>& __y)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() <= declval<const _Up&>()), bool),
   bool>
 operator<=(const optional<_Tp>& __x, const optional<_Up>& __y)
@@ -1181,7 +1180,7 @@ operator<=(const optional<_Tp>& __x, const optional<_Up>& __y)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() >= declval<const _Up&>()), bool),
   bool>
 operator>=(const optional<_Tp>& __x, const optional<_Up>& __y)
@@ -1272,7 +1271,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator>=(nullopt_t, const optional<_T
 
 // Comparisons with T
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() == declval<const _Up&>()), bool),
   bool>
 operator==(const optional<_Tp>& __x, const _Up& __v)
@@ -1281,7 +1280,7 @@ operator==(const optional<_Tp>& __x, const _Up& __v)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() == declval<const _Up&>()), bool),
   bool>
 operator==(const _Tp& __v, const optional<_Up>& __x)
@@ -1290,7 +1289,7 @@ operator==(const _Tp& __v, const optional<_Up>& __x)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() != declval<const _Up&>()), bool),
   bool>
 operator!=(const optional<_Tp>& __x, const _Up& __v)
@@ -1299,7 +1298,7 @@ operator!=(const optional<_Tp>& __x, const _Up& __v)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() != declval<const _Up&>()), bool),
   bool>
 operator!=(const _Tp& __v, const optional<_Up>& __x)
@@ -1308,7 +1307,7 @@ operator!=(const _Tp& __v, const optional<_Up>& __x)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() < declval<const _Up&>()), bool),
   bool>
 operator<(const optional<_Tp>& __x, const _Up& __v)
@@ -1317,7 +1316,7 @@ operator<(const optional<_Tp>& __x, const _Up& __v)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() < declval<const _Up&>()), bool),
   bool>
 operator<(const _Tp& __v, const optional<_Up>& __x)
@@ -1326,7 +1325,7 @@ operator<(const _Tp& __v, const optional<_Up>& __x)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() <= declval<const _Up&>()), bool),
   bool>
 operator<=(const optional<_Tp>& __x, const _Up& __v)
@@ -1335,7 +1334,7 @@ operator<=(const optional<_Tp>& __x, const _Up& __v)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() <= declval<const _Up&>()), bool),
   bool>
 operator<=(const _Tp& __v, const optional<_Up>& __x)
@@ -1344,7 +1343,7 @@ operator<=(const _Tp& __v, const optional<_Up>& __x)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() > declval<const _Up&>()), bool),
   bool>
 operator>(const optional<_Tp>& __x, const _Up& __v)
@@ -1353,7 +1352,7 @@ operator>(const optional<_Tp>& __x, const _Up& __v)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() > declval<const _Up&>()), bool),
   bool>
 operator>(const _Tp& __v, const optional<_Up>& __x)
@@ -1362,7 +1361,7 @@ operator>(const _Tp& __v, const optional<_Up>& __x)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() >= declval<const _Up&>()), bool),
   bool>
 operator>=(const optional<_Tp>& __x, const _Up& __v)
@@ -1371,7 +1370,7 @@ operator>=(const optional<_Tp>& __x, const _Up& __v)
 }
 
 template <class _Tp, class _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() >= declval<const _Up&>()), bool),
   bool>
 operator>=(const _Tp& __v, const optional<_Up>& __x)
@@ -1380,7 +1379,7 @@ operator>=(const _Tp& __v, const optional<_Up>& __x)
 }
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr __enable_if_t<
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   _CCCL_TRAIT(is_move_constructible, _Tp) && _CCCL_TRAIT(is_swappable, _Tp),
   void>
 swap(optional<_Tp>& __x, optional<_Tp>& __y) noexcept(noexcept(__x.swap(__y)))

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -211,7 +211,7 @@ enum class __tuple_leaf_specialization
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr __tuple_leaf_specialization __tuple_leaf_choose()
 {
-  return _CCCL_TRAIT(is_empty, _Tp) && !__libcpp_is_final<_Tp>::value ? __tuple_leaf_specialization::__empty_non_final
+  return _CCCL_TRAIT(is_empty, _Tp) && !_CCCL_TRAIT(is_final, _Tp) ? __tuple_leaf_specialization::__empty_non_final
        : __must_synthesize_assignment<_Tp>::value
          ? __tuple_leaf_specialization::__synthesize_assignment
          : __tuple_leaf_specialization::__default;
@@ -271,9 +271,9 @@ public:
   {}
 
   template <class _Tp>
-  using __can_forward = _And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp>>;
+  using __can_forward = _And<_IsNotSame<remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp>>;
 
-  template <class _Tp, __enable_if_t<__can_forward<_Tp>::value, int> = 0>
+  template <class _Tp, enable_if_t<__can_forward<_Tp>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI
   _CCCL_CONSTEXPR_CXX14 explicit __tuple_leaf(_Tp&& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Hp, _Tp))
       : __value_(_CUDA_VSTD::forward<_Tp>(__t))
@@ -340,9 +340,9 @@ public:
   }
 
   template <class _Tp>
-  using __can_forward = _And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp>>;
+  using __can_forward = _And<_IsNotSame<remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp>>;
 
-  template <class _Tp, __enable_if_t<__can_forward<_Tp>::value, int> = 0>
+  template <class _Tp, enable_if_t<__can_forward<_Tp>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI
   _CCCL_CONSTEXPR_CXX14 explicit __tuple_leaf(_Tp&& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Hp, _Tp))
       : __value_(_CUDA_VSTD::forward<_Tp>(__t))
@@ -424,9 +424,9 @@ public:
   {}
 
   template <class _Tp>
-  using __can_forward = _And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp>>;
+  using __can_forward = _And<_IsNotSame<remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp>>;
 
-  template <class _Tp, __enable_if_t<__can_forward<_Tp>::value, int> = 0>
+  template <class _Tp, enable_if_t<__can_forward<_Tp>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI
   _CCCL_CONSTEXPR_CXX14 explicit __tuple_leaf(_Tp&& __t) noexcept((is_nothrow_constructible<_Hp, _Tp>::value))
       : _Hp(_CUDA_VSTD::forward<_Tp>(__t))
@@ -447,7 +447,7 @@ public:
       : _Hp(_CUDA_VSTD::forward<_Tp>(__t), __a)
   {}
 
-  template <class _Tp, __enable_if_t<_CCCL_TRAIT(is_assignable, _Hp&, const _Tp&), int> = 0>
+  template <class _Tp, enable_if_t<_CCCL_TRAIT(is_assignable, _Hp&, const _Tp&), int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI __tuple_leaf&
   operator=(const _Tp& __t) noexcept(_CCCL_TRAIT(is_nothrow_assignable, _Hp&, const _Tp&))
   {
@@ -455,7 +455,7 @@ public:
     return *this;
   }
 
-  template <class _Tp, __enable_if_t<_CCCL_TRAIT(is_assignable, _Hp&, _Tp), int> = 0>
+  template <class _Tp, enable_if_t<_CCCL_TRAIT(is_assignable, _Hp&, _Tp), int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI __tuple_leaf& operator=(_Tp&& __t) noexcept(_CCCL_TRAIT(is_nothrow_assignable, _Hp&, _Tp))
   {
     _Hp::operator=(_CUDA_VSTD::forward<_Tp>(__t));
@@ -515,7 +515,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
   // Handle non-allocator, full initialization
   // Old MSVC cannot handle the noexept specifier outside of template arguments
   template <class... _Up,
-            __enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0,
+            enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0,
             bool __all_nothrow_constructible = __all<_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up)...>::value>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 explicit __tuple_impl(
     __tuple_variadic_constructor_tag, _Up&&... __u) noexcept(__all_nothrow_constructible)
@@ -524,7 +524,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
 
   // Handle non-allocator, partial default initialization
   // Recursively delegate until we have full rank
-  template <class... _Up, __enable_if_t<sizeof...(_Up) < sizeof...(_Tp), int> = 0>
+  template <class... _Up, enable_if_t<sizeof...(_Up) < sizeof...(_Tp), int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI
   _CCCL_CONSTEXPR_CXX14 explicit __tuple_impl(__tuple_variadic_constructor_tag __tag, _Up&&... __u) noexcept(
     noexcept(__tuple_impl(__tag, _CUDA_VSTD::forward<_Up>(__u)..., __tuple_leaf_default_constructor_tag{})))
@@ -532,7 +532,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
   {}
 
   // Handle allocator aware, full initialization
-  template <class _Alloc, class... _Up, __enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0>
+  template <class _Alloc, class... _Up, enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit __tuple_impl(
     allocator_arg_t, const _Alloc& __a, __tuple_variadic_constructor_tag, _Up&&... __u)
       : __tuple_leaf<_Indx, _Tp>(__uses_alloc_ctor<_Tp, _Alloc, _Up>(), __a, _CUDA_VSTD::forward<_Up>(__u))...
@@ -547,20 +547,20 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, 
   template <class _Tuple, size_t _Indx2>
   using __tuple_elem_at = __tuple_element_t<_Indx2, __make_tuple_types_t<_Tuple>>;
 
-  template <class _Tuple, __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value, int> = 0>
+  template <class _Tuple, enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __tuple_impl(_Tuple&& __t) noexcept(
     (__all<_CCCL_TRAIT(is_nothrow_constructible, _Tp, __tuple_elem_at<_Tuple, _Indx>)...>::value))
       : __tuple_leaf<_Indx, _Tp>(_CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(_CUDA_VSTD::get<_Indx>(__t)))...
   {}
 
-  template <class _Alloc, class _Tuple, __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value, int> = 0>
+  template <class _Alloc, class _Tuple, enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI __tuple_impl(allocator_arg_t, const _Alloc& __a, _Tuple&& __t)
       : __tuple_leaf<_Indx, _Tp>(__uses_alloc_ctor<_Tp, _Alloc, __tuple_elem_at<_Tuple, _Indx>>(),
                                  __a,
                                  _CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(_CUDA_VSTD::get<_Indx>(__t)))...
   {}
 
-  template <class _Tuple, __enable_if_t<__tuple_assignable<_Tuple, tuple<_Tp...>>::value, int> = 0>
+  template <class _Tuple, enable_if_t<__tuple_assignable<_Tuple, tuple<_Tp...>>::value, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI __tuple_impl& operator=(_Tuple&& __t) noexcept(
     (__all<_CCCL_TRAIT(is_nothrow_assignable, _Tp&, __tuple_elem_at<_Tuple, _Indx>)...>::value))
   {
@@ -615,7 +615,7 @@ struct __tuple_constraints
   {};
 
   template <class _Arg>
-  struct _PackExpandsToThisTuple<_Arg> : is_same<__remove_cvref_t<_Arg>, tuple<_Tp...>>
+  struct _PackExpandsToThisTuple<_Arg> : is_same<remove_cvref_t<_Arg>, tuple<_Tp...>>
   {};
 
   template <class... _Args>
@@ -664,7 +664,7 @@ struct __tuple_constraints
         : _Or<
             // Don't attempt the two checks below if the tuple we are given
             // has the same type as this tuple.
-            _IsSame<__remove_cvref_t<_Tuple2>, tuple<_Tp...>>,
+            _IsSame<remove_cvref_t<_Tuple2>, tuple<_Tp...>>,
             _Lazy<_And, _Not<is_constructible<_Tp..., _Tuple2>>, _Not<is_convertible<_Tuple2, _Tp...>>>>
     {};
 
@@ -700,45 +700,45 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT tuple
   {};
 
   template <class _Arg>
-  struct _PackExpandsToThisTuple<_Arg> : is_same<__remove_cvref_t<_Arg>, tuple>
+  struct _PackExpandsToThisTuple<_Arg> : is_same<remove_cvref_t<_Arg>, tuple>
   {};
 
 public:
   template <size_t _Ip>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __tuple_element_t<_Ip, tuple>& __get_impl() & noexcept
   {
-    typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_element_t<_Ip, tuple> type;
+    typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, tuple> type;
     return static_cast<__tuple_leaf<_Ip, type>&>(__base_).get();
   }
 
   template <size_t _Ip>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 const __tuple_element_t<_Ip, tuple>& __get_impl() const& noexcept
   {
-    typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_element_t<_Ip, tuple> type;
+    typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, tuple> type;
     return static_cast<const __tuple_leaf<_Ip, type>&>(__base_).get();
   }
 
   template <size_t _Ip>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __tuple_element_t<_Ip, tuple>&& __get_impl() && noexcept
   {
-    typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_element_t<_Ip, tuple> type;
+    typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, tuple> type;
     return static_cast<type&&>(static_cast<__tuple_leaf<_Ip, type>&&>(__base_).get());
   }
 
   template <size_t _Ip>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 const __tuple_element_t<_Ip, tuple>&& __get_impl() const&& noexcept
   {
-    typedef _LIBCUDACXX_NODEBUG_TYPE __tuple_element_t<_Ip, tuple> type;
+    typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, tuple> type;
     return static_cast<const type&&>(static_cast<const __tuple_leaf<_Ip, type>&&>(__base_).get());
   }
 
-  template <class _Constraints                                                 = __tuple_constraints<_Tp...>,
-            __enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
+  template <class _Constraints                                               = __tuple_constraints<_Tp...>,
+            enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr tuple() noexcept(_Constraints::__nothrow_default_constructible)
   {}
 
-  template <class _Constraints                                                 = __tuple_constraints<_Tp...>,
-            __enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
+  template <class _Constraints                                               = __tuple_constraints<_Tp...>,
+            enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr tuple() noexcept(_Constraints::__nothrow_default_constructible)
   {}
 
@@ -747,48 +747,48 @@ public:
 
   template <class _AllocArgT,
             class _Alloc,
-            class _Constraints                                                    = __tuple_constraints<_Tp...>,
-            __enable_if_t<_CCCL_TRAIT(is_same, allocator_arg_t, _AllocArgT), int> = 0,
-            __enable_if_t<_Constraints::__implicit_default_constructible, int>    = 0>
+            class _Constraints                                                  = __tuple_constraints<_Tp...>,
+            enable_if_t<_CCCL_TRAIT(is_same, allocator_arg_t, _AllocArgT), int> = 0,
+            enable_if_t<_Constraints::__implicit_default_constructible, int>    = 0>
   _LIBCUDACXX_HIDE_FROM_ABI tuple(_AllocArgT, _Alloc const& __a) noexcept(_Constraints::__nothrow_default_constructible)
       : __base_(allocator_arg_t(), __a)
   {}
 
   template <class _AllocArgT,
             class _Alloc,
-            class _Constraints                                                    = __tuple_constraints<_Tp...>,
-            __enable_if_t<_CCCL_TRAIT(is_same, allocator_arg_t, _AllocArgT), int> = 0,
-            __enable_if_t<_Constraints::__explicit_default_constructible, int>    = 0>
+            class _Constraints                                                  = __tuple_constraints<_Tp...>,
+            enable_if_t<_CCCL_TRAIT(is_same, allocator_arg_t, _AllocArgT), int> = 0,
+            enable_if_t<_Constraints::__explicit_default_constructible, int>    = 0>
   explicit _LIBCUDACXX_HIDE_FROM_ABI
   tuple(_AllocArgT, _Alloc const& __a) noexcept(_Constraints::__nothrow_default_constructible)
       : __base_(allocator_arg_t(), __a)
   {}
 
-  template <class _Constraints                                                       = __tuple_constraints<_Tp...>,
-            __enable_if_t<_Constraints::__implicit_variadic_copy_constructible, int> = 0>
+  template <class _Constraints                                                     = __tuple_constraints<_Tp...>,
+            enable_if_t<_Constraints::__implicit_variadic_copy_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14
   tuple(const _Tp&... __t) noexcept(_Constraints::__nothrow_variadic_copy_constructible)
       : __base_(__tuple_variadic_constructor_tag{}, __t...)
   {}
 
-  template <class _Constraints                                                       = __tuple_constraints<_Tp...>,
-            __enable_if_t<_Constraints::__explicit_variadic_copy_constructible, int> = 0>
+  template <class _Constraints                                                     = __tuple_constraints<_Tp...>,
+            enable_if_t<_Constraints::__explicit_variadic_copy_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI
   _CCCL_CONSTEXPR_CXX14 explicit tuple(const _Tp&... __t) noexcept(_Constraints::__nothrow_variadic_copy_constructible)
       : __base_(__tuple_variadic_constructor_tag{}, __t...)
   {}
 
   template <class _Alloc,
-            class _Constraints                                                       = __tuple_constraints<_Tp...>,
-            __enable_if_t<_Constraints::__implicit_variadic_copy_constructible, int> = 0>
+            class _Constraints                                                     = __tuple_constraints<_Tp...>,
+            enable_if_t<_Constraints::__implicit_variadic_copy_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
     _Constraints::__nothrow_variadic_copy_constructible)
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, __t...)
   {}
 
   template <class _Alloc,
-            class _Constraints                                                       = __tuple_constraints<_Tp...>,
-            __enable_if_t<_Constraints::__explicit_variadic_copy_constructible, int> = 0>
+            class _Constraints                                                     = __tuple_constraints<_Tp...>,
+            enable_if_t<_Constraints::__explicit_variadic_copy_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t) noexcept(
     _Constraints::__nothrow_variadic_copy_constructible)
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, __t...)
@@ -809,15 +809,15 @@ public:
         __invalid_tuple_constraints>;
 
   template <class... _Up,
-            class _Constraints                                         = __variadic_constraints<_Up...>,
-            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+            class _Constraints                                       = __variadic_constraints<_Up...>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 tuple(_Up&&... __u) noexcept(_Constraints::__nothrow_constructible)
       : __base_(__tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
   {}
 
   template <class... _Up,
-            class _Constraints                                         = __variadic_constraints<_Up...>,
-            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+            class _Constraints                                       = __variadic_constraints<_Up...>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI
   _CCCL_CONSTEXPR_CXX14 explicit tuple(_Up&&... __u) noexcept(_Constraints::__nothrow_constructible)
       : __base_(__tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
@@ -830,9 +830,9 @@ public:
         __invalid_tuple_constraints>;
 
   template <class... _Up,
-            class _Constraints                                         = __variadic_constraints_less_rank<_Up...>,
-            __enable_if_t<sizeof...(_Up) < sizeof...(_Tp), int>        = 0,
-            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+            class _Constraints                                       = __variadic_constraints_less_rank<_Up...>,
+            enable_if_t<sizeof...(_Up) < sizeof...(_Tp), int>        = 0,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 explicit tuple(_Up&&... __u) noexcept(
     __base_noexcept_constructible<__tuple_variadic_constructor_tag, _Up...>::value)
       : __base_(__tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
@@ -840,8 +840,8 @@ public:
 
   template <class _Alloc,
             class... _Up,
-            class _Constraints                                         = __variadic_constraints<_Up...>,
-            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+            class _Constraints                                       = __variadic_constraints<_Up...>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI
   tuple(allocator_arg_t, const _Alloc& __a, _Up&&... __u) noexcept(_Constraints::__nothrow_constructible)
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
@@ -849,8 +849,8 @@ public:
 
   template <class _Alloc,
             class... _Up,
-            class _Constraints                                         = __variadic_constraints<_Up...>,
-            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+            class _Constraints                                       = __variadic_constraints<_Up...>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit tuple(allocator_arg_t, const _Alloc& __a, _Up&&... __u) noexcept(
     _Constraints::__nothrow_constructible)
       : __base_(allocator_arg_t(), __a, __tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
@@ -864,46 +864,46 @@ public:
 
   // Horrible hack to make tuple_of_iterator_references work
   template <class _TupleOfIteratorReferences,
-            __enable_if_t<__is_tuple_of_iterator_references<_TupleOfIteratorReferences>::value, int> = 0,
-            __enable_if_t<(tuple_size<_TupleOfIteratorReferences>::value == sizeof...(_Tp)), int>    = 0>
+            enable_if_t<__is_tuple_of_iterator_references<_TupleOfIteratorReferences>::value, int> = 0,
+            enable_if_t<(tuple_size<_TupleOfIteratorReferences>::value == sizeof...(_Tp)), int>    = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 tuple(_TupleOfIteratorReferences&& __t)
       : tuple(_CUDA_VSTD::forward<_TupleOfIteratorReferences>(__t).template __to_tuple<_Tp...>(
           __make_tuple_indices_t<sizeof...(_Tp)>()))
   {}
 
   template <class _Tuple,
-            class _Constraints                                            = __tuple_like_constraints<_Tuple>,
-            __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int>   = 0,
-            __enable_if_t<!_CCCL_TRAIT(is_lvalue_reference, _Tuple), int> = 0,
-            __enable_if_t<_Constraints::__implicit_constructible, int>    = 0>
+            class _Constraints                                          = __tuple_like_constraints<_Tuple>,
+            enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int>   = 0,
+            enable_if_t<!_CCCL_TRAIT(is_lvalue_reference, _Tuple), int> = 0,
+            enable_if_t<_Constraints::__implicit_constructible, int>    = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14
   tuple(_Tuple&& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _BaseT, _Tuple))
       : __base_(_CUDA_VSTD::forward<_Tuple>(__t))
   {}
 
   template <class _Tuple,
-            class _Constraints                                          = __tuple_like_constraints<const _Tuple&>,
-            __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
-            __enable_if_t<_Constraints::__implicit_constructible, int>  = 0>
+            class _Constraints                                        = __tuple_like_constraints<const _Tuple&>,
+            enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
+            enable_if_t<_Constraints::__implicit_constructible, int>  = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14
   tuple(const _Tuple& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _BaseT, const _Tuple&))
       : __base_(__t)
   {}
 
   template <class _Tuple,
-            class _Constraints                                            = __tuple_like_constraints<_Tuple>,
-            __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int>   = 0,
-            __enable_if_t<!_CCCL_TRAIT(is_lvalue_reference, _Tuple), int> = 0,
-            __enable_if_t<_Constraints::__explicit_constructible, int>    = 0>
+            class _Constraints                                          = __tuple_like_constraints<_Tuple>,
+            enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int>   = 0,
+            enable_if_t<!_CCCL_TRAIT(is_lvalue_reference, _Tuple), int> = 0,
+            enable_if_t<_Constraints::__explicit_constructible, int>    = 0>
   _LIBCUDACXX_HIDE_FROM_ABI
   _CCCL_CONSTEXPR_CXX14 explicit tuple(_Tuple&& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _BaseT, _Tuple))
       : __base_(_CUDA_VSTD::forward<_Tuple>(__t))
   {}
 
   template <class _Tuple,
-            class _Constraints                                          = __tuple_like_constraints<const _Tuple&>,
-            __enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
-            __enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
+            class _Constraints                                        = __tuple_like_constraints<const _Tuple&>,
+            enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
+            enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 explicit tuple(const _Tuple& __t) noexcept(
     _CCCL_TRAIT(is_nothrow_constructible, _BaseT, const _Tuple&))
       : __base_(__t)
@@ -911,16 +911,16 @@ public:
 
   template <class _Alloc,
             class _Tuple,
-            class _Constraints                                         = __tuple_like_constraints<_Tuple>,
-            __enable_if_t<_Constraints::__implicit_constructible, int> = 0>
+            class _Constraints                                       = __tuple_like_constraints<_Tuple>,
+            enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t)
       : __base_(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tuple>(__t))
   {}
 
   template <class _Alloc,
             class _Tuple,
-            class _Constraints                                         = __tuple_like_constraints<_Tuple>,
-            __enable_if_t<_Constraints::__explicit_constructible, int> = 0>
+            class _Constraints                                       = __tuple_like_constraints<_Tuple>,
+            enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI explicit tuple(allocator_arg_t, const _Alloc& __a, _Tuple&& __t)
       : __base_(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tuple>(__t))
   {}
@@ -931,7 +931,7 @@ public:
   _CCCL_HIDE_FROM_ABI tuple& operator=(const tuple& __t) = default;
   _CCCL_HIDE_FROM_ABI tuple& operator=(tuple&& __t)      = default;
 
-  template <class _Tuple, __enable_if_t<__tuple_assignable<_Tuple, tuple>::value, bool> = false>
+  template <class _Tuple, enable_if_t<__tuple_assignable<_Tuple, tuple>::value, bool> = false>
   _LIBCUDACXX_HIDE_FROM_ABI tuple& operator=(_Tuple&& __t) noexcept(_CCCL_TRAIT(is_nothrow_assignable, _BaseT&, _Tuple))
   {
     __base_.operator=(_CUDA_VSTD::forward<_Tuple>(__t));
@@ -978,7 +978,7 @@ _CCCL_HOST_DEVICE tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>
 #endif // _LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES
 
 template <class... _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI __enable_if_t<_And<__is_swappable<_Tp>...>::value, void>
+_LIBCUDACXX_HIDE_FROM_ABI enable_if_t<_And<__is_swappable<_Tp>...>::value, void>
 swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
 {
   __t.swap(__u);
@@ -1207,7 +1207,7 @@ struct __tuple_cat_type;
 template <class... _Ttypes, class... _Utypes>
 struct __tuple_cat_type<tuple<_Ttypes...>, __tuple_types<_Utypes...>>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE tuple<_Ttypes..., _Utypes...> type;
+  typedef _CCCL_NODEBUG_ALIAS tuple<_Ttypes..., _Utypes...> type;
 };
 
 template <class _ResultTuple, bool _Is_Tuple0TupleLike, class... _Tuples>
@@ -1217,15 +1217,15 @@ struct __tuple_cat_return_1
 template <class... _Types, class _Tuple0>
 struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE
-    typename __tuple_cat_type<tuple<_Types...>, __make_tuple_types_t<__remove_cvref_t<_Tuple0>>>::type type;
+  typedef _CCCL_NODEBUG_ALIAS
+    typename __tuple_cat_type<tuple<_Types...>, __make_tuple_types_t<remove_cvref_t<_Tuple0>>>::type type;
 };
 
 template <class... _Types, class _Tuple0, class _Tuple1, class... _Tuples>
 struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0, _Tuple1, _Tuples...>
     : public __tuple_cat_return_1<
-        typename __tuple_cat_type<tuple<_Types...>, __make_tuple_types_t<__remove_cvref_t<_Tuple0>>>::type,
-        __tuple_like<__libcpp_remove_reference_t<_Tuple1>>::value,
+        typename __tuple_cat_type<tuple<_Types...>, __make_tuple_types_t<remove_cvref_t<_Tuple0>>>::type,
+        __tuple_like<remove_reference_t<_Tuple1>>::value,
         _Tuple1,
         _Tuples...>
 {};
@@ -1235,13 +1235,13 @@ struct __tuple_cat_return;
 
 template <class _Tuple0, class... _Tuples>
 struct __tuple_cat_return<_Tuple0, _Tuples...>
-    : public __tuple_cat_return_1<tuple<>, __tuple_like<__libcpp_remove_reference_t<_Tuple0>>::value, _Tuple0, _Tuples...>
+    : public __tuple_cat_return_1<tuple<>, __tuple_like<remove_reference_t<_Tuple0>>::value, _Tuple0, _Tuples...>
 {};
 
 template <>
 struct __tuple_cat_return<>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE tuple<> type;
+  typedef _CCCL_NODEBUG_ALIAS tuple<> type;
 };
 
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 tuple<> tuple_cat()
@@ -1255,15 +1255,15 @@ struct __tuple_cat_return_ref_imp;
 template <class... _Types, size_t... _I0, class _Tuple0>
 struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>, _Tuple0>
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tuple0> _T0;
+  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tuple0> _T0;
   typedef tuple<_Types..., __copy_cvref_t<_Tuple0, __tuple_element_t<_I0, _T0>>&&...> type;
 };
 
 template <class... _Types, size_t... _I0, class _Tuple0, class _Tuple1, class... _Tuples>
 struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>, _Tuple0, _Tuple1, _Tuples...>
     : public __tuple_cat_return_ref_imp<
-        tuple<_Types..., __copy_cvref_t<_Tuple0, __tuple_element_t<_I0, __libcpp_remove_reference_t<_Tuple0>>>&&...>,
-        __make_tuple_indices_t<tuple_size<__libcpp_remove_reference_t<_Tuple1>>::value>,
+        tuple<_Types..., __copy_cvref_t<_Tuple0, __tuple_element_t<_I0, remove_reference_t<_Tuple0>>>&&...>,
+        __make_tuple_indices_t<tuple_size<remove_reference_t<_Tuple1>>::value>,
         _Tuple1,
         _Tuples...>
 {};
@@ -1271,7 +1271,7 @@ struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>, _Tu
 template <class _Tuple0, class... _Tuples>
 struct __tuple_cat_return_ref
     : public __tuple_cat_return_ref_imp<tuple<>,
-                                        __make_tuple_indices_t<tuple_size<__libcpp_remove_reference_t<_Tuple0>>::value>,
+                                        __make_tuple_indices_t<tuple_size<remove_reference_t<_Tuple0>>::value>,
                                         _Tuple0,
                                         _Tuples...>
 {};
@@ -1297,8 +1297,8 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
   operator()(tuple<_Types...> __t, _Tuple0&& __t0, _Tuple1&& __t1, _Tuples&&... __tpls)
   {
     (void) __t;
-    typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tuple0> _T0;
-    typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tuple1> _T1;
+    typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tuple0> _T0;
+    typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tuple1> _T1;
     return __tuple_cat<tuple<_Types..., __copy_cvref_t<_Tuple0, __tuple_element_t<_J0, _T0>>&&...>,
                        __make_tuple_indices_t<sizeof...(_Types) + tuple_size<_T0>::value>,
                        __make_tuple_indices_t<tuple_size<_T1>::value>>()(
@@ -1313,7 +1313,7 @@ template <class _Tuple0, class... _Tuples>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 typename __tuple_cat_return<_Tuple0, _Tuples...>::type
 tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls)
 {
-  typedef _LIBCUDACXX_NODEBUG_TYPE __libcpp_remove_reference_t<_Tuple0> _T0;
+  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tuple0> _T0;
   return __tuple_cat<tuple<>, __tuple_indices<>, __make_tuple_indices_t<tuple_size<_T0>::value>>()(
     tuple<>(), _CUDA_VSTD::forward<_Tuple0>(__t0), _CUDA_VSTD::forward<_Tuples>(__tpls)...);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/variant
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/variant
@@ -381,9 +381,9 @@ using __variant_index_t =
 #  ifndef _LIBCUDACXX_ABI_VARIANT_INDEX_TYPE_OPTIMIZATION
   unsigned int;
 #  else
-  __conditional_t<__choose_index_type(_NumAlts) == 0,
-                  unsigned char,
-                  __conditional_t<__choose_index_type(_NumAlts) == 1, unsigned short, unsigned int>>;
+  conditional_t<__choose_index_type(_NumAlts) == 0,
+                unsigned char,
+                conditional_t<__choose_index_type(_NumAlts) == 1, unsigned short, unsigned int>>;
 #  endif
 
 template <class _IndexType>
@@ -663,7 +663,7 @@ struct __variant
     const size_t __first_index = __get_runtime_index<sizeof...(_Vs), 0>(__vs...);
     return __visit_impl(
       integer_sequence<size_t>{},
-      integer_sequence<size_t, (__remove_cvref_t<_Vs>::__size() - 1)...>{},
+      integer_sequence<size_t, (remove_cvref_t<_Vs>::__size() - 1)...>{},
       __first_index,
       __make_value_visitor(_CUDA_VSTD::forward<_Visitor>(__visitor)),
       _CUDA_VSTD::forward<_Vs>(__vs)...);
@@ -676,7 +676,7 @@ struct __variant
     const size_t __first_index = __get_runtime_index<sizeof...(_Vs), 0>(__vs...);
     return __visit_impl(
       integer_sequence<size_t>{},
-      integer_sequence<size_t, (__remove_cvref_t<_Vs>::__size() - 1)...>{},
+      integer_sequence<size_t, (remove_cvref_t<_Vs>::__size() - 1)...>{},
       __first_index,
       __make_value_visitor<_Rp>(_CUDA_VSTD::forward<_Visitor>(__visitor)),
       _CUDA_VSTD::forward<_Vs>(__vs)...);
@@ -913,7 +913,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT __dtor<__traits<_Types...>, _Trait::_Availab
     template <class _Alt>
     _LIBCUDACXX_HIDE_FROM_ABI void operator()(_Alt& __alt) const noexcept
     {
-      using __alt_type = __remove_cvref_t<decltype(__alt)>;
+      using __alt_type = remove_cvref_t<decltype(__alt)>;
       __alt.~__alt_type();
     }
   };
@@ -929,7 +929,7 @@ protected:
   {
     if (!this->valueless_by_exception())
     {
-      constexpr size_t __np = __remove_cvref_t<__dtor>::__size();
+      constexpr size_t __np = remove_cvref_t<__dtor>::__size();
       __destroy(integral_constant<size_t, __np - 1>{}, this->__index);
     }
     this->__index = __variant_npos<__index_t>;
@@ -942,7 +942,7 @@ private:
   {
     if (__index == _CurrentIndex)
     {
-      using __alt_type = __remove_cvref_t<decltype(__access::__base::__get_alt<_CurrentIndex>(this->__as_base()))>;
+      using __alt_type = remove_cvref_t<decltype(__access::__base::__get_alt<_CurrentIndex>(this->__as_base()))>;
       __access::__base::__get_alt<_CurrentIndex>(this->__as_base()).~__alt_type();
       return;
     }
@@ -953,7 +953,7 @@ private:
   {
     if (__index == 0)
     {
-      using __alt_type = __remove_cvref_t<decltype(__access::__base::__get_alt<0>(this->__as_base()))>;
+      using __alt_type = remove_cvref_t<decltype(__access::__base::__get_alt<0>(this->__as_base()))>;
       __access::__base::__get_alt<0>(this->__as_base()).~__alt_type();
       return;
     }
@@ -1028,7 +1028,7 @@ protected:
     __lhs.__destroy();
     if (!__rhs.valueless_by_exception())
     {
-      constexpr size_t __np = __remove_cvref_t<__ctor>::__size();
+      constexpr size_t __np = remove_cvref_t<__ctor>::__size();
       __generic_construct_impl(
         integral_constant<size_t, __np - 1>{}, __rhs.index(), __lhs, _CUDA_VSTD::forward<_Rhs>(__rhs));
       __lhs.__index = static_cast<decltype(__lhs.__index)>(__rhs.index());
@@ -1198,7 +1198,7 @@ protected:
     }
     else
     {
-      constexpr size_t __np = __remove_cvref_t<__assignment>::__size();
+      constexpr size_t __np = remove_cvref_t<__assignment>::__size();
       this->__generic_assign(integral_constant<size_t, __np - 1>{}, __that.index(), _CUDA_VSTD::forward<_That>(__that));
     }
   }
@@ -1332,7 +1332,7 @@ public:
     }
     else if (this->index() == __that.index())
     {
-      constexpr size_t __np = __remove_cvref_t<__impl>::__size();
+      constexpr size_t __np = remove_cvref_t<__impl>::__size();
       __swap_value(integral_constant<size_t, __np - 1>{}, this->index(), *this, __that);
     }
     else
@@ -1360,7 +1360,7 @@ private:
 struct __no_narrowing_check
 {
   template <class _Dest, class _Source>
-  using _Apply = __type_identity<_Dest>;
+  using _Apply = type_identity<_Dest>;
 };
 
 struct __narrowing_check
@@ -1372,15 +1372,15 @@ struct __narrowing_check
   template <class _Dest, class _Source>
   struct __narrowing_check_impl<_Dest, _Source, void_t<decltype(_Dest{_CUDA_VSTD::declval<_Source>()})>>
   {
-    using type = __type_identity<_Dest>;
+    using type = type_identity<_Dest>;
   };
 
   template <class _Dest, class _Source>
-  using _Apply _LIBCUDACXX_NODEBUG_TYPE = typename __narrowing_check_impl<_Dest, _Source>::type;
+  using _Apply _CCCL_NODEBUG_ALIAS = typename __narrowing_check_impl<_Dest, _Source>::type;
 };
 
 template <class _Dest, class _Source>
-using __check_for_narrowing _LIBCUDACXX_NODEBUG_TYPE = typename _If<
+using __check_for_narrowing _CCCL_NODEBUG_ALIAS = typename _If<
 #  ifdef _LIBCUDACXX_ENABLE_NARROWING_CONVERSIONS_IN_VARIANT
   false &&
 #  endif // _LIBCUDACXX_ENABLE_NARROWING_CONVERSIONS_IN_VARIANT
@@ -1398,9 +1398,9 @@ struct __overload
 template <class _Tp, size_t>
 struct __overload_bool
 {
-  template <class _Up, class _Ap = __remove_cvref_t<_Up>>
+  template <class _Up, class _Ap = remove_cvref_t<_Up>>
   _LIBCUDACXX_HIDE_FROM_ABI auto
-  operator()(bool, _Up&&) const -> enable_if_t<_CCCL_TRAIT(is_same, _Ap, bool), __type_identity<_Tp>>;
+  operator()(bool, _Up&&) const -> enable_if_t<_CCCL_TRAIT(is_same, _Ap, bool), type_identity<_Tp>>;
 };
 
 template <size_t _Idx>
@@ -1450,11 +1450,11 @@ template <size_t... _Idx>
 struct __make_overloads_imp<__tuple_indices<_Idx...>>
 {
   template <class... _Types>
-  using _Apply _LIBCUDACXX_NODEBUG_TYPE = __all_overloads<__overload<_Types, _Idx>...>;
+  using _Apply _CCCL_NODEBUG_ALIAS = __all_overloads<__overload<_Types, _Idx>...>;
 };
 
 template <class... _Types>
-using _MakeOverloads _LIBCUDACXX_NODEBUG_TYPE =
+using _MakeOverloads _CCCL_NODEBUG_ALIAS =
   typename __make_overloads_imp<__make_indices_imp<sizeof...(_Types), 0>>::template _Apply<_Types...>;
 
 template <class _Tp, class... _Types>
@@ -1556,8 +1556,8 @@ public:
 
   template <class _Arg>
   using __match_construct =
-    _If<!_CCCL_TRAIT(is_same, __remove_cvref_t<_Arg>, variant) && !__is_inplace_type<__remove_cvref_t<_Arg>>::value //
-          && !__is_inplace_index<__remove_cvref_t<_Arg>>::value,
+    _If<!_CCCL_TRAIT(is_same, remove_cvref_t<_Arg>, variant) && !__is_inplace_type<remove_cvref_t<_Arg>>::value //
+          && !__is_inplace_index<remove_cvref_t<_Arg>>::value,
         typename __constraints::template __match_construct<_Arg>,
         __variant_detail::__invalid_variant_constraints>;
 
@@ -1629,7 +1629,7 @@ public:
 
   template <class _Arg>
   using __match_assign =
-    _If<!_CCCL_TRAIT(is_same, __remove_cvref_t<_Arg>, variant),
+    _If<!_CCCL_TRAIT(is_same, remove_cvref_t<_Arg>, variant),
         typename __constraints::template __match_assign<_Arg>,
         __variant_detail::__invalid_variant_constraints>;
 

--- a/libcudacxx/test/libcudacxx/cuda/tuple/vector_types_get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/tuple/vector_types_get.pass.cpp
@@ -85,7 +85,7 @@ struct get_expected<BaseType, 3>
   }
 };
 
-template <class VType, class BaseType, size_t VSize, size_t Index, cuda::std::__enable_if_t<(Index < VSize), int> = 0>
+template <class VType, class BaseType, size_t VSize, size_t Index, cuda::std::enable_if_t<(Index < VSize), int> = 0>
 __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
 {
   { // & overload
@@ -125,7 +125,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
   }
 }
 
-template <class VType, class BaseType, size_t VSize, size_t Index, cuda::std::__enable_if_t<(Index >= VSize), int> = 0>
+template <class VType, class BaseType, size_t VSize, size_t Index, cuda::std::enable_if_t<(Index >= VSize), int> = 0>
 __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
 {}
 

--- a/libcudacxx/test/libcudacxx/cuda/tuple/vector_types_tuple_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/tuple/vector_types_tuple_element.pass.cpp
@@ -16,7 +16,7 @@
 template <class VType, class BaseType, size_t Index>
 using expected_type = cuda::std::is_same<typename cuda::std::tuple_element<Index, VType>::type, BaseType>;
 
-template <class VType, class BaseType, size_t VSize, size_t Index, cuda::std::__enable_if_t<(Index < VSize), int> = 0>
+template <class VType, class BaseType, size_t VSize, size_t Index, cuda::std::enable_if_t<(Index < VSize), int> = 0>
 __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
 {
   static_assert((expected_type<VType, BaseType, Index>::value), "");
@@ -25,7 +25,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
   static_assert((expected_type<const volatile VType, const volatile BaseType, Index>::value), "");
 }
 
-template <class VType, class BaseType, size_t VSize, size_t Index, cuda::std::__enable_if_t<(Index >= VSize), int> = 0>
+template <class VType, class BaseType, size_t VSize, size_t Index, cuda::std::enable_if_t<(Index >= VSize), int> = 0>
 __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
 {}
 

--- a/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
@@ -89,8 +89,7 @@ struct ForwardFn
 };
 
 // __type
-static_assert(::cuda::std::is_same<::cuda::std::__type<::cuda::std::__type_identity<Incomplete>>, Incomplete>::value,
-              "");
+static_assert(::cuda::std::is_same<::cuda::std::__type<::cuda::std::type_identity<Incomplete>>, Incomplete>::value, "");
 
 // __type_call
 static_assert(::cuda::std::is_same<::cuda::std::__type_call<Fn, Incomplete>, Types<Incomplete>>::value, "");

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.gcd/gcd.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.gcd/gcd.pass.cpp
@@ -41,17 +41,17 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 bool test0(int in1, int in2, int out)
 template <typename Input1, typename Input2 = Input1>
 __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
 {
-  using S1                   = cuda::std::__make_signed_t<Input1>;
-  using S2                   = cuda::std::__make_signed_t<Input2>;
-  using U1                   = cuda::std::__make_signed_t<Input1>;
-  using U2                   = cuda::std::__make_signed_t<Input2>;
+  using S1                   = cuda::std::make_signed_t<Input1>;
+  using S2                   = cuda::std::make_signed_t<Input2>;
+  using U1                   = cuda::std::make_signed_t<Input1>;
+  using U2                   = cuda::std::make_signed_t<Input2>;
   bool accumulate            = true;
   constexpr TestCase Cases[] = {
     {0, 0, 0}, {1, 0, 1}, {0, 1, 1}, {1, 1, 1}, {2, 3, 1}, {2, 4, 2}, {36, 17, 1}, {36, 18, 18}};
   for (auto TC : Cases)
   {
     { // Test with two signed types
-      using Output = cuda::std::__common_type_t<S1, S2>;
+      using Output = cuda::std::common_type_t<S1, S2>;
       accumulate &= test0<S1, S2, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<S1, S2, Output>(-TC.x, TC.y, TC.expect);
       accumulate &= test0<S1, S2, Output>(TC.x, -TC.y, TC.expect);
@@ -62,19 +62,19 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
       accumulate &= test0<S2, S1, Output>(-TC.x, -TC.y, TC.expect);
     }
     { // test with two unsigned types
-      using Output = cuda::std::__common_type_t<U1, U2>;
+      using Output = cuda::std::common_type_t<U1, U2>;
       accumulate &= test0<U1, U2, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<U2, U1, Output>(TC.x, TC.y, TC.expect);
     }
     { // Test with mixed signs
-      using Output = cuda::std::__common_type_t<S1, U2>;
+      using Output = cuda::std::common_type_t<S1, U2>;
       accumulate &= test0<S1, U2, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<U2, S1, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<S1, U2, Output>(-TC.x, TC.y, TC.expect);
       accumulate &= test0<U2, S1, Output>(TC.x, -TC.y, TC.expect);
     }
     { // Test with mixed signs
-      using Output = cuda::std::__common_type_t<S2, U1>;
+      using Output = cuda::std::common_type_t<S2, U1>;
       accumulate &= test0<S2, U1, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<U1, S2, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<S2, U1, Output>(-TC.x, TC.y, TC.expect);

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.lcm/lcm.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.ops.lcm/lcm.pass.cpp
@@ -9,7 +9,7 @@
 // <numeric>
 
 // template<class _M, class _N>
-// constexpr __common_type_t<_M,_N> lcm(_M __m, _N __n)
+// constexpr common_type_t<_M,_N> lcm(_M __m, _N __n)
 
 #include <cuda/std/cassert>
 #include <cuda/std/climits>
@@ -40,17 +40,17 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 bool test0(int in1, int in2, int out)
 template <typename Input1, typename Input2 = Input1>
 __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
 {
-  using S1                    = cuda::std::__make_signed_t<Input1>;
-  using S2                    = cuda::std::__make_signed_t<Input2>;
-  using U1                    = cuda::std::__make_signed_t<Input1>;
-  using U2                    = cuda::std::__make_signed_t<Input2>;
+  using S1                    = cuda::std::make_signed_t<Input1>;
+  using S2                    = cuda::std::make_signed_t<Input2>;
+  using U1                    = cuda::std::make_signed_t<Input1>;
+  using U2                    = cuda::std::make_signed_t<Input2>;
   bool accumulate             = true;
   constexpr TestCases Cases[] = {
     {0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {1, 1, 1}, {2, 3, 6}, {2, 4, 4}, {3, 17, 51}, {36, 18, 36}};
   for (auto TC : Cases)
   {
     { // Test with two signed types
-      using Output = cuda::std::__common_type_t<S1, S2>;
+      using Output = cuda::std::common_type_t<S1, S2>;
       accumulate &= test0<S1, S2, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<S1, S2, Output>(-TC.x, TC.y, TC.expect);
       accumulate &= test0<S1, S2, Output>(TC.x, -TC.y, TC.expect);
@@ -61,19 +61,19 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
       accumulate &= test0<S2, S1, Output>(-TC.x, -TC.y, TC.expect);
     }
     { // test with two unsigned types
-      using Output = cuda::std::__common_type_t<U1, U2>;
+      using Output = cuda::std::common_type_t<U1, U2>;
       accumulate &= test0<U1, U2, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<U2, U1, Output>(TC.x, TC.y, TC.expect);
     }
     { // Test with mixed signs
-      using Output = cuda::std::__common_type_t<S1, U2>;
+      using Output = cuda::std::common_type_t<S1, U2>;
       accumulate &= test0<S1, U2, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<U2, S1, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<S1, U2, Output>(-TC.x, TC.y, TC.expect);
       accumulate &= test0<U2, S1, Output>(TC.x, -TC.y, TC.expect);
     }
     { // Test with mixed signs
-      using Output = cuda::std::__common_type_t<S2, U1>;
+      using Output = cuda::std::common_type_t<S2, U1>;
       accumulate &= test0<S2, U1, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<U1, S2, Output>(TC.x, TC.y, TC.expect);
       accumulate &= test0<S2, U1, Output>(-TC.x, TC.y, TC.expect);

--- a/libcudacxx/test/support/test_iterators.h
+++ b/libcudacxx/test/support/test_iterators.h
@@ -1686,7 +1686,7 @@ struct Proxy
 
   _LIBCUDACXX_TEMPLATE(class Other)
   _LIBCUDACXX_REQUIRES((IsProxy<cuda::std::decay_t<Other>>
-                        && cuda::std::assignable_from<cuda::std::__add_lvalue_reference_t<T>,
+                        && cuda::std::assignable_from<cuda::std::add_lvalue_reference_t<T>,
                                                       decltype(cuda::std::declval<Other>().getData())>) )
   __host__ __device__ constexpr Proxy& operator=(Other&& other)
   {
@@ -1701,7 +1701,7 @@ struct Proxy
   // const assignment required to make ProxyIterator model cuda::std::indirectly_writable
   _LIBCUDACXX_TEMPLATE(class Other)
   _LIBCUDACXX_REQUIRES((IsProxy<cuda::std::decay_t<Other>>
-                        && cuda::std::assignable_from<const cuda::std::__add_lvalue_reference_t<T>,
+                        && cuda::std::assignable_from<const cuda::std::add_lvalue_reference_t<T>,
                                                       decltype(cuda::std::declval<Other>().getData())>) )
   __host__ __device__ constexpr const Proxy& operator=(Other&& other) const
   {

--- a/thrust/testing/complex.cu
+++ b/thrust/testing/complex.cu
@@ -586,7 +586,7 @@ struct TestComplexPowerFunctions
     {
       using T0       = T;
       using T1       = other_floating_point_type_t<T0>;
-      using promoted = ::cuda::std::__common_type_t<T0, T1>;
+      using promoted = ::cuda::std::common_type_t<T0, T1>;
 
       thrust::host_vector<T0> data = unittest::random_samples<T0>(4);
 

--- a/thrust/testing/is_contiguous_iterator.cu
+++ b/thrust/testing/is_contiguous_iterator.cu
@@ -89,8 +89,8 @@ struct expect_passthrough
 template <typename IteratorT, typename PointerT, typename expected_unwrapped_type /* = expect_[pointer|passthrough] */>
 struct check_unwrapped_iterator
 {
-  using unwrapped_t = ::cuda::std::__libcpp_remove_reference_t<decltype(thrust::try_unwrap_contiguous_iterator(
-    cuda::std::declval<IteratorT>()))>;
+  using unwrapped_t =
+    ::cuda::std::remove_reference_t<decltype(thrust::try_unwrap_contiguous_iterator(cuda::std::declval<IteratorT>()))>;
 
   static constexpr bool value =
     std::is_same<expected_unwrapped_type, expect_pointer>::value

--- a/thrust/testing/merge_by_key.cu
+++ b/thrust/testing/merge_by_key.cu
@@ -115,7 +115,7 @@ auto call_merge_by_key(Args&&... args) -> decltype(thrust::merge_by_key(std::for
   else
   {
     // TODO(bgruber): remove next line in C++17 and pass CompareOp{} directly to stable_sort
-    using C = ::cuda::std::__conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
+    using C = ::cuda::std::conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
     return thrust::merge_by_key(std::forward<Args>(args)..., C{});
   }
   _CCCL_UNREACHABLE();
@@ -148,7 +148,7 @@ void TestMergeByKey(size_t n)
     else
     {
       // TODO(bgruber): remove next line in C++17 and pass CompareOp{} directly to stable_sort
-      using C = ::cuda::std::__conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
+      using C = ::cuda::std::conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
       thrust::stable_sort(h_a_keys.begin(), h_a_keys.end(), C{});
       thrust::stable_sort(h_b_keys.begin(), h_b_keys.end(), C{});
     }

--- a/thrust/testing/merge_key_value.cu
+++ b/thrust/testing/merge_key_value.cu
@@ -15,7 +15,7 @@ auto call_merge(Args&&... args) -> decltype(thrust::merge(std::forward<Args>(arg
   else
   {
     // TODO(bgruber): remove next line in C++17 and pass CompareOp{} directly to stable_sort
-    using C = ::cuda::std::__conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
+    using C = ::cuda::std::conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
     return thrust::merge(std::forward<Args>(args)..., C{});
   }
   _CCCL_UNREACHABLE();
@@ -47,7 +47,7 @@ void TestMergeKeyValue(size_t n)
   else
   {
     // TODO(bgruber): remove next line in C++17 and pass CompareOp{} directly to stable_sort
-    using C = ::cuda::std::__conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
+    using C = ::cuda::std::conditional_t<::cuda::std::is_void<CompareOp>::value, thrust::less<T>, CompareOp>;
     thrust::stable_sort(h_a.begin(), h_a.end(), C{});
     thrust::stable_sort(h_b.begin(), h_b.end(), C{});
   }

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -106,7 +106,7 @@ double const DEFAULT_ABSOLUTE_TOL = 1e-4;
 template <typename T>
 struct value_type
 {
-  using type = ::cuda::std::__remove_const_t<::cuda::std::__libcpp_remove_reference_t<T>>;
+  using type = ::cuda::std::remove_const_t<::cuda::std::remove_reference_t<T>>;
 };
 
 template <typename T>
@@ -328,7 +328,7 @@ struct is_complex<std::complex<T>> : public THRUST_NS_QUALIFIER::true_type
 } // namespace
 
 template <typename T1, typename T2>
-inline ::cuda::std::__enable_if_t<is_complex<T1>::value && is_complex<T2>::value, bool>
+inline ::cuda::std::enable_if_t<is_complex<T1>::value && is_complex<T2>::value, bool>
 almost_equal(const T1& a, const T2& b, double a_tol, double r_tol)
 {
   return almost_equal(a.real(), b.real(), a_tol, r_tol) && almost_equal(a.imag(), b.imag(), a_tol, r_tol);

--- a/thrust/testing/unittest/random.h
+++ b/thrust/testing/unittest/random.h
@@ -37,7 +37,7 @@ struct generate_random_integer<
 };
 
 template <typename T>
-struct generate_random_integer<T, ::cuda::std::__enable_if_t<THRUST_NS_QUALIFIER::detail::is_non_bool_integral<T>::value>>
+struct generate_random_integer<T, ::cuda::std::enable_if_t<THRUST_NS_QUALIFIER::detail::is_non_bool_integral<T>::value>>
 {
   T operator()(unsigned int i) const
   {
@@ -49,7 +49,7 @@ struct generate_random_integer<T, ::cuda::std::__enable_if_t<THRUST_NS_QUALIFIER
 };
 
 template <typename T>
-struct generate_random_integer<T, typename ::cuda::std::__enable_if_t<::cuda::std::is_floating_point<T>::value>>
+struct generate_random_integer<T, typename ::cuda::std::enable_if_t<::cuda::std::is_floating_point<T>::value>>
 {
   T operator()(unsigned int i) const
   {

--- a/thrust/testing/unittest/util.h
+++ b/thrust/testing/unittest/util.h
@@ -31,7 +31,7 @@ truncate_to_max_representable(std::size_t n)
 
 // TODO: This probably won't work for `half`.
 template <typename T>
-typename ::cuda::std::__enable_if_t<::cuda::std::is_floating_point<T>::value, T>
+typename ::cuda::std::enable_if_t<::cuda::std::is_floating_point<T>::value, T>
 truncate_to_max_representable(std::size_t n)
 {
   return THRUST_NS_QUALIFIER::min<T>(static_cast<T>(n), THRUST_NS_QUALIFIER::numeric_limits<T>::max());

--- a/thrust/thrust/complex.h
+++ b/thrust/thrust/complex.h
@@ -39,9 +39,9 @@
 #include <sstream>
 
 #define THRUST_STD_COMPLEX_REAL(z) \
-  reinterpret_cast<const typename ::cuda::std::__libcpp_remove_reference_t<decltype(z)>::value_type(&)[2]>(z)[0]
+  reinterpret_cast<const typename ::cuda::std::remove_reference_t<decltype(z)>::value_type(&)[2]>(z)[0]
 #define THRUST_STD_COMPLEX_IMAG(z) \
-  reinterpret_cast<const typename ::cuda::std::__libcpp_remove_reference_t<decltype(z)>::value_type(&)[2]>(z)[1]
+  reinterpret_cast<const typename ::cuda::std::remove_reference_t<decltype(z)>::value_type(&)[2]>(z)[1]
 #define THRUST_STD_COMPLEX_DEVICE _CCCL_DEVICE
 
 THRUST_NAMESPACE_BEGIN
@@ -393,7 +393,7 @@ _CCCL_HOST_DEVICE complex<T> conj(const complex<T>& z);
  *  \param theta The phase of the returned \p complex in radians.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> polar(const T0& m, const T1& theta = T1());
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> polar(const T0& m, const T1& theta = T1());
 
 /*! Returns the projection of a \p complex on the Riemann sphere.
  *  For all finite \p complex it returns the argument. For \p complexs
@@ -416,7 +416,7 @@ _CCCL_HOST_DEVICE complex<T> proj(const T& z);
  *  \param y The second \p complex.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator+(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const complex<T1>& y);
 
 /*! Adds a scalar to a \p complex number.
  *
@@ -427,7 +427,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator+(const 
  *  \param y The scalar.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator+(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const T1& y);
 
 /*! Adds a \p complex number to a scalar.
  *
@@ -438,7 +438,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator+(const 
  *  \param y The \p complex.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator+(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const T0& x, const complex<T1>& y);
 
 /*! Subtracts two \p complex numbers.
  *
@@ -449,7 +449,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator+(const 
  *  \param y The second \p complex (subtrahend).
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator-(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const complex<T1>& y);
 
 /*! Subtracts a scalar from a \p complex number.
  *
@@ -460,7 +460,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator-(const 
  *  \param y The scalar (subtrahend).
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator-(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const T1& y);
 
 /*! Subtracts a \p complex number from a scalar.
  *
@@ -471,7 +471,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator-(const 
  *  \param y The \p complex (subtrahend).
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator-(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const T0& x, const complex<T1>& y);
 
 /*! Multiplies two \p complex numbers.
  *
@@ -482,7 +482,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator-(const 
  *  \param y The second \p complex.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator*(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const complex<T1>& y);
 
 /*! Multiplies a \p complex number by a scalar.
  *
@@ -490,7 +490,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator*(const 
  *  \param y The scalar.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y);
 
 /*! Multiplies a scalar by a \p complex number.
  *
@@ -501,7 +501,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator*(const 
  *  \param y The \p complex.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y);
 
 /*! Divides two \p complex numbers.
  *
@@ -512,7 +512,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator*(const 
  *  \param y The denomimator (divisor).
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator/(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const complex<T1>& y);
 
 /*! Divides a \p complex number by a scalar.
  *
@@ -523,7 +523,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator/(const 
  *  \param y The scalar denomimator (divisor).
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y);
 
 /*! Divides a scalar by a \p complex number.
  *
@@ -534,7 +534,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator/(const 
  *  \param y The complex denomimator (divisor).
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator/(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const T0& x, const complex<T1>& y);
 
 /* --- Unary Arithmetic operators --- */
 
@@ -587,7 +587,7 @@ _CCCL_HOST_DEVICE complex<T> log10(const complex<T>& z);
  *  \param y The exponent.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> pow(const complex<T0>& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> pow(const complex<T0>& x, const complex<T1>& y);
 
 /*! Returns a \p complex number raised to a scalar.
  *
@@ -598,7 +598,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> pow(const comple
  *  \param y The exponent.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> pow(const complex<T0>& x, const T1& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> pow(const complex<T0>& x, const T1& y);
 
 /*! Returns a scalar raised to a \p complex number.
  *
@@ -609,7 +609,7 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> pow(const comple
  *  \param y The exponent.
  */
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> pow(const T0& x, const complex<T1>& y);
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> pow(const T0& x, const complex<T1>& y);
 
 /*! Returns the complex square root of a \p complex number.
  *

--- a/thrust/thrust/detail/allocator/allocator_traits.inl
+++ b/thrust/thrust/detail/allocator/allocator_traits.inl
@@ -138,8 +138,8 @@ public:
 };
 
 template <typename Alloc>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<has_member_allocate_with_hint<Alloc>::value,
-                                             typename allocator_traits<Alloc>::pointer>
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<has_member_allocate_with_hint<Alloc>::value,
+                                           typename allocator_traits<Alloc>::pointer>
 allocate(Alloc& a,
          typename allocator_traits<Alloc>::size_type n,
          typename allocator_traits<Alloc>::const_void_pointer hint)
@@ -148,8 +148,8 @@ allocate(Alloc& a,
 }
 
 template <typename Alloc>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!has_member_allocate_with_hint<Alloc>::value,
-                                             typename allocator_traits<Alloc>::pointer>
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<!has_member_allocate_with_hint<Alloc>::value,
+                                           typename allocator_traits<Alloc>::pointer>
 allocate(Alloc& a, typename allocator_traits<Alloc>::size_type n, typename allocator_traits<Alloc>::const_void_pointer)
 {
   return a.allocate(n);
@@ -163,14 +163,14 @@ struct has_member_construct1 : has_member_construct1_impl<Alloc, void(T*)>
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename Alloc, typename T>
-inline _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<has_member_construct1<Alloc, T>::value> construct(Alloc& a, T* p)
+inline _CCCL_HOST_DEVICE ::cuda::std::enable_if_t<has_member_construct1<Alloc, T>::value> construct(Alloc& a, T* p)
 {
   a.construct(p);
 }
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename Alloc, typename T>
-inline _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!has_member_construct1<Alloc, T>::value> construct(Alloc&, T* p)
+inline _CCCL_HOST_DEVICE ::cuda::std::enable_if_t<!has_member_construct1<Alloc, T>::value> construct(Alloc&, T* p)
 {
   ::new (static_cast<void*>(p)) T();
 }
@@ -183,7 +183,7 @@ struct has_member_construct2 : has_member_construct2_impl<Alloc, void(T*, const 
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename Alloc, typename T, typename Arg1>
-inline _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<has_member_construct2<Alloc, T, Arg1>::value>
+inline _CCCL_HOST_DEVICE ::cuda::std::enable_if_t<has_member_construct2<Alloc, T, Arg1>::value>
 construct(Alloc& a, T* p, const Arg1& arg1)
 {
   a.construct(p, arg1);
@@ -191,7 +191,7 @@ construct(Alloc& a, T* p, const Arg1& arg1)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename Alloc, typename T, typename Arg1>
-inline _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!has_member_construct2<Alloc, T, Arg1>::value>
+inline _CCCL_HOST_DEVICE ::cuda::std::enable_if_t<!has_member_construct2<Alloc, T, Arg1>::value>
 construct(Alloc&, T* p, const Arg1& arg1)
 {
   ::new (static_cast<void*>(p)) T(arg1);
@@ -205,7 +205,7 @@ struct has_member_constructN : has_member_constructN_impl<Alloc, void(T*, Args..
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename Alloc, typename T, typename... Args>
-inline _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<has_member_constructN<Alloc, T, Args...>::value>
+inline _CCCL_HOST_DEVICE ::cuda::std::enable_if_t<has_member_constructN<Alloc, T, Args...>::value>
 construct(Alloc& a, T* p, Args&&... args)
 {
   a.construct(p, THRUST_FWD(args)...);
@@ -213,7 +213,7 @@ construct(Alloc& a, T* p, Args&&... args)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename Alloc, typename T, typename... Args>
-inline _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!has_member_constructN<Alloc, T, Args...>::value>
+inline _CCCL_HOST_DEVICE ::cuda::std::enable_if_t<!has_member_constructN<Alloc, T, Args...>::value>
 construct(Alloc&, T* p, Args&&... args)
 {
   ::new (static_cast<void*>(p)) T(THRUST_FWD(args)...);
@@ -227,14 +227,14 @@ struct has_member_destroy : has_member_destroy_impl<Alloc, void(T*)>
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename Alloc, typename T>
-inline _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<has_member_destroy<Alloc, T>::value> destroy(Alloc& a, T* p)
+inline _CCCL_HOST_DEVICE ::cuda::std::enable_if_t<has_member_destroy<Alloc, T>::value> destroy(Alloc& a, T* p)
 {
   a.destroy(p);
 }
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename Alloc, typename T>
-inline _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!has_member_destroy<Alloc, T>::value> destroy(Alloc&, T* p)
+inline _CCCL_HOST_DEVICE ::cuda::std::enable_if_t<!has_member_destroy<Alloc, T>::value> destroy(Alloc&, T* p)
 {
   p->~T();
 }
@@ -252,16 +252,15 @@ public:
 };
 
 template <typename Alloc>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<has_member_max_size<Alloc>::value,
-                                             typename allocator_traits<Alloc>::size_type>
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<has_member_max_size<Alloc>::value, typename allocator_traits<Alloc>::size_type>
 max_size(const Alloc& a)
 {
   return a.max_size();
 }
 
 template <typename Alloc>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!has_member_max_size<Alloc>::value,
-                                             typename allocator_traits<Alloc>::size_type>
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<!has_member_max_size<Alloc>::value,
+                                           typename allocator_traits<Alloc>::size_type>
 max_size(const Alloc&)
 {
   using size_type = typename allocator_traits<Alloc>::size_type;
@@ -269,7 +268,7 @@ max_size(const Alloc&)
 }
 
 template <typename Alloc>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<has_member_system<Alloc>::value, typename allocator_system<Alloc>::type&>
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<has_member_system<Alloc>::value, typename allocator_system<Alloc>::type&>
 system(Alloc& a)
 {
   // return the allocator's system
@@ -277,7 +276,7 @@ system(Alloc& a)
 }
 
 template <typename Alloc>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!has_member_system<Alloc>::value, typename allocator_system<Alloc>::type>
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<!has_member_system<Alloc>::value, typename allocator_system<Alloc>::type>
 system(Alloc&)
 {
   // return a copy of a value-initialized system

--- a/thrust/thrust/detail/allocator/copy_construct_range.inl
+++ b/thrust/thrust/detail/allocator/copy_construct_range.inl
@@ -203,7 +203,7 @@ copy_construct_range_n(
 
 template <typename FromSystem, typename Allocator, typename InputIterator, typename Pointer>
 _CCCL_HOST_DEVICE ::cuda::std::
-  __enable_if_t<needs_copy_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>::value, Pointer>
+  enable_if_t<needs_copy_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>::value, Pointer>
   copy_construct_range(thrust::execution_policy<FromSystem>& from_system,
                        Allocator& a,
                        InputIterator first,
@@ -215,7 +215,7 @@ _CCCL_HOST_DEVICE ::cuda::std::
 
 template <typename FromSystem, typename Allocator, typename InputIterator, typename Size, typename Pointer>
 _CCCL_HOST_DEVICE ::cuda::std::
-  __enable_if_t<needs_copy_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>::value, Pointer>
+  enable_if_t<needs_copy_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>::value, Pointer>
   copy_construct_range_n(
     thrust::execution_policy<FromSystem>& from_system, Allocator& a, InputIterator first, Size n, Pointer result)
 {

--- a/thrust/thrust/detail/allocator/fill_construct_range.inl
+++ b/thrust/thrust/detail/allocator/fill_construct_range.inl
@@ -72,7 +72,7 @@ struct construct2_via_allocator
 };
 
 template <typename Allocator, typename Pointer, typename Size, typename T>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<
   has_effectful_member_construct2<Allocator, typename pointer_element<Pointer>::type, T>::value>
 fill_construct_range(Allocator& a, Pointer p, Size n, const T& value)
 {
@@ -80,7 +80,7 @@ fill_construct_range(Allocator& a, Pointer p, Size n, const T& value)
 }
 
 template <typename Allocator, typename Pointer, typename Size, typename T>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<
   !has_effectful_member_construct2<Allocator, typename pointer_element<Pointer>::type, T>::value>
 fill_construct_range(Allocator& a, Pointer p, Size n, const T& value)
 {

--- a/thrust/thrust/detail/allocator/value_initialize_range.inl
+++ b/thrust/thrust/detail/allocator/value_initialize_range.inl
@@ -71,7 +71,7 @@ struct needs_default_construct_via_allocator<std::allocator<U>, T>
 {};
 
 template <typename Allocator, typename Pointer, typename Size>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<
   needs_default_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>::value>
 value_initialize_range(Allocator& a, Pointer p, Size n)
 {

--- a/thrust/thrust/detail/complex/arithmetic.h
+++ b/thrust/thrust/detail/complex/arithmetic.h
@@ -30,72 +30,72 @@ THRUST_NAMESPACE_BEGIN
 /* --- Binary Arithmetic Operators --- */
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator+(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() + y.real(), x.imag() + y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator+(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const T1& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() + y, x.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator+(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const T0& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x + y.real(), y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator-(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() - y.real(), x.imag() - y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator-(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const T1& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() - y, x.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator-(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const T0& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x - y.real(), -y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator*(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() * y.real() - x.imag() * y.imag(), x.real() * y.imag() + x.imag() * y.real());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() * y, x.imag() * y);
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x * y.real(), x * y.imag());
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator/(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
 
   // Find `abs` by ADL.
   using std::abs;
@@ -118,16 +118,16 @@ _CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator/(const 
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x.real() / y, x.imag() / y);
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> operator/(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const T0& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return complex<T>(x) / y;
 }
 
@@ -241,9 +241,9 @@ _CCCL_HOST_DEVICE inline double norm(const complex<double>& z)
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> polar(const T0& m, const T1& theta)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> polar(const T0& m, const T1& theta)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
 
   // Find `cos` and `sin` by ADL.
   using std::cos;

--- a/thrust/thrust/detail/complex/cpow.h
+++ b/thrust/thrust/detail/complex/cpow.h
@@ -25,23 +25,23 @@
 THRUST_NAMESPACE_BEGIN
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> pow(const complex<T0>& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> pow(const complex<T0>& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return exp(log(complex<T>(x)) * complex<T>(y));
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> pow(const complex<T0>& x, const T1& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> pow(const complex<T0>& x, const T1& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   return exp(log(complex<T>(x)) * T(y));
 }
 
 template <typename T0, typename T1>
-_CCCL_HOST_DEVICE complex<::cuda::std::__common_type_t<T0, T1>> pow(const T0& x, const complex<T1>& y)
+_CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> pow(const T0& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::__common_type_t<T0, T1>;
+  using T = ::cuda::std::common_type_t<T0, T1>;
   // Find `log` by ADL.
   using std::log;
   return exp(log(T(x)) * complex<T>(y));

--- a/thrust/thrust/detail/execute_with_allocator.h
+++ b/thrust/thrust/detail/execute_with_allocator.h
@@ -42,7 +42,7 @@ template <typename T, typename Allocator, template <typename> class BaseSystem>
 _CCCL_HOST thrust::pair<T*, std::ptrdiff_t>
 get_temporary_buffer(thrust::detail::execute_with_allocator<Allocator, BaseSystem>& system, std::ptrdiff_t n)
 {
-  using naked_allocator = ::cuda::std::__libcpp_remove_reference_t<Allocator>;
+  using naked_allocator = ::cuda::std::remove_reference_t<Allocator>;
   using alloc_traits    = typename thrust::detail::allocator_traits<naked_allocator>;
   using void_pointer    = typename alloc_traits::void_pointer;
   using size_type       = typename alloc_traits::size_type;
@@ -62,7 +62,7 @@ template <typename Pointer, typename Allocator, template <typename> class BaseSy
 _CCCL_HOST void return_temporary_buffer(
   thrust::detail::execute_with_allocator<Allocator, BaseSystem>& system, Pointer p, std::ptrdiff_t n)
 {
-  using naked_allocator = ::cuda::std::__libcpp_remove_reference_t<Allocator>;
+  using naked_allocator = ::cuda::std::remove_reference_t<Allocator>;
   using alloc_traits    = typename thrust::detail::allocator_traits<naked_allocator>;
   using pointer         = typename alloc_traits::pointer;
   using size_type       = typename alloc_traits::size_type;
@@ -80,7 +80,7 @@ _CCCL_HOST thrust::pair<T*, std::ptrdiff_t> get_temporary_buffer(
   thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>& system,
   std::ptrdiff_t n)
 {
-  using naked_allocator = ::cuda::std::__libcpp_remove_reference_t<Allocator>;
+  using naked_allocator = ::cuda::std::remove_reference_t<Allocator>;
   using alloc_traits    = typename thrust::detail::allocator_traits<naked_allocator>;
   using void_pointer    = typename alloc_traits::void_pointer;
   using size_type       = typename alloc_traits::size_type;
@@ -102,7 +102,7 @@ _CCCL_HOST void return_temporary_buffer(
   Pointer p,
   std::ptrdiff_t n)
 {
-  using naked_allocator = ::cuda::std::__libcpp_remove_reference_t<Allocator>;
+  using naked_allocator = ::cuda::std::remove_reference_t<Allocator>;
   using alloc_traits    = typename thrust::detail::allocator_traits<naked_allocator>;
   using pointer         = typename alloc_traits::pointer;
   using size_type       = typename alloc_traits::size_type;

--- a/thrust/thrust/detail/execute_with_allocator_fwd.h
+++ b/thrust/thrust/detail/execute_with_allocator_fwd.h
@@ -53,7 +53,7 @@ public:
       : alloc(alloc_)
   {}
 
-  ::cuda::std::__libcpp_remove_reference_t<Allocator>& get_allocator()
+  ::cuda::std::remove_reference_t<Allocator>& get_allocator()
   {
     return alloc;
   }

--- a/thrust/thrust/detail/functional/actor.h
+++ b/thrust/thrust/detail/functional/actor.h
@@ -182,7 +182,7 @@ struct value
 };
 
 template <typename T>
-_CCCL_HOST_DEVICE auto make_actor(T&& x) -> actor<value<::cuda::std::__decay_t<T>>>
+_CCCL_HOST_DEVICE auto make_actor(T&& x) -> actor<value<::cuda::std::decay_t<T>>>
 {
   return {{THRUST_FWD(x)}};
 }

--- a/thrust/thrust/detail/functional/operators.h
+++ b/thrust/thrust/detail/functional/operators.h
@@ -213,11 +213,11 @@ struct bit_rshift
   }
 };
 
-#define MAKE_BINARY_COMPOSITE(op, functor)                                                                         \
-  template <typename A, typename B, ::cuda::std::__enable_if_t<is_actor<A>::value || is_actor<B>::value, int> = 0> \
-  _CCCL_HOST_DEVICE auto operator op(const A& a, const B& b)->decltype(compose(functor{}, a, b))                   \
-  {                                                                                                                \
-    return compose(functor{}, a, b);                                                                               \
+#define MAKE_BINARY_COMPOSITE(op, functor)                                                                       \
+  template <typename A, typename B, ::cuda::std::enable_if_t<is_actor<A>::value || is_actor<B>::value, int> = 0> \
+  _CCCL_HOST_DEVICE auto operator op(const A& a, const B& b)->decltype(compose(functor{}, a, b))                 \
+  {                                                                                                              \
+    return compose(functor{}, a, b);                                                                             \
   }
 
 MAKE_BINARY_COMPOSITE(==, thrust::equal_to<>)
@@ -341,7 +341,7 @@ struct bit_not
 }; // end prefix_increment
 
 #define MAKE_UNARY_COMPOSITE(op, functor)                                         \
-  template <typename A, ::cuda::std::__enable_if_t<is_actor<A>::value, int> = 0>  \
+  template <typename A, ::cuda::std::enable_if_t<is_actor<A>::value, int> = 0>    \
   _CCCL_HOST_DEVICE auto operator op(const A& a)->decltype(compose(functor{}, a)) \
   {                                                                               \
     return compose(functor{}, a);                                                 \
@@ -357,7 +357,7 @@ MAKE_UNARY_COMPOSITE(~, bit_not)
 #undef MAKE_UNARY_COMPOSITE
 
 #define MAKE_UNARY_COMPOSITE_POSTFIX(op, functor)                                      \
-  template <typename A, ::cuda::std::__enable_if_t<is_actor<A>::value, int> = 0>       \
+  template <typename A, ::cuda::std::enable_if_t<is_actor<A>::value, int> = 0>         \
   _CCCL_HOST_DEVICE auto operator op(const A& a, int)->decltype(compose(functor{}, a)) \
   {                                                                                    \
     return compose(functor{}, a);                                                      \

--- a/thrust/thrust/detail/memory_algorithms.h
+++ b/thrust/thrust/detail/memory_algorithms.h
@@ -42,7 +42,7 @@ template <typename Allocator, typename T>
 _CCCL_HOST_DEVICE void destroy_at(Allocator const& alloc, T* location) noexcept
 {
   using traits = typename detail::allocator_traits<
-    ::cuda::std::__remove_cv_t<::cuda::std::__libcpp_remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
+    ::cuda::std::remove_cv_t<::cuda::std::remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
 
   typename traits::allocator_type alloc_T(alloc);
 
@@ -65,7 +65,7 @@ _CCCL_HOST_DEVICE ForwardIt destroy(Allocator const& alloc, ForwardIt first, For
 {
   using T      = typename iterator_traits<ForwardIt>::value_type;
   using traits = typename detail::allocator_traits<
-    ::cuda::std::__remove_cv_t<::cuda::std::__libcpp_remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
+    ::cuda::std::remove_cv_t<::cuda::std::remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
 
   typename traits::allocator_type alloc_T(alloc);
 
@@ -93,7 +93,7 @@ _CCCL_HOST_DEVICE ForwardIt destroy_n(Allocator const& alloc, ForwardIt first, S
 {
   using T      = typename iterator_traits<ForwardIt>::value_type;
   using traits = typename detail::allocator_traits<
-    ::cuda::std::__remove_cv_t<::cuda::std::__libcpp_remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
+    ::cuda::std::remove_cv_t<::cuda::std::remove_reference_t<Allocator>>>::template rebind_traits<T>::other;
 
   typename traits::allocator_type alloc_T(alloc);
 

--- a/thrust/thrust/detail/raw_reference_cast.h
+++ b/thrust/thrust/detail/raw_reference_cast.h
@@ -76,9 +76,9 @@ struct raw_reference_impl : ::cuda::std::add_lvalue_reference<T>
 {};
 
 template <typename T>
-struct raw_reference_impl<T, ::cuda::std::__enable_if_t<is_wrapped_reference<::cuda::std::__remove_cv_t<T>>::value>>
+struct raw_reference_impl<T, ::cuda::std::enable_if_t<is_wrapped_reference<::cuda::std::remove_cv_t<T>>::value>>
 {
-  using type = ::cuda::std::__add_lvalue_reference_t<typename pointer_element<typename T::pointer>::type>;
+  using type = ::cuda::std::add_lvalue_reference_t<typename pointer_element<typename T::pointer>::type>;
 };
 
 } // namespace raw_reference_detail
@@ -105,7 +105,7 @@ namespace raw_reference_detail
 // wrapped references are unwrapped using raw_reference, otherwise, return T
 template <typename T>
 struct raw_reference_tuple_helper
-    : eval_if<is_unwrappable<::cuda::std::__remove_cv_t<T>>::value, raw_reference<T>, identity_<T>>
+    : eval_if<is_unwrappable<::cuda::std::remove_cv_t<T>>::value, raw_reference<T>, identity_<T>>
 {};
 
 // recurse on tuples
@@ -185,7 +185,7 @@ struct raw_reference_caster
   template <typename... Ts>
   _CCCL_HOST_DEVICE typename detail::raw_reference<thrust::detail::tuple_of_iterator_references<Ts...>>::type
   operator()(thrust::detail::tuple_of_iterator_references<Ts...> t,
-             ::cuda::std::__enable_if_t<is_unwrappable<thrust::detail::tuple_of_iterator_references<Ts...>>::value>* = 0)
+             ::cuda::std::enable_if_t<is_unwrappable<thrust::detail::tuple_of_iterator_references<Ts...>>::value>* = 0)
   {
     return thrust::raw_reference_cast(t);
   }

--- a/thrust/thrust/detail/temporary_array.inl
+++ b/thrust/thrust/detail/temporary_array.inl
@@ -43,13 +43,13 @@ struct avoid_initialization : ::cuda::std::is_trivially_copy_constructible<T>
 {};
 
 template <typename T, typename TemporaryArray, typename Size>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<avoid_initialization<T>::value> construct_values(TemporaryArray&, Size)
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<avoid_initialization<T>::value> construct_values(TemporaryArray&, Size)
 {
   // avoid the overhead of initialization
 } // end construct_values()
 
 template <typename T, typename TemporaryArray, typename Size>
-_CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<!avoid_initialization<T>::value> construct_values(TemporaryArray& a, Size n)
+_CCCL_HOST_DEVICE ::cuda::std::enable_if_t<!avoid_initialization<T>::value> construct_values(TemporaryArray& a, Size n)
 {
   a.value_initialize_n(a.begin(), n);
 } // end construct_values()

--- a/thrust/thrust/detail/type_traits.h
+++ b/thrust/thrust/detail/type_traits.h
@@ -110,7 +110,7 @@ struct lazy_disable_if : lazy_enable_if<!condition, T>
 {};
 
 template <typename T1, typename T2, typename T = void>
-using enable_if_convertible_t = ::cuda::std::__enable_if_t<::cuda::std::is_convertible<T1, T2>::value, T>;
+using enable_if_convertible_t = ::cuda::std::enable_if_t<::cuda::std::is_convertible<T1, T2>::value, T>;
 
 template <typename T1, typename T2, typename T = void>
 struct disable_if_convertible : disable_if<::cuda::std::is_convertible<T1, T2>::value, T>

--- a/thrust/thrust/detail/type_traits/has_member_function.h
+++ b/thrust/thrust/detail/type_traits/has_member_function.h
@@ -39,7 +39,7 @@
   struct trait_name<                                                                                                \
     T,                                                                                                              \
     ResultT(Args...),                                                                                               \
-    ::cuda::std::__enable_if_t<                                                                                     \
+    ::cuda::std::enable_if_t<                                                                                       \
       ::cuda::std::is_same<ResultT, void>::value                                                                    \
       || ::cuda::std::                                                                                              \
         is_convertible<ResultT, decltype(std::declval<T>().member_function_name(std::declval<Args>()...))>::value>> \

--- a/thrust/thrust/detail/type_traits/is_call_possible.h
+++ b/thrust/thrust/detail/type_traits/is_call_possible.h
@@ -110,8 +110,8 @@ THRUST_NAMESPACE_END
     template <typename Result, typename Arg>                                                                           \
     struct impl<true, Result(Arg)>                                                                                     \
     {                                                                                                                  \
-      static ::cuda::std::__add_lvalue_reference_t<derived_type> test_me;                                              \
-      static ::cuda::std::__add_lvalue_reference_t<Arg> arg;                                                           \
+      static ::cuda::std::add_lvalue_reference_t<derived_type> test_me;                                                \
+      static ::cuda::std::add_lvalue_reference_t<Arg> arg;                                                             \
                                                                                                                        \
       static const bool value =                                                                                        \
         sizeof(return_value_check<T, Result>::deduce(                                                                  \
@@ -122,9 +122,9 @@ THRUST_NAMESPACE_END
     template <typename Result, typename Arg1, typename Arg2>                                                           \
     struct impl<true, Result(Arg1, Arg2)>                                                                              \
     {                                                                                                                  \
-      static ::cuda::std::__add_lvalue_reference_t<derived_type> test_me;                                              \
-      static ::cuda::std::__add_lvalue_reference_t<Arg1> arg1;                                                         \
-      static ::cuda::std::__add_lvalue_reference_t<Arg2> arg2;                                                         \
+      static ::cuda::std::add_lvalue_reference_t<derived_type> test_me;                                                \
+      static ::cuda::std::add_lvalue_reference_t<Arg1> arg1;                                                           \
+      static ::cuda::std::add_lvalue_reference_t<Arg2> arg2;                                                           \
                                                                                                                        \
       static const bool value =                                                                                        \
         sizeof(return_value_check<T, Result>::deduce(                                                                  \
@@ -135,10 +135,10 @@ THRUST_NAMESPACE_END
     template <typename Result, typename Arg1, typename Arg2, typename Arg3>                                            \
     struct impl<true, Result(Arg1, Arg2, Arg3)>                                                                        \
     {                                                                                                                  \
-      static ::cuda::std::__add_lvalue_reference_t<derived_type> test_me;                                              \
-      static ::cuda::std::__add_lvalue_reference_t<Arg1> arg1;                                                         \
-      static ::cuda::std::__add_lvalue_reference_t<Arg2> arg2;                                                         \
-      static ::cuda::std::__add_lvalue_reference_t<Arg3> arg3;                                                         \
+      static ::cuda::std::add_lvalue_reference_t<derived_type> test_me;                                                \
+      static ::cuda::std::add_lvalue_reference_t<Arg1> arg1;                                                           \
+      static ::cuda::std::add_lvalue_reference_t<Arg2> arg2;                                                           \
+      static ::cuda::std::add_lvalue_reference_t<Arg3> arg3;                                                           \
                                                                                                                        \
       static const bool value =                                                                                        \
         sizeof(return_value_check<T, Result>::deduce((test_me.member_function_name(arg1, arg2, arg3),                  \
@@ -149,11 +149,11 @@ THRUST_NAMESPACE_END
     template <typename Result, typename Arg1, typename Arg2, typename Arg3, typename Arg4>                             \
     struct impl<true, Result(Arg1, Arg2, Arg3, Arg4)>                                                                  \
     {                                                                                                                  \
-      static ::cuda::std::__add_lvalue_reference_t<derived_type> test_me;                                              \
-      static ::cuda::std::__add_lvalue_reference_t<Arg1> arg1;                                                         \
-      static ::cuda::std::__add_lvalue_reference_t<Arg2> arg2;                                                         \
-      static ::cuda::std::__add_lvalue_reference_t<Arg3> arg3;                                                         \
-      static ::cuda::std::__add_lvalue_reference_t<Arg4> arg4;                                                         \
+      static ::cuda::std::add_lvalue_reference_t<derived_type> test_me;                                                \
+      static ::cuda::std::add_lvalue_reference_t<Arg1> arg1;                                                           \
+      static ::cuda::std::add_lvalue_reference_t<Arg2> arg2;                                                           \
+      static ::cuda::std::add_lvalue_reference_t<Arg3> arg3;                                                           \
+      static ::cuda::std::add_lvalue_reference_t<Arg4> arg4;                                                           \
                                                                                                                        \
       static const bool value =                                                                                        \
         sizeof(return_value_check<T, Result>::deduce((test_me.member_function_name(arg1, arg2, arg3, arg4),            \

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -189,7 +189,7 @@ public:
    *  \param last The end of the range.
    */
   template <typename InputIterator,
-            ::cuda::std::__enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int> = 0>
+            ::cuda::std::enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int> = 0>
   vector_base(InputIterator first, InputIterator last);
 
   /*! This constructor builds a vector_base from a range.
@@ -198,7 +198,7 @@ public:
    *  \param alloc The allocator to use by this vector_base.
    */
   template <typename InputIterator,
-            ::cuda::std::__enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int> = 0>
+            ::cuda::std::enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int> = 0>
   vector_base(InputIterator first, InputIterator last, const Alloc& alloc);
 
   /*! The destructor erases the elements.

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -271,7 +271,7 @@ void vector_base<T, Alloc>::range_init(ForwardIterator first, ForwardIterator la
 
 template <typename T, typename Alloc>
 template <typename InputIterator,
-          ::cuda::std::__enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int>>
+          ::cuda::std::enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int>>
 vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last)
     : m_storage()
     , m_size(0)
@@ -285,7 +285,7 @@ vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last)
 
 template <typename T, typename Alloc>
 template <typename InputIterator,
-          ::cuda::std::__enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int>>
+          ::cuda::std::enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int>>
 vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last, const Alloc& alloc)
     : m_storage(alloc)
     , m_size(0)

--- a/thrust/thrust/functional.h
+++ b/thrust/thrust/functional.h
@@ -1247,9 +1247,9 @@ struct not_fun_t
 //! \see https://en.cppreference.com/w/cpp/utility/functional/not_fn
 // TODO(bgruber): alias to ::cuda::std::not_fn in C++17
 template <class F>
-_CCCL_HOST_DEVICE auto not_fn(F&& f) -> detail::not_fun_t<::cuda::std::__decay_t<F>>
+_CCCL_HOST_DEVICE auto not_fn(F&& f) -> detail::not_fun_t<::cuda::std::decay_t<F>>
 {
-  return detail::not_fun_t<::cuda::std::__decay_t<F>>{std::forward<F>(f)};
+  return detail::not_fun_t<::cuda::std::decay_t<F>>{std::forward<F>(f)};
 }
 
 /*! \}

--- a/thrust/thrust/iterator/detail/counting_iterator.inl
+++ b/thrust/thrust/iterator/detail/counting_iterator.inl
@@ -111,8 +111,8 @@ template <typename Difference, typename Incrementable1, typename Incrementable2>
 struct counting_iterator_equal<Difference,
                                Incrementable1,
                                Incrementable2,
-                               ::cuda::std::__enable_if_t<::cuda::std::is_floating_point<Incrementable1>::value
-                                                          || ::cuda::std::is_floating_point<Incrementable2>::value>>
+                               ::cuda::std::enable_if_t<::cuda::std::is_floating_point<Incrementable1>::value
+                                                        || ::cuda::std::is_floating_point<Incrementable2>::value>>
 {
   _CCCL_HOST_DEVICE static bool equal(Incrementable1 x, Incrementable2 y)
   {

--- a/thrust/thrust/iterator/detail/join_iterator.h
+++ b/thrust/thrust/iterator/detail/join_iterator.h
@@ -43,7 +43,7 @@ namespace join_iterator_detail
 template <typename RandomAccessIterator1, typename RandomAccessIterator2, typename Difference, typename Reference>
 struct join_iterator_base
 {
-  using value_type = ::cuda::std::__libcpp_remove_reference_t<Reference>;
+  using value_type = ::cuda::std::remove_reference_t<Reference>;
 
   using system1 = typename thrust::iterator_system<RandomAccessIterator1>::type;
   using system2 = typename thrust::iterator_system<RandomAccessIterator2>::type;

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -115,7 +115,7 @@ public:
     return *this;
   }
 
-  template <class... Us, ::cuda::std::__enable_if_t<sizeof...(Us) == sizeof...(Ts), int> = 0>
+  template <class... Us, ::cuda::std::enable_if_t<sizeof...(Us) == sizeof...(Ts), int> = 0>
   inline _CCCL_HOST_DEVICE constexpr operator thrust::tuple<Us...>() const
   {
     return __to_tuple<Us...>(typename ::cuda::std::__make_tuple_indices<sizeof...(Ts)>::type{});

--- a/thrust/thrust/iterator/iterator_facade.h
+++ b/thrust/thrust/iterator/iterator_facade.h
@@ -331,7 +331,7 @@ private:
 public:
   /*! The type of element pointed to by \p iterator_facade.
    */
-  using value_type = ::cuda::std::__remove_const_t<Value>;
+  using value_type = ::cuda::std::remove_const_t<Value>;
 
   /*! The return type of \p iterator_facade::operator*().
    */

--- a/thrust/thrust/optional.h
+++ b/thrust/thrust/optional.h
@@ -2816,7 +2816,7 @@ struct hash<THRUST_NS_QUALIFIER::optional<T>>
       return 0;
     }
 
-    return std::hash<::cuda::std::__remove_const_t<T>>()(*o);
+    return std::hash<::cuda::std::remove_const_t<T>>()(*o);
   }
 };
 } // namespace std

--- a/thrust/thrust/system/cuda/detail/core/util.h
+++ b/thrust/thrust/system/cuda/detail/core/util.h
@@ -254,7 +254,7 @@ struct has_enough_shmem_impl<V, A, S, typelist<>>
   {
     value = V
   };
-  using type = ::cuda::std::__conditional_t<value, thrust::detail::true_type, thrust::detail::false_type>;
+  using type = ::cuda::std::conditional_t<value, thrust::detail::true_type, thrust::detail::false_type>;
 };
 
 template <class Agent, size_t MAX_SHMEM>
@@ -514,9 +514,9 @@ struct LoadIterator
   using size_type  = typename iterator_traits<It>::difference_type;
 
   using type =
-    ::cuda::std::__conditional_t<is_contiguous_iterator<It>::value,
-                                 cub::CacheModifiedInputIterator<PtxPlan::LOAD_MODIFIER, value_type, size_type>,
-                                 It>;
+    ::cuda::std::conditional_t<is_contiguous_iterator<It>::value,
+                               cub::CacheModifiedInputIterator<PtxPlan::LOAD_MODIFIER, value_type, size_type>,
+                               It>;
 }; // struct Iterator
 
 template <class PtxPlan, class It>

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -150,7 +150,7 @@ struct Tuning<sm35, T> : Tuning<sm30, T>
               cub::LOAD_LDG,
               cub::GRID_MAPPING_DYNAMIC>;
 
-  using type = ::cuda::std::__conditional_t<(sizeof(T) < 4), ReducePolicy1B, ReducePolicy4B>;
+  using type = ::cuda::std::conditional_t<(sizeof(T) < 4), ReducePolicy1B, ReducePolicy4B>;
 }; // Tuning sm35
 
 template <class InputIt, class OutputIt, class T, class Size, class ReductionOp>

--- a/thrust/thrust/system/cuda/detail/sort.h
+++ b/thrust/thrust/system/cuda/detail/sort.h
@@ -325,7 +325,7 @@ template <
   class KeysIt,
   class ItemsIt,
   class CompareOp,
-  ::cuda::std::__enable_if_t<!can_use_primitive_sort<typename iterator_value<KeysIt>::type, CompareOp>::value, int> = 0>
+  ::cuda::std::enable_if_t<!can_use_primitive_sort<typename iterator_value<KeysIt>::type, CompareOp>::value, int> = 0>
 THRUST_RUNTIME_FUNCTION void
 smart_sort(Policy& policy, KeysIt keys_first, KeysIt keys_last, ItemsIt items_first, CompareOp compare_op)
 {
@@ -339,7 +339,7 @@ template <
   class KeysIt,
   class ItemsIt,
   class CompareOp,
-  ::cuda::std::__enable_if_t<can_use_primitive_sort<typename iterator_value<KeysIt>::type, CompareOp>::value, int> = 0>
+  ::cuda::std::enable_if_t<can_use_primitive_sort<typename iterator_value<KeysIt>::type, CompareOp>::value, int> = 0>
 THRUST_RUNTIME_FUNCTION void smart_sort(
   execution_policy<Policy>& policy, KeysIt keys_first, KeysIt keys_last, ItemsIt items_first, CompareOp compare_op)
 {

--- a/thrust/thrust/system/detail/error_code.inl
+++ b/thrust/thrust/system/detail/error_code.inl
@@ -52,7 +52,7 @@ error_code ::error_code(ErrorCodeEnum e
 // XXX WAR msvc's problem with enable_if
 #if !defined(_CCCL_COMPILER_MSVC)
                         ,
-                        ::cuda::std::__enable_if_t<is_error_code_enum<ErrorCodeEnum>::value>*
+                        ::cuda::std::enable_if_t<is_error_code_enum<ErrorCodeEnum>::value>*
 #endif // !_CCCL_COMPILER_MSVC
 )
 {
@@ -68,7 +68,7 @@ void error_code ::assign(int val, const error_category& cat)
 template <typename ErrorCodeEnum>
 // XXX WAR msvc's problem with enable_if
 #if !defined(_CCCL_COMPILER_MSVC)
-::cuda::std::__enable_if_t<is_error_code_enum<ErrorCodeEnum>::value, error_code>&
+::cuda::std::enable_if_t<is_error_code_enum<ErrorCodeEnum>::value, error_code>&
 #else
 error_code&
 #endif // !_CCCL_COMPILER_MSVC

--- a/thrust/thrust/system/detail/error_condition.inl
+++ b/thrust/thrust/system/detail/error_condition.inl
@@ -53,7 +53,7 @@ error_condition ::error_condition(ErrorConditionEnum e
 // XXX WAR msvc's problem with enable_if
 #if !defined(_CCCL_COMPILER_MSVC)
                                   ,
-                                  ::cuda::std::__enable_if_t<is_error_condition_enum<ErrorConditionEnum>::value>*
+                                  ::cuda::std::enable_if_t<is_error_condition_enum<ErrorConditionEnum>::value>*
 #endif // !_CCCL_COMPILER_MSVC
 )
 {
@@ -69,7 +69,7 @@ void error_condition ::assign(int val, const error_category& cat)
 template <typename ErrorConditionEnum>
 // XXX WAR msvc's problem with enable_if
 #if !defined(_CCCL_COMPILER_MSVC)
-::cuda::std::__enable_if_t<is_error_condition_enum<ErrorConditionEnum>::value, error_condition>&
+::cuda::std::enable_if_t<is_error_condition_enum<ErrorConditionEnum>::value, error_condition>&
 #else
 error_condition&
 #endif // !_CCCL_COMPILER_MSVC

--- a/thrust/thrust/system/detail/generic/copy_if.inl
+++ b/thrust/thrust/system/detail/generic/copy_if.inl
@@ -134,7 +134,7 @@ _CCCL_HOST_DEVICE OutputIterator copy_if(
 
   // create an unsigned version of n (we know n is positive from the comparison above)
   // to avoid a warning in the compare below
-  ::cuda::std::__make_unsigned_t<difference_type> unsigned_n(n);
+  ::cuda::std::make_unsigned_t<difference_type> unsigned_n(n);
 
   // use 32-bit indices when possible (almost always)
   if (sizeof(difference_type) > sizeof(unsigned int)

--- a/thrust/thrust/system/detail/generic/generate.inl
+++ b/thrust/thrust/system/detail/generic/generate.inl
@@ -56,7 +56,7 @@ generate(thrust::execution_policy<ExecutionPolicy>& exec, ForwardIterator first,
   // functionality.
   THRUST_STATIC_ASSERT_MSG(
     !::cuda::std::is_const<
-      ::cuda::std::__libcpp_remove_reference_t<typename thrust::iterator_traits<ForwardIterator>::reference>>::value,
+      ::cuda::std::remove_reference_t<typename thrust::iterator_traits<ForwardIterator>::reference>>::value,
     "generating to `const` iterators is not allowed");
   thrust::for_each(exec, first, last, typename thrust::detail::generate_functor<ExecutionPolicy, Generator>::type(gen));
 } // end generate()
@@ -78,7 +78,7 @@ generate_n(thrust::execution_policy<ExecutionPolicy>& exec, OutputIterator first
   // functionality.
   THRUST_STATIC_ASSERT_MSG(
     !::cuda::std::is_const<
-      ::cuda::std::__libcpp_remove_reference_t<typename thrust::iterator_traits<OutputIterator>::reference>>::value,
+      ::cuda::std::remove_reference_t<typename thrust::iterator_traits<OutputIterator>::reference>>::value,
     "generating to `const` iterators is not allowed");
   return thrust::for_each_n(
     exec, first, n, typename thrust::detail::generate_functor<ExecutionPolicy, Generator>::type(gen));

--- a/thrust/thrust/system/detail/generic/select_system.inl
+++ b/thrust/thrust/system/detail/generic/select_system.inl
@@ -48,7 +48,7 @@ _CCCL_HOST_DEVICE System& min_system(thrust::execution_policy<System>& system1, 
 
 // min_system case 2: systems have differing type and the first type is considered the minimum
 template <typename System1, typename System2>
-_CCCL_HOST_DEVICE typename ::cuda::std::__enable_if_t<
+_CCCL_HOST_DEVICE typename ::cuda::std::enable_if_t<
   ::cuda::std::is_same<System1, typename thrust::detail::minimum_system<System1, System2>::type>::value,
   System1&>
 min_system(thrust::execution_policy<System1>& system1, thrust::execution_policy<System2>&)
@@ -58,7 +58,7 @@ min_system(thrust::execution_policy<System1>& system1, thrust::execution_policy<
 
 // min_system case 3: systems have differing type and the second type is considered the minimum
 template <typename System1, typename System2>
-_CCCL_HOST_DEVICE typename ::cuda::std::__enable_if_t<
+_CCCL_HOST_DEVICE typename ::cuda::std::enable_if_t<
   ::cuda::std::is_same<System2, typename thrust::detail::minimum_system<System1, System2>::type>::value,
   System2&>
 min_system(thrust::execution_policy<System1>&, thrust::execution_policy<System2>& system2)

--- a/thrust/thrust/system/detail/sequential/general_copy.h
+++ b/thrust/thrust/system/detail/sequential/general_copy.h
@@ -61,7 +61,7 @@ struct reference_is_assignable
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename OutputIterator, typename InputIterator>
-inline _CCCL_HOST_DEVICE ::cuda::std::__enable_if_t<reference_is_assignable<InputIterator, OutputIterator>::value>
+inline _CCCL_HOST_DEVICE ::cuda::std::enable_if_t<reference_is_assignable<InputIterator, OutputIterator>::value>
 iter_assign(OutputIterator dst, InputIterator src)
 {
   *dst = *src;

--- a/thrust/thrust/system/error_code.h
+++ b/thrust/thrust/system/error_code.h
@@ -258,7 +258,7 @@ public:
 // XXX WAR msvc's problem with enable_if
 #if !defined(_CCCL_COMPILER_MSVC)
              ,
-             ::cuda::std::__enable_if_t<is_error_code_enum<ErrorCodeEnum>::value>* = 0
+             ::cuda::std::enable_if_t<is_error_code_enum<ErrorCodeEnum>::value>* = 0
 #endif // !_CCCL_COMPILER_MSVC
   );
 
@@ -273,7 +273,7 @@ public:
   template <typename ErrorCodeEnum>
 // XXX WAR msvc's problem with enable_if
 #if !defined(_CCCL_COMPILER_MSVC)
-  ::cuda::std::__enable_if_t<is_error_code_enum<ErrorCodeEnum>::value, error_code>&
+  ::cuda::std::enable_if_t<is_error_code_enum<ErrorCodeEnum>::value, error_code>&
 #else
   error_code&
 #endif // !_CCCL_COMPILER_MSVC
@@ -369,7 +369,7 @@ public:
 // XXX WAR msvc's problem with enable_if
 #if !defined(_CCCL_COMPILER_MSVC)
                   ,
-                  ::cuda::std::__enable_if_t<is_error_condition_enum<ErrorConditionEnum>::value>* = 0
+                  ::cuda::std::enable_if_t<is_error_condition_enum<ErrorConditionEnum>::value>* = 0
 #endif // !_CCCL_COMPILER_MSVC
   );
 
@@ -392,7 +392,7 @@ public:
   template <typename ErrorConditionEnum>
 // XXX WAR msvc's problem with enable_if
 #if !defined(_CCCL_COMPILER_MSVC)
-  ::cuda::std::__enable_if_t<is_error_condition_enum<ErrorConditionEnum>::value, error_condition>&
+  ::cuda::std::enable_if_t<is_error_condition_enum<ErrorConditionEnum>::value, error_condition>&
 #else
   error_condition&
 #endif // !_CCCL_COMPILER_MSVC


### PR DESCRIPTION
For type traits `meow` we currently guard all the aliases `meow_t` by C++14 as depicted in the standard.

However, that requires us to add a ton of `__meow_t` aliases that we use instead for efficiency reasons.

Given that we already backport the world we can just enable them in all standard modes and be done with it. This cleanes up the code considerably and also removes all the fun "is this enabled" questions.

While we are at it, this also fixes a ton of variable templates to be guarded by `_CCCL_NO_VARIABLE_TEMPLATES`