### PR TITLE
Refactor scan_by_key tuning

### DIFF
--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -233,7 +233,7 @@ template <
     cub::detail::value_t<ValuesInputIteratorT>,
     ::cuda::std::_If<std::is_same<InitValueT, NullType>::value, cub::detail::value_t<ValuesInputIteratorT>, InitValueT>>,
   typename SelectedPolicy =
-    DeviceScanByKeyPolicy<KeysInputIteratorT, AccumT, cub::detail::value_t<ValuesInputIteratorT>, ScanOpT>>
+    detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, cub::detail::value_t<ValuesInputIteratorT>, ScanOpT>>
 struct DispatchScanByKey : SelectedPolicy
 {
   //---------------------------------------------------------------------

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -791,7 +791,6 @@ struct DeviceScanByKeyPolicy
   static constexpr size_t MaxInputBytes      = (cub::max)(sizeof(KeyT), sizeof(AccumT));
   static constexpr size_t CombinedInputBytes = sizeof(KeyT) + sizeof(AccumT);
 
-  // SM350
   struct Policy350 : ChainedPolicy<350, Policy350, Policy350>
   {
     static constexpr int NOMINAL_4B_ITEMS_PER_THREAD = 6;
@@ -824,13 +823,11 @@ struct DeviceScanByKeyPolicy
                            detail::default_reduce_by_key_delay_constructor_t<AccumT, int>>;
   };
 
-  // SM520
   struct Policy520
       : DefaultTuning
       , ChainedPolicy<520, Policy520, Policy350>
   {};
 
-  // SM800
   struct Policy800 : ChainedPolicy<800, Policy800, Policy520>
   {
     using tuning = detail::scan_by_key::sm80_tuning<KeyT, ValueT, detail::scan_by_key::is_primitive_op<ScanOpT>()>;
@@ -845,13 +842,11 @@ struct DeviceScanByKeyPolicy
                            typename tuning::delay_constructor>;
   };
 
-  // SM860
   struct Policy860
       : DefaultTuning
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 
-  // SM900
   struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
   {
     using tuning = detail::scan_by_key::sm90_tuning<KeyT, ValueT, detail::scan_by_key::is_primitive_op<ScanOpT>()>;

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -781,11 +781,9 @@ struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size
   using delay_constructor                              = detail::no_delay_constructor_t<1160>;
 };
 #endif
-} // namespace scan_by_key
-} // namespace detail
 
-template <typename KeysInputIteratorT, typename AccumT, typename ValueT = AccumT, typename ScanOpT = ::cuda::std::plus<>>
-struct DeviceScanByKeyPolicy
+template <typename KeysInputIteratorT, typename AccumT, typename ValueT, typename ScanOpT>
+struct policy_hub
 {
   using KeyT                                 = cub::detail::value_t<KeysInputIteratorT>;
   static constexpr size_t MaxInputBytes      = (cub::max)(sizeof(KeyT), sizeof(AccumT));
@@ -863,5 +861,10 @@ struct DeviceScanByKeyPolicy
 
   using MaxPolicy = Policy900;
 };
+} // namespace scan_by_key
+} // namespace detail
+
+template <typename KeysInputIteratorT, typename AccumT, typename ValueT = AccumT, typename ScanOpT = ::cuda::std::plus<>>
+using DeviceScanByKeyPolicy = detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, ValueT, ScanOpT>;
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -140,7 +140,7 @@ struct sm90_tuning
     ((max_input_bytes <= 8) ? 9 : Nominal4BItemsToItemsCombined(nominal_4b_items_per_thread, combined_input_bytes));
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::default_reduce_by_key_delay_constructor_t<AccumT, int>;
+  using delay_constructor                              = default_reduce_by_key_delay_constructor_t<AccumT, int>;
 };
 
 template <class KeyT, class ValueT>
@@ -150,7 +150,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_1, 
   static constexpr int items                           = 12;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = detail::no_delay_constructor_t<650>;
+  using delay_constructor                              = no_delay_constructor_t<650>;
 };
 
 template <class KeyT, class ValueT>
@@ -160,7 +160,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_2, 
   static constexpr int items                           = 16;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<124, 995>;
+  using delay_constructor                              = fixed_delay_constructor_t<124, 995>;
 };
 
 template <class KeyT, class ValueT>
@@ -170,7 +170,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_4, 
   static constexpr int items                           = 15;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<488, 545>;
+  using delay_constructor                              = fixed_delay_constructor_t<488, 545>;
 };
 
 template <class KeyT, class ValueT>
@@ -180,7 +180,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_8, 
   static constexpr int items                           = 10;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<488, 1070>;
+  using delay_constructor                              = fixed_delay_constructor_t<488, 1070>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -191,7 +191,7 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::
   static constexpr int items                           = 23;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<936, 1105>;
+  using delay_constructor                              = fixed_delay_constructor_t<936, 1105>;
 };
 
 template <class KeyT>
@@ -201,7 +201,7 @@ struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_1, val_size:
   static constexpr int items                           = 23;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<936, 1105>;
+  using delay_constructor                              = fixed_delay_constructor_t<936, 1105>;
 };
 #endif
 
@@ -212,7 +212,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_1, 
   static constexpr int items                           = 12;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<136, 785>;
+  using delay_constructor                              = fixed_delay_constructor_t<136, 785>;
 };
 
 template <class KeyT, class ValueT>
@@ -222,7 +222,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_2, 
   static constexpr int items                           = 20;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<445>;
+  using delay_constructor                              = no_delay_constructor_t<445>;
 };
 
 template <class KeyT, class ValueT>
@@ -232,7 +232,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_4, 
   static constexpr int items                           = 22;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<312, 865>;
+  using delay_constructor                              = fixed_delay_constructor_t<312, 865>;
 };
 
 template <class KeyT, class ValueT>
@@ -242,7 +242,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_8, 
   static constexpr int items                           = 10;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<352, 1170>;
+  using delay_constructor                              = fixed_delay_constructor_t<352, 1170>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -253,7 +253,7 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::
   static constexpr int items                           = 23;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<504, 1190>;
+  using delay_constructor                              = fixed_delay_constructor_t<504, 1190>;
 };
 
 template <class KeyT>
@@ -263,7 +263,7 @@ struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_2, val_size:
   static constexpr int items                           = 23;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<504, 1190>;
+  using delay_constructor                              = fixed_delay_constructor_t<504, 1190>;
 };
 #endif
 
@@ -274,7 +274,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_1, 
   static constexpr int items                           = 12;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = detail::no_delay_constructor_t<850>;
+  using delay_constructor                              = no_delay_constructor_t<850>;
 };
 
 template <class KeyT, class ValueT>
@@ -284,7 +284,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_2, 
   static constexpr int items                           = 14;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<128, 965>;
+  using delay_constructor                              = fixed_delay_constructor_t<128, 965>;
 };
 
 template <class KeyT, class ValueT>
@@ -294,7 +294,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_4, 
   static constexpr int items                           = 14;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<700, 1005>;
+  using delay_constructor                              = fixed_delay_constructor_t<700, 1005>;
 };
 
 template <class KeyT, class ValueT>
@@ -304,7 +304,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_8, 
   static constexpr int items                           = 14;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<556, 1195>;
+  using delay_constructor                              = fixed_delay_constructor_t<556, 1195>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -315,7 +315,7 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::
   static constexpr int items                           = 23;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<512, 1030>;
+  using delay_constructor                              = fixed_delay_constructor_t<512, 1030>;
 };
 
 template <class KeyT>
@@ -325,7 +325,7 @@ struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_4, val_size:
   static constexpr int items                           = 23;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<512, 1030>;
+  using delay_constructor                              = fixed_delay_constructor_t<512, 1030>;
 };
 #endif
 
@@ -336,7 +336,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_1, 
   static constexpr int items                           = 12;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<504, 1010>;
+  using delay_constructor                              = fixed_delay_constructor_t<504, 1010>;
 };
 
 template <class KeyT, class ValueT>
@@ -346,7 +346,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_2, 
   static constexpr int items                           = 10;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<420, 970>;
+  using delay_constructor                              = fixed_delay_constructor_t<420, 970>;
 };
 
 template <class KeyT, class ValueT>
@@ -356,7 +356,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_4, 
   static constexpr int items                           = 10;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<500, 1125>;
+  using delay_constructor                              = fixed_delay_constructor_t<500, 1125>;
 };
 
 template <class KeyT, class ValueT>
@@ -366,7 +366,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_8, 
   static constexpr int items                           = 11;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<600, 930>;
+  using delay_constructor                              = fixed_delay_constructor_t<600, 930>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -377,7 +377,7 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::
   static constexpr int items                           = 15;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 1085>;
+  using delay_constructor                              = fixed_delay_constructor_t<364, 1085>;
 };
 
 template <class KeyT>
@@ -387,7 +387,7 @@ struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_8, val_size:
   static constexpr int items                           = 15;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 1085>;
+  using delay_constructor                              = fixed_delay_constructor_t<364, 1085>;
 };
 #endif
 
@@ -398,7 +398,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_1,
   static constexpr int items                           = 7;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<500, 975>;
+  using delay_constructor                              = fixed_delay_constructor_t<500, 975>;
 };
 
 template <class KeyT, class ValueT>
@@ -408,7 +408,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_2,
   static constexpr int items                           = 10;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<164, 1075>;
+  using delay_constructor                              = fixed_delay_constructor_t<164, 1075>;
 };
 
 template <class KeyT, class ValueT>
@@ -418,7 +418,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_4,
   static constexpr int items                           = 9;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<268, 1120>;
+  using delay_constructor                              = fixed_delay_constructor_t<268, 1120>;
 };
 
 template <class KeyT, class ValueT>
@@ -428,7 +428,7 @@ struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_8,
   static constexpr int items                           = 9;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<320, 1200>;
+  using delay_constructor                              = fixed_delay_constructor_t<320, 1200>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -439,7 +439,7 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size:
   static constexpr int items                           = 23;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 1050>;
+  using delay_constructor                              = fixed_delay_constructor_t<364, 1050>;
 };
 
 template <class KeyT>
@@ -449,7 +449,7 @@ struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size
   static constexpr int items                           = 23;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 1050>;
+  using delay_constructor                              = fixed_delay_constructor_t<364, 1050>;
 };
 #endif
 
@@ -469,7 +469,7 @@ struct sm80_tuning
     ((max_input_bytes <= 8) ? 9 : Nominal4BItemsToItemsCombined(nominal_4b_items_per_thread, combined_input_bytes));
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::default_reduce_by_key_delay_constructor_t<AccumT, int>;
+  using delay_constructor                              = default_reduce_by_key_delay_constructor_t<AccumT, int>;
 };
 
 template <class KeyT, class ValueT>
@@ -479,7 +479,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_1, 
   static constexpr int items                           = 12;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = detail::no_delay_constructor_t<795>;
+  using delay_constructor                              = no_delay_constructor_t<795>;
 };
 
 template <class KeyT, class ValueT>
@@ -489,7 +489,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_2, 
   static constexpr int items                           = 12;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<825>;
+  using delay_constructor                              = no_delay_constructor_t<825>;
 };
 
 template <class KeyT, class ValueT>
@@ -499,7 +499,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_4, 
   static constexpr int items                           = 15;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<640>;
+  using delay_constructor                              = no_delay_constructor_t<640>;
 };
 
 template <class KeyT, class ValueT>
@@ -509,7 +509,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_8, 
   static constexpr int items                           = 10;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<124, 1040>;
+  using delay_constructor                              = fixed_delay_constructor_t<124, 1040>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -520,7 +520,7 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::
   static constexpr int items                           = 19;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1095>;
+  using delay_constructor                              = no_delay_constructor_t<1095>;
 };
 
 template <class KeyT>
@@ -530,7 +530,7 @@ struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_1, val_size:
   static constexpr int items                           = 19;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1095>;
+  using delay_constructor                              = no_delay_constructor_t<1095>;
 };
 #endif
 
@@ -541,7 +541,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_1, 
   static constexpr int items                           = 8;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = detail::no_delay_constructor_t<1070>;
+  using delay_constructor                              = no_delay_constructor_t<1070>;
 };
 
 template <class KeyT, class ValueT>
@@ -551,7 +551,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_2, 
   static constexpr int items                           = 14;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<625>;
+  using delay_constructor                              = no_delay_constructor_t<625>;
 };
 
 template <class KeyT, class ValueT>
@@ -561,7 +561,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_4, 
   static constexpr int items                           = 15;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1055>;
+  using delay_constructor                              = no_delay_constructor_t<1055>;
 };
 
 template <class KeyT, class ValueT>
@@ -571,7 +571,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_8, 
   static constexpr int items                           = 17;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<160, 695>;
+  using delay_constructor                              = fixed_delay_constructor_t<160, 695>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -582,7 +582,7 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::
   static constexpr int items                           = 14;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1105>;
+  using delay_constructor                              = no_delay_constructor_t<1105>;
 };
 
 template <class KeyT>
@@ -592,7 +592,7 @@ struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_2, val_size:
   static constexpr int items                           = 14;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1105>;
+  using delay_constructor                              = no_delay_constructor_t<1105>;
 };
 #endif
 
@@ -603,7 +603,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_1, 
   static constexpr int items                           = 12;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = detail::no_delay_constructor_t<1130>;
+  using delay_constructor                              = no_delay_constructor_t<1130>;
 };
 
 template <class KeyT, class ValueT>
@@ -613,7 +613,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_2, 
   static constexpr int items                           = 12;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1130>;
+  using delay_constructor                              = no_delay_constructor_t<1130>;
 };
 
 template <class KeyT, class ValueT>
@@ -623,7 +623,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_4, 
   static constexpr int items                           = 15;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1140>;
+  using delay_constructor                              = no_delay_constructor_t<1140>;
 };
 
 template <class KeyT, class ValueT>
@@ -633,7 +633,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_8, 
   static constexpr int items                           = 9;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<888, 635>;
+  using delay_constructor                              = fixed_delay_constructor_t<888, 635>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -644,7 +644,7 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::
   static constexpr int items                           = 17;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1100>;
+  using delay_constructor                              = no_delay_constructor_t<1100>;
 };
 
 template <class KeyT>
@@ -654,7 +654,7 @@ struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_4, val_size:
   static constexpr int items                           = 17;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1100>;
+  using delay_constructor                              = no_delay_constructor_t<1100>;
 };
 #endif
 
@@ -665,7 +665,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_1, 
   static constexpr int items                           = 11;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1120>;
+  using delay_constructor                              = no_delay_constructor_t<1120>;
 };
 
 template <class KeyT, class ValueT>
@@ -675,7 +675,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_2, 
   static constexpr int items                           = 10;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1115>;
+  using delay_constructor                              = no_delay_constructor_t<1115>;
 };
 
 template <class KeyT, class ValueT>
@@ -685,7 +685,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_4, 
   static constexpr int items                           = 13;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<24, 1060>;
+  using delay_constructor                              = fixed_delay_constructor_t<24, 1060>;
 };
 
 template <class KeyT, class ValueT>
@@ -695,7 +695,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_8, 
   static constexpr int items                           = 10;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1160>;
+  using delay_constructor                              = no_delay_constructor_t<1160>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -706,7 +706,7 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::
   static constexpr int items                           = 8;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<220>;
+  using delay_constructor                              = no_delay_constructor_t<220>;
 };
 
 template <class KeyT>
@@ -716,7 +716,7 @@ struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_8, val_size:
   static constexpr int items                           = 8;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<220>;
+  using delay_constructor                              = no_delay_constructor_t<220>;
 };
 #endif
 
@@ -727,7 +727,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_1,
   static constexpr int items                           = 7;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<144, 1120>;
+  using delay_constructor                              = fixed_delay_constructor_t<144, 1120>;
 };
 
 template <class KeyT, class ValueT>
@@ -737,7 +737,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_2,
   static constexpr int items                           = 7;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 780>;
+  using delay_constructor                              = fixed_delay_constructor_t<364, 780>;
 };
 
 template <class KeyT, class ValueT>
@@ -747,7 +747,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_4,
   static constexpr int items                           = 7;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1170>;
+  using delay_constructor                              = no_delay_constructor_t<1170>;
 };
 
 template <class KeyT, class ValueT>
@@ -757,7 +757,7 @@ struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_8,
   static constexpr int items                           = 15;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1030>;
+  using delay_constructor                              = no_delay_constructor_t<1030>;
 };
 
 #if CUB_IS_INT128_ENABLED
@@ -768,7 +768,7 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size:
   static constexpr int items                           = 15;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1160>;
+  using delay_constructor                              = no_delay_constructor_t<1160>;
 };
 
 template <class KeyT>
@@ -778,15 +778,15 @@ struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size
   static constexpr int items                           = 15;
   static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = detail::no_delay_constructor_t<1160>;
+  using delay_constructor                              = no_delay_constructor_t<1160>;
 };
 #endif
 
 template <typename KeysInputIteratorT, typename AccumT, typename ValueT, typename ScanOpT>
 struct policy_hub
 {
-  using KeyT                                 = cub::detail::value_t<KeysInputIteratorT>;
-  static constexpr size_t MaxInputBytes      = (cub::max)(sizeof(KeyT), sizeof(AccumT));
+  using KeyT                                 = value_t<KeysInputIteratorT>;
+  static constexpr size_t MaxInputBytes      = static_cast<int>(::cuda::std::max(sizeof(KeyT), sizeof(AccumT)));
   static constexpr size_t CombinedInputBytes = sizeof(KeyT) + sizeof(AccumT);
 
   struct Policy350 : ChainedPolicy<350, Policy350, Policy350>
@@ -802,7 +802,7 @@ struct policy_hub
                            LOAD_CA,
                            BLOCK_SCAN_WARP_SCANS,
                            BLOCK_STORE_WARP_TRANSPOSE,
-                           detail::default_reduce_by_key_delay_constructor_t<AccumT, int>>;
+                           default_reduce_by_key_delay_constructor_t<AccumT, int>>;
   };
 
   struct DefaultTuning
@@ -818,7 +818,7 @@ struct policy_hub
                            LOAD_CA,
                            BLOCK_SCAN_WARP_SCANS,
                            BLOCK_STORE_WARP_TRANSPOSE,
-                           detail::default_reduce_by_key_delay_constructor_t<AccumT, int>>;
+                           default_reduce_by_key_delay_constructor_t<AccumT, int>>;
   };
 
   struct Policy520
@@ -828,7 +828,7 @@ struct policy_hub
 
   struct Policy800 : ChainedPolicy<800, Policy800, Policy520>
   {
-    using tuning = detail::scan_by_key::sm80_tuning<KeyT, ValueT, detail::scan_by_key::is_primitive_op<ScanOpT>()>;
+    using tuning = sm80_tuning<KeyT, ValueT, is_primitive_op<ScanOpT>()>;
 
     using ScanByKeyPolicyT =
       AgentScanByKeyPolicy<tuning::threads,
@@ -847,7 +847,7 @@ struct policy_hub
 
   struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
   {
-    using tuning = detail::scan_by_key::sm90_tuning<KeyT, ValueT, detail::scan_by_key::is_primitive_op<ScanOpT>()>;
+    using tuning = sm90_tuning<KeyT, ValueT, is_primitive_op<ScanOpT>()>;
 
     using ScanByKeyPolicyT =
       AgentScanByKeyPolicy<tuning::threads,

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -792,6 +792,7 @@ struct policy_hub
 } // namespace scan_by_key
 } // namespace detail
 
+// TODO(bgruber): deprecate this at some point in the future when we have a better API for users to supply policies
 template <typename KeysInputIteratorT, typename AccumT, typename ValueT = AccumT, typename ScanOpT = ::cuda::std::plus<>>
 using DeviceScanByKeyPolicy = detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, ValueT, ScanOpT>;
 

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -196,13 +196,8 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 23;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<936, 1105>;
-};
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <class KeyT, class ValueT>
@@ -258,13 +253,8 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 23;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<504, 1190>;
-};
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <class KeyT, class ValueT>
@@ -320,13 +310,8 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 23;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<512, 1030>;
-};
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <class KeyT, class ValueT>
@@ -382,13 +367,8 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 192;
-  static constexpr int items                           = 15;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<364, 1085>;
-};
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <class KeyT, class ValueT>
@@ -444,13 +424,8 @@ struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size:
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 23;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<364, 1050>;
-};
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <class KeyT,
@@ -525,13 +500,8 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 19;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = no_delay_constructor_t<1095>;
-};
+    : sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <class KeyT, class ValueT>
@@ -587,13 +557,8 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 160;
-  static constexpr int items                           = 14;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = no_delay_constructor_t<1105>;
-};
+    : sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <class KeyT, class ValueT>
@@ -649,13 +614,8 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 17;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = no_delay_constructor_t<1100>;
-};
+    : sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <class KeyT, class ValueT>
@@ -711,13 +671,8 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 320;
-  static constexpr int items                           = 8;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = no_delay_constructor_t<220>;
-};
+    : sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <class KeyT, class ValueT>
@@ -773,13 +728,8 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size:
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 15;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = no_delay_constructor_t<1160>;
-};
+    : sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
+{};
 #endif
 
 template <typename KeysInputIteratorT, typename AccumT, typename ValueT, typename ScanOpT>

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -713,15 +713,15 @@ struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size
 template <typename KeysInputIteratorT, typename AccumT, typename ValueT, typename ScanOpT>
 struct policy_hub
 {
-  using key_t                                  = value_t<KeysInputIteratorT>;
-  static constexpr size_t max_input_bytes      = static_cast<int>(::cuda::std::max(sizeof(key_t), sizeof(AccumT)));
-  static constexpr size_t combined_input_bytes = sizeof(key_t) + sizeof(AccumT);
+  using key_t                               = value_t<KeysInputIteratorT>;
+  static constexpr int max_input_bytes      = static_cast<int>(::cuda::std::max(sizeof(key_t), sizeof(AccumT)));
+  static constexpr int combined_input_bytes = static_cast<int>(sizeof(key_t) + sizeof(AccumT));
 
   struct Policy350 : ChainedPolicy<350, Policy350, Policy350>
   {
     static constexpr int nominal_4b_items_per_thread = 6;
     static constexpr int items_per_thread =
-      ((max_input_bytes <= 8) ? 6 : Nominal4BItemsToItemsCombined(nominal_4b_items_per_thread, combined_input_bytes));
+      max_input_bytes <= 8 ? 6 : Nominal4BItemsToItemsCombined(nominal_4b_items_per_thread, combined_input_bytes);
 
     using ScanByKeyPolicyT =
       AgentScanByKeyPolicy<128,
@@ -738,7 +738,7 @@ struct policy_hub
   {
     static constexpr int nominal_4b_items_per_thread = 9;
     static constexpr int items_per_thread =
-      ((max_input_bytes <= 8) ? 9 : Nominal4BItemsToItemsCombined(nominal_4b_items_per_thread, combined_input_bytes));
+      max_input_bytes <= 8 ? 9 : Nominal4BItemsToItemsCombined(nominal_4b_items_per_thread, combined_input_bytes);
 
     using ScanByKeyPolicyT =
       AgentScanByKeyPolicy<256,

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -53,7 +53,6 @@ namespace detail
 {
 namespace scan_by_key
 {
-
 enum class primitive_accum
 {
   no,
@@ -134,450 +133,323 @@ template <class KeyT,
 struct sm90_tuning
 {
   static constexpr int nominal_4b_items_per_thread = 9;
-
-  static constexpr int threads = 256;
-
-  static constexpr size_t max_input_bytes = (cub::max)(sizeof(KeyT), sizeof(AccumT));
-
-  static constexpr size_t combined_input_bytes = sizeof(KeyT) + sizeof(AccumT);
-
+  static constexpr int threads                     = 256;
+  static constexpr size_t max_input_bytes          = (cub::max)(sizeof(KeyT), sizeof(AccumT));
+  static constexpr size_t combined_input_bytes     = sizeof(KeyT) + sizeof(AccumT);
   static constexpr int items =
     ((max_input_bytes <= 8) ? 9 : Nominal4BItemsToItemsCombined(nominal_4b_items_per_thread, combined_input_bytes));
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::default_reduce_by_key_delay_constructor_t<AccumT, int>;
+  using delay_constructor                              = detail::default_reduce_by_key_delay_constructor_t<AccumT, int>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 12;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-
-  using delay_constructor = detail::no_delay_constructor_t<650>;
+  using delay_constructor                              = detail::no_delay_constructor_t<650>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 16;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 16;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<124, 995>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<124, 995>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 15;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<488, 545>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<488, 545>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 224;
-
-  static constexpr int items = 10;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<488, 1070>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<488, 1070>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 23;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<936, 1105>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<936, 1105>;
 };
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 23;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<936, 1105>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<936, 1105>;
 };
 #endif
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 12;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<136, 785>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<136, 785>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 20;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 20;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<445>;
+  using delay_constructor                              = detail::no_delay_constructor_t<445>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 22;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 22;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<312, 865>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<312, 865>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 224;
-
-  static constexpr int items = 10;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<352, 1170>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<352, 1170>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 23;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<504, 1190>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<504, 1190>;
 };
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 23;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<504, 1190>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<504, 1190>;
 };
 #endif
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 12;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-
-  using delay_constructor = detail::no_delay_constructor_t<850>;
+  using delay_constructor                              = detail::no_delay_constructor_t<850>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 14;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 14;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<128, 965>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<128, 965>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 288;
-
-  static constexpr int items = 14;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 288;
+  static constexpr int items                           = 14;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<700, 1005>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<700, 1005>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 224;
-
-  static constexpr int items = 14;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 14;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<556, 1195>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<556, 1195>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 23;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<512, 1030>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<512, 1030>;
 };
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 23;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<512, 1030>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<512, 1030>;
 };
 #endif
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 12;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<504, 1010>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<504, 1010>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 224;
-
-  static constexpr int items = 10;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<420, 970>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<420, 970>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 192;
-
-  static constexpr int items = 10;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<500, 1125>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<500, 1125>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 224;
-
-  static constexpr int items = 11;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 11;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<600, 930>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<600, 930>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 192;
-
-  static constexpr int items = 15;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<364, 1085>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 1085>;
 };
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 192;
-
-  static constexpr int items = 15;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<364, 1085>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 1085>;
 };
 #endif
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 192;
-
-  static constexpr int items = 7;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 7;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<500, 975>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<500, 975>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 224;
-
-  static constexpr int items = 10;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<164, 1075>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<164, 1075>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 9;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 9;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<268, 1120>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<268, 1120>;
 };
 
 template <class KeyT, class ValueT>
 struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 192;
-
-  static constexpr int items = 9;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 9;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<320, 1200>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<320, 1200>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 23;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<364, 1050>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 1050>;
 };
 
 template <class KeyT>
 struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 23;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<364, 1050>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 1050>;
 };
 #endif
 
@@ -590,450 +462,323 @@ template <class KeyT,
 struct sm80_tuning
 {
   static constexpr int nominal_4b_items_per_thread = 9;
-
-  static constexpr int threads = 256;
-
-  static constexpr size_t max_input_bytes = (cub::max)(sizeof(KeyT), sizeof(AccumT));
-
-  static constexpr size_t combined_input_bytes = sizeof(KeyT) + sizeof(AccumT);
-
+  static constexpr int threads                     = 256;
+  static constexpr size_t max_input_bytes          = (cub::max)(sizeof(KeyT), sizeof(AccumT));
+  static constexpr size_t combined_input_bytes     = sizeof(KeyT) + sizeof(AccumT);
   static constexpr int items =
     ((max_input_bytes <= 8) ? 9 : Nominal4BItemsToItemsCombined(nominal_4b_items_per_thread, combined_input_bytes));
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::default_reduce_by_key_delay_constructor_t<AccumT, int>;
+  using delay_constructor                              = detail::default_reduce_by_key_delay_constructor_t<AccumT, int>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 12;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-
-  using delay_constructor = detail::no_delay_constructor_t<795>;
+  using delay_constructor                              = detail::no_delay_constructor_t<795>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 288;
-
-  static constexpr int items = 12;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 288;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<825>;
+  using delay_constructor                              = detail::no_delay_constructor_t<825>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 15;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<640>;
+  using delay_constructor                              = detail::no_delay_constructor_t<640>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 192;
-
-  static constexpr int items = 10;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<124, 1040>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<124, 1040>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 19;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 19;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1095>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1095>;
 };
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 19;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 19;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1095>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1095>;
 };
 #endif
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 8;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 8;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-
-  using delay_constructor = detail::no_delay_constructor_t<1070>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1070>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 320;
-
-  static constexpr int items = 14;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 320;
+  static constexpr int items                           = 14;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<625>;
+  using delay_constructor                              = detail::no_delay_constructor_t<625>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 15;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1055>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1055>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 160;
-
-  static constexpr int items = 17;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 160;
+  static constexpr int items                           = 17;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<160, 695>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<160, 695>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 160;
-
-  static constexpr int items = 14;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 160;
+  static constexpr int items                           = 14;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1105>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1105>;
 };
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 160;
-
-  static constexpr int items = 14;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 160;
+  static constexpr int items                           = 14;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1105>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1105>;
 };
 #endif
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 12;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-
-  using delay_constructor = detail::no_delay_constructor_t<1130>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1130>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 12;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1130>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1130>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 15;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1140>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1140>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 9;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 9;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<888, 635>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<888, 635>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 17;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 17;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1100>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1100>;
 };
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 17;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 17;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1100>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1100>;
 };
 #endif
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 11;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 11;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1120>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1120>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 10;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1115>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1115>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 224;
-
-  static constexpr int items = 13;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 13;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<24, 1060>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<24, 1060>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 224;
-
-  static constexpr int items = 10;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1160>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1160>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 320;
-
-  static constexpr int items = 8;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 320;
+  static constexpr int items                           = 8;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<220>;
+  using delay_constructor                              = detail::no_delay_constructor_t<220>;
 };
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 320;
-
-  static constexpr int items = 8;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 320;
+  static constexpr int items                           = 8;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<220>;
+  using delay_constructor                              = detail::no_delay_constructor_t<220>;
 };
 #endif
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_1, primitive_accum::yes>
 {
-  static constexpr int threads = 192;
-
-  static constexpr int items = 7;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 7;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<144, 1120>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<144, 1120>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_2, primitive_accum::yes>
 {
-  static constexpr int threads = 192;
-
-  static constexpr int items = 7;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 7;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<364, 780>;
+  using delay_constructor                              = detail::fixed_delay_constructor_t<364, 780>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_4, primitive_accum::yes>
 {
-  static constexpr int threads = 256;
-
-  static constexpr int items = 7;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 7;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1170>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1170>;
 };
 
 template <class KeyT, class ValueT>
 struct sm80_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_8, primitive_accum::yes>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 15;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1030>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1030>;
 };
 
 #if CUB_IS_INT128_ENABLED
 template <class KeyT>
 struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 15;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1160>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1160>;
 };
 
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
 {
-  static constexpr int threads = 128;
-
-  static constexpr int items = 15;
-
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
   static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1160>;
+  using delay_constructor                              = detail::no_delay_constructor_t<1160>;
 };
 #endif
 } // namespace scan_by_key
@@ -1042,10 +787,8 @@ struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size
 template <typename KeysInputIteratorT, typename AccumT, typename ValueT = AccumT, typename ScanOpT = ::cuda::std::plus<>>
 struct DeviceScanByKeyPolicy
 {
-  using KeyT = cub::detail::value_t<KeysInputIteratorT>;
-
-  static constexpr size_t MaxInputBytes = (cub::max)(sizeof(KeyT), sizeof(AccumT));
-
+  using KeyT                                 = cub::detail::value_t<KeysInputIteratorT>;
+  static constexpr size_t MaxInputBytes      = (cub::max)(sizeof(KeyT), sizeof(AccumT));
   static constexpr size_t CombinedInputBytes = sizeof(KeyT) + sizeof(AccumT);
 
   // SM350

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -130,299 +130,6 @@ template <class KeyT,
           key_size KeySize                     = classify_key_size<KeyT>(),
           val_size AccumSize                   = classify_val_size<AccumT>(),
           primitive_accum PrimitiveAccumulator = is_primitive_accum<AccumT>()>
-struct sm90_tuning;
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_1, primitive_accum::yes>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 12;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = no_delay_constructor_t<650>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_2, primitive_accum::yes>
-{
-  static constexpr int threads                         = 256;
-  static constexpr int items                           = 16;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<124, 995>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_4, primitive_accum::yes>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 15;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<488, 545>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_8, primitive_accum::yes>
-{
-  static constexpr int threads                         = 224;
-  static constexpr int items                           = 10;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<488, 1070>;
-};
-
-#if CUB_IS_INT128_ENABLED
-template <class KeyT>
-struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 23;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<936, 1105>;
-};
-
-template <class KeyT>
-struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
-    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
-{};
-#endif
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_1, primitive_accum::yes>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 12;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = fixed_delay_constructor_t<136, 785>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_2, primitive_accum::yes>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 20;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = no_delay_constructor_t<445>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_4, primitive_accum::yes>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 22;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<312, 865>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_8, primitive_accum::yes>
-{
-  static constexpr int threads                         = 224;
-  static constexpr int items                           = 10;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<352, 1170>;
-};
-
-#if CUB_IS_INT128_ENABLED
-template <class KeyT>
-struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 23;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<504, 1190>;
-};
-
-template <class KeyT>
-struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
-    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
-{};
-#endif
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_1, primitive_accum::yes>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 12;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = no_delay_constructor_t<850>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_2, primitive_accum::yes>
-{
-  static constexpr int threads                         = 256;
-  static constexpr int items                           = 14;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<128, 965>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_4, primitive_accum::yes>
-{
-  static constexpr int threads                         = 288;
-  static constexpr int items                           = 14;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<700, 1005>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_8, primitive_accum::yes>
-{
-  static constexpr int threads                         = 224;
-  static constexpr int items                           = 14;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<556, 1195>;
-};
-
-#if CUB_IS_INT128_ENABLED
-template <class KeyT>
-struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 23;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<512, 1030>;
-};
-
-template <class KeyT>
-struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
-    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
-{};
-#endif
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_1, primitive_accum::yes>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 12;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
-  using delay_constructor                              = fixed_delay_constructor_t<504, 1010>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_2, primitive_accum::yes>
-{
-  static constexpr int threads                         = 224;
-  static constexpr int items                           = 10;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<420, 970>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_4, primitive_accum::yes>
-{
-  static constexpr int threads                         = 192;
-  static constexpr int items                           = 10;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<500, 1125>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_8, primitive_accum::yes>
-{
-  static constexpr int threads                         = 224;
-  static constexpr int items                           = 11;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<600, 930>;
-};
-
-#if CUB_IS_INT128_ENABLED
-template <class KeyT>
-struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 192;
-  static constexpr int items                           = 15;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<364, 1085>;
-};
-
-template <class KeyT>
-struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
-    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
-{};
-#endif
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_1, primitive_accum::yes>
-{
-  static constexpr int threads                         = 192;
-  static constexpr int items                           = 7;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<500, 975>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_2, primitive_accum::yes>
-{
-  static constexpr int threads                         = 224;
-  static constexpr int items                           = 10;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<164, 1075>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_4, primitive_accum::yes>
-{
-  static constexpr int threads                         = 256;
-  static constexpr int items                           = 9;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<268, 1120>;
-};
-
-template <class KeyT, class ValueT>
-struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_8, primitive_accum::yes>
-{
-  static constexpr int threads                         = 192;
-  static constexpr int items                           = 9;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<320, 1200>;
-};
-
-#if CUB_IS_INT128_ENABLED
-template <class KeyT>
-struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
-{
-  static constexpr int threads                         = 128;
-  static constexpr int items                           = 23;
-  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
-  using delay_constructor                              = fixed_delay_constructor_t<364, 1050>;
-};
-
-template <class KeyT>
-struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
-    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
-{};
-#endif
-
-template <class KeyT,
-          class AccumT,
-          primitive_op PrimitiveOp,
-          key_size KeySize                     = classify_key_size<KeyT>(),
-          val_size AccumSize                   = classify_val_size<AccumT>(),
-          primitive_accum PrimitiveAccumulator = is_primitive_accum<AccumT>()>
 struct sm80_tuning;
 
 template <class KeyT, class ValueT>
@@ -707,6 +414,299 @@ struct sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size:
 template <class KeyT>
 struct sm80_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
     : sm80_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
+{};
+#endif
+
+template <class KeyT,
+          class AccumT,
+          primitive_op PrimitiveOp,
+          key_size KeySize                     = classify_key_size<KeyT>(),
+          val_size AccumSize                   = classify_val_size<AccumT>(),
+          primitive_accum PrimitiveAccumulator = is_primitive_accum<AccumT>()>
+struct sm90_tuning;
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
+  using delay_constructor                              = no_delay_constructor_t<650>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 16;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<124, 995>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<488, 545>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_1, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<488, 1070>;
+};
+
+#if CUB_IS_INT128_ENABLED
+template <class KeyT>
+struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<936, 1105>;
+};
+
+template <class KeyT>
+struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_1, val_size::_16, primitive_accum::no>
+{};
+#endif
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
+  using delay_constructor                              = fixed_delay_constructor_t<136, 785>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 20;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = no_delay_constructor_t<445>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 22;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<312, 865>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_2, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<352, 1170>;
+};
+
+#if CUB_IS_INT128_ENABLED
+template <class KeyT>
+struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<504, 1190>;
+};
+
+template <class KeyT>
+struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_2, val_size::_16, primitive_accum::no>
+{};
+#endif
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
+  using delay_constructor                              = no_delay_constructor_t<850>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 14;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<128, 965>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads                         = 288;
+  static constexpr int items                           = 14;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<700, 1005>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_4, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 14;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<556, 1195>;
+};
+
+#if CUB_IS_INT128_ENABLED
+template <class KeyT>
+struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<512, 1030>;
+};
+
+template <class KeyT>
+struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_4, val_size::_16, primitive_accum::no>
+{};
+#endif
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_DIRECT;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_DIRECT;
+  using delay_constructor                              = fixed_delay_constructor_t<504, 1010>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<420, 970>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<500, 1125>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_8, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 11;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<600, 930>;
+};
+
+#if CUB_IS_INT128_ENABLED
+template <class KeyT>
+struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 15;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<364, 1085>;
+};
+
+template <class KeyT>
+struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_8, val_size::_16, primitive_accum::no>
+{};
+#endif
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_1, primitive_accum::yes>
+{
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 7;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<500, 975>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_2, primitive_accum::yes>
+{
+  static constexpr int threads                         = 224;
+  static constexpr int items                           = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<164, 1075>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_4, primitive_accum::yes>
+{
+  static constexpr int threads                         = 256;
+  static constexpr int items                           = 9;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<268, 1120>;
+};
+
+template <class KeyT, class ValueT>
+struct sm90_tuning<KeyT, ValueT, primitive_op::yes, key_size::_16, val_size::_8, primitive_accum::yes>
+{
+  static constexpr int threads                         = 192;
+  static constexpr int items                           = 9;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<320, 1200>;
+};
+
+#if CUB_IS_INT128_ENABLED
+template <class KeyT>
+struct sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
+{
+  static constexpr int threads                         = 128;
+  static constexpr int items                           = 23;
+  static constexpr BlockLoadAlgorithm load_algorithm   = BLOCK_LOAD_WARP_TRANSPOSE;
+  static constexpr BlockStoreAlgorithm store_algorithm = BLOCK_STORE_WARP_TRANSPOSE;
+  using delay_constructor                              = fixed_delay_constructor_t<364, 1050>;
+};
+
+template <class KeyT>
+struct sm90_tuning<KeyT, __uint128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
+    : sm90_tuning<KeyT, __int128_t, primitive_op::yes, key_size::_16, val_size::_16, primitive_accum::no>
 {};
 #endif
 


### PR DESCRIPTION
- [x] No SASS changes in `cub.test.device_scan_by_key.lid_0.types_0` except for kernel symbol names