### PR TITLE
Make discovery mechanism for `cuda/_include` directory compatible with `pip install --editable`

### DIFF
--- a/python/cuda_cooperative/cuda/cooperative/experimental/_nvrtc.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_nvrtc.py
@@ -45,11 +45,13 @@ def compile_impl(cpp, cc, rdc, code, nvrtc_path, nvrtc_version):
     check_in('rdc', rdc, [True, False])
     check_in('code', code, ['lto', 'ptx'])
 
-    with pkg_resources.path('cuda', '_include') as include_path:
-        cub_path = include_path
-        thrust_path = include_path
-        libcudacxx_path = os.path.join(include_path, 'libcudacxx')
-        cuda_include_path = os.path.join(get_cuda_path(), 'include')
+    # Using `.parent` for compatibility with pip install --editable:
+    include_path = pkg_resources.files(
+        'cuda.cooperative').parent.joinpath('_include')
+    cub_path = include_path
+    thrust_path = include_path
+    libcudacxx_path = os.path.join(include_path, 'libcudacxx')
+    cuda_include_path = os.path.join(get_cuda_path(), 'include')
 
     opts = [b"--std=c++17", \
             bytes(f"--include-path={cub_path}", encoding='ascii'), \

--- a/python/cuda_cooperative/setup.py
+++ b/python/cuda_cooperative/setup.py
@@ -84,6 +84,7 @@ setup(
     extras_require={
         "test": [
             "pytest",
+            "pytest-xdist",
         ]
     },
     cmdclass={

--- a/python/cuda_parallel/cuda/parallel/experimental/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/__init__.py
@@ -160,7 +160,8 @@ def _get_bindings():
 def _get_paths():
     global _paths
     if _paths is None:
-        include_path = importlib.resources.files('cuda').joinpath('_include')
+        include_path = importlib.resources.files(
+            'cuda.parallel').parent.joinpath('_include')
         include_path_str = str(include_path)
         include_option = '-I' + include_path_str
         cub_path = include_option.encode('utf-8')

--- a/python/cuda_parallel/cuda/parallel/experimental/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/__init__.py
@@ -160,6 +160,7 @@ def _get_bindings():
 def _get_paths():
     global _paths
     if _paths is None:
+        # Using `.parent` for compatibility with pip install --editable:
         include_path = importlib.resources.files(
             'cuda.parallel').parent.joinpath('_include')
         include_path_str = str(include_path)

--- a/python/cuda_parallel/setup.py
+++ b/python/cuda_parallel/setup.py
@@ -112,6 +112,7 @@ setup(
     extras_require={
         "test": [
             "pytest",
+            "pytest-xdist",
             "cupy-cuda12x",
         ]
     },


### PR DESCRIPTION
## Description
Also add [pytest-xdist](https://pypi.org/project/pytest-xdist/) (pytest plugin for distributed testing) to test requirements. This speeds up iterative development:

cuda_cooperative:
* `pytest` default (one worker): 322.17s
* `pytest -n 16`: 27.17s

cuda_parallel:
* `pytest` default (one worker): 33.88s
* `pytest -n 16`: 17.00s

`pip install --editable` documentation:
* https://setuptools.pypa.io/en/latest/userguide/development_mode.html (Thanks a lot @leofang for pointing this out to me today!)

Tested interactively with:

```
cd python/cuda_cooperative
pip3 uninstall cuda_cooperative
rm -rf build cuda/_include
pip3 install --editable .[test]
pytest -v tests/ -n 16
```

```
cd python/cuda_parallel
pip3 uninstall cuda_parallel
rm -rf build cuda/_include
pip3 install --editable .[test]
pytest -v tests/ -n 16
```
________

Also resolving this warning when testing cuda_cooperative:

```
  /home/coder/cccl/python/cuda_cooperative/cuda/cooperative/experimental/_nvrtc.py:49: DeprecationWarning: pathlib.Path.__enter__() is deprecated and scheduled for removal in Python 3.13; Path objects as a context manager is a no-op
    with pkg_resources.files('cuda.cooperative').parent.joinpath('_include') as include_path:
```
