### PR TITLE
Enable assertions for CCCL users in CMake Debug builds

### DIFF
--- a/lib/cmake/libcudacxx/libcudacxx-config.cmake
+++ b/lib/cmake/libcudacxx/libcudacxx-config.cmake
@@ -39,6 +39,7 @@ set(_libcudacxx_INCLUDE_DIR "${_libcudacxx_VERSION_INCLUDE_DIR}"
 )
 unset(_libcudacxx_VERSION_INCLUDE_DIR CACHE) # Clear tmp variable from cache
 target_include_directories(_libcudacxx_libcudacxx INTERFACE "${_libcudacxx_INCLUDE_DIR}")
+target_compile_definitions(_libcudacxx_libcudacxx INTERFACE $<$<CONFIG:Debug>:CCCL_ENABLE_ASSERTIONS>)
 
 #
 # Standardize version info


### PR DESCRIPTION
This PR defines `CCCL_ENABLE_ASSERTIONS` for  libcu++ whenever it is consumed via CMake and the CMake build type is `Debug`. This regards internal use in tests as well as any external user. Non-CMake builds are not affected.

Fixes: #2975 
