### PR TITLE
backport `to_underlying`

### DIFF
--- a/libcudacxx/include/cuda/std/__utility/to_underlying.h
+++ b/libcudacxx/include/cuda/std/__utility/to_underlying.h
@@ -26,18 +26,10 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr typename underlying_type<_Tp>::type __to_underlying(_Tp __val) noexcept
-{
-  return static_cast<typename underlying_type<_Tp>::type>(__val);
-}
-
-#if _CCCL_STD_VER > 2020
-template <class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr underlying_type_t<_Tp> to_underlying(_Tp __val) noexcept
 {
-  return _CUDA_VSTD::__to_underlying(__val);
+  return static_cast<underlying_type_t<_Tp>>(__val);
 }
-#endif
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -29,6 +29,8 @@
 #  include <ciso646> // otherwise go for the smallest possible header
 #endif // !_CCCL_COMPILER(NVRTC)
 
+#define __cccl_lib_to_underlying 202102L
+
 #if _CCCL_STD_VER >= 2014
 #  define __cccl_lib_bit_cast     201806L
 #  define __cccl_lib_chrono_udls  201304L
@@ -244,8 +246,7 @@
 // # define __cccl_lib_stdatomic_h                          202011L
 // # define __cccl_lib_string_contains                      202011L
 // # define __cccl_lib_string_resize_and_overwrite          202110L
-#  define __cccl_lib_to_underlying 202102L
-#  define __cccl_lib_unreachable   202202L
+#  define __cccl_lib_unreachable 202202L
 
 #endif // _CCCL_STD_VER >= 2023
 

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.underlying/to_underlying.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.underlying/to_underlying.pass.cpp
@@ -7,11 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-
 // [utility.underlying], to_underlying
 // template <class T>
-//     constexpr underlying_type_t<T> to_underlying( T value ) noexcept; // C++2b
+//     constexpr underlying_type_t<T> to_underlying( T value ) noexcept;
 
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/utility.underlying/to_underlying.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/utility.underlying/to_underlying.verify.cpp
@@ -7,11 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-
 // [utility.underlying], to_underlying
 // template <class T>
-//     constexpr underlying_type_t<T> to_underlying( T value ) noexcept; // C++2b
+//     constexpr underlying_type_t<T> to_underlying( T value ) noexcept;
 
 #include <cuda/std/utility>
 


### PR DESCRIPTION
This PR makes C++23's `to_underlying` available in older C++ versions (back to C++11).