### PR TITLE
Fix proclaim_copyable_arguments for lambdas

### DIFF
--- a/cudax/cmake/cudaxBuildCompilerTargets.cmake
+++ b/cudax/cmake/cudaxBuildCompilerTargets.cmake
@@ -47,6 +47,7 @@ function(cudax_build_compiler_targets)
   if("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     # stf heavily uses host device lambdas which break on clang due to a warning about the implicitly
     # deleted copy constructor
+    # TODO(bgruber): remove this when NVBug 4980157 is resolved
     append_option_if_available("-Wno-deprecated-copy" cxx_compile_options)
   endif()
 

--- a/libcudacxx/include/cuda/__functional/address_stability.h
+++ b/libcudacxx/include/cuda/__functional/address_stability.h
@@ -48,6 +48,13 @@ _CCCL_INLINE_VAR constexpr bool proclaims_copyable_arguments_v = proclaims_copya
 template <typename F>
 struct __callable_permitting_copied_arguments : F
 {
+#if _CCCL_STD_VER < 2017
+  template <typename G>
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr __callable_permitting_copied_arguments(G&& g)
+      : F(::cuda::std::forward<G>(g))
+  {}
+#endif
+
   using F::operator();
 };
 
@@ -61,9 +68,9 @@ struct proclaims_copyable_arguments<__callable_permitting_copied_arguments<F>> :
 //! @see proclaims_copyable_arguments
 template <typename F>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr auto
-proclaim_copyable_arguments(F f) -> __callable_permitting_copied_arguments<F>
+proclaim_copyable_arguments(F&& f) -> __callable_permitting_copied_arguments<::cuda::std::decay_t<F>>
 {
-  return __callable_permitting_copied_arguments<F>{_CUDA_VSTD::move(f)};
+  return {::cuda::std::forward<F>(f)};
 }
 
 // Specializations for libcu++ function objects are provided here to not pull this include into `<cuda/std/...>` headers

--- a/libcudacxx/include/cuda/__functional/address_stability.h
+++ b/libcudacxx/include/cuda/__functional/address_stability.h
@@ -48,12 +48,12 @@ _CCCL_INLINE_VAR constexpr bool proclaims_copyable_arguments_v = proclaims_copya
 template <typename F>
 struct __callable_permitting_copied_arguments : F
 {
-#if _CCCL_STD_VER < 2017
+#if _CCCL_STD_VER <= 2014
   template <typename G>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr __callable_permitting_copied_arguments(G&& g)
       : F(::cuda::std::forward<G>(g))
   {}
-#endif
+#endif // _CCCL_STD_VER <= 2014
 
   using F::operator();
 };

--- a/thrust/testing/address_stability.cmake
+++ b/thrust/testing/address_stability.cmake
@@ -1,0 +1,1 @@
+target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)

--- a/thrust/testing/address_stability.cmake
+++ b/thrust/testing/address_stability.cmake
@@ -1,8 +1,12 @@
 target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>: --extended-lambda>)
 
-# When clang >= 13 is used as host compiler, we get the following warning:
-#   nvcc_internal_extended_lambda_implementation:312:22: error: definition of implicit copy constructor for '__nv_hdl_wrapper_t<false, true, false, __nv_dl_tag<void (*)(), &TestAddressStabilityLambda, 2>, int (const int &)>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
-#   312 | __nv_hdl_wrapper_t & operator=(const __nv_hdl_wrapper_t &in) = delete;
-#   |                      ^
-# Let's suppress it until NVBug 4980157 is resolved.
-target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>: -Wno-deprecated-copy>)
+# this check is actually not correct, because we must check the host compiler, not the CXX compiler.
+# We rely on that those are usually the same ;)
+if ("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+    # When clang >= 13 is used as host compiler, we get the following warning:
+    #   nvcc_internal_extended_lambda_implementation:312:22: error: definition of implicit copy constructor for '__nv_hdl_wrapper_t<false, true, false, __nv_dl_tag<void (*)(), &TestAddressStabilityLambda, 2>, int (const int &)>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
+    #   312 | __nv_hdl_wrapper_t & operator=(const __nv_hdl_wrapper_t &in) = delete;
+    #   |                      ^
+    # Let's suppress it until NVBug 4980157 is resolved.
+    target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>: -Wno-deprecated-copy>)
+endif ()

--- a/thrust/testing/address_stability.cmake
+++ b/thrust/testing/address_stability.cmake
@@ -1,1 +1,8 @@
-target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
+target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>: --extended-lambda>)
+
+# When clang >= 13 is used as host compiler, we get the following warning:
+#   nvcc_internal_extended_lambda_implementation:312:22: error: definition of implicit copy constructor for '__nv_hdl_wrapper_t<false, true, false, __nv_dl_tag<void (*)(), &TestAddressStabilityLambda, 2>, int (const int &)>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
+#   312 | __nv_hdl_wrapper_t & operator=(const __nv_hdl_wrapper_t &in) = delete;
+#   |                      ^
+# Let's suppress it until NVBug 4980157 is resolved.
+target_compile_options(${test_target} PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>: -Wno-deprecated-copy>)

--- a/thrust/testing/address_stability.cu
+++ b/thrust/testing/address_stability.cu
@@ -83,3 +83,40 @@ void TestAddressStabilityUserDefinedFunctionObject()
   static_assert(proclaims_copyable_arguments<decltype(proclaim_copyable_arguments(my_plus<const int&&>{}))>::value, "");
 }
 DECLARE_UNITTEST(TestAddressStabilityUserDefinedFunctionObject);
+
+void TestAddressStabilityLambda()
+{
+  using ::cuda::proclaim_copyable_arguments;
+  using ::cuda::proclaims_copyable_arguments;
+
+  {
+    auto l = [](const int& i) {
+      return i + 2;
+    };
+    static_assert(!proclaims_copyable_arguments<decltype(l)>::value, "");
+    auto pr_l = proclaim_copyable_arguments(l);
+    ASSERT_EQUAL(pr_l(3), 5);
+    static_assert(proclaims_copyable_arguments<decltype(pr_l)>::value, "");
+  }
+
+  {
+    auto l = [] _CCCL_DEVICE(const int& i) {
+      return i + 2;
+    };
+    static_assert(!proclaims_copyable_arguments<decltype(l)>::value, "");
+    auto pr_device_l = proclaim_copyable_arguments(l);
+    (void) &pr_device_l;
+    static_assert(proclaims_copyable_arguments<decltype(pr_device_l)>::value, "");
+  }
+
+  {
+    auto l = [] _CCCL_HOST_DEVICE(const int& i) {
+      return i + 2;
+    };
+    static_assert(!proclaims_copyable_arguments<decltype(l)>::value, "");
+    auto pr_l = proclaim_copyable_arguments(l);
+    ASSERT_EQUAL(pr_l(3), 5);
+    static_assert(proclaims_copyable_arguments<decltype(pr_l)>::value, "");
+  }
+}
+DECLARE_UNITTEST(TestAddressStabilityLambda);


### PR DESCRIPTION
Adds tests for proclaiming host/device extended lambdas as having copyable arguments. Needs to suppress a warning as well, which will be addressed by NVBug 4980157 eventually.

Fixes: #2834 