### PR TITLE
Refactor scan tunings

### DIFF
--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -1322,7 +1322,7 @@ struct DeviceScan
       detail::InputValue<InitValueT>,
       OffsetT,
       AccumT,
-      DeviceScanPolicy<AccumT, ScanOpT>,
+      detail::scan::policy_hub<AccumT, ScanOpT>,
       ForceInclusive>::Dispatch(d_temp_storage,
                                 temp_storage_bytes,
                                 d_in,

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -239,7 +239,7 @@ template <typename InputIteratorT,
                                                                  ::cuda::std::_If<std::is_same<InitValueT, NullType>::value,
                                                                                   cub::detail::value_t<InputIteratorT>,
                                                                                   typename InitValueT::value_type>>,
-          typename SelectedPolicy = DeviceScanPolicy<AccumT, ScanOpT>,
+          typename SelectedPolicy = detail::scan::policy_hub<AccumT, ScanOpT>,
           bool ForceInclusive     = false>
 struct DispatchScan : SelectedPolicy
 {

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -53,7 +53,6 @@ namespace detail
 {
 namespace scan
 {
-
 enum class keep_rejects
 {
   no,
@@ -114,8 +113,7 @@ struct tuning
 {
   static constexpr int threads = Threads;
   static constexpr int items   = Items;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<L2B, L2W>;
+  using delay_constructor      = fixed_delay_constructor_t<L2B, L2W>;
 };
 
 template <class AccumT,
@@ -126,8 +124,7 @@ struct sm90_tuning
 {
   static constexpr int threads = 128;
   static constexpr int items   = 15;
-
-  using delay_constructor = detail::default_delay_constructor_t<AccumT>;
+  using delay_constructor      = default_delay_constructor_t<AccumT>;
 };
 
 // clang-format off
@@ -154,13 +151,10 @@ template <class AccumT,
           accum_size AccumSize                 = classify_accum_size<AccumT>()>
 struct sm80_tuning
 {
-  static constexpr int threads = 128;
-  static constexpr int items   = 15;
-
-  using delay_constructor = detail::default_delay_constructor_t<AccumT>;
-
-  static constexpr bool LargeValues = sizeof(AccumT) > 128;
-
+  static constexpr int threads                       = 128;
+  static constexpr int items                         = 15;
+  using delay_constructor                            = default_delay_constructor_t<AccumT>;
+  static constexpr bool LargeValues                  = sizeof(AccumT) > 128;
   static constexpr BlockLoadAlgorithm load_algorithm = //
     LargeValues ? BLOCK_LOAD_WARP_TRANSPOSE_TIMESLICED : BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = //
@@ -170,11 +164,9 @@ struct sm80_tuning
 template <class T>
 struct sm80_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_1>
 {
-  static constexpr int threads = 320;
-  static constexpr int items   = 14;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<368, 725>;
-
+  static constexpr int threads                         = 320;
+  static constexpr int items                           = 14;
+  using delay_constructor                              = fixed_delay_constructor_t<368, 725>;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
 };
@@ -182,11 +174,9 @@ struct sm80_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_1>
 template <class T>
 struct sm80_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_2>
 {
-  static constexpr int threads = 352;
-  static constexpr int items   = 16;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<488, 1040>;
-
+  static constexpr int threads                         = 352;
+  static constexpr int items                           = 16;
+  using delay_constructor                              = fixed_delay_constructor_t<488, 1040>;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
 };
@@ -194,11 +184,9 @@ struct sm80_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_2>
 template <class T>
 struct sm80_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_4>
 {
-  static constexpr int threads = 320;
-  static constexpr int items   = 12;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<268, 1180>;
-
+  static constexpr int threads                         = 320;
+  static constexpr int items                           = 12;
+  using delay_constructor                              = fixed_delay_constructor_t<268, 1180>;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
 };
@@ -206,11 +194,9 @@ struct sm80_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_4>
 template <class T>
 struct sm80_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_8>
 {
-  static constexpr int threads = 288;
-  static constexpr int items   = 22;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<716, 785>;
-
+  static constexpr int threads                         = 288;
+  static constexpr int items                           = 22;
+  using delay_constructor                              = fixed_delay_constructor_t<716, 785>;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
 };
@@ -218,11 +204,9 @@ struct sm80_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_8>
 template <>
 struct sm80_tuning<float, primitive_op::yes, primitive_accum::yes, accum_size::_4>
 {
-  static constexpr int threads = 288;
-  static constexpr int items   = 8;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<724, 1050>;
-
+  static constexpr int threads                         = 288;
+  static constexpr int items                           = 8;
+  using delay_constructor                              = fixed_delay_constructor_t<724, 1050>;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
 };
@@ -230,11 +214,9 @@ struct sm80_tuning<float, primitive_op::yes, primitive_accum::yes, accum_size::_
 template <>
 struct sm80_tuning<double, primitive_op::yes, primitive_accum::yes, accum_size::_8>
 {
-  static constexpr int threads = 384;
-  static constexpr int items   = 12;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<388, 1100>;
-
+  static constexpr int threads                         = 384;
+  static constexpr int items                           = 12;
+  using delay_constructor                              = fixed_delay_constructor_t<388, 1100>;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
 };
@@ -243,11 +225,9 @@ struct sm80_tuning<double, primitive_op::yes, primitive_accum::yes, accum_size::
 template <>
 struct sm80_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
 {
-  static constexpr int threads = 640;
-  static constexpr int items   = 24;
-
-  using delay_constructor = detail::no_delay_constructor_t<1200>;
-
+  static constexpr int threads                         = 640;
+  static constexpr int items                           = 24;
+  using delay_constructor                              = no_delay_constructor_t<1200>;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
 };

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -238,11 +238,8 @@ struct sm80_tuning<__uint128_t, primitive_op::yes, primitive_accum::no, accum_si
 {};
 #endif
 
-} // namespace scan
-} // namespace detail
-
-template <typename AccumT, typename ScanOpT = ::cuda::std::plus<>>
-struct DeviceScanPolicy
+template <typename AccumT, typename ScanOpT>
+struct policy_hub
 {
   // For large values, use timesliced loads/stores to fit shared memory.
   static constexpr bool LargeValues = sizeof(AccumT) > 128;
@@ -353,5 +350,11 @@ struct DeviceScanPolicy
 
   using MaxPolicy = Policy900;
 };
+} // namespace scan
+} // namespace detail
+
+// TODO(bgruber): deprecate this at some point when we have a better way to allow users to supply tunings
+template <typename AccumT, typename ScanOpT = ::cuda::std::plus<>>
+using DeviceScanPolicy = detail::scan::policy_hub<AccumT, ScanOpT>;
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -120,35 +120,6 @@ template <class AccumT,
           primitive_op PrimitiveOp,
           primitive_accum PrimitiveAccumulator = is_primitive_accum<AccumT>(),
           accum_size AccumSize                 = classify_accum_size<AccumT>()>
-struct sm90_tuning
-{
-  static constexpr int threads = 128;
-  static constexpr int items   = 15;
-  using delay_constructor      = default_delay_constructor_t<AccumT>;
-};
-
-// clang-format off
-template <class T> struct sm90_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_1> : tuning<192, 22, 168, 1140> {};
-template <class T> struct sm90_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_2> : tuning<512, 12, 376, 1125> {};
-template <class T> struct sm90_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_4> : tuning<128, 24, 648, 1245> {};
-template <class T> struct sm90_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_8> : tuning<224, 24, 632, 1290> {};
-
-template <> struct sm90_tuning<float,  primitive_op::yes, primitive_accum::yes, accum_size::_4> : tuning<128, 24, 688, 1140> {};
-template <> struct sm90_tuning<double, primitive_op::yes, primitive_accum::yes, accum_size::_8> : tuning<224, 24, 576, 1215> {};
-
-#if CUB_IS_INT128_ENABLED
-template <> struct sm90_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16> : tuning<576, 21, 860, 630> {};
-template <>
-struct sm90_tuning<__uint128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
-    : sm90_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
-{};
-#endif
-// clang-format on
-
-template <class AccumT,
-          primitive_op PrimitiveOp,
-          primitive_accum PrimitiveAccumulator = is_primitive_accum<AccumT>(),
-          accum_size AccumSize                 = classify_accum_size<AccumT>()>
 struct sm80_tuning
 {
   static constexpr int threads                       = 128;
@@ -237,6 +208,35 @@ struct sm80_tuning<__uint128_t, primitive_op::yes, primitive_accum::no, accum_si
     : sm80_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
 {};
 #endif
+
+template <class AccumT,
+          primitive_op PrimitiveOp,
+          primitive_accum PrimitiveAccumulator = is_primitive_accum<AccumT>(),
+          accum_size AccumSize                 = classify_accum_size<AccumT>()>
+struct sm90_tuning
+{
+  static constexpr int threads = 128;
+  static constexpr int items   = 15;
+  using delay_constructor      = default_delay_constructor_t<AccumT>;
+};
+
+// clang-format off
+template <class T> struct sm90_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_1> : tuning<192, 22, 168, 1140> {};
+template <class T> struct sm90_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_2> : tuning<512, 12, 376, 1125> {};
+template <class T> struct sm90_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_4> : tuning<128, 24, 648, 1245> {};
+template <class T> struct sm90_tuning<T, primitive_op::yes, primitive_accum::yes, accum_size::_8> : tuning<224, 24, 632, 1290> {};
+
+template <> struct sm90_tuning<float,  primitive_op::yes, primitive_accum::yes, accum_size::_4> : tuning<128, 24, 688, 1140> {};
+template <> struct sm90_tuning<double, primitive_op::yes, primitive_accum::yes, accum_size::_8> : tuning<224, 24, 576, 1215> {};
+
+#if CUB_IS_INT128_ENABLED
+template <> struct sm90_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16> : tuning<576, 21, 860, 630> {};
+template <>
+struct sm90_tuning<__uint128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
+    : sm90_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
+{};
+#endif
+// clang-format on
 
 template <typename AccumT, typename ScanOpT>
 struct policy_hub

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -140,8 +140,11 @@ template <> struct sm90_tuning<float,  primitive_op::yes, primitive_accum::yes, 
 template <> struct sm90_tuning<double, primitive_op::yes, primitive_accum::yes, accum_size::_8> : tuning<224, 24, 576, 1215> {};
 
 #if CUB_IS_INT128_ENABLED
-template <> struct sm90_tuning< __int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16> : tuning<576, 21, 860, 630> {};
-template <> struct sm90_tuning<__uint128_t, primitive_op::yes, primitive_accum::no, accum_size::_16> : tuning<576, 21, 860, 630> {};
+template <> struct sm90_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16> : tuning<576, 21, 860, 630> {};
+template <>
+struct sm90_tuning<__uint128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
+    : sm90_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
+{};
 #endif
 // clang-format on
 
@@ -251,15 +254,8 @@ struct sm80_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_siz
 
 template <>
 struct sm80_tuning<__uint128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
-{
-  static constexpr int threads = 640;
-  static constexpr int items   = 24;
-
-  using delay_constructor = detail::no_delay_constructor_t<1200>;
-
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-};
+    : sm80_tuning<__int128_t, primitive_op::yes, primitive_accum::no, accum_size::_16>
+{};
 #endif
 
 } // namespace scan

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -294,7 +294,6 @@ struct DeviceScanPolicy
                     MemBoundScaling<NOMINAL_BLOCK_THREADS_4B, NOMINAL_ITEMS_PER_THREAD_4B, ComputeT>,
                     DelayConstructorT>;
 
-  /// SM350
   struct Policy350 : ChainedPolicy<350, Policy350, Policy350>
   {
     // GTX Titan: 29.5B items/s (232.4 GB/s) @ 48M 32-bit T
@@ -309,7 +308,6 @@ struct DeviceScanPolicy
                detail::default_delay_constructor_t<AccumT>>;
   };
 
-  /// SM520
   struct Policy520 : ChainedPolicy<520, Policy520, Policy350>
   {
     // Titan X: 32.47B items/s @ 48M 32-bit T
@@ -324,7 +322,6 @@ struct DeviceScanPolicy
                detail::default_delay_constructor_t<AccumT>>;
   };
 
-  /// SM600
   struct DefaultTuning
   {
     using ScanPolicyT =
@@ -338,13 +335,11 @@ struct DeviceScanPolicy
                detail::default_delay_constructor_t<AccumT>>;
   };
 
-  /// SM600
   struct Policy600
       : DefaultTuning
       , ChainedPolicy<600, Policy600, Policy520>
   {};
 
-  /// SM800
   struct Policy800 : ChainedPolicy<800, Policy800, Policy600>
   {
     using tuning = detail::scan::sm80_tuning<AccumT, detail::scan::is_primitive_op<ScanOpT>()>;
@@ -360,13 +355,11 @@ struct DeviceScanPolicy
                typename tuning::delay_constructor>;
   };
 
-  /// SM860
   struct Policy860
       : DefaultTuning
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 
-  /// SM900
   struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
   {
     using tuning = detail::scan::sm90_tuning<AccumT, detail::scan::is_primitive_op<ScanOpT>()>;

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -292,7 +292,7 @@ struct policy_hub
                default_delay_constructor_t<AccumT>>;
   };
 
-  struct DefaultTuning
+  struct DefaultPolicy
   {
     using ScanPolicyT =
       policy_t<128,
@@ -305,7 +305,7 @@ struct policy_hub
   };
 
   struct Policy600
-      : DefaultTuning
+      : DefaultPolicy
       , ChainedPolicy<600, Policy600, Policy520>
   {};
 
@@ -324,7 +324,7 @@ struct policy_hub
   };
 
   struct Policy860
-      : DefaultTuning
+      : DefaultPolicy
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 

--- a/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
@@ -144,7 +144,7 @@ unique_eager_event async_inclusive_scan_n(
                       InputValueT,
                       std::int32_t,
                       AccumT,
-                      cub::DeviceScanPolicy<AccumT, BinaryOp>,
+                      cub::detail::scan::policy_hub<AccumT, BinaryOp>,
                       ForceInclusive>;
   using Dispatch64 =
     cub::DispatchScan<ForwardIt,
@@ -153,7 +153,7 @@ unique_eager_event async_inclusive_scan_n(
                       InputValueT,
                       std::int64_t,
                       AccumT,
-                      cub::DeviceScanPolicy<AccumT, BinaryOp>,
+                      cub::detail::scan::policy_hub<AccumT, BinaryOp>,
                       ForceInclusive>;
 
   InputValueT init_value(init);

--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -130,7 +130,7 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
                       InputValueT,
                       std::int32_t,
                       AccumT,
-                      cub::DeviceScanPolicy<AccumT, ScanOp>,
+                      cub::detail::scan::policy_hub<AccumT, ScanOp>,
                       ForceInclusive>;
   using Dispatch64 =
     cub::DispatchScan<InputIt,
@@ -139,7 +139,7 @@ _CCCL_HOST_DEVICE OutputIt inclusive_scan_n_impl(
                       InputValueT,
                       std::int64_t,
                       AccumT,
-                      cub::DeviceScanPolicy<AccumT, ScanOp>,
+                      cub::detail::scan::policy_hub<AccumT, ScanOp>,
                       ForceInclusive>;
 
   cudaStream_t stream = thrust::cuda_cub::stream(policy);


### PR DESCRIPTION
- [x] No changes in SASS for `cub.test.device_scan.lid_0.types_0` except kernel symbol names