### PR TITLE
Allow passing debug flags to NVRTC in libcudacxx tests

### DIFF
--- a/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc.cpp
+++ b/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc.cpp
@@ -158,7 +158,7 @@ ArgPair argHandlers[] = {
    }},
   {// Matches -G/--device-debug
    std::regex("^(?:-G|--device-debug)$"),
-   [](const std::smatch& match) {
+   [](const std::smatch&) {
      nvrtcArguments.emplace_back("-G");
      return NORMAL;
    }},

--- a/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc.cpp
+++ b/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc.cpp
@@ -156,6 +156,12 @@ ArgPair argHandlers[] = {
      nvrtcArguments.emplace_back("-std=" + match[1].str());
      return NORMAL;
    }},
+  {// Matches -G/--device-debug
+   std::regex("^(?:-G|--device-debug)$"),
+   [](const std::smatch& match) {
+     nvrtcArguments.emplace_back("-G");
+     return NORMAL;
+   }},
   {// Capture an argument that is just '-'. If no input file is listed input is on stdin
    std::regex("^-$"),
    [](const std::smatch& match) {


### PR DESCRIPTION
## Description

Allows reproducing compiler bugs with NVRTC.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
