### PR TITLE
give `completion_signatures` a fast lookup cache

### DIFF
--- a/cudax/include/cuda/experimental/__async/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__async/completion_signatures.cuh
@@ -27,28 +27,37 @@
 
 #include <cuda/experimental/__async/cpos.cuh>
 #include <cuda/experimental/__async/exception.cuh>
+#include <cuda/experimental/__async/type_traits.cuh>
 
 #include <cuda/experimental/__async/prologue.cuh>
 
 namespace cuda::experimental::__async
 {
 // A typelist for completion signatures
-template <class... _Ts>
+template <class... _Sigs>
 struct completion_signatures
-{};
+{
+  struct __partitioned;
+};
 
-// A metafunction to determine if a type is a completion signature
+template <class _CompletionSignatures>
+using __partitioned_completions_of = typename _CompletionSignatures::__partitioned;
+
+constexpr int __invalid_disposition = -1;
+
+// A metafunction to determine whether a type is a completion signature, and if
+// so, what its disposition is.
 template <class>
-inline constexpr bool __is_valid_signature = false;
+inline constexpr int __signature_disposition = __invalid_disposition;
 
 template <class... _Ts>
-inline constexpr bool __is_valid_signature<set_value_t(_Ts...)> = true;
+inline constexpr __disposition_t __signature_disposition<set_value_t(_Ts...)> = __disposition_t::__value;
 
 template <class _Error>
-inline constexpr bool __is_valid_signature<set_error_t(_Error)> = true;
+inline constexpr __disposition_t __signature_disposition<set_error_t(_Error)> = __disposition_t::__error;
 
 template <>
-inline constexpr bool __is_valid_signature<set_stopped_t()> = true;
+inline constexpr __disposition_t __signature_disposition<set_stopped_t()> = __disposition_t::__stopped;
 
 // The implementation of transform_completion_signatures starts here
 template <class _Sig, template <class...> class _Vy, template <class...> class _Ey, class _Sy>
@@ -188,21 +197,105 @@ template <class _Sigs,
 using __gather_completion_signatures =
   typename __gather_sigs_fn<_WantedTag>::template __call<_Sigs, _Then, _Else, _Variant, _More...>;
 
+// __partitioned_completions is a cache of completion signatures for fast
+// access. The completion_signatures<Sigs...>::__partitioned nested struct
+// inherits from __partitioned_completions. If the cache is never accessed,
+// it is never instantiated.
+template <class _ValueTuplesList = _CUDA_VSTD::__type_list<>,
+          class _ErrorsList      = _CUDA_VSTD::__type_list<>,
+          bool _HasStopped       = false>
+struct __partitioned_completions;
+
+template <class... _ValueTuples, class... _Errors, bool _HasStopped>
+struct __partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>,
+                                 _CUDA_VSTD::__type_list<_Errors...>,
+                                 _HasStopped>
+{
+  using __stopped_sigs =
+    _CUDA_VSTD::conditional_t<_HasStopped, _CUDA_VSTD::__type_list<set_stopped_t()>, _CUDA_VSTD::__type_list<>>;
+
+  template <template <class...> class _Tuple, template <class...> class _Variant>
+  using __value_types = _Variant<_CUDA_VSTD::__type_call1<_ValueTuples, _CUDA_VSTD::__type_quote<_Tuple>>...>;
+
+  template <template <class...> class _Variant>
+  using __error_types = _Variant<_Errors...>;
+
+  template <template <class...> class _Variant, class _Type>
+  using __stopped_types = _CUDA_VSTD::__type_call1<
+    _CUDA_VSTD::conditional_t<_HasStopped, _CUDA_VSTD::__type_list<_Type>, _CUDA_VSTD::__type_list<>>,
+    _CUDA_VSTD::__type_quote<_Variant>>;
+
+  using __count_values  = _CUDA_VSTD::integral_constant<size_t, sizeof...(_ValueTuples)>;
+  using __count_errors  = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Errors)>;
+  using __count_stopped = _CUDA_VSTD::integral_constant<size_t, _HasStopped>;
+
+  struct __nothrow_decay_copyable
+  {
+    // These aliases are placed in a separate struct to avoid computing them
+    // if they are not needed.
+    using __fn     = _CUDA_VSTD::__type_quote<__nothrow_decay_copyable_t>;
+    using __values = _CUDA_VSTD::_And<_CUDA_VSTD::__type_call1<_ValueTuples, __fn>...>;
+    using __errors = __nothrow_decay_copyable_t<_Errors...>;
+    using __all    = _CUDA_VSTD::_And<__values, __errors>;
+  };
+};
+
+// The following overload set of operator* is used to build up the cache of
+// completion signatures. We fold over operator*, accumulating the completion
+// signatures in the cache. `__undefined` is used here to prevent the
+// instantiation of the intermediate types.
+
+template <class... _ValueTuples, class... _Errors, bool _HasStopped, class... _Values>
+auto operator*(__undefined<__partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>,
+                                                     _CUDA_VSTD::__type_list<_Errors...>,
+                                                     _HasStopped>>&,
+               set_value_t (*)(_Values...))
+  -> __undefined<__partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples..., _CUDA_VSTD::__type_list<_Values...>>,
+                                           _CUDA_VSTD::__type_list<_Errors...>,
+                                           _HasStopped>>&;
+
+template <class... _ValueTuples, class... _Errors, bool _HasStopped, class _Error>
+auto operator*(__undefined<__partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>,
+                                                     _CUDA_VSTD::__type_list<_Errors...>,
+                                                     _HasStopped>>&,
+               set_error_t (*)(_Error))
+  -> __undefined<__partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>,
+                                           _CUDA_VSTD::__type_list<_Errors..., _Error>,
+                                           _HasStopped>>&;
+
+template <class... _ValueTuples, class... _Errors>
+auto operator*(__undefined<__partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>, //
+                                                     _CUDA_VSTD::__type_list<_Errors...>,
+                                                     false>>&,
+               set_stopped_t (*)())
+  -> __undefined<__partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>, //
+                                           _CUDA_VSTD::__type_list<_Errors...>,
+                                           true>>&;
+
+// This unary overload is used to extract the cache from the `__undefined` type.
+template <class... _ValueTuples, class... _Errors, bool _HasStopped>
+auto operator*(__undefined<__partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>,
+                                                     _CUDA_VSTD::__type_list<_Errors...>,
+                                                     _HasStopped>>&)
+  -> __partitioned_completions<_CUDA_VSTD::__type_list<_ValueTuples...>, //
+                               _CUDA_VSTD::__type_list<_Errors...>,
+                               _HasStopped>;
+
+template <class... _Sigs>
+using __partition_completions =
+  decltype(*(__declval<__undefined<__partitioned_completions<>>&>() * ... * static_cast<_Sigs*>(nullptr)));
+
+// Here we give the completion_signatures<Sigs...> type a nested struct that
+// contains the fast lookup cache of completion signatures.
+template <class... _Sigs>
+struct completion_signatures<_Sigs...>::__partitioned : __partition_completions<_Sigs...>
+{};
+
 template <class... _Ts>
 using __set_value_transform_t = completion_signatures<set_value_t(_Ts...)>;
 
 template <class _Ty>
 using __set_error_transform_t = completion_signatures<set_error_t(_Ty)>;
-
-template <class... _Ts, class... _Us>
-auto operator*(_CUDA_VSTD::__type_set<_Ts...>&, __undefined<completion_signatures<_Us...>>&)
-  -> _CUDA_VSTD::__type_set_insert<_CUDA_VSTD::__type_set<_Ts...>, _Us...>&;
-
-template <class... _Ts, class... _What>
-auto operator*(_CUDA_VSTD::__type_set<_Ts...>&, __undefined<_ERROR<_What...>>&) -> _ERROR<_What...>&;
-
-template <class... _What, class... _Us>
-auto operator*(_ERROR<_What...>&, __undefined<completion_signatures<_Us...>>&) -> _ERROR<_What...>&;
 
 template <class... _Sigs>
 using __concat_completion_signatures = //
@@ -238,51 +331,32 @@ using transform_completion_signatures_of = //
                                   _ErrorTransform,
                                   _StoppedSigs>;
 
-template <class _Sigs,
-          template <class...>
-          class _Tuple,
-          template <class...>
-          class _Variant>
-using __value_types = //
-  __transform_completion_signatures<_Sigs,
-                                    __type_compose_quote<_CUDA_VSTD::__type_list, _Tuple>::template __call,
-                                    _CUDA_VSTD::__type_always<_CUDA_VSTD::__type_list<>>::__call,
-                                    _CUDA_VSTD::__type_list<>,
-                                    __type_concat_into_quote<_Variant>::template __call>;
+template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
+using __value_types = typename _Sigs::__partitioned::template __value_types<_Tuple, _Variant>;
 
 template <class _Sndr, class _Rcvr, template <class...> class _Tuple, template <class...> class _Variant>
 using value_types_of_t =
   __value_types<completion_signatures_of_t<_Sndr, _Rcvr>, _Tuple, __type_try_quote<_Variant>::template __call>;
 
-template <class _Sigs,
-          template <class...>
-          class _Variant>
-using __error_types = //
-  __transform_completion_signatures<_Sigs,
-                                    _CUDA_VSTD::__type_always<_CUDA_VSTD::__type_list<>>::__call,
-                                    _CUDA_VSTD::__type_list,
-                                    _CUDA_VSTD::__type_list<>,
-                                    __type_concat_into_quote<_Variant>::template __call>;
+template <class _Sigs, template <class...> class _Variant>
+using __error_types = typename _Sigs::__partitioned::template __error_types<_Variant>;
 
 template <class _Sndr, class _Rcvr, template <class...> class _Variant>
 using error_types_of_t = __error_types<completion_signatures_of_t<_Sndr, _Rcvr>, _Variant>;
 
+template <class _Sigs, template <class...> class _Variant, class _Type>
+using __stopped_types = typename _Sigs::__partitioned::template __stopped_types<_Variant, _Type>;
+
 template <class _Sigs>
-inline constexpr bool __sends_stopped = //
-  __transform_completion_signatures<_Sigs,
-                                    _CUDA_VSTD::__type_always<_CUDA_VSTD::false_type>::__call,
-                                    _CUDA_VSTD::__type_always<_CUDA_VSTD::false_type>::__call,
-                                    _CUDA_VSTD::true_type,
-                                    _CUDA_VSTD::_Or>::value;
+inline constexpr bool __sends_stopped = _Sigs::__partitioned::__count_stopped::value != 0;
 
 template <class _Sndr, class _Rcvr = receiver_archetype>
-inline constexpr bool sends_stopped = //
-  __sends_stopped<completion_signatures_of_t<_Sndr, _Rcvr>>;
+inline constexpr bool sends_stopped = __sends_stopped<completion_signatures_of_t<_Sndr, _Rcvr>>;
 
 using __eptr_completion = completion_signatures<set_error_t(::std::exception_ptr)>;
 
 template <bool _NoExcept>
-using __eptr_completion_if = _CUDA_VSTD::_If<_NoExcept, completion_signatures<>, __eptr_completion>;
+using __eptr_completion_unless = _CUDA_VSTD::conditional_t<_NoExcept, completion_signatures<>, __eptr_completion>;
 
 template <class>
 inline constexpr bool __is_completion_signatures = false;
@@ -335,7 +409,8 @@ auto completions_of(_Sndr&&,
 
 template <bool _PotentiallyThrowing>
 auto eptr_completion_if()
-  -> _CUDA_VSTD::_If<_PotentiallyThrowing, __csig::__sigs<set_error_t(::std::exception_ptr)>, __csig::__sigs<>>&;
+  -> _CUDA_VSTD::
+    conditional_t<_PotentiallyThrowing, __csig::__sigs<set_error_t(::std::exception_ptr)>, __csig::__sigs<>>&;
 } // namespace meta
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/continue_on.cuh
+++ b/cudax/include/cuda/experimental/__async/continue_on.cuh
@@ -54,15 +54,15 @@ private:
 
   template <class... _Ts>
   using __set_value_completion =
-    _CUDA_VSTD::_If<__nothrow_decay_copyable<_Ts...>,
-                    completion_signatures<set_value_t(__decay_t<_Ts>...)>,
-                    completion_signatures<set_value_t(__decay_t<_Ts>...), set_error_t(::std::exception_ptr)>>;
+    _CUDA_VSTD::conditional_t<__nothrow_decay_copyable<_Ts...>,
+                              completion_signatures<set_value_t(__decay_t<_Ts>...)>,
+                              completion_signatures<set_value_t(__decay_t<_Ts>...), set_error_t(::std::exception_ptr)>>;
 
   template <class _Error>
   using __set_error_completion =
-    _CUDA_VSTD::_If<__nothrow_decay_copyable<_Error>,
-                    completion_signatures<set_error_t(__decay_t<_Error>)>,
-                    completion_signatures<set_error_t(__decay_t<_Error>), set_error_t(::std::exception_ptr)>>;
+    _CUDA_VSTD::conditional_t<__nothrow_decay_copyable<_Error>,
+                              completion_signatures<set_error_t(__decay_t<_Error>)>,
+                              completion_signatures<set_error_t(__decay_t<_Error>), set_error_t(::std::exception_ptr)>>;
 
   template <class _Rcvr, class _Result>
   struct __rcvr_t

--- a/cudax/include/cuda/experimental/__async/just_from.cuh
+++ b/cudax/include/cuda/experimental/__async/just_from.cuh
@@ -66,9 +66,9 @@ private:
   using _JustTag = decltype(__detail::__just_from_tag<_Disposition>());
   using _SetTag  = decltype(__detail::__set_tag<_Disposition>());
 
-  using __diag_t = _CUDA_VSTD::_If<_CUDA_VSTD::is_same_v<_SetTag, set_error_t>,
-                                   _AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT,
-                                   _A_STOPPED_COMPLETION_MUST_HAVE_NO_ARGUMENTS>;
+  using __diag_t = _CUDA_VSTD::conditional_t<_CUDA_VSTD::is_same_v<_SetTag, set_error_t>,
+                                             _AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT,
+                                             _A_STOPPED_COMPLETION_MUST_HAVE_NO_ARGUMENTS>;
 
   template <class... _Ts>
   using __error_t =
@@ -78,8 +78,9 @@ private:
   {
     template <class... _Ts>
     auto operator()(_Ts&&... __ts) const noexcept
-      -> _CUDA_VSTD::
-        _If<__is_valid_signature<_SetTag(_Ts...)>, completion_signatures<_SetTag(_Ts...)>, __error_t<_Ts...>>;
+      -> _CUDA_VSTD::conditional_t<__signature_disposition<_SetTag(_Ts...)> != __invalid_disposition,
+                                   completion_signatures<_SetTag(_Ts...)>,
+                                   __error_t<_Ts...>>;
   };
 
   template <class _Rcvr = receiver_archetype>

--- a/cudax/include/cuda/experimental/__async/let_value.cuh
+++ b/cudax/include/cuda/experimental/__async/let_value.cuh
@@ -103,7 +103,7 @@ private:
 
     template <class _Ty>
     using __ensure_sender = //
-      _CUDA_VSTD::_If<__is_sender<_Ty> || __type_is_error<_Ty>, _Ty, __error_non_sender_return>;
+      _CUDA_VSTD::conditional_t<__is_sender<_Ty> || __type_is_error<_Ty>, _Ty, __error_non_sender_return>;
 
     template <class... _As>
     using __error_not_callable_with = //
@@ -158,8 +158,8 @@ private:
     // Don't try to compute the type of the variant of operation states
     // if the computation of the completion signatures failed.
     using __deferred_opstate_fn = _CUDA_VSTD::__type_bind_back<__type_try_quote<__opstate2_t>, _CvSndr, _Fn, _Rcvr>;
-    using __opstate_variant_fn =
-      _CUDA_VSTD::_If<__type_is_error<completion_signatures>, _CUDA_VSTD::__type_always<__empty>, __deferred_opstate_fn>;
+    using __opstate_variant_fn  = _CUDA_VSTD::
+      conditional_t<__type_is_error<completion_signatures>, _CUDA_VSTD::__type_always<__empty>, __deferred_opstate_fn>;
     using __opstate_variant_t = __type_try_call<__opstate_variant_fn>;
 
     _Rcvr __rcvr_;

--- a/cudax/include/cuda/experimental/__async/meta.cuh
+++ b/cudax/include/cuda/experimental/__async/meta.cuh
@@ -93,9 +93,22 @@ struct __merror_base
 template <class... _What>
 struct _ERROR : __merror_base
 {
+  // The following aliases are to simplify error propagation
+  // in the completion signatures meta-programming.
   template <class...>
   using __call _CCCL_NODEBUG_ALIAS = _ERROR;
 
+  using __partitions _CCCL_NODEBUG_ALIAS = _ERROR;
+
+  template <template <class...> class, template <class...> class>
+  using __value_types _CCCL_NODEBUG_ALIAS = _ERROR;
+
+  template <template <class...> class>
+  using __error_types _CCCL_NODEBUG_ALIAS = _ERROR;
+
+  using __sends_stopped _CCCL_NODEBUG_ALIAS = _ERROR;
+
+  // The following operator overloads also simplify error propagation.
   _ERROR operator+();
 
   template <class _Ty>
@@ -208,9 +221,9 @@ struct __type_try_quote<_Fn, _Default>
 {
   template <class... _Ts>
   using __call _CCCL_NODEBUG_ALIAS =
-    typename _CUDA_VSTD::_If<__type_valid_v<_Fn, _Ts...>, //
-                             __type_try_quote<_Fn>,
-                             _CUDA_VSTD::__type_always<_Default>>::template __call<_Ts...>;
+    typename _CUDA_VSTD::conditional_t<__type_valid_v<_Fn, _Ts...>, //
+                                       __type_try_quote<_Fn>,
+                                       _CUDA_VSTD::__type_always<_Default>>::template __call<_Ts...>;
 };
 
 template <class _First, class _Second>
@@ -239,20 +252,30 @@ struct __type_count
   using __call _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::integral_constant<size_t, sizeof...(_Ts)>;
 };
 
-template <template <class...> class _Continuation>
-struct __type_concat_into_quote
+template <class _Continuation>
+struct __type_concat_into
 {
   template <class... _Args>
   using __call _CCCL_NODEBUG_ALIAS =
-    _CUDA_VSTD::__type_call1<_CUDA_VSTD::__type_concat<_CUDA_VSTD::__as_type_list<_Args>...>,
-                             _CUDA_VSTD::__type_quote<_Continuation>>;
+    _CUDA_VSTD::__type_call1<_CUDA_VSTD::__type_concat<_CUDA_VSTD::__as_type_list<_Args>...>, _Continuation>;
 };
+
+template <template <class...> class _Continuation>
+struct __type_concat_into_quote : __type_concat_into<_CUDA_VSTD::__type_quote<_Continuation>>
+{};
 
 template <class _Ty>
 struct __type_self_or
 {
   template <class _Uy = _Ty>
   using __call _CCCL_NODEBUG_ALIAS = _Uy;
+};
+
+template <class _Ret>
+struct __type_quote_function
+{
+  template <class... _Args>
+  using __call _CCCL_NODEBUG_ALIAS = _Ret(_Args...);
 };
 } // namespace cuda::experimental::__async
 

--- a/cudax/include/cuda/experimental/__async/read_env.cuh
+++ b/cudax/include/cuda/experimental/__async/read_env.cuh
@@ -53,7 +53,7 @@ private:
   struct __completions_fn
   {
     template <class _Query, class _Env>
-    using __call = _CUDA_VSTD::_If<
+    using __call = _CUDA_VSTD::conditional_t<
       __nothrow_callable<_Query, _Env>,
       completion_signatures<set_value_t(__call_result_t<_Query, _Env>)>,
       completion_signatures<set_value_t(__call_result_t<_Query, _Env>), set_error_t(::std::exception_ptr)>>;
@@ -64,11 +64,11 @@ private:
   {
     using operation_state_concept = operation_state_t;
     using completion_signatures   = //
-      _CUDA_VSTD::__type_call<
-        _CUDA_VSTD::
-          _If<__callable<_Query, env_of_t<_Rcvr>>, __completions_fn, __error_env_lacks_query<_Query, env_of_t<_Rcvr>>>,
-        _Query,
-        env_of_t<_Rcvr>>;
+      _CUDA_VSTD::__type_call<_CUDA_VSTD::conditional_t<__callable<_Query, env_of_t<_Rcvr>>,
+                                                        __completions_fn,
+                                                        __error_env_lacks_query<_Query, env_of_t<_Rcvr>>>,
+                              _Query,
+                              env_of_t<_Rcvr>>;
 
     _Rcvr __rcvr_;
 

--- a/cudax/include/cuda/experimental/__async/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__async/type_traits.cuh
@@ -114,6 +114,9 @@ using __nothrow_copyable_ = _CUDA_VSTD::enable_if_t<noexcept(_Ty(__declval<const
 template <class... _As>
 inline constexpr bool __nothrow_copyable = (__type_valid_v<__nothrow_copyable_, _As> && ...);
 #endif
+
+template <class... _As>
+using __nothrow_decay_copyable_t = _CUDA_VSTD::bool_constant<__nothrow_decay_copyable<_As...>>;
 } // namespace cuda::experimental::__async
 
 #include <cuda/experimental/__async/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__async/utility.cuh
+++ b/cudax/include/cuda/experimental/__async/utility.cuh
@@ -40,8 +40,7 @@ struct __ignore
   _CUDAX_API constexpr __ignore(_As&&...) noexcept {};
 };
 
-template <class...>
-struct __undefined;
+using _CUDA_VSTD::__undefined; // NOLINT: misc-unused-using-decls
 
 struct __empty
 {};


### PR DESCRIPTION
## Description

much of the metaprogramming in std::execution is for computing a sender's completion signatures, which are represented as a list of function types, each function type describing one way that sender's operation may complete.

but a flat list of function types isn't a very convenient data structure to work with. `transform_completion_signatures` makes it easy to apply transformation metafunctions to each signature in the list, but some tasks involve multiple passes to compute everything, which gets expensive.

what is needed instead is a way to "compile" a set of completion signatures into a data structure that provides fast access to precomputed data. you can ask it for just the value completions, or just the errors, or how many different value completions it has, or whether all the values and errors can be nothrow decay-copied.

this PR adds a nested type `__partitioned` to the `completion_signatures` class template. when accessed, it will populate its cache so that basic questions about a sender's completions can be answered quickly.

`__partitioned` provides the following interface:

```c++
template <template <class...> class Tuple, template <class...> class Variant>
using __value_types = Variant< Tuple< {value-types-1}... >, Tuple< {value-types-2}...> ... >;

template <template <class...> class Variant>
using __error_types = Variant< {error-types}... >;

template <template <class...> class Variant, class Type>
using __stopped_types = Variant< Type? >;

using __count_values = {count of value completions};
using __count_errors = {count of error completions};
using __count_stopped = {1 or 0};

// in a separate nested struct so it's computed only if needed
struct __nothrow_decay_copyable
{
  using __values = {true if all value types are nothrow decay-copyable};
  using __errors = {true if all error types are nothrow decay-copyable};
  using __all = conjunction<__values, __errors>;
};
```

this PR also changes some of the library's type traits to query the cache rather than computing things on demand.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
