### PR TITLE
Fix parameter space for TUNE_LOAD in scan benchmark

### DIFF
--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -43,7 +43,7 @@
 
 #  if TUNE_LOAD == 0
 #    define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
-#  else // TUNE_LOAD == 1
+#  elif TUNE_LOAD == 1
 #    define TUNE_LOAD_MODIFIER cub::LOAD_CA
 #  endif // TUNE_LOAD
 

--- a/cub/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/cub/benchmarks/bench/scan/exclusive/by_key.cu
@@ -36,7 +36,7 @@
 // %RANGE% TUNE_DELAY_CONSTRUCTOR_ID dcid 0:7:1
 // %RANGE% TUNE_L2_WRITE_LATENCY_NS l2w 0:1200:5
 // %RANGE% TUNE_TRANSPOSE trp 0:1:1
-// %RANGE% TUNE_LOAD ld 0:2:1
+// %RANGE% TUNE_LOAD ld 0:1:1
 
 #if !TUNE_BASE
 #  if TUNE_TRANSPOSE == 0
@@ -49,7 +49,7 @@
 
 #  if TUNE_LOAD == 0
 #    define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
-#  else // TUNE_LOAD == 1
+#  elif TUNE_LOAD == 1
 #    define TUNE_LOAD_MODIFIER cub::LOAD_CA
 #  endif // TUNE_LOAD
 

--- a/cub/benchmarks/bench/scan/exclusive/max.cu
+++ b/cub/benchmarks/bench/scan/exclusive/max.cu
@@ -31,7 +31,7 @@
 // %RANGE% TUNE_DELAY_CONSTRUCTOR_ID dcid 0:7:1
 // %RANGE% TUNE_L2_WRITE_LATENCY_NS l2w 0:1200:5
 // %RANGE% TUNE_TRANSPOSE trp 0:1:1
-// %RANGE% TUNE_LOAD ld 0:2:1
+// %RANGE% TUNE_LOAD ld 0:1:1
 
 #include <nvbench_helper.cuh>
 

--- a/cub/benchmarks/bench/scan/exclusive/sum.cu
+++ b/cub/benchmarks/bench/scan/exclusive/sum.cu
@@ -33,7 +33,7 @@
 // %RANGE% TUNE_DELAY_CONSTRUCTOR_ID dcid 0:7:1
 // %RANGE% TUNE_L2_WRITE_LATENCY_NS l2w 0:1200:5
 // %RANGE% TUNE_TRANSPOSE trp 0:1:1
-// %RANGE% TUNE_LOAD ld 0:2:1
+// %RANGE% TUNE_LOAD ld 0:1:1
 
 using op_t = ::cuda::std::plus<>;
 #include "base.cuh"


### PR DESCRIPTION
The scan benchmark tuning parameter space for  `TUNE_LOAD` was defined as:
```c++
// %RANGE% TUNE_LOAD ld 0:2:1
```
(valid values are 0, 1, and 2)

However, the tuning parameter is then translated to tuning policy values like:
```c++
#  if TUNE_LOAD == 0
#    define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
#  else // TUNE_LOAD == 1
#    define TUNE_LOAD_MODIFIER cub::LOAD_CA
#  endif // TUNE_LOAD
```
Thus collapsing the values 1 and 2 into the same load modifier. This needlessly largens the tuning search space.
