### PR TITLE
[Improvement] Don't require specifying output type when constructing TransformIterator (cuda.parallel)

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/__init__.py
@@ -162,7 +162,7 @@ class _Op:
 
 def _extract_ctypes_ltoirs(numba_cuda_compile_results):
     view_lst = [_CCCLStringView(ltoir, len(ltoir))
-                for ltoir, _ in numba_cuda_compile_results]
+                for ltoir in numba_cuda_compile_results]
     view_arr = (_CCCLStringView * len(view_lst))(*view_lst)
     return ctypes.pointer(_CCCLStringViews(view_arr, len(view_arr)))
 

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -103,7 +103,7 @@ class RawPointer:
             _ncc(
                 f"{self.prefix}_advance",
                 RawPointer.pointer_advance,
-                (data_as_ntype_pp, _DISTANCE_NUMBA_TYPE),
+                numba.types.void(data_as_ntype_pp, _DISTANCE_NUMBA_TYPE),
             ).ltoir,
             _ncc(
                 f"{self.prefix}_dereference",
@@ -181,7 +181,7 @@ class CacheModifiedPointer:
             _ncc(
                 f"{self.prefix}_advance",
                 CacheModifiedPointer.cache_advance,
-                (data_as_ntype_pp, _DISTANCE_NUMBA_TYPE),
+                numba.types.void(data_as_ntype_pp, _DISTANCE_NUMBA_TYPE),
             ).ltoir,
             _ncc(
                 f"{self.prefix}_dereference",
@@ -221,7 +221,7 @@ class ConstantIterator:
             _ncc(
                 f"{self.prefix}_advance",
                 ConstantIterator.constant_advance,
-                (thisty, _DISTANCE_NUMBA_TYPE),
+                numba.types.void(thisty, _DISTANCE_NUMBA_TYPE),
             ).ltoir,
             _ncc(
                 f"{self.prefix}_dereference",
@@ -261,7 +261,7 @@ class CountingIterator:
             _ncc(
                 f"{self.prefix}_advance",
                 CountingIterator.count_advance,
-                (thisty, _DISTANCE_NUMBA_TYPE),
+                numba.types.void(thisty, _DISTANCE_NUMBA_TYPE),
             ).ltoir,
             _ncc(
                 f"{self.prefix}_dereference",
@@ -424,7 +424,7 @@ def TransformIterator(op, it):
         _ncc(
             f"{prefix}_advance",
             transform_advance,
-            (
+            numba.types.void(
                 numba.types.CPointer(numba.types.char), _DISTANCE_NUMBA_TYPE
             ),
         ).ltoir,

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -1,5 +1,6 @@
 import ctypes
 import operator
+import collections
 
 from numba.core import cgutils
 from llvmlite import ir
@@ -54,10 +55,12 @@ def _ctypes_type_given_numba_type(ntype):
     return mapping[ntype]
 
 
+CompileResult = collections.namedtuple('CompileResult', ['ltoir', 'result_type'])
+
 def _ncc(abi_name, pyfunc, sig):
-    return numba.cuda.compile(
+    return CompileResult(*numba.cuda.compile(
         pyfunc=pyfunc, sig=sig, abi_info={"abi_name": abi_name}, output="ltoir"
-    )
+    ))
 
 
 def sizeof_pointee(context, ptr):
@@ -96,18 +99,18 @@ class RawPointer:
         data_as_ntype_pp = numba.types.CPointer(numba.types.CPointer(ntype))
         self.ntype = ntype
         self.prefix = "pointer_" + ntype.name
-        self.ltoirs, _ = zip(*[
+        self.ltoirs = [
             _ncc(
                 f"{self.prefix}_advance",
                 RawPointer.pointer_advance,
                 (data_as_ntype_pp, _DISTANCE_NUMBA_TYPE),
-            ),
+            ).ltoir,
             _ncc(
                 f"{self.prefix}_dereference",
                 RawPointer.pointer_dereference,
                 (data_as_ntype_pp,),
-            ),
-        ])
+            ).ltoir
+        ]
 
     # Exclusively for numba.cuda.compile (this is not an actual method).
     def pointer_advance(this, distance):
@@ -174,18 +177,18 @@ class CacheModifiedPointer:
         self.ntype = ntype
         data_as_ntype_pp = numba.types.CPointer(numba.types.CPointer(ntype))
         self.prefix = "cache" + ntype.name
-        self.ltoirs, _ = zip(*[
+        self.ltoirs = [
             _ncc(
                 f"{self.prefix}_advance",
                 CacheModifiedPointer.cache_advance,
-                numba.types.void(data_as_ntype_pp, _DISTANCE_NUMBA_TYPE),
-            ),
+                (data_as_ntype_pp, _DISTANCE_NUMBA_TYPE),
+            ).ltoir,
             _ncc(
                 f"{self.prefix}_dereference",
                 CacheModifiedPointer.cache_dereference,
-                ntype(data_as_ntype_pp),
-            ),
-        ])
+                (data_as_ntype_pp,),
+            ).ltoir,
+        ]
 
     # Exclusively for numba.cuda.compile (this is not an actual method).
     def cache_advance(this, distance):
@@ -214,18 +217,18 @@ class ConstantIterator:
         self.val = _ctypes_type_given_numba_type(ntype)(val)
         self.ntype = ntype
         self.prefix = "constant_" + ntype.name
-        self.ltoirs, _ = zip(*[
+        self.ltoirs = [
             _ncc(
                 f"{self.prefix}_advance",
                 ConstantIterator.constant_advance,
-                numba.types.void(thisty, _DISTANCE_NUMBA_TYPE),
-            ),
+                (thisty, _DISTANCE_NUMBA_TYPE),
+            ).ltoir,
             _ncc(
                 f"{self.prefix}_dereference",
                 ConstantIterator.constant_dereference,
-                ntype(thisty),
-            ),
-        ])
+                (thisty,),
+            ).ltoir,
+        ]
 
     # Exclusively for numba.cuda.compile (this is not an actual method).
     def constant_advance(this, _):
@@ -254,18 +257,18 @@ class CountingIterator:
         self.count = _ctypes_type_given_numba_type(ntype)(count)
         self.ntype = ntype
         self.prefix = "count_" + ntype.name
-        self.ltoirs, _ = zip(*[
+        self.ltoirs = [
             _ncc(
                 f"{self.prefix}_advance",
                 CountingIterator.count_advance,
-                numba.types.void(thisty, _DISTANCE_NUMBA_TYPE),
-            ),
+                (thisty, _DISTANCE_NUMBA_TYPE),
+            ).ltoir,
             _ncc(
                 f"{self.prefix}_dereference",
                 CountingIterator.count_dereference,
-                ntype(thisty),
-            ),
-        ])
+                (thisty,),
+            ).ltoir,
+        ]
 
     # Exclusively for numba.cuda.compile (this is not an actual method).
     def count_advance(this, diff):
@@ -325,8 +328,7 @@ def TransformIterator(op, it):
         raise RuntimeError(f"Unsupported: {type(it.ntype)=}")
 
     op_abi_name = f"{op.__name__}_{it.ntype.name}"
-    op_ltoir = _ncc(op_abi_name, op, (it.ntype,))
-    op_return_ntype = op_ltoir[1]
+    op_ltoir, op_return_ntype = _ncc(op_abi_name, op, (it.ntype,))
     op_return_ntype_ir = _ir_type_given_numba_type(op_return_ntype)
 
     def source_advance(it_state_ptr, diff):
@@ -418,20 +420,19 @@ def TransformIterator(op, it):
         return op_caller(source_dereference(it_state_ptr))
 
     prefix = f"transform_{it.prefix}_{op.__name__}"
-    ltoirs =  [
-        *it.ltoirs,
+    ltoirs =  it.ltoirs + [
         _ncc(
             f"{prefix}_advance",
             transform_advance,
-            numba.types.void(
+            (
                 numba.types.CPointer(numba.types.char), _DISTANCE_NUMBA_TYPE
             ),
-        )[0],
+        ).ltoir,
         _ncc(
             f"{prefix}_dereference",
             transform_dereference,
-            op_return_ntype(numba.types.CPointer(numba.types.char)),
-        )[0],
+            (numba.types.CPointer(numba.types.char),),
+        ).ltoir,
         # ATTENTION: NOT op_caller here! (see issue #3064)
         op_ltoir
     ]

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators.py
@@ -30,8 +30,6 @@ def CountingIterator(offset, value_type):
     )
 
 
-def TransformIterator(op, it, op_return_value_type):
+def TransformIterator(op, it):
     """Python fascade (similar to built-in map) mimicking a C++ Random Access TransformIterator."""
-    return _iterators.TransformIterator(
-        op, it, _iterators.numba_type_from_any(op_return_value_type)
-    )
+    return _iterators.TransformIterator(op, it)

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -251,7 +251,6 @@ def test_device_sum_map_mul2_count_it(
     i_input = iterators.TransformIterator(
         mul2,
         iterators.CountingIterator(start_sum_with, value_type=vtn_inp),
-        op_return_value_type=vtn_out,
     )
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
@@ -287,9 +286,7 @@ def test_device_sum_map_mul_map_mul_count_it(
         iterators.TransformIterator(
             mul_funcs[fac_mid],
             iterators.CountingIterator(start_sum_with, value_type=vtn_inp),
-            op_return_value_type=vtn_mid,
-        ),
-        op_return_value_type=vtn_out,
+        )
     )
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
@@ -313,7 +310,7 @@ def test_device_sum_map_mul2_cp_array_it(
     rng = random.Random(0)
     l_d_in = [rng.randrange(100) for _ in range(num_items)]
     a_d_in = cp.array(l_d_in, dtype_inp)
-    i_input = iterators.TransformIterator(mul2, a_d_in, vtn_out)
+    i_input = iterators.TransformIterator(mul2, a_d_in)
     l_varr = [mul2(v) for v in l_d_in]
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array


### PR DESCRIPTION
## Description

As a follow up to my comment [here](https://github.com/NVIDIA/cccl/pull/2788#discussion_r1872373616), this PR makes it so that we rely on numba to infer the return type of the op when constructing a `TransformIterator`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
