### PR TITLE
replace CUB concept emulation with CCCL's

### DIFF
--- a/cub/cub/detail/type_traits.cuh
+++ b/cub/cub/detail/type_traits.cuh
@@ -52,10 +52,9 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 #if __cccl_lib_mdspan
 #  include <cuda/std/mdspan>
 #endif // __cccl_lib_mdspan
+#include <cuda/std/__concepts/__concept_macros.h>
 #include <cuda/std/span>
 #include <cuda/std/type_traits>
-
-#define _CUB_TEMPLATE_REQUIRES(...) ::cuda::std::enable_if_t<(__VA_ARGS__)>* = nullptr
 
 CUB_NAMESPACE_BEGIN
 namespace detail

--- a/cub/cub/device/dispatch/kernels/for_each_in_extents_kernel.cuh
+++ b/cub/cub/device/dispatch/kernels/for_each_in_extents_kernel.cuh
@@ -55,10 +55,8 @@ namespace detail
 namespace for_each_in_extents
 {
 
-template <int Rank,
-          typename ExtendType,
-          typename FastDivModType,
-          _CUB_TEMPLATE_REQUIRES(ExtendType::static_extent(Rank) != ::cuda::std::dynamic_extent)>
+_LIBCUDACXX_TEMPLATE(int Rank, typename ExtendType, typename FastDivModType)
+_LIBCUDACXX_REQUIRES(ExtendType::static_extent(Rank) != ::cuda::std::dynamic_extent)
 _CCCL_DEVICE _CCCL_FORCEINLINE auto get_extent_size(ExtendType ext, FastDivModType extent_size)
 {
   using extent_index_type   = typename ExtendType::index_type;
@@ -67,28 +65,22 @@ _CCCL_DEVICE _CCCL_FORCEINLINE auto get_extent_size(ExtendType ext, FastDivModTy
   return static_cast<unsigned_index_type>(ext.static_extent(Rank));
 }
 
-template <int Rank,
-          typename ExtendType,
-          typename FastDivModType,
-          _CUB_TEMPLATE_REQUIRES(ExtendType::static_extent(Rank) == ::cuda::std::dynamic_extent)>
+_LIBCUDACXX_TEMPLATE(int Rank, typename ExtendType, typename FastDivModType)
+_LIBCUDACXX_REQUIRES(ExtendType::static_extent(Rank) == ::cuda::std::dynamic_extent)
 _CCCL_DEVICE _CCCL_FORCEINLINE auto get_extent_size(ExtendType ext, FastDivModType extent_size)
 {
   return extent_size;
 }
 
-template <int Rank,
-          typename ExtendType,
-          typename FastDivModType,
-          _CUB_TEMPLATE_REQUIRES(cub::detail::is_sub_size_static<Rank + 1, ExtendType>())>
+_LIBCUDACXX_TEMPLATE(int Rank, typename ExtendType, typename FastDivModType)
+_LIBCUDACXX_REQUIRES(cub::detail::is_sub_size_static<Rank + 1, ExtendType>())
 _CCCL_DEVICE _CCCL_FORCEINLINE auto get_extents_sub_size(ExtendType ext, FastDivModType extents_sub_size)
 {
   return sub_size<Rank + 1>(ext);
 }
 
-template <int Rank,
-          typename ExtendType,
-          typename FastDivModType,
-          _CUB_TEMPLATE_REQUIRES(!cub::detail::is_sub_size_static<Rank + 1, ExtendType>())>
+_LIBCUDACXX_TEMPLATE(int Rank, typename ExtendType, typename FastDivModType)
+_LIBCUDACXX_REQUIRES((!cub::detail::is_sub_size_static<Rank + 1, ExtendType>()))
 _CCCL_DEVICE _CCCL_FORCEINLINE auto get_extents_sub_size(ExtendType ext, FastDivModType extents_sub_size)
 {
   return extents_sub_size;

--- a/cub/cub/thread/thread_reduce.cuh
+++ b/cub/cub/thread/thread_reduce.cuh
@@ -74,7 +74,7 @@ CUB_NAMESPACE_BEGIN
 //!
 //! .. code-block:: c++
 //!
-//!    template <typename Input,
+//!    _LIBCUDACXX_TEMPLATE(typename Input,
 //!              typename ReductionOp,
 //!              typename PrefixT,
 //!              typename ValueT = ::cuda::std::remove_cvref_t<decltype(::cuda::std::declval<Input>()[0])>,
@@ -471,9 +471,8 @@ ThreadReduceTernaryTree(const Input& input, ReductionOp reduction_op)
  **********************************************************************************************************************/
 
 // never reached. Protect instantion of ThreadReduceSimd with arbitrary types and operators
-template <typename Input,
-          typename ReductionOp,
-          _CUB_TEMPLATE_REQUIRES(!cub::internal::enable_generic_simd_reduction<Input, ReductionOp>())>
+_LIBCUDACXX_TEMPLATE(typename Input, typename ReductionOp)
+_LIBCUDACXX_REQUIRES((!cub::internal::enable_generic_simd_reduction<Input, ReductionOp>()))
 _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE auto
 ThreadReduceSimd(const Input& input, ReductionOp) -> ::cuda::std::remove_cvref_t<decltype(input[0])>
 {
@@ -481,9 +480,8 @@ ThreadReduceSimd(const Input& input, ReductionOp) -> ::cuda::std::remove_cvref_t
   return input[0];
 }
 
-template <typename Input,
-          typename ReductionOp,
-          _CUB_TEMPLATE_REQUIRES(cub::internal::enable_generic_simd_reduction<Input, ReductionOp>())>
+_LIBCUDACXX_TEMPLATE(typename Input, typename ReductionOp)
+_LIBCUDACXX_REQUIRES(cub::internal::enable_generic_simd_reduction<Input, ReductionOp>())
 _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE auto
 ThreadReduceSimd(const Input& input, ReductionOp reduction_op) -> ::cuda::std::remove_cvref_t<decltype(input[0])>
 {
@@ -675,12 +673,12 @@ _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE AccumT ThreadReduce(const T* inpu
  *
  * @return Aggregate of type <tt>cuda::std::__accumulator_t<ReductionOp, T, PrefixT></tt>
  */
-template <int Length,
-          typename T,
-          typename ReductionOp,
-          typename PrefixT,
-          typename AccumT = ::cuda::std::__accumulator_t<ReductionOp, T, PrefixT>,
-          _CUB_TEMPLATE_REQUIRES(Length > 0)>
+_LIBCUDACXX_TEMPLATE(int Length,
+                     typename T,
+                     typename ReductionOp,
+                     typename PrefixT,
+                     typename AccumT = ::cuda::std::__accumulator_t<ReductionOp, T, PrefixT>)
+_LIBCUDACXX_REQUIRES((Length > 0))
 _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE AccumT
 ThreadReduce(const T* input, ReductionOp reduction_op, PrefixT prefix)
 {
@@ -690,7 +688,8 @@ ThreadReduce(const T* input, ReductionOp reduction_op, PrefixT prefix)
   return cub::ThreadReduce(*array, reduction_op, prefix);
 }
 
-template <int Length, typename T, typename ReductionOp, typename PrefixT, _CUB_TEMPLATE_REQUIRES(Length == 0)>
+_LIBCUDACXX_TEMPLATE(int Length, typename T, typename ReductionOp, typename PrefixT)
+_LIBCUDACXX_REQUIRES((Length == 0))
 _CCCL_NODISCARD _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadReduce(const T*, ReductionOp, PrefixT prefix)
 {
   return prefix;


### PR DESCRIPTION
## Description

for one of my PR's, the build is broken because of "duplicate" definitions of a function. the duplicates actually have different constraints, but the functions are defined with `_CUB_TEMPLATE_REQUIRES`, which doesn't do the proper dance to make msvc recognize the differences in the constraints.

this fixes the problem and is one small step toward CCCL unification.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
