### PR TITLE
Use consistent spelling for aliasing select benchmarks

### DIFF
--- a/cub/benchmarks/bench/select/flagged.cu
+++ b/cub/benchmarks/bench/select/flagged.cu
@@ -78,8 +78,8 @@ struct policy_hub_t
 };
 #endif // !TUNE_BASE
 
-template <typename T, typename OffsetT, typename InPlaceAlgT>
-void select(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlaceAlgT>)
+template <typename T, typename OffsetT, typename MayAlias>
+void select(nvbench::state& state, nvbench::type_list<T, OffsetT, MayAlias>)
 {
   using input_it_t         = const T*;
   using flag_it_t          = const bool*;
@@ -88,7 +88,7 @@ void select(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlaceAlgT>)
   using select_op_t        = cub::NullType;
   using equality_op_t      = cub::NullType;
   using offset_t           = OffsetT;
-  constexpr bool may_alias = InPlaceAlgT::value;
+  constexpr bool may_alias = MayAlias::value;
 
 #if !TUNE_BASE
   using policy_t   = policy_hub_t<T>;
@@ -163,10 +163,10 @@ void select(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlaceAlgT>)
   });
 }
 
-using in_place_alg = nvbench::type_list<::cuda::std::false_type, ::cuda::std::true_type>;
+using may_alias = nvbench::type_list<::cuda::std::false_type, ::cuda::std::true_type>;
 
-NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, offset_types, in_place_alg))
+NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, offset_types, may_alias))
   .set_name("base")
-  .set_type_axes_names({"T{ct}", "OffsetT{ct}", "IsInPlace{ct}"})
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}", "MayAlias{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
   .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/cub/benchmarks/bench/select/if.cu
+++ b/cub/benchmarks/bench/select/if.cu
@@ -105,8 +105,8 @@ T value_from_entropy(double percentage)
   return static_cast<T>(result);
 }
 
-template <typename T, typename OffsetT, typename InPlaceAlgT>
-void select(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlaceAlgT>)
+template <typename T, typename OffsetT, typename MayAlias>
+void select(nvbench::state& state, nvbench::type_list<T, OffsetT, MayAlias>)
 {
   using input_it_t         = const T*;
   using flag_it_t          = cub::NullType*;
@@ -115,7 +115,7 @@ void select(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlaceAlgT>)
   using select_op_t        = less_then_t<T>;
   using equality_op_t      = cub::NullType;
   using offset_t           = OffsetT;
-  constexpr bool may_alias = InPlaceAlgT::value;
+  constexpr bool may_alias = MayAlias::value;
 
 #if !TUNE_BASE
   using policy_t   = policy_hub_t<T>;
@@ -189,10 +189,10 @@ void select(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlaceAlgT>)
   });
 }
 
-using in_place_alg = nvbench::type_list<::cuda::std::false_type, ::cuda::std::true_type>;
+using may_alias = nvbench::type_list<::cuda::std::false_type, ::cuda::std::true_type>;
 
-NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, offset_types, in_place_alg))
+NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, offset_types, may_alias))
   .set_name("base")
-  .set_type_axes_names({"T{ct}", "OffsetT{ct}", "IsInPlace{ct}"})
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}", "MayAlias{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
   .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/cub/benchmarks/bench/select/unique.cu
+++ b/cub/benchmarks/bench/select/unique.cu
@@ -54,8 +54,8 @@ struct policy_hub_t
 };
 #endif // !TUNE_BASE
 
-template <typename T, typename OffsetT, typename InPlaceAlgT>
-static void unique(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlaceAlgT>)
+template <typename T, typename OffsetT, typename MayAlias>
+static void unique(nvbench::state& state, nvbench::type_list<T, OffsetT, MayAlias>)
 {
   using input_it_t         = const T*;
   using flag_it_t          = cub::NullType*;
@@ -64,7 +64,7 @@ static void unique(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlace
   using select_op_t        = cub::NullType;
   using equality_op_t      = ::cuda::std::equal_to<>;
   using offset_t           = OffsetT;
-  constexpr bool may_alias = InPlaceAlgT::value;
+  constexpr bool may_alias = MayAlias::value;
 
 #if !TUNE_BASE
   using policy_t   = policy_hub_t<T>;
@@ -141,10 +141,10 @@ static void unique(nvbench::state& state, nvbench::type_list<T, OffsetT, InPlace
   });
 }
 
-using in_place_alg = nvbench::type_list<::cuda::std::false_type, ::cuda::std::true_type>;
+using may_alias = nvbench::type_list<::cuda::std::false_type, ::cuda::std::true_type>;
 
-NVBENCH_BENCH_TYPES(unique, NVBENCH_TYPE_AXES(fundamental_types, offset_types, in_place_alg))
+NVBENCH_BENCH_TYPES(unique, NVBENCH_TYPE_AXES(fundamental_types, offset_types, may_alias))
   .set_name("base")
-  .set_type_axes_names({"T{ct}", "OffsetT{ct}", "IsInPlace{ct}"})
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}", "MayAlias{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
   .add_int64_power_of_two_axis("MaxSegSize", {1, 4, 8});


### PR DESCRIPTION
CUB uses the term `MayAlias` in its configurations, while the benchmarks mix it with the term `IsInPlace`. This is confusing and should be unified.