### PR TITLE
[CUDAX] Remove launch overloads taking dimensions and make everything except make_hierarchy return kernel_config

### DIFF
--- a/cudax/examples/vector_add.cu
+++ b/cudax/examples/vector_add.cu
@@ -92,11 +92,12 @@ try
 
   // Define the kernel launch parameters
   constexpr int threadsPerBlock = 256;
-  auto dims                     = cudax::distribute<threadsPerBlock>(numElements);
+  auto config                   = cudax::distribute<threadsPerBlock>(numElements);
 
   // Launch the vectorAdd kernel
-  printf("CUDA kernel launch with %d blocks of %d threads\n", dims.count(cudax::block, cudax::grid), threadsPerBlock);
-  cudax::launch(stream, dims, vectorAdd, in(A), in(B), out(C));
+  printf(
+    "CUDA kernel launch with %d blocks of %d threads\n", config.dims.count(cudax::block, cudax::grid), threadsPerBlock);
+  cudax::launch(stream, config, vectorAdd, in(A), in(B), out(C));
 
   printf("waiting for the stream to finish\n");
   stream.wait();

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -363,10 +363,10 @@ struct kernel_config
 
   constexpr kernel_config(const Dimensions& dims, const Options&... opts)
       : dims(dims)
-      , options(opts...) {};
+      , options(opts...){};
   constexpr kernel_config(const Dimensions& dims, const ::cuda::std::tuple<Options...>& opts)
       : dims(dims)
-      , options(opts) {};
+      , options(opts){};
 
   /**
    * @brief Add a new option to this configuration
@@ -384,6 +384,28 @@ struct kernel_config
       dims, ::cuda::std::tuple_cat(options, ::cuda::std::make_tuple(new_options...)));
   }
 };
+
+// We can consider removing the operator&, but its convenient for in-line construction
+template <typename Dimensions, typename... Options, typename NewLevel>
+_CUDAX_HOST_API constexpr auto
+operator&(const kernel_config<Dimensions, Options...>& config, const NewLevel& new_level) noexcept
+{
+  return kernel_config(hierarchy_add_level(config.dims, new_level), config.options);
+}
+
+template <typename NewLevel, typename Dimensions, typename... Options>
+_CUDAX_HOST_API constexpr auto
+operator&(const NewLevel& new_level, const kernel_config<Dimensions, Options...>& config) noexcept
+{
+  return kernel_config(hierarchy_add_level(config.dims, new_level), config.options);
+}
+
+template <typename L1, typename Dims1, typename L2, typename Dims2>
+_CUDAX_HOST_API constexpr auto
+operator&(const level_dimensions<L1, Dims1>& l1, const level_dimensions<L2, Dims2>& l2) noexcept
+{
+  return kernel_config(make_hierarchy_fragment(l1, l2));
+}
 
 template <typename Dimensions,
           typename... Options,
@@ -421,6 +443,31 @@ _CCCL_NODISCARD constexpr auto
 make_config(const hierarchy_dimensions_fragment<BottomUnit, Levels...>& dims, const Opts&... opts) noexcept
 {
   return kernel_config<hierarchy_dimensions_fragment<BottomUnit, Levels...>, Opts...>(dims, opts...);
+}
+
+/**
+ * @brief A shorthand for creating a kernel configuration with a hierarchy of CUDA threads evenly
+ * distributing elements among blocks and threads.
+ *
+ * @par Snippet
+ * @code
+ * #include <cudax/hierarchy_dimensions.cuh>
+ * using namespace cuda::experimental;
+ *
+ * constexpr int threadsPerBlock = 256;
+ * auto dims = distribute<threadsPerBlock>(numElements);
+ *
+ * // Equivalent to:
+ * constexpr int threadsPerBlock = 256;
+ * int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
+ * auto dims = make_hierarchy(grid_dims(blocksPerGrid), block_dims<threadsPerBlock>());
+ * @endcode
+ */
+template <int _ThreadsPerBlock>
+constexpr auto distribute(int numElements) noexcept
+{
+  int blocksPerGrid = (numElements + _ThreadsPerBlock - 1) / _ThreadsPerBlock;
+  return make_config(make_hierarchy(grid_dims(blocksPerGrid), block_dims<_ThreadsPerBlock>()));
 }
 
 template <typename... Args>

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -363,10 +363,10 @@ struct kernel_config
 
   constexpr kernel_config(const Dimensions& dims, const Options&... opts)
       : dims(dims)
-      , options(opts...){};
+      , options(opts...) {};
   constexpr kernel_config(const Dimensions& dims, const ::cuda::std::tuple<Options...>& opts)
       : dims(dims)
-      , options(opts){};
+      , options(opts) {};
 
   /**
    * @brief Add a new option to this configuration

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -154,80 +154,6 @@ void launch(
 }
 
 /**
- * @brief Launch a kernel functor with specified thread hierarchy and arguments
- *
- * Launches a kernel functor object on the specified stream and with specified thread hierarchy.
- * Kernel functor object is a type with __device__ operator().
- * Functor might or might not accept the hierarchy as its first argument.
- *
- *
- * @par Snippet
- * @code
- * #include <cstdio>
- * #include <cuda/experimental/launch.cuh>
- *
- * struct kernel {
- *     template <typename Dimensions>
- *     __device__ void operator()(Dimensions dims, unsigned int thread_to_print) {
- *         if (dims.rank(cudax::thread, cudax::grid) == thread_to_print) {
- *             printf("Hello from the GPU\n");
- *         }
- *     }
- * };
- *
- * void launch_kernel(cuda::stream_ref stream) {
- *     auto dims = cudax::make_hierarchy(cudax::block_dims<128>(), cudax::grid_dims(4));
- *
- *     cudax::launch(stream, dims, kernel(), 42);
- * }
- * @endcode
- *
- * @param stream
- * cuda::stream_ref to launch the kernel into
- *
- * @param dims
- * thread hierarchy dimensions for this launch
- *
- * @param kernel
- * kernel functor to be launched
- *
- * @param args
- * arguments to be passed into the kernel functor
- */
-template <typename... Args, typename... Levels, typename Kernel>
-void launch(::cuda::stream_ref stream, const hierarchy_dimensions<Levels...>& dims, const Kernel& kernel, Args&&... args)
-{
-  __ensure_current_device __dev_setter(stream);
-  cudaError_t status;
-  if constexpr (::cuda::std::is_invocable_v<Kernel, hierarchy_dimensions<Levels...>, as_kernel_arg_t<Args>...>)
-  {
-    auto launcher = detail::kernel_launcher<hierarchy_dimensions<Levels...>, Kernel, as_kernel_arg_t<Args>...>;
-    status        = detail::launch_impl(
-      stream,
-      kernel_config(dims),
-      launcher,
-      dims,
-      kernel,
-      static_cast<as_kernel_arg_t<Args>>(detail::__launch_transform(stream, std::forward<Args>(args)))...);
-  }
-  else
-  {
-    static_assert(::cuda::std::is_invocable_v<Kernel, as_kernel_arg_t<Args>...>);
-    auto launcher = detail::kernel_launcher_no_config<Kernel, as_kernel_arg_t<Args>...>;
-    status        = detail::launch_impl(
-      stream,
-      kernel_config(dims),
-      launcher,
-      kernel,
-      static_cast<as_kernel_arg_t<Args>>(detail::__launch_transform(stream, std::forward<Args>(args)))...);
-  }
-  if (status != cudaSuccess)
-  {
-    ::cuda::__throw_cuda_error(status, "Failed to launch a kernel");
-  }
-}
-
-/**
  * @brief Launch a kernel function with specified configuration and arguments
  *
  * Launches a kernel function on the specified stream and with specified configuration.
@@ -288,65 +214,6 @@ void launch(::cuda::stream_ref stream,
 }
 
 /**
- * @brief Launch a kernel function with specified thread hierarchy and arguments
- *
- * Launches a kernel function on the specified stream and with specified thread hierarchy.
- * Kernel function is a function with __global__ annotation.
- * Function might or might not accept the hierarchy as its first argument.
- *
- *
- * @par Snippet
- * @code
- * #include <cstdio>
- * #include <cuda/experimental/launch.cuh>
- *
- * template <typename Dimensions>
- * __global__ void kernel(Dimensions dims, unsigned int thread_to_print) {
- *     if (dims.rank(cudax::thread, cudax::grid) == thread_to_print) {
- *         printf("Hello from the GPU\n");
- *     }
- * }
- *
- * void launch_kernel(cuda::stream_ref stream) {
- *     auto dims = cudax::make_hierarchy(cudax::block_dims<128>(), cudax::grid_dims(4));
- *
- *     cudax::launch(stream, dims, kernel<decltype(dims)>, 42);
- * }
- * @endcode
- *
- * @param stream
- * cuda::stream_ref to launch the kernel into
- *
- * @param dims
- * thread hierarchy dimensions for this launch
- *
- * @param kernel
- * kernel function to be launched
- *
- * @param args
- * arguments to be passed into the kernel function
- */
-template <typename... ExpArgs, typename... ActArgs, typename... Levels>
-void launch(::cuda::stream_ref stream,
-            const hierarchy_dimensions<Levels...>& dims,
-            void (*kernel)(hierarchy_dimensions<Levels...>, ExpArgs...),
-            ActArgs&&... args)
-{
-  __ensure_current_device __dev_setter(stream);
-  cudaError_t status = detail::launch_impl(
-    stream,
-    kernel_config(dims),
-    kernel,
-    dims,
-    static_cast<as_kernel_arg_t<ActArgs>>(detail::__launch_transform(stream, std::forward<ActArgs>(args)))...);
-
-  if (status != cudaSuccess)
-  {
-    ::cuda::__throw_cuda_error(status, "Failed to launch a kernel");
-  }
-}
-
-/**
  * @brief Launch a kernel function with specified configuration and arguments
  *
  * Launches a kernel function on the specified stream and with specified configuration.
@@ -395,62 +262,6 @@ void launch(::cuda::stream_ref stream,
   cudaError_t status = detail::launch_impl(
     stream, //
     conf,
-    kernel,
-    static_cast<as_kernel_arg_t<ActArgs>>(detail::__launch_transform(stream, std::forward<ActArgs>(args)))...);
-
-  if (status != cudaSuccess)
-  {
-    ::cuda::__throw_cuda_error(status, "Failed to launch a kernel");
-  }
-}
-
-/**
- * @brief Launch a kernel function with specified thread hierarchy and arguments
- *
- * Launches a kernel function on the specified stream and with specified thread hierarchy.
- * Kernel function is a function with __global__ annotation.
- * Function might or might not accept the hierarchy as its first argument.
- *
- *
- * @par Snippet
- * @code
- * #include <cstdio>
- * #include <cuda/experimental/launch.cuh>
- *
- * template <typename Dimensions>
- * __global__ void kernel(Dimensions dims, unsigned int thread_to_print) {
- *     if (dims.rank(cudax::thread, cudax::grid) == thread_to_print) {
- *         printf("Hello from the GPU\n");
- *     }
- * }
- *
- * void launch_kernel(cuda::stream_ref stream) {
- *     auto dims = cudax::make_hierarchy(cudax::block_dims<128>(), cudax::grid_dims(4));
- *
- *     cudax::launch(stream, dims, kernel<decltype(dims)>, 42);
- * }
- * @endcode
- *
- * @param stream
- * cuda::stream_ref to launch the kernel into
- *
- * @param dims
- * thread hierarchy dimensions for this launch
- *
- * @param kernel
- * kernel function to be launched
- *
- * @param args
- * arguments to be passed into the kernel function
- */
-template <typename... ExpArgs, typename... ActArgs, typename... Levels>
-void launch(
-  ::cuda::stream_ref stream, const hierarchy_dimensions<Levels...>& dims, void (*kernel)(ExpArgs...), ActArgs&&... args)
-{
-  __ensure_current_device __dev_setter(stream);
-  cudaError_t status = detail::launch_impl(
-    stream,
-    kernel_config(dims),
     kernel,
     static_cast<as_kernel_arg_t<ActArgs>>(detail::__launch_transform(stream, std::forward<ActArgs>(args)))...);
 

--- a/cudax/test/common/testing.cuh
+++ b/cudax/test/common/testing.cuh
@@ -11,7 +11,7 @@
 #ifndef __COMMON_TESTING_H__
 #define __COMMON_TESTING_H__
 
-#include <cuda/experimental/hierarchy.cuh>
+#include <cuda/experimental/launch.cuh>
 
 #include <exception> // IWYU pragma: keep
 #include <iostream>

--- a/cudax/test/common/utility.cuh
+++ b/cudax/test/common/utility.cuh
@@ -30,7 +30,7 @@ namespace
 namespace test
 {
 
-constexpr auto one_thread_dims = cudax::make_hierarchy(cudax::block_dims<1>(), cudax::grid_dims<1>());
+constexpr auto one_thread_dims = cudax::make_config(cudax::block_dims<1>(), cudax::grid_dims<1>());
 
 struct _malloc_managed
 {

--- a/cudax/test/containers/uninitialized_buffer.cu
+++ b/cudax/test/containers/uninitialized_buffer.cu
@@ -223,22 +223,22 @@ TEST_CASE("uninitialized_buffer is usable with cudax::launch", "[container]")
   {
     const int grid_size = 4;
     cudax::uninitialized_buffer<int, ::cuda::mr::device_accessible> buffer{cudax::device_memory_resource{}, 1024};
-    auto dimensions = cudax::make_hierarchy(cudax::grid_dims(grid_size), cudax::block_dims<256>());
+    auto configuration = cudax::make_config(cudax::grid_dims(grid_size), cudax::block_dims<256>());
 
     cudax::stream stream;
 
-    cudax::launch(stream, dimensions, kernel, buffer);
+    cudax::launch(stream, configuration, kernel, buffer);
   }
 
   SECTION("const")
   {
     const int grid_size = 4;
     const cudax::uninitialized_buffer<int, ::cuda::mr::device_accessible> buffer{cudax::device_memory_resource{}, 1024};
-    auto dimensions = cudax::make_hierarchy(cudax::grid_dims(grid_size), cudax::block_dims<256>());
+    auto configuration = cudax::make_config(cudax::grid_dims(grid_size), cudax::block_dims<256>());
 
     cudax::stream stream;
 
-    cudax::launch(stream, dimensions, const_kernel, buffer);
+    cudax::launch(stream, configuration, const_kernel, buffer);
   }
 }
 

--- a/cudax/test/hierarchy/hierarchy_custom_types.cu
+++ b/cudax/test/hierarchy/hierarchy_custom_types.cu
@@ -25,7 +25,7 @@ struct custom_level_dims : public cudax::level_dimensions<Level, Dims>
 {
   int dummy;
   constexpr custom_level_dims()
-      : cudax::level_dimensions<Level, Dims>(){};
+      : cudax::level_dimensions<Level, Dims>() {};
 };
 
 struct custom_level_test

--- a/cudax/test/hierarchy/hierarchy_custom_types.cu
+++ b/cudax/test/hierarchy/hierarchy_custom_types.cu
@@ -25,7 +25,7 @@ struct custom_level_dims : public cudax::level_dimensions<Level, Dims>
 {
   int dummy;
   constexpr custom_level_dims()
-      : cudax::level_dimensions<Level, Dims>() {};
+      : cudax::level_dimensions<Level, Dims>(){};
 };
 
 struct custom_level_test
@@ -44,7 +44,7 @@ struct custom_level_test
     // Check extending level_dimensions with custom info
     custom_level_dims<cudax::block_level, cudax::dimensions<int, 64, 1, 1>> custom_block;
     custom_block.dummy     = 2;
-    auto custom_dims       = cudax::grid_dims<256>() & cudax::cluster_dims<8>() & custom_block;
+    auto custom_dims       = cudax::make_hierarchy(cudax::grid_dims<256>(), cudax::cluster_dims<8>(), custom_block);
     auto custom_block_back = custom_dims.level(cudax::block);
     CUDAX_REQUIRE(custom_block_back.dummy == 2);
 

--- a/cudax/test/memory_resource/device_memory_resource.cu
+++ b/cudax/test/memory_resource/device_memory_resource.cu
@@ -487,11 +487,11 @@ TEST_CASE("Async memory resource peer access")
       CUDAX_CHECK(resource.is_accessible_from(cudax::devices[0]));
 
       auto allocate_and_check_access = [&](auto& resource) {
-        auto* ptr1 = resource.allocate_async(sizeof(int), stream);
-        auto* ptr2 = resource.allocate(sizeof(int));
-        auto dims  = cudax::distribute<1>(1);
-        cudax::launch(stream, dims, test::assign_42{}, (int*) ptr1);
-        cudax::launch(stream, dims, test::assign_42{}, (int*) ptr2);
+        auto* ptr1  = resource.allocate_async(sizeof(int), stream);
+        auto* ptr2  = resource.allocate(sizeof(int));
+        auto config = cudax::distribute<1>(1);
+        cudax::launch(stream, config, test::assign_42{}, (int*) ptr1);
+        cudax::launch(stream, config, test::assign_42{}, (int*) ptr2);
         stream.wait();
         resource.deallocate_async(ptr1, sizeof(int), stream);
         resource.deallocate(ptr2, sizeof(int));

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -129,7 +129,7 @@ TEST_CASE("ensure current device", "[device]")
   {
     cudax::stream stream(target_device);
     CUDAX_REQUIRE(test::count_driver_stack() == 0);
-    cudax::launch(stream, cudax::make_hierarchy(cudax::block_dims<1>(), cudax::grid_dims<1>()), test::empty_kernel{});
+    cudax::launch(stream, cudax::make_config(cudax::block_dims<1>(), cudax::grid_dims<1>()), test::empty_kernel{});
     CUDAX_REQUIRE(test::count_driver_stack() == 0);
   }
 }


### PR DESCRIPTION
I believe that at this point launch overloads taking `hierarchy_dimensions` instead of `kernel_config` is more of a past design artifact.
Hierarchy design predates kernel config and initially launch overloads taking a hierarchy were provided to make sure user won't need to take that extra step of converting hierarchy to a config (implicit conversion was not possible as well).
Recently `make_config` was extended to accept hierarchy levels. Now given a set of levels, if no launch options are needed the difference is literally `make_hierarchy` producing a hierarchy type and `make_config` producing a kernel config containing the same hierarchy.
I believe we should force users to use the `kernel_config` type in majority of cases and make it the only possible `launch` argument for below reasons:
- It simplifies kernels that take config/dimensions as argument, before there was ambiguity which one to expect, now its consistent.
- It simplifies that even further with the upcoming default kernel configuration, where kernel and launch site could have a mix of hierarchies or configs and it would be difficult to track what will end up being passed into the kernel. Trying to handle all of these cases in the implementation would also be a major pain
- I think even for shorthands for config creation, I think I prefer `distribute<N>(M).add(option1, option2)` vs `make_config(distribute<N>(M), option1, option2)`. I like how now user is mostly concerned about manipulating configs, instead of both hierarchies and configs and how they interact, unless they have some very specific case.
- Operating only on configs is also closer to the equivalent launch function in python.

As a consequence of this change I also changed `distribute` and all of the `operator&` to return `kernel_config` so it works well with `launch`. I think we should keep `make_hierarchy` function for some special cases user would be interested only in the hierarchy type, but vast majority of cases it shouldn't be needed.