### PR TITLE
suppress `-Werror=empty-body` in `char_traits` implementation

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__string
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__string
@@ -263,7 +263,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT char_traits<char>
 #if _CCCL_COMPILER(GCC, <, 13)
     // absurd workaround for GCC "internal compiler error: in cxx_eval_array_reference"
     if (_CUDA_VSTD::is_constant_evaluated())
-      ;
+    {
+    }
 #endif
 #if defined(_CCCL_BUILTIN_STRLEN)
     NV_IF_ELSE_TARGET(NV_IS_DEVICE,


### PR DESCRIPTION
## Description

i just ran into this with gcc-9 when compiling cccl headers as C++ (.cpp) instead of CUDA (.cu).

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
