### PR TITLE
Add `nvrtc_sm_top_level::add_link_list()` and use in c/parallel/src/reduce.cu

### DIFF
--- a/c/parallel/src/nvrtc/command_list.h
+++ b/c/parallel/src/nvrtc/command_list.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <vector>
 
 #include <nvJitLink.h>
 #include <nvrtc.h>
@@ -53,6 +54,7 @@ struct nvrtc_ltoir
   const char* ltoir;
   int ltsz;
 };
+using nvrtc_ltoir_list = std::vector<nvrtc_ltoir>;
 struct nvrtc_jitlink_cleanup
 {
   nvrtc_cubin& cubin_ref;
@@ -131,6 +133,13 @@ struct nvrtc_command_list_visitor
   {
     check(nvJitLinkAddData(
       jitlink.handle, NVJITLINK_INPUT_LTOIR, (const void*) lto.ltoir, (size_t) lto.ltsz, program_name.data()));
+  }
+  void execute(const nvrtc_ltoir_list& lto_list)
+  {
+    for (auto lto : lto_list)
+    {
+      execute(lto);
+    }
   }
   void execute(nvrtc_jitlink_cleanup cleanup)
   {
@@ -212,6 +221,11 @@ struct nvrtc_sm_top_level
   }
   // Add linkable unit to whole program
   nvrtc_sm_top_level<Tx..., nvrtc_ltoir> add_link(nvrtc_ltoir arg)
+  {
+    return {nvrtc_command_list_append(std::move(cl), std::move(arg))};
+  }
+  // Add linkable units to whole program
+  nvrtc_sm_top_level<Tx..., nvrtc_ltoir_list> add_link_list(nvrtc_ltoir_list arg)
   {
     return {nvrtc_command_list_append(std::move(cl), std::move(arg))};
   }


### PR DESCRIPTION
## Description

This PR is in support of the work tracked under #2479. The change here was extracted from https://github.com/rwgk/cccl/tree/fancy_iterators ([this commit](https://github.com/rwgk/cccl/commit/4b97983e1e9af279e1ef84c793472efcdc17805d)).

More concretely, this PR supports adding LTO-IRs as collected in [@gevtushenko 's POC code](https://github.com/NVIDIA/cccl/issues/2479#issuecomment-2422913019) here:

From main.py:

```
    class TransformIterator:
        def __init__(self, it, op):
            ...
            self.ltoirs = it.ltoirs + [numba.cuda.compile(TransformIterator.transform_advance, sig=numba.types.void(numba.types.CPointer(numba.types.char), numba.types.int32), output='ltoir', abi_info={"abi_name": f"{self.prefix}_advance"}),
                                       numba.cuda.compile(TransformIterator.transform_dereference, sig=numba.types.int32(numba.types.CPointer(numba.types.char)), output='ltoir', abi_info={"abi_name": f"{self.prefix}_dereference"}),
                                       numba.cuda.compile(op, sig=numba.types.int32(numba.types.int32), output='ltoir')]
```
