### PR TITLE
add support for comparing type-erased wrappers to non-type-erased objects

### DIFF
--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_from.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_from.cuh
@@ -21,6 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/decay.h>
+
+#include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__utility/basic_any/basic_any_fwd.cuh>
 
 _CCCL_PUSH_MACROS
@@ -82,6 +85,12 @@ _CCCL_NODISCARD _CUDAX_HOST_API auto basic_any_from(_Interface<> const*) noexcep
   // unspecialized interfaces.
   _CCCL_UNREACHABLE();
 }
+
+template <class _CvInterface>
+using cvref_basic_any_from_t = decltype(__cudax::basic_any_from(declval<_CvInterface>()));
+
+template <class _CvInterface>
+using basic_any_from_t = _CUDA_VSTD::decay_t<cvref_basic_any_from_t<_CvInterface>>;
 } // namespace cuda::experimental
 
 _CCCL_POP_MACROS

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -27,6 +27,7 @@
 #include <cuda/std/__concepts/movable.h>
 #include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/__utility/typeid.h>
+#include <cuda/std/__utility/unreachable.h>
 
 #include <cuda/experimental/__utility/basic_any/access.cuh>
 #include <cuda/experimental/__utility/basic_any/basic_any_base.cuh>
@@ -156,18 +157,16 @@ struct iequality_comparable_base : interface<iequality_comparable>
   // These overloads are only necessary so that iequality_comparable<> itself
   // satisfies the std::equality_comparable constraint that is used by the
   // `iequality_comparable<>::overloads` alias template below.
-  _CCCL_NODISCARD_FRIEND _CUDAX_TRIVIAL_HOST_API auto
+  _CCCL_NORETURN friend _CUDAX_TRIVIAL_HOST_API auto
   operator==(iequality_comparable<> const&, iequality_comparable<> const&) noexcept -> bool
   {
-    _CCCL_UNREACHABLE();
-    return true;
+    _CUDA_VSTD::unreachable();
   }
 
-  _CCCL_NODISCARD_FRIEND _CUDAX_TRIVIAL_HOST_API auto
+  _CCCL_NORETURN friend _CUDAX_TRIVIAL_HOST_API auto
   operator!=(iequality_comparable<> const&, iequality_comparable<> const&) noexcept -> bool
   {
-    _CCCL_UNREACHABLE();
-    return false;
+    _CUDA_VSTD::unreachable();
   }
 
   template <class _Interface>

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -168,11 +168,11 @@ struct iequality_comparable_base : interface<iequality_comparable>
   }
 
   template <class _Interface>
-  struct __object
+  struct __const_reference
   {
     _CCCL_TEMPLATE(class _Object)
-    _CCCL_REQUIRES(__satisfies<_Object, _Interface>)
-    __object(_Object const& __obj) noexcept
+    _CCCL_REQUIRES((!__is_basic_any<_Object>) _CCCL_AND __satisfies<_Object, _Interface>)
+    __const_reference(_Object const& __obj) noexcept
         : __obj_(&__obj)
         , __type_(_CCCL_TYPEID(_Object))
     {}
@@ -208,15 +208,16 @@ struct iequality_comparable_base : interface<iequality_comparable>
   template <class _Interface>
   _CCCL_NODISCARD_FRIEND _CUDAX_HOST_API auto
   operator==(iequality_comparable<_Interface> const& __lhs,
-             _CUDA_VSTD::type_identity_t<__object<_Interface>> __rhs) noexcept -> bool
+             _CUDA_VSTD::type_identity_t<__const_reference<_Interface>> __rhs) noexcept -> bool
   {
     constexpr auto __eq = &__equal_fn<iequality_comparable<_Interface>>;
     return __cudax::virtcall<__eq>(&__lhs, __rhs.__type_, __rhs.__obj_);
   }
 
   template <class _Interface>
-  _CCCL_NODISCARD_FRIEND _CUDAX_HOST_API auto operator==(_CUDA_VSTD::type_identity_t<__object<_Interface>> __lhs,
-                                                         iequality_comparable<_Interface> const& __rhs) noexcept -> bool
+  _CCCL_NODISCARD_FRIEND _CUDAX_HOST_API auto
+  operator==(_CUDA_VSTD::type_identity_t<__const_reference<_Interface>> __lhs,
+             iequality_comparable<_Interface> const& __rhs) noexcept -> bool
   {
     constexpr auto __eq = &__equal_fn<iequality_comparable<_Interface>>;
     return __cudax::virtcall<__eq>(&__rhs, __lhs.__type_, __lhs.__obj_);
@@ -225,14 +226,14 @@ struct iequality_comparable_base : interface<iequality_comparable>
   template <class _Interface>
   _CCCL_NODISCARD_FRIEND _CUDAX_TRIVIAL_HOST_API auto
   operator!=(iequality_comparable<_Interface> const& __lhs,
-             _CUDA_VSTD::type_identity_t<__object<_Interface>> __rhs) noexcept -> bool
+             _CUDA_VSTD::type_identity_t<__const_reference<_Interface>> __rhs) noexcept -> bool
   {
     return !(__lhs == __rhs);
   }
 
   template <class _Interface>
   _CCCL_NODISCARD_FRIEND _CUDAX_TRIVIAL_HOST_API auto
-  operator!=(_CUDA_VSTD::type_identity_t<__object<_Interface>> __lhs,
+  operator!=(_CUDA_VSTD::type_identity_t<__const_reference<_Interface>> __lhs,
              iequality_comparable<_Interface> const& __rhs) noexcept -> bool
   {
     return !(__lhs == __rhs);

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -30,6 +30,7 @@
 #include <cuda/std/__utility/typeid.h>
 
 #include <cuda/experimental/__utility/basic_any/access.cuh>
+#include <cuda/experimental/__utility/basic_any/basic_any_base.cuh>
 #include <cuda/experimental/__utility/basic_any/basic_any_from.cuh>
 #include <cuda/experimental/__utility/basic_any/basic_any_fwd.cuh>
 #include <cuda/experimental/__utility/basic_any/interfaces.cuh>

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -172,7 +172,8 @@ struct iequality_comparable_base : interface<iequality_comparable>
   struct __const_reference
   {
     _CCCL_TEMPLATE(class _Object)
-    _CCCL_REQUIRES((!__is_basic_any<_Object>) _CCCL_AND __satisfies<_Object, _Interface>)
+    _CCCL_REQUIRES((!__is_basic_any<_Object>) _CCCL_AND(!__is_interface<_Object>)
+                     _CCCL_AND __satisfies<_Object, _Interface>)
     __const_reference(_Object const& __obj) noexcept
         : __obj_(&__obj)
         , __type_(_CCCL_TYPEID(_Object))

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -22,7 +22,6 @@
 #endif // no system header
 
 #include <cuda/std/__concepts/concept_macros.h>
-#include <cuda/std/__concepts/convertible_to.h>
 #include <cuda/std/__concepts/copyable.h>
 #include <cuda/std/__concepts/equality_comparable.h>
 #include <cuda/std/__concepts/movable.h>
@@ -33,6 +32,7 @@
 #include <cuda/experimental/__utility/basic_any/basic_any_base.cuh>
 #include <cuda/experimental/__utility/basic_any/basic_any_from.cuh>
 #include <cuda/experimental/__utility/basic_any/basic_any_fwd.cuh>
+#include <cuda/experimental/__utility/basic_any/conversions.cuh>
 #include <cuda/experimental/__utility/basic_any/interfaces.cuh>
 #include <cuda/experimental/__utility/basic_any/storage.cuh>
 #include <cuda/experimental/__utility/basic_any/virtcall.cuh>
@@ -186,8 +186,8 @@ struct iequality_comparable_base : interface<iequality_comparable>
   // These are the overloads that actually get used when testing `basic_any`
   // objects for equality.
   _CCCL_TEMPLATE(class _ILeft, class _IRight)
-  _CCCL_REQUIRES(_CUDA_VSTD::convertible_to<basic_any<_ILeft> const&, basic_any<_IRight> const&>
-                 || _CUDA_VSTD::convertible_to<basic_any<_IRight> const&, basic_any<_ILeft> const&>)
+  _CCCL_REQUIRES(__any_convertible_to<basic_any<_ILeft> const&, basic_any<_IRight> const&>
+                 || __any_convertible_to<basic_any<_IRight> const&, basic_any<_ILeft> const&>)
   _CCCL_NODISCARD_FRIEND _CUDAX_HOST_API auto
   operator==(iequality_comparable<_ILeft> const& __lhs, iequality_comparable<_IRight> const& __rhs) noexcept -> bool
   {
@@ -197,8 +197,8 @@ struct iequality_comparable_base : interface<iequality_comparable>
   }
 
   _CCCL_TEMPLATE(class _ILeft, class _IRight)
-  _CCCL_REQUIRES(_CUDA_VSTD::convertible_to<basic_any<_ILeft> const&, basic_any<_IRight> const&>
-                 || _CUDA_VSTD::convertible_to<basic_any<_IRight> const&, basic_any<_ILeft> const&>)
+  _CCCL_REQUIRES(__any_convertible_to<basic_any<_ILeft> const&, basic_any<_IRight> const&>
+                 || __any_convertible_to<basic_any<_IRight> const&, basic_any<_ILeft> const&>)
   _CCCL_NODISCARD_FRIEND _CUDAX_TRIVIAL_HOST_API auto
   operator!=(iequality_comparable<_ILeft> const& __lhs, iequality_comparable<_IRight> const& __rhs) noexcept -> bool
   {

--- a/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/semiregular.cuh
@@ -160,12 +160,14 @@ struct iequality_comparable_base : interface<iequality_comparable>
   operator==(iequality_comparable<> const&, iequality_comparable<> const&) noexcept -> bool
   {
     _CCCL_UNREACHABLE();
+    return true;
   }
 
   _CCCL_NODISCARD_FRIEND _CUDAX_TRIVIAL_HOST_API auto
   operator!=(iequality_comparable<> const&, iequality_comparable<> const&) noexcept -> bool
   {
     _CCCL_UNREACHABLE();
+    return false;
   }
 
   template <class _Interface>

--- a/cudax/test/utility/basic_any.cu
+++ b/cudax/test/utility/basic_any.cu
@@ -547,7 +547,20 @@ TEMPLATE_TEST_CASE_METHOD(BasicAnyTestsFixture, "basic_any tests", "[utility][ba
     CHECK_FALSE(e != b);
     CHECK(e != c);
     CHECK(e != d);
+
+    CHECK(a == 42);
+    CHECK(42 == a);
+    CHECK(a != 43);
+    CHECK(43 != a);
   }
 }
 
+#else
+// BUGBUG TODO:
+// temporary hack to prevent sccache from ignoring changes in code guarded by
+// !defined(__CUDA_ARCH__)
+char const* __fool_sccache()
+{
+  return __TIME__;
+}
 #endif // __CUDA_ARCH__


### PR DESCRIPTION
## Description

this pr is part of #1502 and #2824. we want `any_resource` and `resource_ref` to be directly comparable to a concrete (non-type-erased) memory resource object _without_ first type-erasing the resource.

this pr extends `basic_any`'s `iequality_comparable` interface to support such cross-type equality comparisons.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
