### PR TITLE
Restore thrust single config options.

### DIFF
--- a/thrust/cmake/ThrustMultiConfig.cmake
+++ b/thrust/cmake/ThrustMultiConfig.cmake
@@ -99,8 +99,6 @@ function(thrust_configure_multiconfig)
     if (DEFINED THRUST_HOST_SYSTEM)
       set_property(CACHE THRUST_HOST_SYSTEM PROPERTY TYPE INTERNAL)
       set_property(CACHE THRUST_DEVICE_SYSTEM PROPERTY TYPE INTERNAL)
-    endif()
-    if (DEFINED THRUST_CPP_DIALECT)
       set_property(CACHE THRUST_CPP_DIALECT PROPERTY TYPE INTERNAL)
     endif()
 
@@ -110,15 +108,25 @@ function(thrust_configure_multiconfig)
     if (DEFINED THRUST_HOST_SYSTEM)
       set_property(CACHE THRUST_HOST_SYSTEM PROPERTY TYPE STRING)
       set_property(CACHE THRUST_DEVICE_SYSTEM PROPERTY TYPE STRING)
-    endif()
+      set_property(CACHE THRUST_CPP_DIALECT PROPERTY TYPE STRING)
+    else()
+      set(THRUST_HOST_SYSTEM "CPP" CACHE STRING "The targeted host system: ${THRUST_HOST_SYSTEM_OPTIONS}")
+      set(THRUST_DEVICE_SYSTEM "CUDA" CACHE STRING "The targeted device system: ${THRUST_DEVICE_SYSTEM_OPTIONS}")
+      set(THRUST_CPP_DIALECT 17 CACHE STRING "The C++ standard to target: ${THRUST_CPP_DIALECT_OPTIONS}")
 
-    set(THRUST_CPP_DIALECT 17
-      CACHE STRING "The C++ standard to target: ${THRUST_CPP_DIALECT_OPTIONS}"
-    )
-    set_property(CACHE THRUST_CPP_DIALECT
-      PROPERTY STRINGS
-      ${THRUST_CPP_DIALECT_OPTIONS}
-    )
+      set_property(CACHE THRUST_HOST_SYSTEM
+        PROPERTY STRINGS
+        ${THRUST_HOST_SYSTEM_OPTIONS}
+      )
+      set_property(CACHE THRUST_DEVICE_SYSTEM
+        PROPERTY STRINGS
+        ${THRUST_DEVICE_SYSTEM_OPTIONS}
+      )
+      set_property(CACHE THRUST_CPP_DIALECT
+        PROPERTY STRINGS
+        ${THRUST_CPP_DIALECT_OPTIONS}
+      )
+    endif()
 
     # CMake fixed C++17 support for NVCC + MSVC targets in 3.18.3:
     if (THRUST_CPP_DIALECT EQUAL 17 AND


### PR DESCRIPTION
Fixes #2963

Restores the options for thrust singleconfig.
