### PR TITLE
Only tune streaming DeviceSelect versions for 64-bit offsets

### DIFF
--- a/cub/benchmarks/bench/select/flagged.cu
+++ b/cub/benchmarks/bench/select/flagged.cu
@@ -164,8 +164,11 @@ void select(nvbench::state& state, nvbench::type_list<T, OffsetT, MayAlias>)
 }
 
 using may_alias = nvbench::type_list<::cuda::std::false_type, ::cuda::std::true_type>;
+// The implementation of DeviceSelect for 64-bit offset types uses a streaming approach, where it runs multiple passes
+// using a 32-bit offset type, so we only need to test one (to save time for tuning and the benchmark CI).
+using select_offset_types = nvbench::type_list<int64_t>;
 
-NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, offset_types, may_alias))
+NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, select_offset_types, may_alias))
   .set_name("base")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}", "MayAlias{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))

--- a/cub/benchmarks/bench/select/if.cu
+++ b/cub/benchmarks/bench/select/if.cu
@@ -190,8 +190,11 @@ void select(nvbench::state& state, nvbench::type_list<T, OffsetT, MayAlias>)
 }
 
 using may_alias = nvbench::type_list<::cuda::std::false_type, ::cuda::std::true_type>;
+// The implementation of DeviceSelect for 64-bit offset types uses a streaming approach, where it runs multiple passes
+// using a 32-bit offset type, so we only need to test one (to save time for tuning and the benchmark CI).
+using select_offset_types = nvbench::type_list<int64_t>;
 
-NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, offset_types, may_alias))
+NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, select_offset_types, may_alias))
   .set_name("base")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}", "MayAlias{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))

--- a/cub/benchmarks/bench/select/unique.cu
+++ b/cub/benchmarks/bench/select/unique.cu
@@ -142,8 +142,11 @@ static void unique(nvbench::state& state, nvbench::type_list<T, OffsetT, MayAlia
 }
 
 using may_alias = nvbench::type_list<::cuda::std::false_type, ::cuda::std::true_type>;
+// The implementation of DeviceSelect for 64-bit offset types uses a streaming approach, where it runs multiple passes
+// using a 32-bit offset type, so we only need to test one (to save time for tuning and the benchmark CI).
+using select_offset_types = nvbench::type_list<int64_t>;
 
-NVBENCH_BENCH_TYPES(unique, NVBENCH_TYPE_AXES(fundamental_types, offset_types, may_alias))
+NVBENCH_BENCH_TYPES(unique, NVBENCH_TYPE_AXES(fundamental_types, select_offset_types, may_alias))
   .set_name("base")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}", "MayAlias{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))


### PR DESCRIPTION
The implementation of DeviceSelect for 64-bit offset types uses a streaming approach, where it runs multiple passes using a 32-bit offset type, so we only need to test one (to save time for tuning and the benchmark CI).