### PR TITLE
Add environment to encapsulate information needed for `cudax::vector`

### DIFF
--- a/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
@@ -250,7 +250,7 @@ public:
   //! Returns a \c const reference to the :ref:`any_async_resource <cudax-memory-resource-any-async-resource>`
   //! that holds the memory resource used to allocate the buffer
   //! @endrst
-  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI const __async_resource& get_resource() const noexcept
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI const __async_resource& get_memory_resource() const noexcept
   {
     return __mr_;
   }

--- a/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
@@ -233,7 +233,7 @@ public:
   //! Returns a \c const reference to the :ref:`any_resource <cudax-memory-resource-any-resource>`
   //! that holds the memory resource used to allocate the buffer
   //! @endrst
-  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI const __resource& get_resource() const noexcept
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI const __resource& get_memory_resource() const noexcept
   {
     return __mr_;
   }

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -45,7 +45,7 @@ private:
   using __stream_ref = ::cuda::experimental::stream_ref;
 
   __resource __mr_           = ::cuda::experimental::mr::device_memory_resource{};
-  __stream_ref __stream_     = cudaStream_t{0};
+  __stream_ref __stream_     = ::cuda::experimental::detail::__invalid_stream;
   execution_policy __policy_ = execution_policy::unsequenced_device;
 
 public:
@@ -60,7 +60,7 @@ public:
   //! @param __stream The stream_ref passed in
   //! @param __policy The execution_policy passed in
   _CCCL_HIDE_FROM_ABI env_t(__resource __mr,
-                            __stream_ref __stream     = cudaStream_t{0},
+                            __stream_ref __stream     = ::cuda::experimental::detail::__invalid_stream,
                             execution_policy __policy = execution_policy::unsequenced_device) noexcept
       : __mr_(_CUDA_VSTD::move(__mr))
       , __stream_(__stream)

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -46,13 +46,13 @@ private:
 
   __resource __mr_           = ::cuda::experimental::mr::device_memory_resource{};
   __stream_ref __stream_     = ::cuda::experimental::detail::__invalid_stream;
-  execution_policy __policy_ = execution_policy::unsequenced_device;
+  execution_policy __policy_ = execution_policy::invalid_execution_policy;
 
 public:
   //! @brief Default constructs an environment using
   //! * ``::cuda::experimental::mr::device_memory_resource`` as the resource
   //! * the default stream
-  //! * ``execution_policy::unsequenced_device`` as the execution policy
+  //! * ``execution_policy::invalid_execution_policy`` as the execution policy
   _CCCL_HIDE_FROM_ABI env_t() = default;
 
   //! @brief Construct an env_t from an any_resource, a stream and a policy
@@ -61,7 +61,7 @@ public:
   //! @param __policy The execution_policy passed in
   _CCCL_HIDE_FROM_ABI env_t(__resource __mr,
                             __stream_ref __stream     = ::cuda::experimental::detail::__invalid_stream,
-                            execution_policy __policy = execution_policy::unsequenced_device) noexcept
+                            execution_policy __policy = execution_policy::invalid_execution_policy) noexcept
       : __mr_(_CUDA_VSTD::move(__mr))
       , __stream_(__stream)
       , __policy_(__policy)

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -41,7 +41,7 @@ template <class... _Properties>
 class env_t
 {
 private:
-  using __resource   = ::cuda::experimental::mr::any_resource<_Properties...>;
+  using __resource   = ::cuda::experimental::mr::any_async_resource<_Properties...>;
   using __stream_ref = ::cuda::experimental::stream_ref;
 
   __resource __mr_           = ::cuda::experimental::mr::device_memory_resource{};

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -34,34 +34,33 @@
 #include <cuda/experimental/__stream/get_stream.cuh>
 #include <cuda/experimental/__stream/stream_ref.cuh>
 
-namespace cuda::experimental::execution
+namespace cuda::experimental
 {
 
 template <class... _Properties>
 class env_t
 {
 private:
-  using __resource   = ::cuda::experimental::mr::any_async_resource<_Properties...>;
-  using __stream_ref = ::cuda::experimental::stream_ref;
+  using __resource   = any_async_resource<_Properties...>;
+  using __stream_ref = stream_ref;
 
-  __resource __mr_           = ::cuda::experimental::mr::device_memory_resource{};
-  __stream_ref __stream_     = ::cuda::experimental::detail::__invalid_stream;
-  execution_policy __policy_ = execution_policy::invalid_execution_policy;
+  __resource __mr_                      = device_memory_resource{};
+  __stream_ref __stream_                = detail::__invalid_stream;
+  execution::execution_policy __policy_ = execution::execution_policy::invalid_execution_policy;
 
 public:
-  //! @brief Default constructs an environment using
-  //! * ``::cuda::experimental::mr::device_memory_resource`` as the resource
-  //! * the default stream
-  //! * ``execution_policy::invalid_execution_policy`` as the execution policy
+  //! @brief Default constructs an environment using ``device_memory_resource`` as the resource the default stream
+  //! ``execution_policy::invalid_execution_policy`` as the execution policy
   _CCCL_HIDE_FROM_ABI env_t() = default;
 
   //! @brief Construct an env_t from an any_resource, a stream and a policy
   //! @param __mr The any_resource passed in
   //! @param __stream The stream_ref passed in
   //! @param __policy The execution_policy passed in
-  _CCCL_HIDE_FROM_ABI env_t(__resource __mr,
-                            __stream_ref __stream     = ::cuda::experimental::detail::__invalid_stream,
-                            execution_policy __policy = execution_policy::invalid_execution_policy) noexcept
+  _CCCL_HIDE_FROM_ABI
+  env_t(__resource __mr,
+        __stream_ref __stream                = detail::__invalid_stream,
+        execution::execution_policy __policy = execution::execution_policy::invalid_execution_policy) noexcept
       : __mr_(_CUDA_VSTD::move(__mr))
       , __stream_(__stream)
       , __policy_(__policy)
@@ -71,9 +70,8 @@ public:
   //! properties we need
   template <class _Env>
   static constexpr bool __is_compatible_env =
-    ::cuda::experimental::__async::__queryable<_Env, get_memory_resource_t>
-    && ::cuda::experimental::__async::__queryable<_Env, get_stream_t>
-    && ::cuda::experimental::__async::__queryable<_Env, get_execution_policy_t>;
+    __async::__queryable<_Env, get_memory_resource_t> && __async::__queryable<_Env, get_stream_t>
+    && __async::__queryable<_Env, execution::get_execution_policy_t>;
 
   //! @brief Construct from an environment that has the right queries
   //! @param __env The environment we are querying for the required information
@@ -82,7 +80,7 @@ public:
   _CCCL_HIDE_FROM_ABI env_t(const _Env& __env) noexcept
       : __mr_(__env.query(get_memory_resource))
       , __stream_(__env.query(get_stream))
-      , __policy_(__env.query(get_execution_policy))
+      , __policy_(__env.query(execution::get_execution_policy))
   {}
 
   _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI const __resource& query(get_memory_resource_t) const noexcept
@@ -95,12 +93,12 @@ public:
     return __stream_;
   }
 
-  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI execution_policy query(get_execution_policy_t) const noexcept
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI execution::execution_policy query(execution::get_execution_policy_t) const noexcept
   {
     return __policy_;
   }
 };
 
-} // namespace cuda::experimental::execution
+} // namespace cuda::experimental
 
 #endif //__CUDAX___EXECUTION_ENV_CUH

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX___EXECUTION_ENV_CUH
+#define __CUDAX___EXECUTION_ENV_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__memory_resource/properties.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/move.h>
+
+#include <cuda/experimental/__async/queries.cuh>
+#include <cuda/experimental/__execution/policy.cuh>
+#include <cuda/experimental/__memory_resource/any_resource.cuh>
+#include <cuda/experimental/__memory_resource/device_memory_resource.cuh>
+#include <cuda/experimental/__memory_resource/get_memory_resource.cuh>
+#include <cuda/experimental/__stream/get_stream.cuh>
+#include <cuda/experimental/__stream/stream_ref.cuh>
+
+namespace cuda::experimental::execution
+{
+
+template <class... _Properties>
+class env_t
+{
+private:
+  using __resource   = ::cuda::experimental::mr::any_resource<_Properties...>;
+  using __stream_ref = ::cuda::experimental::stream_ref;
+
+  __resource __mr_           = ::cuda::experimental::mr::device_memory_resource{};
+  __stream_ref __stream_     = cudaStream_t{0};
+  execution_policy __policy_ = execution_policy::unsequenced_device;
+
+public:
+  //! @brief Default constructs an environment using
+  //! * ``::cuda::experimental::mr::device_memory_resource`` as the resource
+  //! * the default stream
+  //! * ``execution_policy::unsequenced_device`` as the execution policy
+  _CCCL_HIDE_FROM_ABI env_t() = default;
+
+  //! @brief Construct an env_t from an any_resource, a stream and a policy
+  //! @param __mr The any_resource passed in
+  //! @param __stream The stream_ref passed in
+  //! @param __policy The execution_policy passed in
+  _CCCL_HIDE_FROM_ABI env_t(__resource __mr,
+                            __stream_ref __stream     = cudaStream_t{0},
+                            execution_policy __policy = execution_policy::unsequenced_device) noexcept
+      : __mr_(_CUDA_VSTD::move(__mr))
+      , __stream_(__stream)
+      , __policy_(__policy)
+  {}
+
+  //! @brief Checks whether another env is compatible with this one. That requires it to have queries for the three
+  //! properties we need
+  template <class _Env>
+  static constexpr bool __is_compatible_env =
+    ::cuda::experimental::__async::__queryable<_Env, get_memory_resource_t>
+    && ::cuda::experimental::__async::__queryable<_Env, get_stream_t>
+    && ::cuda::experimental::__async::__queryable<_Env, get_execution_policy_t>;
+
+  //! @brief Construct from an environment that has the right queries
+  //! @param __env The environment we are querying for the required information
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES((!_CCCL_TRAIT(_CUDA_VSTD::is_same, _Env, env_t)) _CCCL_AND __is_compatible_env<_Env>)
+  _CCCL_HIDE_FROM_ABI env_t(const _Env& __env) noexcept
+      : __mr_(__env.query(get_memory_resource))
+      , __stream_(__env.query(get_stream))
+      , __policy_(__env.query(get_execution_policy))
+  {}
+
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI const __resource& query(get_memory_resource_t) const noexcept
+  {
+    return __mr_;
+  }
+
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI __stream_ref query(get_stream_t) const noexcept
+  {
+    return __stream_;
+  }
+
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI execution_policy query(get_execution_policy_t) const noexcept
+  {
+    return __policy_;
+  }
+};
+
+} // namespace cuda::experimental::execution
+
+#endif //__CUDAX___EXECUTION_ENV_CUH

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -26,7 +26,7 @@
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
 
-#include <cuda/experimental/__async/queries.cuh>
+#include <cuda/experimental/__async/sender/queries.cuh>
 #include <cuda/experimental/__execution/policy.cuh>
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
 #include <cuda/experimental/__memory_resource/device_memory_resource.cuh>

--- a/cudax/include/cuda/experimental/__execution/policy.cuh
+++ b/cudax/include/cuda/experimental/__execution/policy.cuh
@@ -32,6 +32,7 @@ namespace cuda::experimental::execution
 
 enum class execution_policy
 {
+  invalid_execution_policy,
   sequenced_host,
   sequenced_device,
   parallel_host,

--- a/cudax/include/cuda/experimental/__execution/policy.cuh
+++ b/cudax/include/cuda/experimental/__execution/policy.cuh
@@ -24,6 +24,7 @@
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 
+#include <cuda/experimental/__async/sender/queries.cuh>
 #include <cuda/experimental/__async/sender/utility.cuh>
 
 namespace cuda::experimental::execution
@@ -60,25 +61,18 @@ _CCCL_INLINE_VAR constexpr bool __is_unsequenced_execution_policy =
   _Policy == execution_policy::unsequenced_host || _Policy == execution_policy::unsequenced_device
   || _Policy == execution_policy::parallel_unsequenced_host || _Policy == execution_policy::parallel_unsequenced_device;
 
-template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__has_member_get_execution_policy_,
-                       requires(const _Tp& __t)(requires(_CCCL_TRAIT(
-                         _CUDA_VSTD::is_convertible, decltype(__t.get_execution_policy()), execution_policy))));
-
 struct get_execution_policy_t;
 
 template <class _Tp>
-_CCCL_CONCEPT __has_member_get_execution_policy = _CCCL_FRAGMENT(__has_member_get_execution_policy_, _Tp);
+_CCCL_CONCEPT __has_member_get_execution_policy = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(
+  requires(_CCCL_TRAIT(_CUDA_VSTD::is_convertible, decltype(__t.get_execution_policy()), execution_policy)));
 
 template <class _Env>
-_CCCL_CONCEPT_FRAGMENT(
-  __has_query_get_execution_policy_,
-  requires(const _Env& __env, const get_execution_policy_t& __cpo)(
-    requires(!__has_member_get_execution_policy<_Env>),
-    requires(_CCCL_TRAIT(_CUDA_VSTD::is_convertible, decltype(__env.query(__cpo)), execution_policy))));
-
-template <class _Env>
-_CCCL_CONCEPT __has_query_get_execution_policy = _CCCL_FRAGMENT(__has_query_get_execution_policy_, _Env);
+_CCCL_CONCEPT __has_query_get_execution_policy = _CCCL_REQUIRES_EXPR((_Env))(
+  requires(!__has_member_get_execution_policy<_Env>),
+  requires(_CCCL_TRAIT(_CUDA_VSTD::is_convertible,
+                       ::cuda::experimental::__async::__query_result_t<const _Env&, get_execution_policy_t>,
+                       execution_policy)));
 
 struct get_execution_policy_t
 {

--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -237,6 +237,16 @@ public:
   //! @param __rhs The other \c basic_any_resource
   //! @return Checks whether both resources have the same equality function stored in their vtable and if so returns
   //! the result of that equality comparison. Otherwise returns false.
+  _CCCL_NODISCARD bool operator==(const basic_any_resource& __rhs) const
+  {
+    return (this->__static_vtable->__equal_fn == __rhs.__static_vtable->__equal_fn)
+        && this->__static_vtable->__equal_fn(this->_Get_object(), __rhs._Get_object());
+  }
+
+  //! @brief Equality comparison between two \c basic_any_resource
+  //! @param __rhs The other \c basic_any_resource
+  //! @return Checks whether both resources have the same equality function stored in their vtable and if so returns
+  //! the result of that equality comparison. Otherwise returns false.
   _CCCL_TEMPLATE(class... _OtherProperties)
   _CCCL_REQUIRES((sizeof...(_Properties) == sizeof...(_OtherProperties))
                    _CCCL_AND __properties_match<_OtherProperties...>)
@@ -244,6 +254,15 @@ public:
   {
     return (this->__static_vtable->__equal_fn == __rhs.__static_vtable->__equal_fn)
         && this->__static_vtable->__equal_fn(this->_Get_object(), __rhs._Get_object());
+  }
+
+  //! @brief Inequality comparison between two \c basic_any_resource
+  //! @param __rhs The other \c basic_any_resource
+  //! @return Checks whether both resources have the same equality function stored in their vtable and if so returns
+  //! the inverse result of that equality comparison. Otherwise returns true.
+  _CCCL_NODISCARD bool operator!=(const basic_any_resource& __rhs) const
+  {
+    return !(*this == __rhs);
   }
 
   //! @brief Inequality comparison between two \c basic_any_resource

--- a/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
@@ -39,29 +39,23 @@
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/std/__type_traits/is_same.h>
 
+#include <cuda/experimental/__async/queries.cuh>
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
 
 namespace cuda::experimental
 {
 
-template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(__has_member_get_resource_,
-                       requires(const _Tp& __t)(
-                         requires(_CUDA_VMR::async_resource<cuda::std::remove_cvref_t<decltype(__t.get_resource())>>)));
-
-template <class _Tp>
-_CCCL_CONCEPT __has_member_get_resource = _CCCL_FRAGMENT(__has_member_get_resource_, _Tp);
-
 struct get_memory_resource_t;
 
-template <class _Env>
-_CCCL_CONCEPT_FRAGMENT(__has_query_get_memory_resource_,
-                       requires(const _Env& __env, const get_memory_resource_t& __cpo)(
-                         requires(!__has_member_get_resource<_Env>),
-                         requires(_CUDA_VMR::async_resource<cuda::std::remove_cvref_t<decltype(__env.query(__cpo))>>)));
+template <class _Tp>
+_CCCL_CONCEPT __has_member_get_resource = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(
+  requires(_CUDA_VMR::async_resource<cuda::std::remove_cvref_t<decltype(__t.get_resource())>>));
 
 template <class _Env>
-_CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_FRAGMENT(__has_query_get_memory_resource_, _Env);
+_CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_REQUIRES_EXPR((_Env))(
+  requires(!__has_member_get_resource<_Env>),
+  requires(
+    _CUDA_VMR::async_resource<cuda::std::remove_cvref_t<__async::__query_result_t<const _Env&, get_memory_resource_t>>>));
 
 //! @brief `get_memory_resource_t` is a customization point object that queries a type `T` for an associated memory
 //! resource

--- a/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
@@ -39,7 +39,7 @@
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/std/__type_traits/is_same.h>
 
-#include <cuda/experimental/__async/queries.cuh>
+#include <cuda/experimental/__async/sender/queries.cuh>
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
 
 namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__MEMORY_RESOURCE_GET_MEMORY_RESOURCE_CUH
+#define _CUDAX__MEMORY_RESOURCE_GET_MEMORY_RESOURCE_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// If the memory resource header was included without the experimental flag,
+// tell the user to define the experimental flag.
+#if defined(_CUDA_MEMORY_RESOURCE) && !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
+#  error "To use the experimental memory resource, define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
+#endif
+
+// cuda::mr is unavable on MSVC 2017
+#if defined(_CCCL_COMPILER_MSVC_2017)
+#  error "The any_resource header is not supported on MSVC 2017"
+#endif
+
+#if !defined(LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE)
+#  define LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+#endif
+
+#include <cuda/__memory_resource/properties.h>
+#include <cuda/std/__type_traits/is_same.h>
+
+#include <cuda/experimental/__memory_resource/any_resource.cuh>
+
+namespace cuda::experimental
+{
+
+template <class _Tp>
+_CCCL_CONCEPT_FRAGMENT(__has_member_get_resource_,
+                       requires(const _Tp& __t)(
+                         requires(_CUDA_VMR::async_resource<cuda::std::remove_cvref_t<decltype(__t.get_resource())>>)));
+
+template <class _Tp>
+_CCCL_CONCEPT __has_member_get_resource = _CCCL_FRAGMENT(__has_member_get_resource_, _Tp);
+
+struct get_memory_resource_t;
+
+template <class _Env>
+_CCCL_CONCEPT_FRAGMENT(__has_query_get_memory_resource_,
+                       requires(const _Env& __env, const get_memory_resource_t& __cpo)(
+                         requires(!__has_member_get_resource<_Env>),
+                         requires(_CUDA_VMR::async_resource<cuda::std::remove_cvref_t<decltype(__env.query(__cpo))>>)));
+
+template <class _Env>
+_CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_FRAGMENT(__has_query_get_memory_resource_, _Env);
+
+//! @brief `get_memory_resource_t` is a customization point object that queries a type `T` for an associated memory
+//! resource
+struct get_memory_resource_t
+{
+  _CCCL_TEMPLATE(class _Tp)
+  _CCCL_REQUIRES(__has_member_get_resource<_Tp>)
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr decltype(auto) operator()(const _Tp& __t) const
+    noexcept(noexcept(__t.get_resource()))
+  {
+    return __t.get_resource();
+  } // namespace cuda::experimental
+
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES(__has_query_get_memory_resource<_Env>)
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr decltype(auto) operator()(const _Env& __env) const noexcept
+  {
+    static_assert(noexcept(__env.query(*this)), "");
+    return __env.query(*this);
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT auto get_memory_resource = get_memory_resource_t{};
+
+} // namespace cuda::experimental
+
+#endif //_CUDAX__MEMORY_RESOURCE_GET_MEMORY_RESOURCE_CUH

--- a/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/get_memory_resource.cuh
@@ -49,7 +49,7 @@ struct get_memory_resource_t;
 
 template <class _Tp>
 _CCCL_CONCEPT __has_member_get_resource = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(
-  requires(_CUDA_VMR::async_resource<cuda::std::remove_cvref_t<decltype(__t.get_resource())>>));
+  requires(_CUDA_VMR::async_resource<cuda::std::remove_cvref_t<decltype(__t.get_memory_resource())>>));
 
 template <class _Env>
 _CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_REQUIRES_EXPR((_Env))(
@@ -63,17 +63,17 @@ struct get_memory_resource_t
 {
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__has_member_get_resource<_Tp>)
-  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr decltype(auto) operator()(const _Tp& __t) const
-    noexcept(noexcept(__t.get_resource()))
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr decltype(auto) operator()(const _Tp& __t) const noexcept
   {
-    return __t.get_resource();
-  } // namespace cuda::experimental
+    static_assert(noexcept(__t.get_memory_resource()), "get_memory_resource must be noexcept");
+    return __t.get_memory_resource();
+  }
 
   _CCCL_TEMPLATE(class _Env)
   _CCCL_REQUIRES(__has_query_get_memory_resource<_Env>)
   _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr decltype(auto) operator()(const _Env& __env) const noexcept
   {
-    static_assert(noexcept(__env.query(*this)), "");
+    static_assert(noexcept(__env.query(*this)), "get_memory_resource_t query must be noexcept");
     return __env.query(*this);
   }
 };

--- a/cudax/include/cuda/experimental/__stream/get_stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/get_stream.cuh
@@ -37,21 +37,25 @@ namespace cuda::experimental
 
 struct get_stream_t;
 
-// clang-format off
 template <class _Tp>
-_CCCL_CONCEPT __has_member_get_stream =
-  _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)
-  (
-    requires(!_CUDA_VSTD::convertible_to<_Tp, ::cuda::stream_ref>),
-    _Same_as(::cuda::stream_ref) __t.get_stream()
-  );
-// clang-format on
+_CCCL_CONCEPT __convertible_to_stream_ref = _CUDA_VSTD::convertible_to<_Tp, ::cuda::stream_ref>;
+
+template <class _Tp>
+_CCCL_CONCEPT __has_member_get_stream = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(
+  requires(!__convertible_to_stream_ref<_Tp>), //
+  requires(__convertible_to_stream_ref<decltype(__t.get_stream())>));
+
+template <class _Env>
+_CCCL_CONCEPT __has_query_get_stream = _CCCL_REQUIRES_EXPR((_Env), const _Env& __env, const get_stream_t& __cpo)(
+  requires(!__convertible_to_stream_ref<_Env>),
+  requires(!__has_member_get_stream<_Env>),
+  requires(__convertible_to_stream_ref<decltype(__env.query(__cpo))>));
 
 //! @brief `get_stream` is a customization point object that queries a type `T` for an associated stream
 struct get_stream_t
 {
   _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES((_CUDA_VSTD::convertible_to<_Tp, ::cuda::stream_ref>) )
+  _CCCL_REQUIRES(__convertible_to_stream_ref<_Tp>)
   _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Tp& __t) const
     noexcept(noexcept(static_cast<::cuda::stream_ref>(__t)))
   {

--- a/cudax/include/cuda/experimental/__stream/get_stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/get_stream.cuh
@@ -29,10 +29,14 @@
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/stream_ref>
 
+#include <cuda/experimental/__async/queries.cuh>
 #include <cuda/experimental/__stream/stream.cuh>
 
 namespace cuda::experimental
 {
+
+struct get_stream_t;
+
 // clang-format off
 template <class _Tp>
 _CCCL_CONCEPT __has_member_get_stream =
@@ -62,9 +66,8 @@ struct get_stream_t
     return __t.get_stream();
   }
 
-  _CCCL_TEMPLATE(class _Env,
-                 class _Ret = decltype(_CUDA_VSTD::declval<const _Env&>().query(_CUDA_VSTD::declval<get_stream_t>())))
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Ret, ::cuda::stream_ref))
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES(__has_query_get_stream<_Env>)
   _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref operator()(const _Env& __env) const noexcept
   {
     static_assert(noexcept(__env.query(*this)), "");

--- a/cudax/include/cuda/experimental/__stream/get_stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/get_stream.cuh
@@ -29,7 +29,7 @@
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/stream_ref>
 
-#include <cuda/experimental/__async/queries.cuh>
+#include <cuda/experimental/__async/sender/queries.cuh>
 #include <cuda/experimental/__stream/stream.cuh>
 
 namespace cuda::experimental

--- a/cudax/include/cuda/experimental/execution.cuh
+++ b/cudax/include/cuda/experimental/execution.cuh
@@ -11,6 +11,7 @@
 #ifndef __CUDAX_EXECUTION__
 #define __CUDAX_EXECUTION__
 
+#include <cuda/experimental/__execution/env.cuh>
 #include <cuda/experimental/__execution/policy.cuh>
 
 #endif // __CUDAX_EXECUTION__

--- a/cudax/include/cuda/experimental/memory_resource.cuh
+++ b/cudax/include/cuda/experimental/memory_resource.cuh
@@ -14,6 +14,7 @@
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
 #include <cuda/experimental/__memory_resource/device_memory_pool.cuh>
 #include <cuda/experimental/__memory_resource/device_memory_resource.cuh>
+#include <cuda/experimental/__memory_resource/get_memory_resource.cuh>
 #include <cuda/experimental/__memory_resource/managed_memory_resource.cuh>
 #include <cuda/experimental/__memory_resource/pinned_memory_resource.cuh>
 #include <cuda/experimental/__memory_resource/properties.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -88,6 +88,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
 
   cudax_add_catch2_test(test_target execution ${cn_target}
     execution/policies/policies.cu
+    execution/policies/get_execution_policy.cu
   )
 
   cudax_add_catch2_test(test_target stream ${cn_target}

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -87,6 +87,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
   target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
 
   cudax_add_catch2_test(test_target execution ${cn_target}
+    execution/env.cu
     execution/policies/policies.cu
     execution/policies/get_execution_policy.cu
   )

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -110,6 +110,7 @@ foreach(cn_target IN LISTS cudax_TARGETS)
     memory_resource/any_resource.cu
     memory_resource/device_memory_pool.cu
     memory_resource/device_memory_resource.cu
+    memory_resource/get_memory_resource.cu
     memory_resource/managed_memory_resource.cu
     memory_resource/pinned_memory_resource.cu
     memory_resource/shared_resource.cu

--- a/cudax/test/containers/uninitialized_async_buffer.cu
+++ b/cudax/test/containers/uninitialized_async_buffer.cu
@@ -144,7 +144,7 @@ TEMPLATE_TEST_CASE(
     CUDAX_CHECK(buf.begin() == buf.data());
     CUDAX_CHECK(buf.end() == buf.begin() + buf.size());
     CUDAX_CHECK(buf.get_stream() == stream);
-    CUDAX_CHECK(buf.get_resource() == resource);
+    CUDAX_CHECK(buf.get_memory_resource() == resource);
 
     CUDAX_CHECK(cuda::std::as_const(buf).data() != nullptr);
     CUDAX_CHECK(cuda::std::as_const(buf).size() == 42);
@@ -152,7 +152,7 @@ TEMPLATE_TEST_CASE(
     CUDAX_CHECK(cuda::std::as_const(buf).begin() == buf.data());
     CUDAX_CHECK(cuda::std::as_const(buf).end() == buf.begin() + buf.size());
     CUDAX_CHECK(cuda::std::as_const(buf).get_stream() == stream);
-    CUDAX_CHECK(cuda::std::as_const(buf).get_resource() == resource);
+    CUDAX_CHECK(cuda::std::as_const(buf).get_memory_resource() == resource);
   }
 
   SECTION("properties")
@@ -245,7 +245,7 @@ TEST_CASE("uninitialized_async_buffer's memory resource does not dangle", "[cont
     CHECK(test_async_device_memory_resource::count == 1);
 
     cudax::uninitialized_async_buffer<int, ::cuda::mr::device_accessible> dst_buffer{
-      src_buffer.get_resource(), stream, 1024};
+      src_buffer.get_memory_resource(), stream, 1024};
 
     CHECK(test_async_device_memory_resource::count == 2);
 

--- a/cudax/test/containers/uninitialized_buffer.cu
+++ b/cudax/test/containers/uninitialized_buffer.cu
@@ -122,7 +122,7 @@ TEMPLATE_TEST_CASE(
       CUDAX_CHECK(buf.data() == old_input_ptr);
       CUDAX_CHECK(buf.size() == 42);
       CUDAX_CHECK(buf.size_bytes() == 42 * sizeof(TestType));
-      CUDAX_CHECK(buf.get_resource() == other_resource);
+      CUDAX_CHECK(buf.get_memory_resource() == other_resource);
 
       CUDAX_CHECK(input.data() == nullptr);
       CUDAX_CHECK(input.size() == 0);
@@ -148,13 +148,13 @@ TEMPLATE_TEST_CASE(
     CUDAX_CHECK(buf.size_bytes() == 42 * sizeof(TestType));
     CUDAX_CHECK(buf.begin() == buf.data());
     CUDAX_CHECK(buf.end() == buf.begin() + buf.size());
-    CUDAX_CHECK(buf.get_resource() == resource);
+    CUDAX_CHECK(buf.get_memory_resource() == resource);
 
     CUDAX_CHECK(cuda::std::as_const(buf).data() != nullptr);
     CUDAX_CHECK(cuda::std::as_const(buf).size() == 42);
     CUDAX_CHECK(cuda::std::as_const(buf).begin() == buf.data());
     CUDAX_CHECK(cuda::std::as_const(buf).end() == buf.begin() + buf.size());
-    CUDAX_CHECK(cuda::std::as_const(buf).get_resource() == resource);
+    CUDAX_CHECK(cuda::std::as_const(buf).get_memory_resource() == resource);
   }
 
   SECTION("properties")
@@ -278,7 +278,7 @@ TEST_CASE("uninitialized_buffer's memory resource does not dangle", "[container]
 
     CHECK(test_device_memory_resource::count == 1);
 
-    cudax::uninitialized_buffer<int, ::cuda::mr::device_accessible> dst_buffer{src_buffer.get_resource(), 1024};
+    cudax::uninitialized_buffer<int, ::cuda::mr::device_accessible> dst_buffer{src_buffer.get_memory_resource(), 1024};
 
     CHECK(test_device_memory_resource::count == 2);
 

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -1,0 +1,256 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/type_traits>
+
+#include <cuda/experimental/__async/queries.cuh>
+#include <cuda/experimental/execution.cuh>
+
+#include "cuda/__memory_resource/properties.h"
+#include "cuda/experimental/__memory_resource/any_resource.cuh"
+#include "cuda/experimental/__memory_resource/device_memory_resource.cuh"
+#include "cuda/std/__type_traits/is_constructible.h"
+#include <catch2/catch.hpp>
+
+namespace cudax = cuda::experimental;
+using env_t     = cudax::execution::env_t<cuda::mr::device_accessible>;
+
+struct test_resource
+{
+  void* allocate(size_t, size_t)
+  {
+    return nullptr;
+  }
+  void* allocate_async(size_t, size_t, cuda::stream_ref)
+  {
+    return nullptr;
+  }
+  void deallocate(void*, size_t, size_t) {}
+  void deallocate_async(void*, size_t, size_t, cuda::stream_ref) {}
+
+  constexpr bool operator==(const test_resource&) const noexcept
+  {
+    return true;
+  }
+
+  constexpr bool operator!=(const test_resource&) const noexcept
+  {
+    return false;
+  }
+
+  friend void get_property(const test_resource&, cuda::mr::device_accessible) noexcept {}
+};
+
+TEST_CASE("env_t is queryable for all properties we want", "[execution, env]")
+{
+  STATIC_REQUIRE(cudax::__async::__queryable<env_t, cudax::get_stream_t>);
+  STATIC_REQUIRE(cudax::__async::__queryable<env_t, cudax::get_memory_resource_t>);
+  STATIC_REQUIRE(cudax::__async::__queryable<env_t, cudax::execution::get_execution_policy_t>);
+}
+
+TEST_CASE("env_t is default constructible", "[execution, env]")
+{
+  env_t env;
+  CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+  CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+  CHECK(env.query(cudax::get_memory_resource) == cudax::mr::device_memory_resource{});
+}
+
+TEST_CASE("env_t is constructible from an any_resource", "[execution, env]")
+{
+  const cudax::mr::any_async_resource<cuda::mr::device_accessible> mr{test_resource{}};
+
+  SECTION("Passing an any_resource")
+  {
+    env_t env{mr};
+    CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource) == mr);
+  }
+
+  SECTION("Passing an any_resource and a stream")
+  {
+    cudax::stream stream{};
+    env_t env{mr, stream};
+    CHECK(env.query(cudax::get_stream) == stream);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource) == mr);
+  }
+
+  SECTION("Passing an any_resource, a stream and a policy")
+  {
+    cudax::stream stream{};
+    env_t env{mr, stream, cudax::execution::execution_policy::parallel_unsequenced_device};
+    CHECK(env.query(cudax::get_stream) == stream);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::parallel_unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource) == mr);
+  }
+}
+
+TEST_CASE("env_t is constructible from an any_resource passed as an rvalue", "[execution, env]")
+{
+  SECTION("Passing an any_resource")
+  {
+    env_t env{cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}}};
+    CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource)
+          == cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
+  }
+
+  SECTION("Passing an any_resource and a stream")
+  {
+    cudax::stream stream{};
+    env_t env{cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}}, stream};
+    CHECK(env.query(cudax::get_stream) == stream);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource)
+          == cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
+  }
+
+  SECTION("Passing an any_resource, a stream and a policy")
+  {
+    cudax::stream stream{};
+    env_t env{cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}},
+              stream,
+              cudax::execution::execution_policy::parallel_unsequenced_device};
+    CHECK(env.query(cudax::get_stream) == stream);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::parallel_unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource)
+          == cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
+  }
+}
+
+TEST_CASE("env_t is constructible from a resource", "[execution, env]")
+{
+  test_resource mr{};
+
+  SECTION("Passing an any_resource")
+  {
+    env_t env{mr};
+    CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource) == mr);
+  }
+
+  SECTION("Passing an any_resource and a stream")
+  {
+    cudax::stream stream{};
+    env_t env{mr, stream};
+    CHECK(env.query(cudax::get_stream) == stream);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource) == mr);
+  }
+
+  SECTION("Passing an any_resource, a stream and a policy")
+  {
+    cudax::stream stream{};
+    env_t env{mr, stream, cudax::execution::execution_policy::parallel_unsequenced_device};
+    CHECK(env.query(cudax::get_stream) == stream);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::parallel_unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource) == mr);
+  }
+}
+
+TEST_CASE("env_t is constructible from a resource passed as an rvalue", "[execution, env]")
+{
+  SECTION("Passing an any_resource")
+  {
+    env_t env{test_resource{}};
+    CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource) == test_resource{});
+  }
+
+  SECTION("Passing an any_resource and a stream")
+  {
+    cudax::stream stream{};
+    env_t env{test_resource{}, stream};
+    CHECK(env.query(cudax::get_stream) == stream);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource) == test_resource{});
+  }
+
+  SECTION("Passing an any_resource, a stream and a policy")
+  {
+    cudax::stream stream{};
+    env_t env{test_resource{}, stream, cudax::execution::execution_policy::parallel_unsequenced_device};
+    CHECK(env.query(cudax::get_stream) == stream);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::parallel_unsequenced_device);
+    CHECK(env.query(cudax::get_memory_resource) == test_resource{});
+  }
+}
+
+struct some_env_t
+{
+  test_resource res_{};
+  cudax::stream stream_{};
+  cudax::execution::execution_policy policy_ = cudax::execution::execution_policy::parallel_unsequenced_device;
+
+  const test_resource& query(cudax::get_memory_resource_t) const noexcept
+  {
+    return res_;
+  }
+
+  cudax::stream_ref query(cudax::get_stream_t) const noexcept
+  {
+    return stream_;
+  }
+
+  cudax::execution::execution_policy query(cudax::execution::get_execution_policy_t) const noexcept
+  {
+    return policy_;
+  }
+};
+TEST_CASE("env_t is constructible from a suitable env", "[execution, env]")
+{
+  some_env_t other_env{};
+  env_t env{other_env};
+  CHECK(env.query(cudax::get_stream) == other_env.stream_);
+  CHECK(env.query(cudax::execution::get_execution_policy) == other_env.policy_);
+  CHECK(env.query(cudax::get_memory_resource) == other_env.res_);
+}
+
+template <bool WithResource, bool WithStream, bool WithPolicy>
+struct bad_env_t
+{
+  test_resource res_{};
+  cudax::stream stream_{};
+  cudax::execution::execution_policy policy_ = cudax::execution::execution_policy::parallel_unsequenced_device;
+
+  template <bool Enable = WithResource, cuda::std::enable_if_t<Enable, int> = 0>
+  const test_resource& query(cudax::get_memory_resource_t) const noexcept
+  {
+    return res_;
+  }
+
+  template <bool Enable = WithStream, cuda::std::enable_if_t<Enable, int> = 0>
+  cudax::stream_ref query(cudax::get_stream_t) const noexcept
+  {
+    return stream_;
+  }
+
+  template <bool Enable = WithPolicy, cuda::std::enable_if_t<Enable, int> = 0>
+  cudax::execution::execution_policy query(cudax::execution::get_execution_policy_t) const noexcept
+  {
+    return policy_;
+  }
+};
+TEST_CASE("env_t is not constructible from a env missing querries", "[execution, env]")
+{
+  STATIC_REQUIRE(cuda::std::is_constructible_v<env_t, bad_env_t<true, true, true>>);
+  STATIC_REQUIRE(!cuda::std::is_constructible_v<env_t, bad_env_t<false, true, true>>);
+  STATIC_REQUIRE(!cuda::std::is_constructible_v<env_t, bad_env_t<true, false, true>>);
+  STATIC_REQUIRE(!cuda::std::is_constructible_v<env_t, bad_env_t<true, true, false>>);
+}

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -59,7 +59,8 @@ TEST_CASE("env_t is default constructible", "[execution, env]")
 {
   env_t env;
   CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
-  CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+  CHECK(env.query(cudax::execution::get_execution_policy)
+        == cudax::execution::execution_policy::invalid_execution_policy);
   CHECK(env.query(cudax::get_memory_resource) == cudax::mr::device_memory_resource{});
 }
 
@@ -71,7 +72,8 @@ TEST_CASE("env_t is constructible from an any_resource", "[execution, env]")
   {
     env_t env{mr};
     CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource) == mr);
   }
 
@@ -80,7 +82,8 @@ TEST_CASE("env_t is constructible from an any_resource", "[execution, env]")
     cudax::stream stream{};
     env_t env{mr, stream};
     CHECK(env.query(cudax::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource) == mr);
   }
 
@@ -101,7 +104,8 @@ TEST_CASE("env_t is constructible from an any_resource passed as an rvalue", "[e
   {
     env_t env{cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}}};
     CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource)
           == cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
   }
@@ -111,7 +115,8 @@ TEST_CASE("env_t is constructible from an any_resource passed as an rvalue", "[e
     cudax::stream stream{};
     env_t env{cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}}, stream};
     CHECK(env.query(cudax::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource)
           == cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
   }
@@ -138,7 +143,8 @@ TEST_CASE("env_t is constructible from a resource", "[execution, env]")
   {
     env_t env{mr};
     CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource) == mr);
   }
 
@@ -147,7 +153,8 @@ TEST_CASE("env_t is constructible from a resource", "[execution, env]")
     cudax::stream stream{};
     env_t env{mr, stream};
     CHECK(env.query(cudax::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource) == mr);
   }
 
@@ -168,7 +175,8 @@ TEST_CASE("env_t is constructible from a resource passed as an rvalue", "[execut
   {
     env_t env{test_resource{}};
     CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource) == test_resource{});
   }
 
@@ -177,7 +185,8 @@ TEST_CASE("env_t is constructible from a resource passed as an rvalue", "[execut
     cudax::stream stream{};
     env_t env{test_resource{}, stream};
     CHECK(env.query(cudax::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
+    CHECK(env.query(cudax::execution::get_execution_policy)
+          == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource) == test_resource{});
   }
 

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -58,7 +58,7 @@ TEST_CASE("env_t is queryable for all properties we want", "[execution, env]")
 TEST_CASE("env_t is default constructible", "[execution, env]")
 {
   env_t env;
-  CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+  CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
   CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
   CHECK(env.query(cudax::get_memory_resource) == cudax::mr::device_memory_resource{});
 }
@@ -70,7 +70,7 @@ TEST_CASE("env_t is constructible from an any_resource", "[execution, env]")
   SECTION("Passing an any_resource")
   {
     env_t env{mr};
-    CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+    CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
     CHECK(env.query(cudax::get_memory_resource) == mr);
   }
@@ -100,7 +100,7 @@ TEST_CASE("env_t is constructible from an any_resource passed as an rvalue", "[e
   SECTION("Passing an any_resource")
   {
     env_t env{cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}}};
-    CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+    CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
     CHECK(env.query(cudax::get_memory_resource)
           == cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
@@ -137,7 +137,7 @@ TEST_CASE("env_t is constructible from a resource", "[execution, env]")
   SECTION("Passing an any_resource")
   {
     env_t env{mr};
-    CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+    CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
     CHECK(env.query(cudax::get_memory_resource) == mr);
   }
@@ -167,7 +167,7 @@ TEST_CASE("env_t is constructible from a resource passed as an rvalue", "[execut
   SECTION("Passing an any_resource")
   {
     env_t env{test_resource{}};
-    CHECK(env.query(cudax::get_stream) == ::cuda::stream_ref{});
+    CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::execution_policy::unsequenced_device);
     CHECK(env.query(cudax::get_memory_resource) == test_resource{});
   }

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -276,7 +276,7 @@ TEST_CASE("Can use query to construct various objects", "[execution, env]")
     env_t env{test_resource{}, stream_};
     cudax::uninitialized_async_buffer<int, cuda::mr::device_accessible> buf{
       env.query(cudax::get_memory_resource), env.query(cudax::get_stream), 0ull};
-    CHECK(buf.get_resource() == test_resource{});
+    CHECK(buf.get_memory_resource() == test_resource{});
     CHECK(buf.get_stream() == stream_);
   }
 }

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -17,7 +17,7 @@
 #include <catch2/catch.hpp>
 
 namespace cudax = cuda::experimental;
-using env_t     = cudax::execution::env_t<cuda::mr::device_accessible>;
+using env_t     = cudax::env_t<cuda::mr::device_accessible>;
 
 struct test_resource
 {
@@ -58,12 +58,12 @@ TEST_CASE("env_t is default constructible", "[execution, env]")
   CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
   CHECK(env.query(cudax::execution::get_execution_policy)
         == cudax::execution::execution_policy::invalid_execution_policy);
-  CHECK(env.query(cudax::get_memory_resource) == cudax::mr::device_memory_resource{});
+  CHECK(env.query(cudax::get_memory_resource) == cudax::device_memory_resource{});
 }
 
 TEST_CASE("env_t is constructible from an any_resource", "[execution, env]")
 {
-  const cudax::mr::any_async_resource<cuda::mr::device_accessible> mr{test_resource{}};
+  const cudax::any_async_resource<cuda::mr::device_accessible> mr{test_resource{}};
 
   SECTION("Passing an any_resource")
   {
@@ -99,36 +99,36 @@ TEST_CASE("env_t is constructible from an any_resource passed as an rvalue", "[e
 {
   SECTION("Passing an any_resource")
   {
-    env_t env{cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}}};
+    env_t env{cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}}};
     CHECK(env.query(cudax::get_stream) == ::cuda::experimental::detail::__invalid_stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
           == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource)
-          == cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
+          == cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
   }
 
   SECTION("Passing an any_resource and a stream")
   {
     cudax::stream stream{};
-    env_t env{cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}}, stream};
+    env_t env{cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}}, stream};
     CHECK(env.query(cudax::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
           == cudax::execution::execution_policy::invalid_execution_policy);
     CHECK(env.query(cudax::get_memory_resource)
-          == cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
+          == cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
   }
 
   SECTION("Passing an any_resource, a stream and a policy")
   {
     cudax::stream stream{};
-    env_t env{cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}},
+    env_t env{cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}},
               stream,
               cudax::execution::execution_policy::parallel_unsequenced_device};
     CHECK(env.query(cudax::get_stream) == stream);
     CHECK(env.query(cudax::execution::get_execution_policy)
           == cudax::execution::execution_policy::parallel_unsequenced_device);
     CHECK(env.query(cudax::get_memory_resource)
-          == cudax::mr::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
+          == cudax::any_async_resource<cuda::mr::device_accessible>{test_resource{}});
   }
 }
 
@@ -266,7 +266,7 @@ TEST_CASE("Can use query to construct various objects", "[execution, env]")
   SECTION("Can create an any_resource")
   {
     env_t env{test_resource{}};
-    cudax::mr::any_resource<cuda::mr::device_accessible> resource = env.query(cudax::get_memory_resource);
+    cudax::any_resource<cuda::mr::device_accessible> resource = env.query(cudax::get_memory_resource);
     CHECK(resource == test_resource{});
   }
 

--- a/cudax/test/execution/policies/get_execution_policy.cu
+++ b/cudax/test/execution/policies/get_execution_policy.cu
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/type_traits>
+
+#include <cuda/experimental/execution.cuh>
+
+#include <catch2/catch.hpp>
+
+using cuda::experimental::execution::execution_policy;
+
+struct with_get_execution_policy_const_lvalue
+{
+  execution_policy pol_ = execution_policy::sequenced_host;
+
+  const execution_policy& get_execution_policy() const noexcept
+  {
+    return pol_;
+  }
+};
+TEST_CASE("Can call get_execution_policy on a type with a get_execution_policy method that returns a const lvalue",
+          "[execution, policies]")
+{
+  with_get_execution_policy_const_lvalue val{};
+  auto&& res = cuda::experimental::execution::get_execution_policy(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  CHECK(val.pol_ == res);
+}
+
+struct with_get_execution_policy_rvalue
+{
+  execution_policy pol_{};
+
+  execution_policy get_execution_policy() const noexcept
+  {
+    return pol_;
+  }
+};
+TEST_CASE("Can call get_execution_policy on a type with a get_execution_policy method returns an rvalue",
+          "[execution, policies]")
+{
+  with_get_execution_policy_rvalue val{};
+  auto&& res = cuda::experimental::execution::get_execution_policy(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  CHECK(val.pol_ == res);
+}
+
+struct with_get_execution_policy_non_const
+{
+  execution_policy pol_{};
+
+  execution_policy get_execution_policy() noexcept
+  {
+    return pol_;
+  }
+};
+TEST_CASE("Cannot call get_execution_policy on a type with a non-const get_execution_policy method",
+          "[execution, policies]")
+{
+  STATIC_REQUIRE(!::cuda::std::is_invocable_v<cuda::experimental::execution::get_execution_policy_t,
+                                              const with_get_execution_policy_non_const&>);
+}
+
+struct env_with_query_const_ref
+{
+  execution_policy pol_{};
+
+  execution_policy query(cuda::experimental::execution::get_execution_policy_t) const noexcept
+  {
+    return pol_;
+  }
+};
+TEST_CASE("Can call get_execution_policy on an env with a get_execution_policy query that returns a const lvalue",
+          "[execution, policies]")
+{
+  env_with_query_const_ref val{};
+  auto&& res = cuda::experimental::execution::get_execution_policy(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  CHECK(val.pol_ == res);
+}
+
+struct env_with_query_rvalue
+{
+  execution_policy pol_{};
+
+  execution_policy query(cuda::experimental::execution::get_execution_policy_t) const noexcept
+  {
+    return pol_;
+  }
+};
+TEST_CASE("Can call get_execution_policy on an env with a get_execution_policy query that returns an rvalue",
+          "[execution, policies]")
+{
+  env_with_query_rvalue val{};
+  auto&& res = cuda::experimental::execution::get_execution_policy(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  CHECK(val.pol_ == res);
+}
+
+struct env_with_query_non_const
+{
+  execution_policy pol_{};
+
+  execution_policy query(cuda::experimental::execution::get_execution_policy_t) noexcept
+  {
+    return pol_;
+  }
+};
+TEST_CASE("Cannot call get_execution_policy on an env with a non-const query", "[execution, policies]")
+{
+  STATIC_REQUIRE(
+    !::cuda::std::is_invocable_v<cuda::experimental::execution::get_execution_policy_t, const env_with_query_non_const&>);
+}
+
+struct env_with_query_and_method
+{
+  execution_policy pol_{};
+
+  execution_policy get_execution_policy() const noexcept
+  {
+    return pol_;
+  }
+
+  execution_policy query(cuda::experimental::execution::get_execution_policy_t) const noexcept
+  {
+    return pol_;
+  }
+};
+TEST_CASE("Can call get_execution_policy on a type with both get_execution_policy and query", "[execution, policies]")
+{
+  env_with_query_and_method val{};
+  auto&& res = cuda::experimental::execution::get_execution_policy(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), execution_policy&&>);
+  CHECK(val.pol_ == res);
+}

--- a/cudax/test/memory_resource/get_memory_resource.cu
+++ b/cudax/test/memory_resource/get_memory_resource.cu
@@ -22,12 +22,13 @@ struct with_get_resource_const_lvalue
 {
   device_resource res_{};
 
-  const device_resource& get_resource() const noexcept
+  const device_resource& get_memory_resource() const noexcept
   {
     return res_;
   }
 };
-TEST_CASE("Can call get_resource on a type with a get_resource method that returns a const lvalue", "[resource]")
+TEST_CASE("Can call get_memory_resource on a type with a get_memory_resource method that returns a const lvalue",
+          "[resource]")
 {
   with_get_resource_const_lvalue val{};
   auto&& res = ::cuda::experimental::get_memory_resource(val);
@@ -39,12 +40,12 @@ struct with_get_resource_rvalue
 {
   device_resource res_{};
 
-  device_resource get_resource() const noexcept
+  device_resource get_memory_resource() const noexcept
   {
     return res_;
   }
 };
-TEST_CASE("Can call get_resource on a type with a get_resource method returns an rvalue", "[resource]")
+TEST_CASE("Can call get_memory_resource on a type with a get_memory_resource method returns an rvalue", "[resource]")
 {
   with_get_resource_rvalue val{};
   auto&& res = ::cuda::experimental::get_memory_resource(val);
@@ -56,12 +57,12 @@ struct with_get_resource_non_const
 {
   device_resource res_{};
 
-  device_resource get_resource() noexcept
+  device_resource get_memory_resource() noexcept
   {
     return res_;
   }
 };
-TEST_CASE("Cannot call get_resource on a type with a non-const get_resource method", "[resource]")
+TEST_CASE("Cannot call get_memory_resource on a type with a non-const get_memory_resource method", "[resource]")
 {
   STATIC_REQUIRE(
     !::cuda::std::is_invocable_v<::cuda::experimental::get_memory_resource_t, const with_get_resource_non_const&>);
@@ -76,7 +77,8 @@ struct env_with_query_const_ref
     return res_;
   }
 };
-TEST_CASE("Can call get_resource on an env with a get_memory_resource query that returns a const lvalue", "[resource]")
+TEST_CASE("Can call get_memory_resource on an env with a get_memory_resource query that returns a const lvalue",
+          "[resource]")
 {
   env_with_query_const_ref val{};
   auto&& res = ::cuda::experimental::get_memory_resource(val);
@@ -93,7 +95,8 @@ struct env_with_query_rvalue
     return res_;
   }
 };
-TEST_CASE("Can call get_resource on an env with a get_memory_resource query that returns an rvalue", "[resource]")
+TEST_CASE("Can call get_memory_resource on an env with a get_memory_resource query that returns an rvalue",
+          "[resource]")
 {
   env_with_query_rvalue val{};
   auto&& res = ::cuda::experimental::get_memory_resource(val);
@@ -110,7 +113,7 @@ struct env_with_query_non_const
     return res_;
   }
 };
-TEST_CASE("Cannot call get_resource on an env with a non-const query", "[resource]")
+TEST_CASE("Cannot call get_memory_resource on an env with a non-const query", "[resource]")
 {
   STATIC_REQUIRE(
     !::cuda::std::is_invocable_v<::cuda::experimental::get_memory_resource_t, const env_with_query_non_const&>);
@@ -120,7 +123,7 @@ struct env_with_query_and_method
 {
   device_resource res_{};
 
-  const device_resource& get_resource() const noexcept
+  const device_resource& get_memory_resource() const noexcept
   {
     return res_;
   }
@@ -130,7 +133,7 @@ struct env_with_query_and_method
     return res_;
   }
 };
-TEST_CASE("Can call get_resource on a type with both get_resource and query", "[resource]")
+TEST_CASE("Can call get_memory_resource on a type with both get_memory_resource and query", "[resource]")
 {
   env_with_query_and_method val{};
   auto&& res = ::cuda::experimental::get_memory_resource(val);
@@ -160,12 +163,12 @@ struct with_get_resource_non_async
   };
   resource res_{};
 
-  resource get_resource() const noexcept
+  resource get_memory_resource() const noexcept
   {
     return res_;
   }
 };
-TEST_CASE("Cannot call get_resource on an env with a non-async resource", "[resource]")
+TEST_CASE("Cannot call get_memory_resource on an env with a non-async resource", "[resource]")
 {
   STATIC_REQUIRE(
     !::cuda::std::is_invocable_v<::cuda::experimental::get_memory_resource_t, const with_get_resource_non_async&>);

--- a/cudax/test/memory_resource/get_memory_resource.cu
+++ b/cudax/test/memory_resource/get_memory_resource.cu
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/memory_resource>
+
+#include <cuda/experimental/memory_resource.cuh>
+
+#include "test_resource.cuh"
+#include <catch2/catch.hpp>
+#include <testing.cuh>
+
+using device_resource = cuda::experimental::device_memory_resource;
+
+struct with_get_resource_const_lvalue
+{
+  device_resource res_{};
+
+  const device_resource& get_resource() const noexcept
+  {
+    return res_;
+  }
+};
+TEST_CASE("Can call get_resource on a type with a get_resource method that returns a const lvalue", "[resource]")
+{
+  with_get_resource_const_lvalue val{};
+  auto&& res = ::cuda::experimental::get_memory_resource(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), const device_resource&>);
+  CUDAX_CHECK(val.res_ == res);
+}
+
+struct with_get_resource_rvalue
+{
+  device_resource res_{};
+
+  device_resource get_resource() const noexcept
+  {
+    return res_;
+  }
+};
+TEST_CASE("Can call get_resource on a type with a get_resource method returns an rvalue", "[resource]")
+{
+  with_get_resource_rvalue val{};
+  auto&& res = ::cuda::experimental::get_memory_resource(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), device_resource&&>);
+  CUDAX_CHECK(val.res_ == res);
+}
+
+struct with_get_resource_non_const
+{
+  device_resource res_{};
+
+  device_resource get_resource() noexcept
+  {
+    return res_;
+  }
+};
+TEST_CASE("Cannot call get_resource on a type with a non-const get_resource method", "[resource]")
+{
+  STATIC_REQUIRE(
+    !::cuda::std::is_invocable_v<::cuda::experimental::get_memory_resource_t, const with_get_resource_non_const&>);
+}
+
+struct env_with_query_const_ref
+{
+  device_resource res_{};
+
+  const device_resource& query(::cuda::experimental::get_memory_resource_t) const noexcept
+  {
+    return res_;
+  }
+};
+TEST_CASE("Can call get_resource on an env with a get_memory_resource query that returns a const lvalue", "[resource]")
+{
+  env_with_query_const_ref val{};
+  auto&& res = ::cuda::experimental::get_memory_resource(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), const device_resource&>);
+  CUDAX_CHECK(val.res_ == res);
+}
+
+struct env_with_query_rvalue
+{
+  device_resource res_{};
+
+  device_resource query(::cuda::experimental::get_memory_resource_t) const noexcept
+  {
+    return res_;
+  }
+};
+TEST_CASE("Can call get_resource on an env with a get_memory_resource query that returns an rvalue", "[resource]")
+{
+  env_with_query_rvalue val{};
+  auto&& res = ::cuda::experimental::get_memory_resource(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), device_resource&&>);
+  CUDAX_CHECK(val.res_ == res);
+}
+
+struct env_with_query_non_const
+{
+  device_resource res_{};
+
+  const device_resource& query(::cuda::experimental::get_memory_resource_t) noexcept
+  {
+    return res_;
+  }
+};
+TEST_CASE("Cannot call get_resource on an env with a non-const query", "[resource]")
+{
+  STATIC_REQUIRE(
+    !::cuda::std::is_invocable_v<::cuda::experimental::get_memory_resource_t, const env_with_query_non_const&>);
+}
+
+struct env_with_query_and_method
+{
+  device_resource res_{};
+
+  const device_resource& get_resource() const noexcept
+  {
+    return res_;
+  }
+
+  device_resource query(::cuda::experimental::get_memory_resource_t) const noexcept
+  {
+    return res_;
+  }
+};
+TEST_CASE("Can call get_resource on a type with both get_resource and query", "[resource]")
+{
+  env_with_query_and_method val{};
+  auto&& res = ::cuda::experimental::get_memory_resource(val);
+  STATIC_REQUIRE(cuda::std::is_same_v<decltype(res), const device_resource&>);
+  CUDAX_CHECK(val.res_ == res);
+}
+
+struct with_get_resource_non_async
+{
+  cudax::device_memory_resource res_{};
+
+  cudax::device_memory_resource get_resource() noexcept
+  {
+    return res_;
+  }
+};
+TEST_CASE("Cannot call get_resource on an env with a non-async resource", "[resource]")
+{
+  STATIC_REQUIRE(
+    !::cuda::std::is_invocable_v<::cuda::experimental::get_memory_resource_t, const with_get_resource_non_async&>);
+}

--- a/cudax/test/memory_resource/get_memory_resource.cu
+++ b/cudax/test/memory_resource/get_memory_resource.cu
@@ -140,9 +140,27 @@ TEST_CASE("Can call get_resource on a type with both get_resource and query", "[
 
 struct with_get_resource_non_async
 {
-  cudax::device_memory_resource res_{};
+  struct resource
+  {
+    void* allocate(std::size_t, std::size_t)
+    {
+      return nullptr;
+    }
 
-  cudax::device_memory_resource get_resource() noexcept
+    void deallocate(void*, std::size_t, std::size_t) noexcept {}
+
+    bool operator==(const resource&) const noexcept
+    {
+      return true;
+    }
+    bool operator!=(const resource&) const noexcept
+    {
+      return false;
+    }
+  };
+  resource res_{};
+
+  resource get_resource() const noexcept
   {
     return res_;
   }

--- a/cudax/test/memory_resource/shared_resource.cu
+++ b/cudax/test/memory_resource/shared_resource.cu
@@ -139,7 +139,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       {
         // accounting for new storage
         bytes(1337 * sizeof(int));
-        cudax::uninitialized_buffer<int, cuda::mr::host_accessible> other_buffer{buffer.get_resource(), 1337};
+        cudax::uninitialized_buffer<int, cuda::mr::host_accessible> other_buffer{buffer.get_memory_resource(), 1337};
         ++expected.allocate_count;
         CHECK(this->counts == expected);
       }

--- a/libcudacxx/include/cuda/__memory_resource/get_property.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_property.h
@@ -51,7 +51,8 @@ _CCCL_INLINE_VAR constexpr bool has_property<
   _CUDA_VSTD::void_t<decltype(get_property(_CUDA_VSTD::declval<const _Resource&>(), _CUDA_VSTD::declval<_Property>()))>> =
   true;
 
-#    if _CCCL_COMPILER(NVHPC) // NVHPC has issues accepting this at compile time if it is in a variable template
+// NVHPC and NVCC have issues accepting this at compile time if it is in a variable template
+#    if _CCCL_COMPILER(NVHPC) || defined(_CCCL_CUDA_COMPILER_NVCC)
 template <class _Resource, class _Property, class = void>
 struct __has_property_impl
 {
@@ -66,7 +67,7 @@ struct __has_property_impl<
 {
   static constexpr bool value = true;
 };
-#    endif // _CCCL_COMPILER(NVHPC)
+#    endif // _CCCL_COMPILER(NVHPC) || _CCCL_CUDA_COMPILER_NVCC
 
 template <class _Property>
 using __property_value_t = typename _Property::value_type;

--- a/libcudacxx/include/cuda/__memory_resource/get_property.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_property.h
@@ -41,33 +41,9 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //!    get_property(const Resource& res, Property prop);
 //!
 //! @endrst
-template <class _Resource, class _Property, class = void>
-_CCCL_INLINE_VAR constexpr bool has_property = false;
-
 template <class _Resource, class _Property>
-_CCCL_INLINE_VAR constexpr bool has_property<
-  _Resource,
-  _Property,
-  _CUDA_VSTD::void_t<decltype(get_property(_CUDA_VSTD::declval<const _Resource&>(), _CUDA_VSTD::declval<_Property>()))>> =
-  true;
-
-// NVHPC and NVCC have issues accepting this at compile time if it is in a variable template
-#    if _CCCL_COMPILER(NVHPC) || defined(_CCCL_CUDA_COMPILER_NVCC)
-template <class _Resource, class _Property, class = void>
-struct __has_property_impl
-{
-  static constexpr bool value = false;
-};
-
-template <class _Resource, class _Property>
-struct __has_property_impl<
-  _Resource,
-  _Property,
-  _CUDA_VSTD::void_t<decltype(get_property(_CUDA_VSTD::declval<const _Resource&>(), _CUDA_VSTD::declval<_Property>()))>>
-{
-  static constexpr bool value = true;
-};
-#    endif // _CCCL_COMPILER(NVHPC) || _CCCL_CUDA_COMPILER_NVCC
+_CCCL_CONCEPT has_property =
+  _CCCL_REQUIRES_EXPR((_Resource, _Property), const _Resource& __res, _Property __prop)(get_property(__res, __prop));
 
 template <class _Property>
 using __property_value_t = typename _Property::value_type;
@@ -84,12 +60,8 @@ using __property_value_t = typename _Property::value_type;
 //!    static_assert(!cuda::property_with_value<stateful_property>);
 //!
 //! @endrst
-template <class _Property, class = void>
-_CCCL_INLINE_VAR constexpr bool property_with_value = false;
-
 template <class _Property>
-_CCCL_INLINE_VAR constexpr bool property_with_value<_Property, _CUDA_VSTD::void_t<__property_value_t<_Property>>> =
-  true;
+_CCCL_CONCEPT property_with_value = _CCCL_REQUIRES_EXPR((_Property))(typename(__property_value_t<_Property>));
 
 //! @brief The \c has_property_with concept verifies that a Resource satisfies a given stateful Property
 //! @rst

--- a/libcudacxx/include/cuda/__memory_resource/get_property.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_property.h
@@ -42,8 +42,8 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //!
 //! @endrst
 template <class _Resource, class _Property>
-_CCCL_CONCEPT has_property =
-  _CCCL_REQUIRES_EXPR((_Resource, _Property), const _Resource& __res, _Property __prop)(get_property(__res, __prop));
+_CCCL_CONCEPT has_property = _CCCL_REQUIRES_EXPR((_Resource, _Property), const _Resource& __res, _Property __prop)(
+  ((void) get_property(__res, __prop)));
 
 template <class _Property>
 using __property_value_t = typename _Property::value_type;

--- a/libcudacxx/include/cuda/__memory_resource/resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource.h
@@ -83,7 +83,7 @@ _CCCL_CONCEPT async_resource = _CCCL_REQUIRES_EXPR(
 //! @tparam _Properties
 template <class _Resource, class... _Properties>
 _CCCL_CONCEPT resource_with =
-#    if _CCCL_COMPILER(NVHPC)
+#    if _CCCL_COMPILER(NVHPC) || defined(_CCCL_CUDA_COMPILER_NVCC)
   resource<_Resource> && _CUDA_VSTD::__fold_and_v<__has_property_impl<_Resource, _Properties>::value...>;
 #    else // ^^^ _CCCL_COMPILER(NVHPC) ^^^ / vvv !_CCCL_COMPILER(NVHPC) vvv
   resource<_Resource> && _CUDA_VSTD::__fold_and_v<has_property<_Resource, _Properties>...>;
@@ -95,9 +95,9 @@ _CCCL_CONCEPT resource_with =
 //! @tparam _Properties
 template <class _Resource, class... _Properties>
 _CCCL_CONCEPT async_resource_with =
-#    if _CCCL_COMPILER(NVHPC)
+#    if _CCCL_COMPILER(NVHPC) || defined(_CCCL_CUDA_COMPILER_NVCC)
   async_resource<_Resource> && _CUDA_VSTD::__fold_and_v<__has_property_impl<_Resource, _Properties>::value...>;
-#    else // ^^^ _CCCL_COMPILER(NVHPC) ^^^ / vvv !_CCCL_COMPILER(NVHPC) vvv
+#    else // ^^^ _CCCL_COMPILER(NVHPC) || ^^^ / vvv !_CCCL_COMPILER(NVHPC) vvv
   async_resource<_Resource> && _CUDA_VSTD::__fold_and_v<has_property<_Resource, _Properties>...>;
 #    endif // !_CCCL_COMPILER(NVHPC)
 

--- a/libcudacxx/include/cuda/__memory_resource/resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource.h
@@ -28,6 +28,7 @@
 #  include <cuda/std/__concepts/convertible_to.h>
 #  include <cuda/std/__concepts/equality_comparable.h>
 #  include <cuda/std/__concepts/same_as.h>
+#  include <cuda/std/__tuple_dir/sfinae_helpers.h>
 #  include <cuda/std/__type_traits/decay.h>
 #  include <cuda/std/__type_traits/fold.h>
 #  include <cuda/stream_ref>
@@ -81,25 +82,19 @@ _CCCL_CONCEPT async_resource = _CCCL_REQUIRES_EXPR(
 //! also satisfies all the provided Properties
 //! @tparam _Resource
 //! @tparam _Properties
+// We cannot use fold expressions here due to a nvcc bug
 template <class _Resource, class... _Properties>
-_CCCL_CONCEPT resource_with =
-#    if _CCCL_COMPILER(NVHPC) || defined(_CCCL_CUDA_COMPILER_NVCC)
-  resource<_Resource> && _CUDA_VSTD::__fold_and_v<__has_property_impl<_Resource, _Properties>::value...>;
-#    else // ^^^ _CCCL_COMPILER(NVHPC) ^^^ / vvv !_CCCL_COMPILER(NVHPC) vvv
-  resource<_Resource> && _CUDA_VSTD::__fold_and_v<has_property<_Resource, _Properties>...>;
-#    endif // !_CCCL_COMPILER(NVHPC)
+_CCCL_CONCEPT resource_with = _CCCL_REQUIRES_EXPR((_Resource, variadic _Properties))(
+  requires(resource<_Resource>), requires(_CUDA_VSTD::__all<has_property<_Resource, _Properties>...>::value));
 
 //! @brief The \c async_resource_with concept verifies that a type Resource satisfies the `async_resource`
 //! concept and also satisfies all the provided Properties
 //! @tparam _Resource
 //! @tparam _Properties
+// We cannot use fold expressions here due to a nvcc bug
 template <class _Resource, class... _Properties>
-_CCCL_CONCEPT async_resource_with =
-#    if _CCCL_COMPILER(NVHPC) || defined(_CCCL_CUDA_COMPILER_NVCC)
-  async_resource<_Resource> && _CUDA_VSTD::__fold_and_v<__has_property_impl<_Resource, _Properties>::value...>;
-#    else // ^^^ _CCCL_COMPILER(NVHPC) || ^^^ / vvv !_CCCL_COMPILER(NVHPC) vvv
-  async_resource<_Resource> && _CUDA_VSTD::__fold_and_v<has_property<_Resource, _Properties>...>;
-#    endif // !_CCCL_COMPILER(NVHPC)
+_CCCL_CONCEPT async_resource_with = _CCCL_REQUIRES_EXPR((_Resource, variadic _Properties))(
+  requires(async_resource<_Resource>), requires(_CUDA_VSTD::__all<has_property<_Resource, _Properties>...>::value));
 
 template <bool _Convertible>
 struct __different_resource__

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
@@ -18,7 +18,12 @@
 #include <cuda/std/cstdint>
 #include <cuda/stream_ref>
 
+#include "test_macros.h"
 #include "types.h"
+
+#if defined(TEST_COMPILER_MSVC)
+struct someStruct;
+#endif // TEST_COMPILER_MSVC
 
 namespace properties_test
 {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
@@ -21,17 +21,16 @@
 #include "test_macros.h"
 #include "types.h"
 
-#if defined(TEST_COMPILER_MSVC)
-struct someStruct;
-#endif // TEST_COMPILER_MSVC
-
 namespace properties_test
 {
+struct someStruct
+{};
+
 static_assert(cuda::property_with_value<property_with_value<int>>, "");
-static_assert(cuda::property_with_value<property_with_value<struct someStruct>>, "");
+static_assert(cuda::property_with_value<property_with_value<someStruct>>, "");
 
 static_assert(!cuda::property_with_value<property_without_value<int>>, "");
-static_assert(!cuda::property_with_value<property_without_value<struct otherStruct>>, "");
+static_assert(!cuda::property_with_value<property_without_value<someStruct>>, "");
 } // namespace properties_test
 
 namespace resource_test

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
@@ -20,17 +20,16 @@
 #include "test_macros.h"
 #include "types.h"
 
-#if defined(TEST_COMPILER_MSVC)
-struct someStruct;
-#endif // TEST_COMPILER_MSVC
-
 namespace properties_test
 {
+struct someStruct
+{};
+
 static_assert(cuda::property_with_value<property_with_value<int>>, "");
-static_assert(cuda::property_with_value<property_with_value<struct someStruct>>, "");
+static_assert(cuda::property_with_value<property_with_value<someStruct>>, "");
 
 static_assert(!cuda::property_with_value<property_without_value<int>>, "");
-static_assert(!cuda::property_with_value<property_without_value<struct someStruct>>, "");
+static_assert(!cuda::property_with_value<property_without_value<someStruct>>, "");
 } // namespace properties_test
 
 namespace resource_test

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
@@ -17,7 +17,12 @@
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
 
+#include "test_macros.h"
 #include "types.h"
+
+#if defined(TEST_COMPILER_MSVC)
+struct someStruct;
+#endif // TEST_COMPILER_MSVC
 
 namespace properties_test
 {
@@ -25,7 +30,7 @@ static_assert(cuda::property_with_value<property_with_value<int>>, "");
 static_assert(cuda::property_with_value<property_with_value<struct someStruct>>, "");
 
 static_assert(!cuda::property_with_value<property_without_value<int>>, "");
-static_assert(!cuda::property_with_value<property_without_value<struct otherStruct>>, "");
+static_assert(!cuda::property_with_value<property_without_value<struct someStruct>>, "");
 } // namespace properties_test
 
 namespace resource_test


### PR DESCRIPTION
We need to pass around a ton of information to efficiently use a container in a heterogeneous setting.

This adds more sender like queries `get_memory_resource_t` and `get_execution_policy_t` which we can then use to define a proper environment