### PR TITLE
Mark test as potentially passing

### DIFF
--- a/libcudacxx/test/libcudacxx/std/language.support/support.srcloc/general.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.srcloc/general.pass.cpp
@@ -9,7 +9,7 @@
 
 // UNSUPPORTED: nvcc-11.1, nvcc-11.2
 // The way we currently compile nvrtc is not working with that test
-// XFAIL: nvrtc && !c++20
+// UNSUPPORTED: nvrtc && !c++20
 
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>


### PR DESCRIPTION
NVRTC has added some compiler builtins, so the test should pass now

Fixes nvbug4999000
