### PR TITLE
Fix: make launchers a CUB detail; make kernel source functions hidden.

### DIFF
--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -9,9 +9,9 @@
 //===----------------------------------------------------------------------===//
 
 #include <cub/detail/choose_offset.cuh>
+#include <cub/detail/launcher/cuda_driver.cuh>
 #include <cub/device/device_reduce.cuh>
 #include <cub/grid/grid_even_share.cuh>
-#include <cub/detail/launcher/cuda_driver.cuh>
 #include <cub/util_device.cuh>
 
 #include <cuda/std/cstdint>

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -11,7 +11,7 @@
 #include <cub/detail/choose_offset.cuh>
 #include <cub/device/device_reduce.cuh>
 #include <cub/grid/grid_even_share.cuh>
-#include <cub/launcher/cuda_driver.cuh>
+#include <cub/detail/launcher/cuda_driver.cuh>
 #include <cub/util_device.cuh>
 
 #include <cuda/std/cstdint>
@@ -405,7 +405,7 @@ extern "C" CCCL_C_API CUresult cccl_device_reduce(
                         dynamic_reduce_policy_t<&get_policy>,
                         ::cuda::std::__identity,
                         reduce_kernel_source,
-                        cub::CudaDriverLauncherFactory>::
+                        cub::detail::CudaDriverLauncherFactory>::
       Dispatch(
         d_temp_storage,
         *temp_storage_bytes,
@@ -417,7 +417,7 @@ extern "C" CCCL_C_API CUresult cccl_device_reduce(
         stream,
         {},
         {build},
-        cub::CudaDriverLauncherFactory{cu_device, build.cc},
+        cub::detail::CudaDriverLauncherFactory{cu_device, build.cc},
         {get_accumulator_type(op, d_in, init)});
   }
   catch (const std::exception& exc)

--- a/cub/cub/detail/launcher/cuda_driver.cuh
+++ b/cub/cub/detail/launcher/cuda_driver.cuh
@@ -18,6 +18,9 @@
 
 CUB_NAMESPACE_BEGIN
 
+namespace detail
+{
+
 struct CudaDriverLauncher
 {
   dim3 grid;
@@ -77,6 +80,8 @@ struct CudaDriverLauncherFactory
   CUdevice device;
   int cc;
 };
+
+} // namespace detail
 
 CUB_NAMESPACE_END
 

--- a/cub/cub/detail/launcher/cuda_driver.cuh
+++ b/cub/cub/detail/launcher/cuda_driver.cuh
@@ -29,7 +29,7 @@ struct CudaDriverLauncher
   CUstream stream;
 
   template <typename... Args>
-  cudaError_t doit(CUkernel kernel, Args const&... args) const
+  _CCCL_HIDE_FROM_ABI cudaError_t doit(CUkernel kernel, Args const&... args) const
   {
     void* kernel_args[] = {const_cast<void*>(static_cast<void const*>(&args))...};
 
@@ -58,12 +58,13 @@ struct CudaDriverLauncherFactory
     return cudaSuccess;
   }
 
-  cudaError_t MultiProcessorCount(int& sm_count) const
+  _CCCL_HIDE_FROM_ABI cudaError_t MultiProcessorCount(int& sm_count) const
   {
     return static_cast<cudaError_t>(cuDeviceGetAttribute(&sm_count, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device));
   }
 
-  cudaError_t MaxSmOccupancy(int& sm_occupancy, CUkernel kernel, int block_size, int dynamic_smem_bytes = 0) const
+  _CCCL_HIDE_FROM_ABI cudaError_t
+  MaxSmOccupancy(int& sm_occupancy, CUkernel kernel, int block_size, int dynamic_smem_bytes = 0) const
   {
     // Older drivers have issues handling CUkernel in the occupancy queries, get the CUfunction instead.
     CUfunction kernel_fn;

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -16,6 +16,9 @@
 
 CUB_NAMESPACE_BEGIN
 
+namespace detail
+{
+
 struct TripleChevronFactory
 {
   CUB_RUNTIME_FUNCTION THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron
@@ -49,5 +52,7 @@ struct TripleChevronFactory
     return cudaOccupancyMaxActiveBlocksPerMultiprocessor(&sm_occupancy, kernel_ptr, block_size, dynamic_smem_bytes);
   }
 };
+
+} // namespace detail
 
 CUB_NAMESPACE_END

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -32,7 +32,7 @@ struct TripleChevronFactory
     return cub::PtxVersion(version);
   }
 
-  CUB_RUNTIME_FUNCTION cudaError_t MultiProcessorCount(int& sm_count) const
+  _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION cudaError_t MultiProcessorCount(int& sm_count) const
   {
     int device_ordinal;
     cudaError_t error = CubDebug(cudaGetDevice(&device_ordinal));
@@ -46,7 +46,7 @@ struct TripleChevronFactory
   }
 
   template <typename Kernel>
-  CUB_RUNTIME_FUNCTION cudaError_t
+  _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION cudaError_t
   MaxSmOccupancy(int& sm_occupancy, Kernel kernel_ptr, int block_size, int dynamic_smem_bytes = 0)
   {
     return cudaOccupancyMaxActiveBlocksPerMultiprocessor(&sm_occupancy, kernel_ptr, block_size, dynamic_smem_bytes);

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -45,11 +45,11 @@
 #endif // no system header
 
 #include <cub/agent/agent_reduce.cuh>
+#include <cub/detail/launcher/cuda_runtime.cuh>
 #include <cub/device/dispatch/kernels/reduce.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce.cuh>
 #include <cub/grid/grid_even_share.cuh>
 #include <cub/iterator/arg_index_input_iterator.cuh>
-#include <cub/detail/launcher/cuda_runtime.cuh>
 #include <cub/thread/thread_operators.cuh>
 #include <cub/thread/thread_store.cuh>
 #include <cub/util_debug.cuh>

--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -49,7 +49,7 @@
 #include <cub/device/dispatch/tuning/tuning_reduce.cuh>
 #include <cub/grid/grid_even_share.cuh>
 #include <cub/iterator/arg_index_input_iterator.cuh>
-#include <cub/launcher/cuda_runtime.cuh>
+#include <cub/detail/launcher/cuda_runtime.cuh>
 #include <cub/thread/thread_operators.cuh>
 #include <cub/thread/thread_store.cuh>
 #include <cub/util_debug.cuh>
@@ -273,7 +273,7 @@ template <typename InputIteratorT,
             InitT,
             AccumT,
             TransformOpT>,
-          typename KernelLauncherFactory = TripleChevronFactory>
+          typename KernelLauncherFactory = detail::TripleChevronFactory>
 struct DispatchReduce
 {
   //---------------------------------------------------------------------------
@@ -754,7 +754,7 @@ template <
     InitT,
     AccumT,
     TransformOpT>,
-  typename KernelLauncherFactory = TripleChevronFactory>
+  typename KernelLauncherFactory = detail::TripleChevronFactory>
 using DispatchTransformReduce =
   DispatchReduce<InputIteratorT,
                  OutputIteratorT,

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -635,7 +635,8 @@ CUB_RUNTIME_FUNCTION PolicyWrapper<PolicyT> MakePolicyWrapper(PolicyT policy)
   return PolicyWrapper<PolicyT>{policy};
 }
 
-namespace detail {
+namespace detail
+{
 struct TripleChevronFactory;
 }
 

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -635,7 +635,9 @@ CUB_RUNTIME_FUNCTION PolicyWrapper<PolicyT> MakePolicyWrapper(PolicyT policy)
   return PolicyWrapper<PolicyT>{policy};
 }
 
+namespace detail {
 struct TripleChevronFactory;
+}
 
 /**
  * Kernel dispatch configuration
@@ -654,7 +656,7 @@ struct KernelConfig
       , sm_occupancy(0)
   {}
 
-  template <typename AgentPolicyT, typename KernelPtrT, typename LauncherFactory = TripleChevronFactory>
+  template <typename AgentPolicyT, typename KernelPtrT, typename LauncherFactory = detail::TripleChevronFactory>
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE cudaError_t
   Init(KernelPtrT kernel_ptr, AgentPolicyT agent_policy = {}, LauncherFactory launcher_factory = {})
   {
@@ -784,4 +786,4 @@ private:
 
 CUB_NAMESPACE_END
 
-#include <cub/launcher/cuda_runtime.cuh> // to complete the definition of TripleChevronFactory
+#include <cub/detail/launcher/cuda_runtime.cuh> // to complete the definition of TripleChevronFactory

--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -121,19 +121,18 @@ _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 #endif // !CUB_DISABLE_KERNEL_VISIBILITY_WARNING_SUPPRESSION
 
 #ifndef CUB_DEFINE_KERNEL_GETTER
-#  define CUB_DEFINE_KERNEL_GETTER(name, ...)                           \
-    CUB_RUNTIME_FUNCTION static constexpr decltype(&__VA_ARGS__) name() \
-    {                                                                   \
-      return &__VA_ARGS__;                                              \
+#  define CUB_DEFINE_KERNEL_GETTER(name, ...)                                               \
+    _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION static constexpr decltype(&__VA_ARGS__) name() \
+    {                                                                                       \
+      return &__VA_ARGS__;                                                                  \
     }
 #endif
 
 #ifndef CUB_DEFINE_SUB_POLICY_GETTER
-#  define CUB_DEFINE_SUB_POLICY_GETTER(name)                                                                      \
-    _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION static constexpr PolicyWrapper<typename StaticPolicyT::name##Policy> \
-    name()                                                                                                        \
-    {                                                                                                             \
-      return MakePolicyWrapper(typename StaticPolicyT::name##Policy());                                           \
+#  define CUB_DEFINE_SUB_POLICY_GETTER(name)                                                         \
+    CUB_RUNTIME_FUNCTION static constexpr PolicyWrapper<typename StaticPolicyT::name##Policy> name() \
+    {                                                                                                \
+      return MakePolicyWrapper(typename StaticPolicyT::name##Policy());                              \
     }
 #endif
 

--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -129,10 +129,11 @@ _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 #endif
 
 #ifndef CUB_DEFINE_SUB_POLICY_GETTER
-#  define CUB_DEFINE_SUB_POLICY_GETTER(name)                                                         \
-    CUB_RUNTIME_FUNCTION static constexpr PolicyWrapper<typename StaticPolicyT::name##Policy> name() \
-    {                                                                                                \
-      return MakePolicyWrapper(typename StaticPolicyT::name##Policy());                              \
+#  define CUB_DEFINE_SUB_POLICY_GETTER(name)                                                                      \
+    _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION static constexpr PolicyWrapper<typename StaticPolicyT::name##Policy> \
+    name()                                                                                                        \
+    {                                                                                                             \
+      return MakePolicyWrapper(typename StaticPolicyT::name##Policy());                                           \
     }
 #endif
 


### PR DESCRIPTION
## Description

This is a cleanup PR that resolves a couple of issues introduced with #2448.

First, the new launcher factory and launcher APIs are not currently for public consumption, but they were not placed into detail directories/namespaces. This is now fixed.

Second, the new concept of a kernel source, which abstracts the process of instantiating CUB kernels from the dispatch layers, does not correctly hide its member functions that return kernel pointers; this would result in issues in the case of programs linking together two copies of CUB, compiled with their own separate runtimes, where the runtime linker would select one of the versions of those functions, breaking the users of the other one. This should now be fixed. I went for `_CCCL_HIDE_FROM_ABI`, as that seems to me to be the most robust option that we currently have for this kind of thing, but if there's concerns about this specific solution, please let me know.

Resolves #3207
Resolves #3208 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
