### PR TITLE
cudax fixes for msvc 14.41

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -307,7 +307,7 @@ private:
   static_assert(_CUDA_VMR::__contains_execution_space_property<_Properties...>,
                 "The properties of cuda::experimental::any_resource must contain at least one execution space "
                 "property!");
-  using __base_t = __cudax::basic_any<__iresource<_Properties...>>;
+  using __base_t = __cudax::basic_any<__cudax::__iresource<_Properties...>>;
   using __base_t::interface;
 
 public:
@@ -340,7 +340,7 @@ private:
   template <class...>
   friend struct any_resource;
 
-  using __base_t = __cudax::basic_any<__iasync_resource<_Properties...>>;
+  using __base_t = __cudax::basic_any<__cudax::__iasync_resource<_Properties...>>;
   using __base_t::interface;
 
   __base_t& __base() noexcept
@@ -364,7 +364,7 @@ private:
   static_assert(_CUDA_VMR::__contains_execution_space_property<_Properties...>,
                 "The properties of cuda::experimental::resource_ref must contain at least one execution space "
                 "property!");
-  using __base_t = __cudax::basic_any<__iresource<_Properties...>&>;
+  using __base_t = __cudax::basic_any<__cudax::__iresource<_Properties...>&>;
   using __base_t::interface;
 
 public:
@@ -401,7 +401,7 @@ private:
   template <class...>
   friend struct resource_ref;
 
-  using __base_t = __cudax::basic_any<__iasync_resource<_Properties...>&>;
+  using __base_t = __cudax::basic_any<__cudax::__iasync_resource<_Properties...>&>;
   using __base_t::interface;
 
   __base_t& __base() noexcept

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -140,6 +140,7 @@ public:
   // internal typedefs which for technical reasons are public
   using __storage_t =
     __detail::__partially_static_sizes_tagged<__detail::__extents_tag, index_type, size_t, _Extents...>;
+  using __indices_t = _CUDA_VSTD::integer_sequence<size_t, _Extents...>;
 
 #  ifndef _CCCL_HAS_NO_ATTRIBUTE_NO_UNIQUE_ADDRESS
   _CCCL_NO_UNIQUE_ADDRESS __storage_t __storage_;
@@ -251,7 +252,7 @@ public:
     /* multi-stage check to protect from invalid pack expansion when sizes don't match? */
     (decltype(__detail::__check_compatible_extents(
       integral_constant<bool, sizeof...(_Extents) == sizeof...(_OtherExtents)>{},
-      _CUDA_VSTD::integer_sequence<size_t, _Extents...>{},
+      __indices_t{}, // _CUDA_VSTD::integer_sequence<size_t, _Extents...>{}
       _CUDA_VSTD::integer_sequence<size_t, _OtherExtents...>{}))::value))
   _LIBCUDACXX_HIDE_FROM_ABI __MDSPAN_CONDITIONAL_EXPLICIT(
     (((_Extents != dynamic_extent) && (_OtherExtents == dynamic_extent)) || ...)


### PR DESCRIPTION
## Description

I needed these changes to build cudax with VC++ 2022 (v14.41) which we currently do not test in CI.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
