### PR TITLE
remove use of assignment expression for greater portability

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
@@ -58,7 +58,8 @@ def get_paths() -> List[bytes]:
     thrust_include_path = cub_include_path
     libcudacxx_include_path = str(os.path.join(cub_include_path, "libcudacxx"))
     cuda_include_path = None
-    if cuda_path := _get_cuda_path():
+    cuda_path = _get_cuda_path()
+    if cuda_path:
         cuda_include_path = str(os.path.join(cuda_path, "include"))
     paths = [
         f"-I{path}".encode()


### PR DESCRIPTION
## Description

pr #3180 added an assignment expression (`a := b`) to a python script that is used to build the docs. assignment expressions are a relatively new addition to python and are not supported by the version of python used in ci to build the docs.

this pr replaces the assignment expression with an ordinary assignment.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
