### PR TITLE
change `__as_type_list` so it doesn't cause the instantiation of its argument

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -47,6 +47,9 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class... _Ts>
 struct __type_list;
 
+template <class...>
+struct __undefined; // leave this undefined
+
 template <class _Ty>
 using __type = typename _Ty::type;
 
@@ -326,16 +329,22 @@ using __type_push_front = __type_call1<_List, __type_bind_front_quote<__type_lis
 namespace __detail
 {
 template <template <class...> class _Fn, class... _Ts>
-_LIBCUDACXX_HIDE_FROM_ABI auto __as_type_list_fn(_Fn<_Ts...>*) -> __type_list<_Ts...>;
+_LIBCUDACXX_HIDE_FROM_ABI auto __as_type_list_fn(__undefined<_Fn<_Ts...>>*) //
+  -> __type_list<_Ts...>;
 
 template <template <class _Ty, _Ty...> class _Fn, class _Ty, _Ty... _Us>
-_LIBCUDACXX_HIDE_FROM_ABI auto __as_type_list_fn(_Fn<_Ty, _Us...>*) -> __type_list<integral_constant<_Ty, _Us>...>;
+_LIBCUDACXX_HIDE_FROM_ABI auto __as_type_list_fn(__undefined<_Fn<_Ty, _Us...>>*) //
+  -> __type_list<integral_constant<_Ty, _Us>...>;
+
+template <class _Ret, class... _Args>
+_LIBCUDACXX_HIDE_FROM_ABI auto __as_type_list_fn(__undefined<_Ret(_Args...)>*) //
+  -> __type_list<_Args...>;
 } // namespace __detail
 
 //! \brief Given a type that is a specialization of a class template, return a
 //! type list of the template arguments.
 template <class _List>
-using __as_type_list = decltype(__detail::__as_type_list_fn(static_cast<_List*>(nullptr)));
+using __as_type_list = decltype(__detail::__as_type_list_fn(static_cast<__undefined<_List>*>(nullptr)));
 
 //! \brief Given a type that is a specialization of a class template and a
 //! meta-callable, invoke the callable with the template arguments.

--- a/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/type_list.pass.cpp
@@ -13,6 +13,8 @@
 // Test that the type_list header is self-contained.
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/type_identity.h>
+#include <cuda/std/__utility/integer_sequence.h>
+#include <cuda/std/__utility/pair.h>
 
 #if defined(_CCCL_COMPILER_ICC) || defined(_CCCL_CUDA_COMPILER_NVCC) || defined(_CCCL_COMPILER_NVRTC) \
   || defined(_CCCL_CUDA_COMPILER_CLANG)
@@ -216,6 +218,22 @@ static_assert(::cuda::std::is_same<::cuda::std::__type_push_back<::cuda::std::__
 // __type_list_push_front
 static_assert(::cuda::std::is_same<::cuda::std::__type_push_front<::cuda::std::__type_list<int, float>, double>,
                                    ::cuda::std::__type_list<double, int, float>>::value,
+              "");
+
+// __as_type_list
+static_assert(::cuda::std::is_same<::cuda::std::__as_type_list<DoNotInstantiate<int, float, double>>,
+                                   ::cuda::std::__type_list<int, float, double>>::value,
+              "");
+static_assert(::cuda::std::is_same<::cuda::std::__as_type_list<_CUDA_VSTD::pair<int, float>>,
+                                   ::cuda::std::__type_list<int, float>>::value,
+              "");
+static_assert(
+  ::cuda::std::is_same<
+    ::cuda::std::__as_type_list<_CUDA_VSTD::index_sequence<0, 1>>,
+    ::cuda::std::__type_list<_CUDA_VSTD::integral_constant<size_t, 0>, _CUDA_VSTD::integral_constant<size_t, 1>>>::value,
+  "");
+static_assert(::cuda::std::is_same<::cuda::std::__as_type_list<int(float&, double&&)>,
+                                   ::cuda::std::__type_list<float&, double&&>>::value,
               "");
 
 // __type_callable


### PR DESCRIPTION

## Description

`__as_type_list< pair<int, float> >` should be an alias for `__type_list<int, float>`, and it should not cause the instantiation of `pair<int, float>`. the current implementation is erroneously causing the instantiation of its argument, which is a compile-time performance bug.

this PR corrects the problem and adds a test. it also adds the ability to convert a function type to a `__type_list` of the function's arguments. this is handy for std::execution, which must manipulate function types a great deal.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
