### PR TITLE
Forward declare half types in `cuda::ptx`

### DIFF
--- a/libcudacxx/include/cuda/__ptx/instructions/cp_reduce_async_bulk.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/cp_reduce_async_bulk.h
@@ -28,16 +28,12 @@
 
 #include <nv/target> // __CUDA_MINIMUM_ARCH__ and friends
 
-#if defined(_LIBCUDACXX_HAS_NVFP16)
-#  include <cuda_fp16.h>
-#endif // _LIBCUDACXX_HAS_NVFP16
-
-#if defined(_LIBCUDACXX_HAS_NVBF16)
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-function")
-#  include <cuda_bf16.h>
-_CCCL_DIAG_POP
-#endif // _LIBCUDACXX_HAS_NVBF16
+// Forward-declare __half and __nv_bfloat16. The cuda_fp16.h and cuda_bf16.h are
+// expensive to include. The APIs use only pointers, so we do not have to define
+// the types. If the user wants to use these types, it is their responsibility
+// to include the headers.
+struct __half;
+struct __nv_bfloat16;
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA_PTX
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #2933

<!-- Provide a standalone description of changes in this PR. -->
Forward declare half types to avoid including the (expensive) fp16 headers.

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
