### PR TITLE
fix feature test for operator<=>

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -390,7 +390,7 @@ struct hierarchy_dimensions_fragment
       : levels(ls)
   {}
 
-#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
+#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON) && !_CCCL_COMPILER(MSVC, <, 19, 39)
   _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr bool
   operator==(const hierarchy_dimensions_fragment&) const noexcept = default;
 #  else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -391,7 +391,8 @@ struct hierarchy_dimensions_fragment
   {}
 
 #  if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
-  _CCCL_NODISCARD _CUDAX_API constexpr bool operator==(const hierarchy_dimensions_fragment&) const noexcept = default;
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr bool
+  operator==(const hierarchy_dimensions_fragment&) const noexcept = default;
 #  else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_API constexpr bool
   operator==(const hierarchy_dimensions_fragment& left, const hierarchy_dimensions_fragment& right) noexcept

--- a/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
@@ -130,7 +130,7 @@ struct level_dimensions
       : dims(){};
 
 #  if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
-  _CCCL_NODISCARD _CUDAX_API constexpr bool operator==(const level_dimensions&) const noexcept = default;
+  _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr bool operator==(const level_dimensions&) const noexcept = default;
 #  else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_API constexpr bool
   operator==(const level_dimensions& left, const level_dimensions& right) noexcept

--- a/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
@@ -129,7 +129,7 @@ struct level_dimensions
   _CCCL_HOST_DEVICE constexpr level_dimensions()
       : dims(){};
 
-#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
+#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON) && !_CCCL_COMPILER(MSVC, <, 19, 39)
   _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr bool operator==(const level_dimensions&) const noexcept = default;
 #  else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_API constexpr bool

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -155,9 +155,9 @@ struct iequality_comparable : interface<iequality_comparable>
 #if !defined(_CCCL_NO_THREE_WAY_COMPARISON)
   _CCCL_NODISCARD _CUDAX_HOST_API auto operator==(iequality_comparable const& __other) const -> bool
   {
-    auto const& __other = __cudax::basic_any_from(__other);
-    void const* __obj   = __basic_any_access::__get_optr(__other);
-    return __cudax::virtcall<&__equal_fn<iequality_comparable>>(this, __other.type(), __obj);
+    auto const& __rhs = __cudax::basic_any_from(__other);
+    void const* __obj = __basic_any_access::__get_optr(__rhs);
+    return __cudax::virtcall<&__equal_fn<iequality_comparable>>(this, __rhs.type(), __obj);
   }
 #else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_HOST_API auto

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -120,9 +120,9 @@
 #endif // _CCCL_STD_VER <= 2014 || __cpp_nontype_template_parameter_auto < 201606L
 
 // Three way comparison is only available from C++20 onwards
-#if _CCCL_STD_VER <= 2017 || __cpp_three_way_comparison < 201907
+#if _CCCL_STD_VER <= 2017 || __cpp_impl_three_way_comparison < 201907L
 #  define _CCCL_NO_THREE_WAY_COMPARISON
-#endif // _CCCL_STD_VER <= 2017 || __cpp_three_way_comparison < 201907
+#endif // _CCCL_STD_VER <= 2017 || __cpp_impl_three_way_comparison < 201907L
 
 // Variable templates are only available from C++14 onwards and require some compiler support
 #if _CCCL_STD_VER <= 2011 || __cpp_variable_templates < 201304L


### PR DESCRIPTION
## Description

the correct feature test macro for the spaceship operator is `__cpp_impl_three_way_comparison`. the `_CCCL_NO_THREE_WAY_COMPARISON` macro was incorrectly using `__cpp_three_way_comparison`.

this pr fixes that and also removes host/device annotations on defaulted assignment operations, an error that happens on conditional branches that are now taken.

(this will probably cause a lot of code to break. this pr is a wip.)

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
