### PR TITLE
add missing `DOXYGEN_*` predefined macros when building the cudax docs

### DIFF
--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -442,6 +442,8 @@ doxygen_predefined = [
   "_LIBCUDACXX_TEMPLATE(x)=template<x, ",
   "_LIBCUDACXX_TRAILING_REQUIRES(x)=-> x _LIBCUDACXX_EAT_REST",
   "LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE=",
+  "DOXYGEN_SHOULD_SKIP_THIS",
+  "DOXYGEN_ACTIVE",
 ]
 
 # make sure to use ./fetch_imgs.sh
@@ -453,7 +455,7 @@ doxygen_conf_extra = """
   EXTENSION_MAPPING      = cuh=c++ cu=c++
   EXAMPLE_RECURSIVE      = NO
   EXAMPLE_PATTERNS       = *.cu
-  EXCLUDE_SYMBOLS        = "*detail*" "*RESERVED*" "*reserved*" "__*" "_A*" "_B*" "_C*" "_D*" "_E*" "_F*" "_G*" "_H*" "_I*" "_J*" "_K*" "_L*" "_M*" "_N*" "_O*" "_P*" "_Q*" "_R*" "_S*" "_T*" "_U*" "_V*" "_W*" "_X*" "_Y*" "_Z*" "UNITTEST"
+  EXCLUDE_SYMBOLS        = "*detail*" "*RESERVED*" "*reserved*" "*__*" "_A*" "_B*" "_C*" "_D*" "_E*" "_F*" "_G*" "_H*" "_I*" "_J*" "_K*" "_L*" "_M*" "_N*" "_O*" "_P*" "_Q*" "_R*" "_S*" "_T*" "_U*" "_V*" "_W*" "_X*" "_Y*" "_Z*" "UNITTEST"
   AUTOLINK_SUPPORT       = YES
   FULL_PATH_NAMES        = YES
   STRIP_FROM_PATH        = ../../cudax


### PR DESCRIPTION
## Description

The CUDAX docs are not being built with the `DOXYGEN_ACTIVE` or `DOXYGEN_SHOULD_SKIP_THIS` macros defined, which will result in implementation details leaking into the reference section. This corrects the problem.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
