### PR TITLE
[STF] Replace CUDASTF_CODE_GENERATION by !CUDASTF_DISABLE_CODE_GENERATION

### DIFF
--- a/cudax/cmake/cudaxSTFConfigureTarget.cmake
+++ b/cudax/cmake/cudaxSTFConfigureTarget.cmake
@@ -16,7 +16,8 @@ function(cudax_stf_configure_target target_name)
     target_compile_options(${target_name} PRIVATE
       $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>
     )
-    target_compile_definitions(${target_name} PRIVATE "CUDASTF_CODE_GENERATION")
+  else()
+    target_compile_definitions(${target_name} PRIVATE "CUDASTF_DISABLE_CODE_GENERATION")
   endif()
 
   target_compile_options(${target_name} PRIVATE

--- a/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/graph/graph_ctx.cuh
@@ -763,7 +763,7 @@ UNITTEST("set_symbol on graph_task and graph_task<>")
   ctx.finalize();
 };
 
-#  if defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#  if !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 namespace reserved
 {
 
@@ -1028,7 +1028,7 @@ UNITTEST("create many graph ctxs")
 
 } // end namespace reserved
 
-#  endif // defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#  endif // !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 
 #endif // UNITTESTED_FILE
 } // end namespace cuda::experimental::stf

--- a/cudax/include/cuda/experimental/__stf/internal/launch.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/launch.cuh
@@ -31,7 +31,7 @@ namespace cuda::experimental::stf
 {
 
 // This feature requires a CUDA compiler
-#if defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#if !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 
 class stream_ctx;
 template <typename...>
@@ -505,5 +505,5 @@ private:
 
 } // namespace reserved
 
-#endif // defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#endif // !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 } // end namespace cuda::experimental::stf

--- a/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/parallel_for_scope.cuh
@@ -29,7 +29,7 @@
 namespace cuda::experimental::stf
 {
 
-#if defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#if !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 
 class stream_ctx;
 class graph_ctx;
@@ -468,6 +468,6 @@ private:
 };
 } // end namespace reserved
 
-#endif // defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#endif // !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 
 } // end namespace cuda::experimental::stf

--- a/cudax/include/cuda/experimental/__stf/internal/thread_hierarchy.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/thread_hierarchy.cuh
@@ -419,7 +419,7 @@ private:
 };
 
 #ifdef UNITTESTED_FILE
-#  if defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#  if !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 namespace reserved
 {
 template <auto... spec>
@@ -525,7 +525,7 @@ UNITTEST("thread hierarchy inner sync")
   cuda_safe_call(cudaDeviceSynchronize());
 };
 
-#  endif // defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#  endif // !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 #endif // UNITTESTED_FILE
 
 } // end namespace cuda::experimental::stf

--- a/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/stream/stream_ctx.cuh
@@ -1125,7 +1125,7 @@ UNITTEST("get logical_data from a task_dep")
   ctx.finalize();
 };
 
-#  if defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#  if !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 namespace reserved
 {
 inline void unit_test_pfor()
@@ -1313,7 +1313,7 @@ UNITTEST("basic launch test")
 };
 
 } // end namespace reserved
-#  endif // defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#  endif // !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 
 #endif // UNITTESTED_FILE
 

--- a/cudax/include/cuda/experimental/stf.cuh
+++ b/cudax/include/cuda/experimental/stf.cuh
@@ -357,7 +357,7 @@ public:
     return task(default_exec_place(), mv(deps)...);
   }
 
-#if defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#if !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
   /*
    * parallel_for : apply an operation over a shaped index space
    */
@@ -392,7 +392,7 @@ public:
   {
     return parallel_for(default_exec_place(), mv(shape), mv(deps)...);
   }
-#endif // defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#endif // !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 
   template <typename... Deps>
   auto host_launch(task_dep<Deps>... deps)
@@ -463,7 +463,7 @@ public:
       payload);
   }
 
-#if defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#if !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
   template <typename thread_hierarchy_spec_t, typename... Deps>
   auto launch(thread_hierarchy_spec_t spec, exec_place e_place, task_dep<Deps>... deps)
   {
@@ -497,7 +497,7 @@ public:
   {
     return launch(mv(ths), default_exec_place(), mv(deps)...);
   }
-#endif // defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#endif // !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 
   auto repeat(size_t count)
   {
@@ -786,7 +786,7 @@ UNITTEST("context with arguments")
   cuda_safe_call(cudaStreamDestroy(stream));
 };
 
-#  if defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#  if !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 namespace reserved
 {
 inline void unit_test_context_pfor()
@@ -1235,7 +1235,7 @@ UNITTEST("unit_test_partitioner_product")
 };
 
 } // namespace reserved
-#  endif // defined(CUDASTF_CODE_GENERATION) && defined(__CUDACC__)
+#  endif // !defined(CUDASTF_DISABLE_CODE_GENERATION) && defined(__CUDACC__)
 
 UNITTEST("make_tuple_indexwise")
 {


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

When defining an option that should be enabled by default, it's better not to expect the user to provide some extra compilation flag. This will avoid bloating external cmake and Makefile configurations.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ x] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
