### PR TITLE
Enable PDL for DeviceMergeSortBlockSortKernel

### DIFF
--- a/cub/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -512,7 +512,7 @@ struct DispatchMergeSort
 
       // Invoke DeviceMergeSortBlockSortKernel
       THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
-        static_cast<int>(num_tiles), merge_sort_helper_t::policy_t::BLOCK_THREADS, 0, stream)
+        static_cast<int>(num_tiles), merge_sort_helper_t::policy_t::BLOCK_THREADS, 0, stream, true)
         .doit(
           DeviceMergeSortBlockSortKernel<
             typename PolicyHub::MaxPolicy,


### PR DESCRIPTION
The kernel already contains a call to _CCCL_PDL_GRID_DEPENDENCY_SYNC, but PDL was not enabled when launching it. This was missed in #3114.

Running `cub.bench.merge_sort.keys` before and after reports no change in performance. This is expected because there is no kernel running before merge sort to overlap.