### PR TITLE
Deprecate public CUB/Thrust deprecation macros

### DIFF
--- a/cub/cub/util_deprecated.cuh
+++ b/cub/cub/util_deprecated.cuh
@@ -50,22 +50,34 @@
 #endif
 
 #ifdef CUB_IGNORE_DEPRECATED_API
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED_BECAUSE(MSG)
 #elif _CCCL_STD_VER >= 2014
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED              [[deprecated]]
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED_BECAUSE(MSG) [[deprecated(MSG)]]
 #elif _CCCL_COMPILER(MSVC)
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED              __declspec(deprecated)
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED_BECAUSE(MSG) __declspec(deprecated(MSG))
 #elif _CCCL_COMPILER(CLANG)
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED              __attribute__((deprecated))
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED_BECAUSE(MSG) __attribute__((deprecated(MSG)))
 #elif _CCCL_COMPILER(GCC)
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED              __attribute__((deprecated))
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED_BECAUSE(MSG) __attribute__((deprecated(MSG)))
 #else
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED
+//! deprecated [Since 2.8]
 #  define CUB_DEPRECATED_BECAUSE(MSG)
 #endif
 

--- a/thrust/thrust/detail/config/deprecated.h
+++ b/thrust/thrust/detail/config/deprecated.h
@@ -38,21 +38,33 @@
 #endif
 
 #ifdef THRUST_IGNORE_DEPRECATED_API
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED_BECAUSE(MSG)
 #elif _CCCL_STD_VER >= 2014
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED              [[deprecated]]
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED_BECAUSE(MSG) [[deprecated(MSG)]]
 #elif _CCCL_COMPILER(MSVC)
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED              __declspec(deprecated)
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED_BECAUSE(MSG) __declspec(deprecated(MSG))
 #elif _CCCL_COMPILER(CLANG)
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED              __attribute__((deprecated))
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED_BECAUSE(MSG) __attribute__((deprecated(MSG)))
 #elif _CCCL_COMPILER(GCC)
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED              __attribute__((deprecated))
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED_BECAUSE(MSG) __attribute__((deprecated(MSG)))
 #else
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED
+//! deprecated [Since 2.8]
 #  define THRUST_DEPRECATED_BECAUSE(MSG)
 #endif


### PR DESCRIPTION
PR #2934 is trying to rework the deprecation macros but we hit some difficulties, since `[CUB_|THRUST]_DEPRECATED*` are publicly provided macros. So let's at least deprecate them so we can remove them at some point and replace them by a common CCCL-wide deprecation macro.