### PR TITLE
Fix a typo in the documentation of cub::DeviceReduce::Reduce

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -109,7 +109,7 @@ struct DeviceReduce
   //!    struct CustomMin
   //!    {
   //!        template <typename T>
-  //!        __host__ __forceinline__
+  //!        __device__ __forceinline__
   //!        T operator()(const T &a, const T &b) const {
   //!            return (b < a) ? b : a;
   //!        }


### PR DESCRIPTION
## Description

The documentation of cub::DeviceReduce::Reduce was showing a custom operator which was implemented on the host rather than on the device

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
