### PR TITLE
[BACKPORT: Fix Thrust/CUB tests by adding empty base opt-ins to iterator classes (#3066)

### DIFF
--- a/cudax/samples/CMakeLists.txt
+++ b/cudax/samples/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CCCL_TAG "main" CACHE STRING "Git tag/branch to fetch from CCCL repository")
 CPMAddPackage(
   NAME CCCL
   GITHUB_REPOSITORY ${CCCL_REPOSITORY}
-  GIT_TAG ${CCCL_TAG}
+  GIT_TAG branch/2.7.x
   GIT_SHALLOW ON
   # The following is required to make the `CCCL::cudax` target available:
   OPTIONS "CCCL_ENABLE_UNSTABLE ON"

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -515,7 +515,7 @@ struct __tuple_variadic_constructor_tag
 // __tuple_impl
 
 template <class _Indx, class... _Tp>
-struct __tuple_impl;
+struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl;
 
 template <size_t... _Indx, class... _Tp>
 struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...>

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -135,7 +135,8 @@ template <typename Incrementable,
           typename System     = use_default,
           typename Traversal  = use_default,
           typename Difference = use_default>
-class counting_iterator : public detail::counting_iterator_base<Incrementable, System, Traversal, Difference>::type
+class _LIBCUDACXX_DECLSPEC_EMPTY_BASES counting_iterator
+    : public detail::counting_iterator_base<Incrementable, System, Traversal, Difference>::type
 {
   /*! \cond
    */

--- a/thrust/thrust/iterator/iterator_adaptor.h
+++ b/thrust/thrust/iterator/iterator_adaptor.h
@@ -126,7 +126,7 @@ template <typename Derived,
           typename Traversal  = use_default,
           typename Reference  = use_default,
           typename Difference = use_default>
-class iterator_adaptor
+class _LIBCUDACXX_DECLSPEC_EMPTY_BASES iterator_adaptor
     : public detail::iterator_adaptor_base<Derived, Base, Value, System, Traversal, Reference, Difference>::type
 {
   /*! \cond


### PR DESCRIPTION
We need to fix tuple size for trivially copyable types