### PR TITLE
Fixes pre-CTK 11.5 diag suppression issues

### DIFF
--- a/cub/test/catch2_test_device_reduce.cu
+++ b/cub/test/catch2_test_device_reduce.cu
@@ -289,7 +289,3 @@ C2H_TEST("Device reduce works with all device interfaces", "[reduce][device]", f
   }
 #endif
 }
-
-#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
-_CCCL_NV_DIAG_DEFAULT(1444)
-#endif

--- a/cub/test/catch2_test_device_reduce_fp_inf.cu
+++ b/cub/test/catch2_test_device_reduce_fp_inf.cu
@@ -129,9 +129,3 @@ C2H_TEST("Device reduce arg{min,max} works with inf items", "[reduce][device]")
     REQUIRE(result.value == -inf);
   }
 }
-
-// Pre-nv_diag support, suppression of the warning for the deprecated ArgMin and ArgMax interfaces wouldn't work when
-// defaulting
-#if defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
-_CCCL_NV_DIAG_DEFAULT(1444)
-#endif

--- a/libcudacxx/include/cuda/std/__cccl/diagnostic.h
+++ b/libcudacxx/include/cuda/std/__cccl/diagnostic.h
@@ -127,7 +127,7 @@
 #    define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _CCCL_PRAGMA(diagnostic push) _CCCL_PRAGMA(diag_suppress _WARNING)
 #    define _CCCL_NV_DIAG_DEFAULT(_WARNING)  _CCCL_PRAGMA(diagnostic pop)
 #  else // ^^^ __NVCC_DIAG_PRAGMA_SUPPORT__ ^^^ / vvv !__NVCC_DIAG_PRAGMA_SUPPORT__ vvv
-#    if _CCCL_COMPILER(MSVC2017) // MSVC 2017 has issues with restoring the warning
+#    if _CCCL_COMPILER(MSVC2017) || _CCCL_COMPILER(GCC) // these compilers have issues with restoring the warning
 #      define _CCCL_NV_DIAG_SUPPRESS(_WARNING) _CCCL_PRAGMA(diag_suppress _WARNING)
 #      define _CCCL_NV_DIAG_DEFAULT(_WARNING)
 #    else // ^^^ _CCCL_COMPILER(MSVC2017) ^^^ / vvv !_CCCL_COMPILER(MSVC2017) vvv


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
During https://github.com/NVIDIA/cccl/pull/3148, we ran into diagnostic suppression issues for CTK pre-11.5. This PR tries to fix these issues more broadly. <!-- Link issue here -->
