### PR TITLE
use `_CCCL_HAS_FEATURE` instead of plain `__has_feature` everywhere

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/rtti.h
+++ b/libcudacxx/include/cuda/std/__cccl/rtti.h
@@ -22,6 +22,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__cccl/builtin.h>
+
 // NOTE: some compilers support the `typeid` feature but not the `dynamic_cast`
 // feature. This is why we have separate macros for each.
 
@@ -41,7 +43,7 @@
 #      define _CCCL_NO_RTTI
 #    endif
 #  elif defined(_CCCL_COMPILER_CLANG)
-#    if !__has_feature(cxx_rtti)
+#    if !_CCCL_HAS_FEATURE(cxx_rtti)
 #      define _CCCL_NO_RTTI
 #    endif
 #  else
@@ -66,7 +68,7 @@
 #  elif defined(_CCCL_COMPILER_MSVC)
 // No-op, MSVC always supports typeid even when RTTI is disabled
 #  elif defined(_CCCL_COMPILER_CLANG)
-#    if !__has_feature(cxx_rtti)
+#    if !_CCCL_HAS_FEATURE(cxx_rtti)
 #      define _CCCL_NO_TYPEID
 #    endif
 #  else


### PR DESCRIPTION
## Description

Fix usage of `__has_feature` instead of `_CCCL_HAS_FEATURE` in `cuda/std/__cccl/rtti.h`

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
