### PR TITLE
turn off cuda version check for clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -29,6 +29,8 @@ CompileFlags:
   Add:
     - -x
     - cuda
+    - -Wno-unknown-cuda-version
+    - --no-cuda-version-check
     # report all errors
     - "-ferror-limit=0"
     - "-ftemplate-backtrace-limit=0"


### PR DESCRIPTION
## Description

it's a small thing, but when i'm working with cccl locally (not in a devcontainer), clangd complains about every CUDA file (see image). this pr fixes the issue for me.

![Screenshot from 2024-12-18 16-30-13](https://github.com/user-attachments/assets/27e0331a-539a-4812-8810-9df11ca92012)


