### PR TITLE
make the `_CCCL_REQUIRES_EXPR` macro more robust

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/preprocessor.h
+++ b/libcudacxx/include/cuda/std/__cccl/preprocessor.h
@@ -28,6 +28,12 @@
 #  define _CCCL_HAS_INCLUDE(_X) 0
 #endif
 
+#ifdef __COUNTER__
+#  define _CCCL_COUNTER() __COUNTER__
+#else
+#  define _CCCL_COUNTER() __LINE__
+#endif
+
 #define _CCCL_PP_EXPAND(...) __VA_ARGS__
 #define _CCCL_PP_EAT(...)
 

--- a/libcudacxx/include/cuda/std/__concepts/concept_macros.h
+++ b/libcudacxx/include/cuda/std/__concepts/concept_macros.h
@@ -244,12 +244,12 @@ namespace __cccl_unqualified_cuda_std = _CUDA_VSTD; // NOLINT(misc-unused-alias-
 
 #    define _CCCL_REQUIRES_EXPR(_TY, ...)                                                                             \
       ::__cccl_requires_expr_impl<                                                                                    \
-        struct _CCCL_PP_CAT(__cccl_requires_expr_detail_, __LINE__) _CCCL_REQUIRES_EXPR_EXPAND_TPARAMS                \
+        struct _CCCL_PP_CAT(__cccl_requires_expr_detail_, _CCCL_COUNTER()) _CCCL_REQUIRES_EXPR_EXPAND_TPARAMS         \
           _TY>::__cccl_is_satisfied(static_cast<::__cccl_tag<void _CCCL_REQUIRES_EXPR_EXPAND_TPARAMS _TY>*>(nullptr), \
                                     static_cast<void (*)(__VA_ARGS__)>(nullptr));                                     \
-      struct _CCCL_PP_CAT(__cccl_requires_expr_detail_, __LINE__)                                                     \
+      struct _CCCL_PP_CAT(__cccl_requires_expr_detail_, _CCCL_COUNTER())                                              \
       {                                                                                                               \
-        using __cccl_self_t = _CCCL_PP_CAT(__cccl_requires_expr_detail_, __LINE__);                                   \
+        using __cccl_self_t = _CCCL_PP_CAT(__cccl_requires_expr_detail_, _CCCL_COUNTER());                            \
         template <class _CCCL_REQUIRES_EXPR_TPARAMS _TY>                                                              \
         _LIBCUDACXX_HIDE_FROM_ABI static auto __cccl_well_formed(__VA_ARGS__) _CCCL_REQUIRES_EXPR_2
 

--- a/libcudacxx/include/cuda/std/__concepts/concept_macros.h
+++ b/libcudacxx/include/cuda/std/__concepts/concept_macros.h
@@ -242,14 +242,15 @@ namespace __cccl_unqualified_cuda_std = _CUDA_VSTD; // NOLINT(misc-unused-alias-
 
 #    define _CCCL_REQUIRES_EXPR_EXPAND_TPARAMS(...) _CCCL_PP_FOR_EACH(_CCCL_REQUIRES_EXPR_EXPAND_TPARAM, __VA_ARGS__)
 
-#    define _CCCL_REQUIRES_EXPR(_TY, ...)                                                                             \
+#    define _CCCL_REQUIRES_EXPR(_TY, ...) _CCCL_REQUIRES_EXPR_IMPL(_TY, _CCCL_COUNTER(), ...)
+#    define _CCCL_REQUIRES_EXPR_IMPL(_TY, _ID, ...)                                                                   \
       ::__cccl_requires_expr_impl<                                                                                    \
-        struct _CCCL_PP_CAT(__cccl_requires_expr_detail_, _CCCL_COUNTER()) _CCCL_REQUIRES_EXPR_EXPAND_TPARAMS         \
+        struct _CCCL_PP_CAT(__cccl_requires_expr_detail_, _ID) _CCCL_REQUIRES_EXPR_EXPAND_TPARAMS                     \
           _TY>::__cccl_is_satisfied(static_cast<::__cccl_tag<void _CCCL_REQUIRES_EXPR_EXPAND_TPARAMS _TY>*>(nullptr), \
                                     static_cast<void (*)(__VA_ARGS__)>(nullptr));                                     \
-      struct _CCCL_PP_CAT(__cccl_requires_expr_detail_, _CCCL_COUNTER())                                              \
+      struct _CCCL_PP_CAT(__cccl_requires_expr_detail_, _ID)                                                          \
       {                                                                                                               \
-        using __cccl_self_t = _CCCL_PP_CAT(__cccl_requires_expr_detail_, _CCCL_COUNTER());                            \
+        using __cccl_self_t = _CCCL_PP_CAT(__cccl_requires_expr_detail_, _ID);                                        \
         template <class _CCCL_REQUIRES_EXPR_TPARAMS _TY>                                                              \
         _LIBCUDACXX_HIDE_FROM_ABI static auto __cccl_well_formed(__VA_ARGS__) _CCCL_REQUIRES_EXPR_2
 

--- a/libcudacxx/include/cuda/std/__concepts/concept_macros.h
+++ b/libcudacxx/include/cuda/std/__concepts/concept_macros.h
@@ -242,7 +242,7 @@ namespace __cccl_unqualified_cuda_std = _CUDA_VSTD; // NOLINT(misc-unused-alias-
 
 #    define _CCCL_REQUIRES_EXPR_EXPAND_TPARAMS(...) _CCCL_PP_FOR_EACH(_CCCL_REQUIRES_EXPR_EXPAND_TPARAM, __VA_ARGS__)
 
-#    define _CCCL_REQUIRES_EXPR(_TY, ...) _CCCL_REQUIRES_EXPR_IMPL(_TY, _CCCL_COUNTER(), ...)
+#    define _CCCL_REQUIRES_EXPR(_TY, ...) _CCCL_REQUIRES_EXPR_IMPL(_TY, _CCCL_COUNTER(), __VA_ARGS__)
 #    define _CCCL_REQUIRES_EXPR_IMPL(_TY, _ID, ...)                                                                   \
       ::__cccl_requires_expr_impl<                                                                                    \
         struct _CCCL_PP_CAT(__cccl_requires_expr_detail_, _ID) _CCCL_REQUIRES_EXPR_EXPAND_TPARAMS                     \


### PR DESCRIPTION
## Description

`_CCCL_REQUIRES_EXPR` needs a unique identifier. currently it uses `__LINE__` to make an identifier unique, but that can cause conflicts. this PR changes it to use `__COUNTER__` instead when available.

it also adds `_CCCL_COUNTER()` to `__cccl/preprocessor.h`. when `__COUNTER__` is unavailable, it expands to `__LINE__`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
