### PR TITLE
[CUDAX] Fix the other copy of vector_add after migration to use configs in launch

### DIFF
--- a/examples/cudax/vector_add/vector_add.cu
+++ b/examples/cudax/vector_add/vector_add.cu
@@ -92,11 +92,12 @@ try
 
   // Define the kernel launch parameters
   constexpr int threadsPerBlock = 256;
-  auto dims                     = cudax::distribute<threadsPerBlock>(numElements);
+  auto config                   = cudax::distribute<threadsPerBlock>(numElements);
 
   // Launch the vectorAdd kernel
-  printf("CUDA kernel launch with %d blocks of %d threads\n", dims.count(cudax::block, cudax::grid), threadsPerBlock);
-  cudax::launch(stream, dims, vectorAdd, in(A), in(B), out(C));
+  printf(
+    "CUDA kernel launch with %d blocks of %d threads\n", config.dims.count(cudax::block, cudax::grid), threadsPerBlock);
+  cudax::launch(stream, config, vectorAdd, in(A), in(B), out(C));
 
   printf("waiting for the stream to finish\n");
   stream.wait();


### PR DESCRIPTION
It seems we have two copies of `vector_add` example, one in `cccl/examples/cudax` and one in `cccl/cudax/examples`. Long term we should decide on one place and remove the other copy.

`cudax::distribute` was recently changed to return configs, the `cccl/examples` copy of `vector_add` is now failing. This PR fixes the sample.