### PR TITLE
[CUDAX] Add combine API to kernel_config and allow adding default configuration to kernel functors

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -730,7 +730,7 @@ public:
   //!
   //! @return Hierarchy holding the combined levels from both hierarchies
   template <typename OtherUnit, typename... OtherLevels>
-  constexpr auto combine(const hierarchy_dimensions_fragment<OtherUnit, OtherLevels...>& other)
+  constexpr auto combine(const hierarchy_dimensions_fragment<OtherUnit, OtherLevels...>& other) const
   {
     using this_top_level     = __level_type_of<::cuda::std::__type_index_c<0, Levels...>>;
     using this_bottom_level  = __level_type_of<::cuda::std::__type_index_c<sizeof...(Levels) - 1, Levels...>>;

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -339,6 +339,18 @@ struct rank_helper
 };
 } // namespace detail
 
+// Artificial empty hierarchy to make it possible for the config type to be empty,
+// seems easier than checking everywhere in hierarchy APIs if its not empty.
+// Any usage of an empty hierarchy other than combine should lead to an error anyway
+struct __empty_hierarchy
+{
+  template <typename _Other>
+  _CCCL_NODISCARD _Other combine(const _Other& __other) const
+  {
+    return __other;
+  }
+};
+
 /**
  * @brief Type representing a hierarchy of CUDA threads
  *
@@ -775,6 +787,13 @@ public:
       }
     }
   }
+
+#  ifndef _CCCL_DOXYGEN_INVOKED // Do not document
+  constexpr hierarchy_dimensions_fragment combine([[maybe_unused]] __empty_hierarchy __empty) const
+  {
+    return *this;
+  }
+#  endif // _CCCL_DOXYGEN_INVOKED
 };
 
 /**

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -377,9 +377,6 @@ struct __filter_options
 template <typename _Dimensions, typename... _Options>
 auto __make_config_from_tuple(const _Dimensions& __dims, const ::cuda::std::tuple<_Options...>& __opts);
 
-template <typename _Dimensions, typename... _Options>
-struct __kernel_config;
-
 template <typename _T>
 inline constexpr bool __is_kernel_config = false;
 
@@ -434,6 +431,20 @@ struct kernel_config
       dims, ::cuda::std::tuple_cat(options, ::cuda::std::make_tuple(new_options...)));
   }
 
+  /**
+   * @brief Combine this configuration with another configuration object
+   *
+   * Returns a new `kernel_config` that is a combination of this configuration and the configuration from argument.
+   * It contains dimensions that are combination of dimensions in this object and the other configuration. The resulting
+   * hierarchy holds levels present in both hierarchies. In case of overlap of levels hierarchy from this configuration
+   * is prioritized, so the result always holds all levels from this hierarchy and non-overlapping
+   * levels from the other hierarchy. This behavior is the same as `combine()` member function of the hierarchy type.
+   * The result also contains configuration options from both configurations. In case the same type of a configuration
+   * option is present in both configration this configuration is copied into the resulting configuration.
+   *
+   * @param __other_config
+   * Other configuration to combine with this configuration
+   */
   template <typename _OtherDimensions, typename... _OtherOptions>
   _CCCL_NODISCARD auto combine(const kernel_config<_OtherDimensions, _OtherOptions...>& __other_config) const
   {
@@ -444,6 +455,17 @@ struct kernel_config
       ::cuda::std::tuple_cat(options, ::cuda::std::apply(__filter_options<Options...>{}, __other_config.options)));
   }
 
+  /**
+   * @brief Combine this configuration with default configuration of a kernel functor
+   *
+   * Returns a new `kernel_config` that is a combination of this configuration and a default configuration from the
+   * kernel argument. Default configuration is a `kernel_config` object returned from `default_config()` member function
+   * of the kernel type. The configurations are combined using the `combine()` member function of this configuration.
+   * If the kernel has no default configuration, a copy of this configuration is returned without any changes.
+   *
+   * @param __kernel
+   * Kernel functor to search for the default configuration
+   */
   template <typename _Kernel>
   _CCCL_NODISCARD auto combine_with_default(const _Kernel& __kernel) const
   {

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -363,10 +363,10 @@ struct kernel_config
 
   constexpr kernel_config(const Dimensions& dims, const Options&... opts)
       : dims(dims)
-      , options(opts...) {};
+      , options(opts...){};
   constexpr kernel_config(const Dimensions& dims, const ::cuda::std::tuple<Options...>& opts)
       : dims(dims)
-      , options(opts) {};
+      , options(opts){};
 
   /**
    * @brief Add a new option to this configuration
@@ -382,6 +382,18 @@ struct kernel_config
   {
     return kernel_config<Dimensions, Options..., NewOptions...>(
       dims, ::cuda::std::tuple_cat(options, ::cuda::std::make_tuple(new_options...)));
+  }
+
+  template <typename OtherDimensions, typename... OtherOptions>
+  auto combine(const kernel_config<OtherDimensions, OtherOptions...>& other_config)
+  {
+    if constexpr (false)
+    {
+    }
+    else
+    {
+      return *this;
+    }
   }
 };
 

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -125,14 +125,15 @@ void launch(
 {
   __ensure_current_device __dev_setter(stream);
   cudaError_t status;
+  auto combined = conf.combine(kernel);
   if constexpr (::cuda::std::is_invocable_v<Kernel, kernel_config<Dimensions, Config...>, as_kernel_arg_t<Args>...>)
   {
-    auto launcher = detail::kernel_launcher<kernel_config<Dimensions, Config...>, Kernel, as_kernel_arg_t<Args>...>;
+    auto launcher = detail::kernel_launcher<decltype(combined), Kernel, as_kernel_arg_t<Args>...>;
     status        = detail::launch_impl(
       stream,
-      conf,
+      combined,
       launcher,
-      conf,
+      combined,
       kernel,
       static_cast<as_kernel_arg_t<Args>>(detail::__launch_transform(stream, std::forward<Args>(args)))...);
   }
@@ -142,7 +143,7 @@ void launch(
     auto launcher = detail::kernel_launcher_no_config<Kernel, as_kernel_arg_t<Args>...>;
     status        = detail::launch_impl(
       stream,
-      conf,
+      combined,
       launcher,
       kernel,
       static_cast<as_kernel_arg_t<Args>>(detail::__launch_transform(stream, std::forward<Args>(args)))...);

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -125,7 +125,7 @@ void launch(
 {
   __ensure_current_device __dev_setter(stream);
   cudaError_t status;
-  auto combined = conf.combine(kernel);
+  auto combined = conf.combine_with_default(kernel);
   if constexpr (::cuda::std::is_invocable_v<Kernel, kernel_config<Dimensions, Config...>, as_kernel_arg_t<Args>...>)
   {
     auto launcher = detail::kernel_launcher<decltype(combined), Kernel, as_kernel_arg_t<Args>...>;

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -209,6 +209,7 @@ TEST_CASE("Configuration combine", "[launch]")
   auto grid    = cudax::grid_dims<2>;
   auto cluster = cudax::cluster_dims<2, 2>;
   auto block   = cudax::block_dims(256);
+  SECTION("Combine with no overlap")
   {
     auto config_part1                         = make_config(grid);
     auto config_part2                         = make_config(block, cudax::launch_priority(2));
@@ -223,6 +224,7 @@ TEST_CASE("Configuration combine", "[launch]")
     static_assert(cuda::std::is_same_v<decltype(combined), decltype(empty_with_combined)>);
     CUDAX_REQUIRE(combined.dims.count(cudax::thread) == 512);
   }
+  SECTION("Combine with overlap")
   {
     auto config_part1 = make_config(grid, cluster, cudax::launch_priority(2));
     auto config_part2 = make_config(cudax::cluster_dims<256>, block, cudax::launch_priority(42));

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -203,3 +203,15 @@ TEST_CASE("Hierarchy construction in config", "[launch]")
   [[maybe_unused]] auto config_no_dims = cudax::make_config(cudax::cooperative_launch());
   static_assert(cuda::std::is_same_v<decltype(config_no_dims.dims), cudax::uninit_t>);
 }
+
+TEST_CASE("Configuration combine", "[launch]")
+{
+  auto grid         = cudax::grid_dims<2>;
+  auto block        = cudax::block_dims(256);
+  auto config_part1 = make_config(grid, cudax::cooperative_launch());
+  auto config_part2 = make_config(block, cudax::cooperative_launch());
+  auto combined     = config_part1.combine(config_part2);
+  static_assert(
+    cuda::std::is_same_v<decltype(combined), decltype(make_config(grid, block, cudax::cooperative_launch()))>);
+  CUDAX_REQUIRE(combined.dims.count(cudax::thread) == 512);
+}

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -201,17 +201,42 @@ TEST_CASE("Hierarchy construction in config", "[launch]")
   CUDAX_REQUIRE(config_no_options.dims.count(cudax::thread) == 256);
 
   [[maybe_unused]] auto config_no_dims = cudax::make_config(cudax::cooperative_launch());
-  static_assert(cuda::std::is_same_v<decltype(config_no_dims.dims), cudax::uninit_t>);
+  static_assert(cuda::std::is_same_v<decltype(config_no_dims.dims), cudax::__empty_hierarchy>);
 }
 
 TEST_CASE("Configuration combine", "[launch]")
 {
-  auto grid         = cudax::grid_dims<2>;
-  auto block        = cudax::block_dims(256);
-  auto config_part1 = make_config(grid, cudax::cooperative_launch());
-  auto config_part2 = make_config(block, cudax::cooperative_launch());
-  auto combined     = config_part1.combine(config_part2);
-  static_assert(
-    cuda::std::is_same_v<decltype(combined), decltype(make_config(grid, block, cudax::cooperative_launch()))>);
-  CUDAX_REQUIRE(combined.dims.count(cudax::thread) == 512);
+  auto grid    = cudax::grid_dims<2>;
+  auto cluster = cudax::cluster_dims<2, 2>;
+  auto block   = cudax::block_dims(256);
+  {
+    auto config_part1                         = make_config(grid);
+    auto config_part2                         = make_config(block, cudax::launch_priority(2));
+    auto combined                             = config_part1.combine(config_part2);
+    [[maybe_unused]] auto combined_other_way  = config_part2.combine(config_part1);
+    [[maybe_unused]] auto combined_with_empty = combined.combine(cudax::make_config());
+    [[maybe_unused]] auto empty_with_combined = cudax::make_config().combine(combined);
+    static_assert(
+      cuda::std::is_same_v<decltype(combined), decltype(make_config(grid, block, cudax::launch_priority(2)))>);
+    static_assert(cuda::std::is_same_v<decltype(combined), decltype(combined_other_way)>);
+    static_assert(cuda::std::is_same_v<decltype(combined), decltype(combined_with_empty)>);
+    static_assert(cuda::std::is_same_v<decltype(combined), decltype(empty_with_combined)>);
+    CUDAX_REQUIRE(combined.dims.count(cudax::thread) == 512);
+  }
+  {
+    auto config_part1 = make_config(grid, cluster, cudax::launch_priority(2));
+    auto config_part2 = make_config(cudax::cluster_dims<256>, block, cudax::launch_priority(42));
+    auto combined     = config_part1.combine(config_part2);
+    CUDAX_REQUIRE(combined.dims.count(cudax::thread) == 2048);
+    CUDAX_REQUIRE(cuda::std::get<0>(combined.options).priority == 2);
+
+    auto replaced_one_option = cudax::make_config(cudax::launch_priority(3)).combine(combined);
+    CUDAX_REQUIRE(replaced_one_option.dims.count(cudax::thread) == 2048);
+    CUDAX_REQUIRE(cuda::std::get<0>(replaced_one_option.options).priority == 3);
+
+    [[maybe_unused]] auto combined_with_extra_option =
+      combined.combine(cudax::make_config(cudax::cooperative_launch()));
+    static_assert(cuda::std::is_same_v<decltype(combined.dims), decltype(combined_with_extra_option.dims)>);
+    static_assert(cuda::std::tuple_size_v<decltype(combined_with_extra_option.options)> == 2);
+  }
 }

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -271,7 +271,7 @@ struct kernel_with_default_config
   }
 };
 
-TEST_CASE("Launch with default config")
+void test_default_config()
 {
   cudax::stream stream;
   auto grid  = cudax::grid_dims(4);
@@ -304,4 +304,9 @@ TEST_CASE("Launch with default config")
     cudax::launch(stream, cudax::make_config(block, grid, cudax::cooperative_launch()), kernel, verify_lambda);
     stream.wait();
   }
+}
+
+TEST_CASE("Launch with default config")
+{
+  test_default_config();
 }

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -277,8 +277,8 @@ TEST_CASE("Launch with default config")
   auto grid  = cudax::grid_dims(4);
   auto block = cudax::block_dims<256>;
 
-  auto verify_lambda = [] __device__(auto& config) {
-    CUDAX_REQUIRE(config.dims.count(cudax::thread, cudax::block) == 256);
+  auto verify_lambda = [] __device__(auto config) {
+    static_assert(config.dims.count(cudax::thread, cudax::block) == 256);
     CUDAX_REQUIRE(config.dims.count(cudax::block) == 4);
     cooperative_groups::this_grid().sync();
   };


### PR DESCRIPTION
Kernel functors are more flexible than a normal kernel function, since they are types they can hold other members beyond just the function.

We would like to allow users to define default configuration of a kernel functor object. This configuration can be partial and it will be combined with the configuration provided at launch.

This PR adds:
- `combine()` function to `kernel_config` type that will combine the hierarchy and config options from that object and an argument into one config. Whatever is present in the object its called on will be prioritized in case of overlap (same as hierarchy object `combine()`.
- `combine_with_default()` function to `kernel_config` type that takes a kernel functor as argument. It will check if the supplied object has `default_config()` member function that returns `kernel_config`. If that is the case it will combine itself with it, otherwise just return a copy of itself.
- Launch of a kernel functor will call into `combine_with_default()` automatically.
- I had to add a internal `__empty_hierarchy` type used instead of `uninit_t` to support combining it with a hierarchy.
- I changed `make_config()` to accept 0 arguments in case launch site is not adding any configuration beyond the default one, in which case empty config is needed.