### PR TITLE
Fix libcudacxx example

### DIFF
--- a/libcudacxx/examples/concurrent_hash_table.cu
+++ b/libcudacxx/examples/concurrent_hash_table.cu
@@ -15,7 +15,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/pair.h>
 #include <thrust/universal_allocator.h>
-#include <thrust/system/cuda/vector.h>
+#include <thrust/universal_vector.h>
 
 #include <cassert>
 #include <cstdio>
@@ -187,8 +187,8 @@ int main()
 
     auto freq = thrust::allocate_unique<table>(thrust::universal_allocator<table>{}, 8);
 
-    thrust::cuda::universal_vector<int> input = [] {
-      thrust::cuda::universal_vector<int> v(2048);
+    thrust::universal_vector<int> input = [] {
+      thrust::universal_vector<int> v(2048);
       std::mt19937 gen(1337);
       std::uniform_int_distribution<long> dis(0, 7);
       thrust::generate(v.begin(), v.end(), [&] {
@@ -218,8 +218,8 @@ int main()
 
     auto freq = thrust::allocate_unique<table>(thrust::universal_allocator<table>{}, 8, identity_modulo<int>(4));
 
-    thrust::cuda::universal_vector<int> input = [] {
-      thrust::cuda::universal_vector<int> v(2048);
+    thrust::universal_vector<int> input = [] {
+      thrust::universal_vector<int> v(2048);
       std::mt19937 gen(1337);
       std::uniform_int_distribution<long> dis(0, 7);
       thrust::generate(v.begin(), v.end(), [&] {

--- a/libcudacxx/examples/concurrent_hash_table.cu
+++ b/libcudacxx/examples/concurrent_hash_table.cu
@@ -14,6 +14,7 @@
 #include <thrust/host_vector.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/pair.h>
+#include <thrust/universal_allocator.h>
 #include <thrust/system/cuda/vector.h>
 
 #include <cassert>
@@ -25,7 +26,7 @@ template <typename Key,
           typename Value,
           typename Hash           = thrust::identity<Key>,
           typename KeyEqual       = thrust::equal_to<Key>,
-          typename MemoryResource = thrust::universal_raw_memory_resource>
+          typename MemoryResource = thrust::universal_memory_resource>
 struct concurrent_hash_table
 {
   // Elements transition from state_empty -> state_reserved ->

--- a/libcudacxx/examples/concurrent_hash_table.cu
+++ b/libcudacxx/examples/concurrent_hash_table.cu
@@ -9,6 +9,7 @@
 // TODO: It would be great if this example could NOT depend on Thrust.
 #include <thrust/allocate_unique.h>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 #include <thrust/functional.h>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/libcudacxx/examples/trie.cu
+++ b/libcudacxx/examples/trie.cu
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 */
 
-#include <cuda/std/atomic>
+#include <cuda/atomic>
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 

--- a/libcudacxx/examples/trie_mt.cpp
+++ b/libcudacxx/examples/trie_mt.cpp
@@ -36,11 +36,11 @@ struct trie
 {
   struct ref
   {
-    std::atomic<trie*> ptr = LIBCUDACXX_ATOMIC_VAR_INIT(nullptr);
+    std::atomic<trie*> ptr = ATOMIC_VAR_INIT(nullptr);
     // the flag will protect against multiple pointer updates
-    std::atomic_flag flag = LIBCUDACXX_ATOMIC_VAR_INIT(0);
+    std::atomic_flag flag = ATOMIC_VAR_INIT(0);
   } next[26];
-  std::atomic<int> count = LIBCUDACXX_ATOMIC_VAR_INIT(0);
+  std::atomic<int> count = ATOMIC_VAR_INIT(0);
 };
 int index_of(char c)
 {


### PR DESCRIPTION
## Description

closes https://github.com/NVIDIA/cccl/issues/3012

Fix compile errors in `libcudacxx/examples/*`.
- Fixed `trie_mt.cpp`
- Fixed `trie.cu`
- (WIP) Fixing `concurrent_hash_table.cu`