### PR TITLE
implement C++26 `std::ignore`

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/ignore.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/ignore.h
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___TUPLE_IGNORE_H
+#define _LIBCUDACXX___TUPLE_IGNORE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+template <class _Up>
+struct __ignore_t
+{
+  template <class _Tp>
+  _LIBCUDACXX_HIDE_FROM_ABI constexpr const __ignore_t& operator=(const _Tp&) const noexcept
+  {
+    return *this;
+  }
+};
+
+namespace
+{
+_CCCL_GLOBAL_CONSTANT __ignore_t<unsigned char> ignore{};
+} // namespace
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___TUPLE_IGNORE_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -158,6 +158,7 @@ template <class... Types>
 #include <cuda/std/__functional/unwrap_ref.h>
 #include <cuda/std/__fwd/array.h>
 #include <cuda/std/__memory/allocator_arg_t.h>
+#include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__tuple_dir/make_tuple_types.h>
 #include <cuda/std/__tuple_dir/sfinae_helpers.h>
 #include <cuda/std/__tuple_dir/structured_bindings.h>
@@ -1115,21 +1116,6 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 tuple<_Tp&...> tie(_Tp&... __t) 
 {
   return tuple<_Tp&...>(__t...);
 }
-
-template <class _Up>
-struct __ignore_t
-{
-  template <class _Tp>
-  _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 const __ignore_t& operator=(_Tp&&) const
-  {
-    return *this;
-  }
-};
-
-namespace
-{
-_CCCL_GLOBAL_CONSTANT __ignore_t<unsigned char> ignore{};
-} // namespace
 
 template <class... _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 tuple<typename __unwrap_ref_decay<_Tp>::type...> make_tuple(_Tp&&... __t)

--- a/libcudacxx/include/cuda/std/utility
+++ b/libcudacxx/include/cuda/std/utility
@@ -69,6 +69,9 @@
 #endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
 #include <cuda/std/initializer_list>
 
+// [tuple.creation]
+#include <cuda/std/__tuple_dir/ignore.h>
+
 // [tuple.helper]
 #include <cuda/std/__tuple_dir/tuple_element.h>
 #include <cuda/std/__tuple_dir/tuple_size.h>

--- a/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.general/ignore.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/tuple/tuple.general/ignore.pass.cpp
@@ -10,45 +10,69 @@
 
 // constexpr unspecified ignore;
 
-// UNSUPPORTED: c++98, c++03
-
 #include <cuda/std/cassert>
 #include <cuda/std/tuple>
 
 #include "test_macros.h"
 
+static_assert(cuda::std::is_trivial<decltype(cuda::std::ignore)>::value, "");
+
+#if TEST_STD_VER >= 2017
+[[nodiscard]] __host__ __device__ constexpr int test_nodiscard()
+{
+  return 8294;
+}
+#endif
+
 __host__ __device__ TEST_CONSTEXPR_CXX14 bool test()
 {
-  { // Test that std::ignore provides constexpr converting assignment.
+  {
+    auto& ignore_v = cuda::std::ignore;
+    unused(ignore_v);
+  }
+
+  { // Test that std::ignore provides converting assignment.
     auto& res = (cuda::std::ignore = 42);
+    static_assert(noexcept(res = (cuda::std::ignore = 42)), "");
     assert(&res == &cuda::std::ignore);
   }
-  { // Test that cuda::std::ignore provides constexpr copy/move constructors
+  { // Test bit-field binding.
+    struct S
+    {
+      unsigned int bf : 3;
+    };
+    S s{0b010};
+    auto& res = (cuda::std::ignore = s.bf);
+    assert(&res == &cuda::std::ignore);
+  }
+  { // Test that std::ignore provides copy/move constructors
     auto copy  = cuda::std::ignore;
     auto moved = cuda::std::move(copy);
     unused(moved);
   }
-  { // Test that cuda::std::ignore provides constexpr copy/move assignment
+  { // Test that std::ignore provides copy/move assignment
     auto copy  = cuda::std::ignore;
     copy       = cuda::std::ignore;
     auto moved = cuda::std::ignore;
     moved      = cuda::std::move(copy);
     unused(moved);
   }
+
+#if TEST_STD_VER >= 2017
+  {
+    cuda::std::ignore = test_nodiscard();
+  }
+#endif
+
   return true;
 }
-static_assert(cuda::std::is_trivial<decltype(cuda::std::ignore)>::value, "");
 
 int main(int, char**)
 {
-  {
-    constexpr auto& ignore_v = cuda::std::ignore;
-    unused(ignore_v);
-  }
   test();
 #if TEST_STD_VER >= 2014
   static_assert(test(), "");
-#endif // TEST_STD_VER >= 2014
+#endif
 
   return 0;
 }


### PR DESCRIPTION
Implementation of [P2968R2](https://wg21.link/P2968R2) "Make std::ignore a first-class object" from C++26.