### PR TITLE
Use only signed offset types in CUB benchmarks

### DIFF
--- a/cub/benchmarks/bench/copy/memcpy.cu
+++ b/cub/benchmarks/bench/copy/memcpy.cu
@@ -288,13 +288,7 @@ void large(nvbench::state& state, nvbench::type_list<T, OffsetT> tl)
 
 using types = nvbench::type_list<nvbench::uint8_t, nvbench::uint32_t>;
 
-#ifdef TUNE_OffsetT
-using u_offset_types = nvbench::type_list<TUNE_OffsetT>;
-#else
-using u_offset_types = nvbench::type_list<uint32_t, uint64_t>;
-#endif
-
-NVBENCH_BENCH_TYPES(uniform, NVBENCH_TYPE_AXES(types, u_offset_types))
+NVBENCH_BENCH_TYPES(uniform, NVBENCH_TYPE_AXES(types, offset_types))
   .set_name("uniform")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(25, 29, 2))
@@ -302,7 +296,7 @@ NVBENCH_BENCH_TYPES(uniform, NVBENCH_TYPE_AXES(types, u_offset_types))
   .add_int64_axis("MaxBufferSize", {8, 64, 256, 1024, 64 * 1024})
   .add_int64_axis("Randomize", {0, 1});
 
-NVBENCH_BENCH_TYPES(large, NVBENCH_TYPE_AXES(types, u_offset_types))
+NVBENCH_BENCH_TYPES(large, NVBENCH_TYPE_AXES(types, offset_types))
   .set_name("large")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", {28, 29});

--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -90,7 +90,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   using accum_t     = ::cuda::std::__accumulator_t<op_t, T, T>;
   using input_it_t  = const T*;
   using output_it_t = T*;
-  using offset_t    = OffsetT;
+  using offset_t    = cub::detail::choose_offset_t<OffsetT>;
 
 #if !TUNE_BASE
   using policy_t   = policy_hub_t<accum_t>;
@@ -131,13 +131,7 @@ static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   });
 }
 
-#ifdef TUNE_OffsetT
-using some_offset_types = nvbench::type_list<TUNE_OffsetT>;
-#else
-using some_offset_types = nvbench::type_list<uint32_t, uint64_t>;
-#endif
-
-NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(all_types, some_offset_types))
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(all_types, offset_types))
   .set_name("base")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));

--- a/cub/benchmarks/bench/segmented_sort/keys.cu
+++ b/cub/benchmarks/bench/segmented_sort/keys.cu
@@ -226,7 +226,7 @@ void seg_sort(nvbench::state& state,
   });
 }
 
-using some_offset_types = nvbench::type_list<uint32_t>;
+using some_offset_types = nvbench::type_list<int32_t>;
 
 template <class T, typename OffsetT>
 void power_law(nvbench::state& state, nvbench::type_list<T, OffsetT> ts)

--- a/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cu
+++ b/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cu
@@ -751,8 +751,8 @@ void do_not_optimize(const void* ptr)
   template std::size_t detail::gen_uniform_segment_offsets_device<TYPE>(                                        \
     seed_t, cuda::std::span<TYPE>, std::size_t, std::size_t)
 
-INSTANTIATE(uint32_t);
-INSTANTIATE(uint64_t);
+INSTANTIATE(int32_t);
+INSTANTIATE(int64_t);
 
 #undef INSTANTIATE
 


### PR DESCRIPTION
We have three CUB benchmarks that don't use signed offset types. To make tuning easier, they should also use signed types, so have consistency when specifying axes. 