### PR TITLE
Use synchronize_optional for device-to-device copy in thrust::copy()

### DIFF
--- a/thrust/thrust/system/cuda/detail/util.h
+++ b/thrust/thrust/system/cuda/detail/util.h
@@ -174,7 +174,7 @@ trivial_copy_device_to_device(Policy& policy, Type* dst, Type const* src, size_t
   cudaStream_t stream = cuda_cub::stream(policy);
   //
   status = ::cudaMemcpyAsync(dst, src, sizeof(Type) * count, cudaMemcpyDeviceToDevice, stream);
-  cuda_cub::synchronize(policy);
+  cuda_cub::synchronize_optional(policy);
   return status;
 }
 


### PR DESCRIPTION
## Description
Changes the call to `synchronize()` for the target stream to `synchronize_optional()` in the `trivial_copy_device_to_device()` utility. This allows the caller to pass in a `thrust::cuda::par_nosync` policy without requiring a sync on the stream. The return value for `thrust::copy()` does not rely on the copy result but is simply an increment of the output iterator.

Reference issue #1474 -- only handles device-to-device stream sync case.

For RAPIDS libcudf this results in an up to 2x performance improvement certain cases that use `thrust::copy()`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
