### PR TITLE
Fix Thrust/CUB tests by adding empty base opt-ins to iterator classes

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -529,7 +529,7 @@ struct __tuple_variadic_constructor_tag
 // __tuple_impl
 
 template <class _Indx, class... _Tp>
-struct __tuple_impl;
+struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl;
 
 template <size_t... _Indx, class... _Tp>
 struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...>

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -135,7 +135,7 @@ template <typename Incrementable,
           typename System     = use_default,
           typename Traversal  = use_default,
           typename Difference = use_default>
-class counting_iterator : public detail::counting_iterator_base<Incrementable, System, Traversal, Difference>::type
+class _LIBCUDACXX_DECLSPEC_EMPTY_BASES counting_iterator : public detail::counting_iterator_base<Incrementable, System, Traversal, Difference>::type
 {
   /*! \cond
    */

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -135,7 +135,8 @@ template <typename Incrementable,
           typename System     = use_default,
           typename Traversal  = use_default,
           typename Difference = use_default>
-class _LIBCUDACXX_DECLSPEC_EMPTY_BASES counting_iterator : public detail::counting_iterator_base<Incrementable, System, Traversal, Difference>::type
+class _LIBCUDACXX_DECLSPEC_EMPTY_BASES counting_iterator
+    : public detail::counting_iterator_base<Incrementable, System, Traversal, Difference>::type
 {
   /*! \cond
    */

--- a/thrust/thrust/iterator/iterator_adaptor.h
+++ b/thrust/thrust/iterator/iterator_adaptor.h
@@ -126,7 +126,7 @@ template <typename Derived,
           typename Traversal  = use_default,
           typename Reference  = use_default,
           typename Difference = use_default>
-class iterator_adaptor
+class _LIBCUDACXX_DECLSPEC_EMPTY_BASES iterator_adaptor
     : public detail::iterator_adaptor_base<Derived, Base, Value, System, Traversal, Reference, Difference>::type
 {
   /*! \cond


### PR DESCRIPTION
## Description

closes nvbug/4911089 && nvbug/4920716 && further challenges my sanity

By using `-Xcompiler /d1reportSingleClassLayout__tuple_impl` on NVCC we can see that the tuple base has a different class size when it contains Thrust iterators. I've written a test that outputs the difference when compiled with MSVC vs NVCC.

```
#ifdef __CUDACC__
__global__ void test() {
  {
    thrust::counting_iterator<uint64_t> begin(0);
    thrust::counting_iterator<uint64_t> end(5);
    auto zip = thrust::make_zip_iterator(begin, end);
    printf("%llu\n", sizeof(zip));
  }

  {
    auto zip = cuda::std::make_tuple((uint64_t)0ll, (uint64_t)5ll);
    printf("%llu\n", sizeof(zip));
  }
}
#endif
int main() {
  {
    thrust::counting_iterator<uint64_t> begin(0);
    thrust::counting_iterator<uint64_t> end(5);
    auto zip = thrust::make_zip_iterator(begin, end);
    printf("%llu\n", sizeof(zip));
  }

  {
    auto zip = cuda::std::make_tuple((uint64_t)0ll, (uint64_t)5ll);
    printf("%llu\n", sizeof(zip));
  }

#ifdef __CUDACC__
  test<<<1,1>>>();
  cudaDeviceSynchronize();
#endif
}
```

On NVCC this outputs:
```
24
16
16
16
```

MSVC (Only after applying the missing ebo declspec to the forward declaration of `__tuple_impl` though):
```
16
16
```

Thrust's classes needed to be changed as well. I expect this is *some kind of NVCC bug* as the declspec shouldn't need to be bubbled up to iterator interfaces.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
