### PR TITLE
help older clang and gcc to disambiguate `basic_any<__ireference<I>>` and `basic_any<I&>` bases

### DIFF
--- a/cudax/include/cuda/experimental/__utility/basic_any/basic_any_value.cuh
+++ b/cudax/include/cuda/experimental/__utility/basic_any/basic_any_value.cuh
@@ -176,6 +176,17 @@ public:
     __convert_from(__other);
   }
 
+#if _CCCL_COMPILER(CLANG, <, 12) || _CCCL_COMPILER(GCC, <, 11)
+  // Older versions of clang and gcc need help disambiguating between
+  // basic_any<__ireference<I>> and basic_any<I&>.
+  _CCCL_TEMPLATE(class _OtherInterface)
+  _CCCL_REQUIRES(__any_convertible_to<basic_any<_OtherInterface&>, basic_any>)
+  _CUDAX_HOST_API basic_any(basic_any<_OtherInterface&> __other)
+  {
+    __convert_from(__other);
+  }
+#endif // _CCCL_COMPILER(CLANG, <, 12) || _CCCL_COMPILER(GCC, <, 11)
+
   //! \brief Destroys the contained value, if any.
   _CUDAX_HOST_API ~basic_any()
   {
@@ -242,6 +253,17 @@ public:
   {
     return __assign_from(__other);
   }
+
+#if _CCCL_COMPILER(CLANG, <, 12) || _CCCL_COMPILER(GCC, <, 11)
+  // Older versions of clang and gcc need help disambiguating between
+  // basic_any<__ireference<I>> and basic_any<I&>.
+  _CCCL_TEMPLATE(class _OtherInterface)
+  _CCCL_REQUIRES(__any_convertible_to<basic_any<_OtherInterface&>, basic_any>)
+  _CUDAX_HOST_API auto operator=(basic_any<_OtherInterface&> __other) -> basic_any&
+  {
+    return __assign_from(__other);
+  }
+#endif // _CCCL_COMPILER(CLANG, <, 12) || _CCCL_COMPILER(GCC, <, 11)
 
   //! \brief Implicitly convert to a `basic_any` non-const reference type:
   _CCCL_NODISCARD _CUDAX_HOST_API operator basic_any<__ireference<_Interface>>() & noexcept

--- a/cudax/test/utility/basic_any.cu
+++ b/cudax/test/utility/basic_any.cu
@@ -550,4 +550,31 @@ TEMPLATE_TEST_CASE_METHOD(BasicAnyTestsFixture, "basic_any tests", "[utility][ba
   }
 }
 
+struct any_regular : cudax::basic_any<iregular<>>
+{
+  using cudax::basic_any<iregular<>>::basic_any;
+};
+
+struct any_regular_ref : cudax::basic_any<iregular<>&>
+{
+  using cudax::basic_any<iregular<>&>::basic_any;
+};
+
+TEST_CASE("basic_any test for ambiguous conversions", "[utility][basic_any]")
+{
+  int i = 42;
+  any_regular_ref ref{i};
+
+  any_regular a = ref;
+  a             = ref;
+}
+
+#else // ^^^ !__CUDA_ARCH__ ^^^ / vvv __CUDA_ARCH__ vvv
+// BUGBUG TODO:
+// temporary hack to prevent sccache from ignoring changes in code guarded by
+// !defined(__CUDA_ARCH__)
+char const* __fool_sccache()
+{
+  return __TIME__;
+}
 #endif // __CUDA_ARCH__


### PR DESCRIPTION
## Description

this PR avoids a bug in earlier clang and gcc versions regarding "ambiguous" bases. consider the following code:

```c++
template <class I>
struct basic_any {};

template <class I>
struct basic_any<I&> : basic_any<I> {};

struct any_ref : basic_any<int&> {};

template <class I>
void foo(basic_any<I>) {}

int main()
{
  foo(any_ref{});
}
```

when calling `foo` with `any_ref{}`, the expectation is that `foo<int&>` would be called since the conversion sequence from `any_ref` to `basic_any<int&>` is shorter than the conversion sequence from `any_ref` to `basic_any<int>`. modern compilers get this right. older clang and gcc thing the conversion is ambiguous. they see that `foo` can be called with `basic_any<int&>` _or_ `basic_any<int>`, and they see no difference between the conversions respective sequences. consequently, they determine that `foo(any_ref{})` is ambiguous.

in #2824 , `any_resource_ref` is defined similarly to `any_ref` above, so it hits this problem. this, incidentally, was the reason for the complicated definition of `basic_any` that #3085 simplified.

the workaround is to give `basic_any` an extra overload that will cause it to prefer binding to `basic_any<I&>` over any other `basic_any` base. the workaround is restricted to only the effected compilers.



## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
