### PR TITLE
Drop some of the mdspan fold implementation

### DIFF
--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -61,6 +61,7 @@
 #include <cuda/std/__mdspan/standard_layout_static_array.h>
 #include <cuda/std/__mdspan/static_array.h>
 #include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/fold.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
@@ -111,8 +112,7 @@ struct __compare_extent_compatible
 
 template <size_t... _Extents, size_t... _OtherExtents>
 static integral_constant<bool,
-                         __MDSPAN_FOLD_AND((__compare_extent_compatible<_Extents, _OtherExtents>::value) /* && ... */
-                                           )> _CCCL_HOST_DEVICE
+                         __fold_and_v<(__compare_extent_compatible<_Extents, _OtherExtents>::value)...>> _CCCL_HOST_DEVICE
 __check_compatible_extents(true_type,
                            _CUDA_VSTD::integer_sequence<size_t, _Extents...>,
                            _CUDA_VSTD::integer_sequence<size_t, _OtherExtents...>) noexcept
@@ -285,18 +285,16 @@ public:
   _CCCL_REQUIRES(
     // TODO: check whether the other version works with newest NVCC, doesn't with 11.4
     // NVCC seems to pick up rank_dynamic from the wrong extents type???
-    __MDSPAN_FOLD_AND(_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Integral, index_type) /* && ... */)
-      _CCCL_AND __MDSPAN_FOLD_AND(_CCCL_TRAIT(_CUDA_VSTD::is_nothrow_constructible, index_type, _Integral) /* && ... */)
-        _CCCL_AND
+    __fold_and_v<_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Integral, index_type)...> _CCCL_AND
+      __fold_and_v<_CCCL_TRAIT(_CUDA_VSTD::is_nothrow_constructible, index_type, _Integral)...> _CCCL_AND
     // NVCC chokes on the fold thingy here so wrote the workaround
     ((sizeof...(_Integral) == __detail::__count_dynamic_extents<_Extents...>::val)
      || (sizeof...(_Integral) == sizeof...(_Extents))))
 #  else
   _CCCL_TEMPLATE(class... _Integral)
-  _CCCL_REQUIRES(
-    __MDSPAN_FOLD_AND(_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Integral, index_type) /* && ... */)
-      _CCCL_AND __MDSPAN_FOLD_AND(_CCCL_TRAIT(_CUDA_VSTD::is_nothrow_constructible, index_type, _Integral) /* && ... */)
-        _CCCL_AND((sizeof...(_Integral) == rank_dynamic()) || (sizeof...(_Integral) == rank())))
+  _CCCL_REQUIRES(__fold_and_v<_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Integral, index_type)...> _CCCL_AND
+                   __fold_and_v<_CCCL_TRAIT(_CUDA_VSTD::is_nothrow_constructible, index_type, _Integral)...> _CCCL_AND(
+                     (sizeof...(_Integral) == rank_dynamic()) || (sizeof...(_Integral) == rank())))
 #  endif
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr extents(_Integral... __exts) noexcept
 #  ifndef _CCCL_HAS_NO_ATTRIBUTE_NO_UNIQUE_ADDRESS
@@ -318,8 +316,8 @@ public:
 #  endif
   {
     /* TODO: precondition check
-     * If sizeof...(_IndexTypes) != rank_dynamic() is true, exts_arr[r] equals Er for each r for which Er is a static
-     * extent, and either
+     * If sizeof...(_IndexTypes) != rank_dynamic() is true, exts_arr[r] equals Er for each r for which Er is a
+     * static extent, and either
      *   - sizeof...(__exts) == 0 is true, or
      *   - each element of __exts is nonnegative and is a representable value of type index_type.
      */

--- a/libcudacxx/include/cuda/std/__mdspan/layout_left.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_left.h
@@ -57,6 +57,7 @@
 #include <cuda/std/__mdspan/extents.h>
 #include <cuda/std/__mdspan/layout_stride.h>
 #include <cuda/std/__mdspan/macros.h>
+#include <cuda/std/__type_traits/fold.h>
 #include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
@@ -187,9 +188,9 @@ public:
   //--------------------------------------------------------------------------------
 
   _CCCL_TEMPLATE(class... _Indices)
-  _CCCL_REQUIRES((sizeof...(_Indices) == extents_type::rank()) _CCCL_AND __MDSPAN_FOLD_AND(
-    (_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Indices, index_type)
-     && _CCCL_TRAIT(_CUDA_VSTD::is_nothrow_constructible, index_type, _Indices))))
+  _CCCL_REQUIRES((sizeof...(_Indices) == extents_type::rank())
+                   _CCCL_AND __fold_and_v<_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Indices, index_type)...> //
+                     _CCCL_AND __fold_and_v<_CCCL_TRAIT(_CUDA_VSTD::is_nothrow_constructible, index_type, _Indices)...>)
   _CCCL_HOST_DEVICE constexpr index_type operator()(_Indices... __idxs) const noexcept
   {
     // Immediately cast incoming indices to `index_type`

--- a/libcudacxx/include/cuda/std/__mdspan/layout_right.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_right.h
@@ -57,6 +57,7 @@
 #include <cuda/std/__mdspan/extents.h>
 #include <cuda/std/__mdspan/layout_stride.h>
 #include <cuda/std/__mdspan/macros.h>
+#include <cuda/std/__type_traits/fold.h>
 #include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
@@ -192,9 +193,9 @@ public:
   //--------------------------------------------------------------------------------
 
   _CCCL_TEMPLATE(class... _Indices)
-  _CCCL_REQUIRES((sizeof...(_Indices) == extents_type::rank()) _CCCL_AND __MDSPAN_FOLD_AND(
-    (_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Indices, index_type)
-     && _CCCL_TRAIT(_CUDA_VSTD::is_nothrow_constructible, index_type, _Indices))))
+  _CCCL_REQUIRES((sizeof...(_Indices) == extents_type::rank())
+                   _CCCL_AND __fold_and_v<_CCCL_TRAIT(_CUDA_VSTD::is_convertible, _Indices, index_type)...> //
+                     _CCCL_AND __fold_and_v<_CCCL_TRAIT(_CUDA_VSTD::is_nothrow_constructible, index_type, _Indices)...>)
   _CCCL_HOST_DEVICE constexpr index_type operator()(_Indices... __idxs) const noexcept
   {
     return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(__idxs)...);

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -61,6 +61,7 @@
 #  include <cuda/std/__mdspan/no_unique_address.h>
 #endif // _CCCL_HAS_NO_ATTRIBUTE_NO_UNIQUE_ADDRESS
 #include <cuda/std/__mdspan/static_array.h>
+#include <cuda/std/__type_traits/fold.h>
 #include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
@@ -425,10 +426,9 @@ struct layout_stride
     }
 
     _CCCL_TEMPLATE(class... _Indices)
-    _CCCL_REQUIRES(
-      (sizeof...(_Indices) == _Extents::rank())
-        _CCCL_AND __MDSPAN_FOLD_AND(_CCCL_TRAIT(is_convertible, _Indices, index_type) /*&& ...*/)
-          _CCCL_AND __MDSPAN_FOLD_AND(_CCCL_TRAIT(is_nothrow_constructible, index_type, _Indices) /*&& ...*/))
+    _CCCL_REQUIRES((sizeof...(_Indices) == _Extents::rank())
+                     _CCCL_AND __fold_and_v<_CCCL_TRAIT(is_convertible, _Indices, index_type)...> //
+                       _CCCL_AND __fold_and_v<_CCCL_TRAIT(is_nothrow_constructible, index_type, _Indices)...>)
     __MDSPAN_FORCE_INLINE_FUNCTION
     constexpr index_type operator()(_Indices... __idxs) const noexcept
     {

--- a/libcudacxx/include/cuda/std/__mdspan/macros.h
+++ b/libcudacxx/include/cuda/std/__mdspan/macros.h
@@ -276,9 +276,6 @@
 //==============================================================================
 // <editor-fold desc="fold expressions"> {{{1
 
-struct __mdspan_enable_fold_comma
-{};
-
 #  ifdef __MDSPAN_USE_FOLD_EXPRESSIONS
 #    define __MDSPAN_FOLD_AND(...)                 ((__VA_ARGS__) && ...)
 #    define __MDSPAN_FOLD_OR(...)                  ((__VA_ARGS__) || ...)

--- a/libcudacxx/include/cuda/std/__mdspan/macros.h
+++ b/libcudacxx/include/cuda/std/__mdspan/macros.h
@@ -280,14 +280,11 @@ struct __mdspan_enable_fold_comma
 {};
 
 #  ifdef __MDSPAN_USE_FOLD_EXPRESSIONS
-#    define __MDSPAN_FOLD_AND(...)                  ((__VA_ARGS__) && ...)
-#    define __MDSPAN_FOLD_AND_TEMPLATE(...)         ((__VA_ARGS__) && ...)
-#    define __MDSPAN_FOLD_OR(...)                   ((__VA_ARGS__) || ...)
-#    define __MDSPAN_FOLD_ASSIGN_LEFT(__INIT, ...)  (__INIT = ... = (__VA_ARGS__))
-#    define __MDSPAN_FOLD_ASSIGN_RIGHT(__PACK, ...) (__PACK = ... = (__VA_ARGS__))
-#    define __MDSPAN_FOLD_TIMES_RIGHT(__PACK, ...)  (__PACK * ... * (__VA_ARGS__))
-#    define __MDSPAN_FOLD_PLUS_RIGHT(__PACK, ...)   (__PACK + ... + (__VA_ARGS__))
-#    define __MDSPAN_FOLD_COMMA(...)                ((__VA_ARGS__), ...)
+#    define __MDSPAN_FOLD_AND(...)                 ((__VA_ARGS__) && ...)
+#    define __MDSPAN_FOLD_OR(...)                  ((__VA_ARGS__) || ...)
+#    define __MDSPAN_FOLD_ASSIGN_LEFT(__INIT, ...) (__INIT = ... = (__VA_ARGS__))
+#    define __MDSPAN_FOLD_TIMES_RIGHT(__PACK, ...) (__PACK * ... * (__VA_ARGS__))
+#    define __MDSPAN_FOLD_PLUS_RIGHT(__PACK, ...)  (__PACK + ... + (__VA_ARGS__))
 #  else
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
@@ -601,12 +598,6 @@ __fold_left_assign_impl(_Args&&... __args)
 
 #    endif
 
-template <class... _Args>
-_CCCL_HOST_DEVICE constexpr __mdspan_enable_fold_comma __fold_comma_impl(_Args&&...) noexcept
-{
-  return {};
-}
-
 template <bool... _Bs>
 struct __bools;
 
@@ -618,18 +609,10 @@ _LIBCUDACXX_END_NAMESPACE_STD
 #    define __MDSPAN_FOLD_OR(...)  _CUDA_VSTD::__fold_compatibility_impl::__fold_right_or_impl((__VA_ARGS__)...)
 #    define __MDSPAN_FOLD_ASSIGN_LEFT(__INIT, ...) \
       _CUDA_VSTD::__fold_compatibility_impl::__fold_left_assign_impl(__INIT, (__VA_ARGS__)...)
-#    define __MDSPAN_FOLD_ASSIGN_RIGHT(__PACK, ...) \
-      _CUDA_VSTD::__fold_compatibility_impl::__fold_right_assign_impl((__PACK)..., __VA_ARGS__)
 #    define __MDSPAN_FOLD_TIMES_RIGHT(__PACK, ...) \
       _CUDA_VSTD::__fold_compatibility_impl::__fold_right_times_impl((__PACK)..., __VA_ARGS__)
 #    define __MDSPAN_FOLD_PLUS_RIGHT(__PACK, ...) \
       _CUDA_VSTD::__fold_compatibility_impl::__fold_right_plus_impl((__PACK)..., __VA_ARGS__)
-#    define __MDSPAN_FOLD_COMMA(...) _CUDA_VSTD::__fold_compatibility_impl::__fold_comma_impl((__VA_ARGS__)...)
-
-#    define __MDSPAN_FOLD_AND_TEMPLATE(...)                                   \
-      _CCCL_TRAIT(_CUDA_VSTD::is_same,                                        \
-                  __fold_compatibility_impl::__bools<(__VA_ARGS__)..., true>, \
-                  __fold_compatibility_impl::__bools<true, (__VA_ARGS__)...>)
 
 #  endif
 

--- a/libcudacxx/include/cuda/std/__mdspan/maybe_static_value.h
+++ b/libcudacxx/include/cuda/std/__mdspan/maybe_static_value.h
@@ -88,10 +88,9 @@ struct __maybe_static_value
     return static_cast<_dynamic_t>(__v);
   }
   template <class _Up>
-  __MDSPAN_FORCE_INLINE_FUNCTION constexpr __mdspan_enable_fold_comma __set_value(_Up&& /*__rhs*/) noexcept
+  __MDSPAN_FORCE_INLINE_FUNCTION constexpr void __set_value(_Up&& /*__rhs*/) noexcept
   {
     // Should we assert that the value matches the static value here?
-    return {};
   }
 
   //--------------------------------------------------------------------------
@@ -132,10 +131,9 @@ struct __maybe_static_value<_dynamic_t, _static_t, __is_dynamic_sentinal, __is_d
     return __v;
   }
   template <class _Up>
-  __MDSPAN_FORCE_INLINE_FUNCTION constexpr __mdspan_enable_fold_comma __set_value(_Up&& __rhs) noexcept
+  __MDSPAN_FORCE_INLINE_FUNCTION constexpr void __set_value(_Up&& __rhs) noexcept
   {
     __v = (_Up&&) rhs;
-    return {};
   }
 #    else
   __MDSPAN_FORCE_INLINE_FUNCTION constexpr _dynamic_t __value() const noexcept
@@ -147,10 +145,9 @@ struct __maybe_static_value<_dynamic_t, _static_t, __is_dynamic_sentinal, __is_d
     return this->__no_unique_address_emulation<_dynamic_t>::__ref();
   }
   template <class _Up>
-  __MDSPAN_FORCE_INLINE_FUNCTION constexpr __mdspan_enable_fold_comma __set_value(_Up&& __rhs) noexcept
+  __MDSPAN_FORCE_INLINE_FUNCTION constexpr void __set_value(_Up&& __rhs) noexcept
   {
     this->__no_unique_address_emulation<_dynamic_t>::__ref() = (_Up&&) __rhs;
-    return {};
   }
 #    endif
 };

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -59,6 +59,7 @@
 #include <cuda/std/__mdspan/extents.h>
 #include <cuda/std/__mdspan/layout_right.h>
 #include <cuda/std/__type_traits/extent.h>
+#include <cuda/std/__type_traits/fold.h>
 #include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_default_constructible.h>
@@ -177,12 +178,11 @@ public:
   _CCCL_HIDE_FROM_ABI constexpr mdspan(mdspan&&)      = default;
 
   _CCCL_TEMPLATE(class... _SizeTypes)
-  _CCCL_REQUIRES(
-    __MDSPAN_FOLD_AND(_CCCL_TRAIT(is_convertible, _SizeTypes, index_type) /* && ... */)
-      _CCCL_AND __MDSPAN_FOLD_AND(_CCCL_TRAIT(is_nothrow_constructible, index_type, _SizeTypes) /* && ... */)
-        _CCCL_AND((sizeof...(_SizeTypes) == rank()) || (sizeof...(_SizeTypes) == rank_dynamic()))
-          _CCCL_AND _CCCL_TRAIT(is_constructible, mapping_type, extents_type)
-            _CCCL_AND _CCCL_TRAIT(is_default_constructible, accessor_type))
+  _CCCL_REQUIRES(__fold_and_v<_CCCL_TRAIT(is_convertible, _SizeTypes, index_type)...> _CCCL_AND
+                   __fold_and_v<_CCCL_TRAIT(is_nothrow_constructible, index_type, _SizeTypes)...> _CCCL_AND(
+                     (sizeof...(_SizeTypes) == rank()) || (sizeof...(_SizeTypes) == rank_dynamic()))
+                     _CCCL_AND _CCCL_TRAIT(is_constructible, mapping_type, extents_type)
+                       _CCCL_AND _CCCL_TRAIT(is_default_constructible, accessor_type))
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr mdspan(data_handle_type __p, _SizeTypes... __dynamic_extents)
       // TODO @proposal-bug shouldn't I be allowed to do `move(__p)` here?
       : __members(
@@ -264,10 +264,9 @@ public:
 
 #  if __MDSPAN_USE_BRACKET_OPERATOR
   _CCCL_TEMPLATE(class... _SizeTypes)
-  _CCCL_REQUIRES(
-    __MDSPAN_FOLD_AND(_CCCL_TRAIT(is_convertible, _SizeTypes, index_type) /* && ... */)
-      _CCCL_AND __MDSPAN_FOLD_AND(_CCCL_TRAIT(is_nothrow_constructible, index_type, _SizeTypes) /* && ... */)
-        _CCCL_AND(rank() == sizeof...(_SizeTypes)))
+  _CCCL_REQUIRES(__fold_and_v<_CCCL_TRAIT(is_convertible, _SizeTypes, index_type)...> _CCCL_AND
+                   __fold_and_v<_CCCL_TRAIT(is_nothrow_constructible, index_type, _SizeTypes)...> _CCCL_AND(
+                     rank() == sizeof...(_SizeTypes)))
   __MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](_SizeTypes... __indices) const
   {
@@ -307,10 +306,9 @@ public:
 
 #  if __MDSPAN_USE_PAREN_OPERATOR
   _CCCL_TEMPLATE(class... _SizeTypes)
-  _CCCL_REQUIRES(
-    __MDSPAN_FOLD_AND(_CCCL_TRAIT(is_convertible, _SizeTypes, index_type) /* && ... */)
-      _CCCL_AND __MDSPAN_FOLD_AND(_CCCL_TRAIT(is_nothrow_constructible, index_type, _SizeTypes) /* && ... */)
-        _CCCL_AND(extents_type::rank() == sizeof...(_SizeTypes)))
+  _CCCL_REQUIRES(__fold_and_v<_CCCL_TRAIT(is_convertible, _SizeTypes, index_type)...> _CCCL_AND
+                   __fold_and_v<_CCCL_TRAIT(is_nothrow_constructible, index_type, _SizeTypes)...> _CCCL_AND(
+                     extents_type::rank() == sizeof...(_SizeTypes)))
   __MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator()(_SizeTypes... __indices) const
   {
@@ -440,8 +438,7 @@ private:
 
 #  if defined(__MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 _CCCL_TEMPLATE(class _ElementType, class... _SizeTypes)
-_CCCL_REQUIRES(__MDSPAN_FOLD_AND(_CCCL_TRAIT(is_integral, _SizeTypes) /* && ... */)
-                 _CCCL_AND(sizeof...(_SizeTypes) > 0))
+_CCCL_REQUIRES(__fold_and_v<_CCCL_TRAIT(is_integral, _SizeTypes)...> _CCCL_AND(sizeof...(_SizeTypes) > 0))
 _CCCL_HOST_DEVICE explicit mdspan(_ElementType*,
                                   _SizeTypes...) -> mdspan<_ElementType, dextents<size_t, sizeof...(_SizeTypes)>>;
 


### PR DESCRIPTION
The fold emulation macros from mdspan are duplicating a lot of effort.

Furthermore they are actually breaking code through introducing global names like `__mdspan_enable_fold_comma`

Just dropunused macros and replace those we can with our internal implementation