### PR TITLE
Add bound checks for each dimension of `mdspan`

### DIFF
--- a/docs/libcudacxx/standard_api.rst
+++ b/docs/libcudacxx/standard_api.rst
@@ -103,15 +103,15 @@ Feature availability:
 
 -  C++23 ``invoke_r`` in ``<functional>`` is available in C++14.
 
--  C++23 ``<mdspan>`` is available in C++17.
+-  C++23 ``<mdspan>`` is available in C++14.
 
-   -  ``mdspan`` is feature complete in C++17 onwards.
+   -  ``mdspan`` is feature complete in C++14 onwards.
    -  ``mdspan`` on msvc is only supported in C++20 and onwards.
+
+-  C++26 ``std::dims`` is available in C++14.
 
 -  C++23 ``forward_like``, ``to_underlying`` and ``unreachable`` from ``<utility>`` are available in C++11.
 
 -  C++23 ``is_scoped_enum`` in ``<type_traits>`` is available in C++11.
-
--  C++26 ``std::dims`` is available in C++17.
 
 -  C++26 tuple protocol to ``complex`` is available in C++11.

--- a/docs/libcudacxx/standard_api/container_library/mdspan.rst
+++ b/docs/libcudacxx/standard_api/container_library/mdspan.rst
@@ -6,8 +6,9 @@
 Extensions
 ----------
 
--  All features of ``<mdspan>`` are made available in C++17 onwards
--  C++26 ``std::dims`` is made available in C++17 onwards
+-  All features of ``<mdspan>`` are made available in C++14 onwards
+-  The C++23 multidimensional ``operator[]`` is replaced with ``operator()``
+-  C++26 ``std::dims`` is made available in C++14 onwards
 
 Restrictions
 ------------

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -119,8 +119,10 @@ private:
     __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
       // std::array supports zero size
-      array<bool, sizeof...(_SizeTypes)> __res{((is_unsigned_v<index_type> || static_cast<index_type>(__indices) >= 0)
-                                                && static_cast<index_type>(__indices) < exts.extent(_Idxs))...};
+      // ternary avoids "pointless comparison of unsigned integer with zero" warning
+      array<bool, sizeof...(_SizeTypes)> __res{
+        ((is_unsigned_v<index_type> ? true : static_cast<index_type>(__indices) >= 0)
+         && static_cast<index_type>(__indices) < exts.extent(_Idxs))...};
       return _CUDA_VSTD::all_of(__res.begin(), __res.end(), identity{});
     }
 

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -116,13 +116,15 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool
     __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
-      index_type __zero = 0; // avoid warning:186 (ICC/NVCC) pointless comparison of unsigned integer with zero
-      array<bool, sizeof...(_SizeTypes)> __res{((is_signed_v<index_type> && static_cast<index_type>(__indices) < __zero)
-                                                || static_cast<index_type>(__indices) >= exts.extent(_Idxs))...};
-      _LIBCUDACXX_UNUSED_VAR(__zero * 2);
-      return _CUDA_VSTD::all_of(__res.begin(), __res.end(), [](bool __v) {
-        return __v;
-      });
+      _CCCL_NV_DIAG_SUPPRESS(186) // pointless comparison of unsigned integer with zero
+      _CCCL_DIAG_PUSH
+      _CCCL_DIAG_SUPPRESS_ICC(186)
+      // std::array supports zero size
+      array<bool, sizeof...(_SizeTypes)> __res{((is_unsigned_v<index_type> || static_cast<index_type>(__indices) >= 0)
+                                                && static_cast<index_type>(__indices) < exts.extent(_Idxs))...};
+      return _CUDA_VSTD::all_of(__res.begin(), __res.end(), identity{});
+      _CCCL_DIAG_POP
+      _CCCL_NV_DIAG_DEFAULT(186)
     }
 
     template <class... _SizeTypes>

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -82,6 +82,8 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if _CCCL_STD_VER >= 2014
 
+_CCCL_NV_DIAG_SUPPRESS(186) // pointless comparison of unsigned integer with zero
+
 template <class _ElementType,
           class _Extents,
           class _LayoutPolicy   = layout_right,
@@ -117,13 +119,11 @@ private:
     __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
       _CCCL_DIAG_PUSH
-      _CCCL_NV_DIAG_SUPPRESS(186) // pointless comparison of unsigned integer with zero
       _CCCL_DIAG_SUPPRESS_ICC(186)
       // std::array supports zero size
       array<bool, sizeof...(_SizeTypes)> __res{((is_unsigned_v<index_type> || static_cast<index_type>(__indices) >= 0)
                                                 && static_cast<index_type>(__indices) < exts.extent(_Idxs))...};
       return _CUDA_VSTD::all_of(__res.begin(), __res.end(), identity{});
-      _CCCL_NV_DIAG_DEFAULT(186)
       _CCCL_DIAG_POP
     }
 
@@ -509,6 +509,8 @@ _CCCL_HOST_DEVICE mdspan(const typename _AccessorType::data_handle_type, const _
             typename _MappingType::layout_type,
             _AccessorType>;
 #  endif // __MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
+
+_CCCL_NV_DIAG_DEFAULT(186)
 
 #endif // _CCCL_STD_VER >= 2014
 

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -115,7 +115,8 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool
     __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
-      array<bool, sizeof...(_SizeTypes)> __res{((is_signed_v<index_type> && static_cast<index_type>(__indices) < 0)
+      index_type zero = 0; // avoid warning:186 (ICC/NVCC) pointless comparison of unsigned integer with zero
+      array<bool, sizeof...(_SizeTypes)> __res{((is_signed_v<index_type> && static_cast<index_type>(__indices) < zero)
                                                 || static_cast<index_type>(__indices) >= exts.extent(_Idxs))...};
       return _CUDA_VSTD::all_of(__res.begin(), __res.end(), [](bool __v) {
         return __v;

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -118,12 +118,9 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool
     __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
-      // std::array supports zero size
-      // ternary avoids "pointless comparison of unsigned integer with zero" warning
-      array<bool, sizeof...(_SizeTypes)> __res{
-        ((is_unsigned_v<index_type> ? true : static_cast<index_type>(__indices) >= 0)
-         && static_cast<index_type>(__indices) < exts.extent(_Idxs))...};
-      return _CUDA_VSTD::all_of(__res.begin(), __res.end(), identity{});
+      return
+        (((is_unsigned_v<index_type> ? true : static_cast<index_type>(__indices) >= 0)
+         && static_cast<index_type>(__indices) < exts.extent(_Idxs))) && ...);
     }
 
     template <class... _SizeTypes>

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -118,9 +118,13 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool
     __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
-      return
-        (((is_unsigned_v<index_type> ? true : static_cast<index_type>(__indices) >= 0)
-         && static_cast<index_type>(__indices) < exts.extent(_Idxs))) && ...);
+#  if _CCCL_STD_VER >= 2017
+      return (((is_unsigned_v<index_type> ? true : static_cast<index_type>(__indices) >= 0)
+               && static_cast<index_type>(__indices) < exts.extent(_Idxs))
+              && ...);
+#  else
+      return true;
+#  endif // _CCCL_STD_VER >= 2017
     }
 
     template <class... _SizeTypes>

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -116,15 +116,15 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool
     __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
-      _CCCL_NV_DIAG_SUPPRESS(186) // pointless comparison of unsigned integer with zero
       _CCCL_DIAG_PUSH
+      _CCCL_NV_DIAG_SUPPRESS(186) // pointless comparison of unsigned integer with zero
       _CCCL_DIAG_SUPPRESS_ICC(186)
       // std::array supports zero size
       array<bool, sizeof...(_SizeTypes)> __res{((is_unsigned_v<index_type> || static_cast<index_type>(__indices) >= 0)
                                                 && static_cast<index_type>(__indices) < exts.extent(_Idxs))...};
       return _CUDA_VSTD::all_of(__res.begin(), __res.end(), identity{});
-      _CCCL_DIAG_POP
       _CCCL_NV_DIAG_DEFAULT(186)
+      _CCCL_DIAG_POP
     }
 
     template <class... _SizeTypes>

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -55,6 +55,7 @@
 #endif // no system header
 
 #include <cuda/std/__algorithm/all_of.h>
+#include <cuda/std/__functional/identity.h>
 #include <cuda/std/__mdspan/compressed_pair.h>
 #include <cuda/std/__mdspan/default_accessor.h>
 #include <cuda/std/__mdspan/extents.h>

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -115,10 +115,10 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool
     __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
-      index_type zero = 0; // avoid warning:186 (ICC/NVCC) pointless comparison of unsigned integer with zero
-      array<bool, sizeof...(_SizeTypes)> __res{((is_signed_v<index_type> && static_cast<index_type>(__indices) < zero)
+      index_type __zero = 0; // avoid warning:186 (ICC/NVCC) pointless comparison of unsigned integer with zero
+      array<bool, sizeof...(_SizeTypes)> __res{((is_signed_v<index_type> && static_cast<index_type>(__indices) < __zero)
                                                 || static_cast<index_type>(__indices) >= exts.extent(_Idxs))...};
-      static_cast<void>(zero);
+      _LIBCUDACXX_UNUSED_VAR(__zero * 2);
       return _CUDA_VSTD::all_of(__res.begin(), __res.end(), [](bool __v) {
         return __v;
       });

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -118,13 +118,10 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool
     __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
-      _CCCL_DIAG_PUSH
-      _CCCL_DIAG_SUPPRESS_ICC(186)
       // std::array supports zero size
       array<bool, sizeof...(_SizeTypes)> __res{((is_unsigned_v<index_type> || static_cast<index_type>(__indices) >= 0)
                                                 && static_cast<index_type>(__indices) < exts.extent(_Idxs))...};
       return _CUDA_VSTD::all_of(__res.begin(), __res.end(), identity{});
-      _CCCL_DIAG_POP
     }
 
     template <class... _SizeTypes>

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -118,6 +118,7 @@ private:
       index_type zero = 0; // avoid warning:186 (ICC/NVCC) pointless comparison of unsigned integer with zero
       array<bool, sizeof...(_SizeTypes)> __res{((is_signed_v<index_type> && static_cast<index_type>(__indices) < zero)
                                                 || static_cast<index_type>(__indices) >= exts.extent(_Idxs))...};
+      static_cast<void>(zero);
       return _CUDA_VSTD::all_of(__res.begin(), __res.end(), [](bool __v) {
         return __v;
       });

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -113,7 +113,7 @@ private:
 
     template <class... _SizeTypes>
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr bool
-    __check_index(const _Extents& exts, _SizeTypes... __indices)
+    __check_index(_Extents const& exts, _SizeTypes... __indices)
     {
       array<bool, sizeof...(_SizeTypes)> __res{((is_signed_v<index_type> && static_cast<index_type>(__indices) < 0)
                                                 || static_cast<index_type>(__indices) >= exts.extent(_Idxs))...};
@@ -135,7 +135,7 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr index_type
     __index(mdspan const& __self, const _CUDA_VSTD::array<_SizeType, _Np>& __indices) noexcept
     {
-      _CCCL_ASSERT(__check_index(__indices, __self.__mapping_ref().extents()),
+      _CCCL_ASSERT(__check_index(__self.__mapping_ref().extents(), __indices...),
                    "cuda::std::mdspan subscript out of range!");
       const index_type __res = __self.__mapping_ref()(__indices[_Idxs]...);
       return __res;
@@ -144,7 +144,7 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr index_type
     __index(mdspan const& __self, const _CUDA_VSTD::span<_SizeType, _Np>& __indices) noexcept
     {
-      _CCCL_ASSERT(__check_index(__indices, __self.__mapping_ref().extents()),
+      _CCCL_ASSERT(__check_index(__self.__mapping_ref().extents(), __indices...),
                    "cuda::std::mdspan subscript out of range!");
       const index_type __res = __self.__mapping_ref()(__indices[_Idxs]...);
       return __res;

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -135,7 +135,7 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr index_type
     __index(mdspan const& __self, const _CUDA_VSTD::array<_SizeType, _Np>& __indices) noexcept
     {
-      _CCCL_ASSERT(__check_index(__self.__mapping_ref().extents(), __indices...),
+      _CCCL_ASSERT(__check_index(__self.__mapping_ref().extents(), __indices[_Idxs]...),
                    "cuda::std::mdspan subscript out of range!");
       const index_type __res = __self.__mapping_ref()(__indices[_Idxs]...);
       return __res;
@@ -144,7 +144,7 @@ private:
     _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI static constexpr index_type
     __index(mdspan const& __self, const _CUDA_VSTD::span<_SizeType, _Np>& __indices) noexcept
     {
-      _CCCL_ASSERT(__check_index(__self.__mapping_ref().extents(), __indices...),
+      _CCCL_ASSERT(__check_index(__self.__mapping_ref().extents(), __indices[_Idxs]...),
                    "cuda::std::mdspan subscript out of range!");
       const index_type __res = __self.__mapping_ref()(__indices[_Idxs]...);
       return __res;


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cccl/issues/3063 and https://github.com/NVIDIA/cccl/issues/3045

## Description

Add bound checks for each dimension of `mdspan`. This replaces the global index check