### PR TITLE
backport std integer comparison functions to C++11

### DIFF
--- a/libcudacxx/include/cuda/std/__utility/cmp.h
+++ b/libcudacxx/include/cuda/std/__utility/cmp.h
@@ -33,94 +33,119 @@ _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
 template <class _Tp, class... _Up>
 struct _IsSameAsAny : _Or<_IsSame<_Tp, _Up>...>
 {};
 
 template <class _Tp>
-concept __is_safe_integral_cmp =
-  is_integral_v<_Tp>
-  && !_IsSameAsAny<_Tp,
-                   bool,
-                   char,
-                   char16_t,
-                   char32_t
-#  ifndef _LIBCUDACXX_NO_HAS_CHAR8_T
-                   ,
-                   char8_t
-#  endif
-#  ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
-                   ,
-                   wchar_t
-#  endif
-                   >::value;
+struct __is_safe_integral_cmp
+    : bool_constant<is_integral<_Tp>::value
+                    && !_IsSameAsAny<_Tp,
+                                     bool,
+                                     char,
+                                     char16_t,
+                                     char32_t
+#ifndef _LIBCUDACXX_NO_HAS_CHAR8_T
+                                     ,
+                                     char8_t
+#endif
+#ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
+                                     ,
+                                     wchar_t
+#endif
+                                     >::value>
+{};
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept
+struct __cmp_equal_impl
 {
-  if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
+  template <class _Tp, class _Up, enable_if_t<is_signed<_Tp>::value && is_signed<_Up>::value, int> = 0>
+  static constexpr bool __do_cmp(_Tp __t, _Up __u) noexcept
   {
     return __t == __u;
   }
-  else if constexpr (is_signed_v<_Tp>)
+
+  template <class _Tp, class _Up, enable_if_t<is_signed<_Tp>::value, int> = 0>
+  static constexpr bool __do_cmp(_Tp __t, _Up __u) noexcept
   {
     return __t < 0 ? false : make_unsigned_t<_Tp>(__t) == __u;
   }
-  else
+
+  template <class _Tp, class _Up>
+  static constexpr bool __do_cmp(_Tp __t, _Up __u) noexcept
   {
     return __u < 0 ? false : __t == make_unsigned_t<_Up>(__u);
   }
+};
+
+template <class _Tp, class _Up>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept
+{
+  static_assert(__is_safe_integral_cmp<_Tp>::value && __is_safe_integral_cmp<_Up>::value,
+                "comparison operands must be integral types");
+
+  return __cmp_equal_impl::__do_cmp(__t, __u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <class _Tp, class _Up>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_not_equal(_Tp __t, _Up __u) noexcept
 {
   return !_CUDA_VSTD::cmp_equal(__t, __u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_less(_Tp __t, _Up __u) noexcept
+struct __cmp_less_impl
 {
-  if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
+  template <class _Tp, class _Up, enable_if_t<is_signed<_Tp>::value == is_signed<_Up>::value, int> = 0>
+  static constexpr bool __do_cmp(_Tp __t, _Up __u) noexcept
   {
     return __t < __u;
   }
-  else if constexpr (is_signed_v<_Tp>)
+
+  template <class _Tp, class _Up, enable_if_t<is_signed<_Tp>::value, int> = 0>
+  static constexpr bool __do_cmp(_Tp __t, _Up __u) noexcept
   {
     return __t < 0 ? true : make_unsigned_t<_Tp>(__t) < __u;
   }
-  else
+
+  template <class _Tp, class _Up>
+  static constexpr bool __do_cmp(_Tp __t, _Up __u) noexcept
   {
     return __u < 0 ? false : __t < make_unsigned_t<_Up>(__u);
   }
+};
+
+template <class _Tp, class _Up>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_less(_Tp __t, _Up __u) noexcept
+{
+  static_assert(__is_safe_integral_cmp<_Tp>::value && __is_safe_integral_cmp<_Up>::value,
+                "comparison operands must be integral types");
+
+  return __cmp_less_impl::__do_cmp(__t, __u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <class _Tp, class _Up>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_greater(_Tp __t, _Up __u) noexcept
 {
   return _CUDA_VSTD::cmp_less(__u, __t);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <class _Tp, class _Up>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_less_equal(_Tp __t, _Up __u) noexcept
 {
   return !_CUDA_VSTD::cmp_greater(__t, __u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <class _Tp, class _Up>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool cmp_greater_equal(_Tp __t, _Up __u) noexcept
 {
   return !_CUDA_VSTD::cmp_less(__t, __u);
 }
 
-template <__is_safe_integral_cmp _Tp, __is_safe_integral_cmp _Up>
+template <class _Tp, class _Up>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr bool in_range(_Up __u) noexcept
 {
   return _CUDA_VSTD::cmp_less_equal(__u, numeric_limits<_Tp>::max())
       && _CUDA_VSTD::cmp_greater_equal(__u, numeric_limits<_Tp>::min());
 }
-#endif // _CCCL_STD_VER > 2017
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -29,6 +29,8 @@
 #  include <ciso646> // otherwise go for the smallest possible header
 #endif
 
+#define __cccl_lib_integer_comparison_functions 202002L
+
 #if _CCCL_STD_VER >= 2014
 #  define __cccl_lib_bit_cast     201806L
 #  define __cccl_lib_chrono_udls  201304L
@@ -171,7 +173,6 @@
 // #   define __cccl_lib_format                             202106L
 // # define __cccl_lib_generic_unordered_lookup             201811L
 // # define __cccl_lib_int_pow2                             202002L
-// # define __cccl_lib_integer_comparison_functions         202002L
 // # define __cccl_lib_interpolate                          201902L
 #  ifdef _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
 #    define __cccl_lib_is_constant_evaluated 201811L

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_equal/cmp_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_equal/cmp_equal.pass.cpp
@@ -7,12 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17
-
 // <utility>
 
 // template<class T, class U>
-//   constexpr bool cmp_equal(T t, U u) noexcept;         // C++20
+//   constexpr bool cmp_equal(T t, U u) noexcept;
 
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_greater/cmp_greater.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_greater/cmp_greater.pass.cpp
@@ -6,11 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17
-
 // <utility>
 
-//   constexpr bool cmp_greater(T t, U u) noexcept;       // C++20
+//   constexpr bool cmp_greater(T t, U u) noexcept;
 
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_greater_equal/cmp_greater_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_greater_equal/cmp_greater_equal.pass.cpp
@@ -6,11 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17
-
 // <utility>
 
-//   constexpr bool cmp_greater_equal(T t, U u) noexcept; // C++20
+//   constexpr bool cmp_greater_equal(T t, U u) noexcept;
 
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_less/cmp_less.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_less/cmp_less.pass.cpp
@@ -6,12 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17
-
 // <utility>
 
 // template<class T, class U>
-//   constexpr bool cmp_less(T t, U u) noexcept;          // C++20
+//   constexpr bool cmp_less(T t, U u) noexcept;
 
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_less_equal/cmp_less_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_less_equal/cmp_less_equal.pass.cpp
@@ -6,11 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17
-
 // <utility>
 
-//   constexpr bool cmp_less_equal(T t, U u) noexcept;    // C++20
+//   constexpr bool cmp_less_equal(T t, U u) noexcept;
 
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_not_equal/cmp_not_equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.cmp_not_equal/cmp_not_equal.pass.cpp
@@ -6,12 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17
-
 // <utility>
 
 // template<class T, class U>
-//   constexpr bool cmp_not_equal(T t, U u) noexcept;     // C++20
+//   constexpr bool cmp_not_equal(T t, U u) noexcept;
 
 #include <cuda/std/cassert>
 #include <cuda/std/limits>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.fail.cpp
@@ -6,30 +6,28 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17
-
 // <utility>
 
 // template<class T, class U>
-//   constexpr bool cmp_equal(T t, U u) noexcept; // C++20
+//   constexpr bool cmp_equal(T t, U u) noexcept;
 
 // template<class T, class U>
-//   constexpr bool cmp_not_equal(T t, U u) noexcept; // C++20
+//   constexpr bool cmp_not_equal(T t, U u) noexcept;
 
 // template<class T, class U>
-//   constexpr bool cmp_less(T t, U u) noexcept; // C++20
+//   constexpr bool cmp_less(T t, U u) noexcept;
 
 // template<class T, class U>
-//   constexpr bool cmp_less_equal(T t, U u) noexcept; // C++20
+//   constexpr bool cmp_less_equal(T t, U u) noexcept;
 
 // template<class T, class U>
-//   constexpr bool cmp_greater(T t, U u) noexcept; // C++20
+//   constexpr bool cmp_greater(T t, U u) noexcept;
 
 // template<class T, class U>
-//   constexpr bool cmp_greater_equal(T t, U u) noexcept; // C++20
+//   constexpr bool cmp_greater_equal(T t, U u) noexcept;
 
 // template<class R, class T>
-//   constexpr bool in_range(T t) noexcept;      // C++20
+//   constexpr bool in_range(T t) noexcept;
 
 #include <cuda/std/cstddef>
 #include <cuda/std/utility>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.in_range/in_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.intcmp/intcmp.in_range/in_range.pass.cpp
@@ -6,12 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17
-
 // <utility>
 
 // template<class R, class T>
-//   constexpr bool in_range(T t) noexcept;               // C++20
+//   constexpr bool in_range(T t) noexcept;
 
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>


### PR DESCRIPTION
## Description

This PR implements backport of C++20 integer comparison functions [P0586R2](https://wg21.link/P0586R2) to (hopefully) C++11.

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
