### PR TITLE
Add Python codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@ thrust/ @nvidia/cccl-thrust-codeowners @nvidia/cccl-codeowners
 cub/ @nvidia/cccl-cub-codeowners @nvidia/cccl-codeowners
 libcudacxx/ @nvidia/cccl-libcudacxx-codeowners @nvidia/cccl-codeowners
 cudax/ @nvidia/cccl-cudax-codeowners
+c/ @nvidia/cccl-python-codeowners
+python/ @nvidia/cccl-python-codeowners
 
 # Infrastructure
 .github/ @nvidia/cccl-infra-codeowners @nvidia/cccl-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@ thrust/ @nvidia/cccl-thrust-codeowners @nvidia/cccl-codeowners
 cub/ @nvidia/cccl-cub-codeowners @nvidia/cccl-codeowners
 libcudacxx/ @nvidia/cccl-libcudacxx-codeowners @nvidia/cccl-codeowners
 cudax/ @nvidia/cccl-cudax-codeowners
-c/ @nvidia/cccl-python-codeowners
+c/ @nvidia/cccl-c-codeowners
 python/ @nvidia/cccl-python-codeowners
 
 # Infrastructure


### PR DESCRIPTION
Adds the @NVIDIA/cccl-python-codeowners team as codeowners for `python/` directory and @NVIDIA/cccl-c-codeowners for `c/`. 