### PR TITLE
Add missing header in bench scan exclusive base header

### DIFF
--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -30,6 +30,7 @@
 #include <cuda/std/__functional/invoke.h>
 
 #include <look_back_helper.cuh>
+#include <nvbench_helper.cuh>
 
 #if !TUNE_BASE
 #  if TUNE_TRANSPOSE == 0


### PR DESCRIPTION
clangd fails to identify `all_types` and `offset_types` in `NVBENCH_TYPE_AXES(all_types, offset_types)` without the added header.