### PR TITLE
[Internal Cleanup] pre-commit ruff (excluding docs/tools, libcudacxx/test)

### DIFF
--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -157,7 +157,6 @@ def canonicalize_host_compiler_name(cxx_string):
         )
 
     hc_def = matrix_yaml["host_compilers"][id]
-    hc_versions = hc_def["versions"]
 
     if not version:
         version = max(
@@ -852,10 +851,10 @@ def apply_matrix_job_exclusion(matrix_job, exclusion):
         # Some tags are left unexploded (e.g. 'jobs') to optimize scheduling,
         # so the values can be either a list or a single value.
         # Standardize to a list for comparison:
-        if type(excluded_values) != list:
+        if not isinstance(excluded_values, list):
             excluded_values = [excluded_values]
         matrix_values = matrix_job[tag]
-        if type(matrix_values) != list:
+        if not isinstance(matrix_values, list):
             matrix_values = [matrix_values]
 
         # Identify excluded values that are present in the matrix job for this tag:
@@ -1075,7 +1074,7 @@ def parse_workflow_matrix_jobs(args, workflow_name):
 
     if args:
         if (
-            args.dirty_projects != None
+            args.dirty_projects is not None
         ):  # Explicitly check for None, as an empty list is valid:
             matrix_jobs = [
                 job for job in matrix_jobs if job["project"] in args.dirty_projects

--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -71,8 +71,12 @@ matrix_yaml = None
 # Decorators to cache static results of functions:
 # static_result: function has no args, same result each invocation.
 # memoize_result: result depends on args.
-def static_result(func): return functools.lru_cache(maxsize=1)(func)
-def memoize_result(func): return functools.lru_cache(maxsize=None)(func)
+def static_result(func):
+    return functools.lru_cache(maxsize=1)(func)
+
+
+def memoize_result(func):
+    return functools.lru_cache(maxsize=None)(func)
 
 
 def generate_guids():
@@ -84,9 +88,9 @@ def generate_guids():
     i = 0
     while True:
         # Generates a base64 hash of an incrementing 16-bit integer:
-        hash = base64.b64encode(struct.pack(">H", i)).decode('ascii')
+        hash = base64.b64encode(struct.pack(">H", i)).decode("ascii")
         # Strips off up-to 2 leading 'A' characters and a single trailing '=' characters, if they exist:
-        guid = re.sub(r'^A{0,2}', '', hash).removesuffix("=")
+        guid = re.sub(r"^A{0,2}", "", hash).removesuffix("=")
         yield guid
         i += 1
         if i >= 65535:
@@ -97,12 +101,12 @@ guid_generator = generate_guids()
 
 
 def write_json_file(filename, json_object):
-    with open(filename, 'w') as f:
+    with open(filename, "w") as f:
         json.dump(json_object, f, indent=2)
 
 
 def write_text_file(filename, text):
-    with open(filename, 'w') as f:
+    with open(filename, "w") as f:
         print(text, file=f)
 
 
@@ -112,19 +116,19 @@ def error_message_with_matrix_job(matrix_job, message):
 
 @memoize_result
 def canonicalize_ctk_version(ctk_string):
-    if ctk_string in matrix_yaml['ctk_versions']:
+    if ctk_string in matrix_yaml["ctk_versions"]:
         return ctk_string
 
     # Check for aka's:
-    for ctk_key, ctk_value in matrix_yaml['ctk_versions'].items():
-        if 'aka' in ctk_value and ctk_string == ctk_value['aka']:
+    for ctk_key, ctk_value in matrix_yaml["ctk_versions"].items():
+        if "aka" in ctk_value and ctk_string == ctk_value["aka"]:
             return ctk_key
 
     raise Exception(f"Unknown CTK version '{ctk_string}'")
 
 
 def get_ctk(ctk_string):
-    result = matrix_yaml['ctk_versions'][ctk_string]
+    result = matrix_yaml["ctk_versions"][ctk_string]
     result["version"] = ctk_string
     return result
 
@@ -132,7 +136,7 @@ def get_ctk(ctk_string):
 @memoize_result
 def parse_cxx_string(cxx_string):
     "Returns (id, version) tuple. Version may be None if not present."
-    return re.match(r'^([a-z]+)-?([\d\.]+)?$', cxx_string).groups()
+    return re.match(r"^([a-z]+)-?([\d\.]+)?$", cxx_string).groups()
 
 
 @memoize_result
@@ -147,25 +151,27 @@ def canonicalize_host_compiler_name(cxx_string):
     """
     id, version = parse_cxx_string(cxx_string)
 
-    if not id in matrix_yaml['host_compilers']:
+    if id not in matrix_yaml["host_compilers"]:
         raise Exception(
-            f"Unknown host compiler '{id}'. Valid options are: {', '.join(matrix_yaml['host_compilers'].keys())}")
+            f"Unknown host compiler '{id}'. Valid options are: {', '.join(matrix_yaml['host_compilers'].keys())}"
+        )
 
-    hc_def = matrix_yaml['host_compilers'][id]
-    hc_versions = hc_def['versions']
+    hc_def = matrix_yaml["host_compilers"][id]
+    hc_versions = hc_def["versions"]
 
     if not version:
-        version = max(hc_def['versions'].keys(), key=lambda x: tuple(map(int, x.split('.'))))
+        version = max(
+            hc_def["versions"].keys(), key=lambda x: tuple(map(int, x.split(".")))
+        )
 
     # Check for aka's:
-    if not version in hc_def['versions']:
-        for version_key, version_data in hc_def['versions'].items():
-            if 'aka' in version_data and version == version_data['aka']:
+    if version not in hc_def["versions"]:
+        for version_key, version_data in hc_def["versions"].items():
+            if "aka" in version_data and version == version_data["aka"]:
                 version = version_key
 
-    if not version in hc_def['versions']:
-        raise Exception(
-            f"Unknown version '{version}' for host compiler '{id}'.")
+    if version not in hc_def["versions"]:
+        raise Exception(f"Unknown version '{version}' for host compiler '{id}'.")
 
     cxx_string = f"{id}{version}"
 
@@ -177,23 +183,27 @@ def get_host_compiler(cxx_string):
     "Expects a canonicalized cxx_string."
     id, version = parse_cxx_string(cxx_string)
 
-    if not id in matrix_yaml['host_compilers']:
+    if id not in matrix_yaml["host_compilers"]:
         raise Exception(
-            f"Unknown host compiler '{id}'. Valid options are: {', '.join(matrix_yaml['host_compilers'].keys())}")
+            f"Unknown host compiler '{id}'. Valid options are: {', '.join(matrix_yaml['host_compilers'].keys())}"
+        )
 
-    hc_def = matrix_yaml['host_compilers'][id]
+    hc_def = matrix_yaml["host_compilers"][id]
 
-    if not version in hc_def['versions']:
+    if version not in hc_def["versions"]:
         raise Exception(
-            f"Unknown version '{version}' for host compiler '{id}'. Valid options are: {', '.join(hc_def['versions'].keys())}")
+            f"Unknown version '{version}' for host compiler '{id}'. Valid options are: {', '.join(hc_def['versions'].keys())}"
+        )
 
-    version_def = hc_def['versions'][version]
+    version_def = hc_def["versions"][version]
 
-    result = {'id': id,
-              'name': hc_def['name'],
-              'version': version,
-              'container_tag': hc_def['container_tag'],
-              'exe': hc_def['exe']}
+    result = {
+        "id": id,
+        "name": hc_def["name"],
+        "version": version,
+        "container_tag": hc_def["container_tag"],
+        "exe": hc_def["exe"],
+    }
 
     for key, value in version_def.items():
         result[key] = value
@@ -202,21 +212,22 @@ def get_host_compiler(cxx_string):
 
 
 def get_device_compiler(matrix_job):
-    id = matrix_job['cudacxx']
-    if not id in matrix_yaml['device_compilers'].keys():
+    id = matrix_job["cudacxx"]
+    if id not in matrix_yaml["device_compilers"].keys():
         raise Exception(
-            f"Unknown device compiler '{id}'. Valid options are: {', '.join(matrix_yaml['device_compilers'].keys())}")
-    result = matrix_yaml['device_compilers'][id]
-    result['id'] = id
+            f"Unknown device compiler '{id}'. Valid options are: {', '.join(matrix_yaml['device_compilers'].keys())}"
+        )
+    result = matrix_yaml["device_compilers"][id]
+    result["id"] = id
 
-    if id == 'nvcc':
-        ctk = get_ctk(matrix_job['ctk'])
-        result['version'] = ctk['version']
-        result['stds'] = ctk['stds']
-    elif id == 'clang':
-        host_compiler = get_host_compiler(matrix_job['cxx'])
-        result['version'] = host_compiler['version']
-        result['stds'] = host_compiler['stds']
+    if id == "nvcc":
+        ctk = get_ctk(matrix_job["ctk"])
+        result["version"] = ctk["version"]
+        result["stds"] = ctk["stds"]
+    elif id == "clang":
+        host_compiler = get_host_compiler(matrix_job["cxx"])
+        result["version"] = host_compiler["version"]
+        result["stds"] = host_compiler["stds"]
     else:
         raise Exception(f"Cannot determine version/std info for device compiler '{id}'")
 
@@ -225,95 +236,108 @@ def get_device_compiler(matrix_job):
 
 @memoize_result
 def get_gpu(gpu_string):
-    if not gpu_string in matrix_yaml['gpus']:
+    if gpu_string not in matrix_yaml["gpus"]:
         raise Exception(
-            f"Unknown gpu '{gpu_string}'. Valid options are: {', '.join(matrix_yaml['gpus'].keys())}")
+            f"Unknown gpu '{gpu_string}'. Valid options are: {', '.join(matrix_yaml['gpus'].keys())}"
+        )
 
-    result = matrix_yaml['gpus'][gpu_string]
-    result['id'] = gpu_string
+    result = matrix_yaml["gpus"][gpu_string]
+    result["id"] = gpu_string
 
-    if not 'testing' in result:
-        result['testing'] = False
+    if "testing" not in result:
+        result["testing"] = False
 
     return result
 
 
 @memoize_result
 def get_project(project):
-    if not project in matrix_yaml['projects'].keys():
+    if project not in matrix_yaml["projects"].keys():
         raise Exception(
-            f"Unknown project '{project}'. Valid options are: {', '.join(matrix_yaml['projects'].keys())}")
+            f"Unknown project '{project}'. Valid options are: {', '.join(matrix_yaml['projects'].keys())}"
+        )
 
-    result = matrix_yaml['projects'][project]
-    result['id'] = project
+    result = matrix_yaml["projects"][project]
+    result["id"] = project
 
-    if not 'name' in result:
-        result['name'] = project
+    if "name" not in result:
+        result["name"] = project
 
-    if not 'job_map' in result:
-        result['job_map'] = {}
+    if "job_map" not in result:
+        result["job_map"] = {}
 
     return result
 
 
 @memoize_result
 def get_job_type_info(job):
-    if not job in matrix_yaml['jobs'].keys():
+    if job not in matrix_yaml["jobs"].keys():
         raise Exception(
-            f"Unknown job '{job}'. Valid options are: {', '.join(matrix_yaml['jobs'].keys())}")
+            f"Unknown job '{job}'. Valid options are: {', '.join(matrix_yaml['jobs'].keys())}"
+        )
 
-    result = matrix_yaml['jobs'][job]
-    result['id'] = job
+    result = matrix_yaml["jobs"][job]
+    result["id"] = job
 
-    if not 'name' in result:
-        result['name'] = job.capitalize()
-    if not 'gpu' in result:
-        result['gpu'] = False
-    if not 'cuda_ext' in result:
-        result['cuda_ext'] = False
-    if not 'needs' in result:
-        result['needs'] = None
-    if not 'invoke' in result:
-        result['invoke'] = {}
-    if not 'prefix' in result['invoke']:
-        result['invoke']['prefix'] = job
-    if not 'args' in result['invoke']:
-        result['invoke']['args'] = ""
+    if "name" not in result:
+        result["name"] = job.capitalize()
+    if "gpu" not in result:
+        result["gpu"] = False
+    if "cuda_ext" not in result:
+        result["cuda_ext"] = False
+    if "needs" not in result:
+        result["needs"] = None
+    if "invoke" not in result:
+        result["invoke"] = {}
+    if "prefix" not in result["invoke"]:
+        result["invoke"]["prefix"] = job
+    if "args" not in result["invoke"]:
+        result["invoke"]["args"] = ""
 
     return result
 
 
 @memoize_result
 def get_tag_info(tag):
-    if not tag in matrix_yaml['tags'].keys():
+    if tag not in matrix_yaml["tags"].keys():
         raise Exception(
-            f"Unknown tag '{tag}'. Valid options are: {', '.join(matrix_yaml['tags'].keys())}")
+            f"Unknown tag '{tag}'. Valid options are: {', '.join(matrix_yaml['tags'].keys())}"
+        )
 
-    result = matrix_yaml['tags'][tag]
-    result['id'] = tag
+    result = matrix_yaml["tags"][tag]
+    result["id"] = tag
 
-    if 'required' not in result:
-        result['required'] = False
+    if "required" not in result:
+        result["required"] = False
 
-    if 'default' in result:
-        result['required'] = False
+    if "default" in result:
+        result["required"] = False
     else:
-        result['default'] = None
-
+        result["default"] = None
 
     return result
 
 
 @static_result
 def get_all_matrix_job_tags_sorted():
-    all_tags = set(matrix_yaml['tags'].keys())
+    all_tags = set(matrix_yaml["tags"].keys())
 
     # Sorted using a highly subjective opinion on importance:
     # Always first, information dense:
-    sorted_important_tags = ['project', 'jobs', 'cudacxx', 'cxx', 'ctk', 'gpu', 'std', 'sm', 'cpu']
+    sorted_important_tags = [
+        "project",
+        "jobs",
+        "cudacxx",
+        "cxx",
+        "ctk",
+        "gpu",
+        "std",
+        "sm",
+        "cpu",
+    ]
 
     # Always last, derived:
-    sorted_noise_tags = ['origin']
+    sorted_noise_tags = ["origin"]
 
     # In between?
     sorted_tags = set(sorted_important_tags + sorted_noise_tags)
@@ -323,44 +347,46 @@ def get_all_matrix_job_tags_sorted():
 
 
 def lookup_supported_stds(matrix_job):
-    stds = set(matrix_yaml['all_stds'])
-    if 'ctk' in matrix_job:
-        ctk = get_ctk(matrix_job['ctk'])
-        stds = stds & set(ctk['stds'])
-    if 'cxx' in matrix_job:
-        host_compiler = get_host_compiler(matrix_job['cxx'])
-        stds = stds & set(host_compiler['stds'])
-    if 'cudacxx' in matrix_job:
+    stds = set(matrix_yaml["all_stds"])
+    if "ctk" in matrix_job:
+        ctk = get_ctk(matrix_job["ctk"])
+        stds = stds & set(ctk["stds"])
+    if "cxx" in matrix_job:
+        host_compiler = get_host_compiler(matrix_job["cxx"])
+        stds = stds & set(host_compiler["stds"])
+    if "cudacxx" in matrix_job:
         device_compiler = get_device_compiler(matrix_job)
-        stds = stds & set(device_compiler['stds'])
-    if 'project' in matrix_job:
-        project = get_project(matrix_job['project'])
-        stds = stds & set(project['stds'])
+        stds = stds & set(device_compiler["stds"])
+    if "project" in matrix_job:
+        project = get_project(matrix_job["project"])
+        stds = stds & set(project["stds"])
     if len(stds) == 0:
-        raise Exception(error_message_with_matrix_job(matrix_job, "No supported stds found."))
+        raise Exception(
+            error_message_with_matrix_job(matrix_job, "No supported stds found.")
+        )
     return sorted(list(stds))
 
 
 def is_windows(matrix_job):
-    host_compiler = get_host_compiler(matrix_job['cxx'])
-    return host_compiler['container_tag'] == 'cl'
+    host_compiler = get_host_compiler(matrix_job["cxx"])
+    return host_compiler["container_tag"] == "cl"
 
 
 def is_nvhpc(matrix_job):
-    host_compiler = get_host_compiler(matrix_job['cxx'])
-    return host_compiler['container_tag'] == "nvhpc"
+    host_compiler = get_host_compiler(matrix_job["cxx"])
+    return host_compiler["container_tag"] == "nvhpc"
 
 
 def generate_dispatch_group_name(matrix_job):
-    project = get_project(matrix_job['project'])
-    ctk = matrix_job['ctk']
+    project = get_project(matrix_job["project"])
+    ctk = matrix_job["ctk"]
     device_compiler = get_device_compiler(matrix_job)
-    host_compiler = get_host_compiler(matrix_job['cxx'])
+    host_compiler = get_host_compiler(matrix_job["cxx"])
 
     compiler_info = ""
-    if device_compiler['id'] == 'nvcc':
+    if device_compiler["id"] == "nvcc":
         compiler_info = f"{device_compiler['name']} {host_compiler['name']}"
-    elif device_compiler['id'] == 'clang':
+    elif device_compiler["id"] == "clang":
         compiler_info = f"{device_compiler['name']}"
     else:
         compiler_info = f"{device_compiler['name']}-{device_compiler['version']} {host_compiler['name']}"
@@ -370,53 +396,61 @@ def generate_dispatch_group_name(matrix_job):
 
 def generate_dispatch_job_name(matrix_job, job_type):
     job_info = get_job_type_info(job_type)
-    std_str = ("C++" + str(matrix_job['std']) + " ") if 'std' in matrix_job else ''
-    cpu_str = matrix_job['cpu']
-    gpu_str = (', ' + matrix_job['gpu'].upper()) if job_info['gpu'] else ""
-    cuda_compile_arch = (" sm{" + str(matrix_job['sm']) + "}") if 'sm' in matrix_job else ""
-    cmake_options = (' ' + matrix_job['cmake_options']) if 'cmake_options' in matrix_job else ""
+    std_str = ("C++" + str(matrix_job["std"]) + " ") if "std" in matrix_job else ""
+    cpu_str = matrix_job["cpu"]
+    gpu_str = (", " + matrix_job["gpu"].upper()) if job_info["gpu"] else ""
+    cuda_compile_arch = (
+        (" sm{" + str(matrix_job["sm"]) + "}") if "sm" in matrix_job else ""
+    )
+    cmake_options = (
+        (" " + matrix_job["cmake_options"]) if "cmake_options" in matrix_job else ""
+    )
 
-    host_compiler = get_host_compiler(matrix_job['cxx'])
+    host_compiler = get_host_compiler(matrix_job["cxx"])
 
     config_tag = f"{std_str}{host_compiler['name']}{host_compiler['version']}"
 
-    extra_info = f":{cuda_compile_arch}{cmake_options}" if cuda_compile_arch or cmake_options else ""
+    extra_info = (
+        f":{cuda_compile_arch}{cmake_options}"
+        if cuda_compile_arch or cmake_options
+        else ""
+    )
 
     return f"[{config_tag}] {job_info['name']}({cpu_str}{gpu_str}){extra_info}"
 
 
 def generate_dispatch_job_runner(matrix_job, job_type):
     runner_os = "windows" if is_windows(matrix_job) else "linux"
-    cpu = matrix_job['cpu']
+    cpu = matrix_job["cpu"]
 
     job_info = get_job_type_info(job_type)
-    if not job_info['gpu']:
+    if not job_info["gpu"]:
         return f"{runner_os}-{cpu}-cpu16"
 
-    gpu = get_gpu(matrix_job['gpu'])
-    suffix = "-testing" if gpu['testing'] else ""
+    gpu = get_gpu(matrix_job["gpu"])
+    suffix = "-testing" if gpu["testing"] else ""
 
     return f"{runner_os}-{cpu}-gpu-{gpu['id']}-latest-1{suffix}"
 
 
 def generate_dispatch_job_ctk_version(matrix_job, job_type):
     ".devcontainers/launch.sh --cuda option:"
-    return matrix_job['ctk']
+    return matrix_job["ctk"]
 
 
 def generate_dispatch_job_host_compiler(matrix_job, job_type):
     ".devcontainers/launch.sh --host option:"
-    host_compiler = get_host_compiler(matrix_job['cxx'])
-    return host_compiler['container_tag'] + host_compiler['version']
+    host_compiler = get_host_compiler(matrix_job["cxx"])
+    return host_compiler["container_tag"] + host_compiler["version"]
 
 
 def generate_dispatch_job_image(matrix_job, job_type):
-    devcontainer_version = matrix_yaml['devcontainer_version']
-    ctk = matrix_job['ctk']
+    devcontainer_version = matrix_yaml["devcontainer_version"]
+    ctk = matrix_job["ctk"]
     host_compiler = generate_dispatch_job_host_compiler(matrix_job, job_type)
 
     job_info = get_job_type_info(job_type)
-    ctk_suffix = "ext" if job_info['cuda_ext'] else ""
+    ctk_suffix = "ext" if job_info["cuda_ext"] else ""
 
     if is_windows(matrix_job):
         return f"rapidsai/devcontainers:{devcontainer_version}-cuda{ctk}{ctk_suffix}-{host_compiler}"
@@ -432,76 +466,76 @@ def generate_dispatch_job_command(matrix_job, job_type):
     script_ext = ".ps1" if is_windows(matrix_job) else ".sh"
 
     job_info = get_job_type_info(job_type)
-    job_prefix = job_info['invoke']['prefix']
-    job_args = job_info['invoke']['args']
+    job_prefix = job_info["invoke"]["prefix"]
+    job_args = job_info["invoke"]["args"]
 
-    project = get_project(matrix_job['project'])
+    project = get_project(matrix_job["project"])
     script_name = f"{script_path}/{job_prefix}_{project['id']}{script_ext}"
 
-    std_str = str(matrix_job['std']) if 'std' in matrix_job else ''
+    std_str = str(matrix_job["std"]) if "std" in matrix_job else ""
 
     device_compiler = get_device_compiler(matrix_job)
 
-    cuda_compile_arch = matrix_job['sm'] if 'sm' in matrix_job else ''
-    cmake_options = matrix_job['cmake_options'] if 'cmake_options' in matrix_job else ''
+    cuda_compile_arch = matrix_job["sm"] if "sm" in matrix_job else ""
+    cmake_options = matrix_job["cmake_options"] if "cmake_options" in matrix_job else ""
 
-    command = f"\"{script_name}\""
+    command = f'"{script_name}"'
     if job_args:
         command += f" {job_args}"
     if std_str:
-        command += f" -std \"{std_str}\""
+        command += f' -std "{std_str}"'
     if cuda_compile_arch:
-        command += f" -arch \"{cuda_compile_arch}\""
-    if device_compiler['id'] != 'nvcc':
+        command += f' -arch "{cuda_compile_arch}"'
+    if device_compiler["id"] != "nvcc":
         command += f" -cuda \"{device_compiler['exe']}\""
     if cmake_options:
-        command += f" -cmake-options \"{cmake_options}\""
+        command += f' -cmake-options "{cmake_options}"'
 
     return command
 
 
 def generate_dispatch_job_origin(matrix_job, job_type):
     # Already has silename, line number, etc:
-    origin = matrix_job['origin'].copy()
+    origin = matrix_job["origin"].copy()
 
     origin_job = matrix_job.copy()
-    del origin_job['origin']
+    del origin_job["origin"]
 
     job_info = get_job_type_info(job_type)
 
     # The origin tags are used to build the execution summary for the CI PR comment.
     # Use the human readable job label for the execution summary:
-    origin_job['jobs'] = job_info['name']
+    origin_job["jobs"] = job_info["name"]
 
     # Replace some of the clunkier tags with a summary-friendly version:
-    if 'cxx' in origin_job:
-        host_compiler = get_host_compiler(matrix_job['cxx'])
-        del origin_job['cxx']
+    if "cxx" in origin_job:
+        host_compiler = get_host_compiler(matrix_job["cxx"])
+        del origin_job["cxx"]
 
-        origin_job['cxx'] = host_compiler['name'] + host_compiler['version']
-        origin_job['cxx_family'] = host_compiler['name']
+        origin_job["cxx"] = host_compiler["name"] + host_compiler["version"]
+        origin_job["cxx_family"] = host_compiler["name"]
 
-    if 'cudacxx' in origin_job:
+    if "cudacxx" in origin_job:
         device_compiler = get_device_compiler(matrix_job)
-        del origin_job['cudacxx']
+        del origin_job["cudacxx"]
 
-        origin_job['cudacxx'] = device_compiler['name'] + device_compiler['version']
-        origin_job['cudacxx_family'] = device_compiler['name']
+        origin_job["cudacxx"] = device_compiler["name"] + device_compiler["version"]
+        origin_job["cudacxx_family"] = device_compiler["name"]
 
-    origin['matrix_job'] = origin_job
+    origin["matrix_job"] = origin_job
 
     return origin
 
 
 def generate_dispatch_job_json(matrix_job, job_type):
     return {
-        'cuda': generate_dispatch_job_ctk_version(matrix_job, job_type),
-        'host': generate_dispatch_job_host_compiler(matrix_job, job_type),
-        'name': generate_dispatch_job_name(matrix_job, job_type),
-        'runner': generate_dispatch_job_runner(matrix_job, job_type),
-        'image': generate_dispatch_job_image(matrix_job, job_type),
-        'command': generate_dispatch_job_command(matrix_job, job_type),
-        'origin': generate_dispatch_job_origin(matrix_job, job_type)
+        "cuda": generate_dispatch_job_ctk_version(matrix_job, job_type),
+        "host": generate_dispatch_job_host_compiler(matrix_job, job_type),
+        "name": generate_dispatch_job_name(matrix_job, job_type),
+        "runner": generate_dispatch_job_runner(matrix_job, job_type),
+        "image": generate_dispatch_job_image(matrix_job, job_type),
+        "command": generate_dispatch_job_command(matrix_job, job_type),
+        "origin": generate_dispatch_job_origin(matrix_job, job_type),
     }
 
 
@@ -513,27 +547,21 @@ def generate_dispatch_two_stage_json(matrix_job, producer_job_type, consumer_job
     for consumer_job_type in consumer_job_types:
         consumers_json.append(generate_dispatch_job_json(matrix_job, consumer_job_type))
 
-    return {
-        "producers": [producer_json],
-        "consumers": consumers_json
-    }
+    return {"producers": [producer_json], "consumers": consumers_json}
 
 
 def generate_dispatch_group_jobs(matrix_job):
-    dispatch_group_jobs = {
-        "standalone": [],
-        "two_stage": []
-    }
+    dispatch_group_jobs = {"standalone": [], "two_stage": []}
 
     # The jobs tag is left unexploded to optimize scheduling here.
-    job_types = set(matrix_job['jobs'])
+    job_types = set(matrix_job["jobs"])
 
     # Add all dpendencies to the job_types set:
     standalone = set([])
     two_stage = {}  # {producer: set([consumer, ...])}
     for job_type in job_types:
         job_info = get_job_type_info(job_type)
-        dep = job_info['needs']
+        dep = job_info["needs"]
         if dep:
             if dep in two_stage:
                 two_stage[dep].add(job_type)
@@ -545,18 +573,25 @@ def generate_dispatch_group_jobs(matrix_job):
     standalone.difference_update(two_stage.keys())
 
     for producer, consumers in two_stage.items():
-        dispatch_group_jobs['two_stage'].append(
-            generate_dispatch_two_stage_json(matrix_job, producer, list(consumers)))
+        dispatch_group_jobs["two_stage"].append(
+            generate_dispatch_two_stage_json(matrix_job, producer, list(consumers))
+        )
 
     for job_type in standalone:
-        dispatch_group_jobs['standalone'].append(generate_dispatch_job_json(matrix_job, job_type))
+        dispatch_group_jobs["standalone"].append(
+            generate_dispatch_job_json(matrix_job, job_type)
+        )
 
     return dispatch_group_jobs
 
 
 def matrix_job_to_dispatch_group(matrix_job, group_prefix=""):
-    return {group_prefix + generate_dispatch_group_name(matrix_job):
-            generate_dispatch_group_jobs(matrix_job)}
+    return {
+        group_prefix
+        + generate_dispatch_group_name(matrix_job): generate_dispatch_group_jobs(
+            matrix_job
+        )
+    }
 
 
 def merge_dispatch_groups(accum_dispatch_groups, new_dispatch_groups):
@@ -572,10 +607,12 @@ def merge_dispatch_groups(accum_dispatch_groups, new_dispatch_groups):
 def compare_dispatch_jobs(job1, job2):
     "Compare two dispatch job specs for equality. Considers only name/runner/image/command."
     # Ignores the 'origin' key, which may vary between identical job specifications.
-    return (job1['name'] == job2['name'] and
-            job1['runner'] == job2['runner'] and
-            job1['image'] == job2['image'] and
-            job1['command'] == job2['command'])
+    return (
+        job1["name"] == job2["name"]
+        and job1["runner"] == job2["runner"]
+        and job1["image"] == job2["image"]
+        and job1["command"] == job2["command"]
+    )
 
 
 def dispatch_job_in_container(job, container):
@@ -609,49 +646,59 @@ def finalize_workflow_dispatch_groups(workflow_dispatch_groups_orig):
     # Check to see if any .two_stage.producers arrays have more than 1 job, which is not supported.
     # See ci-dispatch-two-stage.yml for details.
     for group_name, group_json in workflow_dispatch_groups.items():
-        if 'two_stage' in group_json:
-            for two_stage_json in group_json['two_stage']:
-                num_producers = len(two_stage_json['producers'])
+        if "two_stage" in group_json:
+            for two_stage_json in group_json["two_stage"]:
+                num_producers = len(two_stage_json["producers"])
                 if num_producers > 1:
                     producer_names = ""
-                    for job in two_stage_json['producers']:
+                    for job in two_stage_json["producers"]:
                         producer_names += f" - {job['name']}\n"
-                    error_message = f"ci-dispatch-two-stage.yml currently only supports a single producer. "
+                    error_message = "ci-dispatch-two-stage.yml currently only supports a single producer. "
                     error_message += f"Found {num_producers} producers in '{group_name}':\n{producer_names}"
-                    print(f"::error file=ci/matrix.yaml::{error_message}", file=sys.stderr)
+                    print(
+                        f"::error file=ci/matrix.yaml::{error_message}", file=sys.stderr
+                    )
                     raise Exception(error_message)
 
     # Merge consumers for any two_stage arrays that have the same producer(s). Print a warning.
     for group_name, group_json in workflow_dispatch_groups.items():
-        if not 'two_stage' in group_json:
+        if "two_stage" not in group_json:
             continue
-        two_stage_json = group_json['two_stage']
+        two_stage_json = group_json["two_stage"]
         merged_producers = []
         merged_consumers = []
         for two_stage in two_stage_json:
-            producers = two_stage['producers']
-            consumers = two_stage['consumers']
+            producers = two_stage["producers"]
+            consumers = two_stage["consumers"]
 
             # Make sure this gets updated if we add support for multiple producers:
-            assert (len(producers) == 1)
+            assert len(producers) == 1
             producer = producers[0]
 
             if dispatch_job_in_container(producer, merged_producers):
-                producer_index = index_of_dispatch_job_in_container(producer, merged_producers)
+                producer_index = index_of_dispatch_job_in_container(
+                    producer, merged_producers
+                )
                 matching_consumers = merged_consumers[producer_index]
 
-                producer_name = producer['name']
-                print(f"Merging consumers for duplicate producer '{producer_name}' in '{group_name}'",
-                      file=sys.stderr)
-                consumer_names = ", ".join([consumer['name'] for consumer in matching_consumers])
+                producer_name = producer["name"]
+                print(
+                    f"Merging consumers for duplicate producer '{producer_name}' in '{group_name}'",
+                    file=sys.stderr,
+                )
+                consumer_names = ", ".join(
+                    [consumer["name"] for consumer in matching_consumers]
+                )
                 print(f"Original consumers: {consumer_names}", file=sys.stderr)
-                consumer_names = ", ".join([consumer['name'] for consumer in consumers])
+                consumer_names = ", ".join([consumer["name"] for consumer in consumers])
                 print(f"Duplicate consumers: {consumer_names}", file=sys.stderr)
                 # Merge if unique:
                 for consumer in consumers:
                     if not dispatch_job_in_container(consumer, matching_consumers):
                         matching_consumers.append(consumer)
-                consumer_names = ", ".join([consumer['name'] for consumer in matching_consumers])
+                consumer_names = ", ".join(
+                    [consumer["name"] for consumer in matching_consumers]
+                )
                 print(f"Merged consumers: {consumer_names}", file=sys.stderr)
             else:
                 merged_producers.append(producer)
@@ -659,87 +706,106 @@ def finalize_workflow_dispatch_groups(workflow_dispatch_groups_orig):
         # Update with the merged lists:
         two_stage_json = []
         for producer, consumers in zip(merged_producers, merged_consumers):
-            two_stage_json.append({'producers': [producer], 'consumers': consumers})
-        group_json['two_stage'] = two_stage_json
+            two_stage_json.append({"producers": [producer], "consumers": consumers})
+        group_json["two_stage"] = two_stage_json
 
     # Check for any duplicate jobs in standalone arrays. Warn and remove duplicates.
     for group_name, group_json in workflow_dispatch_groups.items():
-        standalone_jobs = group_json['standalone'] if 'standalone' in group_json else []
+        standalone_jobs = group_json["standalone"] if "standalone" in group_json else []
         unique_standalone_jobs = []
         for job_json in standalone_jobs:
             if dispatch_job_in_container(job_json, unique_standalone_jobs):
-                print(f"Removing duplicate standalone job '{job_json['name']}' in '{group_name}'",
-                      file=sys.stderr)
+                print(
+                    f"Removing duplicate standalone job '{job_json['name']}' in '{group_name}'",
+                    file=sys.stderr,
+                )
             else:
                 unique_standalone_jobs.append(job_json)
 
         # If any producer/consumer jobs exist in standalone arrays, warn and remove the standalones.
-        two_stage_jobs = group_json['two_stage'] if 'two_stage' in group_json else []
+        two_stage_jobs = group_json["two_stage"] if "two_stage" in group_json else []
         for two_stage_job in two_stage_jobs:
-            for producer in two_stage_job['producers']:
+            for producer in two_stage_job["producers"]:
                 if remove_dispatch_job_from_container(producer, unique_standalone_jobs):
-                    print(f"Removing standalone job '{producer['name']}' " +
-                          f"as it appears as a producer in '{group_name}'",
-                          file=sys.stderr)
-            for consumer in two_stage_job['consumers']:
+                    print(
+                        f"Removing standalone job '{producer['name']}' "
+                        + f"as it appears as a producer in '{group_name}'",
+                        file=sys.stderr,
+                    )
+            for consumer in two_stage_job["consumers"]:
                 if remove_dispatch_job_from_container(producer, unique_standalone_jobs):
-                    print(f"Removing standalone job '{consumer['name']}' " +
-                          f"as it appears as a consumer in '{group_name}'",
-                          file=sys.stderr)
+                    print(
+                        f"Removing standalone job '{consumer['name']}' "
+                        + f"as it appears as a consumer in '{group_name}'",
+                        file=sys.stderr,
+                    )
         standalone_jobs = list(unique_standalone_jobs)
-        group_json['standalone'] = standalone_jobs
+        group_json["standalone"] = standalone_jobs
 
         # If any producer or consumer job appears more than once, warn and leave as-is.
         all_two_stage_jobs = []
         duplicate_jobs = {}
         for two_stage_job in two_stage_jobs:
-            for job in two_stage_job['producers'] + two_stage_job['consumers']:
+            for job in two_stage_job["producers"] + two_stage_job["consumers"]:
                 if dispatch_job_in_container(job, all_two_stage_jobs):
-                    duplicate_jobs[job['name']] = duplicate_jobs.get(job['name'], 1) + 1
+                    duplicate_jobs[job["name"]] = duplicate_jobs.get(job["name"], 1) + 1
                 else:
                     all_two_stage_jobs.append(job)
         for job_name, count in duplicate_jobs.items():
-            print(f"::warning file=ci/matrix.yaml::" +
-                  f"Job '{job_name}' appears {count} times in '{group_name}'.",
-                  f"Cannot remove duplicate while resolving dependencies. This job WILL execute {count} times.",
-                  file=sys.stderr)
+            print(
+                "::warning file=ci/matrix.yaml::"
+                + f"Job '{job_name}' appears {count} times in '{group_name}'.",
+                f"Cannot remove duplicate while resolving dependencies. This job WILL execute {count} times.",
+                file=sys.stderr,
+            )
 
     # Remove all named values that contain an empty list of jobs:
     for group_name, group_json in workflow_dispatch_groups.items():
-        if not group_json['standalone'] and not group_json['two_stage']:
+        if not group_json["standalone"] and not group_json["two_stage"]:
             del workflow_dispatch_groups[group_name]
-        elif not group_json['standalone']:
-            del group_json['standalone']
-        elif not group_json['two_stage']:
-            del group_json['two_stage']
+        elif not group_json["standalone"]:
+            del group_json["standalone"]
+        elif not group_json["two_stage"]:
+            del group_json["two_stage"]
 
     # Natural sort impl (handles embedded numbers in strings, case insensitive)
     def natural_sort_key(key):
-        return [(int(text) if text.isdigit() else text.lower()) for text in re.split('(\\d+)', key)]
+        return [
+            (int(text) if text.isdigit() else text.lower())
+            for text in re.split("(\\d+)", key)
+        ]
 
     # Sort the dispatch groups by name:
-    workflow_dispatch_groups = dict(sorted(workflow_dispatch_groups.items(), key=lambda x: natural_sort_key(x[0])))
+    workflow_dispatch_groups = dict(
+        sorted(workflow_dispatch_groups.items(), key=lambda x: natural_sort_key(x[0]))
+    )
 
     # Sort the jobs within each dispatch group:
     for group_name, group_json in workflow_dispatch_groups.items():
-        if 'standalone' in group_json:
-            group_json['standalone'] = sorted(group_json['standalone'], key=lambda x: natural_sort_key(x['name']))
-        if 'two_stage' in group_json:
-            group_json['two_stage'] = sorted(
-                group_json['two_stage'], key=lambda x: natural_sort_key(x['producers'][0]['name']))
+        if "standalone" in group_json:
+            group_json["standalone"] = sorted(
+                group_json["standalone"], key=lambda x: natural_sort_key(x["name"])
+            )
+        if "two_stage" in group_json:
+            group_json["two_stage"] = sorted(
+                group_json["two_stage"],
+                key=lambda x: natural_sort_key(x["producers"][0]["name"]),
+            )
 
     # Assign unique IDs in appropriate locations.
     # These are used to give "hidden" dispatch jobs a short, unique name,
     # otherwise GHA generates a long, cluttered name.
     for group_name, group_json in workflow_dispatch_groups.items():
-        if 'standalone' in group_json:
-            for job_json in group_json['standalone']:
-                job_json['id'] = next(guid_generator)
-        if 'two_stage' in group_json:
-            for two_stage_json in group_json['two_stage']:
-                two_stage_json['id'] = next(guid_generator)
-                for job_json in two_stage_json['producers'] + two_stage_json['consumers']:
-                    job_json['id'] = next(guid_generator)
+        if "standalone" in group_json:
+            for job_json in group_json["standalone"]:
+                job_json["id"] = next(guid_generator)
+        if "two_stage" in group_json:
+            for two_stage_json in group_json["two_stage"]:
+                two_stage_json["id"] = next(guid_generator)
+                for job_json in (
+                    two_stage_json["producers"] + two_stage_json["consumers"]
+                ):
+                    job_json["id"] = next(guid_generator)
 
     return workflow_dispatch_groups
 
@@ -747,30 +813,31 @@ def finalize_workflow_dispatch_groups(workflow_dispatch_groups_orig):
 def find_workflow_line_number(workflow_name):
     regex = re.compile(f"^( )*{workflow_name}:", re.IGNORECASE)
     line_number = 0
-    with open(matrix_yaml['filename'], 'r') as f:
+    with open(matrix_yaml["filename"], "r") as f:
         for line in f:
             line_number += 1
             if regex.match(line):
                 return line_number
     raise Exception(
-        f"Workflow '{workflow_name}' not found in {matrix_yaml['filename]']} (could not match regex: {regex})")
+        f"Workflow '{workflow_name}' not found in {matrix_yaml['filename]']} (could not match regex: {regex})"
+    )
 
 
 def get_matrix_job_origin(matrix_job, workflow_name, workflow_location):
-    filename = matrix_yaml['filename']
-    original_matrix_job = json.dumps(matrix_job, indent=None, separators=(', ', ': '))
-    original_matrix_job = original_matrix_job.replace('"', '')
+    filename = matrix_yaml["filename"]
+    original_matrix_job = json.dumps(matrix_job, indent=None, separators=(", ", ": "))
+    original_matrix_job = original_matrix_job.replace('"', "")
     return {
-        'filename': filename,
-        'workflow_name': workflow_name,
-        'workflow_location': workflow_location,
-        'original_matrix_job': original_matrix_job
+        "filename": filename,
+        "workflow_name": workflow_name,
+        "workflow_location": workflow_location,
+        "original_matrix_job": original_matrix_job,
     }
 
 
 @static_result
 def get_excluded_matrix_jobs():
-    return parse_workflow_matrix_jobs(None, 'exclude')
+    return parse_workflow_matrix_jobs(None, "exclude")
 
 
 def apply_matrix_job_exclusion(matrix_job, exclusion):
@@ -779,7 +846,7 @@ def apply_matrix_job_exclusion(matrix_job, exclusion):
 
     for tag, excluded_values in exclusion.items():
         # Not excluded if a specified tag isn't even present:
-        if not tag in matrix_job:
+        if tag not in matrix_job:
             return matrix_job
 
         # Some tags are left unexploded (e.g. 'jobs') to optimize scheduling,
@@ -792,7 +859,9 @@ def apply_matrix_job_exclusion(matrix_job, exclusion):
             matrix_values = [matrix_values]
 
         # Identify excluded values that are present in the matrix job for this tag:
-        matched_tag_values = [value for value in matrix_values if value in excluded_values]
+        matched_tag_values = [
+            value for value in matrix_values if value in excluded_values
+        ]
         # Not excluded if no values match for a tag:
         if not matched_tag_values:
             return matrix_job
@@ -817,7 +886,7 @@ def apply_matrix_job_exclusion(matrix_job, exclusion):
 
 
 def remove_excluded_jobs(matrix_jobs):
-    '''Remove jobs that match all tags in any of the exclusion matrix jobs.'''
+    """Remove jobs that match all tags in any of the exclusion matrix jobs."""
     excluded = get_excluded_matrix_jobs()
     filtered_matrix_jobs = []
     for matrix_job_orig in matrix_jobs:
@@ -832,88 +901,107 @@ def remove_excluded_jobs(matrix_jobs):
 
 
 def validate_tags(matrix_job, ignore_required=False):
-    all_tags = matrix_yaml['tags'].keys()
+    all_tags = matrix_yaml["tags"].keys()
 
     if not ignore_required:
         for tag in all_tags:
             tag_info = get_tag_info(tag)
             if tag not in matrix_job:
-                if tag_info['required']:
-                    raise Exception(error_message_with_matrix_job(matrix_job, f"Missing required tag '{tag}'"))
-        if 'cudacxx' in matrix_job:
-            if matrix_job['cudacxx'] == 'clang' and ('cxx' not in matrix_job or 'clang' not in matrix_job['cxx']):
-                raise Exception(error_message_with_matrix_job(matrix_job, f"cudacxx=clang requires cxx=clang."))
+                if tag_info["required"]:
+                    raise Exception(
+                        error_message_with_matrix_job(
+                            matrix_job, f"Missing required tag '{tag}'"
+                        )
+                    )
+        if "cudacxx" in matrix_job:
+            if matrix_job["cudacxx"] == "clang" and (
+                "cxx" not in matrix_job or "clang" not in matrix_job["cxx"]
+            ):
+                raise Exception(
+                    error_message_with_matrix_job(
+                        matrix_job, "cudacxx=clang requires cxx=clang."
+                    )
+                )
 
     for tag in matrix_job:
-        if tag == 'origin':
+        if tag == "origin":
             continue
         if tag not in all_tags:
-            raise Exception(error_message_with_matrix_job(matrix_job, f"Unknown tag '{tag}'"))
+            raise Exception(
+                error_message_with_matrix_job(matrix_job, f"Unknown tag '{tag}'")
+            )
 
-    if 'gpu' in matrix_job and matrix_job['gpu'] not in matrix_yaml['gpus'].keys():
-        raise Exception(error_message_with_matrix_job(matrix_job, f"Unknown gpu '{matrix_job['gpu']}'"))
+    if "gpu" in matrix_job and matrix_job["gpu"] not in matrix_yaml["gpus"].keys():
+        raise Exception(
+            error_message_with_matrix_job(
+                matrix_job, f"Unknown gpu '{matrix_job['gpu']}'"
+            )
+        )
 
 
 def set_default_tags(matrix_job):
-    all_tags = matrix_yaml['tags'].keys()
+    all_tags = matrix_yaml["tags"].keys()
     for tag in all_tags:
         if tag in matrix_job:
             continue
 
         tag_info = get_tag_info(tag)
-        if tag_info['default']:
-            matrix_job[tag] = tag_info['default']
+        if tag_info["default"]:
+            matrix_job[tag] = tag_info["default"]
 
 
 def canonicalize_tags(matrix_job):
-    if 'ctk' in matrix_job:
-        matrix_job['ctk'] = canonicalize_ctk_version(matrix_job['ctk'])
-    if 'cxx' in matrix_job:
-        matrix_job['cxx'] = canonicalize_host_compiler_name(matrix_job['cxx'])
+    if "ctk" in matrix_job:
+        matrix_job["ctk"] = canonicalize_ctk_version(matrix_job["ctk"])
+    if "cxx" in matrix_job:
+        matrix_job["cxx"] = canonicalize_host_compiler_name(matrix_job["cxx"])
 
 
 def set_derived_tags(matrix_job):
-    if 'sm' in matrix_job and matrix_job['sm'] == 'gpu':
-        if not 'gpu' in matrix_job:
-            raise Exception(error_message_with_matrix_job(matrix_job, f"\"sm: 'gpu'\" requires tag 'gpu'."))
-        gpu = get_gpu(matrix_job['gpu'])
-        matrix_job['sm'] = gpu['sm']
+    if "sm" in matrix_job and matrix_job["sm"] == "gpu":
+        if "gpu" not in matrix_job:
+            raise Exception(
+                error_message_with_matrix_job(
+                    matrix_job, "\"sm: 'gpu'\" requires tag 'gpu'."
+                )
+            )
+        gpu = get_gpu(matrix_job["gpu"])
+        matrix_job["sm"] = gpu["sm"]
 
-    if 'std' in matrix_job:
-        if matrix_job['std'] == 'all':
-            matrix_job['std'] = lookup_supported_stds(matrix_job)
-        elif matrix_job['std'] == 'min':
-            matrix_job['std'] = min(lookup_supported_stds(matrix_job))
-        elif matrix_job['std'] == 'max':
-            matrix_job['std'] = max(lookup_supported_stds(matrix_job))
-        elif matrix_job['std'] == 'minmax':
+    if "std" in matrix_job:
+        if matrix_job["std"] == "all":
+            matrix_job["std"] = lookup_supported_stds(matrix_job)
+        elif matrix_job["std"] == "min":
+            matrix_job["std"] = min(lookup_supported_stds(matrix_job))
+        elif matrix_job["std"] == "max":
+            matrix_job["std"] = max(lookup_supported_stds(matrix_job))
+        elif matrix_job["std"] == "minmax":
             stds = lookup_supported_stds(matrix_job)
             if len(stds) == 1:
-                matrix_job['std'] = stds[0]
+                matrix_job["std"] = stds[0]
             else:
-                matrix_job['std'] = [min(stds), max(stds)]
-
+                matrix_job["std"] = [min(stds), max(stds)]
 
     # Add all deps before applying project job maps:
-    for job in matrix_job['jobs']:
+    for job in matrix_job["jobs"]:
         job_info = get_job_type_info(job)
-        dep = job_info['needs']
-        if dep and dep not in matrix_job['jobs']:
-            matrix_job['jobs'].append(dep)
+        dep = job_info["needs"]
+        if dep and dep not in matrix_job["jobs"]:
+            matrix_job["jobs"].append(dep)
 
     # Apply project job map:
-    project = get_project(matrix_job['project'])
-    for original_job, expanded_jobs in project['job_map'].items():
-        if original_job in matrix_job['jobs']:
-            matrix_job['jobs'].remove(original_job)
-            matrix_job['jobs'] += expanded_jobs
+    project = get_project(matrix_job["project"])
+    for original_job, expanded_jobs in project["job_map"].items():
+        if original_job in matrix_job["jobs"]:
+            matrix_job["jobs"].remove(original_job)
+            matrix_job["jobs"] += expanded_jobs
 
 
 def next_explode_tag(matrix_job):
-    non_exploded_tags = ['jobs']
+    non_exploded_tags = ["jobs"]
 
     for tag in matrix_job:
-        if not tag in non_exploded_tags and isinstance(matrix_job[tag], list):
+        if tag not in non_exploded_tags and isinstance(matrix_job[tag], list):
             return tag
     return None
 
@@ -956,14 +1044,16 @@ def preprocess_matrix_jobs(matrix_jobs, is_exclusion_matrix=False):
 
 def parse_workflow_matrix_jobs(args, workflow_name):
     # Special handling for exclusion matrix: don't validate, add default, etc. Only explode.
-    is_exclusion_matrix = (workflow_name == 'exclude')
+    is_exclusion_matrix = workflow_name == "exclude"
 
-    if not workflow_name in matrix_yaml['workflows']:
-        if (is_exclusion_matrix):  # Valid, no exclusions if not defined
+    if workflow_name not in matrix_yaml["workflows"]:
+        if is_exclusion_matrix:  # Valid, no exclusions if not defined
             return []
-        raise Exception(f"Workflow '{workflow_name}' not found in matrix file '{matrix_yaml['filename']}'")
+        raise Exception(
+            f"Workflow '{workflow_name}' not found in matrix file '{matrix_yaml['filename']}'"
+        )
 
-    matrix_jobs = matrix_yaml['workflows'][workflow_name]
+    matrix_jobs = matrix_yaml["workflows"][workflow_name]
     if not matrix_jobs or len(matrix_jobs) == 0:
         return []
 
@@ -973,15 +1063,23 @@ def parse_workflow_matrix_jobs(args, workflow_name):
     # Do this first so the original tags / order /idx match the inpt object exactly.
     if not is_exclusion_matrix:
         for idx, matrix_job in enumerate(matrix_jobs):
-            workflow_location = f"{matrix_yaml['filename']}:{workflow_line_number} (job {idx + 1})"
-            matrix_job['origin'] = get_matrix_job_origin(matrix_job, workflow_name, workflow_location)
+            workflow_location = (
+                f"{matrix_yaml['filename']}:{workflow_line_number} (job {idx + 1})"
+            )
+            matrix_job["origin"] = get_matrix_job_origin(
+                matrix_job, workflow_name, workflow_location
+            )
 
     # Fill in default values, explode lists.
     matrix_jobs = preprocess_matrix_jobs(matrix_jobs, is_exclusion_matrix)
 
     if args:
-        if args.dirty_projects != None:  # Explicitly check for None, as an empty list is valid:
-            matrix_jobs = [job for job in matrix_jobs if job['project'] in args.dirty_projects]
+        if (
+            args.dirty_projects != None
+        ):  # Explicitly check for None, as an empty list is valid:
+            matrix_jobs = [
+                job for job in matrix_jobs if job["project"] in args.dirty_projects
+            ]
 
     # Don't remove excluded jobs if we're currently parsing them:
     if not is_exclusion_matrix:
@@ -989,7 +1087,10 @@ def parse_workflow_matrix_jobs(args, workflow_name):
 
     # Sort the tags by, *ahem*, "importance":
     sorted_tags = get_all_matrix_job_tags_sorted()
-    matrix_jobs = [{tag: matrix_job[tag] for tag in sorted_tags if tag in matrix_job} for matrix_job in matrix_jobs]
+    matrix_jobs = [
+        {tag: matrix_job[tag] for tag in sorted_tags if tag in matrix_job}
+        for matrix_job in matrix_jobs
+    ]
 
     return matrix_jobs
 
@@ -1005,7 +1106,9 @@ def parse_workflow_dispatch_groups(args, workflow_name):
     # Convert the matrix jobs into a dispatch group object:
     workflow_dispatch_groups = {}
     for matrix_job in matrix_jobs:
-        matrix_job_dispatch_group = matrix_job_to_dispatch_group(matrix_job, group_prefix)
+        matrix_job_dispatch_group = matrix_job_to_dispatch_group(
+            matrix_job, group_prefix
+        )
         merge_dispatch_groups(workflow_dispatch_groups, matrix_job_dispatch_group)
 
     return workflow_dispatch_groups
@@ -1026,21 +1129,28 @@ def write_outputs(final_workflow):
         job_array = parent_json[array_name] if array_name in parent_json else []
         for job_json in job_array:
             total_jobs += 1
-            job_list.append(f"{total_jobs:4} id: {job_json['id']:<4}   {array_name:13} {job_json['name']}")
-            id_to_full_job_name[job_json['id']] = f"{group_name} {job_json['name']}"
-            runner = job_json['runner']
+            job_list.append(
+                f"{total_jobs:4} id: {job_json['id']:<4}   {array_name:13} {job_json['name']}"
+            )
+            id_to_full_job_name[job_json["id"]] = f"{group_name} {job_json['name']}"
+            runner = job_json["runner"]
             runner_counts[runner] = runner_counts.get(runner, 0) + 1
 
     for group_name, group_json in final_workflow.items():
         job_list.append(f"{'':4} {group_name}:")
-        process_job_array(group_name, 'standalone', group_json)
-        if 'two_stage' in group_json:
-            for two_stage_json in group_json['two_stage']:
-                process_job_array(group_name, 'producers', two_stage_json)
-                process_job_array(group_name, 'consumers', two_stage_json)
+        process_job_array(group_name, "standalone", group_json)
+        if "two_stage" in group_json:
+            for two_stage_json in group_json["two_stage"]:
+                process_job_array(group_name, "producers", two_stage_json)
+                process_job_array(group_name, "consumers", two_stage_json)
 
     # Sort by descending counts:
-    runner_counts = {k: v for k, v in sorted(runner_counts.items(), key=lambda item: item[1], reverse=True)}
+    runner_counts = {
+        k: v
+        for k, v in sorted(
+            runner_counts.items(), key=lambda item: item[1], reverse=True
+        )
+    }
 
     runner_heading = f"🏃‍ Runner counts (total jobs: {total_jobs})"
 
@@ -1065,11 +1175,11 @@ def write_override_matrix(override_matrix):
 
 def print_gha_workflow(args):
     workflow_names = args.workflows
-    if args.allow_override and 'override' in matrix_yaml['workflows']:
-        override_matrix = matrix_yaml['workflows']['override']
+    if args.allow_override and "override" in matrix_yaml["workflows"]:
+        override_matrix = matrix_yaml["workflows"]["override"]
         if override_matrix and len(override_matrix) > 0:
             print(f"::notice::Using 'override' workflow instead of '{workflow_names}'")
-            workflow_names = ['override']
+            workflow_names = ["override"]
             write_override_matrix(override_matrix)
 
     final_workflow = {}
@@ -1083,28 +1193,30 @@ def print_gha_workflow(args):
 
 
 def print_devcontainer_info(args):
-    devcontainer_version = matrix_yaml['devcontainer_version']
+    devcontainer_version = matrix_yaml["devcontainer_version"]
 
     matrix_jobs = []
 
     # Remove the `exclude` and `override` entries:
-    ignored_matrix_keys = ['exclude', 'override']
-    workflow_names = [key for key in matrix_yaml['workflows'].keys() if key not in ignored_matrix_keys]
+    ignored_matrix_keys = ["exclude", "override"]
+    workflow_names = [
+        key for key in matrix_yaml["workflows"].keys() if key not in ignored_matrix_keys
+    ]
     for workflow_name in workflow_names:
         matrix_jobs.extend(parse_workflow_matrix_jobs(args, workflow_name))
 
     # Check if the extended cuda images are needed:
     for matrix_job in matrix_jobs:
         cuda_ext = False
-        for job in matrix_job['jobs']:
+        for job in matrix_job["jobs"]:
             job_info = get_job_type_info(job)
-            if job_info['cuda_ext']:
+            if job_info["cuda_ext"]:
                 cuda_ext = True
                 break
-        matrix_job['cuda_ext'] = cuda_ext
+        matrix_job["cuda_ext"] = cuda_ext
 
     # Remove all but the following keys from the matrix jobs:
-    keep_keys = ['ctk', 'cxx', 'cuda_ext']
+    keep_keys = ["ctk", "cxx", "cuda_ext"]
     combinations = [{key: job[key] for key in keep_keys} for job in matrix_jobs]
 
     # Remove duplicates and filter out windows jobs:
@@ -1114,16 +1226,19 @@ def print_devcontainer_info(args):
             unique_combinations.append(combo)
 
     for combo in unique_combinations:
-        host_compiler = get_host_compiler(combo['cxx'])
-        del combo['cxx']
-        combo['compiler_name'] = host_compiler['container_tag']
-        combo['compiler_version'] = host_compiler['version']
-        combo['compiler_exe'] = host_compiler['exe']
+        host_compiler = get_host_compiler(combo["cxx"])
+        del combo["cxx"]
+        combo["compiler_name"] = host_compiler["container_tag"]
+        combo["compiler_version"] = host_compiler["version"]
+        combo["compiler_exe"] = host_compiler["exe"]
 
-        combo['cuda'] = combo['ctk']
-        del combo['ctk']
+        combo["cuda"] = combo["ctk"]
+        del combo["ctk"]
 
-    devcontainer_json = {'devcontainer_version': devcontainer_version, 'combinations': unique_combinations}
+    devcontainer_json = {
+        "devcontainer_version": devcontainer_version,
+        "combinations": unique_combinations,
+    }
 
     # Pretty print the devcontainer json to stdout:
     print(json.dumps(devcontainer_json, indent=2))
@@ -1132,32 +1247,45 @@ def print_devcontainer_info(args):
 def preprocess_matrix_yaml(matrix):
     # Make all CTK version keys into strings:
     new_ctk = {}
-    for version, attrs in matrix['ctk_versions'].items():
+    for version, attrs in matrix["ctk_versions"].items():
         new_ctk[str(version)] = attrs
-    matrix['ctk_versions'] = new_ctk
+    matrix["ctk_versions"] = new_ctk
 
     # Make all compiler version keys into strings:
-    for id, hc_def in matrix['host_compilers'].items():
+    for id, hc_def in matrix["host_compilers"].items():
         new_versions = {}
-        for version, attrs in hc_def['versions'].items():
+        for version, attrs in hc_def["versions"].items():
             new_versions[str(version)] = attrs
-        hc_def['versions'] = new_versions
+        hc_def["versions"] = new_versions
 
     return matrix
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Compute matrix for workflow')
-    parser.add_argument('matrix_file', help='Path to the matrix YAML file')
-    parser_mode_group = parser.add_argument_group('Output Mode', "Must specify one of these options.")
+    parser = argparse.ArgumentParser(description="Compute matrix for workflow")
+    parser.add_argument("matrix_file", help="Path to the matrix YAML file")
+    parser_mode_group = parser.add_argument_group(
+        "Output Mode", "Must specify one of these options."
+    )
     parser_mode = parser_mode_group.add_mutually_exclusive_group(required=True)
-    parser_mode.add_argument('--workflows', nargs='+',
-                             help='Print GHA workflow with jobs from [pull_request, nightly, weekly, etc]')
-    parser_mode.add_argument('--devcontainer-info', action='store_true',
-                             help='Print devcontainer info instead of GHA workflows.')
-    parser.add_argument('--dirty-projects', nargs='*', help='Filter jobs to only these projects')
-    parser.add_argument('--allow-override', action='store_true',
-                        help='If a non-empty "override" workflow exists, it will be used instead of those in --workflows.')
+    parser_mode.add_argument(
+        "--workflows",
+        nargs="+",
+        help="Print GHA workflow with jobs from [pull_request, nightly, weekly, etc]",
+    )
+    parser_mode.add_argument(
+        "--devcontainer-info",
+        action="store_true",
+        help="Print devcontainer info instead of GHA workflows.",
+    )
+    parser.add_argument(
+        "--dirty-projects", nargs="*", help="Filter jobs to only these projects"
+    )
+    parser.add_argument(
+        "--allow-override",
+        action="store_true",
+        help='If a non-empty "override" workflow exists, it will be used instead of those in --workflows.',
+    )
     args = parser.parse_args()
 
     # Check if the matrix file exists
@@ -1165,11 +1293,11 @@ def main():
         print(f"Error: Matrix file '{args.matrix_file}' does not exist.")
         sys.exit(1)
 
-    with open(args.matrix_file, 'r') as f:
+    with open(args.matrix_file, "r") as f:
         global matrix_yaml
         matrix_yaml = yaml.safe_load(f)
         matrix_yaml = preprocess_matrix_yaml(matrix_yaml)
-        matrix_yaml['filename'] = args.matrix_file
+        matrix_yaml["filename"] = args.matrix_file
 
     if args.workflows:
         print_gha_workflow(args)
@@ -1180,5 +1308,5 @@ def main():
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/actions/workflow-build/prepare-workflow-dispatch.py
+++ b/.github/actions/workflow-build/prepare-workflow-dispatch.py
@@ -14,12 +14,12 @@ import sys
 
 
 def write_json_file(filename, json_object):
-    with open(filename, 'w') as f:
+    with open(filename, "w") as f:
         json.dump(json_object, f, indent=2)
 
 
 def is_windows(job):
-    return job['runner'].startswith('windows')
+    return job["runner"].startswith("windows")
 
 
 def split_workflow(workflow):
@@ -29,11 +29,11 @@ def split_workflow(workflow):
     windows_two_stage = {}
 
     def strip_extra_info(job):
-        del job['origin']
+        del job["origin"]
 
     for group_name, group_json in workflow.items():
-        standalone = group_json['standalone'] if 'standalone' in group_json else []
-        two_stage = group_json['two_stage'] if 'two_stage' in group_json else []
+        standalone = group_json["standalone"] if "standalone" in group_json else []
+        two_stage = group_json["two_stage"] if "two_stage" in group_json else []
 
         if len(standalone) > 0:
             for job in standalone:
@@ -46,38 +46,44 @@ def split_workflow(workflow):
 
         if len(two_stage) > 0:
             for ts in two_stage:
-                for job in ts['producers']:
+                for job in ts["producers"]:
                     strip_extra_info(job)
-                for job in ts['consumers']:
+                for job in ts["consumers"]:
                     strip_extra_info(job)
 
-            if is_windows(two_stage[0]['producers'][0]):
+            if is_windows(two_stage[0]["producers"][0]):
                 windows_two_stage[group_name] = two_stage
             else:
                 linux_two_stage[group_name] = two_stage
 
     dispatch = {
-        'linux_standalone': {
-            'keys': list(linux_standalone.keys()),
-            'jobs': linux_standalone},
-        'linux_two_stage': {
-            'keys': list(linux_two_stage.keys()),
-            'jobs': linux_two_stage},
-        'windows_standalone': {
-            'keys': list(windows_standalone.keys()),
-            'jobs': windows_standalone},
-        'windows_two_stage': {
-            'keys': list(windows_two_stage.keys()),
-            'jobs': windows_two_stage}
+        "linux_standalone": {
+            "keys": list(linux_standalone.keys()),
+            "jobs": linux_standalone,
+        },
+        "linux_two_stage": {
+            "keys": list(linux_two_stage.keys()),
+            "jobs": linux_two_stage,
+        },
+        "windows_standalone": {
+            "keys": list(windows_standalone.keys()),
+            "jobs": windows_standalone,
+        },
+        "windows_two_stage": {
+            "keys": list(windows_two_stage.keys()),
+            "jobs": windows_two_stage,
+        },
     }
 
-    os.makedirs('workflow', exist_ok=True)
-    write_json_file('workflow/dispatch.json', dispatch)
+    os.makedirs("workflow", exist_ok=True)
+    write_json_file("workflow/dispatch.json", dispatch)
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Prepare a full workflow for GHA dispatch.')
-    parser.add_argument('workflow_json', help='Path to the full workflow.json file')
+    parser = argparse.ArgumentParser(
+        description="Prepare a full workflow for GHA dispatch."
+    )
+    parser.add_argument("workflow_json", help="Path to the full workflow.json file")
     args = parser.parse_args()
 
     # Check if the workflow file exists
@@ -91,5 +97,5 @@ def main():
     split_workflow(workflow)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/actions/workflow-results/final-summary.py
+++ b/.github/actions/workflow-results/final-summary.py
@@ -3,11 +3,10 @@
 import json
 import os
 import re
-import sys
 
 
 def read_file(filepath):
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return f.read().rstrip("\n ")
 
 
@@ -17,14 +16,16 @@ def print_text_file(filepath):
 
 
 def print_json_summary(summary, heading_level):
-    print(f"<details><summary><h{heading_level}>{summary['heading']}</h{heading_level}></summary>\n")
+    print(
+        f"<details><summary><h{heading_level}>{summary['heading']}</h{heading_level}></summary>\n"
+    )
     print(summary["body"] + "\n")
     print("</details>\n")
 
 
 def print_summary_file(filepath, heading_level):
     if os.path.exists(filepath):
-        with open(filepath, 'r') as f:
+        with open(filepath, "r") as f:
             print_json_summary(json.load(f), heading_level)
 
 
@@ -32,9 +33,9 @@ def print_json_file(filepath, heading):
     if os.path.exists(filepath):
         json_data = json.load(open(filepath))
         print(f"<details><summary><h3>{heading}</h3></summary>\n")
-        print('```json')
+        print("```json")
         print(json.dumps(json_data, indent=2))
-        print('```')
+        print("```")
         print("</details>\n")
 
 
@@ -45,7 +46,7 @@ def main():
     for filename in sorted(os.listdir("execution/projects")):
         match = re.match(project_file_regex, filename)
         if match:
-            with open(f"execution/projects/{filename}", 'r') as f:
+            with open(f"execution/projects/{filename}", "r") as f:
                 projects.append(json.load(f))
 
     print(f"<details><summary>{read_file('execution/heading.txt')}</summary>\n")
@@ -56,12 +57,12 @@ def main():
         print_json_summary(project, 3)
     print("</ul>\n")
 
-    print_json_file('workflow/override.json', '🛠️ Override Matrix')
-    print_text_file('workflow/changes.md')
+    print_json_file("workflow/override.json", "🛠️ Override Matrix")
+    print_text_file("workflow/changes.md")
     print_summary_file("workflow/runner_summary.json", 2)
 
     print("</details>")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/actions/workflow-results/parse-job-times.py
+++ b/.github/actions/workflow-results/parse-job-times.py
@@ -4,7 +4,6 @@ import argparse
 import datetime
 import json
 import os
-import sys
 
 
 def get_jobs_json(jobs_file):
@@ -22,34 +21,34 @@ def get_workflow_json(workflow_file):
 
 
 def write_json(filepath, json_object):
-    with open(filepath, 'w') as f:
+    with open(filepath, "w") as f:
         json.dump(json_object, f, indent=4)
 
 
 def generate_job_id_map(workflow):
-    '''Map full job name to job id'''
+    """Map full job name to job id"""
     job_id_map = {}
     for group_name, group_json in workflow.items():
-        standalone = group_json['standalone'] if 'standalone' in group_json else []
+        standalone = group_json["standalone"] if "standalone" in group_json else []
         for job in standalone:
             name = f"{group_name} / {job['name']}"
-            job_id_map[name] = job['id']
-        two_stage = group_json['two_stage'] if 'two_stage' in group_json else []
+            job_id_map[name] = job["id"]
+        two_stage = group_json["two_stage"] if "two_stage" in group_json else []
         for pc in two_stage:
-            producers = pc['producers']
-            consumers = pc['consumers']
+            producers = pc["producers"]
+            consumers = pc["consumers"]
             for job in producers + consumers:
                 name = f"{group_name} / {pc['id']} / {job['name']}"
-                job_id_map[name] = job['id']
+                job_id_map[name] = job["id"]
 
     return job_id_map
 
 
 def main():
     # Accept two command line arguments: <workflow.json> <jobs.json>
-    parser = argparse.ArgumentParser(description='Parse job times')
-    parser.add_argument('workflow', type=str, help='Path to workflow.json')
-    parser.add_argument('jobs', type=str, help='Path to jobs.json')
+    parser = argparse.ArgumentParser(description="Parse job times")
+    parser.add_argument("workflow", type=str, help="Path to workflow.json")
+    parser.add_argument("jobs", type=str, help="Path to jobs.json")
     args = parser.parse_args()
 
     jobs = get_jobs_json(args.jobs)
@@ -61,21 +60,21 @@ def main():
     # Map of id -> { <job stats> }
     result = {}
 
-    unknown_jobs = [job for job in jobs if job['name'] not in job_id_map]
-    jobs = [job for job in jobs if job['name'] in job_id_map]
+    unknown_jobs = [job for job in jobs if job["name"] not in job_id_map]
+    jobs = [job for job in jobs if job["name"] in job_id_map]
 
     # Process jobs:
     for job in jobs:
-        name = job['name']
+        name = job["name"]
 
         id = job_id_map[name]
 
         # Job times are 2024-05-09T06:52:20Z
-        started_at = job['started_at']
+        started_at = job["started_at"]
         started_time = datetime.datetime.strptime(started_at, "%Y-%m-%dT%H:%M:%SZ")
         started_time_epoch_secs = started_time.timestamp()
 
-        completed_at = job['completed_at']
+        completed_at = job["completed_at"]
         completed_time = datetime.datetime.strptime(completed_at, "%Y-%m-%dT%H:%M:%SZ")
         completed_time_epoch_secs = completed_time.timestamp()
 
@@ -83,45 +82,57 @@ def main():
         job_duration = str(datetime.timedelta(seconds=job_seconds))
 
         result[id] = {}
-        result[id]['name'] = name
-        result[id]['started_at'] = started_at
-        result[id]['completed_at'] = completed_at
-        result[id]['started_epoch_secs'] = started_time_epoch_secs
-        result[id]['completed_epoch_secs'] = completed_time_epoch_secs
-        result[id]['job_duration'] = job_duration
-        result[id]['job_seconds'] = job_seconds
+        result[id]["name"] = name
+        result[id]["started_at"] = started_at
+        result[id]["completed_at"] = completed_at
+        result[id]["started_epoch_secs"] = started_time_epoch_secs
+        result[id]["completed_epoch_secs"] = completed_time_epoch_secs
+        result[id]["job_duration"] = job_duration
+        result[id]["job_seconds"] = job_seconds
 
         # Find the "Run command" step and record its duration:
         command_seconds = 0
-        for step in job['steps']:
-            if step['name'].lower() == "run command":
-                step_started_at = step['started_at']
-                step_started_time = datetime.datetime.strptime(step_started_at, "%Y-%m-%dT%H:%M:%SZ")
-                step_completed_at = step['completed_at']
-                step_completed_time = datetime.datetime.strptime(step_completed_at, "%Y-%m-%dT%H:%M:%SZ")
-                command_seconds = (step_completed_time - step_started_time).total_seconds()
+        for step in job["steps"]:
+            if step["name"].lower() == "run command":
+                step_started_at = step["started_at"]
+                step_started_time = datetime.datetime.strptime(
+                    step_started_at, "%Y-%m-%dT%H:%M:%SZ"
+                )
+                step_completed_at = step["completed_at"]
+                step_completed_time = datetime.datetime.strptime(
+                    step_completed_at, "%Y-%m-%dT%H:%M:%SZ"
+                )
+                command_seconds = (
+                    step_completed_time - step_started_time
+                ).total_seconds()
                 break
 
         command_duration = str(datetime.timedelta(seconds=command_seconds))
 
-        result[id]['command_seconds'] = command_seconds
-        result[id]['command_duration'] = command_duration
+        result[id]["command_seconds"] = command_seconds
+        result[id]["command_duration"] = command_duration
 
     os.makedirs("results", exist_ok=True)
     write_json("results/job_times.json", result)
 
     print("::group::Unmapped jobs")
-    print("\n".join([job['name'] for job in unknown_jobs]))
+    print("\n".join([job["name"] for job in unknown_jobs]))
     print("::endgroup::")
 
     print("::group::Job times")
     print(f"{'Job':^10} {'Command':^10} {'Overhead':^10} Name")
     print(f"{'-'*10} {'-'*10} {'-'*10} {'-'*10}")
     for id, stats in result.items():
-        job_seconds = stats['job_seconds']
-        command_seconds = stats['command_seconds']
-        overhead = (job_seconds - command_seconds) * 100 / command_seconds if command_seconds > 0 else 100
-        print(f"{stats['job_duration']:10} {stats['command_duration']:10} {overhead:10.0f} {stats['name']}")
+        job_seconds = stats["job_seconds"]
+        command_seconds = stats["command_seconds"]
+        overhead = (
+            (job_seconds - command_seconds) * 100 / command_seconds
+            if command_seconds > 0
+            else 100
+        )
+        print(
+            f"{stats['job_duration']:10} {stats['command_duration']:10} {overhead:10.0f} {stats['name']}"
+        )
     print("::endgroup::")
 
 

--- a/.github/actions/workflow-results/prepare-execution-summary.py
+++ b/.github/actions/workflow-results/prepare-execution-summary.py
@@ -6,7 +6,6 @@ import functools
 import json
 import os
 import re
-import sys
 
 
 def job_succeeded(job):
@@ -16,18 +15,21 @@ def job_succeeded(job):
 
 def natural_sort_key(key):
     # Natural sort impl (handles embedded numbers in strings, case insensitive)
-    return [(int(text) if text.isdigit() else text.lower()) for text in re.split('(\d+)', key)]
+    return [
+        (int(text) if text.isdigit() else text.lower())
+        for text in re.split("(\d+)", key)
+    ]
 
 
 # Print the prepared text summary to the file at the given path
 def write_text(filepath, summary):
-    with open(filepath, 'w') as f:
+    with open(filepath, "w") as f:
         print(summary, file=f)
 
 
 # Print the prepared JSON object to the file at the given path
 def write_json(filepath, json_object):
-    with open(filepath, 'w') as f:
+    with open(filepath, "w") as f:
         json.dump(json_object, f, indent=4)
 
 
@@ -45,7 +47,7 @@ def extract_jobs(workflow):
 
 @functools.lru_cache(maxsize=None)
 def get_sccache_stats(job_id):
-    sccache_file = f'jobs/{job_id}/sccache_stats.json'
+    sccache_file = f"jobs/{job_id}/sccache_stats.json"
     if os.path.exists(sccache_file):
         with open(sccache_file) as f:
             return json.load(f)
@@ -53,55 +55,55 @@ def get_sccache_stats(job_id):
 
 
 def update_summary_entry(entry, job, job_times=None):
-    if 'passed' not in entry:
-        entry['passed'] = 0
-    if 'failed' not in entry:
-        entry['failed'] = 0
+    if "passed" not in entry:
+        entry["passed"] = 0
+    if "failed" not in entry:
+        entry["failed"] = 0
 
     if job_succeeded(job):
-        entry['passed'] += 1
+        entry["passed"] += 1
     else:
-        entry['failed'] += 1
+        entry["failed"] += 1
 
     if job_times:
         time_info = job_times[job["id"]]
         job_time = time_info["job_seconds"]
         command_time = time_info["command_seconds"]
 
-        if not 'job_time' in entry:
-            entry['job_time'] = 0
-        if not 'command_time' in entry:
-            entry['command_time'] = 0
-        if not 'max_job_time' in entry:
-            entry['max_job_time'] = 0
+        if "job_time" not in entry:
+            entry["job_time"] = 0
+        if "command_time" not in entry:
+            entry["command_time"] = 0
+        if "max_job_time" not in entry:
+            entry["max_job_time"] = 0
 
-        entry['job_time'] += job_time
-        entry['command_time'] += command_time
-        entry['max_job_time'] = max(entry['max_job_time'], job_time)
+        entry["job_time"] += job_time
+        entry["command_time"] += command_time
+        entry["max_job_time"] = max(entry["max_job_time"], job_time)
 
     sccache_stats = get_sccache_stats(job["id"])
     if sccache_stats:
-        sccache_stats = sccache_stats['stats']
-        requests = sccache_stats.get('compile_requests', 0)
+        sccache_stats = sccache_stats["stats"]
+        requests = sccache_stats.get("compile_requests", 0)
         hits = 0
-        if 'cache_hits' in sccache_stats:
-            cache_hits = sccache_stats['cache_hits']
-            if 'counts' in cache_hits:
-                counts = cache_hits['counts']
+        if "cache_hits" in sccache_stats:
+            cache_hits = sccache_stats["cache_hits"]
+            if "counts" in cache_hits:
+                counts = cache_hits["counts"]
                 for lang, lang_hits in counts.items():
                     hits += lang_hits
-        if 'sccache' not in entry:
-            entry['sccache'] = {'requests': requests, 'hits': hits}
+        if "sccache" not in entry:
+            entry["sccache"] = {"requests": requests, "hits": hits}
         else:
-            entry['sccache']['requests'] += requests
-            entry['sccache']['hits'] += hits
+            entry["sccache"]["requests"] += requests
+            entry["sccache"]["hits"] += hits
 
     return entry
 
 
 def build_summary(jobs, job_times=None):
-    summary = {'projects': {}}
-    projects = summary['projects']
+    summary = {"projects": {}}
+    projects = summary["projects"]
 
     for job in jobs:
         update_summary_entry(summary, job, job_times)
@@ -109,33 +111,37 @@ def build_summary(jobs, job_times=None):
         matrix_job = job["origin"]["matrix_job"]
 
         project = matrix_job["project"]
-        if not project in projects:
-            projects[project] = {'tags': {}}
-        tags = projects[project]['tags']
+        if project not in projects:
+            projects[project] = {"tags": {}}
+        tags = projects[project]["tags"]
 
         update_summary_entry(projects[project], job, job_times)
 
         for tag in matrix_job.keys():
-            if tag == 'project':
+            if tag == "project":
                 continue
 
-            if not tag in tags:
-                tags[tag] = {'values': {}}
-            values = tags[tag]['values']
+            if tag not in tags:
+                tags[tag] = {"values": {}}
+            values = tags[tag]["values"]
 
             update_summary_entry(tags[tag], job, job_times)
 
             value = str(matrix_job[tag])
 
-            if not value in values:
+            if value not in values:
                 values[value] = {}
             update_summary_entry(values[value], job, job_times)
 
     # Natural sort the value strings within each tag:
     for project, project_summary in projects.items():
-        for tag, tag_summary in project_summary['tags'].items():
-            tag_summary['values'] = dict(sorted(tag_summary['values'].items(),
-                                         key=lambda item: natural_sort_key(item[0])))
+        for tag, tag_summary in project_summary["tags"].items():
+            tag_summary["values"] = dict(
+                sorted(
+                    tag_summary["values"].items(),
+                    key=lambda item: natural_sort_key(item[0]),
+                )
+            )
 
     # Sort the tags within each project so that:
     # - "Likely culprits" come first. These are tags that have multiple values, but only one has failures.
@@ -143,9 +149,13 @@ def build_summary(jobs, job_times=None):
     # - Tags with all failing values come next.
     # - Tags with no failures are last.
     def rank_tag(tag_summary):
-        tag_failures = tag_summary['failed']
-        num_values = len(tag_summary['values'])
-        num_failing_values = sum(1 for value_summary in tag_summary['values'].values() if value_summary['failed'] > 0)
+        tag_failures = tag_summary["failed"]
+        num_values = len(tag_summary["values"])
+        num_failing_values = sum(
+            1
+            for value_summary in tag_summary["values"].values()
+            if value_summary["failed"] > 0
+        )
 
         if num_values > 1:
             if num_failing_values == 1:
@@ -155,9 +165,14 @@ def build_summary(jobs, job_times=None):
         elif tag_failures > 0:
             return 2
         return 3
+
     for project, project_summary in projects.items():
-        project_summary['tags'] = dict(sorted(project_summary['tags'].items(),
-                                       key=lambda item: (rank_tag(item[1]), item[0])))
+        project_summary["tags"] = dict(
+            sorted(
+                project_summary["tags"].items(),
+                key=lambda item: (rank_tag(item[1]), item[0]),
+            )
+        )
 
     return summary
 
@@ -167,8 +182,8 @@ def get_walltime(job_times):
     start = None
     end = None
     for job_id, job_time in job_times.items():
-        job_start_timestamp = job_time['started_epoch_secs']
-        job_end_timestamp = job_time['completed_epoch_secs']
+        job_start_timestamp = job_time["started_epoch_secs"]
+        job_end_timestamp = job_time["completed_epoch_secs"]
         if not start or job_start_timestamp < start:
             start = job_start_timestamp
         if not end or job_end_timestamp > end:
@@ -184,135 +199,135 @@ def format_seconds(seconds):
     hours = int(hours)
     minutes = int(minutes)
     seconds = int(seconds)
-    if (days > 0):
-        return f'{days}d {hours:02}h'
-    elif (hours > 0):
-        return f'{hours}h {minutes:02}m'
+    if days > 0:
+        return f"{days}d {hours:02}h"
+    elif hours > 0:
+        return f"{hours}h {minutes:02}m"
     else:
-        return f'{minutes}m {seconds:02}s'
+        return f"{minutes}m {seconds:02}s"
 
 
 def get_summary_stats(summary):
-    passed = summary['passed']
-    failed = summary['failed']
+    passed = summary["passed"]
+    failed = summary["failed"]
     total = passed + failed
 
     percent = int(100 * passed / total) if total > 0 else 0
-    pass_string = f'Pass: {percent:>3}%/{total}'
+    pass_string = f"Pass: {percent:>3}%/{total}"
 
-    stats = f'{pass_string:<14}'
+    stats = f"{pass_string:<14}"
 
-    if 'job_time' in summary and total > 0 and summary['job_time'] > 0:
-        job_time = summary['job_time']
-        max_job_time = summary['max_job_time']
+    if "job_time" in summary and total > 0 and summary["job_time"] > 0:
+        job_time = summary["job_time"]
+        max_job_time = summary["max_job_time"]
         total_job_duration = format_seconds(job_time)
         avg_job_duration = format_seconds(job_time / total)
         max_job_duration = format_seconds(max_job_time)
-        stats += f' | Total: {total_job_duration:>7} | Avg: {avg_job_duration:>7} | Max: {max_job_duration:>7}'
+        stats += f" | Total: {total_job_duration:>7} | Avg: {avg_job_duration:>7} | Max: {max_job_duration:>7}"
 
-    if 'sccache' in summary:
-        sccache = summary['sccache']
+    if "sccache" in summary:
+        sccache = summary["sccache"]
         requests = sccache["requests"]
         hits = sccache["hits"]
         hit_percent = int(100 * hits / requests) if requests > 0 else 0
-        hit_string = f'Hits: {hit_percent:>3}%/{requests}'
-        stats += f' | {hit_string:<17}'
+        hit_string = f"Hits: {hit_percent:>3}%/{requests}"
+        stats += f" | {hit_string:<17}"
 
     return stats
 
 
 def get_summary_heading(summary, walltime):
-    passed = summary['passed']
-    failed = summary['failed']
+    passed = summary["passed"]
+    failed = summary["failed"]
 
-    if summary['passed'] == 0:
-        flag = '🟥'
-    elif summary['failed'] > 0:
-        flag = '🟨'
+    if summary["passed"] == 0:
+        flag = "🟥"
+    elif summary["failed"] > 0:
+        flag = "🟨"
     else:
-        flag = '🟩'
+        flag = "🟩"
 
-    return f'{flag} CI finished in {walltime}: {get_summary_stats(summary)}'
+    return f"{flag} CI finished in {walltime}: {get_summary_stats(summary)}"
 
 
 def get_project_heading(project, project_summary):
-    if project_summary['passed'] == 0:
-        flag = '🟥'
-    elif project_summary['failed'] > 0:
-        flag = '🟨'
+    if project_summary["passed"] == 0:
+        flag = "🟥"
+    elif project_summary["failed"] > 0:
+        flag = "🟨"
     else:
-        flag = '🟩'
+        flag = "🟩"
 
-    return f'{flag} {project}: {get_summary_stats(project_summary)}'
+    return f"{flag} {project}: {get_summary_stats(project_summary)}"
 
 
 def get_tag_line(tag, tag_summary):
-    passed = tag_summary['passed']
-    failed = tag_summary['failed']
-    values = tag_summary['values']
+    passed = tag_summary["passed"]
+    failed = tag_summary["failed"]
+    values = tag_summary["values"]
 
     # Find the value with an failure rate that matches the tag's failure rate:
     suspicious = None
     if len(values) > 1 and failed > 0:
         for value, value_summary in values.items():
-            if value_summary['failed'] == failed:
+            if value_summary["failed"] == failed:
                 suspicious = value_summary
-                suspicious['name'] = value
+                suspicious["name"] = value
                 break
 
     # Did any jobs with this value pass?
-    likely_culprit = suspicious if suspicious and suspicious['passed'] == 0 else None
+    likely_culprit = suspicious if suspicious and suspicious["passed"] == 0 else None
 
-    note = ''
+    note = ""
     if likely_culprit:
-        flag = '🚨'
+        flag = "🚨"
         note = f': {likely_culprit["name"]} {flag}'
     elif suspicious:
-        flag = '🔍'
+        flag = "🔍"
         note = f': {suspicious["name"]} {flag}'
     elif passed == 0:
-        flag = '🟥'
+        flag = "🟥"
     elif failed > 0:
-        flag = '🟨'
+        flag = "🟨"
     else:
-        flag = '🟩'
+        flag = "🟩"
 
-    return f'{flag} {tag}{note}'
+    return f"{flag} {tag}{note}"
 
 
 def get_value_line(value, value_summary, tag_summary):
-    passed = value_summary['passed']
-    failed = value_summary['failed']
+    passed = value_summary["passed"]
+    failed = value_summary["failed"]
     total = passed + failed
 
-    parent_size = len(tag_summary['values'])
-    parent_failed = tag_summary['failed']
+    parent_size = len(tag_summary["values"])
+    parent_failed = tag_summary["failed"]
 
     is_suspicious = failed > 0 and failed == parent_failed and parent_size > 1
     is_likely_culprit = is_suspicious and passed == 0
 
     if is_likely_culprit:
-        flag = '🔥'
+        flag = "🔥"
     elif is_suspicious:
-        flag = '🔍'
+        flag = "🔍"
     elif passed == 0:
-        flag = '🟥'
+        flag = "🟥"
     elif failed > 0:
-        flag = '🟨'
+        flag = "🟨"
     else:
-        flag = '🟩'
+        flag = "🟩"
 
     left_aligned = f"{flag} {value}"
-    return f'  {left_aligned:<20} {get_summary_stats(value_summary)}'
+    return f"  {left_aligned:<20} {get_summary_stats(value_summary)}"
 
 
 def get_project_summary_body(project, project_summary):
-    body = ['```']
-    for tag, tag_summary in project_summary['tags'].items():
+    body = ["```"]
+    for tag, tag_summary in project_summary["tags"].items():
         body.append(get_tag_line(tag, tag_summary))
-        for value, value_summary in tag_summary['values'].items():
+        for value, value_summary in tag_summary["values"].items():
             body.append(get_value_line(value, value_summary, tag_summary))
-    body.append('```')
+    body.append("```")
     return "\n".join(body)
 
 
@@ -320,34 +335,36 @@ def write_project_summary(idx, project, project_summary):
     heading = get_project_heading(project, project_summary)
     body = get_project_summary_body(project, project_summary)
 
-    summary = {'heading': heading, 'body': body}
+    summary = {"heading": heading, "body": body}
 
-    write_json(f'execution/projects/{idx:03}_{project}_summary.json', summary)
+    write_json(f"execution/projects/{idx:03}_{project}_summary.json", summary)
 
 
 def write_workflow_summary(workflow, job_times=None):
     summary = build_summary(extract_jobs(workflow), job_times)
-    walltime = format_seconds(get_walltime(job_times)) if job_times else '[unknown]'
+    walltime = format_seconds(get_walltime(job_times)) if job_times else "[unknown]"
 
-    os.makedirs('execution/projects', exist_ok=True)
+    os.makedirs("execution/projects", exist_ok=True)
 
-    write_text('execution/heading.txt', get_summary_heading(summary, walltime))
+    write_text("execution/heading.txt", get_summary_heading(summary, walltime))
 
     # Sort summary projects so that projects with failures come first, and ties
     # are broken by the total number of jobs:
     def sort_project_key(project_summary):
-        failed = project_summary[1]['failed']
-        total = project_summary[1]['passed'] + failed
+        failed = project_summary[1]["failed"]
+        total = project_summary[1]["passed"] + failed
         return (-failed, -total)
 
-    for i, (project, project_summary) in enumerate(sorted(summary['projects'].items(), key=sort_project_key)):
+    for i, (project, project_summary) in enumerate(
+        sorted(summary["projects"].items(), key=sort_project_key)
+    ):
         write_project_summary(i, project, project_summary)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('workflow', type=argparse.FileType('r'))
-    parser.add_argument('job_times', type=argparse.FileType('r'))
+    parser.add_argument("workflow", type=argparse.FileType("r"))
+    parser.add_argument("job_times", type=argparse.FileType("r"))
     args = parser.parse_args()
 
     workflow = json.load(args.workflow)
@@ -361,5 +378,5 @@ def main():
     write_workflow_summary(workflow, job_times)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/actions/workflow-results/prepare-execution-summary.py
+++ b/.github/actions/workflow-results/prepare-execution-summary.py
@@ -237,9 +237,6 @@ def get_summary_stats(summary):
 
 
 def get_summary_heading(summary, walltime):
-    passed = summary["passed"]
-    failed = summary["failed"]
-
     if summary["passed"] == 0:
         flag = "🟥"
     elif summary["failed"] > 0:
@@ -298,7 +295,6 @@ def get_tag_line(tag, tag_summary):
 def get_value_line(value, value_summary, tag_summary):
     passed = value_summary["passed"]
     failed = value_summary["failed"]
-    total = passed + failed
 
     parent_size = len(tag_summary["values"])
     parent_failed = tag_summary["failed"]
@@ -372,7 +368,7 @@ def main():
     # The timing file is not required.
     try:
         job_times = json.load(args.job_times)
-    except:
+    except Exception:
         job_times = None
 
     write_workflow_summary(workflow, job_times)

--- a/.github/actions/workflow-results/verify-job-success.py
+++ b/.github/actions/workflow-results/verify-job-success.py
@@ -8,7 +8,7 @@ import sys
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("job_id_map", type=argparse.FileType('r'))
+    parser.add_argument("job_id_map", type=argparse.FileType("r"))
     args = parser.parse_args()
 
     job_id_map = json.load(args.job_id_map)
@@ -16,7 +16,7 @@ def main():
     # For each job id, verify that the success artifact exists
     success = True
     for job_id, job_name in job_id_map.items():
-        success_file = f'jobs/{job_id}/success'
+        success_file = f"jobs/{job_id}/success"
         print(f'Verifying job with id "{job_id}": "{job_name}"')
         if not os.path.exists(success_file):
             print(f'Failed: Artifact "{success_file}" not found')
@@ -26,5 +26,5 @@ def main():
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,5 +36,16 @@ repos:
           )
         args: ["-fallback-style=none", "-style=file", "-i"]
 
+  # TODO/REMINDER: add the Ruff vscode extension to the devcontainers
+  # Ruff, the Python auto-correcting linter/formatter written in Rust
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.2
+    hooks:
+    - id: ruff
+      args: ["--fix", "--show-fixes"]
+      exclude: "^docs/tools/|^libcudacxx/test/"
+    - id: ruff-format
+      exclude: "^docs/tools/|^libcudacxx/test/"
+
 default_language_version:
   python: python3

--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -293,7 +293,10 @@ def case_top(alpha, N, algname, ct_point_name, case_dfs):
     print("{}[{}]:".format(algname, ct_point_name))
 
     if alpha < 1.0:
-        case_df = remove_matching_distributions(alpha, case_df)
+        for subbench in case_dfs:
+            case_dfs[subbench] = remove_matching_distributions(
+                alpha, case_dfs[subbench]
+            )
 
     for subbench in case_dfs:
         case_dfs[subbench] = extract_complete_variants(case_dfs[subbench])

--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -16,7 +16,7 @@ from scipy.stats.mstats import hdquantiles
 
 pd.options.display.max_colwidth = 100
 
-default_colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
+default_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 color_cycle = itertools.cycle(default_colors)
 color_map = {}
 
@@ -25,31 +25,35 @@ sensitivity = 0.5
 
 
 def get_bench_columns():
-    return ['variant', 'elapsed', 'center', 'samples', 'bw']
+    return ["variant", "elapsed", "center", "samples", "bw"]
 
 
 def get_extended_bench_columns():
-    return get_bench_columns() + ['speedup', 'base_samples']
+    return get_bench_columns() + ["speedup", "base_samples"]
 
 
 def compute_speedup(df):
     bench_columns = get_bench_columns()
     workload_columns = [col for col in df.columns if col not in bench_columns]
-    base_df = df[df['variant'] == 'base'].drop(columns=['variant']).rename(
-        columns={'center': 'base_center', 'samples': 'base_samples'})
-    base_df.drop(columns=['elapsed', 'bw'], inplace=True)
+    base_df = (
+        df[df["variant"] == "base"]
+        .drop(columns=["variant"])
+        .rename(columns={"center": "base_center", "samples": "base_samples"})
+    )
+    base_df.drop(columns=["elapsed", "bw"], inplace=True)
 
     merged_df = df.merge(
-        base_df, on=[col for col in df.columns if col in workload_columns])
-    merged_df['speedup'] = merged_df['base_center'] / merged_df['center']
-    merged_df = merged_df.drop(columns=['base_center'])
+        base_df, on=[col for col in df.columns if col in workload_columns]
+    )
+    merged_df["speedup"] = merged_df["base_center"] / merged_df["center"]
+    merged_df = merged_df.drop(columns=["base_center"])
     return merged_df
 
 
 def get_ct_axes(df):
     ct_axes = []
     for col in df.columns:
-        if '{ct}' in col:
+        if "{ct}" in col:
             ct_axes.append(col)
 
     return ct_axes
@@ -83,7 +87,7 @@ def extract_case(df, ct_point):
 
     for ct_axis in ct_point:
         if tuning_df_loc is None:
-            tuning_df_loc = (df[ct_axis] == ct_point[ct_axis])
+            tuning_df_loc = df[ct_axis] == ct_point[ct_axis]
         else:
             tuning_df_loc = tuning_df_loc & (df[ct_axis] == ct_point[ct_axis])
 
@@ -115,16 +119,14 @@ def extract_rt_space(df):
 
 def filter_variants(df, group):
     rt_axes = get_rt_axes(df)
-    unique_combinations = set(
-        df[rt_axes].drop_duplicates().itertuples(index=False))
-    group_combinations = set(
-        group[rt_axes].drop_duplicates().itertuples(index=False))
+    unique_combinations = set(df[rt_axes].drop_duplicates().itertuples(index=False))
+    group_combinations = set(group[rt_axes].drop_duplicates().itertuples(index=False))
     has_all_combinations = group_combinations == unique_combinations
     return has_all_combinations
 
 
 def extract_complete_variants(df):
-    return df.groupby('variant').filter(functools.partial(filter_variants, df))
+    return df.groupby("variant").filter(functools.partial(filter_variants, df))
 
 
 def compute_workload_score(rt_axes_values, rt_axes_ids, weights, row):
@@ -132,12 +134,16 @@ def compute_workload_score(rt_axes_values, rt_axes_ids, weights, row):
     for rt_axis in rt_axes_values:
         rt_workload.append("{}={}".format(rt_axis, row[rt_axis]))
 
-    weight = cccl.bench.get_workload_weight(rt_workload, rt_axes_values, rt_axes_ids, weights)
-    return row['speedup'] * weight
+    weight = cccl.bench.get_workload_weight(
+        rt_workload, rt_axes_values, rt_axes_ids, weights
+    )
+    return row["speedup"] * weight
 
 
 def compute_variant_score(rt_axes_values, rt_axes_ids, weight_matrix, group):
-    workload_score_closure = functools.partial(compute_workload_score, rt_axes_values, rt_axes_ids, weight_matrix)
+    workload_score_closure = functools.partial(
+        compute_workload_score, rt_axes_values, rt_axes_ids, weight_matrix
+    )
     score_sum = group.apply(workload_score_closure, axis=1).sum()
     return score_sum
 
@@ -153,24 +159,31 @@ def extract_scores(dfs):
     score_dfs = []
     for subbench in dfs:
         score_closure = functools.partial(
-            compute_variant_score, rt_axes_values[subbench], rt_axes_ids[subbench], weights[subbench])
-        grouped = dfs[subbench].groupby('variant')
-        scores = grouped.apply(score_closure, include_groups = False).reset_index()
-        scores.columns = ['variant', 'score']
-        stat = grouped.agg(mins=('speedup', 'min'),
-                           means=('speedup', 'mean'),
-                           maxs=('speedup', 'max'))
-        scores = pd.merge(scores, stat, on='variant')
+            compute_variant_score,
+            rt_axes_values[subbench],
+            rt_axes_ids[subbench],
+            weights[subbench],
+        )
+        grouped = dfs[subbench].groupby("variant")
+        scores = grouped.apply(score_closure, include_groups=False).reset_index()
+        scores.columns = ["variant", "score"]
+        stat = grouped.agg(
+            mins=("speedup", "min"), means=("speedup", "mean"), maxs=("speedup", "max")
+        )
+        scores = pd.merge(scores, stat, on="variant")
         score_dfs.append(scores)
     score_df = pd.concat(score_dfs)
-    result = score_df.groupby('variant').agg(
-        {'score': 'sum', 'mins': 'min', 'means': 'mean', 'maxs': 'max'}).reset_index()
-    return result.sort_values(by=['score'], ascending=False)
+    result = (
+        score_df.groupby("variant")
+        .agg({"score": "sum", "mins": "min", "means": "mean", "maxs": "max"})
+        .reset_index()
+    )
+    return result.sort_values(by=["score"], ascending=False)
 
 
 def distributions_are_different(alpha, row):
-    ref_samples = row['base_samples']
-    cmp_samples = row['samples']
+    ref_samples = row["base_samples"]
+    cmp_samples = row["samples"]
 
     # H0: the distributions are not different
     # H1: the distribution are different
@@ -196,7 +209,7 @@ def get_filenames_map(arr):
         if not prefix:
             break
 
-    return {string: string[len(prefix):] for string in arr}
+    return {string: string[len(prefix) :] for string in arr}
 
 
 def is_finite(x):
@@ -219,7 +232,7 @@ def iterate_case_dfs(args, callable):
     exact_values = {}
     if args.args:
         for value in args.args:
-            name, val = value.split('=')
+            name, val = value.split("=")
             exact_values[name] = val
 
     for algname in algnames:
@@ -233,33 +246,44 @@ def iterate_case_dfs(args, callable):
                 df = storage.alg_to_df(algname, subbench)
 
                 df = df.map(lambda x: x if is_finite(x) else np.nan)
-                df = df.dropna(subset=['center'], how='all')
+                df = df.dropna(subset=["center"], how="all")
 
-                for _, row in df[['ctk', 'cccl']].drop_duplicates().iterrows():
-                    ctk_version = row['ctk']
-                    cccl_version = row['cccl']
-                    ctk_cub_df = df[(df['ctk'] == ctk_version) &
-                                    (df['cccl'] == cccl_version)]
+                for _, row in df[["ctk", "cccl"]].drop_duplicates().iterrows():
+                    ctk_version = row["ctk"]
+                    cccl_version = row["cccl"]
+                    ctk_cub_df = df[
+                        (df["ctk"] == ctk_version) & (df["cccl"] == cccl_version)
+                    ]
 
-                    for gpu in ctk_cub_df['gpu'].unique():
-                        target_df = ctk_cub_df[ctk_cub_df['gpu'] == gpu]
-                        target_df = target_df.drop(columns=['ctk', 'cccl', 'gpu'])
+                    for gpu in ctk_cub_df["gpu"].unique():
+                        target_df = ctk_cub_df[ctk_cub_df["gpu"] == gpu]
+                        target_df = target_df.drop(columns=["ctk", "cccl", "gpu"])
                         target_df = compute_speedup(target_df)
 
                         for key in exact_values:
                             if key in target_df.columns:
-                                target_df = target_df[target_df[key] == exact_values[key]]
+                                target_df = target_df[
+                                    target_df[key] == exact_values[key]
+                                ]
 
                         for ct_point in ct_space(target_df):
-                            point_str = ", ".join(["{}={}".format(k, ct_point[k]) for k in ct_point])
-                            case_df = extract_complete_variants(extract_case(target_df, ct_point))
-                            case_df['variant'] = case_df['variant'].astype(str) + " ({})".format(file)
+                            point_str = ", ".join(
+                                ["{}={}".format(k, ct_point[k]) for k in ct_point]
+                            )
+                            case_df = extract_complete_variants(
+                                extract_case(target_df, ct_point)
+                            )
+                            case_df["variant"] = case_df["variant"].astype(
+                                str
+                            ) + " ({})".format(file)
                             if point_str not in case_dfs:
                                 case_dfs[point_str] = {}
                             if subbench not in case_dfs[point_str]:
                                 case_dfs[point_str][subbench] = case_df
                             else:
-                                case_dfs[point_str][subbench] = pd.concat([case_dfs[point_str][subbench], case_df])
+                                case_dfs[point_str][subbench] = pd.concat(
+                                    [case_dfs[point_str][subbench], case_df]
+                                )
 
         for point_str in case_dfs:
             callable(algname, point_str, case_dfs[point_str])
@@ -273,7 +297,7 @@ def case_top(alpha, N, algname, ct_point_name, case_dfs):
 
     for subbench in case_dfs:
         case_dfs[subbench] = extract_complete_variants(case_dfs[subbench])
-    with pd.option_context('display.max_rows', None):
+    with pd.option_context("display.max_rows", None):
         print(extract_scores(case_dfs).head(N))
 
 
@@ -285,12 +309,15 @@ def case_coverage(algname, ct_point_name, case_dfs):
     num_variants = cccl.bench.Config().variant_space_size(algname)
     min_coverage = 100.0
     for subbench in case_dfs:
-        num_covered_variants = len(case_dfs[subbench]['variant'].unique())
+        num_covered_variants = len(case_dfs[subbench]["variant"].unique())
         coverage = (num_covered_variants / num_variants) * 100
         min_coverage = min(min_coverage, coverage)
     case_str = "{}[{}]".format(algname, ct_point_name)
-    print("{} coverage: {} / {} ({:.4f}%)".format(
-          case_str, num_covered_variants, num_variants, min_coverage))
+    print(
+        "{} coverage: {} / {} ({:.4f}%)".format(
+            case_str, num_covered_variants, num_variants, min_coverage
+        )
+    )
 
 
 def coverage(args):
@@ -314,8 +341,7 @@ def parallel_coordinates_plot(df, title):
     dics_vars = []
     for v, var in enumerate(my_vars):
         if df_plot[var].dtype.kind not in ["i", "u", "f"]:
-            dic_var = dict([(val, c)
-                           for c, val in enumerate(df_plot[var].unique())])
+            dic_var = dict([(val, c) for c, val in enumerate(df_plot[var].unique())])
             dics_vars += [dic_var]
             ym += [[dic_var[i] for i in df_plot[var].tolist()]]
         else:
@@ -326,15 +352,15 @@ def parallel_coordinates_plot(df, title):
     ymins = ym.min(axis=0)
     ymaxs = ym.max(axis=0)
     dys = ymaxs - ymins
-    ymins -= dys*0.05
-    ymaxs += dys*0.05
+    ymins -= dys * 0.05
+    ymaxs += dys * 0.05
 
     dys = ymaxs - ymins
 
     # Adjust to the main axis:
     zs = np.zeros_like(ym)
     zs[:, 0] = ym[:, 0]
-    zs[:, 1:] = (ym[:, 1:] - ymins[1:])/dys[1:]*dys[0] + ymins[0]
+    zs[:, 1:] = (ym[:, 1:] - ymins[1:]) / dys[1:] * dys[0] + ymins[0]
 
     # Plot:
     fig, host_ax = plt.subplots(figsize=(20, 10), tight_layout=True)
@@ -343,17 +369,14 @@ def parallel_coordinates_plot(df, title):
     axes = [host_ax] + [host_ax.twinx() for i in range(ym.shape[1] - 1)]
     dic_count = 0
     for i, ax in enumerate(axes):
-        ax.set_ylim(
-            bottom=ymins[i],
-            top=ymaxs[i]
-        )
+        ax.set_ylim(bottom=ymins[i], top=ymaxs[i])
         ax.spines.top.set_visible(False)
         ax.spines.bottom.set_visible(False)
-        ax.ticklabel_format(style='plain')
+        ax.ticklabel_format(style="plain")
         if ax != host_ax:
             ax.spines.left.set_visible(False)
             ax.yaxis.set_ticks_position("right")
-            ax.spines.right.set_position(("axes", i/(ym.shape[1] - 1)))
+            ax.spines.right.set_position(("axes", i / (ym.shape[1] - 1)))
         if df_plot.iloc[:, i].dtype.kind not in ["i", "u", "f"]:
             dic_var_i = dics_vars[dic_count]
             ax.set_yticks(range(len(dic_var_i)))
@@ -368,29 +391,36 @@ def parallel_coordinates_plot(df, title):
     host_ax.tick_params(axis="x", which="major", pad=7)
 
     # Color map:
-    colormap = cm.get_cmap('turbo')
+    colormap = cm.get_cmap("turbo")
 
     # Normalize speedups:
-    df["speedup_normalized"] = (
-        df["speedup"] - df["speedup"].min()) / (df["speedup"].max() - df["speedup"].min())
+    df["speedup_normalized"] = (df["speedup"] - df["speedup"].min()) / (
+        df["speedup"].max() - df["speedup"].min()
+    )
 
     # Make the curves:
     host_ax.spines.right.set_visible(False)
     host_ax.xaxis.tick_top()
     for j in range(ym.shape[0]):
-        verts = list(zip([x for x in np.linspace(0, len(ym) - 1, len(ym)*3 - 2,
-                                                 endpoint=True)],
-                     np.repeat(zs[j, :], 3)[1: -1]))
+        verts = list(
+            zip(
+                [
+                    x
+                    for x in np.linspace(0, len(ym) - 1, len(ym) * 3 - 2, endpoint=True)
+                ],
+                np.repeat(zs[j, :], 3)[1:-1],
+            )
+        )
         codes = [Path.MOVETO] + [Path.CURVE4 for _ in range(len(verts) - 1)]
         path = Path(verts, codes)
         color_first_cat_var = colormap(df.loc[j, "speedup_normalized"])
         patch = patches.PathPatch(
-            path, facecolor="none", lw=2, alpha=0.05, edgecolor=color_first_cat_var)
+            path, facecolor="none", lw=2, alpha=0.05, edgecolor=color_first_cat_var
+        )
         host_ax.add_patch(patch)
 
     host_ax.set_title(title)
     plt.show()
-
 
 
 def case_coverage_plot(algname, ct_point_name, case_dfs):
@@ -398,22 +428,22 @@ def case_coverage_plot(algname, ct_point_name, case_dfs):
 
     for subbench in case_dfs:
         for _, row_description in case_dfs[subbench].iterrows():
-            variant = row_description['variant']
-            speedup = row_description['speedup']
+            variant = row_description["variant"]
+            speedup = row_description["speedup"]
 
-            if variant.startswith('base'):
+            if variant.startswith("base"):
                 continue
 
-            varname, _ = variant.split(' ')
-            params = varname.split('.')
-            data_dict = {'variant': variant}
+            varname, _ = variant.split(" ")
+            params = varname.split(".")
+            data_dict = {"variant": variant}
 
             for param in params:
                 print(variant)
-                name, val = param.split('_')
+                name, val = param.split("_")
                 data_dict[name] = int(val)
 
-            data_dict['speedup'] = speedup
+            data_dict["speedup"] = speedup
             # data_dict['variant'] = variant
             data_list.append(data_dict)
 
@@ -427,30 +457,31 @@ def coverage_plot(args):
 
 def case_pair_plot(algname, ct_point_name, case_dfs):
     import seaborn as sns
+
     data_list = []
 
     for subbench in case_dfs:
         for _, row_description in case_dfs[subbench].iterrows():
-            variant = row_description['variant']
-            speedup = row_description['speedup']
+            variant = row_description["variant"]
+            speedup = row_description["speedup"]
 
-            if variant.startswith('base'):
+            if variant.startswith("base"):
                 continue
 
-            varname, _ = variant.split(' ')
-            params = varname.split('.')
+            varname, _ = variant.split(" ")
+            params = varname.split(".")
             data_dict = {}
 
             for param in params:
                 print(variant)
-                name, val = param.split('_')
+                name, val = param.split("_")
                 data_dict[name] = int(val)
 
-            data_dict['speedup'] = speedup
+            data_dict["speedup"] = speedup
             data_list.append(data_dict)
 
     df = pd.DataFrame(data_list)
-    sns.pairplot(df, hue='speedup')
+    sns.pairplot(df, hue="speedup")
     plt.title("{} ({})".format(algname, ct_point_name))
     plt.show()
 
@@ -579,7 +610,7 @@ def hd_displot(samples, label, ax):
         ax.plot([xs[bin], xs[bin]], [0, ys[bin]], color=color)
 
     ax.plot(xs, ys, label=label, color=color)
-    ax.plot(peak_xs, peak_ys, 'o', color=color)
+    ax.plot(peak_xs, peak_ys, "o", color=color)
     ax.legend()
 
 
@@ -594,7 +625,7 @@ def variant_ratio(data, variant, ax):
     color = color_map[variant]
 
     variant_samples = data[variant]
-    base_samples = data['base']
+    base_samples = data["base"]
 
     variant_widths, variant_heights = qrde_hd(variant_samples)
     base_widths, base_heights = qrde_hd(base_samples)
@@ -612,28 +643,30 @@ def variant_ratio(data, variant, ax):
         ratios.append(base_x / variant_x)
 
     ax.plot(quantiles, ratios, label=variant, color=color)
-    ax.axhline(1, color='red', alpha=0.7)
+    ax.axhline(1, color="red", alpha=0.7)
     ax.legend()
-    ax.tick_params(axis='both', direction='in', pad=-22)
+    ax.tick_params(axis="both", direction="in", pad=-22)
 
 
 def ratio(data, ax):
     for variant in data:
-        if variant != 'base':
+        if variant != "base":
             variant_ratio(data, variant, ax)
 
 
 def case_variants(pattern, mode, algname, ct_point_name, case_dfs):
     for subbench in case_dfs:
         case_df = case_dfs[subbench]
-        title = "{}[{}]:".format(algname + '/' + subbench, ct_point_name)
-        df = case_df[case_df['variant'].str.contains(pattern, regex=True)].reset_index(drop=True)
+        title = "{}[{}]:".format(algname + "/" + subbench, ct_point_name)
+        df = case_df[case_df["variant"].str.contains(pattern, regex=True)].reset_index(
+            drop=True
+        )
         rt_axes = get_rt_axes(df)
         rt_axes_values = extract_rt_axes_values(df)
 
         vertical_axis_name = rt_axes[0]
-        if 'Elements{io}[pow2]' in rt_axes:
-            vertical_axis_name = 'Elements{io}[pow2]'
+        if "Elements{io}[pow2]" in rt_axes:
+            vertical_axis_name = "Elements{io}[pow2]"
         horizontal_axes = rt_axes
         horizontal_axes.remove(vertical_axis_name)
         vertical_axis_values = rt_axes_values[vertical_axis_name]
@@ -645,7 +678,9 @@ def case_variants(pattern, mode, algname, ct_point_name, case_dfs):
         def extract_horizontal_space(df):
             values = []
             for rt_axis in horizontal_axes:
-                values.append(["{}={}".format(rt_axis, v) for v in df[rt_axis].unique()])
+                values.append(
+                    ["{}={}".format(rt_axis, v) for v in df[rt_axis].unique()]
+                )
             return list(itertools.product(*values))
 
         if len(horizontal_axes) > 0:
@@ -661,56 +696,71 @@ def case_variants(pattern, mode, algname, ct_point_name, case_dfs):
         if num_rows == 0:
             return
 
-        fig, axes = plt.subplots(nrows=num_rows, ncols=num_cols, gridspec_kw = {'wspace': 0, 'hspace': 0})
+        fig, axes = plt.subplots(
+            nrows=num_rows, ncols=num_cols, gridspec_kw={"wspace": 0, "hspace": 0}
+        )
 
-
-        for _, vertical_row_description in df[[vertical_axis_name]].drop_duplicates().iterrows():
+        for _, vertical_row_description in (
+            df[[vertical_axis_name]].drop_duplicates().iterrows()
+        ):
             vertical_val = vertical_row_description[vertical_axis_name]
             vertical_id = vertical_axis_ids[vertical_val]
             vertical_name = "{}={}".format(vertical_axis_name, vertical_val)
 
             vertical_df = df[df[vertical_axis_name] == vertical_val]
 
-            for _, horizontal_row_description in vertical_df[horizontal_axes].drop_duplicates().iterrows():
+            for _, horizontal_row_description in (
+                vertical_df[horizontal_axes].drop_duplicates().iterrows()
+            ):
                 horizontal_df = vertical_df
 
                 for axis in horizontal_axes:
-                    horizontal_df = horizontal_df[horizontal_df[axis] == horizontal_row_description[axis]]
+                    horizontal_df = horizontal_df[
+                        horizontal_df[axis] == horizontal_row_description[axis]
+                    ]
 
                 horizontal_id = 0
 
                 if len(horizontal_axes) > 0:
                     horizontal_point = []
                     for rt_axis in horizontal_axes:
-                        horizontal_point.append("{}={}".format(rt_axis, horizontal_row_description[rt_axis]))
+                        horizontal_point.append(
+                            "{}={}".format(rt_axis, horizontal_row_description[rt_axis])
+                        )
                     horizontal_name = " / ".join(horizontal_point)
                     horizontal_id = horizontal_axis_ids[horizontal_name]
-                    ax=axes[vertical_id, horizontal_id]
+                    ax = axes[vertical_id, horizontal_id]
                 else:
-                    ax=axes[vertical_id]
+                    ax = axes[vertical_id]
                     ax.set_ylabel(vertical_name)
 
                 data = {}
-                for _, variant in horizontal_df[['variant']].drop_duplicates().iterrows():
-                    variant_name = variant['variant']
-                    if 'base' not in data:
-                        data['base'] = horizontal_df[horizontal_df['variant'] == variant_name].iloc[0]['base_samples']
-                    data[variant_name] = horizontal_df[horizontal_df['variant'] == variant_name].iloc[0]['samples']
+                for _, variant in (
+                    horizontal_df[["variant"]].drop_duplicates().iterrows()
+                ):
+                    variant_name = variant["variant"]
+                    if "base" not in data:
+                        data["base"] = horizontal_df[
+                            horizontal_df["variant"] == variant_name
+                        ].iloc[0]["base_samples"]
+                    data[variant_name] = horizontal_df[
+                        horizontal_df["variant"] == variant_name
+                    ].iloc[0]["samples"]
 
-                if mode == 'pdf':
+                if mode == "pdf":
                     # sns.histplot(data=data, ax=ax, kde=True)
                     displot(data, ax)
                 else:
                     ratio(data, ax)
 
                 if len(horizontal_axes) > 0:
-                    ax=axes[vertical_id, horizontal_id]
+                    ax = axes[vertical_id, horizontal_id]
                     if vertical_id == (num_rows - 1):
                         ax.set_xlabel(horizontal_name)
                     if horizontal_id == 0:
                         ax.set_ylabel(vertical_name)
                     else:
-                        ax.set_ylabel('')
+                        ax.set_ylabel("")
 
         for ax in axes.flat:
             ax.set_xticklabels([])
@@ -720,9 +770,12 @@ def case_variants(pattern, mode, algname, ct_point_name, case_dfs):
         plt.show()
 
 
-
 def variants(args, mode):
-    pattern = re.compile(args.variants_pdf) if mode == 'pdf' else re.compile(args.variants_ratio)
+    pattern = (
+        re.compile(args.variants_pdf)
+        if mode == "pdf"
+        else re.compile(args.variants_ratio)
+    )
     iterate_case_dfs(args, functools.partial(case_variants, pattern, mode))
 
 
@@ -738,15 +791,15 @@ def case_offload(algname, ct_point_name, case_dfs):
         for rt_point in extract_rt_space(df):
             point_df = df
             for rt_kv in rt_point:
-                key, value = rt_kv.split('=')
+                key, value = rt_kv.split("=")
                 point_df = point_df[point_df[key] == value]
             point_name = ct_point_name + " " + " ".join(rt_point)
-            point_name = point_name.replace(',', '')
+            point_name = point_name.replace(",", "")
             bench_name = "{}.{}-{}".format(algname, subbench, point_name)
-            bench_name = bench_name.replace(' ', '___')
+            bench_name = bench_name.replace(" ", "___")
             bench_name = "".join(c if c.isalnum() else "_" for c in bench_name)
-            with open(bench_name + '.json', 'w') as f:
-                obj = json.loads(point_df.to_json(orient='records'))
+            with open(bench_name + ".json", "w") as f:
+                obj = json.loads(point_df.to_json(orient="records"))
                 json.dump(obj, f, indent=2)
 
 
@@ -757,29 +810,52 @@ def offload(args):
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Analyze benchmark results.")
     parser.add_argument(
-        '-R', type=str, default='.*', help="Regex for benchmarks selection.")
+        "-R", type=str, default=".*", help="Regex for benchmarks selection."
+    )
     parser.add_argument(
-        '--list-benches', action=argparse.BooleanOptionalAction, help="Show available benchmarks.")
+        "--list-benches",
+        action=argparse.BooleanOptionalAction,
+        help="Show available benchmarks.",
+    )
     parser.add_argument(
-        '--coverage', action=argparse.BooleanOptionalAction, help="Show variant space coverage.")
+        "--coverage",
+        action=argparse.BooleanOptionalAction,
+        help="Show variant space coverage.",
+    )
     parser.add_argument(
-        '--coverage-plot', action=argparse.BooleanOptionalAction, help="Plot variant space coverage.")
+        "--coverage-plot",
+        action=argparse.BooleanOptionalAction,
+        help="Plot variant space coverage.",
+    )
     parser.add_argument(
-        '--pair-plot', action=argparse.BooleanOptionalAction, help="Pair plot.")
+        "--pair-plot", action=argparse.BooleanOptionalAction, help="Pair plot."
+    )
     parser.add_argument(
-        '--top', default=7, type=int, action='store', nargs='?', help="Show top N variants with highest score.")
+        "--top",
+        default=7,
+        type=int,
+        action="store",
+        nargs="?",
+        help="Show top N variants with highest score.",
+    )
     parser.add_argument(
-        'files', type=file_exists, nargs='+', help='At least one file is required.')
+        "files", type=file_exists, nargs="+", help="At least one file is required."
+    )
+    parser.add_argument("--alpha", default=1.0, type=float)
+    parser.add_argument("--variants-pdf", type=str, help="Show matching variants data.")
     parser.add_argument(
-        '--alpha', default=1.0, type=float)
+        "--variants-ratio", type=str, help="Show matching variants data."
+    )
     parser.add_argument(
-        '--variants-pdf', type=str, help="Show matching variants data.")
+        "-a",
+        "--args",
+        action="append",
+        type=str,
+        help="Parameter in the format `Param=Value`.",
+    )
     parser.add_argument(
-        '--variants-ratio', type=str, help="Show matching variants data.")
-    parser.add_argument('-a', '--args', action='append',
-                        type=str, help="Parameter in the format `Param=Value`.")
-    parser.add_argument(
-        '-o', '--offload', action=argparse.BooleanOptionalAction, help="Offload samples")
+        "-o", "--offload", action=argparse.BooleanOptionalAction, help="Offload samples"
+    )
     return parser.parse_args()
 
 
@@ -803,11 +879,11 @@ def main():
         return
 
     if args.variants_pdf:
-        variants(args, 'pdf')
+        variants(args, "pdf")
         return
 
     if args.variants_ratio:
-        variants(args, 'ratio')
+        variants(args, "ratio")
         return
 
     if args.offload:

--- a/benchmarks/scripts/cccl/__init__.py
+++ b/benchmarks/scripts/cccl/__init__.py
@@ -1,1 +1,3 @@
 from . import bench
+
+__all__ = ["bench"]

--- a/benchmarks/scripts/cccl/bench/__init__.py
+++ b/benchmarks/scripts/cccl/bench/__init__.py
@@ -1,6 +1,6 @@
-from .config import *
-from .storage import *
-from .bench import Bench
-from .cmake import CMake
-from .score import *
-from .search import *
+from .config import *  # noqa: F403
+from .storage import *  # noqa: F403
+from .bench import Bench  # noqa: F401
+from .cmake import CMake  # noqa: F401
+from .score import *  # noqa: F403
+from .search import *  # noqa: F403

--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -19,7 +19,11 @@ def first_val(my_dict):
     first_value = values[0]
 
     if not all(value == first_value for value in values):
-        raise ValueError('All values in the dictionary are not equal. First value: {} All values: {}'.format(first_value, values))
+        raise ValueError(
+            "All values in the dictionary are not equal. First value: {} All values: {}".format(
+                first_value, values
+            )
+        )
 
     return first_value
 
@@ -37,19 +41,22 @@ class JsonCache:
     def get_bench(self, algname):
         if algname not in self.bench_cache:
             result = subprocess.check_output(
-                [os.path.join('.', 'bin', algname + '.base'), "--jsonlist-benches"])
+                [os.path.join(".", "bin", algname + ".base"), "--jsonlist-benches"]
+            )
             self.bench_cache[algname] = json.loads(result)
         return self.bench_cache[algname]
 
     def get_device(self, algname):
         if algname not in self.device_cache:
             result = subprocess.check_output(
-                [os.path.join('.', 'bin', algname + '.base'), "--jsonlist-devices"])
+                [os.path.join(".", "bin", algname + ".base"), "--jsonlist-devices"]
+            )
             devices = json.loads(result)["devices"]
 
             if len(devices) != 1:
                 raise Exception(
-                    "NVBench doesn't work well with multiple GPUs, use `CUDA_VISIBLE_DEVICES`")
+                    "NVBench doesn't work well with multiple GPUs, use `CUDA_VISIBLE_DEVICES`"
+                )
 
             self.device_cache[algname] = devices[0]
 
@@ -72,19 +79,23 @@ def create_benches_tables(conn, subbench, bench_axes):
 
         for algorithm_name in bench_axes:
             axes = bench_axes[algorithm_name]
-            column_names = ", ".join(["\"{}\"".format(name) for name in axes])
-            columns = ", ".join(["\"{}\" TEXT".format(name) for name in axes])
+            column_names = ", ".join(['"{}"'.format(name) for name in axes])
+            columns = ", ".join(['"{}" TEXT'.format(name) for name in axes])
 
-            conn.execute("""
+            conn.execute(
+                """
             INSERT INTO subbenches (algorithm, bench)
             VALUES (?, ?)
             ON CONFLICT DO NOTHING;
-            """, (algorithm_name, subbench))
+            """,
+                (algorithm_name, subbench),
+            )
 
             if axes:
                 columns = ", " + columns
                 column_names = ", " + column_names
-                conn.execute("""
+                conn.execute(
+                    """
                 CREATE TABLE IF NOT EXISTS "{0}" (
                     ctk TEXT NOT NULL,
                     cccl TEXT NOT NULL,
@@ -97,7 +108,12 @@ def create_benches_tables(conn, subbench, bench_axes):
                     {1}
                     , UNIQUE(ctk, cccl, gpu, variant {2})
                 );
-                """.format(get_bench_table_name(subbench, algorithm_name), columns, column_names))
+                """.format(
+                        get_bench_table_name(subbench, algorithm_name),
+                        columns,
+                        column_names,
+                    )
+                )
 
 
 def read_json(filename):
@@ -109,21 +125,21 @@ def read_json(filename):
 def extract_filename(summary):
     summary_data = summary["data"]
     value_data = next(filter(lambda v: v["name"] == "filename", summary_data))
-    assert (value_data["type"] == "string")
+    assert value_data["type"] == "string"
     return value_data["value"]
 
 
 def extract_size(summary):
     summary_data = summary["data"]
     value_data = next(filter(lambda v: v["name"] == "size", summary_data))
-    assert (value_data["type"] == "int64")
+    assert value_data["type"] == "int64"
     return int(value_data["value"])
 
 
 def extract_bw(summary):
     summary_data = summary["data"]
     value_data = next(filter(lambda v: v["name"] == "value", summary_data))
-    assert (value_data["type"] == "float64")
+    assert value_data["type"] == "float64"
     return float(value_data["value"])
 
 
@@ -132,9 +148,10 @@ def parse_samples_meta(state):
     if not summaries:
         return None, None
 
-    summary = next(filter(lambda s: s["tag"] == "nv/json/bin:nv/cold/sample_times",
-                          summaries),
-                   None)
+    summary = next(
+        filter(lambda s: s["tag"] == "nv/json/bin:nv/cold/sample_times", summaries),
+        None,
+    )
     if not summary:
         return None, None
 
@@ -153,17 +170,22 @@ def parse_samples(state):
 
     samples.sort()
 
-    assert (sample_count == len(samples))
+    assert sample_count == len(samples)
     return samples
 
 
 def parse_bw(state):
-    bwutil = next(filter(lambda s: s["tag"] == "nv/cold/bw/global/utilization",
-                         state['summaries']), None)
+    bwutil = next(
+        filter(
+            lambda s: s["tag"] == "nv/cold/bw/global/utilization", state["summaries"]
+        ),
+        None,
+    )
     if not bwutil:
         return None
 
     return extract_bw(bwutil)
+
 
 class SubBenchState:
     def __init__(self, state, axes_names, axes_values):
@@ -172,18 +194,19 @@ class SubBenchState:
 
         self.point = {}
         for axis in state["axis_values"]:
-            name = axes_names[axis['name']]
-            value = axes_values[axis['name']][axis['value']]
+            name = axes_names[axis["name"]]
+            value = axes_values[axis["name"]][axis["value"]]
             self.point[name] = value
 
     def __repr__(self):
         return str(self.__dict__)
 
     def name(self):
-        return ' '.join(f'{k}={v}' for k, v in self.point.items())
+        return " ".join(f"{k}={v}" for k, v in self.point.items())
 
     def center(self, estimator):
         return estimator(self.samples)
+
 
 class SubBenchResult:
     def __init__(self, bench):
@@ -196,9 +219,13 @@ class SubBenchResult:
             axes_values[short_name] = {}
             for value in axis["values"]:
                 if "value" in value:
-                    axes_values[axis["name"]][str(value["value"])] = value["input_string"]
+                    axes_values[axis["name"]][str(value["value"])] = value[
+                        "input_string"
+                    ]
                 else:
-                    axes_values[axis["name"]][value["input_string"]] = value["input_string"]
+                    axes_values[axis["name"]][value["input_string"]] = value[
+                        "input_string"
+                    ]
 
         self.states = []
         for state in bench["states"]:
@@ -246,17 +273,17 @@ def get_device_name(device):
     sms = device["number_of_sms"]
     ecc = "eccon" if device["ecc_state"] else "eccoff"
     name = "{} ({}, {}, {})".format(gpu_name, bus_width, sms, ecc)
-    return name.replace('NVIDIA ', '')
+    return name.replace("NVIDIA ", "")
 
 
 def is_ct_axis(name):
-    return '{ct}' in name
+    return "{ct}" in name
 
 
 def state_to_rt_workload(bench, state):
     rt_workload = []
-    for param in state.split(' '):
-        name, value = param.split('=')
+    for param in state.split(" "):
+        name, value = param.split("=")
         if is_ct_axis(name):
             continue
         rt_workload.append("{}={}".format(name, value))
@@ -277,39 +304,41 @@ def create_runs_table(conn):
 
 
 class RunsCache:
-  _instance = None
+    _instance = None
 
-  def __new__(cls, *args, **kwargs):
-      if cls._instance is None:
-          cls._instance = super().__new__(cls, *args, **kwargs)
-          create_runs_table(Storage().connection())
-      return cls._instance
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls, *args, **kwargs)
+            create_runs_table(Storage().connection())
+        return cls._instance
 
-  def pull_run(self, bench):
-      config = Config()
-      ctk = config.ctk
-      cccl = config.cccl
-      conn = Storage().connection()
+    def pull_run(self, bench):
+        config = Config()
+        ctk = config.ctk
+        cccl = config.cccl
+        conn = Storage().connection()
 
-      with conn:
-          query = "SELECT code, elapsed FROM runs WHERE ctk = ? AND cccl = ? AND bench = ?;"
-          result = conn.execute(query, (ctk, cccl, bench.label())).fetchone()
+        with conn:
+            query = "SELECT code, elapsed FROM runs WHERE ctk = ? AND cccl = ? AND bench = ?;"
+            result = conn.execute(query, (ctk, cccl, bench.label())).fetchone()
 
-          if result:
-              code, elapsed = result
-              return int(code), float(elapsed)
+            if result:
+                code, elapsed = result
+                return int(code), float(elapsed)
 
-          return result
+            return result
 
-  def push_run(self, bench, code, elapsed):
-      config = Config()
-      ctk = config.ctk
-      cccl = config.cccl
-      conn = Storage().connection()
+    def push_run(self, bench, code, elapsed):
+        config = Config()
+        ctk = config.ctk
+        cccl = config.cccl
+        conn = Storage().connection()
 
-      with conn:
-          conn.execute("INSERT INTO runs (ctk, cccl, bench, code, elapsed) VALUES (?, ?, ?, ?, ?);",
-                       (ctk, cccl, bench.label(), code, elapsed))
+        with conn:
+            conn.execute(
+                "INSERT INTO runs (ctk, cccl, bench, code, elapsed) VALUES (?, ?, ?, ?, ?);",
+                (ctk, cccl, bench.label(), code, elapsed),
+            )
 
 
 class BenchCache:
@@ -322,7 +351,6 @@ class BenchCache:
 
         return cls._instance
 
-
     def create_table_if_not_exists(self, conn, bench):
         bench_base = bench.get_base()
         alg_name = bench_base.algorithm_name()
@@ -330,9 +358,10 @@ class BenchCache:
         if alg_name not in self.existing_tables:
             subbench_axes_names = bench_base.axes_names()
             for subbench in subbench_axes_names:
-                create_benches_tables(conn, subbench, {alg_name: subbench_axes_names[subbench]})
+                create_benches_tables(
+                    conn, subbench, {alg_name: subbench_axes_names[subbench]}
+                )
                 self.existing_tables.add(alg_name)
-
 
     def push_bench_centers(self, bench, result, estimator):
         config = Config()
@@ -355,15 +384,23 @@ class BenchCache:
 
                     for name in state.point:
                         value = state.point[name]
-                        columns = columns + ", \"{}\"".format(name)
+                        columns = columns + ', "{}"'.format(name)
                         placeholders = placeholders + ", ?"
                         values.append(value)
 
                     values = tuple(values)
                     samples = fpzip.compress(state.samples)
                     center = estimator(state.samples)
-                    to_insert = (ctk, cccl, gpu, bench.variant_name(),
-                                 result.elapsed, center, state.bw, samples) + values
+                    to_insert = (
+                        ctk,
+                        cccl,
+                        gpu,
+                        bench.variant_name(),
+                        result.elapsed,
+                        center,
+                        state.bw,
+                        samples,
+                    ) + values
 
                     query = """
                     INSERT INTO "{0}" (ctk, cccl, gpu, variant, elapsed, center, bw, samples {1})
@@ -397,22 +434,27 @@ class BenchCache:
                     point_checks = ""
                     workload_point = list(ct_workload_point) + list(rt_point)
                     for axis in workload_point:
-                        name, value = axis.split('=')
+                        name, value = axis.split("=")
                         point_map[name] = value
-                        point_checks = point_checks + " AND \"{}\" = \"{}\"".format(name, value)
+                        point_checks = point_checks + ' AND "{}" = "{}"'.format(
+                            name, value
+                        )
 
                     query = """
                     SELECT center FROM "{0}" WHERE ctk = ? AND cccl = ? AND gpu = ? AND variant = ?{1};
                     """.format(table_name, point_checks)
 
-                    result = conn.execute(query, (ctk, cccl, gpu, bench.variant_name())).fetchone()
+                    result = conn.execute(
+                        query, (ctk, cccl, gpu, bench.variant_name())
+                    ).fetchone()
                     if result is None:
                         return None
 
-                    state_name = ' '.join(f'{k}={v}' for k, v in point_map.items())
+                    state_name = " ".join(f"{k}={v}" for k, v in point_map.items())
                     centers[subbench][state_name] = float(result[0])
 
         return centers
+
 
 def get_axis_name(axis):
     name = axis["name"]
@@ -467,15 +509,17 @@ class ProcessRunner:
         signal.signal(signal.SIGTERM, self.signal_handler)
 
     def new_process(self, cmd):
-        self.process = subprocess.Popen(cmd,
-                                        start_new_session=True,
-                                        stdout=subprocess.DEVNULL,
-                                        stderr=subprocess.DEVNULL)
+        self.process = subprocess.Popen(
+            cmd,
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         return self.process
 
     def signal_handler(self, signum, frame):
         self.kill_process()
-        raise SystemExit('search was interrupted')
+        raise SystemExit("search was interrupted")
 
     def kill_process(self):
         if self.process is not None:
@@ -489,7 +533,7 @@ class Bench:
         self.ct_workload = ct_workload
 
     def label(self):
-        return self.algname + '.' + self.variant.label()
+        return self.algname + "." + self.variant.label()
 
     def variant_name(self):
         return self.variant.label()
@@ -505,11 +549,11 @@ class Bench:
 
     def exe_name(self):
         if self.is_base():
-            return self.algorithm_name() + '.base'
-        return self.algorithm_name() + '.variant'
+            return self.algorithm_name() + ".base"
+        return self.algorithm_name() + ".variant"
 
     def bench_names(self):
-        return [bench['name'] for bench in json_benches(self.algname)["benchmarks"]]
+        return [bench["name"] for bench in json_benches(self.algname)["benchmarks"]]
 
     def axes_names(self):
         subbench_names = {}
@@ -518,7 +562,7 @@ class Bench:
             for axis in bench["axes"]:
                 names.append(get_axis_name(axis))
 
-            subbench_names[bench['name']] = names
+            subbench_names[bench["name"]] = names
         return subbench_names
 
     def axes_values(self, sub_space, ct):
@@ -529,10 +573,10 @@ class Bench:
                 name = get_axis_name(axis)
 
                 if ct:
-                    if not '{ct}' in name:
+                    if "{ct}" not in name:
                         continue
                 else:
-                    if '{ct}' in name:
+                    if "{ct}" in name:
                         continue
 
                 axis_space = []
@@ -545,7 +589,7 @@ class Bench:
 
                 space[name] = axis_space
 
-            subbench_space[bench['name']] = space
+            subbench_space[bench["name"]] = space
         return subbench_space
 
     def ct_axes_value_descriptions(self):
@@ -554,7 +598,7 @@ class Bench:
             descriptions = {}
             for axis in bench["axes"]:
                 name = axis["name"]
-                if not '{ct}' in name:
+                if "{ct}" not in name:
                     continue
                 if axis["flags"]:
                     name = name + "[{}]".format(axis["flags"])
@@ -564,7 +608,6 @@ class Bench:
 
             subbench_descriptions[bench["name"]] = descriptions
         return first_val(subbench_descriptions)
-
 
     def axis_values(self, axis_name):
         result = json_benches(self.algname)
@@ -601,10 +644,12 @@ class Bench:
 
         descriptions = self.ct_axes_value_descriptions()
         for ct_component in self.ct_workload:
-            ct_axis_name, ct_value = ct_component.split('=')
+            ct_axis_name, ct_value = ct_component.split("=")
             description = descriptions[ct_axis_name][ct_value]
-            ct_axis_name = ct_axis_name.replace('{ct}', '')
-            definitions = definitions + "#define TUNE_{} {}\n".format(ct_axis_name, description)
+            ct_axis_name = ct_axis_name.replace("{ct}", "")
+            definitions = definitions + "#define TUNE_{} {}\n".format(
+                ct_axis_name, description
+            )
 
         return definitions
 
@@ -612,18 +657,18 @@ class Bench:
         logger = Logger()
 
         try:
-            result_path = 'result.json'
+            result_path = "result.json"
             if os.path.exists(result_path):
                 os.remove(result_path)
 
-            bench_path = os.path.join('.', 'bin', self.exe_name())
+            bench_path = os.path.join(".", "bin", self.exe_name())
             cmd = [bench_path]
 
             for value in ct_point:
-                cmd.append('-a')
+                cmd.append("-a")
                 cmd.append(value)
 
-            cmd.append('--jsonbin')
+            cmd.append("--jsonbin")
             cmd.append(result_path)
 
             cmd.append("--stopping-criterion")
@@ -634,27 +679,39 @@ class Bench:
             cmd.append("0")
 
             for bench in rt_values:
-                cmd.append('-b')
+                cmd.append("-b")
                 cmd.append(bench)
 
                 for axis in rt_values[bench]:
-                    cmd.append('-a')
+                    cmd.append("-a")
                     cmd.append("{}=[{}]".format(axis, ",".join(rt_values[bench][axis])))
 
-            logger.info("starting benchmark {} with {}: {}".format(self.label(), ct_point, " ".join(cmd)))
+            logger.info(
+                "starting benchmark {} with {}: {}".format(
+                    self.label(), ct_point, " ".join(cmd)
+                )
+            )
 
             begin = time.time()
             p = ProcessRunner().new_process(cmd)
             p.wait(timeout=timeout)
             elapsed = time.time() - begin
 
-            logger.info("finished benchmark {} with {} ({}) in {:.3f}s".format(self.label(), ct_point, p.returncode, elapsed))
+            logger.info(
+                "finished benchmark {} with {} ({}) in {:.3f}s".format(
+                    self.label(), ct_point, p.returncode, elapsed
+                )
+            )
 
             return BenchResult(result_path, p.returncode, elapsed)
         except subprocess.TimeoutExpired:
-            logger.info("benchmark {} with {} reached timeout of {:.3f}s".format(self.label(), ct_point, timeout))
+            logger.info(
+                "benchmark {} with {} reached timeout of {:.3f}s".format(
+                    self.label(), ct_point, timeout
+                )
+            )
             os.killpg(os.getpgid(p.pid), signal.SIGTERM)
-            return BenchResult(None, 42, float('inf'))
+            return BenchResult(None, 42, float("inf"))
 
     def ct_workload_space(self, sub_space):
         if not self.build():
@@ -672,7 +729,9 @@ class Bench:
         logger = Logger()
         bench_cache = BenchCache()
         runs_cache = RunsCache()
-        cached_centers = bench_cache.pull_bench_centers(self, ct_workload_point, rt_values)
+        cached_centers = bench_cache.pull_bench_centers(
+            self, ct_workload_point, rt_values
+        )
         if cached_centers:
             logger.info("found benchmark {} in cache".format(self.label()))
             return cached_centers
@@ -702,10 +761,12 @@ class Bench:
         if self.is_base():
             return 1.0
 
-        speedups = self.speedup(ct_workload, rt_values, base_estimator, variant_estimator)
+        speedups = self.speedup(
+            ct_workload, rt_values, base_estimator, variant_estimator
+        )
 
         if not speedups:
-            return float('-inf')
+            return float("-inf")
 
         rt_axes_ids = compute_axes_ids(rt_values)
         weight_matrices = compute_weight_matrices(rt_values, rt_axes_ids)
@@ -715,7 +776,9 @@ class Bench:
             for state in speedups[bench]:
                 rt_workload = state_to_rt_workload(bench, state)
                 weights = weight_matrices[bench]
-                weight = get_workload_weight(rt_workload, rt_values[bench], rt_axes_ids[bench], weights)
+                weight = get_workload_weight(
+                    rt_workload, rt_values[bench], rt_axes_ids[bench], weights
+                )
                 speedup = speedups[bench][state]
                 score = score + weight * speedup
 

--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -8,10 +8,10 @@ import subprocess
 import numpy as np
 
 from .cmake import CMake
-from .config import *
+from .config import BasePoint, Config
 from .storage import Storage, get_bench_table_name
-from .score import *
-from .logger import *
+from .score import compute_axes_ids, compute_weight_matrices, get_workload_weight
+from .logger import Logger
 
 
 def first_val(my_dict):

--- a/benchmarks/scripts/cccl/bench/build.py
+++ b/benchmarks/scripts/cccl/bench/build.py
@@ -1,8 +1,7 @@
-
 class Build:
-  def __init__(self, code, elapsed):
-      self.code = code
-      self.elapsed = elapsed
+    def __init__(self, code, elapsed):
+        self.code = code
+        self.elapsed = elapsed
 
-  def __repr__(self):
-      return "Build(code = {}, elapsed = {:.4f}s)".format(self.code, self.elapsed)
+    def __repr__(self):
+        return "Build(code = {}, elapsed = {:.4f}s)".format(self.code, self.elapsed)

--- a/benchmarks/scripts/cccl/bench/cmake.py
+++ b/benchmarks/scripts/cccl/bench/cmake.py
@@ -6,7 +6,7 @@ import subprocess
 from .build import Build
 from .config import Config
 from .storage import Storage
-from .logger import *
+from .logger import Logger
 
 
 def create_builds_table(conn):

--- a/benchmarks/scripts/cccl/bench/cmake.py
+++ b/benchmarks/scripts/cccl/bench/cmake.py
@@ -23,105 +23,116 @@ def create_builds_table(conn):
 
 
 class CMakeCache:
-  _instance = None
+    _instance = None
 
-  def __new__(cls, *args, **kwargs):
-      if cls._instance is None:
-          cls._instance = super().__new__(cls, *args, **kwargs)
-          create_builds_table(Storage().connection())
-      return cls._instance
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls, *args, **kwargs)
+            create_builds_table(Storage().connection())
+        return cls._instance
 
-  def pull_build(self, bench):
-      config = Config()
-      ctk = config.ctk
-      cccl = config.cccl
-      conn = Storage().connection()
+    def pull_build(self, bench):
+        config = Config()
+        ctk = config.ctk
+        cccl = config.cccl
+        conn = Storage().connection()
 
-      with conn:
-          query = "SELECT code, elapsed FROM builds WHERE ctk = ? AND cccl = ? AND bench = ?;"
-          result = conn.execute(query, (ctk, cccl, bench.label())).fetchone()
+        with conn:
+            query = "SELECT code, elapsed FROM builds WHERE ctk = ? AND cccl = ? AND bench = ?;"
+            result = conn.execute(query, (ctk, cccl, bench.label())).fetchone()
 
-          if result:
-              code, elapsed = result
-              return Build(int(code), float(elapsed))
+            if result:
+                code, elapsed = result
+                return Build(int(code), float(elapsed))
 
-          return result
+            return result
 
-  def push_build(self, bench, build):
-      config = Config()
-      ctk = config.ctk
-      cccl = config.cccl
-      conn = Storage().connection()
+    def push_build(self, bench, build):
+        config = Config()
+        ctk = config.ctk
+        cccl = config.cccl
+        conn = Storage().connection()
 
-      with conn:
-          conn.execute("INSERT INTO builds (ctk, cccl, bench, code, elapsed) VALUES (?, ?, ?, ?, ?);",
-                       (ctk, cccl, bench.label(), build.code, build.elapsed))
+        with conn:
+            conn.execute(
+                "INSERT INTO builds (ctk, cccl, bench, code, elapsed) VALUES (?, ?, ?, ?, ?);",
+                (ctk, cccl, bench.label(), build.code, build.elapsed),
+            )
 
 
 class CMake:
-  def __init__(self):
-    pass
+    def __init__(self):
+        pass
 
-  def do_build(self, bench, timeout):
-      logger = Logger()
+    def do_build(self, bench, timeout):
+        logger = Logger()
 
-      try:
-          if not bench.is_base():
-              with open(bench.exe_name() + ".h", "w") as f:
-                  f.writelines(bench.definitions())
+        try:
+            if not bench.is_base():
+                with open(bench.exe_name() + ".h", "w") as f:
+                    f.writelines(bench.definitions())
 
-          cmd = ["cmake", "--build", ".", "--target", bench.exe_name()]
-          logger.info("starting build for {}: {}".format(bench.label(), " ".join(cmd)))
+            cmd = ["cmake", "--build", ".", "--target", bench.exe_name()]
+            logger.info(
+                "starting build for {}: {}".format(bench.label(), " ".join(cmd))
+            )
 
-          begin = time.time()
-          p = subprocess.Popen(cmd,
-                              start_new_session=True,
-                              stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL)
-          p.wait(timeout=timeout)
-          elapsed = time.time() - begin
-          logger.info("finished build for {} (exit code: {}) in {:.3f}s".format(bench.label(), p.returncode, elapsed))
+            begin = time.time()
+            p = subprocess.Popen(
+                cmd,
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            p.wait(timeout=timeout)
+            elapsed = time.time() - begin
+            logger.info(
+                "finished build for {} (exit code: {}) in {:.3f}s".format(
+                    bench.label(), p.returncode, elapsed
+                )
+            )
 
-          return Build(p.returncode, elapsed)
-      except subprocess.TimeoutExpired:
-          logger.info("build for {} reached timeout of {}s".format(bench.label(), timeout))
-          os.killpg(os.getpgid(p.pid), signal.SIGTERM)
-          return Build(424242, float('inf'))
+            return Build(p.returncode, elapsed)
+        except subprocess.TimeoutExpired:
+            logger.info(
+                "build for {} reached timeout of {}s".format(bench.label(), timeout)
+            )
+            os.killpg(os.getpgid(p.pid), signal.SIGTERM)
+            return Build(424242, float("inf"))
 
-  def build(self, bench):
-      logger = Logger()
-      timeout = None
+    def build(self, bench):
+        logger = Logger()
+        timeout = None
 
-      cache = CMakeCache()
+        cache = CMakeCache()
 
-      if bench.is_base():
-          # Only base build can be pulled from cache
-          build = cache.pull_build(bench)
+        if bench.is_base():
+            # Only base build can be pulled from cache
+            build = cache.pull_build(bench)
 
-          if build:
-              logger.info("found cached base build for {}".format(bench.label()))
-              if bench.is_base():
-                  if not os.path.exists("bin/{}".format(bench.exe_name())):
-                      self.do_build(bench, None)
+            if build:
+                logger.info("found cached base build for {}".format(bench.label()))
+                if bench.is_base():
+                    if not os.path.exists("bin/{}".format(bench.exe_name())):
+                        self.do_build(bench, None)
 
-              return build
-      else:
-          base_build = self.build(bench.get_base())
+                return build
+        else:
+            base_build = self.build(bench.get_base())
 
-          if base_build.code != 0:
-              raise Exception("Base build failed")
+            if base_build.code != 0:
+                raise Exception("Base build failed")
 
-          timeout = base_build.elapsed * 10
+            timeout = base_build.elapsed * 10
 
-      build = self.do_build(bench, timeout)
-      cache.push_build(bench, build)
-      return build
+        build = self.do_build(bench, timeout)
+        cache.push_build(bench, build)
+        return build
 
-  def clean():
-      cmd = ["cmake", "--build", ".", "--target", "clean"]
-      p = subprocess.Popen(cmd, stdout=subprocess.DEVNULL,
-                           stderr=subprocess.DEVNULL)
-      p.wait()
+    def clean():
+        cmd = ["cmake", "--build", ".", "--target", "clean"]
+        p = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        p.wait()
 
-      if p.returncode != 0:
-          raise Exception("Unable to clean build directory")
+        if p.returncode != 0:
+            raise Exception("Unable to clean build directory")

--- a/benchmarks/scripts/cccl/bench/config.py
+++ b/benchmarks/scripts/cccl/bench/config.py
@@ -5,8 +5,8 @@ import random
 
 def randomized_cartesian_product(list_of_lists):
     length = 1
-    for l in list_of_lists:
-        length *= len(l)
+    for lst in list_of_lists:
+        length *= len(lst)
 
     visited = set()
     while len(visited) < length:

--- a/benchmarks/scripts/cccl/bench/config.py
+++ b/benchmarks/scripts/cccl/bench/config.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import random
-import itertools
 
 
 def randomized_cartesian_product(list_of_lists):
@@ -39,8 +38,10 @@ class VariantPoint:
 
     def label(self):
         if self.is_base():
-            return 'base'
-        return '.'.join(["{}_{}".format(point.label, point.value) for point in self.range_points])
+            return "base"
+        return ".".join(
+            ["{}_{}".format(point.label, point.value) for point in self.range_points]
+        )
 
     def is_base(self):
         return len(self.range_points) == 0
@@ -63,9 +64,9 @@ class BasePoint(VariantPoint):
 def parse_ranges(columns):
     ranges = []
     for column in columns:
-        definition, label_range = column.split('|')
-        label, range = label_range.split('=')
-        start, end, step = [int(x) for x in range.split(':')]
+        definition, label_range = column.split("|")
+        label, range = label_range.split("=")
+        start, end, step = [int(x) for x in range.split(":")]
         ranges.append(Range(definition, label, start, end + 1, step))
 
     return ranges
@@ -74,8 +75,9 @@ def parse_ranges(columns):
 def parse_meta():
     if not os.path.isfile("cccl_meta_bench.csv"):
         print("cccl_meta_bench.csv not found", file=sys.stderr)
-        print("make sure to run the script from the CUB build directory",
-              file=sys.stderr)
+        print(
+            "make sure to run the script from the CUB build directory", file=sys.stderr
+        )
 
     benchmarks = {}
     ctk_version = "0.0.0"
@@ -83,10 +85,10 @@ def parse_meta():
     with open("cccl_meta_bench.csv", "r") as f:
         lines = f.readlines()
         for line in lines:
-            if ',' in line:
-                columns = line.split(',')
+            if "," in line:
+                columns = line.split(",")
             else:
-                columns = [' '.join(line.split())]
+                columns = [" ".join(line.split())]
 
             name = columns[0]
 
@@ -109,7 +111,9 @@ class Config:
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
             cls._instance = super().__new__(cls, *args, **kwargs)
-            cls._instance.ctk, cls._instance.cccl, cls._instance.benchmarks = parse_meta()
+            cls._instance.ctk, cls._instance.cccl, cls._instance.benchmarks = (
+                parse_meta()
+            )
         return cls._instance
 
     def label_to_variant_point(self, algname, label):
@@ -121,8 +125,8 @@ class Config:
             label_to_definition[param_space.label] = param_space.definition
 
         points = []
-        for point in label.split('.'):
-            label, value = point.split('_')
+        for point in label.split("."):
+            label, value = point.split("_")
             points.append(RangePoint(label_to_definition[label], label, int(value)))
 
         return VariantPoint(points)
@@ -132,12 +136,18 @@ class Config:
         for param_space in self.benchmarks[algname]:
             variants.append([])
             for value in range(param_space.low, param_space.high, param_space.step):
-                variants[-1].append(RangePoint(param_space.definition, param_space.label, value))
+                variants[-1].append(
+                    RangePoint(param_space.definition, param_space.label, value)
+                )
 
-        return (VariantPoint(points) for points in randomized_cartesian_product(variants))
+        return (
+            VariantPoint(points) for points in randomized_cartesian_product(variants)
+        )
 
     def variant_space_size(self, algname):
         num_variants = 1
         for param_space in self.benchmarks[algname]:
-            num_variants = num_variants * len(range(param_space.low, param_space.high, param_space.step))
+            num_variants = num_variants * len(
+                range(param_space.low, param_space.high, param_space.step)
+            )
         return num_variants

--- a/benchmarks/scripts/cccl/bench/logger.py
+++ b/benchmarks/scripts/cccl/bench/logger.py
@@ -1,5 +1,6 @@
 import logging
 
+
 class Logger:
     _instance = None
 
@@ -8,8 +9,8 @@ class Logger:
             cls._instance = super().__new__(cls, *args, **kwargs)
             logger = logging.getLogger()
             logger.setLevel(logging.DEBUG)
-            file_handler = logging.FileHandler('cccl_meta_bench.log')
-            file_handler.setFormatter(logging.Formatter('%(asctime)s: %(message)s'))
+            file_handler = logging.FileHandler("cccl_meta_bench.log")
+            file_handler.setFormatter(logging.Formatter("%(asctime)s: %(message)s"))
             logger.addHandler(file_handler)
             cls._instance.logger = logger
 

--- a/benchmarks/scripts/cccl/bench/score.py
+++ b/benchmarks/scripts/cccl/bench/score.py
@@ -14,9 +14,9 @@ def compute_weights(num_values):
     least_importance = 0.6
     most_importance = 0.999
 
-    assert(least_importance < most_importance)
-    assert(least_importance >= 0 and least_importance < 1)
-    assert(most_importance > 0 and most_importance < 1)
+    assert least_importance < most_importance
+    assert least_importance >= 0 and least_importance < 1
+    assert most_importance > 0 and most_importance < 1
 
     begin = x_by_importance(least_importance)
     end = x_by_importance(most_importance)
@@ -47,6 +47,7 @@ def compute_axes_ids(rt_axes_values):
         result[bench] = rt_axes_ids
     return result
 
+
 def compute_raw_weight_matrix(rt_axes_values, rt_axes_ids):
     rt_axes_weights = {}
 
@@ -58,7 +59,7 @@ def compute_raw_weight_matrix(rt_axes_values, rt_axes_ids):
             first_rt_axis = False
         values = rt_axes_values[rt_axis]
         rt_axes_values[rt_axis] = values
-        if '{io}' in rt_axis:
+        if "{io}" in rt_axis:
             rt_axes_weights[rt_axis] = io_weights(values)
         else:
             rt_axes_weights[rt_axis] = ei_weights(values)
@@ -78,11 +79,14 @@ def compute_raw_weight_matrix(rt_axes_values, rt_axes_ids):
 
     return weights_matrix
 
+
 def compute_weight_matrices(rt_axes_values, rt_axes_ids):
     matrices = {}
     aggregate = 0.0
     for bench in rt_axes_values:
-        matrices[bench] = compute_raw_weight_matrix(rt_axes_values[bench], rt_axes_ids[bench])
+        matrices[bench] = compute_raw_weight_matrix(
+            rt_axes_values[bench], rt_axes_ids[bench]
+        )
         aggregate = aggregate + np.sum(matrices[bench])
     for bench in rt_axes_values:
         matrices[bench] = matrices[bench] / aggregate
@@ -92,9 +96,10 @@ def compute_weight_matrices(rt_axes_values, rt_axes_ids):
 def get_workload_coordinates(rt_workload, rt_axes_values, rt_axes_ids):
     coordinates = [0] * len(rt_axes_ids)
     for point in rt_workload:
-        rt_axis, rt_value = point.split('=')
+        rt_axis, rt_value = point.split("=")
         coordinates[rt_axes_ids[rt_axis]] = rt_axes_values[rt_axis].index(rt_value)
     return coordinates
+
 
 def get_workload_weight(rt_workload, rt_axes_values, rt_axes_ids, weights_matrix):
     coordinates = get_workload_coordinates(rt_workload, rt_axes_values, rt_axes_ids)

--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -26,11 +26,11 @@ def list_benches(algnames):
 def parse_sub_space(args):
     sub_space = {}
     for axis in args:
-        name, value = axis.split('=')
+        name, value = axis.split("=")
 
-        if '[' in value:
-            value = value.replace('[', '').replace(']', '')
-            values = value.split(',')
+        if "[" in value:
+            value = value.replace("[", "").replace("]", "")
+            values = value.split(",")
         else:
             values = [value]
         sub_space[name] = values
@@ -40,30 +40,61 @@ def parse_sub_space(args):
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
-        description="Runs benchmarks and stores results in a database.")
-    parser.add_argument('-R', type=str, default='.*',
-                        help="Regex for benchmarks selection.")
-    parser.add_argument('-a', '--args', action='append',
-                        type=str, help="Parameter in the format `Param=Value`.")
-    parser.add_argument('-l', '--list-benches', action='store_true', help="Show available benchmarks.")
-    parser.add_argument('--num-shards', type=int, default=1,
-                        help='Split benchmarks into NUM_SHARDS pieces and only run one')
-    parser.add_argument('--run-shard', type=int, default=0, help='Run benchmark shard RUN_SHARD from NUM_SHARDS pieces')
-    parser.add_argument('-P0', action='store_true', help="Run P0 benchmarks")
+        description="Runs benchmarks and stores results in a database."
+    )
+    parser.add_argument(
+        "-R", type=str, default=".*", help="Regex for benchmarks selection."
+    )
+    parser.add_argument(
+        "-a",
+        "--args",
+        action="append",
+        type=str,
+        help="Parameter in the format `Param=Value`.",
+    )
+    parser.add_argument(
+        "-l", "--list-benches", action="store_true", help="Show available benchmarks."
+    )
+    parser.add_argument(
+        "--num-shards",
+        type=int,
+        default=1,
+        help="Split benchmarks into NUM_SHARDS pieces and only run one",
+    )
+    parser.add_argument(
+        "--run-shard",
+        type=int,
+        default=0,
+        help="Run benchmark shard RUN_SHARD from NUM_SHARDS pieces",
+    )
+    parser.add_argument("-P0", action="store_true", help="Run P0 benchmarks")
     return parser.parse_args()
 
 
 def filter_benchmark_space_for_p0(algname, ct_space, rt_values):
-    if algname in ['cub.bench.merge_sort.pairs', 'cub.bench.radix_sort.pairs', 'cub.bench.select.unique_by_key']:
-        ct_space = list(filter(lambda variant: not (("OffsetT{ct}=I64" in variant) or ("KeyT{ct}=I16" in variant) or (
-                "ValueT{ct}=I16" in variant) or ("KeyT{ct}=I128" in variant) or ("ValueT{ct}=I128" in variant)),
-                               ct_space))
+    if algname in [
+        "cub.bench.merge_sort.pairs",
+        "cub.bench.radix_sort.pairs",
+        "cub.bench.select.unique_by_key",
+    ]:
+        ct_space = list(
+            filter(
+                lambda variant: not (
+                    ("OffsetT{ct}=I64" in variant)
+                    or ("KeyT{ct}=I16" in variant)
+                    or ("ValueT{ct}=I16" in variant)
+                    or ("KeyT{ct}=I128" in variant)
+                    or ("ValueT{ct}=I128" in variant)
+                ),
+                ct_space,
+            )
+        )
 
-    if algname == 'cub.bench.merge_sort.pairs':
+    if algname == "cub.bench.merge_sort.pairs":
         for subbench in rt_values:
             for axis in rt_values[subbench]:
                 if axis == "Entropy":
-                    rt_values[subbench][axis] = ['1.000']
+                    rt_values[subbench][axis] = ["1.000"]
 
     return ct_space, rt_values
 
@@ -75,10 +106,14 @@ def run_benches(algnames, sub_space, seeker, args):
             ct_space = bench.ct_workload_space(sub_space)
             rt_values = bench.rt_axes_values(sub_space)
             if args.P0:
-                ct_space, rt_values = filter_benchmark_space_for_p0(algname, ct_space, rt_values)
+                ct_space, rt_values = filter_benchmark_space_for_p0(
+                    algname, ct_space, rt_values
+                )
             seeker(algname, ct_space, rt_values)
         except Exception as e:
-            print("#### ERROR exception occured while running {}: '{}'".format(algname, e))
+            print(
+                "#### ERROR exception occured while running {}: '{}'".format(algname, e)
+            )
 
 
 def filter_benchmarks_by_regex(benchmarks, R):
@@ -88,11 +123,13 @@ def filter_benchmarks_by_regex(benchmarks, R):
 
 def filter_benchmarks(benchmarks, args):
     if args.run_shard >= args.num_shards:
-        raise ValueError('run-shard must be less than num-shards')
+        raise ValueError("run-shard must be less than num-shards")
 
     algnames = filter_benchmarks_by_regex(benchmarks.keys(), args.R)
     if args.P0:
-        algnames = filter_benchmarks_by_regex(algnames, '^(?!.*segmented).*(scan|reduce|select|sort).*')
+        algnames = filter_benchmarks_by_regex(
+            algnames, "^(?!.*segmented).*(scan|reduce|select|sort).*"
+        )
     algnames.sort()
 
     if args.num_shards > 1:
@@ -148,9 +185,11 @@ class BruteForceSeeker:
             for variant in variants:
                 bench = Bench(algname, variant, list(ct_workload))
                 if bench.build():
-                    score = bench.score(ct_workload,
-                                        rt_values,
-                                        self.base_center_estimator,
-                                        self.variant_center_estimator)
+                    score = bench.score(
+                        ct_workload,
+                        rt_values,
+                        self.base_center_estimator,
+                        self.variant_center_estimator,
+                    )
 
                     print(bench.label(), score)

--- a/benchmarks/scripts/cccl/bench/storage.py
+++ b/benchmarks/scripts/cccl/bench/storage.py
@@ -28,25 +28,29 @@ class StorageBase:
 
     def algnames(self):
         with self.conn:
-            rows = self.conn.execute('SELECT DISTINCT algorithm FROM subbenches').fetchall()
+            rows = self.conn.execute(
+                "SELECT DISTINCT algorithm FROM subbenches"
+            ).fetchall()
             return [row[0] for row in rows]
 
     def subbenches(self, algname):
         with self.conn:
-            rows = self.conn.execute('SELECT DISTINCT bench FROM subbenches WHERE algorithm=?', (algname,)).fetchall()
+            rows = self.conn.execute(
+                "SELECT DISTINCT bench FROM subbenches WHERE algorithm=?", (algname,)
+            ).fetchall()
             return [row[0] for row in rows]
 
     def alg_to_df(self, algname, subbench):
         table = get_bench_table_name(subbench, algname)
         with self.conn:
-            df = pd.read_sql_query("SELECT * FROM \"{}\"".format(table), self.conn)
-            df['samples'] = df['samples'].apply(blob_to_samples)
+            df = pd.read_sql_query('SELECT * FROM "{}"'.format(table), self.conn)
+            df["samples"] = df["samples"].apply(blob_to_samples)
 
         return df
 
     def store_df(self, algname, df):
-        df['samples'] = df['samples'].apply(fpzip.compress)
-        df.to_sql(algname, self.conn, if_exists='replace', index=False)
+        df["samples"] = df["samples"].apply(fpzip.compress)
+        df.to_sql(algname, self.conn, if_exists="replace", index=False)
 
 
 class Storage:

--- a/benchmarks/scripts/run.py
+++ b/benchmarks/scripts/run.py
@@ -7,65 +7,74 @@ import cccl.bench
 
 
 def elapsed_time_looks_good(x):
-  if isinstance(x, float):
-    if math.isfinite(x):
-      return True
-  return False
+    if isinstance(x, float):
+        if math.isfinite(x):
+            return True
+    return False
 
 
 def get_largest_problem_size(rt_values):
-  # Small problem sizes do not utilize entire GPU.
-  # Benchmarking small problem sizes in environments where we do not control
-  # distributions comparison, e.g. CI, is not useful because of stability issues.
-  elements = []
-  for element in rt_values:
-    if element.isdigit():
-      elements.append(int(element))
-  return [str(max(elements))]
+    # Small problem sizes do not utilize entire GPU.
+    # Benchmarking small problem sizes in environments where we do not control
+    # distributions comparison, e.g. CI, is not useful because of stability issues.
+    elements = []
+    for element in rt_values:
+        if element.isdigit():
+            elements.append(int(element))
+    return [str(max(elements))]
+
 
 def filter_runtime_workloads_for_ci(rt_values):
-  for subbench in rt_values:
-    for axis in rt_values[subbench]:
-      if axis.startswith('Elements') and axis.endswith('[pow2]'):
-        rt_values[subbench][axis] = get_largest_problem_size(rt_values[subbench][axis])
+    for subbench in rt_values:
+        for axis in rt_values[subbench]:
+            if axis.startswith("Elements") and axis.endswith("[pow2]"):
+                rt_values[subbench][axis] = get_largest_problem_size(
+                    rt_values[subbench][axis]
+                )
 
-  return rt_values
+    return rt_values
 
 
 class BaseRunner:
-  def __init__(self):
-    self.estimator = cccl.bench.MedianCenterEstimator()
+    def __init__(self):
+        self.estimator = cccl.bench.MedianCenterEstimator()
 
-  def __call__(self, algname, ct_workload_space, rt_values):
-    failure_occured = False
-    rt_values = filter_runtime_workloads_for_ci(rt_values)
+    def __call__(self, algname, ct_workload_space, rt_values):
+        failure_occured = False
+        rt_values = filter_runtime_workloads_for_ci(rt_values)
 
-    for ct_workload in ct_workload_space:
-      bench = cccl.bench.BaseBench(algname)
-      if bench.build(): # might throw
-        results = bench.run(ct_workload, rt_values, self.estimator, False)
-        for subbench in results:
-          for point in results[subbench]:
-            bench_name = "{}.{}-{}".format(bench.algorithm_name(), subbench, point)
-            bench_name = bench_name.replace(' ', '___')
-            bench_name = "".join(c if c.isalnum() else "_" for c in bench_name)
-            elapsed_time = results[subbench][point]
-            if elapsed_time_looks_good(elapsed_time):
-              print("&&&& PERF {} {} -sec".format(bench_name, elapsed_time))
-      else:
-        failure_occured = True
-        print("&&&& FAILED {}".format(algname))
+        for ct_workload in ct_workload_space:
+            bench = cccl.bench.BaseBench(algname)
+            if bench.build():  # might throw
+                results = bench.run(ct_workload, rt_values, self.estimator, False)
+                for subbench in results:
+                    for point in results[subbench]:
+                        bench_name = "{}.{}-{}".format(
+                            bench.algorithm_name(), subbench, point
+                        )
+                        bench_name = bench_name.replace(" ", "___")
+                        bench_name = "".join(
+                            c if c.isalnum() else "_" for c in bench_name
+                        )
+                        elapsed_time = results[subbench][point]
+                        if elapsed_time_looks_good(elapsed_time):
+                            print(
+                                "&&&& PERF {} {} -sec".format(bench_name, elapsed_time)
+                            )
+            else:
+                failure_occured = True
+                print("&&&& FAILED {}".format(algname))
 
-    if failure_occured:
-      sys.exit(1)
+        if failure_occured:
+            sys.exit(1)
 
 
 def main():
-  print("&&&& RUNNING bench")
-  os.environ["CUDA_MODULE_LOADING"] = "EAGER"
-  cccl.bench.search(BaseRunner())
-  print("&&&& PASSED bench")
+    print("&&&& RUNNING bench")
+    os.environ["CUDA_MODULE_LOADING"] = "EAGER"
+    cccl.bench.search(BaseRunner())
+    print("&&&& PASSED bench")
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import sys
 import cccl
 import argparse
 import numpy as np
@@ -18,25 +17,25 @@ def is_finite(x):
 
 def filter_by_problem_size(df):
     min_elements_pow2 = 28
-    if 'Elements{io}[pow2]' in df.columns:
-        df['Elements{io}[pow2]'] = df['Elements{io}[pow2]'].astype(int)
-        df = df[df['Elements{io}[pow2]'] >= min_elements_pow2]
+    if "Elements{io}[pow2]" in df.columns:
+        df["Elements{io}[pow2]"] = df["Elements{io}[pow2]"].astype(int)
+        df = df[df["Elements{io}[pow2]"] >= min_elements_pow2]
     return df
 
 
 def filter_by_offset_type(df):
-    if 'OffsetT{ct}' in df.columns:
-        df = df[(df['OffsetT{ct}'] == 'I32') | (df['OffsetT{ct}'] == 'U32')]
+    if "OffsetT{ct}" in df.columns:
+        df = df[(df["OffsetT{ct}"] == "I32") | (df["OffsetT{ct}"] == "U32")]
     return df
 
 
 def filter_by_type(df):
-    if 'T{ct}' in df:
+    if "T{ct}" in df:
         # df = df[df['T{ct}'].str.contains('64')]
-        df = df[~df['T{ct}'].str.contains('C')]
-    elif 'KeyT{ct}' in df:
+        df = df[~df["T{ct}"].str.contains("C")]
+    elif "KeyT{ct}" in df:
         # df = df[df['KeyT{ct}'].str.contains('64')]
-        df = df[~df['KeyT{ct}'].str.contains('C')]
+        df = df[~df["KeyT{ct}"].str.contains("C")]
     return df
 
 
@@ -48,12 +47,16 @@ def alg_dfs(files):
             for subbench in storage.subbenches(algname):
                 df = storage.alg_to_df(algname, subbench)
                 df = df.map(lambda x: x if is_finite(x) else np.nan)
-                df = df.dropna(subset=['center'], how='all')
+                df = df.dropna(subset=["center"], how="all")
                 df = filter_by_type(filter_by_offset_type(filter_by_problem_size(df)))
-                df = df.filter(items=['ctk', 'cccl', 'gpu', 'variant', 'bw'])
-                df['variant'] = df['variant'].astype(str)
-                df['bw'] = df['bw'] * 100
-                fused_algname = algname.removeprefix("cub.bench.").removeprefix("thrust.bench.") + '.' + subbench
+                df = df.filter(items=["ctk", "cccl", "gpu", "variant", "bw"])
+                df["variant"] = df["variant"].astype(str)
+                df["bw"] = df["bw"] * 100
+                fused_algname = (
+                    algname.removeprefix("cub.bench.").removeprefix("thrust.bench.")
+                    + "."
+                    + subbench
+                )
                 if fused_algname in result:
                     result[fused_algname] = pd.concat([result[fused_algname], df])
                 else:
@@ -66,23 +69,31 @@ def alg_bws(dfs, verbose):
     medians = None
     for algname in dfs:
         df = dfs[algname]
-        df['alg'] = algname
+        df["alg"] = algname
         if df is None:
             medians = df
         else:
             medians = pd.concat([medians, df])
     # print more information if it's not unique across all runs or when requested (verbose)
-    medians['hue'] = ''
-    if verbose or medians['cccl'].unique().size > 1:
-        medians['hue'] = medians['hue'] + 'CCCL ' + medians['cccl'].astype(str) + ' '
-    gpuname = medians['gpu'] if verbose else medians['gpu'].astype(str).map(lambda x: x[:x.find('(') - 1])
-    medians['hue'] = medians['hue'] + gpuname + ' '
-    if medians['variant'].unique().size > 1:
-        variant = medians['variant'].astype(str).map(lambda x : (' ' + x if x != 'base' else ''))
-        medians['hue'] = medians['hue'] + variant + ' '
-    if verbose or medians['ctk'].unique().size > 1:
-        medians['hue'] = medians['hue'] + 'CTK ' + medians['ctk'].astype(str)
-    return medians.drop(columns=['ctk', 'cccl', 'gpu', 'variant'])
+    medians["hue"] = ""
+    if verbose or medians["cccl"].unique().size > 1:
+        medians["hue"] = medians["hue"] + "CCCL " + medians["cccl"].astype(str) + " "
+    gpuname = (
+        medians["gpu"]
+        if verbose
+        else medians["gpu"].astype(str).map(lambda x: x[: x.find("(") - 1])
+    )
+    medians["hue"] = medians["hue"] + gpuname + " "
+    if medians["variant"].unique().size > 1:
+        variant = (
+            medians["variant"]
+            .astype(str)
+            .map(lambda x: (" " + x if x != "base" else ""))
+        )
+        medians["hue"] = medians["hue"] + variant + " "
+    if verbose or medians["ctk"].unique().size > 1:
+        medians["hue"] = medians["hue"] + "CTK " + medians["ctk"].astype(str)
+    return medians.drop(columns=["ctk", "cccl", "gpu", "variant"])
 
 
 def file_exists(value):
@@ -93,32 +104,47 @@ def file_exists(value):
 
 def plot_sol(medians, box):
     if box:
-        ax = sns.boxenplot(data=medians, x='alg', y='bw', hue='hue')
+        ax = sns.boxenplot(data=medians, x="alg", y="bw", hue="hue")
     else:
-        ax = sns.barplot(data=medians, x='alg', y='bw', hue='hue', errorbar=lambda x: (x.min(), x.max()))
-        ax.bar_label(ax.containers[0], fmt='%.1f')
+        ax = sns.barplot(
+            data=medians,
+            x="alg",
+            y="bw",
+            hue="hue",
+            errorbar=lambda x: (x.min(), x.max()),
+        )
+        ax.bar_label(ax.containers[0], fmt="%.1f")
         for container in ax.containers[1:]:
-            labels = [f'{c:.1f}\n({(c/f)*100:.0f}%)' for f, c in zip(ax.containers[0].datavalues, container.datavalues)]
+            labels = [
+                f"{c:.1f}\n({(c/f)*100:.0f}%)"
+                for f, c in zip(ax.containers[0].datavalues, container.datavalues)
+            ]
             ax.bar_label(container, labels=labels)
 
     ax.legend(title=None)
-    ax.set_xlabel('Algorithm')
-    ax.set_ylabel('Bandwidth (%SOL)')
-    ax.set_xticklabels(ax.get_xticklabels(), rotation=30, rotation_mode='anchor', ha='right')
+    ax.set_xlabel("Algorithm")
+    ax.set_ylabel("Bandwidth (%SOL)")
+    ax.set_xticklabels(
+        ax.get_xticklabels(), rotation=30, rotation_mode="anchor", ha="right"
+    )
     plt.show()
 
+
 def print_speedup(medians):
-    m = medians.groupby(['alg', 'hue'], sort=False).mean()
-    m['speedup'] = (m['bw'] / m.groupby(['alg'])['bw'].transform('first'))
-    print('# Speedups:')
+    m = medians.groupby(["alg", "hue"], sort=False).mean()
+    m["speedup"] = m["bw"] / m.groupby(["alg"])["bw"].transform("first")
+    print("# Speedups:")
     print()
-    print(m.drop(columns='bw').sort_values(by='speedup', ascending=False).to_markdown())
+    print(m.drop(columns="bw").sort_values(by="speedup", ascending=False).to_markdown())
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Analyze benchmark results.")
-    parser.add_argument('files', type=file_exists, nargs='+', help='At least one file is required.')
-    parser.add_argument('--box', action='store_true', help='Plot box instead of bar.')
-    parser.add_argument('-v', action='store_true', help='Verbose legend.')
+    parser.add_argument(
+        "files", type=file_exists, nargs="+", help="At least one file is required."
+    )
+    parser.add_argument("--box", action="store_true", help="Plot box instead of bar.")
+    parser.add_argument("-v", action="store_true", help="Verbose legend.")
     return parser.parse_args()
 
 

--- a/benchmarks/scripts/verify.py
+++ b/benchmarks/scripts/verify.py
@@ -6,11 +6,13 @@ import cccl.bench
 
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(description='Verify tuning variant')
-    parser.add_argument('--variant', type=str, help='Variant to verify', default=None, required=True)
+    parser = argparse.ArgumentParser(description="Verify tuning variant")
+    parser.add_argument(
+        "--variant", type=str, help="Variant to verify", default=None, required=True
+    )
 
     variant = parser.parse_known_args()[0].variant
-    sys.argv.remove('--variant={}'.format(variant))
+    sys.argv.remove("--variant={}".format(variant))
 
     return variant
 
@@ -19,12 +21,12 @@ def workload_header(ct_workload_space, rt_workload_space):
     for ct_workload in ct_workload_space:
         for rt_workload in rt_workload_space:
             workload_point = ct_workload + rt_workload
-            return ", ".join([x.split('=')[0] for x in workload_point])
+            return ", ".join([x.split("=")[0] for x in workload_point])
 
 
 def workload_entry(ct_workload, rt_workload):
     workload_point = ct_workload + rt_workload
-    return ", ".join([x.split('=')[1] for x in workload_point])
+    return ", ".join([x.split("=")[1] for x in workload_point])
 
 
 class VerifySeeker:
@@ -35,7 +37,11 @@ class VerifySeeker:
     def __call__(self, algname, ct_workload_space, rt_workload_space):
         variant_point = cccl.bench.Config().label_to_variant_point(algname, self.label)
 
-        print("{}, MinS, MedianS, MaxS".format(workload_header(ct_workload_space, rt_workload_space)))
+        print(
+            "{}, MinS, MedianS, MaxS".format(
+                workload_header(ct_workload_space, rt_workload_space)
+            )
+        )
         for ct_workload in ct_workload_space:
             bench = cccl.bench.Bench(algname, variant_point, list(ct_workload))
             if bench.build():
@@ -45,10 +51,16 @@ class VerifySeeker:
                     base_samples, base_elapsed = base.do_run(workload_point, None)
                     variant_samples, _ = bench.do_run(workload_point, base_elapsed * 10)
                     min_speedup = min(base_samples) / min(variant_samples)
-                    median_speedup = self.estimator(base_samples) / self.estimator(variant_samples)
+                    median_speedup = self.estimator(base_samples) / self.estimator(
+                        variant_samples
+                    )
                     max_speedup = max(base_samples) / max(variant_samples)
                     point_str = workload_entry(ct_workload, rt_workload)
-                    print("{}, {}, {}, {}".format(point_str, min_speedup, median_speedup, max_speedup))
+                    print(
+                        "{}, {}, {}, {}".format(
+                            point_str, min_speedup, median_speedup, max_speedup
+                        )
+                    )
 
 
 def main():

--- a/cub/benchmarks/docker/recipe.py
+++ b/cub/benchmarks/docker/recipe.py
@@ -2,12 +2,25 @@
 
 import hpccm
 
-hpccm.config.set_container_format('docker')
+hpccm.config.set_container_format("docker")
 
-Stage0 += hpccm.primitives.baseimage(image='nvidia/cuda:12.2.0-devel-ubuntu22.04')
-Stage0 += hpccm.building_blocks.apt_get(ospackages=['git', 'tmux', 'gcc', 'g++', 'vim', 'python3', 'python-is-python3', 'ninja-build'])
+Stage0 += hpccm.primitives.baseimage(image="nvidia/cuda:12.2.0-devel-ubuntu22.04")
+Stage0 += hpccm.building_blocks.apt_get(
+    ospackages=[
+        "git",
+        "tmux",
+        "gcc",
+        "g++",
+        "vim",
+        "python3",
+        "python-is-python3",
+        "ninja-build",
+    ]
+)
 # Stage0 += hpccm.building_blocks.llvm(version='15', extra_tools=True, toolset=True)
-Stage0 += hpccm.building_blocks.cmake(eula=True, version='3.26.3')
+Stage0 += hpccm.building_blocks.cmake(eula=True, version="3.26.3")
 # Stage0 += hpccm.building_blocks.nsight_compute(eula=True, version='2023.1.1')
-Stage0 += hpccm.building_blocks.pip(packages=['fpzip', 'numpy', 'pandas', 'pynvml'], pip='pip3')
-Stage0 += hpccm.primitives.environment(variables={'CUDA_MODULE_LOADING': 'EAGER'})
+Stage0 += hpccm.building_blocks.pip(
+    packages=["fpzip", "numpy", "pandas", "pynvml"], pip="pip3"
+)
+Stage0 += hpccm.primitives.environment(variables={"CUDA_MODULE_LOADING": "EAGER"})

--- a/cub/benchmarks/docker/recipe.py
+++ b/cub/benchmarks/docker/recipe.py
@@ -4,7 +4,7 @@ import hpccm
 
 hpccm.config.set_container_format("docker")
 
-Stage0 += hpccm.primitives.baseimage(image="nvidia/cuda:12.2.0-devel-ubuntu22.04")
+Stage0 = hpccm.primitives.baseimage(image="nvidia/cuda:12.2.0-devel-ubuntu22.04")
 Stage0 += hpccm.building_blocks.apt_get(
     ospackages=[
         "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+target-version = "py310"

--- a/python/cuda_cooperative/cuda/cooperative/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/__init__.py
@@ -2,5 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import cuda.cooperative.experimental
 from cuda.cooperative._version import __version__
+
+__all__ = ["__version__"]

--- a/python/cuda_cooperative/cuda/cooperative/experimental/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/__init__.py
@@ -2,5 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from cuda.cooperative.experimental import block, warp
+from cuda.cooperative.experimental import block
+from cuda.cooperative.experimental import warp
 from cuda.cooperative.experimental._types import StatefulFunction
+
+__all__ = ["block", "warp", "StatefulFunction"]

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_caching.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_caching.py
@@ -7,19 +7,21 @@ import pickle
 import json
 import hashlib
 
-_ENABLE_CACHE = 'CCCL_ENABLE_CACHE' in os.environ
+_ENABLE_CACHE = "CCCL_ENABLE_CACHE" in os.environ
 if _ENABLE_CACHE:
     _CACHE_LOCATION = os.path.join(os.path.expanduser("~"), ".cache", "cccl")
     if not os.path.exists(_CACHE_LOCATION):
         os.makedirs(_CACHE_LOCATION)
+
 
 # We use
 # json.dumps to serialize args/kwargs to a string
 # hashlib to compute the hash
 def json_hash(*args, **kwargs):
     hasher = hashlib.sha1()
-    hasher.update(json.dumps([args, kwargs]).encode('utf-8'))
+    hasher.update(json.dumps([args, kwargs]).encode("utf-8"))
     return hasher.hexdigest()
+
 
 def disk_cache(func):
     def cacher(*args, **kwargs):
@@ -29,7 +31,7 @@ def disk_cache(func):
             # if file exist...
             if os.path.isfile(os.path.join(_CACHE_LOCATION, h)):
                 # open it
-                with open(os.path.join(_CACHE_LOCATION, h), 'rb') as f:
+                with open(os.path.join(_CACHE_LOCATION, h), "rb") as f:
                     out = pickle.load(f)
                 # return cache
                 return out
@@ -37,7 +39,7 @@ def disk_cache(func):
                 # compute output
                 out = func(*args, **kwargs)
                 # store to file
-                with open(os.path.join(_CACHE_LOCATION, h), 'wb') as f:
+                with open(os.path.join(_CACHE_LOCATION, h), "wb") as f:
                     pickle.dump(out, f)
                 return out
         else:

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -6,37 +6,45 @@ import tempfile
 import re
 from collections import namedtuple
 
-version = namedtuple('version', ('major', 'minor'))
-code = namedtuple('code', ('kind', 'version', 'data'))
-symbol = namedtuple('symbol', ('kind', 'name'))
-dim3 = namedtuple('dim3', ('x', 'y', 'z'))
+version = namedtuple("version", ("major", "minor"))
+code = namedtuple("code", ("kind", "version", "data"))
+symbol = namedtuple("symbol", ("kind", "name"))
+dim3 = namedtuple("dim3", ("x", "y", "z"))
+
 
 def make_binary_tempfile(content, suffix):
-    tmp = tempfile.NamedTemporaryFile(mode='w+b', suffix=suffix, buffering=0)
+    tmp = tempfile.NamedTemporaryFile(mode="w+b", suffix=suffix, buffering=0)
     tmp.write(content)
     return tmp
+
 
 def check_in(name, arg, set):
     if arg not in set:
         raise ValueError(f"{name} must be in {set} ; got {name} = {arg}")
 
+
 def check_not_in(name, arg, set):
     if arg in set:
-        raise ValueError(f"{name} must not be any of those value {set} ; got {name} = {arg}")
+        raise ValueError(
+            f"{name} must not be any of those value {set} ; got {name} = {arg}"
+        )
+
 
 def check_contains(set, key):
     if key not in set:
         raise ValueError(f"{key} must be in {set}")
 
+
 def check_dim3(name, arg):
     if len(arg) != 3:
         raise ValueError(f"{name} should be a length-3 tuple ; got {name} = {arg}")
 
+
 def find_unsigned(name, txt):
-    regex = re.compile(f'.global .align 4 .u32 {name} = ([0-9]*);', re.MULTILINE)
+    regex = re.compile(f".global .align 4 .u32 {name} = ([0-9]*);", re.MULTILINE)
     found = regex.search(txt)
-    if found is None: # TODO: improve regex logic
-        regex = re.compile(f'.global .align 4 .u32 {name};', re.MULTILINE)
+    if found is None:  # TODO: improve regex logic
+        regex = re.compile(f".global .align 4 .u32 {name};", re.MULTILINE)
         found = regex.search(txt)
         if found is not None:
             return 0
@@ -45,12 +53,19 @@ def find_unsigned(name, txt):
     else:
         return int(found.group(1))
 
+
 def find_mangled_name(name, txt):
-    regex = re.compile(f'[_a-zA-Z0-9]*{name}[_a-zA-Z0-9]*', re.MULTILINE)
+    regex = re.compile(f"[_a-zA-Z0-9]*{name}[_a-zA-Z0-9]*", re.MULTILINE)
     return regex.search(txt).group(0)
 
+
 def find_dim2(name, txt):
-    return (find_unsigned(f'{name}_x', txt), find_unsigned(f'{name}_y', txt))
+    return (find_unsigned(f"{name}_x", txt), find_unsigned(f"{name}_y", txt))
+
 
 def find_dim3(name, txt):
-    return (find_unsigned(f'{name}_x', txt), find_unsigned(f'{name}_y', txt), find_unsigned(f'{name}_z', txt))
+    return (
+        find_unsigned(f"{name}_x", txt),
+        find_unsigned(f"{name}_y", txt),
+        find_unsigned(f"{name}_z", txt),
+    )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_nvrtc.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_nvrtc.py
@@ -20,15 +20,15 @@ def CHECK_NVRTC(err, prog):
 
 
 def get_cuda_path():
-    cuda_path = os.environ.get('CUDA_PATH', '')
+    cuda_path = os.environ.get("CUDA_PATH", "")
     if os.path.exists(cuda_path):
         return cuda_path
 
-    nvcc_path = shutil.which('nvcc')
+    nvcc_path = shutil.which("nvcc")
     if nvcc_path is not None:
         return os.path.dirname(os.path.dirname(nvcc_path))
 
-    default_path = '/usr/local/cuda'
+    default_path = "/usr/local/cuda"
     if os.path.exists(default_path):
         return default_path
 
@@ -43,75 +43,76 @@ def get_cuda_path():
 @functools.lru_cache(maxsize=32)  # Always enabled
 @disk_cache  # Optional, see caching.py
 def compile_impl(cpp, cc, rdc, code, nvrtc_path, nvrtc_version):
-    check_in('rdc', rdc, [True, False])
-    check_in('code', code, ['lto', 'ptx'])
+    check_in("rdc", rdc, [True, False])
+    check_in("code", code, ["lto", "ptx"])
 
-    with pkg_resources.path('cuda', '_include') as include_path:
+    with pkg_resources.path("cuda", "_include") as include_path:
         # Using `.parent` for compatibility with pip install --editable:
-        include_path = pkg_resources.files(
-            'cuda.cooperative').parent.joinpath('_include')
+        include_path = pkg_resources.files("cuda.cooperative").parent.joinpath(
+            "_include"
+        )
         cub_path = include_path
         thrust_path = include_path
-        libcudacxx_path = os.path.join(include_path, 'libcudacxx')
-        cuda_include_path = os.path.join(get_cuda_path(), 'include')
+        libcudacxx_path = os.path.join(include_path, "libcudacxx")
+        cuda_include_path = os.path.join(get_cuda_path(), "include")
 
-    opts = [b"--std=c++17",
-            bytes(f"--include-path={cub_path}", encoding='ascii'),
-            bytes(f"--include-path={thrust_path}", encoding='ascii'),
-            bytes(f"--include-path={libcudacxx_path}", encoding='ascii'),
-            bytes(f"--include-path={cuda_include_path}", encoding='ascii'),
-            bytes(f"--gpu-architecture=compute_{cc}", encoding='ascii')]
+    opts = [
+        b"--std=c++17",
+        bytes(f"--include-path={cub_path}", encoding="ascii"),
+        bytes(f"--include-path={thrust_path}", encoding="ascii"),
+        bytes(f"--include-path={libcudacxx_path}", encoding="ascii"),
+        bytes(f"--include-path={cuda_include_path}", encoding="ascii"),
+        bytes(f"--gpu-architecture=compute_{cc}", encoding="ascii"),
+    ]
     if rdc:
         opts += [b"--relocatable-device-code=true"]
 
-    if code == 'lto':
+    if code == "lto":
         opts += [b"-dlto"]
 
     # Some strange linking issues
     opts += [b"-DCCCL_DISABLE_BF16_SUPPORT"]
 
     # Create program
-    err, prog = nvrtc.nvrtcCreateProgram(
-        str.encode(cpp), b"code.cu", 0, [], [])
+    err, prog = nvrtc.nvrtcCreateProgram(str.encode(cpp), b"code.cu", 0, [], [])
     if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
         raise RuntimeError(f"nvrtcCreateProgram error: {err}")
 
-    err, = nvrtc.nvrtcCompileProgram(prog, len(opts), opts)
+    (err,) = nvrtc.nvrtcCompileProgram(prog, len(opts), opts)
     CHECK_NVRTC(err, prog)
 
-    if code == 'lto':
+    if code == "lto":
         err, ltoSize = nvrtc.nvrtcGetLTOIRSize(prog)
         CHECK_NVRTC(err, prog)
 
         lto = b" " * ltoSize
-        err, = nvrtc.nvrtcGetLTOIR(prog, lto)
+        (err,) = nvrtc.nvrtcGetLTOIR(prog, lto)
         CHECK_NVRTC(err, prog)
 
-        err, = nvrtc.nvrtcDestroyProgram(prog)
+        (err,) = nvrtc.nvrtcDestroyProgram(prog)
         CHECK_NVRTC(err, prog)
 
         return lto
 
-    elif code == 'ptx':
+    elif code == "ptx":
         err, ptxSize = nvrtc.nvrtcGetPTXSize(prog)
         CHECK_NVRTC(err, prog)
 
         ptx = b" " * ptxSize
-        err, = nvrtc.nvrtcGetPTX(prog, ptx)
+        (err,) = nvrtc.nvrtcGetPTX(prog, ptx)
         CHECK_NVRTC(err, prog)
 
-        err, = nvrtc.nvrtcDestroyProgram(prog)
+        (err,) = nvrtc.nvrtcDestroyProgram(prog)
         CHECK_NVRTC(err, prog)
 
-        return ptx.decode('ascii')
+        return ptx.decode("ascii")
 
 
 def compile(**kwargs):
-
     err, major, minor = nvrtc.nvrtcVersion()
     if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
         raise RuntimeError(f"nvrtcVersion error: {err}")
     nvrtc_version = version(major, minor)
-    return nvrtc_version, compile_impl(**kwargs,
-                                       nvrtc_path=nvrtc.__file__,
-                                       nvrtc_version=nvrtc_version)
+    return nvrtc_version, compile_impl(
+        **kwargs, nvrtc_path=nvrtc.__file__, nvrtc_version=nvrtc_version
+    )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -7,7 +7,6 @@ import numba
 from numba import cuda, types
 from numba.core import cgutils
 from llvmlite import ir
-from numba import types
 from numba.core.typing import signature
 from numba.core.extending import intrinsic, overload
 from cuda.cooperative.experimental._nvrtc import compile
@@ -16,32 +15,32 @@ import jinja2
 
 
 NUMBA_TYPES_TO_CPP = {
-    types.boolean: 'bool',
-    types.int8: '::cuda::std::int8_t',
-    types.int16: '::cuda::std::int16_t',
-    types.int32: '::cuda::std::int32_t',
-    types.int64: '::cuda::std::int64_t',
-    types.uint8: '::cuda::std::uint8_t',
-    types.uint16: '::cuda::std::uint16_t',
-    types.uint32: '::cuda::std::uint32_t',
-    types.uint64: '::cuda::std::uint64_t',
-    types.float32: 'float',
-    types.float64: 'double'
+    types.boolean: "bool",
+    types.int8: "::cuda::std::int8_t",
+    types.int16: "::cuda::std::int16_t",
+    types.int32: "::cuda::std::int32_t",
+    types.int64: "::cuda::std::int64_t",
+    types.uint8: "::cuda::std::uint8_t",
+    types.uint16: "::cuda::std::uint16_t",
+    types.uint32: "::cuda::std::uint32_t",
+    types.uint64: "::cuda::std::uint64_t",
+    types.float32: "float",
+    types.float64: "double",
 }
 
 
 def numba_type_to_cpp(numba_type):
-    return NUMBA_TYPES_TO_CPP.get(numba_type, 'storage_t')
+    return NUMBA_TYPES_TO_CPP.get(numba_type, "storage_t")
 
 
 def method_to_signature(numba_type, method):
     ptr_type = types.CPointer(numba_type)
-    if method == 'construct':
+    if method == "construct":
         return signature(types.void, ptr_type)
-    elif method == 'assign':
+    elif method == "assign":
         return signature(types.void, ptr_type, ptr_type)
     else:
-        raise ValueError('Unexpected method {}'.format(method))
+        raise ValueError("Unexpected method {}".format(method))
 
 
 class TypeWrapper:
@@ -49,21 +48,18 @@ class TypeWrapper:
         self.lto_irs = []
 
         if numba_type in NUMBA_TYPES_TO_CPP:
-            self.code = ''
+            self.code = ""
         else:
             context = cuda.descriptor.cuda_target.target_context
-            size = context.get_value_type(
-                numba_type).get_abi_size(context.target_data)
-            alignment = context.get_value_type(
-                numba_type).get_abi_alignment(context.target_data)
-            parameters = {
-                'size': size,
-                'alignment': alignment
-            }
-            if 'construct' in methods:
-                parameters['construct'] = methods['construct'].__name__
-            if 'assign' in methods:
-                parameters['assign'] = methods['assign'].__name__
+            size = context.get_value_type(numba_type).get_abi_size(context.target_data)
+            alignment = context.get_value_type(numba_type).get_abi_alignment(
+                context.target_data
+            )
+            parameters = {"size": size, "alignment": alignment}
+            if "construct" in methods:
+                parameters["construct"] = methods["construct"].__name__
+            if "assign" in methods:
+                parameters["assign"] = methods["assign"].__name__
             environment = jinja2.Environment()
             template = environment.from_string("""
         {% if construct %}
@@ -94,8 +90,11 @@ class TypeWrapper:
             self.code = template.render(**parameters)
 
             for method in methods:
-                lto_fn, _ = cuda.compile(methods[method], sig=method_to_signature(
-                    numba_type, method), output='ltoir')
+                lto_fn, _ = cuda.compile(
+                    methods[method],
+                    sig=method_to_signature(numba_type, method),
+                    output="ltoir",
+                )
                 self.lto_irs.append(lto_fn)
 
 
@@ -103,8 +102,8 @@ def numba_type_to_wrapper(numba_type, methods=None):
     if methods is None:
         methods = {}
     for method in methods:
-        if method not in ['construct', 'assign']:
-            raise ValueError('Unexpected method {}'.format(method))
+        if method not in ["construct", "assign"]:
+            raise ValueError("Unexpected method {}".format(method))
     return TypeWrapper(numba_type, methods)
 
 
@@ -113,7 +112,7 @@ class Parameter:
         self.is_output = is_output
 
     def __repr__(self) -> str:
-        return f'Parameter(out={self.is_output})'
+        return f"Parameter(out={self.is_output})"
 
     def specialize(self, _):
         return self
@@ -128,16 +127,16 @@ class Value(Parameter):
         super().__init__(is_output)
 
     def __repr__(self) -> str:
-        return f'Value(dtype={self.value_type}, out={self.is_output})'
+        return f"Value(dtype={self.value_type}, out={self.is_output})"
 
     def dtype(self):
         return self.value_type
 
     def cpp_decl(self, name):
-        return numba_type_to_cpp(self.value_type) + ' ' + name
+        return numba_type_to_cpp(self.value_type) + " " + name
 
     def mangled_name(self):
-        return f'{self.value_type}'
+        return f"{self.value_type}"
 
 
 class Pointer(Parameter):
@@ -146,16 +145,16 @@ class Pointer(Parameter):
         super().__init__(is_output)
 
     def __repr__(self) -> str:
-        return f'Pointer(dtype={self.value_dtype}, out={self.is_output})'
+        return f"Pointer(dtype={self.value_dtype}, out={self.is_output})"
 
     def cpp_decl(self, name):
-        return numba_type_to_cpp(self.value_dtype) + '* ' + name
+        return numba_type_to_cpp(self.value_dtype) + "* " + name
 
     def dtype(self):
-        return numba.types.Array(self.value_dtype, 1, 'A')
+        return numba.types.Array(self.value_dtype, 1, "A")
 
     def mangled_name(self):
-        return f'P{self.value_dtype}'
+        return f"P{self.value_dtype}"
 
 
 class DependentPointer(Parameter):
@@ -164,7 +163,7 @@ class DependentPointer(Parameter):
         super().__init__(is_output)
 
     def __repr__(self) -> str:
-        return f'DependentPointer(dep={self.value_dtype}, out={self.is_output})'
+        return f"DependentPointer(dep={self.value_dtype}, out={self.is_output})"
 
     def specialize(self, template_arguments):
         return Pointer(self.value_dtype.resolve(template_arguments), self.is_output)
@@ -176,16 +175,16 @@ class Reference(Parameter):
         super().__init__(is_output)
 
     def __repr__(self) -> str:
-        return f'Reference(dtype={self.value_dtype}, out={self.is_output})'
+        return f"Reference(dtype={self.value_dtype}, out={self.is_output})"
 
     def cpp_decl(self, name):
-        return numba_type_to_cpp(self.value_dtype) + '& ' + name
+        return numba_type_to_cpp(self.value_dtype) + "& " + name
 
     def dtype(self):
         return self.value_dtype
 
     def mangled_name(self):
-        return f'R{self.value_dtype}'
+        return f"R{self.value_dtype}"
 
 
 class DependentReference(Parameter):
@@ -194,7 +193,7 @@ class DependentReference(Parameter):
         super().__init__(is_output)
 
     def __repr__(self) -> str:
-        return f'DependentReference(dep={self.value_dtype}, out={self.is_output})'
+        return f"DependentReference(dep={self.value_dtype}, out={self.is_output})"
 
     def specialize(self, template_arguments):
         return Reference(self.value_dtype.resolve(template_arguments), self.is_output)
@@ -206,16 +205,16 @@ class Array(Pointer):
         super().__init__(value_dtype, is_output)
 
     def __repr__(self) -> str:
-        return f'Array(dtype={self.value_dtype}, out={self.is_output})'
+        return f"Array(dtype={self.value_dtype}, out={self.is_output})"
 
     def cpp_decl(self, name):
-        return f'{numba_type_to_cpp(self.value_dtype)} (&{name})[{self.size}]'
+        return f"{numba_type_to_cpp(self.value_dtype)} (&{name})[{self.size}]"
 
     def dtype(self):
-        return numba.types.Array(self.value_dtype, 1, 'C')
+        return numba.types.Array(self.value_dtype, 1, "C")
 
     def mangled_name(self):
-        return f'P{self.value_dtype}'
+        return f"P{self.value_dtype}"
 
 
 class SubstitutionFailure(Exception):
@@ -230,10 +229,9 @@ class Dependency:
 
     def resolve(self, template_arguments):
         if self.dep not in template_arguments:
-            raise SubstitutionFailure(
-                f'Template argument {self.dep} not provided')
+            raise SubstitutionFailure(f"Template argument {self.dep} not provided")
         if template_arguments[self.dep] is None:
-            raise SubstitutionFailure(f'Template argument {self.dep} is None')
+            raise SubstitutionFailure(f"Template argument {self.dep} is None")
         return template_arguments[self.dep]
 
 
@@ -270,33 +268,32 @@ class StatefulOperator:
         self.is_output = False
 
     def mangled_name(self):
-        return f'{self.name}'
+        return f"{self.name}"
 
     def forward_decl(self):
-        arg_decls = ['char *state']
-        if self.ret_cpp_type == 'storage_t':
-            ret_decl = 'void'
-            arg_decls.append('void*')
+        arg_decls = ["char *state"]
+        if self.ret_cpp_type == "storage_t":
+            ret_decl = "void"
+            arg_decls.append("void*")
         else:
             ret_decl = self.ret_cpp_type
         for arg in self.arg_cpp_types:
-            arg_decls.append('const void*' if arg == 'storage_t' else arg)
+            arg_decls.append("const void*" if arg == "storage_t" else arg)
         return f'extern "C" __device__ {ret_decl} {self.mangled_name()}({", ".join(arg_decls)});'
 
     def cpp_decl(self, name):
-        return f'char* {name}_state'
+        return f"char* {name}_state"
 
     def dtype(self):
-        return numba.types.Array(self.op_type, 1, 'C')
+        return numba.types.Array(self.op_type, 1, "C")
 
     def wrap_decl(self, name):
         param_decls = []
         param_refs = []
         for aid, arg_type in enumerate(self.arg_cpp_types):
-            arg_name = f'wp_{aid}'
-            param_decls.append(f'const {arg_type}& {arg_name}')
-            param_refs.append('&' + arg_name if arg_type ==
-                              'storage_t' else arg_name)
+            arg_name = f"wp_{aid}"
+            param_decls.append(f"const {arg_type}& {arg_name}")
+            param_refs.append("&" + arg_name if arg_type == "storage_t" else arg_name)
 
         environment = jinja2.Environment()
         template = environment.from_string("""
@@ -310,11 +307,13 @@ class StatefulOperator:
               {% endif %}
             };
         """)
-        return template.render(name=name,
-                               ret_cpp_type=self.ret_cpp_type,
-                               param_decls=', '.join(param_decls),
-                               param_refs=', '.join(param_refs),
-                               mangled_name=self.mangled_name())
+        return template.render(
+            name=name,
+            ret_cpp_type=self.ret_cpp_type,
+            param_decls=", ".join(param_decls),
+            param_refs=", ".join(param_refs),
+            mangled_name=self.mangled_name(),
+        )
 
     def is_provided_by_user(self):
         return True
@@ -328,27 +327,26 @@ class StatelessOperator:
         self.arg_cpp_types = arg_cpp_types
 
     def mangled_name(self):
-        return f'{self.name}'
+        return f"{self.name}"
 
     def forward_decl(self):
         arg_decls = []
-        if self.ret_cpp_type == 'storage_t':
-            ret_decl = 'void'
-            arg_decls.append('void*')
+        if self.ret_cpp_type == "storage_t":
+            ret_decl = "void"
+            arg_decls.append("void*")
         else:
             ret_decl = self.ret_cpp_type
         for arg in self.arg_cpp_types:
-            arg_decls.append('const void*' if arg == 'storage_t' else arg)
+            arg_decls.append("const void*" if arg == "storage_t" else arg)
         return f'extern "C" __device__ {ret_decl} {self.mangled_name()}({", ".join(arg_decls)});'
 
     def wrap_decl(self, name):
         param_decls = []
         param_refs = []
         for aid, arg_type in enumerate(self.arg_cpp_types):
-            arg_name = f'wp_{aid}'
-            param_decls.append(f'const {arg_type}& {arg_name}')
-            param_refs.append('&' + arg_name if arg_type ==
-                              'storage_t' else arg_name)
+            arg_name = f"wp_{aid}"
+            param_decls.append(f"const {arg_type}& {arg_name}")
+            param_refs.append("&" + arg_name if arg_type == "storage_t" else arg_name)
 
         environment = jinja2.Environment()
         template = environment.from_string("""
@@ -362,11 +360,13 @@ class StatelessOperator:
               {% endif %}
             };
         """)
-        return template.render(name=name,
-                               ret_cpp_type=self.ret_cpp_type,
-                               param_decls=', '.join(param_decls),
-                               param_refs=', '.join(param_refs),
-                               mangled_name=self.mangled_name())
+        return template.render(
+            name=name,
+            ret_cpp_type=self.ret_cpp_type,
+            param_decls=", ".join(param_decls),
+            param_refs=", ".join(param_refs),
+            mangled_name=self.mangled_name(),
+        )
 
     def is_provided_by_user(self):
         return False
@@ -382,8 +382,9 @@ class DependentOperator:
         op = self.op.resolve(template_arguments)
         ret_dtype = self.ret_dtype.resolve(template_arguments)
         ret_cpp_type = numba_type_to_cpp(ret_dtype)
-        ret_numba_type = types.CPointer(
-            ret_dtype) if ret_cpp_type == 'storage_t' else ret_dtype
+        ret_numba_type = (
+            types.CPointer(ret_dtype) if ret_cpp_type == "storage_t" else ret_dtype
+        )
         arg_cpp_types = []
         arg_dtypes = []
         arg_numba_types = []
@@ -392,36 +393,44 @@ class DependentOperator:
             arg_cpp_type = numba_type_to_cpp(arg_dtype)
             arg_cpp_types.append(arg_cpp_type)
             arg_dtypes.append(str(arg_dtype))
-            arg_numba_types.append(types.CPointer(
-                arg_dtype) if arg_cpp_type == 'storage_t' else arg_dtype)
+            arg_numba_types.append(
+                types.CPointer(arg_dtype) if arg_cpp_type == "storage_t" else arg_dtype
+            )
 
         if isinstance(op, StatefulFunction):
             binary_op = op.op.__call__
-            mangled_name = f'F{binary_op.__name__}_{ret_dtype}__' + \
-                '_'.join(arg_dtypes)
-            if ret_cpp_type == 'storage_t':
-                binary_op_signature = signature(types.void, types.CPointer(
-                    op.dtype), *arg_numba_types, ret_numba_type)
+            mangled_name = f"F{binary_op.__name__}_{ret_dtype}__" + "_".join(arg_dtypes)
+            if ret_cpp_type == "storage_t":
+                binary_op_signature = signature(
+                    types.void,
+                    types.CPointer(op.dtype),
+                    *arg_numba_types,
+                    ret_numba_type,
+                )
             else:
                 binary_op_signature = signature(
-                    ret_numba_type, types.CPointer(op.dtype), *arg_numba_types)
-            abi_info = {'abi_name': mangled_name}
+                    ret_numba_type, types.CPointer(op.dtype), *arg_numba_types
+                )
+            abi_info = {"abi_name": mangled_name}
             ltoir, _ = cuda.compile(
-                binary_op, sig=binary_op_signature, output='ltoir', abi_info=abi_info)
-            return StatefulOperator(mangled_name, op.dtype, ret_cpp_type, arg_cpp_types, ltoir)
+                binary_op, sig=binary_op_signature, output="ltoir", abi_info=abi_info
+            )
+            return StatefulOperator(
+                mangled_name, op.dtype, ret_cpp_type, arg_cpp_types, ltoir
+            )
         else:
             binary_op = op
-            mangled_name = f'F{binary_op.__name__}_{ret_dtype}__' + \
-                '_'.join(arg_dtypes)
-            if ret_cpp_type == 'storage_t':
+            mangled_name = f"F{binary_op.__name__}_{ret_dtype}__" + "_".join(arg_dtypes)
+            if ret_cpp_type == "storage_t":
                 binary_op_signature = signature(
-                    types.void, *arg_numba_types, ret_numba_type)
+                    types.void, *arg_numba_types, ret_numba_type
+                )
             else:
-                binary_op_signature = signature(
-                    ret_numba_type, *arg_numba_types)
-            abi_info = {'abi_name': mangled_name}
+                binary_op_signature = signature(ret_numba_type, *arg_numba_types)
+            abi_info = {"abi_name": mangled_name}
             ltoir, _ = cuda.compile(
-                binary_op, sig=binary_op_signature, output='ltoir', abi_info=abi_info)
+                binary_op, sig=binary_op_signature, output="ltoir", abi_info=abi_info
+            )
             return StatelessOperator(mangled_name, ret_cpp_type, arg_cpp_types, ltoir)
 
 
@@ -432,12 +441,14 @@ class DependentArray(Parameter):
         super().__init__(is_output)
 
     def __repr__(self) -> str:
-        return f'DependentArray(dep={self.value_dtype}, out={self.is_output})'
+        return f"DependentArray(dep={self.value_dtype}, out={self.is_output})"
 
     def specialize(self, template_arguments):
-        return Array(self.value_dtype.resolve(template_arguments),
-                     self.size.resolve(template_arguments),
-                     self.is_output)
+        return Array(
+            self.value_dtype.resolve(template_arguments),
+            self.size.resolve(template_arguments),
+            self.is_output,
+        )
 
 
 class TemplateParameter:
@@ -445,40 +456,66 @@ class TemplateParameter:
         self.name = name
 
     def __repr__(self) -> str:
-        return f'{self.name}'
+        return f"{self.name}"
 
 
 def mangle_symbol(name, template_parameters):
-    return '_'.join([name] + [template_parameter.mangled_name() for template_parameter in template_parameters])
+    return "_".join(
+        [name]
+        + [
+            template_parameter.mangled_name()
+            for template_parameter in template_parameters
+        ]
+    )
 
 
 def war_introspection(fn, n):
     if n == 1:
+
         def impl(param0):
             return fn(param0)
+
         return impl
     elif n == 2:
+
         def impl(param0, param1):
             return fn(param0, param1)
+
         return impl
     elif n == 3:
+
         def impl(param0, param1, param2):
             return fn(param0, param1, param2)
+
         return impl
     elif n == 4:
+
         def impl(param0, param1, param2, param3):
             return fn(param0, param1, param2, param3)
+
         return impl
     elif n == 5:
+
         def impl(param0, param1, param2, param3, param4):
             return fn(param0, param1, param2, param3, param4)
+
         return impl
     else:
-        raise ValueError('Unsupported number of arguments')
+        raise ValueError("Unsupported number of arguments")
 
 
 class Algorithm:
-    def __init__(self, struct_name, method_name, c_name, includes, template_parameters, parameters, type_definitions=None, fake_return=False):
+    def __init__(
+        self,
+        struct_name,
+        method_name,
+        c_name,
+        includes,
+        template_parameters,
+        parameters,
+        type_definitions=None,
+        fake_return=False,
+    ):
         self.struct_name = struct_name
         self.method_name = method_name
         self.c_name = c_name
@@ -489,7 +526,7 @@ class Algorithm:
         self.fake_return = fake_return
 
     def __repr__(self) -> str:
-        return f'{self.struct_name}::{self.method_name}{self.template_parameters}: {self.parameters}'
+        return f"{self.struct_name}::{self.method_name}{self.template_parameters}: {self.parameters}"
 
     def mangled_name(self, parameters):
         return mangle_symbol(self.c_name, parameters)
@@ -500,7 +537,8 @@ class Algorithm:
         for template_parameter in self.template_parameters:
             if template_parameter.name not in template_arguments:
                 raise ValueError(
-                    f'Template argument {template_parameter.name} not provided')
+                    f"Template argument {template_parameter.name} not provided"
+                )
             template_argument = template_arguments[template_parameter.name]
             if isinstance(template_argument, int):
                 template_list.append(str(template_argument))
@@ -508,10 +546,10 @@ class Algorithm:
                 template_list.append(template_argument)
             else:
                 template_list.append(numba_type_to_cpp(template_argument))
-        template_list = ', '.join(template_list)
+        template_list = ", ".join(template_list)
 
         # '::cuda::std::int32_t, 32' -> __cuda__std__int32_t__32
-        mangle = re.sub(r'[^a-zA-Z0-9]', '_', template_list)
+        mangle = re.sub(r"[^a-zA-Z0-9]", "_", template_list)
 
         specialized_parameters = []
         for method in self.parameters:
@@ -519,13 +557,23 @@ class Algorithm:
             try:
                 for parameter in method:
                     specialized_signature.append(
-                        parameter.specialize(template_arguments))
+                        parameter.specialize(template_arguments)
+                    )
                 specialized_parameters.append(specialized_signature)
-            except SubstitutionFailure as e:
+            except SubstitutionFailure:
                 pass  # Substitution failure is not an error
 
-        specialized_name = f'{self.struct_name}<{template_list}>'
-        return Algorithm(specialized_name, self.method_name, self.c_name + mangle, self.includes, [], specialized_parameters, type_definitions=self.type_definitions, fake_return=self.fake_return)
+        specialized_name = f"{self.struct_name}<{template_list}>"
+        return Algorithm(
+            specialized_name,
+            self.method_name,
+            self.c_name + mangle,
+            self.includes,
+            [],
+            specialized_parameters,
+            type_definitions=self.type_definitions,
+            fake_return=self.fake_return,
+        )
 
     def get_temp_storage_bytes(self):
         # TODO Should be in value types, not bytes for alignment perposes?
@@ -548,14 +596,16 @@ class Algorithm:
 
             __device__ constexpr unsigned temp_storage_bytes = sizeof(temp_storage_t);
             """)
-        src = template.render(algorithm_name=self.struct_name,
-                              includes=self.includes,
-                              type_definitions=self.type_definitions)
+        src = template.render(
+            algorithm_name=self.struct_name,
+            includes=self.includes,
+            type_definitions=self.type_definitions,
+        )
         device = cuda.get_current_device()
         cc_major, cc_minor = device.compute_capability
         cc = cc_major * 10 + cc_minor
-        _, ptx = compile(cpp=src, cc=cc, rdc=True, code='ptx')
-        return find_unsigned('temp_storage_bytes', ptx)
+        _, ptx = compile(cpp=src, cc=cc, rdc=True, code="ptx")
+        return find_unsigned("temp_storage_bytes", ptx)
 
     def get_lto_ir(self, threads=None):
         lto_irs = []
@@ -568,7 +618,9 @@ class Algorithm:
 
         for method in self.parameters:
             for param in method:
-                if isinstance(param, StatelessOperator) or isinstance(param, StatefulOperator):
+                if isinstance(param, StatelessOperator) or isinstance(
+                    param, StatefulOperator
+                ):
                     if param.name not in udf_declarations:
                         udf_declarations[param.name] = param.forward_decl()
                         lto_irs.append(param.ltoir)
@@ -594,10 +646,12 @@ class Algorithm:
             using algorithm_t = cub::{{ algorithm_name }};
             using temp_storage_t = typename algorithm_t::TempStorage;
             """)
-        src = template.render(algorithm_name=self.struct_name,
-                              includes=self.includes,
-                              udf_declarations=udf_declarations,
-                              type_definitions=self.type_definitions)
+        src = template.render(
+            algorithm_name=self.struct_name,
+            includes=self.includes,
+            udf_declarations=udf_declarations,
+            type_definitions=self.type_definitions,
+        )
 
         for method in self.parameters:
             param_decls = []
@@ -607,28 +661,26 @@ class Algorithm:
 
             for pid, param in enumerate(method[1:]):
                 if isinstance(param, StatelessOperator):
-                    func_decls.append(param.wrap_decl(f'param_{pid}'))
-                    param_args.append(f'param_{pid}')
+                    func_decls.append(param.wrap_decl(f"param_{pid}"))
+                    param_args.append(f"param_{pid}")
                 elif isinstance(param, StatefulOperator):
-                    name = f'param_{pid}'
+                    name = f"param_{pid}"
                     func_decls.append(param.wrap_decl(name))
                     param_args.append(name)
                     param_decls.append(param.cpp_decl(name))
                 else:
-                    name = f'param_{pid}'
+                    name = f"param_{pid}"
                     param_decls.append(param.cpp_decl(name))
                     if not self.fake_return and param.is_output:
                         if out_param is not None:
-                            raise ValueError(
-                                'Multiple output parameters not supported')
+                            raise ValueError("Multiple output parameters not supported")
                         out_param = name
                     else:
                         param_args.append(name)
 
-            if self.struct_name.startswith('Warp'):
+            if self.struct_name.startswith("Warp"):
                 if threads is None:
-                    raise ValueError(
-                        'Warp algorithm must specify number of threads')
+                    raise ValueError("Warp algorithm must specify number of threads")
                 # sub hw warps require computing masks for syncwarp, which is not supported
                 # allocate temporary storage explicitly
                 provide_alloc_version = threads == 32
@@ -637,7 +689,7 @@ class Algorithm:
                 storage = f"__shared__ temp_storage_t temp_storages[1024 / {threads}];"
                 storage += f"temp_storage_t &temp_storage = temp_storages[threadIdx.x / {threads}];"
                 sync = "__syncwarp();"
-            elif self.struct_name.startswith('Block'):
+            elif self.struct_name.startswith("Block"):
                 provide_alloc_version = True
                 storage = "__shared__ temp_storage_t temp_storage;"
                 sync = "__syncthreads();"
@@ -675,36 +727,38 @@ class Algorithm:
                    algorithm_t(*temp_storage).{{ method_name }}({{ param_args }});
                 }
                 """)
-            src += template.render(param_decls=', '.join(param_decls),
-                                   param_args=', '.join(param_args),
-                                   func_decls=func_decls,
-                                   out_param=out_param,
-                                   method_name=self.method_name,
-                                   mangled_name=self.mangled_name(method),
-                                   sync=sync,
-                                   storage=storage,
-                                   provide_alloc_version=provide_alloc_version)
+            src += template.render(
+                param_decls=", ".join(param_decls),
+                param_args=", ".join(param_args),
+                func_decls=func_decls,
+                out_param=out_param,
+                method_name=self.method_name,
+                mangled_name=self.mangled_name(method),
+                sync=sync,
+                storage=storage,
+                provide_alloc_version=provide_alloc_version,
+            )
 
         device = cuda.get_current_device()
         cc_major, cc_minor = device.compute_capability
         cc = cc_major * 10 + cc_minor
-        _, lto_fn = compile(cpp=src, cc=cc, rdc=True, code='lto')
+        _, lto_fn = compile(cpp=src, cc=cc, rdc=True, code="lto")
         lto_irs.append(lto_fn)
         return lto_irs
 
     def codegen(self, func_to_overload):
         if len(self.template_parameters):
-            raise ValueError('Cannot generate codegen for a template')
+            raise ValueError("Cannot generate codegen for a template")
 
         for method in self.parameters:
-            self.codegen_method(func_to_overload, method,
-                                self.mangled_name(method))
-            self.codegen_method(func_to_overload, method[1:],
-                                self.mangled_name(method) + '_alloc')
+            self.codegen_method(func_to_overload, method, self.mangled_name(method))
+            self.codegen_method(
+                func_to_overload, method[1:], self.mangled_name(method) + "_alloc"
+            )
 
     def codegen_method(self, func_to_overload, method, mangled_name):
         if len(self.template_parameters):
-            raise ValueError('Cannot generate codegen for a template')
+            raise ValueError("Cannot generate codegen for a template")
 
         def intrinsic_impl(*args):
             def codegen(context, builder, sig, args):
@@ -717,18 +771,22 @@ class Algorithm:
                         dtype = param.dtype()
                         if isinstance(param, StatefulOperator):
                             arg = args[arg_id]
-                            state_ptr = cgutils.create_struct_proxy(
-                                dtype)(context, builder, arg).data
+                            state_ptr = cgutils.create_struct_proxy(dtype)(
+                                context, builder, arg
+                            ).data
                             void_ptr = builder.bitcast(
-                                state_ptr, ir.PointerType(ir.IntType(8)))
+                                state_ptr, ir.PointerType(ir.IntType(8))
+                            )
                             types.append(ir.PointerType(ir.IntType(8)))
                             arguments.append(void_ptr)
                         if isinstance(param, Reference):
                             if param.is_output:
                                 ptr = cgutils.alloca_once(
-                                    builder, context.get_value_type(dtype))
+                                    builder, context.get_value_type(dtype)
+                                )
                                 void_ptr = builder.bitcast(
-                                    ptr, ir.PointerType(ir.IntType(8)))
+                                    ptr, ir.PointerType(ir.IntType(8))
+                                )
                                 types.append(ir.PointerType(ir.IntType(8)))
                                 arguments.append(void_ptr)
                                 ret = ptr
@@ -737,20 +795,24 @@ class Algorithm:
                                 ptr = cgutils.alloca_once_value(builder, arg)
                                 data_type = context.get_value_type(dtype)
                                 void_ptr = builder.bitcast(
-                                    ptr, ir.PointerType(ir.IntType(8)))
+                                    ptr, ir.PointerType(ir.IntType(8))
+                                )
                                 types.append(ir.PointerType(ir.IntType(8)))
                                 arguments.append(void_ptr)
                         elif isinstance(param, Array) or isinstance(param, Pointer):
                             if param.is_output:
-                                raise ValueError('Output arrays not supported')
+                                raise ValueError("Output arrays not supported")
                             arg = args[arg_id]
                             data_type = context.get_value_type(dtype.dtype)
                             types.append(ir.PointerType(data_type))
-                            arguments.append(cgutils.create_struct_proxy(
-                                dtype)(context, builder, arg).data)
+                            arguments.append(
+                                cgutils.create_struct_proxy(dtype)(
+                                    context, builder, arg
+                                ).data
+                            )
                         else:
                             if param.is_output:
-                                raise ValueError('Output values not supported')
+                                raise ValueError("Output values not supported")
                             arg = args[arg_id]
                             data_type = context.get_value_type(dtype)
                             types.append(data_type)
@@ -761,7 +823,8 @@ class Algorithm:
 
                 function_type = ir.FunctionType(ir.VoidType(), types)
                 function = cgutils.get_or_insert_function(
-                    builder.module, function_type, mangled_name)
+                    builder.module, function_type, mangled_name
+                )
                 builder.call(function, arguments)
 
                 if ret is not None:
@@ -773,8 +836,7 @@ class Algorithm:
                 if not isinstance(param, StatelessOperator):
                     if param.is_output:
                         if ret is not numba.types.void:
-                            raise ValueError(
-                                'Multiple output parameters not supported')
+                            raise ValueError("Multiple output parameters not supported")
                         ret = param.dtype()
                     else:
                         params.append(param.dtype())
@@ -782,16 +844,19 @@ class Algorithm:
             return signature(ret, *params), codegen
 
         num_user_provided_params = sum(
-            [param.is_provided_by_user() for param in method])
-        numba_intrinsic = intrinsic(war_introspection(
-            intrinsic_impl, 1 + num_user_provided_params))
+            [param.is_provided_by_user() for param in method]
+        )
+        numba_intrinsic = intrinsic(
+            war_introspection(intrinsic_impl, 1 + num_user_provided_params)
+        )
 
         def algorithm_impl(*args):
             return war_introspection(numba_intrinsic, len(args))
 
         wrapped_algorithm_impl = war_introspection(
-            algorithm_impl, num_user_provided_params)
-        overload(func_to_overload, target='cuda')(wrapped_algorithm_impl)
+            algorithm_impl, num_user_provided_params
+        )
+        overload(func_to_overload, target="cuda")(wrapped_algorithm_impl)
 
 
 class Invocable:
@@ -810,4 +875,5 @@ class Invocable:
 
     def __call__(self, *args):
         raise Exception(
-            "__call__ should not be called directly outside of a numba.cuda.jit(...) kernel.")
+            "__call__ should not be called directly outside of a numba.cuda.jit(...) kernel."
+        )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
@@ -3,10 +3,23 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from cuda.cooperative.experimental.block._block_merge_sort import merge_sort_keys
-from cuda.cooperative.experimental.block._block_reduce import reduce, sum
+from cuda.cooperative.experimental.block._block_reduce import reduce
+from cuda.cooperative.experimental.block._block_reduce import sum
 from cuda.cooperative.experimental.block._block_scan import exclusive_sum
+from cuda.cooperative.experimental.block._block_radix_sort import radix_sort_keys
 from cuda.cooperative.experimental.block._block_radix_sort import (
-    radix_sort_keys,
     radix_sort_keys_descending,
 )
-from cuda.cooperative.experimental.block._block_load_store import load, store
+from cuda.cooperative.experimental.block._block_load_store import load
+from cuda.cooperative.experimental.block._block_load_store import store
+
+__all__ = [
+    "merge_sort_keys",
+    "reduce",
+    "sum",
+    "exclusive_sum",
+    "radix_sort_keys",
+    "radix_sort_keys_descending",
+    "load",
+    "store",
+]

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
@@ -5,5 +5,8 @@
 from cuda.cooperative.experimental.block._block_merge_sort import merge_sort_keys
 from cuda.cooperative.experimental.block._block_reduce import reduce, sum
 from cuda.cooperative.experimental.block._block_scan import exclusive_sum
-from cuda.cooperative.experimental.block._block_radix_sort import radix_sort_keys, radix_sort_keys_descending
+from cuda.cooperative.experimental.block._block_radix_sort import (
+    radix_sort_keys,
+    radix_sort_keys_descending,
+)
 from cuda.cooperative.experimental.block._block_load_store import load, store

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_load_store.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_load_store.py
@@ -3,7 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
-from cuda.cooperative.experimental._types import *
+import numba
+
+from cuda.cooperative.experimental._types import (
+    Algorithm,
+    Dependency,
+    DependentArray,
+    DependentPointer,
+    Invocable,
+    Pointer,
+    TemplateParameter,
+)
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 CUB_BLOCK_LOAD_ALGOS = {

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
@@ -7,7 +7,9 @@ from cuda.cooperative.experimental._types import *
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 
-def merge_sort_keys(dtype, threads_in_block, items_per_thread, compare_op, methods=None):
+def merge_sort_keys(
+    dtype, threads_in_block, items_per_thread, compare_op, methods=None
+):
     """Performs a block-wide merge sort over a :ref:`blocked arrangement <flexible-data-arrangement>` of keys.
 
     Example:
@@ -43,22 +45,42 @@ def merge_sort_keys(dtype, threads_in_block, items_per_thread, compare_op, metho
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('BlockMergeSort',
-                         'Sort',
-                         'block_merge_sort',
-                         ['cub/block/block_merge_sort.cuh'],
-                         [TemplateParameter('KeyT'),
-                          TemplateParameter('BLOCK_DIM_X'),
-                          TemplateParameter('ITEMS_PER_THREAD')],
-                         [[Pointer(numba.uint8),
-                           DependentArray(Dependency('KeyT'),
-                                          Dependency('ITEMS_PER_THREAD')),
-                           DependentOperator(Constant(numba.int8), [Dependency('KeyT'), Dependency('KeyT')], Dependency('Op'))]],
-                         type_definitions=[numba_type_to_wrapper(dtype, methods=methods)])
-    specialization = template.specialize({'KeyT': dtype,
-                                          'BLOCK_DIM_X': threads_in_block,
-                                          'ITEMS_PER_THREAD': items_per_thread,
-                                          'Op': compare_op})
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir()],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    template = Algorithm(
+        "BlockMergeSort",
+        "Sort",
+        "block_merge_sort",
+        ["cub/block/block_merge_sort.cuh"],
+        [
+            TemplateParameter("KeyT"),
+            TemplateParameter("BLOCK_DIM_X"),
+            TemplateParameter("ITEMS_PER_THREAD"),
+        ],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
+                DependentOperator(
+                    Constant(numba.int8),
+                    [Dependency("KeyT"), Dependency("KeyT")],
+                    Dependency("Op"),
+                ),
+            ]
+        ],
+        type_definitions=[numba_type_to_wrapper(dtype, methods=methods)],
+    )
+    specialization = template.specialize(
+        {
+            "KeyT": dtype,
+            "BLOCK_DIM_X": threads_in_block,
+            "ITEMS_PER_THREAD": items_per_thread,
+            "Op": compare_op,
+        }
+    )
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir()
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
@@ -3,7 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import numba
-from cuda.cooperative.experimental._types import *
+
+from cuda.cooperative.experimental._types import (
+    Algorithm,
+    Constant,
+    Dependency,
+    DependentArray,
+    DependentOperator,
+    Invocable,
+    Pointer,
+    TemplateParameter,
+    numba_type_to_wrapper,
+)
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_radix_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_radix_sort.py
@@ -42,23 +42,44 @@ def radix_sort_keys(dtype, threads_in_block, items_per_thread):
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('BlockRadixSort',
-                         'Sort',
-                         'block_radix_sort',
-                         ['cub/block/block_radix_sort.cuh'],
-                         [TemplateParameter('KeyT'),
-                          TemplateParameter('BLOCK_DIM_X'),
-                          TemplateParameter('ITEMS_PER_THREAD')],
-                         [[Pointer(numba.uint8), DependentArray(Dependency('KeyT'), Dependency('ITEMS_PER_THREAD'))],
-                          [Pointer(numba.uint8), DependentArray(Dependency('KeyT'), Dependency(
-                              'ITEMS_PER_THREAD')), Value(numba.int32), Value(numba.int32)]
-                          ])
-    specialization = template.specialize({'KeyT': dtype,
-                                          'BLOCK_DIM_X': threads_in_block,
-                                          'ITEMS_PER_THREAD': items_per_thread})
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir()],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    template = Algorithm(
+        "BlockRadixSort",
+        "Sort",
+        "block_radix_sort",
+        ["cub/block/block_radix_sort.cuh"],
+        [
+            TemplateParameter("KeyT"),
+            TemplateParameter("BLOCK_DIM_X"),
+            TemplateParameter("ITEMS_PER_THREAD"),
+        ],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
+            ],
+            [
+                Pointer(numba.uint8),
+                DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
+                Value(numba.int32),
+                Value(numba.int32),
+            ],
+        ],
+    )
+    specialization = template.specialize(
+        {
+            "KeyT": dtype,
+            "BLOCK_DIM_X": threads_in_block,
+            "ITEMS_PER_THREAD": items_per_thread,
+        }
+    )
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir()
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )
 
 
 def radix_sort_keys_descending(dtype, threads_in_block, items_per_thread):
@@ -96,21 +117,42 @@ def radix_sort_keys_descending(dtype, threads_in_block, items_per_thread):
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('BlockRadixSort',
-                         'SortDescending',
-                         'block_radix_sort',
-                         ['cub/block/block_radix_sort.cuh'],
-                         [TemplateParameter('KeyT'),
-                          TemplateParameter('BLOCK_DIM_X'),
-                          TemplateParameter('ITEMS_PER_THREAD')],
-                         [[Pointer(numba.uint8), DependentArray(Dependency('KeyT'), Dependency('ITEMS_PER_THREAD'))],
-                          [Pointer(numba.uint8), DependentArray(Dependency('KeyT'), Dependency(
-                              'ITEMS_PER_THREAD')), Value(numba.int32), Value(numba.int32)]
-                          ])
-    specialization = template.specialize({'KeyT': dtype,
-                                          'BLOCK_DIM_X': threads_in_block,
-                                          'ITEMS_PER_THREAD': items_per_thread})
+    template = Algorithm(
+        "BlockRadixSort",
+        "SortDescending",
+        "block_radix_sort",
+        ["cub/block/block_radix_sort.cuh"],
+        [
+            TemplateParameter("KeyT"),
+            TemplateParameter("BLOCK_DIM_X"),
+            TemplateParameter("ITEMS_PER_THREAD"),
+        ],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
+            ],
+            [
+                Pointer(numba.uint8),
+                DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
+                Value(numba.int32),
+                Value(numba.int32),
+            ],
+        ],
+    )
+    specialization = template.specialize(
+        {
+            "KeyT": dtype,
+            "BLOCK_DIM_X": threads_in_block,
+            "ITEMS_PER_THREAD": items_per_thread,
+        }
+    )
 
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir()],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir()
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_radix_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_radix_sort.py
@@ -3,7 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import numba
-from cuda.cooperative.experimental._types import *
+
+from cuda.cooperative.experimental._types import (
+    Algorithm,
+    Dependency,
+    DependentArray,
+    Invocable,
+    Pointer,
+    TemplateParameter,
+    Value,
+)
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
@@ -43,25 +43,38 @@ def reduce(dtype, threads_in_block, binary_op, methods=None):
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('BlockReduce',
-                         'Reduce',
-                         'block_reduce',
-                         ['cub/block/block_reduce.cuh'],
-                         [TemplateParameter('T'),
-                          TemplateParameter('BLOCK_DIM_X')],
-                         [[Pointer(numba.uint8),
-                           DependentReference(Dependency('T')),
-                           DependentOperator(Dependency('T'), [Dependency(
-                               'T'), Dependency('T')], Dependency('Op')),
-                           DependentReference(Dependency('T'), True)]],
-                         type_definitions=[numba_type_to_wrapper(dtype, methods=methods)])
-    specialization = template.specialize({'T': dtype,
-                                          'BLOCK_DIM_X': threads_in_block,
-                                          'Op': binary_op})
+    template = Algorithm(
+        "BlockReduce",
+        "Reduce",
+        "block_reduce",
+        ["cub/block/block_reduce.cuh"],
+        [TemplateParameter("T"), TemplateParameter("BLOCK_DIM_X")],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentReference(Dependency("T")),
+                DependentOperator(
+                    Dependency("T"),
+                    [Dependency("T"), Dependency("T")],
+                    Dependency("Op"),
+                ),
+                DependentReference(Dependency("T"), True),
+            ]
+        ],
+        type_definitions=[numba_type_to_wrapper(dtype, methods=methods)],
+    )
+    specialization = template.specialize(
+        {"T": dtype, "BLOCK_DIM_X": threads_in_block, "Op": binary_op}
+    )
 
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir()],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir()
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )
 
 
 def sum(dtype, threads_in_block):
@@ -100,16 +113,32 @@ def sum(dtype, threads_in_block):
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('BlockReduce',
-                         'Sum',
-                         'block_reduce',
-                         ['cub/block/block_reduce.cuh'],
-                         [TemplateParameter('T'),
-                          TemplateParameter('BLOCK_DIM_X')],
-                         [[Pointer(numba.uint8), DependentReference(Dependency('T')), DependentReference(Dependency('T'), True)],
-                          [Pointer(numba.uint8), DependentReference(Dependency('T')), Value(numba.int32), DependentReference(Dependency('T'), True)]])
-    specialization = template.specialize({'T': dtype,
-                                          'BLOCK_DIM_X': threads_in_block})
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir()],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    template = Algorithm(
+        "BlockReduce",
+        "Sum",
+        "block_reduce",
+        ["cub/block/block_reduce.cuh"],
+        [TemplateParameter("T"), TemplateParameter("BLOCK_DIM_X")],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentReference(Dependency("T")),
+                DependentReference(Dependency("T"), True),
+            ],
+            [
+                Pointer(numba.uint8),
+                DependentReference(Dependency("T")),
+                Value(numba.int32),
+                DependentReference(Dependency("T"), True),
+            ],
+        ],
+    )
+    specialization = template.specialize({"T": dtype, "BLOCK_DIM_X": threads_in_block})
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir()
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
@@ -2,7 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from cuda.cooperative.experimental._types import *
+import numba
+
+from cuda.cooperative.experimental._types import (
+    Algorithm,
+    Dependency,
+    DependentOperator,
+    DependentReference,
+    Invocable,
+    Pointer,
+    TemplateParameter,
+    Value,
+    numba_type_to_wrapper,
+)
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -44,26 +44,41 @@ def exclusive_sum(dtype, threads_in_block, items_per_thread, prefix_op=None):
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('BlockScan',
-                         'ExclusiveSum',
-                         'block_scan',
-                         ['cub/block/block_scan.cuh'],
-                         [TemplateParameter('T'),
-                          TemplateParameter('BLOCK_DIM_X')],
-                         [[Pointer(numba.uint8),
-                           DependentArray(Dependency(
-                               'T'), Dependency('ITEMS_PER_THREAD')),
-                           DependentArray(Dependency(
-                               'T'), Dependency('ITEMS_PER_THREAD')),
-                           DependentOperator(Dependency('T'), [Dependency('T')], Dependency('PrefixOp'))],
-                          [Pointer(numba.uint8),
-                           DependentArray(Dependency(
-                               'T'), Dependency('ITEMS_PER_THREAD')),
-                           DependentArray(Dependency('T'), Dependency('ITEMS_PER_THREAD'))]])
-    specialization = template.specialize({'T': dtype,
-                                          'BLOCK_DIM_X': threads_in_block,
-                                          'ITEMS_PER_THREAD': items_per_thread,
-                                          'PrefixOp': prefix_op})
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir()],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    template = Algorithm(
+        "BlockScan",
+        "ExclusiveSum",
+        "block_scan",
+        ["cub/block/block_scan.cuh"],
+        [TemplateParameter("T"), TemplateParameter("BLOCK_DIM_X")],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                DependentOperator(
+                    Dependency("T"), [Dependency("T")], Dependency("PrefixOp")
+                ),
+            ],
+            [
+                Pointer(numba.uint8),
+                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+                DependentArray(Dependency("T"), Dependency("ITEMS_PER_THREAD")),
+            ],
+        ],
+    )
+    specialization = template.specialize(
+        {
+            "T": dtype,
+            "BLOCK_DIM_X": threads_in_block,
+            "ITEMS_PER_THREAD": items_per_thread,
+            "PrefixOp": prefix_op,
+        }
+    )
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir()
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -2,8 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import numba
 
-from cuda.cooperative.experimental._types import *
+from cuda.cooperative.experimental._types import (
+    Algorithm,
+    Invocable,
+    Dependency,
+    DependentArray,
+    DependentOperator,
+    Pointer,
+    TemplateParameter,
+)
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/__init__.py
@@ -3,5 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from cuda.cooperative.experimental.warp._warp_scan import exclusive_sum
-from cuda.cooperative.experimental.warp._warp_reduce import reduce, sum
+from cuda.cooperative.experimental.warp._warp_reduce import reduce
+from cuda.cooperative.experimental.warp._warp_reduce import sum
 from cuda.cooperative.experimental.warp._warp_merge_sort import merge_sort_keys
+
+__all__ = ["exclusive_sum", "reduce", "sum", "merge_sort_keys"]

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
@@ -7,7 +7,9 @@ from cuda.cooperative.experimental._types import *
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 
-def merge_sort_keys(dtype, items_per_thread, compare_op, threads_in_warp=32, methods=None):
+def merge_sort_keys(
+    dtype, items_per_thread, compare_op, threads_in_warp=32, methods=None
+):
     """Performs a warp-wide merge sort over a :ref:`blocked arrangement <flexible-data-arrangement>` of keys.
 
     Example:
@@ -43,22 +45,42 @@ def merge_sort_keys(dtype, items_per_thread, compare_op, threads_in_warp=32, met
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('WarpMergeSort',
-                         'Sort',
-                         'warp_merge_sort',
-                         ['cub/warp/warp_merge_sort.cuh'],
-                         [TemplateParameter('KeyT'),
-                          TemplateParameter('ITEMS_PER_THREAD'),
-                          TemplateParameter('VIRTUAL_WARP_THREADS')],
-                         [[Pointer(numba.uint8),
-                           DependentArray(Dependency('KeyT'),
-                                          Dependency('ITEMS_PER_THREAD')),
-                           DependentOperator(Constant(numba.int8), [Dependency('KeyT'), Dependency('KeyT')], Dependency('Op'))]],
-                         type_definitions=[numba_type_to_wrapper(dtype, methods=methods)])
-    specialization = template.specialize({'KeyT': dtype,
-                                          'VIRTUAL_WARP_THREADS': threads_in_warp,
-                                          'ITEMS_PER_THREAD': items_per_thread,
-                                          'Op': compare_op})
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir(threads=threads_in_warp)],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    template = Algorithm(
+        "WarpMergeSort",
+        "Sort",
+        "warp_merge_sort",
+        ["cub/warp/warp_merge_sort.cuh"],
+        [
+            TemplateParameter("KeyT"),
+            TemplateParameter("ITEMS_PER_THREAD"),
+            TemplateParameter("VIRTUAL_WARP_THREADS"),
+        ],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentArray(Dependency("KeyT"), Dependency("ITEMS_PER_THREAD")),
+                DependentOperator(
+                    Constant(numba.int8),
+                    [Dependency("KeyT"), Dependency("KeyT")],
+                    Dependency("Op"),
+                ),
+            ]
+        ],
+        type_definitions=[numba_type_to_wrapper(dtype, methods=methods)],
+    )
+    specialization = template.specialize(
+        {
+            "KeyT": dtype,
+            "VIRTUAL_WARP_THREADS": threads_in_warp,
+            "ITEMS_PER_THREAD": items_per_thread,
+            "Op": compare_op,
+        }
+    )
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir(threads=threads_in_warp)
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
@@ -3,7 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import numba
-from cuda.cooperative.experimental._types import *
+
+from cuda.cooperative.experimental._types import (
+    Algorithm,
+    Constant,
+    Dependency,
+    DependentArray,
+    DependentOperator,
+    Invocable,
+    Pointer,
+    TemplateParameter,
+    numba_type_to_wrapper,
+)
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
@@ -44,25 +44,38 @@ def reduce(dtype, binary_op, threads_in_warp=32, methods=None):
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('WarpReduce',
-                         'Reduce',
-                         'warp_reduce',
-                         ['cub/warp/warp_reduce.cuh'],
-                         [TemplateParameter('T'),
-                          TemplateParameter('VIRTUAL_WARP_THREADS')],
-                         [[Pointer(numba.uint8),
-                           DependentReference(Dependency('T')),
-                           DependentOperator(Dependency('T'), [Dependency(
-                               'T'), Dependency('T')], Dependency('Op')),
-                           DependentReference(Dependency('T'), True)]],
-                         type_definitions=[numba_type_to_wrapper(dtype, methods=methods)])
-    specialization = template.specialize({'T': dtype,
-                                          'VIRTUAL_WARP_THREADS': threads_in_warp,
-                                          'Op': binary_op})
+    template = Algorithm(
+        "WarpReduce",
+        "Reduce",
+        "warp_reduce",
+        ["cub/warp/warp_reduce.cuh"],
+        [TemplateParameter("T"), TemplateParameter("VIRTUAL_WARP_THREADS")],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentReference(Dependency("T")),
+                DependentOperator(
+                    Dependency("T"),
+                    [Dependency("T"), Dependency("T")],
+                    Dependency("Op"),
+                ),
+                DependentReference(Dependency("T"), True),
+            ]
+        ],
+        type_definitions=[numba_type_to_wrapper(dtype, methods=methods)],
+    )
+    specialization = template.specialize(
+        {"T": dtype, "VIRTUAL_WARP_THREADS": threads_in_warp, "Op": binary_op}
+    )
 
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir(threads=threads_in_warp)],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir(threads=threads_in_warp)
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )
 
 
 def sum(dtype, threads_in_warp=32):
@@ -101,17 +114,28 @@ def sum(dtype, threads_in_warp=32):
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('WarpReduce',
-                         'Sum',
-                         'warp_reduce',
-                         ['cub/warp/warp_reduce.cuh'],
-                         [TemplateParameter('T'),
-                          TemplateParameter('VIRTUAL_WARP_THREADS')],
-                         [[Pointer(numba.uint8),
-                           DependentReference(Dependency('T')),
-                           DependentReference(Dependency('T'), True)]])
-    specialization = template.specialize({'T': dtype,
-                                          'VIRTUAL_WARP_THREADS': threads_in_warp})
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir(threads=threads_in_warp)],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    template = Algorithm(
+        "WarpReduce",
+        "Sum",
+        "warp_reduce",
+        ["cub/warp/warp_reduce.cuh"],
+        [TemplateParameter("T"), TemplateParameter("VIRTUAL_WARP_THREADS")],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentReference(Dependency("T")),
+                DependentReference(Dependency("T"), True),
+            ]
+        ],
+    )
+    specialization = template.specialize(
+        {"T": dtype, "VIRTUAL_WARP_THREADS": threads_in_warp}
+    )
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir(threads=threads_in_warp)
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
@@ -2,8 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import numba
 
-from cuda.cooperative.experimental._types import *
+from cuda.cooperative.experimental._types import (
+    Algorithm,
+    Dependency,
+    DependentOperator,
+    DependentReference,
+    Invocable,
+    Pointer,
+    TemplateParameter,
+    numba_type_to_wrapper,
+)
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_scan.py
@@ -40,18 +40,29 @@ def exclusive_sum(dtype, threads_in_warp=32):
     Returns:
         A callable object that can be linked to and invoked from a CUDA kernel
     """
-    template = Algorithm('WarpScan',
-                         'ExclusiveSum',
-                         'warp_scan',
-                         ['cub/warp/warp_scan.cuh'],
-                         [TemplateParameter('T'),
-                          TemplateParameter('VIRTUAL_WARP_THREADS')],
-                         [[Pointer(numba.uint8),
-                           DependentReference(Dependency('T')),
-                           DependentReference(Dependency('T'), True)]],
-                         fake_return=True)
-    specialization = template.specialize({'T': dtype,
-                                          'VIRTUAL_WARP_THREADS': threads_in_warp})
-    return Invocable(temp_files=[make_binary_tempfile(ltoir, '.ltoir') for ltoir in specialization.get_lto_ir(threads=threads_in_warp)],
-                     temp_storage_bytes=specialization.get_temp_storage_bytes(),
-                     algorithm=specialization)
+    template = Algorithm(
+        "WarpScan",
+        "ExclusiveSum",
+        "warp_scan",
+        ["cub/warp/warp_scan.cuh"],
+        [TemplateParameter("T"), TemplateParameter("VIRTUAL_WARP_THREADS")],
+        [
+            [
+                Pointer(numba.uint8),
+                DependentReference(Dependency("T")),
+                DependentReference(Dependency("T"), True),
+            ]
+        ],
+        fake_return=True,
+    )
+    specialization = template.specialize(
+        {"T": dtype, "VIRTUAL_WARP_THREADS": threads_in_warp}
+    )
+    return Invocable(
+        temp_files=[
+            make_binary_tempfile(ltoir, ".ltoir")
+            for ltoir in specialization.get_lto_ir(threads=threads_in_warp)
+        ],
+        temp_storage_bytes=specialization.get_temp_storage_bytes(),
+        algorithm=specialization,
+    )

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_scan.py
@@ -3,7 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
-from cuda.cooperative.experimental._types import *
+import numba
+
+from cuda.cooperative.experimental._types import (
+    Algorithm,
+    Dependency,
+    DependentReference,
+    Invocable,
+    Pointer,
+    TemplateParameter,
+)
 from cuda.cooperative.experimental._common import make_binary_tempfile
 
 

--- a/python/cuda_cooperative/setup.py
+++ b/python/cuda_cooperative/setup.py
@@ -13,8 +13,10 @@ from wheel.bdist_wheel import bdist_wheel
 project_path = os.path.abspath(os.path.dirname(__file__))
 cccl_path = os.path.abspath(os.path.join(project_path, "..", ".."))
 cccl_headers = [["cub", "cub"], ["libcudacxx", "include"], ["thrust", "thrust"]]
+__version__ = None
 with open(os.path.join(project_path, "cuda", "cooperative", "_version.py")) as f:
     exec(f.read())
+assert __version__ is not None
 ver = __version__
 del __version__
 

--- a/python/cuda_cooperative/setup.py
+++ b/python/cuda_cooperative/setup.py
@@ -2,24 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys
 import os
-import glob
 import shutil
 
-from setuptools import Command, setup, find_packages, find_namespace_packages
+from setuptools import Command, setup, find_namespace_packages
 from setuptools.command.build_py import build_py
 from wheel.bdist_wheel import bdist_wheel
 
 
 project_path = os.path.abspath(os.path.dirname(__file__))
-cccl_path = os.path.abspath(os.path.join(project_path, "..", '..'))
-cccl_headers = [
-    ['cub', 'cub'],
-    ['libcudacxx', 'include'],
-    ['thrust', 'thrust']
-]
-with open(os.path.join(project_path, 'cuda', 'cooperative', '_version.py')) as f:
+cccl_path = os.path.abspath(os.path.join(project_path, "..", ".."))
+cccl_headers = [["cub", "cub"], ["libcudacxx", "include"], ["thrust", "thrust"]]
+with open(os.path.join(project_path, "cuda", "cooperative", "_version.py")) as f:
     exec(f.read())
 ver = __version__
 del __version__
@@ -31,19 +25,18 @@ with open("README.md") as f:
 
 class CustomBuildCommand(build_py):
     def run(self):
-        self.run_command('package_cccl')
+        self.run_command("package_cccl")
         build_py.run(self)
 
 
 class CustomWheelBuild(bdist_wheel):
-
     def run(self):
-        self.run_command('package_cccl')
+        self.run_command("package_cccl")
         super().run()
 
 
 class PackageCCCLCommand(Command):
-    description = 'Generate additional files'
+    description = "Generate additional files"
     user_options = []
 
     def initialize_options(self):
@@ -54,9 +47,8 @@ class PackageCCCLCommand(Command):
 
     def run(self):
         for proj_dir, header_dir in cccl_headers:
-            src_path = os.path.abspath(
-                os.path.join(cccl_path, proj_dir, header_dir))
-            dst_path = os.path.join(project_path, 'cuda', '_include', proj_dir)
+            src_path = os.path.abspath(os.path.join(cccl_path, proj_dir, header_dir))
+            dst_path = os.path.join(project_path, "cuda", "_include", proj_dir)
             if os.path.exists(dst_path):
                 shutil.rmtree(dst_path)
             shutil.copytree(src_path, dst_path)
@@ -73,13 +65,13 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Environment :: GPU :: NVIDIA CUDA",
     ],
-    packages=find_namespace_packages(include=['cuda.*']),
-    python_requires='>=3.9',
+    packages=find_namespace_packages(include=["cuda.*"]),
+    python_requires=">=3.9",
     install_requires=[
         "numba>=0.60.0",
         "pynvjitlink-cu12>=0.2.4",
         "cuda-python",
-        "jinja2"
+        "jinja2",
     ],
     extras_require={
         "test": [
@@ -88,11 +80,11 @@ setup(
         ]
     },
     cmdclass={
-        'package_cccl': PackageCCCLCommand,
-        'build_py': CustomBuildCommand,
-        'bdist_wheel': CustomWheelBuild,
+        "package_cccl": PackageCCCLCommand,
+        "build_py": CustomBuildCommand,
+        "bdist_wheel": CustomWheelBuild,
     },
     include_package_data=True,
     license="Apache-2.0 with LLVM exception",
-    license_files = ('../../LICENSE',),
+    license_files=("../../LICENSE",),
 )

--- a/python/cuda_cooperative/tests/helpers.py
+++ b/python/cuda_cooperative/tests/helpers.py
@@ -6,17 +6,18 @@ from numba import types
 import numpy as np
 
 NUMBA_TYPES_TO_NP = {
-  types.int8: np.int8,
-  types.int16: np.int16,
-  types.int32: np.int32,
-  types.int64: np.int64,
-  types.uint8: np.uint8,
-  types.uint16: np.uint16,
-  types.uint32: np.uint32,
-  types.uint64: np.uint64,
-  types.float32: np.float32,
-  types.float64: np.float64,
+    types.int8: np.int8,
+    types.int16: np.int16,
+    types.int32: np.int32,
+    types.int64: np.int64,
+    types.uint8: np.uint8,
+    types.uint16: np.uint16,
+    types.uint32: np.uint32,
+    types.uint64: np.uint64,
+    types.float32: np.float32,
+    types.float64: np.float64,
 }
 
+
 def random_int(shape, dtype):
-  return np.random.randint(0, 128, size=shape).astype(dtype)
+    return np.random.randint(0, 128, size=shape).astype(dtype)

--- a/python/cuda_cooperative/tests/test_block_load.py
+++ b/python/cuda_cooperative/tests/test_block_load.py
@@ -44,7 +44,6 @@ def test_block_load(T, threads_in_block, items_per_thread, algorithm):
 
     @cuda.jit(link=block_load.files)
     def kernel(d_input, d_output):
-        tid = cuda.threadIdx.x
         temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         block_load(temp_storage, d_input, thread_data)

--- a/python/cuda_cooperative/tests/test_block_load.py
+++ b/python/cuda_cooperative/tests/test_block_load.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from pynvjitlink import patch
-import numpy as np
 import cuda.cooperative.experimental as cudax
 from helpers import random_int, NUMBA_TYPES_TO_NP
 import pytest

--- a/python/cuda_cooperative/tests/test_block_merge_sort.py
+++ b/python/cuda_cooperative/tests/test_block_merge_sort.py
@@ -9,26 +9,30 @@ from helpers import random_int, NUMBA_TYPES_TO_NP
 import pytest
 from numba import cuda, types
 import numba
+
 patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 
-@pytest.mark.parametrize('T', [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize('threads_in_block', [32, 128, 256, 1024])
-@pytest.mark.parametrize('items_per_thread', [1, 3])
+@pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 128, 256, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_merge_sort(T, threads_in_block, items_per_thread):
     def op(a, b):
         return a < b
 
     block_merge_sort = cudax.block.merge_sort_keys(
-        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread, compare_op=op)
+        dtype=T,
+        threads_in_block=threads_in_block,
+        items_per_thread=items_per_thread,
+        compare_op=op,
+    )
     temp_storage_bytes = block_merge_sort.temp_storage_bytes
 
     @cuda.jit(link=block_merge_sort.files)
     def kernel(input, output):
         tid = cuda.threadIdx.x
-        temp_storage = cuda.shared.array(
-            shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         for i in range(items_per_thread):
             thread_data[i] = input[tid * items_per_thread + i]
@@ -52,26 +56,29 @@ def test_block_merge_sort(T, threads_in_block, items_per_thread):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
-@pytest.mark.parametrize('T', [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize('threads_in_block', [32, 128, 256, 1024])
-@pytest.mark.parametrize('items_per_thread', [1, 3])
+@pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 128, 256, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_merge_sort_descending(T, threads_in_block, items_per_thread):
     def op(a, b):
         return a > b
 
     block_merge_sort = cudax.block.merge_sort_keys(
-        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread, compare_op=op)
+        dtype=T,
+        threads_in_block=threads_in_block,
+        items_per_thread=items_per_thread,
+        compare_op=op,
+    )
     temp_storage_bytes = block_merge_sort.temp_storage_bytes
 
     @cuda.jit(link=block_merge_sort.files)
     def kernel(input, output):
         tid = cuda.threadIdx.x
-        temp_storage = cuda.shared.array(
-            shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         for i in range(items_per_thread):
             thread_data[i] = input[tid * items_per_thread + i]
@@ -95,8 +102,8 @@ def test_block_merge_sort_descending(T, threads_in_block, items_per_thread):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
 def test_block_merge_sort_user_defined_type():
@@ -108,14 +115,17 @@ def test_block_merge_sort_user_defined_type():
         return a[0].real > b[0].real
 
     block_merge_sort = cudax.block.merge_sort_keys(
-        dtype=numba.complex128, threads_in_block=threads_in_block, items_per_thread=items_per_thread, compare_op=op)
+        dtype=numba.complex128,
+        threads_in_block=threads_in_block,
+        items_per_thread=items_per_thread,
+        compare_op=op,
+    )
     temp_storage_bytes = block_merge_sort.temp_storage_bytes
 
     @cuda.jit(link=block_merge_sort.files)
     def kernel(input, output):
         tid = cuda.threadIdx.x
-        temp_storage = cuda.shared.array(
-            shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         for i in range(items_per_thread):
             thread_data[i] = input[tid * items_per_thread + i]
@@ -125,8 +135,7 @@ def test_block_merge_sort_user_defined_type():
 
     dtype = np.complex128
     items_per_tile = threads_in_block * items_per_thread
-    input = np.random.random(items_per_tile) + 1j * \
-        np.random.random(items_per_tile)
+    input = np.random.random(items_per_tile) + 1j * np.random.random(items_per_tile)
     input = input.astype(dtype)
     d_input = cuda.to_device(input)
     d_output = cuda.device_array(items_per_tile, dtype=dtype)

--- a/python/cuda_cooperative/tests/test_block_merge_sort_api.py
+++ b/python/cuda_cooperative/tests/test_block_merge_sort_api.py
@@ -7,6 +7,7 @@ import cuda.cooperative.experimental as cudax
 import numpy as np
 import numba
 from numba import cuda
+
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-begin imports
@@ -24,14 +25,14 @@ def test_block_merge_sort():
     items_per_thread = 4
     threads_per_block = 128
     block_merge_sort = cudax.block.merge_sort_keys(
-        numba.int32, threads_per_block, items_per_thread, compare_op)
+        numba.int32, threads_per_block, items_per_thread, compare_op
+    )
 
     # Link the merge sort to a CUDA kernel
     @cuda.jit(link=block_merge_sort.files)
     def kernel(keys):
         # Obtain a segment of consecutive items that are blocked across threads
-        thread_keys = cuda.local.array(
-            shape=items_per_thread, dtype=numba.int32)
+        thread_keys = cuda.local.array(shape=items_per_thread, dtype=numba.int32)
 
         for i in range(items_per_thread):
             thread_keys[i] = keys[cuda.threadIdx.x * items_per_thread + i]
@@ -42,6 +43,7 @@ def test_block_merge_sort():
         # Copy the sorted keys back to the output
         for i in range(items_per_thread):
             keys[cuda.threadIdx.x * items_per_thread + i] = thread_keys[i]
+
     # example-end merge-sort
 
     tile_size = threads_per_block * items_per_thread

--- a/python/cuda_cooperative/tests/test_block_radix_sort.py
+++ b/python/cuda_cooperative/tests/test_block_radix_sort.py
@@ -8,24 +8,26 @@ from helpers import random_int, NUMBA_TYPES_TO_NP
 import pytest
 from numba import cuda, types
 import numba
+
 patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 
-@pytest.mark.parametrize('T', [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize('threads_in_block', [32, 128, 256, 1024])
-@pytest.mark.parametrize('items_per_thread', [1, 3])
+@pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 128, 256, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_radix_sort_descending(T, threads_in_block, items_per_thread):
     begin_bit = numba.int32(0)
     end_bit = numba.int32(T.bitwidth)
     block_radix_sort = cudax.block.radix_sort_keys_descending(
-        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread)
+        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+    )
     temp_storage_bytes = block_radix_sort.temp_storage_bytes
 
     @cuda.jit(link=block_radix_sort.files)
     def kernel(input, output):
         tid = cuda.threadIdx.x
-        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         for i in range(items_per_thread):
             thread_data[i] = input[tid * items_per_thread + i]
@@ -49,25 +51,25 @@ def test_block_radix_sort_descending(T, threads_in_block, items_per_thread):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
-
-@pytest.mark.parametrize('T', [types.int8, types.int16, types.uint32, types.uint64])
-@pytest.mark.parametrize('threads_in_block', [32, 128, 256, 1024])
-@pytest.mark.parametrize('items_per_thread', [1, 3])
+@pytest.mark.parametrize("T", [types.int8, types.int16, types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 128, 256, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 3])
 def test_block_radix_sort(T, threads_in_block, items_per_thread):
     items_per_tile = threads_in_block * items_per_thread
 
     block_radix_sort = cudax.block.radix_sort_keys(
-        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread)
+        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+    )
     temp_storage_bytes = block_radix_sort.temp_storage_bytes
 
     @cuda.jit(link=block_radix_sort.files)
     def kernel(input, output):
         tid = cuda.threadIdx.x
-        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         for i in range(items_per_thread):
             thread_data[i] = input[tid * items_per_thread + i]
@@ -90,8 +92,8 @@ def test_block_radix_sort(T, threads_in_block, items_per_thread):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
 def test_block_radix_sort_overloads_work():
@@ -101,14 +103,15 @@ def test_block_radix_sort_overloads_work():
     items_per_tile = threads_in_block * items_per_thread
 
     block_radix_sort = cudax.block.radix_sort_keys(
-        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread)
+        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+    )
     temp_storage_bytes = block_radix_sort.temp_storage_bytes
 
     @cuda.jit(link=block_radix_sort.files)
     def kernel(input, output):
         tid = cuda.threadIdx.x
-        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype='uint8')
-        thread_data = cuda.local.array(shape=items_per_thread, dtype='int32')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
+        thread_data = cuda.local.array(shape=items_per_thread, dtype="int32")
         for i in range(items_per_thread):
             thread_data[i] = input[tid * items_per_thread + i]
         block_radix_sort(temp_storage, thread_data, numba.int32(0), numba.int32(32))
@@ -129,44 +132,58 @@ def test_block_radix_sort_overloads_work():
 
 
 def test_block_radix_sort_mangling():
-    return # TODO Return to linker issue
+    return  # TODO Return to linker issue
     threads_in_block = 128
     items_per_thread = 3
     items_per_tile = threads_in_block * items_per_thread
 
     int_block_radix_sort = cudax.block.radix_sort_keys(
-        dtype=numba.int32, threads_in_block=threads_in_block, items_per_thread=items_per_thread)
+        dtype=numba.int32,
+        threads_in_block=threads_in_block,
+        items_per_thread=items_per_thread,
+    )
     int_temp_storage_bytes = int_block_radix_sort.temp_storage_bytes
 
     double_block_radix_sort = cudax.block.radix_sort_keys(
-        dtype=numba.float64, threads_in_block=threads_in_block, items_per_thread=items_per_thread)
+        dtype=numba.float64,
+        threads_in_block=threads_in_block,
+        items_per_thread=items_per_thread,
+    )
     double_temp_storage_bytes = double_block_radix_sort.temp_storage_bytes
 
     @cuda.jit(link=int_block_radix_sort.files + double_block_radix_sort.files)
     def kernel(int_input, int_output, double_input, double_output):
         tid = cuda.threadIdx.x
-        int_temp_storage = cuda.shared.array(shape=int_temp_storage_bytes, dtype='uint8')
+        int_temp_storage = cuda.shared.array(
+            shape=int_temp_storage_bytes, dtype="uint8"
+        )
         int_thread_data = cuda.local.array(shape=items_per_thread, dtype=numba.int32)
         for i in range(items_per_thread):
             int_thread_data[i] = int_input[tid * items_per_thread + i]
         int_block_radix_sort(int_temp_storage, int_thread_data)
         for i in range(items_per_thread):
             int_output[tid * items_per_thread + i] = int_thread_data[i]
-        double_temp_storage = cuda.shared.array(shape=double_temp_storage_bytes, dtype='uint8')
-        double_thread_data = cuda.local.array(shape=items_per_thread, dtype=numba.float64)
+        double_temp_storage = cuda.shared.array(
+            shape=double_temp_storage_bytes, dtype="uint8"
+        )
+        double_thread_data = cuda.local.array(
+            shape=items_per_thread, dtype=numba.float64
+        )
         for i in range(items_per_thread):
             double_thread_data[i] = double_input[tid * items_per_thread + i]
         double_block_radix_sort(double_temp_storage, double_thread_data)
         for i in range(items_per_thread):
             double_output[tid * items_per_thread + i] = double_thread_data[i]
 
-    int_input = random_int(items_per_tile, 'int32')
+    int_input = random_int(items_per_tile, "int32")
     d_int_input = cuda.to_device(int_input)
-    d_int_output = cuda.device_array(items_per_tile, dtype='int32')
-    double_input = random_int(items_per_tile, 'float64')
+    d_int_output = cuda.device_array(items_per_tile, dtype="int32")
+    double_input = random_int(items_per_tile, "float64")
     d_double_input = cuda.to_device(double_input)
-    d_double_output = cuda.device_array(items_per_tile, dtype='float64')
-    kernel[1, threads_in_block](d_int_input, d_int_output, d_double_input, d_double_output)
+    d_double_output = cuda.device_array(items_per_tile, dtype="float64")
+    kernel[1, threads_in_block](
+        d_int_input, d_int_output, d_double_input, d_double_output
+    )
     cuda.synchronize()
 
     int_output = d_int_output.copy_to_host()

--- a/python/cuda_cooperative/tests/test_block_radix_sort_api.py
+++ b/python/cuda_cooperative/tests/test_block_radix_sort_api.py
@@ -7,6 +7,7 @@ import cuda.cooperative.experimental as cudax
 import numpy as np
 import numba
 from numba import cuda
+
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-begin imports
@@ -20,14 +21,14 @@ def test_block_radix_sort():
     items_per_thread = 4
     threads_per_block = 128
     block_radix_sort = cudax.block.radix_sort_keys(
-        numba.int32, threads_per_block, items_per_thread)
+        numba.int32, threads_per_block, items_per_thread
+    )
 
     # Link the radix sort to a CUDA kernel
     @cuda.jit(link=block_radix_sort.files)
     def kernel(keys):
         # Obtain a segment of consecutive items that are blocked across threads
-        thread_keys = cuda.local.array(
-            shape=items_per_thread, dtype=numba.int32)
+        thread_keys = cuda.local.array(shape=items_per_thread, dtype=numba.int32)
 
         for i in range(items_per_thread):
             thread_keys[i] = keys[cuda.threadIdx.x * items_per_thread + i]
@@ -38,6 +39,7 @@ def test_block_radix_sort():
         # Copy the sorted keys back to the output
         for i in range(items_per_thread):
             keys[cuda.threadIdx.x * items_per_thread + i] = thread_keys[i]
+
     # example-end radix-sort
 
     tile_size = threads_per_block * items_per_thread
@@ -56,14 +58,14 @@ def test_block_radix_sort_descending():
     items_per_thread = 4
     threads_per_block = 128
     block_radix_sort = cudax.block.radix_sort_keys_descending(
-        numba.int32, threads_per_block, items_per_thread)
+        numba.int32, threads_per_block, items_per_thread
+    )
 
     # Link the radix sort to a CUDA kernel
     @cuda.jit(link=block_radix_sort.files)
     def kernel(keys):
         # Obtain a segment of consecutive items that are blocked across threads
-        thread_keys = cuda.local.array(
-            shape=items_per_thread, dtype=numba.int32)
+        thread_keys = cuda.local.array(shape=items_per_thread, dtype=numba.int32)
 
         for i in range(items_per_thread):
             thread_keys[i] = keys[cuda.threadIdx.x * items_per_thread + i]
@@ -74,6 +76,7 @@ def test_block_radix_sort_descending():
         # Copy the sorted keys back to the output
         for i in range(items_per_thread):
             keys[cuda.threadIdx.x * items_per_thread + i] = thread_keys[i]
+
     # example-end radix-sort-descending
 
     tile_size = threads_per_block * items_per_thread

--- a/python/cuda_cooperative/tests/test_block_reduce.py
+++ b/python/cuda_cooperative/tests/test_block_reduce.py
@@ -4,15 +4,21 @@
 
 from pynvjitlink import patch
 import cuda.cooperative.experimental as cudax
-from numba.core.extending import (lower_builtin, make_attribute_wrapper,
-                                  models, register_model, type_callable,
-                                  typeof_impl)
+from numba.core.extending import (
+    lower_builtin,
+    make_attribute_wrapper,
+    models,
+    register_model,
+    type_callable,
+    typeof_impl,
+)
 from numba.core import cgutils
 import numpy as np
 from helpers import random_int, NUMBA_TYPES_TO_NP
 import pytest
 from numba import cuda, types
 import numba
+
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 
@@ -34,7 +40,7 @@ class Complex:
 
 class ComplexType(types.Type):
     def __init__(self):
-        super().__init__(name='Complex')
+        super().__init__(name="Complex")
 
 
 complex_type = ComplexType()
@@ -50,18 +56,19 @@ def type__complex(context):
     def typer(real, imag):
         if isinstance(real, types.Integer) and isinstance(imag, types.Integer):
             return complex_type
+
     return typer
 
 
 @register_model(ComplexType)
 class ComplexModel(models.StructModel):
     def __init__(self, dmm, fe_type):
-        members = [('real', types.int32), ('imag', types.int32)]
+        members = [("real", types.int32), ("imag", types.int32)]
         models.StructModel.__init__(self, dmm, fe_type, members)
 
 
-make_attribute_wrapper(ComplexType, 'real', 'real')
-make_attribute_wrapper(ComplexType, 'imag', 'imag')
+make_attribute_wrapper(ComplexType, "real", "real")
+make_attribute_wrapper(ComplexType, "imag", "imag")
 
 
 @lower_builtin(Complex, types.Integer, types.Integer)
@@ -74,38 +81,40 @@ def impl_complex(context, builder, sig, args):
     return state._getvalue()
 
 
-@pytest.mark.parametrize('threads_in_block', [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
 def test_block_reduction_of_user_defined_type_without_temp_storage(threads_in_block):
     def op(result_ptr, lhs_ptr, rhs_ptr):
         real_value = numba.int32(lhs_ptr[0].real + rhs_ptr[0].real)
         imag_value = numba.int32(lhs_ptr[0].imag + rhs_ptr[0].imag)
         result_ptr[0] = Complex(real_value, imag_value)
 
-    block_reduce = cudax.block.reduce(dtype=complex_type,
-                                      binary_op=op,
-                                      threads_in_block=threads_in_block,
-                                      methods={
-                                          'construct': Complex.construct,
-                                          'assign': Complex.assign,
-                                      })
+    block_reduce = cudax.block.reduce(
+        dtype=complex_type,
+        binary_op=op,
+        threads_in_block=threads_in_block,
+        methods={
+            "construct": Complex.construct,
+            "assign": Complex.assign,
+        },
+    )
 
     @cuda.jit(link=block_reduce.files)
     def kernel(input, output):
         block_output = block_reduce(
-            Complex(input[cuda.threadIdx.x], input[threads_in_block + cuda.threadIdx.x]))
+            Complex(input[cuda.threadIdx.x], input[threads_in_block + cuda.threadIdx.x])
+        )
 
         if cuda.threadIdx.x == 0:
             output[0] = block_output.real
             output[1] = block_output.imag
 
-    h_input = random_int(2 * threads_in_block, 'int32')
+    h_input = random_int(2 * threads_in_block, "int32")
     d_input = cuda.to_device(h_input)
-    d_output = cuda.device_array(2, dtype='int32')
+    d_output = cuda.device_array(2, dtype="int32")
     kernel[1, threads_in_block](d_input, d_output)
     cuda.synchronize()
     h_output = d_output.copy_to_host()
-    h_expected = np.sum(h_input[:threads_in_block]), np.sum(
-        h_input[threads_in_block:])
+    h_expected = np.sum(h_input[:threads_in_block]), np.sum(h_input[threads_in_block:])
 
     assert h_output[0] == h_expected[0]
     assert h_output[1] == h_expected[1]
@@ -113,45 +122,49 @@ def test_block_reduction_of_user_defined_type_without_temp_storage(threads_in_bl
     sig = (numba.int32[::1], numba.int32[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
-@pytest.mark.parametrize('threads_in_block', [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
 def test_block_reduction_of_user_defined_type(threads_in_block):
     def op(result_ptr, lhs_ptr, rhs_ptr):
         real_value = numba.int32(lhs_ptr[0].real + rhs_ptr[0].real)
         imag_value = numba.int32(lhs_ptr[0].imag + rhs_ptr[0].imag)
         result_ptr[0] = Complex(real_value, imag_value)
 
-    block_reduce = cudax.block.reduce(dtype=complex_type,
-                                      binary_op=op,
-                                      threads_in_block=threads_in_block,
-                                      methods={
-                                          'construct': Complex.construct,
-                                          'assign': Complex.assign,
-                                      })
+    block_reduce = cudax.block.reduce(
+        dtype=complex_type,
+        binary_op=op,
+        threads_in_block=threads_in_block,
+        methods={
+            "construct": Complex.construct,
+            "assign": Complex.assign,
+        },
+    )
     temp_storage_bytes = block_reduce.temp_storage_bytes
 
     @cuda.jit(link=block_reduce.files)
     def kernel(input, output):
-        temp_storage = cuda.shared.array(
-            shape=temp_storage_bytes, dtype='uint8')
-        block_output = block_reduce(temp_storage, Complex(input[cuda.threadIdx.x],
-                                                          input[threads_in_block + cuda.threadIdx.x]))
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
+        block_output = block_reduce(
+            temp_storage,
+            Complex(
+                input[cuda.threadIdx.x], input[threads_in_block + cuda.threadIdx.x]
+            ),
+        )
 
         if cuda.threadIdx.x == 0:
             output[0] = block_output.real
             output[1] = block_output.imag
 
-    h_input = random_int(2 * threads_in_block, 'int32')
+    h_input = random_int(2 * threads_in_block, "int32")
     d_input = cuda.to_device(h_input)
-    d_output = cuda.device_array(2, dtype='int32')
+    d_output = cuda.device_array(2, dtype="int32")
     kernel[1, threads_in_block](d_input, d_output)
     cuda.synchronize()
     h_output = d_output.copy_to_host()
-    h_expected = np.sum(h_input[:threads_in_block]), np.sum(
-        h_input[threads_in_block:])
+    h_expected = np.sum(h_input[:threads_in_block]), np.sum(h_input[threads_in_block:])
 
     assert h_output[0] == h_expected[0]
     assert h_output[1] == h_expected[1]
@@ -159,25 +172,24 @@ def test_block_reduction_of_user_defined_type(threads_in_block):
     sig = (numba.int32[::1], numba.int32[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
-@pytest.mark.parametrize('T', [types.uint32, types.uint64])
-@pytest.mark.parametrize('threads_in_block', [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
 def test_block_reduction_of_integral_type(T, threads_in_block):
     def op(a, b):
         return a if a < b else b
 
-    block_reduce = cudax.block.reduce(dtype=T,
-                                      binary_op=op,
-                                      threads_in_block=threads_in_block)
+    block_reduce = cudax.block.reduce(
+        dtype=T, binary_op=op, threads_in_block=threads_in_block
+    )
     temp_storage_bytes = block_reduce.temp_storage_bytes
 
     @cuda.jit(link=block_reduce.files)
     def kernel(input, output):
-        temp_storage = cuda.shared.array(
-            shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         block_output = block_reduce(temp_storage, input[cuda.threadIdx.x])
 
         if cuda.threadIdx.x == 0:
@@ -197,21 +209,19 @@ def test_block_reduction_of_integral_type(T, threads_in_block):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
-@pytest.mark.parametrize('T', [types.uint32, types.uint64])
-@pytest.mark.parametrize('threads_in_block', [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
 def test_block_sum(T, threads_in_block):
-    block_reduce = cudax.block.sum(
-        dtype=T, threads_in_block=threads_in_block)
+    block_reduce = cudax.block.sum(dtype=T, threads_in_block=threads_in_block)
     temp_storage_bytes = block_reduce.temp_storage_bytes
 
     @cuda.jit(link=block_reduce.files)
     def kernel(input, output):
-        temp_storage = cuda.shared.array(
-            shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         block_output = block_reduce(temp_storage, input[cuda.threadIdx.x])
 
         if cuda.threadIdx.x == 0:
@@ -231,22 +241,22 @@ def test_block_sum(T, threads_in_block):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
-@pytest.mark.parametrize('T', [types.uint32, types.uint64])
-@pytest.mark.parametrize('threads_in_block', [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
 def test_block_valid_sum(T, threads_in_block):
     block_reduce = cudax.block.sum(dtype=T, threads_in_block=threads_in_block)
     temp_storage_bytes = block_reduce.temp_storage_bytes
 
     @cuda.jit(link=block_reduce.files)
     def kernel(input, output):
-        temp_storage = cuda.shared.array(
-            shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         block_output = block_reduce(
-            temp_storage, input[cuda.threadIdx.x], numba.int32(threads_in_block / 2))
+            temp_storage, input[cuda.threadIdx.x], numba.int32(threads_in_block / 2)
+        )
 
         if cuda.threadIdx.x == 0:
             output[0] = block_output
@@ -258,12 +268,12 @@ def test_block_valid_sum(T, threads_in_block):
     kernel[1, threads_in_block](d_input, d_output)
     cuda.synchronize()
     h_output = d_output.copy_to_host()
-    h_expected = np.sum(h_input[:threads_in_block // 2])
+    h_expected = np.sum(h_input[: threads_in_block // 2])
 
     assert h_output[0] == h_expected
 
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass

--- a/python/cuda_cooperative/tests/test_block_reduce_api.py
+++ b/python/cuda_cooperative/tests/test_block_reduce_api.py
@@ -7,6 +7,7 @@ import cuda.cooperative.experimental as cudax
 import numpy as np
 import numba
 from numba import cuda
+
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-begin imports
@@ -28,6 +29,7 @@ def test_block_reduction():
 
         if cuda.threadIdx.x == 0:
             output[0] = block_output
+
     # example-end reduce
 
     h_input = np.random.randint(0, 42, threads_in_block, dtype=np.int32)
@@ -51,6 +53,7 @@ def test_block_sum():
 
         if cuda.threadIdx.x == 0:
             output[0] = block_output
+
     # example-end sum
 
     h_input = np.ones(threads_in_block, dtype=np.int32)

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -6,14 +6,18 @@ from pynvjitlink import patch
 import cuda.cooperative.experimental as cudax
 import numba
 from helpers import random_int, NUMBA_TYPES_TO_NP
-from numba.core.extending import (lower_builtin, make_attribute_wrapper,
-                                  models, register_model, type_callable,
-                                  typeof_impl)
+from numba.core.extending import (
+    lower_builtin,
+    make_attribute_wrapper,
+    models,
+    register_model,
+    type_callable,
+    typeof_impl,
+)
 from numba.core import cgutils
 import numpy as np
 import pytest
 from numba import cuda, types
-import numba
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
@@ -21,19 +25,19 @@ numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 patch.patch_numba_linker(lto=True)
 
 
-@pytest.mark.parametrize('T', [types.uint32, types.uint64])
-@pytest.mark.parametrize('threads_in_block', [32, 64, 128, 256, 512, 1024])
-@pytest.mark.parametrize('items_per_thread', [1, 2, 3, 4])
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
+@pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
 def test_block_exclusive_sum(T, threads_in_block, items_per_thread):
-    block_exclusive_sum = cudax.block.exclusive_sum(dtype=T,
-                                                    threads_in_block=threads_in_block,
-                                                    items_per_thread=items_per_thread)
+    block_exclusive_sum = cudax.block.exclusive_sum(
+        dtype=T, threads_in_block=threads_in_block, items_per_thread=items_per_thread
+    )
     temp_storage_bytes = block_exclusive_sum.temp_storage_bytes
 
     @cuda.jit(link=block_exclusive_sum.files)
     def kernel(input, output):
         tid = cuda.threadIdx.x
-        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         for i in range(items_per_thread):
             thread_data[i] = input[tid * items_per_thread + i]
@@ -57,8 +61,8 @@ def test_block_exclusive_sum(T, threads_in_block, items_per_thread):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
 class BlockPrefixCallbackOp:
@@ -73,7 +77,7 @@ class BlockPrefixCallbackOp:
 
 class BlockPrefixCallbackOpType(types.Type):
     def __init__(self):
-        super().__init__(name='BlockPrefixCallbackOp')
+        super().__init__(name="BlockPrefixCallbackOp")
 
 
 block_prefix_callback_op_type = BlockPrefixCallbackOpType()
@@ -89,18 +93,18 @@ def type__block_prefix_callback_op(context):
     def typer(running_total):
         if isinstance(running_total, types.Integer):
             return block_prefix_callback_op_type
+
     return typer
 
 
 @register_model(BlockPrefixCallbackOpType)
 class BlockPrefixCallbackOpModel(models.StructModel):
     def __init__(self, dmm, fe_type):
-        members = [('running_total', types.int64)]
+        members = [("running_total", types.int64)]
         models.StructModel.__init__(self, dmm, fe_type, members)
 
 
-make_attribute_wrapper(BlockPrefixCallbackOpType,
-                       'running_total', 'running_total')
+make_attribute_wrapper(BlockPrefixCallbackOpType, "running_total", "running_total")
 
 
 @lower_builtin(BlockPrefixCallbackOp, types.Integer)
@@ -112,44 +116,48 @@ def impl_block_prefix_callback_op(context, builder, sig, args):
     return state._getvalue()
 
 
-
-@pytest.mark.parametrize('threads_in_block', [32, 64, 128, 256, 512, 1024])
-@pytest.mark.parametrize('items_per_thread', [1, 2, 3, 4])
+@pytest.mark.parametrize("threads_in_block", [32, 64, 128, 256, 512, 1024])
+@pytest.mark.parametrize("items_per_thread", [1, 2, 3, 4])
 def test_block_exclusive_sum_prefix(threads_in_block, items_per_thread):
     tile_items = threads_in_block * items_per_thread
     segment_size = 2 * 1024
     num_segments = 128
     num_elements = segment_size * num_segments
 
-    prefix_op = cudax.StatefulFunction(BlockPrefixCallbackOp,
-                                      block_prefix_callback_op_type)
-    block_exclusive_sum = cudax.block.exclusive_sum(dtype=numba.types.int32,
-                                                    threads_in_block=threads_in_block,
-                                                    items_per_thread=items_per_thread,
-                                                    prefix_op=prefix_op)
+    prefix_op = cudax.StatefulFunction(
+        BlockPrefixCallbackOp, block_prefix_callback_op_type
+    )
+    block_exclusive_sum = cudax.block.exclusive_sum(
+        dtype=numba.types.int32,
+        threads_in_block=threads_in_block,
+        items_per_thread=items_per_thread,
+        prefix_op=prefix_op,
+    )
     temp_storage_bytes = block_exclusive_sum.temp_storage_bytes
 
     @cuda.jit(link=block_exclusive_sum.files)
     def kernel(input, output):
         segment_offset = cuda.blockIdx.x * segment_size
-        temp_storage = cuda.shared.array(
-            shape=temp_storage_bytes, dtype='uint8')
-        block_prefix_op = cuda.local.array(
-            shape=1, dtype=block_prefix_callback_op_type)
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
+        block_prefix_op = cuda.local.array(shape=1, dtype=block_prefix_callback_op_type)
         block_prefix_op[0] = BlockPrefixCallbackOp(0)
-        thread_input = cuda.local.array(shape=items_per_thread, dtype='int32')
-        thread_output = cuda.local.array(shape=items_per_thread, dtype='int32')
+        thread_input = cuda.local.array(shape=items_per_thread, dtype="int32")
+        thread_output = cuda.local.array(shape=items_per_thread, dtype="int32")
 
         tile_offset = 0
 
         while tile_offset < segment_size:
             for item in range(items_per_thread):
                 item_offset = tile_offset + cuda.threadIdx.x * items_per_thread + item
-                thread_input[item] = input[segment_offset +
-                                           item_offset] if item_offset < segment_size else 0
+                thread_input[item] = (
+                    input[segment_offset + item_offset]
+                    if item_offset < segment_size
+                    else 0
+                )
 
-            block_exclusive_sum(temp_storage, thread_input,
-                                thread_output, block_prefix_op)
+            block_exclusive_sum(
+                temp_storage, thread_input, thread_output, block_prefix_op
+            )
 
             for item in range(items_per_thread):
                 item_offset = tile_offset + cuda.threadIdx.x * items_per_thread + item
@@ -158,27 +166,33 @@ def test_block_exclusive_sum_prefix(threads_in_block, items_per_thread):
 
             tile_offset += tile_items
 
-    h_input = np.arange(num_elements, dtype='int32')
+    h_input = np.arange(num_elements, dtype="int32")
     d_input = cuda.to_device(h_input)
-    d_output = cuda.to_device(np.zeros(num_elements, dtype='int32'))
+    d_output = cuda.to_device(np.zeros(num_elements, dtype="int32"))
     kernel[num_segments, threads_in_block](d_input, d_output)
     cuda.synchronize()
     h_output = d_output.copy_to_host()
-    h_reference = np.zeros(segment_size * num_segments, dtype='int32')
+    h_reference = np.zeros(segment_size * num_segments, dtype="int32")
     for sid in range(num_segments):
         h_reference[sid * segment_size] = 0
         for i in range(1, segment_size):
-            h_reference[sid * segment_size + i] = h_reference[sid *
-                                                              segment_size + i - 1] + h_input[sid * segment_size + i - 1]
+            h_reference[sid * segment_size + i] = (
+                h_reference[sid * segment_size + i - 1]
+                + h_input[sid * segment_size + i - 1]
+            )
 
     for sid in range(num_segments):
         for i in range(segment_size):
             if h_output[sid * segment_size + i] != h_reference[sid * segment_size + i]:
-                print(sid, i, h_output[sid * segment_size + i],
-                      h_reference[sid * segment_size + i])
+                print(
+                    sid,
+                    i,
+                    h_output[sid * segment_size + i],
+                    h_reference[sid * segment_size + i],
+                )
 
     sig = (types.int32[::1], types.int32[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass

--- a/python/cuda_cooperative/tests/test_block_scan_api.py
+++ b/python/cuda_cooperative/tests/test_block_scan_api.py
@@ -7,6 +7,7 @@ import cuda.cooperative.experimental as cudax
 import numpy as np
 import numba
 from numba import cuda
+
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-begin imports
@@ -21,14 +22,14 @@ def test_block_exclusive_sum():
 
     # Specialize exclusive sum for a 1D block of 128 threads owning 4 integer items each
     block_exclusive_sum = cudax.block.exclusive_sum(
-        numba.int32, threads_per_block, items_per_thread)
+        numba.int32, threads_per_block, items_per_thread
+    )
 
     # Link the exclusive sum to a CUDA kernel
     @cuda.jit(link=block_exclusive_sum.files)
     def kernel(data):
         # Obtain a segment of consecutive items that are blocked across threads
-        thread_data = cuda.local.array(
-            shape=items_per_thread, dtype=numba.int32)
+        thread_data = cuda.local.array(shape=items_per_thread, dtype=numba.int32)
         for i in range(items_per_thread):
             thread_data[i] = data[cuda.threadIdx.x * items_per_thread + i]
 
@@ -38,6 +39,7 @@ def test_block_exclusive_sum():
         # Copy the scanned keys back to the output
         for i in range(items_per_thread):
             data[cuda.threadIdx.x * items_per_thread + i] = thread_data[i]
+
     # example-end exclusive-sum
 
     tile_size = threads_per_block * items_per_thread

--- a/python/cuda_cooperative/tests/test_block_store.py
+++ b/python/cuda_cooperative/tests/test_block_store.py
@@ -44,7 +44,6 @@ def test_block_store(T, threads_in_block, items_per_thread, algorithm):
 
     @cuda.jit(link=block_store.files)
     def kernel(d_input, d_output):
-        tid = cuda.threadIdx.x
         temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         thread_data = cuda.local.array(shape=items_per_thread, dtype=dtype)
         for i in range(items_per_thread):

--- a/python/cuda_cooperative/tests/test_block_store.py
+++ b/python/cuda_cooperative/tests/test_block_store.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from pynvjitlink import patch
-import numpy as np
 import cuda.cooperative.experimental as cudax
 from helpers import random_int, NUMBA_TYPES_TO_NP
 import pytest

--- a/python/cuda_cooperative/tests/test_warp_merge_sort_api.py
+++ b/python/cuda_cooperative/tests/test_warp_merge_sort_api.py
@@ -7,6 +7,7 @@ import cuda.cooperative.experimental as cudax
 import numpy as np
 import numba
 from numba import cuda
+
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-begin imports
@@ -23,14 +24,14 @@ def test_warp_merge_sort():
     # Specialize merge sort for a warp of threads owning 4 integer items each
     items_per_thread = 4
     warp_merge_sort = cudax.warp.merge_sort_keys(
-        numba.int32, items_per_thread, compare_op)
+        numba.int32, items_per_thread, compare_op
+    )
 
     # Link the merge sort to a CUDA kernel
     @cuda.jit(link=warp_merge_sort.files)
     def kernel(keys):
         # Obtain a segment of consecutive items that are blocked across threads
-        thread_keys = cuda.local.array(
-            shape=items_per_thread, dtype=numba.int32)
+        thread_keys = cuda.local.array(shape=items_per_thread, dtype=numba.int32)
 
         for i in range(items_per_thread):
             thread_keys[i] = keys[cuda.threadIdx.x * items_per_thread + i]
@@ -41,6 +42,7 @@ def test_warp_merge_sort():
         # Copy the sorted keys back to the output
         for i in range(items_per_thread):
             keys[cuda.threadIdx.x * items_per_thread + i] = thread_keys[i]
+
     # example-end merge-sort
 
     tile_size = 32 * items_per_thread

--- a/python/cuda_cooperative/tests/test_warp_reduce.py
+++ b/python/cuda_cooperative/tests/test_warp_reduce.py
@@ -4,22 +4,19 @@
 
 from pynvjitlink import patch
 import cuda.cooperative.experimental as cudax
-from numba.core.extending import (lower_builtin, make_attribute_wrapper,
-                                  models, register_model, type_callable,
-                                  typeof_impl)
-from numba.core import cgutils
 import numpy as np
 from helpers import random_int, NUMBA_TYPES_TO_NP
 import pytest
 from numba import cuda, types
 import numba
+
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 
 patch.patch_numba_linker(lto=True)
 
 
-@pytest.mark.parametrize('T', [types.uint32, types.uint64])
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
 def test_warp_reduction_of_integral_type(T):
     def op(a, b):
         return a if a < b else b
@@ -29,8 +26,7 @@ def test_warp_reduction_of_integral_type(T):
 
     @cuda.jit(link=warp_reduce.files)
     def kernel(input, output):
-        temp_storage = cuda.shared.array(
-            shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         warp_output = warp_reduce(temp_storage, input[cuda.threadIdx.x])
 
         if cuda.threadIdx.x == 0:
@@ -50,18 +46,18 @@ def test_warp_reduction_of_integral_type(T):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass
 
 
-@pytest.mark.parametrize('T', [types.uint32, types.uint64])
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
 def test_warp_sum(T):
     warp_reduce = cudax.warp.sum(T)
     temp_storage_bytes = warp_reduce.temp_storage_bytes
 
     @cuda.jit(link=warp_reduce.files)
     def kernel(input, output):
-        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         warp_output = warp_reduce(temp_storage, input[cuda.threadIdx.x])
 
         if cuda.threadIdx.x == 0:
@@ -81,5 +77,5 @@ def test_warp_sum(T):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass

--- a/python/cuda_cooperative/tests/test_warp_reduce_api.py
+++ b/python/cuda_cooperative/tests/test_warp_reduce_api.py
@@ -7,6 +7,7 @@ import cuda.cooperative.experimental as cudax
 import numpy as np
 import numba
 from numba import cuda
+
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-begin imports
@@ -27,6 +28,7 @@ def test_warp_reduction():
 
         if cuda.threadIdx.x == 0:
             output[0] = warp_output
+
     # example-end reduce
 
     h_input = np.random.randint(0, 42, 32, dtype=np.int32)
@@ -49,6 +51,7 @@ def test_warp_sum():
 
         if cuda.threadIdx.x == 0:
             output[0] = warp_output
+
     # example-end sum
 
     h_input = np.ones(32, dtype=np.int32)

--- a/python/cuda_cooperative/tests/test_warp_scan.py
+++ b/python/cuda_cooperative/tests/test_warp_scan.py
@@ -9,7 +9,6 @@ from helpers import random_int, NUMBA_TYPES_TO_NP
 import numpy as np
 import pytest
 from numba import cuda, types
-import numba
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
@@ -17,7 +16,7 @@ numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 patch.patch_numba_linker(lto=True)
 
 
-@pytest.mark.parametrize('T', [types.uint32, types.uint64])
+@pytest.mark.parametrize("T", [types.uint32, types.uint64])
 def test_warp_exclusive_sum(T):
     warp_exclusive_sum = cudax.warp.exclusive_sum(dtype=T)
     temp_storage_bytes = warp_exclusive_sum.temp_storage_bytes
@@ -25,7 +24,7 @@ def test_warp_exclusive_sum(T):
     @cuda.jit(link=warp_exclusive_sum.files)
     def kernel(input, output):
         tid = cuda.threadIdx.x
-        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype='uint8')
+        temp_storage = cuda.shared.array(shape=temp_storage_bytes, dtype="uint8")
         output[tid] = warp_exclusive_sum(temp_storage, input[tid])
 
     dtype = NUMBA_TYPES_TO_NP[T]
@@ -43,5 +42,5 @@ def test_warp_exclusive_sum(T):
     sig = (T[::1], T[::1])
     sass = kernel.inspect_sass(sig)
 
-    assert 'LDL' not in sass
-    assert 'STL' not in sass
+    assert "LDL" not in sass
+    assert "STL" not in sass

--- a/python/cuda_cooperative/tests/test_warp_scan_api.py
+++ b/python/cuda_cooperative/tests/test_warp_scan_api.py
@@ -7,6 +7,7 @@ import cuda.cooperative.experimental as cudax
 import numpy as np
 import numba
 from numba import cuda
+
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
 # example-begin imports
@@ -24,6 +25,7 @@ def test_warp_exclusive_sum():
     def kernel(data):
         # Collectively compute the warp-wide exclusive prefix sum
         data[cuda.threadIdx.x] = warp_exclusive_sum(data[cuda.threadIdx.x])
+
     # example-end exclusive-sum
 
     tile_size = 32

--- a/python/cuda_parallel/cuda/parallel/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/__init__.py
@@ -2,5 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import cuda.parallel.experimental
 from cuda.parallel._version import __version__
+
+__all__ = ["__version__"]

--- a/python/cuda_parallel/cuda/parallel/experimental/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/__init__.py
@@ -77,50 +77,54 @@ def _type_to_enum(numba_type):
 
 # MUST match `cccl_type_info` in c/include/cccl/c/types.h
 class _TypeInfo(ctypes.Structure):
-    _fields_ = [("size", ctypes.c_int),
-                ("alignment", ctypes.c_int),
-                ("type", _TypeEnum)]
+    _fields_ = [
+        ("size", ctypes.c_int),
+        ("alignment", ctypes.c_int),
+        ("type", _TypeEnum),
+    ]
 
 
 # MUST match `cccl_op_t` in c/include/cccl/c/types.h
 class _CCCLOp(ctypes.Structure):
-    _fields_ = [("type", _CCCLOpKindEnum),
-                ("name", ctypes.c_char_p),
-                ("ltoir", ctypes.c_char_p),
-                ("ltoir_size", ctypes.c_int),
-                ("size", ctypes.c_int),
-                ("alignment", ctypes.c_int),
-                ("state", ctypes.c_void_p)]
+    _fields_ = [
+        ("type", _CCCLOpKindEnum),
+        ("name", ctypes.c_char_p),
+        ("ltoir", ctypes.c_char_p),
+        ("ltoir_size", ctypes.c_int),
+        ("size", ctypes.c_int),
+        ("alignment", ctypes.c_int),
+        ("state", ctypes.c_void_p),
+    ]
 
 
 # MUST match `cccl_string_view` in c/include/cccl/c/types.h
 class _CCCLStringView(ctypes.Structure):
-    _fields_ = [("begin", ctypes.c_char_p),
-                ("size", ctypes.c_int)]
+    _fields_ = [("begin", ctypes.c_char_p), ("size", ctypes.c_int)]
 
 
 # MUST match `cccl_string_views` in c/include/cccl/c/types.h
 class _CCCLStringViews(ctypes.Structure):
-    _fields_ = [("views", ctypes.POINTER(_CCCLStringView)),
-                ("size", ctypes.c_int)]
+    _fields_ = [("views", ctypes.POINTER(_CCCLStringView)), ("size", ctypes.c_int)]
 
 
 # MUST match `cccl_iterator_t` in c/include/cccl/c/types.h
 class _CCCLIterator(ctypes.Structure):
-    _fields_ = [("size", ctypes.c_int),
-                ("alignment", ctypes.c_int),
-                ("type", _CCCLIteratorKindEnum),
-                ("advance", _CCCLOp),
-                ("dereference", _CCCLOp),
-                ("value_type", _TypeInfo),
-                ("state", ctypes.c_void_p),
-                ("ltoirs", ctypes.POINTER(_CCCLStringViews))]
+    _fields_ = [
+        ("size", ctypes.c_int),
+        ("alignment", ctypes.c_int),
+        ("type", _CCCLIteratorKindEnum),
+        ("advance", _CCCLOp),
+        ("dereference", _CCCLOp),
+        ("value_type", _TypeInfo),
+        ("state", ctypes.c_void_p),
+        ("ltoirs", ctypes.POINTER(_CCCLStringViews)),
+    ]
 
 
 # MUST match `cccl_value_t` in c/include/cccl/c/types.h
 class _CCCLValue(ctypes.Structure):
-    _fields_ = [("type", _TypeInfo),
-                ("state", ctypes.c_void_p)]
+    _fields_ = [("type", _TypeInfo), ("state", ctypes.c_void_p)]
+
 
 # TODO: replace with functools.cache once our docs build environment
 # is upgraded to at least Python 3.9
@@ -128,8 +132,9 @@ class _CCCLValue(ctypes.Structure):
 def _numba_type_to_info(numba_type):
     context = cuda.descriptor.cuda_target.target_context
     size = context.get_value_type(numba_type).get_abi_size(context.target_data)
-    alignment = context.get_value_type(
-        numba_type).get_abi_alignment(context.target_data)
+    alignment = context.get_value_type(numba_type).get_abi_alignment(
+        context.target_data
+    )
     return _TypeInfo(size, alignment, _type_to_enum(numba_type))
 
 
@@ -144,7 +149,16 @@ def _device_array_to_pointer(array):
     info = _numpy_type_to_info(dtype)
     # Note: this is slightly slower, but supports all ndarray-like objects as long as they support CAI
     # TODO: switch to use gpumemoryview once it's ready
-    return _CCCLIterator(1, 1, _CCCLIteratorKindEnum.POINTER, _CCCLOp(), _CCCLOp(), info, array.__cuda_array_interface__["data"][0], None)
+    return _CCCLIterator(
+        1,
+        1,
+        _CCCLIteratorKindEnum.POINTER,
+        _CCCLOp(),
+        _CCCLOp(),
+        info,
+        array.__cuda_array_interface__["data"][0],
+        None,
+    )
 
 
 def _host_array_to_value(array):
@@ -156,50 +170,74 @@ def _host_array_to_value(array):
 class _Op:
     def __init__(self, dtype, op):
         value_type = numba.from_dtype(dtype)
-        self.ltoir, _ = cuda.compile(op, sig=value_type(
-            value_type, value_type), output='ltoir')
-        self.name = op.__name__.encode('utf-8')
+        self.ltoir, _ = cuda.compile(
+            op, sig=value_type(value_type, value_type), output="ltoir"
+        )
+        self.name = op.__name__.encode("utf-8")
 
     def handle(self):
-        return _CCCLOp(_CCCLOpKindEnum.STATELESS, self.name, ctypes.c_char_p(self.ltoir), len(self.ltoir), 1, 1, None)
+        return _CCCLOp(
+            _CCCLOpKindEnum.STATELESS,
+            self.name,
+            ctypes.c_char_p(self.ltoir),
+            len(self.ltoir),
+            1,
+            1,
+            None,
+        )
 
 
 def _extract_ctypes_ltoirs(numba_cuda_compile_results):
-    view_lst = [_CCCLStringView(ltoir, len(ltoir))
-                for ltoir in numba_cuda_compile_results]
+    view_lst = [
+        _CCCLStringView(ltoir, len(ltoir)) for ltoir in numba_cuda_compile_results
+    ]
     view_arr = (_CCCLStringView * len(view_lst))(*view_lst)
     return ctypes.pointer(_CCCLStringViews(view_arr, len(view_arr)))
 
 
 def _facade_iter_as_cccl_iter(d_in):
     def prefix_name(name):
-        return (d_in.prefix + "_" + name).encode('utf-8')
+        return (d_in.prefix + "_" + name).encode("utf-8")
+
     # type name ltoi ltoir_size size alignment state
-    adv = _CCCLOp(_CCCLOpKindEnum.STATELESS, prefix_name("advance"), None, 0, 1, 1, None)
-    drf = _CCCLOp(_CCCLOpKindEnum.STATELESS, prefix_name("dereference"), None, 0, 1, 1, None)
+    adv = _CCCLOp(
+        _CCCLOpKindEnum.STATELESS, prefix_name("advance"), None, 0, 1, 1, None
+    )
+    drf = _CCCLOp(
+        _CCCLOpKindEnum.STATELESS, prefix_name("dereference"), None, 0, 1, 1, None
+    )
     info = _numba_type_to_info(d_in.ntype)
     ltoirs = _extract_ctypes_ltoirs(d_in.ltoirs)
     # size alignment type advance dereference value_type state ltoirs
-    return _CCCLIterator(d_in.size, d_in.alignment, _CCCLIteratorKindEnum.ITERATOR, adv, drf, info, d_in.state_c_void_p, ltoirs)
+    return _CCCLIterator(
+        d_in.size,
+        d_in.alignment,
+        _CCCLIteratorKindEnum.ITERATOR,
+        adv,
+        drf,
+        info,
+        d_in.state_c_void_p,
+        ltoirs,
+    )
 
 
 def _d_in_as_cccl_iter(d_in):
-    if hasattr(d_in, 'ntype'):
+    if hasattr(d_in, "ntype"):
         return _facade_iter_as_cccl_iter(d_in)
-    assert hasattr(d_in, 'dtype')
+    assert hasattr(d_in, "dtype")
     return _device_array_to_pointer(d_in)
 
 
 def _get_cuda_path():
-    cuda_path = os.environ.get('CUDA_PATH', '')
+    cuda_path = os.environ.get("CUDA_PATH", "")
     if os.path.exists(cuda_path):
         return cuda_path
 
-    nvcc_path = shutil.which('nvcc')
+    nvcc_path = shutil.which("nvcc")
     if nvcc_path is not None:
         return os.path.dirname(os.path.dirname(nvcc_path))
 
-    default_path = '/usr/local/cuda'
+    default_path = "/usr/local/cuda"
     if os.path.exists(default_path):
         return default_path
 
@@ -213,13 +251,23 @@ _paths = None
 def _get_bindings():
     global _bindings
     if _bindings is None:
-        include_path = importlib.resources.files(
-            'cuda.parallel.experimental').joinpath('cccl')
-        cccl_c_path = os.path.join(include_path, 'libcccl.c.parallel.so')
+        include_path = importlib.resources.files("cuda.parallel.experimental").joinpath(
+            "cccl"
+        )
+        cccl_c_path = os.path.join(include_path, "libcccl.c.parallel.so")
         _bindings = ctypes.CDLL(cccl_c_path)
         _bindings.cccl_device_reduce.restype = ctypes.c_int
-        _bindings.cccl_device_reduce.argtypes = [_CCCLDeviceReduceBuildResult, ctypes.c_void_p, ctypes.POINTER(
-            ctypes.c_ulonglong), _CCCLIterator, _CCCLIterator, ctypes.c_ulonglong, _CCCLOp, _CCCLValue, ctypes.c_void_p]
+        _bindings.cccl_device_reduce.argtypes = [
+            _CCCLDeviceReduceBuildResult,
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_ulonglong),
+            _CCCLIterator,
+            _CCCLIterator,
+            ctypes.c_ulonglong,
+            _CCCLOp,
+            _CCCLValue,
+            ctypes.c_void_p,
+        ]
         _bindings.cccl_device_reduce_cleanup.restype = ctypes.c_int
     return _bindings
 
@@ -228,32 +276,35 @@ def _get_paths():
     global _paths
     if _paths is None:
         # Using `.parent` for compatibility with pip install --editable:
-        include_path = importlib.resources.files(
-            'cuda.parallel').parent.joinpath('_include')
+        include_path = importlib.resources.files("cuda.parallel").parent.joinpath(
+            "_include"
+        )
         include_path_str = str(include_path)
-        include_option = '-I' + include_path_str
-        cub_path = include_option.encode('utf-8')
+        include_option = "-I" + include_path_str
+        cub_path = include_option.encode("utf-8")
         thrust_path = cub_path
-        libcudacxx_path_str = str(os.path.join(include_path, 'libcudacxx'))
-        libcudacxx_option = '-I' + libcudacxx_path_str
-        libcudacxx_path = libcudacxx_option.encode('utf-8')
-        cuda_include_str = os.path.join(_get_cuda_path(), 'include')
-        cuda_include_option = '-I' + cuda_include_str
-        cuda_include_path = cuda_include_option.encode('utf-8')
+        libcudacxx_path_str = str(os.path.join(include_path, "libcudacxx"))
+        libcudacxx_option = "-I" + libcudacxx_path_str
+        libcudacxx_path = libcudacxx_option.encode("utf-8")
+        cuda_include_str = os.path.join(_get_cuda_path(), "include")
+        cuda_include_option = "-I" + cuda_include_str
+        cuda_include_path = cuda_include_option.encode("utf-8")
         _paths = cub_path, thrust_path, libcudacxx_path, cuda_include_path
     return _paths
 
 
 # MUST match `cccl_device_reduce_build_result_t` in c/include/cccl/c/reduce.h
 class _CCCLDeviceReduceBuildResult(ctypes.Structure):
-    _fields_ = [("cc", ctypes.c_int),
-                ("cubin", ctypes.c_void_p),
-                ("cubin_size", ctypes.c_size_t),
-                ("library", ctypes.c_void_p),
-                ("accumulator_size", ctypes.c_ulonglong),
-                ("single_tile_kernel", ctypes.c_void_p),
-                ("single_tile_second_kernel", ctypes.c_void_p),
-                ("reduction_kernel", ctypes.c_void_p)]
+    _fields_ = [
+        ("cc", ctypes.c_int),
+        ("cubin", ctypes.c_void_p),
+        ("cubin_size", ctypes.c_size_t),
+        ("library", ctypes.c_void_p),
+        ("accumulator_size", ctypes.c_ulonglong),
+        ("single_tile_kernel", ctypes.c_void_p),
+        ("single_tile_second_kernel", ctypes.c_void_p),
+        ("reduction_kernel", ctypes.c_void_p),
+    ]
 
 
 def _dtype_validation(dt1, dt2):
@@ -266,7 +317,8 @@ class _Reduce:
     def __init__(self, d_in, d_out, op, h_init):
         d_in_cccl = _d_in_as_cccl_iter(d_in)
         self._ctor_d_in_cccl_type_enum_name = _cccl_type_enum_as_name(
-            d_in_cccl.value_type.type.value)
+            d_in_cccl.value_type.type.value
+        )
         self._ctor_d_out_dtype = d_out.dtype
         self._ctor_init_dtype = h_init.dtype
         cc_major, cc_minor = cuda.get_current_device().compute_capability
@@ -278,20 +330,21 @@ class _Reduce:
         self.build_result = _CCCLDeviceReduceBuildResult()
 
         # TODO Figure out caching
-        error = bindings.cccl_device_reduce_build(ctypes.byref(self.build_result),
-                                                  d_in_cccl,
-                                                  d_out_ptr,
-                                                  self.op_wrapper.handle(),
-                                                  _host_array_to_value(h_init),
-                                                  cc_major,
-                                                  cc_minor,
-                                                  ctypes.c_char_p(cub_path),
-                                                  ctypes.c_char_p(thrust_path),
-                                                  ctypes.c_char_p(
-                                                      libcudacxx_path),
-                                                  ctypes.c_char_p(cuda_include_path))
+        error = bindings.cccl_device_reduce_build(
+            ctypes.byref(self.build_result),
+            d_in_cccl,
+            d_out_ptr,
+            self.op_wrapper.handle(),
+            _host_array_to_value(h_init),
+            cc_major,
+            cc_minor,
+            ctypes.c_char_p(cub_path),
+            ctypes.c_char_p(thrust_path),
+            ctypes.c_char_p(libcudacxx_path),
+            ctypes.c_char_p(cuda_include_path),
+        )
         if error != enums.CUDA_SUCCESS:
-            raise ValueError('Error building reduce')
+            raise ValueError("Error building reduce")
 
     def __call__(self, temp_storage, d_in, d_out, num_items, h_init):
         d_in_cccl = _d_in_as_cccl_iter(d_in)
@@ -303,8 +356,10 @@ class _Reduce:
                 num_items = d_in.size
             else:
                 assert num_items == d_in.size
-        _dtype_validation(self._ctor_d_in_cccl_type_enum_name,
-                          _cccl_type_enum_as_name(d_in_cccl.value_type.type.value))
+        _dtype_validation(
+            self._ctor_d_in_cccl_type_enum_name,
+            _cccl_type_enum_as_name(d_in_cccl.value_type.type.value),
+        )
         _dtype_validation(self._ctor_d_out_dtype, d_out.dtype)
         _dtype_validation(self._ctor_init_dtype, h_init.dtype)
         bindings = _get_bindings()
@@ -317,17 +372,19 @@ class _Reduce:
             # TODO: switch to use gpumemoryview once it's ready
             d_temp_storage = temp_storage.__cuda_array_interface__["data"][0]
         d_out_ptr = _device_array_to_pointer(d_out)
-        error = bindings.cccl_device_reduce(self.build_result,
-                                            d_temp_storage,
-                                            ctypes.byref(temp_storage_bytes),
-                                            d_in_cccl,
-                                            d_out_ptr,
-                                            ctypes.c_ulonglong(num_items),
-                                            self.op_wrapper.handle(),
-                                            _host_array_to_value(h_init),
-                                            None)
+        error = bindings.cccl_device_reduce(
+            self.build_result,
+            d_temp_storage,
+            ctypes.byref(temp_storage_bytes),
+            d_in_cccl,
+            d_out_ptr,
+            ctypes.c_ulonglong(num_items),
+            self.op_wrapper.handle(),
+            _host_array_to_value(h_init),
+            None,
+        )
         if error != enums.CUDA_SUCCESS:
-            raise ValueError('Error reducing')
+            raise ValueError("Error reducing")
 
         return temp_storage_bytes.value
 

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -55,12 +55,15 @@ def _ctypes_type_given_numba_type(ntype):
     return mapping[ntype]
 
 
-CompileResult = collections.namedtuple('CompileResult', ['ltoir', 'result_type'])
+CompileResult = collections.namedtuple("CompileResult", ["ltoir", "result_type"])
+
 
 def _ncc(abi_name, pyfunc, sig):
-    return CompileResult(*numba.cuda.compile(
-        pyfunc=pyfunc, sig=sig, abi_info={"abi_name": abi_name}, output="ltoir"
-    ))
+    return CompileResult(
+        *numba.cuda.compile(
+            pyfunc=pyfunc, sig=sig, abi_info={"abi_name": abi_name}, output="ltoir"
+        )
+    )
 
 
 def sizeof_pointee(context, ptr):
@@ -109,7 +112,7 @@ class RawPointer:
                 f"{self.prefix}_dereference",
                 RawPointer.pointer_dereference,
                 (data_as_ntype_pp,),
-            ).ltoir
+            ).ltoir,
         ]
 
     # Exclusively for numba.cuda.compile (this is not an actual method).
@@ -422,7 +425,7 @@ def TransformIterator(op, it):
         return op_caller(source_dereference(it_state_ptr))
 
     prefix = f"transform_{it.prefix}_{op.__name__}"
-    ltoirs =  it.ltoirs + [
+    ltoirs = it.ltoirs + [
         _ncc(
             f"{prefix}_advance",
             transform_advance,
@@ -436,9 +439,7 @@ def TransformIterator(op, it):
             (numba.types.CPointer(numba.types.char),),
         ).ltoir,
         # ATTENTION: NOT op_caller here! (see issue #3064)
-        op_ltoir
+        op_ltoir,
     ]
 
-    return TransformIteratorImpl(
-        it, op.__name__, op_return_ntype, ltoirs
-    )
+    return TransformIteratorImpl(it, op.__name__, op_return_ntype, ltoirs)

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators.py
@@ -19,13 +19,11 @@ def CacheModifiedInputIterator(device_array, modifier):
 
 def ConstantIterator(value):
     """Python facade (similar to itertools.repeat) for C++ Random Access ConstantIterator."""
-    value_type = value.dtype
     return _iterators.ConstantIterator(value)
 
 
 def CountingIterator(offset):
     """Python facade (similar to itertools.count) for C++ Random Access CountingIterator."""
-    value_type = offset.dtype
     return _iterators.CountingIterator(offset)
 
 

--- a/python/cuda_parallel/setup.py
+++ b/python/cuda_parallel/setup.py
@@ -15,8 +15,10 @@ from wheel.bdist_wheel import bdist_wheel
 project_path = os.path.abspath(os.path.dirname(__file__))
 cccl_path = os.path.abspath(os.path.join(project_path, "..", ".."))
 cccl_headers = [["cub", "cub"], ["libcudacxx", "include"], ["thrust", "thrust"]]
+__version__ = None
 with open(os.path.join(project_path, "cuda", "parallel", "_version.py")) as f:
     exec(f.read())
+assert __version__ is not None
 ver = __version__
 del __version__
 

--- a/python/cuda_parallel/setup.py
+++ b/python/cuda_parallel/setup.py
@@ -6,20 +6,16 @@ import os
 import shutil
 import subprocess
 
-from setuptools import Command, Extension, setup, find_packages, find_namespace_packages
+from setuptools import Command, Extension, setup, find_namespace_packages
 from setuptools.command.build_py import build_py
 from setuptools.command.build_ext import build_ext
 from wheel.bdist_wheel import bdist_wheel
 
 
 project_path = os.path.abspath(os.path.dirname(__file__))
-cccl_path = os.path.abspath(os.path.join(project_path, "..", '..'))
-cccl_headers = [
-    ['cub', 'cub'],
-    ['libcudacxx', 'include'],
-    ['thrust', 'thrust']
-]
-with open(os.path.join(project_path, 'cuda', 'parallel', '_version.py')) as f:
+cccl_path = os.path.abspath(os.path.join(project_path, "..", ".."))
+cccl_headers = [["cub", "cub"], ["libcudacxx", "include"], ["thrust", "thrust"]]
+with open(os.path.join(project_path, "cuda", "parallel", "_version.py")) as f:
     exec(f.read())
 ver = __version__
 del __version__
@@ -31,19 +27,18 @@ with open("README.md") as f:
 
 class CustomBuildCommand(build_py):
     def run(self):
-        self.run_command('package_cccl')
+        self.run_command("package_cccl")
         build_py.run(self)
 
 
 class CustomWheelBuild(bdist_wheel):
-
     def run(self):
-        self.run_command('package_cccl')
+        self.run_command("package_cccl")
         super().run()
 
 
 class PackageCCCLCommand(Command):
-    description = 'Generate additional files'
+    description = "Generate additional files"
     user_options = []
 
     def initialize_options(self):
@@ -54,10 +49,9 @@ class PackageCCCLCommand(Command):
 
     def run(self):
         for proj_dir, header_dir in cccl_headers:
-            src_path = os.path.abspath(
-                os.path.join(cccl_path, proj_dir, header_dir))
+            src_path = os.path.abspath(os.path.join(cccl_path, proj_dir, header_dir))
             # TODO Extract cccl headers into a standalone package
-            dst_path = os.path.join(project_path, 'cuda', '_include', proj_dir)
+            dst_path = os.path.join(project_path, "cuda", "_include", proj_dir)
             if os.path.exists(dst_path):
                 shutil.rmtree(dst_path)
             shutil.copytree(src_path, dst_path)
@@ -74,21 +68,21 @@ class BuildCMakeExtension(build_ext):
             self.build_extension(ext)
 
     def build_extension(self, ext):
-        extdir = os.path.abspath(os.path.dirname(
-            self.get_ext_fullpath(ext.name)))
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = [
-            '-DCCCL_ENABLE_C=YES',
-            '-DCCCL_C_PARALLEL_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-            '-DCMAKE_BUILD_TYPE=Release',
+            "-DCCCL_ENABLE_C=YES",
+            "-DCCCL_C_PARALLEL_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
+            "-DCMAKE_BUILD_TYPE=Release",
         ]
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
 
-        subprocess.check_call(['cmake', cccl_path] +
-                              cmake_args, cwd=self.build_temp)
+        subprocess.check_call(["cmake", cccl_path] + cmake_args, cwd=self.build_temp)
         subprocess.check_call(
-            ['cmake', '--build', '.', '--target', 'cccl.c.parallel'], cwd=self.build_temp)
+            ["cmake", "--build", ".", "--target", "cccl.c.parallel"],
+            cwd=self.build_temp,
+        )
 
 
 setup(
@@ -102,13 +96,9 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Environment :: GPU :: NVIDIA CUDA",
     ],
-    packages=find_namespace_packages(include=['cuda.*']),
-    python_requires='>=3.9',
-    install_requires=[
-        "numba>=0.60.0",
-        "cuda-python",
-        "jinja2"
-    ],
+    packages=find_namespace_packages(include=["cuda.*"]),
+    python_requires=">=3.9",
+    install_requires=["numba>=0.60.0", "cuda-python", "jinja2"],
     extras_require={
         "test": [
             "pytest",
@@ -117,13 +107,13 @@ setup(
         ]
     },
     cmdclass={
-        'package_cccl': PackageCCCLCommand,
-        'build_py': CustomBuildCommand,
-        'bdist_wheel': CustomWheelBuild,
-        'build_ext': BuildCMakeExtension
+        "package_cccl": PackageCCCLCommand,
+        "build_py": CustomBuildCommand,
+        "bdist_wheel": CustomWheelBuild,
+        "build_ext": BuildCMakeExtension,
     },
-    ext_modules=[CMakeExtension('cuda.parallel.experimental.cccl.c')],
+    ext_modules=[CMakeExtension("cuda.parallel.experimental.cccl.c")],
     include_package_data=True,
     license="Apache-2.0 with LLVM exception",
-    license_files=('../../LICENSE',),
+    license_files=("../../LICENSE",),
 )

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -9,7 +9,6 @@ import cupy as cp
 import numpy
 import pytest
 import random
-import re
 import numba.cuda
 import numba.types
 import cuda.parallel.experimental as cudax
@@ -196,9 +195,7 @@ def test_device_sum_cache_modified_input_it(
     dtype_inp = numpy.dtype(supported_value_type)
     dtype_out = dtype_inp
     input_devarr = numba.cuda.to_device(numpy.array(l_varr, dtype=dtype_inp))
-    i_input = iterators.CacheModifiedInputIterator(
-        input_devarr, modifier="stream"
-    )
+    i_input = iterators.CacheModifiedInputIterator(input_devarr, modifier="stream")
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
     )
@@ -247,8 +244,7 @@ def test_device_sum_map_mul2_count_it(
     dtype_inp = numpy.dtype(vtn_inp)
     dtype_out = numpy.dtype(vtn_out)
     i_input = iterators.TransformIterator(
-        mul2,
-        iterators.CountingIterator(dtype_inp.type(start_sum_with))
+        mul2, iterators.CountingIterator(dtype_inp.type(start_sum_with))
     )
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
@@ -284,7 +280,7 @@ def test_device_sum_map_mul_map_mul_count_it(
         iterators.TransformIterator(
             mul_funcs[fac_mid],
             iterators.CountingIterator(dtype_inp.type(start_sum_with)),
-        )
+        ),
     )
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# TODO(rwgk): Format entire file.
-# fmt: off
-
 import cupy as cp
 import numpy
 import pytest
@@ -33,7 +30,9 @@ def type_to_problem_sizes(dtype):
         raise ValueError("Unsupported dtype")
 
 
-@pytest.mark.parametrize('dtype', [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64])
+@pytest.mark.parametrize(
+    "dtype", [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]
+)
 def test_device_reduce(dtype):
     def op(a, b):
         return a + b
@@ -44,12 +43,11 @@ def test_device_reduce(dtype):
     reduce_into = cudax.reduce_into(d_output, d_output, op, h_init)
 
     for num_items_pow2 in type_to_problem_sizes(dtype):
-        num_items = 2 ** num_items_pow2
+        num_items = 2**num_items_pow2
         h_input = random_int(num_items, dtype)
         d_input = numba.cuda.to_device(h_input)
         temp_storage_size = reduce_into(None, d_input, d_output, None, h_init)
-        d_temp_storage = numba.cuda.device_array(
-            temp_storage_size, dtype=numpy.uint8)
+        d_temp_storage = numba.cuda.device_array(temp_storage_size, dtype=numpy.uint8)
         reduce_into(d_temp_storage, d_input, d_output, None, h_init)
         h_output = d_output.copy_to_host()
         assert h_output[0] == sum(h_input) + init_value
@@ -64,8 +62,7 @@ def test_complex_device_reduce():
     reduce_into = cudax.reduce_into(d_output, d_output, op, h_init)
 
     for num_items in [42, 420000]:
-        h_input = numpy.random.random(
-            num_items) + 1j * numpy.random.random(num_items)
+        h_input = numpy.random.random(num_items) + 1j * numpy.random.random(num_items)
         d_input = numba.cuda.to_device(h_input)
         temp_storage_bytes = reduce_into(None, d_input, d_output, None, h_init)
         d_temp_storage = numba.cuda.device_array(temp_storage_bytes, numpy.uint8)
@@ -89,11 +86,18 @@ def test_device_reduce_dtype_mismatch():
     reduce_into = cudax.reduce_into(d_inputs[0], d_outputs[0], min_op, h_inits[0])
 
     for ix in range(3):
-        with pytest.raises(TypeError, match=r"^dtype mismatch: __init__=int32, __call__=int64$"):
-          reduce_into(None, d_inputs[int(ix == 0)], d_outputs[int(ix == 1)], None, h_inits[int(ix == 2)])
+        with pytest.raises(
+            TypeError, match=r"^dtype mismatch: __init__=int32, __call__=int64$"
+        ):
+            reduce_into(
+                None,
+                d_inputs[int(ix == 0)],
+                d_outputs[int(ix == 1)],
+                None,
+                h_inits[int(ix == 2)],
+            )
 
 
-# fmt: on
 def _test_device_sum_with_iterator(
     l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
 ):

--- a/python/cuda_parallel/tests/test_reduce_api.py
+++ b/python/cuda_parallel/tests/test_reduce_api.py
@@ -8,8 +8,6 @@ import numpy as np
 import cuda.parallel.experimental as cudax
 # example-end imports
 
-import pytest
-
 
 def test_device_reduce():
     # example-begin reduce-min


### PR DESCRIPTION
Consolidation of results obtained in prior incremental PRs into 3 commits:

1. Add ruff configs: 4114ee25dd2da7ddd0d15bad17d89f29530c6c68 (**Please review**)
2. ruff auto-fixes (NO manual changes): 9413cafa3a377b36d835ae6338feb2dd181c1677 (**Do not review**)
3. All manual fixes: c716ce3c7bbd4df1adf967c33f33072a14b7d8be (**Please review**)

The cleanup uncovered these oversights:

* benchmarks/scripts/analyze.py:

```diff
     if alpha < 1.0:                                                            
-        case_df = remove_matching_distributions(alpha, case_df)                
+        for subbench in case_dfs:                                              
+            case_dfs[subbench] = remove_matching_distributions(                
+                alpha, case_dfs[subbench]                                      
+            )                                                                  
```

* cub/benchmarks/docker/recipe.py:

```diff
-Stage0 += hpccm.primitives.baseimage(image='nvidia/cuda:12.2.0-devel-ubuntu22.04')
+Stage0 = hpccm.primitives.baseimage(image="nvidia/cuda:12.2.0-devel-ubuntu22.04")
```

________
For easy future reference, the list of prior incremental PRs (all obsolete): #3104, #3101, #3099, #3086