### PR TITLE
Implement `abs` and `div` from `cstdlib`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -146,21 +146,6 @@
 #  define _CCCL_BUILTIN_EXPECT(...) __builtin_expect(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_expect)
 
-#if _CCCL_CHECK_BUILTIN(builtin_abs)
-#  define _CCCL_BUILTIN_ABS(...)   __builtin_abs(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LABS(...)  __builtin_labs(__VA_ARGS__)
-#  define _CCCL_BUILTIN_LLABS(...) __builtin_llabs(__VA_ARGS__)
-#  if !_CCCL_COMPILER(CLANG, <, 20) && !_CCCL_COMPILER(GCC, <, 10) && !_CCCL_HAS_CUDA_COMPILER
-#    define _CCCL_HAS_CONSTEXPR_BUILTIN_ABS 1
-#  endif // !_CCCL_COMPILER(CLANG, <, 20) && !_CCCL_COMPILER(GCC, <, 10) && !_CCCL_HAS_CUDA_COMPILER
-#endif // _CCCL_CHECK_BUILTIN(builtin_abs)
-
-#if _CCCL_CHECK_BUILTIN(builtin_labs)
-#endif // _CCCL_CHECK_BUILTIN(builtin_labs)
-
-#if _CCCL_CHECK_BUILTIN(builtin_llabs)
-#endif // _CCCL_CHECK_BUILTIN(builtin_llabs)
-
 #if _CCCL_CHECK_BUILTIN(builtin_fmax) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_FMAXF(...) __builtin_fmaxf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_FMAX(...)  __builtin_fmax(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -146,6 +146,18 @@
 #  define _CCCL_BUILTIN_EXPECT(...) __builtin_expect(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_expect)
 
+#if _CCCL_CHECK_BUILTIN(builtin_abs)
+#  define _CCCL_BUILTIN_ABS(...) __builtin_abs(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_abs)
+
+#if _CCCL_CHECK_BUILTIN(builtin_labs)
+#  define _CCCL_BUILTIN_LABS(...) __builtin_labs(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_labs)
+
+#if _CCCL_CHECK_BUILTIN(builtin_llabs)
+#  define _CCCL_BUILTIN_LLABS(...) __builtin_llabs(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_llabs)
+
 #if _CCCL_CHECK_BUILTIN(builtin_fmax) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_FMAXF(...) __builtin_fmaxf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_FMAX(...)  __builtin_fmax(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -147,15 +147,18 @@
 #endif // _CCCL_CHECK_BUILTIN(builtin_expect)
 
 #if _CCCL_CHECK_BUILTIN(builtin_abs)
-#  define _CCCL_BUILTIN_ABS(...) __builtin_abs(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ABS(...)   __builtin_abs(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LABS(...)  __builtin_labs(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LLABS(...) __builtin_llabs(__VA_ARGS__)
+#  if !_CCCL_COMPILER(CLANG, <, 20) && !_CCCL_COMPILER(GCC, <, 10) && !_CCCL_HAS_CUDA_COMPILER
+#    define _CCCL_HAS_CONSTEXPR_BUILTIN_ABS 1
+#  endif // !_CCCL_COMPILER(CLANG, <, 20) && !_CCCL_COMPILER(GCC, <, 10) && !_CCCL_HAS_CUDA_COMPILER
 #endif // _CCCL_CHECK_BUILTIN(builtin_abs)
 
 #if _CCCL_CHECK_BUILTIN(builtin_labs)
-#  define _CCCL_BUILTIN_LABS(...) __builtin_labs(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_labs)
 
 #if _CCCL_CHECK_BUILTIN(builtin_llabs)
-#  define _CCCL_BUILTIN_LLABS(...) __builtin_llabs(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_llabs)
 
 #if _CCCL_CHECK_BUILTIN(builtin_fmax) || _CCCL_COMPILER(GCC)

--- a/libcudacxx/include/cuda/std/__cmath/abs.h
+++ b/libcudacxx/include/cuda/std/__cmath/abs.h
@@ -21,15 +21,13 @@
 #  pragma system_header
 #endif // no system header
 
-#if !_CCCL_COMPILER(NVRTC)
-
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 using ::fabs;
 using ::fabsf;
-#  if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
 using ::fabsl;
-#  endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float abs(float __val) noexcept
 {
@@ -41,15 +39,13 @@ _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double abs(double __val) noexcept
   return _CUDA_VSTD::fabs(__val);
 }
 
-#  if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double abs(long double __val) noexcept
 {
   return _CUDA_VSTD::fabsl(__val);
 }
-#  endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 _LIBCUDACXX_END_NAMESPACE_STD
-
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #endif // _LIBCUDACXX___CMATH_ABS_H

--- a/libcudacxx/include/cuda/std/__cmath/abs.h
+++ b/libcudacxx/include/cuda/std/__cmath/abs.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _LIBCUDACXX___CSTDLIB_ABS_H
-#define _LIBCUDACXX___CSTDLIB_ABS_H
+#ifndef _LIBCUDACXX___CMATH_ABS_H
+#define _LIBCUDACXX___CMATH_ABS_H
 
 #include <cuda/std/detail/__config>
 
@@ -21,33 +21,35 @@
 #  pragma system_header
 #endif // no system header
 
+#if !_CCCL_COMPILER(NVRTC)
+
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr int abs(int __val) noexcept
+using ::fabs;
+using ::fabsf;
+#  if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+using ::fabsl;
+#  endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float abs(float __val) noexcept
 {
-  return (__val < 0) ? -__val : __val;
+  return _CUDA_VSTD::fabsf(__val);
 }
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr long labs(long __val) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double abs(double __val) noexcept
 {
-  return (__val < 0l) ? -__val : __val;
+  return _CUDA_VSTD::fabs(__val);
 }
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr long abs(long __val) noexcept
+#  if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double abs(long double __val) noexcept
 {
-  return _CUDA_VSTD::labs(__val);
+  return _CUDA_VSTD::fabsl(__val);
 }
-
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr long long llabs(long long __val) noexcept
-{
-  return (__val < 0ll) ? -__val : __val;
-}
-
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr long long abs(long long __val) noexcept
-{
-  return _CUDA_VSTD::llabs(__val);
-}
+#  endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // _LIBCUDACXX___CSTDLIB_ABS_H
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _LIBCUDACXX___CMATH_ABS_H

--- a/libcudacxx/include/cuda/std/__cstdlib/abs.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/abs.h
@@ -1,0 +1,88 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CSTDLIB_ABS_H
+#define _LIBCUDACXX___CSTDLIB_ABS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+#  include <cstdlib>
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#include <cuda/std/__type_traits/is_constant_evaluated.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 int abs(int __val) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+#if defined(_CCCL_BUILTIN_ABS)
+    return _CCCL_BUILTIN_ABS(__val);
+#else // ^^^ _CCCL_BUILTIN_ABS ^^^ / vvv !_CCCL_BUILTIN_ABS vvv
+    return ::abs(__val);
+#endif // !_CCCL_BUILTIN_ABS
+  }
+
+#if defined(_CCCL_BUILTIN_ABS) && !_CCCL_COMPILER(CLANG, <=, 19)
+  return _CCCL_BUILTIN_ABS(__val);
+#else // ^^^ _CCCL_BUILTIN_ABS ^^^ / vvv !_CCCL_BUILTIN_ABS vvv
+  return (__val < 0) ? -__val : __val;
+#endif // !_CCCL_BUILTIN_ABS
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 long labs(long __val) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+#if defined(_CCCL_BUILTIN_LABS)
+    return _CCCL_BUILTIN_LABS(__val);
+#else // ^^^ _CCCL_BUILTIN_LABS ^^^ / vvv !_CCCL_BUILTIN_LABS vvv
+    return ::labs(__val);
+#endif // !_CCCL_BUILTIN_LABS
+  }
+
+#if defined(_CCCL_BUILTIN_LABS) && !_CCCL_COMPILER(CLANG, <=, 19)
+  return _CCCL_BUILTIN_LABS(__val);
+#else // ^^^ _CCCL_BUILTIN_LABS ^^^ / vvv !_CCCL_BUILTIN_LABS vvv
+  return (__val < 0) ? -__val : __val;
+#endif // !_CCCL_BUILTIN_LABS
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 long long llabs(long long __val) noexcept
+{
+  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+  {
+#if defined(_CCCL_BUILTIN_LLABS)
+    return _CCCL_BUILTIN_LLABS(__val);
+#else // ^^^ _CCCL_BUILTIN_LLABS ^^^ / vvv !_CCCL_BUILTIN_LLABS vvv
+    return ::llabs(__val);
+#endif // !_CCCL_BUILTIN_LLABS
+  }
+
+#if defined(_CCCL_BUILTIN_LLABS) && !_CCCL_COMPILER(CLANG, <=, 19)
+  return _CCCL_BUILTIN_LLABS(__val);
+#else // ^^^ _CCCL_BUILTIN_LLABS ^^^ / vvv !_CCCL_BUILTIN_LLABS vvv
+  return (__val < 0) ? -__val : __val;
+#endif // !_CCCL_BUILTIN_LLABS
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CSTDLIB_ABS_H

--- a/libcudacxx/include/cuda/std/__cstdlib/abs.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/abs.h
@@ -27,60 +27,61 @@
 
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 
+#if (_CCCL_STD_VER >= 2014 && defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)) || _CCCL_HAS_CONSTEXPR_BUILTIN_ABS
+#  define _CCCL_HAS_CONSTEXPR_INT_ABS 1
+#  define _CCCL_CONSTEXPR_INT_ABS     constexpr
+#else
+#  define _CCCL_CONSTEXPR_INT_ABS
+#endif
+
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 int abs(int __val) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_INT_ABS int abs(int __val) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+#if !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
+  if (_CUDA_VSTD::is_constant_evaluated())
   {
-#if defined(_CCCL_BUILTIN_ABS)
-    return _CCCL_BUILTIN_ABS(__val);
-#else // ^^^ _CCCL_BUILTIN_ABS ^^^ / vvv !_CCCL_BUILTIN_ABS vvv
-    return ::abs(__val);
-#endif // !_CCCL_BUILTIN_ABS
+    return (__val < 0) ? -__val : __val;
   }
+#endif // !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
 
-#if defined(_CCCL_BUILTIN_ABS) && !_CCCL_COMPILER(CLANG, <=, 19)
+#if defined(_CCCL_BUILTIN_ABS)
   return _CCCL_BUILTIN_ABS(__val);
 #else // ^^^ _CCCL_BUILTIN_ABS ^^^ / vvv !_CCCL_BUILTIN_ABS vvv
-  return (__val < 0) ? -__val : __val;
+  return ::abs(__val);
 #endif // !_CCCL_BUILTIN_ABS
 }
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 long labs(long __val) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_INT_ABS long labs(long __val) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+#if !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
+  if (_CUDA_VSTD::is_constant_evaluated())
   {
-#if defined(_CCCL_BUILTIN_LABS)
-    return _CCCL_BUILTIN_LABS(__val);
-#else // ^^^ _CCCL_BUILTIN_LABS ^^^ / vvv !_CCCL_BUILTIN_LABS vvv
-    return ::labs(__val);
-#endif // !_CCCL_BUILTIN_LABS
+    return (__val < 0) ? -__val : __val;
   }
+#endif // !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
 
-#if defined(_CCCL_BUILTIN_LABS) && !_CCCL_COMPILER(CLANG, <=, 19)
+#if defined(_CCCL_BUILTIN_ABS)
   return _CCCL_BUILTIN_LABS(__val);
-#else // ^^^ _CCCL_BUILTIN_LABS ^^^ / vvv !_CCCL_BUILTIN_LABS vvv
-  return (__val < 0) ? -__val : __val;
-#endif // !_CCCL_BUILTIN_LABS
+#else // ^^^ _CCCL_BUILTIN_ABS ^^^ / vvv !_CCCL_BUILTIN_ABS vvv
+  return ::labs(__val);
+#endif // !_CCCL_BUILTIN_ABS
 }
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 long long llabs(long long __val) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_INT_ABS long long llabs(long long __val) noexcept
 {
-  if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
+#if !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
+  if (_CUDA_VSTD::is_constant_evaluated())
   {
-#if defined(_CCCL_BUILTIN_LLABS)
-    return _CCCL_BUILTIN_LLABS(__val);
-#else // ^^^ _CCCL_BUILTIN_LLABS ^^^ / vvv !_CCCL_BUILTIN_LLABS vvv
-    return ::llabs(__val);
-#endif // !_CCCL_BUILTIN_LLABS
+    return (__val < 0) ? -__val : __val;
   }
+#endif // !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
 
-#if defined(_CCCL_BUILTIN_LLABS) && !_CCCL_COMPILER(CLANG, <=, 19)
+#if defined(_CCCL_BUILTIN_ABS)
   return _CCCL_BUILTIN_LLABS(__val);
-#else // ^^^ _CCCL_BUILTIN_LLABS ^^^ / vvv !_CCCL_BUILTIN_LLABS vvv
-  return (__val < 0) ? -__val : __val;
-#endif // !_CCCL_BUILTIN_LLABS
+#else // ^^^ _CCCL_BUILTIN_ABS ^^^ / vvv !_CCCL_BUILTIN_ABS vvv
+  return ::llabs(__val);
+#endif // !_CCCL_BUILTIN_ABS
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__cstdlib/abs.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/abs.h
@@ -21,67 +21,21 @@
 #  pragma system_header
 #endif // no system header
 
-#if !_CCCL_COMPILER(NVRTC)
-#  include <cstdlib>
-#endif // !_CCCL_COMPILER(NVRTC)
-
-#include <cuda/std/__type_traits/is_constant_evaluated.h>
-
-#if (_CCCL_STD_VER >= 2014 && defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)) || _CCCL_HAS_CONSTEXPR_BUILTIN_ABS
-#  define _CCCL_HAS_CONSTEXPR_INT_ABS 1
-#  define _CCCL_CONSTEXPR_INT_ABS     constexpr
-#else
-#  define _CCCL_CONSTEXPR_INT_ABS
-#endif
-
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_INT_ABS int abs(int __val) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr int abs(int __val) noexcept
 {
-#if !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
-  if (_CUDA_VSTD::is_constant_evaluated())
-  {
-    return (__val < 0) ? -__val : __val;
-  }
-#endif // !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
-
-#if defined(_CCCL_BUILTIN_ABS)
-  return _CCCL_BUILTIN_ABS(__val);
-#else // ^^^ _CCCL_BUILTIN_ABS ^^^ / vvv !_CCCL_BUILTIN_ABS vvv
-  return ::abs(__val);
-#endif // !_CCCL_BUILTIN_ABS
+  return (__val < 0) ? -__val : __val;
 }
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_INT_ABS long labs(long __val) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr long labs(long __val) noexcept
 {
-#if !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
-  if (_CUDA_VSTD::is_constant_evaluated())
-  {
-    return (__val < 0) ? -__val : __val;
-  }
-#endif // !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
-
-#if defined(_CCCL_BUILTIN_ABS)
-  return _CCCL_BUILTIN_LABS(__val);
-#else // ^^^ _CCCL_BUILTIN_ABS ^^^ / vvv !_CCCL_BUILTIN_ABS vvv
-  return ::labs(__val);
-#endif // !_CCCL_BUILTIN_ABS
+  return (__val < 0l) ? -__val : __val;
 }
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_INT_ABS long long llabs(long long __val) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr long long llabs(long long __val) noexcept
 {
-#if !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
-  if (_CUDA_VSTD::is_constant_evaluated())
-  {
-    return (__val < 0) ? -__val : __val;
-  }
-#endif // !_CCCL_HAS_CONSTEXPR_BUILTIN_ABS
-
-#if defined(_CCCL_BUILTIN_ABS)
-  return _CCCL_BUILTIN_LLABS(__val);
-#else // ^^^ _CCCL_BUILTIN_ABS ^^^ / vvv !_CCCL_BUILTIN_ABS vvv
-  return ::llabs(__val);
-#endif // !_CCCL_BUILTIN_ABS
+  return (__val < 0ll) ? -__val : __val;
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__cstdlib/div.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/div.h
@@ -1,0 +1,71 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CSTDLIB_DIV_H
+#define _LIBCUDACXX___CSTDLIB_DIV_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT div_t
+{
+  int quot;
+  int rem;
+};
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr div_t div(int __x, int __y) noexcept
+{
+  return {__x / __y, __x % __y};
+}
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT ldiv_t
+{
+  long quot;
+  long rem;
+};
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr ldiv_t ldiv(long __x, long __y) noexcept
+{
+  return {__x / __y, __x % __y};
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr ldiv_t div(long __x, long __y) noexcept
+{
+  return _CUDA_VSTD::ldiv(__x, __y);
+}
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT lldiv_t
+{
+  long long quot;
+  long long rem;
+};
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr lldiv_t lldiv(long long __x, long long __y) noexcept
+{
+  return {__x / __y, __x % __y};
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr lldiv_t div(long long __x, long long __y) noexcept
+{
+  return _CUDA_VSTD::lldiv(__x, __y);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CSTDLIB_DIV_H

--- a/libcudacxx/include/cuda/std/__cstdlib/div.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/div.h
@@ -21,18 +21,24 @@
 #  pragma system_header
 #endif // no system header
 
+#if !_CCCL_COMPILER(NVRTC)
+#  include <cstdlib>
+#endif // !_CCCL_COMPILER(NVRTC)
+
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
+// If available, use the host's div_t, ldiv_t, and lldiv_t types because the struct members order is
+// implementation-defined.
+#if !_CCCL_COMPILER(NVRTC)
+using ::div_t;
+using ::ldiv_t;
+using ::lldiv_t;
+#else // ^^^ !_CCCL_COMPILER(NVRTC) / _CCCL_COMPILER(NVRTC) vvv
 struct _CCCL_TYPE_VISIBILITY_DEFAULT div_t
 {
   int quot;
   int rem;
 };
-
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr div_t div(int __x, int __y) noexcept
-{
-  return {__x / __y, __x % __y};
-}
 
 struct _CCCL_TYPE_VISIBILITY_DEFAULT ldiv_t
 {
@@ -40,28 +46,43 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT ldiv_t
   long rem;
 };
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr ldiv_t ldiv(long __x, long __y) noexcept
-{
-  return {__x / __y, __x % __y};
-}
-
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr ldiv_t div(long __x, long __y) noexcept
-{
-  return _CUDA_VSTD::ldiv(__x, __y);
-}
-
 struct _CCCL_TYPE_VISIBILITY_DEFAULT lldiv_t
 {
   long long quot;
   long long rem;
 };
+#endif // !_CCCL_COMPILER(NVRTC)
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr lldiv_t lldiv(long long __x, long long __y) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 div_t div(int __x, int __y) noexcept
 {
-  return {__x / __y, __x % __y};
+  div_t __result{};
+  __result.quot = __x / __y;
+  __result.rem  = __x % __y;
+  return __result;
 }
 
-_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr lldiv_t div(long long __x, long long __y) noexcept
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 ldiv_t ldiv(long __x, long __y) noexcept
+{
+  ldiv_t __result{};
+  __result.quot = __x / __y;
+  __result.rem  = __x % __y;
+  return __result;
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 ldiv_t div(long __x, long __y) noexcept
+{
+  return _CUDA_VSTD::ldiv(__x, __y);
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 lldiv_t lldiv(long long __x, long long __y) noexcept
+{
+  lldiv_t __result{};
+  __result.quot = __x / __y;
+  __result.rem  = __x % __y;
+  return __result;
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 lldiv_t div(long long __x, long long __y) noexcept
 {
   return _CUDA_VSTD::lldiv(__x, __y);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -318,11 +318,13 @@ long double    truncl(long double x);
 #  include <cmath>
 #endif // _CCCL_COMPILER(NVHPC)
 
+#include <cuda/std/__cmath/abs.h>
 #include <cuda/std/__cmath/fpclassify.h>
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/min_max.h>
 #include <cuda/std/__cmath/traits.h>
+#include <cuda/std/__cstdlib/abs.h>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/version>
@@ -389,17 +391,11 @@ using ::atanhf;
 using ::hypot;
 using ::hypotf;
 
-#ifndef _AIX
-using ::abs;
-#endif
-
 #if !_CCCL_COMPILER(NVRTC)
 
 using ::double_t;
 using ::float_t;
 
-using ::fabs;
-using ::fabsf;
 using ::floor;
 using ::floorf;
 
@@ -499,7 +495,6 @@ using ::ceill;
 using ::coshl;
 using ::cosl;
 using ::expl;
-using ::fabsl;
 using ::floorl;
 using ::fmodl;
 using ::frexpl;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
@@ -95,6 +95,8 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 #  include <cstdlib>
 #endif // !_CCCL_COMPILER(NVRTC)
 
+#include <cuda/std/__cstdlib/abs.h>
+
 _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
@@ -137,15 +139,10 @@ using ::srand;
 using ::getenv;
 using ::system;
 #  endif
-using ::abs;
 using ::bsearch;
-using ::labs;
-using ::qsort;
-#  ifndef _LIBCUDACXX_HAS_NO_LONG_LONG
-using ::llabs;
-#  endif // _LIBCUDACXX_HAS_NO_LONG_LONG
 using ::div;
 using ::ldiv;
+using ::qsort;
 #  ifndef _LIBCUDACXX_HAS_NO_LONG_LONG
 using ::lldiv;
 #  endif // _LIBCUDACXX_HAS_NO_LONG_LONG

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cstdlib
@@ -96,21 +96,17 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 #endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cstdlib/abs.h>
+#include <cuda/std/__cstdlib/div.h>
 
 _CCCL_PUSH_MACROS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 #if !_CCCL_COMPILER(NVRTC)
-using ::div_t;
-using ::ldiv_t;
-using ::size_t;
-#  ifndef _LIBCUDACXX_HAS_NO_LONG_LONG
-using ::lldiv_t;
-#  endif // _LIBCUDACXX_HAS_NO_LONG_LONG
 using ::atof;
 using ::atoi;
 using ::atol;
+using ::size_t;
 #  ifndef _LIBCUDACXX_HAS_NO_LONG_LONG
 using ::atoll;
 #  endif // _LIBCUDACXX_HAS_NO_LONG_LONG
@@ -140,15 +136,10 @@ using ::getenv;
 using ::system;
 #  endif
 using ::bsearch;
-using ::div;
-using ::ldiv;
-using ::qsort;
-#  ifndef _LIBCUDACXX_HAS_NO_LONG_LONG
-using ::lldiv;
-#  endif // _LIBCUDACXX_HAS_NO_LONG_LONG
 using ::mblen;
 using ::mbstowcs;
 using ::mbtowc;
+using ::qsort;
 using ::wcstombs;
 using ::wctomb;
 #  if defined(_LIBCUDACXX_HAS_QUICK_EXIT)

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
@@ -10,41 +10,51 @@
 #include <cuda/std/cassert>
 #include <cuda/std/cstdlib>
 #include <cuda/std/limits>
-#include <cuda/std/utility>
 
 #include "test_macros.h"
 
-__host__ __device__ constexpr int abs_overload(int value)
+using I   = int;
+using IL  = long;
+using ILL = long long;
+
+__host__ __device__ constexpr I abs_overload(I value)
 {
-  ASSERT_SAME_TYPE(int, decltype(cuda::std::abs(cuda::std::declval<int>())));
-  static_assert(noexcept(cuda::std::abs(cuda::std::declval<int>())), "");
+  ASSERT_SAME_TYPE(I, decltype(cuda::std::abs(I{})));
+  static_assert(noexcept(cuda::std::abs(I{})), "");
   return cuda::std::abs(value);
 }
 
-__host__ __device__ constexpr long abs_overload(long value)
+__host__ __device__ constexpr IL abs_overload(IL value)
 {
-  ASSERT_SAME_TYPE(long, decltype(cuda::std::labs(cuda::std::declval<long>())));
-  static_assert(noexcept(cuda::std::labs(cuda::std::declval<long>())), "");
+  ASSERT_SAME_TYPE(IL, decltype(cuda::std::labs(IL{})));
+  static_assert(noexcept(cuda::std::labs(IL{})), "");
   return cuda::std::labs(value);
 }
 
-__host__ __device__ constexpr long long abs_overload(long long value)
+__host__ __device__ constexpr ILL abs_overload(ILL value)
 {
-  ASSERT_SAME_TYPE(long long, decltype(cuda::std::llabs(cuda::std::declval<long long>())));
-  static_assert(noexcept(cuda::std::llabs(cuda::std::declval<long long>())), "");
+  ASSERT_SAME_TYPE(ILL, decltype(cuda::std::llabs(ILL{})));
+  static_assert(noexcept(cuda::std::llabs(ILL{})), "");
   return cuda::std::llabs(value);
+}
+
+template <class T>
+__host__ __device__ TEST_CONSTEXPR_CXX14 bool test_abs(T in, T ref, T zero_value)
+{
+  assert(abs_overload(zero_value + in) == ref);
+  return true;
 }
 
 template <class T>
 __host__ __device__ TEST_CONSTEXPR_CXX14 bool test_abs(T zero_value)
 {
-  assert(abs_overload(zero_value + T{0}) == T{0});
-  assert(abs_overload(zero_value + T{1}) == T{1});
-  assert(abs_overload(zero_value + T{-1}) == T{1});
-  assert(abs_overload(zero_value + T{257}) == T{257});
-  assert(abs_overload(zero_value + T{-257}) == T{257});
-  assert(abs_overload(zero_value + cuda::std::numeric_limits<T>::max()) == cuda::std::numeric_limits<T>::max());
-  assert(abs_overload(zero_value + cuda::std::numeric_limits<T>::min() + T{1}) == cuda::std::numeric_limits<T>::max());
+  test_abs(T{0}, T{0}, zero_value);
+  test_abs(T{1}, T{1}, zero_value);
+  test_abs(T{-1}, T{1}, zero_value);
+  test_abs(T{257}, T{257}, zero_value);
+  test_abs(T{-257}, T{257}, zero_value);
+  test_abs(cuda::std::numeric_limits<T>::max(), cuda::std::numeric_limits<T>::max(), zero_value);
+  test_abs(cuda::std::numeric_limits<T>::min() + T{1}, cuda::std::numeric_limits<T>::max(), zero_value);
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
@@ -42,6 +42,7 @@ template <class T>
 __host__ __device__ TEST_CONSTEXPR_CXX14 bool test_abs(T in, T ref, T zero_value)
 {
   assert(abs_overload(zero_value + in) == ref);
+  assert(cuda::std::abs(zero_value + in) == ref);
   return true;
 }
 
@@ -55,14 +56,18 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 bool test_abs(T zero_value)
   test_abs(T{-257}, T{257}, zero_value);
   test_abs(cuda::std::numeric_limits<T>::max(), cuda::std::numeric_limits<T>::max(), zero_value);
   test_abs(cuda::std::numeric_limits<T>::min() + T{1}, cuda::std::numeric_limits<T>::max(), zero_value);
+
+  static_assert(noexcept(cuda::std::abs(T{})), "");
+  ASSERT_SAME_TYPE(T, decltype(cuda::std::abs(T{})));
+
   return true;
 }
 
 __host__ __device__ TEST_CONSTEXPR_CXX14 bool test(int zero_value)
 {
   test_abs(zero_value);
-  test_abs(static_cast<long>(zero_value));
-  test_abs(static_cast<long long>(zero_value));
+  test_abs(static_cast<IL>(zero_value));
+  test_abs(static_cast<ILL>(zero_value));
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
@@ -69,6 +69,9 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 bool test(int zero_value)
 __global__ void test_global_kernel(int* zero_value)
 {
   test(*zero_value);
+#if TEST_STD_VER >= 2014
+  static_assert(test(0), "");
+#endif // TEST_STD_VER >= 2014
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
@@ -14,28 +14,21 @@
 
 #include "test_macros.h"
 
-#if _CCCL_HAS_CONSTEXPR_INT_ABS && TEST_STD_VER >= 2014
-#  define ALLOW_CONSTEXPR 1
-#  define CONSTEXPR       constexpr
-#else
-#  define CONSTEXPR
-#endif
-
-__host__ __device__ CONSTEXPR int abs_overload(int value)
+__host__ __device__ constexpr int abs_overload(int value)
 {
   ASSERT_SAME_TYPE(int, decltype(cuda::std::abs(cuda::std::declval<int>())));
   static_assert(noexcept(cuda::std::abs(cuda::std::declval<int>())), "");
   return cuda::std::abs(value);
 }
 
-__host__ __device__ CONSTEXPR long abs_overload(long value)
+__host__ __device__ constexpr long abs_overload(long value)
 {
   ASSERT_SAME_TYPE(long, decltype(cuda::std::labs(cuda::std::declval<long>())));
   static_assert(noexcept(cuda::std::labs(cuda::std::declval<long>())), "");
   return cuda::std::labs(value);
 }
 
-__host__ __device__ CONSTEXPR long long abs_overload(long long value)
+__host__ __device__ constexpr long long abs_overload(long long value)
 {
   ASSERT_SAME_TYPE(long long, decltype(cuda::std::llabs(cuda::std::declval<long long>())));
   static_assert(noexcept(cuda::std::llabs(cuda::std::declval<long long>())), "");
@@ -43,7 +36,7 @@ __host__ __device__ CONSTEXPR long long abs_overload(long long value)
 }
 
 template <class T>
-__host__ __device__ CONSTEXPR bool test_abs(T zero_value)
+__host__ __device__ TEST_CONSTEXPR_CXX14 bool test_abs(T zero_value)
 {
   assert(abs_overload(zero_value + T{0}) == T{0});
   assert(abs_overload(zero_value + T{1}) == T{1});
@@ -55,7 +48,7 @@ __host__ __device__ CONSTEXPR bool test_abs(T zero_value)
   return true;
 }
 
-__host__ __device__ CONSTEXPR bool test(int zero_value)
+__host__ __device__ TEST_CONSTEXPR_CXX14 bool test(int zero_value)
 {
   test_abs(zero_value);
   test_abs(static_cast<long>(zero_value));
@@ -72,8 +65,8 @@ int main(int, char**)
 {
   volatile int zero_value = 0;
   assert(test(zero_value));
-#if ALLOW_CONSTEXPR
+#if TEST_STD_VER >= 2014
   static_assert(test(0), "");
-#endif // _CCCL_HAS_CONSTEXPR_INT_ABS
+#endif // TEST_STD_VER >= 2014
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/abs.pass.cpp
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/cstdlib>
+#include <cuda/std/limits>
+#include <cuda/std/utility>
+
+#include "test_macros.h"
+
+__host__ __device__ TEST_CONSTEXPR_CXX14 void test_int()
+{
+  ASSERT_SAME_TYPE(int, decltype(cuda::std::abs(cuda::std::declval<int>())));
+  static_assert(noexcept(cuda::std::abs(cuda::std::declval<int>())), "");
+  assert(cuda::std::abs(0) == 0);
+  assert(cuda::std::abs(1) == 1);
+  assert(cuda::std::abs(-1) == 1);
+  assert(cuda::std::abs(257) == 257);
+  assert(cuda::std::abs(-257) == 257);
+  assert(cuda::std::abs(cuda::std::numeric_limits<int>::min() + 1) == cuda::std::numeric_limits<int>::max());
+}
+
+__host__ __device__ TEST_CONSTEXPR_CXX14 void test_long()
+{
+  ASSERT_SAME_TYPE(long, decltype(cuda::std::labs(cuda::std::declval<long>())));
+  static_assert(noexcept(cuda::std::abs(cuda::std::declval<long>())), "");
+  assert(cuda::std::labs(0l) == 0l);
+  assert(cuda::std::labs(1l) == 1l);
+  assert(cuda::std::labs(-1l) == 1l);
+  assert(cuda::std::labs(257l) == 257l);
+  assert(cuda::std::labs(-257l) == 257l);
+  assert(cuda::std::labs(cuda::std::numeric_limits<long>::min() + 1l) == cuda::std::numeric_limits<long>::max());
+}
+
+__host__ __device__ TEST_CONSTEXPR_CXX14 void test_long_long()
+{
+  ASSERT_SAME_TYPE(long long, decltype(cuda::std::llabs(cuda::std::declval<long long>())));
+  static_assert(noexcept(cuda::std::abs(cuda::std::declval<long long>())), "");
+  assert(cuda::std::llabs(0ll) == 0ll);
+  assert(cuda::std::llabs(1ll) == 1ll);
+  assert(cuda::std::llabs(-1ll) == 1ll);
+  assert(cuda::std::llabs(257ll) == 257ll);
+  assert(cuda::std::llabs(-257ll) == 257ll);
+  assert(cuda::std::llabs(cuda::std::numeric_limits<long long>::min() + 1ll)
+         == cuda::std::numeric_limits<long long>::max());
+}
+
+__host__ __device__ TEST_CONSTEXPR_CXX14 bool test()
+{
+  test_int();
+  test_long();
+  test_long_long();
+  return true;
+}
+
+int main(int, char**)
+{
+  assert(test());
+#if TEST_STD_VER > 2014
+  static_assert(test(), "");
+#endif // TEST_STD_VER > 2014
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/div.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/div.pass.cpp
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/cstdlib>
+#include <cuda/std/limits>
+
+#include "test_macros.h"
+
+using I   = int;
+using IL  = long;
+using ILL = long long;
+
+__host__ __device__ constexpr cuda::std::div_t div_overload(I x, I y)
+{
+  ASSERT_SAME_TYPE(cuda::std::div_t, decltype(cuda::std::div(I{}, I{})));
+  static_assert(noexcept(cuda::std::div(I{}, I{})), "");
+  return cuda::std::div(x, y);
+}
+
+__host__ __device__ constexpr cuda::std::ldiv_t div_overload(IL x, IL y)
+{
+  ASSERT_SAME_TYPE(cuda::std::ldiv_t, decltype(cuda::std::ldiv(IL{}, IL{})));
+  static_assert(noexcept(cuda::std::ldiv(IL{}, IL{})), "");
+  return cuda::std::ldiv(x, y);
+}
+
+__host__ __device__ constexpr cuda::std::lldiv_t div_overload(ILL x, ILL y)
+{
+  ASSERT_SAME_TYPE(cuda::std::lldiv_t, decltype(cuda::std::lldiv(ILL{}, ILL{})));
+  static_assert(noexcept(cuda::std::lldiv(ILL{}, ILL{})), "");
+  return cuda::std::lldiv(x, y);
+}
+
+template <class T>
+__host__ __device__ TEST_CONSTEXPR_CXX14 void test_div(T x_in, T y_in, T x_ref, T r_ref, T zero_value)
+{
+  auto result = div_overload(zero_value + x_in, zero_value + y_in);
+  assert(result.quot == x_ref && result.rem == r_ref);
+}
+
+template <class T, class Ret>
+__host__ __device__ TEST_CONSTEXPR_CXX14 bool test_div(T zero_value)
+{
+  test_div(T{0}, T{1}, T{0}, T{0}, zero_value);
+  test_div(T{0}, cuda::std::numeric_limits<T>::max(), T{0}, T{0}, zero_value);
+  test_div(T{0}, cuda::std::numeric_limits<T>::min(), T{0}, T{0}, zero_value);
+
+  test_div(T{1}, T{1}, T{1}, T{0}, zero_value);
+  test_div(T{1}, T{-1}, T{-1}, T{0}, zero_value);
+  test_div(T{-1}, T{1}, T{-1}, T{0}, zero_value);
+  test_div(T{-1}, T{-1}, T{1}, T{0}, zero_value);
+
+  test_div(T{20}, T{3}, T{6}, T{2}, zero_value);
+  test_div(T{20}, T{-3}, T{-6}, T{2}, zero_value);
+  test_div(T{-20}, T{3}, T{-6}, T{-2}, zero_value);
+  test_div(T{-20}, T{-3}, T{6}, T{-2}, zero_value);
+
+  ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(T{}, T{})));
+  ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(T{}, float{})));
+  ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(float{}, T{})));
+  ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(T{}, double{})));
+  ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(double{}, T{})));
+  ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(T{}, unsigned{})));
+  ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(unsigned{}, T{})));
+
+  return true;
+}
+
+__host__ __device__ TEST_CONSTEXPR_CXX14 bool test(int zero_value)
+{
+  test_div<I, cuda::std::div_t>(zero_value);
+  test_div<IL, cuda::std::ldiv_t>(static_cast<long>(zero_value));
+  test_div<ILL, cuda::std::lldiv_t>(static_cast<long long>(zero_value));
+
+  return true;
+}
+
+__global__ void test_global_kernel(int* zero_value)
+{
+  test(*zero_value);
+}
+
+int main(int, char**)
+{
+  volatile int zero_value = 0;
+  assert(test(zero_value));
+#if TEST_STD_VER >= 2014
+  static_assert(test(0), "");
+#endif // TEST_STD_VER >= 2014
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/div.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/div.pass.cpp
@@ -17,21 +17,21 @@ using I   = int;
 using IL  = long;
 using ILL = long long;
 
-__host__ __device__ constexpr cuda::std::div_t div_overload(I x, I y)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::div_t div_overload(I x, I y)
 {
   ASSERT_SAME_TYPE(cuda::std::div_t, decltype(cuda::std::div(I{}, I{})));
   static_assert(noexcept(cuda::std::div(I{}, I{})), "");
   return cuda::std::div(x, y);
 }
 
-__host__ __device__ constexpr cuda::std::ldiv_t div_overload(IL x, IL y)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::ldiv_t div_overload(IL x, IL y)
 {
   ASSERT_SAME_TYPE(cuda::std::ldiv_t, decltype(cuda::std::ldiv(IL{}, IL{})));
   static_assert(noexcept(cuda::std::ldiv(IL{}, IL{})), "");
   return cuda::std::ldiv(x, y);
 }
 
-__host__ __device__ constexpr cuda::std::lldiv_t div_overload(ILL x, ILL y)
+__host__ __device__ TEST_CONSTEXPR_CXX14 cuda::std::lldiv_t div_overload(ILL x, ILL y)
 {
   ASSERT_SAME_TYPE(cuda::std::lldiv_t, decltype(cuda::std::lldiv(ILL{}, ILL{})));
   static_assert(noexcept(cuda::std::lldiv(ILL{}, ILL{})), "");
@@ -85,6 +85,9 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 bool test(int zero_value)
 __global__ void test_global_kernel(int* zero_value)
 {
   test(*zero_value);
+#if TEST_STD_VER >= 2014
+  static_assert(test(0), "");
+#endif // TEST_STD_VER >= 2014
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/div.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/div.pass.cpp
@@ -13,6 +13,8 @@
 
 #include "test_macros.h"
 
+_CCCL_DIAG_SUPPRESS_MSVC(4244) // conversion from fp to integral, possible loss of data
+
 using I   = int;
 using IL  = long;
 using ILL = long long;

--- a/libcudacxx/test/libcudacxx/std/language.support/cstdlib/div.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/cstdlib/div.pass.cpp
@@ -43,6 +43,9 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 void test_div(T x_in, T y_in, T x_ref, 
 {
   auto result = div_overload(zero_value + x_in, zero_value + y_in);
   assert(result.quot == x_ref && result.rem == r_ref);
+
+  result = cuda::std::div(zero_value + x_in, zero_value + y_in);
+  assert(result.quot == x_ref && result.rem == r_ref);
 }
 
 template <class T, class Ret>
@@ -62,6 +65,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 bool test_div(T zero_value)
   test_div(T{-20}, T{3}, T{-6}, T{-2}, zero_value);
   test_div(T{-20}, T{-3}, T{6}, T{-2}, zero_value);
 
+  static_assert(noexcept(cuda::std::div(T{}, T{})), "");
   ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(T{}, T{})));
   ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(T{}, float{})));
   ASSERT_SAME_TYPE(Ret, decltype(cuda::std::div(float{}, T{})));
@@ -76,8 +80,8 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 bool test_div(T zero_value)
 __host__ __device__ TEST_CONSTEXPR_CXX14 bool test(int zero_value)
 {
   test_div<I, cuda::std::div_t>(zero_value);
-  test_div<IL, cuda::std::ldiv_t>(static_cast<long>(zero_value));
-  test_div<ILL, cuda::std::lldiv_t>(static_cast<long long>(zero_value));
+  test_div<IL, cuda::std::ldiv_t>(static_cast<IL>(zero_value));
+  test_div<ILL, cuda::std::lldiv_t>(static_cast<ILL>(zero_value));
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_abs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/fp_abs.pass.cpp
@@ -1,0 +1,155 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+
+#include "test_macros.h"
+
+using F  = float;
+using D  = double;
+using LD = long double;
+
+__host__ __device__ F fabs_overload(F value)
+{
+  ASSERT_SAME_TYPE(F, decltype(cuda::std::fabsf(F{})));
+  // static_assert(noexcept(cuda::std::fabsf(F{})), "");
+  return cuda::std::fabsf(value);
+}
+
+__host__ __device__ D fabs_overload(D value)
+{
+  ASSERT_SAME_TYPE(D, decltype(cuda::std::fabs(D{})));
+  // static_assert(noexcept(cuda::std::fabs(D{})), "");
+  return cuda::std::fabs(value);
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+__host__ __device__ LD fabs_overload(LD value)
+{
+  ASSERT_SAME_TYPE(LD, decltype(cuda::std::fabsl(LD{})));
+  // static_assert(noexcept(cuda::std::fabsl(LD{})), "");
+  return cuda::std::fabsl(value);
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+template <class T, class = void>
+struct OverloadTester;
+
+template <class T>
+struct OverloadTester<T, cuda::std::enable_if_t<!cuda::std::__is_extended_floating_point<T>::value>>
+{
+  __host__ __device__ static bool test_fabs(T in, T ref, T zero_value)
+  {
+    assert(fabs_overload(zero_value + in) == ref);
+    assert(cuda::std::abs(zero_value + in) == ref);
+    return true;
+  }
+
+  __host__ __device__ static bool test_fabs_nan(T zero_value)
+  {
+    assert(cuda::std::isnan(fabs_overload(zero_value + cuda::std::numeric_limits<T>::quiet_NaN())));
+    assert(cuda::std::isnan(cuda::std::abs(zero_value + cuda::std::numeric_limits<T>::quiet_NaN())));
+    return true;
+  }
+};
+
+template <class T>
+struct OverloadTester<T, cuda::std::enable_if_t<cuda::std::__is_extended_floating_point<T>::value>>
+{
+  __host__ __device__ static bool test_fabs(T in, T ref, T zero_value)
+  {
+    assert(cuda::std::abs(zero_value + in) == ref);
+    return true;
+  }
+
+  __host__ __device__ static bool test_fabs_nan(T zero_value)
+  {
+    assert(cuda::std::isnan(cuda::std::abs(zero_value + cuda::std::numeric_limits<T>::quiet_NaN())));
+    return true;
+  }
+};
+
+template <class T>
+__host__ __device__ bool test_fabs(T in, T ref, T zero_value)
+{
+  return OverloadTester<T>::test_fabs(in, ref, zero_value);
+}
+
+template <class T>
+__host__ __device__ bool test_fabs_nan(T zero_value)
+{
+  return OverloadTester<T>::test_fabs_nan(zero_value);
+}
+
+template <class T>
+__host__ __device__ bool test_fabs(T zero_value)
+{
+  test_fabs(T{0.0}, T{0.0}, zero_value);
+  test_fabs(T{-0.0}, T{0.0}, zero_value);
+
+  test_fabs(T{1.0}, T{1.0}, zero_value);
+  test_fabs(T{-1.0}, T{1.0}, zero_value);
+
+  test_fabs(T{257.0}, T{257.0}, zero_value);
+  test_fabs(T{-257.0}, T{257.0}, zero_value);
+
+  test_fabs(cuda::std::numeric_limits<T>::max(), cuda::std::numeric_limits<T>::max(), zero_value);
+  test_fabs(-cuda::std::numeric_limits<T>::max(), cuda::std::numeric_limits<T>::max(), zero_value);
+
+  test_fabs(cuda::std::numeric_limits<T>::min(), cuda::std::numeric_limits<T>::min(), zero_value);
+  test_fabs(-cuda::std::numeric_limits<T>::min(), cuda::std::numeric_limits<T>::min(), zero_value);
+
+  test_fabs(cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity(), zero_value);
+  test_fabs(-cuda::std::numeric_limits<T>::infinity(), cuda::std::numeric_limits<T>::infinity(), zero_value);
+
+  // __half and __nvbfloat have precision issues here
+  if (!cuda::std::__is_extended_floating_point<T>::value)
+  {
+    test_fabs_nan(zero_value);
+  }
+
+  return true;
+}
+
+__host__ __device__ bool test(F zero_value)
+{
+  test_fabs(zero_value);
+  test_fabs(static_cast<D>(zero_value));
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test_fabs(static_cast<LD>(zero_value));
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test_fabs(__float2half(zero_value));
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test_fabs(__float2bfloat16(zero_value));
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  return true;
+}
+
+__global__ void test_global_kernel(F* zero_value)
+{
+  test(*zero_value);
+  // #if TEST_STD_VER >= 2014
+  //   static_assert(test(0.f), "");
+  // #endif // TEST_STD_VER >= 2014
+}
+
+int main(int, char**)
+{
+  volatile F zero_value = 0.f;
+  assert(test(zero_value));
+  // #if TEST_STD_VER >= 2014
+  //   static_assert(test(0.f), "");
+  // #endif // TEST_STD_VER >= 2014
+  return 0;
+}


### PR DESCRIPTION
This PR implements integer `abs` and `div` free functions from `cstdlib` and makes them available in device code.