### PR TITLE
fix `max_align_t` for `__int128`

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cstddef
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cstddef
@@ -59,8 +59,10 @@ using ::size_t;
   || defined(__NetBS)
 // Re-use the compiler's <stddef.h> max_align_t where possible.
 using ::max_align_t;
+#elif !defined(_LIBCUDACXX_HAS_NO_INT128)
+using max_align_t = __int128;
 #else
-typedef long double max_align_t;
+using max_align_t = long double;
 #endif
 
 _LIBCUDACXX_END_NAMESPACE_STD


### PR DESCRIPTION
The `max_align_t` is described as:

*max_align_t is a [standard-layout](https://en.cppreference.com/w/cpp/named_req/StandardLayoutType) [TrivialType](https://en.cppreference.com/w/cpp/named_req/TrivialType)(until C++26)[TriviallyCopyable](https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable) type(since C++26) whose [alignment requirement](https://en.cppreference.com/w/cpp/language/object#Alignment) is at least as strict (as large) as that of every scalar type.*

The `max_align_t` was defined to be of type `long double` which could lead to invalid alignment e. g. for NVRTC with `__int128` support because `long double` may be implemented as `double` which would lead to 8-byte alignment instead of 16-byte.

This PR adds a check for `__int128` support before falling back to `long double`.