### PR TITLE
Move our CUDACC version checks towards the new version check design

### DIFF
--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -172,12 +172,12 @@ struct agent_t
 
     // if items are provided, merge them
     static constexpr bool have_items = !std::is_same<item_type, NullType>::value;
-#ifdef _CCCL_CUDACC_BELOW_11_8
+#if _CCCL_CUDACC_BELOW(11, 8)
     if (have_items) // nvcc 11.1 cannot handle #pragma unroll inside if constexpr but 11.8 can.
                     // nvcc versions between may work
-#else
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv _CCCL_CUDACC_AT_LEAST(11, 8)
     _CCCL_IF_CONSTEXPR (have_items)
-#endif
+#endif // _CCCL_CUDACC_AT_LEAST(11, 8)
     {
       item_type items_loc[items_per_thread];
       gmem_to_reg<threads_per_block, IsFullTile>(

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -634,12 +634,12 @@ struct AgentMerge
     }
 
     // if items are provided, merge them
-#ifdef _CCCL_CUDACC_BELOW_11_8
+#if _CCCL_CUDACC_BELOW(11, 8)
     if (!KEYS_ONLY) // nvcc 11.1 cannot handle #pragma unroll inside if constexpr but 11.8 can.
                     // nvcc versions between may work
-#else
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 8) ^^^ / vvv _CCCL_CUDACC_AT_LEAST(11, 8)
     _CCCL_IF_CONSTEXPR (!KEYS_ONLY)
-#endif
+#endif // _CCCL_CUDACC_AT_LEAST(11, 8)
     {
       CTA_SYNC();
 

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -13,12 +13,12 @@
 #  pragma system_header
 #endif // no system header
 
-#if defined(_CCCL_CUDA_COMPILER) && _CCCL_CUDACC_VER < 1105000
+#if defined(_CCCL_CUDA_COMPILER) && _CCCL_CUDACC_BELOW(11, 5)
 _CCCL_NV_DIAG_SUPPRESS(186)
 #  include <cuda_pipeline_primitives.h>
 // we cannot re-enable the warning here, because it is triggered outside the translation unit
 // see also: https://godbolt.org/z/1x8b4hn3G
-#endif // defined(_CCCL_CUDA_COMPILER) && _CCCL_CUDACC_VER < 1105000
+#endif // defined(_CCCL_CUDA_COMPILER) && _CCCL_CUDACC_BELOW(11, 5)
 
 #include <cub/detail/uninitialized_copy.cuh>
 #include <cub/util_arch.cuh>
@@ -55,9 +55,9 @@ CUB_NAMESPACE_BEGIN
 
 // The ublkcp kernel needs PTX features that are only available and understood by nvcc >=12.
 // Also, cooperative groups do not support NVHPC yet.
-#if _CCCL_CUDACC_VER_MAJOR >= 12 && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#if _CCCL_CUDACC_AT_LEAST(12, 0) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
 #  define _CUB_HAS_TRANSFORM_UBLKCP
-#endif // _CCCL_CUDACC_VER_MAJOR >= 12 && !defined(_CCCL_CUDA_COMPILER_NVHPC)
+#endif // _CCCL_CUDACC_AT_LEAST(12, 0) && !defined(_CCCL_CUDA_COMPILER_NVHPC)
 
 namespace detail
 {

--- a/cub/cub/launcher/cuda_driver.cuh
+++ b/cub/cub/launcher/cuda_driver.cuh
@@ -10,7 +10,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if !defined(_CCCL_CUDACC_BELOW_12_0)
+#if _CCCL_CUDACC_AT_LEAST(12, 0)
 
 #  include <cuda.h>
 
@@ -80,4 +80,4 @@ struct CudaDriverLauncherFactory
 
 CUB_NAMESPACE_END
 
-#endif // !defined(_CCCL_CUDACC_BELOW_12_0)
+#endif // _CCCL_CUDACC_AT_LEAST(12, 0)

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -51,12 +51,12 @@
 #include <cuda/std/type_traits>
 
 #if defined(_CCCL_HAS_NVBF16)
-#  if !defined(_CCCL_CUDACC_BELOW_11_8)
+#  if _CCCL_CUDACC_AT_LEAST(11, 8)
 // cuda_fp8.h resets default for C4127, so we have to guard the inclusion
 _CCCL_DIAG_PUSH
 #    include <cuda_fp8.h>
 _CCCL_DIAG_POP
-#  endif // !_CCCL_CUDACC_BELOW_11_8
+#  endif // _CCCL_CUDACC_AT_LEAST(11, 8)
 #endif // _CCCL_HAS_NV_BF16
 
 #ifdef _CCCL_COMPILER_NVRTC
@@ -73,12 +73,12 @@ CUB_NAMESPACE_BEGIN
 #      define CUB_IS_INT128_ENABLED 1
 #    endif // !defined(__CUDACC_RTC_INT128__)
 #  else // !defined(__CUDACC_RTC__)
-#    if _CCCL_CUDACC_VER >= 1105000
+#    if _CCCL_CUDACC_AT_LEAST(11, 5)
 #      if defined(_CCCL_COMPILER_GCC) || defined(_CCCL_COMPILER_CLANG) || defined(_CCCL_COMPILER_ICC) \
         || _CCCL_COMPILER(NVHPC)
 #        define CUB_IS_INT128_ENABLED 1
 #      endif // GCC || CLANG || ICC || NVHPC
-#    endif // CTK >= 11.5
+#    endif // _CCCL_CUDACC_AT_LEAST(11, 5)
 #  endif // !defined(__CUDACC_RTC__)
 #endif // !defined(CUB_IS_INT128_ENABLED)
 

--- a/cudax/include/cuda/experimental/__detail/config.cuh
+++ b/cudax/include/cuda/experimental/__detail/config.cuh
@@ -24,7 +24,7 @@
 // Debuggers do not step into functions marked with __attribute__((__artificial__)).
 // This is useful for small wrapper functions that just dispatch to other functions and
 // that are inlined into the caller.
-#if _CCCL_HAS_ATTRIBUTE(__artificial__) && !defined(_CCCL_CUDACC)
+#if _CCCL_HAS_ATTRIBUTE(__artificial__) && !_CCCL_CUDACC
 #  define _CUDAX_ARTIFICIAL __attribute__((__artificial__))
 #else // ^^^ _CCCL_HAS_ATTRIBUTE(__artificial__) ^^^ / vvv !_CCCL_HAS_ATTRIBUTE(__artificial__) vvv
 #  define _CUDAX_ARTIFICIAL

--- a/cudax/include/cuda/experimental/__memory_resource/device_memory_pool.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/device_memory_pool.cuh
@@ -22,7 +22,7 @@
 #endif // no system header
 
 // cudaMallocAsync was introduced in CTK 11.2
-#if !defined(_CCCL_COMPILER_MSVC_2017) && !defined(_CCCL_CUDACC_BELOW_11_2)
+#if !defined(_CCCL_COMPILER_MSVC_2017) && _CCCL_CUDACC_AT_LEAST(11, 2)
 
 #  if defined(_CCCL_CUDA_COMPILER_CLANG)
 #    include <cuda_runtime.h>
@@ -133,7 +133,7 @@ private:
   static void __cuda_supports_export_handle_type(const int __device_id, cudaMemAllocationHandleType __handle_type)
   {
     int __supported_handles = static_cast<int>(cudaMemAllocationHandleType::cudaMemHandleTypeNone);
-#    if !defined(_CCCL_CUDACC_BELOW_11_3)
+#    if _CCCL_CUDACC_AT_LEAST(11, 3)
     if (__handle_type != cudaMemAllocationHandleType::cudaMemHandleTypeNone)
     {
       const ::cudaError_t __status =
@@ -152,7 +152,7 @@ private:
           ::cuda::__throw_cuda_error(__status, "Failed to call cudaDeviceGetAttribute");
       }
     }
-#    endif //_CCCL_CUDACC_BELOW_11_3
+#    endif // _CCCL_CUDACC_BELOW(11, 3)
     if ((static_cast<int>(__handle_type) & __supported_handles) != static_cast<int>(__handle_type))
     {
       ::cuda::__throw_cuda_error(
@@ -428,6 +428,6 @@ public:
 
 #  endif // _CCCL_STD_VER >= 2014
 
-#endif // !_CCCL_COMPILER_MSVC_2017 && !_CCCL_CUDACC_BELOW_11_2
+#endif // !_CCCL_COMPILER_MSVC_2017 && _CCCL_CUDACC_AT_LEAST(11, 2)
 
 #endif // _CUDAX__MEMORY_RESOURCE_DEVICE_MEMORY_POOL

--- a/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
@@ -22,7 +22,7 @@
 #endif // no system header
 
 // cudaMallocAsync was introduced in CTK 11.2
-#if !defined(_CCCL_COMPILER_MSVC_2017) && !defined(_CCCL_CUDACC_BELOW_11_2)
+#if !defined(_CCCL_COMPILER_MSVC_2017) && _CCCL_CUDACC_AT_LEAST(11, 2)
 
 #  if defined(_CCCL_CUDA_COMPILER_CLANG)
 #    include <cuda_runtime.h>
@@ -417,6 +417,6 @@ static_assert(_CUDA_VMR::resource_with<device_memory_resource, _CUDA_VMR::device
 
 #  endif // _CCCL_STD_VER >= 2014
 
-#endif // !_CCCL_COMPILER_MSVC_2017 && !_CCCL_CUDACC_BELOW_11_2
+#endif // !_CCCL_COMPILER_MSVC_2017 && _CCCL_CUDACC_AT_LEAST(11, 2)
 
 #endif //_CUDAX__MEMORY_RESOURCE_CUDA_DEVICE_MEMORY_RESOURCE

--- a/cudax/test/memory_resource/device_memory_pool.cu
+++ b/cudax/test/memory_resource/device_memory_pool.cu
@@ -144,7 +144,7 @@ TEST_CASE("device_memory_pool construction", "[memory_resource]")
   }
 
   // Allocation handles are only supported after 11.2
-#if !defined(_CCCL_CUDACC_BELOW_11_2)
+#if _CCCL_CUDACC_AT_LEAST(11, 2)
   SECTION("Construct with allocation handle")
   {
     cudax::mr::memory_pool_properties props = {
@@ -163,7 +163,7 @@ TEST_CASE("device_memory_pool construction", "[memory_resource]")
     // Ensure that we disable export
     CHECK(ensure_export_handle(get, static_cast<cudaMemAllocationHandleType>(props.allocation_handle_type)));
   }
-#endif // !_CCCL_CUDACC_BELOW_11_2
+#endif // _CCCL_CUDACC_AT_LEAST(11, 2)
 
   SECTION("Take ownership of native handle")
   {

--- a/cudax/test/memory_resource/device_memory_resource.cu
+++ b/cudax/test/memory_resource/device_memory_resource.cu
@@ -191,7 +191,7 @@ TEST_CASE("device_memory_resource construction", "[memory_resource]")
   }
 
   // Allocation handles are only supported after 11.2
-#if !defined(_CCCL_CUDACC_BELOW_11_2)
+#if _CCCL_CUDACC_AT_LEAST(11, 2)
   SECTION("Construct with allocation handle")
   {
     cuda::experimental::mr::memory_pool_properties props = {
@@ -214,7 +214,7 @@ TEST_CASE("device_memory_resource construction", "[memory_resource]")
     // Ensure that we disable export
     CHECK(ensure_export_handle(get, static_cast<cudaMemAllocationHandleType>(props.allocation_handle_type)));
   }
-#endif // !_CCCL_CUDACC_BELOW_11_2
+#endif // _CCCL_CUDACC_AT_LEAST(11, 2)
 }
 
 static void ensure_device_ptr(void* ptr)

--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -402,6 +402,8 @@ doxygen_predefined = [
   "__device__",
   "__host__",
   "__global__",
+  "_CCCL_CUDACC_AT_LEAST(x, y)=1",
+  "_CCCL_CUDACC_BELOW(x, y)=0",
   "_CCCL_DEVICE=",
   "_CCCL_EXEC_CHECK_DISABLE=",
   "_CCCL_FORCEINLINE=",

--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -64,7 +64,7 @@
 // However, MSVC implements [[msvc::no_unique_address]] which does what
 // [[no_unique_address]] is supposed to do, in general.
 #  define _CCCL_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
-#elif defined(_CCCL_CUDACC_BELOW_11_3) || (_CCCL_HAS_CPP_ATTRIBUTE(no_unique_address) < 201803L)
+#elif _CCCL_CUDACC_BELOW(11, 3) || (_CCCL_HAS_CPP_ATTRIBUTE(no_unique_address) < 201803L)
 #  define _CCCL_HAS_NO_ATTRIBUTE_NO_UNIQUE_ADDRESS
 #  define _CCCL_NO_UNIQUE_ADDRESS
 #elif _CCCL_HAS_CPP_ATTRIBUTE(no_unique_address)
@@ -88,18 +88,18 @@
 
 // NVCC below 11.3 does not support nodiscard on friend operators
 // It always fails with clang
-#if defined(_CCCL_CUDACC_BELOW_11_3) || defined(_CCCL_COMPILER_CLANG)
+#if _CCCL_CUDACC_BELOW(11, 3) || defined(_CCCL_COMPILER_CLANG)
 #  define _CCCL_NODISCARD_FRIEND friend
-#else // ^^^ _CCCL_CUDACC_BELOW_11_3 ^^^ / vvv !_CCCL_CUDACC_BELOW_11_3 vvv
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 3) ^^^ / vvv _CCCL_CUDACC_AT_LEAST(11, 3) vvv
 #  define _CCCL_NODISCARD_FRIEND _CCCL_NODISCARD friend
-#endif // !_CCCL_CUDACC_BELOW_11_3 && !_CCCL_COMPILER_CLANG
+#endif // _CCCL_CUDACC_AT_LEAST(11, 3) && !_CCCL_COMPILER_CLANG
 
 // NVCC below 11.3 does not support attributes on alias declarations
-#ifdef _CCCL_CUDACC_BELOW_11_3
+#if _CCCL_CUDACC_BELOW(11, 3)
 #  define _CCCL_ALIAS_ATTRIBUTE(...)
-#else // ^^^ _CCCL_CUDACC_BELOW_11_3 ^^^ / vvv !_CCCL_CUDACC_BELOW_11_3 vvv
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 3) ^^^ / vvv _CCCL_CUDACC_AT_LEAST(11, 3) vvv
 #  define _CCCL_ALIAS_ATTRIBUTE(...) __VA_ARGS__
-#endif // !_CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_AT_LEAST(11, 3)
 
 #if defined(_CCCL_COMPILER_MSVC)
 #  define _CCCL_NORETURN __declspec(noreturn)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -92,9 +92,9 @@
 #endif // _CCCL_HAS_BUILTIN(__builtin_assume_aligned)
 
 // NVCC below 11.2 treats this as a host only function
-#if defined(_CCCL_CUDACC_BELOW_11_2)
+#if _CCCL_CUDACC_BELOW(11, 2)
 #  undef _CCCL_BUILTIN_ASSUME_ALIGNED
-#endif // _CCCL_CUDACC_BELOW_11_2
+#endif // _CCCL_CUDACC_BELOW(11, 2)
 
 // nvhpc has a bug where it supports __builtin_addressof but does not mark it via _CCCL_CHECK_BUILTIN
 #if _CCCL_CHECK_BUILTIN(builtin_addressof) || (defined(_CCCL_COMPILER_GCC) && _CCCL_GCC_VERSION >= 70000) \
@@ -107,14 +107,14 @@
 #endif // _CCCL_CHECK_BUILTIN(builtin_assume)
 
 // NVCC prior to 11.2 cannot handle __builtin_assume
-#if defined(_CCCL_CUDACC_BELOW_11_2)
+#if _CCCL_CUDACC_BELOW(11, 2)
 #  undef _CCCL_BUILTIN_ASSUME
-#endif // _CCCL_CUDACC_BELOW_11_2
+#endif // _CCCL_CUDACC_BELOW(11, 2)
 
 // NVCC prior to 11.2 does not understand __builtin_assume
-#if defined(_CCCL_CUDACC_BELOW_11_2)
+#if _CCCL_CUDACC_BELOW(11, 2)
 #  undef _CCCL_BUILTIN_ASSUME
-#endif // _CCCL_CUDACC_BELOW_11_2
+#endif // _CCCL_CUDACC_BELOW(11, 2)
 
 // MSVC supports __builtin_bit_cast from 19.25 on
 #if _CCCL_CHECK_BUILTIN(builtin_bit_cast) || (defined(_CCCL_COMPILER_MSVC) && _CCCL_MSVC_VERSION > 1925)
@@ -123,7 +123,7 @@
 
 // clang prior to clang-10 supports __builtin_bit_cast but it is not a constant expression
 // NVCC prior to 11.7 cannot parse __builtin_bit_cast
-#if (defined(_CCCL_COMPILER_CLANG) && _CCCL_CLANG_VERSION < 100000) || defined(_CCCL_CUDACC_BELOW_11_7)
+#if (defined(_CCCL_COMPILER_CLANG) && _CCCL_CLANG_VERSION < 100000) || _CCCL_CUDACC_BELOW(11, 7)
 #  undef _CCCL_BUILTIN_BIT_CAST
 #endif // clang < 10 || nvcc < 11.7
 
@@ -134,10 +134,10 @@
 #endif // !_CCCL_HAS_BUILTIN(__builtin_COLUMN)
 
 // NVCC below 11.3 cannot handle __builtin_COLUMN
-#if defined(_CCCL_CUDACC_BELOW_11_3)
+#if _CCCL_CUDACC_BELOW(11, 3)
 #  undef _CCCL_BUILTIN_COLUMN
 #  define _CCCL_BUILTIN_COLUMN() 0
-#endif // _CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_BELOW(11, 3)
 
 #if _CCCL_CHECK_BUILTIN(builtin_contant_p) || defined(_CCCL_COMPILER_GCC)
 #  define _CCCL_BUILTIN_CONSTANT_P(...) __builtin_constant_p(__VA_ARGS__)
@@ -155,10 +155,10 @@
 #endif // !_CCCL_HAS_BUILTIN(__builtin_LINE)
 
 // NVCC below 11.3 cannot handle __builtin_FILE
-#if defined(_CCCL_CUDACC_BELOW_11_3)
+#if _CCCL_CUDACC_BELOW(11, 3)
 #  undef _CCCL_BUILTIN_FILE
 #  define _CCCL_BUILTIN_FILE() __FILE__
-#endif // _CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_BELOW(11, 3)
 
 #if _CCCL_HAS_BUILTIN(__builtin_FUNCTION) || defined(_CCCL_COMPILER_GCC) \
   || (defined(_CCCL_COMPILER_MSVC) && _CCCL_MSVC_VERSION >= 1927)
@@ -168,13 +168,13 @@
 #endif // !_CCCL_HAS_BUILTIN(__builtin_FUNCTION)
 
 // NVCC below 11.3 cannot handle __builtin_FUNCTION
-#if defined(_CCCL_CUDACC_BELOW_11_3)
+#if _CCCL_CUDACC_BELOW(11, 3)
 #  undef _CCCL_BUILTIN_FUNCTION
 #  define _CCCL_BUILTIN_FUNCTION() "__builtin_FUNCTION is unsupported"
-#endif // _CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_BELOW(11, 3)
 
 #if _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated) || (defined(_CCCL_COMPILER_GCC) && _CCCL_GCC_VERSION >= 90000) \
-  || (defined(_CCCL_COMPILER_MSVC) && _CCCL_MSVC_VERSION > 1924 && !defined(_CCCL_CUDACC_BELOW_11_3))
+  || (defined(_CCCL_COMPILER_MSVC) && _CCCL_MSVC_VERSION > 1924 && _CCCL_CUDACC_AT_LEAST(11, 3))
 #  define _CCCL_BUILTIN_IS_CONSTANT_EVALUATED(...) __builtin_is_constant_evaluated(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated)
 
@@ -190,7 +190,7 @@
 
 // NVCC prior to 11.3 and clang prior to clang-10 accept __builtin_launder but break with a compiler error about an
 // invalid return type
-#if (defined(_CCCL_COMPILER_CLANG) && _CCCL_CLANG_VERSION < 100000) || defined(_CCCL_CUDACC_BELOW_11_3)
+#if (defined(_CCCL_COMPILER_CLANG) && _CCCL_CLANG_VERSION < 100000) || _CCCL_CUDACC_BELOW(11, 3)
 #  undef _CCCL_BUILTIN_LAUNDER
 #endif // clang < 10 || nvcc < 11.3
 
@@ -202,10 +202,10 @@
 #endif // !_CCCL_HAS_BUILTIN(__builtin_LINE)
 
 // NVCC below 11.3 cannot handle __builtin_LINE
-#if defined(_CCCL_CUDACC_BELOW_11_3)
+#if _CCCL_CUDACC_BELOW(11, 3)
 #  undef _CCCL_BUILTIN_LINE
 #  define _CCCL_BUILTIN_LINE() __LINE__
-#endif // _CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_BELOW(11, 3)
 
 #if _CCCL_CHECK_BUILTIN(__builtin_operator_new) && _CCCL_CHECK_BUILTIN(__builtin_operator_delete) \
   && defined(_CCCL_CUDA_COMPILER_CLANG)
@@ -353,9 +353,9 @@
 #endif // _CCCL_CHECK_BUILTIN(is_lvalue_reference)
 
 // NVCC prior to 11.3 cannot parse __is_lvalue_reference
-#if defined(_CCCL_CUDACC_BELOW_11_3)
+#if _CCCL_CUDACC_BELOW(11, 3)
 #  undef _CCCL_BUILTIN_IS_LVALUE_REFERENCE
-#endif // _CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_BELOW(11, 3)
 
 #if _CCCL_HAS_BUILTIN(__is_member_function_pointer)
 #  define _CCCL_BUILTIN_IS_MEMBER_FUNCTION_POINTER(...) __is_member_function_pointer(__VA_ARGS__)
@@ -386,9 +386,9 @@
 #endif // _CCCL_CHECK_BUILTIN(is_object)
 
 // NVCC prior to 11.3 cannot parse __is_object
-#if defined(_CCCL_CUDACC_BELOW_11_3)
+#if _CCCL_CUDACC_BELOW(11, 3)
 #  undef _CCCL_BUILTIN_IS_OBJECT
-#endif // _CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_BELOW(11, 3)
 
 #if _CCCL_CHECK_BUILTIN(is_pod) || (defined(_CCCL_COMPILER_GCC) && _CCCL_GCC_VERSION >= 40300) \
   || defined(_CCCL_COMPILER_MSVC) || defined(_CCCL_COMPILER_NVRTC)
@@ -471,9 +471,9 @@
 #endif // _CCCL_CHECK_BUILTIN(is_unsigned)
 
 // NVCC prior to 11.3 cannot parse __is_unsigned
-#if defined(_CCCL_CUDACC_BELOW_11_3)
+#if _CCCL_CUDACC_BELOW(11, 3)
 #  undef _CCCL_BUILTIN_IS_UNSIGNED
-#endif // _CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_BELOW(11, 3)
 
 // Disabled due to libstdc++ conflict
 #if 0 // _CCCL_HAS_BUILTIN(__is_void)
@@ -550,9 +550,9 @@
 #endif // _CCCL_HAS_BUILTIN(__type_pack_element)
 
 // NVCC prior to 12.2 have trouble with pack expansion into __type_pack_element in an alias template
-#if defined(_CCCL_CUDACC_BELOW_12_2)
+#if _CCCL_CUDACC_BELOW(12, 2)
 #  undef _CCCL_BUILTIN_TYPE_PACK_ELEMENT
-#endif // _CCCL_CUDACC_BELOW_12_2
+#endif // _CCCL_CUDACC_BELOW(12, 2)
 
 #if _CCCL_CHECK_BUILTIN(underlying_type) || (defined(_CCCL_COMPILER_GCC) && _CCCL_GCC_VERSION >= 40700) \
   || defined(_CCCL_COMPILER_MSVC) || defined(_CCCL_COMPILER_NVRTC)
@@ -561,7 +561,7 @@
 
 #if defined(_CCCL_COMPILER_MSVC)
 #  // To use __builtin_FUNCSIG(), both MSVC and nvcc need to support it
-#  if _CCCL_MSVC_VERSION >= 1935 && !defined(_CCCL_CUDACC_BELOW_12_3)
+#  if _CCCL_MSVC_VERSION >= 1935 && _CCCL_CUDACC_AT_LEAST(12, 3)
 #    define _CCCL_BUILTIN_PRETTY_FUNCTION() __builtin_FUNCSIG()
 #  else // ^^^ _CCCL_MSVC_VERSION >= 1935 ^^^ / vvv _CCCL_MSVC_VERSION < 1935 vvv
 #    define _CCCL_BUILTIN_PRETTY_FUNCTION() __FUNCSIG__

--- a/libcudacxx/include/cuda/std/__cccl/compiler.h
+++ b/libcudacxx/include/cuda/std/__cccl/compiler.h
@@ -82,50 +82,19 @@
 // clang-cuda does not define __CUDACC_VER_MAJOR__ and friends. They are instead retrieved from the CUDA_VERSION macro
 // defined in "cuda.h". clang-cuda automatically pre-includes "__clang_cuda_runtime_wrapper.h" which includes "cuda.h"
 #if defined(_CCCL_CUDA_COMPILER_CLANG)
-#  define _CCCL_CUDACC
+#  define _CCCL_CUDACC           1
 #  define _CCCL_CUDACC_VER_MAJOR CUDA_VERSION / 1000
 #  define _CCCL_CUDACC_VER_MINOR (CUDA_VERSION % 1000) / 10
-#  define _CCCL_CUDACC_VER_BUILD 0
-#  define _CCCL_CUDACC_VER       CUDA_VERSION * 100
+#  define _CCCL_CUDACC_VER       CUDA_VERSION
 #elif defined(_CCCL_CUDA_COMPILER)
-#  define _CCCL_CUDACC
+#  define _CCCL_CUDACC           1
 #  define _CCCL_CUDACC_VER_MAJOR __CUDACC_VER_MAJOR__
 #  define _CCCL_CUDACC_VER_MINOR __CUDACC_VER_MINOR__
-#  define _CCCL_CUDACC_VER_BUILD __CUDACC_VER_BUILD__
-#  define _CCCL_CUDACC_VER       _CCCL_CUDACC_VER_MAJOR * 100000 + _CCCL_CUDACC_VER_MINOR * 1000 + _CCCL_CUDACC_VER_BUILD
+#  define _CCCL_CUDACC_VER       _CCCL_CUDACC_VER_MAJOR * 1000 + _CCCL_CUDACC_VER_MINOR * 10
 #endif // _CCCL_CUDA_COMPILER
 
-// Some convenience macros to filter CUDACC versions
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1102000
-#  define _CCCL_CUDACC_BELOW_11_2
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1102000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1103000
-#  define _CCCL_CUDACC_BELOW_11_3
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1103000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1104000
-#  define _CCCL_CUDACC_BELOW_11_4
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1104000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1107000
-#  define _CCCL_CUDACC_BELOW_11_7
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1107000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000
-#  define _CCCL_CUDACC_BELOW_11_8
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1108000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1200000
-#  define _CCCL_CUDACC_BELOW_12_0
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1200000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1202000
-#  define _CCCL_CUDACC_BELOW_12_2
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1202000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
-#  define _CCCL_CUDACC_BELOW_12_3
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1203000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1204000
-#  define _CCCL_CUDACC_BELOW_12_4
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1204000
-#if defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1205000
-#  define _CCCL_CUDACC_BELOW_12_5
-#endif // defined(_CCCL_CUDACC) && _CCCL_CUDACC_VER < 1205000
+#define _CCCL_CUDACC_BELOW(_MAJOR, _MINOR)    (_CCCL_CUDACC && _CCCL_CUDACC_VER < (_MAJOR * 1000 + _MINOR * 10))
+#define _CCCL_CUDACC_AT_LEAST(_MAJOR, _MINOR) (_CCCL_CUDACC && !_CCCL_CUDACC_BELOW(_MAJOR, _MINOR))
 
 // Convert parameter to string
 #define _CCCL_TO_STRING2(_STR) #_STR

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -85,11 +85,11 @@
 #endif // _CCCL_STD_VER <= 2014
 
 // In nvcc prior to 11.3 global variables could not be marked constexpr
-#if defined(_CCCL_CUDACC_BELOW_11_3)
+#if _CCCL_CUDACC_BELOW(11, 3)
 #  define _CCCL_CONSTEXPR_GLOBAL const
-#else // ^^^ _CCCL_CUDACC_BELOW_11_3 ^^^ / vvv !_CCCL_CUDACC_BELOW_11_3 vvv
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 3) ^^^ / vvv _CCCL_CUDACC_AT_LEAST(11, 3) vvv
 #  define _CCCL_CONSTEXPR_GLOBAL constexpr
-#endif // !_CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_AT_LEAST(11, 3)
 
 // Inline variables are only available from C++17 onwards
 #if _CCCL_STD_VER >= 2017 && defined(__cpp_inline_variables) && (__cpp_inline_variables >= 201606L)

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -42,11 +42,11 @@
 #endif
 
 // Compile with NVCC compiler and only device code, Volta+  GPUs
-#if defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_PTX_ARCH >= 700 && !defined(_CCCL_CUDACC_BELOW_11_7)
+#if defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_PTX_ARCH >= 700 && _CCCL_CUDACC_AT_LEAST(11, 7)
 #  define _CCCL_GRID_CONSTANT __grid_constant__
 #else // ^^^ _CCCL_CUDA_COMPILER_NVCC ^^^ / vvv !_CCCL_CUDA_COMPILER_NVCC vvv
 #  define _CCCL_GRID_CONSTANT
-#endif // defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_PTX_ARCH >= 700 && !defined(_CCCL_CUDACC_BELOW_11_7)
+#endif // defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_PTX_ARCH >= 700 && _CCCL_CUDACC_AT_LEAST(11, 7)
 
 #if !defined(_CCCL_EXEC_CHECK_DISABLE)
 #  if defined(_CCCL_CUDA_COMPILER_NVCC)

--- a/libcudacxx/include/cuda/std/__cccl/ptx_isa.h
+++ b/libcudacxx/include/cuda/std/__cccl/ptx_isa.h
@@ -34,52 +34,52 @@
 // PTX ISA 8.5 is available from CUDA 12.5
 // The first define is for future major versions of CUDACC.
 // We make sure that these get the highest known PTX ISA version.
-#if (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR > 12))
+#if _CCCL_CUDACC_AT_LEAST(13, 0)
 #  define __cccl_ptx_isa 850ULL
 // PTX ISA 8.5 is available from CUDA 12.5, driver r555
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 12 && _CCCL_CUDACC_VER_MINOR >= 5))
+#elif _CCCL_CUDACC_AT_LEAST(12, 5)
 #  define __cccl_ptx_isa 850ULL
 // PTX ISA 8.4 is available from CUDA 12.4, driver r550
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 12 && _CCCL_CUDACC_VER_MINOR >= 4))
+#elif _CCCL_CUDACC_AT_LEAST(12, 4)
 #  define __cccl_ptx_isa 840ULL
 // PTX ISA 8.3 is available from CUDA 12.3, driver r545
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 12 && _CCCL_CUDACC_VER_MINOR >= 3))
+#elif _CCCL_CUDACC_AT_LEAST(12, 3)
 #  define __cccl_ptx_isa 830ULL
 // PTX ISA 8.2 is available from CUDA 12.2, driver r535
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 12 && _CCCL_CUDACC_VER_MINOR >= 2))
+#elif _CCCL_CUDACC_AT_LEAST(12, 2)
 #  define __cccl_ptx_isa 820ULL
 // PTX ISA 8.1 is available from CUDA 12.1, driver r530
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 12 && _CCCL_CUDACC_VER_MINOR >= 1))
+#elif _CCCL_CUDACC_AT_LEAST(12, 1)
 #  define __cccl_ptx_isa 810ULL
 // PTX ISA 8.0 is available from CUDA 12.0, driver r525
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 12 && _CCCL_CUDACC_VER_MINOR >= 0))
+#elif _CCCL_CUDACC_AT_LEAST(12, 0)
 #  define __cccl_ptx_isa 800ULL
 // PTX ISA 7.8 is available from CUDA 11.8, driver r520
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 11 && _CCCL_CUDACC_VER_MINOR >= 8))
+#elif _CCCL_CUDACC_AT_LEAST(11, 8)
 #  define __cccl_ptx_isa 780ULL
 // PTX ISA 7.7 is available from CUDA 11.7, driver r515
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 11 && _CCCL_CUDACC_VER_MINOR >= 7))
+#elif _CCCL_CUDACC_AT_LEAST(11, 7)
 #  define __cccl_ptx_isa 770ULL
 // PTX ISA 7.6 is available from CUDA 11.6, driver r510
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 11 && _CCCL_CUDACC_VER_MINOR >= 6))
+#elif _CCCL_CUDACC_AT_LEAST(11, 6)
 #  define __cccl_ptx_isa 760ULL
 // PTX ISA 7.5 is available from CUDA 11.5, driver r495
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 11 && _CCCL_CUDACC_VER_MINOR >= 5))
+#elif _CCCL_CUDACC_AT_LEAST(11, 5)
 #  define __cccl_ptx_isa 750ULL
 // PTX ISA 7.4 is available from CUDA 11.4, driver r470
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 11 && _CCCL_CUDACC_VER_MINOR >= 4))
+#elif _CCCL_CUDACC_AT_LEAST(11, 4)
 #  define __cccl_ptx_isa 740ULL
 // PTX ISA 7.3 is available from CUDA 11.3, driver r465
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 11 && _CCCL_CUDACC_VER_MINOR >= 3))
+#elif _CCCL_CUDACC_AT_LEAST(11, 3)
 #  define __cccl_ptx_isa 730ULL
 // PTX ISA 7.2 is available from CUDA 11.2, driver r460
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 11 && _CCCL_CUDACC_VER_MINOR >= 2))
+#elif _CCCL_CUDACC_AT_LEAST(11, 2)
 #  define __cccl_ptx_isa 720ULL
 // PTX ISA 7.1 is available from CUDA 11.1, driver r455
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 11 && _CCCL_CUDACC_VER_MINOR >= 1))
+#elif _CCCL_CUDACC_AT_LEAST(11, 1)
 #  define __cccl_ptx_isa 710ULL
 // PTX ISA 7.0 is available from CUDA 11.0, driver r445
-#elif (defined(_CCCL_CUDACC) && (_CCCL_CUDACC_VER_MAJOR >= 11 && _CCCL_CUDACC_VER_MINOR >= 0))
+#elif _CCCL_CUDACC_AT_LEAST(11, 0)
 #  define __cccl_ptx_isa 700ULL
 // Fallback case. Define the ISA version to be zero. This ensures that the macro is always defined.
 #else

--- a/libcudacxx/include/cuda/std/__cccl/unreachable.h
+++ b/libcudacxx/include/cuda/std/__cccl/unreachable.h
@@ -27,9 +27,9 @@
 #if defined(_CCCL_CUDA_COMPILER_CLANG)
 #  define _CCCL_UNREACHABLE() __builtin_unreachable()
 #elif defined(__CUDA_ARCH__)
-#  if defined(_CCCL_CUDACC_BELOW_11_2)
+#  if _CCCL_CUDACC_BELOW(11, 2)
 #    define _CCCL_UNREACHABLE() __trap()
-#  elif defined(_CCCL_CUDACC_BELOW_11_3)
+#  elif _CCCL_CUDACC_BELOW(11, 3)
 #    define _CCCL_UNREACHABLE() __builtin_assume(false)
 #  else
 #    define _CCCL_UNREACHABLE() __builtin_unreachable()

--- a/libcudacxx/include/cuda/std/__concepts/__concept_macros.h
+++ b/libcudacxx/include/cuda/std/__concepts/__concept_macros.h
@@ -460,7 +460,7 @@ using _Requires_expr_impl = //
 // _CUDA_VSTD macro is fully qualified.
 namespace _Vstd = _CUDA_VSTD; // NOLINT(misc-unused-alias-decls)
 
-#  if defined(_CCCL_CUDACC_BELOW_12_2)
+#  if _CCCL_CUDACC_BELOW(12, 2)
 #    define _LIBCUDACXX_CONCEPT_VSTD _Concept::_Vstd // must not be fully qualified
 #  else
 #    define _LIBCUDACXX_CONCEPT_VSTD _CUDA_VSTD

--- a/libcudacxx/include/cuda/std/__cuda/cmath_nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cuda/cmath_nvbf16.h
@@ -98,12 +98,12 @@ _LIBCUDACXX_HIDE_FROM_ABI bool isnan(__nv_bfloat16 __v)
 
 _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isinf(__nv_bfloat16 __x) noexcept
 {
-#  if _CCCL_STD_VER >= 2020 && defined(_CCCL_CUDACC_BELOW_12_3)
+#  if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
   // this is a workaround for nvbug 4362808
   return !::__hisnan(__x) && ::__hisnan(__x - __x);
 #  else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
   return ::__hisinf(__x) != 0;
-#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_VER < 1203000
+#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_BELOW(12, 3)
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI bool isinf(__nv_bfloat16 __v)

--- a/libcudacxx/include/cuda/std/__cuda/cmath_nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cuda/cmath_nvfp16.h
@@ -185,12 +185,12 @@ _LIBCUDACXX_HIDE_FROM_ABI bool isnan(__half __v)
 
 _LIBCUDACXX_HIDE_FROM_ABI bool __constexpr_isinf(__half __x) noexcept
 {
-#  if _CCCL_STD_VER >= 2020 && defined(_CCCL_CUDACC_BELOW_12_3)
+#  if _CCCL_STD_VER >= 2020 && _CCCL_CUDACC_BELOW(12, 3)
   // this is a workaround for nvbug 4362808
   return !::__hisnan(__x) && ::__hisnan(__x - __x);
 #  else // ^^^ C++20 && below 12.3 ^^^ / vvv C++17 or 12.3+ vvv
   return ::__hisinf(__x) != 0;
-#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_VER < 1203000
+#  endif // _CCCL_STD_VER <= 2017 || _CCCL_CUDACC_BELOW(12, 3)
 }
 
 _LIBCUDACXX_HIDE_FROM_ABI bool isinf(__half __v)

--- a/libcudacxx/include/cuda/std/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/__functional/invoke.h
@@ -450,13 +450,13 @@ struct __invoke_of
     : public enable_if<__invokable<_Fp, _Args...>::value, typename __invokable_r<void, _Fp, _Args...>::_Result>
 {
 #if defined(__NVCC__) && defined(__CUDACC_EXTENDED_LAMBDA__) && !defined(__CUDA_ARCH__)
-#  if defined(_CCCL_CUDACC_BELOW_12_3)
+#  if _CCCL_CUDACC_BELOW(12, 3)
   static_assert(!__nv_is_extended_device_lambda_closure_type(_Fp),
                 "Attempt to use an extended __device__ lambda in a context "
                 "that requires querying its return type in host code. Use a "
                 "named function object, an extended __host__ __device__ lambda, or "
                 "cuda::proclaim_return_type instead.");
-#  else // ^^^ _CCCL_CUDACC_BELOW_12_3 ^^^ / vvv !_CCCL_CUDACC_BELOW_12_3 vvv
+#  else // ^^^ _CCCL_CUDACC_BELOW(12, 3) ^^^ / vvv _CCCL_CUDACC_AT_LEAST(12, 3) vvv
   static_assert(
     !__nv_is_extended_device_lambda_closure_type(_Fp) || __nv_is_extended_host_device_lambda_closure_type(_Fp)
       || __nv_is_extended_device_lambda_with_preserved_return_type(_Fp),
@@ -465,7 +465,7 @@ struct __invoke_of
     "named function object, an extended __host__ __device__ lambda, "
     "cuda::proclaim_return_type, or an extended __device__ lambda "
     "with a trailing return type instead ([] __device__ (...) -> RETURN_TYPE {...}).");
-#  endif // !_CCCL_CUDACC_BELOW_12_3
+#  endif // _CCCL_CUDACC_AT_LEAST(12, 3)
 #endif
 };
 

--- a/libcudacxx/include/cuda/std/__mdspan/standard_layout_static_array.h
+++ b/libcudacxx/include/cuda/std/__mdspan/standard_layout_static_array.h
@@ -627,7 +627,7 @@ struct __partially_static_sizes_tagged
   using __tag_t = _Tag;
   using __psa_impl_t =
     __standard_layout_psa<_Tag, T, _static_t, _CUDA_VSTD::integer_sequence<_static_t, __values_or_sentinals...>>;
-#    if defined(_CCCL_COMPILER_NVRTC) || defined(_CCCL_CUDACC_BELOW_11_3)
+#    if defined(_CCCL_COMPILER_NVRTC) || _CCCL_CUDACC_BELOW(11, 3)
   template <class... _Args, enable_if_t<_CCCL_TRAIT(is_constructible, __psa_impl_t, _Args...), int> = 0>
   __MDSPAN_FORCE_INLINE_FUNCTION constexpr __partially_static_sizes_tagged(_Args&&... __args) noexcept(
     noexcept(__psa_impl_t(_CUDA_VSTD::declval<_Args>()...)))
@@ -680,7 +680,7 @@ private:
   {}
 
 public:
-#    if defined(_CCCL_COMPILER_NVRTC) || defined(_CCCL_CUDACC_BELOW_11_3)
+#    if defined(_CCCL_COMPILER_NVRTC) || _CCCL_CUDACC_BELOW(11, 3)
   template <class... _Args, enable_if_t<_CCCL_TRAIT(is_constructible, __base_t, _Args...), int> = 0>
   __MDSPAN_FORCE_INLINE_FUNCTION constexpr __partially_static_sizes(_Args&&... __args) noexcept(
     noexcept(__base_t(_CUDA_VSTD::declval<_Args>()...)))

--- a/libcudacxx/include/cuda/std/__mdspan/static_array.h
+++ b/libcudacxx/include/cuda/std/__mdspan/static_array.h
@@ -254,7 +254,7 @@ private:
   using __base_t = typename __partially_static_array_impl_maker<_Tp, _static_t, _ValsSeq, __sentinal>::__impl_base;
 
 public:
-#    if defined(_CCCL_COMPILER_NVRTC) || defined(_CCCL_CUDACC_BELOW_11_3)
+#    if defined(_CCCL_COMPILER_NVRTC) || _CCCL_CUDACC_BELOW(11, 3)
   _CCCL_HIDE_FROM_ABI constexpr __partially_static_array_with_sentinal() = default;
 
   template <class... _Args>
@@ -282,7 +282,7 @@ private:
                                            _CUDA_VSTD::integer_sequence<_static_t, __values_or_sentinals...>>;
 
 public:
-#    if defined(_CCCL_COMPILER_NVRTC) || defined(_CCCL_CUDACC_BELOW_11_3)
+#    if defined(_CCCL_COMPILER_NVRTC) || _CCCL_CUDACC_BELOW(11, 3)
   _CCCL_HIDE_FROM_ABI constexpr __partially_static_sizes() = default;
 
   template <class... _Args>

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -342,9 +342,9 @@ public:
     {
       return _CUDA_VSTD::__to_unsigned_like(__end_ - __begin_);
     }
-#  if defined(_CCCL_CUDACC_BELOW_11_3)
+#  if _CCCL_CUDACC_BELOW(11, 3)
     _CCCL_UNREACHABLE();
-#  endif // _CCCL_CUDACC_BELOW_11_3
+#  endif // _CCCL_CUDACC_BELOW(11, 3)
   }
 
   _LIBCUDACXX_TEMPLATE(class _It = _Iter)

--- a/libcudacxx/include/cuda/std/__utility/declval.h
+++ b/libcudacxx/include/cuda/std/__utility/declval.h
@@ -30,7 +30,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // MSVC < 19.39 to miscompile so we use the fallback instead. The use of the
 // `__identity_t` alias is help MSVC parse the declaration correctly.
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES) && !defined(_CCCL_NO_NOEXCEPT_FUNCTION_TYPE) \
-  && !(defined(_CCCL_CUDA_COMPILER_NVCC) && defined(_CCCL_CUDACC_BELOW_12_4))          \
+  && !(defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_CUDACC_BELOW(12, 4))                 \
   && !(defined(_CCCL_COMPILER_MSVC) && _CCCL_MSVC_VERSION < 1939)
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -468,20 +468,20 @@ typedef __char32_t char32_t;
 
 #  ifndef _LIBCUDACXX_HAS_NO_INT128
 #    if defined(_CCCL_COMPILER_MSVC) || (defined(_CCCL_COMPILER_NVRTC) && !defined(__CUDACC_RTC_INT128__)) \
-      || (defined(_CCCL_CUDA_COMPILER_NVCC) && (_CCCL_CUDACC_VER < 1105000)) || !defined(__SIZEOF_INT128__)
+      || (defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_CUDACC_BELOW(11, 5)) || !defined(__SIZEOF_INT128__)
 #      define _LIBCUDACXX_HAS_NO_INT128
 #    endif
 #  endif // !_LIBCUDACXX_HAS_NO_INT128
 
 #  ifndef _LIBCUDACXX_HAS_NO_LONG_DOUBLE
-#    if defined(_CCCL_CUDACC)
+#    if _CCCL_CUDACC
 #      define _LIBCUDACXX_HAS_NO_LONG_DOUBLE
 #    endif
 #  endif // _LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 // libcu++ requires host device support for its tests. Until then restrict usage to at least 12.2
 #  ifndef _LIBCUDACXX_HAS_NVFP16
-#    if defined(_CCCL_HAS_NVFP16) && !defined(_CCCL_CUDACC_BELOW_12_2) \
+#    if defined(_CCCL_HAS_NVFP16) && _CCCL_CUDACC_AT_LEAST(12, 2) \
       && (defined(_CCCL_CUDA_COMPILER) || defined(LIBCUDACXX_ENABLE_HOST_NVFP16))
 #      define _LIBCUDACXX_HAS_NVFP16
 #    endif
@@ -489,7 +489,7 @@ typedef __char32_t char32_t;
 
 // libcu++ requires host device support for its tests. Until then restrict usage to at least 12.2
 #  ifndef _LIBCUDACXX_HAS_NVBF16
-#    if defined(_CCCL_HAS_NVBF16) && !defined(_CCCL_CUDACC_BELOW_12_2)
+#    if defined(_CCCL_HAS_NVBF16) && _CCCL_CUDACC_AT_LEAST(12, 2)
 #      define _LIBCUDACXX_HAS_NVBF16
 #    endif
 #  endif // !_LIBCUDACXX_HAS_NVBF16
@@ -635,7 +635,7 @@ typedef unsigned int char32_t;
 // Deprecations warnings are always enabled, except when users explicitly opt-out
 // by defining _LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS.
 // NVCC 11.1 and 11.2 are broken with the deprecated attribute, so disable it
-#  if !defined(_LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS) && !defined(_CCCL_CUDACC_BELOW_11_3)
+#  if !defined(_LIBCUDACXX_DISABLE_DEPRECATION_WARNINGS) && _CCCL_CUDACC_AT_LEAST(11, 3)
 #    if _CCCL_HAS_ATTRIBUTE(deprecated)
 #      define _LIBCUDACXX_DEPRECATED __attribute__((deprecated))
 #    elif _CCCL_STD_VER > 2011
@@ -755,8 +755,7 @@ typedef unsigned int char32_t;
 #  endif
 
 // CUDA Atomics supersede host atomics in order to insert the host/device dispatch layer
-#  if defined(_CCCL_CUDA_COMPILER_NVCC) || defined(_CCCL_COMPILER_NVRTC) || _CCCL_COMPILER(NVHPC) \
-    || defined(_CCCL_CUDACC)
+#  if defined(_CCCL_CUDA_COMPILER_NVCC) || defined(_CCCL_COMPILER_NVRTC) || _CCCL_COMPILER(NVHPC) || _CCCL_CUDACC
 #    define _LIBCUDACXX_HAS_CUDA_ATOMIC_IMPL
 #  endif
 
@@ -831,7 +830,7 @@ typedef unsigned int char32_t;
 #    define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
 #  elif defined(_CCCL_COMPILER_MSVC)
 #    define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
-#  elif defined(_CCCL_CUDACC_BELOW_11_8)
+#  elif _CCCL_CUDACC_BELOW(11, 8)
 #    define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
 #  elif defined(_CCCL_CUDA_COMPILER_CLANG)
 #    define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS
@@ -883,7 +882,7 @@ typedef unsigned int char32_t;
 
 // NVRTC has a bug that prevented the use of delegated constructors, as it did not accept execution space annotations.
 // This creates a whole lot of boilerplate that we can avoid through a macro (see nvbug3961621)
-#  if defined(_CCCL_COMPILER_NVRTC) || (defined(_CCCL_CUDACC_BELOW_11_3) && defined(_CCCL_COMPILER_CLANG))
+#  if defined(_CCCL_COMPILER_NVRTC) || (_CCCL_CUDACC_BELOW(11, 3) && defined(_CCCL_COMPILER_CLANG))
 #    define _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__class, __baseclass, ...)                               \
       using __base = __baseclass<__VA_ARGS__>;                                                         \
       template <class... _Args, enable_if_t<_CCCL_TRAIT(is_constructible, __base, _Args...), int> = 0> \

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -624,7 +624,7 @@ template <class _A1>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isnan(_A1 __lcpp_x) noexcept
 {
-#if defined(_CCCL_CUDACC_BELOW_11_8)
+#if _CCCL_CUDACC_BELOW(11, 8)
   return __isnan(__lcpp_x);
 #elif defined(_CCCL_BUILTIN_ISNAN)
   // nvcc at times has issues determining the type of __lcpp_x
@@ -645,7 +645,7 @@ template <class _A1>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isinf(_A1 __lcpp_x) noexcept
 {
-#if defined(_CCCL_CUDACC_BELOW_11_8)
+#if _CCCL_CUDACC_BELOW(11, 8)
   return __isinf(__lcpp_x);
 #elif defined(_CCCL_BUILTIN_ISINF)
   // nvcc at times has issues determining the type of __lcpp_x
@@ -666,7 +666,7 @@ template <class _A1>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_floating_point<_A1>::value, bool>
 __constexpr_isfinite(_A1 __lcpp_x) noexcept
 {
-#if defined(_CCCL_CUDACC_BELOW_11_8)
+#if _CCCL_CUDACC_BELOW(11, 8)
   return !__isinf(__lcpp_x) && !__isnan(__lcpp_x);
 #elif defined(_CCCL_BUILTIN_ISFINITE)
   // nvcc at times has issues determining the type of __lcpp_x

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
@@ -252,10 +252,10 @@ __host__ __device__ constexpr bool test()
   return true;
 }
 
-#ifndef _CCCL_CUDACC_BELOW_11_3 // nvcc segfaults here
+#if _CCCL_CUDACC_AT_LEAST(11, 3) // nvcc segfaults here
 static_assert(!cuda::std::is_invocable_v<IterMoveT, int*, int*>); // too many arguments
 static_assert(!cuda::std::is_invocable_v<IterMoveT, int>);
-#endif // _CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_AT_LEAST(11, 3)
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.

--- a/libcudacxx/test/libcudacxx/std/language.support/support.srcloc/general.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.srcloc/general.pass.cpp
@@ -51,12 +51,12 @@ static_assert(cuda::std::is_same<const char*, decltype(empty.file_name())>::valu
 static_assert(cuda::std::is_same<const char*, decltype(empty.function_name())>::value, "");
 
 __device__ _CCCL_CONSTEXPR_GLOBAL cuda::std::source_location device_empty{};
-#if !defined(_CCCL_CUDACC_BELOW_11_3)
+#if _CCCL_CUDACC_AT_LEAST(11, 3)
 static_assert(device_empty.line() == 0, "");
 static_assert(device_empty.column() == 0, "");
 static_assert(device_empty.file_name()[0] == '\0', "");
 static_assert(device_empty.function_name()[0] == '\0', "");
-#endif // _CCCL_CUDACC_BELOW_11_3
+#endif // _CCCL_CUDACC_BELOW(11, 3)
 
 ASSERT_NOEXCEPT(device_empty.line());
 ASSERT_NOEXCEPT(device_empty.column());

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/count.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/count.pass.cpp
@@ -61,7 +61,7 @@ int main(int, char**)
   test();
   test_count<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/flip_all.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/flip_all.pass.cpp
@@ -57,7 +57,7 @@ int main(int, char**)
   test();
   test_flip_all<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/flip_one.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/flip_one.pass.cpp
@@ -57,7 +57,7 @@ int main(int, char**)
   test();
   test_flip_one<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/index.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/index.pass.cpp
@@ -73,7 +73,7 @@ int main(int, char**)
   test();
   test_index<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/index_const.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/index_const.pass.cpp
@@ -64,7 +64,7 @@ int main(int, char**)
   test();
   test_index_const<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift.pass.cpp
@@ -51,7 +51,7 @@ int main(int, char**)
   test_left_shift<65>();
   test_left_shift<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_left_shift<0>(), "");
   static_assert(test_left_shift<1>(), "");
   static_assert(test_left_shift<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp
@@ -65,7 +65,7 @@ int main(int, char**)
   test_left_shift<65>();
   test_left_shift<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_left_shift<0>(), "");
   static_assert(test_left_shift<1>(), "");
   static_assert(test_left_shift<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/not_all.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/not_all.pass.cpp
@@ -56,7 +56,7 @@ int main(int, char**)
   test();
   test_not_all<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_and_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_and_eq.pass.cpp
@@ -56,7 +56,7 @@ int main(int, char**)
   test_op_and_eq<65>();
   test_op_and_eq<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_op_and_eq<0>(), "");
   static_assert(test_op_and_eq<1>(), "");
   static_assert(test_op_and_eq<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_eq_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_eq_eq.pass.cpp
@@ -54,7 +54,7 @@ int main(int, char**)
   test();
   test_equality<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_or_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_or_eq.pass.cpp
@@ -62,7 +62,7 @@ int main(int, char**)
   test_op_or_eq<65>();
   test_op_or_eq<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_op_or_eq<0>(), "");
   static_assert(test_op_or_eq<1>(), "");
   static_assert(test_op_or_eq<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_xor_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/op_xor_eq.pass.cpp
@@ -59,7 +59,7 @@ int main(int, char**)
   test_op_xor_eq<65>();
   test_op_xor_eq<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_op_xor_eq<0>(), "");
   static_assert(test_op_xor_eq<1>(), "");
   static_assert(test_op_xor_eq<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/reset_one.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/reset_one.pass.cpp
@@ -53,7 +53,7 @@ int main(int, char**)
   test_reset_one<65>();
   test_reset_one<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_reset_one<0>(), "");
   static_assert(test_reset_one<1>(), "");
   static_assert(test_reset_one<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift.pass.cpp
@@ -49,7 +49,7 @@ __host__ __device__ int main(int, char**)
   test_right_shift<65>();
   test_right_shift<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_right_shift<0>(), "");
   static_assert(test_right_shift<1>(), "");
   static_assert(test_right_shift<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp
@@ -67,7 +67,7 @@ __host__ __device__ int main(int, char**)
   test_right_shift<65>();
   test_right_shift<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_right_shift<0>(), "");
   static_assert(test_right_shift<1>(), "");
   static_assert(test_right_shift<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/set_one.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/set_one.pass.cpp
@@ -52,7 +52,7 @@ int main(int, char**)
   test();
   test_set_one<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/test.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/test.pass.cpp
@@ -52,7 +52,7 @@ int main(int, char**)
   test();
   test_test<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/to_ullong.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/to_ullong.pass.cpp
@@ -67,7 +67,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 bool test()
 int main(int, char**)
 {
   test();
-#if TEST_STD_VER >= 2014 && (!defined(_CCCL_CUDACC_BELOW_11_8) || !defined(_CCCL_COMPILER_MSVC))
+#if TEST_STD_VER >= 2014 && (_CCCL_CUDACC_AT_LEAST(11, 8) || !defined(_CCCL_COMPILER_MSVC))
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/to_ulong.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.members/to_ulong.pass.cpp
@@ -66,7 +66,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 bool test()
 int main(int, char**)
 {
   test();
-#if TEST_STD_VER >= 2014 && (!defined(_CCCL_CUDACC_BELOW_11_8) || !defined(_CCCL_COMPILER_MSVC))
+#if TEST_STD_VER >= 2014 && (_CCCL_CUDACC_AT_LEAST(11, 8) || !defined(_CCCL_COMPILER_MSVC))
   static_assert(test(), "");
 #endif // TEST_STD_VER >= 2014
 

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_and.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_and.pass.cpp
@@ -45,7 +45,7 @@ int main(int, char**)
   test_op_and<65>();
   test_op_and<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_op_and<0>(), "");
   static_assert(test_op_and<1>(), "");
   static_assert(test_op_and<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_not.pass.cpp
@@ -45,7 +45,7 @@ int main(int, char**)
   test_op_not<65>();
   test_op_not<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_op_not<0>(), "");
   static_assert(test_op_not<1>(), "");
   static_assert(test_op_not<31>(), "");

--- a/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/template.bitset/bitset.operators/op_or.pass.cpp
@@ -45,7 +45,7 @@ int main(int, char**)
   test_op_or<65>();
   test_op_or<1000>(); // not in constexpr because of constexpr evaluation step limits
 // 11.4 added support for constexpr device vars needed here
-#if TEST_STD_VER >= 2014 && !defined(_CCCL_CUDACC_BELOW_11_4)
+#if TEST_STD_VER >= 2014 && _CCCL_CUDACC_AT_LEAST(11, 4)
   static_assert(test_op_or<0>(), "");
   static_assert(test_op_or<1>(), "");
   static_assert(test_op_or<31>(), "");

--- a/libcudacxx/test/support/test_macros.h
+++ b/libcudacxx/test/support/test_macros.h
@@ -146,7 +146,7 @@
 #endif
 
 #if TEST_HAS_BUILTIN(__builtin_is_constant_evaluated) || (defined(_CCCL_COMPILER_GCC) && _GNUC_VER >= 900) \
-  || (defined(_CCCL_COMPILER_MSVC) && _MSC_VER > 1924 && !defined(_CCCL_CUDACC_BELOW_11_3))
+  || (defined(_CCCL_COMPILER_MSVC) && _MSC_VER > 1924 && _CCCL_CUDACC_AT_LEAST(11, 3))
 #  define TEST_IS_CONSTANT_EVALUATED() _CUDA_VSTD::__libcpp_is_constant_evaluated()
 #else
 #  define TEST_IS_CONSTANT_EVALUATED() false
@@ -451,12 +451,12 @@ __host__ __device__ constexpr bool unused(T&&...)
 #define TEST_CONSTEXPR_GLOBAL _CCCL_CONSTEXPR_GLOBAL
 
 // Some convenience macros for checking nvcc versions
-#if defined(__CUDACC__) && _CCCL_CUDACC_VER < 1103000
+#if defined(__CUDACC__) && _CCCL_CUDACC_BELOW(11, 3)
 #  define TEST_COMPILER_CUDACC_BELOW_11_3
-#endif // defined(__CUDACC__) && _CCCL_CUDACC_VER < 1103000
-#if defined(__CUDACC__) && _CCCL_CUDACC_VER < 1203000
+#endif // defined(__CUDACC__) && _CCCL_CUDACC_BELOW(11, 3)
+#if defined(__CUDACC__) && _CCCL_CUDACC_BELOW(12, 3)
 #  define TEST_COMPILER_CUDACC_BELOW_12_3
-#endif // defined(__CUDACC__) && _CCCL_CUDACC_VER < 1203000
+#endif // defined(__CUDACC__) && _CCCL_CUDACC_BELOW(12, 3)
 
 #if defined(TEST_COMPILER_MSVC)
 #  if _MSC_VER < 1920

--- a/libcudacxx/test/support/test_macros.h
+++ b/libcudacxx/test/support/test_macros.h
@@ -15,7 +15,9 @@
 // minimal header possible. If we're testing libc++, we should use `<__config>`.
 // If <__config> isn't available, fall back to <ciso646>.
 #ifdef __has_include
-#  if __has_include("<__config>")
+#  if __has_include(<cuda/__cccl_config>)
+#    include <cuda/__cccl_config>
+#  elif __has_include("<__config>")
 #    include <__config>
 #    define TEST_IMP_INCLUDED_HEADER
 #  endif
@@ -451,12 +453,14 @@ __host__ __device__ constexpr bool unused(T&&...)
 #define TEST_CONSTEXPR_GLOBAL _CCCL_CONSTEXPR_GLOBAL
 
 // Some convenience macros for checking nvcc versions
-#if defined(__CUDACC__) && _CCCL_CUDACC_BELOW(11, 3)
-#  define TEST_COMPILER_CUDACC_BELOW_11_3
-#endif // defined(__CUDACC__) && _CCCL_CUDACC_BELOW(11, 3)
-#if defined(__CUDACC__) && _CCCL_CUDACC_BELOW(12, 3)
-#  define TEST_COMPILER_CUDACC_BELOW_12_3
-#endif // defined(__CUDACC__) && _CCCL_CUDACC_BELOW(12, 3)
+#if defined(_CCCL_CUDACC)
+#  if _CCCL_CUDACC_BELOW(11, 3)
+#    define TEST_COMPILER_CUDACC_BELOW_11_3
+#  endif // _CCCL_CUDACC_BELOW(11, 3)
+#  if _CCCL_CUDACC_BELOW(12, 3)
+#    define TEST_COMPILER_CUDACC_BELOW_12_3
+#  endif // _CCCL_CUDACC_BELOW(12, 3)
+#endif // _CCCL_CUDACC
 
 #if defined(TEST_COMPILER_MSVC)
 #  if _MSC_VER < 1920

--- a/thrust/testing/cuda/sort.cu
+++ b/thrust/testing/cuda/sort.cu
@@ -281,7 +281,7 @@ SimpleUnitTest<TestSortAscendingKey,
                                 unittest::type_list<__int128_t, __uint128_t>
 #endif
 // CTK 12.2 offers __host__ __device__ operators for __half and __nv_bfloat16, so we can use std::sort
-#if _CCCL_CUDACC_VER >= 1202000
+#if _CCCL_CUDACC_AT_LEAST(12, 2)
 #  if defined(_CCCL_HAS_NVFP16) || !defined(__CUDA_NO_HALF_OPERATORS__) && !defined(__CUDA_NO_HALF_CONVERSIONS__)
                                 ,
                                 unittest::type_list<__half>
@@ -291,6 +291,6 @@ SimpleUnitTest<TestSortAscendingKey,
                                 ,
                                 unittest::type_list<__nv_bfloat16>
 #  endif
-#endif // _CCCL_CUDACC_VER >= 1202000
+#endif // _CCCL_CUDACC_AT_LEAST(12, 2)
                                 >>
   TestSortAscendingKeyMoreTypes;

--- a/thrust/thrust/complex.h
+++ b/thrust/thrust/complex.h
@@ -339,13 +339,13 @@ public:
   }
 
 private:
-#if defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_CUDACC_VER < 1107000
+#if defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_CUDACC_BELOW(11, 7)
   struct __align__(sizeof(T) * 2) storage
 #elif defined(_CCCL_COMPILER_ICC)
   struct storage
-#else // !(defined(_CCCL_COMPILER_ICC) || (defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_CUDACC_VER < 1107000))
+#else // !(defined(_CCCL_COMPILER_ICC) || (defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_CUDACC_BELOW(11, 7)))
   struct alignas(sizeof(T) * 2) storage
-#endif // !(defined(_CCCL_COMPILER_ICC) || (defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_CUDACC_VER < 1107000))
+#endif // !(defined(_CCCL_COMPILER_ICC) || (defined(_CCCL_CUDA_COMPILER_NVCC) && _CCCL_CUDACC_BELOW(11, 7)))
   {
     T x;
     T y;


### PR DESCRIPTION
While we are at it just drop _CCCL_CUDACC_VER_BUILD, we never care about that
