### PR TITLE
Define the destructor of `kernel_arg`

### DIFF
--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -506,8 +506,8 @@ union kernel_arg
   // thrust::normal_iterator<thrust::device_pointer<T>>), so because of
   // https://eel.is/c++draft/class.union#general-note-3, kernel_args's special members are deleted. We work around it by
   // explicitly defining them.
-
-  _CCCL_HOST_DEVICE kernel_arg() {}
+  _CCCL_HOST_DEVICE kernel_arg() noexcept {}
+  _CCCL_HOST_DEVICE ~kernel_arg() noexcept {}
 
   _CCCL_HOST_DEVICE kernel_arg(const kernel_arg& other)
   {


### PR DESCRIPTION
We are seing some internal CI failures, when used with some technically nontrivial types, where the destructor is not defined.

We need to ensure that we properly do nothing there, because we just copied bits arount.

Fixes nvbug4972845
