### PR TITLE
Utility scripts for benchmark database

### DIFF
--- a/benchmarks/scripts/compare.py
+++ b/benchmarks/scripts/compare.py
@@ -102,6 +102,7 @@ def compare():
     compare_df = alg_dfs(args.compare)
     for alg in reference_df.keys() & compare_df.keys():
         print()
+        print()
         print(f'# {alg}')
         merge_columns = [col for col in reference_df[alg].columns if col not in ['Noise', 'Mean']]
         df = pd.merge(reference_df[alg], compare_df[alg], on=merge_columns, suffixes=('Ref', 'Cmp'))
@@ -116,6 +117,7 @@ def compare():
             case_df = case_df.drop(columns=['ctk', 'gpu', 'variant'])
             print()
             print(f'## CTK {ctk_version} GPU {gpu} ({variant})')
+            print()
             print(case_df.to_markdown(index=False))
 
 

--- a/benchmarks/scripts/compare.py
+++ b/benchmarks/scripts/compare.py
@@ -74,7 +74,7 @@ def alg_dfs(file):
             result[fused_algname] = pd.concat([result[fused_algname], subbench_df])
         else:
             result[fused_algname] = subbench_df
-    
+
     for algname in result:
         if result[algname]['cccl'].nunique() != 1:
             raise ValueError(f"Multiple CCCL versions in one db '{algname}'")

--- a/benchmarks/scripts/compare.py
+++ b/benchmarks/scripts/compare.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import cccl
+import argparse
+import numpy as np
+import pandas as pd
+
+
+def get_filenames_map(arr):
+    if not arr:
+        return []
+
+    prefix = arr[0]
+    for string in arr:
+        while not string.startswith(prefix):
+            prefix = prefix[:-1]
+        if not prefix:
+            break
+
+    return {string: string[len(prefix):] for string in arr}
+
+
+def is_finite(x):
+    if isinstance(x, float):
+        return x != np.inf and x != -np.inf
+    return True
+
+
+def filter_by_problem_size(df):
+    min_elements_pow2 = 28
+    if 'Elements{io}[pow2]' in df.columns:
+        df['Elements{io}[pow2]'] = df['Elements{io}[pow2]'].astype(int)
+        df = df[df['Elements{io}[pow2]'] >= min_elements_pow2]
+    return df
+
+
+def filter_by_offset_type(df):
+    if 'OffsetT{ct}' in df.columns:
+        df = df[(df['OffsetT{ct}'] == 'I32') | (df['OffsetT{ct}'] == 'U32')]
+    return df
+
+
+def filter_by_type(df):
+    if 'T{ct}' in df:
+        # df = df[df['T{ct}'].str.contains('64')]
+        df = df[~df['T{ct}'].str.contains('C')]
+    elif 'KeyT{ct}' in df:
+        # df = df[df['KeyT{ct}'].str.contains('64')]
+        df = df[~df['KeyT{ct}'].str.contains('C')]
+    return df
+
+
+def alg_dfs(file):
+    result = {}
+    storage = cccl.bench.StorageBase(file)
+    for algname in storage.algnames():
+        subbench_df = None
+        for subbench in storage.subbenches(algname):
+            df = storage.alg_to_df(algname, subbench)
+            df = df.map(lambda x: x if is_finite(x) else np.nan)
+            df = df.dropna(subset=['center'], how='all')
+            df = filter_by_type(filter_by_offset_type(filter_by_problem_size(df)))
+            df['Noise'] = df['samples'].apply(lambda x: np.std(x) / np.mean(x)) * 100
+            df['Mean'] = df['samples'].apply(lambda x: np.mean(x))
+            df = df.drop(columns=['samples', 'center', 'bw', 'elapsed'])
+            if subbench_df is None:
+                subbench_df = df
+            else:
+                subbench_df = pd.concat([subbench_df, df])
+        fused_algname = algname + '.' + subbench
+        if fused_algname in result:
+            result[fused_algname] = pd.concat([result[fused_algname], subbench_df])
+        else:
+            result[fused_algname] = subbench_df
+    
+    for algname in result:
+        if result[algname]['cccl'].nunique() != 1:
+            raise ValueError(f"Multiple CCCL versions in one db '{algname}'")
+        result[algname] = result[algname].drop(columns=['cccl'])
+
+    return result
+
+
+def file_exists(value):
+    if not os.path.isfile(value):
+        raise argparse.ArgumentTypeError(f"The file '{value}' does not exist.")
+    return value
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Analyze benchmark results.")
+    parser.add_argument('reference', type=file_exists, help='Reference database file.')
+    parser.add_argument('compare', type=file_exists, help='Comparison database file.')
+    return parser.parse_args()
+
+
+def compare():
+    args = parse_args()
+    reference_df = alg_dfs(args.reference)
+    compare_df = alg_dfs(args.compare)
+    for alg in reference_df.keys() & compare_df.keys():
+        print()
+        print(f'# {alg}')
+        merge_columns = [col for col in reference_df[alg].columns if col not in ['Noise', 'Mean']]
+        df = pd.merge(reference_df[alg], compare_df[alg], on=merge_columns, suffixes=('Ref', 'Cmp'))
+        df['Diff'] = df['MeanCmp'] - df['MeanRef']
+        df['FDiff'] = (df['Diff'] / df['MeanRef']) * 100
+
+        for _, row in df[['ctk', 'gpu', 'variant']].drop_duplicates().iterrows():
+            ctk_version = row['ctk']
+            variant = row['variant']
+            gpu = row['gpu']
+            case_df = df[(df['ctk'] == ctk_version) & (df['gpu'] == gpu) & (df['variant'] == variant)]
+            case_df = case_df.drop(columns=['ctk', 'gpu', 'variant'])
+            print()
+            print(f'## CTK {ctk_version} GPU {gpu} ({variant})')
+            print(case_df.to_markdown(index=False))
+
+
+if __name__ == "__main__":
+    compare()

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -85,12 +85,11 @@ def file_exists(value):
 
 
 def plot_sol(medians):
-    plt.figure(figsize=(14, 10))
     ax = sns.barplot(data=medians, x='alg', y='bw', hue='hue')
     for container in ax.containers:
         ax.bar_label(container, fmt='%.1f')
         ax.set_xticklabels(ax.get_xticklabels(), rotation=15, rotation_mode='anchor', ha='right')
-    plt.savefig('sol.png')
+    plt.show()
 
 
 def sol():

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -64,11 +64,10 @@ def alg_bws(dfs):
     for algname in dfs:
         df = dfs[algname]
         df['alg'] = algname
-        median = df.groupby([col for col in df.columns if col != 'bw'])['bw'].median().reset_index()
-        if medians is None:
-            medians = median
+        if df is None:
+            medians = df
         else:
-            medians = pd.concat([medians, median])
+            medians = pd.concat([medians, df])
     medians['hue'] = medians['ctk'].astype(str) + ' ' + medians['cccl'].astype(
         str) + ' ' + medians['gpu'].astype(str) + ' ' + medians['variant']
     return medians.drop(columns=['ctk', 'cccl', 'gpu', 'variant'])
@@ -81,10 +80,10 @@ def file_exists(value):
 
 
 def plot_sol(medians):
-    ax = sns.barplot(data=medians, x='alg', y='bw', hue='hue')
+    ax = sns.boxenplot(data=medians, x='alg', y='bw', hue='hue')
     for container in ax.containers:
         ax.bar_label(container, fmt='%.1f')
-        ax.set_xticklabels(ax.get_xticklabels(), rotation=15, rotation_mode='anchor', ha='right')
+    ax.set_xticklabels(ax.get_xticklabels(), rotation=15, rotation_mode='anchor', ha='right')
     plt.show()
 
 

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -105,7 +105,7 @@ def plot_sol(medians, box):
 def parse_args():
     parser = argparse.ArgumentParser(description="Analyze benchmark results.")
     parser.add_argument('files', type=file_exists, nargs='+', help='At least one file is required.')
-    parser.add_argument('--box', type=bool, default=False, help='Plot box instead of bar.')
+    parser.add_argument('--box', action='store_true', help='Plot box instead of bar.')
     return parser.parse_args()
 
 

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import cccl
+import argparse
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+
+def get_filenames_map(arr):
+    if not arr:
+        return []
+
+    prefix = arr[0]
+    for string in arr:
+        while not string.startswith(prefix):
+            prefix = prefix[:-1]
+        if not prefix:
+            break
+
+    return {string: string[len(prefix):] for string in arr}
+
+
+def is_finite(x):
+    if isinstance(x, float):
+        return x != np.inf and x != -np.inf
+    return True
+
+
+def alg_dfs(files, min_elements_pow2=0):
+    storages = {}
+    algnames = set()
+    filenames_map = get_filenames_map(files)
+    for file in files:
+        storage = cccl.bench.StorageBase(file)
+        algnames.update(storage.algnames())
+        storages[filenames_map[file]] = storage
+
+    result = {}
+    for algname in algnames:
+        for subbench in storage.subbenches(algname):
+            subbench_df = None
+            for file in storages:
+                storage = storages[file]
+                df = storage.alg_to_df(algname, subbench)
+                df = df.map(lambda x: x if is_finite(x) else np.nan)
+                df = df.dropna(subset=['center'], how='all')
+                if 'Elements{io}[pow2]' in df.columns:
+                    df['Elements{io}[pow2]'] = df['Elements{io}[pow2]'].astype(int)
+                    df = df[df['Elements{io}[pow2]'] >= min_elements_pow2]
+                df = df.filter(items=['ctk', 'cccl', 'gpu', 'variant', 'bw'])
+                df['variant'] = df['variant'].astype(str) + " ({})".format(file)
+                df['bw'] = df['bw'] * 100
+                if subbench_df is None:
+                    subbench_df = df
+                else:
+                    subbench_df = pd.concat([subbench_df, df])
+            result[algname + '.' + subbench] = subbench_df
+
+    return result
+
+
+def alg_bws(dfs):
+    medians = None
+    for algname in dfs:
+        df = dfs[algname]
+        df['alg'] = algname
+        median = df.groupby([col for col in df.columns if col != 'bw'])['bw'].median().reset_index()
+        if medians is None:
+            medians = median
+        else:
+            medians = pd.concat([medians, median])
+    medians['hue'] = medians['ctk'].astype(str) + ' ' + medians['cccl'].astype(
+        str) + ' ' + medians['gpu'].astype(str) + ' ' + medians['variant']
+    return medians.drop(columns=['ctk', 'cccl', 'gpu', 'variant'])
+
+
+def file_exists(value):
+    if not os.path.isfile(value):
+        raise argparse.ArgumentTypeError(f"The file '{value}' does not exist.")
+    return value
+
+
+def plot_sol(medians):
+    plt.figure(figsize=(14, 10))
+    ax = sns.barplot(data=medians, x='alg', y='bw', hue='hue')
+    for container in ax.containers:
+        ax.bar_label(container, fmt='%.1f')
+        ax.set_xticklabels(ax.get_xticklabels(), rotation=15, rotation_mode='anchor', ha='right')
+    plt.savefig('sol.png')
+
+
+def sol():
+    parser = argparse.ArgumentParser(description="Analyze benchmark results.")
+    parser.add_argument('files', type=file_exists, nargs='+', help='At least one file is required.')
+    plot_sol(alg_bws(alg_dfs(parser.parse_args().files)))
+
+
+if __name__ == "__main__":
+    sol()

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -31,20 +31,12 @@ def is_finite(x):
 
 
 def alg_dfs(files, min_elements_pow2=0):
-    storages = {}
-    algnames = set()
-    filenames_map = get_filenames_map(files)
+    result = {}
     for file in files:
         storage = cccl.bench.StorageBase(file)
-        algnames.update(storage.algnames())
-        storages[filenames_map[file]] = storage
-
-    result = {}
-    for algname in algnames:
-        for subbench in storage.subbenches(algname):
-            subbench_df = None
-            for file in storages:
-                storage = storages[file]
+        for algname in storage.algnames():
+            for subbench in storage.subbenches(algname):
+                subbench_df = None
                 df = storage.alg_to_df(algname, subbench)
                 df = df.map(lambda x: x if is_finite(x) else np.nan)
                 df = df.dropna(subset=['center'], how='all')
@@ -58,7 +50,11 @@ def alg_dfs(files, min_elements_pow2=0):
                     subbench_df = df
                 else:
                     subbench_df = pd.concat([subbench_df, df])
-            result[algname + '.' + subbench] = subbench_df
+            fused_algname = algname + '.' + subbench
+            if fused_algname in result:
+                result[fused_algname] = pd.concat([result[fused_algname], subbench_df])
+            else:
+                result[fused_algname] = subbench_df
 
     return result
 

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -79,19 +79,27 @@ def file_exists(value):
     return value
 
 
-def plot_sol(medians):
-    ax = sns.boxenplot(data=medians, x='alg', y='bw', hue='hue')
+def plot_sol(medians, box):
+    if box:
+        ax = sns.boxenplot(data=medians, x='alg', y='bw', hue='hue')
+    else:
+        ax = sns.barplot(data=medians, x='alg', y='bw', hue='hue', errorbar=lambda x: (x.min(), x.max()))
     for container in ax.containers:
         ax.bar_label(container, fmt='%.1f')
     ax.set_xticklabels(ax.get_xticklabels(), rotation=15, rotation_mode='anchor', ha='right')
     plt.show()
 
 
-def sol():
-    min_elements_pow2 = 28
+def parse_args():
     parser = argparse.ArgumentParser(description="Analyze benchmark results.")
     parser.add_argument('files', type=file_exists, nargs='+', help='At least one file is required.')
-    plot_sol(alg_bws(alg_dfs(parser.parse_args().files, min_elements_pow2)))
+    parser.add_argument('--box', type=bool, default=False, help='Plot box instead of bar.')
+    return parser.parse_args()
+
+def sol():
+    args = parse_args()
+    min_elements_pow2 = 28
+    plot_sol(alg_bws(alg_dfs(args.files, min_elements_pow2)), args.box)
 
 
 if __name__ == "__main__":

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -93,9 +93,10 @@ def plot_sol(medians):
 
 
 def sol():
+    min_elements_pow2 = 28
     parser = argparse.ArgumentParser(description="Analyze benchmark results.")
     parser.add_argument('files', type=file_exists, nargs='+', help='At least one file is required.')
-    plot_sol(alg_bws(alg_dfs(parser.parse_args().files)))
+    plot_sol(alg_bws(alg_dfs(parser.parse_args().files, min_elements_pow2)))
 
 
 if __name__ == "__main__":

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -44,6 +44,17 @@ def filter_by_offset_type(df):
     return df
 
 
+def filter_by_type(df):
+    if 'T{ct}' in df:
+        # df = df[df['T{ct}'].str.contains('64')]
+        df = df[~df['T{ct}'].str.contains('C')]
+    elif 'KeyT{ct}' in df:
+        print(df)
+        # df = df[df['KeyT{ct}'].str.contains('64')]
+        df = df[~df['KeyT{ct}'].str.contains('C')]
+    return df
+
+
 def alg_dfs(files):
     result = {}
     for file in files:
@@ -54,7 +65,7 @@ def alg_dfs(files):
                 df = storage.alg_to_df(algname, subbench)
                 df = df.map(lambda x: x if is_finite(x) else np.nan)
                 df = df.dropna(subset=['center'], how='all')
-                df = filter_by_offset_type(filter_by_problem_size(df))
+                df = filter_by_type(filter_by_offset_type(filter_by_problem_size(df)))
                 df = df.filter(items=['ctk', 'cccl', 'gpu', 'variant', 'bw'])
                 df['variant'] = df['variant'].astype(str) + " ({})".format(file)
                 df['bw'] = df['bw'] * 100

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -49,7 +49,6 @@ def filter_by_type(df):
         # df = df[df['T{ct}'].str.contains('64')]
         df = df[~df['T{ct}'].str.contains('C')]
     elif 'KeyT{ct}' in df:
-        print(df)
         # df = df[df['KeyT{ct}'].str.contains('64')]
         df = df[~df['KeyT{ct}'].str.contains('C')]
     return df


### PR DESCRIPTION
## Description

This PR introduces perf databases comparison script similar to `nvbench_compare.py`:

```bash
python3 ./cccl/benchmarks/scripts/compare.py cccl_52.db cccl_89.db
```

### cub.bench.radix_sort.keys.base

#### CTK 12.6.68 GPU RTX 6000 Ada Generation (384, 142, eccoff) (base)

| T{ct}   | OffsetT{ct}   |   Elements{io}[pow2] |   Entropy |   NoiseRef |    MeanRef |   NoiseCmp |    MeanCmp |         Diff |      FDiff |
|:--------|:--------------|---------------------:|----------:|-----------:|-----------:|-----------:|-----------:|-------------:|-----------:|
| I8      | I32           |                   28 |     1     |  2.81948   | 0.00262718 |   4.54923  | 0.00248399 | -0.000143189 |  -5.45028  |
| I8      | I32           |                   28 |     0.544 |  0.982392  | 0.00247031 |   3.74053  | 0.00224022 | -0.000230087 |  -9.31411  |
| I8      | I32           |                   28 |     0.201 |  0.774083  | 0.00244218 |   2.05809  | 0.00213283 | -0.000309349 | -12.6669   |
| I16     | I32           |                   28 |     1     |  0.730504  | 0.00638244 |   0.703749 | 0.00613477 | -0.000247671 |  -3.88051  |
| I16     | I32           |                   28 |     0.544 |  0.764199  | 0.00614175 |   0.82686  | 0.00604548 | -9.62671e-05 |  -1.56742  |
| I16     | I32           |                   28 |     0.201 |  0.796367  | 0.00605263 |   0.846468 | 0.00600274 | -4.98914e-05 |  -0.824293 |
| I32     | I32           |                   28 |     1     |  0.322565  | 0.0213539  |   1.41756  | 0.0120062  | -0.0093477   | -43.7751   |
| I32     | I32           |                   28 |     0.544 |  0.414317  | 0.0204187  |   1.26466  | 0.0119681  | -0.00845064  | -41.3868   |
| I32     | I32           |                   28 |     0.201 |  0.339595  | 0.0201124  |   1.58942  | 0.0118935  | -0.00821889  | -40.8647   |
| I64     | I32           |                   28 |     1     |  0.1897    | 0.0827264  |   0.673    | 0.0462751  | -0.0364512   | -44.0624   |
| I64     | I32           |                   28 |     0.544 |  0.350938  | 0.0805613  |   0.822275 | 0.0464476  | -0.0341137   | -42.345    |
| I64     | I32           |                   28 |     0.201 |  0.190399  | 0.0791822  |   0.680187 | 0.0462322  | -0.03295     | -41.6129   |
| I128    | I32           |                   28 |     1     |  0.0817631 | 0.305609   |   0.568132 | 0.181183   | -0.124426    | -40.7142   |
| I128    | I32           |                   28 |     0.544 |  0.0750161 | 0.302254   |   0.375363 | 0.182424   | -0.11983     | -39.6455   |
| I128    | I32           |                   28 |     0.201 |  0.0534963 | 0.298813   |   0.424861 | 0.180336   | -0.118476    | -39.649    |
| F32     | I32           |                   28 |     1     |  0.340511  | 0.020903   |   1.58978  | 0.0120336  | -0.00886944  | -42.4314   |
| F32     | I32           |                   28 |     0.544 |  0.397896  | 0.020168   |   1.32738  | 0.0119358  | -0.00823222  | -40.8182   |
| F32     | I32           |                   28 |     0.201 |  0.334014  | 0.0200527  |   1.56084  | 0.0118976  | -0.00815514  | -40.6684   |
| F64     | I32           |                   28 |     1     |  0.213676  | 0.0821132  |   0.279862 | 0.0465905  | -0.0355227   | -43.2606   |
| F64     | I32           |                   28 |     0.544 |  0.388119  | 0.080259   |   0.649057 | 0.0465545  | -0.0337045   | -41.9947   |
| F64     | I32           |                   28 |     0.201 |  0.182324  | 0.0791171  |   0.462161 | 0.0462688  | -0.0328483   | -41.5185   |

It also adds `sol.py` script for plotting aggregated Speed-of-Light (BWUtil) across workloads for a given algorithm:

```bash
python3 ~/Developer/github/cccl/benchmarks/scripts/sol.py cccl_52.db cccl_89.db
```

<img width="1684" alt="image" src="https://github.com/user-attachments/assets/7a8a842d-4a65-4082-8136-9d5d829aaeaa">

```bash
python3 ~/Developer/github/cccl/benchmarks/scripts/sol.py —box cccl_52.db cccl_89.db
```

<img width="1684" alt="image" src="https://github.com/user-attachments/assets/6c3c027a-640b-4c67-a73c-4e6073495c7d">


<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
