### PR TITLE
[PERF] cuda.parallel: Cache intermediate results to improve performance of `cudax.reduce_into` 

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/__init__.py
@@ -258,16 +258,17 @@ def _dtype_validation(dt1, dt2):
 
 
 class _Reduce:
-    def __init__(self, d_in, d_out, op, init):
+    # TODO: constructor shouldn't require concrete `d_in`, `d_out`:
+    def __init__(self, d_in, d_out, op, h_init):
         d_in_cccl = _d_in_as_cccl_iter(d_in)
         self._ctor_d_in_cccl_type_enum_name = _cccl_type_enum_as_name(
             d_in_cccl.value_type.type.value)
         self._ctor_d_out_dtype = d_out.dtype
-        self._ctor_init_dtype = init.dtype
+        self._ctor_init_dtype = h_init.dtype
         cc_major, cc_minor = cuda.get_current_device().compute_capability
         cub_path, thrust_path, libcudacxx_path, cuda_include_path = _get_paths()
         bindings = _get_bindings()
-        accum_t = init.dtype
+        accum_t = h_init.dtype
         self.op_wrapper = _Op(accum_t, op)
         d_out_ptr = _device_array_to_pointer(d_out)
         self.build_result = _CCCLDeviceReduceBuildResult()
@@ -277,7 +278,7 @@ class _Reduce:
                                                   d_in_cccl,
                                                   d_out_ptr,
                                                   self.op_wrapper.handle(),
-                                                  _host_array_to_value(init),
+                                                  _host_array_to_value(h_init),
                                                   cc_major,
                                                   cc_minor,
                                                   ctypes.c_char_p(cub_path),
@@ -288,7 +289,7 @@ class _Reduce:
         if error != enums.CUDA_SUCCESS:
             raise ValueError('Error building reduce')
 
-    def __call__(self, temp_storage, d_in, d_out, num_items, init):
+    def __call__(self, temp_storage, d_in, d_out, num_items, h_init):
         d_in_cccl = _d_in_as_cccl_iter(d_in)
         if d_in_cccl.type.value == _CCCLIteratorKindEnum.ITERATOR:
             assert num_items is not None
@@ -301,7 +302,7 @@ class _Reduce:
         _dtype_validation(self._ctor_d_in_cccl_type_enum_name,
                           _cccl_type_enum_as_name(d_in_cccl.value_type.type.value))
         _dtype_validation(self._ctor_d_out_dtype, d_out.dtype)
-        _dtype_validation(self._ctor_init_dtype, init.dtype)
+        _dtype_validation(self._ctor_init_dtype, h_init.dtype)
         bindings = _get_bindings()
         if temp_storage is None:
             temp_storage_bytes = ctypes.c_size_t()
@@ -319,7 +320,7 @@ class _Reduce:
                                             d_out_ptr,
                                             ctypes.c_ulonglong(num_items),
                                             self.op_wrapper.handle(),
-                                            _host_array_to_value(init),
+                                            _host_array_to_value(h_init),
                                             None)
         if error != enums.CUDA_SUCCESS:
             raise ValueError('Error reducing')
@@ -331,10 +332,9 @@ class _Reduce:
         bindings.cccl_device_reduce_cleanup(ctypes.byref(self.build_result))
 
 
-# TODO Figure out iterators
 # TODO Figure out `sum` without operator and initial value
 # TODO Accept stream
-def reduce_into(d_in, d_out, op, init):
+def reduce_into(d_in, d_out, op, h_init):
     """Computes a device-wide reduction using the specified binary ``op`` functor and initial value ``init``.
 
     Example:
@@ -364,4 +364,4 @@ def reduce_into(d_in, d_out, op, init):
     Returns:
         A callable object that can be used to perform the reduction
     """
-    return _Reduce(d_in, d_out, op, init)
+    return _Reduce(d_in, d_out, op, h_init)

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -116,11 +116,11 @@ def _test_device_sum_with_iterator(
     h_init = numpy.array([start_sum_with], dtype_out)
 
     reduce_into = cudax.reduce_into(
-        d_in=d_input, d_out=d_output, op=add_op, init=h_init
+        d_in=d_input, d_out=d_output, op=add_op, h_init=h_init
     )
 
     temp_storage_size = reduce_into(
-        None, d_in=d_input, d_out=d_output, num_items=len(l_varr), init=h_init
+        None, d_in=d_input, d_out=d_output, num_items=len(l_varr), h_init=h_init
     )
     d_temp_storage = numba.cuda.device_array(temp_storage_size, dtype=numpy.uint8)
 


### PR DESCRIPTION
## Description

This PR caches the result of a couple of helper functions using `functools.lru_cache`. 

## Additional context

This came up in the initial investigations for #2958.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
