### PR TITLE
Make PDL available with CTK 12.0

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/cuda_capabilities.h
+++ b/libcudacxx/include/cuda/std/__cccl/cuda_capabilities.h
@@ -37,7 +37,7 @@
 #endif // no system header
 
 // True, when programmatic dependent launch is available, otherwise false.
-#define _CCCL_HAS_PDL _CCCL_CUDACC_AT_LEAST(11, 8)
+#define _CCCL_HAS_PDL _CCCL_CUDACC_AT_LEAST(12, 0)
 #if _CCCL_HAS_PDL
 // Waits for the previous kernel to complete (when it reaches its final membar). Should be put before the first global
 // memory access in a kernel.


### PR DESCRIPTION
For some reason, I made PDL available with CTK 11.8 in #3114, but it seems the feature is only available starting with CTK 12.0.