### PR TITLE
Fix rendering of cuda.parallel docs

### DIFF
--- a/docs/cuda_parallel/index.rst
+++ b/docs/cuda_parallel/index.rst
@@ -7,7 +7,12 @@ CUDA Parallel
   Python exposure of parallel algorithms is in public beta.
   The API is subject to change without notice.
 
-.. automodule:: cuda.parallel.experimental
+.. automodule:: cuda.parallel.experimental.algorithms
+  :members:
+  :undoc-members:
+  :imported-members:
+
+.. automodule:: cuda.parallel.experimental.iterators
   :members:
   :undoc-members:
   :imported-members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,6 @@ target-version = "py310"
 skip = "./.git,./build,./CITATION.md"
 # ignore short words, and typename parameters like OffsetT
 ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-ignore-words-list = "inout,imovable,optionN,aCount,quitted,Invokable,countr,unexpect,numer,euclidian,couldn"
+ignore-words-list = "inout,imovable,optionN,aCount,quitted,Invokable,countr,unexpect,numer,euclidian,couldn,OffsetT"
 builtin = "clear"
 quiet-level = 3

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/__init__.py
@@ -3,7 +3,7 @@ import numba
 
 
 def CacheModifiedInputIterator(device_array, modifier):
-    """Python facade for Random Access Cache Modified Iterator that wraps a native device pointer.
+    """Random Access Cache Modified Iterator that wraps a native device pointer.
 
     Similar to https://nvidia.github.io/cccl/cub/api/classcub_1_1CacheModifiedInputIterator.html
 
@@ -18,15 +18,15 @@ def CacheModifiedInputIterator(device_array, modifier):
 
 
 def ConstantIterator(value):
-    """Python facade (similar to itertools.repeat) for C++ Random Access ConstantIterator."""
+    """Returns an Iterator representing a sequence of constant values."""
     return _iterators.ConstantIterator(value)
 
 
 def CountingIterator(offset):
-    """Python facade (similar to itertools.count) for C++ Random Access CountingIterator."""
+    """Returns an Iterator representing a sequence of incrementing values."""
     return _iterators.CountingIterator(offset)
 
 
-def TransformIterator(op, it):
-    """Python facade (similar to built-in map) mimicking a C++ Random Access TransformIterator."""
+def TransformIterator(it, op):
+    """Returns an Iterator representing a transformed sequence of values."""
     return _iterators.make_transform_iterator(it, op)

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -220,7 +220,7 @@ def test_device_sum_map_mul2_count_it(
     dtype_inp = numpy.dtype(vtn_inp)
     dtype_out = numpy.dtype(vtn_out)
     i_input = iterators.TransformIterator(
-        mul2, iterators.CountingIterator(dtype_inp.type(start_sum_with))
+        iterators.CountingIterator(dtype_inp.type(start_sum_with)), mul2
     )
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
@@ -252,11 +252,11 @@ def test_device_sum_map_mul_map_mul_count_it(
     dtype_out = numpy.dtype(vtn_out)
     mul_funcs = {2: mul2, 3: mul3}
     i_input = iterators.TransformIterator(
-        mul_funcs[fac_out],
         iterators.TransformIterator(
-            mul_funcs[fac_mid],
             iterators.CountingIterator(dtype_inp.type(start_sum_with)),
+            mul_funcs[fac_mid],
         ),
+        mul_funcs[fac_out],
     )
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
@@ -280,7 +280,7 @@ def test_device_sum_map_mul2_cp_array_it(
     rng = random.Random(0)
     l_d_in = [rng.randrange(100) for _ in range(num_items)]
     a_d_in = cp.array(l_d_in, dtype_inp)
-    i_input = iterators.TransformIterator(mul2, a_d_in)
+    i_input = iterators.TransformIterator(a_d_in, mul2)
     l_varr = [mul2(v) for v in l_d_in]
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array


### PR DESCRIPTION
## Description

This PR fixes the rendered docs for `cuda.parallel` so that it picks up the `cuda.parallel.experimental.iterators` and `cuda.parallel.experimental.algorithms` subpackages and the exposed types/functions therein.

There's also a couple of smaller changes

- The `Iterator` docstrings are changed so as to not reference `itertools`
- `TransformIterator` arguments are swapped to match `thrust::transform_iterator`


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
