### PR TITLE
Fix analyze.py bug

### DIFF
--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -155,7 +155,7 @@ def extract_scores(dfs):
         score_closure = functools.partial(
             compute_variant_score, rt_axes_values[subbench], rt_axes_ids[subbench], weights[subbench])
         grouped = dfs[subbench].groupby('variant')
-        scores = grouped.apply(score_closure).reset_index()
+        scores = grouped.apply(score_closure, include_groups = False).reset_index()
         scores.columns = ['variant', 'score']
         stat = grouped.agg(mins=('speedup', 'min'),
                            means=('speedup', 'mean'),

--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -227,9 +227,9 @@ def iterate_case_dfs(args, callable):
             continue
 
         case_dfs = {}
-        for subbench in storage.subbenches(algname):
-            for file in storages:
-                storage = storages[file]
+        for file in storages:
+            storage = storages[file]
+            for subbench in storage.subbenches(algname):
                 df = storage.alg_to_df(algname, subbench)
 
                 df = df.map(lambda x: x if is_finite(x) else np.nan)


### PR DESCRIPTION
Minor bug in `analyze.py` fix

@bernhardmgruber might seem useful to you.

Also fixes the following deprecation warning. It does not seem to break something but please verify:

> analyze.py:158: DeprecationWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning.
  scores = grouped.apply(score_closure).reset_index()