### PR TITLE
help the ranges concepts recognize standard contiguous iterators in c++14/17

### DIFF
--- a/cudax/include/cuda/experimental/__algorithm/common.cuh
+++ b/cudax/include/cuda/experimental/__algorithm/common.cuh
@@ -31,26 +31,8 @@
 namespace cuda::experimental
 {
 
-#if _CCCL_STD_VER >= 2020 && defined(_CCCL_SPAN_USES_RANGES)
 template <typename _Tp>
-concept __valid_1d_copy_fill_argument = _CUDA_VRANGES::contiguous_range<detail::__as_copy_arg_t<_Tp>>;
-
-#else
-template <typename _Tp, typename = int>
-inline constexpr bool __convertible_to_span = false;
-
-template <typename _Tp>
-inline constexpr bool __convertible_to_span<
-  _Tp,
-  _CUDA_VSTD::enable_if_t<
-    _CUDA_VSTD::is_convertible_v<_Tp, _CUDA_VSTD::span<typename _CUDA_VSTD::decay_t<_Tp>::value_type>>,
-    int>> = true;
-
-template <typename _Tp>
-inline constexpr bool __valid_1d_copy_fill_argument =
-  _CUDA_VRANGES::contiguous_range<detail::__as_copy_arg_t<_Tp>> || __convertible_to_span<_Tp>;
-
-#endif
+_CCCL_CONCEPT __valid_1d_copy_fill_argument = _CUDA_VRANGES::contiguous_range<detail::__as_copy_arg_t<_Tp>>;
 
 template <typename _Tp, typename _Decayed = _CUDA_VSTD::decay_t<_Tp>>
 using __as_mdspan_t =

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -170,24 +170,23 @@ struct __iter_traits_cache
 template <class _Iter>
 using _ITER_TRAITS = typename __iter_traits_cache<_Iter>::type;
 
-#if defined(_GLIBCXX_DEBUG)
+#if _CCCL_STD_VER >= 2014
+#  if defined(_GLIBCXX_DEBUG)
 _CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
 _CCCL_REQUIRES(_IsSame<_Iter, ::__gnu_debug::_Safe_iterator<_Ty*, _Range>>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto
   __iter_concept_fn(::__gnu_debug::_Safe_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
-#endif
-#if defined(__GLIBCXX__)
+#  endif
+#  if defined(__GLIBCXX__)
 _CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
 _CCCL_REQUIRES(_IsSame<_Iter, ::__gnu_cxx::__normal_iterator<_Ty*, _Range>>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto
   __iter_concept_fn(::__gnu_cxx::__normal_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
-#endif
-#if defined(_LIBCPP_VERSION)
+#  elif defined(_LIBCPP_VERSION)
 _CCCL_TEMPLATE(class _Iter, class _Ty)
 _CCCL_REQUIRES(_IsSame<_Iter, ::std::__wrap_iter<_Ty*>>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(::std::__wrap_iter<_Ty*>, __priority_tag<3>) -> contiguous_iterator_tag;
-#endif
-#if defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
+#  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 _CCCL_TEMPLATE(class _Iter)
 _CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Array_iterator>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
@@ -209,10 +208,14 @@ _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> co
 _CCCL_TEMPLATE(class _Iter)
 _CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_view_iterator>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
-#endif
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Span_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+#  endif
 _CCCL_TEMPLATE(class _Iter, class _Ty)
 _CCCL_REQUIRES(_IsSame<_Iter, _Ty*>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Ty*, __priority_tag<3>) -> contiguous_iterator_tag;
+#endif // _CCCL_STD_VER >= 2014
 template <class _Iter>
 _LIBCUDACXX_HIDE_FROM_ABI auto
   __iter_concept_fn(_Iter, __priority_tag<2>) -> class _ITER_TRAITS<_Iter>::iterator_concept;

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -172,51 +172,55 @@ using _ITER_TRAITS = typename __iter_traits_cache<_Iter>::type;
 
 #if defined(_GLIBCXX_DEBUG)
 _CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
-_CCCL_REQUIRES(same_as<_Iter, ::__gnu_debug::_Safe_iterator<_Ty*, _Range>>)
-auto __iter_concept_fn(::__gnu_debug::_Safe_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, ::__gnu_debug::_Safe_iterator<_Ty*, _Range>>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto
+  __iter_concept_fn(::__gnu_debug::_Safe_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
 #endif
 #if defined(__GLIBCXX__)
 _CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
-_CCCL_REQUIRES(same_as<_Iter, ::__gnu_cxx::__normal_iterator<_Ty*, _Range>>)
-auto __iter_concept_fn(::__gnu_cxx::__normal_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, ::__gnu_cxx::__normal_iterator<_Ty*, _Range>>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto
+  __iter_concept_fn(::__gnu_cxx::__normal_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
 #endif
 #if defined(_LIBCPP_VERSION)
 _CCCL_TEMPLATE(class _Iter, class _Ty)
-_CCCL_REQUIRES(same_as<_Iter, ::std::__wrap_iter<_Ty*>>)
-auto __iter_concept_fn(::std::__wrap_iter<_Ty*>, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, ::std::__wrap_iter<_Ty*>>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(::std::__wrap_iter<_Ty*>, __priority_tag<3>) -> contiguous_iterator_tag;
 #endif
 #if defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(same_as<_Iter, class _Iter::_Array_iterator>)
-auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Array_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(same_as<_Iter, class _Iter::_Array_const_iterator>)
-auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Array_const_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(same_as<_Iter, class _Iter::_Vector_iterator>)
-auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Vector_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(same_as<_Iter, class _Iter::_Vector_const_iterator>)
-auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Vector_const_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(same_as<_Iter, class _Iter::_String_iterator>)
-auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(same_as<_Iter, class _Iter::_String_const_iterator>)
-auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_const_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(same_as<_Iter, class _Iter::_String_view_iterator>)
-auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_view_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
 #endif
 _CCCL_TEMPLATE(class _Iter, class _Ty)
-_CCCL_REQUIRES(same_as<_Iter, _Ty*>)
-auto __iter_concept_fn(_Ty*, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, _Ty*>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Ty*, __priority_tag<3>) -> contiguous_iterator_tag;
 template <class _Iter>
-auto __iter_concept_fn(_Iter, __priority_tag<2>) -> class _ITER_TRAITS<_Iter>::iterator_concept;
+_LIBCUDACXX_HIDE_FROM_ABI auto
+  __iter_concept_fn(_Iter, __priority_tag<2>) -> class _ITER_TRAITS<_Iter>::iterator_concept;
 template <class _Iter>
-auto __iter_concept_fn(_Iter, __priority_tag<1>) -> class _ITER_TRAITS<_Iter>::iterator_category;
+_LIBCUDACXX_HIDE_FROM_ABI auto
+  __iter_concept_fn(_Iter, __priority_tag<1>) -> class _ITER_TRAITS<_Iter>::iterator_category;
 template <class _Iter>
-auto __iter_concept_fn(_Iter, __priority_tag<0>)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<0>)
   -> enable_if_t<__is_primary_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
 
 template <class _Iter>

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -37,6 +37,7 @@
 #include <cuda/std/__type_traits/is_primary_template.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/__type_traits/void_t.h>
+#include <cuda/std/__utility/priority_tag.h>
 #include <cuda/std/cstddef>
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -45,6 +46,10 @@
 #  else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 #    include <iterator> // for ::std::input_iterator_tag
 #  endif // !_CCCL_COMPILER(MSVC)
+
+#  ifdef _GLIBCXX_DEBUG
+#    include <debug/safe_iterator.h>
+#  endif
 
 #  if _CCCL_STD_VER >= 2020
 template <class _Tp, class = void>
@@ -109,7 +114,7 @@ _CCCL_CONCEPT __dereferenceable = _CCCL_FRAGMENT(__dereferenceable_, _Tp);
 
 // [iterator.traits]
 template <class _Tp>
-using iter_reference_t = enable_if_t<__dereferenceable<_Tp>, decltype(*_CUDA_VSTD::declval<_Tp&>())>;
+using iter_reference_t = enable_if_t<__dereferenceable<_Tp>, decltype(*declval<_Tp&>())>;
 
 template <class, class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
@@ -165,38 +170,70 @@ struct __iter_traits_cache
 template <class _Iter>
 using _ITER_TRAITS = typename __iter_traits_cache<_Iter>::type;
 
-struct __iter_concept_concept_test
-{
-  template <class _Iter>
-  using _Apply = typename _ITER_TRAITS<_Iter>::iterator_concept;
-};
-struct __iter_concept_category_test
-{
-  template <class _Iter>
-  using _Apply = typename _ITER_TRAITS<_Iter>::iterator_category;
-};
-struct __iter_concept_random_fallback
-{
-  template <class _Iter>
-  using _Apply = enable_if_t<__is_primary_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
-};
+#if defined(_GLIBCXX_DEBUG)
+_CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
+_CCCL_REQUIRES(same_as<_Iter, ::__gnu_debug::_Safe_iterator<_Ty*, _Range>>)
+auto __iter_concept_fn(::__gnu_debug::_Safe_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
+#endif
+#if defined(__GLIBCXX__)
+_CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
+_CCCL_REQUIRES(same_as<_Iter, ::__gnu_cxx::__normal_iterator<_Ty*, _Range>>)
+auto __iter_concept_fn(::__gnu_cxx::__normal_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
+#endif
+#if defined(_LIBCPP_VERSION)
+_CCCL_TEMPLATE(class _Iter, class _Ty)
+_CCCL_REQUIRES(same_as<_Iter, ::std::__wrap_iter<_Ty*>>)
+auto __iter_concept_fn(::std::__wrap_iter<_Ty*>, __priority_tag<3>) -> contiguous_iterator_tag;
+#endif
+#if defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(same_as<_Iter, class _Iter::_Array_iterator>)
+auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(same_as<_Iter, class _Iter::_Array_const_iterator>)
+auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(same_as<_Iter, class _Iter::_Vector_iterator>)
+auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(same_as<_Iter, class _Iter::_Vector_const_iterator>)
+auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(same_as<_Iter, class _Iter::_String_iterator>)
+auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(same_as<_Iter, class _Iter::_String_const_iterator>)
+auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(same_as<_Iter, class _Iter::_String_view_iterator>)
+auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+#endif
+_CCCL_TEMPLATE(class _Iter, class _Ty)
+_CCCL_REQUIRES(same_as<_Iter, _Ty*>)
+auto __iter_concept_fn(_Ty*, __priority_tag<3>) -> contiguous_iterator_tag;
+template <class _Iter>
+auto __iter_concept_fn(_Iter, __priority_tag<2>) -> class _ITER_TRAITS<_Iter>::iterator_concept;
+template <class _Iter>
+auto __iter_concept_fn(_Iter, __priority_tag<1>) -> class _ITER_TRAITS<_Iter>::iterator_category;
+template <class _Iter>
+auto __iter_concept_fn(_Iter, __priority_tag<0>)
+  -> enable_if_t<__is_primary_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
 
-template <class _Iter, class _Tester>
-struct __test_iter_concept
-    : _IsValidExpansion<_Tester::template _Apply, _Iter>
-    , _Tester
+template <class _Iter>
+using __iter_concept_t = decltype(_CUDA_VSTD::__iter_concept_fn<_Iter>(declval<_Iter>(), __priority_tag<3>{}));
+
+template <class _Iter, class = void>
+struct __iter_concept_cache
 {};
 
 template <class _Iter>
-struct __iter_concept_cache
+struct __iter_concept_cache<_Iter, void_t<__iter_concept_t<_Iter>>>
 {
-  using type = _Or<__test_iter_concept<_Iter, __iter_concept_concept_test>,
-                   __test_iter_concept<_Iter, __iter_concept_category_test>,
-                   __test_iter_concept<_Iter, __iter_concept_random_fallback>>;
+  using type = __iter_concept_t<_Iter>;
 };
 
 template <class _Iter>
-using _ITER_CONCEPT = typename __iter_concept_cache<_Iter>::type::template _Apply<_Iter>;
+using _ITER_CONCEPT = typename __iter_concept_cache<_Iter>::type;
 
 template <class _Tp>
 struct __has_iterator_typedefs

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -175,40 +175,42 @@ using _ITER_TRAITS = typename __iter_traits_cache<_Iter>::type;
 #  if defined(_GLIBCXX_DEBUG)
 _CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
 _CCCL_REQUIRES(_IsSame<_Iter, ::__gnu_debug::_Safe_iterator<_Ty*, _Range>>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto
-  __iter_concept_fn(::__gnu_debug::_Safe_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<::__gnu_debug::_Safe_iterator<_Ty*, _Range>>*,
+                                                 __priority_tag<3>) -> contiguous_iterator_tag;
 #  endif
 #  if defined(__GLIBCXX__)
 _CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
 _CCCL_REQUIRES(_IsSame<_Iter, ::__gnu_cxx::__normal_iterator<_Ty*, _Range>>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto
-  __iter_concept_fn(::__gnu_cxx::__normal_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<::__gnu_cxx::__normal_iterator<_Ty*, _Range>>*,
+                                                 __priority_tag<3>) -> contiguous_iterator_tag;
 #  endif // __GLIBCXX__
 #  if defined(_LIBCPP_VERSION)
 _CCCL_TEMPLATE(class _Iter, class _Ty)
 _CCCL_REQUIRES(_IsSame<_Iter, ::std::__wrap_iter<_Ty*>>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(::std::__wrap_iter<_Ty*>, __priority_tag<3>) -> contiguous_iterator_tag;
+_LIBCUDACXX_HIDE_FROM_ABI auto
+__iter_concept_fn(__undefined<::std::__wrap_iter<_Ty*>>*, __priority_tag<3>) -> contiguous_iterator_tag;
 #  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 _CCCL_TEMPLATE(class _Iter)
 _CCCL_REQUIRES((_CCCL_TRAIT(is_pointer, ::std::_Unwrapped_t<_Iter>)))
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Iter>*, __priority_tag<3>) -> contiguous_iterator_tag;
 #  endif // _MSVC_STL_VERSION
 _CCCL_TEMPLATE(class _Iter, class _Ty)
 _CCCL_REQUIRES(_IsSame<_Iter, _Ty*>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Ty*, __priority_tag<3>) -> contiguous_iterator_tag;
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Ty*>*, __priority_tag<3>) -> contiguous_iterator_tag;
 #endif // _CCCL_STD_VER >= 2014
 template <class _Iter>
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<2>) ->
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Iter>*, __priority_tag<2>) ->
   typename _ITER_TRAITS<_Iter>::iterator_concept;
 template <class _Iter>
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<1>) ->
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Iter>*, __priority_tag<1>) ->
   typename _ITER_TRAITS<_Iter>::iterator_category;
 template <class _Iter>
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<0>)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Iter>*, __priority_tag<0>)
   -> enable_if_t<__is_primary_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
 
 template <class _Iter>
-using __iter_concept_t = decltype(_CUDA_VSTD::__iter_concept_fn<_Iter>(declval<_Iter>(), __priority_tag<3>{}));
+using __iter_concept_t =
+  decltype(_CUDA_VSTD::__iter_concept_fn<_Iter>(static_cast<__undefined<_Iter>*>(nullptr), __priority_tag<3>{}));
 
 template <class _Iter, class = void>
 struct __iter_concept_cache

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -34,6 +34,7 @@
 #include <cuda/std/__type_traits/add_const.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_pointer.h>
 #include <cuda/std/__type_traits/is_primary_template.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/__type_traits/void_t.h>
@@ -182,36 +183,16 @@ _CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
 _CCCL_REQUIRES(_IsSame<_Iter, ::__gnu_cxx::__normal_iterator<_Ty*, _Range>>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto
   __iter_concept_fn(::__gnu_cxx::__normal_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
-#  elif defined(_LIBCPP_VERSION)
+#  endif // __GLIBCXX__
+#  if defined(_LIBCPP_VERSION)
 _CCCL_TEMPLATE(class _Iter, class _Ty)
 _CCCL_REQUIRES(_IsSame<_Iter, ::std::__wrap_iter<_Ty*>>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(::std::__wrap_iter<_Ty*>, __priority_tag<3>) -> contiguous_iterator_tag;
 #  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Array_iterator>::value)
+_CCCL_REQUIRES((_CCCL_TRAIT(is_pointer, ::std::_Unwrapped_t<_Iter>)))
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
-_CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Array_const_iterator>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
-_CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Vector_iterator>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
-_CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Vector_const_iterator>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
-_CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_iterator>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
-_CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_const_iterator>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
-_CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_view_iterator>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
-_CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Span_iterator>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
-#  endif
+#  endif // _MSVC_STL_VERSION
 _CCCL_TEMPLATE(class _Iter, class _Ty)
 _CCCL_REQUIRES(_IsSame<_Iter, _Ty*>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Ty*, __priority_tag<3>) -> contiguous_iterator_tag;

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -191,7 +191,7 @@ _LIBCUDACXX_HIDE_FROM_ABI auto
 __iter_concept_fn(__undefined<::std::__wrap_iter<_Ty*>>*, __priority_tag<3>) -> contiguous_iterator_tag;
 #  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES((_CCCL_TRAIT(is_pointer, ::std::_Unwrapped_t<_Iter>)))
+_CCCL_REQUIRES(_CCCL_TRAIT(is_pointer, ::std::_Unwrapped_t<_Iter>))
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Iter>*, __priority_tag<3>) -> contiguous_iterator_tag;
 #  endif // _MSVC_STL_VERSION
 _CCCL_TEMPLATE(class _Iter, class _Ty)

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -175,42 +175,61 @@ using _ITER_TRAITS = typename __iter_traits_cache<_Iter>::type;
 #  if defined(_GLIBCXX_DEBUG)
 _CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
 _CCCL_REQUIRES(_IsSame<_Iter, ::__gnu_debug::_Safe_iterator<_Ty*, _Range>>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<::__gnu_debug::_Safe_iterator<_Ty*, _Range>>*,
-                                                 __priority_tag<3>) -> contiguous_iterator_tag;
+_LIBCUDACXX_HIDE_FROM_ABI auto
+  __iter_concept_fn(::__gnu_debug::_Safe_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
 #  endif
 #  if defined(__GLIBCXX__)
 _CCCL_TEMPLATE(class _Iter, class _Ty, class _Range)
 _CCCL_REQUIRES(_IsSame<_Iter, ::__gnu_cxx::__normal_iterator<_Ty*, _Range>>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<::__gnu_cxx::__normal_iterator<_Ty*, _Range>>*,
-                                                 __priority_tag<3>) -> contiguous_iterator_tag;
+_LIBCUDACXX_HIDE_FROM_ABI auto
+  __iter_concept_fn(::__gnu_cxx::__normal_iterator<_Ty*, _Range>, __priority_tag<3>) -> contiguous_iterator_tag;
 #  endif // __GLIBCXX__
 #  if defined(_LIBCPP_VERSION)
 _CCCL_TEMPLATE(class _Iter, class _Ty)
 _CCCL_REQUIRES(_IsSame<_Iter, ::std::__wrap_iter<_Ty*>>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto
-__iter_concept_fn(__undefined<::std::__wrap_iter<_Ty*>>*, __priority_tag<3>) -> contiguous_iterator_tag;
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(::std::__wrap_iter<_Ty*>, __priority_tag<3>) -> contiguous_iterator_tag;
 #  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 _CCCL_TEMPLATE(class _Iter)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_pointer, ::std::_Unwrapped_t<_Iter>))
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Iter>*, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Array_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Array_const_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Vector_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Vector_const_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_const_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_String_view_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
+_CCCL_TEMPLATE(class _Iter)
+_CCCL_REQUIRES(_IsSame<_Iter, class _Iter::_Span_iterator>::value)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<3>) -> contiguous_iterator_tag;
 #  endif // _MSVC_STL_VERSION
 _CCCL_TEMPLATE(class _Iter, class _Ty)
 _CCCL_REQUIRES(_IsSame<_Iter, _Ty*>::value)
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Ty*>*, __priority_tag<3>) -> contiguous_iterator_tag;
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Ty*, __priority_tag<3>) -> contiguous_iterator_tag;
 #endif // _CCCL_STD_VER >= 2014
 template <class _Iter>
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Iter>*, __priority_tag<2>) ->
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<2>) ->
   typename _ITER_TRAITS<_Iter>::iterator_concept;
 template <class _Iter>
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Iter>*, __priority_tag<1>) ->
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<1>) ->
   typename _ITER_TRAITS<_Iter>::iterator_category;
 template <class _Iter>
-_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(__undefined<_Iter>*, __priority_tag<0>)
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<0>)
   -> enable_if_t<__is_primary_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;
 
 template <class _Iter>
-using __iter_concept_t =
-  decltype(_CUDA_VSTD::__iter_concept_fn<_Iter>(static_cast<__undefined<_Iter>*>(nullptr), __priority_tag<3>{}));
+using __iter_concept_t = decltype(_CUDA_VSTD::__iter_concept_fn<_Iter>(declval<_Iter>(), __priority_tag<3>{}));
 
 template <class _Iter, class = void>
 struct __iter_concept_cache

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -217,11 +217,11 @@ _CCCL_REQUIRES(_IsSame<_Iter, _Ty*>::value)
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Ty*, __priority_tag<3>) -> contiguous_iterator_tag;
 #endif // _CCCL_STD_VER >= 2014
 template <class _Iter>
-_LIBCUDACXX_HIDE_FROM_ABI auto
-  __iter_concept_fn(_Iter, __priority_tag<2>) -> class _ITER_TRAITS<_Iter>::iterator_concept;
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<2>) ->
+  typename _ITER_TRAITS<_Iter>::iterator_concept;
 template <class _Iter>
-_LIBCUDACXX_HIDE_FROM_ABI auto
-  __iter_concept_fn(_Iter, __priority_tag<1>) -> class _ITER_TRAITS<_Iter>::iterator_category;
+_LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<1>) ->
+  typename _ITER_TRAITS<_Iter>::iterator_category;
 template <class _Iter>
 _LIBCUDACXX_HIDE_FROM_ABI auto __iter_concept_fn(_Iter, __priority_tag<0>)
   -> enable_if_t<__is_primary_template<iterator_traits<_Iter>>::value, random_access_iterator_tag>;


### PR DESCRIPTION
## Description

In range-v3, @CaseyCarter and I found a sneaky way to "detect" the contiguous iterators of the 3 major stdlib implementations: libstdc++, libc++, and msvc's stdlib. This PR ports the implementation over so that the following standard containers are now recognized as contiguous:

* `std::vector`
* `std::array`
* `std::string`
* `std::string_view`
* `std::span`

this PR also removes a hack in cudax that was only necessary because the std:: containers weren't considered contiguous in c++17.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
