### PR TITLE
add a `_CCCL_NO_CONCEPTS` config macro

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -80,6 +80,7 @@
 #  define _CCCL_IF_CONSTEXPR      if constexpr
 #  define _CCCL_ELSE_IF_CONSTEXPR else if constexpr
 #else // ^^^ C++17 ^^^ / vvv C++14 vvv
+#  define _CCCL_NO_IF_CONSTEXPR
 #  define _CCCL_IF_CONSTEXPR      if
 #  define _CCCL_ELSE_IF_CONSTEXPR else if
 #endif // _CCCL_STD_VER <= 2014

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -108,7 +108,7 @@
 // concepts are only available from C++20 onwards
 #if _CCCL_STD_VER <= 2017 || !defined(__cpp_concepts) || (__cpp_concepts < 201907L)
 #  define _CCCL_NO_CONCEPTS
-#endif // _CCCL_STD_VER <= 2017
+#endif // _CCCL_STD_VER <= 2017 || !defined(__cpp_concepts) || (__cpp_concepts < 201907L)
 
 // noexcept function types are only available from C++17 onwards
 #if _CCCL_STD_VER >= 2017 && defined(__cpp_noexcept_function_type) && (__cpp_noexcept_function_type >= 201510L)

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -104,6 +104,11 @@
 #  define _CCCL_NO_VARIABLE_TEMPLATES
 #endif // _CCCL_STD_VER <= 2011
 
+// concepts are only available from C++20 onwards
+#if _CCCL_STD_VER <= 2017 || !defined(__cpp_concepts) || (__cpp_concepts < 201907L)
+#  define _CCCL_NO_CONCEPTS
+#endif // _CCCL_STD_VER <= 2017
+
 // noexcept function types are only available from C++17 onwards
 #if _CCCL_STD_VER >= 2017 && defined(__cpp_noexcept_function_type) && (__cpp_noexcept_function_type >= 201510L)
 #  define _CCCL_FUNCTION_TYPE_NOEXCEPT noexcept

--- a/libcudacxx/include/cuda/std/__concepts/arithmetic.h
+++ b/libcudacxx/include/cuda/std/__concepts/arithmetic.h
@@ -30,7 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 
 // [concepts.arithmetic], arithmetic concepts
 
@@ -49,7 +49,7 @@ _CCCL_CONCEPT floating_point = _CCCL_TRAIT(is_floating_point, _Tp);
 template <class _Tp>
 _CCCL_CONCEPT __libcpp_signed_integer = __libcpp_is_signed_integer<_Tp>::value;
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/assignable.h
+++ b/libcudacxx/include/cuda/std/__concepts/assignable.h
@@ -29,7 +29,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.assignable]
 
@@ -40,7 +40,7 @@ concept assignable_from =
        { __lhs = _CUDA_VSTD::forward<_Rhs>(__rhs) } -> same_as<_Lhs>;
      };
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Lhs, class _Rhs>
 _CCCL_CONCEPT_FRAGMENT(
@@ -53,7 +53,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Lhs, class _Rhs>
 _CCCL_CONCEPT assignable_from = _CCCL_FRAGMENT(__assignable_from_, _Lhs, _Rhs);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/boolean_testable.h
+++ b/libcudacxx/include/cuda/std/__concepts/boolean_testable.h
@@ -26,7 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concepts.booleantestable]
 
@@ -38,7 +38,7 @@ concept __boolean_testable = __boolean_testable_impl<_Tp> && requires(_Tp&& __t)
   { !_CUDA_VSTD::forward<_Tp>(__t) } -> __boolean_testable_impl;
 };
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Tp>
 _CCCL_CONCEPT __boolean_testable_impl = convertible_to<_Tp, bool>;
@@ -52,7 +52,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Tp>
 _CCCL_CONCEPT __boolean_testable = _CCCL_FRAGMENT(__boolean_testable_, _Tp);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/class_or_enum.h
+++ b/libcudacxx/include/cuda/std/__concepts/class_or_enum.h
@@ -28,7 +28,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 
 template <class _Tp>
 _CCCL_CONCEPT __class_or_enum = _CCCL_TRAIT(is_class, _Tp) || _CCCL_TRAIT(is_union, _Tp) || _CCCL_TRAIT(is_enum, _Tp);
@@ -39,7 +39,7 @@ template <class _Tp>
 _CCCL_CONCEPT __workaround_52970 =
   _CCCL_TRAIT(is_class, remove_cvref_t<_Tp>) || _CCCL_TRAIT(is_union, remove_cvref_t<_Tp>);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/common_reference_with.h
+++ b/libcudacxx/include/cuda/std/__concepts/common_reference_with.h
@@ -29,7 +29,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.commonref]
 
@@ -38,7 +38,7 @@ concept common_reference_with =
   same_as<common_reference_t<_Tp, _Up>, common_reference_t<_Up, _Tp>>
   && convertible_to<_Tp, common_reference_t<_Tp, _Up>> && convertible_to<_Up, common_reference_t<_Tp, _Up>>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT_FRAGMENT(__common_reference_exists_,
@@ -58,7 +58,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Tp, class _Up>
 _CCCL_CONCEPT common_reference_with = _CCCL_FRAGMENT(__common_reference_with_, _Tp, _Up);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/common_with.h
+++ b/libcudacxx/include/cuda/std/__concepts/common_with.h
@@ -29,7 +29,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.common]
 
@@ -39,7 +39,7 @@ concept common_with = same_as<common_type_t<_Tp, _Up>, common_type_t<_Up, _Tp>> 
   static_cast<common_type_t<_Tp, _Up>>(_CUDA_VSTD::declval<_Up>());
 } && common_reference_with<add_lvalue_reference_t<const _Tp>, add_lvalue_reference_t<const _Up>> && common_reference_with<add_lvalue_reference_t<common_type_t<_Tp, _Up>>, common_reference_t<add_lvalue_reference_t<const _Tp>, add_lvalue_reference_t<const _Up>>>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT_FRAGMENT(__common_type_exists_,
@@ -71,7 +71,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Tp, class _Up>
 _CCCL_CONCEPT common_with = _CCCL_FRAGMENT(__common_with_, _Tp, _Up);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/concept_macros.h
+++ b/libcudacxx/include/cuda/std/__concepts/concept_macros.h
@@ -64,7 +64,8 @@ using __cccl_requires_t = typename __cccl_select<_Bp>::template type<_Tp>;
 #  define _CCCL_TRAILING_REQUIRES(...)      ->__cccl_requires_t < __VA_ARGS__ _CCCL_TRAILING_REQUIRES_AUX_
 #endif // !defined(_CCCL_NO_CONCEPTS)
 
-#if _CCCL_STD_VER >= 2014
+// The following concepts emulation macros need variable template support
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 
 namespace __cccl_concept
 {
@@ -171,7 +172,7 @@ namespace __unqualified_cuda_std = _CUDA_VSTD; // NOLINT(misc-unused-alias-decls
 
 #    define _CCCL_FRAGMENT(_NAME, ...) _NAME<__VA_ARGS__>
 
-#  else
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 
 #    define _CCCL_CONCEPT _CCCL_INLINE_VAR constexpr bool
 
@@ -212,7 +213,7 @@ namespace __unqualified_cuda_std = _CUDA_VSTD; // NOLINT(misc-unused-alias-decls
 #    define _CCCL_FRAGMENT(_NAME, ...) \
       (1u == sizeof(_NAME##_CCCL_CONCEPT_FRAGMENT_(static_cast<__cccl_concept::_Tag<__VA_ARGS__>*>(nullptr), nullptr)))
 
-#  endif
+#  endif // ^^^ _CCCL_NO_CONCEPTS ^^^
 
 ////////////////////////////////////////////////////////////////////////////////
 // _CCCL_REQUIRES_EXPR
@@ -228,7 +229,7 @@ namespace __unqualified_cuda_std = _CUDA_VSTD; // NOLINT(misc-unused-alias-decls
 #  if !defined(_CCCL_NO_CONCEPTS) || defined(_CCCL_DOXYGEN_INVOKED)
 #    define _CCCL_REQUIRES_EXPR(_TY, ...) requires(__VA_ARGS__) _CCCL_REQUIRES_EXPR_2
 #    define _CCCL_REQUIRES_EXPR_2(...)    {_CCCL_PP_FOR_EACH(_CCCL_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__)}
-#  else
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 #    define _CCCL_REQUIRES_EXPR_TPARAM_PROBE_variadic _CCCL_PP_PROBE(~)
 #    define _CCCL_REQUIRES_EXPR_TPARAM_variadic
 
@@ -271,8 +272,8 @@ namespace __unqualified_cuda_std = _CUDA_VSTD; // NOLINT(misc-unused-alias-decls
         return false;                                                                                           \
       }                                                                                                         \
       }
-#  endif
+#  endif // ^^^ _CCCL_NO_CONCEPTS ^^^
 
-#endif // _CCCL_STD_VER >= 2014
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES ^^^
 
 #endif //_CUDA___CONCEPTS

--- a/libcudacxx/include/cuda/std/__concepts/concept_macros.h
+++ b/libcudacxx/include/cuda/std/__concepts/concept_macros.h
@@ -50,19 +50,19 @@ using __cccl_enable_if_t = typename __cccl_select<_Bp>::template type<_Tp>;
 template <class _Tp, bool _Bp>
 using __cccl_requires_t = typename __cccl_select<_Bp>::template type<_Tp>;
 
-#if (defined(__cpp_concepts) && _CCCL_STD_VER >= 2020)
+#if !defined(_CCCL_NO_CONCEPTS) || defined(_CCCL_DOXYGEN_INVOKED)
 #  define _CCCL_TEMPLATE(...)               template <__VA_ARGS__>
 #  define _CCCL_REQUIRES(...)               requires __VA_ARGS__
 #  define _CCCL_AND                         &&
 #  define _CCCL_TRAILING_REQUIRES_AUX_(...) requires __VA_ARGS__
 #  define _CCCL_TRAILING_REQUIRES(...)      ->__VA_ARGS__ _CCCL_TRAILING_REQUIRES_AUX_
-#else // ^^^ __cpp_concepts ^^^ / vvv !__cpp_concepts vvv
+#else // ^^^ _CCCL_NO_CONCEPTS ^^^ / vvv !_CCCL_NO_CONCEPTS vvv
 #  define _CCCL_TEMPLATE(...)               template <__VA_ARGS__
 #  define _CCCL_REQUIRES(...)               , bool _CCCL_true_ = true, __cccl_enable_if_t < __VA_ARGS__ && _CCCL_true_, int > = 0 >
 #  define _CCCL_AND                         &&_CCCL_true_, int > = 0, __cccl_enable_if_t <
 #  define _CCCL_TRAILING_REQUIRES_AUX_(...) , __VA_ARGS__ >
 #  define _CCCL_TRAILING_REQUIRES(...)      ->__cccl_requires_t < __VA_ARGS__ _CCCL_TRAILING_REQUIRES_AUX_
-#endif // !__cpp_concepts
+#endif // !defined(_CCCL_NO_CONCEPTS)
 
 #if _CCCL_STD_VER >= 2014
 
@@ -145,7 +145,7 @@ namespace __unqualified_cuda_std = _CUDA_VSTD; // NOLINT(misc-unused-alias-decls
 #  define _CCCL_PP_EAT_TYPENAME_SELECT_1(...) _CCCL_PP_CAT3(_CCCL_PP_EAT_TYPENAME_, __VA_ARGS__)
 #  define _CCCL_PP_EAT_TYPENAME_typename
 
-#  if (defined(__cpp_concepts) && _CCCL_STD_VER >= 2020) || defined(_CCCL_DOXYGEN_INVOKED)
+#  if !defined(_CCCL_NO_CONCEPTS) || defined(_CCCL_DOXYGEN_INVOKED)
 
 #    define _CCCL_CONCEPT concept
 
@@ -225,7 +225,7 @@ namespace __unqualified_cuda_std = _CUDA_VSTD; // NOLINT(misc-unused-alias-decls
 //     );
 //
 // Can only be used as the last requirement in a concept definition.
-#  if defined(__cpp_concepts) && _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS) || defined(_CCCL_DOXYGEN_INVOKED)
 #    define _CCCL_REQUIRES_EXPR(_TY, ...) requires(__VA_ARGS__) _CCCL_REQUIRES_EXPR_2
 #    define _CCCL_REQUIRES_EXPR_2(...)    {_CCCL_PP_FOR_EACH(_CCCL_CONCEPT_FRAGMENT_REQS_M, __VA_ARGS__)}
 #  else

--- a/libcudacxx/include/cuda/std/__concepts/constructible.h
+++ b/libcudacxx/include/cuda/std/__concepts/constructible.h
@@ -28,7 +28,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.constructible]
 template <class _Tp, class... _Args>
@@ -52,7 +52,7 @@ concept copy_constructible =
   && constructible_from<_Tp, const _Tp&> && convertible_to<const _Tp&, _Tp> && constructible_from<_Tp, const _Tp>
   && convertible_to<const _Tp, _Tp>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Tp, class... _Args>
 _CCCL_CONCEPT_FRAGMENT(__constructible_from_,
@@ -96,7 +96,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Tp>
 _CCCL_CONCEPT copy_constructible = _CCCL_FRAGMENT(__copy_constructible_, _Tp);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/convertible_to.h
+++ b/libcudacxx/include/cuda/std/__concepts/convertible_to.h
@@ -28,12 +28,12 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // [concept.convertible]
 
-#if _CCCL_STD_VER >= 2020
+#if !defined(_CCCL_NO_CONCEPTS)
 
 template <class _From, class _To>
 concept convertible_to = is_convertible_v<_From, _To> && requires { static_cast<_To>(_CUDA_VSTD::declval<_From>()); };
 
-#elif _CCCL_STD_VER >= 2014 // ^^^ C++20 ^^^ / vvv C++14/17 vvv
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 #  if _CCCL_COMPILER(MSVC)
 _CCCL_NV_DIAG_SUPPRESS(1211) // nonstandard cast to array type ignored
@@ -60,7 +60,7 @@ _CCCL_NV_DIAG_DEFAULT(1211) // nonstandard cast to array type ignored
 #  endif // _CCCL_COMPILER(MSVC)
 _CCCL_NV_DIAG_DEFAULT(171) // invalid type conversion, e.g. [with _From=int **, _To=const int *const *]
 
-#endif // _CCCL_STD_VER >= 2014
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES ^^^
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/copyable.h
+++ b/libcudacxx/include/cuda/std/__concepts/copyable.h
@@ -27,7 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concepts.object]
 
@@ -35,7 +35,7 @@ template <class _Tp>
 concept copyable = copy_constructible<_Tp> && movable<_Tp> && assignable_from<_Tp&, _Tp&>
                 && assignable_from<_Tp&, const _Tp&> && assignable_from<_Tp&, const _Tp>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
@@ -49,7 +49,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Tp>
 _CCCL_CONCEPT copyable = _CCCL_FRAGMENT(__copyable_, _Tp);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/derived_from.h
+++ b/libcudacxx/include/cuda/std/__concepts/derived_from.h
@@ -27,14 +27,14 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.derived]
 
 template <class _Dp, class _Bp>
 concept derived_from = is_base_of_v<_Bp, _Dp> && is_convertible_v<const volatile _Dp*, const volatile _Bp*>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Dp, class _Bp>
 _CCCL_CONCEPT_FRAGMENT(
@@ -46,7 +46,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Dp, class _Bp>
 _CCCL_CONCEPT derived_from = _CCCL_FRAGMENT(__derived_from_, _Dp, _Bp);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/destructible.h
+++ b/libcudacxx/include/cuda/std/__concepts/destructible.h
@@ -30,7 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 
 #  if _CCCL_COMPILER(MSVC)
 
@@ -69,7 +69,7 @@ _CCCL_CONCEPT destructible = __destructible<_Tp>;
 
 #  endif // !_CCCL_COMPILER(MSVC)
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/different_from.h
+++ b/libcudacxx/include/cuda/std/__concepts/different_from.h
@@ -26,12 +26,12 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT __different_from = !same_as<remove_cvref_t<_Tp>, remove_cvref_t<_Up>>;
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/equality_comparable.h
+++ b/libcudacxx/include/cuda/std/__concepts/equality_comparable.h
@@ -28,7 +28,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.equalitycomparable]
 
@@ -51,7 +51,7 @@ concept equality_comparable_with =
   && equality_comparable<common_reference_t<__make_const_lvalue_ref<_Tp>, __make_const_lvalue_ref<_Up>>>
   && __weakly_equality_comparable_with<_Tp, _Up>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__with_lvalue_reference_, requires()(typename(__make_const_lvalue_ref<_Tp>)));
@@ -89,7 +89,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Tp, class _Up>
 _CCCL_CONCEPT equality_comparable_with = _CCCL_FRAGMENT(__equality_comparable_with_, _Tp, _Up);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/invocable.h
+++ b/libcudacxx/include/cuda/std/__concepts/invocable.h
@@ -27,7 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.invocable]
 
@@ -48,7 +48,7 @@ concept __invoke_constructible = requires(_Fun&& __fun, _Args&&... __args) {
     _CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fun>(__fun), _CUDA_VSTD::forward<_Args>(__args)...));
 };
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Fn, class... _Args>
 _CCCL_CONCEPT_FRAGMENT(_Invocable_,
@@ -69,7 +69,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Fun, class... _Args>
 _CCCL_CONCEPT __invoke_constructible = _CCCL_FRAGMENT(__invoke_constructible_, _Fun, _Args...);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/movable.h
+++ b/libcudacxx/include/cuda/std/__concepts/movable.h
@@ -28,12 +28,12 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 template <class _Tp>
 concept movable = is_object_v<_Tp> && move_constructible<_Tp> && assignable_from<_Tp&, _Tp> && swappable<_Tp>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [concepts.object]
 template <class _Tp>
@@ -47,7 +47,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Tp>
 _CCCL_CONCEPT movable = _CCCL_FRAGMENT(_Movable_, _Tp);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/predicate.h
+++ b/libcudacxx/include/cuda/std/__concepts/predicate.h
@@ -27,12 +27,12 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 template <class _Fn, class... _Args>
 concept predicate = regular_invocable<_Fn, _Args...> && __boolean_testable<invoke_result_t<_Fn, _Args...>>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [concept.predicate]
 template <class _Fn, class... _Args>
@@ -43,7 +43,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Fn, class... _Args>
 _CCCL_CONCEPT predicate = _CCCL_FRAGMENT(_Predicate_, _Fn, _Args...);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/regular.h
+++ b/libcudacxx/include/cuda/std/__concepts/regular.h
@@ -26,14 +26,14 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.object]
 
 template <class _Tp>
 concept regular = semiregular<_Tp> && equality_comparable<_Tp>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [concept.object]
 
@@ -43,7 +43,7 @@ _CCCL_CONCEPT_FRAGMENT(__regular_, requires()(requires(semiregular<_Tp>), requir
 template <class _Tp>
 _CCCL_CONCEPT regular = _CCCL_FRAGMENT(__regular_, _Tp);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/relation.h
+++ b/libcudacxx/include/cuda/std/__concepts/relation.h
@@ -25,7 +25,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.relation]
 
@@ -43,7 +43,7 @@ concept equivalence_relation = relation<_Rp, _Tp, _Up>;
 template <class _Rp, class _Tp, class _Up>
 concept strict_weak_order = relation<_Rp, _Tp, _Up>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Rp, class _Tp, class _Up>
 _CCCL_CONCEPT_FRAGMENT(
@@ -66,7 +66,7 @@ _CCCL_CONCEPT equivalence_relation = relation<_Rp, _Tp, _Up>;
 template <class _Rp, class _Tp, class _Up>
 _CCCL_CONCEPT strict_weak_order = relation<_Rp, _Tp, _Up>;
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/same_as.h
+++ b/libcudacxx/include/cuda/std/__concepts/same_as.h
@@ -25,7 +25,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 
 // [concept.same]
 
@@ -35,7 +35,7 @@ _CCCL_CONCEPT __same_as_impl = _IsSame<_Tp, _Up>::value;
 template <class _Tp, class _Up>
 _CCCL_CONCEPT same_as = __same_as_impl<_Tp, _Up> && __same_as_impl<_Up, _Tp>;
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/semiregular.h
+++ b/libcudacxx/include/cuda/std/__concepts/semiregular.h
@@ -26,14 +26,14 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.object]
 
 template <class _Tp>
 concept semiregular = copyable<_Tp> && default_initializable<_Tp>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [concept.object]
 
@@ -43,7 +43,7 @@ _CCCL_CONCEPT_FRAGMENT(__semiregular_, requires()(requires(copyable<_Tp>), requi
 template <class _Tp>
 _CCCL_CONCEPT semiregular = _CCCL_FRAGMENT(__semiregular_, _Tp);
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/swappable.h
+++ b/libcudacxx/include/cuda/std/__concepts/swappable.h
@@ -41,7 +41,7 @@
 _CCCL_NV_DIAG_SUPPRESS(461) // nonstandard cast to array type ignored
 #endif // _CCCL_COMPILER(MSVC)
 
-#if _CCCL_STD_VER > 2011
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
@@ -52,7 +52,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__swap)
 template <class _Tp>
 void swap(_Tp&, _Tp&) = delete;
 
-#  if _CCCL_STD_VER > 2017
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp, class _Up>
 concept __unqualified_swappable_with =
   (__class_or_enum<remove_cvref_t<_Tp>> || __class_or_enum<remove_cvref_t<_Up>>)
@@ -62,7 +62,7 @@ template <class _Tp>
 concept __exchangeable =
   !__unqualified_swappable_with<_Tp&, _Tp&> && move_constructible<_Tp> && assignable_from<_Tp&, _Tp>;
 
-#  else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT_FRAGMENT(
@@ -80,9 +80,9 @@ _CCCL_CONCEPT_FRAGMENT(__exchangeable_,
 
 template <class _Tp>
 _CCCL_CONCEPT __exchangeable = _CCCL_FRAGMENT(__exchangeable_, _Tp);
-#  endif // _CCCL_STD_VER < 2020
+#  endif // _CCCL_NO_CONCEPTS
 
-#  if _CCCL_STD_VER > 2017 && !_CCCL_COMPILER(NVHPC) // nvbug4051640
+#  if !defined(_CCCL_NO_CONCEPTS) && !_CCCL_COMPILER(NVHPC) // nvbug4051640
 struct __fn;
 
 _CCCL_NV_DIAG_SUPPRESS(2642)
@@ -92,10 +92,10 @@ concept __swappable_arrays =
   && requires(_Tp (&__t)[_Size], _Up (&__u)[_Size], const __fn& __swap) { __swap(__t[0], __u[0]); };
 _CCCL_NV_DIAG_DEFAULT(2642)
 
-#  else
+#  else // ^^^ !_CCCL_NO_CONCEPTS && !_CCCL_COMPILER(NVHPC) ^^^ / vvv _CCCL_NO_CONCEPTS || _CCCL_COMPILER(NVHPC) vvv
 template <class _Tp, class _Up, size_t _Size, class = void>
 _CCCL_INLINE_VAR constexpr bool __swappable_arrays = false;
-#  endif // _CCCL_STD_VER < 2020 || _CCCL_COMPILER(NVHPC)
+#  endif // _CCCL_NO_CONCEPTS || _CCCL_COMPILER(NVHPC)
 
 template <class _Tp, class _Up, class = void>
 _CCCL_INLINE_VAR constexpr bool __noexcept_swappable_arrays = false;
@@ -135,7 +135,7 @@ struct __fn
   }
 };
 
-#  if _CCCL_STD_VER < 2020 || _CCCL_COMPILER(NVHPC)
+#  if defined(_CCCL_NO_CONCEPTS) || _CCCL_COMPILER(NVHPC)
 template <class _Tp, class _Up, class _Size>
 _CCCL_CONCEPT_FRAGMENT(
   __swappable_arrays_,
@@ -147,7 +147,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Tp, class _Up, size_t _Size>
 _CCCL_INLINE_VAR constexpr bool __swappable_arrays<_Tp, _Up, _Size, void_t<type_identity_t<_Tp>>> =
   _CCCL_FRAGMENT(__swappable_arrays_, _Tp, _Up, _CUDA_VSTD::integral_constant<size_t, _Size>);
-#  endif // _CCCL_STD_VER < 2020 || _CCCL_COMPILER(NVHPC)
+#  endif // _CCCL_NO_CONCEPTS || _CCCL_COMPILER(NVHPC)
 
 template <class _Tp, class _Up>
 _CCCL_INLINE_VAR constexpr bool __noexcept_swappable_arrays<_Tp, _Up, void_t<type_identity_t<_Tp>>> =
@@ -163,7 +163,7 @@ _LIBCUDACXX_END_NAMESPACE_RANGES
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#  if _CCCL_STD_VER > 2017
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept swappable = requires(_Tp& __a, _Tp& __b) { _CUDA_VRANGES::swap(__a, __b); };
 
@@ -174,7 +174,7 @@ concept swappable_with = common_reference_with<_Tp, _Up> && requires(_Tp&& __t, 
   _CUDA_VRANGES::swap(_CUDA_VSTD::forward<_Tp>(__t), _CUDA_VSTD::forward<_Up>(__u));
   _CUDA_VRANGES::swap(_CUDA_VSTD::forward<_Up>(__u), _CUDA_VSTD::forward<_Tp>(__t));
 };
-#  else
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__swappable_, requires(_Tp& __a, _Tp& __b)((_CUDA_VRANGES::swap(__a, __b))));
 
@@ -193,11 +193,11 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT swappable_with = _CCCL_FRAGMENT(__swappable_with_, _Tp, _Up);
-#  endif
+#  endif // ^^^ _CCCL_NO_CONCEPTS ^^^
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 #if _CCCL_COMPILER(MSVC)
 _CCCL_NV_DIAG_DEFAULT(461) // nonstandard cast to array type ignored

--- a/libcudacxx/include/cuda/std/__concepts/totally_ordered.h
+++ b/libcudacxx/include/cuda/std/__concepts/totally_ordered.h
@@ -28,7 +28,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [concept.totallyordered]
 
@@ -53,7 +53,7 @@ concept totally_ordered_with =
   && totally_ordered<common_reference_t<__make_const_lvalue_ref<_Tp>, __make_const_lvalue_ref<_Up>>>
   && __partially_ordered_with<_Tp, _Up>;
 
-#elif _CCCL_STD_VER > 2011
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT_FRAGMENT(
@@ -91,7 +91,7 @@ template <class _Tp, class _Up>
 _CCCL_CONCEPT totally_ordered_with = _CCCL_FRAGMENT(__totally_ordered_with_, _Tp, _Up);
 ;
 
-#endif // _CCCL_STD_VER > 2011
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -53,7 +53,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [iterator.concept.readable]
 template <class _In>
@@ -254,7 +254,7 @@ concept indirectly_copyable_storable =
 // Note: indirectly_swappable is located in iter_swap.h to prevent a dependency cycle
 // (both iter_swap and indirectly_swappable require indirectly_readable).
 
-#elif _CCCL_STD_VER > 2014
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [iterator.concept.readable]
 template <class _In>
@@ -622,7 +622,7 @@ _CCCL_INLINE_VAR constexpr bool __has_iter_concept = false;
 template <class _Ip>
 _CCCL_INLINE_VAR constexpr bool __has_iter_concept<_Ip, void_t<typename _Ip::iterator_concept>> = true;
 
-#endif // _CCCL_STD_VER > 2014
+#endif // ^^^ _CCCL_NO_VARIABLE_TEMPLATES ^^^
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -254,7 +254,7 @@ concept indirectly_copyable_storable =
 // Note: indirectly_swappable is located in iter_swap.h to prevent a dependency cycle
 // (both iter_swap and indirectly_swappable require indirectly_readable).
 
-#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
+#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [iterator.concept.readable]
 template <class _In>
@@ -622,7 +622,7 @@ _CCCL_INLINE_VAR constexpr bool __has_iter_concept = false;
 template <class _Ip>
 _CCCL_INLINE_VAR constexpr bool __has_iter_concept<_Ip, void_t<typename _Ip::iterator_concept>> = true;
 
-#endif // ^^^ _CCCL_NO_VARIABLE_TEMPLATES ^^^
+#endif // _CCCL_STD_VER > 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
@@ -37,7 +37,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [incrementable.traits]
 template <class>
@@ -88,7 +88,7 @@ using iter_difference_t =
                          incrementable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::difference_type;
 
-#elif _CCCL_STD_VER > 2014
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [incrementable.traits]
 template <class, class = void>
@@ -150,7 +150,7 @@ using iter_difference_t =
                          incrementable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::difference_type;
 
-#endif // _CCCL_STD_VER > 2014
+#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES ^^^
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
@@ -88,7 +88,7 @@ using iter_difference_t =
                          incrementable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::difference_type;
 
-#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
+#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [incrementable.traits]
 template <class, class = void>
@@ -150,7 +150,7 @@ using iter_difference_t =
                          incrementable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::difference_type;
 
-#endif // ^^^ !_CCCL_NO_VARIABLE_TEMPLATES ^^^
+#endif // _CCCL_STD_VER > 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_move.h
@@ -124,14 +124,14 @@ _LIBCUDACXX_END_NAMESPACE_RANGES
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <__dereferenceable _Tp>
   requires requires(_Tp& __t) {
     { _CUDA_VRANGES::iter_move(__t) } -> __can_reference;
   }
 using iter_rvalue_reference_t = decltype(_CUDA_VRANGES::iter_move(_CUDA_VSTD::declval<_Tp&>()));
 
-#  else // ^^^ _CCCL_STD_VER >= 2020 ^^^ / vvv _CCCL_STD_VER <= 2017 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__can_iter_rvalue_reference_t_,
@@ -146,7 +146,7 @@ using __iter_rvalue_reference_t = decltype(_CUDA_VRANGES::iter_move(_CUDA_VSTD::
 
 template <class _Tp>
 using iter_rvalue_reference_t = enable_if_t<__can_iter_rvalue_reference_t<_Tp>, __iter_rvalue_reference_t<_Tp>>;
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_move.h
@@ -42,7 +42,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__iter_move)
 
 _CCCL_HOST_DEVICE void iter_move();
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __unqualified_iter_move =
   __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) { iter_move(_CUDA_VSTD::forward<_Tp>(__t)); };
@@ -59,7 +59,7 @@ concept __just_deref = !__unqualified_iter_move<_Tp> && !__move_deref<_Tp> && re
   requires(!is_lvalue_reference_v<decltype(*__t)>);
 };
 
-#  else // ^^^ _CCCL_STD_VER >= 2020 ^^^ / vvv _CCCL_STD_VER <= 2017 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
@@ -85,7 +85,7 @@ _CCCL_CONCEPT_FRAGMENT(__just_deref_,
 
 template <class _Tp>
 _CCCL_CONCEPT __just_deref = _CCCL_FRAGMENT(__just_deref_, _Tp);
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 // [iterator.cust.move]
 

--- a/libcudacxx/include/cuda/std/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_swap.h
@@ -39,7 +39,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__iter_swap)
 template <class _I1, class _I2>
 void iter_swap(_I1, _I2) = delete;
 
-#  if _CCCL_STD_VER > 2017
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _T1, class _T2>
 concept __unqualified_iter_swap =
   (__class_or_enum<remove_cvref_t<_T1>> || __class_or_enum<remove_cvref_t<_T2>>)
@@ -52,7 +52,7 @@ concept __readable_swappable = !__unqualified_iter_swap<_T1, _T2> && indirectly_
 template <class _T1, class _T2>
 concept __moveable_storable = !__unqualified_iter_swap<_T1, _T2> && !__readable_swappable<_T1, _T2>
                            && indirectly_movable_storable<_T1, _T2> && indirectly_movable_storable<_T2, _T1>;
-#  else
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _T1, class _T2>
 _CCCL_CONCEPT_FRAGMENT(
   __unqualified_iter_swap_,
@@ -83,7 +83,7 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _T1, class _T2>
 _CCCL_CONCEPT __moveable_storable = _CCCL_FRAGMENT(__moveable_storable_, _T1, _T2);
-#  endif // _CCCL_STD_VER > 2011
+#  endif // _CCCL_NO_CONCEPTS
 
 struct __fn
 {

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -67,7 +67,7 @@ struct __cccl_std_contiguous_iterator_tag_exists : __cccl_type_is_defined<struct
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER >= 2020
+#if !defined(_CCCL_NO_CONCEPTS)
 
 template <class _Tp>
 using __with_reference = _Tp&;
@@ -87,7 +87,7 @@ using iter_reference_t = decltype(*declval<_Tp&>());
 template <class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
 
-#elif _CCCL_STD_VER >= 2017
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 
 template <class _Tp>
 using __with_reference = _Tp&;
@@ -242,7 +242,7 @@ public:
   static const bool value = decltype(__test<_Tp>(nullptr))::value;
 };
 
-#if _CCCL_STD_VER >= 2020
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // The `cpp17-*-iterator` exposition-only concepts have very similar names to the `Cpp17*Iterator` named requirements
 // from `[iterator.cpp17]`. To avoid confusion between the two, the exposition-only concepts have been banished to
@@ -484,7 +484,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Ip>
   using __primary_template = iterator_traits;
 };
 
-#elif _CCCL_STD_VER >= 2017
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // The `cpp17-*-iterator` exposition-only concepts have very similar names to the `Cpp17*Iterator` named requirements
 // from `[iterator.cpp17]`. To avoid confusion between the two, the exposition-only concepts have been banished to
@@ -801,10 +801,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Iter, 
 {
   using __primary_template = iterator_traits;
 };
-#endif // _CCCL_STD_VER <= 2014
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 template <class _Tp>
-#if _CCCL_STD_VER >= 2020
+#if !defined(_CCCL_NO_CONCEPTS)
   requires is_object_v<_Tp>
 #endif
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits<_Tp*>

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -87,7 +87,7 @@ using iter_reference_t = decltype(*declval<_Tp&>());
 template <class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
 
-#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES)
+#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Tp>
 using __with_reference = _Tp&;
@@ -113,7 +113,7 @@ using iter_reference_t = enable_if_t<__dereferenceable<_Tp>, decltype(*_CUDA_VST
 
 template <class, class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
-#else // ^^^ _CCCL_STD_VER >= 2017 ^^^ / vvv _CCCL_STD_VER <= 2014 vvv
+#else // ^^^ _CCCL_STD_VER > 2014 ^^^ / vvv _CCCL_STD_VER <= 2014 vvv
 template <class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
 #endif // _CCCL_STD_VER <= 2014
@@ -484,7 +484,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Ip>
   using __primary_template = iterator_traits;
 };
 
-#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
+#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_STD_VER > 2014 vvv
 
 // The `cpp17-*-iterator` exposition-only concepts have very similar names to the `Cpp17*Iterator` named requirements
 // from `[iterator.cpp17]`. To avoid confusion between the two, the exposition-only concepts have been banished to
@@ -764,7 +764,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Ip>
   using __primary_template = iterator_traits;
 };
 
-#else // _CCCL_STD_VER >= 2014
+#else // ^^^ _CCCL_STD_VER > 2014 ^^^ / vvv _CCCL_STD_VER <= 2014 vvv
 
 template <class _Iter, bool>
 struct __iterator_traits
@@ -801,7 +801,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Iter, 
 {
   using __primary_template = iterator_traits;
 };
-#endif // !_CCCL_NO_VARIABLE_TEMPLATES
+#endif // _CCCL_STD_VER <= 2014
 
 template <class _Tp>
 #if !defined(_CCCL_NO_CONCEPTS)
@@ -814,7 +814,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits<_Tp*>
   typedef _Tp* pointer;
   typedef typename add_lvalue_reference<_Tp>::type reference;
   typedef random_access_iterator_tag iterator_category;
-#if _CCCL_STD_VER >= 2017
+#if _CCCL_STD_VER > 2014
   typedef contiguous_iterator_tag iterator_concept;
 #endif
 };
@@ -860,17 +860,17 @@ struct __is_cpp17_random_access_iterator
 // Such iterators receive special "contiguous" optimizations in
 // std::copy and std::sort.
 //
-#if _CCCL_STD_VER >= 2017
+#if _CCCL_STD_VER > 2014
 template <class _Tp>
 struct __is_cpp17_contiguous_iterator
     : _Or<__has_iterator_category_convertible_to<_Tp, contiguous_iterator_tag>,
           __has_iterator_concept_convertible_to<_Tp, contiguous_iterator_tag>>
 {};
-#else
+#else // ^^^ _CCCL_STD_VER > 2014 ^^^ / vvv _CCCL_STD_VER <= 2014 vvv
 template <class _Tp>
 struct __is_cpp17_contiguous_iterator : false_type
 {};
-#endif
+#endif // _CCCL_STD_VER <= 2014
 
 // Any native pointer which is an iterator is also a contiguous iterator.
 template <class _Up>

--- a/libcudacxx/include/cuda/std/__iterator/move_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/move_iterator.h
@@ -44,7 +44,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 template <class _Iter, class = void>
 struct __move_iter_category_base
 {};
@@ -67,7 +67,7 @@ concept __move_iter_comparable = requires {
 template <class _Iter>
 _CCCL_INLINE_VAR constexpr bool __noexcept_move_iter_iter_move =
   noexcept(_CUDA_VRANGES::iter_move(_CUDA_VSTD::declval<_Iter>()));
-#elif _CCCL_STD_VER >= 2017
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Iter, class = void>
 struct __move_iter_category_base
 {};
@@ -92,7 +92,7 @@ _CCCL_CONCEPT __move_iter_comparable = _CCCL_FRAGMENT(__move_iter_comparable_, _
 template <class _Iter>
 _CCCL_INLINE_VAR constexpr bool __noexcept_move_iter_iter_move =
   noexcept(_CUDA_VRANGES::iter_move(_CUDA_VSTD::declval<_Iter>()));
-#endif // _CCCL_STD_VER >= 2017
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 template <class _Iter>
 class _CCCL_TYPE_VISIBILITY_DEFAULT move_iterator
@@ -179,18 +179,18 @@ public:
   }
 
 #if _CCCL_STD_VER > 2014
-#  if _CCCL_STD_VER > 2017
+#  if !defined(_CCCL_NO_CONCEPTS)
   _LIBCUDACXX_HIDE_FROM_ABI constexpr move_iterator()
     requires is_constructible_v<_Iter>
       : __current_()
   {}
-#  else // ^^^ _CCCL_STD_VER > 2017 ^^^ / vvv _CCCL_STD_VER < 2020 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
   _CCCL_TEMPLATE(class _It2 = _Iter)
   _CCCL_REQUIRES(is_constructible_v<_It2>)
   _LIBCUDACXX_HIDE_FROM_ABI constexpr move_iterator()
       : __current_()
   {}
-#  endif // _CCCL_STD_VER < 2020
+#  endif // _CCCL_NO_CONCEPTS
 
   _CCCL_TEMPLATE(class _Up)
   _CCCL_REQUIRES((!_IsSame<_Up, _Iter>::value) && convertible_to<const _Up&, _Iter>)
@@ -460,7 +460,7 @@ operator-(const move_iterator<_Iter1>& __x, const move_iterator<_Iter2>& __y) ->
   return __x.base() - __y.base();
 }
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 template <class _Iter>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr move_iterator<_Iter>
 operator+(iter_difference_t<_Iter> __n, const move_iterator<_Iter>& __x)
@@ -470,14 +470,14 @@ operator+(iter_difference_t<_Iter> __n, const move_iterator<_Iter>& __x)
 {
   return __x + __n;
 }
-#else // ^^^ _CCCL_STD_VER > 2017 ^^^ / vvv _CCCL_STD_VER < 2020 vvv
+#else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Iter>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 move_iterator<_Iter>
 operator+(typename move_iterator<_Iter>::difference_type __n, const move_iterator<_Iter>& __x)
 {
   return move_iterator<_Iter>(__x.base() + __n);
 }
-#endif // _CCCL_STD_VER < 2020
+#endif // _CCCL_NO_CONCEPTS
 
 template <class _Iter>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 move_iterator<_Iter> make_move_iterator(_Iter __i)

--- a/libcudacxx/include/cuda/std/__iterator/move_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/move_iterator.h
@@ -67,7 +67,7 @@ concept __move_iter_comparable = requires {
 template <class _Iter>
 _CCCL_INLINE_VAR constexpr bool __noexcept_move_iter_iter_move =
   noexcept(_CUDA_VRANGES::iter_move(_CUDA_VSTD::declval<_Iter>()));
-#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES)
+#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_STD_VER > 2014 vvv
 template <class _Iter, class = void>
 struct __move_iter_category_base
 {};
@@ -92,7 +92,7 @@ _CCCL_CONCEPT __move_iter_comparable = _CCCL_FRAGMENT(__move_iter_comparable_, _
 template <class _Iter>
 _CCCL_INLINE_VAR constexpr bool __noexcept_move_iter_iter_move =
   noexcept(_CUDA_VRANGES::iter_move(_CUDA_VSTD::declval<_Iter>()));
-#endif // !_CCCL_NO_VARIABLE_TEMPLATES
+#endif // _CCCL_STD_VER > 2014
 
 template <class _Iter>
 class _CCCL_TYPE_VISIBILITY_DEFAULT move_iterator

--- a/libcudacxx/include/cuda/std/__iterator/readable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/readable_traits.h
@@ -36,7 +36,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 
 // [readable.traits]
 template <class>
@@ -106,7 +106,7 @@ using iter_value_t =
                          indirectly_readable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::value_type;
 
-#elif _CCCL_STD_VER > 2014
+#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [readable.traits]
 template <class, class = void>
@@ -183,7 +183,7 @@ using iter_value_t =
                          indirectly_readable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::value_type;
 
-#endif // _CCCL_STD_VER > 2014
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/readable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/readable_traits.h
@@ -106,7 +106,7 @@ using iter_value_t =
                          indirectly_readable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::value_type;
 
-#elif !defined(_CCCL_NO_VARIABLE_TEMPLATES) // ^^^ !_CCCL_NO_CONCEPTS ^^^
+#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [readable.traits]
 template <class, class = void>
@@ -183,7 +183,7 @@ using iter_value_t =
                          indirectly_readable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::value_type;
 
-#endif // !_CCCL_NO_VARIABLE_TEMPLATES
+#endif // _CCCL_STD_VER > 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
@@ -175,7 +175,7 @@ public:
     return *--__tmp;
   }
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS) && !defined(_CCCL_NO_IF_CONSTEXPR)
   _LIBCUDACXX_HIDE_FROM_ABI constexpr pointer operator->() const
     requires is_pointer_v<_Iter> || requires(const _Iter __i) { __i.operator->(); }
   {
@@ -285,11 +285,11 @@ struct __is_reverse_iterator<reverse_iterator<_Iter>> : true_type
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool
 operator==(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
   requires requires {
     { __x.base() == __y.base() } -> convertible_to<bool>;
   }
-#endif // _CCCL_STD_VER > 2017
+#endif // !_CCCL_NO_CONCEPTS
 {
   return __x.base() == __y.base();
 }
@@ -297,11 +297,11 @@ operator==(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& 
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool
 operator<(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
   requires requires {
     { __x.base() > __y.base() } -> convertible_to<bool>;
   }
-#endif // _CCCL_STD_VER > 2017
+#endif // !_CCCL_NO_CONCEPTS
 {
   return __x.base() > __y.base();
 }
@@ -309,11 +309,11 @@ operator<(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& _
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool
 operator!=(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
   requires requires {
     { __x.base() != __y.base() } -> convertible_to<bool>;
   }
-#endif // _CCCL_STD_VER > 2017
+#endif // !_CCCL_NO_CONCEPTS
 {
   return __x.base() != __y.base();
 }
@@ -321,11 +321,11 @@ operator!=(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& 
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool
 operator>(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
   requires requires {
     { __x.base() < __y.base() } -> convertible_to<bool>;
   }
-#endif // _CCCL_STD_VER > 2017
+#endif // !_CCCL_NO_CONCEPTS
 {
   return __x.base() < __y.base();
 }
@@ -333,11 +333,11 @@ operator>(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& _
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool
 operator>=(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
   requires requires {
     { __x.base() <= __y.base() } -> convertible_to<bool>;
   }
-#endif // _CCCL_STD_VER > 2017
+#endif // !_CCCL_NO_CONCEPTS
 {
   return __x.base() <= __y.base();
 }
@@ -345,11 +345,11 @@ operator>=(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& 
 template <class _Iter1, class _Iter2>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 bool
 operator<=(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
   requires requires {
     { __x.base() >= __y.base() } -> convertible_to<bool>;
   }
-#endif // _CCCL_STD_VER > 2017
+#endif // !_CCCL_NO_CONCEPTS
 {
   return __x.base() >= __y.base();
 }
@@ -377,11 +377,11 @@ operator+(typename reverse_iterator<_Iter>::difference_type __n, const reverse_i
   return reverse_iterator<_Iter>(__x.base() - __n);
 }
 
-#if _CCCL_STD_VER > 2017
+#if !defined(_CCCL_NO_CONCEPTS)
 template <class _Iter1, class _Iter2>
   requires(!sized_sentinel_for<_Iter1, _Iter2>)
 inline constexpr bool disable_sized_sentinel_for<reverse_iterator<_Iter1>, reverse_iterator<_Iter2>> = true;
-#endif // _CCCL_STD_VER > 2017
+#endif // !_CCCL_NO_CONCEPTS
 
 #if _CCCL_STD_VER > 2011
 template <class _Iter>

--- a/libcudacxx/include/cuda/std/__ranges/access.h
+++ b/libcudacxx/include/cuda/std/__ranges/access.h
@@ -46,7 +46,7 @@ void begin(_Tp&) = delete;
 template <class _Tp>
 void begin(const _Tp&) = delete;
 
-#  if _CCCL_STD_VER > 2017
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __member_begin = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
   { _LIBCUDACXX_AUTO_CAST(__t.begin()) } -> input_or_output_iterator;
@@ -57,7 +57,7 @@ concept __unqualified_begin =
   !__member_begin<_Tp> && __can_borrow<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
     { _LIBCUDACXX_AUTO_CAST(begin(__t)) } -> input_or_output_iterator;
   };
-#  else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
   __member_begin_,
@@ -78,7 +78,7 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _Tp>
 _CCCL_CONCEPT __unqualified_begin = _CCCL_FRAGMENT(__unqualified_begin_, _Tp);
-#  endif // _CCCL_STD_VER < 2020
+#  endif // _CCCL_NO_CONCEPTS
 
 struct __fn
 {
@@ -141,7 +141,7 @@ void end(_Tp&) = delete;
 template <class _Tp>
 void end(const _Tp&) = delete;
 
-#  if _CCCL_STD_VER > 2017
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __member_end = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
   typename iterator_t<_Tp>;
@@ -154,7 +154,7 @@ concept __unqualified_end =
     typename iterator_t<_Tp>;
     { _LIBCUDACXX_AUTO_CAST(end(__t)) } -> sentinel_for<iterator_t<_Tp>>;
   };
-#  else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
   __member_end_,
@@ -177,7 +177,7 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _Tp>
 _CCCL_CONCEPT __unqualified_end = _CCCL_FRAGMENT(__unqualified_end_, _Tp);
-#  endif // _CCCL_STD_VER < 2020
+#  endif // _CCCL_NO_CONCEPTS
 
 struct __fn
 {

--- a/libcudacxx/include/cuda/std/__ranges/concepts.h
+++ b/libcudacxx/include/cuda/std/__ranges/concepts.h
@@ -46,7 +46,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
 #if _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 
 // [range.range]
 
@@ -138,7 +138,8 @@ concept viewable_range =
       || (!view<remove_cvref_t<_Tp>>
           && (is_lvalue_reference_v<_Tp>
               || (movable<remove_reference_t<_Tp>> && !__is_std_initializer_list<remove_cvref_t<_Tp>>) )));
-#  else // ^^^ C++20 ^^^ / vvv C++17 vvv
+
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 // [range.range]
 
 template <class _Tp>
@@ -285,13 +286,13 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Tp>
 _CCCL_CONCEPT viewable_range = _CCCL_FRAGMENT(__viewable_range_, _Tp);
 
-#  endif // _CCCL_STD_VER >= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 //[container.intro.reqmts]
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Range, class _Tp>
 concept __container_compatible_range = input_range<_Range> && convertible_to<range_reference_t<_Range>, _Tp>;
-#  else // ^^^ C++20 ^^^ / vvv C++17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Range, class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
   __container_compatible_range_,
@@ -299,7 +300,7 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _Range, class _Tp>
 _CCCL_CONCEPT __container_compatible_range = _CCCL_FRAGMENT(__container_compatible_range_, _Range, _Tp);
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 #endif // _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
 

--- a/libcudacxx/include/cuda/std/__ranges/data.h
+++ b/libcudacxx/include/cuda/std/__ranges/data.h
@@ -43,7 +43,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__data)
 template <class _Tp>
 _CCCL_CONCEPT __ptr_to_object = is_pointer_v<_Tp> && is_object_v<remove_pointer_t<_Tp>>;
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __member_data = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
   { _LIBCUDACXX_AUTO_CAST(__t.data()) } -> __ptr_to_object;
@@ -53,7 +53,7 @@ template <class _Tp>
 concept __ranges_begin_invocable = !__member_data<_Tp> && __can_borrow<_Tp> && requires(_Tp&& __t) {
   { _CUDA_VRANGES::begin(__t) } -> contiguous_iterator;
 };
-#  else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__member_data_,
                        requires(_Tp&& __t)(requires(__can_borrow<_Tp>),
@@ -71,7 +71,7 @@ _CCCL_CONCEPT_FRAGMENT(__ranges_begin_invocable_,
 
 template <class _Tp>
 _CCCL_CONCEPT __ranges_begin_invocable = _CCCL_FRAGMENT(__ranges_begin_invocable_, _Tp);
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 struct __fn
 {

--- a/libcudacxx/include/cuda/std/__ranges/empty.h
+++ b/libcudacxx/include/cuda/std/__ranges/empty.h
@@ -33,7 +33,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__empty)
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __member_empty = __workaround_52970<_Tp> && requires(_Tp&& __t) { bool(__t.empty()); };
 
@@ -45,7 +45,7 @@ concept __can_compare_begin_end = !__member_empty<_Tp> && !__can_invoke_size<_Tp
   bool(_CUDA_VRANGES::begin(__t) == _CUDA_VRANGES::end(__t));
   { _CUDA_VRANGES::begin(__t) } -> forward_iterator;
 };
-#  else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__member_empty_, requires(_Tp&& __t)(requires(__workaround_52970<_Tp>), (bool(__t.empty()))));
 
@@ -69,7 +69,7 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _Tp>
 _CCCL_CONCEPT __can_compare_begin_end = _CCCL_FRAGMENT(__can_compare_begin_end_, _Tp);
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 struct __fn
 {

--- a/libcudacxx/include/cuda/std/__ranges/enable_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/enable_view.h
@@ -56,14 +56,14 @@ _CCCL_TEMPLATE(class _Op, class _Yp)
 _CCCL_REQUIRES(is_convertible_v<_Op*, view_interface<_Yp>*>)
 _LIBCUDACXX_HIDE_FROM_ABI void __is_derived_from_view_interface(const _Op*, const view_interface<_Yp>*);
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool enable_view = derived_from<_Tp, view_base> || requires {
   _CUDA_VRANGES::__is_derived_from_view_interface((_Tp*) nullptr, (_Tp*) nullptr);
 };
 
-#  else // ^^^ _CCCL_STD_VER >= 2020 ^^^ / vvv _CCCL_STD_VER <= 2017 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 
 template <class _Tp, class = void>
 _CCCL_INLINE_VAR constexpr bool enable_view = derived_from<_Tp, view_base>;
@@ -72,7 +72,7 @@ template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool
   enable_view<_Tp, void_t<decltype(_CUDA_VRANGES::__is_derived_from_view_interface((_Tp*) nullptr, (_Tp*) nullptr))>> =
     true;
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 #endif // _CCCL_STD_VER >= 2017
 

--- a/libcudacxx/include/cuda/std/__ranges/rbegin.h
+++ b/libcudacxx/include/cuda/std/__ranges/rbegin.h
@@ -43,7 +43,7 @@ void rbegin(_Tp&) = delete;
 template <class _Tp>
 void rbegin(const _Tp&) = delete;
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __member_rbegin = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
   { _LIBCUDACXX_AUTO_CAST(__t.rbegin()) } -> input_or_output_iterator;
@@ -61,7 +61,7 @@ concept __can_reverse =
     { _CUDA_VRANGES::begin(__t) } -> same_as<decltype(_CUDA_VRANGES::end(__t))>;
     { _CUDA_VRANGES::begin(__t) } -> bidirectional_iterator;
   };
-#  else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
   __member_rbegin_,
@@ -94,7 +94,7 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _Tp>
 _CCCL_CONCEPT __can_reverse = _CCCL_FRAGMENT(__can_reverse_, _Tp);
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 struct __fn
 {

--- a/libcudacxx/include/cuda/std/__ranges/rend.h
+++ b/libcudacxx/include/cuda/std/__ranges/rend.h
@@ -44,7 +44,7 @@ void rend(_Tp&) = delete;
 template <class _Tp>
 void rend(const _Tp&) = delete;
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __member_rend = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
   _CUDA_VRANGES::rbegin(__t);
@@ -63,7 +63,7 @@ concept __can_reverse = __can_borrow<_Tp> && !__member_rend<_Tp> && !__unqualifi
   { _CUDA_VRANGES::begin(__t) } -> same_as<decltype(_CUDA_VRANGES::end(__t))>;
   { _CUDA_VRANGES::begin(__t) } -> bidirectional_iterator;
 };
-#  else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
   __member_rend_,
@@ -100,7 +100,7 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _Tp>
 _CCCL_CONCEPT __can_reverse = _CCCL_FRAGMENT(__can_reverse_, _Tp);
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 class __fn
 {

--- a/libcudacxx/include/cuda/std/__ranges/size.h
+++ b/libcudacxx/include/cuda/std/__ranges/size.h
@@ -52,7 +52,7 @@ void size(const _Tp&) = delete;
 template <class _Tp>
 _CCCL_CONCEPT __size_enabled = !disable_sized_range<remove_cvref_t<_Tp>>;
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __member_size = __size_enabled<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
   { _LIBCUDACXX_AUTO_CAST(__t.size()) } -> __integer_like;
@@ -70,7 +70,7 @@ concept __difference =
     { _CUDA_VRANGES::begin(__t) } -> forward_iterator;
     { _CUDA_VRANGES::end(__t) } -> sized_sentinel_for<decltype(_CUDA_VRANGES::begin(_CUDA_VSTD::declval<_Tp>()))>;
   };
-#  else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__member_size_,
                        requires(_Tp&& __t)(requires(__size_enabled<_Tp>),
@@ -103,7 +103,7 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _Tp>
 _CCCL_CONCEPT __difference = _CCCL_FRAGMENT(__difference_, _Tp);
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
 struct __fn
 {
@@ -162,10 +162,10 @@ _CCCL_GLOBAL_CONSTANT auto size = __size::__fn{};
 // [range.prim.ssize]
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__ssize)
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __can_ssize = requires(_Tp&& __t) { _CUDA_VRANGES::size(__t); };
-#  else // ^^^ CXX20 ^^^ / vvv CXX17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__can_ssize_,
                        requires(_Tp&& __t)(requires(!is_unbounded_array_v<_Tp>), ((void) _CUDA_VRANGES::size(__t))));

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -60,7 +60,7 @@ _CCCL_DIAG_SUPPRESS_MSVC(4848)
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES_ABI
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _From, class _To>
 concept __uses_nonqualification_pointer_conversion =
   is_pointer_v<_From> && is_pointer_v<_To>
@@ -106,7 +106,7 @@ template <class _Iter, class _Sent, subrange_kind _Kind, class _Pair>
 concept __subrange_to_pair = __different_from<_Pair, subrange<_Iter, _Sent, _Kind>>
                           && __pair_like_convertible_from<_Pair, const _Iter&, const _Sent&>;
 
-#  else // ^^^ C++20 ^^^ / vvv C++17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 
 template <class _From, class _To>
 _CCCL_CONCEPT_FRAGMENT(
@@ -211,19 +211,19 @@ _CCCL_CONCEPT_FRAGMENT(__subrange_to_pair_,
 template <class _Iter, class _Sent, subrange_kind _Kind, class _Pair>
 _CCCL_CONCEPT __subrange_to_pair =
   _CCCL_FRAGMENT(__subrange_to_pair_, _Iter, _Sent, integral_constant<subrange_kind, _Kind>, _Pair);
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent, subrange_kind _Kind>
   requires(_Kind == subrange_kind::sized || !sized_sentinel_for<_Sent, _Iter>)
-#  else // ^^^ C++20 ^^^ / vvv C++17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Iter,
           class _Sent,
           subrange_kind _Kind,
           enable_if_t<input_or_output_iterator<_Iter>, int>,
           enable_if_t<sentinel_for<_Sent, _Iter>, int>,
           enable_if_t<(_Kind == subrange_kind::sized || !sized_sentinel_for<_Sent, _Iter>), int>>
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 class _CCCL_TYPE_VISIBILITY_DEFAULT subrange : public view_interface<subrange<_Iter, _Sent, _Kind>>
 {
 public:
@@ -243,15 +243,15 @@ private:
   _CCCL_NO_UNIQUE_ADDRESS _Size __size_  = 0;
 
 public:
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
   subrange()
     requires default_initializable<_Iter>
   = default;
-#  else // ^^^ C++20 ^^^ / vvv C++17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
   template <class _It = _Iter, enable_if_t<default_initializable<_It>, int> = 0>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr subrange() noexcept(is_nothrow_default_constructible_v<_It>)
       : view_interface<subrange<_Iter, _Sent, _Kind>>(){};
-#  endif // _CCCL_STD_VER <= 2017
+#  endif // _CCCL_NO_CONCEPTS
 
   _CCCL_TEMPLATE(class _It)
   _CCCL_REQUIRES(__subrange_from_iter_sent<_Iter, _It, _StoreSize>)

--- a/libcudacxx/include/cuda/std/__ranges/view_interface.h
+++ b/libcudacxx/include/cuda/std/__ranges/view_interface.h
@@ -39,25 +39,25 @@ _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
 #if _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Tp>
 concept __can_empty = requires(_Tp& __t) { _CUDA_VRANGES::empty(__t); };
-#  else // ^^^ C++20 ^^^ / vvv C++17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__can_empty_, requires(_Tp& __t)(typename(decltype(_CUDA_VRANGES::empty(__t)))));
 
 template <class _Tp>
 _CCCL_CONCEPT __can_empty = _CCCL_FRAGMENT(__can_empty_, _Tp);
-#  endif //  _CCCL_STD_VER <= 2017
+#  endif //  _CCCL_NO_CONCEPTS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES_ABI
 
-#  if _CCCL_STD_VER >= 2020
+#  if !defined(_CCCL_NO_CONCEPTS)
 template <class _Derived>
   requires is_class_v<_Derived> && same_as<_Derived, remove_cv_t<_Derived>>
-#  else // ^^^ C++20 ^^^ / vvv C++17 vvv
+#  else // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_NO_CONCEPTS vvv
 template <class _Derived, enable_if_t<is_class_v<_Derived> && same_as<_Derived, remove_cv_t<_Derived>>, int>>
-#  endif //  _CCCL_STD_VER <= 2017
+#  endif //  _CCCL_NO_CONCEPTS
 class view_interface
 {
   _LIBCUDACXX_HIDE_FROM_ABI constexpr _Derived& __derived() noexcept


### PR DESCRIPTION
## Description

direct feature testing in multiple headers has the potential to be inconsistent and error-prone; e.g., is the right value of `__cpp_some_feature` `123456L` or `654321L`?. we should prefer instead to feature-test in `cuda/std/__cccl/dialect.h` and define a `_CCCL_NO_SOME_FEATURE` macro so it can be used consistently everywhere. It also makes the code easier to read.

This pr adds a `_CCCL_NO_CONCEPTS` macro for detecting the absence of C++20 Concepts support.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
