### PR TITLE
Refactor cub histogram tuning

### DIFF
--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -555,12 +555,8 @@ template <int NUM_CHANNELS,
           typename CounterT,
           typename LevelT,
           typename OffsetT,
-          typename SelectedPolicy = //
-          detail::device_histogram_policy_hub< //
-            cub::detail::value_t<SampleIteratorT>,
-            CounterT,
-            NUM_CHANNELS,
-            NUM_ACTIVE_CHANNELS>>
+          typename SelectedPolicy =
+            detail::histogram::policy_hub<detail::value_t<SampleIteratorT>, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS>>
 struct DispatchHistogram : SelectedPolicy
 {
   static_assert(NUM_CHANNELS <= 4, "Histograms only support up to 4 channels");

--- a/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_histogram.cuh
@@ -42,14 +42,14 @@
 #include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 
+#include <cuda/std/__algorithm/max.h>
+
 CUB_NAMESPACE_BEGIN
 
 namespace detail
 {
-
 namespace histogram
 {
-
 enum class primitive_sample
 {
   no,
@@ -87,37 +87,13 @@ constexpr sample_size classify_sample_size()
   return sizeof(SampleT) == 1 ? sample_size::_1 : sizeof(SampleT) == 2 ? sample_size::_2 : sample_size::unknown;
 }
 
-template <class SampleT>
-constexpr int v_scale()
-{
-  return (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int);
-}
-
-template <class SampleT, int NumActiveChannels, int NominalItemsPerThread>
-constexpr int t_scale()
-{
-  return CUB_MAX((NominalItemsPerThread / NumActiveChannels / v_scale<SampleT>()), 1);
-}
-
 template <class SampleT,
           int NumChannels,
           int NumActiveChannels,
           counter_size CounterSize,
           primitive_sample PrimitiveSample = is_primitive_sample<SampleT>(),
           sample_size SampleSize           = classify_sample_size<SampleT>()>
-struct sm90_tuning
-{
-  static constexpr int threads = 384;
-  static constexpr int items   = t_scale<SampleT, NumActiveChannels, 16>();
-
-  static constexpr CacheLoadModifier load_modifier               = LOAD_LDG;
-  static constexpr BlockHistogramMemoryPreference mem_preference = SMEM;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
-  static constexpr bool rle_compress  = true;
-  static constexpr bool work_stealing = false;
-};
+struct sm90_tuning;
 
 template <class SampleT>
 struct sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sample_size::_1>
@@ -149,56 +125,57 @@ struct sm90_tuning<SampleT, 1, 1, counter_size::_4, primitive_sample::yes, sampl
   static constexpr bool work_stealing = false;
 };
 
-} // namespace histogram
-
 template <class SampleT, class CounterT, int NumChannels, int NumActiveChannels>
-struct device_histogram_policy_hub
+struct policy_hub
 {
-  template <int NOMINAL_ITEMS_PER_THREAD>
-  struct TScale
-  {
-    enum
-    {
-      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
-      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NumActiveChannels / V_SCALE), 1)
-    };
-  };
+  // TODO(bgruber): move inside t_scale in C++14
+  static constexpr int v_scale = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int);
 
-  /// SM35
+  static constexpr int t_scale(int nominalItemsPerThread)
+  {
+    return ::cuda::std::max(nominalItemsPerThread / NumActiveChannels / v_scale, 1);
+  }
+
+  // SM35
   struct Policy350 : ChainedPolicy<350, Policy350, Policy350>
   {
     // TODO This might be worth it to separate usual histogram and the multi one
-    using AgentHistogramPolicyT =
-      AgentHistogramPolicy<128, TScale<8>::VALUE, BLOCK_LOAD_DIRECT, LOAD_LDG, true, BLEND, true>;
+    using AgentHistogramPolicyT = AgentHistogramPolicy<128, t_scale(8), BLOCK_LOAD_DIRECT, LOAD_LDG, true, BLEND, true>;
   };
 
-  /// SM50
+  // SM50
   struct Policy500 : ChainedPolicy<500, Policy500, Policy350>
   {
     // TODO This might be worth it to separate usual histogram and the multi one
     using AgentHistogramPolicyT =
-      AgentHistogramPolicy<384, TScale<16>::VALUE, cub::BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false>;
+      AgentHistogramPolicy<384, t_scale(16), BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false>;
   };
 
-  /// SM900
+  // SM90
   struct Policy900 : ChainedPolicy<900, Policy900, Policy500>
   {
-    using tuning = detail::histogram::
-      sm90_tuning<SampleT, NumChannels, NumActiveChannels, histogram::classify_counter_size<CounterT>()>;
+    // Use values from tuning if a specialization exists, otherwise pick Policy500
+    template <typename Tuning>
+    static auto select_agent_policy(int)
+      -> AgentHistogramPolicy<Tuning::threads,
+                              Tuning::items,
+                              Tuning::load_algorithm,
+                              Tuning::load_modifier,
+                              Tuning::rle_compress,
+                              Tuning::mem_preference,
+                              Tuning::work_stealing>;
+
+    template <typename Tuning>
+    static auto select_agent_policy(long) -> typename Policy500::AgentHistogramPolicyT;
 
     using AgentHistogramPolicyT =
-      AgentHistogramPolicy<tuning::threads,
-                           tuning::items,
-                           tuning::load_algorithm,
-                           tuning::load_modifier,
-                           tuning::rle_compress,
-                           tuning::mem_preference,
-                           tuning::work_stealing>;
+      decltype(select_agent_policy<
+               sm90_tuning<SampleT, NumChannels, NumActiveChannels, histogram::classify_counter_size<CounterT>()>>(0));
   };
 
   using MaxPolicy = Policy900;
 };
-
+} // namespace histogram
 } // namespace detail
 
 CUB_NAMESPACE_END


### PR DESCRIPTION
- [x] No changes in SASS for `cub.test.device_histogram.lid_0` except for kernel symbol names