### PR TITLE
[CUDAX] Throw in managed_memory_resource::deallocate_async

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
@@ -123,7 +123,9 @@ public:
   //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate_async`.
   void deallocate_async(void* __ptr, const size_t __bytes, const size_t __alignment, const ::cuda::stream_ref __stream)
   {
-    deallocate(__ptr, __bytes);
+    _CUDA_VSTD::__throw_runtime_error("Asynchronous deallocation is not available for managed memory.");
+    (void) __ptr;
+    (void) __bytes;
     (void) __alignment;
     (void) __stream;
   }
@@ -138,7 +140,9 @@ public:
   //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate_async`.
   void deallocate_async(void* __ptr, size_t __bytes, const ::cuda::stream_ref __stream)
   {
-    deallocate(__ptr, __bytes);
+    _CUDA_VSTD::__throw_runtime_error("Asynchronous deallocation is not available for managed memory.");
+    (void) __ptr;
+    (void) __bytes;
     (void) __stream;
   }
 

--- a/cudax/test/memory_resource/managed_memory_resource.cu
+++ b/cudax/test/memory_resource/managed_memory_resource.cu
@@ -84,7 +84,9 @@ TEST_CASE("managed_memory_resource allocation", "[memory_resource]")
     stream.wait();
     ensure_managed_ptr(ptr);
 
-    res.deallocate_async(ptr, 42, stream);
+    // deallocate_async on managed not available
+    // res.deallocate_async(ptr, 42, stream);
+    res.deallocate(ptr, 42);
   }
 
   { // allocate_async / deallocate_async with alignment
@@ -94,7 +96,9 @@ TEST_CASE("managed_memory_resource allocation", "[memory_resource]")
     stream.wait();
     ensure_managed_ptr(ptr);
 
-    res.deallocate_async(ptr, 42, 4, stream);
+    // deallocate_async on managed not available
+    // res.deallocate_async(ptr, 42, 4, stream);
+    res.deallocate(ptr, 42, 4);
   }
 
 #ifndef _LIBCUDACXX_NO_EXCEPTIONS


### PR DESCRIPTION
While it is fine to forward `allocate_async` to `allocate`, it is invalid to forward `deallocate_async` to `deallocate`, since the memory might still be in use. This PR changes `deallocate_async` on `managed_memory_resource` to throw, while `pinned_memory_resource` will be handled separately.