### PR TITLE
merge metaprogramming libs from libcudac++ and µstdex

### DIFF
--- a/cudax/include/cuda/experimental/__async/conditional.cuh
+++ b/cudax/include/cuda/experimental/__async/conditional.cuh
@@ -73,12 +73,14 @@ struct __cond_t
 
     template <class... _Args>
     using __opstate_t = //
-      __mlist< //
+      _CUDA_VSTD::__type_list< //
         connect_result_t<__call_result_t<_Then, __just_from_t<_Args...>>, __rcvr_ref_t<_Rcvr&>>,
         connect_result_t<__call_result_t<_Else, __just_from_t<_Args...>>, __rcvr_ref_t<_Rcvr&>>>;
 
     using __next_ops_variant_t = //
-      __value_types<completion_signatures_of_t<_Sndr, __opstate*>, __opstate_t, __mconcat_into_q<__variant>::__f>;
+      __value_types<completion_signatures_of_t<_Sndr, __opstate*>,
+                    __opstate_t,
+                    __type_concat_into_quote<__variant>::__call>;
 
     using completion_signatures = //
       transform_completion_signatures_of<_Sndr, __opstate*, __async::completion_signatures<>, __value_t>;

--- a/cudax/include/cuda/experimental/__async/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/continue_on.cuh
@@ -147,7 +147,7 @@ private:
     using __scheduler_completions = //
       transform_completion_signatures<completion_signatures_of_t<schedule_result_t<_Sch>, __rcvr_t<_Rcvr, __result_t>*>,
                                       __async::completion_signatures<>,
-                                      __malways<__async::completion_signatures<>>::__f>;
+                                      _CUDA_VSTD::__type_always<__async::completion_signatures<>>::__call>;
 
     // The continue_on completions are the scheduler's error
     // and stopped completions, plus the sender's completions

--- a/cudax/include/cuda/experimental/__async/cpos.cuh
+++ b/cudax/include/cuda/experimental/__async/cpos.cuh
@@ -53,13 +53,13 @@ template <class _Ty>
 using __scheduler_concept_t = typename __remove_ref_t<_Ty>::scheduler_concept;
 
 template <class _Ty>
-inline constexpr bool __is_sender = __mvalid_q<__sender_concept_t, _Ty>;
+inline constexpr bool __is_sender = __type_valid_v<__sender_concept_t, _Ty>;
 
 template <class _Ty>
-inline constexpr bool __is_receiver = __mvalid_q<__receiver_concept_t, _Ty>;
+inline constexpr bool __is_receiver = __type_valid_v<__receiver_concept_t, _Ty>;
 
 template <class _Ty>
-inline constexpr bool __is_scheduler = __mvalid_q<__scheduler_concept_t, _Ty>;
+inline constexpr bool __is_scheduler = __type_valid_v<__scheduler_concept_t, _Ty>;
 
 _CCCL_GLOBAL_CONSTANT struct set_value_t
 {
@@ -133,7 +133,7 @@ _CCCL_GLOBAL_CONSTANT struct start_t
   template <class _OpState>
   _CUDAX_TRIVIAL_API auto operator()(_OpState& __opstate) const noexcept -> decltype(__opstate.start())
   {
-    static_assert(!__is_error<typename _OpState::completion_signatures>);
+    static_assert(!__type_is_error<typename _OpState::completion_signatures>);
     static_assert(_CUDA_VSTD::is_same_v<decltype(__opstate.start()), void>);
     static_assert(noexcept(__opstate.start()));
     __opstate.start();

--- a/cudax/include/cuda/experimental/__async/lazy.cuh
+++ b/cudax/include/cuda/experimental/__async/lazy.cuh
@@ -24,6 +24,7 @@
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__memory/construct_at.h>
 #include <cuda/std/__new/launder.h>
+#include <cuda/std/__utility/integer_sequence.h>
 
 #include <cuda/experimental/__async/meta.cuh>
 #include <cuda/experimental/__async/type_traits.cuh>
@@ -84,7 +85,7 @@ template <class _Idx, class... _Ts>
 struct __lazy_tupl;
 
 template <>
-struct __lazy_tupl<__mindices<>>
+struct __lazy_tupl<_CUDA_VSTD::index_sequence<>>
 {
   template <class _Fn, class _Self, class... _Us>
   _CUDAX_TRIVIAL_API static auto __apply(_Fn&& __fn, _Self&&, _Us&&... __us) //
@@ -95,10 +96,10 @@ struct __lazy_tupl<__mindices<>>
 };
 
 template <size_t... _Idx, class... _Ts>
-struct __lazy_tupl<__mindices<_Idx...>, _Ts...> : __detail::__lazy_box<_Idx, _Ts>...
+struct __lazy_tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...> : __detail::__lazy_box<_Idx, _Ts>...
 {
   template <size_t _Ny>
-  using __at = __m_at_c<_Ny, _Ts...>;
+  using __at = _CUDA_VSTD::__type_index_c<_Ny, _Ts...>;
 
   _CUDAX_TRIVIAL_API __lazy_tupl() noexcept {}
 
@@ -139,15 +140,15 @@ struct __lazy_tupl<__mindices<_Idx...>, _Ts...> : __detail::__lazy_box<_Idx, _Ts
 template <class... _Ts>
 struct __mk_lazy_tuple_
 {
-  using __indices_t = __mmake_indices<sizeof...(_Ts)>;
+  using __indices_t = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>;
   using type        = __lazy_tupl<__indices_t, _Ts...>;
 };
 
 template <class... _Ts>
-using __lazy_tuple = __t<__mk_lazy_tuple_<_Ts...>>;
+using __lazy_tuple = typename __mk_lazy_tuple_<_Ts...>::type;
 #else
 template <class... _Ts>
-using __lazy_tuple = __lazy_tupl<__mmake_indices<sizeof...(_Ts)>, _Ts...>;
+using __lazy_tuple = __lazy_tupl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
 #endif
 
 template <class... _Ts>

--- a/cudax/include/cuda/experimental/__async/let_value.cuh
+++ b/cudax/include/cuda/experimental/__async/let_value.cuh
@@ -82,7 +82,7 @@ private:
   struct __opstate_fn
   {
     template <class... _As>
-    using __f = connect_result_t<__call_result_t<_Fn, __decay_t<_As>&...>, __rcvr_ref_t<_Rcvr&>>;
+    using __call = connect_result_t<__call_result_t<_Fn, __decay_t<_As>&...>, __rcvr_ref_t<_Rcvr&>>;
   };
 
   /// @brief Computes the type of a variant of operation states to hold
@@ -91,7 +91,7 @@ private:
   using __opstate2_t =
     __gather_completion_signatures<completion_signatures_of_t<_CvSndr, _Rcvr>,
                                    _SetTag,
-                                   __opstate_fn<_Fn, _Rcvr>::template __f,
+                                   __opstate_fn<_Fn, _Rcvr>::template __call,
                                    __empty_tuple,
                                    __variant>;
 
@@ -103,7 +103,7 @@ private:
 
     template <class _Ty>
     using __ensure_sender = //
-      _CUDA_VSTD::_If<__is_sender<_Ty> || __is_error<_Ty>, _Ty, __error_non_sender_return>;
+      _CUDA_VSTD::_If<__is_sender<_Ty> || __type_is_error<_Ty>, _Ty, __error_non_sender_return>;
 
     template <class... _As>
     using __error_not_callable_with = //
@@ -116,27 +116,27 @@ private:
     // predecessor sender's results. If the function is not callable with
     // the results, it returns an _ERROR.
     template <class... _As>
-    using __call_result =
-      __minvoke<__mtry_quote<__call_result_t, __error_not_callable_with<_As...>>, _Fn, __decay_t<_As>&...>;
+    using __call_result = _CUDA_VSTD::
+      __type_call<__type_try_quote<__call_result_t, __error_not_callable_with<_As...>>, _Fn, __decay_t<_As>&...>;
 
     // This computes the completion signatures of sender returned by the
     // function when called with the given arguments. It returns an _ERROR if
     // the function is not callable with the arguments or if the function
     // returns a non-sender.
     template <class... _As>
-    using __f =
-      __mtry_invoke_q<completion_signatures_of_t, __ensure_sender<__call_result<_As...>>, __rcvr_ref_t<_Rcvr&>>;
+    using __call =
+      __type_try_call_quote<completion_signatures_of_t, __ensure_sender<__call_result<_As...>>, __rcvr_ref_t<_Rcvr&>>;
   };
 
   /// @brief Computes the completion signatures of the
   /// `let_(value|error|stopped)` sender.
   template <class _CvSndr, class _Fn, class _Rcvr>
-  using __completions =
-    __gather_completion_signatures<completion_signatures_of_t<_CvSndr, _Rcvr>,
-                                   _SetTag,
-                                   __completions_fn<_Fn, _Rcvr>::template __f,
-                                   __default_completions,
-                                   __mbind_front<__mtry_quote<__concat_completion_signatures>, __eptr_completion>::__f>;
+  using __completions = __gather_completion_signatures<
+    completion_signatures_of_t<_CvSndr, _Rcvr>,
+    _SetTag,
+    __completions_fn<_Fn, _Rcvr>::template __call,
+    __default_completions,
+    _CUDA_VSTD::__type_bind_front<__type_try_quote<__concat_completion_signatures>, __eptr_completion>::__call>;
 
   /// @brief The `let_(value|error|stopped)` operation state.
   /// @tparam _CvSndr The cvref-qualified predecessor sender type.
@@ -157,10 +157,10 @@ private:
 
     // Don't try to compute the type of the variant of operation states
     // if the computation of the completion signatures failed.
-    using __deferred_opstate_fn = __mbind_back<__mtry_quote<__opstate2_t>, _CvSndr, _Fn, _Rcvr>;
+    using __deferred_opstate_fn = _CUDA_VSTD::__type_bind_back<__type_try_quote<__opstate2_t>, _CvSndr, _Fn, _Rcvr>;
     using __opstate_variant_fn =
-      _CUDA_VSTD::_If<__is_error<completion_signatures>, __malways<__empty>, __deferred_opstate_fn>;
-    using __opstate_variant_t = __mtry_invoke<__opstate_variant_fn>;
+      _CUDA_VSTD::_If<__type_is_error<completion_signatures>, _CUDA_VSTD::__type_always<__empty>, __deferred_opstate_fn>;
+    using __opstate_variant_t = __type_try_call<__opstate_variant_fn>;
 
     _Rcvr __rcvr_;
     _Fn __fn_;
@@ -190,7 +190,7 @@ private:
             // Store the results so the lvalue refs we pass to the function
             // will be valid for the duration of the async op.
             auto& __tupl = __result_.template __emplace<__decayed_tuple<_As...>>(static_cast<_As&&>(__as)...);
-            if constexpr (!__is_error<completion_signatures>)
+            if constexpr (!__type_is_error<completion_signatures>)
             {
               // Call the function with the results and connect the resulting
               // sender, storing the operation state in __opstate2_.

--- a/cudax/include/cuda/experimental/__async/meta.cuh
+++ b/cudax/include/cuda/experimental/__async/meta.cuh
@@ -21,9 +21,10 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/integral_constant.h>
-#include <cuda/std/__type_traits/is_base_of.h>
-#include <cuda/std/__utility/integer_sequence.h>
+#include <cuda/std/__type_traits/is_valid_expansion.h>
+#include <cuda/std/__type_traits/type_list.h>
 
 #include <cuda/experimental/__detail/config.cuh>
 
@@ -42,183 +43,11 @@ namespace cuda::experimental::__async
 template <class _Ret, class... _Args>
 using __fn_t = _Ret(_Args...);
 
-template <class _Ret, class... _Args>
-using __nothrow_fn_t = _Ret(_Args...) noexcept;
-
 template <class _Ty>
 _Ty&& __declval() noexcept;
 
-template <class...>
-using __mvoid = void;
-
-template <class _Ty>
-struct __mtype
-{
-  using type = _Ty;
-};
-
-template <class _Ty>
-using __t = typename _Ty::type;
-
-template <class... _Ts>
-struct __mlist;
-
-template <auto _Val>
-struct __mvalue
-{
-  static constexpr auto __value = _Val;
-};
-
-// A separate __mbool template is needed in addition to __mvalue
-// because of an EDG bug in the handling of auto template parameters.
-template <bool _Val>
-struct __mbool
-{
-  static constexpr auto __value = _Val;
-};
-
-using __mtrue  = __mbool<true>;
-using __mfalse = __mbool<false>;
-
-template <auto... _Vals>
-struct __mvalues;
-
 template <size_t... _Vals>
 struct __moffsets;
-
-template <class... _Bools>
-using __mand = __mbool<(_Bools::__value && ...)>;
-
-template <class... _Bools>
-using __mor = __mbool<(_Bools::__value || ...)>;
-
-template <size_t... _Idx>
-using __mindices = _CUDA_VSTD::index_sequence<_Idx...>*;
-
-template <size_t Count>
-using __mmake_indices = _CUDA_VSTD::make_index_sequence<Count>*;
-
-template <class... _Ts>
-using __mmake_indices_for = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>*;
-
-constexpr size_t __mpow2(size_t __size) noexcept
-{
-  --__size;
-  __size |= __size >> 1;
-  __size |= __size >> 2;
-  __size |= __size >> 4;
-  __size |= __size >> 8;
-  if constexpr (sizeof(__size) >= 4)
-  {
-    __size |= __size >> 16;
-  }
-  if constexpr (sizeof(__size) >= 8)
-  {
-    __size |= __size >> 32;
-  }
-  return ++__size;
-}
-
-template <class _Ty>
-constexpr _Ty __mmin(_Ty __lhs, _Ty __rhs) noexcept
-{
-  return __lhs < __rhs ? __lhs : __rhs;
-}
-
-template <class _Ty>
-constexpr int __mcompare(_Ty __lhs, _Ty __rhs) noexcept
-{
-  return __lhs < __rhs ? -1 : __lhs > __rhs ? 1 : 0;
-}
-
-template <size_t _Len>
-struct __mstring
-{
-  template <size_t _Ny, size_t... _Is>
-  constexpr __mstring(const char (&__str)[_Ny], __mindices<_Is...>) noexcept
-      : __len_{_Ny}
-      , __what_{(_Is < _Ny ? __str[_Is] : '\0')...}
-  {}
-
-  template <size_t _Ny>
-  constexpr __mstring(const char (&__str)[_Ny], int = 0) noexcept
-      : __mstring{__str, __mmake_indices<_Len>{}}
-  {}
-
-  constexpr auto length() const noexcept -> size_t
-  {
-    return __len_;
-  }
-
-  template <size_t _OtherLen>
-  constexpr int compare(const __mstring<_OtherLen>& __other) const noexcept
-  {
-    size_t const len = __mmin(__len_, __other.__len_);
-    for (size_t i = 0; i < len; ++i)
-    {
-      if (auto const cmp = __mcompare(__what_[i], __other.__what_[i]))
-      {
-        return cmp;
-      }
-    }
-    return __mcompare(__len_, __other.__len_);
-  }
-
-  template <size_t _OtherLen>
-  constexpr auto operator==(const __mstring<_OtherLen>& __other) const noexcept -> bool
-  {
-    return __len_ == __other.__len_ && compare(__other) == 0;
-  }
-
-  template <size_t _OtherLen>
-  constexpr auto operator!=(const __mstring<_OtherLen>& __other) const noexcept -> bool
-  {
-    return !operator==(__other);
-  }
-
-  template <size_t _OtherLen>
-  constexpr auto operator<(const __mstring<_OtherLen>& __other) const noexcept -> bool
-  {
-    return compare(__other) < 0;
-  }
-
-  template <size_t _OtherLen>
-  constexpr auto operator>(const __mstring<_OtherLen>& __other) const noexcept -> bool
-  {
-    return compare(__other) > 0;
-  }
-
-  template <size_t _OtherLen>
-  constexpr auto operator<=(const __mstring<_OtherLen>& __other) const noexcept -> bool
-  {
-    return compare(__other) <= 0;
-  }
-
-  template <size_t _OtherLen>
-  constexpr auto operator>=(const __mstring<_OtherLen>& __other) const noexcept -> bool
-  {
-    return compare(__other) >= 0;
-  }
-
-  size_t __len_;
-  char __what_[_Len];
-};
-
-template <size_t _Len>
-__mstring(const char (&__str)[_Len]) -> __mstring<_Len>;
-
-template <size_t _Len>
-__mstring(const char (&__str)[_Len], int) -> __mstring<__mpow2(_Len)>;
-
-template <class _Ty>
-constexpr auto __mnameof() noexcept
-{
-#if defined(_CCCL_COMPILER_MSVC)
-  return __mstring{__FUNCSIG__, 0};
-#else
-  return __mstring{__PRETTY_FUNCTION__, 0};
-#endif
-}
 
 // The following must be left undefined
 template <class...>
@@ -265,7 +94,7 @@ template <class... _What>
 struct _ERROR : __merror_base
 {
   template <class...>
-  using __f = _ERROR;
+  using __call _LIBCUDACXX_NODEBUG_TYPE = _ERROR;
 
   _ERROR operator+();
 
@@ -282,475 +111,148 @@ constexpr bool __ustdex_unhandled_error(...) noexcept
 }
 
 template <class _Ty>
-inline constexpr bool __is_error = false;
+inline constexpr bool __type_is_error = false;
 
 template <class... _What>
-inline constexpr bool __is_error<_ERROR<_What...>> = true;
+inline constexpr bool __type_is_error<_ERROR<_What...>> = true;
 
 template <class... _What>
-inline constexpr bool __is_error<_ERROR<_What...>&> = true;
+inline constexpr bool __type_is_error<_ERROR<_What...>&> = true;
 
 // True if any of the types in _Ts... are errors; false otherwise.
 template <class... _Ts>
-inline constexpr bool __contains_error =
+inline constexpr bool __type_contains_error =
 #if defined(_CCCL_COMPILER_MSVC)
-  (__is_error<_Ts> || ...);
+  (__type_is_error<_Ts> || ...);
 #else
-  __ustdex_unhandled_error(static_cast<__mlist<_Ts...>*>(nullptr));
+  __ustdex_unhandled_error(static_cast<_CUDA_VSTD::__type_list<_Ts...>*>(nullptr));
 #endif
 
 template <class... _Ts>
-using __find_error = decltype(+(__declval<_Ts&>(), ..., __declval<_ERROR<_UNKNOWN>&>()));
+using __type_find_error = decltype(+(__declval<_Ts&>(), ..., __declval<_ERROR<_UNKNOWN>&>()));
 
 template <template <class...> class _Fn, class... _Ts>
-using __minvoke_q = _Fn<_Ts...>;
-
-template <class _Fn, class... _Ts>
-using __minvoke = typename _Fn::template __f<_Ts...>;
-
-template <class _Fn, class _Ty>
-using __minvoke1 = typename _Fn::template __f<_Ty>;
-
-template <class _Fn, template <class...> class _Cy, class... _Ts, class _Ret = __minvoke<_Fn, _Ts...>>
-auto __apply_fn(_Cy<_Ts...>*) -> _Ret;
-
-template <template <class...> class _Fn, template <class...> class _Cy, class... _Ts, class _Ret = _Fn<_Ts...>>
-auto __apply_fn_q(_Cy<_Ts...>*) -> _Ret;
-
-template <class _Fn, class _List>
-using __mapply = decltype(__async::__apply_fn<_Fn>(static_cast<_List*>(nullptr)));
-
-template <template <class...> class _Fn, class _List>
-using __mapply_q = decltype(__async::__apply_fn_q<_Fn>(static_cast<_List*>(nullptr)));
-
-template <class _Ty, class...>
-using __mfront = _Ty;
-
-template <template <class...> class _Fn, class _List, class _Enable = void>
-inline constexpr bool __mvalid_ = false;
-
-template <template <class...> class _Fn, class... _Ts>
-inline constexpr bool __mvalid_<_Fn, __mlist<_Ts...>, __mvoid<_Fn<_Ts...>>> = true;
-
-template <template <class...> class _Fn, class... _Ts>
-inline constexpr bool __mvalid_q = __mvalid_<_Fn, __mlist<_Ts...>>;
-
-template <class _Fn, class... _Ts>
-inline constexpr bool __mvalid = __mvalid_<_Fn::template __f, __mlist<_Ts...>>;
-
-template <class _Tp>
-inline constexpr auto __v = _Tp::__value;
-
-template <auto _Value>
-inline constexpr auto __v<__mvalue<_Value>> = _Value;
-
-template <bool _Value>
-inline constexpr auto __v<__mbool<_Value>> = _Value;
-
-template <class _Tp, _Tp _Value>
-inline constexpr auto __v<_CUDA_VSTD::integral_constant<_Tp, _Value>> = _Value;
-
-struct __midentity
-{
-  template <class _Ty>
-  using __f = _Ty;
-};
-
-template <class _Ty>
-struct __malways
-{
-  template <class...>
-  using __f = _Ty;
-};
-
-template <class _Ty>
-struct __malways1
-{
-  template <class>
-  using __f = _Ty;
-};
-
-template <bool>
-struct __mif_
-{
-  template <class _Then, class...>
-  using __f = _Then;
-};
-
-template <>
-struct __mif_<false>
-{
-  template <class _Then, class _Else>
-  using __f = _Else;
-};
-
-template <bool If, class _Then = void, class... _Else>
-using __mif = typename __mif_<If>::template __f<_Then, _Else...>;
-
-template <class If, class _Then = void, class... _Else>
-using __mif_t = typename __mif_<__v<If>>::template __f<_Then, _Else...>;
+inline constexpr bool __type_valid_v = _CUDA_VSTD::_IsValidExpansion<_Fn, _Ts...>::value;
 
 template <bool _Error>
-struct __midentity_or_error_with_
+struct __type_self_or_error_with_
 {
   template <class _Ty, class... _With>
-  using __f = _Ty;
+  using __call _LIBCUDACXX_NODEBUG_TYPE = _Ty;
 };
 
 template <>
-struct __midentity_or_error_with_<true>
+struct __type_self_or_error_with_<true>
 {
   template <class _Ty, class... _With>
-  using __f = decltype(__declval<_Ty&>().with(__declval<_ERROR<_With...>&>()));
+  using __call _LIBCUDACXX_NODEBUG_TYPE = decltype(__declval<_Ty&>().with(__declval<_ERROR<_With...>&>()));
 };
 
 template <class _Ty, class... _With>
-using __midentity_or_error_with = __minvoke<__midentity_or_error_with_<__is_error<_Ty>>, _Ty, _With...>;
+using __type_self_or_error_with =
+  _CUDA_VSTD::__type_call<__type_self_or_error_with_<__type_is_error<_Ty>>, _Ty, _With...>;
 
 template <bool>
-struct __mtry_;
+struct __type_try__;
 
 template <>
-struct __mtry_<false>
+struct __type_try__<false>
 {
   template <template <class...> class _Fn, class... _Ts>
-  using __g = _Fn<_Ts...>;
+  using __call_q = _Fn<_Ts...>;
 
   template <class _Fn, class... _Ts>
-  using __f = typename _Fn::template __f<_Ts...>;
+  using __call _LIBCUDACXX_NODEBUG_TYPE = typename _Fn::template __call<_Ts...>;
 };
 
 template <>
-struct __mtry_<true>
+struct __type_try__<true>
 {
   template <template <class...> class _Fn, class... _Ts>
-  using __g = __find_error<_Ts...>;
+  using __call_q = __type_find_error<_Ts...>;
 
   template <class _Fn, class... _Ts>
-  using __f = __find_error<_Fn, _Ts...>;
+  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_find_error<_Fn, _Ts...>;
 };
 
 template <class _Fn, class... _Ts>
-using __mtry_invoke = typename __mtry_<__contains_error<_Ts...>>::template __f<_Fn, _Ts...>;
+using __type_try_call = typename __type_try__<__type_contains_error<_Fn, _Ts...>>::template __call<_Fn, _Ts...>;
 
 template <template <class...> class _Fn, class... _Ts>
-using __mtry_invoke_q = typename __mtry_<__contains_error<_Ts...>>::template __g<_Fn, _Ts...>;
+using __type_try_call_quote = typename __type_try__<__type_contains_error<_Ts...>>::template __call_q<_Fn, _Ts...>;
 
+// wraps a meta-callable such that if any of the arguments are errors, the
+// result is an error.
 template <class _Fn>
-struct __mtry
+struct __type_try
 {
   template <class... _Ts>
-  using __f = __mtry_invoke<_Fn, _Ts...>;
-};
-
-template <class _Fn>
-struct __mpoly
-{
-  template <class... _Ts>
-  using __f = typename __mtry_<(sizeof...(_Ts) == ~0ul)>::template __f<_Fn, _Ts...>;
-};
-
-template <template <class...> class _Fn>
-struct __mpoly_q
-{
-  template <class... _Ts>
-  using __f = typename __mtry_<(sizeof...(_Ts) == ~0ul)>::template __g<_Fn, _Ts...>;
+  using __call _LIBCUDACXX_NODEBUG_TYPE = __type_try_call<_Fn, _Ts...>;
 };
 
 template <template <class...> class _Fn, class... _Default>
-struct __mquote;
+struct __type_try_quote;
 
+// equivalent to __type_try<__type_quote<_Fn>>
 template <template <class...> class _Fn>
-struct __mquote<_Fn>
+struct __type_try_quote<_Fn>
 {
   template <class... _Ts>
-  using __f = _Fn<_Ts...>;
+  using __call _LIBCUDACXX_NODEBUG_TYPE =
+    typename __type_try__<__type_contains_error<_Ts...>>::template __call_q<_Fn, _Ts...>;
 };
 
+// equivalent to __type_try<__type_quote<_Fn, _Default>>
 template <template <class...> class _Fn, class _Default>
-struct __mquote<_Fn, _Default>
+struct __type_try_quote<_Fn, _Default>
 {
   template <class... _Ts>
-  using __f = typename __mif<__mvalid_q<_Fn, _Ts...>, __mquote<_Fn>, __malways<_Default>>::template __f<_Ts...>;
+  using __call _LIBCUDACXX_NODEBUG_TYPE =
+    typename _CUDA_VSTD::_If<__type_valid_v<_Fn, _Ts...>, //
+                             __type_try_quote<_Fn>,
+                             _CUDA_VSTD::__type_always<_Default>>::template __call<_Ts...>;
 };
-
-template <template <class> class _Fn, class... _Default>
-struct __mquote1;
-
-template <template <class> class _Fn>
-struct __mquote1<_Fn>
-{
-  template <class _Ty>
-  using __f = _Fn<_Ty>;
-};
-
-template <template <class> class _Fn, class _Default>
-struct __mquote1<_Fn, _Default>
-{
-  template <class _Ty>
-  using __f = typename __mif<__mvalid_q<_Fn, _Ty>, __mquote1<_Fn>, __malways<_Default>>::template __f<_Ty>;
-};
-
-template <template <class...> class _Fn, class... _Default>
-struct __mtry_quote;
-
-template <template <class...> class _Fn>
-struct __mtry_quote<_Fn>
-{
-  template <class... _Ts>
-  using __f = typename __mtry_<__contains_error<_Ts...>>::template __g<_Fn, _Ts...>;
-};
-
-template <template <class...> class _Fn, class _Default>
-struct __mtry_quote<_Fn, _Default>
-{
-  template <class... _Ts>
-  using __f = typename __mif<__mvalid_q<_Fn, _Ts...>, __mtry_quote<_Fn>, __malways<_Default>>::template __f<_Ts...>;
-};
-
-template <class _Fn, class... _Ts>
-struct __mbind_front
-{
-  template <class... _Us>
-  using __f = __minvoke<_Fn, _Ts..., _Us...>;
-};
-
-template <class _Fn, class _Ty>
-struct __mbind_front1
-{
-  template <class... _Us>
-  using __f = __minvoke<_Fn, _Ty, _Us...>;
-};
-
-template <template <class...> class _Fn, class... _Ts>
-struct __mbind_front_q
-{
-  template <class... _Us>
-  using __f = __minvoke_q<_Fn, _Ts..., _Us...>;
-};
-
-template <class _Fn, class... _Ts>
-struct __mbind_back
-{
-  template <class... _Us>
-  using __f = __minvoke<_Fn, _Us..., _Ts...>;
-};
-
-template <template <class...> class _Fn, class... _Ts>
-struct __mbind_back_q
-{
-  template <class... _Us>
-  using __f = __minvoke_q<_Fn, _Us..., _Ts...>;
-};
-
-#if defined(__cpp_pack_indexing)
-
-template <class _Np, class... _Ts>
-using __m_at = _Ts...[__v<_Np>];
-
-template <size_t _Np, class... _Ts>
-using __m_at_c = _Ts...[_Np];
-
-#elif defined(_CCCL_BUILTIN_TYPE_PACK_ELEMENT)
-
-template <bool>
-struct __m_at_
-{
-  template <class _Np, class... _Ts>
-  using __f = _CCCL_BUILTIN_TYPE_PACK_ELEMENT(__v<_Np>, _Ts...);
-};
-
-template <class _Np, class... _Ts>
-using __m_at = __minvoke<__m_at_<__v<_Np> == ~0ul>, _Np, _Ts...>;
-
-template <size_t _Np, class... _Ts>
-using __m_at_c = __minvoke<__m_at_<_Np == ~0ul>, __mvalue<_Np>, _Ts...>;
-
-template <size_t _Idx>
-struct __mget
-{
-  template <class... _Ts>
-  using __f = __m_at<__mvalue<_Idx>, _Ts...>;
-};
-
-#else
-
-template <size_t _Idx>
-struct __mget
-{
-  template <class, class, class, class, class... _Ts>
-  using __f = __minvoke<__mtry_<sizeof...(_Ts) == ~0ull>, __mget<_Idx - 4>, _Ts...>;
-};
-
-template <>
-struct __mget<0>
-{
-  template <class _Ty, class...>
-  using __f = _Ty;
-};
-
-template <>
-struct __mget<1>
-{
-  template <class, class _Ty, class...>
-  using __f = _Ty;
-};
-
-template <>
-struct __mget<2>
-{
-  template <class, class, class _Ty, class...>
-  using __f = _Ty;
-};
-
-template <>
-struct __mget<3>
-{
-  template <class, class, class, class _Ty, class...>
-  using __f = _Ty;
-};
-
-template <class _Np, class... _Ts>
-using __m_at = __minvoke<__mget<__v<_Np>>, _Ts...>;
-
-template <size_t _Np, class... _Ts>
-using __m_at_c = __minvoke<__mget<_Np>, _Ts...>;
-
-#endif
 
 template <class _First, class _Second>
-struct __mpair
+struct __type_pair
 {
   using first  = _First;
   using second = _Second;
 };
 
 template <class _Pair>
-using __mfirst = typename _Pair::first;
+using __type_first = typename _Pair::first;
 
 template <class _Pair>
-using __msecond = typename _Pair::second;
+using __type_second = typename _Pair::second;
 
 template <template <class...> class _Second, template <class...> class _First>
-struct __mcompose_q
+struct __type_compose_quote
 {
   template <class... _Ts>
-  using __f = _Second<_First<_Ts...>>;
+  using __call _LIBCUDACXX_NODEBUG_TYPE = _Second<_First<_Ts...>>;
 };
 
-struct __mcount
+struct __type_count
 {
   template <class... _Ts>
-  using __f = __mvalue<sizeof...(_Ts)>;
+  using __call _LIBCUDACXX_NODEBUG_TYPE = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Ts)>;
 };
 
-template <bool>
-struct __mconcat_
-{
-  template <class... _Ts,
-            template <class...> class _Ap = __mlist,
-            class... _As,
-            template <class...> class _Bp = __mlist,
-            class... _Bs,
-            template <class...> class _Cp = __mlist,
-            class... _Cs,
-            template <class...> class _Dp = __mlist,
-            class... _Ds,
-            class... _Tail>
-  static auto
-  __f(__mlist<_Ts...>*,
-      _Ap<_As...>*,
-      _Bp<_Bs...>* = nullptr,
-      _Cp<_Cs...>* = nullptr,
-      _Dp<_Ds...>* = nullptr,
-      _Tail*... __tail)
-    -> decltype(__mconcat_<(sizeof...(_Tail) == 0)>::__f(
-      static_cast<__mlist<_Ts..., _As..., _Bs..., _Cs..., _Ds...>*>(nullptr), __tail...));
-};
-
-template <>
-struct __mconcat_<true>
-{
-  template <class... _As>
-  static auto __f(__mlist<_As...>*) -> __mlist<_As...>;
-};
-
-template <class _Continuation = __mquote<__mlist>>
-struct __mconcat_into
+template <template <class...> class _Continuation>
+struct __type_concat_into_quote
 {
   template <class... _Args>
-  using __f =
-    __mapply<_Continuation, decltype(__mconcat_<(sizeof...(_Args) == 0)>::__f({}, static_cast<_Args*>(nullptr)...))>;
-};
-
-template <template <class...> class _Continuation = __mlist>
-struct __mconcat_into_q
-{
-  template <class... _Args>
-  using __f =
-    __mapply_q<_Continuation, decltype(__mconcat_<(sizeof...(_Args) == 0)>::__f({}, static_cast<_Args*>(nullptr)...))>;
-};
-
-// The following must be super-fast to compile, so use an intrinsic directly if it is available
-template <class _Set, class... _Ty>
-inline constexpr bool __mset_contains = (_CUDA_VSTD::is_base_of_v<__mtype<_Ty>, _Set> && ...);
-
-namespace __set
-{
-template <class... _Ts>
-struct __inherit
-{};
-
-template <class _Ty, class... _Ts>
-struct __inherit<_Ty, _Ts...>
-    : __mtype<_Ty>
-    , __inherit<_Ts...>
-{};
-
-template <class... _Set>
-auto operator+(__inherit<_Set...>&) -> __inherit<_Set...>;
-
-template <class... _Set, class _Ty>
-auto operator%(__inherit<_Set...>&, __mtype<_Ty>&) //
-  -> __mif< //
-    __mset_contains<__inherit<_Set...>, _Ty>,
-    __inherit<_Set...>,
-    __inherit<_Ty, _Set...>>&;
-
-template <class _ExpectedSet>
-struct __eq
-{
-  static constexpr size_t __count = __v<__mapply<__mcount, _ExpectedSet>>;
-
-  template <class... _Ts>
-  using __f = __mbool<sizeof...(_Ts) == __count && __mset_contains<_ExpectedSet, _Ts...>>;
-};
-} // namespace __set
-
-template <class... _Ts>
-using __mset = __set::__inherit<_Ts...>;
-
-template <class _Set, class... _Ts>
-using __mset_insert = decltype(+(__declval<_Set&>() % ... % __declval<__mtype<_Ts>&>()));
-
-template <class... _Ts>
-using __mmake_set = __mset_insert<__mset<>, _Ts...>;
-
-template <class _Set1, class _Set2>
-inline constexpr bool __mset_eq = __v<__mapply<__set::__eq<_Set1>, _Set2>>;
-
-template <class _Fn>
-struct __munique
-{
-  template <class... _Ts>
-  using __f = __minvoke<__mmake_set<_Ts...>, _Fn>;
+  using __call _LIBCUDACXX_NODEBUG_TYPE =
+    _CUDA_VSTD::__type_call1<_CUDA_VSTD::__type_concat<_CUDA_VSTD::__as_type_list<_Args>...>,
+                             _CUDA_VSTD::__type_quote<_Continuation>>;
 };
 
 template <class _Ty>
-struct __msingle_or
+struct __type_self_or
 {
   template <class _Uy = _Ty>
-  using __f = _Uy;
+  using __call _LIBCUDACXX_NODEBUG_TYPE = _Uy;
 };
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/queries.cuh
+++ b/cudax/include/cuda/experimental/__async/queries.cuh
@@ -21,6 +21,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/enable_if.h>
+
 _CCCL_SUPPRESS_DEPRECATED_PUSH
 #include <cuda/std/__memory/allocator.h>
 _CCCL_SUPPRESS_DEPRECATED_POP
@@ -41,17 +43,17 @@ template <class _Ty, class _Query>
 using __query_result_t = decltype(__query_result_<_Ty, _Query>());
 
 template <class _Ty, class _Query>
-inline constexpr bool __queryable = __mvalid_q<__query_result_t, _Ty, _Query>;
+inline constexpr bool __queryable = __type_valid_v<__query_result_t, _Ty, _Query>;
 
 #if defined(__CUDA_ARCH__)
 template <class _Ty, class _Query>
 inline constexpr bool __nothrow_queryable = true;
 #else
 template <class _Ty, class _Query>
-using __nothrow_queryable_ = __mif<noexcept(__declval<_Ty>().query(_Query()))>;
+using __nothrow_queryable_ = _CUDA_VSTD::enable_if_t<noexcept(__declval<_Ty>().query(_Query()))>;
 
 template <class _Ty, class _Query>
-inline constexpr bool __nothrow_queryable = __mvalid_q<__nothrow_queryable_, _Ty, _Query>;
+inline constexpr bool __nothrow_queryable = __type_valid_v<__nothrow_queryable_, _Ty, _Query>;
 #endif
 
 _CCCL_GLOBAL_CONSTANT struct get_allocator_t

--- a/cudax/include/cuda/experimental/__async/read_env.cuh
+++ b/cudax/include/cuda/experimental/__async/read_env.cuh
@@ -53,7 +53,7 @@ private:
   struct __completions_fn
   {
     template <class _Query, class _Env>
-    using __f = _CUDA_VSTD::_If<
+    using __call = _CUDA_VSTD::_If<
       __nothrow_callable<_Query, _Env>,
       completion_signatures<set_value_t(__call_result_t<_Query, _Env>)>,
       completion_signatures<set_value_t(__call_result_t<_Query, _Env>), set_error_t(::std::exception_ptr)>>;
@@ -64,7 +64,7 @@ private:
   {
     using operation_state_concept = operation_state_t;
     using completion_signatures   = //
-      __minvoke<
+      _CUDA_VSTD::__type_call<
         _CUDA_VSTD::
           _If<__callable<_Query, env_of_t<_Rcvr>>, __completions_fn, __error_env_lacks_query<_Query, env_of_t<_Rcvr>>>,
         _Query,

--- a/cudax/include/cuda/experimental/__async/sequence.cuh
+++ b/cudax/include/cuda/experimental/__async/sequence.cuh
@@ -57,7 +57,8 @@ struct __seq
         __sndr1_t,
         __opstate*,
         completion_signatures_of_t<__sndr2_t, __rcvr_ref_t<__rcvr_t&>>,
-        __malways<__async::completion_signatures<>>::__f>; // swallow the first sender's value completions
+        _CUDA_VSTD::__type_always<__async::completion_signatures<>>::__call>; // swallow the first sender's value
+                                                                              // completions
 
     _CUDAX_API friend env_of_t<__rcvr_t> get_env(const __opstate* __self) noexcept
     {

--- a/cudax/include/cuda/experimental/__async/start_on.cuh
+++ b/cudax/include/cuda/experimental/__async/start_on.cuh
@@ -66,7 +66,7 @@ private:
         completion_signatures_of_t<_CvSndr, __rcvr_with_env_t<_Rcvr, __sch_env_t<_Sch>>*>,
         transform_completion_signatures<completion_signatures_of_t<schedule_result_t<_Sch>, __opstate_t*>,
                                         __async::completion_signatures<>,
-                                        __malways<__async::completion_signatures<>>::__f>>;
+                                        _CUDA_VSTD::__type_always<__async::completion_signatures<>>::__call>>;
 
     __rcvr_with_env_t<_Rcvr, __sch_env_t<_Sch>> __env_rcvr_;
     connect_result_t<schedule_result_t<_Sch>, __opstate_t*> __opstate1_;

--- a/cudax/include/cuda/experimental/__async/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__async/sync_wait.cuh
@@ -114,7 +114,7 @@ private:
       }
     };
 
-    using __values_t = value_types_of_t<_Sndr, __rcvr_t, _CUDA_VSTD::tuple, __midentity::__f>;
+    using __values_t = value_types_of_t<_Sndr, __rcvr_t, _CUDA_VSTD::tuple, _CUDA_VSTD::__type_self_t>;
 
     _CUDA_VSTD::optional<__values_t>* __values_;
     ::std::exception_ptr __eptr_;

--- a/cudax/include/cuda/experimental/__async/then.cuh
+++ b/cudax/include/cuda/experimental/__async/then.cuh
@@ -58,32 +58,33 @@ template <bool IsVoid, bool _Nothrow>
 struct __completion_fn
 { // non-void, potentially throwing case
   template <class _Result>
-  using __f = completion_signatures<set_value_t(_Result), set_error_t(::std::exception_ptr)>;
+  using __call = completion_signatures<set_value_t(_Result), set_error_t(::std::exception_ptr)>;
 };
 
 template <>
 struct __completion_fn<true, false>
 { // void, potentially throwing case
   template <class>
-  using __f = completion_signatures<set_value_t(), set_error_t(::std::exception_ptr)>;
+  using __call = completion_signatures<set_value_t(), set_error_t(::std::exception_ptr)>;
 };
 
 template <>
 struct __completion_fn<false, true>
 { // non-void, non-throwing case
   template <class _Result>
-  using __f = completion_signatures<set_value_t(_Result)>;
+  using __call = completion_signatures<set_value_t(_Result)>;
 };
 
 template <>
 struct __completion_fn<true, true>
 { // void, non-throwing case
   template <class>
-  using __f = completion_signatures<set_value_t()>;
+  using __call = completion_signatures<set_value_t()>;
 };
 
 template <class _Result, bool _Nothrow>
-using __completion_ = __minvoke1<__completion_fn<_CUDA_VSTD::is_same_v<_Result, void>, _Nothrow>, _Result>;
+using __completion_ =
+  _CUDA_VSTD::__type_call1<__completion_fn<_CUDA_VSTD::is_same_v<_Result, void>, _Nothrow>, _Result>;
 
 template <class _Fn, class... _Ts>
 using __completion = __completion_<__call_result_t<_Fn, _Ts...>, __nothrow_callable<_Fn, _Ts...>>;
@@ -111,16 +112,17 @@ private:
   struct __transform_completion
   {
     template <class... _Ts>
-    using __f = __minvoke<__mtry_quote<__upon::__completion, __error_not_callable<_Fn, _Ts...>>, _Fn, _Ts...>;
+    using __call =
+      _CUDA_VSTD::__type_call<__type_try_quote<__upon::__completion, __error_not_callable<_Fn, _Ts...>>, _Fn, _Ts...>;
   };
 
   template <class _CvSndr, class _Fn, class _Rcvr>
   using __completions =
     __gather_completion_signatures<completion_signatures_of_t<_CvSndr, _Rcvr>,
                                    _SetTag,
-                                   __transform_completion<_Fn>::template __f,
+                                   __transform_completion<_Fn>::template __call,
                                    __default_completions,
-                                   __mtry_quote<__concat_completion_signatures>::__f>;
+                                   __type_try_quote<__concat_completion_signatures>::__call>;
 
   template <class _Rcvr, class _CvSndr, class _Fn>
   struct __opstate_t

--- a/cudax/include/cuda/experimental/__async/tuple.cuh
+++ b/cudax/include/cuda/experimental/__async/tuple.cuh
@@ -21,6 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__utility/integer_sequence.h>
+
 #include <cuda/experimental/__async/meta.cuh>
 #include <cuda/experimental/__async/type_traits.cuh>
 #include <cuda/experimental/__detail/config.cuh>
@@ -48,7 +51,7 @@ template <class _Idx, class... _Ts>
 struct __tupl;
 
 template <size_t... _Idx, class... _Ts>
-struct __tupl<__mindices<_Idx...>, _Ts...> : __box<_Idx, _Ts>...
+struct __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...> : __box<_Idx, _Ts>...
 {
   template <class _Fn, class _Self, class... _Us>
   _CUDAX_TRIVIAL_API static auto __apply(_Fn&& __fn, _Self&& __self, _Us&&... __us) //
@@ -63,7 +66,7 @@ struct __tupl<__mindices<_Idx...>, _Ts...> : __box<_Idx, _Ts>...
   template <class _Fn, class _Self, class... _Us>
   _CUDAX_TRIVIAL_API static auto __for_each(_Fn&& __fn, _Self&& __self, _Us&&... __us) //
     noexcept((__nothrow_callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>>
-              && ...)) -> __mif<(__callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>> && ...)>
+              && ...)) -> _CUDA_VSTD::enable_if_t<(__callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>> && ...)>
   {
     return (
       static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)..., static_cast<_Self&&>(__self).__box<_Idx, _Ts>::__value_),
@@ -73,7 +76,7 @@ struct __tupl<__mindices<_Idx...>, _Ts...> : __box<_Idx, _Ts>...
 
 template <class... _Ts>
 _CUDAX_API __tupl(_Ts...) //
-  -> __tupl<__mmake_indices<sizeof...(_Ts)>, _Ts...>;
+  -> __tupl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
 
 template <class _Fn, class _Tupl, class... _Us>
 using __apply_result_t =
@@ -83,15 +86,15 @@ using __apply_result_t =
 template <class... _Ts>
 struct __mk_tuple_
 {
-  using __indices_t = __mmake_indices<sizeof...(_Ts)>;
+  using __indices_t = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>;
   using type        = __tupl<__indices_t, _Ts...>;
 };
 
 template <class... _Ts>
-using __tuple = __t<__mk_tuple_<_Ts...>>;
+using __tuple = typename __mk_tuple_<_Ts...>::type;
 #else
 template <class... _Ts>
-using __tuple = __tupl<__mmake_indices<sizeof...(_Ts)>, _Ts...>;
+using __tuple = __tupl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
 #endif
 
 template <class... _Ts>

--- a/cudax/include/cuda/experimental/__async/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__async/type_traits.cuh
@@ -22,7 +22,10 @@
 #endif // no system header
 
 #include <cuda/std/__type_traits/copy_cvref.h>
+#include <cuda/std/__type_traits/decay.h>
+#include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/remove_reference.h>
+#include <cuda/std/__type_traits/type_list.h>
 
 #include <cuda/experimental/__async/meta.cuh>
 #include <cuda/experimental/__detail/config.cuh>
@@ -40,94 +43,12 @@ using __remove_ref_t = _CUDA_VSTD::__libcpp_remove_reference_t<_Ty>;
 #if defined(_CCCL_BUILTIN_DECAY)
 
 template <class _Ty>
-using __decay_t = __decay(_Ty);
-
-// #elif defined(_CCCL_COMPILER_NVHPC)
-
-//   template <class _Ty>
-//   using __decay_t = _CUDA_VSTD::decay_t<_Ty>;
+using __decay_t = _CCCL_BUILTIN_DECAY(_Ty);
 
 #else // ^^^ _CCCL_BUILTIN_DECAY ^^^ / vvv !_CCCL_BUILTIN_DECAY vvv
 
-struct __decay_object
-{
-  template <class _Ty>
-  static _Ty __g(_Ty const&);
-  template <class _Ty>
-  using __f = decltype(__g(__declval<_Ty>()));
-};
-
-struct __decay_default
-{
-  template <class _Ty>
-  static _Ty __g(_Ty);
-  template <class _Ty>
-  using __f = decltype(__g(__declval<_Ty>()));
-};
-
-// I don't care to support abominable function types,
-// but if that's needed, this is the way to do it:
-// struct __decay_abominable {
-//   template <class _Ty>
-//   using __f = _Ty;
-// };
-
-struct __decay_void
-{
-  template <class _Ty>
-  using __f = void;
-};
-
 template <class _Ty>
-extern __decay_object __mdecay;
-
-template <class _Ty, class... _Us>
-extern __decay_default __mdecay<_Ty(_Us...)>;
-
-template <class _Ty, class... _Us>
-extern __decay_default __mdecay<_Ty(_Us...) noexcept>;
-
-template <class _Ty, class... _Us>
-extern __decay_default __mdecay<_Ty (&)(_Us...)>;
-
-template <class _Ty, class... _Us>
-extern __decay_default __mdecay<_Ty (&)(_Us...) noexcept>;
-
-// template <class _Ty, class... _Us>
-// extern __decay_abominable __mdecay<_Ty(_Us...) const>;
-
-// template <class _Ty, class... _Us>
-// extern __decay_abominable __mdecay<_Ty(_Us...) const noexcept>;
-
-// template <class _Ty, class... _Us>
-// extern __decay_abominable __mdecay<_Ty(_Us...) const &>;
-
-// template <class _Ty, class... _Us>
-// extern __decay_abominable __mdecay<_Ty(_Us...) const & noexcept>;
-
-// template <class _Ty, class... _Us>
-// extern __decay_abominable __mdecay<_Ty(_Us...) const &&>;
-
-// template <class _Ty, class... _Us>
-// extern __decay_abominable __mdecay<_Ty(_Us...) const && noexcept>;
-
-template <class _Ty>
-extern __decay_default __mdecay<_Ty[]>;
-
-template <class _Ty, size_t _Ny>
-extern __decay_default __mdecay<_Ty[_Ny]>;
-
-template <class _Ty, size_t _Ny>
-extern __decay_default __mdecay<_Ty (&)[_Ny]>;
-
-template <>
-inline __decay_void __mdecay<void>;
-
-template <>
-inline __decay_void __mdecay<void const>;
-
-template <class _Ty>
-using __decay_t = typename decltype(__mdecay<_Ty>)::template __f<_Ty>;
+using __decay_t = _CUDA_VSTD::decay_t<_Ty>;
 
 #endif // _CCCL_BUILTIN_DECAY
 
@@ -138,8 +59,8 @@ using __decay_t = typename decltype(__mdecay<_Ty>)::template __f<_Ty>;
 template <class _Ty>
 using __cref_t = _Ty const&;
 
-using __cp    = __midentity;
-using __cpclr = __mquote1<__cref_t>;
+using __cp    = _CUDA_VSTD::__type_self;
+using __cpclr = _CUDA_VSTD::__type_quote1<__cref_t>;
 
 template <class _From, class _To>
 using __copy_cvref_t = _CUDA_VSTD::__copy_cvref_t<_From, _To>;
@@ -148,7 +69,7 @@ template <class _Fn, class... _As>
 using __call_result_t = decltype(__declval<_Fn>()(__declval<_As>()...));
 
 template <class _Fn, class... _As>
-inline constexpr bool __callable = __mvalid_q<__call_result_t, _Fn, _As...>;
+inline constexpr bool __callable = __type_valid_v<__call_result_t, _Fn, _As...>;
 
 #if defined(__CUDA_ARCH__)
 template <class _Fn, class... _As>
@@ -167,34 +88,34 @@ template <class... _As>
 inline constexpr bool __nothrow_copyable = true;
 #else
 template <class _Fn, class... _As>
-using __nothrow_callable_ = __mif<noexcept(__declval<_Fn>()(__declval<_As>()...))>;
+using __nothrow_callable_ = _CUDA_VSTD::enable_if_t<noexcept(__declval<_Fn>()(__declval<_As>()...))>;
 
 template <class _Fn, class... _As>
-inline constexpr bool __nothrow_callable = __mvalid_q<__nothrow_callable_, _Fn, _As...>;
+inline constexpr bool __nothrow_callable = __type_valid_v<__nothrow_callable_, _Fn, _As...>;
 
 template <class _Ty, class... _As>
-using __nothrow_constructible_ = __mif<noexcept(_Ty{__declval<_As>()...})>;
+using __nothrow_constructible_ = _CUDA_VSTD::enable_if_t<noexcept(_Ty{__declval<_As>()...})>;
 
 template <class _Ty, class... _As>
-inline constexpr bool __nothrow_constructible = __mvalid_q<__nothrow_constructible_, _Ty, _As...>;
+inline constexpr bool __nothrow_constructible = __type_valid_v<__nothrow_constructible_, _Ty, _As...>;
 
 template <class _Ty>
-using __nothrow_decay_copyable_ = __mif<noexcept(__decay_t<_Ty>(__declval<_Ty>()))>;
+using __nothrow_decay_copyable_ = _CUDA_VSTD::enable_if_t<noexcept(__decay_t<_Ty>(__declval<_Ty>()))>;
 
 template <class... _As>
-inline constexpr bool __nothrow_decay_copyable = (__mvalid_q<__nothrow_decay_copyable_, _As> && ...);
+inline constexpr bool __nothrow_decay_copyable = (__type_valid_v<__nothrow_decay_copyable_, _As> && ...);
 
 template <class _Ty>
-using __nothrow_movable_ = __mif<noexcept(_Ty(__declval<_Ty>()))>;
+using __nothrow_movable_ = _CUDA_VSTD::enable_if_t<noexcept(_Ty(__declval<_Ty>()))>;
 
 template <class... _As>
-inline constexpr bool __nothrow_movable = (__mvalid_q<__nothrow_movable_, _As> && ...);
+inline constexpr bool __nothrow_movable = (__type_valid_v<__nothrow_movable_, _As> && ...);
 
 template <class _Ty>
-using __nothrow_copyable_ = __mif<noexcept(_Ty(__declval<const _Ty&>()))>;
+using __nothrow_copyable_ = _CUDA_VSTD::enable_if_t<noexcept(_Ty(__declval<const _Ty&>()))>;
 
 template <class... _As>
-inline constexpr bool __nothrow_copyable = (__mvalid_q<__nothrow_copyable_, _As> && ...);
+inline constexpr bool __nothrow_copyable = (__type_valid_v<__nothrow_copyable_, _As> && ...);
 #endif
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/variant.cuh
+++ b/cudax/include/cuda/experimental/__async/variant.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__memory/construct_at.h>
 #include <cuda/std/__new/launder.h>
+#include <cuda/std/__utility/integer_sequence.h>
 
 #include <cuda/experimental/__async/meta.cuh>
 #include <cuda/experimental/__async/type_traits.cuh>
@@ -45,7 +46,7 @@ template <class _Idx, class... _Ts>
 class __variant_impl;
 
 template <>
-class __variant_impl<__mindices<>>
+class __variant_impl<_CUDA_VSTD::index_sequence<>>
 {
 public:
   template <class _Fn, class... _Us>
@@ -54,7 +55,7 @@ public:
 };
 
 template <size_t... _Idx, class... _Ts>
-class __variant_impl<__mindices<_Idx...>, _Ts...>
+class __variant_impl<_CUDA_VSTD::index_sequence<_Idx...>, _Ts...>
 {
   static constexpr size_t __max_size = __maximum({sizeof(_Ts)...});
   static_assert(__max_size != 0);
@@ -62,7 +63,7 @@ class __variant_impl<__mindices<_Idx...>, _Ts...>
   alignas(_Ts...) unsigned char __storage_[__max_size];
 
   template <size_t _Ny>
-  using __at = __m_at_c<_Ny, _Ts...>;
+  using __at = _CUDA_VSTD::__type_index_c<_Ny, _Ts...>;
 
   _CUDAX_API void __destroy() noexcept
   {
@@ -172,15 +173,15 @@ public:
 template <class... _Ts>
 struct __mk_variant_
 {
-  using __indices_t = __mmake_indices<sizeof...(_Ts)>;
+  using __indices_t = _CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>;
   using type        = __variant_impl<__indices_t, _Ts...>;
 };
 
 template <class... _Ts>
-using __variant = __t<__mk_variant_<_Ts...>>;
+using __variant = typename __mk_variant_<_Ts...>::type;
 #else
 template <class... _Ts>
-using __variant = __variant_impl<__mmake_indices<sizeof...(_Ts)>, _Ts...>;
+using __variant = __variant_impl<_CUDA_VSTD::make_index_sequence<sizeof...(_Ts)>, _Ts...>;
 #endif
 
 template <class... _Ts>

--- a/cudax/include/cuda/experimental/__async/when_all.cuh
+++ b/cudax/include/cuda/experimental/__async/when_all.cuh
@@ -21,6 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/conjunction.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__utility/integer_sequence.h>
 #include <cuda/std/atomic>
 
 #include <cuda/experimental/__async/completion_signatures.cuh>
@@ -62,16 +65,16 @@ using __tombstone = _ERROR<_WHERE(_IN_ALGORITHM, when_all_t), _WHAT(_SENDER_HAS_
 template <class _Bool>
 struct __all_nothrow_decay_copyable
 {
-  static_assert(_CUDA_VSTD::is_same_v<_Bool, __mtrue>);
+  static_assert(_CUDA_VSTD::is_same_v<_Bool, _CUDA_VSTD::true_type>);
   template <class... _Ts>
-  using __f = __mbool<__nothrow_decay_copyable<_Ts...>>;
+  using __call = _CUDA_VSTD::bool_constant<__nothrow_decay_copyable<_Ts...>>;
 };
 
 template <>
-struct __all_nothrow_decay_copyable<__mfalse>
+struct __all_nothrow_decay_copyable<_CUDA_VSTD::false_type>
 {
   template <class... _Ts>
-  using __f = __mfalse;
+  using __call = _CUDA_VSTD::false_type;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -95,25 +98,25 @@ struct __reduce_completions;
 template <class... _What>
 struct __reduce_completions<_ERROR<_What...>&>
 {
-  using type = __mpair<_ERROR<_What...>, __moffsets<>>;
+  using type = __type_pair<_ERROR<_What...>, __moffsets<>>;
 };
 
 template <class _ValsOK, class _ErrsOK, class _Offsets, class... _Sigs>
 struct __reduce_completions<__completion_metadata<_ValsOK, _ErrsOK, _Offsets, _Sigs...>&>
 {
-  using type = __mpair< //
+  using type = __type_pair< //
     __concat_completion_signatures<completion_signatures<_Sigs..., set_error_t(::std::exception_ptr)>>,
     _Offsets>;
 };
 
 template <class _Offsets, class... _Sigs>
-struct __reduce_completions<__completion_metadata<__mtrue, __mtrue, _Offsets, _Sigs...>&>
+struct __reduce_completions<__completion_metadata<_CUDA_VSTD::true_type, _CUDA_VSTD::true_type, _Offsets, _Sigs...>&>
 {
-  using type = __mpair<__concat_completion_signatures<completion_signatures<_Sigs...>>, _Offsets>;
+  using type = __type_pair<__concat_completion_signatures<completion_signatures<_Sigs...>>, _Offsets>;
 };
 
 template <class _Ty>
-using __reduce_completions_t = __t<__reduce_completions<_Ty>>;
+using __reduce_completions_t = typename __reduce_completions<_Ty>::type;
 
 //////////////////////////////////////////////////////////////////////////////////////
 // __append_completion
@@ -127,7 +130,7 @@ extern __undefined<_Metadata> __append_completion;
 
 template <class _ValsOK, class _ErrsOK, class... _Sigs, class _Tag, class... _As>
 extern __completion_metadata<_ValsOK,
-                             __minvoke<__all_nothrow_decay_copyable<_ErrsOK>, _As...>,
+                             _CUDA_VSTD::__type_call<__all_nothrow_decay_copyable<_ErrsOK>, _As...>,
                              __moffsets<>,
                              _Sigs...,
                              _Tag(__decay_t<_As>...)>&
@@ -137,7 +140,7 @@ extern __completion_metadata<_ValsOK,
 // signature.
 template <class _ValsOK, class _ErrsOK, class... _Sigs, class... _As>
 extern __completion_metadata<
-  __minvoke<__all_nothrow_decay_copyable<_ValsOK>, _As...>,
+  _CUDA_VSTD::__type_call<__all_nothrow_decay_copyable<_ValsOK>, _As...>,
   _ErrsOK,
   __moffsets<>,
   set_value_t(__decay_t<_As>...), // Insert the value signature at the front
@@ -163,7 +166,7 @@ template <class _Metadata, class _Sig>
 auto operator|(_Metadata&, _Sig*) -> decltype(__append_completion<_Metadata, _Sig>);
 
 // The initial value of the fold expression:
-using __inner_fold_init = __completion_metadata<__mtrue, __mtrue, __moffsets<>>;
+using __inner_fold_init = __completion_metadata<_CUDA_VSTD::true_type, _CUDA_VSTD::true_type, __moffsets<>>;
 
 template <class... _Sigs>
 using __collect_inner = //
@@ -193,9 +196,13 @@ template <class _LeftValsOK,
           class _RightValsOK,
           class _RightErrsOK,
           class... _RightSigs>
-extern __completion_metadata<__mtrue, __mand<_LeftErrsOK, _RightErrsOK>, __moffsets<>, _LeftSigs..., _RightSigs...>&
-  __merge_metadata<__completion_metadata<_LeftValsOK, _LeftErrsOK, _Offsets, _LeftSigs...>,
-                   __completion_metadata<_RightValsOK, _RightErrsOK, __moffsets<>, _RightSigs...>>;
+extern __completion_metadata<
+  _CUDA_VSTD::true_type,
+  _CUDA_VSTD::_And<_LeftErrsOK, _RightErrsOK>,
+  __moffsets<>,
+  _LeftSigs...,
+  _RightSigs...>& __merge_metadata<__completion_metadata<_LeftValsOK, _LeftErrsOK, _Offsets, _LeftSigs...>,
+                                   __completion_metadata<_RightValsOK, _RightErrsOK, __moffsets<>, _RightSigs...>>;
 
 // The following two specializations are selected when one of the metadata
 // structs is for a sender with no value completions. In that case, the
@@ -209,8 +216,8 @@ template <class _LeftValsOK,
           class _RightValsOK,
           class _RightErrsOK,
           class... _RightSigs>
-extern __completion_metadata<__mtrue, // There will be no value completion, so values need not be copied.
-                             __mand<_LeftErrsOK, _RightErrsOK>,
+extern __completion_metadata<_CUDA_VSTD::true_type, // There will be no value completion, so values need not be copied.
+                             _CUDA_VSTD::_And<_LeftErrsOK, _RightErrsOK>,
                              __moffsets<>,
                              _LeftSigs...,
                              _RightSigs...>&
@@ -225,8 +232,8 @@ template <class _LeftValsOK,
           class _RightErrsOK,
           class... _As,
           class... _RightSigs>
-extern __completion_metadata<__mtrue, // There will be no value completion, so values need not be copied.
-                             __mand<_LeftErrsOK, _RightErrsOK>,
+extern __completion_metadata<_CUDA_VSTD::true_type, // There will be no value completion, so values need not be copied.
+                             _CUDA_VSTD::_And<_LeftErrsOK, _RightErrsOK>,
                              __moffsets<>,
                              _LeftSigs...,
                              _RightSigs...>&
@@ -258,8 +265,8 @@ template <class _LeftValsOK,
           class _RightErrsOK,
           class... _Bs,
           class... _RightSigs>
-extern __completion_metadata<__mand<_LeftValsOK, _RightValsOK>,
-                             __mand<_LeftErrsOK, _RightErrsOK>,
+extern __completion_metadata<_CUDA_VSTD::_And<_LeftValsOK, _RightValsOK>,
+                             _CUDA_VSTD::_And<_LeftErrsOK, _RightErrsOK>,
                              __append_offset<sizeof...(_Bs), _Offsets...>,
                              set_value_t(_As..., _Bs...), // Concatenate the value types.
                              _LeftSigs...,
@@ -278,7 +285,8 @@ template <class _Meta1, class _Meta2>
 auto operator&(_Meta1&, _Meta2&) -> decltype(__merge_metadata<_Meta1, _Meta2>);
 
 // The initial value for the fold.
-using __outer_fold_init = __completion_metadata<__mtrue, __mtrue, __moffsets<0ul>, set_value_t(), set_stopped_t()>;
+using __outer_fold_init =
+  __completion_metadata<_CUDA_VSTD::true_type, _CUDA_VSTD::true_type, __moffsets<0ul>, set_value_t(), set_stopped_t()>;
 
 template <class... _Sigs>
 using __collect_outer = //
@@ -287,7 +295,7 @@ using __collect_outer = //
 // Extract the first template parameter of the __state_t specialization.
 // The first template parameter is the receiver type.
 template <class _State>
-using __rcvr_from_state_t = __mapply<__mpoly_q<__mfront>, _State>;
+using __rcvr_from_state_t = _CUDA_VSTD::__type_apply<_CUDA_VSTD::__detail::__type_at_fn<0>, _State>;
 
 /// The receivers connected to the when_all's sub-operations expose this as
 /// their environment. Its `get_stop_token` query returns the token from
@@ -324,7 +332,7 @@ struct __rcvr_t
   template <class... _Ts>
   _CUDAX_TRIVIAL_API void set_value(_Ts&&... __ts) noexcept
   {
-    constexpr auto idx = __mmake_indices<sizeof...(_Ts)>();
+    constexpr _CUDA_VSTD::index_sequence_for<_Ts...>* idx = nullptr;
     __state_.template __set_value<_Index>(idx, static_cast<_Ts&&>(__ts)...);
     __state_.__arrive();
   }
@@ -350,11 +358,12 @@ struct __rcvr_t
 
 template <class _CvSndr, size_t _Idx, class _StateZip>
 using __inner_completions_ = //
-  __mapply_q<__collect_inner, completion_signatures_of_t<_CvSndr, __rcvr_t<_StateZip, _Idx>>>;
+  _CUDA_VSTD::__type_apply<_CUDA_VSTD::__type_quote<__collect_inner>,
+                           completion_signatures_of_t<_CvSndr, __rcvr_t<_StateZip, _Idx>>>;
 
 template <class _CvSndr, size_t _Idx, class _StateZip>
 using __inner_completions = //
-  __midentity_or_error_with< //
+  __type_self_or_error_with< //
     __inner_completions_<_CvSndr, _Idx, _StateZip>, //
     _WITH_SENDER(_CvSndr)>;
 
@@ -374,16 +383,17 @@ template <class _Rcvr, class _CvFn, class _Sndrs>
 struct __state_t;
 
 template <class _Rcvr, class _CvFn, size_t... _Idx, class... _Sndrs>
-struct __state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
+struct __state_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Sndrs...>>
 {
   using __completions_offsets_pair_t = //
     __collect_outer< //
-      __inner_completions<__minvoke1<_CvFn, _Sndrs>, _Idx, __zip<__state_t>>...>;
-  using __completions_t = __mfirst<__completions_offsets_pair_t>;
-  using __indices_t     = __mindices<_Idx...>;
-  using __offsets_t     = __msecond<__completions_offsets_pair_t>;
-  using __values_t      = __value_types<__completions_t, __lazy_tuple, __mpoly<__msingle_or<__nil>>::__f>;
-  using __errors_t      = __error_types<__completions_t, __variant>;
+      __inner_completions<_CUDA_VSTD::__type_call1<_CvFn, _Sndrs>, _Idx, __zip<__state_t>>...>;
+  using __completions_t = __type_first<__completions_offsets_pair_t>;
+  using __indices_t     = _CUDA_VSTD::index_sequence<_Idx...>;
+  using __offsets_t     = __type_second<__completions_offsets_pair_t>;
+  using __values_t =
+    __value_types<__completions_t, __lazy_tuple, _CUDA_VSTD::__type_indirect<__type_self_or<__nil>>::__call>;
+  using __errors_t = __error_types<__completions_t, __variant>;
 
   using __stop_tok_t      = stop_token_of_t<env_of_t<_Rcvr>>;
   using __stop_callback_t = stop_callback_for_t<__stop_tok_t, __on_stop_request>;
@@ -407,7 +417,7 @@ struct __state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
   }
 
   template <size_t _Index, size_t... _Jdx, class... _Ts>
-  _CUDAX_API void __set_value(__mindices<_Jdx...>, [[maybe_unused]] _Ts&&... __ts) noexcept
+  _CUDAX_API void __set_value(_CUDA_VSTD::index_sequence<_Jdx...>*, [[maybe_unused]] _Ts&&... __ts) noexcept
   {
     [[maybe_unused]] constexpr size_t _Offset = __offset_for<_Index>(static_cast<__offsets_t*>(nullptr));
     if constexpr (!_CUDA_VSTD::is_same_v<__values_t, __nil>)
@@ -514,11 +524,11 @@ struct __state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
 
 /// The operation state for when_all
 template <class _Rcvr, class _CvFn, size_t... _Idx, class... _Sndrs>
-struct __opstate_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>
+struct __opstate_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Sndrs...>>
 {
   using operation_state_concept = operation_state_t;
-  using __sndrs_t               = __minvoke<_CvFn, __tuple<_Sndrs...>>;
-  using __state_t               = __when_all::__state_t<_Rcvr, _CvFn, __tupl<__mindices<_Idx...>, _Sndrs...>>;
+  using __sndrs_t               = _CUDA_VSTD::__type_call<_CvFn, __tuple<_Sndrs...>>;
+  using __state_t = __when_all::__state_t<_Rcvr, _CvFn, __tupl<_CUDA_VSTD::index_sequence<_Idx...>, _Sndrs...>>;
 
   using completion_signatures = typename __state_t::__completions_t;
   using __offsets_t           = typename __state_t::__offsets_t;

--- a/cudax/include/cuda/experimental/__async/write_env.cuh
+++ b/cudax/include/cuda/experimental/__async/write_env.cuh
@@ -21,8 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__type_traits/conditional.h>
-
 #include <cuda/experimental/__async/cpos.cuh>
 #include <cuda/experimental/__async/env.cuh>
 #include <cuda/experimental/__async/exception.cuh>

--- a/cudax/test/async/common/checked_receiver.cuh
+++ b/cudax/test/async/common/checked_receiver.cuh
@@ -28,7 +28,7 @@ struct checked_value_receiver
   // pack is not visible within the scope of a lambda.
   _CCCL_HOST_DEVICE void set_value() && noexcept
   {
-    if constexpr (!_CUDA_VSTD::is_same_v<cudax_async::__mlist<Values...>, cudax_async::__mlist<>>)
+    if constexpr (!_CUDA_VSTD::is_same_v<_CUDA_VSTD::__type_list<Values...>, _CUDA_VSTD::__type_list<>>)
     {
       CUDAX_FAIL("expected a value completion; got a different value");
     }
@@ -37,7 +37,7 @@ struct checked_value_receiver
   template <class... As>
   _CCCL_HOST_DEVICE void set_value(As... as) && noexcept
   {
-    if constexpr (_CUDA_VSTD::is_same_v<cudax_async::__mlist<Values...>, cudax_async::__mlist<As...>>)
+    if constexpr (_CUDA_VSTD::is_same_v<_CUDA_VSTD::__type_list<Values...>, _CUDA_VSTD::__type_list<As...>>)
     {
       _values.__apply(
         [&](auto const&... vs) {

--- a/cudax/test/async/common/utility.cuh
+++ b/cudax/test/async/common/utility.cuh
@@ -162,24 +162,20 @@ void check_values(Sndr&& sndr, const Values&... values) noexcept
 #endif // !defined(__CUDA_ARCH__)
 
 template <class... Ts>
-using types = cudax_async::__mlist<Ts...>;
+using types = _CUDA_VSTD::__type_list<Ts...>;
 
 template <class... Values, class Sndr>
 _CCCL_HOST_DEVICE void check_value_types(Sndr&&) noexcept
 {
-  using actual_t   = cudax_async::value_types_of_t<Sndr, cudax_async::env<>, types, cudax_async::__mmake_set>;
-  using expected_t = cudax_async::__mmake_set<Values...>;
-
-  static_assert(cudax_async::__mset_eq<expected_t, actual_t>, "value_types_of_t does not match expected types");
+  using actual_t = cudax_async::value_types_of_t<Sndr, cudax_async::env<>, types, _CUDA_VSTD::__make_type_set>;
+  static_assert(_CUDA_VSTD::__type_set_eq_v<actual_t, Values...>, "value_types_of_t does not match expected types");
 }
 
 template <class... Errors, class Sndr>
 _CCCL_HOST_DEVICE void check_error_types(Sndr&&) noexcept
 {
-  using actual_t   = cudax_async::error_types_of_t<Sndr, cudax_async::env<>, cudax_async::__mmake_set>;
-  using expected_t = cudax_async::__mmake_set<Errors...>;
-
-  static_assert(cudax_async::__mset_eq<expected_t, actual_t>, "error_types_of_t does not match expected types");
+  using actual_t = cudax_async::error_types_of_t<Sndr, cudax_async::env<>, _CUDA_VSTD::__make_type_set>;
+  static_assert(_CUDA_VSTD::__type_set_eq_v<actual_t, Errors...>, "error_types_of_t does not match expected types");
 }
 
 template <bool SendsStopped, class Sndr>

--- a/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
@@ -14,7 +14,7 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/type_identity.h>
 
-#if defined(_CCCL_CUDACC_BELOW_12_2) || defined(_CCCL_COMPILER_ICC) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#if defined(_CCCL_COMPILER_ICC) || defined(_CCCL_CUDA_COMPILER_NVCC) || defined(_CCCL_CUDA_COMPILER_CLANG)
 // These compilers have trouble making substitution failures during
 // alias template instantiation non-fatal.
 #  define SKIP_SFINAE_TESTS

--- a/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
@@ -14,7 +14,8 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/type_identity.h>
 
-#if defined(_CCCL_COMPILER_ICC) || defined(_CCCL_CUDA_COMPILER_NVCC) || defined(_CCCL_CUDA_COMPILER_CLANG)
+#if defined(_CCCL_COMPILER_ICC) || defined(_CCCL_CUDA_COMPILER_NVCC) || defined(_CCCL_COMPILER_NVRTC) \
+  || defined(_CCCL_CUDA_COMPILER_CLANG)
 // These compilers have trouble making substitution failures during
 // alias template instantiation non-fatal.
 #  define SKIP_SFINAE_TESTS

--- a/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
@@ -14,7 +14,7 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/type_identity.h>
 
-#if defined(_CCCL_CUDACC_BELOW_12_2) || defined(_CCCL_COMPILER_ICC)
+#if defined(_CCCL_CUDACC_BELOW_12_2) || defined(_CCCL_COMPILER_ICC) || defined(_CCCL_CUDA_COMPILER_CLANG)
 // These compilers have trouble making substitution failures during
 // alias template instantiation non-fatal.
 #  define SKIP_SFINAE_TESTS
@@ -80,6 +80,13 @@ struct Fn2
   using __call = Types<T, U>;
 };
 
+template <class Fn>
+struct ForwardFn
+{
+  template <class... Ts>
+  using __call = ::cuda::std::__type_call<Fn, Ts...>;
+};
+
 // __type
 static_assert(::cuda::std::is_same<::cuda::std::__type<::cuda::std::__type_identity<Incomplete>>, Incomplete>::value,
               "");
@@ -92,6 +99,17 @@ static_assert(::cuda::std::is_same<::cuda::std::__type_call<Fn2, Incomplete, Emp
 static_assert(::cuda::std::is_same<::cuda::std::__type_call1<Fn1, Incomplete>, Types<Incomplete>>::value, "");
 static_assert(::cuda::std::is_same<::cuda::std::__type_call2<Fn2, Incomplete, Empty>, Types<Incomplete, Empty>>::value,
               "");
+
+// __type_indirect
+#if !defined(SKIP_SFINAE_TESTS)
+static_assert(!::cuda::std::__type_callable<ForwardFn<Fn2>, Incomplete, Empty>::value, "");
+static_assert(!::cuda::std::__type_callable<ForwardFn<::cuda::std::__type_indirect<Fn2>>, Incomplete>::value, "");
+#endif
+static_assert(::cuda::std::__type_callable<ForwardFn<::cuda::std::__type_indirect<Fn2>>, Incomplete, Empty>::value, "");
+static_assert(
+  ::cuda::std::is_same<::cuda::std::__type_call<ForwardFn<::cuda::std::__type_indirect<Fn2>>, Incomplete, Empty>,
+                       Types<Incomplete, Empty>>::value,
+  "");
 
 // __type_call_indirect
 template <class... Ts, class = ::cuda::std::__type_call_indirect<Fn2, Ts...>>
@@ -169,7 +187,7 @@ static_assert(::cuda::std::is_same<::cuda::std::__type_call<::cuda::std::__type_
                                    Types<Empty, Incomplete>>::value,
               "");
 
-// __type_bind_back
+// __type_bind_front
 static_assert(::cuda::std::is_same<::cuda::std::__type_call<::cuda::std::__type_bind_front<Fn, Incomplete>, Empty>,
                                    Types<Incomplete, Empty>>::value,
               "");
@@ -217,14 +235,14 @@ static_assert(::cuda::std::__type_index_c<1, int, Int<42>, double>::value == 42,
 static_assert(
   ::cuda::std::__type_index<::cuda::std::integral_constant<::cuda::std::size_t, 1>, int, Int<42>, double>::value == 42,
   "");
-static_assert(::cuda::std::__type_callable<::cuda::std::__type_quote_indirect<::cuda::std::__type_index>,
+static_assert(::cuda::std::__type_callable<::cuda::std::__type_indirect_quote<::cuda::std::__type_index>,
                                            ::cuda::std::integral_constant<::cuda::std::size_t, 1>,
                                            int,
                                            Int<42>>::value,
               "");
 
 #if !defined(SKIP_SFINAE_TESTS)
-static_assert(!::cuda::std::__type_callable<::cuda::std::__type_quote_indirect<::cuda::std::__type_index>,
+static_assert(!::cuda::std::__type_callable<::cuda::std::__type_indirect_quote<::cuda::std::__type_index>,
                                             ::cuda::std::integral_constant<::cuda::std::size_t, 1>,
                                             int>::value,
               "");
@@ -431,12 +449,12 @@ static_assert(::cuda::std::__type_at<::cuda::std::integral_constant<::cuda::std:
                                      ::cuda::std::__type_list<int, Int<42>, double>>::value
                 == 42,
               "");
-static_assert(::cuda::std::__type_callable<::cuda::std::__type_quote_indirect<::cuda::std::__type_at>,
+static_assert(::cuda::std::__type_callable<::cuda::std::__type_indirect_quote<::cuda::std::__type_at>,
                                            ::cuda::std::integral_constant<::cuda::std::size_t, 1>,
                                            ::cuda::std::__type_list<int, Int<42>>>::value,
               "");
 #if !defined(SKIP_SFINAE_TESTS)
-static_assert(!::cuda::std::__type_callable<::cuda::std::__type_quote_indirect<::cuda::std::__type_at>,
+static_assert(!::cuda::std::__type_callable<::cuda::std::__type_indirect_quote<::cuda::std::__type_at>,
                                             ::cuda::std::integral_constant<::cuda::std::size_t, 1>,
                                             ::cuda::std::__type_list<int>>::value,
               "");


### PR DESCRIPTION
## Description

now that CCCL has some metaprogramming utilities, we can eliminate much of the metaprogramming in the std::execution implementation in cudax.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
