### PR TITLE
make `shared_resource` usable as a mixin

### DIFF
--- a/cudax/include/cuda/experimental/__device/arch_traits.cuh
+++ b/cudax/include/cuda/experimental/__device/arch_traits.cuh
@@ -329,7 +329,6 @@ _CCCL_HOST_DEVICE inline constexpr arch_traits_t arch_traits(unsigned int __sm_v
   switch (__sm_version)
   {
     case 600:
-    case 610:
       return detail::sm_600_traits;
     case 700:
       return detail::sm_700_traits;

--- a/cudax/include/cuda/experimental/__device/arch_traits.cuh
+++ b/cudax/include/cuda/experimental/__device/arch_traits.cuh
@@ -329,6 +329,7 @@ _CCCL_HOST_DEVICE inline constexpr arch_traits_t arch_traits(unsigned int __sm_v
   switch (__sm_version)
   {
     case 600:
+    case 610:
       return detail::sm_600_traits;
     case 700:
       return detail::sm_700_traits;

--- a/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
@@ -227,13 +227,13 @@ struct shared_resource
   }
 
 private:
-  template <class T, class = typename T::impl>
+  template <class _Ty, class _Uy = typename _Ty::impl>
   _CUDAX_HOST_API static _CUDA_VSTD::true_type __impl_test(int);
-  template <class T>
+  template <class _Ty>
   _CUDAX_HOST_API static _CUDA_VSTD::false_type __impl_test(long);
 
-  template <class T>
-  using __has_impl = decltype(shared_resource::__impl_test<T>(0));
+  template <class _Ty>
+  using __has_impl = decltype(shared_resource::__impl_test<_Ty>(0));
 
   template <bool HasImpl, class = void>
   struct __impl_base : _Resource::impl
@@ -244,8 +244,8 @@ private:
     {}
   };
 
-  template <class T>
-  struct __impl_base<false, T> : _Resource
+  template <class _Ty>
+  struct __impl_base<false, _Ty> : _Resource
   {
     static_assert(!_CUDA_VSTD::is_base_of_v<shared_resource, _Resource>,
                   "It looks like shared_resource is being used as a mixin, but the specified Resource does not have an "

--- a/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
@@ -236,7 +236,7 @@ private:
   _CUDAX_HOST_API static _CUDA_VSTD::false_type __impl_test(long);
 
   template <class _Ty>
-  using __has_impl = decltype(shared_resource::__impl_test<_Ty>(0));
+  static constexpr bool __has_impl = decltype(shared_resource::__impl_test<_Ty>(0))::value;
 
   template <bool HasImpl, class = void>
   struct __impl_base : _Resource::impl
@@ -261,7 +261,7 @@ private:
   };
 
   struct __impl
-      : __impl_base<__has_impl<_Resource>::value>
+      : __impl_base<__has_impl<_Resource>>
       , ::std::enable_shared_from_this<__impl>
   {
     template <class... _Args>

--- a/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
@@ -97,14 +97,15 @@ namespace cuda::experimental::mr
 //! concept. Copies all share ownership of the underlying ``impl`` object.
 //!
 //! @note ``shared_resource`` satisfies the ``cuda::mr::async_resource`` concept
-//!     iff \tparam _Resource satisfies it.
+//! iff \tparam _Resource satisfies it.
+//!
 //! @tparam _Resource The resource type to hold, or the derived type when using
-//!     ``shared_resource`` as a mixin. When used directly, \c _Resource must
-//!     satisfy the :ref:`resource <libcudacxx-extended-api-memory-resources-resource>`
-//!     concept. When used as a mixin, there must be an accessible nested type
-//!     ``_Resource::impl`` that satisfies the
-//!     :ref:`resource <libcudacxx-extended-api-memory-resources-resource>`
-//!     concept.
+//! ``shared_resource`` as a mixin. When used directly, \c _Resource must
+//! satisfy the :ref:`resource <libcudacxx-extended-api-memory-resources-resource>`
+//! concept. When used as a mixin, there must be an accessible nested type
+//! ``_Resource::impl`` that satisfies the
+//! :ref:`resource <libcudacxx-extended-api-memory-resources-resource>`
+//! concept.
 //! @endrst
 template <class _Resource>
 struct shared_resource

--- a/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
@@ -229,7 +229,9 @@ struct shared_resource
 
 private:
   template <class _Ty>
-  _CUDAX_HOST_API static _CUDA_VSTD::true_type __impl_test(int, typename _Ty::impl* = nullptr);
+  using __impl_of = typename _Ty::impl;
+  template <class _Ty>
+  _CUDAX_HOST_API static _CUDA_VSTD::true_type __impl_test(int, __impl_of<_Ty>* = nullptr);
   template <class _Ty>
   _CUDAX_HOST_API static _CUDA_VSTD::false_type __impl_test(long);
 

--- a/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
@@ -61,14 +61,15 @@ namespace cuda::experimental::mr
 //! avoiding lifetime issues. It can be used directly, like so:
 //!
 //! .. code-block:: cpp
-//!   auto mr = shared_resource< MyCustomResource >{ args... };
 //!
+//!   auto mr = shared_resource< MyCustomResource >{ args... };
 //!
 //! It can also be used as a mixin when defining a custom resource. When used
 //! as a mixin, the implementation of the resource should be in a nested type
 //! named ``impl`` as shown below.
 //!
 //! .. code-block:: cpp
+//!
 //!   struct MyCustomSharedResource : shared_resource< MyCustomSharedResource >
 //!   {
 //!     MyCustomSharedResource( Arg arg )

--- a/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/shared_resource.cuh
@@ -60,38 +60,37 @@ namespace cuda::experimental::mr
 //! This allows the user to pass a resource around with reference semantics while
 //! avoiding lifetime issues. It can be used directly, like so:
 //!
-//! @code{.cpp}
-//! auto mr = shared_resource< MyCustomResource >{ args... };
-//! @endcode
+//! .. code-block:: cpp
+//!   auto mr = shared_resource< MyCustomResource >{ args... };
+//!
 //!
 //! It can also be used as a mixin when defining a custom resource. When used
 //! as a mixin, the implementation of the resource should be in a nested type
 //! named ``impl`` as shown below.
 //!
-//! @code{.cpp}
-//! struct MyCustomSharedResource : shared_resource< MyCustomSharedResource >
-//! {
-//!   MyCustomSharedResource( Arg arg )
-//!       : shared_resource( arg )
-//!   {}
-//!
-//! private:
-//!   friend shared_resource;
-//!
-//!   struct impl // put the implementation of the resource here
+//! .. code-block:: cpp
+//!   struct MyCustomSharedResource : shared_resource< MyCustomSharedResource >
 //!   {
-//!     impl( Arg arg )
-//!     impl(impl&&) = delete; // immovable impls are ok
-//!
-//!     void* allocate(size_t, size_t);
-//!     void deallocate(void*, size_t, size_t);
-//!     bool operator==(const impl&) const = default;
+//!     MyCustomSharedResource( Arg arg )
+//!         : shared_resource( arg )
+//!     {}
 //!
 //!   private:
-//!     Arg arg;
+//!     friend shared_resource;
+//!
+//!     struct impl // put the implementation of the resource here
+//!     {
+//!       impl( Arg arg )
+//!       impl(impl&&) = delete; // immovable impls are ok
+//!
+//!       void* allocate(size_t, size_t);
+//!       void deallocate(void*, size_t, size_t);
+//!       bool operator==(const impl&) const = default;
+//!
+//!     private:
+//!       Arg arg;
+//!     };
 //!   };
-//! };
-//! @endcode
 //!
 //! Instances of ``MyCustomSharedResource`` satisfy the ``cuda::mr::resource``
 //! concept. Copies all share ownership of the underlying ``impl`` object.
@@ -228,8 +227,8 @@ struct shared_resource
   }
 
 private:
-  template <class _Ty, class _Uy = typename _Ty::impl>
-  _CUDAX_HOST_API static _CUDA_VSTD::true_type __impl_test(int);
+  template <class _Ty>
+  _CUDAX_HOST_API static _CUDA_VSTD::true_type __impl_test(int, typename _Ty::impl* = nullptr);
   template <class _Ty>
   _CUDAX_HOST_API static _CUDA_VSTD::false_type __impl_test(long);
 

--- a/cudax/test/memory_resource/shared_resource.cu
+++ b/cudax/test/memory_resource/shared_resource.cu
@@ -216,9 +216,10 @@ TEST_CASE("shared_resource mixin", "[container][resource]")
   static_assert(cuda::mr::resource<shared_test_resource>);
   static_assert(!cuda::mr::async_resource<shared_test_resource>);
   {
-    shared_test_resource mr(&mr);
+    int i = 0;
+    shared_test_resource mr(&i);
     CHECK(shared_test_resource::instance_count == 1);
-    CHECK(mr.allocate(0, 0) == &mr);
+    CHECK(mr.allocate(0, 0) == &i);
     shared_test_resource copy = mr;
     CHECK(shared_test_resource::instance_count == 1);
     CHECK(copy == mr);


### PR DESCRIPTION
## Description

`shared_resource` is directly usable today to create a ref-counted memory resource. but often the author of a custom resource type knows a priori that their resource type should _always_ be reference-counted.

this pr adds the ability to use `shared_resource` as a mixin when defining a custom resource type. when used like that, the implementation of the resource goes into a nested `::impl` class, as shown below:

```c++
struct MyCustomSharedResource : shared_resource< MyCustomSharedResource >
{
  MyCustomSharedResource( Arg arg )
      : shared_resource( arg )
  {}

private:
  friend shared_resource;

  struct impl // put the implementation of the resource here
  {
    impl( Arg arg )
    impl(impl&&) = delete; // immovable impls are ok

    void* allocate(size_t, size_t);
    void deallocate(void*, size_t, size_t);
    bool operator==(const impl&) const = default;

  private:
    Arg arg;
  };
};
```

Instances of `MyCustomSharedResource` satisfy the `cuda::mr::resource` concept. Copies all share ownership of the underlying `impl` object.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
