### PR TITLE
[Internal Cleanup] pre-commit ruff libcudacxx/tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,9 +43,9 @@ repos:
     hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
-      exclude: "^docs/tools/|^libcudacxx/test/"
+      exclude: "^docs/tools/"
     - id: ruff-format
-      exclude: "^docs/tools/|^libcudacxx/test/"
+      exclude: "^docs/tools/"
 
 default_language_version:
   python: python3

--- a/libcudacxx/test/support/filesystem_dynamic_test_helper.py
+++ b/libcudacxx/test/support/filesystem_dynamic_test_helper.py
@@ -1,21 +1,27 @@
 import sys
 import os
 import socket
-import stat
 
 # Ensure that this is being run on a specific platform
-assert sys.platform.startswith('linux') or sys.platform.startswith('darwin') \
-    or sys.platform.startswith('cygwin') or sys.platform.startswith('freebsd') \
-    or sys.platform.startswith('netbsd')
+assert (
+    sys.platform.startswith("linux")
+    or sys.platform.startswith("darwin")
+    or sys.platform.startswith("cygwin")
+    or sys.platform.startswith("freebsd")
+    or sys.platform.startswith("netbsd")
+)
+
 
 def env_path():
-    ep = os.environ.get('LIBCXX_FILESYSTEM_DYNAMIC_TEST_ROOT')
+    ep = os.environ.get("LIBCXX_FILESYSTEM_DYNAMIC_TEST_ROOT")
     assert ep is not None
     ep = os.path.realpath(ep)
     assert os.path.isdir(ep)
     return ep
 
+
 env_path_global = env_path()
+
 
 # Make sure we don't try and write outside of env_path.
 # All paths used should be sanitized
@@ -25,11 +31,14 @@ def sanitize(p):
         return p
     assert False
 
+
 """
 Some of the tests restrict permissions to induce failures.
 Before we delete the test environment, we have to walk it and re-raise the
 permissions.
 """
+
+
 def clean_recursive(root_p):
     if not os.path.islink(root_p):
         os.chmod(root_p, 0o777)
@@ -56,8 +65,8 @@ def destroy_test_directory(root_p):
 
 
 def create_file(fname, size):
-    with open(sanitize(fname), 'w') as f:
-        f.write('c' * size)
+    with open(sanitize(fname), "w") as f:
+        f.write("c" * size)
 
 
 def create_dir(dname):
@@ -86,7 +95,7 @@ def create_socket(source):
     sock.bind(os.path.basename(sanitized_source))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     command = " ".join(sys.argv[1:])
     eval(command)
     sys.exit(0)

--- a/libcudacxx/test/utils/libcudacxx/__init__.py
+++ b/libcudacxx/test/utils/libcudacxx/__init__.py
@@ -1,16 +1,16 @@
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 
 """libcxx python utilities"""
 
-__author__ = 'Eric Fiselier'
-__email__ = 'eric@efcs.ca'
+__author__ = "Eric Fiselier"
+__email__ = "eric@efcs.ca"
 __versioninfo__ = (0, 1, 0)
-__version__ = ' '.join(str(v) for v in __versioninfo__) + 'dev'
+__version__ = " ".join(str(v) for v in __versioninfo__) + "dev"
 
 __all__ = []

--- a/libcudacxx/test/utils/libcudacxx/compiler.py
+++ b/libcudacxx/test/utils/libcudacxx/compiler.py
@@ -172,7 +172,7 @@ class CXXCompiler(object):
             self.type = compiler_type
             self.version = (major_ver, minor_ver, patchlevel)
             self.default_dialect = default_dialect
-        except:
+        except Exception:
             (self.type, self.version, self.default_dialect) = self.dumpVersion()
 
         if self.type == "nvcc":
@@ -386,7 +386,7 @@ class CXXCompiler(object):
             version = None
             try:
                 version = eval(out)
-            except:
+            except Exception:
                 pass
 
             if not (isinstance(version, tuple) and 3 == len(version)):
@@ -428,13 +428,13 @@ class CXXCompiler(object):
             raise BaseException("Macros failed to dump")
 
         parsed_macros = {}
-        lines = [l.strip() for l in out.split("\n") if l.strip()]
-        for l in lines:
+        lines = [line.strip() for line in out.split("\n") if line.strip()]
+        for line in lines:
             # NVHPC also outputs the file contents from -E -dM for some reason; handle that
-            if not l.startswith("#define "):
+            if not line.startswith("#define "):
                 continue
-            l = l[len("#define ") :]
-            macro, _, value = l.partition(" ")
+            line = line[len("#define ") :]
+            macro, _, value = line.partition(" ")
             parsed_macros[macro] = value
         return parsed_macros
 

--- a/libcudacxx/test/utils/libcudacxx/compiler.py
+++ b/libcudacxx/test/utils/libcudacxx/compiler.py
@@ -406,7 +406,7 @@ class CXXCompiler(object):
             cmd, out, err, rc = self.preprocess(source_files, flags=flags, cwd=cwd)
             # Older MSVC does not support dumping macros
             if err.find("D9002") > 0:
-                raise BaseException("Cannot be dumped on old MSVC")
+                raise RuntimeError("Cannot be dumped on old MSVC")
             if rc != 0:
                 flags = [
                     "-Xcompiler",
@@ -416,7 +416,7 @@ class CXXCompiler(object):
                 ] + old_flags
                 cmd, out, err, rc = self.preprocess(source_files, flags=flags, cwd=cwd)
                 if err.find("D9002") > 0:
-                    raise BaseException("Cannot be dumped on old MSVC")
+                    raise RuntimeError("Cannot be dumped on old MSVC")
         else:
             flags = ["-dM"] + flags
             cmd, out, err, rc = self.preprocess(source_files, flags=flags, cwd=cwd)
@@ -425,7 +425,7 @@ class CXXCompiler(object):
                 cmd, out, err, rc = self.preprocess(source_files, flags=flags, cwd=cwd)
 
         if rc != 0:
-            raise BaseException("Macros failed to dump")
+            raise RuntimeError("Macros failed to dump")
 
         parsed_macros = {}
         lines = [line.strip() for line in out.split("\n") if line.strip()]

--- a/libcudacxx/test/utils/libcudacxx/compiler.py
+++ b/libcudacxx/test/utils/libcudacxx/compiler.py
@@ -343,10 +343,13 @@ class CXXCompiler(object):
             raise TypeError("This function only accepts a single input file")
         if object_file is None:
             # Create, use and delete a temporary object file if none is given.
-            with_fn = lambda: libcudacxx.util.guardedTempFilename(suffix=".o")
+            def with_fn():
+                return libcudacxx.util.guardedTempFilename(suffix=".o")
         else:
             # Otherwise wrap the filename in a context manager function.
-            with_fn = lambda: libcudacxx.util.nullContext(object_file)
+            def with_fn():
+                return libcudacxx.util.nullContext(object_file)
+
         with with_fn() as object_file:
             cc_cmd, cc_stdout, cc_stderr, rc = self.compile(
                 source_file, object_file, flags=flags, cwd=cwd
@@ -367,7 +370,10 @@ class CXXCompiler(object):
         dumpversion_cpp = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "dumpversion.cpp"
         )
-        with_fn = lambda: libcudacxx.util.guardedTempFilename(suffix=".exe")
+
+        def with_fn():
+            return libcudacxx.util.guardedTempFilename(suffix=".exe")
+
         with with_fn() as exe:
             cmd, out, err, rc = self.compileLink(
                 [dumpversion_cpp], out=exe, flags=flags, cwd=cwd

--- a/libcudacxx/test/utils/libcudacxx/compiler.py
+++ b/libcudacxx/test/utils/libcudacxx/compiler.py
@@ -1,10 +1,10 @@
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 
 import platform
 import os
@@ -18,16 +18,29 @@ class CXXCompiler(object):
     CM_Compile = 3
     CM_Link = 4
 
-    def __init__(self, path, first_arg,
-                 flags=None, compile_flags=None, link_flags=None,
-                 warning_flags=None, verify_supported=None,
-                 verify_flags=None, use_verify=False,
-                 modules_flags=None, use_modules=False,
-                 use_ccache=False, use_warnings=False, compile_env=None,
-                 cxx_type=None, cxx_version=None, cuda_path=None):
-        self.source_lang = 'c++'
+    def __init__(
+        self,
+        path,
+        first_arg,
+        flags=None,
+        compile_flags=None,
+        link_flags=None,
+        warning_flags=None,
+        verify_supported=None,
+        verify_flags=None,
+        use_verify=False,
+        modules_flags=None,
+        use_modules=False,
+        use_ccache=False,
+        use_warnings=False,
+        compile_env=None,
+        cxx_type=None,
+        cxx_version=None,
+        cuda_path=None,
+    ):
+        self.source_lang = "c++"
         self.path = path
-        self.first_arg = first_arg or ''
+        self.first_arg = first_arg or ""
         self.flags = list(flags or [])
         self.compile_flags = list(compile_flags or [])
         self.link_flags = list(link_flags or [])
@@ -54,13 +67,16 @@ class CXXCompiler(object):
 
     def isVerifySupported(self):
         if self.verify_supported is None:
-            self.verify_supported = self.hasCompileFlag(['-Xclang',
-                                        '-verify-ignore-unexpected'])
+            self.verify_supported = self.hasCompileFlag(
+                ["-Xclang", "-verify-ignore-unexpected"]
+            )
             if self.verify_supported:
                 self.verify_flags = [
-                    '-Xclang', '-verify',
-                    '-Xclang', '-verify-ignore-unexpected=note',
-                    '-ferror-limit=1024'
+                    "-Xclang",
+                    "-verify",
+                    "-Xclang",
+                    "-verify-ignore-unexpected=note",
+                    "-ferror-limit=1024",
                 ]
         return self.verify_supported
 
@@ -85,46 +101,46 @@ class CXXCompiler(object):
             compiler_type = None
             major_ver = minor_ver = patchlevel = None
 
-            if '__NVCC__' in macros.keys():
-                compiler_type = 'nvcc'
-                major_ver = macros['__CUDACC_VER_MAJOR__']
-                minor_ver = macros['__CUDACC_VER_MINOR__']
-                patchlevel = macros['__CUDACC_VER_BUILD__']
-            elif '__NVCOMPILER' in macros.keys():
-                compiler_type = 'nvhpc'
+            if "__NVCC__" in macros.keys():
+                compiler_type = "nvcc"
+                major_ver = macros["__CUDACC_VER_MAJOR__"]
+                minor_ver = macros["__CUDACC_VER_MINOR__"]
+                patchlevel = macros["__CUDACC_VER_BUILD__"]
+            elif "__NVCOMPILER" in macros.keys():
+                compiler_type = "nvhpc"
                 # NVHPC, unfortunately, adds an extra space between the macro name
                 # and macro value in their macro dump mode.
-                major_ver = macros['__NVCOMPILER_MAJOR__'].strip()
-                minor_ver = macros['__NVCOMPILER_MINOR__'].strip()
-                patchlevel = macros['__NVCOMPILER_PATCHLEVEL__'].strip()
-            elif '__INTEL_COMPILER' in macros.keys():
-                compiler_type = 'icc'
-                major_ver = int(macros['__INTEL_COMPILER']) / 100
-                minor_ver = (int(macros['__INTEL_COMPILER']) % 100) / 10
-                patchlevel = int(macros['__INTEL_COMPILER']) % 10
-            elif '__clang__' in macros.keys():
-                compiler_type = 'clang'
+                major_ver = macros["__NVCOMPILER_MAJOR__"].strip()
+                minor_ver = macros["__NVCOMPILER_MINOR__"].strip()
+                patchlevel = macros["__NVCOMPILER_PATCHLEVEL__"].strip()
+            elif "__INTEL_COMPILER" in macros.keys():
+                compiler_type = "icc"
+                major_ver = int(macros["__INTEL_COMPILER"]) / 100
+                minor_ver = (int(macros["__INTEL_COMPILER"]) % 100) / 10
+                patchlevel = int(macros["__INTEL_COMPILER"]) % 10
+            elif "__clang__" in macros.keys():
+                compiler_type = "clang"
                 # Treat Apple's LLVM fork differently.
-                if '__apple_build_version__' in macros.keys():
-                    compiler_type = 'apple-clang'
-                major_ver = macros['__clang_major__']
-                minor_ver = macros['__clang_minor__']
-                patchlevel = macros['__clang_patchlevel__']
-            elif '__GNUC__' in macros.keys():
-                compiler_type = 'gcc'
-                major_ver = macros['__GNUC__']
-                minor_ver = macros['__GNUC_MINOR__']
-                patchlevel = macros['__GNUC_PATCHLEVEL__']
-            elif '_MSC_VER' in macros.keys():
+                if "__apple_build_version__" in macros.keys():
+                    compiler_type = "apple-clang"
+                major_ver = macros["__clang_major__"]
+                minor_ver = macros["__clang_minor__"]
+                patchlevel = macros["__clang_patchlevel__"]
+            elif "__GNUC__" in macros.keys():
+                compiler_type = "gcc"
+                major_ver = macros["__GNUC__"]
+                minor_ver = macros["__GNUC_MINOR__"]
+                patchlevel = macros["__GNUC_PATCHLEVEL__"]
+            elif "_MSC_VER" in macros.keys():
                 compiler_type = "msvc"
-                major_ver  = int(int(macros['_MSC_FULL_VER']) / 10000000)
-                minor_ver  = int(int(macros['_MSC_FULL_VER']) / 100000 % 100)
-                patchlevel = int(int(macros['_MSC_FULL_VER']) % 100000)
+                major_ver = int(int(macros["_MSC_FULL_VER"]) / 10000000)
+                minor_ver = int(int(macros["_MSC_FULL_VER"]) / 100000 % 100)
+                patchlevel = int(int(macros["_MSC_FULL_VER"]) % 100000)
 
-            if '__cplusplus' in macros.keys():
-                if '_MSVC_LANG' in macros.keys():
-                    msvc_lang = macros['_MSVC_LANG']
-                    if msvc_lang[-1] == 'L':
+            if "__cplusplus" in macros.keys():
+                if "_MSVC_LANG" in macros.keys():
+                    msvc_lang = macros["_MSVC_LANG"]
+                    if msvc_lang[-1] == "L":
                         msvc_lang = msvc_lang[:-1]
                     msvc_lang = int(msvc_lang)
                     if msvc_lang <= 201103:
@@ -136,8 +152,8 @@ class CXXCompiler(object):
                     elif msvc_lang > 201703:
                         default_dialect = "c++20"
                 else:
-                    cplusplus = macros['__cplusplus']
-                    if cplusplus[-1] == 'L':
+                    cplusplus = macros["__cplusplus"]
+                    if cplusplus[-1] == "L":
                         cplusplus = cplusplus[:-1]
                     cpp_standard = int(cplusplus)
                     if cpp_standard <= 199711:
@@ -157,40 +173,41 @@ class CXXCompiler(object):
             self.version = (major_ver, minor_ver, patchlevel)
             self.default_dialect = default_dialect
         except:
-            (self.type, self.version, self.default_dialect) = \
-                self.dumpVersion()
+            (self.type, self.version, self.default_dialect) = self.dumpVersion()
 
-        if self.type == 'nvcc':
+        if self.type == "nvcc":
             # Treat C++ as CUDA when the compiler is NVCC.
-            self.source_lang = 'cu'
-        elif self.type == 'clang':
+            self.source_lang = "cu"
+        elif self.type == "clang":
             # Treat C++ as clang-cuda when the compiler is Clang.
-            self.source_lang = 'cu'
+            self.source_lang = "cu"
 
-    def _basicCmdCl(self, source_files, out, mode=CM_Default, flags=[],
-                  input_is_cxx=False):
+    def _basicCmdCl(
+        self, source_files, out, mode=CM_Default, flags=[], input_is_cxx=False
+    ):
         cmd = []
 
-        if self.use_ccache \
-            and not mode == self.CM_Link \
-            and not mode == self.CM_PreProcess \
-            and not mode == self.CM_CheckCompileFlag:
-            cmd += [os.environ.get('CMAKE_CUDA_COMPILER_LAUNCHER')]
+        if (
+            self.use_ccache
+            and not mode == self.CM_Link
+            and not mode == self.CM_PreProcess
+            and not mode == self.CM_CheckCompileFlag
+        ):
+            cmd += [os.environ.get("CMAKE_CUDA_COMPILER_LAUNCHER")]
 
-        cmd += [self.path] + ([self.first_arg] if self.first_arg != '' else [])
-
+        cmd += [self.path] + ([self.first_arg] if self.first_arg != "" else [])
 
         if isinstance(source_files, list):
             cmd += source_files
         elif isinstance(source_files, str):
             cmd += [source_files]
         else:
-            raise TypeError('source_files must be a string or list')
+            raise TypeError("source_files must be a string or list")
 
         if mode == self.CM_PreProcess or mode == self.CM_CheckCompileFlag:
-            cmd += ['/Zs', '/options:strict']
+            cmd += ["/Zs", "/options:strict"]
         elif mode == self.CM_Compile:
-            cmd += ['/c']
+            cmd += ["/c"]
 
         cmd += self.flags
         if self.use_verify:
@@ -202,43 +219,53 @@ class CXXCompiler(object):
             cmd += self.compile_flags
             if self.use_warnings:
                 cmd += self.warning_flags
-        if mode != self.CM_PreProcess and mode != self.CM_Compile and mode != self.CM_CheckCompileFlag:
+        if (
+            mode != self.CM_PreProcess
+            and mode != self.CM_Compile
+            and mode != self.CM_CheckCompileFlag
+        ):
             cmd += self.link_flags
         cmd += flags
         if out is not None:
-            cmd += ["/link", "/out:\"{}\"".format(out)]
+            cmd += ["/link", '/out:"{}"'.format(out)]
         return cmd
 
-    def _basicCmd(self, source_files, out, mode=CM_Default, flags=[],
-                  input_is_cxx=False):
-        if self.path.startswith('cl') and not self.path.startswith('clang'):
+    def _basicCmd(
+        self, source_files, out, mode=CM_Default, flags=[], input_is_cxx=False
+    ):
+        if self.path.startswith("cl") and not self.path.startswith("clang"):
             return self._basicCmdCl(source_files, out, mode, flags)
 
         cmd = []
 
-        if self.use_ccache \
-            and not mode == self.CM_Link \
-            and not mode == self.CM_PreProcess \
-            and not mode == self.CM_CheckCompileFlag:
-            cmd += [os.environ.get('CMAKE_CUDA_COMPILER_LAUNCHER')]
-        cmd += [self.path] + ([self.first_arg] if self.first_arg != '' else [])
+        if (
+            self.use_ccache
+            and not mode == self.CM_Link
+            and not mode == self.CM_PreProcess
+            and not mode == self.CM_CheckCompileFlag
+        ):
+            cmd += [os.environ.get("CMAKE_CUDA_COMPILER_LAUNCHER")]
+        cmd += [self.path] + ([self.first_arg] if self.first_arg != "" else [])
         if out is not None:
-            cmd += ['-o', out]
+            cmd += ["-o", out]
         if input_is_cxx:
-            cmd += ['-x', self.source_lang]
-        if self.type == "clang"  and self.source_lang == 'cu' and self.cuda_path is not None:
-            cmd += ['--cuda-path=' + self.cuda_path]
+            cmd += ["-x", self.source_lang]
+        if (
+            self.type == "clang"
+            and self.source_lang == "cu"
+            and self.cuda_path is not None
+        ):
+            cmd += ["--cuda-path=" + self.cuda_path]
         if isinstance(source_files, list):
             cmd += source_files
         elif isinstance(source_files, str):
             cmd += [source_files]
         else:
-            raise TypeError('source_files must be a string or list')
+            raise TypeError("source_files must be a string or list")
         if mode == self.CM_PreProcess:
-            cmd += ['-E']
-        elif mode == self.CM_Compile \
-          or mode == self.CM_CheckCompileFlag:
-            cmd += ['-c']
+            cmd += ["-E"]
+        elif mode == self.CM_Compile or mode == self.CM_CheckCompileFlag:
+            cmd += ["-c"]
         cmd += self.flags
         if self.use_verify:
             cmd += self.verify_flags
@@ -249,91 +276,107 @@ class CXXCompiler(object):
             cmd += self.compile_flags
             if self.use_warnings:
                 cmd += self.warning_flags
-        if mode != self.CM_PreProcess   \
-            and mode != self.CM_Compile \
-            and mode != self.CM_CheckCompileFlag:
+        if (
+            mode != self.CM_PreProcess
+            and mode != self.CM_Compile
+            and mode != self.CM_CheckCompileFlag
+        ):
             cmd += self.link_flags
         cmd += flags
         return cmd
 
     def preprocessCmd(self, source_files, out=None, flags=[]):
-        return self._basicCmd(source_files, out, flags=flags,
-                             mode=self.CM_PreProcess,
-                             input_is_cxx=True)
+        return self._basicCmd(
+            source_files, out, flags=flags, mode=self.CM_PreProcess, input_is_cxx=True
+        )
 
-    def compileCmd(self, source_files, out=None, flags=[], mode = CM_Compile):
-        return self._basicCmd(source_files, out, flags=flags, mode=mode,
-                             input_is_cxx=True) + ['-c']
+    def compileCmd(self, source_files, out=None, flags=[], mode=CM_Compile):
+        return self._basicCmd(
+            source_files, out, flags=flags, mode=mode, input_is_cxx=True
+        ) + ["-c"]
 
     def linkCmd(self, source_files, out=None, flags=[]):
-        return self._basicCmd(source_files, out, flags=flags,
-                              mode=self.CM_Link)
+        return self._basicCmd(source_files, out, flags=flags, mode=self.CM_Link)
 
     def compileLinkCmd(self, source_files, out=None, flags=[]):
         return self._basicCmd(source_files, out, flags=flags)
 
     def preprocess(self, source_files, out=None, flags=[], cwd=None):
         cmd = self.preprocessCmd(source_files, out, flags)
-        out, err, rc = libcudacxx.util.executeCommand(cmd, env=self.compile_env,
-                                                  cwd=cwd)
+        out, err, rc = libcudacxx.util.executeCommand(
+            cmd, env=self.compile_env, cwd=cwd
+        )
         return cmd, out, err, rc
 
     def checkCompileFlag(self, source_files, out=None, flags=[], cwd=None):
         cmd = self.compileCmd(source_files, out, flags, self.CM_CheckCompileFlag)
-        out, err, rc = libcudacxx.util.executeCommand(cmd, env=self.compile_env,
-                                                  cwd=cwd)
+        out, err, rc = libcudacxx.util.executeCommand(
+            cmd, env=self.compile_env, cwd=cwd
+        )
         return cmd, out, err, rc
 
     def compile(self, source_files, out=None, flags=[], cwd=None):
         cmd = self.compileCmd(source_files, out, flags, self.CM_Compile)
-        out, err, rc = libcudacxx.util.executeCommand(cmd, env=self.compile_env,
-                                                  cwd=cwd)
+        out, err, rc = libcudacxx.util.executeCommand(
+            cmd, env=self.compile_env, cwd=cwd
+        )
         return cmd, out, err, rc
 
     def link(self, source_files, out=None, flags=[], cwd=None):
         cmd = self.linkCmd(source_files, out, flags)
-        out, err, rc = libcudacxx.util.executeCommand(cmd, env=self.compile_env,
-                                                  cwd=cwd)
+        out, err, rc = libcudacxx.util.executeCommand(
+            cmd, env=self.compile_env, cwd=cwd
+        )
         return cmd, out, err, rc
 
-    def compileLink(self, source_files, out=None, flags=[],
-                    cwd=None):
+    def compileLink(self, source_files, out=None, flags=[], cwd=None):
         cmd = self.compileLinkCmd(source_files, out, flags)
-        out, err, rc = libcudacxx.util.executeCommand(cmd, env=self.compile_env,
-                                                  cwd=cwd)
+        out, err, rc = libcudacxx.util.executeCommand(
+            cmd, env=self.compile_env, cwd=cwd
+        )
         return cmd, out, err, rc
 
-    def compileLinkTwoSteps(self, source_file, out=None, object_file=None,
-                            flags=[], cwd=None):
+    def compileLinkTwoSteps(
+        self, source_file, out=None, object_file=None, flags=[], cwd=None
+    ):
         if not isinstance(source_file, str):
-            raise TypeError('This function only accepts a single input file')
+            raise TypeError("This function only accepts a single input file")
         if object_file is None:
             # Create, use and delete a temporary object file if none is given.
-            with_fn = lambda: libcudacxx.util.guardedTempFilename(suffix='.o')
+            with_fn = lambda: libcudacxx.util.guardedTempFilename(suffix=".o")
         else:
             # Otherwise wrap the filename in a context manager function.
             with_fn = lambda: libcudacxx.util.nullContext(object_file)
         with with_fn() as object_file:
             cc_cmd, cc_stdout, cc_stderr, rc = self.compile(
-                source_file, object_file, flags=flags, cwd=cwd)
+                source_file, object_file, flags=flags, cwd=cwd
+            )
             if rc != 0:
                 return cc_cmd, cc_stdout, cc_stderr, rc
             link_cmd, link_stdout, link_stderr, rc = self.link(
-                object_file, out=out, flags=flags, cwd=cwd)
-            return (cc_cmd + ['&&'] + link_cmd, cc_stdout + link_stdout,
-                    cc_stderr + link_stderr, rc)
+                object_file, out=out, flags=flags, cwd=cwd
+            )
+            return (
+                cc_cmd + ["&&"] + link_cmd,
+                cc_stdout + link_stdout,
+                cc_stderr + link_stderr,
+                rc,
+            )
 
     def dumpVersion(self, flags=[], cwd=None):
         dumpversion_cpp = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "dumpversion.cpp")
+            os.path.dirname(os.path.abspath(__file__)), "dumpversion.cpp"
+        )
         with_fn = lambda: libcudacxx.util.guardedTempFilename(suffix=".exe")
         with with_fn() as exe:
-            cmd, out, err, rc = self.compileLink([dumpversion_cpp], out=exe,
-                                               flags=flags, cwd=cwd)
+            cmd, out, err, rc = self.compileLink(
+                [dumpversion_cpp], out=exe, flags=flags, cwd=cwd
+            )
             if rc != 0:
                 return ("unknown", (0, 0, 0), "c++03")
-            out, err, rc = libcudacxx.util.executeCommand(exe, env=self.compile_env,
-                                                    cwd=cwd)
+            out, err, rc = libcudacxx.util.executeCommand(
+                exe, env=self.compile_env, cwd=cwd
+            )
             version = None
             try:
                 version = eval(out)
@@ -346,46 +389,53 @@ class CXXCompiler(object):
 
     def dumpMacros(self, source_files=None, flags=[], cwd=None):
         if source_files is None:
-            source_files = os.path.join(os.path.dirname(os.path.abspath(__file__)), "empty.cpp")
+            source_files = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "empty.cpp"
+            )
 
         old_flags = flags
         # Assume MSVC flags on Windows
-        if platform.system() == 'Windows':
-            flags = ['/Zc:preprocessor', '/PD'] + old_flags
+        if platform.system() == "Windows":
+            flags = ["/Zc:preprocessor", "/PD"] + old_flags
             cmd, out, err, rc = self.preprocess(source_files, flags=flags, cwd=cwd)
             # Older MSVC does not support dumping macros
             if err.find("D9002") > 0:
                 raise BaseException("Cannot be dumped on old MSVC")
             if rc != 0:
-                flags = ['-Xcompiler', '/Zc:preprocessor', '-Xcompiler', '/PD'] + old_flags
+                flags = [
+                    "-Xcompiler",
+                    "/Zc:preprocessor",
+                    "-Xcompiler",
+                    "/PD",
+                ] + old_flags
                 cmd, out, err, rc = self.preprocess(source_files, flags=flags, cwd=cwd)
                 if err.find("D9002") > 0:
                     raise BaseException("Cannot be dumped on old MSVC")
         else:
-            flags = ['-dM'] + flags
+            flags = ["-dM"] + flags
             cmd, out, err, rc = self.preprocess(source_files, flags=flags, cwd=cwd)
             if rc != 0:
-                flags = ['-Xcompiler'] + flags
+                flags = ["-Xcompiler"] + flags
                 cmd, out, err, rc = self.preprocess(source_files, flags=flags, cwd=cwd)
 
         if rc != 0:
             raise BaseException("Macros failed to dump")
 
         parsed_macros = {}
-        lines = [l.strip() for l in out.split('\n') if l.strip()]
+        lines = [l.strip() for l in out.split("\n") if l.strip()]
         for l in lines:
             # NVHPC also outputs the file contents from -E -dM for some reason; handle that
-            if not l.startswith('#define '):
+            if not l.startswith("#define "):
                 continue
-            l = l[len('#define '):]
-            macro, _, value = l.partition(' ')
+            l = l[len("#define ") :]
+            macro, _, value = l.partition(" ")
             parsed_macros[macro] = value
         return parsed_macros
 
     def getTriple(self):
         if self.type == "msvc":
             return "x86_64-pc-windows-msvc"
-        cmd = [self.path] + self.flags + ['-dumpmachine']
+        cmd = [self.path] + self.flags + ["-dumpmachine"]
         return libcudacxx.util.capture(cmd).strip()
 
     def hasCompileFlag(self, flag):
@@ -396,16 +446,20 @@ class CXXCompiler(object):
 
         # Add -Werror to ensure that an unrecognized flag causes a non-zero
         # exit code. -Werror is supported on all known non-nvcc compiler types.
-        if self.type is not None and self.type != 'nvcc' and self.type != 'msvc':
-            flags += ['-Werror', '-fsyntax-only']
-        if self.type == 'clang' and self.source_lang == 'cu':
-            flags += ['-Wno-unused-command-line-argument']
+        if self.type is not None and self.type != "nvcc" and self.type != "msvc":
+            flags += ["-Werror", "-fsyntax-only"]
+        if self.type == "clang" and self.source_lang == "cu":
+            flags += ["-Wno-unused-command-line-argument"]
 
-        empty_cpp = os.path.join(os.path.dirname(os.path.abspath(__file__)), "empty.cpp")
-        cmd, out, err, rc = self.checkCompileFlag(empty_cpp, out=os.devnull, flags=flags)
-        if out.find('flag is not supported with the configured host compiler') != -1:
+        empty_cpp = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "empty.cpp"
+        )
+        cmd, out, err, rc = self.checkCompileFlag(
+            empty_cpp, out=os.devnull, flags=flags
+        )
+        if out.find("flag is not supported with the configured host compiler") != -1:
             return False
-        if err.find('flag is not supported with the configured host compiler') != -1:
+        if err.find("flag is not supported with the configured host compiler") != -1:
             return False
         return rc == 0
 
@@ -440,21 +494,22 @@ class CXXCompiler(object):
         another error is triggered during compilation.
         """
         assert isinstance(flag, str)
-        assert flag.startswith('-W')
-        if not flag.startswith('-Wno-'):
+        assert flag.startswith("-W")
+        if not flag.startswith("-Wno-"):
             return self.hasCompileFlag(flag)
-        flags = ['-Werror', flag]
+        flags = ["-Werror", flag]
         old_use_warnings = self.use_warnings
         self.useWarnings(False)
-        cmd = self.compileCmd('-', os.devnull, flags)
+        cmd = self.compileCmd("-", os.devnull, flags)
         self.useWarnings(old_use_warnings)
         # Remove '-v' because it will cause the command line invocation
         # to be printed as part of the error output.
         # TODO(EricWF): Are there other flags we need to worry about?
-        if '-v' in cmd:
-            cmd.remove('-v')
+        if "-v" in cmd:
+            cmd.remove("-v")
         out, err, rc = libcudacxx.util.executeCommand(
-            cmd, input=libcudacxx.util.to_bytes('#error\n'))
+            cmd, input=libcudacxx.util.to_bytes("#error\n")
+        )
         assert rc != 0
         if flag in err:
             return False

--- a/libcudacxx/test/utils/libcudacxx/sym_check/__init__.py
+++ b/libcudacxx/test/utils/libcudacxx/sym_check/__init__.py
@@ -1,16 +1,16 @@
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 
 """libcxx abi symbol checker"""
 
-__author__ = 'Eric Fiselier'
-__email__ = 'eric@efcs.ca'
+__author__ = "Eric Fiselier"
+__email__ = "eric@efcs.ca"
 __versioninfo__ = (0, 1, 0)
-__version__ = ' '.join(str(v) for v in __versioninfo__) + 'dev'
+__version__ = " ".join(str(v) for v in __versioninfo__) + "dev"
 
-__all__ = ['diff', 'extract', 'util']
+__all__ = ["diff", "extract", "util"]

--- a/libcudacxx/test/utils/libcudacxx/sym_check/diff.py
+++ b/libcudacxx/test/utils/libcudacxx/sym_check/diff.py
@@ -1,11 +1,11 @@
 # -*- Python -*- vim: set syntax=python tabstop=4 expandtab cc=80:
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 """
 diff - A set of functions for diff-ing two symbol lists.
 """
@@ -14,15 +14,15 @@ from libcudacxx.sym_check import util
 
 
 def _symbol_difference(lhs, rhs):
-    lhs_names = set(((n['name'], n['type']) for n in lhs))
-    rhs_names = set(((n['name'], n['type']) for n in rhs))
+    lhs_names = set(((n["name"], n["type"]) for n in lhs))
+    rhs_names = set(((n["name"], n["type"]) for n in rhs))
     diff_names = lhs_names - rhs_names
-    return [n for n in lhs if (n['name'], n['type']) in diff_names]
+    return [n for n in lhs if (n["name"], n["type"]) in diff_names]
 
 
 def _find_by_key(sym_list, k):
     for sym in sym_list:
-        if sym['name'] == k:
+        if sym["name"] == k:
             return sym
     return None
 
@@ -40,9 +40,8 @@ def changed_symbols(old, new):
     for old_sym in old:
         if old_sym in new:
             continue
-        new_sym = _find_by_key(new, old_sym['name'])
-        if (new_sym is not None and not new_sym in old
-                and old_sym != new_sym):
+        new_sym = _find_by_key(new, old_sym["name"])
+        if new_sym is not None and new_sym not in old and old_sym != new_sym:
             changed += [(old_sym, new_sym)]
     return changed
 
@@ -54,49 +53,51 @@ def diff(old, new):
     return added, removed, changed
 
 
-def report_diff(added_syms, removed_syms, changed_syms, names_only=False,
-                demangle=True):
+def report_diff(
+    added_syms, removed_syms, changed_syms, names_only=False, demangle=True
+):
     def maybe_demangle(name):
         return util.demangle_symbol(name) if demangle else name
 
-    report = ''
+    report = ""
     for sym in added_syms:
-        report += 'Symbol added: %s\n' % maybe_demangle(sym['name'])
+        report += "Symbol added: %s\n" % maybe_demangle(sym["name"])
         if not names_only:
-            report += '    %s\n\n' % sym
+            report += "    %s\n\n" % sym
     if added_syms and names_only:
-        report += '\n'
+        report += "\n"
     for sym in removed_syms:
-        report += 'SYMBOL REMOVED: %s\n' % maybe_demangle(sym['name'])
+        report += "SYMBOL REMOVED: %s\n" % maybe_demangle(sym["name"])
         if not names_only:
-            report += '    %s\n\n' % sym
+            report += "    %s\n\n" % sym
     if removed_syms and names_only:
-        report += '\n'
+        report += "\n"
     if not names_only:
         for sym_pair in changed_syms:
             old_sym, new_sym = sym_pair
-            old_str = '\n    OLD SYMBOL: %s' % old_sym
-            new_str = '\n    NEW SYMBOL: %s' % new_sym
-            report += ('SYMBOL CHANGED: %s%s%s\n\n' %
-                       (maybe_demangle(old_sym['name']),
-                        old_str, new_str))
+            old_str = "\n    OLD SYMBOL: %s" % old_sym
+            new_str = "\n    NEW SYMBOL: %s" % new_sym
+            report += "SYMBOL CHANGED: %s%s%s\n\n" % (
+                maybe_demangle(old_sym["name"]),
+                old_str,
+                new_str,
+            )
 
     added = bool(len(added_syms) != 0)
     abi_break = bool(len(removed_syms))
     if not names_only:
         abi_break = abi_break or len(changed_syms)
     if added or abi_break:
-        report += 'Summary\n'
-        report += '    Added:   %d\n' % len(added_syms)
-        report += '    Removed: %d\n' % len(removed_syms)
+        report += "Summary\n"
+        report += "    Added:   %d\n" % len(added_syms)
+        report += "    Removed: %d\n" % len(removed_syms)
         if not names_only:
-            report += '    Changed: %d\n' % len(changed_syms)
+            report += "    Changed: %d\n" % len(changed_syms)
         if not abi_break:
-            report += 'Symbols added.'
+            report += "Symbols added."
         else:
-            report += 'ABI BREAKAGE: SYMBOLS ADDED OR REMOVED!'
+            report += "ABI BREAKAGE: SYMBOLS ADDED OR REMOVED!"
     else:
-        report += 'Symbols match.'
-    is_different = abi_break or bool(len(added_syms)) \
-                   or bool(len(changed_syms))
+        report += "Symbols match."
+    is_different = abi_break or bool(len(added_syms)) or bool(len(changed_syms))
     return report, abi_break, is_different

--- a/libcudacxx/test/utils/libcudacxx/sym_check/extract.py
+++ b/libcudacxx/test/utils/libcudacxx/sym_check/extract.py
@@ -1,23 +1,24 @@
 # -*- Python -*- vim: set syntax=python tabstop=4 expandtab cc=80:
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 """
 extract - A set of function that extract symbol lists from shared libraries.
 """
+
 import distutils.spawn
 import os.path
 import sys
-import re
 
 import libcudacxx.util
 from libcudacxx.sym_check import util
 
-extract_ignore_names = ['_init', '_fini']
+extract_ignore_names = ["_init", "_fini"]
+
 
 class NMExtractor(object):
     """
@@ -29,7 +30,7 @@ class NMExtractor(object):
         """
         Search for the nm executable and return the path.
         """
-        return distutils.spawn.find_executable('nm')
+        return distutils.spawn.find_executable("nm")
 
     def __init__(self, static_lib):
         """
@@ -42,8 +43,7 @@ class NMExtractor(object):
             print("ERROR: Could not find nm")
             sys.exit(1)
         self.static_lib = static_lib
-        self.flags = ['-P', '-g']
-
+        self.flags = ["-P", "-g"]
 
     def extract(self, lib):
         """
@@ -53,9 +53,8 @@ class NMExtractor(object):
         cmd = [self.nm_exe] + self.flags + [lib]
         out, _, exit_code = libcudacxx.util.executeCommandVerbose(cmd)
         if exit_code != 0:
-            raise RuntimeError('Failed to run %s on %s' % (self.nm_exe, lib))
-        fmt_syms = (self._extract_sym(l)
-                    for l in out.splitlines() if l.strip())
+            raise RuntimeError("Failed to run %s on %s" % (self.nm_exe, lib))
+        fmt_syms = (self._extract_sym(l) for l in out.splitlines() if l.strip())
         # Cast symbol to string.
         final_syms = (repr(s) for s in fmt_syms if self._want_sym(s))
         # Make unique and sort strings.
@@ -69,15 +68,15 @@ class NMExtractor(object):
         if len(bits) < 2:
             return None
         new_sym = {
-            'name': bits[0],
-            'type': bits[1],
-            'is_defined': (bits[1].lower() != 'u')
+            "name": bits[0],
+            "type": bits[1],
+            "is_defined": (bits[1].lower() != "u"),
         }
-        new_sym['name'] = new_sym['name'].replace('@@', '@')
+        new_sym["name"] = new_sym["name"].replace("@@", "@")
         new_sym = self._transform_sym_type(new_sym)
         # NM types which we want to save the size for.
-        if new_sym['type'] == 'OBJECT' and len(bits) > 3:
-            new_sym['size'] = int(bits[3], 16)
+        if new_sym["type"] == "OBJECT" and len(bits) > 3:
+            new_sym["size"] = int(bits[3], 16)
         return new_sym
 
     @staticmethod
@@ -87,11 +86,14 @@ class NMExtractor(object):
         """
         if sym is None or len(sym) < 2:
             return False
-        if sym['name'] in extract_ignore_names:
+        if sym["name"] in extract_ignore_names:
             return False
-        bad_types = ['t', 'b', 'r', 'd', 'w']
-        return (sym['type'] not in bad_types
-                and sym['name'] not in ['__bss_start', '_end', '_edata'])
+        bad_types = ["t", "b", "r", "d", "w"]
+        return sym["type"] not in bad_types and sym["name"] not in [
+            "__bss_start",
+            "_end",
+            "_edata",
+        ]
 
     @staticmethod
     def _transform_sym_type(sym):
@@ -99,13 +101,14 @@ class NMExtractor(object):
         Map the nm single letter output for type to either FUNC or OBJECT.
         If the type is not recognized it is left unchanged.
         """
-        func_types = ['T', 'W']
-        obj_types = ['B', 'D', 'R', 'V', 'S']
-        if sym['type'] in func_types:
-            sym['type'] = 'FUNC'
-        elif sym['type'] in obj_types:
-            sym['type'] = 'OBJECT'
+        func_types = ["T", "W"]
+        obj_types = ["B", "D", "R", "V", "S"]
+        if sym["type"] in func_types:
+            sym["type"] = "FUNC"
+        elif sym["type"] in obj_types:
+            sym["type"] = "OBJECT"
         return sym
+
 
 class ReadElfExtractor(object):
     """
@@ -117,7 +120,7 @@ class ReadElfExtractor(object):
         """
         Search for the readelf executable and return the path.
         """
-        return distutils.spawn.find_executable('readelf')
+        return distutils.spawn.find_executable("readelf")
 
     def __init__(self, static_lib):
         """
@@ -131,7 +134,7 @@ class ReadElfExtractor(object):
             sys.exit(1)
         # TODO: Support readelf for reading symbols from archives
         assert not static_lib and "RealElf does not yet support static libs"
-        self.flags = ['--wide', '--symbols']
+        self.flags = ["--wide", "--symbols"]
 
     def extract(self, lib):
         """
@@ -141,7 +144,7 @@ class ReadElfExtractor(object):
         cmd = [self.tool] + self.flags + [lib]
         out, _, exit_code = libcudacxx.util.executeCommandVerbose(cmd)
         if exit_code != 0:
-            raise RuntimeError('Failed to run %s on %s' % (self.nm_exe, lib))
+            raise RuntimeError("Failed to run %s on %s" % (self.nm_exe, lib))
         dyn_syms = self.get_dynsym_table(out)
         return self.process_syms(dyn_syms)
 
@@ -155,18 +158,18 @@ class ReadElfExtractor(object):
             if len(parts) == 7:
                 continue
             new_sym = {
-                'name': parts[7],
-                'size': int(parts[2]),
-                'type': parts[3],
-                'is_defined': (parts[6] != 'UND')
+                "name": parts[7],
+                "size": int(parts[2]),
+                "type": parts[3],
+                "is_defined": (parts[6] != "UND"),
             }
-            assert new_sym['type'] in ['OBJECT', 'FUNC', 'NOTYPE', 'TLS']
-            if new_sym['name'] in extract_ignore_names:
+            assert new_sym["type"] in ["OBJECT", "FUNC", "NOTYPE", "TLS"]
+            if new_sym["name"] in extract_ignore_names:
                 continue
-            if new_sym['type'] == 'NOTYPE':
+            if new_sym["type"] == "NOTYPE":
                 continue
-            if new_sym['type'] == 'FUNC':
-                del new_sym['size']
+            if new_sym["type"] == "FUNC":
+                del new_sym["size"]
             new_syms += [new_sym]
         return new_syms
 
@@ -193,7 +196,7 @@ def extract_symbols(lib_file, static_lib=None):
     """
     if static_lib is None:
         _, ext = os.path.splitext(lib_file)
-        static_lib = True if ext in ['.a'] else False
+        static_lib = True if ext in [".a"] else False
     if ReadElfExtractor.find_tool() and not static_lib:
         extractor = ReadElfExtractor(static_lib=static_lib)
     else:

--- a/libcudacxx/test/utils/libcudacxx/sym_check/extract.py
+++ b/libcudacxx/test/utils/libcudacxx/sym_check/extract.py
@@ -54,7 +54,9 @@ class NMExtractor(object):
         out, _, exit_code = libcudacxx.util.executeCommandVerbose(cmd)
         if exit_code != 0:
             raise RuntimeError("Failed to run %s on %s" % (self.nm_exe, lib))
-        fmt_syms = (self._extract_sym(l) for l in out.splitlines() if l.strip())
+        fmt_syms = (
+            self._extract_sym(line) for line in out.splitlines() if line.strip()
+        )
         # Cast symbol to string.
         final_syms = (repr(s) for s in fmt_syms if self._want_sym(s))
         # Make unique and sort strings.

--- a/libcudacxx/test/utils/libcudacxx/sym_check/match.py
+++ b/libcudacxx/test/utils/libcudacxx/sym_check/match.py
@@ -1,11 +1,11 @@
 # -*- Python -*- vim: set syntax=python tabstop=4 expandtab cc=80:
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 """
 match - A set of functions for matching symbols in a list to a list of regexs
 """
@@ -14,19 +14,19 @@ import re
 
 
 def find_and_report_matching(symbol_list, regex_list):
-    report = ''
+    report = ""
     found_count = 0
     for regex_str in regex_list:
         report += 'Matching regex "%s":\n' % regex_str
         matching_list = find_matching_symbols(symbol_list, regex_str)
         if not matching_list:
-            report += '    No matches found\n\n'
+            report += "    No matches found\n\n"
             continue
         # else
         found_count += len(matching_list)
         for m in matching_list:
-            report += '    MATCHES: %s\n' % m['name']
-        report += '\n'
+            report += "    MATCHES: %s\n" % m["name"]
+        report += "\n"
     return found_count, report
 
 
@@ -34,6 +34,6 @@ def find_matching_symbols(symbol_list, regex_str):
     regex = re.compile(regex_str)
     matching_list = []
     for s in symbol_list:
-        if regex.match(s['name']):
+        if regex.match(s["name"]):
             matching_list += [s]
     return matching_list

--- a/libcudacxx/test/utils/libcudacxx/sym_check/util.py
+++ b/libcudacxx/test/utils/libcudacxx/sym_check/util.py
@@ -19,7 +19,7 @@ def read_syms_from_list(slist):
     Read a list of symbols from a list of strings.
     Each string is one symbol.
     """
-    return [ast.literal_eval(l) for l in slist]
+    return [ast.literal_eval(s) for s in slist]
 
 
 def read_syms_from_file(filename):
@@ -34,8 +34,8 @@ def read_syms_from_file(filename):
 def read_blacklist(filename):
     with open(filename, "r") as f:
         data = f.read()
-    lines = [l.strip() for l in data.splitlines() if l.strip()]
-    lines = [l for l in lines if not l.startswith("#")]
+    lines = [line.strip() for line in data.splitlines() if line.strip()]
+    lines = [line for line in lines if not line.startswith("#")]
     return lines
 
 

--- a/libcudacxx/test/utils/libcudacxx/sym_check/util.py
+++ b/libcudacxx/test/utils/libcudacxx/sym_check/util.py
@@ -1,10 +1,10 @@
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 
 import ast
 import distutils.spawn
@@ -26,16 +26,16 @@ def read_syms_from_file(filename):
     """
     Read a list of symbols in from a file.
     """
-    with open(filename, 'r') as f:
+    with open(filename, "r") as f:
         data = f.read()
     return read_syms_from_list(data.splitlines())
 
 
 def read_blacklist(filename):
-    with open(filename, 'r') as f:
+    with open(filename, "r") as f:
         data = f.read()
     lines = [l.strip() for l in data.splitlines() if l.strip()]
-    lines = [l for l in lines if not l.startswith('#')]
+    lines = [l for l in lines if not l.startswith("#")]
     return lines
 
 
@@ -43,57 +43,58 @@ def write_syms(sym_list, out=None, names_only=False, filter=None):
     """
     Write a list of symbols to the file named by out.
     """
-    out_str = ''
+    out_str = ""
     out_list = sym_list
-    out_list.sort(key=lambda x: x['name'])
+    out_list.sort(key=lambda x: x["name"])
     if filter is not None:
         out_list = filter(out_list)
     if names_only:
-        out_list = [sym['name'] for sym in out_list]
+        out_list = [sym["name"] for sym in out_list]
     for sym in out_list:
         # Use pformat for consistent ordering of keys.
-        out_str += pformat(sym, width=100000) + '\n'
+        out_str += pformat(sym, width=100000) + "\n"
     if out is None:
         sys.stdout.write(out_str)
     else:
-        with open(out, 'w') as f:
+        with open(out, "w") as f:
             f.write(out_str)
 
 
-_cppfilt_exe = distutils.spawn.find_executable('c++filt')
+_cppfilt_exe = distutils.spawn.find_executable("c++filt")
 
 
 def demangle_symbol(symbol):
     if _cppfilt_exe is None:
         return symbol
     out, _, exit_code = libcudacxx.util.executeCommandVerbose(
-        [_cppfilt_exe], input=symbol)
+        [_cppfilt_exe], input=symbol
+    )
     if exit_code != 0:
         return symbol
     return out
 
 
 def is_elf(filename):
-    with open(filename, 'rb') as f:
+    with open(filename, "rb") as f:
         magic_bytes = f.read(4)
-    return magic_bytes == b'\x7fELF'
+    return magic_bytes == b"\x7fELF"
 
 
 def is_mach_o(filename):
-    with open(filename, 'rb') as f:
+    with open(filename, "rb") as f:
         magic_bytes = f.read(4)
     return magic_bytes in [
-        '\xfe\xed\xfa\xce',  # MH_MAGIC
-        '\xce\xfa\xed\xfe',  # MH_CIGAM
-        '\xfe\xed\xfa\xcf',  # MH_MAGIC_64
-        '\xcf\xfa\xed\xfe',  # MH_CIGAM_64
-        '\xca\xfe\xba\xbe',  # FAT_MAGIC
-        '\xbe\xba\xfe\xca'   # FAT_CIGAM
+        "\xfe\xed\xfa\xce",  # MH_MAGIC
+        "\xce\xfa\xed\xfe",  # MH_CIGAM
+        "\xfe\xed\xfa\xcf",  # MH_MAGIC_64
+        "\xcf\xfa\xed\xfe",  # MH_CIGAM_64
+        "\xca\xfe\xba\xbe",  # FAT_MAGIC
+        "\xbe\xba\xfe\xca",  # FAT_CIGAM
     ]
 
 
 def is_library_file(filename):
-    if sys.platform == 'darwin':
+    if sys.platform == "darwin":
         return is_mach_o(filename)
     else:
         return is_elf(filename)
@@ -101,169 +102,167 @@ def is_library_file(filename):
 
 def extract_or_load(filename):
     import libcudacxx.sym_check.extract
+
     if is_library_file(filename):
         return libcudacxx.sym_check.extract.extract_symbols(filename)
     return read_syms_from_file(filename)
 
+
 def adjust_mangled_name(name):
-    if not name.startswith('__Z'):
+    if not name.startswith("__Z"):
         return name
     return name[1:]
 
-new_delete_std_symbols = [
-    '_Znam',
-    '_Znwm',
-    '_ZdaPv',
-    '_ZdaPvm',
-    '_ZdlPv',
-    '_ZdlPvm'
-]
+
+new_delete_std_symbols = ["_Znam", "_Znwm", "_ZdaPv", "_ZdaPvm", "_ZdlPv", "_ZdlPvm"]
 
 cxxabi_symbols = [
-    '___dynamic_cast',
-    '___gxx_personality_v0',
-    '_ZTIDi',
-    '_ZTIDn',
-    '_ZTIDs',
-    '_ZTIPDi',
-    '_ZTIPDn',
-    '_ZTIPDs',
-    '_ZTIPKDi',
-    '_ZTIPKDn',
-    '_ZTIPKDs',
-    '_ZTIPKa',
-    '_ZTIPKb',
-    '_ZTIPKc',
-    '_ZTIPKd',
-    '_ZTIPKe',
-    '_ZTIPKf',
-    '_ZTIPKh',
-    '_ZTIPKi',
-    '_ZTIPKj',
-    '_ZTIPKl',
-    '_ZTIPKm',
-    '_ZTIPKs',
-    '_ZTIPKt',
-    '_ZTIPKv',
-    '_ZTIPKw',
-    '_ZTIPKx',
-    '_ZTIPKy',
-    '_ZTIPa',
-    '_ZTIPb',
-    '_ZTIPc',
-    '_ZTIPd',
-    '_ZTIPe',
-    '_ZTIPf',
-    '_ZTIPh',
-    '_ZTIPi',
-    '_ZTIPj',
-    '_ZTIPl',
-    '_ZTIPm',
-    '_ZTIPs',
-    '_ZTIPt',
-    '_ZTIPv',
-    '_ZTIPw',
-    '_ZTIPx',
-    '_ZTIPy',
-    '_ZTIa',
-    '_ZTIb',
-    '_ZTIc',
-    '_ZTId',
-    '_ZTIe',
-    '_ZTIf',
-    '_ZTIh',
-    '_ZTIi',
-    '_ZTIj',
-    '_ZTIl',
-    '_ZTIm',
-    '_ZTIs',
-    '_ZTIt',
-    '_ZTIv',
-    '_ZTIw',
-    '_ZTIx',
-    '_ZTIy',
-    '_ZTSDi',
-    '_ZTSDn',
-    '_ZTSDs',
-    '_ZTSPDi',
-    '_ZTSPDn',
-    '_ZTSPDs',
-    '_ZTSPKDi',
-    '_ZTSPKDn',
-    '_ZTSPKDs',
-    '_ZTSPKa',
-    '_ZTSPKb',
-    '_ZTSPKc',
-    '_ZTSPKd',
-    '_ZTSPKe',
-    '_ZTSPKf',
-    '_ZTSPKh',
-    '_ZTSPKi',
-    '_ZTSPKj',
-    '_ZTSPKl',
-    '_ZTSPKm',
-    '_ZTSPKs',
-    '_ZTSPKt',
-    '_ZTSPKv',
-    '_ZTSPKw',
-    '_ZTSPKx',
-    '_ZTSPKy',
-    '_ZTSPa',
-    '_ZTSPb',
-    '_ZTSPc',
-    '_ZTSPd',
-    '_ZTSPe',
-    '_ZTSPf',
-    '_ZTSPh',
-    '_ZTSPi',
-    '_ZTSPj',
-    '_ZTSPl',
-    '_ZTSPm',
-    '_ZTSPs',
-    '_ZTSPt',
-    '_ZTSPv',
-    '_ZTSPw',
-    '_ZTSPx',
-    '_ZTSPy',
-    '_ZTSa',
-    '_ZTSb',
-    '_ZTSc',
-    '_ZTSd',
-    '_ZTSe',
-    '_ZTSf',
-    '_ZTSh',
-    '_ZTSi',
-    '_ZTSj',
-    '_ZTSl',
-    '_ZTSm',
-    '_ZTSs',
-    '_ZTSt',
-    '_ZTSv',
-    '_ZTSw',
-    '_ZTSx',
-    '_ZTSy'
+    "___dynamic_cast",
+    "___gxx_personality_v0",
+    "_ZTIDi",
+    "_ZTIDn",
+    "_ZTIDs",
+    "_ZTIPDi",
+    "_ZTIPDn",
+    "_ZTIPDs",
+    "_ZTIPKDi",
+    "_ZTIPKDn",
+    "_ZTIPKDs",
+    "_ZTIPKa",
+    "_ZTIPKb",
+    "_ZTIPKc",
+    "_ZTIPKd",
+    "_ZTIPKe",
+    "_ZTIPKf",
+    "_ZTIPKh",
+    "_ZTIPKi",
+    "_ZTIPKj",
+    "_ZTIPKl",
+    "_ZTIPKm",
+    "_ZTIPKs",
+    "_ZTIPKt",
+    "_ZTIPKv",
+    "_ZTIPKw",
+    "_ZTIPKx",
+    "_ZTIPKy",
+    "_ZTIPa",
+    "_ZTIPb",
+    "_ZTIPc",
+    "_ZTIPd",
+    "_ZTIPe",
+    "_ZTIPf",
+    "_ZTIPh",
+    "_ZTIPi",
+    "_ZTIPj",
+    "_ZTIPl",
+    "_ZTIPm",
+    "_ZTIPs",
+    "_ZTIPt",
+    "_ZTIPv",
+    "_ZTIPw",
+    "_ZTIPx",
+    "_ZTIPy",
+    "_ZTIa",
+    "_ZTIb",
+    "_ZTIc",
+    "_ZTId",
+    "_ZTIe",
+    "_ZTIf",
+    "_ZTIh",
+    "_ZTIi",
+    "_ZTIj",
+    "_ZTIl",
+    "_ZTIm",
+    "_ZTIs",
+    "_ZTIt",
+    "_ZTIv",
+    "_ZTIw",
+    "_ZTIx",
+    "_ZTIy",
+    "_ZTSDi",
+    "_ZTSDn",
+    "_ZTSDs",
+    "_ZTSPDi",
+    "_ZTSPDn",
+    "_ZTSPDs",
+    "_ZTSPKDi",
+    "_ZTSPKDn",
+    "_ZTSPKDs",
+    "_ZTSPKa",
+    "_ZTSPKb",
+    "_ZTSPKc",
+    "_ZTSPKd",
+    "_ZTSPKe",
+    "_ZTSPKf",
+    "_ZTSPKh",
+    "_ZTSPKi",
+    "_ZTSPKj",
+    "_ZTSPKl",
+    "_ZTSPKm",
+    "_ZTSPKs",
+    "_ZTSPKt",
+    "_ZTSPKv",
+    "_ZTSPKw",
+    "_ZTSPKx",
+    "_ZTSPKy",
+    "_ZTSPa",
+    "_ZTSPb",
+    "_ZTSPc",
+    "_ZTSPd",
+    "_ZTSPe",
+    "_ZTSPf",
+    "_ZTSPh",
+    "_ZTSPi",
+    "_ZTSPj",
+    "_ZTSPl",
+    "_ZTSPm",
+    "_ZTSPs",
+    "_ZTSPt",
+    "_ZTSPv",
+    "_ZTSPw",
+    "_ZTSPx",
+    "_ZTSPy",
+    "_ZTSa",
+    "_ZTSb",
+    "_ZTSc",
+    "_ZTSd",
+    "_ZTSe",
+    "_ZTSf",
+    "_ZTSh",
+    "_ZTSi",
+    "_ZTSj",
+    "_ZTSl",
+    "_ZTSm",
+    "_ZTSs",
+    "_ZTSt",
+    "_ZTSv",
+    "_ZTSw",
+    "_ZTSx",
+    "_ZTSy",
 ]
+
 
 def is_stdlib_symbol_name(name, sym):
     name = adjust_mangled_name(name)
     if re.search("@GLIBC|@GCC", name):
         # Only when symbol is defined do we consider it ours
-        return sym['is_defined']
-    if re.search('(St[0-9])|(__cxa)|(__cxxabi)', name):
+        return sym["is_defined"]
+    if re.search("(St[0-9])|(__cxa)|(__cxxabi)", name):
         return True
     if name in new_delete_std_symbols:
         return True
     if name in cxxabi_symbols:
         return True
-    if name.startswith('_Z'):
+    if name.startswith("_Z"):
         return True
     return False
+
 
 def filter_stdlib_symbols(syms):
     stdlib_symbols = []
     other_symbols = []
     for s in syms:
-        canon_name = adjust_mangled_name(s['name'])
+        canon_name = adjust_mangled_name(s["name"])
         if not is_stdlib_symbol_name(canon_name, s):
             other_symbols += [s]
         else:

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -1,15 +1,13 @@
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 
-import locale
 import os
 import platform
-import pkgutil
 import pipes
 import re
 import shlex
@@ -23,22 +21,24 @@ from libcudacxx.test.executor import *
 from libcudacxx.test.tracing import *
 import libcudacxx.util
 
+
 def loadSiteConfig(lit_config, config, param_name, env_name):
     # We haven't loaded the site specific configuration (the user is
     # probably trying to run on a test file directly, and either the site
     # configuration hasn't been created by the build system, or we are in an
     # out-of-tree build situation).
-    site_cfg = lit_config.params.get(param_name,
-                                     os.environ.get(env_name))
+    site_cfg = lit_config.params.get(param_name, os.environ.get(env_name))
     if not site_cfg:
-        lit_config.warning('No site specific configuration file found!'
-                           ' Running the tests in the default configuration.')
+        lit_config.warning(
+            "No site specific configuration file found!"
+            " Running the tests in the default configuration."
+        )
     elif not os.path.isfile(site_cfg):
         lit_config.fatal(
-            "Specified site configuration file does not exist: '%s'" %
-            site_cfg)
+            "Specified site configuration file does not exist: '%s'" % site_cfg
+        )
     else:
-        lit_config.note('using site specific configuration at %s' % site_cfg)
+        lit_config.note("using site specific configuration at %s" % site_cfg)
         ld_fn = lit_config.load_config
 
         # Null out the load_config function so that lit.site.cfg doesn't
@@ -46,21 +46,24 @@ def loadSiteConfig(lit_config, config, param_name, env_name):
         # TODO: This is one hell of a hack. Fix it.
         def prevent_reload_fn(*args, **kwargs):
             pass
+
         lit_config.load_config = prevent_reload_fn
         ld_fn(config, site_cfg)
         lit_config.load_config = ld_fn
 
+
 # Extract the value of a numeric macro such as __cplusplus or a feature-test
 # macro.
 def intMacroValue(token):
-    return int(token.rstrip('LlUu'))
+    return int(token.rstrip("LlUu"))
+
 
 class Configuration(object):
     # pylint: disable=redefined-outer-name
     def __init__(self, lit_config, config):
         self.lit_config = lit_config
         self.config = config
-        self.is_windows = platform.system() == 'Windows'
+        self.is_windows = platform.system() == "Windows"
         self.cxx = None
         self.cxx_is_clang_cl = None
         self.cxx_stdlib_under_test = None
@@ -70,8 +73,8 @@ class Configuration(object):
         self.cxx_library_root = None
         self.cxx_runtime_root = None
         self.abi_library_root = None
-        self.link_shared = self.get_lit_bool('enable_shared', default=True)
-        self.debug_build = self.get_lit_bool('debug_build',   default=False)
+        self.link_shared = self.get_lit_bool("enable_shared", default=True)
+        self.debug_build = self.get_lit_bool("debug_build", default=False)
         self.exec_env = dict(os.environ)
         self.use_target = False
         self.use_system_cxx_lib = False
@@ -94,28 +97,33 @@ class Configuration(object):
             if isinstance(value, bool):
                 return value
             if not isinstance(value, str):
-                raise TypeError('expected bool or string')
-            if value.lower() in ('1', 'true'):
+                raise TypeError("expected bool or string")
+            if value.lower() in ("1", "true"):
                 return True
-            if value.lower() in ('', '0', 'false'):
+            if value.lower() in ("", "0", "false"):
                 return False
             self.lit_config.fatal(
-                "parameter '{}' should be true or false".format(var_name))
+                "parameter '{}' should be true or false".format(var_name)
+            )
 
         conf_val = self.get_lit_conf(name)
-        if env_var is not None and env_var in os.environ and \
-                os.environ[env_var] is not None:
+        if (
+            env_var is not None
+            and env_var in os.environ
+            and os.environ[env_var] is not None
+        ):
             val = os.environ[env_var]
             if conf_val is not None:
                 self.lit_config.warning(
-                    'Environment variable %s=%s is overriding explicit '
-                    '--param=%s=%s' % (env_var, val, name, conf_val))
+                    "Environment variable %s=%s is overriding explicit "
+                    "--param=%s=%s" % (env_var, val, name, conf_val)
+                )
             return check_value(val, env_var)
         return check_value(conf_val, name)
 
     def get_compute_capabilities(self):
         deduced_compute_archs = []
-        libnames = ('libcuda.so', 'libcuda.dylib', 'nvcuda.dll', 'cuda.dll')
+        libnames = ("libcuda.so", "libcuda.dylib", "nvcuda.dll", "cuda.dll")
         for libname in libnames:
             try:
                 cuda = ctypes.CDLL(libname)
@@ -124,56 +132,77 @@ class Configuration(object):
             else:
                 break
         else:
-            raise OSError("could not load any of: " + ' '.join(libnames))
+            raise OSError("could not load any of: " + " ".join(libnames))
 
-        self.lit_config.note("compute_archs set to \"native\", computing available archs")
+        self.lit_config.note('compute_archs set to "native", computing available archs')
         CUDA_SUCCESS = 0
-        nGpus    = ctypes.c_int()
+        nGpus = ctypes.c_int()
         cc_major = ctypes.c_int()
         cc_minor = ctypes.c_int()
 
-        result   = ctypes.c_int()
-        device   = ctypes.c_int()
+        result = ctypes.c_int()
+        device = ctypes.c_int()
         error_str = ctypes.c_char_p()
 
         result = cuda.cuInit(0)
         if result != CUDA_SUCCESS:
             cuda.cuGetErrorString(result, ctypes.byref(error_str))
-            self.lit_config.note("cuInit failed with error code %d: %s" % (result, error_str.value.decode()))
-            return 'native'
+            self.lit_config.note(
+                "cuInit failed with error code %d: %s"
+                % (result, error_str.value.decode())
+            )
+            return "native"
 
         result = cuda.cuDeviceGetCount(ctypes.byref(nGpus))
         if result != CUDA_SUCCESS:
             cuda.cuGetErrorString(result, ctypes.byref(error_str))
-            self.lit_config.note("cuDeviceGetCount failed with error code %d: %s" % (result, error_str.value.decode()))
-            return 'native'
+            self.lit_config.note(
+                "cuDeviceGetCount failed with error code %d: %s"
+                % (result, error_str.value.decode())
+            )
+            return "native"
         self.lit_config.note("Found %d device(s)." % nGpus.value)
         for i in range(nGpus.value):
             result = cuda.cuDeviceGet(ctypes.byref(device), i)
             if result != CUDA_SUCCESS:
                 cuda.cuGetErrorString(result, ctypes.byref(error_str))
-                self.lit_config.note("cuDeviceGet failed with error code %d: %s" % (result, error_str.value.decode()))
-                return 'native'
-            if cuda.cuDeviceComputeCapability(ctypes.byref(cc_major), ctypes.byref(cc_minor), device) == CUDA_SUCCESS:
-                self.lit_config.note("Deduced compute capability of device %d to: %d%d" % ( i + 1, cc_major.value, cc_minor.value))
+                self.lit_config.note(
+                    "cuDeviceGet failed with error code %d: %s"
+                    % (result, error_str.value.decode())
+                )
+                return "native"
+            if (
+                cuda.cuDeviceComputeCapability(
+                    ctypes.byref(cc_major), ctypes.byref(cc_minor), device
+                )
+                == CUDA_SUCCESS
+            ):
+                self.lit_config.note(
+                    "Deduced compute capability of device %d to: %d%d"
+                    % (i + 1, cc_major.value, cc_minor.value)
+                )
                 deduced_compute_archs.append(cc_major.value * 10 + cc_minor.value)
 
-        self.lit_config.note("Deduced compute capabilities are: %s" % deduced_compute_archs)
-        deduced_comput_archs_str = ', '.join([str(element) for element in deduced_compute_archs])
+        self.lit_config.note(
+            "Deduced compute capabilities are: %s" % deduced_compute_archs
+        )
+        deduced_comput_archs_str = ", ".join(
+            [str(element) for element in deduced_compute_archs]
+        )
         return deduced_comput_archs_str
 
     def get_modules_enabled(self):
-        return self.get_lit_bool('enable_modules',
-                                default=False,
-                                env_var='LIBCUDACXX_ENABLE_MODULES')
+        return self.get_lit_bool(
+            "enable_modules", default=False, env_var="LIBCUDACXX_ENABLE_MODULES"
+        )
 
     def make_static_lib_name(self, name):
         """Return the full filename for the specified library name"""
         if self.is_windows:
-            assert name == 'c++'  # Only allow libc++ to use this function for now.
-            return 'lib' + name + '.lib'
+            assert name == "c++"  # Only allow libc++ to use this function for now.
+            return "lib" + name + ".lib"
         else:
-            return 'lib' + name + '.a'
+            return "lib" + name + ".a"
 
     def configure(self):
         self.configure_executor()
@@ -196,50 +225,53 @@ class Configuration(object):
         self.configure_link_flags()
         self.configure_env()
         self.configure_color_diagnostics()
-        if (self.cxx.type != 'nvrtcc'):
-          self.configure_debug_mode()
-          self.configure_warnings()
-          self.configure_sanitizer()
-          self.configure_coverage()
-          self.configure_modules()
-          self.configure_coroutines()
-          self.configure_substitutions()
-          self.configure_features()
+        if self.cxx.type != "nvrtcc":
+            self.configure_debug_mode()
+            self.configure_warnings()
+            self.configure_sanitizer()
+            self.configure_coverage()
+            self.configure_modules()
+            self.configure_coroutines()
+            self.configure_substitutions()
+            self.configure_features()
 
     def print_config_info(self):
         # Print the final compile and link flags.
-        self.lit_config.note('Using compiler: %s %s' % (self.cxx.path, self.cxx.first_arg))
-        self.lit_config.note('Using flags: %s' % self.cxx.flags)
+        self.lit_config.note(
+            "Using compiler: %s %s" % (self.cxx.path, self.cxx.first_arg)
+        )
+        self.lit_config.note("Using flags: %s" % self.cxx.flags)
         if self.cxx.use_modules:
-            self.lit_config.note('Using modules flags: %s' %
-                                 self.cxx.modules_flags)
-        self.lit_config.note('Using compile flags: %s'
-                             % self.cxx.compile_flags)
+            self.lit_config.note("Using modules flags: %s" % self.cxx.modules_flags)
+        self.lit_config.note("Using compile flags: %s" % self.cxx.compile_flags)
         if len(self.cxx.warning_flags):
-            self.lit_config.note('Using warnings: %s' % self.cxx.warning_flags)
-        self.lit_config.note('Using link flags: %s' % self.cxx.link_flags)
+            self.lit_config.note("Using warnings: %s" % self.cxx.warning_flags)
+        self.lit_config.note("Using link flags: %s" % self.cxx.link_flags)
         # Print as list to prevent "set([...])" from being printed.
-        self.lit_config.note('Using available_features: %s' %
-                             list(self.config.available_features))
+        self.lit_config.note(
+            "Using available_features: %s" % list(self.config.available_features)
+        )
         show_env_vars = {}
-        for k,v in self.exec_env.items():
+        for k, v in self.exec_env.items():
             if k not in os.environ or os.environ[k] != v:
                 show_env_vars[k] = v
-        self.lit_config.note('Adding environment variables: %r' % show_env_vars)
+        self.lit_config.note("Adding environment variables: %r" % show_env_vars)
         sys.stderr.flush()  # Force flushing to avoid broken output on Windows
 
     def get_test_format(self):
         from libcudacxx.test.format import LibcxxTestFormat
+
         return LibcxxTestFormat(
             self.cxx,
             self.use_clang_verify,
             self.execute_external,
             self.executor,
-            exec_env=self.exec_env)
+            exec_env=self.exec_env,
+        )
 
     def configure_executor(self):
-        exec_str = self.get_lit_conf('executor', "None")
-        exec_timeout = self.get_lit_conf('maxIndividualTestTime', "None")
+        exec_str = self.get_lit_conf("executor", "None")
+        exec_timeout = self.get_lit_conf("maxIndividualTestTime", "None")
         te = eval(exec_str)
         if te:
             self.lit_config.note("Using executor: %r" % exec_str)
@@ -248,8 +280,9 @@ class Configuration(object):
                 # ValgrindExecutor is supposed to go. It is likely
                 # that the user wants it at the end, but we have no
                 # way of getting at that easily.
-                selt.lit_config.fatal("Cannot infer how to create a Valgrind "
-                                      " executor.")
+                selt.lit_config.fatal(
+                    "Cannot infer how to create a Valgrind " " executor."
+                )
         else:
             te = LocalExecutor()
             te.timeout = 0
@@ -264,12 +297,13 @@ class Configuration(object):
 
     def configure_cxx(self):
         # Gather various compiler parameters.
-        cxx = self.get_lit_conf('cxx_under_test')
-        cxx_first_arg = self.get_lit_conf('cxx_first_arg')
-        nvrtc = self.get_lit_bool('is_nvrtc', False)
+        cxx = self.get_lit_conf("cxx_under_test")
+        cxx_first_arg = self.get_lit_conf("cxx_first_arg")
+        nvrtc = self.get_lit_bool("is_nvrtc", False)
 
-        self.cxx_is_clang_cl = cxx is not None and \
-                               os.path.basename(cxx) == 'clang-cl.exe'
+        self.cxx_is_clang_cl = (
+            cxx is not None and os.path.basename(cxx) == "clang-cl.exe"
+        )
 
         ## Build CXXCompiler manually for NVRTCC
         if nvrtc is True:
@@ -278,43 +312,47 @@ class Configuration(object):
                 path=cxx,
                 first_arg=cxx_first_arg,
                 cxx_type=cxx_type,
-                cxx_version=('1', '1', '1'))
+                cxx_version=("1", "1", "1"),
+            )
 
             self.cxx.default_dialect = "c++11"
-            self.cxx.source_lang = 'cu'
+            self.cxx.source_lang = "cu"
             maj_v, min_v, patch_v = self.cxx.version
             self.config.available_features.add("nvrtc")
-            self.config.available_features.add('%s-%s' % (self.cxx.type, maj_v))
-            self.config.available_features.add('%s-%s.%s' % (
-                self.cxx.type, maj_v, min_v))
-            self.config.available_features.add('%s-%s.%s.%s' % (
-                self.cxx.type, maj_v, min_v, patch_v))
-            self.lit_config.note("detected cxx.type as: {}".format(
-                                self.cxx.type))
-            self.lit_config.note("detected cxx.version as: {}".format(
-                                self.cxx.version))
-            self.lit_config.note("detected cxx.default_dialect as: {}".format(
-                                self.cxx.default_dialect))
+            self.config.available_features.add("%s-%s" % (self.cxx.type, maj_v))
+            self.config.available_features.add(
+                "%s-%s.%s" % (self.cxx.type, maj_v, min_v)
+            )
+            self.config.available_features.add(
+                "%s-%s.%s.%s" % (self.cxx.type, maj_v, min_v, patch_v)
+            )
+            self.lit_config.note("detected cxx.type as: {}".format(self.cxx.type))
+            self.lit_config.note("detected cxx.version as: {}".format(self.cxx.version))
+            self.lit_config.note(
+                "detected cxx.default_dialect as: {}".format(self.cxx.default_dialect)
+            )
             self.cxx.compile_env = dict(os.environ)
         # If compiler is *not* NVRTCC
         else:
             # If no specific cxx_under_test was given, attempt to infer it as
             # clang++.
             if cxx is None or self.cxx_is_clang_cl:
-                search_paths = self.config.environment['PATH']
+                search_paths = self.config.environment["PATH"]
                 if cxx is not None and os.path.isabs(cxx):
                     search_paths = os.path.dirname(cxx)
-                clangxx = libcudacxx.util.which('clang++', search_paths)
+                clangxx = libcudacxx.util.which("clang++", search_paths)
                 if clangxx:
                     cxx = clangxx
-                    self.lit_config.note(
-                        "inferred cxx_under_test as: %r" % cxx)
+                    self.lit_config.note("inferred cxx_under_test as: %r" % cxx)
                 elif self.cxx_is_clang_cl:
-                    self.lit_config.fatal('Failed to find clang++ substitution for'
-                                          ' clang-cl')
+                    self.lit_config.fatal(
+                        "Failed to find clang++ substitution for" " clang-cl"
+                    )
             if not cxx:
-                self.lit_config.fatal('must specify user parameter cxx_under_test '
-                                      '(e.g., --param=cxx_under_test=clang++)')
+                self.lit_config.fatal(
+                    "must specify user parameter cxx_under_test "
+                    "(e.g., --param=cxx_under_test=clang++)"
+                )
             if self.cxx_is_clang_cl:
                 self.cxx = self._configure_clang_cl(cxx)
             else:
@@ -322,39 +360,40 @@ class Configuration(object):
                     cxx,
                     cxx_first_arg,
                     compile_flags=self.get_lit_conf("cmake_cxx_flags"),
-                    cuda_path= self.get_lit_conf('cuda_path'),
+                    cuda_path=self.get_lit_conf("cuda_path"),
                 )
             cxx_type = self.cxx.type
             if cxx_type is not None:
                 assert self.cxx.version is not None
                 maj_v, min_v, patch_v = self.cxx.version
                 self.config.available_features.add(cxx_type)
-                self.config.available_features.add('%s-%s' % (cxx_type, maj_v))
-                self.config.available_features.add('%s-%s.%s' % (
-                    cxx_type, maj_v, min_v))
-                self.config.available_features.add('%s-%s.%s.%s' % (
-                    cxx_type, maj_v, min_v, patch_v))
-            self.lit_config.note("detected cxx.type as: {}".format(
-                                 self.cxx.type))
-            self.lit_config.note("detected cxx.version as: {}".format(
-                                 self.cxx.version))
-            self.lit_config.note("detected cxx.default_dialect as: {}".format(
-                                 self.cxx.default_dialect))
+                self.config.available_features.add("%s-%s" % (cxx_type, maj_v))
+                self.config.available_features.add(
+                    "%s-%s.%s" % (cxx_type, maj_v, min_v)
+                )
+                self.config.available_features.add(
+                    "%s-%s.%s.%s" % (cxx_type, maj_v, min_v, patch_v)
+                )
+            self.lit_config.note("detected cxx.type as: {}".format(self.cxx.type))
+            self.lit_config.note("detected cxx.version as: {}".format(self.cxx.version))
+            self.lit_config.note(
+                "detected cxx.default_dialect as: {}".format(self.cxx.default_dialect)
+            )
             self.cxx.compile_env = dict(os.environ)
             # 'CCACHE_CPP2' prevents ccache from stripping comments while
             # preprocessing. This is required to prevent stripping of '-verify'
             # comments.
-            self.cxx.compile_env['CCACHE_CPP2'] = '1'
+            self.cxx.compile_env["CCACHE_CPP2"] = "1"
 
-            if self.cxx.type == 'nvcc':
-                nvcc_host_compiler = self.get_lit_conf('nvcc_host_compiler')
+            if self.cxx.type == "nvcc":
+                nvcc_host_compiler = self.get_lit_conf("nvcc_host_compiler")
                 if len(nvcc_host_compiler.strip()) == 0:
-                    if platform.system() == 'Darwin':
-                        nvcc_host_compiler = 'clang'
-                    elif platform.system() == 'Windows':
-                        nvcc_host_compiler = 'cl.exe'
+                    if platform.system() == "Darwin":
+                        nvcc_host_compiler = "clang"
+                    elif platform.system() == "Windows":
+                        nvcc_host_compiler = "cl.exe"
                     else:
-                        nvcc_host_compiler = 'gcc'
+                        nvcc_host_compiler = "gcc"
 
                 self.host_cxx = CXXCompiler(nvcc_host_compiler, None)
                 self.host_cxx_type = self.host_cxx.type
@@ -362,41 +401,51 @@ class Configuration(object):
                     assert self.host_cxx.version is not None
                     maj_v, min_v, _ = self.host_cxx.version
                     self.config.available_features.add(self.host_cxx_type)
-                    self.config.available_features.add('%s-%s' % (
-                        self.host_cxx_type, maj_v))
-                    self.config.available_features.add('%s-%s.%s' % (
-                        self.host_cxx_type, maj_v, min_v))
-                self.lit_config.note("detected host_cxx.type as: {}".format(
-                                      self.host_cxx.type))
-                self.lit_config.note("detected host_cxx.version as: {}".format(
-                                      self.host_cxx.version))
-                self.lit_config.note("detected host_cxx.default_dialect as: {}".format(
-                                      self.host_cxx.default_dialect))
+                    self.config.available_features.add(
+                        "%s-%s" % (self.host_cxx_type, maj_v)
+                    )
+                    self.config.available_features.add(
+                        "%s-%s.%s" % (self.host_cxx_type, maj_v, min_v)
+                    )
+                self.lit_config.note(
+                    "detected host_cxx.type as: {}".format(self.host_cxx.type)
+                )
+                self.lit_config.note(
+                    "detected host_cxx.version as: {}".format(self.host_cxx.version)
+                )
+                self.lit_config.note(
+                    "detected host_cxx.default_dialect as: {}".format(
+                        self.host_cxx.default_dialect
+                    )
+                )
 
-            if 'icc' in self.config.available_features:
-                self.cxx.link_flags += ['-lirc']
-                self.cxx.compile_flags += ['-Xcompiler=-diag-disable=10441']
+            if "icc" in self.config.available_features:
+                self.cxx.link_flags += ["-lirc"]
+                self.cxx.compile_flags += ["-Xcompiler=-diag-disable=10441"]
 
     def _configure_clang_cl(self, clang_path):
         def _split_env_var(var):
-            return [p.strip() for p in os.environ.get(var, '').split(';') if p.strip()]
+            return [p.strip() for p in os.environ.get(var, "").split(";") if p.strip()]
 
         def _prefixed_env_list(var, prefix):
             from itertools import chain
-            return list(chain.from_iterable((prefix, path) for path in _split_env_var(var)))
+
+            return list(
+                chain.from_iterable((prefix, path) for path in _split_env_var(var))
+            )
 
         assert self.cxx_is_clang_cl
         flags = []
-        compile_flags = _prefixed_env_list('INCLUDE', '-isystem')
-        link_flags = _prefixed_env_list('LIB', '-L')
-        for path in _split_env_var('LIB'):
+        compile_flags = _prefixed_env_list("INCLUDE", "-isystem")
+        link_flags = _prefixed_env_list("LIB", "-L")
+        for path in _split_env_var("LIB"):
             self.add_path(self.exec_env, path)
-        return CXXCompiler(clang_path, flags=flags,
-                           compile_flags=compile_flags,
-                           link_flags=link_flags)
+        return CXXCompiler(
+            clang_path, flags=flags, compile_flags=compile_flags, link_flags=link_flags
+        )
 
     def _dump_macros_verbose(self, *args, **kwargs):
-        if (self.cxx.type == 'nvrtcc'):
+        if self.cxx.type == "nvrtcc":
             return None
         macros_or_error = self.cxx.dumpMacros(*args, **kwargs)
         if isinstance(macros_or_error, tuple):
@@ -410,16 +459,17 @@ class Configuration(object):
 
     def configure_src_root(self):
         self.libcudacxx_src_root = self.get_lit_conf(
-            'libcudacxx_src_root', os.path.dirname(self.config.test_source_root))
+            "libcudacxx_src_root", os.path.dirname(self.config.test_source_root)
+        )
 
     def configure_obj_root(self):
-        self.project_obj_root = self.get_lit_conf('project_obj_root')
-        self.libcudacxx_obj_root = self.get_lit_conf('libcudacxx_obj_root')
+        self.project_obj_root = self.get_lit_conf("project_obj_root")
+        self.libcudacxx_obj_root = self.get_lit_conf("libcudacxx_obj_root")
         if not self.libcudacxx_obj_root and self.project_obj_root is not None:
             possible_roots = [
-                os.path.join(self.project_obj_root, 'libcudacxx'),
-                os.path.join(self.project_obj_root, 'projects', 'libcudacxx'),
-                os.path.join(self.project_obj_root, 'runtimes', 'libcudacxx'),
+                os.path.join(self.project_obj_root, "libcudacxx"),
+                os.path.join(self.project_obj_root, "projects", "libcudacxx"),
+                os.path.join(self.project_obj_root, "runtimes", "libcudacxx"),
             ]
             for possible_root in possible_roots:
                 if os.path.isdir(possible_root):
@@ -429,10 +479,12 @@ class Configuration(object):
                 self.libcudacxx_obj_root = self.project_obj_root
 
     def configure_cxx_library_root(self):
-        self.cxx_library_root = self.get_lit_conf('cxx_library_root',
-                                                  self.libcudacxx_obj_root)
-        self.cxx_runtime_root = self.get_lit_conf('cxx_runtime_root',
-                                                   self.cxx_library_root)
+        self.cxx_library_root = self.get_lit_conf(
+            "cxx_library_root", self.libcudacxx_obj_root
+        )
+        self.cxx_runtime_root = self.get_lit_conf(
+            "cxx_runtime_root", self.cxx_library_root
+        )
 
     def configure_use_system_cxx_lib(self):
         # This test suite supports testing against either the system library or
@@ -440,92 +492,102 @@ class Configuration(object):
         # compatibility between the current headers and a shipping dynamic
         # library.
         # Default to testing against the locally built libc++ library.
-        self.use_system_cxx_lib = self.get_lit_conf('use_system_cxx_lib')
-        if self.use_system_cxx_lib == 'true':
+        self.use_system_cxx_lib = self.get_lit_conf("use_system_cxx_lib")
+        if self.use_system_cxx_lib == "true":
             self.use_system_cxx_lib = True
-        elif self.use_system_cxx_lib == 'false':
+        elif self.use_system_cxx_lib == "false":
             self.use_system_cxx_lib = False
         elif self.use_system_cxx_lib:
-            assert os.path.isdir(self.use_system_cxx_lib), "the specified use_system_cxx_lib parameter (%s) is not a valid directory" % self.use_system_cxx_lib
+            assert os.path.isdir(self.use_system_cxx_lib), (
+                "the specified use_system_cxx_lib parameter (%s) is not a valid directory"
+                % self.use_system_cxx_lib
+            )
             self.use_system_cxx_lib = os.path.abspath(self.use_system_cxx_lib)
         self.lit_config.note(
-            "inferred use_system_cxx_lib as: %r" % self.use_system_cxx_lib)
+            "inferred use_system_cxx_lib as: %r" % self.use_system_cxx_lib
+        )
 
     def configure_cxx_stdlib_under_test(self):
         self.cxx_stdlib_under_test = self.get_lit_conf(
-            'cxx_stdlib_under_test', 'libc++')
-        if self.cxx_stdlib_under_test not in \
-                ['libc++', 'libstdc++', 'msvc', 'cxx_default']:
+            "cxx_stdlib_under_test", "libc++"
+        )
+        if self.cxx_stdlib_under_test not in [
+            "libc++",
+            "libstdc++",
+            "msvc",
+            "cxx_default",
+        ]:
             self.lit_config.fatal(
                 'unsupported value for "cxx_stdlib_under_test": %s'
-                % self.cxx_stdlib_under_test)
+                % self.cxx_stdlib_under_test
+            )
         self.config.available_features.add(self.cxx_stdlib_under_test)
-        if self.cxx_stdlib_under_test == 'libstdc++':
-            self.config.available_features.add('libstdc++')
+        if self.cxx_stdlib_under_test == "libstdc++":
+            self.config.available_features.add("libstdc++")
             # Manually enable the experimental and filesystem tests for libstdc++
             # if the options aren't present.
             # FIXME this is a hack.
-            if self.get_lit_conf('enable_experimental') is None:
-                self.config.enable_experimental = 'true'
+            if self.get_lit_conf("enable_experimental") is None:
+                self.config.enable_experimental = "true"
 
     def configure_use_clang_verify(self):
-        if self.cxx.type == 'nvrtcc':
+        if self.cxx.type == "nvrtcc":
             return
-        '''If set, run clang with -verify on failing tests.'''
-        self.use_clang_verify = self.get_lit_bool('use_clang_verify')
+        """If set, run clang with -verify on failing tests."""
+        self.use_clang_verify = self.get_lit_bool("use_clang_verify")
         if self.use_clang_verify is None:
             # NOTE: We do not test for the -verify flag directly because
             #   -verify will always exit with non-zero on an empty file.
             self.use_clang_verify = self.cxx.isVerifySupported()
             self.lit_config.note(
-                "inferred use_clang_verify as: %r" % self.use_clang_verify)
+                "inferred use_clang_verify as: %r" % self.use_clang_verify
+            )
         if self.use_clang_verify:
-                self.config.available_features.add('verify-support')
+            self.config.available_features.add("verify-support")
 
     def configure_use_thread_safety(self):
-        '''If set, run clang with -verify on failing tests.'''
-        has_thread_safety = self.cxx.hasCompileFlag('-Werror=thread-safety')
+        """If set, run clang with -verify on failing tests."""
+        has_thread_safety = self.cxx.hasCompileFlag("-Werror=thread-safety")
         if has_thread_safety:
-            self.cxx.compile_flags += ['-Werror=thread-safety']
-            self.config.available_features.add('thread-safety')
+            self.cxx.compile_flags += ["-Werror=thread-safety"]
+            self.config.available_features.add("thread-safety")
             self.lit_config.note("enabling thread-safety annotations")
 
     def configure_execute_external(self):
         # Choose between lit's internal shell pipeline runner and a real shell.
         # If LIT_USE_INTERNAL_SHELL is in the environment, we use that as the
         # default value. Otherwise we ask the target_info.
-        use_lit_shell_default = os.environ.get('LIT_USE_INTERNAL_SHELL')
+        use_lit_shell_default = os.environ.get("LIT_USE_INTERNAL_SHELL")
         if use_lit_shell_default is not None:
-            use_lit_shell_default = use_lit_shell_default != '0'
+            use_lit_shell_default = use_lit_shell_default != "0"
         else:
             use_lit_shell_default = self.target_info.use_lit_shell_default()
         # Check for the command line parameter using the default value if it is
         # not present.
-        use_lit_shell = self.get_lit_bool('use_lit_shell',
-                                          use_lit_shell_default)
+        use_lit_shell = self.get_lit_bool("use_lit_shell", use_lit_shell_default)
         self.execute_external = not use_lit_shell
 
     def configure_no_execute(self):
         if type(self.executor) == NoopExecutor:
-            self.config.available_features.add('no_execute')
+            self.config.available_features.add("no_execute")
 
     def configure_ccache(self):
-        use_ccache_default = os.environ.get('CMAKE_CUDA_COMPILER_LAUNCHER') is not None
-        use_ccache = self.get_lit_bool('use_ccache', use_ccache_default)
-        if use_ccache and not self.cxx.type == 'nvrtcc':
+        use_ccache_default = os.environ.get("CMAKE_CUDA_COMPILER_LAUNCHER") is not None
+        use_ccache = self.get_lit_bool("use_ccache", use_ccache_default)
+        if use_ccache and not self.cxx.type == "nvrtcc":
             self.cxx.use_ccache = True
-            self.lit_config.note('enabling ccache')
+            self.lit_config.note("enabling ccache")
 
     def add_deployment_feature(self, feature):
         (arch, name, version) = self.config.deployment
-        self.config.available_features.add('%s=%s-%s' % (feature, arch, name))
-        self.config.available_features.add('%s=%s' % (feature, name))
-        self.config.available_features.add('%s=%s%s' % (feature, name, version))
+        self.config.available_features.add("%s=%s-%s" % (feature, arch, name))
+        self.config.available_features.add("%s=%s" % (feature, name))
+        self.config.available_features.add("%s=%s%s" % (feature, name, version))
 
     def configure_features(self):
-        additional_features = self.get_lit_conf('additional_features')
+        additional_features = self.get_lit_conf("additional_features")
         if additional_features:
-            for f in additional_features.split(','):
+            for f in additional_features.split(","):
                 self.config.available_features.add(f.strip())
         self.target_info.add_locale_features(self.config.available_features)
 
@@ -536,145 +598,149 @@ class Configuration(object):
         # XFAIL markers for tests that are known to fail with versions of
         # libc++ as were shipped with a particular triple.
         if self.use_system_cxx_lib:
-            self.config.available_features.add('with_system_cxx_lib')
+            self.config.available_features.add("with_system_cxx_lib")
             self.config.available_features.add(
-                'with_system_cxx_lib=%s' % self.config.target_triple)
+                "with_system_cxx_lib=%s" % self.config.target_triple
+            )
 
             # Add subcomponents individually.
-            target_components = self.config.target_triple.split('-')
+            target_components = self.config.target_triple.split("-")
             for component in target_components:
-                self.config.available_features.add(
-                    'with_system_cxx_lib=%s' % component)
+                self.config.available_features.add("with_system_cxx_lib=%s" % component)
 
             # Add available features for more generic versions of the target
             # triple attached to  with_system_cxx_lib.
             if self.use_deployment:
-                self.add_deployment_feature('with_system_cxx_lib')
+                self.add_deployment_feature("with_system_cxx_lib")
 
         # Configure the availability feature. Availability is only enabled
         # with libc++, because other standard libraries do not provide
         # availability markup.
-        if self.use_deployment and self.cxx_stdlib_under_test == 'libc++':
-            self.config.available_features.add('availability')
-            self.add_deployment_feature('availability')
+        if self.use_deployment and self.cxx_stdlib_under_test == "libc++":
+            self.config.available_features.add("availability")
+            self.add_deployment_feature("availability")
 
-        if platform.system() == 'Darwin':
-            self.config.available_features.add('apple-darwin')
+        if platform.system() == "Darwin":
+            self.config.available_features.add("apple-darwin")
 
         # Insert the platform name into the available features as a lower case.
         self.config.available_features.add(target_platform)
 
         # Simulator testing can take a really long time for some of these tests
         # so add a feature check so we can REQUIRES: long_tests in them
-        self.long_tests = self.get_lit_bool('long_tests')
+        self.long_tests = self.get_lit_bool("long_tests")
         if self.long_tests is None:
             # Default to running long tests.
             self.long_tests = True
-            self.lit_config.note(
-                "inferred long_tests as: %r" % self.long_tests)
+            self.lit_config.note("inferred long_tests as: %r" % self.long_tests)
 
         if self.long_tests:
-            self.config.available_features.add('long_tests')
+            self.config.available_features.add("long_tests")
 
-        if not self.get_lit_bool('enable_filesystem', default=True):
-            self.config.available_features.add('c++filesystem-disabled')
-            self.config.available_features.add('dylib-has-no-filesystem')
-
+        if not self.get_lit_bool("enable_filesystem", default=True):
+            self.config.available_features.add("c++filesystem-disabled")
+            self.config.available_features.add("dylib-has-no-filesystem")
 
         # Run a compile test for the -fsized-deallocation flag. This is needed
         # in test/std/language.support/support.dynamic/new.delete
-        if self.cxx.hasCompileFlag('-fsized-deallocation'):
-            self.config.available_features.add('-fsized-deallocation')
+        if self.cxx.hasCompileFlag("-fsized-deallocation"):
+            self.config.available_features.add("-fsized-deallocation")
 
-        if self.cxx.hasCompileFlag('-faligned-allocation'):
-            self.config.available_features.add('-faligned-allocation')
+        if self.cxx.hasCompileFlag("-faligned-allocation"):
+            self.config.available_features.add("-faligned-allocation")
         else:
             # FIXME remove this once more than just clang-4.0 support
             # C++17 aligned allocation.
-            self.config.available_features.add('no-aligned-allocation')
+            self.config.available_features.add("no-aligned-allocation")
 
-        if self.cxx.hasCompileFlag('-fdelayed-template-parsing'):
-            self.config.available_features.add('fdelayed-template-parsing')
+        if self.cxx.hasCompileFlag("-fdelayed-template-parsing"):
+            self.config.available_features.add("fdelayed-template-parsing")
 
-        if self.get_lit_bool('has_libatomic', False):
-            self.config.available_features.add('libatomic')
+        if self.get_lit_bool("has_libatomic", False):
+            self.config.available_features.add("libatomic")
 
-        if 'msvc' not in self.config.available_features:
+        if "msvc" not in self.config.available_features:
             macros = self._dump_macros_verbose()
-            if '__cpp_if_constexpr' not in macros:
-                self.config.available_features.add('libcpp-no-if-constexpr')
+            if "__cpp_if_constexpr" not in macros:
+                self.config.available_features.add("libcpp-no-if-constexpr")
 
-            if '__cpp_structured_bindings' not in macros:
-                self.config.available_features.add('libcpp-no-structured-bindings')
+            if "__cpp_structured_bindings" not in macros:
+                self.config.available_features.add("libcpp-no-structured-bindings")
 
-            if '__cpp_deduction_guides' not in macros or \
-                    intMacroValue(macros['__cpp_deduction_guides']) < 201611:
-                self.config.available_features.add('libcpp-no-deduction-guides')
+            if (
+                "__cpp_deduction_guides" not in macros
+                or intMacroValue(macros["__cpp_deduction_guides"]) < 201611
+            ):
+                self.config.available_features.add("libcpp-no-deduction-guides")
 
         if self.is_windows:
-            self.config.available_features.add('windows')
-            if self.cxx_stdlib_under_test == 'libc++':
+            self.config.available_features.add("windows")
+            if self.cxx_stdlib_under_test == "libc++":
                 # LIBCXX-WINDOWS-FIXME is the feature name used to XFAIL the
                 # initial Windows failures until they can be properly diagnosed
                 # and fixed. This allows easier detection of new test failures
                 # and regressions. Note: New failures should not be suppressed
                 # using this feature. (Also see llvm.org/PR32730)
-                self.config.available_features.add('LIBCUDACXX-WINDOWS-FIXME')
+                self.config.available_features.add("LIBCUDACXX-WINDOWS-FIXME")
 
-        if 'msvc' not in self.config.available_features:
+        if "msvc" not in self.config.available_features:
             # Attempt to detect the glibc version by querying for __GLIBC__
             # in 'features.h'.
-            macros = self.cxx.dumpMacros(flags=['-include', 'features.h'])
-            if isinstance(macros, dict) and '__GLIBC__' in macros:
-                maj_v, min_v = (macros['__GLIBC__'], macros['__GLIBC_MINOR__'])
-                self.config.available_features.add('glibc')
-                self.config.available_features.add('glibc-%s' % maj_v)
-                self.config.available_features.add('glibc-%s.%s' % (maj_v, min_v))
+            macros = self.cxx.dumpMacros(flags=["-include", "features.h"])
+            if isinstance(macros, dict) and "__GLIBC__" in macros:
+                maj_v, min_v = (macros["__GLIBC__"], macros["__GLIBC_MINOR__"])
+                self.config.available_features.add("glibc")
+                self.config.available_features.add("glibc-%s" % maj_v)
+                self.config.available_features.add("glibc-%s.%s" % (maj_v, min_v))
 
-        libcudacxx_gdb = self.get_lit_conf('libcudacxx_gdb')
-        if libcudacxx_gdb and 'NOTFOUND' not in libcudacxx_gdb:
-            self.config.available_features.add('libcudacxx_gdb')
+        libcudacxx_gdb = self.get_lit_conf("libcudacxx_gdb")
+        if libcudacxx_gdb and "NOTFOUND" not in libcudacxx_gdb:
+            self.config.available_features.add("libcudacxx_gdb")
             self.cxx.libcudacxx_gdb = libcudacxx_gdb
 
     def configure_compile_flags(self):
         self.configure_default_compile_flags()
         # Configure extra flags
-        compile_flags_str = self.get_lit_conf('compile_flags', '')
+        compile_flags_str = self.get_lit_conf("compile_flags", "")
         self.cxx.compile_flags += shlex.split(compile_flags_str)
-        self.cxx.compile_flags += ['-D_CCCL_NO_SYSTEM_HEADER']
+        self.cxx.compile_flags += ["-D_CCCL_NO_SYSTEM_HEADER"]
         if self.is_windows:
             # FIXME: Can we remove this?
-            self.cxx.compile_flags += ['-D_CRT_SECURE_NO_WARNINGS']
-            self.cxx.compile_flags += ['--use-local-env']
+            self.cxx.compile_flags += ["-D_CRT_SECURE_NO_WARNINGS"]
+            self.cxx.compile_flags += ["--use-local-env"]
             # Required so that tests using min/max don't fail on Windows,
             # and so that those tests don't have to be changed to tolerate
             # this insanity.
-            self.cxx.compile_flags += ['-DNOMINMAX']
-            if 'msvc' in self.config.available_features:
-                if self.cxx.type == 'nvcc':
-                    self.cxx.compile_flags += ['-Xcompiler']
-                self.cxx.compile_flags += ['/bigobj']
-        additional_flags = self.get_lit_conf('test_compiler_flags')
+            self.cxx.compile_flags += ["-DNOMINMAX"]
+            if "msvc" in self.config.available_features:
+                if self.cxx.type == "nvcc":
+                    self.cxx.compile_flags += ["-Xcompiler"]
+                self.cxx.compile_flags += ["/bigobj"]
+        additional_flags = self.get_lit_conf("test_compiler_flags")
         if additional_flags:
             self.cxx.compile_flags += shlex.split(additional_flags)
-        compute_archs = self.get_lit_conf('compute_archs')
-        if self.cxx.type == 'nvrtcc':
+        compute_archs = self.get_lit_conf("compute_archs")
+        if self.cxx.type == "nvrtcc":
             self.config.available_features.add("nvrtc")
-        if self.cxx.type == 'nvcc':
-            self.cxx.compile_flags += ['--extended-lambda']
-        real_arch_format = '-gencode=arch=compute_{0},code=sm_{0}'
-        virt_arch_format = '-gencode=arch=compute_{0},code=compute_{0}'
-        if self.cxx.type == 'clang':
-            real_arch_format = '--cuda-gpu-arch=sm_{0}'
-            virt_arch_format = '--cuda-gpu-arch=compute_{0}'
-            self.cxx.compile_flags += ['-O1']
+        if self.cxx.type == "nvcc":
+            self.cxx.compile_flags += ["--extended-lambda"]
+        real_arch_format = "-gencode=arch=compute_{0},code=sm_{0}"
+        virt_arch_format = "-gencode=arch=compute_{0},code=compute_{0}"
+        if self.cxx.type == "clang":
+            real_arch_format = "--cuda-gpu-arch=sm_{0}"
+            virt_arch_format = "--cuda-gpu-arch=compute_{0}"
+            self.cxx.compile_flags += ["-O1"]
         pre_sm_32 = True
         pre_sm_60 = True
         pre_sm_70 = True
         pre_sm_80 = True
         pre_sm_90 = True
         pre_sm_90a = True
-        if compute_archs and (self.cxx.type == 'nvcc' or self.cxx.type == 'clang' or self.cxx.type == 'nvrtcc'):
+        if compute_archs and (
+            self.cxx.type == "nvcc"
+            or self.cxx.type == "clang"
+            or self.cxx.type == "nvrtcc"
+        ):
             pre_sm_32 = False
             pre_sm_60 = False
             pre_sm_70 = False
@@ -682,27 +748,33 @@ class Configuration(object):
             pre_sm_90 = False
             pre_sm_90a = False
 
-            self.lit_config.note('Compute Archs: %s' % compute_archs)
-            if compute_archs == 'native':
+            self.lit_config.note("Compute Archs: %s" % compute_archs)
+            if compute_archs == "native":
                 compute_archs = self.get_compute_capabilities()
 
-            compute_archs = set(sorted(re.split('\s|;|,', compute_archs)))
+            compute_archs = set(sorted(re.split("\s|;|,", compute_archs)))
             for s in compute_archs:
                 # Split arch and mode i.e. 80-virtual -> 80, virtual
-                arch, *mode = re.split('-', s)
+                arch, *mode = re.split("-", s)
 
                 # With Hopper there are new subarchitectures like 90a we need to handle those
-                subarchitecture = ''
+                subarchitecture = ""
                 if not arch.isnumeric():
                     subarchitecture = arch[-1]
                     arch = arch[:-1]
                 arch = int(arch)
-                if arch < 32: pre_sm_32 = True
-                if arch < 60: pre_sm_60 = True
-                if arch < 70: pre_sm_70 = True
-                if arch < 80: pre_sm_80 = True
-                if arch < 90: pre_sm_90 = True
-                if arch < 90 or (arch == 90 and subarchitecture < 'a') : pre_sm_90a = True
+                if arch < 32:
+                    pre_sm_32 = True
+                if arch < 60:
+                    pre_sm_60 = True
+                if arch < 70:
+                    pre_sm_70 = True
+                if arch < 80:
+                    pre_sm_80 = True
+                if arch < 90:
+                    pre_sm_90 = True
+                if arch < 90 or (arch == 90 and subarchitecture < "a"):
+                    pre_sm_90a = True
                 arch_flag = real_arch_format.format(str(arch) + subarchitecture)
                 if mode.count("virtual"):
                     arch_flag = virt_arch_format.format(str(arch) + subarchitecture)
@@ -721,40 +793,47 @@ class Configuration(object):
             self.config.available_features.add("pre-sm-90a")
 
     def configure_default_compile_flags(self):
-        nvcc_host_compiler = self.get_lit_conf('nvcc_host_compiler')
+        nvcc_host_compiler = self.get_lit_conf("nvcc_host_compiler")
 
-        if nvcc_host_compiler and self.cxx.type == 'nvcc':
-            self.cxx.compile_flags += ['-ccbin={0}'.format(nvcc_host_compiler)]
+        if nvcc_host_compiler and self.cxx.type == "nvcc":
+            self.cxx.compile_flags += ["-ccbin={0}".format(nvcc_host_compiler)]
 
         # Try and get the std version from the command line. Fall back to
         # default given in lit.site.cfg is not present. If default is not
         # present then force c++11.
-        std = self.get_lit_conf('std')
+        std = self.get_lit_conf("std")
         if not std:
             # Choose the newest possible language dialect if none is given.
-            possible_stds = ['c++20', 'c++2a', 'c++17', 'c++1z', 'c++14', 'c++11',
-                             'c++03']
-            if self.cxx.type == 'gcc':
+            possible_stds = [
+                "c++20",
+                "c++2a",
+                "c++17",
+                "c++1z",
+                "c++14",
+                "c++11",
+                "c++03",
+            ]
+            if self.cxx.type == "gcc":
                 maj_v, _, _ = self.cxx.version
                 maj_v = int(maj_v)
                 if maj_v < 6:
-                    possible_stds.remove('c++1z')
-                    possible_stds.remove('c++17')
+                    possible_stds.remove("c++1z")
+                    possible_stds.remove("c++17")
                 # FIXME: How many C++14 tests actually fail under GCC 5 and 6?
                 # Should we XFAIL them individually instead?
                 if maj_v < 6:
-                    possible_stds.remove('c++14')
+                    possible_stds.remove("c++14")
             for s in possible_stds:
                 cxx = self.cxx
                 success = True
 
-                if self.cxx.type == 'nvcc':
+                if self.cxx.type == "nvcc":
                     # NVCC warns, but doesn't error, if the host compiler
                     # doesn't support the dialect. It's also possible that the
                     # host compiler supports the dialect, but NVCC doesn't.
 
                     # So, first we need to check if NVCC supports the dialect...
-                    if not self.cxx.hasCompileFlag('-std=%s' % s):
+                    if not self.cxx.hasCompileFlag("-std=%s" % s):
                         # If it doesn't, give up on this dialect.
                         success = False
 
@@ -762,45 +841,47 @@ class Configuration(object):
                     # dialect.
                     cxx = self.host_cxx
 
-                if cxx.type == 'msvc':
-                    if not cxx.hasCompileFlag('/std:%s' % s):
+                if cxx.type == "msvc":
+                    if not cxx.hasCompileFlag("/std:%s" % s):
                         success = False
                 else:
-                    if not cxx.hasCompileFlag('-std=%s' % s):
+                    if not cxx.hasCompileFlag("-std=%s" % s):
                         success = False
 
                 if success:
                     std = s
-                    self.lit_config.note('inferred language dialect as: %s' % std)
+                    self.lit_config.note("inferred language dialect as: %s" % std)
                     break
 
         if std:
             # We found a dialect flag.
-            stdflag = '-std={0}'.format(std)
-            if self.cxx.type == 'msvc':
-                stdflag = '/std:{0}'.format(std)
+            stdflag = "-std={0}".format(std)
+            if self.cxx.type == "msvc":
+                stdflag = "/std:{0}".format(std)
 
             extraflags = []
-            if self.cxx.type == 'clang':
-                extraflags = ['-Wno-unknown-cuda-version', '--no-cuda-version-check']
+            if self.cxx.type == "clang":
+                extraflags = ["-Wno-unknown-cuda-version", "--no-cuda-version-check"]
 
             # Do a check with the user/config flag to ensure that the flag is supported.
             if not self.cxx.hasCompileFlag([stdflag] + extraflags):
-                raise OSError("Configured compiler does not support flag {0}".format(stdflag))
+                raise OSError(
+                    "Configured compiler does not support flag {0}".format(stdflag)
+                )
 
             self.cxx.flags += [stdflag]
 
         if not std:
             # There is no dialect flag. This happens with older MSVC.
-            if self.cxx.type == 'nvcc':
+            if self.cxx.type == "nvcc":
                 std = self.host_cxx.default_dialect
             else:
                 std = self.cxx.default_dialect
-            self.lit_config.note('using default language dialect: %s' % std)
+            self.lit_config.note("using default language dialect: %s" % std)
 
-        std_feature = std.replace('gnu++', 'c++')
-        std_feature = std.replace('1z', '17')
-        std_feature = std.replace('2a', '20')
+        std_feature = std.replace("gnu++", "c++")
+        std_feature = std.replace("1z", "17")
+        std_feature = std.replace("2a", "20")
         self.config.available_features.add(std_feature)
         # Configure include paths
         self.configure_compile_flags_header_includes()
@@ -809,117 +890,129 @@ class Configuration(object):
         self.configure_compile_flags_exceptions()
         self.configure_compile_flags_rtti()
         self.configure_compile_flags_abi_version()
-        enable_32bit = self.get_lit_bool('enable_32bit', False)
+        enable_32bit = self.get_lit_bool("enable_32bit", False)
         if enable_32bit:
-            self.cxx.flags += ['-m32']
+            self.cxx.flags += ["-m32"]
         # Use verbose output for better errors
-        if not self.cxx.use_ccache or self.cxx.type == 'msvc':
-            self.cxx.flags += ['-v']
-        sysroot = self.get_lit_conf('sysroot')
+        if not self.cxx.use_ccache or self.cxx.type == "msvc":
+            self.cxx.flags += ["-v"]
+        sysroot = self.get_lit_conf("sysroot")
         if sysroot:
-            self.cxx.flags += ['--sysroot=' + sysroot]
-        gcc_toolchain = self.get_lit_conf('gcc_toolchain')
+            self.cxx.flags += ["--sysroot=" + sysroot]
+        gcc_toolchain = self.get_lit_conf("gcc_toolchain")
         if gcc_toolchain:
-            self.cxx.flags += ['--gcc-toolchain=' + gcc_toolchain]
+            self.cxx.flags += ["--gcc-toolchain=" + gcc_toolchain]
         # NOTE: the _DEBUG definition must preceed the triple check because for
         # the Windows build of libc++, the forced inclusion of a header requires
         # that _DEBUG is defined.  Incorrect ordering will result in -target
         # being elided.
         if self.is_windows and self.debug_build:
-            self.cxx.compile_flags += ['-D_DEBUG']
+            self.cxx.compile_flags += ["-D_DEBUG"]
         if self.use_target:
             if not self.cxx.addFlagIfSupported(
-                    ['--target=' + self.config.target_triple]):
-                self.lit_config.warning('use_target is true but --target is '\
-                        'not supported by the compiler')
+                ["--target=" + self.config.target_triple]
+            ):
+                self.lit_config.warning(
+                    "use_target is true but --target is "
+                    "not supported by the compiler"
+                )
         if self.use_deployment:
             arch, name, version = self.config.deployment
-            self.cxx.flags += ['-arch', arch]
-            self.cxx.flags += ['-m' + name + '-version-min=' + version]
+            self.cxx.flags += ["-arch", arch]
+            self.cxx.flags += ["-m" + name + "-version-min=" + version]
 
         # Add includes for support headers used in the tests.
-        support_path = os.path.join(self.libcudacxx_src_root, 'test', 'support')
-        self.cxx.compile_flags += ['-I' + support_path]
+        support_path = os.path.join(self.libcudacxx_src_root, "test", "support")
+        self.cxx.compile_flags += ["-I" + support_path]
 
         # Add includes for the PSTL headers
-        pstl_src_root = self.get_lit_conf('pstl_src_root')
-        pstl_obj_root = self.get_lit_conf('pstl_obj_root')
+        pstl_src_root = self.get_lit_conf("pstl_src_root")
+        pstl_obj_root = self.get_lit_conf("pstl_obj_root")
         if pstl_src_root is not None and pstl_obj_root is not None:
-            self.cxx.compile_flags += ['-I' + os.path.join(pstl_src_root, 'include')]
-            self.cxx.compile_flags += ['-I' + os.path.join(pstl_obj_root, 'generated_headers')]
-            self.cxx.compile_flags += ['-I' + os.path.join(pstl_src_root, 'test')]
-            self.config.available_features.add('parallel-algorithms')
+            self.cxx.compile_flags += ["-I" + os.path.join(pstl_src_root, "include")]
+            self.cxx.compile_flags += [
+                "-I" + os.path.join(pstl_obj_root, "generated_headers")
+            ]
+            self.cxx.compile_flags += ["-I" + os.path.join(pstl_src_root, "test")]
+            self.config.available_features.add("parallel-algorithms")
 
         # FIXME(EricWF): variant_size.pass.cpp requires a slightly larger
         # template depth with older Clang versions.
-        self.cxx.addFlagIfSupported('-ftemplate-depth=270')
+        self.cxx.addFlagIfSupported("-ftemplate-depth=270")
 
         # If running without execution we need to mark tests that only fail at runtime as unsupported
         if self.lit_config.noExecute:
-            self.config.available_features.add('no_execute')
+            self.config.available_features.add("no_execute")
 
     def configure_compile_flags_header_includes(self):
-        support_path = os.path.join(self.libcudacxx_src_root, 'test', 'support')
+        support_path = os.path.join(self.libcudacxx_src_root, "test", "support")
         self.configure_config_site_header()
-        if self.cxx_stdlib_under_test != 'libstdc++' and \
-           not self.is_windows:
+        if self.cxx_stdlib_under_test != "libstdc++" and not self.is_windows:
             self.cxx.compile_flags += [
-                '-include', os.path.join(support_path, 'nasty_macros.h')]
-        if self.cxx_stdlib_under_test == 'msvc':
-            self.cxx.compile_flags += [
-                '-include', os.path.join(support_path,
-                                         'msvc_stdlib_force_include.h')]
-            pass
-        if self.is_windows and self.debug_build and \
-                self.cxx_stdlib_under_test != 'msvc':
-            self.cxx.compile_flags += [
-                '-include', os.path.join(support_path,
-                                         'set_windows_crt_report_mode.h')
+                "-include",
+                os.path.join(support_path, "nasty_macros.h"),
             ]
-        cxx_headers = self.get_lit_conf('cxx_headers')
-        if cxx_headers == '' or (cxx_headers is None
-                                 and self.cxx_stdlib_under_test != 'libc++'):
-            self.lit_config.note('using the system cxx headers')
+        if self.cxx_stdlib_under_test == "msvc":
+            self.cxx.compile_flags += [
+                "-include",
+                os.path.join(support_path, "msvc_stdlib_force_include.h"),
+            ]
+            pass
+        if (
+            self.is_windows
+            and self.debug_build
+            and self.cxx_stdlib_under_test != "msvc"
+        ):
+            self.cxx.compile_flags += [
+                "-include",
+                os.path.join(support_path, "set_windows_crt_report_mode.h"),
+            ]
+        cxx_headers = self.get_lit_conf("cxx_headers")
+        if cxx_headers == "" or (
+            cxx_headers is None and self.cxx_stdlib_under_test != "libc++"
+        ):
+            self.lit_config.note("using the system cxx headers")
             return
         # I don't think this is required, since removing it helps clang-cuda compile and libcudacxx only supports building in CUDA modes?
         # if self.cxx.type != 'nvcc' and self.cxx.type != 'pgi':
         #    self.cxx.compile_flags += ['-nostdinc++']
         if cxx_headers is None:
-            cxx_headers = os.path.join(self.libcudacxx_src_root, 'include')
+            cxx_headers = os.path.join(self.libcudacxx_src_root, "include")
         if not os.path.isdir(cxx_headers):
-            self.lit_config.fatal("cxx_headers='%s' is not a directory."
-                                  % cxx_headers)
-        self.cxx.compile_flags += ['-I' + cxx_headers]
+            self.lit_config.fatal("cxx_headers='%s' is not a directory." % cxx_headers)
+        self.cxx.compile_flags += ["-I" + cxx_headers]
         if self.libcudacxx_obj_root is not None:
-            cxxabi_headers = os.path.join(self.libcudacxx_obj_root, 'include',
-                                          'c++build')
+            cxxabi_headers = os.path.join(
+                self.libcudacxx_obj_root, "include", "c++build"
+            )
             if os.path.isdir(cxxabi_headers):
-                self.cxx.compile_flags += ['-I' + cxxabi_headers]
+                self.cxx.compile_flags += ["-I" + cxxabi_headers]
 
     def configure_config_site_header(self):
         # Check for a possible __config_site in the build directory. We
         # use this if it exists.
         if self.libcudacxx_obj_root is None:
             return
-        config_site_header = os.path.join(self.libcudacxx_obj_root, '__config_site')
+        config_site_header = os.path.join(self.libcudacxx_obj_root, "__config_site")
         if not os.path.isfile(config_site_header):
             return
-        contained_macros = self.parse_config_site_and_add_features(
-            config_site_header)
-        self.lit_config.note('Using __config_site header %s with macros: %r'
-            % (config_site_header, contained_macros))
+        contained_macros = self.parse_config_site_and_add_features(config_site_header)
+        self.lit_config.note(
+            "Using __config_site header %s with macros: %r"
+            % (config_site_header, contained_macros)
+        )
         # FIXME: This must come after the call to
         # 'parse_config_site_and_add_features(...)' in order for it to work.
-        self.cxx.compile_flags += ['-include', config_site_header]
+        self.cxx.compile_flags += ["-include", config_site_header]
 
     def parse_config_site_and_add_features(self, header):
-        """ parse_config_site_and_add_features - Deduce and add the test
-            features that that are implied by the #define's in the __config_site
-            header. Return a dictionary containing the macros found in the
-            '__config_site' header.
+        """parse_config_site_and_add_features - Deduce and add the test
+        features that that are implied by the #define's in the __config_site
+        header. Return a dictionary containing the macros found in the
+        '__config_site' header.
         """
         # MSVC can't dump macros, so we just give up.
-        if 'msvc' in self.config.available_features:
+        if "msvc" in self.config.available_features:
             return {}
         # Parse the macro contents of __config_site by dumping the macros
         # using 'c++ -dM -E' and filtering the predefines.
@@ -930,8 +1023,8 @@ class Configuration(object):
         for k in feature_macros_keys:
             feature_macros[k] = macros[k]
         # We expect the header guard to be one of the definitions
-        assert '_LIBCUDACXX_CONFIG_SITE' in feature_macros
-        del feature_macros['_LIBCUDACXX_CONFIG_SITE']
+        assert "_LIBCUDACXX_CONFIG_SITE" in feature_macros
+        del feature_macros["_LIBCUDACXX_CONFIG_SITE"]
         # The __config_site header should be non-empty. Otherwise it should
         # have never been emitted by CMake.
         assert len(feature_macros) > 0
@@ -939,494 +1032,544 @@ class Configuration(object):
         # If modules are enabled then we have to lift all of the definitions
         # in __config_site onto the command line.
         for m in feature_macros:
-            define = '-D%s' % m
+            define = "-D%s" % m
             if feature_macros[m]:
-                define += '=%s' % (feature_macros[m])
+                define += "=%s" % (feature_macros[m])
             self.cxx.modules_flags += [define]
-        if self.cxx.hasCompileFlag('-Wno-macro-redefined'):
-            self.cxx.compile_flags += ['-Wno-macro-redefined']
+        if self.cxx.hasCompileFlag("-Wno-macro-redefined"):
+            self.cxx.compile_flags += ["-Wno-macro-redefined"]
         # Transform each macro name into the feature name used in the tests.
         # Ex. _LIBCUDACXX_HAS_NO_THREADS -> libcpp-has-no-threads
         for m in feature_macros:
-            if m == '_LIBCUDACXX_DISABLE_VISIBILITY_ANNOTATIONS' or \
-               m == '_LIBCUDACXX_HIDE_FROM_ABI_PER_TU_BY_DEFAULT':
+            if (
+                m == "_LIBCUDACXX_DISABLE_VISIBILITY_ANNOTATIONS"
+                or m == "_LIBCUDACXX_HIDE_FROM_ABI_PER_TU_BY_DEFAULT"
+            ):
                 continue
-            if m == '_LIBCUDACXX_ABI_VERSION':
-                self.config.available_features.add('libcpp-abi-version-v%s'
-                    % feature_macros[m])
+            if m == "_LIBCUDACXX_ABI_VERSION":
+                self.config.available_features.add(
+                    "libcpp-abi-version-v%s" % feature_macros[m]
+                )
                 continue
-            if m == '_LIBCUDACXX_NO_VCRUNTIME':
-                self.config.available_features.add('libcpp-no-vcruntime')
+            if m == "_LIBCUDACXX_NO_VCRUNTIME":
+                self.config.available_features.add("libcpp-no-vcruntime")
                 continue
-            assert m.startswith('_LIBCUDACXX_HAS_') or m.startswith('_LIBCUDACXX_ABI_')
-            m = m.lower()[1:].replace('_', '-')
+            assert m.startswith("_LIBCUDACXX_HAS_") or m.startswith("_LIBCUDACXX_ABI_")
+            m = m.lower()[1:].replace("_", "-")
             self.config.available_features.add(m)
         return feature_macros
 
     def configure_compile_flags_exceptions(self):
-        enable_exceptions = self.get_lit_bool('enable_exceptions', True)
-        nvrtc             = self.get_lit_bool('is_nvrtc', False)
+        enable_exceptions = self.get_lit_bool("enable_exceptions", True)
+        nvrtc = self.get_lit_bool("is_nvrtc", False)
 
         if not enable_exceptions:
-            self.config.available_features.add('libcpp-no-exceptions')
-            if 'nvhpc' in self.config.available_features:
+            self.config.available_features.add("libcpp-no-exceptions")
+            if "nvhpc" in self.config.available_features:
                 # NVHPC reports all expressions as `noexcept(true)` with its
                 # "no exceptions" mode. Override the setting from CMake as
                 # a temporary workaround for that.
                 pass
             # TODO: I don't know how to shut off exceptions with MSVC.
-            elif 'msvc' not in self.config.available_features:
-                if self.cxx.type == 'nvcc':
-                    self.cxx.compile_flags += ['-Xcompiler']
-                self.cxx.compile_flags += ['-fno-exceptions']
+            elif "msvc" not in self.config.available_features:
+                if self.cxx.type == "nvcc":
+                    self.cxx.compile_flags += ["-Xcompiler"]
+                self.cxx.compile_flags += ["-fno-exceptions"]
         elif nvrtc:
-            self.config.available_features.add('libcpp-no-exceptions')
+            self.config.available_features.add("libcpp-no-exceptions")
 
     def configure_compile_flags_rtti(self):
-        enable_rtti = self.get_lit_bool('enable_rtti', True)
+        enable_rtti = self.get_lit_bool("enable_rtti", True)
         if not enable_rtti:
-            self.config.available_features.add('libcpp-no-rtti')
-            if self.cxx.type == 'nvcc':
-                self.cxx.compile_flags += ['-Xcompiler']
-            if 'nvhpc' in self.config.available_features:
-                self.cxx.compile_flags += ['--no_rtti']
-            elif 'msvc' in self.config.available_features:
-                self.cxx.compile_flags += ['/GR-']
-                self.cxx.compile_flags += ['-D_SILENCE_CXX20_CISO646_REMOVED_WARNING']
+            self.config.available_features.add("libcpp-no-rtti")
+            if self.cxx.type == "nvcc":
+                self.cxx.compile_flags += ["-Xcompiler"]
+            if "nvhpc" in self.config.available_features:
+                self.cxx.compile_flags += ["--no_rtti"]
+            elif "msvc" in self.config.available_features:
+                self.cxx.compile_flags += ["/GR-"]
+                self.cxx.compile_flags += ["-D_SILENCE_CXX20_CISO646_REMOVED_WARNING"]
             else:
-                self.cxx.compile_flags += ['-fno-rtti']
+                self.cxx.compile_flags += ["-fno-rtti"]
 
     def configure_compile_flags_abi_version(self):
-        abi_version = self.get_lit_conf('abi_version', '').strip()
-        abi_unstable = self.get_lit_bool('abi_unstable')
+        abi_version = self.get_lit_conf("abi_version", "").strip()
+        abi_unstable = self.get_lit_bool("abi_unstable")
         # Only add the ABI version when it is non-default.
         # FIXME(EricWF): Get the ABI version from the "__config_site".
-        if abi_version and abi_version != '1':
-          self.cxx.compile_flags += ['-D_LIBCUDACXX_ABI_VERSION=' + abi_version]
+        if abi_version and abi_version != "1":
+            self.cxx.compile_flags += ["-D_LIBCUDACXX_ABI_VERSION=" + abi_version]
         if abi_unstable:
-          self.config.available_features.add('libcpp-abi-unstable')
-          self.cxx.compile_flags += ['-D_LIBCUDACXX_ABI_UNSTABLE']
+            self.config.available_features.add("libcpp-abi-unstable")
+            self.cxx.compile_flags += ["-D_LIBCUDACXX_ABI_UNSTABLE"]
 
     def configure_filesystem_compile_flags(self):
-        if not self.get_lit_bool('enable_filesystem', default=True):
+        if not self.get_lit_bool("enable_filesystem", default=True):
             return
 
-        static_env = os.path.join(self.libcudacxx_src_root, 'test', 'libcudacxx', 'std',
-                                  'input.output', 'filesystems', 'Inputs', 'static_test_env')
+        static_env = os.path.join(
+            self.libcudacxx_src_root,
+            "test",
+            "libcudacxx",
+            "std",
+            "input.output",
+            "filesystems",
+            "Inputs",
+            "static_test_env",
+        )
         static_env = os.path.realpath(static_env)
         assert os.path.isdir(static_env)
-        self.cxx.compile_flags += ['-DLIBCXX_FILESYSTEM_STATIC_TEST_ROOT="%s"' % static_env]
+        self.cxx.compile_flags += [
+            '-DLIBCXX_FILESYSTEM_STATIC_TEST_ROOT="%s"' % static_env
+        ]
 
-        dynamic_env = os.path.join(self.config.test_exec_root,
-                                   'filesystem', 'Output', 'dynamic_env')
+        dynamic_env = os.path.join(
+            self.config.test_exec_root, "filesystem", "Output", "dynamic_env"
+        )
         dynamic_env = os.path.realpath(dynamic_env)
         if not os.path.isdir(dynamic_env):
             os.makedirs(dynamic_env)
-        self.cxx.compile_flags += ['-DLIBCXX_FILESYSTEM_DYNAMIC_TEST_ROOT="%s"' % dynamic_env]
-        self.exec_env['LIBCXX_FILESYSTEM_DYNAMIC_TEST_ROOT'] = ("%s" % dynamic_env)
+        self.cxx.compile_flags += [
+            '-DLIBCXX_FILESYSTEM_DYNAMIC_TEST_ROOT="%s"' % dynamic_env
+        ]
+        self.exec_env["LIBCXX_FILESYSTEM_DYNAMIC_TEST_ROOT"] = "%s" % dynamic_env
 
-        dynamic_helper = os.path.join(self.libcudacxx_src_root, 'test', 'support',
-                                      'filesystem_dynamic_test_helper.py')
+        dynamic_helper = os.path.join(
+            self.libcudacxx_src_root,
+            "test",
+            "support",
+            "filesystem_dynamic_test_helper.py",
+        )
         assert os.path.isfile(dynamic_helper)
 
-        self.cxx.compile_flags += ['-DLIBCXX_FILESYSTEM_DYNAMIC_TEST_HELPER="%s %s"'
-                                   % (sys.executable, dynamic_helper)]
-
+        self.cxx.compile_flags += [
+            '-DLIBCXX_FILESYSTEM_DYNAMIC_TEST_HELPER="%s %s"'
+            % (sys.executable, dynamic_helper)
+        ]
 
     def configure_link_flags(self):
-        nvcc_host_compiler = self.get_lit_conf('nvcc_host_compiler')
-        if nvcc_host_compiler and self.cxx.type == 'nvcc':
-            self.cxx.link_flags += ['-ccbin={0}'.format(nvcc_host_compiler)]
+        nvcc_host_compiler = self.get_lit_conf("nvcc_host_compiler")
+        if nvcc_host_compiler and self.cxx.type == "nvcc":
+            self.cxx.link_flags += ["-ccbin={0}".format(nvcc_host_compiler)]
 
         if self.is_windows:
-            self.cxx.link_flags += ['--use-local-env']
+            self.cxx.link_flags += ["--use-local-env"]
 
         # Configure library path
         self.configure_link_flags_cxx_library_path()
         self.configure_link_flags_abi_library_path()
 
         # Configure libraries
-        if self.cxx_stdlib_under_test == 'libc++':
-            if self.get_lit_conf('name') != 'libcu++':
-                if 'nvhpc' not in self.config.available_features or not self.cxx.is_nvrtc:
-                    if self.cxx.type == 'nvcc':
-                        self.cxx.link_flags += ['-Xcompiler']
-                    self.cxx.link_flags += ['-nodefaultlibs']
+        if self.cxx_stdlib_under_test == "libc++":
+            if self.get_lit_conf("name") != "libcu++":
+                if (
+                    "nvhpc" not in self.config.available_features
+                    or not self.cxx.is_nvrtc
+                ):
+                    if self.cxx.type == "nvcc":
+                        self.cxx.link_flags += ["-Xcompiler"]
+                    self.cxx.link_flags += ["-nodefaultlibs"]
 
                     # FIXME: Handle MSVCRT as part of the ABI library handling.
-                    if self.is_windows and 'msvc' not in self.config.available_features:
-                        if self.cxx.type == 'nvcc':
-                            self.cxx.link_flags += ['-Xcompiler']
-                        self.cxx.link_flags += ['-nostdlib']
+                    if self.is_windows and "msvc" not in self.config.available_features:
+                        if self.cxx.type == "nvcc":
+                            self.cxx.link_flags += ["-Xcompiler"]
+                        self.cxx.link_flags += ["-nostdlib"]
             self.configure_link_flags_cxx_library()
             self.configure_link_flags_abi_library()
             self.configure_extra_library_flags()
-        elif self.cxx_stdlib_under_test == 'libstdc++':
-            self.config.available_features.add('c++experimental')
-            self.cxx.link_flags += ['-lstdc++fs', '-lm', '-pthread']
-        elif self.cxx_stdlib_under_test == 'msvc':
+        elif self.cxx_stdlib_under_test == "libstdc++":
+            self.config.available_features.add("c++experimental")
+            self.cxx.link_flags += ["-lstdc++fs", "-lm", "-pthread"]
+        elif self.cxx_stdlib_under_test == "msvc":
             # FIXME: Correctly setup debug/release flags here.
             pass
-        elif self.cxx_stdlib_under_test == 'cxx_default':
-            self.cxx.link_flags += ['-pthread']
+        elif self.cxx_stdlib_under_test == "cxx_default":
+            self.cxx.link_flags += ["-pthread"]
         else:
-            self.lit_config.fatal('invalid stdlib under test')
+            self.lit_config.fatal("invalid stdlib under test")
 
-        link_flags_str = self.get_lit_conf('link_flags', '')
+        link_flags_str = self.get_lit_conf("link_flags", "")
         self.cxx.link_flags += shlex.split(link_flags_str)
 
     def configure_link_flags_cxx_library_path(self):
         if not self.use_system_cxx_lib:
             if self.cxx_library_root:
-                self.cxx.link_flags += ['-L' + self.cxx_library_root]
+                self.cxx.link_flags += ["-L" + self.cxx_library_root]
                 if self.is_windows and self.link_shared:
                     self.add_path(self.cxx.compile_env, self.cxx_library_root)
             if self.cxx_runtime_root:
                 if not self.is_windows:
-                    if self.cxx.type == 'nvcc':
-                        self.cxx.link_flags += ['-Xcompiler',
-                            '"-Wl,-rpath,' + self.cxx_runtime_root + '"']
+                    if self.cxx.type == "nvcc":
+                        self.cxx.link_flags += [
+                            "-Xcompiler",
+                            '"-Wl,-rpath,' + self.cxx_runtime_root + '"',
+                        ]
                     else:
-                        self.cxx.link_flags += ['-Wl,-rpath,' +
-                                                self.cxx_runtime_root]
+                        self.cxx.link_flags += ["-Wl,-rpath," + self.cxx_runtime_root]
                 elif self.is_windows and self.link_shared:
                     self.add_path(self.exec_env, self.cxx_runtime_root)
         elif os.path.isdir(str(self.use_system_cxx_lib)):
-            self.cxx.link_flags += ['-L' + self.use_system_cxx_lib]
+            self.cxx.link_flags += ["-L" + self.use_system_cxx_lib]
             if not self.is_windows:
-                if self.cxx.type == 'nvcc':
-                    self.cxx.link_flags += ['-Xcompiler',
-                        '"-Wl,-rpath,' + self.cxx_runtime_root + '"']
+                if self.cxx.type == "nvcc":
+                    self.cxx.link_flags += [
+                        "-Xcompiler",
+                        '"-Wl,-rpath,' + self.cxx_runtime_root + '"',
+                    ]
                 else:
-                    self.cxx.link_flags += ['-Wl,-rpath,' +
-                                            self.use_system_cxx_lib]
+                    self.cxx.link_flags += ["-Wl,-rpath," + self.use_system_cxx_lib]
             if self.is_windows and self.link_shared:
                 self.add_path(self.cxx.compile_env, self.use_system_cxx_lib)
-        additional_flags = self.get_lit_conf('test_linker_flags')
+        additional_flags = self.get_lit_conf("test_linker_flags")
         if additional_flags:
             self.cxx.link_flags += shlex.split(additional_flags)
 
     def configure_link_flags_abi_library_path(self):
         # Configure ABI library paths.
-        self.abi_library_root = self.get_lit_conf('abi_library_path')
+        self.abi_library_root = self.get_lit_conf("abi_library_path")
         if self.abi_library_root:
-            self.cxx.link_flags += ['-L' + self.abi_library_root]
+            self.cxx.link_flags += ["-L" + self.abi_library_root]
             if not self.is_windows:
-                if self.cxx.type == 'nvcc':
-                    self.cxx.link_flags += ['-Xcompiler',
-                        '"-Wl,-rpath,' + self.cxx_runtime_root + '"']
+                if self.cxx.type == "nvcc":
+                    self.cxx.link_flags += [
+                        "-Xcompiler",
+                        '"-Wl,-rpath,' + self.cxx_runtime_root + '"',
+                    ]
                 else:
-                    self.cxx.link_flags += ['-Wl,-rpath,' +
-                                            self.abi_library_root]
+                    self.cxx.link_flags += ["-Wl,-rpath," + self.abi_library_root]
             else:
                 self.add_path(self.exec_env, self.abi_library_root)
 
     def configure_link_flags_cxx_library(self):
-        libcxx_experimental = self.get_lit_bool('enable_experimental', default=False)
+        libcxx_experimental = self.get_lit_bool("enable_experimental", default=False)
         if libcxx_experimental:
-            self.config.available_features.add('c++experimental')
-            self.cxx.link_flags += ['-lc++experimental']
+            self.config.available_features.add("c++experimental")
+            self.cxx.link_flags += ["-lc++experimental"]
         if self.link_shared:
-            self.cxx.link_flags += ['-lc++']
+            self.cxx.link_flags += ["-lc++"]
+
     def configure_link_flags_abi_library(self):
-        cxx_abi = self.get_lit_conf('cxx_abi', 'libcxxabi')
-        if cxx_abi == 'libstdc++':
-            self.cxx.link_flags += ['-lstdc++']
-        elif cxx_abi == 'libsupc++':
-            self.cxx.link_flags += ['-lsupc++']
-        elif cxx_abi == 'libcxxabi':
+        cxx_abi = self.get_lit_conf("cxx_abi", "libcxxabi")
+        if cxx_abi == "libstdc++":
+            self.cxx.link_flags += ["-lstdc++"]
+        elif cxx_abi == "libsupc++":
+            self.cxx.link_flags += ["-lsupc++"]
+        elif cxx_abi == "libcxxabi":
             # If the C++ library requires explicitly linking to libc++abi, or
             # if we're testing libc++abi itself (the test configs are shared),
             # then link it.
-            testing_libcxxabi = self.get_lit_conf('name', '') == 'libc++abi'
+            testing_libcxxabi = self.get_lit_conf("name", "") == "libc++abi"
             if self.target_info.allow_cxxabi_link() or testing_libcxxabi:
-                libcxxabi_shared = self.get_lit_bool('libcxxabi_shared', default=True)
+                libcxxabi_shared = self.get_lit_bool("libcxxabi_shared", default=True)
                 if libcxxabi_shared:
-                    self.cxx.link_flags += ['-lc++abi']
+                    self.cxx.link_flags += ["-lc++abi"]
                 else:
-                    cxxabi_library_root = self.get_lit_conf('abi_library_path')
+                    cxxabi_library_root = self.get_lit_conf("abi_library_path")
                     if cxxabi_library_root:
-                        libname = self.make_static_lib_name('c++abi')
+                        libname = self.make_static_lib_name("c++abi")
                         abs_path = os.path.join(cxxabi_library_root, libname)
                         self.cxx.link_flags += [abs_path]
                     else:
-                        self.cxx.link_flags += ['-lc++abi']
-        elif cxx_abi == 'libcxxrt':
-            self.cxx.link_flags += ['-lcxxrt']
-        elif cxx_abi == 'vcruntime':
-            debug_suffix = 'd' if self.debug_build else ''
-            self.cxx.link_flags += ['-l%s%s' % (lib, debug_suffix) for lib in
-                                    ['vcruntime', 'ucrt', 'msvcrt']]
-        elif cxx_abi == 'none' or cxx_abi == 'default':
+                        self.cxx.link_flags += ["-lc++abi"]
+        elif cxx_abi == "libcxxrt":
+            self.cxx.link_flags += ["-lcxxrt"]
+        elif cxx_abi == "vcruntime":
+            debug_suffix = "d" if self.debug_build else ""
+            self.cxx.link_flags += [
+                "-l%s%s" % (lib, debug_suffix)
+                for lib in ["vcruntime", "ucrt", "msvcrt"]
+            ]
+        elif cxx_abi == "none" or cxx_abi == "default":
             if self.is_windows:
-                debug_suffix = 'd' if self.debug_build else ''
-                self.cxx.link_flags += ['-lmsvcrt%s' % debug_suffix]
+                debug_suffix = "d" if self.debug_build else ""
+                self.cxx.link_flags += ["-lmsvcrt%s" % debug_suffix]
         else:
-            self.lit_config.fatal(
-                'C++ ABI setting %s unsupported for tests' % cxx_abi)
+            self.lit_config.fatal("C++ ABI setting %s unsupported for tests" % cxx_abi)
 
     def configure_extra_library_flags(self):
-        if self.get_lit_bool('cxx_ext_threads', default=False):
-            self.cxx.link_flags += ['-lc++external_threads']
+        if self.get_lit_bool("cxx_ext_threads", default=False):
+            self.cxx.link_flags += ["-lc++external_threads"]
         self.target_info.add_cxx_link_flags(self.cxx.link_flags)
 
     def configure_color_diagnostics(self):
-        use_color = self.get_lit_conf('color_diagnostics')
+        use_color = self.get_lit_conf("color_diagnostics")
         if use_color is None:
-            use_color = os.environ.get('LIBCXX_COLOR_DIAGNOSTICS')
+            use_color = os.environ.get("LIBCXX_COLOR_DIAGNOSTICS")
         if use_color is None:
             return
-        if use_color != '':
-            self.lit_config.fatal('Invalid value for color_diagnostics "%s".'
-                                  % use_color)
-        color_flag = '-fdiagnostics-color=always'
+        if use_color != "":
+            self.lit_config.fatal(
+                'Invalid value for color_diagnostics "%s".' % use_color
+            )
+        color_flag = "-fdiagnostics-color=always"
         # Check if the compiler supports the color diagnostics flag. Issue a
         # warning if it does not since color diagnostics have been requested.
         if not self.cxx.hasCompileFlag(color_flag):
             self.lit_config.warning(
-                'color diagnostics have been requested but are not supported '
-                'by the compiler')
+                "color diagnostics have been requested but are not supported "
+                "by the compiler"
+            )
         else:
             self.cxx.flags += [color_flag]
 
     def configure_debug_mode(self):
-        debug_level = self.get_lit_conf('debug_level', None)
+        debug_level = self.get_lit_conf("debug_level", None)
         if not debug_level:
             return
-        if debug_level not in ['0', '1']:
-            self.lit_config.fatal('Invalid value for debug_level "%s".'
-                                  % debug_level)
-        self.cxx.compile_flags += ['-D_LIBCUDACXX_DEBUG=%s' % debug_level]
+        if debug_level not in ["0", "1"]:
+            self.lit_config.fatal('Invalid value for debug_level "%s".' % debug_level)
+        self.cxx.compile_flags += ["-D_LIBCUDACXX_DEBUG=%s" % debug_level]
 
     def configure_warnings(self):
-        default_enable_warnings = 'clang' in self.config.available_features or \
-                                  'msvc'  in self.config.available_features or \
-                                  'nvcc'  in self.config.available_features
-        enable_warnings = self.get_lit_bool('enable_warnings',
-                                            default_enable_warnings)
+        default_enable_warnings = (
+            "clang" in self.config.available_features
+            or "msvc" in self.config.available_features
+            or "nvcc" in self.config.available_features
+        )
+        enable_warnings = self.get_lit_bool("enable_warnings", default_enable_warnings)
         self.cxx.useWarnings(enable_warnings)
-        if 'nvcc' in self.config.available_features:
-            self.cxx.warning_flags += [ '-Xcudafe', '--display_error_number' ]
-            self.cxx.warning_flags += [ '-Werror=all-warnings' ]
-            if 'msvc' in self.config.available_features:
-                self.cxx.warning_flags += [ '-Xcompiler', '/W4', '-Xcompiler', '/WX' ]
+        if "nvcc" in self.config.available_features:
+            self.cxx.warning_flags += ["-Xcudafe", "--display_error_number"]
+            self.cxx.warning_flags += ["-Werror=all-warnings"]
+            if "msvc" in self.config.available_features:
+                self.cxx.warning_flags += ["-Xcompiler", "/W4", "-Xcompiler", "/WX"]
                 # warning C4100: 'quack': unreferenced formal parameter
-                self.cxx.warning_flags += [ '-Xcompiler', '-wd4100' ]
+                self.cxx.warning_flags += ["-Xcompiler", "-wd4100"]
                 # warning C4127: conditional expression is constant
-                self.cxx.warning_flags += [ '-Xcompiler', '-wd4127' ]
+                self.cxx.warning_flags += ["-Xcompiler", "-wd4127"]
                 # warning C4180: qualifier applied to function type has no meaning; ignored
-                self.cxx.warning_flags += [ '-Xcompiler', '-wd4180' ]
+                self.cxx.warning_flags += ["-Xcompiler", "-wd4180"]
                 # warning C4309: 'moo': truncation of constant value
-                self.cxx.warning_flags += [ '-Xcompiler', '-wd4309' ]
+                self.cxx.warning_flags += ["-Xcompiler", "-wd4309"]
                 # warning C4996: deprecation warnings
-                self.cxx.warning_flags += [ '-Xcompiler', '-wd4996' ]
+                self.cxx.warning_flags += ["-Xcompiler", "-wd4996"]
             else:
                 # TODO: Re-enable soon.
                 def addIfHostSupports(flag):
-                    if hasattr(self, 'host_cxx') and self.host_cxx.hasWarningFlag(flag):
-                        self.cxx.warning_flags += [ '-Xcompiler', flag ]
+                    if hasattr(self, "host_cxx") and self.host_cxx.hasWarningFlag(flag):
+                        self.cxx.warning_flags += ["-Xcompiler", flag]
 
-                addIfHostSupports('-Wall')
-                addIfHostSupports('-Wextra')
-                addIfHostSupports('-Werror')
-                if 'gcc' in self.config.available_features:
-                    addIfHostSupports('-Wno-literal-suffix') # GCC warning about reserved UDLs
-                addIfHostSupports('-Wno-user-defined-literals') # Clang warning about reserved UDLs
-                addIfHostSupports('-Wno-unused-parameter')
-                addIfHostSupports('-Wno-unused-local-typedefs') # GCC warning local typdefs
-                addIfHostSupports('-Wno-deprecated-declarations')
-                addIfHostSupports('-Wno-noexcept-type')
-                addIfHostSupports('-Wno-unused-function')
+                addIfHostSupports("-Wall")
+                addIfHostSupports("-Wextra")
+                addIfHostSupports("-Werror")
+                if "gcc" in self.config.available_features:
+                    addIfHostSupports(
+                        "-Wno-literal-suffix"
+                    )  # GCC warning about reserved UDLs
+                addIfHostSupports(
+                    "-Wno-user-defined-literals"
+                )  # Clang warning about reserved UDLs
+                addIfHostSupports("-Wno-unused-parameter")
+                addIfHostSupports(
+                    "-Wno-unused-local-typedefs"
+                )  # GCC warning local typdefs
+                addIfHostSupports("-Wno-deprecated-declarations")
+                addIfHostSupports("-Wno-noexcept-type")
+                addIfHostSupports("-Wno-unused-function")
 
-                if 'gcc-4.8' in self.config.available_features:
+                if "gcc-4.8" in self.config.available_features:
                     # GCC pre-GCC5 spuriously generates these on reasonable aggregate initialization.
-                    addIfHostSupports('-Wno-missing-field-initializers')
+                    addIfHostSupports("-Wno-missing-field-initializers")
 
                 # TODO: port the warning disables from the non-NVCC path?
 
-                self.cxx.warning_flags += [ '-D_LIBCUDACXX_DISABLE_PRAGMA_GCC_SYSTEM_HEADER' ]
+                self.cxx.warning_flags += [
+                    "-D_LIBCUDACXX_DISABLE_PRAGMA_GCC_SYSTEM_HEADER"
+                ]
                 pass
         else:
             self.cxx.warning_flags += [
-                '-D_LIBCUDACXX_DISABLE_PRAGMA_GCC_SYSTEM_HEADER',
-                '-Wall', '-Wextra', '-Werror'
+                "-D_LIBCUDACXX_DISABLE_PRAGMA_GCC_SYSTEM_HEADER",
+                "-Wall",
+                "-Wextra",
+                "-Werror",
             ]
-            if self.cxx.hasWarningFlag('-Wuser-defined-warnings'):
-                self.cxx.warning_flags += ['-Wuser-defined-warnings']
-                self.config.available_features.add('diagnose-if-support')
-            self.cxx.addWarningFlagIfSupported('-Wshadow')
-            self.cxx.addWarningFlagIfSupported('-Wno-unused-command-line-argument')
-            self.cxx.addWarningFlagIfSupported('-Wno-attributes')
-            self.cxx.addWarningFlagIfSupported('-Wno-pessimizing-move')
-            self.cxx.addWarningFlagIfSupported('-Wno-c++11-extensions')
-            self.cxx.addWarningFlagIfSupported('-Wno-user-defined-literals')
-            self.cxx.addWarningFlagIfSupported('-Wno-noexcept-type')
-            self.cxx.addWarningFlagIfSupported('-Wno-aligned-allocation-unavailable')
+            if self.cxx.hasWarningFlag("-Wuser-defined-warnings"):
+                self.cxx.warning_flags += ["-Wuser-defined-warnings"]
+                self.config.available_features.add("diagnose-if-support")
+            self.cxx.addWarningFlagIfSupported("-Wshadow")
+            self.cxx.addWarningFlagIfSupported("-Wno-unused-command-line-argument")
+            self.cxx.addWarningFlagIfSupported("-Wno-attributes")
+            self.cxx.addWarningFlagIfSupported("-Wno-pessimizing-move")
+            self.cxx.addWarningFlagIfSupported("-Wno-c++11-extensions")
+            self.cxx.addWarningFlagIfSupported("-Wno-user-defined-literals")
+            self.cxx.addWarningFlagIfSupported("-Wno-noexcept-type")
+            self.cxx.addWarningFlagIfSupported("-Wno-aligned-allocation-unavailable")
             # These warnings should be enabled in order to support the MSVC
             # team using the test suite; They enable the warnings below and
             # expect the test suite to be clean.
-            self.cxx.addWarningFlagIfSupported('-Wsign-compare')
-            self.cxx.addWarningFlagIfSupported('-Wunused-variable')
-            self.cxx.addWarningFlagIfSupported('-Wunused-parameter')
-            self.cxx.addWarningFlagIfSupported('-Wunreachable-code')
+            self.cxx.addWarningFlagIfSupported("-Wsign-compare")
+            self.cxx.addWarningFlagIfSupported("-Wunused-variable")
+            self.cxx.addWarningFlagIfSupported("-Wunused-parameter")
+            self.cxx.addWarningFlagIfSupported("-Wunreachable-code")
 
-        std = self.get_lit_conf('std', None)
-        if std in ['c++98', 'c++03']:
-            if 'nvcc' not in self.config.available_features:
+        std = self.get_lit_conf("std", None)
+        if std in ["c++98", "c++03"]:
+            if "nvcc" not in self.config.available_features:
                 # The '#define static_assert' provided by libc++ in C++03 mode
                 # causes an unused local typedef whenever it is used.
-                self.cxx.addWarningFlagIfSupported('-Wno-unused-local-typedef')
+                self.cxx.addWarningFlagIfSupported("-Wno-unused-local-typedef")
 
     def configure_sanitizer(self):
-        san = self.get_lit_conf('use_sanitizer', '').strip()
+        san = self.get_lit_conf("use_sanitizer", "").strip()
         if san:
             self.target_info.add_sanitizer_features(san, self.config.available_features)
             # Search for llvm-symbolizer along the compiler path first
             # and then along the PATH env variable.
-            symbolizer_search_paths = os.environ.get('PATH', '')
+            symbolizer_search_paths = os.environ.get("PATH", "")
             cxx_path = libcudacxx.util.which(self.cxx.path)
             if cxx_path is not None:
                 symbolizer_search_paths = (
-                    os.path.dirname(cxx_path) +
-                    os.pathsep + symbolizer_search_paths)
-            llvm_symbolizer = libcudacxx.util.which('llvm-symbolizer',
-                                                symbolizer_search_paths)
+                    os.path.dirname(cxx_path) + os.pathsep + symbolizer_search_paths
+                )
+            llvm_symbolizer = libcudacxx.util.which(
+                "llvm-symbolizer", symbolizer_search_paths
+            )
 
             def add_ubsan():
-                self.cxx.flags += ['-fsanitize=undefined',
-                                   '-fno-sanitize=float-divide-by-zero',
-                                   '-fno-sanitize-recover=all']
-                self.exec_env['UBSAN_OPTIONS'] = 'print_stacktrace=1'
-                self.config.available_features.add('ubsan')
+                self.cxx.flags += [
+                    "-fsanitize=undefined",
+                    "-fno-sanitize=float-divide-by-zero",
+                    "-fno-sanitize-recover=all",
+                ]
+                self.exec_env["UBSAN_OPTIONS"] = "print_stacktrace=1"
+                self.config.available_features.add("ubsan")
 
             # Setup the sanitizer compile flags
-            self.cxx.flags += ['-g', '-fno-omit-frame-pointer']
-            if san == 'Address' or san == 'Address;Undefined' or san == 'Undefined;Address':
-                self.cxx.flags += ['-fsanitize=address']
+            self.cxx.flags += ["-g", "-fno-omit-frame-pointer"]
+            if (
+                san == "Address"
+                or san == "Address;Undefined"
+                or san == "Undefined;Address"
+            ):
+                self.cxx.flags += ["-fsanitize=address"]
                 if llvm_symbolizer is not None:
-                    self.exec_env['ASAN_SYMBOLIZER_PATH'] = llvm_symbolizer
+                    self.exec_env["ASAN_SYMBOLIZER_PATH"] = llvm_symbolizer
                 # FIXME: Turn ODR violation back on after PR28391 is resolved
                 # https://bugs.llvm.org/show_bug.cgi?id=28391
-                self.exec_env['ASAN_OPTIONS'] = 'detect_odr_violation=0'
-                self.config.available_features.add('asan')
-                self.config.available_features.add('sanitizer-new-delete')
-                self.cxx.compile_flags += ['-O1']
-                if san == 'Address;Undefined' or san == 'Undefined;Address':
+                self.exec_env["ASAN_OPTIONS"] = "detect_odr_violation=0"
+                self.config.available_features.add("asan")
+                self.config.available_features.add("sanitizer-new-delete")
+                self.cxx.compile_flags += ["-O1"]
+                if san == "Address;Undefined" or san == "Undefined;Address":
                     add_ubsan()
-            elif san == 'Memory' or san == 'MemoryWithOrigins':
-                self.cxx.flags += ['-fsanitize=memory']
-                if san == 'MemoryWithOrigins':
-                    self.cxx.compile_flags += [
-                        '-fsanitize-memory-track-origins']
+            elif san == "Memory" or san == "MemoryWithOrigins":
+                self.cxx.flags += ["-fsanitize=memory"]
+                if san == "MemoryWithOrigins":
+                    self.cxx.compile_flags += ["-fsanitize-memory-track-origins"]
                 if llvm_symbolizer is not None:
-                    self.exec_env['MSAN_SYMBOLIZER_PATH'] = llvm_symbolizer
-                self.config.available_features.add('msan')
-                self.config.available_features.add('sanitizer-new-delete')
-                self.cxx.compile_flags += ['-O1']
-            elif san == 'Undefined':
+                    self.exec_env["MSAN_SYMBOLIZER_PATH"] = llvm_symbolizer
+                self.config.available_features.add("msan")
+                self.config.available_features.add("sanitizer-new-delete")
+                self.cxx.compile_flags += ["-O1"]
+            elif san == "Undefined":
                 add_ubsan()
-                self.cxx.compile_flags += ['-O2']
-            elif san == 'Thread':
-                self.cxx.flags += ['-fsanitize=thread']
-                self.config.available_features.add('tsan')
-                self.config.available_features.add('sanitizer-new-delete')
+                self.cxx.compile_flags += ["-O2"]
+            elif san == "Thread":
+                self.cxx.flags += ["-fsanitize=thread"]
+                self.config.available_features.add("tsan")
+                self.config.available_features.add("sanitizer-new-delete")
             else:
-                self.lit_config.fatal('unsupported value for '
-                                      'use_sanitizer: {0}'.format(san))
-            san_lib = self.get_lit_conf('sanitizer_library')
+                self.lit_config.fatal(
+                    "unsupported value for " "use_sanitizer: {0}".format(san)
+                )
+            san_lib = self.get_lit_conf("sanitizer_library")
             if san_lib:
-                if self.cxx.type == 'nvcc':
-                    self.cxx.link_flags += ['-Xcompiler',
-                        '"-Wl,-rpath,' + os.path.dirname(san_lib) + '"']
+                if self.cxx.type == "nvcc":
+                    self.cxx.link_flags += [
+                        "-Xcompiler",
+                        '"-Wl,-rpath,' + os.path.dirname(san_lib) + '"',
+                    ]
                 else:
-                    self.cxx.link_flags += ['-Wl,-rpath,' +
-                                            os.path.dirname(san_lib)]
+                    self.cxx.link_flags += ["-Wl,-rpath," + os.path.dirname(san_lib)]
 
     def configure_coverage(self):
-        self.generate_coverage = self.get_lit_bool('generate_coverage', False)
+        self.generate_coverage = self.get_lit_bool("generate_coverage", False)
         if self.generate_coverage:
-            self.cxx.flags += ['-g', '--coverage']
-            self.cxx.compile_flags += ['-O0']
+            self.cxx.flags += ["-g", "--coverage"]
+            self.cxx.compile_flags += ["-O0"]
 
     def configure_coroutines(self):
-        if self.cxx.hasCompileFlag('-fcoroutines-ts'):
-            macros = self._dump_macros_verbose(flags=['-fcoroutines-ts'])
-            if '__cpp_coroutines' not in macros:
-                self.lit_config.warning('-fcoroutines-ts is supported but '
-                    '__cpp_coroutines is not defined')
+        if self.cxx.hasCompileFlag("-fcoroutines-ts"):
+            macros = self._dump_macros_verbose(flags=["-fcoroutines-ts"])
+            if "__cpp_coroutines" not in macros:
+                self.lit_config.warning(
+                    "-fcoroutines-ts is supported but "
+                    "__cpp_coroutines is not defined"
+                )
             # Consider coroutines supported only when the feature test macro
             # reflects a recent value.
-            if intMacroValue(macros['__cpp_coroutines']) >= 201703:
-                self.config.available_features.add('fcoroutines-ts')
+            if intMacroValue(macros["__cpp_coroutines"]) >= 201703:
+                self.config.available_features.add("fcoroutines-ts")
 
     def configure_modules(self):
-        modules_flags = ['-fmodules']
-        if platform.system() != 'Darwin':
-            modules_flags += ['-Xclang', '-fmodules-local-submodule-visibility']
+        modules_flags = ["-fmodules"]
+        if platform.system() != "Darwin":
+            modules_flags += ["-Xclang", "-fmodules-local-submodule-visibility"]
         supports_modules = self.cxx.hasCompileFlag(modules_flags)
         enable_modules = self.get_modules_enabled()
         if enable_modules and not supports_modules:
             self.lit_config.fatal(
-                '-fmodules is enabled but not supported by the compiler')
+                "-fmodules is enabled but not supported by the compiler"
+            )
         if not supports_modules:
             return
-        self.config.available_features.add('modules-support')
-        module_cache = os.path.join(self.config.test_exec_root,
-                                   'modules.cache')
+        self.config.available_features.add("modules-support")
+        module_cache = os.path.join(self.config.test_exec_root, "modules.cache")
         module_cache = os.path.realpath(module_cache)
         if os.path.isdir(module_cache):
             shutil.rmtree(module_cache)
         os.makedirs(module_cache)
-        self.cxx.modules_flags += modules_flags + \
-            ['-fmodules-cache-path=' + module_cache]
+        self.cxx.modules_flags += modules_flags + [
+            "-fmodules-cache-path=" + module_cache
+        ]
         if enable_modules:
-            self.config.available_features.add('-fmodules')
+            self.config.available_features.add("-fmodules")
             self.cxx.useModules()
 
     def configure_substitutions(self):
         sub = self.config.substitutions
         cxx_path = pipes.quote(self.cxx.path)
         # Configure compiler substitutions
-        sub.append(('%cxx', cxx_path))
-        sub.append(('%libcxx_src_root', self.libcudacxx_src_root))
+        sub.append(("%cxx", cxx_path))
+        sub.append(("%libcxx_src_root", self.libcudacxx_src_root))
         # Configure flags substitutions
-        flags_str = ' '.join([pipes.quote(f) for f in self.cxx.flags])
-        compile_flags_str = ' '.join([pipes.quote(f) for f in self.cxx.compile_flags])
-        link_flags_str = ' '.join([pipes.quote(f) for f in self.cxx.link_flags])
-        all_flags = '%s %s %s' % (flags_str, compile_flags_str, link_flags_str)
-        sub.append(('%flags', flags_str))
-        sub.append(('%compile_flags', compile_flags_str))
-        sub.append(('%link_flags', link_flags_str))
-        sub.append(('%all_flags', all_flags))
+        flags_str = " ".join([pipes.quote(f) for f in self.cxx.flags])
+        compile_flags_str = " ".join([pipes.quote(f) for f in self.cxx.compile_flags])
+        link_flags_str = " ".join([pipes.quote(f) for f in self.cxx.link_flags])
+        all_flags = "%s %s %s" % (flags_str, compile_flags_str, link_flags_str)
+        sub.append(("%flags", flags_str))
+        sub.append(("%compile_flags", compile_flags_str))
+        sub.append(("%link_flags", link_flags_str))
+        sub.append(("%all_flags", all_flags))
         if self.cxx.isVerifySupported():
-            verify_str = ' ' + ' '.join(self.cxx.verify_flags) + ' '
-            sub.append(('%verify', verify_str))
+            verify_str = " " + " ".join(self.cxx.verify_flags) + " "
+            sub.append(("%verify", verify_str))
         # Add compile and link shortcuts
-        compile_str = (cxx_path + ' -o %t.o %s -c ' + flags_str
-                       + ' ' + compile_flags_str)
-        link_str = (cxx_path + ' -o %t.exe %t.o ' + flags_str + ' '
-                    + link_flags_str)
+        compile_str = cxx_path + " -o %t.o %s -c " + flags_str + " " + compile_flags_str
+        link_str = cxx_path + " -o %t.exe %t.o " + flags_str + " " + link_flags_str
         assert type(link_str) is str
-        build_str = cxx_path + ' -o %t.exe %s ' + all_flags
+        build_str = cxx_path + " -o %t.exe %s " + all_flags
         if self.cxx.use_modules:
-            sub.append(('%compile_module', compile_str))
-            sub.append(('%build_module', build_str))
+            sub.append(("%compile_module", compile_str))
+            sub.append(("%build_module", build_str))
         elif self.cxx.modules_flags is not None:
-            modules_str = ' '.join(self.cxx.modules_flags) + ' '
-            sub.append(('%compile_module', compile_str + ' ' + modules_str))
-            sub.append(('%build_module', build_str + ' ' + modules_str))
-        sub.append(('%compile', compile_str))
-        sub.append(('%link', link_str))
-        sub.append(('%build', build_str))
+            modules_str = " ".join(self.cxx.modules_flags) + " "
+            sub.append(("%compile_module", compile_str + " " + modules_str))
+            sub.append(("%build_module", build_str + " " + modules_str))
+        sub.append(("%compile", compile_str))
+        sub.append(("%link", link_str))
+        sub.append(("%build", build_str))
         # Configure exec prefix substitutions.
         # Configure run env substitution.
-        sub.append(('%run', '%t.exe'))
+        sub.append(("%run", "%t.exe"))
         # Configure not program substitutions
-        not_py = os.path.join(self.libcudacxx_src_root, 'test', 'utils', 'not.py')
-        not_str = '%s %s ' % (pipes.quote(sys.executable), pipes.quote(not_py))
-        sub.append(('not ', not_str))
-        if self.get_lit_conf('libcudacxx_gdb'):
-            sub.append(('%libcxx_gdb', self.get_lit_conf('libcudacxx_gdb')))
+        not_py = os.path.join(self.libcudacxx_src_root, "test", "utils", "not.py")
+        not_str = "%s %s " % (pipes.quote(sys.executable), pipes.quote(not_py))
+        sub.append(("not ", not_str))
+        if self.get_lit_conf("libcudacxx_gdb"):
+            sub.append(("%libcxx_gdb", self.get_lit_conf("libcudacxx_gdb")))
 
     def can_use_deployment(self):
         # Check if the host is on an Apple platform using clang.
@@ -1434,16 +1577,16 @@ class Configuration(object):
             return False
         if not self.target_info.is_host_macosx():
             return False
-        if not self.cxx.type.endswith('clang'):
+        if not self.cxx.type.endswith("clang"):
             return False
         return True
 
     def configure_triple(self):
         # Get or infer the target triple.
-        target_triple = self.get_lit_conf('target_triple')
-        self.use_target = self.get_lit_bool('use_target', False)
+        target_triple = self.get_lit_conf("target_triple")
+        self.use_target = self.get_lit_bool("use_target", False)
         if self.use_target and target_triple:
-            self.lit_config.warning('use_target is true but no triple is specified')
+            self.lit_config.warning("use_target is true but no triple is specified")
 
         # Use deployment if possible.
         self.use_deployment = not self.use_target and self.can_use_deployment()
@@ -1452,41 +1595,47 @@ class Configuration(object):
 
         # Save the triple (and warn on Apple platforms).
         self.config.target_triple = target_triple
-        if self.use_target and 'apple' in target_triple:
-            self.lit_config.warning('consider using arch and platform instead'
-                                    ' of target_triple on Apple platforms')
+        if self.use_target and "apple" in target_triple:
+            self.lit_config.warning(
+                "consider using arch and platform instead"
+                " of target_triple on Apple platforms"
+            )
 
         # If no target triple was given, try to infer it from the compiler
         # under test.
         if not self.config.target_triple:
-            target_triple = (self.cxx if self.cxx.type != 'nvcc' else
-                             self.host_cxx).getTriple()
+            target_triple = (
+                self.cxx if self.cxx.type != "nvcc" else self.host_cxx
+            ).getTriple()
             # Drop sub-major version components from the triple, because the
             # current XFAIL handling expects exact matches for feature checks.
             # Example: x86_64-apple-darwin14.0.0 -> x86_64-apple-darwin14
             # The 5th group handles triples greater than 3 parts
             # (ex x86_64-pc-linux-gnu).
-            target_triple = re.sub(r'([^-]+)-([^-]+)-([^.]+)([^-]*)(.*)',
-                                   r'\1-\2-\3\5', target_triple)
+            target_triple = re.sub(
+                r"([^-]+)-([^-]+)-([^.]+)([^-]*)(.*)", r"\1-\2-\3\5", target_triple
+            )
             # linux-gnu is needed in the triple to properly identify linuxes
             # that use GLIBC. Handle redhat and opensuse triples as special
             # cases and append the missing `-gnu` portion.
-            if (target_triple.endswith('redhat-linux') or
-                target_triple.endswith('suse-linux')):
-                target_triple += '-gnu'
+            if target_triple.endswith("redhat-linux") or target_triple.endswith(
+                "suse-linux"
+            ):
+                target_triple += "-gnu"
             self.config.target_triple = target_triple
             self.lit_config.note(
-                "inferred target_triple as: %r" % self.config.target_triple)
+                "inferred target_triple as: %r" % self.config.target_triple
+            )
 
     def configure_deployment(self):
-        assert not self.use_deployment is None
-        assert not self.use_target is None
+        assert self.use_deployment is not None
+        assert self.use_target is not None
         if not self.use_deployment:
             # Warn about ignored parameters.
-            if self.get_lit_conf('arch'):
-                self.lit_config.warning('ignoring arch, using target_triple')
-            if self.get_lit_conf('platform'):
-                self.lit_config.warning('ignoring platform, using target_triple')
+            if self.get_lit_conf("arch"):
+                self.lit_config.warning("ignoring arch, using target_triple")
+            if self.get_lit_conf("platform"):
+                self.lit_config.warning("ignoring platform, using target_triple")
             return
 
         assert not self.use_target
@@ -1496,10 +1645,13 @@ class Configuration(object):
         # otherwise a platform is picked up from the SDK.  If the SDK version
         # doesn't match the system version, tests that use the system library
         # may fail spuriously.
-        arch = self.get_lit_conf('arch')
+        arch = self.get_lit_conf("arch")
         if not arch:
-            arch = (self.cxx if self.cxx.type != 'nvcc' else
-                    self.host_cxx).getTriple().split('-', 1)[0]
+            arch = (
+                (self.cxx if self.cxx.type != "nvcc" else self.host_cxx)
+                .getTriple()
+                .split("-", 1)[0]
+            )
             self.lit_config.note("inferred arch as: %r" % arch)
 
         inferred_platform, name, version = self.target_info.get_platform()
@@ -1508,9 +1660,10 @@ class Configuration(object):
         self.config.deployment = (arch, name, version)
 
         # Set the target triple for use by lit.
-        self.config.target_triple = arch + '-apple-' + name + version
+        self.config.target_triple = arch + "-apple-" + name + version
         self.lit_config.note(
-            "computed target_triple as: %r" % self.config.target_triple)
+            "computed target_triple as: %r" % self.config.target_triple
+        )
 
         # If we're testing a system libc++ as opposed to the upstream LLVM one,
         # take the version of the system libc++ into account to compute which
@@ -1518,32 +1671,41 @@ class Configuration(object):
         # which is not relevant for non-shipped flavors of libc++.
         if self.use_system_cxx_lib:
             # Dylib support for shared_mutex was added in macosx10.12.
-            if name == 'macosx' and version in ('10.%s' % v for v in range(7, 12)):
-                self.config.available_features.add('dylib-has-no-shared_mutex')
-                self.lit_config.note("shared_mutex is not supported by the deployment target")
+            if name == "macosx" and version in ("10.%s" % v for v in range(7, 12)):
+                self.config.available_features.add("dylib-has-no-shared_mutex")
+                self.lit_config.note(
+                    "shared_mutex is not supported by the deployment target"
+                )
             # Throwing bad_optional_access, bad_variant_access and bad_any_cast is
             # supported starting in macosx10.14.
-            if name == 'macosx' and version in ('10.%s' % v for v in range(7, 14)):
-                self.config.available_features.add('dylib-has-no-bad_optional_access')
-                self.lit_config.note("throwing bad_optional_access is not supported by the deployment target")
+            if name == "macosx" and version in ("10.%s" % v for v in range(7, 14)):
+                self.config.available_features.add("dylib-has-no-bad_optional_access")
+                self.lit_config.note(
+                    "throwing bad_optional_access is not supported by the deployment target"
+                )
 
-                self.config.available_features.add('dylib-has-no-bad_variant_access')
-                self.lit_config.note("throwing bad_variant_access is not supported by the deployment target")
+                self.config.available_features.add("dylib-has-no-bad_variant_access")
+                self.lit_config.note(
+                    "throwing bad_variant_access is not supported by the deployment target"
+                )
 
-                self.config.available_features.add('dylib-has-no-bad_any_cast')
-                self.lit_config.note("throwing bad_any_cast is not supported by the deployment target")
+                self.config.available_features.add("dylib-has-no-bad_any_cast")
+                self.lit_config.note(
+                    "throwing bad_any_cast is not supported by the deployment target"
+                )
             # Filesystem is support on Apple platforms starting with macosx10.15.
-            if name == 'macosx' and version in ('10.%s' % v for v in range(7, 15)):
-                self.config.available_features.add('dylib-has-no-filesystem')
-                self.lit_config.note("the deployment target does not support <filesystem>")
+            if name == "macosx" and version in ("10.%s" % v for v in range(7, 15)):
+                self.config.available_features.add("dylib-has-no-filesystem")
+                self.lit_config.note(
+                    "the deployment target does not support <filesystem>"
+                )
 
     def configure_env(self):
         self.target_info.configure_env(self.exec_env)
 
     def add_path(self, dest_env, new_path):
-        if 'PATH' not in dest_env:
-            dest_env['PATH'] = new_path
+        if "PATH" not in dest_env:
+            dest_env["PATH"] = new_path
         else:
-            split_char = ';' if self.is_windows else ':'
-            dest_env['PATH'] = '%s%s%s' % (new_path, split_char,
-                                           dest_env['PATH'])
+            split_char = ";" if self.is_windows else ":"
+            dest_env["PATH"] = "%s%s%s" % (new_path, split_char, dest_env["PATH"])

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -17,8 +17,12 @@ import ctypes
 
 from libcudacxx.compiler import CXXCompiler
 from libcudacxx.test.target_info import make_target_info
-from libcudacxx.test.executor import *
-from libcudacxx.test.tracing import *
+
+# The wildcard import is to support `eval(exec_str)` in
+# `Configuration.configure_executor()` below.
+from libcudacxx.test.executor import *  # noqa: F403
+from libcudacxx.test.executor import LocalExecutor, NoopExecutor
+
 import libcudacxx.util
 
 
@@ -280,7 +284,7 @@ class Configuration(object):
                 # ValgrindExecutor is supposed to go. It is likely
                 # that the user wants it at the end, but we have no
                 # way of getting at that easily.
-                selt.lit_config.fatal(
+                self.lit_config.fatal(
                     "Cannot infer how to create a Valgrind " " executor."
                 )
         else:
@@ -289,7 +293,8 @@ class Configuration(object):
             if exec_timeout:
                 te.timeout = exec_timeout
             if self.lit_config.useValgrind:
-                te = ValgrindExecutor(self.lit_config.valgrindArgs, te)
+                # te = ValgrindExecutor(self.lit_config.valgrindArgs, te)
+                self.lit_config.fatal("ValgrindExecutor never existed in CCCL.")
         self.executor = te
 
     def configure_target_info(self):
@@ -568,7 +573,7 @@ class Configuration(object):
         self.execute_external = not use_lit_shell
 
     def configure_no_execute(self):
-        if type(self.executor) == NoopExecutor:
+        if isinstance(self.executor, NoopExecutor):
             self.config.available_features.add("no_execute")
 
     def configure_ccache(self):

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -1,21 +1,20 @@
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 
 import copy
 import errno
 import os
 import time
-import random
 
-import lit.Test        # pylint: disable=import-error
+import lit.Test  # pylint: disable=import-error
 import lit.TestRunner  # pylint: disable=import-error
-from lit.TestRunner import ParserKind, IntegratedTestKeywordParser  \
-    # pylint: disable=import-error
+from lit.TestRunner import ParserKind, IntegratedTestKeywordParser
+# pylint: disable=import-error
 
 from libcudacxx.test.executor import LocalExecutor as LocalExecutor
 import libcudacxx.util
@@ -34,8 +33,7 @@ class LibcxxTestFormat(object):
       FOO.sh.cpp   - A test that uses LIT's ShTest format.
     """
 
-    def __init__(self, cxx, use_verify_for_fail, execute_external,
-                 executor, exec_env):
+    def __init__(self, cxx, use_verify_for_fail, execute_external, executor, exec_env):
         self.cxx = copy.deepcopy(cxx)
         self.use_verify_for_fail = use_verify_for_fail
         self.execute_external = execute_external
@@ -45,10 +43,12 @@ class LibcxxTestFormat(object):
     @staticmethod
     def _make_custom_parsers():
         return [
-            IntegratedTestKeywordParser('FLAKY_TEST.', ParserKind.TAG,
-                                        initial_value=False),
-            IntegratedTestKeywordParser('MODULES_DEFINES:', ParserKind.LIST,
-                                        initial_value=[])
+            IntegratedTestKeywordParser(
+                "FLAKY_TEST.", ParserKind.TAG, initial_value=False
+            ),
+            IntegratedTestKeywordParser(
+                "MODULES_DEFINES:", ParserKind.LIST, initial_value=[]
+            ),
         ]
 
     @staticmethod
@@ -59,23 +59,21 @@ class LibcxxTestFormat(object):
         assert False and "parser not found"
 
     # TODO: Move this into lit's FileBasedTest
-    def getTestsInDirectory(self, testSuite, path_in_suite,
-                            litConfig, localConfig):
+    def getTestsInDirectory(self, testSuite, path_in_suite, litConfig, localConfig):
         source_path = testSuite.getSourcePath(path_in_suite)
         for filename in os.listdir(source_path):
             # Ignore dot files and excluded tests.
-            if filename.startswith('.') or filename in localConfig.excludes:
+            if filename.startswith(".") or filename in localConfig.excludes:
                 continue
 
             filepath = os.path.join(source_path, filename)
             if not os.path.isdir(filepath):
-                if any([filename.endswith(ext)
-                        for ext in localConfig.suffixes]):
-                    yield lit.Test.Test(testSuite, path_in_suite + (filename,),
-                                        localConfig)
+                if any([filename.endswith(ext) for ext in localConfig.suffixes]):
+                    yield lit.Test.Test(
+                        testSuite, path_in_suite + (filename,), localConfig
+                    )
 
-    def getTestsForPath(self, testSuite, path_in_suite,
-                            litConfig, localConfig):
+    def getTestsForPath(self, testSuite, path_in_suite, litConfig, localConfig):
         yield lit.Test.Test(testSuite, path_in_suite, localConfig)
 
     def execute(self, test, lit_config):
@@ -90,21 +88,22 @@ class LibcxxTestFormat(object):
     def _execute(self, test, lit_config):
         name = test.path_in_suite[-1]
         name_root, name_ext = os.path.splitext(name)
-        is_libcxx_test = test.path_in_suite[0] == 'libcxx'
-        is_sh_test = name_root.endswith('.sh')
-        is_pass_test = name.endswith('.pass.cpp') or name.endswith('.pass.mm')
-        is_fail_test = name.endswith('.fail.cpp') or name.endswith('.fail.mm')
-        is_runfail_test = name.endswith('.runfail.cpp') or name.endswith('.runfail.mm')
-        assert is_sh_test or name_ext == '.cpp' or name_ext == '.mm', \
-            'non-cpp file must be sh test'
+        is_libcxx_test = test.path_in_suite[0] == "libcxx"
+        is_sh_test = name_root.endswith(".sh")
+        is_pass_test = name.endswith(".pass.cpp") or name.endswith(".pass.mm")
+        is_fail_test = name.endswith(".fail.cpp") or name.endswith(".fail.mm")
+        is_runfail_test = name.endswith(".runfail.cpp") or name.endswith(".runfail.mm")
+        assert (
+            is_sh_test or name_ext == ".cpp" or name_ext == ".mm"
+        ), "non-cpp file must be sh test"
 
         if test.config.unsupported:
-            return (lit.Test.UNSUPPORTED,
-                    "A lit.local.cfg marked this unsupported")
+            return (lit.Test.UNSUPPORTED, "A lit.local.cfg marked this unsupported")
 
         parsers = self._make_custom_parsers()
         script = lit.TestRunner.parseIntegratedTestScript(
-            test, additional_parsers=parsers, require_script=is_sh_test)
+            test, additional_parsers=parsers, require_script=is_sh_test
+        )
         # Check if a result for the test was returned. If so return that
         # result.
         if isinstance(script, lit.Test.Result):
@@ -117,30 +116,29 @@ class LibcxxTestFormat(object):
 
         # Check that we don't have run lines on tests that don't support them.
         if not is_sh_test and len(script) != 0:
-            lit_config.fatal('Unsupported RUN line found in test %s' % name)
+            lit_config.fatal("Unsupported RUN line found in test %s" % name)
 
         tmpDir, tmpBase = lit.TestRunner.getTempPaths(test)
-        substitutions = lit.TestRunner.getDefaultSubstitutions(test, tmpDir,
-                                                               tmpBase)
+        substitutions = lit.TestRunner.getDefaultSubstitutions(test, tmpDir, tmpBase)
         script = lit.TestRunner.applySubstitutions(script, substitutions)
 
         test_cxx = copy.deepcopy(self.cxx)
         if is_fail_test:
             test_cxx.useCCache(False)
             test_cxx.useWarnings(False)
-        extra_modules_defines = self._get_parser('MODULES_DEFINES:',
-                                                 parsers).getValue()
-        if '-fmodules' in test.config.available_features:
-            test_cxx.compile_flags += [('-D%s' % mdef.strip()) for
-                                       mdef in extra_modules_defines]
-            test_cxx.addWarningFlagIfSupported('-Wno-macro-redefined')
+        extra_modules_defines = self._get_parser("MODULES_DEFINES:", parsers).getValue()
+        if "-fmodules" in test.config.available_features:
+            test_cxx.compile_flags += [
+                ("-D%s" % mdef.strip()) for mdef in extra_modules_defines
+            ]
+            test_cxx.addWarningFlagIfSupported("-Wno-macro-redefined")
             # FIXME: libc++ debug tests #define _CCCL_ASSERT to override it
             # If we see this we need to build the test against uniquely built
             # modules.
             if is_libcxx_test:
-                with open(test.getSourcePath(), 'rb') as f:
+                with open(test.getSourcePath(), "rb") as f:
                     contents = f.read()
-                if b'#define _CCCL_ASSERT' in contents:
+                if b"#define _CCCL_ASSERT" in contents:
                     test_cxx.useModules(False)
 
         # Dispatch the test based on its suffix.
@@ -148,20 +146,21 @@ class LibcxxTestFormat(object):
             if not isinstance(self.executor, LocalExecutor):
                 # We can't run ShTest tests with a executor yet.
                 # For now, bail on trying to run them
-                return lit.Test.UNSUPPORTED, 'ShTest format not yet supported'
+                return lit.Test.UNSUPPORTED, "ShTest format not yet supported"
             test.config.environment = dict(self.exec_env)
-            return lit.TestRunner._runShTest(test, lit_config,
-                                             self.execute_external, script,
-                                             tmpBase)
+            return lit.TestRunner._runShTest(
+                test, lit_config, self.execute_external, script, tmpBase
+            )
         elif is_fail_test:
             return self._evaluate_fail_test(test, test_cxx, parsers)
         elif is_pass_test:
-            return self._evaluate_pass_test(test, tmpBase, lit_config,
-                                            test_cxx, parsers)
+            return self._evaluate_pass_test(
+                test, tmpBase, lit_config, test_cxx, parsers
+            )
         elif is_runfail_test:
-            return self._evaluate_pass_test(test, tmpBase, lit_config,
-                                            test_cxx, parsers,
-                                            run_should_pass=False)
+            return self._evaluate_pass_test(
+                test, tmpBase, lit_config, test_cxx, parsers, run_should_pass=False
+            )
         else:
             # No other test type is supported
             assert False
@@ -169,19 +168,20 @@ class LibcxxTestFormat(object):
     def _clean(self, exec_path):  # pylint: disable=no-self-use
         libcudacxx.util.cleanFile(exec_path)
 
-    def _evaluate_pass_test(self, test, tmpBase, lit_config,
-                            test_cxx, parsers, run_should_pass=True):
+    def _evaluate_pass_test(
+        self, test, tmpBase, lit_config, test_cxx, parsers, run_should_pass=True
+    ):
         execDir = os.path.dirname(test.getExecPath())
         source_path = test.getSourcePath()
-        exec_path = tmpBase + '.exe'
-        object_path = tmpBase + '.o'
+        exec_path = tmpBase + ".exe"
+        object_path = tmpBase + ".o"
         # Create the output directory if it does not already exist.
         libcudacxx.util.mkdir_p(os.path.dirname(tmpBase))
         try:
             # Compile the test
             cmd, out, err, rc = test_cxx.compileLinkTwoSteps(
-                source_path, out=exec_path, object_file=object_path,
-                cwd=execDir)
+                source_path, out=exec_path, object_file=object_path, cwd=execDir
+            )
             compile_cmd = cmd
             if rc != 0:
                 report = libcudacxx.util.makeReport(cmd, out, err, rc)
@@ -196,22 +196,27 @@ class LibcxxTestFormat(object):
             # Right now we just mark all of the .dat files in the same
             # directory as dependencies, but it's likely less than that. We
             # should add a `// FILE-DEP: foo.dat` to each test to track this.
-            data_files = [os.path.join(local_cwd, f)
-                          for f in os.listdir(local_cwd) if f.endswith('.dat')]
-            is_flaky = self._get_parser('FLAKY_TEST.', parsers).getValue()
+            data_files = [
+                os.path.join(local_cwd, f)
+                for f in os.listdir(local_cwd)
+                if f.endswith(".dat")
+            ]
+            is_flaky = self._get_parser("FLAKY_TEST.", parsers).getValue()
             max_retry = 3 if is_flaky else 1
             for retry_count in range(max_retry):
-                cmd, out, err, rc = self.executor.run(exec_path, [exec_path],
-                                                      local_cwd, data_files,
-                                                      env)
-                report = "Compiled With: '%s'\n" % ' '.join(compile_cmd)
+                cmd, out, err, rc = self.executor.run(
+                    exec_path, [exec_path], local_cwd, data_files, env
+                )
+                report = "Compiled With: '%s'\n" % " ".join(compile_cmd)
                 report += libcudacxx.util.makeReport(cmd, out, err, rc)
                 result_expected = (rc == 0) == run_should_pass
                 if result_expected:
                     res = lit.Test.PASS if retry_count == 0 else lit.Test.FLAKYPASS
                     return lit.Test.Result(res, report)
                 # Rarely devices are unavailable, so just restart the test to avoid false negatives.
-                elif rc != 0 and "cudaErrorDevicesUnavailable" in out and max_retry <= 5:
+                elif (
+                    rc != 0 and "cudaErrorDevicesUnavailable" in out and max_retry <= 5
+                ):
                     max_retry += 1
                 elif retry_count + 1 == max_retry:
                     if run_should_pass:
@@ -220,7 +225,7 @@ class LibcxxTestFormat(object):
                         report += "Compiled test succeeded unexpectedly!"
                     return lit.Test.Result(lit.Test.FAIL, report)
 
-            assert False # Unreachable
+            assert False  # Unreachable
         finally:
             # Note that cleanup of exec_file happens in `_clean()`. If you
             # override this, cleanup is your reponsibility.
@@ -230,24 +235,29 @@ class LibcxxTestFormat(object):
     def _evaluate_fail_test(self, test, test_cxx, parsers):
         source_path = test.getSourcePath()
         # FIXME: lift this detection into LLVM/LIT.
-        with open(source_path, 'rb') as f:
+        with open(source_path, "rb") as f:
             contents = f.read()
-        verify_tags = [b'expected-note', b'expected-remark',
-                       b'expected-warning', b'expected-error',
-                       b'expected-no-diagnostics']
-        use_verify = self.use_verify_for_fail and \
-                     any([tag in contents for tag in verify_tags])
+        verify_tags = [
+            b"expected-note",
+            b"expected-remark",
+            b"expected-warning",
+            b"expected-error",
+            b"expected-no-diagnostics",
+        ]
+        use_verify = self.use_verify_for_fail and any(
+            [tag in contents for tag in verify_tags]
+        )
         # FIXME(EricWF): GCC 5 does not evaluate static assertions that
         # are dependant on a template parameter when '-fsyntax-only' is passed.
         # This is fixed in GCC 6. However for now we only pass "-fsyntax-only"
         # when using Clang.
-        if test_cxx.type != 'gcc' and test_cxx.type != 'nvcc':
-            test_cxx.flags += ['-fsyntax-only']
+        if test_cxx.type != "gcc" and test_cxx.type != "nvcc":
+            test_cxx.flags += ["-fsyntax-only"]
         if use_verify:
             test_cxx.useVerify()
             test_cxx.useWarnings()
-            if '-Wuser-defined-warnings' in test_cxx.warning_flags:
-                test_cxx.warning_flags += ['-Wno-error=user-defined-warnings']
+            if "-Wuser-defined-warnings" in test_cxx.warning_flags:
+                test_cxx.warning_flags += ["-Wno-error=user-defined-warnings"]
         else:
             # We still need to enable certain warnings on .fail.cpp test when
             # -verify isn't enabled. Such as -Werror=unused-result. However,
@@ -256,16 +266,18 @@ class LibcxxTestFormat(object):
             #
             # Therefore, we check if the test was expected to fail because of
             # nodiscard before enabling it
-            test_str_list = [b'ignoring return value', b'nodiscard',
-                             b'NODISCARD']
+            test_str_list = [b"ignoring return value", b"nodiscard", b"NODISCARD"]
             if any(test_str in contents for test_str in test_str_list):
-                test_cxx.flags += ['-Werror=unused-result']
+                test_cxx.flags += ["-Werror=unused-result"]
         cmd, out, err, rc = test_cxx.compile(source_path, out=os.devnull)
         check_rc = lambda rc: rc == 0 if use_verify else rc != 0
         report = libcudacxx.util.makeReport(cmd, out, err, rc)
         if check_rc(rc):
             return lit.Test.Result(lit.Test.PASS, report)
         else:
-            report += ('Expected compilation to fail!\n' if not use_verify else
-                       'Expected compilation using verify to pass!\n')
+            report += (
+                "Expected compilation to fail!\n"
+                if not use_verify
+                else "Expected compilation using verify to pass!\n"
+            )
             return lit.Test.Result(lit.Test.FAIL, report)

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -270,7 +270,10 @@ class LibcxxTestFormat(object):
             if any(test_str in contents for test_str in test_str_list):
                 test_cxx.flags += ["-Werror=unused-result"]
         cmd, out, err, rc = test_cxx.compile(source_path, out=os.devnull)
-        check_rc = lambda rc: rc == 0 if use_verify else rc != 0
+
+        def check_rc(rc):
+            return rc == 0 if use_verify else rc != 0
+
         report = libcudacxx.util.makeReport(cmd, out, err, rc)
         if check_rc(rc):
             return lit.Test.Result(lit.Test.PASS, report)

--- a/libcudacxx/test/utils/libcudacxx/test/googlebenchmark.py
+++ b/libcudacxx/test/utils/libcudacxx/test/googlebenchmark.py
@@ -8,20 +8,21 @@ import lit.TestRunner
 import lit.util
 from lit.formats.base import TestFormat
 
-kIsWindows = sys.platform in ['win32', 'cygwin']
+kIsWindows = sys.platform in ["win32", "cygwin"]
+
 
 class GoogleBenchmark(TestFormat):
     def __init__(self, test_sub_dirs, test_suffix, benchmark_args=[]):
         self.benchmark_args = list(benchmark_args)
-        self.test_sub_dirs = os.path.normcase(str(test_sub_dirs)).split(';')
+        self.test_sub_dirs = os.path.normcase(str(test_sub_dirs)).split(";")
 
         # On Windows, assume tests will also end in '.exe'.
         exe_suffix = str(test_suffix)
         if kIsWindows:
-            exe_suffix += '.exe'
+            exe_suffix += ".exe"
 
         # Also check for .py files for testing purposes.
-        self.test_suffixes = {exe_suffix, test_suffix + '.py'}
+        self.test_suffixes = {exe_suffix, test_suffix + ".py"}
 
     def getBenchmarkTests(self, path, litConfig, localConfig):
         """getBenchmarkTests(path) - [name]
@@ -36,14 +37,14 @@ class GoogleBenchmark(TestFormat):
         # TODO: allow splitting tests according to the "benchmark family" so
         # the output for a single family of tests all belongs to the same test
         # target.
-        list_test_cmd = [path, '--benchmark_list_tests']
+        list_test_cmd = [path, "--benchmark_list_tests"]
         try:
-            output = subprocess.check_output(list_test_cmd,
-                                             env=localConfig.environment)
+            output = subprocess.check_output(list_test_cmd, env=localConfig.environment)
         except subprocess.CalledProcessError as exc:
             litConfig.warning(
                 "unable to discover google-benchmarks in %r: %s. Process output: %s"
-                % (path, sys.exc_info()[1], exc.output))
+                % (path, sys.exc_info()[1], exc.output)
+            )
             raise StopIteration
 
         nested_tests = []
@@ -53,69 +54,72 @@ class GoogleBenchmark(TestFormat):
                 continue
 
             index = 0
-            while ln[index*2:index*2+2] == '  ':
+            while ln[index * 2 : index * 2 + 2] == "  ":
                 index += 1
             while len(nested_tests) > index:
                 nested_tests.pop()
 
-            ln = ln[index*2:]
-            if ln.endswith('.'):
+            ln = ln[index * 2 :]
+            if ln.endswith("."):
                 nested_tests.append(ln)
-            elif any([name.startswith('DISABLED_')
-                      for name in nested_tests + [ln]]):
+            elif any([name.startswith("DISABLED_") for name in nested_tests + [ln]]):
                 # Gtest will internally skip these tests. No need to launch a
                 # child process for it.
                 continue
             else:
-                yield ''.join(nested_tests) + ln
+                yield "".join(nested_tests) + ln
 
-    def getTestsInDirectory(self, testSuite, path_in_suite,
-                            litConfig, localConfig):
+    def getTestsInDirectory(self, testSuite, path_in_suite, litConfig, localConfig):
         source_path = testSuite.getSourcePath(path_in_suite)
         for subdir in self.test_sub_dirs:
             dir_path = os.path.join(source_path, subdir)
             if not os.path.isdir(dir_path):
                 continue
-            for fn in lit.util.listdir_files(dir_path,
-                                             suffixes=self.test_suffixes):
+            for fn in lit.util.listdir_files(dir_path, suffixes=self.test_suffixes):
                 # Discover the tests in this executable.
                 execpath = os.path.join(source_path, subdir, fn)
                 testnames = self.getBenchmarkTests(execpath, litConfig, localConfig)
                 for testname in testnames:
                     testPath = path_in_suite + (subdir, fn, testname)
-                    yield lit.Test.Test(testSuite, testPath, localConfig,
-                                        file_path=execpath)
+                    yield lit.Test.Test(
+                        testSuite, testPath, localConfig, file_path=execpath
+                    )
 
     def execute(self, test, litConfig):
-        testPath,testName = os.path.split(test.getSourcePath())
+        testPath, testName = os.path.split(test.getSourcePath())
         while not os.path.exists(testPath):
             # Handle GTest parametrized and typed tests, whose name includes
             # some '/'s.
             testPath, namePrefix = os.path.split(testPath)
-            testName = namePrefix + '/' + testName
+            testName = namePrefix + "/" + testName
 
-        cmd = [testPath, '--benchmark_filter=%s$' % testName ] + self.benchmark_args
+        cmd = [testPath, "--benchmark_filter=%s$" % testName] + self.benchmark_args
 
         if litConfig.noExecute:
-            return lit.Test.PASS, ''
+            return lit.Test.PASS, ""
 
         try:
             out, err, exitCode = lit.util.executeCommand(
-                cmd, env=test.config.environment,
-                timeout=litConfig.maxIndividualTestTime)
+                cmd,
+                env=test.config.environment,
+                timeout=litConfig.maxIndividualTestTime,
+            )
         except lit.util.ExecuteCommandTimeoutException:
-            return (lit.Test.TIMEOUT,
-                    'Reached timeout of {} seconds'.format(
-                        litConfig.maxIndividualTestTime)
-                   )
+            return (
+                lit.Test.TIMEOUT,
+                "Reached timeout of {} seconds".format(litConfig.maxIndividualTestTime),
+            )
 
         if exitCode:
-            return lit.Test.FAIL, ('exit code: %d\n' % exitCode) + out + err
+            return lit.Test.FAIL, ("exit code: %d\n" % exitCode) + out + err
 
         passing_test_line = testName
         if passing_test_line not in out:
-            msg = ('Unable to find %r in google benchmark output:\n\n%s%s' %
-                   (passing_test_line, out, err))
+            msg = "Unable to find %r in google benchmark output:\n\n%s%s" % (
+                passing_test_line,
+                out,
+                err,
+            )
             return lit.Test.UNRESOLVED, msg
 
         return lit.Test.PASS, err + out

--- a/libcudacxx/test/utils/libcudacxx/test/target_info.py
+++ b/libcudacxx/test/utils/libcudacxx/test/target_info.py
@@ -1,10 +1,10 @@
-#===----------------------------------------------------------------------===//
+# ===----------------------------------------------------------------------===//
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===//
+# ===----------------------------------------------------------------------===//
 
 import importlib
 import locale
@@ -16,6 +16,7 @@ import sys
 
 from libcudacxx.util import executeCommand
 
+
 class DefaultTargetInfo(object):
     def __init__(self, full_config):
         self.full_config = full_config
@@ -25,14 +26,26 @@ class DefaultTargetInfo(object):
 
     def add_locale_features(self, features):
         self.full_config.lit_config.warning(
-            "No locales entry for target_system: %s" % self.platform())
+            "No locales entry for target_system: %s" % self.platform()
+        )
 
-    def add_cxx_compile_flags(self, flags): pass
-    def add_cxx_link_flags(self, flags): pass
-    def configure_env(self, env): pass
-    def allow_cxxabi_link(self): return True
-    def add_sanitizer_features(self, sanitizer_type, features): pass
-    def use_lit_shell_default(self): return False
+    def add_cxx_compile_flags(self, flags):
+        pass
+
+    def add_cxx_link_flags(self, flags):
+        pass
+
+    def configure_env(self, env):
+        pass
+
+    def allow_cxxabi_link(self):
+        return True
+
+    def add_sanitizer_features(self, sanitizer_type, features):
+        pass
+
+    def use_lit_shell_default(self):
+        return False
 
 
 def test_locale(loc):
@@ -52,21 +65,23 @@ def add_common_locales(features, lit_config, is_windows=False):
     # The list uses the canonical name for the locale used in the test-suite
     # TODO: On Linux ISO8859 *may* needs to hyphenated.
     locales = [
-        ('en_US.UTF-8', 'English_United States.1252'),
-        ('fr_FR.UTF-8', 'French_France.1252'),
-        ('ru_RU.UTF-8', 'Russian_Russia.1251'),
-        ('zh_CN.UTF-8', 'Chinese_China.936'),
-        ('fr_CA.ISO8859-1', 'French_Canada.1252'),
-        ('cs_CZ.ISO8859-2', 'Czech_Czech Republic.1250')
+        ("en_US.UTF-8", "English_United States.1252"),
+        ("fr_FR.UTF-8", "French_France.1252"),
+        ("ru_RU.UTF-8", "Russian_Russia.1251"),
+        ("zh_CN.UTF-8", "Chinese_China.936"),
+        ("fr_CA.ISO8859-1", "French_Canada.1252"),
+        ("cs_CZ.ISO8859-2", "Czech_Czech Republic.1250"),
     ]
     for loc_id, windows_loc_name in locales:
         loc_name = windows_loc_name if is_windows else loc_id
         if test_locale(loc_name):
-            features.add('locale.{0}'.format(loc_id))
+            features.add("locale.{0}".format(loc_id))
         else:
-            lit_config.warning('The locale {0} is not supported by '
-                               'your platform. Some tests will be '
-                               'unsupported.'.format(loc_name))
+            lit_config.warning(
+                "The locale {0} is not supported by "
+                "your platform. Some tests will be "
+                "unsupported.".format(loc_name)
+            )
 
 
 class DarwinLocalTI(DefaultTargetInfo):
@@ -74,37 +89,35 @@ class DarwinLocalTI(DefaultTargetInfo):
         super(DarwinLocalTI, self).__init__(full_config)
 
     def is_host_macosx(self):
-        name = subprocess.check_output(['sw_vers', '-productName']).strip()
+        name = subprocess.check_output(["sw_vers", "-productName"]).strip()
         return name == "Mac OS X"
 
     def get_macosx_version(self):
         assert self.is_host_macosx()
-        version = subprocess.check_output(
-            ['sw_vers', '-productVersion']).strip()
-        version = re.sub(r'([0-9]+\.[0-9]+)(\..*)?', r'\1', version)
+        version = subprocess.check_output(["sw_vers", "-productVersion"]).strip()
+        version = re.sub(r"([0-9]+\.[0-9]+)(\..*)?", r"\1", version)
         return version
 
     def get_sdk_version(self, name):
         assert self.is_host_macosx()
-        cmd = ['xcrun', '--sdk', name, '--show-sdk-path']
+        cmd = ["xcrun", "--sdk", name, "--show-sdk-path"]
         try:
             out = subprocess.check_output(cmd).strip()
         except OSError:
             pass
 
         if not out:
-            self.full_config.lit_config.fatal(
-                    "cannot infer sdk version with: %r" % cmd)
+            self.full_config.lit_config.fatal("cannot infer sdk version with: %r" % cmd)
 
-        return re.sub(r'.*/[^0-9]+([0-9.]+)\.sdk', r'\1', out)
+        return re.sub(r".*/[^0-9]+([0-9.]+)\.sdk", r"\1", out)
 
     def get_platform(self):
-        platform = self.full_config.get_lit_conf('platform')
+        platform = self.full_config.get_lit_conf("platform")
         if platform:
-            platform = re.sub(r'([^0-9]+)([0-9\.]*)', r'\1-\2', platform)
-            name, version = tuple(platform.split('-', 1))
+            platform = re.sub(r"([^0-9]+)([0-9\.]*)", r"\1-\2", platform)
+            name, version = tuple(platform.split("-", 1))
         else:
-            name = 'macosx'
+            name = "macosx"
             version = None
 
         if version:
@@ -113,7 +126,7 @@ class DarwinLocalTI(DefaultTargetInfo):
         # Infer the version, either from the SDK or the system itself.  For
         # macosx, ignore the SDK version; what matters is what's at
         # /usr/lib/libc++.dylib.
-        if name == 'macosx':
+        if name == "macosx":
             version = self.get_macosx_version()
         else:
             version = self.get_sdk_version(name)
@@ -125,20 +138,22 @@ class DarwinLocalTI(DefaultTargetInfo):
     def add_cxx_compile_flags(self, flags):
         if self.full_config.use_deployment:
             _, name, _ = self.full_config.config.deployment
-            cmd = ['xcrun', '--sdk', name, '--show-sdk-path']
+            cmd = ["xcrun", "--sdk", name, "--show-sdk-path"]
         else:
-            cmd = ['xcrun', '--show-sdk-path']
+            cmd = ["xcrun", "--show-sdk-path"]
         out, err, exit_code = executeCommand(cmd)
         if exit_code != 0:
-            self.full_config.lit_config.warning("Could not determine macOS SDK path! stderr was " + err)
+            self.full_config.lit_config.warning(
+                "Could not determine macOS SDK path! stderr was " + err
+            )
         if exit_code == 0 and out:
             sdk_path = out.strip()
-            self.full_config.lit_config.note('using SDKROOT: %r' % sdk_path)
+            self.full_config.lit_config.note("using SDKROOT: %r" % sdk_path)
             assert isinstance(sdk_path, str)
             flags += ["-isysroot", sdk_path]
 
     def add_cxx_link_flags(self, flags):
-        flags += ['-lSystem']
+        flags += ["-lSystem"]
 
     def configure_env(self, env):
         library_paths = []
@@ -146,14 +161,14 @@ class DarwinLocalTI(DefaultTargetInfo):
         if self.full_config.cxx_runtime_root:
             library_paths += [self.full_config.cxx_runtime_root]
         elif self.full_config.use_system_cxx_lib:
-            if (os.path.isdir(str(self.full_config.use_system_cxx_lib))):
+            if os.path.isdir(str(self.full_config.use_system_cxx_lib)):
                 library_paths += [self.full_config.use_system_cxx_lib]
 
         # Configure the abi library path
         if self.full_config.abi_library_root:
             library_paths += [self.full_config.abi_library_root]
         if library_paths:
-            env['DYLD_LIBRARY_PATH'] = ':'.join(library_paths)
+            env["DYLD_LIBRARY_PATH"] = ":".join(library_paths)
 
     def allow_cxxabi_link(self):
         # Don't link libc++abi explicitly on OS X because the symbols
@@ -169,7 +184,7 @@ class FreeBSDLocalTI(DefaultTargetInfo):
         add_common_locales(features, self.full_config.lit_config)
 
     def add_cxx_link_flags(self, flags):
-        flags += ['-lc', '-lm', '-lpthread', '-lgcc_s', '-lcxxrt']
+        flags += ["-lc", "-lm", "-lpthread", "-lgcc_s", "-lcxxrt"]
 
 
 class NetBSDLocalTI(DefaultTargetInfo):
@@ -180,8 +195,7 @@ class NetBSDLocalTI(DefaultTargetInfo):
         add_common_locales(features, self.full_config.lit_config)
 
     def add_cxx_link_flags(self, flags):
-        flags += ['-lc', '-lm', '-lpthread', '-lgcc_s', '-lc++abi',
-                  '-lunwind']
+        flags += ["-lc", "-lm", "-lpthread", "-lgcc_s", "-lc++abi", "-lunwind"]
 
 
 class LinuxLocalTI(DefaultTargetInfo):
@@ -189,47 +203,50 @@ class LinuxLocalTI(DefaultTargetInfo):
         super(LinuxLocalTI, self).__init__(full_config)
 
     def platform(self):
-        return 'linux'
+        return "linux"
 
     def add_locale_features(self, features):
         add_common_locales(features, self.full_config.lit_config)
 
     def add_cxx_compile_flags(self, flags):
-        flags += ['-D__STDC_FORMAT_MACROS',
-                  '-D__STDC_LIMIT_MACROS',
-                  '-D__STDC_CONSTANT_MACROS']
+        flags += [
+            "-D__STDC_FORMAT_MACROS",
+            "-D__STDC_LIMIT_MACROS",
+            "-D__STDC_CONSTANT_MACROS",
+        ]
 
     def add_cxx_link_flags(self, flags):
-        enable_threads = ('libcpp-has-no-threads' not in
-                          self.full_config.config.available_features)
-        llvm_unwinder = self.full_config.get_lit_bool('llvm_unwinder', False)
-        shared_libcxx = self.full_config.get_lit_bool('enable_shared', True)
-        flags += ['-lm']
+        enable_threads = (
+            "libcpp-has-no-threads" not in self.full_config.config.available_features
+        )
+        llvm_unwinder = self.full_config.get_lit_bool("llvm_unwinder", False)
+        shared_libcxx = self.full_config.get_lit_bool("enable_shared", True)
+        flags += ["-lm"]
         if not llvm_unwinder:
-            flags += ['-lgcc_s', '-lgcc']
+            flags += ["-lgcc_s", "-lgcc"]
         if enable_threads:
-            flags += ['-lpthread']
+            flags += ["-lpthread"]
             if not shared_libcxx:
-                flags += ['-lrt']
-        flags += ['-lc']
+                flags += ["-lrt"]
+        flags += ["-lc"]
         if llvm_unwinder:
-            flags += ['-lunwind', '-ldl']
+            flags += ["-lunwind", "-ldl"]
         else:
-            flags += ['-lgcc_s']
-        builtins_lib = self.full_config.get_lit_conf('builtins_library')
+            flags += ["-lgcc_s"]
+        builtins_lib = self.full_config.get_lit_conf("builtins_library")
         if builtins_lib:
             flags += [builtins_lib]
         else:
-            flags += ['-lgcc']
-        use_libatomic = self.full_config.get_lit_bool('use_libatomic', False)
+            flags += ["-lgcc"]
+        use_libatomic = self.full_config.get_lit_bool("use_libatomic", False)
         if use_libatomic:
-            flags += ['-latomic']
-        san = self.full_config.get_lit_conf('use_sanitizer', '').strip()
+            flags += ["-latomic"]
+        san = self.full_config.get_lit_conf("use_sanitizer", "").strip()
         if san:
             # The libraries and their order are taken from the
             # linkSanitizerRuntimeDeps function in
             # clang/lib/Driver/Tools.cpp
-            flags += ['-lpthread', '-lrt', '-lm', '-ldl']
+            flags += ["-lpthread", "-lrt", "-lm", "-ldl"]
 
 
 class WindowsLocalTI(DefaultTargetInfo):
@@ -237,8 +254,7 @@ class WindowsLocalTI(DefaultTargetInfo):
         super(WindowsLocalTI, self).__init__(full_config)
 
     def add_locale_features(self, features):
-        add_common_locales(features, self.full_config.lit_config,
-                           is_windows=True)
+        add_common_locales(features, self.full_config.lit_config, is_windows=True)
 
     def use_lit_shell_default(self):
         # Default to the internal shell on Windows, as bash on Windows is
@@ -248,17 +264,22 @@ class WindowsLocalTI(DefaultTargetInfo):
 
 def make_target_info(full_config):
     default = "libcudacxx.test.target_info.LocalTI"
-    info_str = full_config.get_lit_conf('target_info', default)
+    info_str = full_config.get_lit_conf("target_info", default)
     if info_str != default:
-        mod_path, _, info = info_str.rpartition('.')
+        mod_path, _, info = info_str.rpartition(".")
         mod = importlib.import_module(mod_path)
         target_info = getattr(mod, info)(full_config)
         full_config.lit_config.note("inferred target_info as: %r" % info_str)
         return target_info
     target_system = platform.system()
-    if target_system == 'Darwin':  return DarwinLocalTI(full_config)
-    if target_system == 'FreeBSD': return FreeBSDLocalTI(full_config)
-    if target_system == 'NetBSD':  return NetBSDLocalTI(full_config)
-    if target_system == 'Linux':   return LinuxLocalTI(full_config)
-    if target_system == 'Windows': return WindowsLocalTI(full_config)
+    if target_system == "Darwin":
+        return DarwinLocalTI(full_config)
+    if target_system == "FreeBSD":
+        return FreeBSDLocalTI(full_config)
+    if target_system == "NetBSD":
+        return NetBSDLocalTI(full_config)
+    if target_system == "Linux":
+        return LinuxLocalTI(full_config)
+    if target_system == "Windows":
+        return WindowsLocalTI(full_config)
     return DefaultTargetInfo(full_config)

--- a/libcudacxx/test/utils/libcudacxx/test/tracing.py
+++ b/libcudacxx/test/utils/libcudacxx/test/tracing.py
@@ -1,42 +1,42 @@
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#===----------------------------------------------------------------------===##
+# ===----------------------------------------------------------------------===##
 
-import os
 import inspect
 
 
-def trace_function(function, log_calls, log_results, label=''):
+def trace_function(function, log_calls, log_results, label=""):
     def wrapper(*args, **kwargs):
-        kwarg_strs = ['{}={}'.format(k, v) for (k, v) in kwargs]
-        arg_str = ', '.join([str(a) for a in args] + kwarg_strs)
-        call_str = '{}({})'.format(function.func_name, arg_str)
+        kwarg_strs = ["{}={}".format(k, v) for (k, v) in kwargs]
+        arg_str = ", ".join([str(a) for a in args] + kwarg_strs)
+        call_str = "{}({})".format(function.func_name, arg_str)
 
         # Perform the call itself, logging before, after, and anything thrown.
         try:
             if log_calls:
-                print('{}: Calling {}'.format(label, call_str))
+                print("{}: Calling {}".format(label, call_str))
             res = function(*args, **kwargs)
             if log_results:
-                print('{}: {} -> {}'.format(label, call_str, res))
+                print("{}: {} -> {}".format(label, call_str, res))
             return res
         except Exception as ex:
             if log_results:
-                print('{}: {} raised {}'.format(label, call_str, type(ex)))
+                print("{}: {} raised {}".format(label, call_str, type(ex)))
             raise ex
 
     return wrapper
 
 
-def trace_object(obj, log_calls, log_results, label=''):
+def trace_object(obj, log_calls, log_results, label=""):
     for name, member in inspect.getmembers(obj):
         if inspect.ismethod(member):
             # Skip meta-functions, decorate everything else
-            if not member.func_name.startswith('__'):
-                setattr(obj, name, trace_function(member, log_calls,
-                                                  log_results, label))
+            if not member.func_name.startswith("__"):
+                setattr(
+                    obj, name, trace_function(member, log_calls, log_results, label)
+                )
     return obj

--- a/libcudacxx/test/utils/libcudacxx/util.py
+++ b/libcudacxx/test/utils/libcudacxx/util.py
@@ -231,7 +231,7 @@ def executeCommand(command, cwd=None, env=None, input=None, timeout=0):
         out, err = p.communicate(input=input)
         exitCode = p.wait()
     finally:
-        if timerObject != None:
+        if timerObject is not None:
             timerObject.cancel()
 
     # Ensure the resulting output is always of string type.


### PR DESCRIPTION
Follow-on to #3110: Apply ruff also to libcudacxx/tests

1. Remove libcudacxx/test/ from ruff exclude list: 6d22b1e4aa2e0aad1deff356675e6a1b47115a02 (**trivial/tiny**)

2. ruff auto-fixes (NO manual changes): e35b121a012ba0d1504563d8043c885507d60084 (**Do not review**)

3. ruff --unsafe-fixes auto-fixes (NO manual changes): 8ae58da3d0b6a465c98df1e01e1d2507ebf99004 (**Please review**)

4. All manual fixes in one commit: 1e8a957ca930eda0e9b12e16a673d2fdf3419f4f (**Please review**)

The cleanup uncovered these oversights:

* libcudacxx/test/utils/libcudacxx/test/config.py

```diff
                 # ValgrindExecutor is supposed to go. It is likely
                 # that the user wants it at the end, but we have no
                 # way of getting at that easily.
-                selt.lit_config.fatal(
+                self.lit_config.fatal(
                     "Cannot infer how to create a Valgrind " " executor."
                 )
```

```diff
             if self.lit_config.useValgrind:
-                te = ValgrindExecutor(self.lit_config.valgrindArgs, te)
+                # te = ValgrindExecutor(self.lit_config.valgrindArgs, te)
+                self.lit_config.fatal("ValgrindExecutor never existed in CCCL.")
         self.executor = te
``` 
