### PR TITLE
[STF] Create dot sections to possibly collapse nodes when displaying large DOT graphs

### DIFF
--- a/cudax/examples/stf/linear_algebra/07-cholesky.cu
+++ b/cudax/examples/stf/linear_algebra/07-cholesky.cu
@@ -385,6 +385,8 @@ void PDNRM2_HOST(matrix<double>* A, double* result)
 
 void PDPOTRF(matrix<double>& A)
 {
+  auto guard = ctx.dot_section("PDPOTRF");
+
 #ifdef HAVE_DOT
   reserved::dot::set_current_color("yellow");
 #endif
@@ -505,6 +507,7 @@ void PDTRSM(cublasSideMode_t side,
 
 void PDPOTRS(matrix<double>& A, class matrix<double>& B, cublasFillMode_t uplo)
 {
+  auto guard = ctx.dot_section("PDPOTRS");
 #ifdef HAVE_DOT
   reserved::dot::set_current_color("green");
 #endif
@@ -656,12 +659,14 @@ int main(int argc, char** argv)
     return 1.0 / (col + row + 1.0) + 2.0 * N * (col == row);
   };
 
+  ctx.dot_push_section("fillA");
   if (check_result)
   {
     Aref.fill(hilbert);
   }
 
   A.fill(hilbert);
+  ctx.dot_pop_section();
 
   /* Right-hand side */
   matrix<double> B_potrs(N, 1, NB, 1, false, "B");

--- a/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
@@ -880,15 +880,15 @@ public:
   }
 
   void dot_push_section(::std::string symbol) const {
-    reserved::dot::instance().push_section(mv(symbol));
+    reserved::dot::dot_section::push_section(mv(symbol));
   }
 
   void dot_pop_section() const {
-    reserved::dot::instance().pop_section();
+    reserved::dot::dot_section::pop_section();
   }
 
   auto dot_section(::std::string symbol) const {
-      return reserved::dot::section_guard(mv(symbol));
+      return reserved::dot::dot_section::section_guard(mv(symbol));
   }
 
   auto get_phase() const

--- a/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
@@ -879,6 +879,18 @@ public:
     reserved::per_ctx_dot::set_parent_ctx(parent_ctx.get_dot(), get_dot());
   }
 
+  void dot_push_section(::std::string symbol) const {
+    reserved::dot::instance().push_section(mv(symbol));
+  }
+
+  void dot_pop_section() const {
+    reserved::dot::instance().pop_section();
+  }
+
+  auto dot_section(::std::string symbol) const {
+      return reserved::dot::section_guard(mv(symbol));
+  }
+
   auto get_phase() const
   {
     return pimpl->get_phase();

--- a/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
@@ -881,17 +881,17 @@ public:
 
   void dot_push_section(::std::string symbol) const
   {
-    reserved::dot::dot_section::push_section(mv(symbol));
+    reserved::dot::section::push(mv(symbol));
   }
 
   void dot_pop_section() const
   {
-    reserved::dot::dot_section::pop_section();
+    reserved::dot::section::pop();
   }
 
   auto dot_section(::std::string symbol) const
   {
-    return reserved::dot::dot_section::section_guard(mv(symbol));
+    return reserved::dot::section::guard(mv(symbol));
   }
 
   auto get_phase() const

--- a/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/backend_ctx.cuh
@@ -879,16 +879,19 @@ public:
     reserved::per_ctx_dot::set_parent_ctx(parent_ctx.get_dot(), get_dot());
   }
 
-  void dot_push_section(::std::string symbol) const {
+  void dot_push_section(::std::string symbol) const
+  {
     reserved::dot::dot_section::push_section(mv(symbol));
   }
 
-  void dot_pop_section() const {
+  void dot_pop_section() const
+  {
     reserved::dot::dot_section::pop_section();
   }
 
-  auto dot_section(::std::string symbol) const {
-      return reserved::dot::dot_section::section_guard(mv(symbol));
+  auto dot_section(::std::string symbol) const
+  {
+    return reserved::dot::dot_section::section_guard(mv(symbol));
   }
 
   auto get_phase() const

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -385,7 +385,7 @@ public:
       int id   = sec->get_id();
 
       // Save the section in the map
-      section::map()[id] = sec;
+      map()[id] = sec;
 
       // Push the id in the current stack
       current().push(id);

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -45,8 +45,8 @@
 #include <optional>
 #include <queue>
 #include <sstream>
-#include <unordered_set>
 #include <stack>
+#include <unordered_set>
 
 namespace cuda::experimental::stf::reserved
 {
@@ -66,7 +66,6 @@ struct per_task_info
   ::std::optional<float> timing;
   int dot_section_id;
 };
-
 
 class per_ctx_dot
 {
@@ -344,73 +343,82 @@ public: // XXX protected, friend : dot
 class dot : public reserved::meyers_singleton<dot>
 {
 public:
-/**
- * @brief A named section in the DOT output to potentially collapse multiple nodes in the same section
- */
-class dot_section {
-public:
+  /**
+   * @brief A named section in the DOT output to potentially collapse multiple nodes in the same section
+   */
+  class dot_section
+  {
+  public:
     using unique_id_t = unique_id<dot_section>;
 
     // Constructor to initialize symbol and children
     dot_section(::std::string sym)
-        : symbol(mv(sym)) {
-    }
+        : symbol(mv(sym))
+    {}
 
-    class section_guard {
-        public:
-            section_guard(::std::string symbol) {
-                dot_section::push_section(mv(symbol));
-            }
+    class section_guard
+    {
+    public:
+      section_guard(::std::string symbol)
+      {
+        dot_section::push_section(mv(symbol));
+      }
 
-            ~section_guard() {
-                dot_section::pop_section();
-            }
+      ~section_guard()
+      {
+        dot_section::pop_section();
+      }
     };
 
-    static auto &current() {
-        thread_local ::std::stack<int> s;
-        return s;
+    static auto& current()
+    {
+      thread_local ::std::stack<int> s;
+      return s;
     }
 
-    static void push_section(::std::string symbol) {
-        fprintf(stderr, "PUSHING SECTION %s\n", symbol.c_str());
+    static void push_section(::std::string symbol)
+    {
+      fprintf(stderr, "PUSHING SECTION %s\n", symbol.c_str());
 
-        // We first create a section object, with its unique id
-        auto sec = ::std::make_shared<dot_section>(mv(symbol));
-        int id = sec->get_id();
+      // We first create a section object, with its unique id
+      auto sec = ::std::make_shared<dot_section>(mv(symbol));
+      int id   = sec->get_id();
 
-        // Save the section in the map
-        dot_section::map()[id] = sec;
+      // Save the section in the map
+      dot_section::map()[id] = sec;
 
-        // Push the id in the current stack
-        current().push(id);
+      // Push the id in the current stack
+      current().push(id);
     }
 
-    static void pop_section() {
-        fprintf(stderr, "POP SECTION\n");
-        current().pop();
+    static void pop_section()
+    {
+      fprintf(stderr, "POP SECTION\n");
+      current().pop();
     }
 
-    int get_id() const {
-        return int(id);
+    int get_id() const
+    {
+      return int(id);
     }
 
-    const ::std::string get_symbol() const {
-        return symbol;
+    const ::std::string get_symbol() const
+    {
+      return symbol;
     }
 
-    static ::std::unordered_map<int, ::std::shared_ptr<dot_section>> &map() {
-        static ::std::unordered_map<int, ::std::shared_ptr<dot_section>> m;
-        return m;
+    static ::std::unordered_map<int, ::std::shared_ptr<dot_section>>& map()
+    {
+      static ::std::unordered_map<int, ::std::shared_ptr<dot_section>> m;
+      return m;
     }
 
-private:
+  private:
     ::std::string symbol;
 
     // An identifier for that section
     unique_id_t id;
-};
-
+  };
 
 protected:
   dot()
@@ -625,7 +633,6 @@ public:
   ::std::vector<::std::shared_ptr<per_ctx_dot>> per_ctx;
 
 private:
-
   static thread_local ::std::stack<int> current_dot_section;
 
   // Function to get a color based on task duration relative to the average
@@ -864,13 +871,14 @@ private:
   ::std::string dot_filename;
 };
 
-inline int per_ctx_dot::get_current_section_id() {
-    // Get the stack of IDs, if it's empty return 0, other 1 + the unique id
-    auto &s = dot::dot_section::current();
-    return s.size() == 0 ? 0 : 1 + s.top();
+inline int per_ctx_dot::get_current_section_id()
+{
+  // Get the stack of IDs, if it's empty return 0, other 1 + the unique id
+  auto& s = dot::dot_section::current();
+  return s.size() == 0 ? 0 : 1 + s.top();
 }
 
-///thread_local ::std::shared_ptr<dot_section> dot::current_dot_section = nullptr;
+/// thread_local ::std::shared_ptr<dot_section> dot::current_dot_section = nullptr;
 inline thread_local ::std::stack<int> dot::current_dot_section;
 
 } // namespace cuda::experimental::stf::reserved

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -300,36 +300,6 @@ private:
 
   ::std::unordered_set<int> discarded_tasks;
 
-  // Replace nodes with indices n with index k
-  void replace_in_unordered_set(IntPairSet& set, int n, int k)
-  {
-    IntPairSet updated_set;
-
-    // Traverse the original set
-    for (const auto& p : set)
-    {
-      auto new_pair = p;
-
-      // Replace n with k in the pair
-      if (new_pair.first == n)
-      {
-        new_pair.first = k;
-      }
-      if (new_pair.second == n)
-      {
-        new_pair.second = k;
-      }
-
-      if (new_pair.first != new_pair.second)
-      {
-        updated_set.insert(new_pair);
-      }
-    }
-
-    // Swap the updated set into the original set
-    set = mv(updated_set);
-  }
-
 public:
   // Keep track of existing edges, to make the output possibly look better
   IntPairSet existing_edges;

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -749,8 +749,8 @@ public:
       {
         for (const auto& p : pc->metadata)
         {
-          outFile << "\"NODE_" << p.first << "\" [style=\"filled\" fillcolor=\"" << p.second.color << "\" label=\"" << p.second.label
-                  << "\"]\n";
+          outFile << "\"NODE_" << p.first << "\" [style=\"filled\" fillcolor=\"" << p.second.color << "\" label=\""
+                  << p.second.label << "\"]\n";
         }
       }
 

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -633,8 +633,6 @@ public:
   ::std::vector<::std::shared_ptr<per_ctx_dot>> per_ctx;
 
 private:
-  static thread_local ::std::stack<int> current_section;
-
   // Function to get a color based on task duration relative to the average
   ::std::string get_color_for_duration(double duration, double avg_duration)
   {

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -528,7 +528,7 @@ public:
       }
     }
 
-    /* Display all non-empty sections recursively */
+    /* Display all sections recursively */
     for (auto [id, sec_ptr] : map)
     {
       // Select root nodes only
@@ -539,6 +539,9 @@ public:
     }
   }
 
+  /**
+   * @brief Add a dashed box around a section and its children
+   */
   void
   print_section(::std::ofstream& outFile, int id, ::std::unordered_map<int, ::std::vector<int>>& section_id_to_nodes)
   {
@@ -551,7 +554,7 @@ public:
 
     outFile << "subgraph cluster_section_" << ::std::to_string(id) << " {\n ";
 
-    // Display all children too
+    // Display all children too to have nested boxes
     for (int children_ids : map[id]->children_ids)
     {
       print_section(outFile, children_ids, section_id_to_nodes);
@@ -616,7 +619,11 @@ public:
     }
   }
 
-  // Combine src_id into dst_id
+  /**
+   * @brief Combine two nodes identified by "src_id" and "dst_id" into a single
+   * updated one ("dst_id"), redirecting edges and combining timing if
+   * necessary
+   */
   void merge_nodes(per_ctx_dot& pc, int dst_id, int src_id)
   {
     // ::std::unordered_map<int /* id */, per_task_info> metadata;
@@ -1059,6 +1066,7 @@ private:
 
   ::std::string dot_filename;
 
+  // Map to get dot sections from their ID
   ::std::unordered_map<int, ::std::shared_ptr<section>> map;
 };
 

--- a/cudax/include/cuda/experimental/__stf/internal/dot.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/dot.cuh
@@ -749,7 +749,7 @@ public:
       {
         for (const auto& p : pc->metadata)
         {
-          outFile << "\"NODE_" << p.first << "\" [fillcolor=\"" << p.second.color << "\" label=\"" << p.second.label
+          outFile << "\"NODE_" << p.first << "\" [style=\"filled\" fillcolor=\"" << p.second.color << "\" label=\"" << p.second.label
                   << "\"]\n";
         }
       }

--- a/cudax/include/cuda/experimental/stf.cuh
+++ b/cudax/include/cuda/experimental/stf.cuh
@@ -612,6 +612,9 @@ public:
       payload);
   }
 
+  /**
+   * @brief Start a new section in the DOT file identified by its symbol
+   */
   void dot_push_section(::std::string symbol) const
   {
     _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
@@ -622,6 +625,9 @@ public:
       payload);
   }
 
+  /**
+   * @brief Ends current dot section
+   */
   void dot_pop_section() const
   {
     _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
@@ -632,6 +638,9 @@ public:
       payload);
   }
 
+  /**
+   * @brief RAII-style description of a new section in the DOT file identified by its symbol
+   */
   auto dot_section(::std::string symbol) const
   {
     _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");

--- a/cudax/include/cuda/experimental/stf.cuh
+++ b/cudax/include/cuda/experimental/stf.cuh
@@ -612,6 +612,33 @@ public:
       payload);
   }
 
+  void dot_push_section(::std::string symbol) const {
+      _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
+    ::std::visit(
+      [symbol=mv(symbol)](auto& self) {
+        self.dot_push_section(symbol);
+      },
+      payload);
+  }
+
+  void dot_pop_section() const {
+      _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
+    ::std::visit(
+      [](auto& self) {
+        self.dot_pop_section();
+      },
+      payload);
+  }
+
+  auto dot_section(::std::string symbol) const {
+      _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
+      return ::std::visit(
+      [symbol=mv(symbol)](auto& self) {
+        return self.dot_section(symbol);
+      },
+      payload);
+  }
+
   /* Indicates whether the underlying context is a graph context, so that we
    * may specialize code to deal with the specific constraints of CUDA graphs. */
   bool is_graph_ctx() const

--- a/cudax/include/cuda/experimental/stf.cuh
+++ b/cudax/include/cuda/experimental/stf.cuh
@@ -612,17 +612,19 @@ public:
       payload);
   }
 
-  void dot_push_section(::std::string symbol) const {
-      _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
+  void dot_push_section(::std::string symbol) const
+  {
+    _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
     ::std::visit(
-      [symbol=mv(symbol)](auto& self) {
+      [symbol = mv(symbol)](auto& self) {
         self.dot_push_section(symbol);
       },
       payload);
   }
 
-  void dot_pop_section() const {
-      _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
+  void dot_pop_section() const
+  {
+    _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
     ::std::visit(
       [](auto& self) {
         self.dot_pop_section();
@@ -630,10 +632,11 @@ public:
       payload);
   }
 
-  auto dot_section(::std::string symbol) const {
-      _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
-      return ::std::visit(
-      [symbol=mv(symbol)](auto& self) {
+  auto dot_section(::std::string symbol) const
+  {
+    _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
+    return ::std::visit(
+      [symbol = mv(symbol)](auto& self) {
         return self.dot_section(symbol);
       },
       payload);

--- a/cudax/test/stf/CMakeLists.txt
+++ b/cudax/test/stf/CMakeLists.txt
@@ -7,6 +7,7 @@ set(stf_test_sources
   cpp/user_streams.cu
   dot/basic.cu
   dot/graph_print_to_dot.cu
+  dot/sections.cu
   dot/with_events.cu
   error_checks/ctx_mismatch.cu
   error_checks/data_interface_mismatch.cu

--- a/cudax/test/stf/dot/sections.cu
+++ b/cudax/test/stf/dot/sections.cu
@@ -38,10 +38,11 @@ int main()
   ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
   ctx.dot_pop_section();
   ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
-  for (size_t i = 0; i < 10; i++) {
-      auto guard = ctx.dot_section("loop");
-      ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
-      ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
+  for (size_t i = 0; i < 10; i++)
+  {
+    auto guard = ctx.dot_section("loop");
+    ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
+    ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
   }
   ctx.dot_pop_section();
   ctx.finalize();

--- a/cudax/test/stf/dot/sections.cu
+++ b/cudax/test/stf/dot/sections.cu
@@ -34,13 +34,16 @@ int main()
   auto lA = ctx.logical_data(shape_of<slice<char>>(64));
   ctx.dot_push_section("foo");
   ctx.task(lA.write())->*[](cudaStream_t, auto) {};
+  ctx.dot_push_section("bar");
   ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
   ctx.dot_pop_section();
+  ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
   for (size_t i = 0; i < 10; i++) {
       auto guard = ctx.dot_section("loop");
       ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
       ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
   }
+  ctx.dot_pop_section();
   ctx.finalize();
 
   // Call this explicitely for the purpose of the test

--- a/cudax/test/stf/dot/sections.cu
+++ b/cudax/test/stf/dot/sections.cu
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDASTF in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * @file
+ * @brief This test makes sure we can generate a dot file
+ */
+
+#include <cuda/experimental/stf.cuh>
+
+using namespace cuda::experimental::stf;
+
+int main()
+{
+// TODO (miscco): Make it work for windows
+#if !_CCCL_COMPILER(MSVC)
+  // Generate a random filename
+  int r = rand();
+
+  char filename[64];
+  snprintf(filename, 64, "output_%d.dot", r);
+  // fprintf(stderr, "filename %s\n", filename);
+  setenv("CUDASTF_DOT_FILE", filename, 1);
+
+  context ctx;
+
+  auto lA = ctx.logical_data(shape_of<slice<char>>(64));
+  ctx.dot_push_section("foo");
+  ctx.task(lA.write())->*[](cudaStream_t, auto) {};
+  ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
+  ctx.dot_pop_section();
+  for (size_t i = 0; i < 10; i++) {
+      auto guard = ctx.dot_section("loop");
+      ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
+      ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
+  }
+  ctx.finalize();
+
+  // Call this explicitely for the purpose of the test
+  reserved::dot::instance().finish();
+
+  // Make sure the file exists, and erase it
+  // fprintf(stderr, "ERASE. ...\n");
+  EXPECT(access(filename, F_OK) != -1);
+
+  EXPECT(unlink(filename) == 0);
+#endif // !_CCCL_COMPILER(MSVC)
+}

--- a/cudax/test/stf/dot/sections.cu
+++ b/cudax/test/stf/dot/sections.cu
@@ -32,19 +32,18 @@ int main()
   context ctx;
 
   auto lA = ctx.logical_data(shape_of<slice<char>>(64));
-  ctx.dot_push_section("foo");
-  ctx.task(lA.write())->*[](cudaStream_t, auto) {};
-  ctx.dot_push_section("bar");
-  ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
-  ctx.dot_pop_section();
-  ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
-  for (size_t i = 0; i < 10; i++)
+  ctx.task(lA.write()).set_symbol("foot")->*[](cudaStream_t, auto) {};
+  for (size_t j = 0; j < 3; j++)
   {
-    auto guard = ctx.dot_section("loop");
-    ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
-    ctx.task(lA.rw())->*[](cudaStream_t, auto) {};
+    ctx.task(lA.rw()).set_symbol("presec")->*[](cudaStream_t, auto) {};
+    auto guard = ctx.dot_section("sec_loop " + ::std::to_string(j));
+    for (size_t i = 0; i < 10; i++)
+    {
+      auto guard_inner = ctx.dot_section("sec_inner_loop " + ::std::to_string(i));
+      ctx.task(lA.rw()).set_symbol("a" + ::std::to_string(i))->*[](cudaStream_t, auto) {};
+      ctx.task(lA.rw()).set_symbol("b" + ::std::to_string(i))->*[](cudaStream_t, auto) {};
+    }
   }
-  ctx.dot_pop_section();
   ctx.finalize();
 
   // Call this explicitely for the purpose of the test

--- a/cudax/test/stf/dot/sections.cu
+++ b/cudax/test/stf/dot/sections.cu
@@ -10,7 +10,7 @@
 
 /**
  * @file
- * @brief This test makes sure we can generate a dot file
+ * @brief This test makes sure we can generate a dot file with sections
  */
 
 #include <cuda/experimental/stf.cuh>


### PR DESCRIPTION
## Description

<!-- Provide a standalone description of changes in this PR. -->

Displaying large graphs is a challenge, so we introduce sections which can be used to collapse nodes so that we can concentrate on visualizing what is important at the algorithmic level. We could have a new variable like CUDASTF_DOT_MAX_DEPTH=2

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x ] I am familiar with the [Contributing Guidelines](). -->
- [ x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
