### PR TITLE
revise `<cuda/std/version>`

### DIFF
--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -29,14 +29,41 @@
 #  include <ciso646> // otherwise go for the smallest possible header
 #endif // !_CCCL_COMPILER(NVRTC)
 
+#define __cccl_lib_bitops                       201907L
+#define __cccl_lib_bool_constant                201505L
+#define __cccl_lib_bounded_array_traits         201902L
+#define __cccl_lib_byte                         201603L
+#define __cccl_lib_clamp                        201603L
+#define __cccl_lib_endian                       201907L
 #define __cccl_lib_forward_like                 202207L
+#define __cccl_lib_gcd_lcm                      201606L
 #define __cccl_lib_integer_comparison_functions 202002L
+#define __cccl_lib_integer_sequence             201304L
+#define __cccl_lib_integral_constant_callable   201304L
+#define __cccl_lib_is_final                     201402L
+#define __cccl_lib_is_nothrow_convertible       201806L
+#define __cccl_lib_is_null_pointer              201309L
 #define __cccl_lib_is_scoped_enum               202011L
+#define __cccl_lib_is_swappable                 201603L
+#define __cccl_lib_launder                      201606L
+#define __cccl_lib_logical_traits               201510L
+#define __cccl_lib_shift                        201806L
+#define __cccl_lib_to_address                   201711L
+#define __cccl_lib_to_array                     201907L
 #define __cccl_lib_to_underlying                202102L
+#define __cccl_lib_transparent_operators        201210L
+#define __cccl_lib_transformation_trait_aliases 201304L
+#define __cccl_lib_tuple_element_t              201402L
+// #define __cpp_lib_tuple_like                    202311L // P2819R2 is implemented, but P2165R4 is not yet
+#define __cccl_lib_type_identity 201806L
+#define __cccl_lib_void_t        201411L
 
-// #define __cpp_lib_tuple_like     202311L // P2819R2 is implemented, but P2165R4 is not yet
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
+#  define __cccl_lib_type_trait_variable_templates 201510L
+#endif
 
 #if _CCCL_STD_VER >= 2014
+#  define __cccl_lib_as_const     201510L
 #  define __cccl_lib_bit_cast     201806L
 #  define __cccl_lib_chrono_udls  201304L
 #  define __cccl_lib_complex_udls 201309L
@@ -47,11 +74,9 @@
 #  define __cccl_lib_exchange_function 201304L
 #  define __cccl_lib_expected          202211L
 // # define __cccl_lib_generic_associative_lookup           201304L
-#  define __cccl_lib_integer_sequence           201304L
-#  define __cccl_lib_integral_constant_callable 201304L
-#  define __cccl_lib_is_final                   201402L
-#  define __cccl_lib_is_null_pointer            201309L
-#  define __cccl_lib_make_reverse_iterator      201402L
+#  define __cccl_lib_invoke                201411L
+#  define __cccl_lib_is_invocable          201703L
+#  define __cccl_lib_make_reverse_iterator 201402L
 // # define __cccl_lib_make_unique                          201304L
 #  if !_CCCL_COMPILER(MSVC) || _CCCL_STD_VER >= 2020
 #    define __cccl_lib_mdspan 202207L
@@ -68,10 +93,7 @@
 #  define __cccl_lib_span                  202311L
 #  define __cccl_lib_span_initializer_list 202311L
 // # define __cccl_lib_string_udls                          201304L
-#  define __cccl_lib_transformation_trait_aliases 201304L
-#  define __cccl_lib_transparent_operators        201210L
-#  define __cccl_lib_tuple_element_t              201402L
-#  define __cccl_lib_tuples_by_type               201304L
+#  define __cccl_lib_tuples_by_type 201304L
 #endif // _CCCL_STD_VER >= 2014
 
 #if _CCCL_STD_VER >= 2017
@@ -82,34 +104,24 @@
 // # define __cccl_lib_any                                  201606L
 #  define __cccl_lib_apply           201603L
 #  define __cccl_lib_array_constexpr 201603L
-#  define __cccl_lib_as_const        201510L
 #  ifndef _LIBCUDACXX_HAS_NO_THREADS
 #    define __cccl_lib_atomic_is_always_lock_free 201603L
 #  endif // _LIBCUDACXX_HAS_NO_THREADS
-#  define __cccl_lib_bind_front    201907L
-#  define __cccl_lib_bool_constant 201505L
+#  define __cccl_lib_bind_front 201907L
 // # define __cccl_lib_boyer_moore_searcher                 201603L
-#  define __cccl_lib_byte   201603L
 #  define __cccl_lib_chrono 201611L
-// # define __cccl_lib_clamp                                201603L
 // # define __cccl_lib_enable_shared_from_this              201603L
 // # define __cccl_lib_execution                            201603L
 // # define __cccl_lib_filesystem                           201703L
-#  define __cccl_lib_gcd_lcm                    201606L
-#  define __cccl_lib_hardware_interference_size 201703L
+// #  define __cccl_lib_hardware_interference_size 201703L
 #  ifdef _CCCL_BUILTIN_HAS_UNIQUE_OBJECT_REPRESENTATIONS
 #    define __cccl_lib_has_unique_object_representations 201606L
 #  endif // _CCCL_BUILTIN_HAS_UNIQUE_OBJECT_REPRESENTATIONS
 #  define __cccl_lib_hypot 201603L
 // # define __cccl_lib_incomplete_container_elements        201505L
-#  define __cccl_lib_invoke 201411L
 #  ifndef _LIBCUDACXX_HAS_NO_IS_AGGREGATE
 #    define __cccl_lib_is_aggregate 201703L
 #  endif // _LIBCUDACXX_HAS_NO_IS_AGGREGATE
-#  define __cccl_lib_is_invocable    201703L
-#  define __cccl_lib_is_swappable    201603L
-#  define __cccl_lib_launder         201606L
-#  define __cccl_lib_logical_traits  201510L
 #  define __cccl_lib_make_from_tuple 201606L
 // # define __cccl_lib_map_try_emplace                      201411L
 // # define __cccl_lib_math_special_functions               201603L
@@ -128,11 +140,9 @@
 // # define __cccl_lib_shared_ptr_weak_type                 201606L
 // # define __cccl_lib_string_view                          201606L
 // # define __cccl_lib_to_chars                             201611L
-#  define __cccl_lib_type_trait_variable_templates 201510L
-#  define __cccl_lib_uncaught_exceptions           201411L
-#  define __cccl_lib_unordered_map_try_emplace     201411L
-#  define __cccl_lib_variant                       201606L
-#  define __cccl_lib_void_t                        201411L
+// #  define __cccl_lib_uncaught_exceptions           201411L
+// #  define __cccl_lib_unordered_map_try_emplace     201411L
+#  define __cccl_lib_variant 201606L
 #endif // _CCCL_STD_VER >= 2017
 
 #if _CCCL_STD_VER >= 2020
@@ -151,9 +161,7 @@
 #  ifndef _LIBCUDACXX_HAS_NO_THREADS
 #    define __cccl_lib_barrier 201907L
 #  endif // !_LIBCUDACXX_HAS_NO_THREADS
-#  define __cccl_lib_bit_cast             201806L
-#  define __cccl_lib_bitops               201907L
-#  define __cccl_lib_bounded_array_traits 201902L
+#  define __cccl_lib_bit_cast 201806L
 #  ifndef _LIBCUDACXX_NO_HAS_CHAR8_T
 #    define __cccl_lib_char8_t 201811L
 #  endif // !_LIBCUDACXX_NO_HAS_CHAR8_T
@@ -175,7 +183,6 @@
     && defined(__cpp_lib_destroying_delete)
 #    define __cccl_lib_destroying_delete 201806L
 #  endif
-// # define __cccl_lib_endian                               201907L
 // # define __cccl_lib_erase_if                             201811L
 // # undef  __cccl_lib_execution
 // # define __cccl_lib_execution                            201902L
@@ -187,7 +194,6 @@
 #    define __cccl_lib_is_constant_evaluated 201811L
 #  endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
 // # define __cccl_lib_is_layout_compatible                 201907L
-#  define __cccl_lib_is_nothrow_convertible 201806L
 // # define __cccl_lib_is_pointer_interconvertible          201907L
 #  if !defined(_LIBCUDACXX_HAS_NO_THREADS)
 // #   define __cccl_lib_jthread                            201911L
@@ -205,7 +211,6 @@
 #  endif // !_LIBCUDACXX_HAS_NO_THREADS
 // # undef  __cccl_lib_shared_ptr_arrays
 // # define __cccl_lib_shared_ptr_arrays                    201707L
-// # define __cccl_lib_shift                                201806L
 // # define __cccl_lib_smart_ptr_for_overwrite              202002L
 // # define __cccl_lib_source_location                      201907L
 // # define __cccl_lib_ssize                                201902L
@@ -214,9 +219,6 @@
 // # define __cccl_lib_string_view                          201803L
 // # define __cccl_lib_syncbuf                              201803L
 // # define __cccl_lib_three_way_comparison                 201907L
-// # define __cccl_lib_to_address                           201711L
-// # define __cccl_lib_to_array                             201907L
-// # define __cccl_lib_type_identity                        201806L
 #  define __cccl_lib_unwrap_ref 201811L
 #endif // _CCCL_STD_VER >= 2020
 
@@ -250,7 +252,6 @@
 // # define __cccl_lib_string_contains                      202011L
 // # define __cccl_lib_string_resize_and_overwrite          202110L
 #  define __cccl_lib_unreachable 202202L
-
 #endif // _CCCL_STD_VER >= 2023
 
 #endif // _CUDA_STD_VERSION


### PR DESCRIPTION
I've gone throught the library feature test macros and tried to move them to the correct C++ standard version, because a lot of them are available earlier than specified.