### PR TITLE
[Refactor] cuda.parallel: Simplify TransformIterator implementation and refactor iterators to derive from a common base 

### DIFF
--- a/c/parallel/include/cccl/c/types.h
+++ b/c/parallel/include/cccl/c/types.h
@@ -71,18 +71,6 @@ struct cccl_value_t
   void* state;
 };
 
-struct cccl_string_view
-{
-  const char* begin;
-  int size;
-};
-
-struct cccl_string_views
-{
-  cccl_string_view* views;
-  int size;
-};
-
 struct cccl_iterator_t
 {
   int size;
@@ -92,5 +80,4 @@ struct cccl_iterator_t
   cccl_op_t dereference;
   cccl_type_info value_type;
   void* state;
-  cccl_string_views* ltoirs = nullptr;
 };

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -293,23 +293,16 @@ extern "C" CCCL_C_API CUresult cccl_device_reduce_build(
       }
     };
     ltoir_list_append({op.ltoir, op.ltoir_size});
-    auto extract_ltoirs = [ltoir_list_append](const cccl_iterator_t& it) {
-      if (cccl_iterator_kind_t::iterator == it.type)
-      {
-        ltoir_list_append({it.advance.ltoir, it.advance.ltoir_size});
-        ltoir_list_append({it.dereference.ltoir, it.dereference.ltoir_size});
-        if (it.ltoirs != nullptr)
-        {
-          for (int i = 0; i < it.ltoirs->size; i++)
-          {
-            auto view = it.ltoirs->views[i];
-            ltoir_list_append({view.begin, view.size});
-          }
-        }
-      }
-    };
-    extract_ltoirs(input_it);
-    extract_ltoirs(output_it);
+    if (cccl_iterator_kind_t::iterator == input_it.type)
+    {
+      ltoir_list_append({input_it.advance.ltoir, input_it.advance.ltoir_size});
+      ltoir_list_append({input_it.dereference.ltoir, input_it.dereference.ltoir_size});
+    }
+    if (cccl_iterator_kind_t::iterator == output_it.type)
+    {
+      ltoir_list_append({output_it.advance.ltoir, output_it.advance.ltoir_size});
+      ltoir_list_append({output_it.dereference.ltoir, output_it.dereference.ltoir_size});
+    }
 
     nvrtc_cubin result =
       make_nvrtc_command_list()

--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -325,7 +325,6 @@ autodoc.mock_imports = [
     "cuda.bindings",
     "llvmlite",
     "numpy",
-    "functools", # using >=3.8 feature cached_property
 ]
 
 enhanced_search_enabled = true
@@ -350,7 +349,6 @@ autodoc.mock_imports = [
     "cuda.bindings",
     "llvmlite",
     "numpy",
-    "functools", # using >=3.8 feature cached_property
 ]
 
 enhanced_search_enabled = true

--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -325,6 +325,7 @@ autodoc.mock_imports = [
     "cuda.bindings",
     "llvmlite",
     "numpy",
+    "functools", # using >=3.8 feature cached_property
 ]
 
 enhanced_search_enabled = true
@@ -348,7 +349,8 @@ autodoc.mock_imports = [
     "pynvjitlink",
     "cuda.bindings",
     "llvmlite",
-    "numpy"
+    "numpy",
+    "functools", # using >=3.8 feature cached_property
 ]
 
 enhanced_search_enabled = true

--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -323,7 +323,8 @@ autodoc.mock_imports = [
     "numba",
     "pynvjitlink",
     "cuda.bindings",
-    "llvmlite"
+    "llvmlite",
+    "numpy",
 ]
 
 enhanced_search_enabled = true
@@ -346,7 +347,8 @@ autodoc.mock_imports = [
     "numba",
     "pynvjitlink",
     "cuda.bindings",
-    "llvmlite"
+    "llvmlite",
+    "numpy"
 ]
 
 enhanced_search_enabled = true

--- a/python/cuda_parallel/cuda/parallel/experimental/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/__init__.py
@@ -185,10 +185,10 @@ def _iterator_to_cccl_iter(it):
     alignment = context.get_value_type(numba_type).get_abi_alignment(
         context.target_data
     )
-    advance_ltoir, deref_ltoir = it.ltoirs
+    (advance_abi_name, advance_ltoir), (deref_abi_name, deref_ltoir) = it.ltoirs.items()
     advance_op = _CCCLOp(
         _CCCLOpKindEnum.STATELESS,
-        type(it).advance.__name__.encode("utf-8"),
+        advance_abi_name.encode("utf-8"),
         ctypes.c_char_p(advance_ltoir),
         len(advance_ltoir),
         1,
@@ -197,7 +197,7 @@ def _iterator_to_cccl_iter(it):
     )
     deref_op = _CCCLOp(
         _CCCLOpKindEnum.STATELESS,
-        type(it).dereference.__name__.encode("utf-8"),
+        deref_abi_name.encode("utf-8"),
         ctypes.c_char_p(deref_ltoir),
         len(deref_ltoir),
         1,

--- a/python/cuda_parallel/cuda/parallel/experimental/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/__init__.py
@@ -99,28 +99,15 @@ class _CCCLOp(ctypes.Structure):
     ]
 
 
-# MUST match `cccl_string_view` in c/include/cccl/c/types.h
-class _CCCLStringView(ctypes.Structure):
-    _fields_ = [("begin", ctypes.c_char_p), ("size", ctypes.c_int)]
-
-
-# MUST match `cccl_string_views` in c/include/cccl/c/types.h
-class _CCCLStringViews(ctypes.Structure):
-    _fields_ = [("views", ctypes.POINTER(_CCCLStringView)), ("size", ctypes.c_int)]
-
-
 # MUST match `cccl_iterator_t` in c/include/cccl/c/types.h
 class _CCCLIterator(ctypes.Structure):
-    _fields_ = [
-        ("size", ctypes.c_int),
-        ("alignment", ctypes.c_int),
-        ("type", _CCCLIteratorKindEnum),
-        ("advance", _CCCLOp),
-        ("dereference", _CCCLOp),
-        ("value_type", _TypeInfo),
-        ("state", ctypes.c_void_p),
-        ("ltoirs", ctypes.POINTER(_CCCLStringViews)),
-    ]
+    _fields_ = [("size", ctypes.c_int),
+                ("alignment", ctypes.c_int),
+                ("type", _CCCLIteratorKindEnum),
+                ("advance", _CCCLOp),
+                ("dereference", _CCCLOp),
+                ("value_type", _TypeInfo),
+                ("state", ctypes.c_void_p)]
 
 
 # MUST match `cccl_value_t` in c/include/cccl/c/types.h
@@ -177,7 +164,7 @@ def _device_array_to_cccl_iter(array):
     info = _numpy_type_to_info(dtype)
     # Note: this is slightly slower, but supports all ndarray-like objects as long as they support CAI
     # TODO: switch to use gpumemoryview once it's ready
-    return _CCCLIterator(1, 1, _CCCLIteratorKindEnum.POINTER, _CCCLOp(), _CCCLOp(), info, array.__cuda_array_interface__["data"][0], None)
+    return _CCCLIterator(1, 1, _CCCLIteratorKindEnum.POINTER, _CCCLOp(), _CCCLOp(), info, array.__cuda_array_interface__["data"][0])
 
 
 def _iterator_to_cccl_iter(it):

--- a/python/cuda_parallel/cuda/parallel/experimental/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/__init__.py
@@ -182,7 +182,7 @@ def _device_array_to_cccl_iter(array):
 
 def _iterator_to_cccl_iter(it):
     context = cuda.descriptor.cuda_target.target_context
-    numba_type = it._numba_type
+    numba_type = it.numba_type
     size = context.get_value_type(numba_type).get_abi_size(context.target_data)
     alignment = context.get_value_type(
         numba_type).get_abi_alignment(context.target_data)
@@ -211,7 +211,7 @@ def _iterator_to_cccl_iter(it):
         _CCCLOpKindEnum.STATEFUL,
         advance_op,
         deref_op,
-        _numba_type_to_info(it._value_type),
+        _numba_type_to_info(it.value_type),
         it.state
     )
 

--- a/python/cuda_parallel/cuda/parallel/experimental/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/__init__.py
@@ -9,7 +9,6 @@ import shutil
 import numba
 import os
 
-import numpy as np
 from numba import cuda, types
 from numba.cuda.cudadrv import enums
 

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -69,7 +69,10 @@ class IteratorBase:
         self.value_type = value_type
         self.abi_name = abi_name
 
-    @cached_property
+    # TODO: should we cache this? Current docs environment doesn't allow
+    # using Python > 3.7. We could use a hand-rolled cached_property if
+    # needed.
+    # @cached_property
     def ltoirs(self):
         advance_abi_name = self.abi_name + "_advance"
         deref_abi_name = self.abi_name + "_dereference"

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -1,7 +1,7 @@
 import ctypes
 import operator
 import collections
-from functools import cached_property, lru_cache
+from functools import lru_cache
 from sys import prefix
 
 import numpy as np
@@ -72,7 +72,7 @@ class IteratorBase:
     # TODO: should we cache this? Current docs environment doesn't allow
     # using Python > 3.7. We could use a hand-rolled cached_property if
     # needed.
-    # @cached_property
+    @property
     def ltoirs(self):
         advance_abi_name = self.abi_name + "_advance"
         deref_abi_name = self.abi_name + "_dereference"

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -15,7 +15,6 @@ import numba.types
 
 _DEVICE_POINTER_SIZE = 8
 _DEVICE_POINTER_BITWIDTH = _DEVICE_POINTER_SIZE * 8
-_DISTANCE_NUMBA_TYPE = numba.types.uint64
 
 
 @lru_cache
@@ -50,7 +49,7 @@ class IteratorBase:
             self.__class__.advance,
             (
                 self.numba_type,
-                numba.from_dtype(np.dtype("uint64"))
+                numba.types.uint64  # distance type
             ),
             output="ltoir"
         )

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -262,6 +262,10 @@ def make_transform_iterator(it, op):
             self._it = it
             numba_type = it.numba_type
             op_abi_name = f"{self.__class__.__name__}_{op.py_func.__name__}"
+
+            # TODO: it would be nice to not need to compile `op` to get
+            # its return type, but there's nothing in the numba API
+            # to do that (yet),
             _, op_retty = cached_compile(
                 op,
                 (self._it.value_type,),

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -183,7 +183,7 @@ def load_cs(typingctx, base):
     def codegen(context, builder, sig, args):
         rt = _ir_type_given_numba_type(sig.return_type)
         if rt is None:
-            raise RuntimeError(f"Unsupported: {type(sig.return_type)=}")
+            raise RuntimeError(f"Unsupported return type: {type(sig.return_type)}")
         ftype = ir.FunctionType(rt, [rt.as_pointer()])
         bw = sig.return_type.bitwidth
         asm_txt = f"ld.global.cs.b{bw} $0, [$1];"

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -16,29 +16,6 @@ import numba.types
 _DEVICE_POINTER_SIZE = 8
 _DEVICE_POINTER_BITWIDTH = _DEVICE_POINTER_SIZE * 8
 _DISTANCE_NUMBA_TYPE = numba.types.uint64
-_DISTANCE_IR_TYPE = ir.IntType(64)
-_CHAR_PTR_NUMBA_TYPE = numba.types.CPointer(numba.types.int8)
-_CHAR_PTR_IR_TYPE = ir.PointerType(ir.IntType(8))
-
-
-def numba_type_from_any(value_type):
-    return getattr(numba.types, str(value_type))
-
-
-def _sizeof_numba_type(ntype):
-    mapping = {
-        numba.types.int8: 1,
-        numba.types.int16: 2,
-        numba.types.int32: 4,
-        numba.types.int64: 8,
-        numba.types.uint8: 1,
-        numba.types.uint16: 2,
-        numba.types.uint32: 4,
-        numba.types.uint64: 8,
-        numba.types.float32: 4,
-        numba.types.float64: 8,
-    }
-    return mapping[ntype]
 
 
 @lru_cache

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -66,16 +66,16 @@ def cached_compile(*args, **kwargs):
 
 class IteratorBase:
     def __init__(self, cvalue, value_type, numba_type):
-        self._cvalue = cvalue
-        self._value_type = value_type
-        self._numba_type = numba_type
+        self.cvalue = cvalue
+        self.value_type = value_type
+        self.numba_type = numba_type
 
     @cached_property
     def ltoirs(self):
         advance_ltoir, _ = cached_compile(
             self.__class__.advance,
             (
-                self._numba_type,
+                self.numba_type,
                 numba.from_dtype(np.dtype("uint64"))
             ),
             output="ltoir"
@@ -84,7 +84,7 @@ class IteratorBase:
         deref_ltoir, _ = cached_compile(
             self.__class__.dereference,
             (
-                self._numba_type,
+                self.numba_type,
             ),
             output="ltoir"
         )
@@ -93,7 +93,7 @@ class IteratorBase:
 
     @property
     def state(self):
-        return ctypes.cast(ctypes.pointer(self._cvalue), ctypes.c_void_p)
+        return ctypes.cast(ctypes.pointer(self.cvalue), ctypes.c_void_p)
 
 
 def sizeof_pointee(context, ptr):
@@ -239,12 +239,12 @@ def make_transform_iterator(it, op):
     class TransformIterator(IteratorBase):
         def __init__(self, it, op):
             self._it = it
-            cvalue = it._cvalue
-            numba_type = it._numba_type
+            cvalue = it.cvalue
+            numba_type = it.numba_type
             _, op_retty = cached_compile(
                 op,
                 (
-                    self._it._value_type,
+                    self._it.value_type,
                 ),
                 output="ltoir"
             )

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -18,7 +18,7 @@ _DEVICE_POINTER_SIZE = 8
 _DEVICE_POINTER_BITWIDTH = _DEVICE_POINTER_SIZE * 8
 
 
-@lru_cache
+@lru_cache(maxsize=256)
 def _ctypes_type_given_numba_type(ntype):
     mapping = {
         numba.types.int8: ctypes.c_int8,

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -261,14 +261,15 @@ def make_transform_iterator(it, op):
         def __init__(self, it, op):
             self._it = it
             numba_type = it.numba_type
+            op_abi_name = f"{self.__class__.__name__}_{op.py_func.__name__}"
             _, op_retty = cached_compile(
                 op,
                 (self._it.value_type,),
-                abi_name=f"{self.__class__.__name__}_{op.__name__}",
+                abi_name=op_abi_name,
                 output="ltoir",
             )
             value_type = op_retty
-            abi_name = f"{self.__class__.__name__}_{it.abi_name}"
+            abi_name = f"{self.__class__.__name__}_{it.abi_name}_{op_abi_name}"
             super().__init__(
                 value_type=value_type,
                 numba_type=numba_type,

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -35,10 +35,7 @@ def _ctypes_type_given_numba_type(ntype):
     return mapping[ntype]
 
 
-@lru_cache
-def cached_compile(*args, **kwargs):
-    result = numba.cuda.compile(*args, **kwargs)
-    return result
+cached_compile = lru_cache(maxsize=256)(numba.cuda.compile)  # TODO: what's a reasonable value?
 
 
 class IteratorBase:

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -34,7 +34,9 @@ def _ctypes_type_given_numba_type(ntype):
     return mapping[ntype]
 
 
-cached_compile = lru_cache(maxsize=256)(numba.cuda.compile)  # TODO: what's a reasonable value?
+cached_compile = lru_cache(maxsize=256)(
+    numba.cuda.compile
+)  # TODO: what's a reasonable value?
 
 
 class IteratorBase:
@@ -49,17 +51,13 @@ class IteratorBase:
             self.__class__.advance,
             (
                 self.numba_type,
-                numba.types.uint64  # distance type
+                numba.types.uint64,  # distance type
             ),
-            output="ltoir"
+            output="ltoir",
         )
 
         deref_ltoir, _ = cached_compile(
-            self.__class__.dereference,
-            (
-                self.numba_type,
-            ),
-            output="ltoir"
+            self.__class__.dereference, (self.numba_type,), output="ltoir"
         )
 
         return advance_ltoir, deref_ltoir
@@ -214,15 +212,11 @@ def make_transform_iterator(it, op):
             self._it = it
             cvalue = it.cvalue
             numba_type = it.numba_type
-            _, op_retty = cached_compile(
-                op,
-                (
-                    self._it.value_type,
-                ),
-                output="ltoir"
-            )
+            _, op_retty = cached_compile(op, (self._it.value_type,), output="ltoir")
             value_type = op_retty
-            super().__init__(cvalue=cvalue, value_type=value_type, numba_type=numba_type)
+            super().__init__(
+                cvalue=cvalue, value_type=value_type, numba_type=numba_type
+            )
 
         @staticmethod
         def advance(it, n):

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -1,7 +1,9 @@
 import ctypes
 import operator
 import collections
+from functools import cached_property, lru_cache
 
+import numpy as np
 from numba.core import cgutils
 from llvmlite import ir
 from numba.core.typing import signature
@@ -39,6 +41,7 @@ def _sizeof_numba_type(ntype):
     return mapping[ntype]
 
 
+@lru_cache
 def _ctypes_type_given_numba_type(ntype):
     mapping = {
         numba.types.int8: ctypes.c_int8,
@@ -55,15 +58,10 @@ def _ctypes_type_given_numba_type(ntype):
     return mapping[ntype]
 
 
-CompileResult = collections.namedtuple("CompileResult", ["ltoir", "result_type"])
-
-
-def _ncc(abi_name, pyfunc, sig):
-    return CompileResult(
-        *numba.cuda.compile(
-            pyfunc=pyfunc, sig=sig, abi_info={"abi_name": abi_name}, output="ltoir"
-        )
-    )
+@lru_cache
+def cached_compile(*args, **kwargs):
+    result = numba.cuda.compile(*args, **kwargs)
+    return result
 
 
 class IteratorBase:
@@ -182,272 +180,83 @@ def load_cs(typingctx, base):
     return base.dtype(base), codegen
 
 
-class CacheModifiedPointer:
+class CacheModifiedPointer(IteratorBase):
     def __init__(self, ptr, ntype):
-        self.val = ctypes.c_void_p(ptr)
-        self.ntype = ntype
-        data_as_ntype_pp = numba.types.CPointer(numba.types.CPointer(ntype))
-        self.prefix = "cache" + ntype.name
-        self.ltoirs = [
-            _ncc(
-                f"{self.prefix}_advance",
-                CacheModifiedPointer.cache_advance,
-                numba.types.void(data_as_ntype_pp, _DISTANCE_NUMBA_TYPE),
-            ).ltoir,
-            _ncc(
-                f"{self.prefix}_dereference",
-                CacheModifiedPointer.cache_dereference,
-                (data_as_ntype_pp,),
-            ).ltoir,
-        ]
+        cvalue = ctypes.c_void_p(ptr)
+        value_type = ntype
+        numba_type = numba.types.CPointer(numba.types.CPointer(value_type))
+        super().__init__(cvalue=cvalue, value_type=value_type, numba_type=numba_type)
 
-    # Exclusively for numba.cuda.compile (this is not an actual method).
-    def cache_advance(this, distance):
-        this[0] = this[0] + distance
+    @staticmethod
+    def advance(it, distance):
+        it[0] = it[0] + distance
 
-    # Exclusively for numba.cuda.compile (this is not an actual method).
-    def cache_dereference(this):
-        return load_cs(this[0])
-
-    @property
-    def state_c_void_p(self):
-        return ctypes.cast(ctypes.pointer(self.val), ctypes.c_void_p)
-
-    @property
-    def size(self):
-        return _DEVICE_POINTER_SIZE
-
-    @property
-    def alignment(self):
-        return _DEVICE_POINTER_SIZE
+    @staticmethod
+    def dereference(it):
+        return load_cs(it[0])
 
 
-class ConstantIterator:
-    def __init__(self, val):
-        ntype = numba.from_dtype(val.dtype)
-        thisty = numba.types.CPointer(ntype)
-        self.val = _ctypes_type_given_numba_type(ntype)(val)
-        self.ntype = ntype
-        self.prefix = "constant_" + ntype.name
-        self.ltoirs = [
-            _ncc(
-                f"{self.prefix}_advance",
-                ConstantIterator.constant_advance,
-                numba.types.void(thisty, _DISTANCE_NUMBA_TYPE),
-            ).ltoir,
-            _ncc(
-                f"{self.prefix}_dereference",
-                ConstantIterator.constant_dereference,
-                (thisty,),
-            ).ltoir,
-        ]
+class ConstantIterator(IteratorBase):
+    def __init__(self, value):
+        value_type = numba.from_dtype(value.dtype)
+        cvalue = _ctypes_type_given_numba_type(value_type)(value)
+        numba_type = numba.types.CPointer(value_type)
+        super().__init__(cvalue=cvalue, value_type=value_type, numba_type=numba_type)
 
-    # Exclusively for numba.cuda.compile (this is not an actual method).
-    def constant_advance(this, _):
+    @staticmethod
+    def advance(it, n):
         pass
 
-    # Exclusively for numba.cuda.compile (this is not an actual method).
-    def constant_dereference(this):
-        return this[0]
-
-    @property
-    def state_c_void_p(self):
-        return ctypes.cast(ctypes.pointer(self.val), ctypes.c_void_p)
-
-    @property
-    def size(self):
-        return self.ntype.bitwidth // 8
-
-    @property
-    def alignment(self):
-        return self.size
+    @staticmethod
+    def dereference(it):
+        return it[0]
 
 
-class CountingIterator:
-    def __init__(self, count):
-        ntype = numba.from_dtype(count.dtype)
-        thisty = numba.types.CPointer(ntype)
-        self.count = _ctypes_type_given_numba_type(ntype)(count)
-        self.ntype = ntype
-        self.prefix = "count_" + ntype.name
-        self.ltoirs = [
-            _ncc(
-                f"{self.prefix}_advance",
-                CountingIterator.count_advance,
-                numba.types.void(thisty, _DISTANCE_NUMBA_TYPE),
-            ).ltoir,
-            _ncc(
-                f"{self.prefix}_dereference",
-                CountingIterator.count_dereference,
-                (thisty,),
-            ).ltoir,
-        ]
+class CountingIterator(IteratorBase):
+    def __init__(self, value):
+        value_type = numba.from_dtype(value.dtype)
+        cvalue = _ctypes_type_given_numba_type(value_type)(value)
+        numba_type = numba.types.CPointer(value_type)
+        super().__init__(cvalue=cvalue, value_type=value_type, numba_type=numba_type)
 
-    # Exclusively for numba.cuda.compile (this is not an actual method).
-    def count_advance(this, diff):
-        this[0] += diff
+    @staticmethod
+    def advance(it, n):
+        it[0] += n
 
-    # Exclusively for numba.cuda.compile (this is not an actual method).
-    def count_dereference(this):
-        return this[0]
-
-    @property
-    def state_c_void_p(self):
-        return ctypes.cast(ctypes.pointer(self.count), ctypes.c_void_p)
-
-    @property
-    def size(self):
-        return self.ntype.bitwidth // 8
-
-    @property
-    def alignment(self):
-        return self.size
+    @staticmethod
+    def dereference(it):
+        return it[0]
 
 
-class TransformIteratorImpl:
-    def __init__(
-        self,
-        it,
-        op_name,
-        op_return_ntype,
-        ltoirs,
-    ):
-        self.it = it
-        self.ntype = op_return_ntype
-        self.prefix = f"transform_{it.prefix}_{op_name}"
-        self.ltoirs = ltoirs
+def make_transform_iterator(it, op):
+    if hasattr(it, "__cuda_array_interface__"):
+        it = pointer(it, numba.from_dtype(it.dtype))
 
-    @property
-    def state_c_void_p(self):
-        return self.it.state_c_void_p
+    it_advance = numba.cuda.jit(type(it).advance, device=True)
+    it_dereference = numba.cuda.jit(type(it).dereference, device=True)
+    op = numba.cuda.jit(op, device=True)
 
-    @property
-    def size(self):
-        return self.it.size  # TODO fix for stateful op
-
-    @property
-    def alignment(self):
-        return self.it.alignment  # TODO fix for stateful op
-
-
-def TransformIterator(op, it):
-    # TODO(rwgk): Resolve issue #3064
-
-    if hasattr(it, "dtype"):
-        assert not hasattr(it, "ntype")
-        it = pointer(it, getattr(numba.types, str(it.dtype)))
-    it_ntype_ir = _ir_type_given_numba_type(it.ntype)
-    if it_ntype_ir is None:
-        raise RuntimeError(f"Unsupported: {type(it.ntype)=}")
-
-    op_abi_name = f"{op.__name__}_{it.ntype.name}"
-    op_ltoir, op_return_ntype = _ncc(op_abi_name, op, (it.ntype,))
-    op_return_ntype_ir = _ir_type_given_numba_type(op_return_ntype)
-
-    def source_advance(it_state_ptr, diff):
-        pass
-
-    def make_advance_codegen(name):
-        def codegen(context, builder, sig, args):
-            state_ptr, dist = args
-            fnty = ir.FunctionType(
-                ir.VoidType(), (_CHAR_PTR_IR_TYPE, _DISTANCE_IR_TYPE)
+    class TransformIterator(IteratorBase):
+        def __init__(self, it, op):
+            self._it = it
+            cvalue = it._cvalue
+            numba_type = it._numba_type
+            _, op_retty = cached_compile(
+                op,
+                (
+                    self._it._value_type,
+                ),
+                output="ltoir"
             )
-            fn = cgutils.get_or_insert_function(builder.module, fnty, name)
-            builder.call(fn, (state_ptr, dist))
+            value_type = op_retty
+            super().__init__(cvalue=cvalue, value_type=value_type, numba_type=numba_type)
 
-        return signature(
-            numba.types.void, _CHAR_PTR_NUMBA_TYPE, _DISTANCE_NUMBA_TYPE
-        ), codegen
+        @staticmethod
+        def advance(it, n):
+            return it_advance(it, n)
 
-    def advance_codegen(func_to_overload, name):
-        @intrinsic
-        def intrinsic_impl(typingctx, it_state_ptr, diff):
-            return make_advance_codegen(name)
+        @staticmethod
+        def dereference(it):
+            return op(it_dereference(it))
 
-        @overload(func_to_overload, target="cuda")
-        def impl(it_state_ptr, diff):
-            def impl(it_state_ptr, diff):
-                return intrinsic_impl(it_state_ptr, diff)
-
-            return impl
-
-    def source_dereference(it_state_ptr):
-        pass
-
-    def make_dereference_codegen(name):
-        def codegen(context, builder, sig, args):
-            (state_ptr,) = args
-            fnty = ir.FunctionType(it_ntype_ir, (_CHAR_PTR_IR_TYPE,))
-            fn = cgutils.get_or_insert_function(builder.module, fnty, name)
-            return builder.call(fn, (state_ptr,))
-
-        return signature(it.ntype, _CHAR_PTR_NUMBA_TYPE), codegen
-
-    def dereference_codegen(func_to_overload, name):
-        @intrinsic
-        def intrinsic_impl(typingctx, it_state_ptr):
-            return make_dereference_codegen(name)
-
-        @overload(func_to_overload, target="cuda")
-        def impl(it_state_ptr):
-            def impl(it_state_ptr):
-                return intrinsic_impl(it_state_ptr)
-
-            return impl
-
-    def make_op_codegen(name):
-        def codegen(context, builder, sig, args):
-            (val,) = args
-            fnty = ir.FunctionType(op_return_ntype_ir, (it_ntype_ir,))
-            fn = cgutils.get_or_insert_function(builder.module, fnty, name)
-            return builder.call(fn, (val,))
-
-        return signature(op_return_ntype, it.ntype), codegen
-
-    def op_codegen(func_to_overload, name):
-        @intrinsic
-        def intrinsic_impl(typingctx, val):
-            return make_op_codegen(name)
-
-        @overload(func_to_overload, target="cuda")
-        def impl(val):
-            def impl(val):
-                return intrinsic_impl(val)
-
-            return impl
-
-    advance_codegen(source_advance, f"{it.prefix}_advance")
-    dereference_codegen(source_dereference, f"{it.prefix}_dereference")
-
-    def op_caller(value):
-        return op(value)
-
-    op_codegen(op_caller, op_abi_name)
-
-    def transform_advance(it_state_ptr, diff):
-        source_advance(it_state_ptr, diff)  # just a function call
-
-    def transform_dereference(it_state_ptr):
-        # ATTENTION: op_caller here (see issue #3064)
-        return op_caller(source_dereference(it_state_ptr))
-
-    prefix = f"transform_{it.prefix}_{op.__name__}"
-    ltoirs = it.ltoirs + [
-        _ncc(
-            f"{prefix}_advance",
-            transform_advance,
-            numba.types.void(
-                numba.types.CPointer(numba.types.char), _DISTANCE_NUMBA_TYPE
-            ),
-        ).ltoir,
-        _ncc(
-            f"{prefix}_dereference",
-            transform_dereference,
-            (numba.types.CPointer(numba.types.char),),
-        ).ltoir,
-        # ATTENTION: NOT op_caller here! (see issue #3064)
-        op_ltoir,
-    ]
-
-    return TransformIteratorImpl(it, op.__name__, op_return_ntype, ltoirs)
+    return TransformIterator(it, op)

--- a/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_iterators.py
@@ -1,13 +1,8 @@
 import ctypes
 import operator
-import collections
 from functools import lru_cache
-from sys import prefix
 
-import numpy as np
-from numba.core import cgutils
 from llvmlite import ir
-from numba.core.typing import signature
 from numba.core.extending import intrinsic, overload
 import numba
 import numba.cuda

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators.py
@@ -1,4 +1,5 @@
 from . import _iterators
+import numba
 
 
 def CacheModifiedInputIterator(device_array, modifier):
@@ -13,7 +14,7 @@ def CacheModifiedInputIterator(device_array, modifier):
     value_type = device_array.dtype
     return _iterators.CacheModifiedPointer(
         device_array.__cuda_array_interface__["data"][0],
-        _iterators.numba_type_from_any(value_type),
+        numba.from_dtype(value_type),
     )
 
 
@@ -29,4 +30,4 @@ def CountingIterator(offset):
 
 def TransformIterator(op, it):
     """Python facade (similar to built-in map) mimicking a C++ Random Access TransformIterator."""
-    return _iterators.TransformIterator(op, it)
+    return _iterators.make_transform_iterator(it, op)

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators.py
@@ -11,10 +11,9 @@ def CacheModifiedInputIterator(device_array, modifier):
     """
     if modifier != "stream":
         raise NotImplementedError("Only stream modifier is supported")
-    value_type = device_array.dtype
     return _iterators.CacheModifiedPointer(
         device_array.__cuda_array_interface__["data"][0],
-        numba.from_dtype(value_type),
+        numba.from_dtype(device_array.dtype),
     )
 
 

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -9,7 +9,6 @@ import random
 import numba.cuda
 import numba.types
 import cuda.parallel.experimental as cudax
-from cuda.parallel.experimental import _iterators
 from cuda.parallel.experimental import iterators
 
 
@@ -161,34 +160,6 @@ def supported_value_type(request):
 @pytest.fixture(params=[True, False])
 def use_numpy_array(request):
     return request.param
-
-
-@pytest.mark.parametrize(
-    "type_obj_from_str", [_iterators.numba_type_from_any, numpy.dtype, cp.dtype]
-)
-def test_value_type_name_round_trip(type_obj_from_str, supported_value_type):
-    # If all round trip tests here pass for all value types we are supporting,
-    # this provides a super easy way to support numba.types, numpy.dtypes,
-    # cupy.dtypes and plain strings as `value_type` arguments.
-    type_obj = type_obj_from_str(supported_value_type)
-    assert str(type_obj) == supported_value_type
-
-
-def test_device_sum_raw_pointer_it(
-    use_numpy_array, supported_value_type, num_items=3, start_sum_with=10
-):
-    # Exercise non-public _iterators.pointer() independently from iterators.TransformIterator().
-    rng = random.Random(0)
-    l_varr = [rng.randrange(100) for _ in range(num_items)]
-    dtype_inp = numpy.dtype(supported_value_type)
-    dtype_out = dtype_inp
-    raw_pointer_devarr = numba.cuda.to_device(numpy.array(l_varr, dtype=dtype_inp))
-    i_input = _iterators.pointer(
-        raw_pointer_devarr, _iterators.numba_type_from_any(supported_value_type)
-    )
-    _test_device_sum_with_iterator(
-        l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
-    )
 
 
 def test_device_sum_cache_modified_input_it(


### PR DESCRIPTION
## Description

Closes #3064 

This PR primarily simplifies the implementation of `TransformIterator` to look more like the implementation of the other iterator types. The major change is using numba to compile the unary ("transform") operation on the Python side, rather than passing the LTOIR to C++ and compiling it there.

In addition, this PR introduces a `IteratorBase` class that encapsulates much of the common logic across all the iterator types. Each iterator subclass now simply needs to initialize the base and define the iterator-specific `advance` and `dereference` methods.

In terms of performance, there's a slight improvement (I believe primarily from some additional caching):

## Benchmark

### Before this PR

```python
# 10_000_000 elements
Average time to reduce device array: 0.0002010730910114944                                                                                                                                     
Average time to reduce CountingIterator: 0.014292097103316337                                                                                                                                      
Average time to reduce TransformIterator(CountingIterator): 0.0567475771997123
```

### After this PR

```python
# 10_000_000 elements
Average time to reduce device array: 0.0001940533984452486
Average time to reduce CountingIterator: 0.0004284693975932896
Average time to reduce TransformIterator(CountingIterator): 0.04169541570590809
```

<details>
  <summary>Benchmarking script </summary>

  ```python
import timeit
import matplotlib.pyplot as plt
import cupy as cp
import numpy as np
import cuda.parallel.experimental as cudax
from cuda.parallel.experimental.iterators import ConstantIterator, CountingIterator, TransformIterator
import cProfile

def binary_op(x, y): return x + y

def unary_op(x): return x if x % 2 == 0 else 1

def benchmark_reduce_array(num_runs=10):
    times = []
    size = 10_000_000
    out = cp.empty(1, dtype=cp.int64)
    h_init = np.array([0], dtype="int64")

    inp = cp.arange(size)
    reducer = cudax.reduce_into(inp, out, binary_op, h_init)
    t1 = timeit.default_timer()
    for _ in range(num_runs):
        temp_storage_bytes = reducer(None, inp, out, size, h_init)
        d_temp_storage = cp.zeros(temp_storage_bytes, dtype=np.uint8)
        reducer(d_temp_storage, inp, out, size, h_init)
    t2 = timeit.default_timer()
    assert out.get() == (inp.sum().get())
    print(f"Average time to reduce device array: {(t2 - t1)/  10}")


def benchmark_reduce_counting(num_runs=10):
    times = []
    size = 10_000_000
    out = cp.empty(1, dtype=cp.int64)
    h_init = np.array([0], dtype="int64")

    inp = CountingIterator(np.int64(1))
    reducer = cudax.reduce_into(inp, out, binary_op, h_init)
    t1 = timeit.default_timer()
    for _ in range(num_runs):
        inp = CountingIterator(np.int64(1))
        temp_storage_bytes = reducer(None, inp, out, size, h_init)
        d_temp_storage = cp.zeros(temp_storage_bytes, dtype=np.uint8)
        reducer(d_temp_storage, inp, out, size, h_init)
    t2 = timeit.default_timer()
    assert out.get() == (cp.arange(1, size + 1).sum()).get()
    print(f"Average time to reduce CountingIterator: {(t2 - t1)/  10}")
    

def benchmark_reduce_transform_counting(num_runs=10):
    times = []
    size = 10_000_000
    out = cp.empty(1, dtype=cp.int64)
    h_init = np.array([0], dtype="int64")
    inp = TransformIterator(unary_op, CountingIterator(np.int64(1)))
    reducer = cudax.reduce_into(inp, out, binary_op, h_init)
    t1 = timeit.default_timer()
    for _ in range(num_runs):
        inp = TransformIterator(unary_op, CountingIterator(np.int64(1)))
        temp_storage_bytes = reducer(None, inp, out, size, h_init)
        d_temp_storage = cp.zeros(temp_storage_bytes, dtype=np.uint8)
        reducer(d_temp_storage, inp, out, size, h_init)
    t2 = timeit.default_timer()
    inp = cp.arange(1, size + 1)
    inp[::2] = 1
    assert out.get() == inp.sum().get()
    print(f"Average time to reduce TransformIterator(CountingIterator): {(t2 - t1)/  10}")

benchmark_reduce_array()
benchmark_reduce_counting()
benchmark_reduce_transform_counting()


  ```

</details>

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
