### PR TITLE
Fix CMake warning for FindPythonInterp

### DIFF
--- a/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/CMakeLists.txt
@@ -40,8 +40,8 @@ option(LIBCUDACXX_ENABLE_LIBCUDACXX_TESTS "Enable libcu++ tests." ON)
 if (LIBCUDACXX_ENABLE_LIBCUDACXX_TESTS)
   enable_testing()
 
-  include(FindPythonInterp)
-  if (NOT PYTHONINTERP_FOUND)
+  find_package (Python COMPONENTS Interpreter)
+  if (NOT Python_Interpreter_FOUND)
     message(FATAL_ERROR
       "Failed to find python interpreter, which is required for running tests and "
       "building a libcu++ static library.")


### PR DESCRIPTION
I get this warning a lot:
```
CMake Warning (dev) at libcudacxx/CMakeLists.txt:43 (include):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.
```
So here is the fix.