### PR TITLE
remove vestigal uses of the old `DOXYGEN_SHOULD_SKIP_THIS` macro

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
@@ -159,7 +159,7 @@ public:
   }
 #endif // _CCCL_STD_VER <= 2017
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
+#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 #  if _CCCL_STD_VER >= 2020
   //! @brief Equality comparison between a \c managed_memory_resource and another resource
   //! @param __rhs The resource to compare to
@@ -237,7 +237,7 @@ public:
   friend constexpr void get_property(managed_memory_resource const&, mr::device_accessible) noexcept {}
   //! @brief Enables the \c host_accessible property
   friend constexpr void get_property(managed_memory_resource const&, mr::host_accessible) noexcept {}
-#endif // DOXYGEN_SHOULD_SKIP_THIS
+#endif // _CCCL_DOXYGEN_INVOKED
 
   //! @brief Checks whether the passed in alignment is valid
   static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept

--- a/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
@@ -160,7 +160,7 @@ public:
   }
 #endif // _CCCL_STD_VER <= 2017
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
+#ifndef _CCCL_DOXYGEN_INVOKED // Do not document
 #  if _CCCL_STD_VER >= 2020
   //! @brief Equality comparison between a \c pinned_memory_resource and another resource
   //! @param __rhs The resource to compare to
@@ -239,7 +239,7 @@ public:
   friend constexpr void get_property(pinned_memory_resource const&, device_accessible) noexcept {}
   //! @brief Enables the \c host_accessible property
   friend constexpr void get_property(pinned_memory_resource const&, host_accessible) noexcept {}
-#endif // DOXYGEN_SHOULD_SKIP_THIS
+#endif // _CCCL_DOXYGEN_INVOKED
 
   //! @brief Checks whether the passed in alignment is valid
   static constexpr bool __is_valid_alignment(const size_t __alignment) noexcept


### PR DESCRIPTION
## Description

i stumbled across two additional uses of the no-longer-used `DOXYGEN_SHOULD_SKIP_THIS` macro. i suspect they snuck back in when these two memory resource files were moved into cudax.

this pr replaces the old macro with the new `_CCCL_DOXYGEN_INVOKED` macro.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
