### PR TITLE
Do not use cudaGetErrorString on GPU.

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/utils.h
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/utils.h
@@ -33,7 +33,11 @@ __device__ __host__ void assert_rt_wrap(cudaError_t code, const char* file, int 
   if (code != cudaSuccess)
   {
 #ifndef TEST_COMPILER_NVRTC
+#  if !defined(__CUDA_ARCH__)
     printf("assert: %s %s %d\n", cudaGetErrorString(code), file, line);
+#  else
+    printf("assert: error=%d %s %d\n", code, file, line);
+#  endif
 #endif
     assert(code == cudaSuccess);
   }

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/utils.h
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/utils.h
@@ -16,6 +16,8 @@
 #include <cuda/annotated_ptr>
 #include <cuda/std/cassert>
 
+#include <nv/target>
+
 #if defined(DEBUG)
 #  define DPRINTF(...)     \
     {                      \
@@ -33,12 +35,10 @@ __device__ __host__ void assert_rt_wrap(cudaError_t code, const char* file, int 
   if (code != cudaSuccess)
   {
 #ifndef TEST_COMPILER_NVRTC
-#  if !defined(__CUDA_ARCH__)
-    printf("assert: %s %s %d\n", cudaGetErrorString(code), file, line);
-#  else
-    printf("assert: error=%d %s %d\n", code, file, line);
-#  endif
-#endif
+    NV_IF_ELSE_TARGET(NV_IS_DEVICE,
+                      (printf("assert: %s %s %d\n", cudaGetErrorString(code), file, line);),
+                      (printf("assert: error=%d %s %d\n", code, file, line);))
+#endif // !TEST_COMPILER_NVRTC
     assert(code == cudaSuccess);
   }
 }


### PR DESCRIPTION
## Description

closes https://github.com/NVIDIA/cccl/issues/2752

When cudaGetErrorString is used on GPU, we end up with an unresolved reference: https://godbolt.org/z/KT7xvo9eW

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [n/a] The documentation is up to date with these changes.
