### PR TITLE
Introduces new `DeviceReduce::Arg{Min,Max}` interface with two output iterators

### DIFF
--- a/cub/cub/device/dispatch/kernels/reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/reduce.cuh
@@ -64,6 +64,18 @@ struct empty_problem_init_t
   }
 };
 
+template <class InitT>
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE InitT unwrap_empty_problem_init(InitT init)
+{
+  return init;
+}
+
+template <class InitT>
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE InitT unwrap_empty_problem_init(empty_problem_init_t<InitT> empty_problem_init)
+{
+  return empty_problem_init.init;
+}
+
 /**
  * @brief Applies initial value to the block aggregate and stores the result to the output iterator.
  *
@@ -248,7 +260,7 @@ CUB_DETAIL_KERNEL_ATTRIBUTES __launch_bounds__(
   {
     if (threadIdx.x == 0)
     {
-      *d_out = init;
+      *d_out = detail::reduce::unwrap_empty_problem_init(init);
     }
 
     return;

--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -46,6 +46,14 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMin, device_arg_min);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Max, device_max);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max);
 
+// Suppress deprecation warning for the deprecated ArgMin and ArgMax interfaces=
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+_CCCL_NV_DIAG_SUPPRESS(1444)
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMin, device_arg_min_old);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max_old);
+_CCCL_NV_DIAG_DEFAULT(1444)
+_CCCL_SUPPRESS_DEPRECATED_POP
+
 // %PARAM% TEST_LAUNCH lid 0:1:2
 // %PARAM% TEST_TYPES types 0:1:2:3:4
 
@@ -210,16 +218,18 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
     auto expected_result = std::max_element(host_items.cbegin(), host_items.cend());
 
     // Run test
-
-    using result_t = cub::KeyValuePair<int, unwrap_value_t<output_t>>;
+    using result_t = cuda::std::pair<cuda::std::int32_t, unwrap_value_t<output_t>>;
     c2h::device_vector<result_t> out_result(num_segments);
-    device_arg_max(unwrap_it(d_in_it), thrust::raw_pointer_cast(out_result.data()), num_items);
+    auto d_result_ptr   = thrust::raw_pointer_cast(out_result.data());
+    auto d_index_out    = &d_result_ptr->first;
+    auto d_extremum_out = &d_result_ptr->second;
+    device_arg_max(unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items);
 
     // Verify result
-    result_t gpu_result = out_result[0];
-    output_t gpu_value  = static_cast<output_t>(gpu_result.value); // Explicitly rewrap the gpu value
-    REQUIRE(expected_result[0] == gpu_value);
-    REQUIRE((expected_result - host_items.cbegin()) == gpu_result.key);
+    result_t gpu_result   = out_result[0];
+    output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+    REQUIRE(expected_result[0] == gpu_extremum);
+    REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
   }
 
   SECTION("argmin")
@@ -229,11 +239,50 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
     auto expected_result = std::min_element(host_items.cbegin(), host_items.cend());
 
     // Run test
-    using result_t = cub::KeyValuePair<int, unwrap_value_t<output_t>>;
+    using result_t = cuda::std::pair<cuda::std::int32_t, unwrap_value_t<output_t>>;
     c2h::device_vector<result_t> out_result(num_segments);
-    device_arg_min(unwrap_it(d_in_it), thrust::raw_pointer_cast(out_result.data()), num_items);
+    auto d_result_ptr   = thrust::raw_pointer_cast(out_result.data());
+    auto d_index_out    = &d_result_ptr->first;
+    auto d_extremum_out = &d_result_ptr->second;
+    device_arg_min(unwrap_it(d_in_it), d_extremum_out, d_index_out, num_items);
 
     // Verify result
+    result_t gpu_result   = out_result[0];
+    output_t gpu_extremum = static_cast<output_t>(gpu_result.second); // Explicitly rewrap the gpu value
+    REQUIRE(expected_result[0] == gpu_extremum);
+    REQUIRE((expected_result - host_items.cbegin()) == gpu_result.first);
+  }
+
+  SECTION("argmax deprecated interface")
+  {
+    // Prepare verification data
+    c2h::host_vector<item_t> host_items(in_items);
+    auto expected_result = std::max_element(host_items.cbegin(), host_items.cend());
+
+    // Run test using the deprecated interface
+    using result_t = cub::KeyValuePair<int, unwrap_value_t<output_t>>;
+    c2h::device_vector<result_t> out_result(num_segments);
+    device_arg_max_old(unwrap_it(d_in_it), thrust::raw_pointer_cast(out_result.data()), num_items);
+
+    // Verify result for the deprecated interface
+    result_t gpu_result = out_result[0];
+    output_t gpu_value  = static_cast<output_t>(gpu_result.value); // Explicitly rewrap the gpu value
+    REQUIRE(expected_result[0] == gpu_value);
+    REQUIRE((expected_result - host_items.cbegin()) == gpu_result.key);
+  }
+
+  SECTION("argmin deprecated interface")
+  {
+    // Prepare verification data
+    c2h::host_vector<item_t> host_items(in_items);
+    auto expected_result = std::min_element(host_items.cbegin(), host_items.cend());
+
+    // Run test using the deprecated interface
+    using result_t = cub::KeyValuePair<int, unwrap_value_t<output_t>>;
+    c2h::device_vector<result_t> out_result(num_segments);
+    device_arg_min_old(unwrap_it(d_in_it), thrust::raw_pointer_cast(out_result.data()), num_items);
+
+    // Verify result for the deprecated interface
     result_t gpu_result = out_result[0];
     output_t gpu_value  = static_cast<output_t>(gpu_result.value); // Explicitly rewrap the gpu value
     REQUIRE(expected_result[0] == gpu_value);


### PR DESCRIPTION
## Description

This PR introduces a new overload for the `DeviceReduce::Arg{Min,Max}` interface and deprecates the existing interface. Specifically, the result is now returned to two separate user-provided input iterators, one for the extremum, one for the index instead of returning the (extremum, index)-tuple as a `cub::KeyValuePair` that has shortcomings (see https://github.com/NVIDIA/cccl/issues/3146)

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes https://github.com/NVIDIA/cccl/issues/3146 <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
