### PR TITLE
[Automation] Add release workflow for tagging and testing new RCs

### DIFF
--- a/.github/workflows/release-update-rc.yml
+++ b/.github/workflows/release-update-rc.yml
@@ -58,7 +58,7 @@ jobs:
           branch_name="branch/${major_version}.${minor_version}.x"
 
           log_vars full_version major_version minor_version patch_version branch_name GITHUB_REF GITHUB_SHA
-          export_vars full_version major_version minor_version patch_version branch_name
+          export_vars export_vars log_vars full_version major_version minor_version patch_version branch_name
 
       - name: Validate versions and tags
         run: |

--- a/.github/workflows/release-update-rc.yml
+++ b/.github/workflows/release-update-rc.yml
@@ -93,123 +93,18 @@ jobs:
           log_vars last_rc next_rc tag_name
           export_vars tag_name
 
-  build-workflow:
-    name: Build workflow from matrix
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      workflow: ${{ steps.build-workflow.outputs.workflow }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Build workflow
-        id: build-workflow
-        uses: ./.github/actions/workflow-build
-        with:
-          workflows: pull_request #TODO could add more or create a new release_candidate approval workflow.
-          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
-          slack_log: ${{ secrets.SLACK_CHANNEL_RELEASE_LOG }}
-
-  dispatch-groups-linux-two-stage:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
-    with:
-      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
-
-  dispatch-groups-windows-two-stage:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
-    with:
-      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
-
-  dispatch-groups-linux-standalone:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
-    with:
-      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
-
-  dispatch-groups-windows-standalone:
-    name: ${{ matrix.name }}
-    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]' }}
-    needs: build-workflow
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys'] }}
-    uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
-    with:
-      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
-
-  verify-workflow:
-    name: Verify and summarize workflow results
-    if: ${{ always() && !cancelled() }}
-    needs:
-      - build-workflow
-      - dispatch-groups-linux-two-stage
-      - dispatch-groups-windows-two-stage
-      - dispatch-groups-linux-standalone
-      - dispatch-groups-windows-standalone
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Check workflow success
-        id: check-workflow
-        uses: ./.github/actions/workflow-results
-        with:
-          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
-          slack_log: ${{ secrets.SLACK_CHANNEL_RELEASE_LOG }}
+  # TODO:
+  #  - Kick off CI for repo before tagging release
 
   tag:
     needs:
       - prepare
-      - verify-workflow
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
-        with:
-          persist-credentials: false
 
       - name: Tag the release candidate
         run: |

--- a/.github/workflows/release-update-rc.yml
+++ b/.github/workflows/release-update-rc.yml
@@ -107,6 +107,8 @@ jobs:
       - name: Tag the release candidate
         run: |
           rc_tag=${{ needs.prepare.outputs.tag_name }}
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a -m "CCCL Release Candidate ${rc_tag}" ${rc_tag} ${GITHUB_SHA}
           git push origin ${rc_tag}
           echo "Tagged release candidate ${rc_tag}."

--- a/.github/workflows/release-update-rc.yml
+++ b/.github/workflows/release-update-rc.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Prepare environment
+      - name: Prepare environment and validate tags
         id: prepare
         run: |
           log_vars() {
@@ -58,10 +58,8 @@ jobs:
           branch_name="branch/${major_version}.${minor_version}.x"
 
           log_vars full_version major_version minor_version patch_version branch_name GITHUB_REF GITHUB_SHA
-          export_vars export_vars log_vars full_version major_version minor_version patch_version branch_name
+          export_vars full_version major_version minor_version patch_version branch_name
 
-      - name: Validate versions and tags
-        run: |
           # The workflow must be started on a release branch:
           if [[ "${GITHUB_REF}" != "refs/heads/${branch_name}" ]]; then
             echo "::error::GITHUB_REF (${GITHUB_REF}) does not match expected branch name (${branch_name})."

--- a/.github/workflows/release-update-rc.yml
+++ b/.github/workflows/release-update-rc.yml
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Release: 2. Test and Tag New RC"
+
+# This workflow must be started on the "branch/{major}.{minor}.x" release branch
+# after the release-create-new workflow runs.
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.prepare.outputs.tag_name }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Prepare environment
+        id: prepare
+        run: |
+          log_vars() {
+            for var in "$@"; do
+              printf "%-15s %s\n" "${var}:" "${!var}" | tee -a $GITHUB_STEP_SUMMARY
+            done
+          }
+          export_vars() {
+            for var in "$@"; do
+              echo "${var}=${!var}" | tee -a $GITHUB_ENV | tee -a $GITHUB_OUTPUT
+            done
+          }
+
+          # Parse repo version info:
+          full_version=$(jq -r  .full  cccl-version.json)
+          major_version=$(jq -r .major cccl-version.json)
+          minor_version=$(jq -r .minor cccl-version.json)
+          patch_version=$(jq -r .patch cccl-version.json)
+          branch_name="branch/${major_version}.${minor_version}.x"
+
+          log_vars full_version major_version minor_version patch_version branch_name GITHUB_REF GITHUB_SHA
+          export_vars full_version major_version minor_version patch_version branch_name
+
+      - name: Validate versions and tags
+        run: |
+          # The workflow must be started on a release branch:
+          if [[ "${GITHUB_REF}" != "refs/heads/${branch_name}" ]]; then
+            echo "::error::GITHUB_REF (${GITHUB_REF}) does not match expected branch name (${branch_name})."
+            exit 1
+          fi
+
+          # The release tag must not exist:
+          full_version_escaped=$(echo "${full_version}" | sed 's/\./\\./g')
+          if git ls-remote --tags origin | grep -q "refs/tags/v${full_version_escaped}\$"; then
+            echo "::error::Tag v${full_version} already exists. Was the automated version-bump PR merged?"
+            exit 1
+          fi
+
+          # Look for previous release candidates:
+          declare -i last_rc=-1
+          for tag in $(git ls-remote --tags origin); do
+              if [[ $tag =~ refs/tags/v${full_version_escaped}-rc([0-9]+)$ ]]; then
+                echo "Found prior release candidate: ${tag}"
+                rc=${BASH_REMATCH[1]}
+                if (( rc > last_rc )); then
+                  last_rc=rc
+                fi
+              fi
+          done
+
+          next_rc=$((last_rc + 1))
+          tag_name="v${full_version}-rc${next_rc}"
+
+          log_vars last_rc next_rc tag_name
+          export_vars tag_name
+
+  build-workflow:
+    name: Build workflow from matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      workflow: ${{ steps.build-workflow.outputs.workflow }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Build workflow
+        id: build-workflow
+        uses: ./.github/actions/workflow-build
+        with:
+          workflows: pull_request #TODO could add more or create a new release_candidate approval workflow.
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_RELEASE_LOG }}
+
+  dispatch-groups-linux-two-stage:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+    with:
+      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
+
+  dispatch-groups-windows-two-stage:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+    with:
+      pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
+
+  dispatch-groups-linux-standalone:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
+    with:
+      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
+
+  dispatch-groups-windows-standalone:
+    name: ${{ matrix.name }}
+    if: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]' }}
+    needs: build-workflow
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys'] }}
+    uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
+    with:
+      job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
+
+  verify-workflow:
+    name: Verify and summarize workflow results
+    if: ${{ always() && !cancelled() }}
+    needs:
+      - build-workflow
+      - dispatch-groups-linux-two-stage
+      - dispatch-groups-windows-two-stage
+      - dispatch-groups-linux-standalone
+      - dispatch-groups-windows-standalone
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check workflow success
+        id: check-workflow
+        uses: ./.github/actions/workflow-results
+        with:
+          slack_token: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          slack_log: ${{ secrets.SLACK_CHANNEL_RELEASE_LOG }}
+
+  tag:
+    needs:
+      - prepare
+      - verify-workflow
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Tag the release candidate
+        run: |
+          rc_tag=${{ needs.prepare.outputs.tag_name }}
+          git tag -a -m "CCCL Release Candidate ${rc_tag}" ${rc_tag} ${GITHUB_SHA}
+          git push origin ${rc_tag}
+          echo "Tagged release candidate ${rc_tag}."
+
+  notify-success:
+    if: ${{ success() }}
+    needs: tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+          SUMMARY_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          RC_TAG: ${{ needs.prepare.outputs.tag_name }}
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_RELEASE_LOG }}
+          slack-message: |
+            A new release candidate `${{ env.RC_TAG }}` has been tagged.
+
+            Workflow summary: ${{ env.SUMMARY_URL }}
+
+  notify-failure:
+    if: ${{ failure() }}
+    needs: tag
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify Slack (failure)
+      if: ${{ failure() }}
+      uses: slackapi/slack-github-action@v1.26.0
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFIER_BOT_TOKEN }}
+        SUMMARY_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+        RC_TAG: ${{ needs.prepare.outputs.tag_name }}
+      with:
+        channel-id: ${{ secrets.SLACK_CHANNEL_RELEASE_LOG }}
+        slack-message: |
+          An error has occurred while creating release candidate `${{ env.RC_TAG }}`.
+
+          Details: ${{ env.SUMMARY_URL }}


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/cccl/issues/2916

Adds the release-update-rc.yml file from #1945.

This adds a step for generating RC tags in the release automation process. It will test and tag a new release provided that all tests pass.

I've removed the testing for now. Whenever a PR merges to the release branch it *does* get tested there so testing in the RC is superfluous for now.

Testing: 
RC0 - https://github.com/wmaxey/cccl/actions/runs/12166117189
RC1 - https://github.com/wmaxey/cccl/actions/runs/12166195131

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
