### PR TITLE
simplify the definition of the `basic_any` class template

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,19 +8,6 @@ workflows:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'llvm16']}
   #
   override:
-    - {jobs: ['build'], project: 'cudax', ctk: ['12.0', 'curr'], std: 'all', cxx: ['gcc9', 'gcc10', 'gcc11']}
-    - {jobs: ['build'], project: 'cudax', ctk: ['12.0', 'curr'], std: 'all', cxx: ['clang9', 'clang10', 'clang11', 'clang12', 'clang13']}
-    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['clang14', 'clang15', 'clang16', 'clang17']}
-    - {jobs: ['build'], project: 'cudax', ctk: [        '12.5'], std: 'all', cxx: ['nvhpc']}
-    - {jobs: ['build'], project: 'cudax', ctk: ['12.0',       ], std: 20,    cxx: ['msvc14.36']}
-    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 20,    cxx: ['msvc2022']}
-    - {jobs: ['build'], project: 'cudax', ctk: ['12.0'        ], std: 17,    cxx: ['gcc12'], sm: "90"}
-    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 17,    cxx: ['gcc13'], sm: "90a"}
-    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['gcc13', 'clang16'], cpu: 'arm64'}
-    - {jobs: ['test'],  project: 'cudax', ctk: ['12.0'        ], std: 'min', cxx: ['gcc12']}
-    - {jobs: ['test'],  project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['gcc12']}
-    - {jobs: ['test'],  project: 'cudax', ctk: ['12.0'        ], std: 'max', cxx: ['clang14']}
-    - {jobs: ['test'],  project: 'cudax', ctk: [        'curr'], std: 'max', cxx: ['clang18']}
 
   pull_request:
     # Old CTK

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,6 +8,19 @@ workflows:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: 'curr', cxx: ['gcc12', 'llvm16']}
   #
   override:
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0', 'curr'], std: 'all', cxx: ['gcc9', 'gcc10', 'gcc11']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0', 'curr'], std: 'all', cxx: ['clang9', 'clang10', 'clang11', 'clang12', 'clang13']}
+    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['clang14', 'clang15', 'clang16', 'clang17']}
+    - {jobs: ['build'], project: 'cudax', ctk: [        '12.5'], std: 'all', cxx: ['nvhpc']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0',       ], std: 20,    cxx: ['msvc14.36']}
+    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 20,    cxx: ['msvc2022']}
+    - {jobs: ['build'], project: 'cudax', ctk: ['12.0'        ], std: 17,    cxx: ['gcc12'], sm: "90"}
+    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 17,    cxx: ['gcc13'], sm: "90a"}
+    - {jobs: ['build'], project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['gcc13', 'clang16'], cpu: 'arm64'}
+    - {jobs: ['test'],  project: 'cudax', ctk: ['12.0'        ], std: 'min', cxx: ['gcc12']}
+    - {jobs: ['test'],  project: 'cudax', ctk: [        'curr'], std: 'all', cxx: ['gcc12']}
+    - {jobs: ['test'],  project: 'cudax', ctk: ['12.0'        ], std: 'max', cxx: ['clang14']}
+    - {jobs: ['test'],  project: 'cudax', ctk: [        'curr'], std: 'max', cxx: ['clang18']}
 
   pull_request:
     # Old CTK

--- a/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/hierarchy_dimensions.cuh
@@ -390,7 +390,7 @@ struct hierarchy_dimensions_fragment
       : levels(ls)
   {}
 
-#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON) && !_CCCL_COMPILER(MSVC, <, 19, 39)
+#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON) && !_CCCL_COMPILER(MSVC, <, 19, 39) && !_CCCL_COMPILER(GCC, <, 12)
   _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr bool
   operator==(const hierarchy_dimensions_fragment&) const noexcept = default;
 #  else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv

--- a/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
@@ -129,7 +129,7 @@ struct level_dimensions
   _CCCL_HOST_DEVICE constexpr level_dimensions()
       : dims(){};
 
-#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON) && !_CCCL_COMPILER(MSVC, <, 19, 39)
+#  if !defined(_CCCL_NO_THREE_WAY_COMPARISON) && !_CCCL_COMPILER(MSVC, <, 19, 39) && !_CCCL_COMPILER(GCC, <, 12)
   _CCCL_NODISCARD _CCCL_HIDE_FROM_ABI constexpr bool operator==(const level_dimensions&) const noexcept = default;
 #  else // ^^^ !_CCCL_NO_THREE_WAY_COMPARISON ^^^ / vvv _CCCL_NO_THREE_WAY_COMPARISON vvv
   _CCCL_NODISCARD_FRIEND _CUDAX_API constexpr bool

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_base.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_base.cuh
@@ -55,7 +55,7 @@ template <class _Interface, int = 0>
 struct __basic_any_base : __interface_of<_Interface>
 {
 private:
-  template <class, class>
+  template <class>
   friend struct basic_any;
   friend struct __basic_any_access;
 
@@ -99,7 +99,7 @@ struct __basic_any_base<_Interface, 2> : __interface_of<_Interface> // copyable 
   }
 
 private:
-  template <class, class>
+  template <class>
   friend struct basic_any;
   friend struct __basic_any_access;
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_fwd.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_fwd.cuh
@@ -42,17 +42,14 @@ _CCCL_PUSH_MACROS
 
 namespace cuda::experimental
 {
-struct __primary;
-struct __secondary;
-
 template <class _Interface>
 struct __ireference;
 
-template <class _Interface, class _Select = __primary>
+template <class _Interface>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any;
 
-template <class _Interface, class _Select>
-struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES basic_any<__ireference<_Interface>, _Select>;
+template <class _Interface>
+struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES basic_any<__ireference<_Interface>>;
 
 template <class _Interface>
 struct basic_any<_Interface*>;

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ptr.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ptr.cuh
@@ -247,7 +247,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface*>
 #endif // _CCCL_DOXYGEN_INVOKED
 
 private:
-  template <class, class>
+  template <class>
   friend struct basic_any;
   friend struct __basic_any_access;
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ref.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_ref.cuh
@@ -97,8 +97,8 @@ _CCCL_NV_DIAG_SUPPRESS(554)
 //!
 //! `basic_any<__ireference<_Interface>>` is neither copyable nor movable. It is
 //! not an end-user type.
-template <class _Interface, class Select>
-struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES basic_any<__ireference<_Interface>, Select>
+template <class _Interface>
+struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES basic_any<__ireference<_Interface>>
     : __interface_of<__ireference<_Interface>>
 #if defined(_CCCL_NO_CONCEPTS)
     , __basic_any_reference_conversion_base<_Interface>
@@ -157,7 +157,7 @@ struct _LIBCUDACXX_DECLSPEC_EMPTY_BASES basic_any<__ireference<_Interface>, Sele
 #endif // _CCCL_DOXYGEN_INVOKED
 
 private:
-  template <class, class>
+  template <class>
   friend struct basic_any;
   friend struct __basic_any_access;
 
@@ -256,14 +256,14 @@ _CCCL_DIAG_POP
 //! basic_any<_Interface&>
 //!
 template <class _Interface>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface&> : basic_any<__ireference<_Interface>, __secondary>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface&> : basic_any<__ireference<_Interface>>
 {
   static_assert(_CUDA_VSTD::is_class_v<_Interface>, "expecting a class type");
-  using typename basic_any<__ireference<_Interface>, __secondary>::interface_type;
-  using basic_any<__ireference<_Interface>, __secondary>::__is_const_ref;
+  using typename basic_any<__ireference<_Interface>>::interface_type;
+  using basic_any<__ireference<_Interface>>::__is_const_ref;
 
   _CUDAX_HOST_API basic_any(basic_any const& __other) noexcept
-      : basic_any<__ireference<_Interface>, __secondary>()
+      : basic_any<__ireference<_Interface>>()
   {
     this->__set_ref(__other.__get_vptr(), __other.__get_optr());
   }
@@ -272,7 +272,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface&> : basic_any<__irefer
   _CCCL_REQUIRES((!__is_basic_any<_Tp>) _CCCL_AND __satisfies<_Up, interface_type> _CCCL_AND(
     __is_const_ref || !_CUDA_VSTD::is_const_v<_Tp>))
   _CUDAX_HOST_API basic_any(_Tp& __obj) noexcept
-      : basic_any<__ireference<_Interface>, __secondary>()
+      : basic_any<__ireference<_Interface>>()
   {
     __vptr_for<interface_type> const __vptr = &__vtable_for_v<interface_type, _Up>;
     this->__set_ref(__vptr, &__obj);
@@ -300,7 +300,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface&> : basic_any<__irefer
                   (!__is_value_v<_SrcInterface>) _CUDAX_AND //
                     __any_convertible_to<basic_any<_SrcInterface>, basic_any>)
   _CUDAX_HOST_API basic_any(basic_any<_SrcInterface>&& __src) noexcept
-      : basic_any<__ireference<_Interface>, __secondary>()
+      : basic_any<__ireference<_Interface>>()
   {
     this->__set_ref(__src.__get_vptr(), __src.__get_optr());
   }
@@ -309,7 +309,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface&> : basic_any<__irefer
   _CUDAX_REQUIRES((!_CUDA_VSTD::same_as<_SrcInterface, _Interface&>) _CUDAX_AND //
                     __any_convertible_to<basic_any<_SrcInterface>&, basic_any>)
   _CUDAX_HOST_API basic_any(basic_any<_SrcInterface>& __src) noexcept
-      : basic_any<__ireference<_Interface>, __secondary>()
+      : basic_any<__ireference<_Interface>>()
   {
     this->__set_ref(__src.__get_vptr(), __src.__get_optr());
   }
@@ -318,7 +318,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface&> : basic_any<__irefer
   _CUDAX_REQUIRES((!_CUDA_VSTD::same_as<_SrcInterface, _Interface&>) _CUDAX_AND //
                     __any_convertible_to<basic_any<_SrcInterface> const&, basic_any>)
   _CUDAX_HOST_API basic_any(basic_any<_SrcInterface> const& __src) noexcept
-      : basic_any<__ireference<_Interface>, __secondary>()
+      : basic_any<__ireference<_Interface>>()
   {
     this->__set_ref(__src.__get_vptr(), __src.__get_optr());
   }
@@ -343,7 +343,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any<_Interface&> : basic_any<__irefer
   }
 
 private:
-  template <class, class>
+  template <class>
   friend struct basic_any;
   friend struct __basic_any_access;
 

--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_value.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_value.cuh
@@ -60,7 +60,7 @@ _CCCL_CONCEPT __list_initializable_from =
 //!
 //! basic_any
 //!
-template <class _Interface, class>
+template <class _Interface>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_any : __basic_any_base<_Interface>
 {
 private:
@@ -362,7 +362,7 @@ public:
 #endif // _CCCL_DOXYGEN_INVOKED
 
 private:
-  template <class, class>
+  template <class>
   friend struct basic_any;
   friend struct __basic_any_access;
   template <class, int>


### PR DESCRIPTION
at some point i had complicated the design of the `basic_any` class template to avoid a compiler bug. since then some implementation details of `basic_any` have changed, and i seem not to be triggering the compiler bug anymore.

this pr simplifies the implementation of `basic_any`, removing an extra template parameter that was previously needed to aid with overload disambiguation.