### PR TITLE
`s/get_delegatee_scheduler/get_delegation_scheduler/`

### DIFF
--- a/cudax/include/cuda/experimental/__async/queries.cuh
+++ b/cudax/include/cuda/experimental/__async/queries.cuh
@@ -115,7 +115,7 @@ _CCCL_GLOBAL_CONSTANT struct get_scheduler_t
   }
 } get_scheduler{};
 
-_CCCL_GLOBAL_CONSTANT struct get_delegatee_scheduler_t
+_CCCL_GLOBAL_CONSTANT struct get_delegation_scheduler_t
 {
   template <class _Env>
   _CUDAX_API auto operator()(const _Env& __env) const noexcept //
@@ -124,7 +124,7 @@ _CCCL_GLOBAL_CONSTANT struct get_delegatee_scheduler_t
     static_assert(noexcept(__env.query(*this)));
     return __env.query(*this);
   }
-} get_delegatee_scheduler{};
+} get_delegation_scheduler{};
 
 enum class forward_progress_guarantee
 {

--- a/cudax/include/cuda/experimental/__async/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__async/sync_wait.cuh
@@ -57,7 +57,7 @@ private:
       return __loop_->get_scheduler();
     }
 
-    _CUDAX_API auto query(get_delegatee_scheduler_t) const noexcept
+    _CUDAX_API auto query(get_delegation_scheduler_t) const noexcept
     {
       return __loop_->get_scheduler();
     }
@@ -144,7 +144,7 @@ public:
     /// `sync_wait` connects and starts the given sender, and then drives a
     ///         `run_loop` instance until the sender completes. Additional work
     ///         can be delegated to the `run_loop` by scheduling work on the
-    ///         scheduler returned by calling `get_delegatee_scheduler` on the
+    ///         scheduler returned by calling `get_delegation_scheduler` on the
     ///         receiver's environment.
     ///
     /// @pre The sender must have a exactly one value completion signature. That


### PR DESCRIPTION
## Description

the committee renamed the `get_delegatee_scheduler` to `get_delegation_scheduler` for C++26. this PR does likewise.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
