### PR TITLE
Use programmatic dependent launch in CUB merge sort

### DIFF
--- a/cub/benchmarks/bench/merge_sort/keys.cu
+++ b/cub/benchmarks/bench/merge_sort/keys.cu
@@ -127,7 +127,7 @@ void keys(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   thrust::device_vector<nvbench::uint8_t> temp(temp_size);
   auto* temp_storage = thrust::raw_pointer_cast(temp.data());
 
-  state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     dispatch_t::Dispatch(
       temp_storage,
       temp_size,

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -183,9 +183,9 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::AgentLargeBufferPolicyT::BLO
 
 /**
  * @brief Kernel that copies data from a batch of given source buffers to their corresponding
- * destination buffer. If a buffer's size is to large to be copied by a single thread block, that
+ * destination buffer. If a buffer's size is too large to be copied by a single thread block, that
  * buffer is put into a queue of buffers that will get picked up later on, where multiple blocks
- * collaborate on each of these buffers. All other buffers get copied straight away.
+ * collaborate on each of these buffers. All other buffers get copied straight away.o
  *
  * @param input_buffer_it [in] Iterator providing the pointers to the source memory buffers
  * @param output_buffer_it [in] Iterator providing the pointers to the destination memory buffers

--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -212,6 +212,8 @@ __launch_bounds__(
   VSmemHelperT::discard_temp_storage(temp_storage);
 }
 
+// TODO(bgruber): if we put a call to cudaTriggerProgrammaticLaunchCompletion inside this kernel, the tests fail with
+// cudaErrorIllegalAddress.
 template <typename KeyIteratorT, typename OffsetT, typename CompareOpT, typename KeyT>
 CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceMergeSortPartitionKernel(
   bool ping,
@@ -618,7 +620,7 @@ struct DispatchMergeSort : SelectedPolicy
 
         // Partition
         THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
-          partition_grid_size, threads_per_partition_block, 0, stream)
+          partition_grid_size, threads_per_partition_block, 0, stream, true)
           .doit(DeviceMergeSortPartitionKernel<KeyIteratorT, OffsetT, CompareOpT, KeyT>,
                 ping,
                 d_output_keys,
@@ -645,7 +647,7 @@ struct DispatchMergeSort : SelectedPolicy
 
         // Merge
         THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
-          static_cast<int>(num_tiles), static_cast<int>(merge_sort_helper_t::policy_t::BLOCK_THREADS), 0, stream)
+          static_cast<int>(num_tiles), static_cast<int>(merge_sort_helper_t::policy_t::BLOCK_THREADS), 0, stream, true)
           .doit(
             DeviceMergeSortMergeKernel<MaxPolicyT,
                                        KeyInputIteratorT,

--- a/libcudacxx/include/cuda/std/__cccl/cuda_capabilities.h
+++ b/libcudacxx/include/cuda/std/__cccl/cuda_capabilities.h
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CCCL_CUDA_CAPABILITIES
+#define __CCCL_CUDA_CAPABILITIES
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// CUDA headers might not be present when using NVRTC, see NVIDIA/cccl#2095 for detail
+#if !_CCCL_COMPILER(NVRTC)
+#  include <cuda_runtime_api.h>
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#include <nv/target>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// True, when programmatic dependent launch is available, otherwise false.
+#define _CCCL_HAS_PDL _CCCL_CUDACC_AT_LEAST(11, 8)
+#if _CCCL_HAS_PDL
+// Waits for the previous kernel to complete (when it reaches its final membar). Should be put before the first global
+// memory access in a kernel.
+#  define _CCCL_PDL_GRID_DEPENDENCY_SYNC() NV_IF_TARGET(NV_PROVIDES_SM_90, cudaGridDependencySynchronize();)
+// Allows the subsequent kernel in the same stream to launch. Can be put anywhere in a kernel.
+// Heuristic(ahendriksen): put it after the last load.
+#  define _CCCL_PDL_TRIGGER_NEXT_LAUNCH() NV_IF_TARGET(NV_PROVIDES_SM_90, cudaTriggerProgrammaticLaunchCompletion();)
+#else
+#  define _CCCL_PDL_GRID_DEPENDENCY_SYNC()
+#  define _CCCL_PDL_TRIGGER_NEXT_LAUNCH()
+#endif // _CCCL_HAS_PDL
+
+#endif // __CCCL_CUDA_CAPABILITIES

--- a/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
+++ b/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
@@ -39,6 +39,7 @@
 #include <thrust/system/cuda/config.h>
 
 #include <cuda/cmath>
+#include <cuda/std/__cccl/cuda_capabilities.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -53,19 +54,43 @@ struct _CCCL_VISIBILITY_HIDDEN triple_chevron
   dim3 const grid;
   dim3 const block;
   Size const shared_mem;
+  bool const dependent_launch;
   cudaStream_t const stream;
 
-  THRUST_RUNTIME_FUNCTION triple_chevron(dim3 grid_, dim3 block_, Size shared_mem_ = 0, cudaStream_t stream_ = nullptr)
+  /// @param dependent_launch Launches the kernel using programmatic dependent launch if available.
+  THRUST_RUNTIME_FUNCTION triple_chevron(
+    dim3 grid_, dim3 block_, Size shared_mem_ = 0, cudaStream_t stream_ = nullptr, bool dependent_launch = false)
       : grid(grid_)
       , block(block_)
       , shared_mem(shared_mem_)
+      , dependent_launch(dependent_launch)
       , stream(stream_)
   {}
 
   template <class K, class... Args>
   cudaError_t _CCCL_HOST doit_host(K k, Args const&... args) const
   {
-    k<<<grid, block, shared_mem, stream>>>(args...);
+#if _THRUST_HAS_PDL
+    if (dependent_launch)
+    {
+      cudaLaunchAttribute attribute[1];
+      attribute[0].id                                         = cudaLaunchAttributeProgrammaticStreamSerialization;
+      attribute[0].val.programmaticStreamSerializationAllowed = 1;
+
+      cudaLaunchConfig_t config{};
+      config.gridDim          = grid;
+      config.blockDim         = block;
+      config.dynamicSmemBytes = shared_mem;
+      config.stream           = stream;
+      config.attrs            = attribute;
+      config.numAttrs         = 1;
+      cudaLaunchKernelEx(&config, k, args...);
+    }
+    else
+#endif // _THRUST_HAS_PDL
+    {
+      k<<<grid, block, shared_mem, stream>>>(args...);
+    }
     return cudaPeekAtLastError();
   }
 


### PR DESCRIPTION
This PR explores the use of [programmatic dependent launch (PDL)](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization) for `cub::MergeSort`.

nsys trace for `cub.bench.merge_sort.keys.base -d 0 --stopping-criterion entropy --profile -a 'T{ct}=I8' -a 'OffsetT{ct}=I32' -a 'Elements{io}[pow2]=20' -a 'Entropy=1.000'`
Before:
![image](https://github.com/user-attachments/assets/5ad1fbd6-1fc3-4bf1-b9d0-fe4b06f4e23f)

After:
![image](https://github.com/user-attachments/assets/1f4280d0-a05f-4cf4-b47e-edc803e86c66)
We can see the tighter execution of kernels back-to-back.


<details>
  <summary>Benchmark on H200</summary>
  
  ```
## [0] NVIDIA H200 NVL

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  Entropy  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|-----------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |     1     |  56.637 us |       0.90% |  47.600 us |       0.85% |   -9.037 us | -15.96% |   FAST   |
|   I8    |      I32      |      2^20      |     1     | 125.550 us |       0.53% | 103.864 us |       0.48% |  -21.686 us | -17.27% |   FAST   |
|   I8    |      I32      |      2^24      |     1     | 754.473 us |       0.34% | 715.045 us |       0.28% |  -39.428 us |  -5.23% |   FAST   |
|   I8    |      I32      |      2^28      |     1     |  12.093 ms |       0.11% |  12.060 ms |       0.12% |  -32.455 us |  -0.27% |   FAST   |
|   I8    |      I32      |      2^16      |   0.201   |  57.289 us |       0.90% |  46.955 us |       0.75% |  -10.334 us | -18.04% |   FAST   |
|   I8    |      I32      |      2^20      |   0.201   | 121.903 us |       0.53% | 101.537 us |       0.43% |  -20.366 us | -16.71% |   FAST   |
|   I8    |      I32      |      2^24      |   0.201   | 711.011 us |       0.39% | 674.561 us |       0.31% |  -36.451 us |  -5.13% |   FAST   |
|   I8    |      I32      |      2^28      |   0.201   |  11.337 ms |       0.14% |  11.276 ms |       0.13% |  -60.914 us |  -0.54% |   FAST   |
|   I8    |      I64      |      2^16      |     1     |  60.455 us |       0.82% |  50.153 us |       1.56% |  -10.302 us | -17.04% |   FAST   |
|   I8    |      I64      |      2^20      |     1     | 129.027 us |       0.47% | 109.501 us |       0.37% |  -19.526 us | -15.13% |   FAST   |
|   I8    |      I64      |      2^24      |     1     | 766.632 us |       0.38% | 729.845 us |       0.25% |  -36.786 us |  -4.80% |   FAST   |
|   I8    |      I64      |      2^28      |     1     |  12.212 ms |       0.10% |  12.159 ms |       0.10% |  -52.046 us |  -0.43% |   FAST   |
|   I8    |      I64      |      2^16      |   0.201   |  59.361 us |       0.91% |  49.300 us |       0.69% |  -10.062 us | -16.95% |   FAST   |
|   I8    |      I64      |      2^20      |   0.201   | 125.903 us |       0.50% | 106.021 us |       0.44% |  -19.882 us | -15.79% |   FAST   |
|   I8    |      I64      |      2^24      |   0.201   | 723.476 us |       0.46% | 688.062 us |       0.35% |  -35.414 us |  -4.89% |   FAST   |
|   I8    |      I64      |      2^28      |   0.201   |  11.447 ms |       0.10% |  11.383 ms |       0.08% |  -63.780 us |  -0.56% |   FAST   |
|   I16   |      I32      |      2^16      |     1     |  62.244 us |       0.82% |  52.173 us |       0.90% |  -10.071 us | -16.18% |   FAST   |
|   I16   |      I32      |      2^20      |     1     | 133.690 us |       0.59% | 114.302 us |       0.45% |  -19.388 us | -14.50% |   FAST   |
|   I16   |      I32      |      2^24      |     1     | 882.365 us |       0.30% | 845.034 us |       0.21% |  -37.331 us |  -4.23% |   FAST   |
|   I16   |      I32      |      2^28      |     1     |  13.294 ms |       0.14% |  13.330 ms |       0.14% |   36.765 us |   0.28% |   SLOW   |
|   I16   |      I32      |      2^16      |   0.201   |  61.778 us |       0.86% |  51.693 us |       1.13% |  -10.084 us | -16.32% |   FAST   |
|   I16   |      I32      |      2^20      |   0.201   | 130.022 us |       0.55% | 110.515 us |       0.48% |  -19.507 us | -15.00% |   FAST   |
|   I16   |      I32      |      2^24      |   0.201   | 816.256 us |       0.23% | 779.617 us |       0.29% |  -36.639 us |  -4.49% |   FAST   |
|   I16   |      I32      |      2^28      |   0.201   |  11.769 ms |       0.15% |  11.820 ms |       0.15% |   50.417 us |   0.43% |   SLOW   |
|   I16   |      I64      |      2^16      |     1     |  62.579 us |       0.80% |  52.677 us |       0.87% |   -9.902 us | -15.82% |   FAST   |
|   I16   |      I64      |      2^20      |     1     | 134.663 us |       0.52% | 115.245 us |       0.41% |  -19.418 us | -14.42% |   FAST   |
|   I16   |      I64      |      2^24      |     1     | 891.979 us |       0.36% | 851.583 us |       0.22% |  -40.396 us |  -4.53% |   FAST   |
|   I16   |      I64      |      2^28      |     1     |  13.473 ms |       0.14% |  13.422 ms |       0.14% |  -50.429 us |  -0.37% |   FAST   |
|   I16   |      I64      |      2^16      |   0.201   |  62.149 us |       0.83% |  52.211 us |       0.73% |   -9.938 us | -15.99% |   FAST   |
|   I16   |      I64      |      2^20      |   0.201   | 132.269 us |       0.53% | 111.969 us |       0.63% |  -20.301 us | -15.35% |   FAST   |
|   I16   |      I64      |      2^24      |   0.201   | 827.477 us |       0.31% | 784.111 us |       0.32% |  -43.366 us |  -5.24% |   FAST   |
|   I16   |      I64      |      2^28      |   0.201   |  11.945 ms |       0.15% |  11.897 ms |       0.16% |  -48.360 us |  -0.40% |   FAST   |
|   I32   |      I32      |      2^16      |     1     |  60.291 us |       0.83% |  50.517 us |       0.64% |   -9.774 us | -16.21% |   FAST   |
|   I32   |      I32      |      2^20      |     1     | 130.722 us |       0.51% | 112.443 us |       0.57% |  -18.279 us | -13.98% |   FAST   |
|   I32   |      I32      |      2^24      |     1     | 901.861 us |       0.25% | 860.995 us |       0.37% |  -40.866 us |  -4.53% |   FAST   |
|   I32   |      I32      |      2^28      |     1     |  14.105 ms |       0.23% |  14.129 ms |       0.25% |   24.298 us |   0.17% |   SAME   |
|   I32   |      I32      |      2^16      |   0.201   |  61.565 us |       0.95% |  51.346 us |       0.95% |  -10.219 us | -16.60% |   FAST   |
|   I32   |      I32      |      2^20      |   0.201   | 130.747 us |       0.54% | 111.227 us |       0.43% |  -19.520 us | -14.93% |   FAST   |
|   I32   |      I32      |      2^24      |   0.201   | 850.385 us |       0.32% | 810.549 us |       0.27% |  -39.836 us |  -4.68% |   FAST   |
|   I32   |      I32      |      2^28      |   0.201   |  12.518 ms |       0.06% |  12.496 ms |       0.07% |  -22.119 us |  -0.18% |   FAST   |
|   I32   |      I64      |      2^16      |     1     |  61.368 us |       0.87% |  50.950 us |       0.62% |  -10.418 us | -16.98% |   FAST   |
|   I32   |      I64      |      2^20      |     1     | 132.968 us |       0.45% | 113.945 us |       0.39% |  -19.023 us | -14.31% |   FAST   |
|   I32   |      I64      |      2^24      |     1     | 907.791 us |       0.23% | 866.074 us |       0.23% |  -41.717 us |  -4.60% |   FAST   |
|   I32   |      I64      |      2^28      |     1     |  14.245 ms |       0.29% |  14.282 ms |       0.58% |   36.830 us |   0.26% |   SAME   |
|   I32   |      I64      |      2^16      |   0.201   |  62.014 us |       1.08% |  53.112 us |       2.21% |   -8.902 us | -14.35% |   FAST   |
|   I32   |      I64      |      2^20      |   0.201   | 131.672 us |       0.44% | 112.474 us |       0.64% |  -19.198 us | -14.58% |   FAST   |
|   I32   |      I64      |      2^24      |   0.201   | 856.974 us |       0.23% | 815.076 us |       0.27% |  -41.898 us |  -4.89% |   FAST   |
|   I32   |      I64      |      2^28      |   0.201   |  12.553 ms |       0.07% |  12.570 ms |       0.50% |   16.765 us |   0.13% |   SLOW   |
|   I64   |      I32      |      2^16      |     1     |  71.689 us |       0.88% |  59.153 us |       0.61% |  -12.536 us | -17.49% |   FAST   |
|   I64   |      I32      |      2^20      |     1     | 184.195 us |       0.44% | 163.066 us |       0.34% |  -21.129 us | -11.47% |   FAST   |
|   I64   |      I32      |      2^24      |     1     |   1.846 ms |       0.23% |   1.808 ms |       0.41% |  -37.939 us |  -2.06% |   FAST   |
|   I64   |      I32      |      2^28      |     1     |  31.919 ms |       0.13% |  32.052 ms |       0.25% |  133.313 us |   0.42% |   SLOW   |
|   I64   |      I32      |      2^16      |   0.201   |  71.621 us |       0.90% |  59.835 us |       0.98% |  -11.786 us | -16.46% |   FAST   |
|   I64   |      I32      |      2^20      |   0.201   | 191.616 us |       0.44% | 172.121 us |       0.50% |  -19.495 us | -10.17% |   FAST   |
|   I64   |      I32      |      2^24      |   0.201   |   1.935 ms |       0.17% |   1.896 ms |       0.31% |  -38.850 us |  -2.01% |   FAST   |
|   I64   |      I32      |      2^28      |   0.201   |  32.532 ms |       0.11% |  32.580 ms |       0.10% |   47.636 us |   0.15% |   SLOW   |
|   I64   |      I64      |      2^16      |     1     |  71.718 us |       0.89% |  59.715 us |       0.68% |  -12.003 us | -16.74% |   FAST   |
|   I64   |      I64      |      2^20      |     1     | 184.457 us |       0.51% | 164.217 us |       0.32% |  -20.240 us | -10.97% |   FAST   |
|   I64   |      I64      |      2^24      |     1     |   1.859 ms |       0.22% |   1.813 ms |       0.32% |  -45.745 us |  -2.46% |   FAST   |
|   I64   |      I64      |      2^28      |     1     |  31.864 ms |       0.22% |  31.931 ms |       0.16% |   66.442 us |   0.21% |   SLOW   |
|   I64   |      I64      |      2^16      |   0.201   |  72.281 us |       0.83% |  60.839 us |       0.61% |  -11.443 us | -15.83% |   FAST   |
|   I64   |      I64      |      2^20      |   0.201   | 195.081 us |       0.43% | 174.550 us |       0.40% |  -20.530 us | -10.52% |   FAST   |
|   I64   |      I64      |      2^24      |   0.201   |   1.943 ms |       0.31% |   1.904 ms |       0.26% |  -38.869 us |  -2.00% |   FAST   |
|   I64   |      I64      |      2^28      |   0.201   |  32.660 ms |       0.09% |  32.707 ms |       0.10% |   46.363 us |   0.14% |   SLOW   |
|  I128   |      I32      |      2^16      |     1     |  83.964 us |       0.90% |  70.504 us |       0.92% |  -13.460 us | -16.03% |   FAST   |
|  I128   |      I32      |      2^20      |     1     | 306.784 us |       0.94% | 281.616 us |       0.43% |  -25.167 us |  -8.20% |   FAST   |
|  I128   |      I32      |      2^24      |     1     |   3.924 ms |       0.21% |   3.880 ms |       0.22% |  -44.186 us |  -1.13% |   FAST   |
|  I128   |      I32      |      2^28      |     1     |  71.054 ms |       0.05% |  70.978 ms |       0.06% |  -76.006 us |  -0.11% |   FAST   |
|  I128   |      I32      |      2^16      |   0.201   |  84.151 us |       0.90% |  70.598 us |       1.15% |  -13.554 us | -16.11% |   FAST   |
|  I128   |      I32      |      2^20      |   0.201   | 311.469 us |       0.81% | 288.039 us |       0.49% |  -23.429 us |  -7.52% |   FAST   |
|  I128   |      I32      |      2^24      |   0.201   |   3.827 ms |       0.11% |   3.782 ms |       0.14% |  -45.344 us |  -1.18% |   FAST   |
|  I128   |      I32      |      2^28      |   0.201   |  67.811 ms |       0.05% |  67.806 ms |       0.06% |   -4.941 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |     1     |  86.823 us |       0.92% |  70.720 us |       0.50% |  -16.103 us | -18.55% |   FAST   |
|  I128   |      I64      |      2^20      |     1     | 309.301 us |       0.59% | 282.948 us |       0.49% |  -26.353 us |  -8.52% |   FAST   |
|  I128   |      I64      |      2^24      |     1     |   3.950 ms |       0.22% |   3.898 ms |       0.23% |  -51.825 us |  -1.31% |   FAST   |
|  I128   |      I64      |      2^28      |     1     |  71.455 ms |       0.06% |  71.331 ms |       0.05% | -124.015 us |  -0.17% |   FAST   |
|  I128   |      I64      |      2^16      |   0.201   |  87.248 us |       0.89% |  70.819 us |       1.39% |  -16.429 us | -18.83% |   FAST   |
|  I128   |      I64      |      2^20      |   0.201   | 315.809 us |       0.71% | 289.691 us |       0.49% |  -26.118 us |  -8.27% |   FAST   |
|  I128   |      I64      |      2^24      |   0.201   |   3.849 ms |       0.12% |   3.796 ms |       0.12% |  -52.558 us |  -1.37% |   FAST   |
|  I128   |      I64      |      2^28      |   0.201   |  68.132 ms |       0.05% |  68.100 ms |       0.06% |  -32.555 us |  -0.05% |   SAME   |
|   F32   |      I32      |      2^16      |     1     |  61.164 us |       1.04% |  50.853 us |       0.71% |  -10.311 us | -16.86% |   FAST   |
|   F32   |      I32      |      2^20      |     1     | 132.196 us |       0.70% | 113.560 us |       0.50% |  -18.636 us | -14.10% |   FAST   |
|   F32   |      I32      |      2^24      |     1     | 902.337 us |       0.23% | 860.063 us |       0.30% |  -42.274 us |  -4.68% |   FAST   |
|   F32   |      I32      |      2^28      |     1     |  13.858 ms |       0.31% |  13.890 ms |       0.32% |   32.357 us |   0.23% |   SAME   |
|   F32   |      I32      |      2^16      |   0.201   |  60.981 us |       0.95% |  50.940 us |       0.89% |  -10.040 us | -16.46% |   FAST   |
|   F32   |      I32      |      2^20      |   0.201   | 131.584 us |       0.63% | 111.775 us |       0.45% |  -19.809 us | -15.05% |   FAST   |
|   F32   |      I32      |      2^24      |   0.201   | 851.726 us |       0.35% | 811.535 us |       0.29% |  -40.191 us |  -4.72% |   FAST   |
|   F32   |      I32      |      2^28      |   0.201   |  12.512 ms |       0.04% |  12.505 ms |       0.05% |   -7.101 us |  -0.06% |   FAST   |
|   F32   |      I64      |      2^16      |     1     |  61.315 us |       0.79% |  51.074 us |       0.81% |  -10.241 us | -16.70% |   FAST   |
|   F32   |      I64      |      2^20      |     1     | 133.544 us |       0.52% | 114.561 us |       0.48% |  -18.983 us | -14.21% |   FAST   |
|   F32   |      I64      |      2^24      |     1     | 905.479 us |       0.26% | 864.987 us |       0.20% |  -40.493 us |  -4.47% |   FAST   |
|   F32   |      I64      |      2^28      |     1     |  14.257 ms |       1.98% |  14.536 ms |       1.87% |  278.870 us |   1.96% |   SLOW   |
|   F32   |      I64      |      2^16      |   0.201   |  63.155 us |       2.20% |  53.386 us |       2.33% |   -9.769 us | -15.47% |   FAST   |
|   F32   |      I64      |      2^20      |   0.201   | 131.299 us |       0.64% | 113.528 us |       0.51% |  -17.771 us | -13.54% |   FAST   |
|   F32   |      I64      |      2^24      |   0.201   | 853.180 us |       0.31% | 817.087 us |       0.25% |  -36.093 us |  -4.23% |   FAST   |
|   F32   |      I64      |      2^28      |   0.201   |  12.694 ms |       0.59% |  12.739 ms |       0.50% |   44.592 us |   0.35% |   SAME   |
|   F64   |      I32      |      2^16      |     1     |  70.188 us |       0.86% |  58.910 us |       0.86% |  -11.278 us | -16.07% |   FAST   |
|   F64   |      I32      |      2^20      |     1     | 183.386 us |       0.44% | 162.924 us |       0.40% |  -20.462 us | -11.16% |   FAST   |
|   F64   |      I32      |      2^24      |     1     |   1.846 ms |       0.32% |   1.803 ms |       0.36% |  -43.783 us |  -2.37% |   FAST   |
|   F64   |      I32      |      2^28      |     1     |  32.090 ms |       1.01% |  32.387 ms |       1.54% |  297.135 us |   0.93% |   SAME   |
|   F64   |      I32      |      2^16      |   0.201   |  71.093 us |       1.29% |  61.092 us |       2.54% |  -10.001 us | -14.07% |   FAST   |
|   F64   |      I32      |      2^20      |   0.201   | 190.424 us |       0.47% | 170.151 us |       0.36% |  -20.273 us | -10.65% |   FAST   |
|   F64   |      I32      |      2^24      |   0.201   |   1.919 ms |       0.32% |   1.879 ms |       0.27% |  -39.901 us |  -2.08% |   FAST   |
|   F64   |      I32      |      2^28      |   0.201   |  32.452 ms |       0.09% |  32.492 ms |       0.10% |   39.660 us |   0.12% |   SLOW   |
|   F64   |      I64      |      2^16      |     1     |  70.881 us |       0.71% |  59.049 us |       0.65% |  -11.832 us | -16.69% |   FAST   |
|   F64   |      I64      |      2^20      |     1     | 183.486 us |       0.37% | 163.994 us |       0.32% |  -19.491 us | -10.62% |   FAST   |
|   F64   |      I64      |      2^24      |     1     |   1.850 ms |       0.18% |   1.813 ms |       0.35% |  -37.013 us |  -2.00% |   FAST   |
|   F64   |      I64      |      2^28      |     1     |  31.957 ms |       0.11% |  32.032 ms |       0.11% |   74.882 us |   0.23% |   SLOW   |
|   F64   |      I64      |      2^16      |   0.201   |  71.335 us |       0.69% |  60.037 us |       0.58% |  -11.298 us | -15.84% |   FAST   |
|   F64   |      I64      |      2^20      |   0.201   | 192.146 us |       0.42% | 173.485 us |       0.42% |  -18.661 us |  -9.71% |   FAST   |
|   F64   |      I64      |      2^24      |   0.201   |   1.930 ms |       0.30% |   1.890 ms |       0.25% |  -39.434 us |  -2.04% |   FAST   |
|   F64   |      I64      |      2^28      |   0.201   |  32.608 ms |       0.09% |  32.687 ms |       0.10% |   79.401 us |   0.24% |   SLOW   |
|   C64   |      I32      |      2^16      |     1     | 207.577 us |       0.58% | 196.390 us |       0.50% |  -11.187 us |  -5.39% |   FAST   |
|   C64   |      I32      |      2^20      |     1     | 447.000 us |       0.42% | 427.794 us |       0.37% |  -19.206 us |  -4.30% |   FAST   |
|   C64   |      I32      |      2^24      |     1     |   5.284 ms |       0.17% |   5.283 ms |       0.14% |   -1.195 us |  -0.02% |   SAME   |
|   C64   |      I32      |      2^28      |     1     | 101.346 ms |       0.03% | 102.088 ms |       0.04% |  742.288 us |   0.73% |   SLOW   |
|   C64   |      I32      |      2^16      |   0.201   | 320.975 us |       0.41% | 310.896 us |       0.43% |  -10.079 us |  -3.14% |   FAST   |
|   C64   |      I32      |      2^20      |   0.201   | 700.654 us |       0.53% | 684.135 us |       0.56% |  -16.519 us |  -2.36% |   FAST   |
|   C64   |      I32      |      2^24      |   0.201   |  10.557 ms |       0.28% |  10.542 ms |       0.27% |  -15.063 us |  -0.14% |   SAME   |
|   C64   |      I32      |      2^28      |   0.201   | 173.781 ms |       0.06% | 174.236 ms |       0.05% |  455.522 us |   0.26% |   SLOW   |
|   C64   |      I64      |      2^16      |     1     | 209.579 us |       0.55% | 196.378 us |       0.51% |  -13.200 us |  -6.30% |   FAST   |
|   C64   |      I64      |      2^20      |     1     | 452.551 us |       0.41% | 430.664 us |       0.43% |  -21.887 us |  -4.84% |   FAST   |
|   C64   |      I64      |      2^24      |     1     |   5.374 ms |       0.13% |   5.321 ms |       0.14% |  -52.959 us |  -0.99% |   FAST   |
|   C64   |      I64      |      2^28      |     1     | 103.592 ms |       0.10% | 102.974 ms |       0.12% | -617.989 us |  -0.60% |   FAST   |
|   C64   |      I64      |      2^16      |   0.201   | 324.018 us |       0.51% | 311.103 us |       0.45% |  -12.915 us |  -3.99% |   FAST   |
|   C64   |      I64      |      2^20      |   0.201   | 706.347 us |       0.55% | 685.960 us |       0.55% |  -20.387 us |  -2.89% |   FAST   |
|   C64   |      I64      |      2^24      |   0.201   |  10.639 ms |       0.28% |  10.685 ms |       0.28% |   46.559 us |   0.44% |   SLOW   |
|   C64   |      I64      |      2^28      |   0.201   | 175.164 ms |       0.06% | 176.671 ms |       0.05% |    1.508 ms |   0.86% |   SLOW   |
  ```
  
</details>
We can see basically only improvements (up to 18%), especially for small problem sizes and a maximum of 2% regression.

Addresses part of #3115