### PR TITLE
Add missing `__syncthreads()` to test

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_ptx_compiles.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/barrier/cp_async_bulk_ptx_compiles.pass.cpp
@@ -34,6 +34,7 @@ __global__ void test_bulk_tensor(CUtensorMap* map)
   {
     init(bar, blockDim.x);
   }
+  __syncthreads();
 
   cde::cp_async_bulk_tensor_1d_global_to_shared(&smem, map, 0, *bar);
   cde::cp_async_bulk_tensor_2d_global_to_shared(&smem, map, 0, 0, *bar);
@@ -56,6 +57,7 @@ __global__ void test_bulk(void* gmem)
   {
     init(bar, blockDim.x);
   }
+  __syncthreads();
 
   cde::cp_async_bulk_global_to_shared(&smem, gmem, 1024, *bar);
   cde::cp_async_bulk_shared_to_global(gmem, &smem, 1024);


### PR DESCRIPTION
We need to ensure that the barrier in the tests is properly initialized for all threads.
