### PR TITLE
Prefer c2h::type_name over c2h::demangle

### DIFF
--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -115,7 +115,7 @@ C2H_TEST("DeviceTransform::Transform BabelStream add",
   constexpr auto alg = c2h::get<2, TestType>::value;
   FILTER_UNSUPPORTED_ALGS
   const int num_items = GENERATE(0, 1, 15, 16, 17, 127, 128, 129, 4095, 4096, 4097); // edge cases around 16 and 128
-  CAPTURE(c2h::demangle(typeid(type).name()), c2h::demangle(typeid(offset_t).name()), alg, num_items);
+  CAPTURE(c2h::type_name<type>(), c2h::type_name<offset_t>(), alg, num_items);
 
   c2h::device_vector<type> a(num_items);
   c2h::device_vector<type> b(num_items);
@@ -188,7 +188,7 @@ using overaligned_types =
 C2H_TEST("DeviceTransform::Transform overaligned type", "[device][device_transform]", overaligned_types)
 {
   using type = c2h::get<0, TestType>;
-  CAPTURE(c2h::demangle(typeid(type).name()));
+  CAPTURE(c2h::type_name<type>());
 
   const int num_items = GENERATE(0, 1, 100, 1000);
   c2h::device_vector<int> a(num_items, 3); // put some integers at the front, so SMEM has to handle different alignments
@@ -209,7 +209,7 @@ C2H_TEST("DeviceTransform::Transform huge type", "[device][device_transform]")
 {
   using huge_t = c2h::custom_type_t<c2h::equal_comparable_t, c2h::accumulateable_t, c2h::huge_data<666>::type>;
   static_assert(alignof(huge_t) == 8, "Need a large type with alignment < 16");
-  CAPTURE(c2h::demangle(typeid(huge_t).name()));
+  CAPTURE(c2h::type_name<huge_t>());
 
   const int num_items = GENERATE(0, 1, 100, 1000);
   c2h::device_vector<huge_t> a(num_items);
@@ -285,7 +285,7 @@ C2H_TEST("DeviceTransform::Transform BabelStream nstream",
   using offset_t     = typename c2h::get<1, TestType>;
   constexpr auto alg = c2h::get<2, TestType>::value;
   FILTER_UNSUPPORTED_ALGS
-  CAPTURE(c2h::demangle(typeid(type).name()), c2h::demangle(typeid(offset_t).name()), alg);
+  CAPTURE(c2h::type_name<type>(), c2h::type_name<offset_t>(), alg);
 
   const int num_items = GENERATE(0, 1, 100, 1000, 10000);
   c2h::device_vector<type> a(num_items);
@@ -510,7 +510,7 @@ C2H_TEST("DeviceTransform::Transform buffer start alignment",
 
   constexpr int num_items = 1000;
   const int offset        = GENERATE(1, 2, 4, 8, 16, 32, 64, 128); // global memory is always at least 256 byte aligned
-  CAPTURE(c2h::demangle(typeid(type).name()), offset);
+  CAPTURE(c2h::type_name<type>(), offset);
   c2h::device_vector<type> input(num_items);
   thrust::sequence(input.begin(), input.end());
   c2h::device_vector<type> result(num_items);

--- a/thrust/testing/async/test_policy_overloads.h
+++ b/thrust/testing/async/test_policy_overloads.h
@@ -204,9 +204,9 @@ private:
     // debugging:
     using overload_t = std::tuple_element_t<PostfixIdx, postfix_args_type>;
 
-    std::string const overload_desc = unittest::demangle(typeid(overload_t).name());
-    std::string const input_desc    = unittest::demangle(typeid(input_type).name());
-    std::string const output_desc   = unittest::demangle(typeid(output_type).name());
+    std::string const overload_desc = unittest::type_name<overload_t>();
+    std::string const input_desc    = unittest::type_name<input_type>();
+    std::string const output_desc   = unittest::type_name<output_type>();
 
     exc
       << "\n"


### PR DESCRIPTION
This is a small cleanup.