### PR TITLE
the streams created by `cudax::stream` should not synchronize with the null stream

### DIFF
--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -48,7 +48,7 @@ struct stream : stream_ref
   {
     [[maybe_unused]] __ensure_current_device __dev_setter(__dev);
     _CCCL_TRY_CUDA_API(
-      ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamDefault, __priority);
+      ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamNonBlocking, __priority);
   }
 
   //! @brief Constructs a stream on a specified logical device and with specified priority
@@ -61,7 +61,7 @@ struct stream : stream_ref
   {
     [[maybe_unused]] __ensure_current_device __dev_setter(__dev);
     _CCCL_TRY_CUDA_API(
-      ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamDefault, __priority);
+      ::cudaStreamCreateWithPriority, "Failed to create a stream", &__stream, cudaStreamNonBlocking, __priority);
   }
 
   //! @brief Constructs a stream on the default device


### PR DESCRIPTION
## Description

the null stream was a mistake. in cudax i don't think we should be allowing spooky action at a distance by creating more streams that synchronize with it.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
