### PR TITLE
don't bother sync-ing a stream with itself

### DIFF
--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -92,8 +92,11 @@ struct stream_ref : ::cuda::stream_ref
     // TODO consider an optimization to not create an event every time and instead have one persistent event or one
     // per stream
     _CCCL_ASSERT(__stream != detail::__invalid_stream, "cuda::experimental::stream_ref::wait invalid stream passed");
-    event __tmp(__other);
-    wait(__tmp);
+    if (*this != __other)
+    {
+      event __tmp(__other);
+      wait(__tmp);
+    }
   }
 
   //! @brief Get the logical device under which this stream was created


### PR DESCRIPTION
given two `stream_ref` objects, `stream1.wait(stream2)` should be a no-op if `stream1 == stream2`. don't bother creating an event for it.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
