### PR TITLE
Improve handling of language level features

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -390,9 +390,9 @@ struct hierarchy_dimensions_fragment
       : levels(ls)
   {}
 
-#  if defined(__cpp_three_way_comparison) && __cpp_three_way_comparison >= 201907
+#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
   _CCCL_NODISCARD _CUDAX_API constexpr bool operator==(const hierarchy_dimensions_fragment&) const noexcept = default;
-#  else
+#  else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_API constexpr bool
   operator==(const hierarchy_dimensions_fragment& left, const hierarchy_dimensions_fragment& right) noexcept
   {
@@ -404,7 +404,7 @@ struct hierarchy_dimensions_fragment
   {
     return left.levels != right.levels;
   }
-#  endif
+#  endif // _CCCL_NO_THREE_WAY_COMPARISON
 
 private:
   // This being static is a bit of a hack to make extents_type working without incomplete class member access

--- a/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
@@ -129,9 +129,9 @@ struct level_dimensions
   _CCCL_HOST_DEVICE constexpr level_dimensions()
       : dims(){};
 
-#  if defined(__cpp_three_way_comparison) && __cpp_three_way_comparison >= 201907
+#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
   _CCCL_NODISCARD _CUDAX_API constexpr bool operator==(const level_dimensions&) const noexcept = default;
-#  else
+#  else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_API constexpr bool
   operator==(const level_dimensions& left, const level_dimensions& right) noexcept
   {
@@ -143,7 +143,7 @@ struct level_dimensions
   {
     return left.dims != right.dims;
   }
-#  endif
+#  endif // _CCCL_NO_THREE_WAY_COMPARISON
 };
 
 /**

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ptr.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ptr.cuh
@@ -177,13 +177,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface*>
     return *static_cast<_CUDA_VSTD::__maybe_const<__is_const_ptr, _Vp>**>(static_cast<void*>(&__ref_.__optr_));
   }
 
-#if defined(__cpp_three_way_comparison)
+#if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
   _CCCL_NODISCARD _CUDAX_HOST_API auto operator==(basic_any const& __other) const noexcept -> bool
   {
     using __void_ptr_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__maybe_const<__is_const_ptr, void>* const*;
     return *static_cast<__void_ptr_t>(__get_optr()) == *static_cast<__void_ptr_t>(__other.__get_optr());
   }
-#else // ^^^ __cpp_three_way_comparison ^^^ / vvv !__cpp_three_way_comparison vvv
+#else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_HOST_API auto operator==(basic_any const& __lhs, basic_any const& __rhs) noexcept -> bool
   {
     using __void_ptr_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__maybe_const<__is_const_ptr, void>* const*;
@@ -195,7 +195,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface*>
   {
     return !(__lhs == __rhs);
   }
-#endif // !__cpp_three_way_comparison
+#endif // _CCCL_NO_THREE_WAY_COMPARISON
 
   using __any_ref_t _CCCL_NODEBUG_ALIAS =
     _CUDA_VSTD::__maybe_const<__is_const_ptr, basic_any<__ireference<_Interface>>>;

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -152,14 +152,14 @@ struct iequality_comparable : interface<iequality_comparable>
   _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable<_Tp>)
   using overrides _CCCL_NODEBUG_ALIAS = overrides_for<_Tp, _CUDAX_FNPTR_CONSTANT_WAR(&__equal_fn<_Tp>)>;
 
-#if defined(__cpp_three_way_comparison)
+#if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
   _CCCL_NODISCARD _CUDAX_HOST_API auto operator==(iequality_comparable const& __other) const -> bool
   {
     auto const& __other = __cudax::basic_any_from(__other);
     void const* __obj   = __basic_any_access::__get_optr(__other);
     return __cudax::virtcall<&__equal_fn<iequality_comparable>>(this, __other.type(), __obj);
   }
-#else // ^^^ __cpp_three_way_comparison ^^^ / vvv !__cpp_three_way_comparison vvv
+#else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_HOST_API auto
   operator==(iequality_comparable const& __left, iequality_comparable const& __right) -> bool
   {
@@ -173,7 +173,7 @@ struct iequality_comparable : interface<iequality_comparable>
   {
     return !(__left == __right);
   }
-#endif // !__cpp_three_way_comparison
+#endif // _CCCL_NO_THREE_WAY_COMPARISON
 };
 
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__utility/basic_any/virtual_ptrs.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/virtual_ptrs.cuh
@@ -58,9 +58,9 @@ struct __base_vptr
     return __vptr_;
   }
 
-#if defined(__cpp_three_way_comparison)
+#if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
   bool operator==(__base_vptr const& __other) const noexcept = default;
-#else // ^^^ __cpp_three_way_comparison ^^^ / vvv !__cpp_three_way_comparison vvv
+#else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_HOST_API constexpr auto operator==(__base_vptr __lhs, __base_vptr __rhs) noexcept -> bool
   {
     return __lhs.__vptr_ == __rhs.__vptr_;
@@ -70,7 +70,7 @@ struct __base_vptr
   {
     return !(__lhs == __rhs);
   }
-#endif // !__cpp_three_way_comparison
+#endif // _CCCL_NO_THREE_WAY_COMPARISON
 
   __rtti_base const* __vptr_{};
 };

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -22,6 +22,9 @@
 #  pragma system_header
 #endif // no system header
 
+///////////////////////////////////////////////////////////////////////////////
+// Determine the C++ standard dialect
+///////////////////////////////////////////////////////////////////////////////
 #if _CCCL_COMPILER(MSVC)
 #  if _MSVC_LANG <= 201103L
 #    define _CCCL_STD_VER 2011
@@ -52,6 +55,9 @@
 #  endif
 #endif // !_CCCL_COMPILER(MSVC)
 
+///////////////////////////////////////////////////////////////////////////////
+// Conditionally enable constexpr per standard dialect
+///////////////////////////////////////////////////////////////////////////////
 #if _CCCL_STD_VER >= 2014
 #  define _CCCL_CONSTEXPR_CXX14 constexpr
 #else // ^^^ C++14 ^^^ / vvv C++11 vvv
@@ -76,54 +82,69 @@
 #  define _CCCL_CONSTEXPR_CXX23
 #endif // _CCCL_STD_VER <= 2020
 
-#if _CCCL_STD_VER >= 2017 && defined(__cpp_if_constexpr)
-#  define _CCCL_IF_CONSTEXPR if constexpr
-#else // ^^^ C++17 ^^^ / vvv C++14 vvv
+///////////////////////////////////////////////////////////////////////////////
+// Detect whether we can use some language features based on standard dialect
+///////////////////////////////////////////////////////////////////////////////
+#if _CCCL_STD_VER <= 2014 || __cpp_if_constexpr < 201606L
 #  define _CCCL_NO_IF_CONSTEXPR
-#  define _CCCL_IF_CONSTEXPR if
-#endif // _CCCL_STD_VER <= 2014
-
-// In nvcc prior to 11.3 global variables could not be marked constexpr
-#if _CCCL_CUDACC_BELOW(11, 3)
-#  define _CCCL_CONSTEXPR_GLOBAL const
-#else // ^^^ _CCCL_CUDACC_BELOW(11, 3) ^^^ / vvv _CCCL_CUDACC_AT_LEAST(11, 3) vvv
-#  define _CCCL_CONSTEXPR_GLOBAL constexpr
-#endif // _CCCL_CUDACC_AT_LEAST(11, 3)
-
-// Inline variables are only available from C++17 onwards
-#if _CCCL_STD_VER >= 2017 && defined(__cpp_inline_variables) && (__cpp_inline_variables >= 201606L)
-#  define _CCCL_INLINE_VAR inline
-#else // ^^^ C++17 ^^^ / vvv C++14 vvv
-#  define _CCCL_NO_INLINE_VARIABLES
-#  define _CCCL_INLINE_VAR
-#endif // _CCCL_STD_VER <= 2014
-
-// Variable templates are only available from C++14 onwards and require some compiler support
-#if _CCCL_STD_VER <= 2011 || !defined(__cpp_variable_templates) || (__cpp_variable_templates < 201304L)
-#  define _CCCL_NO_VARIABLE_TEMPLATES
-#endif // _CCCL_STD_VER <= 2011
-
-// Declaring a non-type template parameters with auto is only available from C++17 onwards
-#if _CCCL_STD_VER >= 2017 && defined(__cpp_nontype_template_parameter_auto) \
-  && (__cpp_nontype_template_parameter_auto >= 201606L)
-#  define _CCCL_NTTP_AUTO auto
-#else // ^^^ C++17 ^^^ / vvv C++14 vvv
-#  define _CCCL_NO_NONTYPE_TEMPLATE_PARAMETER_AUTO
-#  define _CCCL_NTTP_AUTO unsigned long long int
-#endif // _CCCL_STD_VER <= 2014
+#endif // _CCCL_STD_VER <= 2014 || !defined(__cpp_if_constexpr)
 
 // concepts are only available from C++20 onwards
-#if _CCCL_STD_VER <= 2017 || !defined(__cpp_concepts) || (__cpp_concepts < 201907L)
+#if _CCCL_STD_VER <= 2017 || __cpp_concepts < 201907L
 #  define _CCCL_NO_CONCEPTS
-#endif // _CCCL_STD_VER <= 2017 || !defined(__cpp_concepts) || (__cpp_concepts < 201907L)
+#endif // _CCCL_STD_VER <= 2017 || __cpp_concepts < 201907L
+
+// Fold expressions are only available from C++17 onwards
+#if _CCCL_STD_VER <= 2014 || __cpp_fold_expressions < 201603L
+#  define _CCCL_NO_FOLD_EXPRESSIONS
+#endif // _CCCL_STD_VER <= 2014 || __cpp_fold_expressions < 201603L
+
+// Inline variables are only available from C++17 onwards
+#if _CCCL_STD_VER <= 2014 || __cpp_inline_variables < 201606L
+#  define _CCCL_NO_INLINE_VARIABLES
+#endif // _CCCL_STD_VER <= 2014 || __cpp_inline_variables < 201606L
 
 // noexcept function types are only available from C++17 onwards
-#if _CCCL_STD_VER >= 2017 && defined(__cpp_noexcept_function_type) && (__cpp_noexcept_function_type >= 201510L)
-#  define _CCCL_FUNCTION_TYPE_NOEXCEPT noexcept
-#else // ^^^ C++17 ^^^ / vvv C++14 vvv
+#if _CCCL_STD_VER <= 2014 || __cpp_noexcept_function_type < 201510L
 #  define _CCCL_NO_NOEXCEPT_FUNCTION_TYPE
+#endif // _CCCL_STD_VER <= 2014 || __cpp_noexcept_function_type < 201510L
+
+// Declaring a non-type template parameters with auto is only available from C++17 onwards
+#if _CCCL_STD_VER <= 2014 || __cpp_nontype_template_parameter_auto < 201606L
+#  define _CCCL_NO_NONTYPE_TEMPLATE_PARAMETER_AUTO
+#endif // _CCCL_STD_VER <= 2014 || __cpp_nontype_template_parameter_auto < 201606L
+
+// Variable templates are only available from C++14 onwards and require some compiler support
+#if _CCCL_STD_VER <= 2011 || __cpp_variable_templates < 201304L
+#  define _CCCL_NO_VARIABLE_TEMPLATES
+#endif // _CCCL_STD_VER <= 2011 || __cpp_variable_templates < 201304L
+
+///////////////////////////////////////////////////////////////////////////////
+// Conditionally use certain language features depending on availablility
+///////////////////////////////////////////////////////////////////////////////
+#if defined(_CCCL_NO_IF_CONSTEXPR)
+#  define _CCCL_IF_CONSTEXPR if
+#else // ^^^ _CCCL_NO_IF_CONSTEXPR ^^^ / vvv !_CCCL_NO_IF_CONSTEXPR vvv
+#  define _CCCL_IF_CONSTEXPR if constexpr
+#endif // !_CCCL_NO_IF_CONSTEXPR
+
+#if defined(_CCCL_NO_INLINE_VARIABLES)
+#  define _CCCL_INLINE_VAR
+#else // ^^^ _CCCL_NO_INLINE_VARIABLES ^^^ / vvv !_CCCL_NO_INLINE_VARIABLES vvv
+#  define _CCCL_INLINE_VAR inline
+#endif // !_CCCL_NO_INLINE_VARIABLES
+
+#if defined(_CCCL_NO_NOEXCEPT_FUNCTION_TYPE)
 #  define _CCCL_FUNCTION_TYPE_NOEXCEPT
-#endif // _CCCL_STD_VER <= 2014
+#else // ^^^ _CCCL_NO_NOEXCEPT_FUNCTION_TYPE ^^^ / vvv !_CCCL_NO_NOEXCEPT_FUNCTION_TYPE vvv
+#  define _CCCL_FUNCTION_TYPE_NOEXCEPT noexcept
+#endif // !_CCCL_NO_NOEXCEPT_FUNCTION_TYPE
+
+#if defined(_CCCL_NO_NONTYPE_TEMPLATE_PARAMETER_AUTO)
+#  define _CCCL_NTTP_AUTO unsigned long long int
+#else // ^^^ _CCCL_NO_NONTYPE_TEMPLATE_PARAMETER_AUTO ^^^ / vvv !_CCCL_NO_NONTYPE_TEMPLATE_PARAMETER_AUTO vvv
+#  define _CCCL_NTTP_AUTO auto
+#endif // !_CCCL_NO_NONTYPE_TEMPLATE_PARAMETER_AUTO
 
 // Variable templates are more efficient most of the time, so we want to use them rather than structs when possible
 #if defined(_CCCL_NO_VARIABLE_TEMPLATES)
@@ -131,6 +152,13 @@
 #else // ^^^ _CCCL_NO_VARIABLE_TEMPLATES ^^^ / vvv !_CCCL_NO_VARIABLE_TEMPLATES vvv
 #  define _CCCL_TRAIT(__TRAIT, ...) __TRAIT##_v<__VA_ARGS__>
 #endif // !_CCCL_NO_VARIABLE_TEMPLATES
+
+// In nvcc prior to 11.3 global variables could not be marked constexpr
+#if _CCCL_CUDACC_BELOW(11, 3)
+#  define _CCCL_CONSTEXPR_GLOBAL const
+#else // ^^^ _CCCL_CUDACC_BELOW(11, 3) ^^^ / vvv _CCCL_CUDACC_AT_LEAST(11, 3) vvv
+#  define _CCCL_CONSTEXPR_GLOBAL constexpr
+#endif // _CCCL_CUDACC_AT_LEAST(11, 3)
 
 // We need to treat host and device separately
 #if defined(__CUDA_ARCH__)

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -94,6 +94,11 @@
 #  define _CCCL_NO_CONCEPTS
 #endif // _CCCL_STD_VER <= 2017 || __cpp_concepts < 201907L
 
+// CTAD is only available from C++17 onwards
+#if _CCCL_STD_VER <= 2014 || __cpp_deduction_guides < 201611L
+#  define _CCCL_NO_DEDUCTION_GUIDES
+#endif // _CCCL_STD_VER <= 2014 || __cpp_deduction_guides < 201611L
+
 // Fold expressions are only available from C++17 onwards
 #if _CCCL_STD_VER <= 2014 || __cpp_fold_expressions < 201603L
 #  define _CCCL_NO_FOLD_EXPRESSIONS

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -119,6 +119,11 @@
 #  define _CCCL_NO_NONTYPE_TEMPLATE_PARAMETER_AUTO
 #endif // _CCCL_STD_VER <= 2014 || __cpp_nontype_template_parameter_auto < 201606L
 
+// Three way comparison is only available from C++20 onwards
+#if _CCCL_STD_VER <= 2017 || __cpp_three_way_comparison < 201907
+#  define _CCCL_NO_THREE_WAY_COMPARISON
+#endif // _CCCL_STD_VER <= 2017 || __cpp_three_way_comparison < 201907
+
 // Variable templates are only available from C++14 onwards and require some compiler support
 #if _CCCL_STD_VER <= 2011 || __cpp_variable_templates < 201304L
 #  define _CCCL_NO_VARIABLE_TEMPLATES

--- a/libcudacxx/include/cuda/std/__expected/unexpected.h
+++ b/libcudacxx/include/cuda/std/__expected/unexpected.h
@@ -161,10 +161,10 @@ private:
   _Err __unex_;
 };
 
-#  if _CCCL_STD_VER > 2014 && !defined(_LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES)
+#  if !defined(_CCCL_NO_DEDUCTION_GUIDES)
 template <class _Err>
 unexpected(_Err) -> unexpected<_Err>;
-#  endif // _CCCL_STD_VER > 2014 && !defined(_LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES)
+#  endif // !defined(_CCCL_NO_DEDUCTION_GUIDES)
 
 #endif // _CCCL_STD_VER > 2011
 

--- a/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
@@ -76,10 +76,10 @@ public:
   }
 };
 
-#if _CCCL_STD_VER > 2014 && !defined(_LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES)
+#if !defined(_CCCL_NO_DEDUCTION_GUIDES)
 template <class _Tp>
 _CCCL_HOST_DEVICE reference_wrapper(_Tp&) -> reference_wrapper<_Tp>;
-#endif
+#endif // !_CCCL_NO_DEDUCTION_GUIDES
 
 template <class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 reference_wrapper<_Tp> ref(_Tp& __t) noexcept

--- a/libcudacxx/include/cuda/std/__type_traits/fold.h
+++ b/libcudacxx/include/cuda/std/__type_traits/fold.h
@@ -26,7 +26,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if !defined(_LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS)
+#if !defined(_CCCL_NO_FOLD_EXPRESSIONS)
 
 // Use fold expressions when possible to implement __fold_and[_v] and
 // __fold_or[_v].
@@ -42,7 +42,7 @@ using __fold_and = bool_constant<bool((_Preds && ...))>; // cast to bool to avoi
 template <bool... _Preds>
 using __fold_or = bool_constant<bool((_Preds || ...))>; // cast to bool to avoid error from gcc < 8
 
-#else // ^^^ !_LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS / _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS vvv
+#else // ^^^ !_CCCL_NO_FOLD_EXPRESSIONS / _CCCL_NO_FOLD_EXPRESSIONS vvv
 
 // Otherwise, we can use a helper class to implement __fold_and and __fold_or.
 template <bool... _Preds>
@@ -62,7 +62,7 @@ template <bool... _Preds>
 _CCCL_INLINE_VAR constexpr bool __fold_or_v = __fold_or<_Preds...>::value;
 #  endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
-#endif // _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS
+#endif // _CCCL_NO_FOLD_EXPRESSIONS
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -525,10 +525,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #endif // !_CCCL_COMPILER(NVRTC)
 };
 
-#if _CCCL_STD_VER > 2014 && !defined(_LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES)
+#if !defined(_CCCL_NO_DEDUCTION_GUIDES)
 template <class _T1, class _T2>
 _CCCL_HOST_DEVICE pair(_T1, _T2) -> pair<_T1, _T2>;
-#endif // _CCCL_STD_VER > 2014 && !defined(_LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES)
+#endif // !_CCCL_NO_DEDUCTION_GUIDES
 
 // [pairs.spec], specialized algorithms
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -802,10 +802,6 @@ typedef unsigned int char32_t;
 #    define _LIBCUDACXX_ENABLE_CXX17_REMOVED_BINDERS
 #  endif // _LIBCUDACXX_ENABLE_CXX17_REMOVED_FEATURES
 
-#  if !defined(__cpp_deduction_guides) || __cpp_deduction_guides < 201611
-#    define _LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES
-#  endif
-
 // We need `is_constant_evaluated` for clang and gcc. MSVC also needs extensive rework
 #  if !defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
 #    define _LIBCUDACXX_HAS_NO_CONSTEXPR_COMPLEX_OPERATIONS

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -883,10 +883,6 @@ typedef unsigned int char32_t;
 
 #  define _LIBCUDACXX_HAS_NO_INCOMPLETE_RANGES
 
-#  if !defined(__cpp_fold_expressions) || __cpp_fold_expressions < 201603L
-#    define _LIBCUDACXX_HAS_NO_FOLD_EXPRESSIONS
-#  endif
-
 #endif // __cplusplus
 
 #endif // _LIBCUDACXX_CONFIG

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -1082,10 +1082,10 @@ public:
   using __base::reset;
 };
 
-#  if _CCCL_STD_VER > 2014 && !defined(_LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES)
+#  if !defined(_CCCL_NO_DEDUCTION_GUIDES)
 template <class _Tp>
 _CCCL_HOST_DEVICE optional(_Tp) -> optional<_Tp>;
-#  endif
+#  endif // _CCCL_NO_DEDUCTION_GUIDES
 
 // Comparisons between optionals
 template <class _Tp, class _Up>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -996,7 +996,7 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI void swap(tuple&) noexcept {}
 };
 
-#ifndef _LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES
+#ifndef _CCCL_NO_DEDUCTION_GUIDES
 template <class... _Tp>
 _CCCL_HOST_DEVICE tuple(_Tp...) -> tuple<_Tp...>;
 template <class _Tp1, class _Tp2>
@@ -1007,7 +1007,7 @@ template <class _Alloc, class _Tp1, class _Tp2>
 _CCCL_HOST_DEVICE tuple(allocator_arg_t, _Alloc, pair<_Tp1, _Tp2>) -> tuple<_Tp1, _Tp2>;
 template <class _Alloc, class... _Tp>
 _CCCL_HOST_DEVICE tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>;
-#endif // _LIBCUDACXX_HAS_NO_DEDUCTION_GUIDES
+#endif // !_CCCL_NO_DEDUCTION_GUIDES
 
 template <class... _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI enable_if_t<_And<__is_swappable<_Tp>...>::value, void>


### PR DESCRIPTION
We currently have a mixed back of checking for language features and defining macros based around that. 

This cleanes up the machinery and uses one consistent alphabetically ordered style to check whether we can safely use a language feature.

We abuse the fact that an undefined macro will evaluate to 0 to simplify the logic