### PR TITLE
Fix DeviceSegmentedSort NVTX range name

### DIFF
--- a/cub/cub/device/device_segmented_sort.cuh
+++ b/cub/cub/device/device_segmented_sort.cuh
@@ -131,7 +131,7 @@ private:
   // Name reported for NVTX ranges
   _CCCL_HOST_DEVICE static constexpr auto GetName() -> const char*
   {
-    return "cub::DeviceSegmentedRadixSort";
+    return "cub::DeviceSegmentedSort";
   }
 
   // Internal version without NVTX range


### PR DESCRIPTION
## Description
Fixes the NVTX range name used by the `cub::DeviceSegmentedSort`.
This confused me for way too long when looking at an nsys trace.

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
