### PR TITLE
Add missing include

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -45,6 +45,8 @@
 #include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 
+#include <cuda/std/functional>
+
 CUB_NAMESPACE_BEGIN
 
 namespace detail


### PR DESCRIPTION
I am hunting an internal bug report, and I am getting desparate. I noticed a missing `#include <cuda/std/functional>` on my way, so here it is.

We need the include because later in the file we use `cuda::std::plus<>`:
```c++
template <typename AccumT, typename ScanOpT = ::cuda::std::plus<>>
struct DeviceScanPolicy
...
```