### PR TITLE
Changes `DispatchScan[ByKey]` documentation to advise using unsigned offset types

### DIFF
--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -143,7 +143,7 @@ DeviceCompactInitKernel(ScanTileStateT tile_state, int num_tiles, NumSelectedIte
  *   (cub::NullType for inclusive scans)
  *
  * @tparam OffsetT
- *   Signed integer type for global offsets
+ *   Unsigned integer type for global offsets
  *
  * @paramInput d_in
  *   data
@@ -223,7 +223,7 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanPolicyT::BLOCK_THREADS))
  *   The init_value element type for ScanOpT (cub::NullType for inclusive scans)
  *
  * @tparam OffsetT
- *   Signed integer type for global offsets
+ *   Unsigned integer type for global offsets
  *
  * @tparam ForceInclusive
  *   Boolean flag to force InclusiveScan invocation when true.

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -92,7 +92,7 @@ CUB_NAMESPACE_BEGIN
  *   The init_value element for ScanOpT type (cub::NullType for inclusive scan)
  *
  * @tparam OffsetT
- *   Signed integer type for global offsets
+ *   Unsigned integer type for global offsets
  *
  * @param d_keys_in
  *   Input keys data
@@ -217,7 +217,7 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanByKeyInitKernel(
  *   The init_value element for ScanOpT type (cub::NullType for inclusive scan)
  *
  * @tparam OffsetT
- *   Signed integer type for global offsets
+ *   Unsigned integer type for global offsets
  *
  */
 template <


### PR DESCRIPTION
## Description

https://github.com/NVIDIA/cccl/pull/2171 introduced support for large problem sizes in `DeviceScan` and `DeviceScanByKey`. With that change, we also switched to using unsigned offset types using the `choose_offset_t` utility. 

In that PR I forgot to adapt the documentation of the corresponding `Dispatch` class templates, which still suggest using signed offset types. This PR fixes that documentation.

Thanks to @bernhardmgruber for pointing it out.

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
