### PR TITLE
[STF] Rename the redux access mode into relaxed

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/acquire_release.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/acquire_release.cuh
@@ -137,9 +137,9 @@ inline event_list task::acquire(backend_ctx_untyped& ctx)
     const data_place& dplace = it->get_dplace() == data_place::affine ? get_affine_data_place() : it->get_dplace();
 
     const instance_id_t instance_id =
-      mode == access_mode::redux ? d.find_unused_instance_id(dplace) : d.find_instance_id(dplace);
+      mode == access_mode::relaxed ? d.find_unused_instance_id(dplace) : d.find_instance_id(dplace);
 
-    if (mode == access_mode::redux)
+    if (mode == access_mode::relaxed)
     {
       d.get_data_instance(instance_id).set_redux_op(it->get_redux_op());
     }
@@ -187,7 +187,7 @@ inline event_list task::acquire(backend_ctx_untyped& ctx)
   {
     logical_data_untyped d = e.get_data();
 
-    if (e.get_access_mode() == access_mode::redux)
+    if (e.get_access_mode() == access_mode::relaxed)
     {
       // Save the last task accessing the instance in with a relaxed coherency mode
       d.get_data_instance(e.get_instance_id()).set_last_task_relaxed(*this);

--- a/cudax/include/cuda/experimental/__stf/internal/constants.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/constants.cuh
@@ -35,11 +35,11 @@ namespace cuda::experimental::stf
  */
 enum class access_mode : unsigned int
 {
-  none  = 0,
-  read  = 1,
-  write = 2,
-  rw    = 3, // READ + WRITE
-  redux = 4, /* operator ? */
+  none    = 0,
+  read    = 1,
+  write   = 2,
+  rw      = 3, // READ + WRITE
+  relaxed = 4, /* operator ? */
 };
 
 /**
@@ -50,8 +50,8 @@ inline access_mode operator|(access_mode lhs, access_mode rhs)
 {
   assert(as_underlying(lhs) < 16);
   assert(as_underlying(rhs) < 16);
-  EXPECT(lhs != access_mode::redux);
-  EXPECT(rhs != access_mode::redux);
+  EXPECT(lhs != access_mode::relaxed);
+  EXPECT(rhs != access_mode::relaxed);
   return access_mode(as_underlying(lhs) | as_underlying(rhs));
 }
 
@@ -75,8 +75,8 @@ inline const char* access_mode_string(access_mode mode)
       return "rw";
     case access_mode::write:
       return "write";
-    case access_mode::redux:
-      return "redux"; // op ?
+    case access_mode::relaxed:
+      return "relaxed"; // op ?
     default:
       assert(false);
       abort();

--- a/cudax/include/cuda/experimental/__stf/internal/task.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/task.cuh
@@ -448,7 +448,7 @@ void dep_allocate(
     }
 
     // After allocating a reduction instance, we need to initialize it
-    if (mode == access_mode::redux)
+    if (mode == access_mode::relaxed)
     {
       assert(eplace.has_value());
       // We have just allocated a new piece of data to perform

--- a/cudax/test/stf/examples/07-cholesky-redux.cu
+++ b/cudax/test/stf/examples/07-cholesky-redux.cu
@@ -263,7 +263,7 @@ void DGEMM(
 
   // If beta == 1.0 (we assume this is exactly 1.0), then this operation is
   // an accumulation with the add operator
-  auto dep_c = (beta == 1.0) ? C.handle(C_row, C_col).redux(redux_op) : C.handle(C_row, C_col).rw();
+  auto dep_c = (beta == 1.0) ? C.handle(C_row, C_col).relaxed(redux_op) : C.handle(C_row, C_col).rw();
   auto t     = ctx.task(exec_place::device(A.get_preferred_devid(C_row, C_col)),
                     A.handle(A_row, A_col).read(),
                     B.handle(B_row, B_col).read(),

--- a/cudax/test/stf/hashtable/fusion_reduction.cu
+++ b/cudax/test/stf/hashtable/fusion_reduction.cu
@@ -98,7 +98,7 @@ int main()
 
   for (size_t dev_id = 0; dev_id < 4; dev_id++)
   {
-    ctx.task(h_handle.redux(fusion_op))->*[&](auto stream, auto h) {
+    ctx.task(h_handle.relaxed(fusion_op))->*[&](auto stream, auto h) {
       EXPECT(h.get_capacity() == 2048);
       fill_table<<<32, 32, 0, stream>>>(dev_id, 10, h);
     };

--- a/cudax/test/stf/reductions/many_inc.cu
+++ b/cudax/test/stf/reductions/many_inc.cu
@@ -35,7 +35,7 @@ int main()
   for (int i = 0; i < K; i++)
   {
     // Increment the variable by 1
-    ctx.task(exec_place::device(i % ndevs), handle.redux(redux_op))->*[](auto stream, auto s) {
+    ctx.task(exec_place::device(i % ndevs), handle.relaxed(redux_op))->*[](auto stream, auto s) {
       add<<<1, 1, 0, stream>>>(s.data_handle());
     };
   }

--- a/cudax/test/stf/reductions/redux_test.cu
+++ b/cudax/test/stf/reductions/redux_test.cu
@@ -25,7 +25,7 @@ int main()
   int a         = 17;
   auto handle   = ctx.logical_data(make_slice(&a, 1));
   auto redux_op = std::make_shared<slice_reduction_op_sum<int>>();
-  ctx.task(handle.redux(redux_op))->*[](auto stream, auto s) {
+  ctx.task(handle.relaxed(redux_op))->*[](auto stream, auto s) {
     add<<<1, 1, 0, stream>>>(s.data_handle(), 42);
   };
 

--- a/cudax/test/stf/reductions/redux_test2.cu
+++ b/cudax/test/stf/reductions/redux_test2.cu
@@ -58,7 +58,7 @@ int main()
   };
 
   // REDUX dev1 (18 + 42)
-  ctx.task(exec_place::device(1), handle.redux(redux_op))->*[](auto stream, auto s) {
+  ctx.task(exec_place::device(1), handle.relaxed(redux_op))->*[](auto stream, auto s) {
     add<<<1, 1, 0, stream>>>(s.data_handle(), 42);
   };
 

--- a/cudax/test/stf/reductions/slice2d_reduction.cu
+++ b/cudax/test/stf/reductions/slice2d_reduction.cu
@@ -38,7 +38,7 @@ int main()
 
   auto redux_op = std::make_shared<slice_reduction_op_sum<int, 2>>();
 
-  ctx.task(handle.redux(redux_op))->*[](auto stream, auto s) {
+  ctx.task(handle.relaxed(redux_op))->*[](auto stream, auto s) {
     add<<<32, 32, 0, stream>>>(s, 42);
   };
 

--- a/cudax/test/stf/reductions/slice_custom_op.cu
+++ b/cudax/test/stf/reductions/slice_custom_op.cu
@@ -51,12 +51,12 @@ int main()
   auto op = std::make_shared<slice_reduction_op<bool, 1, OR_op>>();
 
   // C |= A
-  ctx.task(lC.redux(op), lA.read())->*[](auto stream, auto sC, auto sA) {
+  ctx.task(lC.relaxed(op), lA.read())->*[](auto stream, auto sC, auto sA) {
     cudaMemcpyAsync(sC.data_handle(), sA.data_handle(), sA.extent(0) * sizeof(bool), cudaMemcpyDeviceToDevice, stream);
   };
 
   // C |= B
-  ctx.task(lC.redux(op), lB.read())->*[](auto stream, auto sC, auto sB) {
+  ctx.task(lC.relaxed(op), lB.read())->*[](auto stream, auto sC, auto sB) {
     cudaMemcpyAsync(sC.data_handle(), sB.data_handle(), sB.extent(0) * sizeof(bool), cudaMemcpyDeviceToDevice, stream);
   };
 

--- a/cudax/test/stf/reductions/successive_reductions.cu
+++ b/cudax/test/stf/reductions/successive_reductions.cu
@@ -50,7 +50,7 @@ int main()
     // We add i (total = N(N-1)/2 + initial_value)
     for (int i = 0; i < N; i++)
     {
-      ctx.task(var_handle.redux(redux_op))->*[=](cudaStream_t stream, auto d_var) {
+      ctx.task(var_handle.relaxed(redux_op))->*[=](cudaStream_t stream, auto d_var) {
         add_val<<<1, 1, 0, stream>>>(d_var.data_handle(), i);
         cuda_safe_call(cudaGetLastError());
       };

--- a/cudax/test/stf/reductions/successive_reductions_pfor.cu
+++ b/cudax/test/stf/reductions/successive_reductions_pfor.cu
@@ -29,7 +29,7 @@ int main()
     // We add i (total = N(N-1)/2 + initial_value)
     for (int i = 0; i < N; i++)
     {
-      ctx.parallel_for(var_handle.shape(), var_handle.redux(op))->*[=] _CCCL_DEVICE(size_t ind, auto d_var) {
+      ctx.parallel_for(var_handle.shape(), var_handle.relaxed(op))->*[=] _CCCL_DEVICE(size_t ind, auto d_var) {
         atomicAdd(d_var.data_handle(), i);
       };
     }

--- a/cudax/test/stf/reductions/sum.cu
+++ b/cudax/test/stf/reductions/sum.cu
@@ -92,7 +92,7 @@ int main()
   // We add i (total = N(N-1)/2 + initial_value)
   for (int i = 0; i < N; i++)
   {
-    ctx.task(var_handle.redux(redux_op))->*[&](cudaStream_t stream, auto d_var) {
+    ctx.task(var_handle.relaxed(redux_op))->*[&](cudaStream_t stream, auto d_var) {
       add_val<<<1, 1, 0, stream>>>(d_var.data_handle(), i);
     };
   }

--- a/cudax/test/stf/reductions/sum_array.cu
+++ b/cudax/test/stf/reductions/sum_array.cu
@@ -98,9 +98,10 @@ int main()
 
   for (int i = 0; i < N; i++)
   {
-    ctx.task(var_handle.relaxed(redux_op), array_handles[i].read())->*[](cudaStream_t stream, auto d_var, auto d_array_i) {
-      add<<<1, 1, 0, stream>>>(d_array_i.data_handle(), d_var.data_handle());
-    };
+    ctx.task(var_handle.relaxed(redux_op), array_handles[i].read())
+        ->*[](cudaStream_t stream, auto d_var, auto d_array_i) {
+              add<<<1, 1, 0, stream>>>(d_array_i.data_handle(), d_var.data_handle());
+            };
   }
 
   // Force the reconstruction of data on the device, so that no transfers are

--- a/cudax/test/stf/reductions/sum_array.cu
+++ b/cudax/test/stf/reductions/sum_array.cu
@@ -98,7 +98,7 @@ int main()
 
   for (int i = 0; i < N; i++)
   {
-    ctx.task(var_handle.redux(redux_op), array_handles[i].read())->*[](cudaStream_t stream, auto d_var, auto d_array_i) {
+    ctx.task(var_handle.relaxed(redux_op), array_handles[i].read())->*[](cudaStream_t stream, auto d_var, auto d_array_i) {
       add<<<1, 1, 0, stream>>>(d_array_i.data_handle(), d_var.data_handle());
     };
   }

--- a/cudax/test/stf/reductions/sum_multiple_places.cu
+++ b/cudax/test/stf/reductions/sum_multiple_places.cu
@@ -41,13 +41,13 @@ int main()
     // device
     for (int d = 0; d < ndevs; d++)
     {
-      ctx.task(exec_place::device(d), var_handle.redux(redux_op))->*[=](cudaStream_t s, auto var) {
+      ctx.task(exec_place::device(d), var_handle.relaxed(redux_op))->*[=](cudaStream_t s, auto var) {
         add_val<int><<<1, 1, 0, s>>>(var, i);
       };
     }
 
     // host
-    ctx.host_launch(var_handle.redux(redux_op))->*[=](auto var) {
+    ctx.host_launch(var_handle.relaxed(redux_op))->*[=](auto var) {
       var(0) += i;
     };
   }

--- a/cudax/test/stf/reductions/sum_multiple_places_no_refvalue.cu
+++ b/cudax/test/stf/reductions/sum_multiple_places_no_refvalue.cu
@@ -94,13 +94,13 @@ int main()
     // device
     for (int d = 0; d < ndevs; d++)
     {
-      ctx.task(exec_place::device(d), var_handle.redux(redux_op))->*[&](cudaStream_t s, auto var) {
+      ctx.task(exec_place::device(d), var_handle.relaxed(redux_op))->*[&](cudaStream_t s, auto var) {
         add_val<int><<<1, 1, 0, s>>>(var.data_handle(), i);
       };
     }
 
     // host
-    ctx.task(exec_place::host, var_handle.redux(redux_op))->*[&](cudaStream_t s, auto var) {
+    ctx.task(exec_place::host, var_handle.relaxed(redux_op))->*[&](cudaStream_t s, auto var) {
       cuda_safe_call(cudaStreamSynchronize(s));
       *var.data_handle() += i;
     };

--- a/cudax/test/stf/reductions/write_back_after_redux.cu
+++ b/cudax/test/stf/reductions/write_back_after_redux.cu
@@ -49,13 +49,13 @@ int main()
     // device
     for (int d = 0; d < ndevs; d++)
     {
-      ctx.task(exec_place::device(d), var_handle.redux(redux_op))->*[=](cudaStream_t s, auto var) {
+      ctx.task(exec_place::device(d), var_handle.relaxed(redux_op))->*[=](cudaStream_t s, auto var) {
         add_val<int><<<1, 1, 0, s>>>(var, i);
       };
     }
 
     // host
-    ctx.host_launch(var_handle.redux(redux_op))->*[=](auto var) {
+    ctx.host_launch(var_handle.relaxed(redux_op))->*[=](auto var) {
       var(0) += i;
     };
   }

--- a/docs/cudax/stf.rst
+++ b/docs/cudax/stf.rst
@@ -558,7 +558,7 @@ write-only access (using the ``write()`` member of ``lX``). A write-only
 access will indeed allocate ``lX`` at the appropriate location, but it
 will not try to load a valid copy of it prior to executing the task.
 
-Using other access modes such as ``read()``, ``redux()`` or ``rw()``
+Using other access modes such as ``read()``, ``relaxed()`` or ``rw()``
 that attempt to provide a valid instance will result in an error.
 
 Similarly, it is possible to define a logical data from a slice shapes


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

This renames the "redux" access mode into "relaxed" which represents better its semantic. This access mode allows concurrent modifications on a logical data, which is reconstructed lazily when a "normal" access mode is made.

This is a preparatory change so that we don't mistake this with a reduction kernel (similar to Kokkos' parallel_reduce)

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
