### PR TITLE
Avoid benchmarking first-time setup in Thrust algorithms

### DIFF
--- a/thrust/benchmarks/bench/equal/basic.cu
+++ b/thrust/benchmarks/bench/equal/basic.cu
@@ -24,6 +24,7 @@ static void benchmark(nvbench::state& state, nvbench::type_list<T>)
                                                                                  // of `elements` corresponds to the
                                                                                  // actual elements read in an early
                                                                                  // exit
+  do_not_optimize(thrust::equal(policy(alloc), a.begin(), a.end(), b.begin()));
   state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     do_not_optimize(thrust::equal(policy(alloc, launch), a.begin(), a.end(), b.begin()));
   });

--- a/thrust/benchmarks/bench/set_operations/base.cuh
+++ b/thrust/benchmarks/bench/set_operations/base.cuh
@@ -50,14 +50,14 @@ static void basic(nvbench::state& state, nvbench::type_list<T>, OpT op)
   thrust::sort(input.begin() + elements_in_A, input.end());
 
   caching_allocator_t alloc;
-  const std::size_t elements_in_AB = thrust::distance(
-    output.begin(),
+  const auto result_ends =
     op(policy(alloc),
        input.cbegin(),
        input.cbegin() + elements_in_A,
        input.cbegin() + elements_in_A,
        input.cend(),
-       output.begin()));
+       output.begin());
+  const std::size_t elements_in_AB = thrust::distance(output.begin(), result_ends);
 
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements);

--- a/thrust/benchmarks/bench/set_operations/by_key.cuh
+++ b/thrust/benchmarks/bench/set_operations/by_key.cuh
@@ -63,7 +63,6 @@ static void basic(nvbench::state& state, nvbench::type_list<KeyT, ValueT>, OpT o
     in_vals.cbegin() + elements_in_A,
     out_keys.begin(),
     out_vals.begin());
-
   const std::size_t elements_in_AB = thrust::distance(out_keys.begin(), result_ends.first);
 
   state.add_element_count(elements);

--- a/thrust/benchmarks/bench/transform/basic.cu
+++ b/thrust/benchmarks/bench/transform/basic.cu
@@ -68,6 +68,17 @@ struct fib_t
   }
 };
 
+template <typename... Args>
+void bench_transform(nvbench::state& state, Args&&... args)
+{
+  caching_allocator_t alloc; // transform shouldn't allocate, but let's be consistent
+  thrust::transform(policy(alloc), ::cuda::std::forward<Args>(args)...); // warmup (queries and caches occupancy)
+
+  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    thrust::transform(policy(alloc, launch), ::cuda::std::forward<Args>(args)...);
+  });
+}
+
 template <typename T>
 static void basic(nvbench::state& state, nvbench::type_list<T>)
 {
@@ -80,13 +91,8 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(elements);
   state.add_global_memory_writes<nvbench::uint32_t>(elements);
 
-  caching_allocator_t alloc;
   fib_t<T, nvbench::uint32_t> op{};
-  thrust::transform(policy(alloc), input.cbegin(), input.cend(), output.begin(), op);
-
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    thrust::transform(policy(alloc, launch), input.cbegin(), input.cend(), output.begin(), op);
-  });
+  bench_transform(state, input.cbegin(), input.cend(), output.begin(), op);
 }
 
 using types = nvbench::type_list<nvbench::uint32_t, nvbench::uint64_t>;
@@ -123,13 +129,11 @@ static void mul(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(n);
   state.add_global_memory_writes<T>(n);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch&) {
-    const T scalar = startScalar;
-    thrust::transform(
-      c.begin(), c.end(), b.begin(), cuda::proclaim_copyable_arguments([=] __device__ __host__(const T& ci) {
-        return ci * scalar;
-      }));
-  });
+  const T scalar = startScalar;
+  bench_transform(
+    state, c.begin(), c.end(), b.begin(), cuda::proclaim_copyable_arguments([=] _CCCL_DEVICE(const T& ci) {
+      return ci * scalar;
+    }));
 }
 
 NVBENCH_BENCH_TYPES(mul, NVBENCH_TYPE_AXES(element_types))
@@ -149,16 +153,15 @@ static void add(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch&) {
-    thrust::transform(
-      a.begin(),
-      a.end(),
-      b.begin(),
-      c.begin(),
-      cuda::proclaim_copyable_arguments([] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
-        return ai + bi;
-      }));
-  });
+  bench_transform(
+    state,
+    a.begin(),
+    a.end(),
+    b.begin(),
+    c.begin(),
+    cuda::proclaim_copyable_arguments([] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
+      return ai + bi;
+    }));
 }
 
 NVBENCH_BENCH_TYPES(add, NVBENCH_TYPE_AXES(element_types))
@@ -178,17 +181,16 @@ static void triad(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch&) {
-    const T scalar = startScalar;
-    thrust::transform(
-      b.begin(),
-      b.end(),
-      c.begin(),
-      a.begin(),
-      cuda::proclaim_copyable_arguments([=] _CCCL_DEVICE(const T& bi, const T& ci) {
-        return bi + scalar * ci;
-      }));
-  });
+  const T scalar = startScalar;
+  bench_transform(
+    state,
+    b.begin(),
+    b.end(),
+    c.begin(),
+    a.begin(),
+    cuda::proclaim_copyable_arguments([=] _CCCL_DEVICE(const T& bi, const T& ci) {
+      return bi + scalar * ci;
+    }));
 }
 
 NVBENCH_BENCH_TYPES(triad, NVBENCH_TYPE_AXES(element_types))
@@ -208,18 +210,15 @@ static void nstream(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(3 * n);
   state.add_global_memory_writes<T>(n);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch&) {
-    const T scalar = startScalar;
-    thrust::transform(
-      thrust::make_zip_iterator(a.begin(), b.begin(), c.begin()),
-      thrust::make_zip_iterator(a.end(), b.end(), c.end()),
-      a.begin(),
-
-      thrust::make_zip_function(
-        cuda::proclaim_copyable_arguments([=] _CCCL_DEVICE(const T& ai, const T& bi, const T& ci) {
-          return ai + bi + scalar * ci;
-        })));
-  });
+  const T scalar = startScalar;
+  bench_transform(
+    state,
+    thrust::make_zip_iterator(a.begin(), b.begin(), c.begin()),
+    thrust::make_zip_iterator(a.end(), b.end(), c.end()),
+    a.begin(),
+    thrust::make_zip_function(cuda::proclaim_copyable_arguments([=] _CCCL_DEVICE(const T& ai, const T& bi, const T& ci) {
+      return ai + bi + scalar * ci;
+    })));
 }
 
 NVBENCH_BENCH_TYPES(nstream, NVBENCH_TYPE_AXES(element_types))
@@ -244,12 +243,10 @@ static void nstream_stable(nvbench::state& state, nvbench::type_list<T>)
   state.add_global_memory_reads<T>(3 * n);
   state.add_global_memory_writes<T>(n);
 
-  state.exec(nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch&) {
-    const T scalar = startScalar;
-    thrust::transform(a.begin(), a.end(), a.begin(), [=] _CCCL_DEVICE(const T& ai) {
-      const auto i = &ai - a_start;
-      return ai + b_start[i] + scalar * c_start[i];
-    });
+  const T scalar = startScalar;
+  bench_transform(state, a.begin(), a.end(), a.begin(), [=] _CCCL_DEVICE(const T& ai) {
+    const auto i = &ai - a_start;
+    return ai + b_start[i] + scalar * c_start[i];
   });
 }
 

--- a/thrust/benchmarks/bench/unique/basic.cu
+++ b/thrust/benchmarks/bench/unique/basic.cu
@@ -43,8 +43,8 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   thrust::device_vector<T> output(elements);
 
   caching_allocator_t alloc;
-  const std::size_t unique_items =
-    thrust::distance(output.begin(), thrust::unique_copy(policy(alloc), input.cbegin(), input.cend(), output.begin()));
+  const auto new_end             = thrust::unique_copy(policy(alloc), input.cbegin(), input.cend(), output.begin());
+  const std::size_t unique_items = thrust::distance(output.begin(), new_end);
 
   state.add_element_count(elements);
   state.add_global_memory_reads<T>(elements);

--- a/thrust/benchmarks/bench/unique/by_key.cu
+++ b/thrust/benchmarks/bench/unique/by_key.cu
@@ -42,13 +42,13 @@ static void basic(nvbench::state& state, nvbench::type_list<KeyT, ValueT>)
   thrust::device_vector<KeyT> in_keys = generate.uniform.key_segments(elements, min_segment_size, max_segment_size);
   thrust::device_vector<KeyT> out_keys(elements);
   thrust::device_vector<ValueT> in_vals(elements);
+  thrust::device_vector<ValueT> out_vals(elements);
 
   caching_allocator_t alloc;
-  const std::size_t unique_elements = thrust::distance(
-    out_keys.begin(), thrust::unique_copy(policy(alloc), in_keys.cbegin(), in_keys.cend(), out_keys.begin()));
+  const auto [new_key_end, new_val_end] = thrust::unique_by_key_copy(
+    policy(alloc), in_keys.cbegin(), in_keys.cend(), in_vals.cbegin(), out_keys.begin(), out_vals.begin());
 
-  thrust::device_vector<ValueT> out_vals(unique_elements);
-
+  const std::size_t unique_elements = thrust::distance(out_keys.begin(), new_key_end);
   state.add_element_count(elements);
   state.add_global_memory_reads<KeyT>(elements);
   state.add_global_memory_writes<KeyT>(unique_elements);


### PR DESCRIPTION
Many Thrust algorithms perform memory allocations which are cached during benchmarking by a custom execution policy, ensuring that allocation does not blur the measured algorithm runtime. I reviewed all Thrust benchmarks and found some inconsitencies.