### PR TITLE
Fixes for Python 3.7 docs environment

### DIFF
--- a/docs/cuda_parallel/index.rst
+++ b/docs/cuda_parallel/index.rst
@@ -7,10 +7,16 @@ CUDA Parallel
   Python exposure of parallel algorithms is in public beta.
   The API is subject to change without notice.
 
+Algorithms
+----------
+
 .. automodule:: cuda.parallel.experimental.algorithms
   :members:
   :undoc-members:
   :imported-members:
+
+Iterators
+---------
 
 .. automodule:: cuda.parallel.experimental.iterators
   :members:

--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
@@ -5,7 +5,6 @@
 
 import os
 import shutil
-from importlib.resources import files, as_file
 import ctypes
 from functools import lru_cache
 from typing import List, Optional
@@ -31,6 +30,10 @@ def _get_cuda_path() -> Optional[str]:
 
 @lru_cache()
 def get_bindings() -> ctypes.CDLL:
+    # TODO: once docs env supports Python >= 3.9, we
+    # can move this to a module-level import.
+    from importlib.resources import as_file, files
+
     with as_file(files("cuda.parallel.experimental")) as f:
         cccl_c_path = str(f / "cccl" / "libcccl.c.parallel.so")
     _bindings = ctypes.CDLL(cccl_c_path)
@@ -52,13 +55,18 @@ def get_bindings() -> ctypes.CDLL:
 
 @lru_cache()
 def get_paths() -> List[bytes]:
+    # TODO: once docs env supports Python >= 3.9, we
+    # can move this to a module-level import.
+    from importlib.resources import as_file, files
+
     with as_file(files("cuda.parallel")) as f:
         # Using `.parent` for compatibility with pip install --editable:
         cub_include_path = str(f.parent / "_include")
     thrust_include_path = cub_include_path
     libcudacxx_include_path = str(os.path.join(cub_include_path, "libcudacxx"))
     cuda_include_path = None
-    if cuda_path := _get_cuda_path():
+    cuda_path = _get_cuda_path()
+    if cuda_path is not None:
         cuda_include_path = str(os.path.join(cuda_path, "include"))
     paths = [
         f"-I{path}".encode()


### PR DESCRIPTION
## Description

Docs builds are currently failing because `cuda.parallel` is not importable on Python 3.7 environments (which our docs build environment is stuck on). This PR fixes that by making `cuda.parallel` importable with Python 3.7.

### Additional Context

The Sphinx [autodoc extension](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) requires modules to be importable.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
