### PR TITLE
Fix value range overflows in tests

### DIFF
--- a/thrust/testing/for_each.cu
+++ b/thrust/testing/for_each.cu
@@ -167,7 +167,7 @@ void TestForEach(const size_t n)
 {
   const size_t output_size = std::min((size_t) 10, 2 * n);
 
-  thrust::host_vector<T> h_input = unittest::random_integers<T>(n);
+  thrust::host_vector<T> h_input = unittest::random_integers<size_t>(n);
 
   for (size_t i = 0; i < n; i++)
   {
@@ -199,7 +199,7 @@ void TestForEachN(const size_t n)
 {
   const size_t output_size = std::min((size_t) 10, 2 * n);
 
-  thrust::host_vector<T> h_input = unittest::random_integers<T>(n);
+  thrust::host_vector<T> h_input = unittest::random_integers<size_t>(n);
 
   for (size_t i = 0; i < n; i++)
   {

--- a/thrust/testing/set_difference.cu
+++ b/thrust/testing/set_difference.cu
@@ -134,7 +134,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetDifferenceEquivalentRanges);
 template <typename T>
 void TestSetDifferenceMultiset(const size_t n)
 {
-  thrust::host_vector<T> vec = unittest::random_integers<T>(2 * n);
+  thrust::host_vector<T> vec = unittest::random_integers<int>(2 * n);
 
   // restrict elements to [min,13)
   for (typename thrust::host_vector<T>::iterator i = vec.begin(); i != vec.end(); ++i)

--- a/thrust/testing/set_difference_by_key.cu
+++ b/thrust/testing/set_difference_by_key.cu
@@ -235,7 +235,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetDifferenceByKeyEquivalentRanges);
 template <typename T>
 void TestSetDifferenceByKeyMultiset(const size_t n)
 {
-  thrust::host_vector<T> vec = unittest::random_integers<T>(2 * n);
+  thrust::host_vector<T> vec = unittest::random_integers<int>(2 * n);
 
   // restrict elements to [min,13)
   for (typename thrust::host_vector<T>::iterator i = vec.begin(); i != vec.end(); ++i)

--- a/thrust/testing/set_intersection.cu
+++ b/thrust/testing/set_intersection.cu
@@ -168,7 +168,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetIntersectionEquivalentRanges);
 template <typename T>
 void TestSetIntersectionMultiset(const size_t n)
 {
-  thrust::host_vector<T> vec = unittest::random_integers<T>(2 * n);
+  thrust::host_vector<T> vec = unittest::random_integers<int>(2 * n);
 
   // restrict elements to [min,13)
   for (typename thrust::host_vector<T>::iterator i = vec.begin(); i != vec.end(); ++i)

--- a/thrust/testing/set_intersection_by_key.cu
+++ b/thrust/testing/set_intersection_by_key.cu
@@ -210,7 +210,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetIntersectionByKeyEquivalentRanges);
 template <typename T>
 void TestSetIntersectionByKeyMultiset(const size_t n)
 {
-  thrust::host_vector<T> vec = unittest::random_integers<T>(2 * n);
+  thrust::host_vector<T> vec = unittest::random_integers<int>(2 * n);
 
   // restrict elements to [min,13)
   for (typename thrust::host_vector<T>::iterator i = vec.begin(); i != vec.end(); ++i)

--- a/thrust/testing/set_symmetric_difference.cu
+++ b/thrust/testing/set_symmetric_difference.cu
@@ -134,7 +134,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetSymmetricDifferenceEquivalentRanges);
 template <typename T>
 void TestSetSymmetricDifferenceMultiset(const size_t n)
 {
-  thrust::host_vector<T> vec = unittest::random_integers<T>(2 * n);
+  thrust::host_vector<T> vec = unittest::random_integers<int>(2 * n);
 
   // restrict elements to [min,13)
   for (typename thrust::host_vector<T>::iterator i = vec.begin(); i != vec.end(); ++i)

--- a/thrust/testing/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/set_symmetric_difference_by_key.cu
@@ -234,7 +234,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetSymmetricDifferenceByKeyEquivalentRanges);
 template <typename T>
 void TestSetSymmetricDifferenceByKeyMultiset(const size_t n)
 {
-  thrust::host_vector<T> vec = unittest::random_integers<T>(2 * n);
+  thrust::host_vector<T> vec = unittest::random_integers<int>(2 * n);
 
   // restrict elements to [min,13)
   for (typename thrust::host_vector<T>::iterator i = vec.begin(); i != vec.end(); ++i)

--- a/thrust/testing/set_union_by_key.cu
+++ b/thrust/testing/set_union_by_key.cu
@@ -234,7 +234,7 @@ DECLARE_VARIABLE_UNITTEST(TestSetUnionByKeyEquivalentRanges);
 template <typename T>
 void TestSetUnionByKeyMultiset(const size_t n)
 {
-  thrust::host_vector<T> vec = unittest::random_integers<T>(2 * n);
+  thrust::host_vector<T> vec = unittest::random_integers<int>(2 * n);
 
   // restrict elements to [min,13)
   for (typename thrust::host_vector<T>::iterator i = vec.begin(); i != vec.end(); ++i)


### PR DESCRIPTION
## Description

closes #3021

`random_integers<fp-type>()` may generate values not representable as an integer type, which results in undefined behavior when we attempt to cast them to integer type later on.

To avoid that, generate random numbers using the integer type we'll cast to later on, so we're guaranteed to have representable values.

## Checklist
- [x] New or existing tests cover these changes.
- [n/a] The documentation is up to date with these changes.
