### PR TITLE
remove definition of macro (`_LIBCUDACXX_NO_RTTI`) that is no longer used

### DIFF
--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -995,7 +995,6 @@ class Configuration(object):
                 self.cxx.compile_flags += ['-D_SILENCE_CXX20_CISO646_REMOVED_WARNING']
             else:
                 self.cxx.compile_flags += ['-fno-rtti']
-            self.cxx.compile_flags += ['-D_LIBCUDACXX_NO_RTTI']
 
     def configure_compile_flags_abi_version(self):
         abi_version = self.get_lit_conf('abi_version', '').strip()


### PR DESCRIPTION
## Description

this pr is a follow-up for #2578, which removed the `_LIBCUDACXX_NO_RTTI` macro. libcu++'s tests should no longer be defining `_LIBCUDACXX_NO_RTTI`. it has no effect.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
