### PR TITLE
backport `byte`

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cstddef
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cstddef
@@ -65,13 +65,8 @@ typedef long double max_align_t;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2011
-#  ifdef _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
 _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
-#  else
-namespace std // purposefully not versioned
-{
-#  endif //_LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION
+
 enum class byte : unsigned char
 {
 };
@@ -82,7 +77,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr byte operator|(byte __lhs, byte __rhs) noexc
     static_cast<unsigned char>(static_cast<unsigned int>(__lhs) | static_cast<unsigned int>(__rhs)));
 }
 
-_LIBCUDACXX_HIDE_FROM_ABI constexpr byte& operator|=(byte& __lhs, byte __rhs) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 byte& operator|=(byte& __lhs, byte __rhs) noexcept
 {
   return __lhs = __lhs | __rhs;
 }
@@ -93,7 +88,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr byte operator&(byte __lhs, byte __rhs) noexc
     static_cast<unsigned char>(static_cast<unsigned int>(__lhs) & static_cast<unsigned int>(__rhs)));
 }
 
-_LIBCUDACXX_HIDE_FROM_ABI constexpr byte& operator&=(byte& __lhs, byte __rhs) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 byte& operator&=(byte& __lhs, byte __rhs) noexcept
 {
   return __lhs = __lhs & __rhs;
 }
@@ -104,7 +99,7 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr byte operator^(byte __lhs, byte __rhs) noexc
     static_cast<unsigned char>(static_cast<unsigned int>(__lhs) ^ static_cast<unsigned int>(__rhs)));
 }
 
-_LIBCUDACXX_HIDE_FROM_ABI constexpr byte& operator^=(byte& __lhs, byte __rhs) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 byte& operator^=(byte& __lhs, byte __rhs) noexcept
 {
   return __lhs = __lhs ^ __rhs;
 }
@@ -115,45 +110,41 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr byte operator~(byte __b) noexcept
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, byte>&
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<_CCCL_TRAIT(is_integral, _Integer), byte>&
 operator<<=(byte& __lhs, _Integer __shift) noexcept
 {
   return __lhs = __lhs << __shift;
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, byte>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<_CCCL_TRAIT(is_integral, _Integer), byte>
 operator<<(byte __lhs, _Integer __shift) noexcept
 {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) << __shift));
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, byte>&
+_LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 enable_if_t<_CCCL_TRAIT(is_integral, _Integer), byte>&
 operator>>=(byte& __lhs, _Integer __shift) noexcept
 {
   return __lhs = __lhs >> __shift;
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, byte>
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<_CCCL_TRAIT(is_integral, _Integer), byte>
 operator>>(byte __lhs, _Integer __shift) noexcept
 {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) >> __shift));
 }
 
 template <class _Integer>
-_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Integer>, _Integer> to_integer(byte __b) noexcept
+_LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<_CCCL_TRAIT(is_integral, _Integer), _Integer>
+to_integer(byte __b) noexcept
 {
   return static_cast<_Integer>(__b);
 }
 
-#  ifdef _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
 _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
-#  else
-}
-#  endif //_LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
-#endif // _CCCL_STD_VER > 2011
 
 _CCCL_POP_MACROS
 

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byte.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byte.pass.cpp
@@ -11,19 +11,13 @@
 
 #include "test_macros.h"
 
-// XFAIL: c++98, c++03, c++11
-
 // If we're just building the test and not executing it, it should pass.
 // UNSUPPORTED: no_execute
 
 // cuda::std::byte is not an integer type, nor a character type.
 // It is a distinct type for accessing the bits that ultimately make up object storage.
 
-#if TEST_STD_VER > 2011
-static_assert(cuda::std::is_trivial<cuda::std::byte>::value, ""); // P0767
-#else
-static_assert(cuda::std::is_pod<cuda::std::byte>::value, "");
-#endif
+static_assert(cuda::std::is_trivial<cuda::std::byte>::value, "");
 static_assert(!cuda::std::is_arithmetic<cuda::std::byte>::value, "");
 static_assert(!cuda::std::is_integral<cuda::std::byte>::value, "");
 

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/and.assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/and.assign.pass.cpp
@@ -10,11 +10,9 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // constexpr byte& operator &=(byte l, byte r) noexcept;
 
-__host__ __device__ constexpr cuda::std::byte test(cuda::std::byte b1, cuda::std::byte b2)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::byte test(cuda::std::byte b1, cuda::std::byte b2)
 {
   cuda::std::byte bret = b1;
   return bret &= b2;
@@ -29,6 +27,15 @@ int main(int, char**)
 
   static_assert(noexcept(b &= b), "");
 
+  assert(cuda::std::to_integer<int>(test(b1, b8)) == 0);
+  assert(cuda::std::to_integer<int>(test(b1, b9)) == 1);
+  assert(cuda::std::to_integer<int>(test(b8, b9)) == 8);
+
+  assert(cuda::std::to_integer<int>(test(b8, b1)) == 0);
+  assert(cuda::std::to_integer<int>(test(b9, b1)) == 1);
+  assert(cuda::std::to_integer<int>(test(b9, b8)) == 8);
+
+#if TEST_STD_VER >= 2014
   static_assert(cuda::std::to_integer<int>(test(b1, b8)) == 0, "");
   static_assert(cuda::std::to_integer<int>(test(b1, b9)) == 1, "");
   static_assert(cuda::std::to_integer<int>(test(b8, b9)) == 8, "");
@@ -36,6 +43,7 @@ int main(int, char**)
   static_assert(cuda::std::to_integer<int>(test(b8, b1)) == 0, "");
   static_assert(cuda::std::to_integer<int>(test(b9, b1)) == 1, "");
   static_assert(cuda::std::to_integer<int>(test(b9, b8)) == 8, "");
+#endif // TEST_STD_VER >= 2014
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/and.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/and.pass.cpp
@@ -10,8 +10,6 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // constexpr byte operator&(byte l, byte r) noexcept;
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/lshift.assign.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/lshift.assign.fail.cpp
@@ -10,24 +10,19 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-// The following compilers don't like "cuda::std::byte b1{1}"
-// UNSUPPORTED: clang-3.5, clang-3.6, clang-3.7, clang-3.8
-// UNSUPPORTED: apple-clang-6, apple-clang-7, apple-clang-8.0
-
 // template <class IntegerType>
 //   constexpr byte& operator<<=(byte& b, IntegerType shift) noexcept;
 // This function shall not participate in overload resolution unless
 //   is_integral_v<IntegerType> is true.
 
-constexpr cuda::std::byte test(cuda::std::byte b)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::byte test(cuda::std::byte b)
 {
   return b <<= 2.0;
 }
 
 int main(int, char**)
 {
-  constexpr cuda::std::byte b1 = test(cuda::std::byte{1});
+  TEST_CONSTEXPR_CXX14 cuda::std::byte b1 = test(static_cast<cuda::std::byte>(1));
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/lshift.assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/lshift.assign.pass.cpp
@@ -10,14 +10,12 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // template <class IntegerType>
 //   constexpr byte& operator<<=(byte& b, IntegerType shift) noexcept;
 // This function shall not participate in overload resolution unless
 //   is_integral_v<IntegerType> is true.
 
-__host__ __device__ constexpr cuda::std::byte test(cuda::std::byte b)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::byte test(cuda::std::byte b)
 {
   return b <<= 2;
 }
@@ -30,8 +28,13 @@ int main(int, char**)
 
   static_assert(noexcept(b <<= 2), "");
 
+  assert(cuda::std::to_integer<int>(test(b2)) == 8);
+  assert(cuda::std::to_integer<int>(test(b3)) == 12);
+
+#if TEST_STD_VER >= 2014
   static_assert(cuda::std::to_integer<int>(test(b2)) == 8, "");
   static_assert(cuda::std::to_integer<int>(test(b3)) == 12, "");
+#endif // TEST_STD_VER >= 2014
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/lshift.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/lshift.fail.cpp
@@ -10,8 +10,6 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // template <class IntegerType>
 //    constexpr byte operator <<(byte b, IntegerType shift) noexcept;
 // These functions shall not participate in overload resolution unless

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/lshift.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/lshift.pass.cpp
@@ -10,8 +10,6 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // template <class IntegerType>
 //    constexpr byte operator <<(byte b, IntegerType shift) noexcept;
 // These functions shall not participate in overload resolution unless

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/not.pass.cpp
@@ -10,8 +10,6 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // constexpr byte operator~(byte b) noexcept;
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/or.assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/or.assign.pass.cpp
@@ -10,11 +10,9 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // constexpr byte& operator |=(byte l, byte r) noexcept;
 
-__host__ __device__ constexpr cuda::std::byte test(cuda::std::byte b1, cuda::std::byte b2)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::byte test(cuda::std::byte b1, cuda::std::byte b2)
 {
   cuda::std::byte bret = b1;
   return bret |= b2;
@@ -29,6 +27,15 @@ int main(int, char**)
 
   static_assert(noexcept(b |= b), "");
 
+  assert(cuda::std::to_integer<int>(test(b1, b2)) == 3);
+  assert(cuda::std::to_integer<int>(test(b1, b8)) == 9);
+  assert(cuda::std::to_integer<int>(test(b2, b8)) == 10);
+
+  assert(cuda::std::to_integer<int>(test(b2, b1)) == 3);
+  assert(cuda::std::to_integer<int>(test(b8, b1)) == 9);
+  assert(cuda::std::to_integer<int>(test(b8, b2)) == 10);
+
+#if TEST_STD_VER >= 2014
   static_assert(cuda::std::to_integer<int>(test(b1, b2)) == 3, "");
   static_assert(cuda::std::to_integer<int>(test(b1, b8)) == 9, "");
   static_assert(cuda::std::to_integer<int>(test(b2, b8)) == 10, "");
@@ -36,6 +43,7 @@ int main(int, char**)
   static_assert(cuda::std::to_integer<int>(test(b2, b1)) == 3, "");
   static_assert(cuda::std::to_integer<int>(test(b8, b1)) == 9, "");
   static_assert(cuda::std::to_integer<int>(test(b8, b2)) == 10, "");
+#endif // TEST_STD_VER >= 2014
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/or.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/or.pass.cpp
@@ -10,8 +10,6 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // constexpr byte operator|(byte l, byte r) noexcept;
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/rshift.assign.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/rshift.assign.fail.cpp
@@ -10,24 +10,19 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-// The following compilers don't like "cuda::std::byte b1{1}"
-// UNSUPPORTED: clang-3.5, clang-3.6, clang-3.7, clang-3.8
-// UNSUPPORTED: apple-clang-6, apple-clang-7, apple-clang-8.0
-
 // template <class IntegerType>
 //   constexpr byte operator>>(byte& b, IntegerType shift) noexcept;
 // This function shall not participate in overload resolution unless
 //   is_integral_v<IntegerType> is true.
 
-constexpr cuda::std::byte test(cuda::std::byte b)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::byte test(cuda::std::byte b)
 {
   return b >>= 2.0;
 }
 
 int main(int, char**)
 {
-  constexpr cuda::std::byte b1 = test(cuda::std::byte{1});
+  TEST_CONSTEXPR_CXX14 cuda::std::byte b1 = test(static_cast<cuda::std::byte>(1));
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/rshift.assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/rshift.assign.pass.cpp
@@ -10,14 +10,12 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // template <class IntegerType>
 //   constexpr byte& operator>>=(byte& b, IntegerType shift) noexcept;
 // This function shall not participate in overload resolution unless
 //   is_integral_v<IntegerType> is true.
 
-__host__ __device__ constexpr cuda::std::byte test(cuda::std::byte b)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::byte test(cuda::std::byte b)
 {
   return b >>= 2;
 }
@@ -30,8 +28,13 @@ int main(int, char**)
 
   static_assert(noexcept(b >>= 2), "");
 
+  assert(cuda::std::to_integer<int>(test(b16)) == 4);
+  assert(cuda::std::to_integer<int>(test(b192)) == 48);
+
+#if TEST_STD_VER >= 2014
   static_assert(cuda::std::to_integer<int>(test(b16)) == 4, "");
   static_assert(cuda::std::to_integer<int>(test(b192)) == 48, "");
+#endif // TEST_STD_VER >= 2014
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/rshift.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/rshift.fail.cpp
@@ -10,8 +10,6 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // template <class IntegerType>
 //    constexpr byte operator >>(byte b, IntegerType shift) noexcept;
 // These functions shall not participate in overload resolution unless

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/rshift.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/rshift.pass.cpp
@@ -10,14 +10,12 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // template <class IntegerType>
 //    constexpr byte operator <<(byte b, IntegerType shift) noexcept;
 // These functions shall not participate in overload resolution unless
 //   is_integral_v<IntegerType> is true.
 
-__host__ __device__ constexpr cuda::std::byte test(cuda::std::byte b)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::byte test(cuda::std::byte b)
 {
   return b <<= 2;
 }
@@ -29,10 +27,17 @@ int main(int, char**)
 
   static_assert(noexcept(b100 << 2), "");
 
+  assert(cuda::std::to_integer<int>(b100 >> 1) == 50);
+  assert(cuda::std::to_integer<int>(b100 >> 2) == 25);
+  assert(cuda::std::to_integer<int>(b115 >> 3) == 14);
+  assert(cuda::std::to_integer<int>(b115 >> 6) == 1);
+
+#if TEST_STD_VER >= 2014
   static_assert(cuda::std::to_integer<int>(b100 >> 1) == 50, "");
   static_assert(cuda::std::to_integer<int>(b100 >> 2) == 25, "");
   static_assert(cuda::std::to_integer<int>(b115 >> 3) == 14, "");
   static_assert(cuda::std::to_integer<int>(b115 >> 6) == 1, "");
+#endif // TEST_STD_VER >= 2014
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/to_integer.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/to_integer.fail.cpp
@@ -10,8 +10,6 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // template <class IntegerType>
 //    constexpr IntegerType to_integer(byte b) noexcept;
 // This function shall not participate in overload resolution unless

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/to_integer.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/to_integer.pass.cpp
@@ -11,8 +11,6 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // template <class IntegerType>
 //    constexpr IntegerType to_integer(byte b) noexcept;
 // This function shall not participate in overload resolution unless

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/xor.assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/xor.assign.pass.cpp
@@ -10,11 +10,9 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // constexpr byte& operator ^=(byte l, byte r) noexcept;
 
-__host__ __device__ constexpr cuda::std::byte test(cuda::std::byte b1, cuda::std::byte b2)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::byte test(cuda::std::byte b1, cuda::std::byte b2)
 {
   cuda::std::byte bret = b1;
   return bret ^= b2;
@@ -29,6 +27,15 @@ int main(int, char**)
 
   static_assert(noexcept(b ^= b), "");
 
+  assert(cuda::std::to_integer<int>(test(b1, b8)) == 9);
+  assert(cuda::std::to_integer<int>(test(b1, b9)) == 8);
+  assert(cuda::std::to_integer<int>(test(b8, b9)) == 1);
+
+  assert(cuda::std::to_integer<int>(test(b8, b1)) == 9);
+  assert(cuda::std::to_integer<int>(test(b9, b1)) == 8);
+  assert(cuda::std::to_integer<int>(test(b9, b8)) == 1);
+
+#if TEST_STD_VER >= 2014
   static_assert(cuda::std::to_integer<int>(test(b1, b8)) == 9, "");
   static_assert(cuda::std::to_integer<int>(test(b1, b9)) == 8, "");
   static_assert(cuda::std::to_integer<int>(test(b8, b9)) == 1, "");
@@ -36,6 +43,7 @@ int main(int, char**)
   static_assert(cuda::std::to_integer<int>(test(b8, b1)) == 9, "");
   static_assert(cuda::std::to_integer<int>(test(b9, b1)) == 8, "");
   static_assert(cuda::std::to_integer<int>(test(b9, b8)) == 1, "");
+#endif // TEST_STD_VER >= 2014
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/xor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.types/byteops/xor.pass.cpp
@@ -10,8 +10,6 @@
 
 #include <test_macros.h>
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14
-
 // constexpr byte operator^(byte l, byte r) noexcept;
 
 int main(int, char**)


### PR DESCRIPTION
This PR implements a backport of C++17 `byte` to back to C++11.

In PR #3043, I've made a mistake and moved the `__cccl_byte` to C++11, so this is more or less a correction to the CCCL state.