### PR TITLE
Refactor three_way_parition tuning

### DIFF
--- a/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -153,16 +153,16 @@ DeviceThreeWayPartitionInitKernel(ScanTileStateT tile_state, int num_tiles, NumS
  * Dispatch
  ******************************************************************************/
 
-template <typename InputIteratorT,
-          typename FirstOutputIteratorT,
-          typename SecondOutputIteratorT,
-          typename UnselectedOutputIteratorT,
-          typename NumSelectedIteratorT,
-          typename SelectFirstPartOp,
-          typename SelectSecondPartOp,
-          typename OffsetT,
-          typename SelectedPolicy =
-            detail::device_three_way_partition_policy_hub<cub::detail::value_t<InputIteratorT>, OffsetT>>
+template <
+  typename InputIteratorT,
+  typename FirstOutputIteratorT,
+  typename SecondOutputIteratorT,
+  typename UnselectedOutputIteratorT,
+  typename NumSelectedIteratorT,
+  typename SelectFirstPartOp,
+  typename SelectSecondPartOp,
+  typename OffsetT,
+  typename SelectedPolicy = detail::three_way_partition::policy_hub<cub::detail::value_t<InputIteratorT>, OffsetT>>
 struct DispatchThreeWayPartitionIf
 {
   /*****************************************************************************

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -95,9 +95,9 @@ struct sm90_tuning
   static constexpr int threads                       = 256;
   static constexpr int items                         = Nominal4BItemsToItems<InputT>(9);
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-  using AccumPackHelperT                             = detail::three_way_partition::accumulator_pack_t<OffsetT>;
+  using AccumPackHelperT                             = accumulator_pack_t<OffsetT>;
   using AccumPackT                                   = typename AccumPackHelperT::pack_t;
-  using delay_constructor                            = detail::default_delay_constructor_t<AccumPackT>;
+  using delay_constructor                            = default_delay_constructor_t<AccumPackT>;
 };
 
 template <class Input, class OffsetT>
@@ -106,7 +106,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_1, offset_size::_4>
   static constexpr int threads                       = 256;
   static constexpr int items                         = 12;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-  using delay_constructor                            = detail::no_delay_constructor_t<445>;
+  using delay_constructor                            = no_delay_constructor_t<445>;
 };
 
 template <class Input, class OffsetT>
@@ -115,7 +115,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_2, offset_size::_4>
   static constexpr int threads                       = 256;
   static constexpr int items                         = 12;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-  using delay_constructor                            = detail::fixed_delay_constructor_t<104, 512>;
+  using delay_constructor                            = fixed_delay_constructor_t<104, 512>;
 };
 
 template <class Input, class OffsetT>
@@ -124,7 +124,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_4, offset_size::_4>
   static constexpr int threads                       = 320;
   static constexpr int items                         = 12;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-  using delay_constructor                            = detail::no_delay_constructor_t<1105>;
+  using delay_constructor                            = no_delay_constructor_t<1105>;
 };
 
 template <class Input, class OffsetT>
@@ -133,7 +133,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_8, offset_size::_4>
   static constexpr int threads                       = 384;
   static constexpr int items                         = 7;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::fixed_delay_constructor_t<464, 1165>;
+  using delay_constructor                            = fixed_delay_constructor_t<464, 1165>;
 };
 
 template <class Input, class OffsetT>
@@ -142,7 +142,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_16, offset_size::_4>
   static constexpr int threads                       = 128;
   static constexpr int items                         = 7;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::no_delay_constructor_t<1040>;
+  using delay_constructor                            = no_delay_constructor_t<1040>;
 };
 
 template <class Input, class OffsetT>
@@ -151,7 +151,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_1, offset_size::_8>
   static constexpr int threads                       = 256;
   static constexpr int items                         = 24;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-  using delay_constructor                            = detail::fixed_delay_constructor_t<4, 285>;
+  using delay_constructor                            = fixed_delay_constructor_t<4, 285>;
 };
 
 template <class Input, class OffsetT>
@@ -160,7 +160,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_2, offset_size::_8>
   static constexpr int threads                       = 640;
   static constexpr int items                         = 24;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::no_delay_constructor_t<245>;
+  using delay_constructor                            = no_delay_constructor_t<245>;
 };
 
 template <class Input, class OffsetT>
@@ -169,7 +169,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_4, offset_size::_8>
   static constexpr int threads                       = 256;
   static constexpr int items                         = 23;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::no_delay_constructor_t<910>;
+  using delay_constructor                            = no_delay_constructor_t<910>;
 };
 
 template <class Input, class OffsetT>
@@ -178,7 +178,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_8, offset_size::_8>
   static constexpr int threads                       = 256;
   static constexpr int items                         = 18;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::no_delay_constructor_t<1145>;
+  using delay_constructor                            = no_delay_constructor_t<1145>;
 };
 
 template <class Input, class OffsetT>
@@ -187,7 +187,7 @@ struct sm90_tuning<Input, OffsetT, input_size::_16, offset_size::_8>
   static constexpr int threads                       = 256;
   static constexpr int items                         = 11;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::no_delay_constructor_t<1050>;
+  using delay_constructor                            = no_delay_constructor_t<1050>;
 };
 
 template <class InputT,
@@ -199,9 +199,9 @@ struct sm80_tuning
   static constexpr int threads                       = 256;
   static constexpr int items                         = Nominal4BItemsToItems<InputT>(9);
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-  using AccumPackHelperT                             = detail::three_way_partition::accumulator_pack_t<OffsetT>;
+  using AccumPackHelperT                             = accumulator_pack_t<OffsetT>;
   using AccumPackT                                   = typename AccumPackHelperT::pack_t;
-  using delay_constructor                            = detail::default_delay_constructor_t<AccumPackT>;
+  using delay_constructor                            = default_delay_constructor_t<AccumPackT>;
 };
 
 template <class Input, class OffsetT>
@@ -210,7 +210,7 @@ struct sm80_tuning<Input, OffsetT, input_size::_2, offset_size::_4>
   static constexpr int threads                       = 256;
   static constexpr int items                         = 12;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::no_delay_constructor_t<910>;
+  using delay_constructor                            = no_delay_constructor_t<910>;
 };
 
 template <class Input, class OffsetT>
@@ -219,7 +219,7 @@ struct sm80_tuning<Input, OffsetT, input_size::_4, offset_size::_4>
   static constexpr int threads                       = 256;
   static constexpr int items                         = 11;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::no_delay_constructor_t<1120>;
+  using delay_constructor                            = no_delay_constructor_t<1120>;
 };
 
 template <class Input, class OffsetT>
@@ -228,7 +228,7 @@ struct sm80_tuning<Input, OffsetT, input_size::_8, offset_size::_4>
   static constexpr int threads                       = 224;
   static constexpr int items                         = 11;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::fixed_delay_constructor_t<264, 1080>;
+  using delay_constructor                            = fixed_delay_constructor_t<264, 1080>;
 };
 
 template <class Input, class OffsetT>
@@ -237,7 +237,7 @@ struct sm80_tuning<Input, OffsetT, input_size::_16, offset_size::_4>
   static constexpr int threads                       = 128;
   static constexpr int items                         = 10;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = detail::fixed_delay_constructor_t<672, 1120>;
+  using delay_constructor                            = fixed_delay_constructor_t<672, 1120>;
 };
 
 template <class InputT, class OffsetT>
@@ -245,14 +245,12 @@ struct policy_hub
 {
   struct DefaultTuning
   {
-    static constexpr int ITEMS_PER_THREAD = Nominal4BItemsToItems<InputT>(9);
-
     using ThreeWayPartitionPolicy =
-      cub::AgentThreeWayPartitionPolicy<256,
-                                        ITEMS_PER_THREAD,
-                                        cub::BLOCK_LOAD_DIRECT,
-                                        cub::LOAD_DEFAULT,
-                                        cub::BLOCK_SCAN_WARP_SCANS>;
+      AgentThreeWayPartitionPolicy<256,
+                                   Nominal4BItemsToItems<InputT>(9),
+                                   BLOCK_LOAD_DIRECT,
+                                   LOAD_DEFAULT,
+                                   BLOCK_SCAN_WARP_SCANS>;
   };
 
   struct Policy350
@@ -262,14 +260,14 @@ struct policy_hub
 
   struct Policy800 : ChainedPolicy<800, Policy800, Policy350>
   {
-    using tuning = detail::three_way_partition::sm80_tuning<InputT, OffsetT>;
+    using tuning = sm80_tuning<InputT, OffsetT>;
 
     using ThreeWayPartitionPolicy =
       AgentThreeWayPartitionPolicy<tuning::threads,
                                    tuning::items,
                                    tuning::load_algorithm,
-                                   cub::LOAD_DEFAULT,
-                                   cub::BLOCK_SCAN_WARP_SCANS,
+                                   LOAD_DEFAULT,
+                                   BLOCK_SCAN_WARP_SCANS,
                                    typename tuning::delay_constructor>;
   };
 
@@ -280,14 +278,14 @@ struct policy_hub
 
   struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
   {
-    using tuning = detail::three_way_partition::sm90_tuning<InputT, OffsetT>;
+    using tuning = sm90_tuning<InputT, OffsetT>;
 
     using ThreeWayPartitionPolicy =
       AgentThreeWayPartitionPolicy<tuning::threads,
                                    tuning::items,
                                    tuning::load_algorithm,
-                                   cub::LOAD_DEFAULT,
-                                   cub::BLOCK_SCAN_WARP_SCANS,
+                                   LOAD_DEFAULT,
+                                   BLOCK_SCAN_WARP_SCANS,
                                    typename tuning::delay_constructor>;
   };
 

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -240,10 +240,8 @@ struct sm80_tuning<Input, OffsetT, input_size::_16, offset_size::_4>
   using delay_constructor                            = detail::fixed_delay_constructor_t<672, 1120>;
 };
 
-} // namespace three_way_partition
-
 template <class InputT, class OffsetT>
-struct device_three_way_partition_policy_hub
+struct policy_hub
 {
   struct DefaultTuning
   {
@@ -295,7 +293,7 @@ struct device_three_way_partition_policy_hub
 
   using MaxPolicy = Policy900;
 };
-
+} // namespace three_way_partition
 } // namespace detail
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -243,7 +243,7 @@ struct sm80_tuning<Input, OffsetT, input_size::_16, offset_size::_4>
 template <class InputT, class OffsetT>
 struct policy_hub
 {
-  struct DefaultTuning
+  struct DefaultPolicy
   {
     using ThreeWayPartitionPolicy =
       AgentThreeWayPartitionPolicy<256,
@@ -254,7 +254,7 @@ struct policy_hub
   };
 
   struct Policy350
-      : DefaultTuning
+      : DefaultPolicy
       , ChainedPolicy<350, Policy350, Policy350>
   {};
 
@@ -272,7 +272,7 @@ struct policy_hub
   };
 
   struct Policy860
-      : DefaultTuning
+      : DefaultPolicy
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -49,10 +49,8 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail
 {
-
 namespace three_way_partition
 {
-
 enum class input_size
 {
   _1,
@@ -94,124 +92,102 @@ template <class InputT,
           offset_size OffsetSize = classify_offset_size<OffsetT>()>
 struct sm90_tuning
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = Nominal4BItemsToItems<InputT>(9);
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = Nominal4BItemsToItems<InputT>(9);
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
-  using AccumPackHelperT  = detail::three_way_partition::accumulator_pack_t<OffsetT>;
-  using AccumPackT        = typename AccumPackHelperT::pack_t;
-  using delay_constructor = detail::default_delay_constructor_t<AccumPackT>;
+  using AccumPackHelperT                             = detail::three_way_partition::accumulator_pack_t<OffsetT>;
+  using AccumPackT                                   = typename AccumPackHelperT::pack_t;
+  using delay_constructor                            = detail::default_delay_constructor_t<AccumPackT>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_1, offset_size::_4>
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = 12;
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 12;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
-  using delay_constructor = detail::no_delay_constructor_t<445>;
+  using delay_constructor                            = detail::no_delay_constructor_t<445>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_2, offset_size::_4>
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = 12;
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 12;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<104, 512>;
+  using delay_constructor                            = detail::fixed_delay_constructor_t<104, 512>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_4, offset_size::_4>
 {
-  static constexpr int threads = 320;
-  static constexpr int items   = 12;
-
+  static constexpr int threads                       = 320;
+  static constexpr int items                         = 12;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
-  using delay_constructor = detail::no_delay_constructor_t<1105>;
+  using delay_constructor                            = detail::no_delay_constructor_t<1105>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_8, offset_size::_4>
 {
-  static constexpr int threads = 384;
-  static constexpr int items   = 7;
-
+  static constexpr int threads                       = 384;
+  static constexpr int items                         = 7;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<464, 1165>;
+  using delay_constructor                            = detail::fixed_delay_constructor_t<464, 1165>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_16, offset_size::_4>
 {
-  static constexpr int threads = 128;
-  static constexpr int items   = 7;
-
+  static constexpr int threads                       = 128;
+  static constexpr int items                         = 7;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1040>;
+  using delay_constructor                            = detail::no_delay_constructor_t<1040>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_1, offset_size::_8>
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = 24;
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 24;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<4, 285>;
+  using delay_constructor                            = detail::fixed_delay_constructor_t<4, 285>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_2, offset_size::_8>
 {
-  static constexpr int threads = 640;
-  static constexpr int items   = 24;
-
+  static constexpr int threads                       = 640;
+  static constexpr int items                         = 24;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<245>;
+  using delay_constructor                            = detail::no_delay_constructor_t<245>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_4, offset_size::_8>
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = 23;
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 23;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<910>;
+  using delay_constructor                            = detail::no_delay_constructor_t<910>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_8, offset_size::_8>
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = 18;
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 18;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1145>;
+  using delay_constructor                            = detail::no_delay_constructor_t<1145>;
 };
 
 template <class Input, class OffsetT>
 struct sm90_tuning<Input, OffsetT, input_size::_16, offset_size::_8>
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = 11;
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 11;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1050>;
+  using delay_constructor                            = detail::no_delay_constructor_t<1050>;
 };
 
 template <class InputT,
@@ -220,58 +196,48 @@ template <class InputT,
           offset_size OffsetSize = classify_offset_size<OffsetT>()>
 struct sm80_tuning
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = Nominal4BItemsToItems<InputT>(9);
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = Nominal4BItemsToItems<InputT>(9);
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_DIRECT;
-
-  using AccumPackHelperT  = detail::three_way_partition::accumulator_pack_t<OffsetT>;
-  using AccumPackT        = typename AccumPackHelperT::pack_t;
-  using delay_constructor = detail::default_delay_constructor_t<AccumPackT>;
+  using AccumPackHelperT                             = detail::three_way_partition::accumulator_pack_t<OffsetT>;
+  using AccumPackT                                   = typename AccumPackHelperT::pack_t;
+  using delay_constructor                            = detail::default_delay_constructor_t<AccumPackT>;
 };
 
 template <class Input, class OffsetT>
 struct sm80_tuning<Input, OffsetT, input_size::_2, offset_size::_4>
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = 12;
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 12;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<910>;
+  using delay_constructor                            = detail::no_delay_constructor_t<910>;
 };
 
 template <class Input, class OffsetT>
 struct sm80_tuning<Input, OffsetT, input_size::_4, offset_size::_4>
 {
-  static constexpr int threads = 256;
-  static constexpr int items   = 11;
-
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 11;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::no_delay_constructor_t<1120>;
+  using delay_constructor                            = detail::no_delay_constructor_t<1120>;
 };
 
 template <class Input, class OffsetT>
 struct sm80_tuning<Input, OffsetT, input_size::_8, offset_size::_4>
 {
-  static constexpr int threads = 224;
-  static constexpr int items   = 11;
-
+  static constexpr int threads                       = 224;
+  static constexpr int items                         = 11;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<264, 1080>;
+  using delay_constructor                            = detail::fixed_delay_constructor_t<264, 1080>;
 };
 
 template <class Input, class OffsetT>
 struct sm80_tuning<Input, OffsetT, input_size::_16, offset_size::_4>
 {
-  static constexpr int threads = 128;
-  static constexpr int items   = 10;
-
+  static constexpr int threads                       = 128;
+  static constexpr int items                         = 10;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-
-  using delay_constructor = detail::fixed_delay_constructor_t<672, 1120>;
+  using delay_constructor                            = detail::fixed_delay_constructor_t<672, 1120>;
 };
 
 } // namespace three_way_partition
@@ -291,7 +257,6 @@ struct device_three_way_partition_policy_hub
                                         cub::BLOCK_SCAN_WARP_SCANS>;
   };
 
-  /// SM35
   struct Policy350
       : DefaultTuning
       , ChainedPolicy<350, Policy350, Policy350>
@@ -315,7 +280,6 @@ struct device_three_way_partition_policy_hub
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 
-  /// SM90
   struct Policy900 : ChainedPolicy<900, Policy900, Policy860>
   {
     using tuning = detail::three_way_partition::sm90_tuning<InputT, OffsetT>;

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -90,6 +90,48 @@ template <class InputT,
           class OffsetT,
           input_size InputSize   = classify_input_size<InputT>(),
           offset_size OffsetSize = classify_offset_size<OffsetT>()>
+struct sm80_tuning;
+
+template <class Input, class OffsetT>
+struct sm80_tuning<Input, OffsetT, input_size::_2, offset_size::_4>
+{
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 12;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+  using delay_constructor                            = no_delay_constructor_t<910>;
+};
+
+template <class Input, class OffsetT>
+struct sm80_tuning<Input, OffsetT, input_size::_4, offset_size::_4>
+{
+  static constexpr int threads                       = 256;
+  static constexpr int items                         = 11;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+  using delay_constructor                            = no_delay_constructor_t<1120>;
+};
+
+template <class Input, class OffsetT>
+struct sm80_tuning<Input, OffsetT, input_size::_8, offset_size::_4>
+{
+  static constexpr int threads                       = 224;
+  static constexpr int items                         = 11;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+  using delay_constructor                            = fixed_delay_constructor_t<264, 1080>;
+};
+
+template <class Input, class OffsetT>
+struct sm80_tuning<Input, OffsetT, input_size::_16, offset_size::_4>
+{
+  static constexpr int threads                       = 128;
+  static constexpr int items                         = 10;
+  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
+  using delay_constructor                            = fixed_delay_constructor_t<672, 1120>;
+};
+
+template <class InputT,
+          class OffsetT,
+          input_size InputSize   = classify_input_size<InputT>(),
+          offset_size OffsetSize = classify_offset_size<OffsetT>()>
 struct sm90_tuning;
 
 template <class Input, class OffsetT>
@@ -180,48 +222,6 @@ struct sm90_tuning<Input, OffsetT, input_size::_16, offset_size::_8>
   static constexpr int items                         = 11;
   static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
   using delay_constructor                            = no_delay_constructor_t<1050>;
-};
-
-template <class InputT,
-          class OffsetT,
-          input_size InputSize   = classify_input_size<InputT>(),
-          offset_size OffsetSize = classify_offset_size<OffsetT>()>
-struct sm80_tuning;
-
-template <class Input, class OffsetT>
-struct sm80_tuning<Input, OffsetT, input_size::_2, offset_size::_4>
-{
-  static constexpr int threads                       = 256;
-  static constexpr int items                         = 12;
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = no_delay_constructor_t<910>;
-};
-
-template <class Input, class OffsetT>
-struct sm80_tuning<Input, OffsetT, input_size::_4, offset_size::_4>
-{
-  static constexpr int threads                       = 256;
-  static constexpr int items                         = 11;
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = no_delay_constructor_t<1120>;
-};
-
-template <class Input, class OffsetT>
-struct sm80_tuning<Input, OffsetT, input_size::_8, offset_size::_4>
-{
-  static constexpr int threads                       = 224;
-  static constexpr int items                         = 11;
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = fixed_delay_constructor_t<264, 1080>;
-};
-
-template <class Input, class OffsetT>
-struct sm80_tuning<Input, OffsetT, input_size::_16, offset_size::_4>
-{
-  static constexpr int threads                       = 128;
-  static constexpr int items                         = 10;
-  static constexpr BlockLoadAlgorithm load_algorithm = BLOCK_LOAD_WARP_TRANSPOSE;
-  using delay_constructor                            = fixed_delay_constructor_t<672, 1120>;
 };
 
 template <class InputT, class OffsetT>


### PR DESCRIPTION
- [x] SASS of `cub.test.device_three_way_partition.lid_0` did not change except for kernel symbol names.