### PR TITLE
Fix pre-commit config for codespell and remaining typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,8 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+        additional_dependencies: [tomli]
+        args: ["--toml", "pyproject.toml"]
         exclude: |
           (?x)^(
             build|

--- a/cub/test/catch2_large_problem_helper.cuh
+++ b/cub/test/catch2_large_problem_helper.cuh
@@ -54,7 +54,7 @@ struct large_problem_test_helper
   c2h::device_vector<std::uint32_t> correctness_flags;
   std::size_t num_elements;
 
-  // Prepare the helper for a given nunber of output elements
+  // Prepare the helper for a given number of output elements
   large_problem_test_helper(std::size_t num_elements)
       : num_elements(num_elements)
   {

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -177,7 +177,7 @@
 #  define _CCCL_GLOBAL_CONSTANT _CCCL_INLINE_VAR constexpr
 #endif // __CUDA_ARCH__
 
-// Check for deprectation opt outs
+// Check for deprecation opt outs
 #if defined(LIBCUDACXX_IGNORE_DEPRECATED_CPP_DIALECT) || defined(THRUST_IGNORE_DEPRECATED_CPP_DIALECT) \
   || defined(CUB_IGNORE_DEPRECATED_CPP_DIALECT)
 #  define _CCCL_IGNORE_DEPRECATED_CPP_DIALECT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,6 @@ target-version = "py310"
 skip = "./.git,./build,./CITATION.md"
 # ignore short words, and typename parameters like OffsetT
 ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-ignore-words-list = "inout,imovable,optionN,aCount,quitted,Invokable,countr,unexpect,numer,euclidian,couldn"
+ignore-words-list = "inout,imovable,optionN,aCount,quitted,Invokable,countr,unexpect,numer,euclidian,couldn,OffsetT"
 builtin = "clear"
 quiet-level = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,6 @@ target-version = "py310"
 skip = "./.git,./build,./CITATION.md"
 # ignore short words, and typename parameters like OffsetT
 ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-ignore-words-list = "inout,imovable,optionN,aCount,quitted,Invokable,countr,unexpect,numer,euclidian,couldn,OffsetT"
+ignore-words-list = "inout,imovable,optionN,aCount,quitted,Invokable,countr,unexpect,numer,euclidian,couldn"
 builtin = "clear"
 quiet-level = 3


### PR DESCRIPTION
## Description

As a follow up to #3168, fixes the pre-commit config so that the options specified in `pyproject.toml` are actually picked up. Also fixes a couple of remaining typos.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
