### PR TITLE
Backport `is_scoped_enum`

### DIFF
--- a/docs/libcudacxx/standard_api.rst
+++ b/docs/libcudacxx/standard_api.rst
@@ -106,6 +106,8 @@ Feature availability:
 
 -  C++23 ``to_underlying`` from ``<utility>`` is available in C++11.
 
+-  C++23 ``is_scoped_enum`` in ``<type_traits>`` is available in C++11.
+
 -  C++26 ``std::dims`` is available in C++17.
 
 -  C++26 tuple protocol to ``complex`` is available in C++11.

--- a/libcudacxx/include/cuda/std/__type_traits/is_scoped_enum.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_scoped_enum.h
@@ -27,22 +27,23 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2020
-template <class _Tp, bool = is_enum_v<_Tp>>
+template <class _Tp, bool = _CCCL_TRAIT(is_enum, _Tp)>
 struct __is_scoped_enum_helper : false_type
 {};
 
 template <class _Tp>
-struct __is_scoped_enum_helper<_Tp, true> : public bool_constant<!is_convertible_v<_Tp, underlying_type_t<_Tp>>>
+struct __is_scoped_enum_helper<_Tp, true>
+    : public bool_constant<!_CCCL_TRAIT(is_convertible, _Tp, underlying_type_t<_Tp>)>
 {};
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_scoped_enum : public __is_scoped_enum_helper<_Tp>
 {};
 
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 template <class _Tp>
 _CCCL_INLINE_VAR constexpr bool is_scoped_enum_v = is_scoped_enum<_Tp>::value;
-#endif
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
@@ -54,7 +54,7 @@ struct underlying_type
   static_assert(_Support,
                 "The underyling_type trait requires compiler "
                 "support. Either no such support exists or "
-                "libc++ does not know how to use it.");
+                "libcu++ does not know how to use it.");
 };
 
 #endif // !_CCCL_BUILTIN_UNDERLYING_TYPE

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -29,7 +29,8 @@
 #  include <ciso646> // otherwise go for the smallest possible header
 #endif // !_CCCL_COMPILER(NVRTC)
 
-#define __cccl_lib_to_underlying 202102L
+#define __cccl_lib_to_underlying  202102L
+#define __cccl_lib_is_scoped_enum 202011L
 // #define __cpp_lib_tuple_like     202311L // P2819R2 is implemented, but P2165R4 is not yet
 
 #if _CCCL_STD_VER >= 2014
@@ -231,7 +232,6 @@
 // # define __cccl_lib_constexpr_typeinfo                   202106L
 #  define __cccl_lib_forward_like 202207L
 // # define __cccl_lib_invoke_r                             202106L
-#  define __cccl_lib_is_scoped_enum 202011L
 // # define __cccl_lib_move_only_function                   202110L
 // # define __cccl_lib_out_ptr                              202106L
 // # define __cccl_lib_ranges_chunk                         202202L

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -29,8 +29,8 @@
 #  include <ciso646> // otherwise go for the smallest possible header
 #endif // !_CCCL_COMPILER(NVRTC)
 
-#define __cccl_lib_to_underlying  202102L
 #define __cccl_lib_is_scoped_enum 202011L
+#define __cccl_lib_to_underlying  202102L
 // #define __cpp_lib_tuple_like     202311L // P2819R2 is implemented, but P2165R4 is not yet
 
 #if _CCCL_STD_VER >= 2014

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_scoped_enum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_scoped_enum.pass.cpp
@@ -53,7 +53,7 @@ class Empty
 
 class NotEmpty
 {
-  virtual ~NotEmpty();
+  __host__ __device__ virtual ~NotEmpty();
 };
 
 union Union
@@ -66,7 +66,7 @@ struct bit_zero
 
 class Abstract
 {
-  virtual ~Abstract() = 0;
+  __host__ __device__ virtual ~Abstract() = 0;
 };
 
 enum Enum
@@ -88,11 +88,11 @@ using FunctionType = void();
 
 struct TestMembers
 {
-  static int static_method(int)
+  __host__ __device__ static int static_method(int)
   {
     return 0;
   }
-  int method()
+  __host__ __device__ int method()
   {
     return 0;
   }
@@ -105,8 +105,8 @@ struct TestMembers
   enum class CE1;
 };
 
-void func1();
-int func2(int);
+__host__ __device__ void func1();
+__host__ __device__ int func2(int);
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_scoped_enum.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_scoped_enum.pass.cpp
@@ -1,0 +1,151 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/type_traits>
+
+// is_scoped_enum
+
+#include <cuda/std/cstddef> // for cuda::std::nullptr_t
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+template <class T>
+__host__ __device__ void test_positive()
+{
+  static_assert(cuda::std::is_scoped_enum<T>::value, "");
+  static_assert(cuda::std::is_scoped_enum<const T>::value, "");
+  static_assert(cuda::std::is_scoped_enum<volatile T>::value, "");
+  static_assert(cuda::std::is_scoped_enum<const volatile T>::value, "");
+
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
+  static_assert(cuda::std::is_scoped_enum_v<T>, "");
+  static_assert(cuda::std::is_scoped_enum_v<const T>, "");
+  static_assert(cuda::std::is_scoped_enum_v<volatile T>, "");
+  static_assert(cuda::std::is_scoped_enum_v<const volatile T>, "");
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
+}
+
+template <class T>
+__host__ __device__ void test_negative()
+{
+  static_assert(!cuda::std::is_scoped_enum<T>::value, "");
+  static_assert(!cuda::std::is_scoped_enum<const T>::value, "");
+  static_assert(!cuda::std::is_scoped_enum<volatile T>::value, "");
+  static_assert(!cuda::std::is_scoped_enum<const volatile T>::value, "");
+
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
+  static_assert(!cuda::std::is_scoped_enum_v<T>, "");
+  static_assert(!cuda::std::is_scoped_enum_v<const T>, "");
+  static_assert(!cuda::std::is_scoped_enum_v<volatile T>, "");
+  static_assert(!cuda::std::is_scoped_enum_v<const volatile T>, "");
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
+}
+
+class Empty
+{};
+
+class NotEmpty
+{
+  virtual ~NotEmpty();
+};
+
+union Union
+{};
+
+struct bit_zero
+{
+  int : 0;
+};
+
+class Abstract
+{
+  virtual ~Abstract() = 0;
+};
+
+enum Enum
+{
+  zero,
+  one
+};
+enum class CEnum1
+{
+  zero,
+  one
+};
+enum class CEnum2;
+enum class CEnum3 : short;
+struct incomplete_type;
+
+using FunctionPtr  = void (*)();
+using FunctionType = void();
+
+struct TestMembers
+{
+  static int static_method(int)
+  {
+    return 0;
+  }
+  int method()
+  {
+    return 0;
+  }
+
+  enum E1
+  {
+    m_zero,
+    m_one
+  };
+  enum class CE1;
+};
+
+void func1();
+int func2(int);
+
+int main(int, char**)
+{
+  test_positive<CEnum1>();
+  test_positive<CEnum2>();
+  test_positive<CEnum3>();
+  test_positive<TestMembers::CE1>();
+
+  test_negative<Enum>();
+  test_negative<TestMembers::E1>();
+
+  test_negative<cuda::std::nullptr_t>();
+  test_negative<void>();
+  test_negative<int>();
+  test_negative<int&>();
+  test_negative<int&&>();
+  test_negative<int*>();
+  test_negative<double>();
+  test_negative<const int*>();
+  test_negative<char[3]>();
+  test_negative<char[]>();
+  test_negative<Union>();
+  test_negative<Empty>();
+  test_negative<bit_zero>();
+  test_negative<NotEmpty>();
+  test_negative<Abstract>();
+  test_negative<FunctionPtr>();
+  test_negative<FunctionType>();
+  test_negative<incomplete_type>();
+  test_negative<int TestMembers::*>();
+  test_negative<void (TestMembers::*)()>();
+
+  test_negative<decltype(func1)>();
+  test_negative<decltype(&func1)>();
+  test_negative<decltype(func2)>();
+  test_negative<decltype(&func2)>();
+  test_negative<decltype(TestMembers::static_method)>();
+  test_negative<decltype(&TestMembers::static_method)>();
+  test_negative<decltype(&TestMembers::method)>();
+
+  return 0;
+}


### PR DESCRIPTION
This PR implements backport of C++23 `is_scoped_enum` to C++11 and proper testing.