### PR TITLE
clean up the `cuda::std::span` implementation with minimal c++14 range support

### DIFF
--- a/libcudacxx/include/cuda/std/__functional/ranges_operations.h
+++ b/libcudacxx/include/cuda/std/__functional/ranges_operations.h
@@ -24,7 +24,7 @@
 #include <cuda/std/__concepts/totally_ordered.h>
 #include <cuda/std/__utility/forward.h>
 
-#if _CCCL_STD_VER >= 2017
+#if _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES_ABI

--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -254,7 +254,7 @@ concept indirectly_copyable_storable =
 // Note: indirectly_swappable is located in iter_swap.h to prevent a dependency cycle
 // (both iter_swap and indirectly_swappable require indirectly_readable).
 
-#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
+#elif _CCCL_STD_VER >= 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [iterator.concept.readable]
 template <class _In>

--- a/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
@@ -88,7 +88,7 @@ using iter_difference_t =
                          incrementable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::difference_type;
 
-#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
+#elif _CCCL_STD_VER >= 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [incrementable.traits]
 template <class, class = void>
@@ -150,7 +150,7 @@ using iter_difference_t =
                          incrementable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::difference_type;
 
-#endif // _CCCL_STD_VER > 2014
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/indirectly_comparable.h
+++ b/libcudacxx/include/cuda/std/__iterator/indirectly_comparable.h
@@ -33,7 +33,7 @@ template <class _Iter1, class _Iter2, class _BinaryPred, class _Proj1 = identity
 concept indirectly_comparable =
   indirect_binary_predicate<_BinaryPred, projected<_Iter1, _Proj1>, projected<_Iter2, _Proj2>>;
 
-#elif _CCCL_STD_VER > 2014
+#elif _CCCL_STD_VER >= 2014
 
 // clang-format off
 
@@ -50,7 +50,7 @@ _CCCL_CONCEPT indirectly_comparable =
 
 // clang-format on
 
-#endif // _CCCL_STD_VER > 2014
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_move.h
@@ -33,7 +33,7 @@
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wvoid-ptr-dereference")
 
-#if _CCCL_STD_VER > 2014
+#if _CCCL_STD_VER >= 2014
 
 // [iterator.cust.move]
 

--- a/libcudacxx/include/cuda/std/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_swap.h
@@ -30,7 +30,7 @@
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
 
-#if _CCCL_STD_VER > 2014
+#if _CCCL_STD_VER >= 2014
 
 // [iter.cust.swap]
 
@@ -158,6 +158,6 @@ _CCCL_INLINE_VAR constexpr bool __noexcept_swappable<_I1, _I2, enable_if_t<indir
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // _CCCL_STD_VER > 2014
+#endif // _CCCL_STD_VER >= 2014
 
 #endif // _LIBCUDACXX___ITERATOR_ITER_SWAP_H

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -34,7 +34,6 @@
 #include <cuda/std/__type_traits/add_const.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_convertible.h>
-#include <cuda/std/__type_traits/is_pointer.h>
 #include <cuda/std/__type_traits/is_primary_template.h>
 #include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/__type_traits/void_t.h>
@@ -93,7 +92,7 @@ using iter_reference_t = decltype(*declval<_Tp&>());
 template <class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
 
-#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
+#elif _CCCL_STD_VER >= 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 template <class _Tp>
 using __with_reference = _Tp&;
@@ -119,10 +118,10 @@ using iter_reference_t = enable_if_t<__dereferenceable<_Tp>, decltype(*declval<_
 
 template <class, class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
-#else // ^^^ _CCCL_STD_VER > 2014 ^^^ / vvv _CCCL_STD_VER <= 2014 vvv
+#else // ^^^ _CCCL_STD_VER >= 2014 ^^^ / vvv _CCCL_STD_VER < 2014 vvv
 template <class>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits;
-#endif // _CCCL_STD_VER <= 2014
+#endif // _CCCL_STD_VER < 2014
 
 #if _CCCL_COMPILER(NVRTC)
 
@@ -530,7 +529,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits : __iterator_traits<_Ip>
   using __primary_template = iterator_traits;
 };
 
-#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_STD_VER > 2014 vvv
+#elif _CCCL_STD_VER >= 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^ / vvv _CCCL_STD_VER > 2014 vvv
 
 // The `cpp17-*-iterator` exposition-only concepts have very similar names to the `Cpp17*Iterator` named requirements
 // from `[iterator.cpp17]`. To avoid confusion between the two, the exposition-only concepts have been banished to
@@ -860,7 +859,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits<_Tp*>
   typedef _Tp* pointer;
   typedef typename add_lvalue_reference<_Tp>::type reference;
   typedef random_access_iterator_tag iterator_category;
-#if _CCCL_STD_VER > 2014
+#if _CCCL_STD_VER >= 2014
   typedef contiguous_iterator_tag iterator_concept;
 #endif
 };

--- a/libcudacxx/include/cuda/std/__iterator/mergeable.h
+++ b/libcudacxx/include/cuda/std/__iterator/mergeable.h
@@ -41,7 +41,7 @@ concept mergeable =
   && indirectly_copyable<_Input1, _Output> && indirectly_copyable<_Input2, _Output>
   && indirect_strict_weak_order<_Comp, projected<_Input1, _Proj1>, projected<_Input2, _Proj2>>;
 
-#elif _CCCL_STD_VER > 2014
+#elif _CCCL_STD_VER >= 2014
 
 template <class _Input1, class _Input2, class _Output, class _Comp, class _Proj1, class _Proj2>
 _CCCL_CONCEPT_FRAGMENT(

--- a/libcudacxx/include/cuda/std/__iterator/permutable.h
+++ b/libcudacxx/include/cuda/std/__iterator/permutable.h
@@ -32,7 +32,7 @@ template <class _Iterator>
 concept permutable = forward_iterator<_Iterator> && indirectly_movable_storable<_Iterator, _Iterator>
                   && indirectly_swappable<_Iterator, _Iterator>;
 
-#elif _CCCL_STD_VER > 2014
+#elif _CCCL_STD_VER >= 2014
 
 template <class _Iterator>
 _CCCL_CONCEPT_FRAGMENT(__permutable_,
@@ -43,7 +43,7 @@ _CCCL_CONCEPT_FRAGMENT(__permutable_,
 template <class _Iterator>
 _CCCL_CONCEPT permutable = _CCCL_FRAGMENT(__permutable_, _Iterator);
 
-#endif // _CCCL_STD_VER > 2014
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/projected.h
+++ b/libcudacxx/include/cuda/std/__iterator/projected.h
@@ -27,7 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-#if _CCCL_STD_VER > 2014
+#if _CCCL_STD_VER >= 2014
 
 template <class _It, class _Proj, class = void>
 struct __projected_impl
@@ -54,7 +54,7 @@ _CCCL_TEMPLATE(class _It, class _Proj)
 _CCCL_REQUIRES(indirectly_readable<_It> _CCCL_AND indirectly_regular_unary_invocable<_Proj, _It>)
 using projected = typename __projected_impl<_It, _Proj>::__type;
 
-#endif // _CCCL_STD_VER > 2014
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/readable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/readable_traits.h
@@ -106,7 +106,7 @@ using iter_value_t =
                          indirectly_readable_traits<remove_cvref_t<_Ip>>,
                          iterator_traits<remove_cvref_t<_Ip>>>::value_type;
 
-#elif _CCCL_STD_VER > 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
+#elif _CCCL_STD_VER >= 2014 // ^^^ !_CCCL_NO_CONCEPTS ^^^
 
 // [readable.traits]
 template <class, class = void>

--- a/libcudacxx/include/cuda/std/__iterator/sortable.h
+++ b/libcudacxx/include/cuda/std/__iterator/sortable.h
@@ -34,7 +34,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Iter, class _Comp = _CUDA_VRANGES::less, class _Proj = identity>
 concept sortable = permutable<_Iter> && indirect_strict_weak_order<_Comp, projected<_Iter, _Proj>>;
 
-#elif _CCCL_STD_VER > 2014
+#elif _CCCL_STD_VER >= 2014
 
 template <class _Iter, class _Comp, class _Proj>
 _CCCL_CONCEPT_FRAGMENT(
@@ -44,7 +44,7 @@ _CCCL_CONCEPT_FRAGMENT(
 template <class _Iter, class _Comp = _CUDA_VRANGES::less, class _Proj = identity>
 _CCCL_CONCEPT sortable = _CCCL_FRAGMENT(__sortable_, _Iter, _Comp, _Proj);
 
-#endif // _CCCL_STD_VER > 2014
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__ranges/access.h
+++ b/libcudacxx/include/cuda/std/__ranges/access.h
@@ -33,7 +33,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
-#if _CCCL_STD_VER > 2014 && !_CCCL_COMPILER(MSVC2017)
+#if _CCCL_STD_VER >= 2014
 
 template <class _Tp>
 _CCCL_CONCEPT __can_borrow = is_lvalue_reference_v<_Tp> || enable_borrowed_range<remove_cvref_t<_Tp>>;
@@ -120,6 +120,14 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES((!__member_begin<_Tp>) _CCCL_AND(!__unqualified_begin<_Tp>))
   void operator()(_Tp&&) const = delete;
+
+#  if _CCCL_COMPILER(MSVC, <, 19, 23)
+  template <class _Tp>
+  void operator()(_Tp (&&)[]) const = delete;
+
+  template <class _Tp, size_t _Np>
+  void operator()(_Tp (&&)[_Np]) const = delete;
+#  endif // _CCCL_COMPILER(MSVC, <, 19, 23)
 };
 _LIBCUDACXX_END_NAMESPACE_CPO
 
@@ -209,6 +217,14 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES((!__member_end<_Tp>) _CCCL_AND(!__unqualified_end<_Tp>))
   void operator()(_Tp&&) const = delete;
+
+#  if _CCCL_COMPILER(MSVC, <, 19, 23)
+  template <class _Tp>
+  void operator()(_Tp (&&)[]) const = delete;
+
+  template <class _Tp, size_t _Np>
+  void operator()(_Tp (&&)[_Np]) const = delete;
+#  endif // _CCCL_COMPILER(MSVC, <, 19, 23)
 };
 _LIBCUDACXX_END_NAMESPACE_CPO
 
@@ -279,7 +295,7 @@ inline namespace __cpo
 {
 _CCCL_GLOBAL_CONSTANT auto cend = __cend::__fn{};
 } // namespace __cpo
-#endif // _CCCL_STD_VER > 2014 && !_CCCL_COMPILER(MSVC2017)
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/concepts.h
+++ b/libcudacxx/include/cuda/std/__ranges/concepts.h
@@ -44,7 +44,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
-#if _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#if _CCCL_STD_VER >= 2014
 
 #  if !defined(_CCCL_NO_CONCEPTS)
 
@@ -302,7 +302,7 @@ template <class _Range, class _Tp>
 _CCCL_CONCEPT __container_compatible_range = _CCCL_FRAGMENT(__container_compatible_range_, _Range, _Tp);
 #  endif // _CCCL_NO_CONCEPTS
 
-#endif // _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/dangling.h
+++ b/libcudacxx/include/cuda/std/__ranges/dangling.h
@@ -27,7 +27,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
-#if _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#if _CCCL_STD_VER >= 2014
 
 struct dangling
 {
@@ -47,7 +47,7 @@ using borrowed_iterator_t = enable_if_t<range<_Rp>, _If<borrowed_range<_Rp>, ite
 
 // borrowed_subrange_t defined in <__ranges/subrange.h>
 
-#endif // _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/data.h
+++ b/libcudacxx/include/cuda/std/__ranges/data.h
@@ -34,7 +34,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
-#if _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#if _CCCL_STD_VER >= 2014
 
 // [range.prim.data]
 
@@ -128,7 +128,7 @@ inline namespace __cpo
 _CCCL_GLOBAL_CONSTANT auto cdata = __cdata::__fn{};
 } // namespace __cpo
 
-#endif // _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/enable_borrowed_range.h
+++ b/libcudacxx/include/cuda/std/__ranges/enable_borrowed_range.h
@@ -25,7 +25,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_STD_VER > 2014
+#if _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/enable_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/enable_view.h
@@ -30,7 +30,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
-#if _CCCL_STD_VER >= 2017
+#if _CCCL_STD_VER >= 2014
 
 struct view_base
 {};
@@ -74,7 +74,7 @@ _CCCL_INLINE_VAR constexpr bool
     true;
 #  endif // _CCCL_NO_CONCEPTS
 
-#endif // _CCCL_STD_VER >= 2017
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/size.h
+++ b/libcudacxx/include/cuda/std/__ranges/size.h
@@ -36,7 +36,7 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
-#if _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#if _CCCL_STD_VER >= 2014
 
 template <class>
 _CCCL_INLINE_VAR constexpr bool disable_sized_range = false;
@@ -182,15 +182,8 @@ struct __fn
     noexcept(noexcept(_CUDA_VRANGES::size(__t)))
   {
     using _Signed = make_signed_t<decltype(_CUDA_VRANGES::size(__t))>;
-    if constexpr (sizeof(ptrdiff_t) > sizeof(_Signed))
-    {
-      return static_cast<ptrdiff_t>(_CUDA_VRANGES::size(__t));
-    }
-    else
-    {
-      return static_cast<_Signed>(_CUDA_VRANGES::size(__t));
-    }
-    _CCCL_UNREACHABLE();
+    using _Result = conditional_t<(sizeof(ptrdiff_t) > sizeof(_Signed)), ptrdiff_t, _Signed>;
+    return static_cast<_Result>(_CUDA_VRANGES::size(__t));
   }
 };
 _LIBCUDACXX_END_NAMESPACE_CPO
@@ -200,7 +193,7 @@ inline namespace __cpo
 _CCCL_GLOBAL_CONSTANT auto ssize = __ssize::__fn{};
 } // namespace __cpo
 
-#endif // _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#endif // _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_END_NAMESPACE_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/views.h
+++ b/libcudacxx/include/cuda/std/__ranges/views.h
@@ -21,7 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#if _CCCL_STD_VER >= 2014
 
 _LIBCUDACXX_BEGIN_NAMESPACE_VIEWS
 
@@ -29,10 +29,10 @@ _LIBCUDACXX_END_NAMESPACE_VIEWS
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-namespace views = ranges::views;
+namespace views = ranges::views; // NOLINT: misc-unused-alias-decls
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#endif // _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#endif // _CCCL_STD_VER >= 2014
 
 #endif // _LIBCUDACXX___RANGES_VIEWS

--- a/libcudacxx/include/cuda/std/__type_traits/common_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/common_reference.h
@@ -37,6 +37,8 @@
 #include <cuda/std/__type_traits/void_t.h>
 #include <cuda/std/__utility/declval.h>
 
+_CCCL_NV_DIAG_SUPPRESS(1384) // warning: pointer converted to bool
+
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // common_reference
@@ -252,5 +254,7 @@ struct common_reference
 {};
 
 _LIBCUDACXX_END_NAMESPACE_STD
+
+_CCCL_NV_DIAG_DEFAULT(1384)
 
 #endif // _LIBCUDACXX___TYPE_TRAITS_COMMON_REFERENCE_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/span
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/span
@@ -203,18 +203,7 @@ _CCCL_INLINE_VAR constexpr bool __is_std_span<span<_Tp, _Extent>> = true;
 template <class _From, class _To>
 _CCCL_CONCEPT __span_array_convertible = _CCCL_TRAIT(is_convertible, _From (*)[], _To (*)[]);
 
-template <class _Tp>
-_CCCL_INLINE_VAR constexpr bool __is_std_initializer_list = false;
-
-template <class _Tp>
-_CCCL_INLINE_VAR constexpr bool __is_std_initializer_list<initializer_list<_Tp>> = true;
-
-// We want to ensure that span interacts nicely with containers that might not have had the ranges treatment
-#  if defined(__cpp_lib_ranges) && !_CCCL_COMPILER(MSVC2017)
-#    define _CCCL_SPAN_USES_RANGES
-#  endif // __cpp_lib_ranges && !_CCCL_COMPILER(MSVC2017)
-
-#  if defined(_CCCL_SPAN_USES_RANGES)
+#  if !_CCCL_COMPILER(MSVC2017)
 template <class _Range, class _ElementType>
 _CCCL_CONCEPT_FRAGMENT(
   __span_compatible_range_,
@@ -223,15 +212,43 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(_CUDA_VRANGES::sized_range<_Range>),
     requires((_CUDA_VRANGES::borrowed_range<_Range> || _CCCL_TRAIT(is_const, _ElementType))),
     requires((!_CCCL_TRAIT(is_array, remove_cvref_t<_Range>))),
-    requires((!__is_std_span<remove_cvref_t<_Range>> && !__is_std_array<remove_cvref_t<_Range>>
-              && !__is_std_initializer_list<remove_cvref_t<_Range>>) ),
+    requires((!__is_std_span<remove_cvref_t<_Range>> && !__is_std_array<remove_cvref_t<_Range>>) ),
     requires(_CCCL_TRAIT(
       is_convertible, remove_reference_t<_CUDA_VRANGES::range_reference_t<_Range>> (*)[], _ElementType (*)[]))));
 
 template <class _Range, class _ElementType>
 _CCCL_CONCEPT __span_compatible_range = _CCCL_FRAGMENT(__span_compatible_range_, _Range, _ElementType);
 
-#    if _CCCL_STD_VER >= 2020
+#  else // // ^^^ !_CCCL_COMPILER(MSVC2017) ^^^ / vvv _CCCL_COMPILER(MSVC2017) vvv
+
+template <class _Range, class _ElementType, class = void>
+_CCCL_INLINE_VAR constexpr bool __span_compatible_range = false;
+
+template <class _Range, class _ElementType>
+_CCCL_INLINE_VAR constexpr bool __span_compatible_range<
+  _Range,
+  _ElementType,
+  void_t<
+    // // is a contiguous range
+    // enable_if_t<_CUDA_VRANGES::contiguous_range<_Range>, nullptr_t>,
+    // // is a sized range
+    // enable_if_t<_CUDA_VRANGES::sized_range<_Range>, nullptr_t>,
+    // // is a borrowed range or ElementType is const
+    // enable_if_t<(_CUDA_VRANGES::borrowed_range<_Range> || _CCCL_TRAIT(is_const, _ElementType)), nullptr_t>,
+    // is not a C-style array
+    enable_if_t<!_CCCL_TRAIT(is_array, remove_cvref_t<_Range>), nullptr_t>,
+    // is not a specialization of span
+    enable_if_t<!__is_std_span<remove_cvref_t<_Range>>, nullptr_t>,
+    // is not a specialization of array
+    enable_if_t<!__is_std_array<remove_cvref_t<_Range>>, nullptr_t>,
+    // remove_pointer_t<decltype(data(cont))>(*)[] is convertible to ElementType(*)[]
+    enable_if_t<_CCCL_TRAIT(is_convertible,
+                            remove_pointer_t<decltype(_CUDA_VSTD::data(declval<_Range&>()))> (*)[],
+                            _ElementType (*)[]),
+                nullptr_t>>> = true;
+#  endif // _CCCL_COMPILER(MSVC2017)
+
+#  if _CCCL_STD_VER >= 2020
 template <class _It, class _Tp>
 _CCCL_CONCEPT __span_compatible_iterator =
   contiguous_iterator<_It> && __span_array_convertible<remove_reference_t<iter_reference_t<_It>>, _Tp>;
@@ -239,7 +256,7 @@ _CCCL_CONCEPT __span_compatible_iterator =
 template <class _Sentinel, class _It>
 _CCCL_CONCEPT __span_compatible_sentinel_for =
   sized_sentinel_for<_Sentinel, _It> && !_CCCL_TRAIT(is_convertible, _Sentinel, size_t);
-#    else // ^^^ C++20 ^^^ / vvv C++17 vvv
+#  else // ^^^ C++20 ^^^ / vvv C++17 vvv
 template <class _It, class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__span_compatible_iterator_,
                        requires()(requires(contiguous_iterator<_It>),
@@ -255,33 +272,7 @@ _CCCL_CONCEPT_FRAGMENT(
 
 template <class _Sentinel, class _It>
 _CCCL_CONCEPT __span_compatible_sentinel_for = _CCCL_FRAGMENT(__span_compatible_sentinel_for_, _Sentinel, _It);
-#    endif // _CCCL_STD_VER <= 2017
-#  else // ^^^ _CCCL_SPAN_USES_RANGES ^^^ / vvv !_CCCL_SPAN_USES_RANGES vvv
-
-template <class _Container, class _ElementType, class = void>
-_CCCL_INLINE_VAR constexpr bool __is_span_compatible_container = false;
-
-template <class _Container, class _ElementType>
-_CCCL_INLINE_VAR constexpr bool __is_span_compatible_container<
-  _Container,
-  _ElementType,
-  void_t<
-    // is not a specialization of span
-    enable_if_t<!__is_std_span<remove_cvref_t<_Container>>, nullptr_t>,
-    // is not a specialization of array
-    enable_if_t<!__is_std_array<remove_cvref_t<_Container>>, nullptr_t>,
-    // is not a specialization of array
-    enable_if_t<!__is_std_initializer_list<remove_cvref_t<_Container>>, nullptr_t>,
-    // is_array_v<Container> is false,
-    enable_if_t<!_CCCL_TRAIT(is_array, remove_cvref_t<_Container>), nullptr_t>,
-    // data(cont) and size(cont) are well formed
-    decltype(_CUDA_VSTD::data(_CUDA_VSTD::declval<_Container&>())),
-    decltype(_CUDA_VSTD::size(_CUDA_VSTD::declval<_Container&>())),
-    // remove_pointer_t<decltype(data(cont))>(*)[] is convertible to ElementType(*)[]
-    enable_if_t<is_convertible<remove_pointer_t<decltype(_CUDA_VSTD::data(declval<_Container&>()))> (*)[],
-                               _ElementType (*)[]>::value,
-                nullptr_t>>> = true;
-#  endif // !_CCCL_SPAN_USES_RANGES
+#  endif // _CCCL_STD_VER <= 2017
 
 #  if _CCCL_STD_VER >= 2020
 
@@ -350,7 +341,6 @@ public:
   _CCCL_HIDE_FROM_ABI span(const span&) noexcept            = default;
   _CCCL_HIDE_FROM_ABI span& operator=(const span&) noexcept = default;
 
-#  if defined(_CCCL_SPAN_USES_RANGES)
   _CCCL_TEMPLATE(class _It)
   _CCCL_REQUIRES(__span_compatible_iterator<_It, element_type>)
   _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit span(_It __first, size_type __count)
@@ -370,20 +360,6 @@ public:
     _CCCL_ASSERT(__last - __first == _Extent,
                  "invalid range in span's constructor (iterator, sentinel): last - first != extent");
   }
-#  else // ^^^ _CCCL_SPAN_USES_RANGES ^^^ / vvv !_CCCL_SPAN_USES_RANGES vvv
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr span(pointer __ptr, size_type __count)
-      : __data_{__ptr}
-  {
-    (void) __count;
-    _CCCL_ASSERT(_Extent == __count, "size mismatch in span's constructor (ptr, len)");
-  }
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr span(pointer __f, pointer __l)
-      : __data_{__f}
-  {
-    (void) __l;
-    _CCCL_ASSERT(_Extent == distance(__f, __l), "size mismatch in span's constructor (ptr, ptr)");
-  }
-#  endif // !_CCCL_SPAN_USES_RANGES
 
 #  if _CCCL_COMPILER(NVRTC) || _CCCL_COMPILER(MSVC2017)
   template <size_t _Sz = _Extent, enable_if_t<_Sz != 0, int> = 0>
@@ -408,7 +384,6 @@ public:
       : __data_{__arr.data()}
   {}
 
-#  if defined(_CCCL_SPAN_USES_RANGES)
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__span_compatible_range<_Range, element_type>)
   _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit span(_Range&& __r)
@@ -416,23 +391,6 @@ public:
   {
     _CCCL_ASSERT(_CUDA_VRANGES::size(__r) == _Extent, "size mismatch in span's constructor (range)");
   }
-#  else // ^^^ _CCCL_SPAN_USES_RANGES ^^^ / vvv !_CCCL_SPAN_USES_RANGES vvv
-  _CCCL_TEMPLATE(class _Container)
-  _CCCL_REQUIRES(__is_span_compatible_container<_Container, _Tp>)
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr span(_Container& __c) noexcept(noexcept(_CUDA_VSTD::data(__c)))
-      : __data_{_CUDA_VSTD::data(__c)}
-  {
-    _CCCL_ASSERT(_Extent == _CUDA_VSTD::size(__c), "size mismatch in span's constructor (other span)");
-  }
-
-  _CCCL_TEMPLATE(class _Container)
-  _CCCL_REQUIRES(__is_span_compatible_container<_Container, const _Tp>)
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr span(const _Container& __c) noexcept(noexcept(_CUDA_VSTD::data(__c)))
-      : __data_{_CUDA_VSTD::data(__c)}
-  {
-    _CCCL_ASSERT(_Extent == _CUDA_VSTD::size(__c), "size mismatch in span's constructor (other span)");
-  }
-#  endif // !_CCCL_SPAN_USES_RANGES
 
   _CCCL_TEMPLATE(class _OtherElementType, size_t _Extent2 = _Extent)
   _CCCL_REQUIRES((_Extent2 != dynamic_extent) _CCCL_AND __span_array_convertible<_OtherElementType, element_type>)
@@ -613,7 +571,6 @@ public:
   _CCCL_HIDE_FROM_ABI span(const span&) noexcept            = default;
   _CCCL_HIDE_FROM_ABI span& operator=(const span&) noexcept = default;
 
-#  if defined(_CCCL_SPAN_USES_RANGES)
   _CCCL_TEMPLATE(class _It)
   _CCCL_REQUIRES(__span_compatible_iterator<_It, element_type>)
   _LIBCUDACXX_HIDE_FROM_ABI constexpr span(_It __first, size_type __count)
@@ -629,17 +586,6 @@ public:
   {
     _CCCL_ASSERT(__last - __first >= 0, "invalid range in span's constructor (iterator, sentinel)");
   }
-
-#  else // ^^^ _CCCL_SPAN_USES_RANGES ^^^ / vvv !_CCCL_SPAN_USES_RANGES vvv
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr span(pointer __ptr, size_type __count)
-      : __data_{__ptr}
-      , __size_{__count}
-  {}
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr span(pointer __f, pointer __l)
-      : __data_{__f}
-      , __size_{static_cast<size_t>(__l - __f)}
-  {}
-#  endif // !_CCCL_SPAN_USES_RANGES
 
   template <size_t _Sz>
   _LIBCUDACXX_HIDE_FROM_ABI constexpr span(type_identity_t<element_type> (&__arr)[_Sz]) noexcept
@@ -661,28 +607,12 @@ public:
       , __size_{_Sz}
   {}
 
-#  if defined(_CCCL_SPAN_USES_RANGES)
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__span_compatible_range<_Range, element_type>)
   _LIBCUDACXX_HIDE_FROM_ABI constexpr span(_Range&& __r)
       : __data_(_CUDA_VRANGES::data(__r))
       , __size_{_CUDA_VRANGES::size(__r)}
   {}
-#  else // ^^^ _CCCL_SPAN_USES_RANGES ^^^ / vvv !_CCCL_SPAN_USES_RANGES vvv
-  _CCCL_TEMPLATE(class _Container)
-  _CCCL_REQUIRES(__is_span_compatible_container<_Container, _Tp>)
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr span(_Container& __c)
-      : __data_{_CUDA_VSTD::data(__c)}
-      , __size_{(size_type) _CUDA_VSTD::size(__c)}
-  {}
-
-  _CCCL_TEMPLATE(class _Container)
-  _CCCL_REQUIRES(__is_span_compatible_container<_Container, const _Tp>)
-  _LIBCUDACXX_HIDE_FROM_ABI constexpr span(const _Container& __c)
-      : __data_{_CUDA_VSTD::data(__c)}
-      , __size_{(size_type) _CUDA_VSTD::size(__c)}
-  {}
-#  endif // !_CCCL_SPAN_USES_RANGES
 
   _CCCL_TEMPLATE(class _OtherElementType, size_t _OtherExtent)
   _CCCL_REQUIRES(__span_array_convertible<_OtherElementType, element_type>)
@@ -812,12 +742,12 @@ public:
 
   _LIBCUDACXX_HIDE_FROM_ABI span<const byte, dynamic_extent> __as_bytes() const noexcept
   {
-    return {reinterpret_cast<const byte*>(data()), size_bytes()};
+    return span<const byte, dynamic_extent>{reinterpret_cast<const byte*>(data()), size_bytes()};
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI span<byte, dynamic_extent> __as_writable_bytes() const noexcept
   {
-    return {reinterpret_cast<byte*>(data()), size_bytes()};
+    return span<byte, dynamic_extent>{reinterpret_cast<byte*>(data()), size_bytes()};
   }
 
 private:
@@ -853,8 +783,6 @@ _CCCL_HOST_DEVICE span(array<_Tp, _Sz>&) -> span<_Tp, _Sz>;
 template <class _Tp, size_t _Sz>
 _CCCL_HOST_DEVICE span(const array<_Tp, _Sz>&) -> span<const _Tp, _Sz>;
 
-#  if defined(_CCCL_SPAN_USES_RANGES)
-
 _CCCL_TEMPLATE(class _It, class _EndOrSize)
 _CCCL_REQUIRES(contiguous_iterator<_It>)
 _CCCL_HOST_DEVICE span(_It,
@@ -864,23 +792,11 @@ _CCCL_TEMPLATE(class _Range)
 _CCCL_REQUIRES(_CUDA_VRANGES::contiguous_range<_Range>)
 _CCCL_HOST_DEVICE span(_Range&&) -> span<remove_reference_t<_CUDA_VRANGES::range_reference_t<_Range>>>;
 
-#  else // ^^^ _CCCL_SPAN_USES_RANGES ^^^ / vvv !_CCCL_SPAN_USES_RANGES vvv
-
-_CCCL_TEMPLATE(class _Container)
-_CCCL_REQUIRES(__is_span_compatible_container<_Container, typename _Container::value_type>)
-_CCCL_HOST_DEVICE span(_Container&) -> span<typename _Container::value_type>;
-
-_CCCL_TEMPLATE(class _Container)
-_CCCL_REQUIRES(__is_span_compatible_container<_Container, const typename _Container::value_type>)
-_CCCL_HOST_DEVICE span(const _Container&) -> span<const typename _Container::value_type>;
-
-#  endif // !_CCCL_SPAN_USES_RANGES
-
 #endif // _CCCL_STD_VER >= 2017
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
-#if _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#if _CCCL_STD_VER >= 2014 && !_CCCL_COMPILER(MSVC2017)
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 template <class _Tp, size_t _Extent>
 _CCCL_INLINE_VAR constexpr bool enable_borrowed_range<span<_Tp, _Extent>> = true;
@@ -888,6 +804,6 @@ _CCCL_INLINE_VAR constexpr bool enable_borrowed_range<span<_Tp, _Extent>> = true
 template <class _Tp, size_t _Extent>
 _CCCL_INLINE_VAR constexpr bool enable_view<span<_Tp, _Extent>> = true;
 _LIBCUDACXX_END_NAMESPACE_RANGES
-#endif // _CCCL_STD_VER >= 2017 && !_CCCL_COMPILER(MSVC2017)
+#endif // _CCCL_STD_VER >= 2014 && !_CCCL_COMPILER(MSVC2017)
 
 #endif // _LIBCUDACXX_SPAN

--- a/libcudacxx/test/libcudacxx/std/containers/views/views.span/enable_borrowed_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/views.span/enable_borrowed_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // <cuda/std/span>
@@ -22,11 +22,11 @@
 
 int main(int, char**)
 {
-  static_assert(cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, 0>>);
-  static_assert(cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, 42>>);
-  static_assert(cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, cuda::std::dynamic_extent>>);
-  static_assert(!cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, 42>&>);
-  static_assert(!cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, 42> const>);
+  static_assert(cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, 0>>, "");
+  static_assert(cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, 42>>, "");
+  static_assert(cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, cuda::std::dynamic_extent>>, "");
+  static_assert(!cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, 42>&>, "");
+  static_assert(!cuda::std::ranges::enable_borrowed_range<cuda::std::span<int, 42> const>, "");
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/containers/views/views.span/range_concept_conformance.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/views.span/range_concept_conformance.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // span
@@ -18,23 +18,23 @@
 
 using range = cuda::std::span<int>;
 
-static_assert(cuda::std::same_as<cuda::std::ranges::iterator_t<range>, range::iterator>);
-static_assert(cuda::std::ranges::common_range<range>);
-static_assert(cuda::std::ranges::random_access_range<range>);
-static_assert(cuda::std::ranges::contiguous_range<range>);
-static_assert(cuda::std::ranges::view<range> && cuda::std::ranges::enable_view<range>);
-static_assert(cuda::std::ranges::sized_range<range>);
-static_assert(cuda::std::ranges::borrowed_range<range>);
-static_assert(cuda::std::ranges::viewable_range<range>);
+static_assert(cuda::std::same_as<cuda::std::ranges::iterator_t<range>, range::iterator>, "");
+static_assert(cuda::std::ranges::common_range<range>, "");
+static_assert(cuda::std::ranges::random_access_range<range>, "");
+static_assert(cuda::std::ranges::contiguous_range<range>, "");
+static_assert(cuda::std::ranges::view<range> && cuda::std::ranges::enable_view<range>, "");
+static_assert(cuda::std::ranges::sized_range<range>, "");
+static_assert(cuda::std::ranges::borrowed_range<range>, "");
+static_assert(cuda::std::ranges::viewable_range<range>, "");
 
-static_assert(cuda::std::same_as<cuda::std::ranges::iterator_t<range const>, range::iterator>);
-static_assert(cuda::std::ranges::common_range<range const>);
-static_assert(cuda::std::ranges::random_access_range<range const>);
-static_assert(cuda::std::ranges::contiguous_range<range const>);
-static_assert(!cuda::std::ranges::view<range const> && !cuda::std::ranges::enable_view<range const>);
-static_assert(cuda::std::ranges::sized_range<range const>);
-static_assert(cuda::std::ranges::borrowed_range<range const>);
-static_assert(cuda::std::ranges::viewable_range<range const>);
+static_assert(cuda::std::same_as<cuda::std::ranges::iterator_t<range const>, range::iterator>, "");
+static_assert(cuda::std::ranges::common_range<range const>, "");
+static_assert(cuda::std::ranges::random_access_range<range const>, "");
+static_assert(cuda::std::ranges::contiguous_range<range const>, "");
+static_assert(!cuda::std::ranges::view<range const> && !cuda::std::ranges::enable_view<range const>, "");
+static_assert(cuda::std::ranges::sized_range<range const>, "");
+static_assert(cuda::std::ranges::borrowed_range<range const>, "");
+static_assert(cuda::std::ranges::viewable_range<range const>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/deduct.pass.cpp
@@ -52,7 +52,6 @@ __host__ __device__ void test_iterator_sentinel()
     assert(s.data() == cuda::std::data(arr));
   }
 
-#if defined(_CCCL_SPAN_USES_RANGES)
   // P3029R1: deduction from `integral_constant`
   {
     cuda::std::span s{cuda::std::begin(arr), cuda::std::integral_constant<size_t, 3>{}};
@@ -60,7 +59,6 @@ __host__ __device__ void test_iterator_sentinel()
     assert(s.size() == cuda::std::size(arr));
     assert(s.data() == cuda::std::data(arr));
   }
-#endif // _CCCL_SPAN_USES_RANGES
 }
 
 __host__ __device__ void test_c_array()

--- a/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/initializer_list.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/initializer_list.pass.cpp
@@ -28,8 +28,8 @@ using cuda::std::is_constructible;
 // Constructor constrains
 static_assert(is_constructible<cuda::std::span<const int>, cuda::std::initializer_list<int>>::value, "");
 static_assert(is_constructible<cuda::std::span<const int, 42>, cuda::std::initializer_list<int>>::value, "");
-static_assert(!is_constructible<cuda::std::span<const int>, cuda::std::initializer_list<const int>>::value, "");
-static_assert(!is_constructible<cuda::std::span<const int, 42>, cuda::std::initializer_list<const int>>::value, "");
+static_assert(is_constructible<cuda::std::span<const int>, cuda::std::initializer_list<const int>>::value, "");
+static_assert(is_constructible<cuda::std::span<const int, 42>, cuda::std::initializer_list<const int>>::value, "");
 
 static_assert(!is_constructible<cuda::std::span<int>, cuda::std::initializer_list<int>>::value, "");
 static_assert(!is_constructible<cuda::std::span<int, 42>, cuda::std::initializer_list<int>>::value, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/cxx20_iterator_traits.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // struct iterator_traits;
@@ -26,32 +26,33 @@
 #include "test_macros.h"
 
 template <class Traits, class = void>
-inline constexpr bool has_iterator_concept_v = false;
+_CCCL_INLINE_VAR constexpr bool has_iterator_concept_v = false;
 
 template <class Traits>
-inline constexpr bool has_iterator_concept_v<Traits, cuda::std::void_t<typename Traits::iterator_concept>> = true;
+_CCCL_INLINE_VAR constexpr bool has_iterator_concept_v<Traits, cuda::std::void_t<typename Traits::iterator_concept>> =
+  true;
 
 template <class It, class Traits, cuda::std::enable_if_t<cuda::std::is_pointer_v<It>, int> = 0>
 __host__ __device__ constexpr void test_iter_concept()
 {
-  static_assert(cuda::std::same_as<typename Traits::iterator_concept, cuda::std::contiguous_iterator_tag>);
+  static_assert(cuda::std::same_as<typename Traits::iterator_concept, cuda::std::contiguous_iterator_tag>, "");
 }
 
 template <class It, class Traits, cuda::std::enable_if_t<!cuda::std::is_pointer_v<It>, int> = 0>
 __host__ __device__ constexpr void test_iter_concept()
 {
-  static_assert(!has_iterator_concept_v<Traits>);
+  static_assert(!has_iterator_concept_v<Traits>, "");
 }
 
 template <class Iter, class Category, class ValueType, class DiffType, class RefType, class PtrType>
 __host__ __device__ constexpr bool test()
 {
   using Traits = cuda::std::iterator_traits<Iter>;
-  static_assert(cuda::std::same_as<typename Traits::iterator_category, Category>);
-  static_assert(cuda::std::same_as<typename Traits::value_type, ValueType>);
-  static_assert(cuda::std::same_as<typename Traits::difference_type, DiffType>);
-  static_assert(cuda::std::same_as<typename Traits::reference, RefType>);
-  static_assert(cuda::std::same_as<typename Traits::pointer, PtrType>);
+  static_assert(cuda::std::same_as<typename Traits::iterator_category, Category>, "");
+  static_assert(cuda::std::same_as<typename Traits::value_type, ValueType>, "");
+  static_assert(cuda::std::same_as<typename Traits::difference_type, DiffType>, "");
+  static_assert(cuda::std::same_as<typename Traits::reference, RefType>, "");
+  static_assert(cuda::std::same_as<typename Traits::pointer, PtrType>, "");
 
   test_iter_concept<Iter, Traits>();
 
@@ -82,8 +83,8 @@ __host__ __device__ constexpr bool testMutable()
 // exists for any particular non-pointer type, we assume it is present
 // only for pointers.
 //
-static_assert(testMutable<cuda::std::array<int, 10>::iterator, cuda::std::random_access_iterator_tag, int>());
-static_assert(testConst<cuda::std::array<int, 10>::const_iterator, cuda::std::random_access_iterator_tag, int>());
+static_assert(testMutable<cuda::std::array<int, 10>::iterator, cuda::std::random_access_iterator_tag, int>(), "");
+static_assert(testConst<cuda::std::array<int, 10>::const_iterator, cuda::std::random_access_iterator_tag, int>(), "");
 
 // Local test iterators.
 
@@ -101,12 +102,12 @@ struct AllMembers
   {};
 };
 using AllMembersTraits = cuda::std::iterator_traits<AllMembers>;
-static_assert(cuda::std::same_as<AllMembersTraits::iterator_category, AllMembers::iterator_category>);
-static_assert(cuda::std::same_as<AllMembersTraits::value_type, AllMembers::value_type>);
-static_assert(cuda::std::same_as<AllMembersTraits::difference_type, AllMembers::difference_type>);
-static_assert(cuda::std::same_as<AllMembersTraits::reference, AllMembers::reference>);
-static_assert(cuda::std::same_as<AllMembersTraits::pointer, AllMembers::pointer>);
-static_assert(!has_iterator_concept_v<AllMembersTraits>);
+static_assert(cuda::std::same_as<AllMembersTraits::iterator_category, AllMembers::iterator_category>, "");
+static_assert(cuda::std::same_as<AllMembersTraits::value_type, AllMembers::value_type>, "");
+static_assert(cuda::std::same_as<AllMembersTraits::difference_type, AllMembers::difference_type>, "");
+static_assert(cuda::std::same_as<AllMembersTraits::reference, AllMembers::reference>, "");
+static_assert(cuda::std::same_as<AllMembersTraits::pointer, AllMembers::pointer>, "");
+static_assert(!has_iterator_concept_v<AllMembersTraits>, "");
 
 struct NoPointerMember
 {
@@ -122,12 +123,12 @@ struct NoPointerMember
   __host__ __device__ value_type* operator->() const;
 };
 using NoPointerMemberTraits = cuda::std::iterator_traits<NoPointerMember>;
-static_assert(cuda::std::same_as<NoPointerMemberTraits::iterator_category, NoPointerMember::iterator_category>);
-static_assert(cuda::std::same_as<NoPointerMemberTraits::value_type, NoPointerMember::value_type>);
-static_assert(cuda::std::same_as<NoPointerMemberTraits::difference_type, NoPointerMember::difference_type>);
-static_assert(cuda::std::same_as<NoPointerMemberTraits::reference, NoPointerMember::reference>);
-static_assert(cuda::std::same_as<NoPointerMemberTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<NoPointerMemberTraits>);
+static_assert(cuda::std::same_as<NoPointerMemberTraits::iterator_category, NoPointerMember::iterator_category>, "");
+static_assert(cuda::std::same_as<NoPointerMemberTraits::value_type, NoPointerMember::value_type>, "");
+static_assert(cuda::std::same_as<NoPointerMemberTraits::difference_type, NoPointerMember::difference_type>, "");
+static_assert(cuda::std::same_as<NoPointerMemberTraits::reference, NoPointerMember::reference>, "");
+static_assert(cuda::std::same_as<NoPointerMemberTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<NoPointerMemberTraits>, "");
 
 struct IterConcept
 {
@@ -146,12 +147,12 @@ struct IterConcept
   {};
 };
 using IterConceptTraits = cuda::std::iterator_traits<IterConcept>;
-static_assert(cuda::std::same_as<IterConceptTraits::iterator_category, IterConcept::iterator_category>);
-static_assert(cuda::std::same_as<IterConceptTraits::value_type, IterConcept::value_type>);
-static_assert(cuda::std::same_as<IterConceptTraits::difference_type, IterConcept::difference_type>);
-static_assert(cuda::std::same_as<IterConceptTraits::reference, IterConcept::reference>);
-static_assert(cuda::std::same_as<IterConceptTraits::pointer, IterConcept::pointer>);
-static_assert(!has_iterator_concept_v<IterConceptTraits>);
+static_assert(cuda::std::same_as<IterConceptTraits::iterator_category, IterConcept::iterator_category>, "");
+static_assert(cuda::std::same_as<IterConceptTraits::value_type, IterConcept::value_type>, "");
+static_assert(cuda::std::same_as<IterConceptTraits::difference_type, IterConcept::difference_type>, "");
+static_assert(cuda::std::same_as<IterConceptTraits::reference, IterConcept::reference>, "");
+static_assert(cuda::std::same_as<IterConceptTraits::pointer, IterConcept::pointer>, "");
+static_assert(!has_iterator_concept_v<IterConceptTraits>, "");
 
 struct LegacyInput
 {
@@ -178,12 +179,12 @@ struct cuda::std::incrementable_traits<LegacyInput>
   using difference_type = short;
 };
 using LegacyInputTraits = cuda::std::iterator_traits<LegacyInput>;
-static_assert(cuda::std::same_as<LegacyInputTraits::iterator_category, LegacyInput::iterator_category>);
-static_assert(cuda::std::same_as<LegacyInputTraits::value_type, LegacyInput::value_type>);
-static_assert(cuda::std::same_as<LegacyInputTraits::difference_type, short>);
-static_assert(cuda::std::same_as<LegacyInputTraits::reference, LegacyInput::reference>);
-static_assert(cuda::std::same_as<LegacyInputTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<LegacyInputTraits>);
+static_assert(cuda::std::same_as<LegacyInputTraits::iterator_category, LegacyInput::iterator_category>, "");
+static_assert(cuda::std::same_as<LegacyInputTraits::value_type, LegacyInput::value_type>, "");
+static_assert(cuda::std::same_as<LegacyInputTraits::difference_type, short>, "");
+static_assert(cuda::std::same_as<LegacyInputTraits::reference, LegacyInput::reference>, "");
+static_assert(cuda::std::same_as<LegacyInputTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<LegacyInputTraits>, "");
 
 struct LegacyInputNoValueType
 {
@@ -209,12 +210,12 @@ struct cuda::std::indirectly_readable_traits<LegacyInputNoValueType>
   using value_type = LegacyInputNoValueType::not_value_type;
 };
 using LegacyInputNoValueTypeTraits = cuda::std::iterator_traits<LegacyInputNoValueType>;
-static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::iterator_category, cuda::std::input_iterator_tag>);
-static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::value_type, LegacyInputNoValueType::not_value_type>);
-static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::difference_type, int>);
-static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::reference, LegacyInputNoValueType::reference>);
-static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<LegacyInputNoValueTypeTraits>);
+static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::iterator_category, cuda::std::input_iterator_tag>, "");
+static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::value_type, LegacyInputNoValueType::not_value_type>, "");
+static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::difference_type, int>, "");
+static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::reference, LegacyInputNoValueType::reference>, "");
+static_assert(cuda::std::same_as<LegacyInputNoValueTypeTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<LegacyInputNoValueTypeTraits>, "");
 
 struct LegacyForward
 {
@@ -240,12 +241,12 @@ struct cuda::std::incrementable_traits<LegacyForward>
   using difference_type = short; // or any signed integral type
 };
 using LegacyForwardTraits = cuda::std::iterator_traits<LegacyForward>;
-static_assert(cuda::std::same_as<LegacyForwardTraits::iterator_category, cuda::std::forward_iterator_tag>);
-static_assert(cuda::std::same_as<LegacyForwardTraits::value_type, LegacyForward::not_value_type>);
-static_assert(cuda::std::same_as<LegacyForwardTraits::difference_type, short>);
-static_assert(cuda::std::same_as<LegacyForwardTraits::reference, const LegacyForward::not_value_type&>);
-static_assert(cuda::std::same_as<LegacyForwardTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<LegacyForwardTraits>);
+static_assert(cuda::std::same_as<LegacyForwardTraits::iterator_category, cuda::std::forward_iterator_tag>, "");
+static_assert(cuda::std::same_as<LegacyForwardTraits::value_type, LegacyForward::not_value_type>, "");
+static_assert(cuda::std::same_as<LegacyForwardTraits::difference_type, short>, "");
+static_assert(cuda::std::same_as<LegacyForwardTraits::reference, const LegacyForward::not_value_type&>, "");
+static_assert(cuda::std::same_as<LegacyForwardTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<LegacyForwardTraits>, "");
 
 struct LegacyBidirectional
 {
@@ -264,12 +265,13 @@ struct LegacyBidirectional
   __host__ __device__ friend short operator-(LegacyBidirectional, LegacyBidirectional);
 };
 using LegacyBidirectionalTraits = cuda::std::iterator_traits<LegacyBidirectional>;
-static_assert(cuda::std::same_as<LegacyBidirectionalTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
-static_assert(cuda::std::same_as<LegacyBidirectionalTraits::value_type, LegacyBidirectional::value_type>);
-static_assert(cuda::std::same_as<LegacyBidirectionalTraits::difference_type, short>);
-static_assert(cuda::std::same_as<LegacyBidirectionalTraits::reference, const LegacyBidirectional::value_type&>);
-static_assert(cuda::std::same_as<LegacyBidirectionalTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<LegacyBidirectionalTraits>);
+static_assert(cuda::std::same_as<LegacyBidirectionalTraits::iterator_category, cuda::std::bidirectional_iterator_tag>,
+              "");
+static_assert(cuda::std::same_as<LegacyBidirectionalTraits::value_type, LegacyBidirectional::value_type>, "");
+static_assert(cuda::std::same_as<LegacyBidirectionalTraits::difference_type, short>, "");
+static_assert(cuda::std::same_as<LegacyBidirectionalTraits::reference, const LegacyBidirectional::value_type&>, "");
+static_assert(cuda::std::same_as<LegacyBidirectionalTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<LegacyBidirectionalTraits>, "");
 
 // Almost a random access iterator except it is missing operator-(It, It).
 struct MinusNotDeclaredIter
@@ -326,12 +328,13 @@ struct cuda::std::incrementable_traits<MinusNotDeclaredIter>
   using difference_type = short;
 };
 using MinusNotDeclaredIterTraits = cuda::std::iterator_traits<MinusNotDeclaredIter>;
-static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
-static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::value_type, MinusNotDeclaredIter::value_type>);
-static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::difference_type, short>);
-static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::reference, const MinusNotDeclaredIter::value_type&>);
-static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<MinusNotDeclaredIterTraits>);
+static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::iterator_category, cuda::std::bidirectional_iterator_tag>,
+              "");
+static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::value_type, MinusNotDeclaredIter::value_type>, "");
+static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::difference_type, short>, "");
+static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::reference, const MinusNotDeclaredIter::value_type&>, "");
+static_assert(cuda::std::same_as<MinusNotDeclaredIterTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<MinusNotDeclaredIterTraits>, "");
 
 struct WrongSubscriptReturnType
 {
@@ -383,12 +386,12 @@ struct WrongSubscriptReturnType
 };
 using WrongSubscriptReturnTypeTraits = cuda::std::iterator_traits<WrongSubscriptReturnType>;
 static_assert(
-  cuda::std::same_as<WrongSubscriptReturnTypeTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
-static_assert(cuda::std::same_as<WrongSubscriptReturnTypeTraits::value_type, WrongSubscriptReturnType::value_type>);
-static_assert(cuda::std::same_as<WrongSubscriptReturnTypeTraits::difference_type, short>);
-static_assert(cuda::std::same_as<WrongSubscriptReturnTypeTraits::reference, WrongSubscriptReturnType::value_type&>);
-static_assert(cuda::std::same_as<WrongSubscriptReturnTypeTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<WrongSubscriptReturnTypeTraits>);
+  cuda::std::same_as<WrongSubscriptReturnTypeTraits::iterator_category, cuda::std::bidirectional_iterator_tag>, "");
+static_assert(cuda::std::same_as<WrongSubscriptReturnTypeTraits::value_type, WrongSubscriptReturnType::value_type>, "");
+static_assert(cuda::std::same_as<WrongSubscriptReturnTypeTraits::difference_type, short>, "");
+static_assert(cuda::std::same_as<WrongSubscriptReturnTypeTraits::reference, WrongSubscriptReturnType::value_type&>, "");
+static_assert(cuda::std::same_as<WrongSubscriptReturnTypeTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<WrongSubscriptReturnTypeTraits>, "");
 
 struct LegacyRandomAccess
 {
@@ -417,12 +420,13 @@ struct LegacyRandomAccess
   __host__ __device__ friend LegacyRandomAccess operator+(int, LegacyRandomAccess);
 };
 using LegacyRandomAccessTraits = cuda::std::iterator_traits<LegacyRandomAccess>;
-static_assert(cuda::std::same_as<LegacyRandomAccessTraits::iterator_category, cuda::std::random_access_iterator_tag>);
-static_assert(cuda::std::same_as<LegacyRandomAccessTraits::value_type, LegacyRandomAccess::value_type>);
-static_assert(cuda::std::same_as<LegacyRandomAccessTraits::difference_type, short>);
-static_assert(cuda::std::same_as<LegacyRandomAccessTraits::reference, const LegacyRandomAccess::value_type&>);
-static_assert(cuda::std::same_as<LegacyRandomAccessTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<LegacyRandomAccessTraits>);
+static_assert(cuda::std::same_as<LegacyRandomAccessTraits::iterator_category, cuda::std::random_access_iterator_tag>,
+              "");
+static_assert(cuda::std::same_as<LegacyRandomAccessTraits::value_type, LegacyRandomAccess::value_type>, "");
+static_assert(cuda::std::same_as<LegacyRandomAccessTraits::difference_type, short>, "");
+static_assert(cuda::std::same_as<LegacyRandomAccessTraits::reference, const LegacyRandomAccess::value_type&>, "");
+static_assert(cuda::std::same_as<LegacyRandomAccessTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<LegacyRandomAccessTraits>, "");
 
 struct LegacyRandomAccessSpaceship
 {
@@ -493,14 +497,14 @@ struct cuda::std::incrementable_traits<LegacyRandomAccessSpaceship>
 };
 using LegacyRandomAccessSpaceshipTraits = cuda::std::iterator_traits<LegacyRandomAccessSpaceship>;
 static_assert(
-  cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+  cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::iterator_category, cuda::std::random_access_iterator_tag>, "");
 static_assert(
-  cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::value_type, LegacyRandomAccessSpaceship::not_value_type>);
-static_assert(cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::difference_type, short>);
+  cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::value_type, LegacyRandomAccessSpaceship::not_value_type>, "");
+static_assert(cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::difference_type, short>, "");
 static_assert(
-  cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::reference, LegacyRandomAccessSpaceship::not_value_type&>);
-static_assert(cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<LegacyRandomAccessSpaceshipTraits>);
+  cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::reference, LegacyRandomAccessSpaceship::not_value_type&>, "");
+static_assert(cuda::std::same_as<LegacyRandomAccessSpaceshipTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<LegacyRandomAccessSpaceshipTraits>, "");
 
 // For output iterators, value_type, difference_type, and reference may be void.
 struct BareLegacyOutput
@@ -512,12 +516,12 @@ struct BareLegacyOutput
   __host__ __device__ BareLegacyOutput operator++(int);
 };
 using BareLegacyOutputTraits = cuda::std::iterator_traits<BareLegacyOutput>;
-static_assert(cuda::std::same_as<BareLegacyOutputTraits::iterator_category, cuda::std::output_iterator_tag>);
-static_assert(cuda::std::same_as<BareLegacyOutputTraits::value_type, void>);
-static_assert(cuda::std::same_as<BareLegacyOutputTraits::difference_type, void>);
-static_assert(cuda::std::same_as<BareLegacyOutputTraits::reference, void>);
-static_assert(cuda::std::same_as<BareLegacyOutputTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<BareLegacyOutputTraits>);
+static_assert(cuda::std::same_as<BareLegacyOutputTraits::iterator_category, cuda::std::output_iterator_tag>, "");
+static_assert(cuda::std::same_as<BareLegacyOutputTraits::value_type, void>, "");
+static_assert(cuda::std::same_as<BareLegacyOutputTraits::difference_type, void>, "");
+static_assert(cuda::std::same_as<BareLegacyOutputTraits::reference, void>, "");
+static_assert(cuda::std::same_as<BareLegacyOutputTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<BareLegacyOutputTraits>, "");
 
 // The operator- means we get difference_type.
 struct LegacyOutputWithMinus
@@ -531,12 +535,12 @@ struct LegacyOutputWithMinus
   // Lacking operator==, this is a LegacyIterator but not a LegacyInputIterator.
 };
 using LegacyOutputWithMinusTraits = cuda::std::iterator_traits<LegacyOutputWithMinus>;
-static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::iterator_category, cuda::std::output_iterator_tag>);
-static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::value_type, void>);
-static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::difference_type, short>);
-static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::reference, void>);
-static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<LegacyOutputWithMinusTraits>);
+static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::iterator_category, cuda::std::output_iterator_tag>, "");
+static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::value_type, void>, "");
+static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::difference_type, short>, "");
+static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::reference, void>, "");
+static_assert(cuda::std::same_as<LegacyOutputWithMinusTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<LegacyOutputWithMinusTraits>, "");
 
 struct LegacyOutputWithMemberTypes
 {
@@ -557,12 +561,13 @@ struct LegacyOutputWithMemberTypes
   // Since (*it) is not convertible to value_type, this is not a LegacyInputIterator.
 };
 using LegacyOutputWithMemberTypesTraits = cuda::std::iterator_traits<LegacyOutputWithMemberTypes>;
-static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::iterator_category, cuda::std::output_iterator_tag>);
-static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::value_type, void>);
-static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::difference_type, long>);
-static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::reference, void>);
-static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<LegacyOutputWithMemberTypesTraits>);
+static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::iterator_category, cuda::std::output_iterator_tag>,
+              "");
+static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::value_type, void>, "");
+static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::difference_type, long>, "");
+static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::reference, void>, "");
+static_assert(cuda::std::same_as<LegacyOutputWithMemberTypesTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<LegacyOutputWithMemberTypesTraits>, "");
 
 struct LegacyRandomAccessSpecialized
 {
@@ -628,88 +633,89 @@ struct cuda::std::iterator_traits<LegacyRandomAccessSpecialized>
 };
 using LegacyRandomAccessSpecializedTraits = cuda::std::iterator_traits<LegacyRandomAccessSpecialized>;
 static_assert(
-  cuda::std::same_as<LegacyRandomAccessSpecializedTraits::iterator_category, cuda::std::output_iterator_tag>);
-static_assert(cuda::std::same_as<LegacyRandomAccessSpecializedTraits::value_type, short>);
-static_assert(cuda::std::same_as<LegacyRandomAccessSpecializedTraits::difference_type, short>);
-static_assert(cuda::std::same_as<LegacyRandomAccessSpecializedTraits::reference, short&>);
-static_assert(cuda::std::same_as<LegacyRandomAccessSpecializedTraits::pointer, short*>);
-static_assert(!has_iterator_concept_v<LegacyRandomAccessSpecializedTraits>);
+  cuda::std::same_as<LegacyRandomAccessSpecializedTraits::iterator_category, cuda::std::output_iterator_tag>, "");
+static_assert(cuda::std::same_as<LegacyRandomAccessSpecializedTraits::value_type, short>, "");
+static_assert(cuda::std::same_as<LegacyRandomAccessSpecializedTraits::difference_type, short>, "");
+static_assert(cuda::std::same_as<LegacyRandomAccessSpecializedTraits::reference, short&>, "");
+static_assert(cuda::std::same_as<LegacyRandomAccessSpecializedTraits::pointer, short*>, "");
+static_assert(!has_iterator_concept_v<LegacyRandomAccessSpecializedTraits>, "");
 
 // Other test iterators.
 
 using InputTestIteratorTraits = cuda::std::iterator_traits<cpp17_input_iterator<int*>>;
-static_assert(cuda::std::same_as<InputTestIteratorTraits::iterator_category, cuda::std::input_iterator_tag>);
-static_assert(cuda::std::same_as<InputTestIteratorTraits::value_type, int>);
-static_assert(cuda::std::same_as<InputTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>);
-static_assert(cuda::std::same_as<InputTestIteratorTraits::reference, int&>);
-static_assert(cuda::std::same_as<InputTestIteratorTraits::pointer, int*>);
-static_assert(!has_iterator_concept_v<InputTestIteratorTraits>);
+static_assert(cuda::std::same_as<InputTestIteratorTraits::iterator_category, cuda::std::input_iterator_tag>, "");
+static_assert(cuda::std::same_as<InputTestIteratorTraits::value_type, int>, "");
+static_assert(cuda::std::same_as<InputTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>, "");
+static_assert(cuda::std::same_as<InputTestIteratorTraits::reference, int&>, "");
+static_assert(cuda::std::same_as<InputTestIteratorTraits::pointer, int*>, "");
+static_assert(!has_iterator_concept_v<InputTestIteratorTraits>, "");
 
 using OutputTestIteratorTraits = cuda::std::iterator_traits<cpp17_output_iterator<int*>>;
-static_assert(cuda::std::same_as<OutputTestIteratorTraits::iterator_category, cuda::std::output_iterator_tag>);
-static_assert(cuda::std::same_as<OutputTestIteratorTraits::value_type, void>);
-static_assert(cuda::std::same_as<OutputTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>);
-static_assert(cuda::std::same_as<OutputTestIteratorTraits::reference, int&>);
-static_assert(cuda::std::same_as<OutputTestIteratorTraits::pointer, int*>);
-static_assert(!has_iterator_concept_v<OutputTestIteratorTraits>);
+static_assert(cuda::std::same_as<OutputTestIteratorTraits::iterator_category, cuda::std::output_iterator_tag>, "");
+static_assert(cuda::std::same_as<OutputTestIteratorTraits::value_type, void>, "");
+static_assert(cuda::std::same_as<OutputTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>, "");
+static_assert(cuda::std::same_as<OutputTestIteratorTraits::reference, int&>, "");
+static_assert(cuda::std::same_as<OutputTestIteratorTraits::pointer, int*>, "");
+static_assert(!has_iterator_concept_v<OutputTestIteratorTraits>, "");
 
 using ForwardTestIteratorTraits = cuda::std::iterator_traits<forward_iterator<int*>>;
-static_assert(cuda::std::same_as<ForwardTestIteratorTraits::iterator_category, cuda::std::forward_iterator_tag>);
-static_assert(cuda::std::same_as<ForwardTestIteratorTraits::value_type, int>);
-static_assert(cuda::std::same_as<ForwardTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>);
-static_assert(cuda::std::same_as<ForwardTestIteratorTraits::reference, int&>);
-static_assert(cuda::std::same_as<ForwardTestIteratorTraits::pointer, int*>);
-static_assert(!has_iterator_concept_v<ForwardTestIteratorTraits>);
+static_assert(cuda::std::same_as<ForwardTestIteratorTraits::iterator_category, cuda::std::forward_iterator_tag>, "");
+static_assert(cuda::std::same_as<ForwardTestIteratorTraits::value_type, int>, "");
+static_assert(cuda::std::same_as<ForwardTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>, "");
+static_assert(cuda::std::same_as<ForwardTestIteratorTraits::reference, int&>, "");
+static_assert(cuda::std::same_as<ForwardTestIteratorTraits::pointer, int*>, "");
+static_assert(!has_iterator_concept_v<ForwardTestIteratorTraits>, "");
 
 using BidirectionalTestIteratorTraits = cuda::std::iterator_traits<bidirectional_iterator<int*>>;
 static_assert(
-  cuda::std::same_as<BidirectionalTestIteratorTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
-static_assert(cuda::std::same_as<BidirectionalTestIteratorTraits::value_type, int>);
-static_assert(cuda::std::same_as<BidirectionalTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>);
-static_assert(cuda::std::same_as<BidirectionalTestIteratorTraits::reference, int&>);
-static_assert(cuda::std::same_as<BidirectionalTestIteratorTraits::pointer, int*>);
-static_assert(!has_iterator_concept_v<BidirectionalTestIteratorTraits>);
+  cuda::std::same_as<BidirectionalTestIteratorTraits::iterator_category, cuda::std::bidirectional_iterator_tag>, "");
+static_assert(cuda::std::same_as<BidirectionalTestIteratorTraits::value_type, int>, "");
+static_assert(cuda::std::same_as<BidirectionalTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>, "");
+static_assert(cuda::std::same_as<BidirectionalTestIteratorTraits::reference, int&>, "");
+static_assert(cuda::std::same_as<BidirectionalTestIteratorTraits::pointer, int*>, "");
+static_assert(!has_iterator_concept_v<BidirectionalTestIteratorTraits>, "");
 
 using RandomAccessTestIteratorTraits = cuda::std::iterator_traits<random_access_iterator<int*>>;
 static_assert(
-  cuda::std::same_as<RandomAccessTestIteratorTraits::iterator_category, cuda::std::random_access_iterator_tag>);
-static_assert(cuda::std::same_as<RandomAccessTestIteratorTraits::value_type, int>);
-static_assert(cuda::std::same_as<RandomAccessTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>);
-static_assert(cuda::std::same_as<RandomAccessTestIteratorTraits::reference, int&>);
-static_assert(cuda::std::same_as<RandomAccessTestIteratorTraits::pointer, int*>);
-static_assert(!has_iterator_concept_v<RandomAccessTestIteratorTraits>);
+  cuda::std::same_as<RandomAccessTestIteratorTraits::iterator_category, cuda::std::random_access_iterator_tag>, "");
+static_assert(cuda::std::same_as<RandomAccessTestIteratorTraits::value_type, int>, "");
+static_assert(cuda::std::same_as<RandomAccessTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>, "");
+static_assert(cuda::std::same_as<RandomAccessTestIteratorTraits::reference, int&>, "");
+static_assert(cuda::std::same_as<RandomAccessTestIteratorTraits::pointer, int*>, "");
+static_assert(!has_iterator_concept_v<RandomAccessTestIteratorTraits>, "");
 
 using ContiguousTestIteratorTraits = cuda::std::iterator_traits<contiguous_iterator<int*>>;
-static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::iterator_category, cuda::std::contiguous_iterator_tag>);
-static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::value_type, int>);
-static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>);
-static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::reference, int&>);
-static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::pointer, int*>);
-static_assert(!has_iterator_concept_v<ContiguousTestIteratorTraits>);
+static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::iterator_category, cuda::std::contiguous_iterator_tag>,
+              "");
+static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::value_type, int>, "");
+static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::difference_type, cuda::std::ptrdiff_t>, "");
+static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::reference, int&>, "");
+static_assert(cuda::std::same_as<ContiguousTestIteratorTraits::pointer, int*>, "");
+static_assert(!has_iterator_concept_v<ContiguousTestIteratorTraits>, "");
 
 using Cpp17BasicIteratorTraits = cuda::std::iterator_traits<iterator_traits_cpp17_iterator>;
-static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::iterator_category, cuda::std::output_iterator_tag>);
-static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::value_type, void>);
-static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::difference_type, void>);
-static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::reference, void>);
-static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<Cpp17BasicIteratorTraits>);
+static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::iterator_category, cuda::std::output_iterator_tag>, "");
+static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::value_type, void>, "");
+static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::difference_type, void>, "");
+static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::reference, void>, "");
+static_assert(cuda::std::same_as<Cpp17BasicIteratorTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<Cpp17BasicIteratorTraits>, "");
 
 using Cpp17InputIteratorTraits = cuda::std::iterator_traits<iterator_traits_cpp17_input_iterator>;
-static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::iterator_category, cuda::std::input_iterator_tag>);
-static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::value_type, long>);
-static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::difference_type, int>);
-static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::reference, int&>);
-static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<Cpp17InputIteratorTraits>);
+static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::iterator_category, cuda::std::input_iterator_tag>, "");
+static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::value_type, long>, "");
+static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::difference_type, int>, "");
+static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::reference, int&>, "");
+static_assert(cuda::std::same_as<Cpp17InputIteratorTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<Cpp17InputIteratorTraits>, "");
 
 using Cpp17ForwardIteratorTraits = cuda::std::iterator_traits<iterator_traits_cpp17_forward_iterator>;
-static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::iterator_category, cuda::std::forward_iterator_tag>);
-static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::value_type, int>);
-static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::difference_type, int>);
-static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::reference, int&>);
-static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::pointer, void>);
-static_assert(!has_iterator_concept_v<Cpp17ForwardIteratorTraits>);
+static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::iterator_category, cuda::std::forward_iterator_tag>, "");
+static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::value_type, int>, "");
+static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::difference_type, int>, "");
+static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::reference, int&>, "");
+static_assert(cuda::std::same_as<Cpp17ForwardIteratorTraits::pointer, void>, "");
+static_assert(!has_iterator_concept_v<Cpp17ForwardIteratorTraits>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/iter_reference_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/iter_reference_t.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // using iter_reference_t = decltype(*declval<T&>());
@@ -17,10 +17,10 @@
 
 #include "test_iterators.h"
 
-static_assert(cuda::std::same_as<cuda::std::iter_reference_t<cpp17_input_iterator<int*>>, int&>);
-static_assert(cuda::std::same_as<cuda::std::iter_reference_t<forward_iterator<int*>>, int&>);
-static_assert(cuda::std::same_as<cuda::std::iter_reference_t<bidirectional_iterator<int*>>, int&>);
-static_assert(cuda::std::same_as<cuda::std::iter_reference_t<random_access_iterator<int*>>, int&>);
+static_assert(cuda::std::same_as<cuda::std::iter_reference_t<cpp17_input_iterator<int*>>, int&>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_reference_t<forward_iterator<int*>>, int&>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_reference_t<bidirectional_iterator<int*>>, int&>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_reference_t<random_access_iterator<int*>>, int&>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/std.iterator.tags/contiguous_iterator_tag.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/std.iterator.tags/contiguous_iterator_tag.pass.cpp
@@ -11,7 +11,7 @@
 
 // struct contiguous_iterator_tag : public random_access_iterator_tag {};
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 #include <cuda/std/iterator>
 #include <cuda/std/type_traits>
@@ -23,8 +23,9 @@ int main(int, char**)
   cuda::std::contiguous_iterator_tag tag;
   ((void) tag); // Prevent unused warning
   static_assert(
-    (cuda::std::is_base_of<cuda::std::random_access_iterator_tag, cuda::std::contiguous_iterator_tag>::value));
-  static_assert((!cuda::std::is_base_of<cuda::std::output_iterator_tag, cuda::std::contiguous_iterator_tag>::value));
+    (cuda::std::is_base_of<cuda::std::random_access_iterator_tag, cuda::std::contiguous_iterator_tag>::value), "");
+  static_assert((!cuda::std::is_base_of<cuda::std::output_iterator_tag, cuda::std::contiguous_iterator_tag>::value),
+                "");
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class In, class Out>
 // concept indirectly_copyable;
@@ -29,43 +29,43 @@ struct CopyOnly
 };
 
 // Can copy the underlying objects between pointers.
-static_assert(cuda::std::indirectly_copyable<int*, int*>);
-static_assert(cuda::std::indirectly_copyable<const int*, int*>);
+static_assert(cuda::std::indirectly_copyable<int*, int*>, "");
+static_assert(cuda::std::indirectly_copyable<const int*, int*>, "");
 
 // Can't copy if the output pointer is const.
-static_assert(!cuda::std::indirectly_copyable<int*, const int*>);
-static_assert(!cuda::std::indirectly_copyable<const int*, const int*>);
+static_assert(!cuda::std::indirectly_copyable<int*, const int*>, "");
+static_assert(!cuda::std::indirectly_copyable<const int*, const int*>, "");
 
 // Can copy from a pointer into an array but arrays aren't considered indirectly copyable-from.
-static_assert(cuda::std::indirectly_copyable<int*, int[2]>);
-static_assert(!cuda::std::indirectly_copyable<int[2], int*>);
-static_assert(!cuda::std::indirectly_copyable<int[2], int[2]>);
-static_assert(!cuda::std::indirectly_copyable<int (&)[2], int (&)[2]>);
+static_assert(cuda::std::indirectly_copyable<int*, int[2]>, "");
+static_assert(!cuda::std::indirectly_copyable<int[2], int*>, "");
+static_assert(!cuda::std::indirectly_copyable<int[2], int[2]>, "");
+static_assert(!cuda::std::indirectly_copyable<int (&)[2], int (&)[2]>, "");
 
 // Can't copy between non-pointer types.
-static_assert(!cuda::std::indirectly_copyable<int*, int>);
-static_assert(!cuda::std::indirectly_copyable<int, int*>);
-static_assert(!cuda::std::indirectly_copyable<int, int>);
+static_assert(!cuda::std::indirectly_copyable<int*, int>, "");
+static_assert(!cuda::std::indirectly_copyable<int, int*>, "");
+static_assert(!cuda::std::indirectly_copyable<int, int>, "");
 
 // Check some less common types.
-static_assert(!cuda::std::indirectly_movable<void*, void*>);
-static_assert(!cuda::std::indirectly_movable<int*, void*>);
-static_assert(!cuda::std::indirectly_movable<int(), int()>);
-static_assert(!cuda::std::indirectly_movable<int*, int()>);
-static_assert(!cuda::std::indirectly_movable<void, void>);
+static_assert(!cuda::std::indirectly_movable<void*, void*>, "");
+static_assert(!cuda::std::indirectly_movable<int*, void*>, "");
+static_assert(!cuda::std::indirectly_movable<int(), int()>, "");
+static_assert(!cuda::std::indirectly_movable<int*, int()>, "");
+static_assert(!cuda::std::indirectly_movable<void, void>, "");
 
 // Can't copy move-only objects.
-static_assert(!cuda::std::indirectly_copyable<MoveOnly*, MoveOnly*>);
-static_assert(!cuda::std::indirectly_copyable<MoveOnly*, const MoveOnly*>);
-static_assert(!cuda::std::indirectly_copyable<const MoveOnly*, MoveOnly*>);
-static_assert(!cuda::std::indirectly_copyable<const MoveOnly*, const MoveOnly*>);
+static_assert(!cuda::std::indirectly_copyable<MoveOnly*, MoveOnly*>, "");
+static_assert(!cuda::std::indirectly_copyable<MoveOnly*, const MoveOnly*>, "");
+static_assert(!cuda::std::indirectly_copyable<const MoveOnly*, MoveOnly*>, "");
+static_assert(!cuda::std::indirectly_copyable<const MoveOnly*, const MoveOnly*>, "");
 
 // Can copy copy-only objects.
 #ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
-static_assert(cuda::std::indirectly_copyable<CopyOnly*, CopyOnly*>);
-static_assert(!cuda::std::indirectly_copyable<CopyOnly*, const CopyOnly*>);
-static_assert(cuda::std::indirectly_copyable<const CopyOnly*, CopyOnly*>);
-static_assert(!cuda::std::indirectly_copyable<const CopyOnly*, const CopyOnly*>);
+static_assert(cuda::std::indirectly_copyable<CopyOnly*, CopyOnly*>, "");
+static_assert(!cuda::std::indirectly_copyable<CopyOnly*, const CopyOnly*>, "");
+static_assert(cuda::std::indirectly_copyable<const CopyOnly*, CopyOnly*>, "");
+static_assert(!cuda::std::indirectly_copyable<const CopyOnly*, const CopyOnly*>, "");
 #endif // TEST_COMPILER_MSVC_2017
 
 template <class T>
@@ -77,13 +77,13 @@ struct PointerTo
 
 #ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
 // Can copy through a dereferenceable class.
-static_assert(cuda::std::indirectly_copyable<int*, PointerTo<int>>);
-static_assert(!cuda::std::indirectly_copyable<int*, PointerTo<const int>>);
-static_assert(cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<int>>);
-static_assert(!cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<const int>>);
-static_assert(cuda::std::indirectly_copyable<CopyOnly*, PointerTo<CopyOnly>>);
-static_assert(cuda::std::indirectly_copyable<PointerTo<CopyOnly>, CopyOnly*>);
-static_assert(cuda::std::indirectly_copyable<PointerTo<CopyOnly>, PointerTo<CopyOnly>>);
+static_assert(cuda::std::indirectly_copyable<int*, PointerTo<int>>, "");
+static_assert(!cuda::std::indirectly_copyable<int*, PointerTo<const int>>, "");
+static_assert(cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<int>>, "");
+static_assert(!cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<const int>>, "");
+static_assert(cuda::std::indirectly_copyable<CopyOnly*, PointerTo<CopyOnly>>, "");
+static_assert(cuda::std::indirectly_copyable<PointerTo<CopyOnly>, CopyOnly*>, "");
+static_assert(cuda::std::indirectly_copyable<PointerTo<CopyOnly>, PointerTo<CopyOnly>>, "");
 #endif // TEST_COMPILER_MSVC_2017
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.subsumption.compile.pass.cpp
@@ -29,7 +29,7 @@ __host__ __device__ constexpr bool indirectly_copyable_subsumption()
   return true;
 }
 
-static_assert(indirectly_copyable_subsumption<int*, int*>());
+static_assert(indirectly_copyable_subsumption<int*, int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class In, class Out>
 // concept indirectly_copyable_storable;
@@ -35,17 +35,17 @@ struct PointerTo
 
 // Copying the underlying object between pointers (or dereferenceable classes) works. This is a non-exhaustive check
 // because this functionality comes from `indirectly_copyable`.
-static_assert(cuda::std::indirectly_copyable_storable<int*, int*>);
-static_assert(cuda::std::indirectly_copyable_storable<const int*, int*>);
-static_assert(!cuda::std::indirectly_copyable_storable<int*, const int*>);
-static_assert(!cuda::std::indirectly_copyable_storable<const int*, const int*>);
-static_assert(cuda::std::indirectly_copyable_storable<int*, int[2]>);
-static_assert(!cuda::std::indirectly_copyable_storable<int[2], int*>);
-static_assert(!cuda::std::indirectly_copyable_storable<MoveOnly*, MoveOnly*>);
-static_assert(!cuda::std::indirectly_copyable_storable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>);
+static_assert(cuda::std::indirectly_copyable_storable<int*, int*>, "");
+static_assert(cuda::std::indirectly_copyable_storable<const int*, int*>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<int*, const int*>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<const int*, const int*>, "");
+static_assert(cuda::std::indirectly_copyable_storable<int*, int[2]>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<int[2], int*>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<MoveOnly*, MoveOnly*>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>, "");
 // `indirectly_copyable_storable` requires the type to be `copyable`, which in turns requires it to be `movable`.
-static_assert(!cuda::std::indirectly_copyable_storable<CopyOnly*, CopyOnly*>);
-static_assert(!cuda::std::indirectly_copyable_storable<PointerTo<CopyOnly>, PointerTo<CopyOnly>>);
+static_assert(!cuda::std::indirectly_copyable_storable<CopyOnly*, CopyOnly*>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<PointerTo<CopyOnly>, PointerTo<CopyOnly>>, "");
 
 // The dereference operator returns a different type from `value_type` and the reference type cannot be assigned from a
 // non-const lvalue of `ValueType` (but all other forms of assignment from `ValueType` work).
@@ -70,12 +70,14 @@ struct NoLvalueAssignment
   __host__ __device__ ReferenceType& operator*() const;
 };
 
-static_assert(cuda::std::indirectly_writable<NoLvalueAssignment, cuda::std::iter_reference_t<NoLvalueAssignment>>);
-static_assert(!cuda::std::indirectly_writable<NoLvalueAssignment, cuda::std::iter_value_t<NoLvalueAssignment>&>);
-static_assert(cuda::std::indirectly_writable<NoLvalueAssignment, const cuda::std::iter_value_t<NoLvalueAssignment>&>);
-static_assert(cuda::std::indirectly_writable<NoLvalueAssignment, cuda::std::iter_value_t<NoLvalueAssignment>&&>);
-static_assert(cuda::std::indirectly_writable<NoLvalueAssignment, const cuda::std::iter_value_t<NoLvalueAssignment>&&>);
-static_assert(!cuda::std::indirectly_copyable_storable<NoLvalueAssignment, NoLvalueAssignment>);
+static_assert(cuda::std::indirectly_writable<NoLvalueAssignment, cuda::std::iter_reference_t<NoLvalueAssignment>>, "");
+static_assert(!cuda::std::indirectly_writable<NoLvalueAssignment, cuda::std::iter_value_t<NoLvalueAssignment>&>, "");
+static_assert(cuda::std::indirectly_writable<NoLvalueAssignment, const cuda::std::iter_value_t<NoLvalueAssignment>&>,
+              "");
+static_assert(cuda::std::indirectly_writable<NoLvalueAssignment, cuda::std::iter_value_t<NoLvalueAssignment>&&>, "");
+static_assert(cuda::std::indirectly_writable<NoLvalueAssignment, const cuda::std::iter_value_t<NoLvalueAssignment>&&>,
+              "");
+static_assert(!cuda::std::indirectly_copyable_storable<NoLvalueAssignment, NoLvalueAssignment>, "");
 
 // The dereference operator returns a different type from `value_type` and the reference type cannot be assigned from a
 // const lvalue of `ValueType` (but all other forms of assignment from `ValueType` work).
@@ -101,16 +103,18 @@ struct NoConstLvalueAssignment
 };
 
 static_assert(
-  cuda::std::indirectly_writable<NoConstLvalueAssignment, cuda::std::iter_reference_t<NoConstLvalueAssignment>>);
+  cuda::std::indirectly_writable<NoConstLvalueAssignment, cuda::std::iter_reference_t<NoConstLvalueAssignment>>, "");
 static_assert(
-  cuda::std::indirectly_writable<NoConstLvalueAssignment, cuda::std::iter_value_t<NoConstLvalueAssignment>&>);
+  cuda::std::indirectly_writable<NoConstLvalueAssignment, cuda::std::iter_value_t<NoConstLvalueAssignment>&>, "");
 static_assert(
-  !cuda::std::indirectly_writable<NoConstLvalueAssignment, const cuda::std::iter_value_t<NoConstLvalueAssignment>&>);
+  !cuda::std::indirectly_writable<NoConstLvalueAssignment, const cuda::std::iter_value_t<NoConstLvalueAssignment>&>,
+  "");
 static_assert(
-  cuda::std::indirectly_writable<NoConstLvalueAssignment, cuda::std::iter_value_t<NoConstLvalueAssignment>&&>);
+  cuda::std::indirectly_writable<NoConstLvalueAssignment, cuda::std::iter_value_t<NoConstLvalueAssignment>&&>, "");
 static_assert(
-  cuda::std::indirectly_writable<NoConstLvalueAssignment, const cuda::std::iter_value_t<NoConstLvalueAssignment>&&>);
-static_assert(!cuda::std::indirectly_copyable_storable<NoConstLvalueAssignment, NoConstLvalueAssignment>);
+  cuda::std::indirectly_writable<NoConstLvalueAssignment, const cuda::std::iter_value_t<NoConstLvalueAssignment>&&>,
+  "");
+static_assert(!cuda::std::indirectly_copyable_storable<NoConstLvalueAssignment, NoConstLvalueAssignment>, "");
 
 // The dereference operator returns a different type from `value_type` and the reference type cannot be assigned from a
 // non-const rvalue of `ValueType` (but all other forms of assignment from `ValueType` work).
@@ -135,12 +139,14 @@ struct NoRvalueAssignment
   __host__ __device__ ReferenceType& operator*() const;
 };
 
-static_assert(cuda::std::indirectly_writable<NoRvalueAssignment, cuda::std::iter_reference_t<NoRvalueAssignment>>);
-static_assert(cuda::std::indirectly_writable<NoRvalueAssignment, cuda::std::iter_value_t<NoRvalueAssignment>&>);
-static_assert(cuda::std::indirectly_writable<NoRvalueAssignment, const cuda::std::iter_value_t<NoRvalueAssignment>&>);
-static_assert(!cuda::std::indirectly_writable<NoRvalueAssignment, cuda::std::iter_value_t<NoRvalueAssignment>&&>);
-static_assert(cuda::std::indirectly_writable<NoRvalueAssignment, const cuda::std::iter_value_t<NoRvalueAssignment>&&>);
-static_assert(!cuda::std::indirectly_copyable_storable<NoRvalueAssignment, NoRvalueAssignment>);
+static_assert(cuda::std::indirectly_writable<NoRvalueAssignment, cuda::std::iter_reference_t<NoRvalueAssignment>>, "");
+static_assert(cuda::std::indirectly_writable<NoRvalueAssignment, cuda::std::iter_value_t<NoRvalueAssignment>&>, "");
+static_assert(cuda::std::indirectly_writable<NoRvalueAssignment, const cuda::std::iter_value_t<NoRvalueAssignment>&>,
+              "");
+static_assert(!cuda::std::indirectly_writable<NoRvalueAssignment, cuda::std::iter_value_t<NoRvalueAssignment>&&>, "");
+static_assert(cuda::std::indirectly_writable<NoRvalueAssignment, const cuda::std::iter_value_t<NoRvalueAssignment>&&>,
+              "");
+static_assert(!cuda::std::indirectly_copyable_storable<NoRvalueAssignment, NoRvalueAssignment>, "");
 
 // The dereference operator returns a different type from `value_type` and the reference type cannot be assigned from a
 // const rvalue of `ValueType` (but all other forms of assignment from `ValueType` work).
@@ -166,16 +172,17 @@ struct NoConstRvalueAssignment
 };
 
 static_assert(
-  cuda::std::indirectly_writable<NoConstRvalueAssignment, cuda::std::iter_reference_t<NoConstRvalueAssignment>>);
+  cuda::std::indirectly_writable<NoConstRvalueAssignment, cuda::std::iter_reference_t<NoConstRvalueAssignment>>, "");
 static_assert(
-  cuda::std::indirectly_writable<NoConstRvalueAssignment, cuda::std::iter_value_t<NoConstRvalueAssignment>&>);
+  cuda::std::indirectly_writable<NoConstRvalueAssignment, cuda::std::iter_value_t<NoConstRvalueAssignment>&>, "");
 static_assert(
-  cuda::std::indirectly_writable<NoConstRvalueAssignment, const cuda::std::iter_value_t<NoConstRvalueAssignment>&>);
+  cuda::std::indirectly_writable<NoConstRvalueAssignment, const cuda::std::iter_value_t<NoConstRvalueAssignment>&>, "");
 static_assert(
-  cuda::std::indirectly_writable<NoConstRvalueAssignment, cuda::std::iter_value_t<NoConstRvalueAssignment>&&>);
+  cuda::std::indirectly_writable<NoConstRvalueAssignment, cuda::std::iter_value_t<NoConstRvalueAssignment>&&>, "");
 static_assert(
-  !cuda::std::indirectly_writable<NoConstRvalueAssignment, const cuda::std::iter_value_t<NoConstRvalueAssignment>&&>);
-static_assert(!cuda::std::indirectly_copyable_storable<NoConstRvalueAssignment, NoConstRvalueAssignment>);
+  !cuda::std::indirectly_writable<NoConstRvalueAssignment, const cuda::std::iter_value_t<NoConstRvalueAssignment>&&>,
+  "");
+static_assert(!cuda::std::indirectly_copyable_storable<NoConstRvalueAssignment, NoConstRvalueAssignment>, "");
 
 struct DeletedCopyCtor
 {
@@ -191,7 +198,7 @@ struct DeletedNonconstCopyCtor
   DeletedNonconstCopyCtor(DeletedNonconstCopyCtor&)                  = delete;
   DeletedNonconstCopyCtor& operator=(DeletedNonconstCopyCtor const&) = default;
 };
-static_assert(!cuda::std::indirectly_copyable_storable<DeletedNonconstCopyCtor*, DeletedNonconstCopyCtor*>);
+static_assert(!cuda::std::indirectly_copyable_storable<DeletedNonconstCopyCtor*, DeletedNonconstCopyCtor*>, "");
 #endif // TEST_STD_VER > 2017 || !defined(TEST_COMPILER_MSVC)
 
 struct DeletedMoveCtor
@@ -208,7 +215,7 @@ struct DeletedConstMoveCtor
   DeletedConstMoveCtor(DeletedConstMoveCtor const&&)      = delete;
   DeletedConstMoveCtor& operator=(DeletedConstMoveCtor&&) = default;
 };
-static_assert(!cuda::std::indirectly_copyable_storable<DeletedConstMoveCtor*, DeletedConstMoveCtor*>);
+static_assert(!cuda::std::indirectly_copyable_storable<DeletedConstMoveCtor*, DeletedConstMoveCtor*>, "");
 #endif // TEST_STD_VER > 2017 || !defined(TEST_COMPILER_MSVC)
 
 struct DeletedCopyAssignment
@@ -225,7 +232,8 @@ struct DeletedNonconstCopyAssignment
   DeletedNonconstCopyAssignment& operator=(DeletedNonconstCopyAssignment const&) = default;
   DeletedNonconstCopyAssignment& operator=(DeletedNonconstCopyAssignment&)       = delete;
 };
-static_assert(!cuda::std::indirectly_copyable_storable<DeletedNonconstCopyAssignment*, DeletedNonconstCopyAssignment*>);
+static_assert(!cuda::std::indirectly_copyable_storable<DeletedNonconstCopyAssignment*, DeletedNonconstCopyAssignment*>,
+              "");
 #endif // TEST_STD_VER > 2017 || !defined(TEST_COMPILER_MSVC)
 
 struct DeletedMoveAssignment
@@ -240,11 +248,11 @@ struct DeletedConstMoveAssignment
   DeletedConstMoveAssignment& operator=(DeletedConstMoveAssignment&&) = delete;
 };
 
-static_assert(!cuda::std::indirectly_copyable_storable<DeletedCopyCtor*, DeletedCopyCtor*>);
-static_assert(!cuda::std::indirectly_copyable_storable<DeletedMoveCtor*, DeletedMoveCtor*>);
-static_assert(!cuda::std::indirectly_copyable_storable<DeletedCopyAssignment*, DeletedCopyAssignment*>);
-static_assert(!cuda::std::indirectly_copyable_storable<DeletedMoveAssignment*, DeletedMoveAssignment*>);
-static_assert(!cuda::std::indirectly_copyable_storable<DeletedConstMoveAssignment*, DeletedConstMoveAssignment*>);
+static_assert(!cuda::std::indirectly_copyable_storable<DeletedCopyCtor*, DeletedCopyCtor*>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<DeletedMoveCtor*, DeletedMoveCtor*>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<DeletedCopyAssignment*, DeletedCopyAssignment*>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<DeletedMoveAssignment*, DeletedMoveAssignment*>, "");
+static_assert(!cuda::std::indirectly_copyable_storable<DeletedConstMoveAssignment*, DeletedConstMoveAssignment*>, "");
 
 struct InconsistentIterator
 {
@@ -267,7 +275,7 @@ struct InconsistentIterator
 
 // `ValueType` can be constructed with a `ReferenceType` and assigned to a `ReferenceType`, so it does model
 // `indirectly_copyable_storable`.
-static_assert(cuda::std::indirectly_copyable_storable<InconsistentIterator, InconsistentIterator>);
+static_assert(cuda::std::indirectly_copyable_storable<InconsistentIterator, InconsistentIterator>, "");
 
 struct CommonType
 {};
@@ -292,22 +300,27 @@ struct NotConstructibleFromRefIn
   __host__ __device__ ReferenceType& operator*() const;
 };
 
+namespace cuda
+{
+namespace std
+{
 template <template <class> class X, template <class> class Y>
-struct cuda::std::
-  basic_common_reference<NotConstructibleFromRefIn::ValueType, NotConstructibleFromRefIn::ReferenceType, X, Y>
+struct basic_common_reference<NotConstructibleFromRefIn::ValueType, NotConstructibleFromRefIn::ReferenceType, X, Y>
 {
   using type = CommonType&;
 };
 
 template <template <class> class X, template <class> class Y>
-struct cuda::std::
-  basic_common_reference<NotConstructibleFromRefIn::ReferenceType, NotConstructibleFromRefIn::ValueType, X, Y>
+struct basic_common_reference<NotConstructibleFromRefIn::ReferenceType, NotConstructibleFromRefIn::ValueType, X, Y>
 {
   using type = CommonType&;
 };
+} // namespace std
+} // namespace cuda
 
 static_assert(
-  cuda::std::common_reference_with<NotConstructibleFromRefIn::ValueType&, NotConstructibleFromRefIn::ReferenceType&>);
+  cuda::std::common_reference_with<NotConstructibleFromRefIn::ValueType&, NotConstructibleFromRefIn::ReferenceType&>,
+  "");
 
 struct AssignableFromAnything
 {
@@ -317,7 +330,7 @@ struct AssignableFromAnything
 
 // A type that can't be constructed from its own reference isn't `indirectly_copyable_storable`, even when assigning it
 // to a type that can be assigned from anything.
-static_assert(!cuda::std::indirectly_copyable_storable<NotConstructibleFromRefIn, AssignableFromAnything*>);
+static_assert(!cuda::std::indirectly_copyable_storable<NotConstructibleFromRefIn, AssignableFromAnything*>, "");
 
 // ReferenceType is a (proxy) reference for ValueType, but ValueType is not assignable from ReferenceType.
 struct NotAssignableFromRefIn
@@ -340,24 +353,30 @@ struct NotAssignableFromRefIn
   __host__ __device__ ReferenceType& operator*() const;
 };
 
+namespace cuda
+{
+namespace std
+{
 template <template <class> class X, template <class> class Y>
-struct cuda::std::basic_common_reference<NotAssignableFromRefIn::ValueType, NotAssignableFromRefIn::ReferenceType, X, Y>
+struct basic_common_reference<NotAssignableFromRefIn::ValueType, NotAssignableFromRefIn::ReferenceType, X, Y>
 {
   using type = CommonType&;
 };
 
 template <template <class> class X, template <class> class Y>
-struct cuda::std::basic_common_reference<NotAssignableFromRefIn::ReferenceType, NotAssignableFromRefIn::ValueType, X, Y>
+struct basic_common_reference<NotAssignableFromRefIn::ReferenceType, NotAssignableFromRefIn::ValueType, X, Y>
 {
   using type = CommonType&;
 };
+} // namespace std
+} // namespace cuda
 
 static_assert(
-  cuda::std::common_reference_with<NotAssignableFromRefIn::ValueType&, NotAssignableFromRefIn::ReferenceType&>);
+  cuda::std::common_reference_with<NotAssignableFromRefIn::ValueType&, NotAssignableFromRefIn::ReferenceType&>, "");
 
 // A type that can't be assigned from its own reference isn't `indirectly_copyable_storable`, even when assigning it
 // to a type that can be assigned from anything.
-static_assert(!cuda::std::indirectly_copyable_storable<NotAssignableFromRefIn, AssignableFromAnything*>);
+static_assert(!cuda::std::indirectly_copyable_storable<NotAssignableFromRefIn, AssignableFromAnything*>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.subsumption.compile.pass.cpp
@@ -29,7 +29,7 @@ __host__ __device__ constexpr bool indirectly_copyable_storable_subsumption()
 }
 
 #ifndef __NVCOMPILER // nvbug 3885350
-static_assert(indirectly_copyable_storable_subsumption<int*, int*>());
+static_assert(indirectly_copyable_storable_subsumption<int*, int*>(), "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class In, class Out>
 // concept indirectly_movable;
@@ -18,35 +18,35 @@
 #include "test_macros.h"
 
 // Can move between pointers.
-static_assert(cuda::std::indirectly_movable<int*, int*>);
-static_assert(cuda::std::indirectly_movable<const int*, int*>);
-static_assert(!cuda::std::indirectly_movable<int*, const int*>);
-static_assert(cuda::std::indirectly_movable<const int*, int*>);
+static_assert(cuda::std::indirectly_movable<int*, int*>, "");
+static_assert(cuda::std::indirectly_movable<const int*, int*>, "");
+static_assert(!cuda::std::indirectly_movable<int*, const int*>, "");
+static_assert(cuda::std::indirectly_movable<const int*, int*>, "");
 
 // Can move from a pointer into an array but arrays aren't considered indirectly movable-from.
-static_assert(cuda::std::indirectly_movable<int*, int[2]>);
-static_assert(!cuda::std::indirectly_movable<int[2], int*>);
-static_assert(!cuda::std::indirectly_movable<int[2], int[2]>);
-static_assert(!cuda::std::indirectly_movable<int (&)[2], int (&)[2]>);
+static_assert(cuda::std::indirectly_movable<int*, int[2]>, "");
+static_assert(!cuda::std::indirectly_movable<int[2], int*>, "");
+static_assert(!cuda::std::indirectly_movable<int[2], int[2]>, "");
+static_assert(!cuda::std::indirectly_movable<int (&)[2], int (&)[2]>, "");
 
 // Can't move between non-pointer types.
-static_assert(!cuda::std::indirectly_movable<int*, int>);
-static_assert(!cuda::std::indirectly_movable<int, int*>);
-static_assert(!cuda::std::indirectly_movable<int, int>);
+static_assert(!cuda::std::indirectly_movable<int*, int>, "");
+static_assert(!cuda::std::indirectly_movable<int, int*>, "");
+static_assert(!cuda::std::indirectly_movable<int, int>, "");
 
 // Check some less common types.
-static_assert(!cuda::std::indirectly_movable<void*, void*>);
-static_assert(!cuda::std::indirectly_movable<int*, void*>);
-static_assert(!cuda::std::indirectly_movable<int(), int()>);
-static_assert(!cuda::std::indirectly_movable<int*, int()>);
-static_assert(!cuda::std::indirectly_movable<void, void>);
+static_assert(!cuda::std::indirectly_movable<void*, void*>, "");
+static_assert(!cuda::std::indirectly_movable<int*, void*>, "");
+static_assert(!cuda::std::indirectly_movable<int(), int()>, "");
+static_assert(!cuda::std::indirectly_movable<int*, int()>, "");
+static_assert(!cuda::std::indirectly_movable<void, void>, "");
 
 #ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
 // Can move move-only objects.
-static_assert(cuda::std::indirectly_movable<MoveOnly*, MoveOnly*>);
-static_assert(!cuda::std::indirectly_movable<MoveOnly*, const MoveOnly*>);
-static_assert(!cuda::std::indirectly_movable<const MoveOnly*, const MoveOnly*>);
-static_assert(!cuda::std::indirectly_movable<const MoveOnly*, MoveOnly*>);
+static_assert(cuda::std::indirectly_movable<MoveOnly*, MoveOnly*>, "");
+static_assert(!cuda::std::indirectly_movable<MoveOnly*, const MoveOnly*>, "");
+static_assert(!cuda::std::indirectly_movable<const MoveOnly*, const MoveOnly*>, "");
+static_assert(!cuda::std::indirectly_movable<const MoveOnly*, MoveOnly*>, "");
 #endif // TEST_COMPILER_MSVC_2017
 
 template <class T>
@@ -58,13 +58,13 @@ struct PointerTo
 
 #ifndef TEST_COMPILER_MSVC_2017 // MSVC2017 has issues determining common_reference
 // Can copy through a dereferenceable class.
-static_assert(cuda::std::indirectly_movable<int*, PointerTo<int>>);
-static_assert(!cuda::std::indirectly_movable<int*, PointerTo<const int>>);
-static_assert(cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<int>>);
-static_assert(!cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<const int>>);
-static_assert(cuda::std::indirectly_movable<MoveOnly*, PointerTo<MoveOnly>>);
-static_assert(cuda::std::indirectly_movable<PointerTo<MoveOnly>, MoveOnly*>);
-static_assert(cuda::std::indirectly_movable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>);
+static_assert(cuda::std::indirectly_movable<int*, PointerTo<int>>, "");
+static_assert(!cuda::std::indirectly_movable<int*, PointerTo<const int>>, "");
+static_assert(cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<int>>, "");
+static_assert(!cuda::std::indirectly_copyable<PointerTo<int>, PointerTo<const int>>, "");
+static_assert(cuda::std::indirectly_movable<MoveOnly*, PointerTo<MoveOnly>>, "");
+static_assert(cuda::std::indirectly_movable<PointerTo<MoveOnly>, MoveOnly*>, "");
+static_assert(cuda::std::indirectly_movable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>, "");
 #endif // TEST_COMPILER_MSVC_2017
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.subsumption.compile.pass.cpp
@@ -29,7 +29,7 @@ __host__ __device__ constexpr bool indirectly_movable_subsumption()
   return true;
 }
 
-static_assert(indirectly_movable_subsumption<int*, int*>());
+static_assert(indirectly_movable_subsumption<int*, int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable_storable.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable_storable.subsumption.compile.pass.cpp
@@ -28,7 +28,7 @@ __host__ __device__ constexpr bool indirectly_movable_storable_subsumption()
   return true;
 }
 
-static_assert(indirectly_movable_storable_subsumption<int*, int*>());
+static_assert(indirectly_movable_storable_subsumption<int*, int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class I1, class I2>
 // concept indirectly_swappable;
@@ -23,8 +23,8 @@ struct PointerTo
   __host__ __device__ T& operator*() const;
 };
 
-static_assert(cuda::std::indirectly_swappable<PointerTo<int>>);
-static_assert(cuda::std::indirectly_swappable<PointerTo<int>, PointerTo<int>>);
+static_assert(cuda::std::indirectly_swappable<PointerTo<int>>, "");
+static_assert(cuda::std::indirectly_swappable<PointerTo<int>, PointerTo<int>>, "");
 
 struct B;
 
@@ -80,12 +80,12 @@ struct G
 };
 
 #if !defined(TEST_COMPILER_CUDACC_BELOW_11_3) && !defined(TEST_COMPILER_MSVC_2017)
-static_assert(cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<B>>);
+static_assert(cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<B>>, "");
 #endif // !TEST_COMPILER_CUDACC_BELOW_11_3 && !TEST_COMPILER_MSVC_2017
-static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<C>>);
-static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<D>>);
-static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<E>>);
-static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<G>>);
+static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<C>>, "");
+static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<D>>, "");
+static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<E>>, "");
+static_assert(!cuda::std::indirectly_swappable<PointerTo<A>, PointerTo<G>>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.swap/indirectly_swappable.subsumption.compile.pass.cpp
@@ -29,7 +29,7 @@ __host__ __device__ constexpr bool indirectly_swappable_subsumption()
   return true;
 }
 
-static_assert(indirectly_swappable_subsumption<int*, int*>());
+static_assert(indirectly_swappable_subsumption<int*, int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.mergeable/mergeable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.mergeable/mergeable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class I1, class I2, class Out,
@@ -25,24 +25,24 @@ using CompInt     = bool (*)(int, int);
 using ProjDefault = cuda::std::identity;
 
 using Input = cpp20_input_iterator<int*>;
-static_assert(cuda::std::input_iterator<Input>);
+static_assert(cuda::std::input_iterator<Input>, "");
 using InputLong = cpp20_input_iterator<long*>;
-static_assert(cuda::std::input_iterator<InputLong>);
+static_assert(cuda::std::input_iterator<InputLong>, "");
 
 using Output = cpp17_output_iterator<int*>;
-static_assert(cuda::std::weakly_incrementable<Output>);
+static_assert(cuda::std::weakly_incrementable<Output>, "");
 
-static_assert(cuda::std::indirectly_copyable<Input, Output>);
-static_assert(cuda::std::indirectly_copyable<InputLong, Output>);
-static_assert(cuda::std::indirect_strict_weak_order<CompDefault, Input, Input>);
-static_assert(cuda::std::indirect_strict_weak_order<CompInt, Input, Input>);
-static_assert(cuda::std::indirect_strict_weak_order<CompDefault, Input, InputLong>);
-static_assert(cuda::std::indirect_strict_weak_order<CompInt, Input, InputLong>);
+static_assert(cuda::std::indirectly_copyable<Input, Output>, "");
+static_assert(cuda::std::indirectly_copyable<InputLong, Output>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompDefault, Input, Input>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompInt, Input, Input>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompDefault, Input, InputLong>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompInt, Input, InputLong>, "");
 
 // All requirements satisfied.
-static_assert(cuda::std::mergeable<Input, Input, Output>);
-static_assert(cuda::std::mergeable<Input, Input, Output, CompInt>);
-static_assert(cuda::std::mergeable<Input, Input, Output, CompInt, ProjDefault>);
+static_assert(cuda::std::mergeable<Input, Input, Output>, "");
+static_assert(cuda::std::mergeable<Input, Input, Output, CompInt>, "");
+static_assert(cuda::std::mergeable<Input, Input, Output, CompInt, ProjDefault>, "");
 
 // Non-default projections.
 struct Foo
@@ -51,17 +51,19 @@ using ProjFooToInt  = int (*)(Foo);
 using ProjFooToLong = long (*)(Foo);
 static_assert(cuda::std::indirect_strict_weak_order<CompDefault,
                                                     cuda::std::projected<Foo*, ProjFooToInt>,
-                                                    cuda::std::projected<Foo*, ProjFooToLong>>);
-static_assert(cuda::std::mergeable<Foo*, Foo*, Foo*, CompDefault, ProjFooToInt, ProjFooToLong>);
+                                                    cuda::std::projected<Foo*, ProjFooToLong>>,
+              "");
+static_assert(cuda::std::mergeable<Foo*, Foo*, Foo*, CompDefault, ProjFooToInt, ProjFooToLong>, "");
 static_assert(cuda::std::indirect_strict_weak_order<CompInt,
                                                     cuda::std::projected<Foo*, ProjFooToInt>,
-                                                    cuda::std::projected<Foo*, ProjFooToLong>>);
-static_assert(cuda::std::mergeable<Foo*, Foo*, Foo*, CompInt, ProjFooToInt, ProjFooToLong>);
+                                                    cuda::std::projected<Foo*, ProjFooToLong>>,
+              "");
+static_assert(cuda::std::mergeable<Foo*, Foo*, Foo*, CompInt, ProjFooToInt, ProjFooToLong>, "");
 
 // I1 or I2 is not an input iterator.
-static_assert(!cuda::std::input_iterator<Output>);
-static_assert(!cuda::std::mergeable<Output, Input, Output>);
-static_assert(!cuda::std::mergeable<Input, Output, Output>);
+static_assert(!cuda::std::input_iterator<Output>, "");
+static_assert(!cuda::std::mergeable<Output, Input, Output>, "");
+static_assert(!cuda::std::mergeable<Input, Output, Output>, "");
 
 // Out is not weakly incrementable.
 struct NotWeaklyIncrementable
@@ -69,10 +71,10 @@ struct NotWeaklyIncrementable
   __host__ __device__ int& operator*() const;
 };
 
-static_assert(!cuda::std::weakly_incrementable<NotWeaklyIncrementable>);
-static_assert(cuda::std::indirectly_copyable<Input, NotWeaklyIncrementable>);
-static_assert(cuda::std::indirect_strict_weak_order<CompDefault, Input, Input>);
-static_assert(!cuda::std::mergeable<Input, Input, NotWeaklyIncrementable>);
+static_assert(!cuda::std::weakly_incrementable<NotWeaklyIncrementable>, "");
+static_assert(cuda::std::indirectly_copyable<Input, NotWeaklyIncrementable>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompDefault, Input, Input>, "");
+static_assert(!cuda::std::mergeable<Input, Input, NotWeaklyIncrementable>, "");
 
 // I1 or I2 is not indirectly copyable into O.
 struct AssignableOnlyFromInt
@@ -82,32 +84,32 @@ struct AssignableOnlyFromInt
   AssignableOnlyFromInt& operator=(T) = delete;
 };
 using OutputOnlyInt = cpp17_output_iterator<AssignableOnlyFromInt*>;
-static_assert(cuda::std::weakly_incrementable<OutputOnlyInt>);
+static_assert(cuda::std::weakly_incrementable<OutputOnlyInt>, "");
 
-static_assert(cuda::std::indirectly_copyable<Input, OutputOnlyInt>);
-static_assert(!cuda::std::indirectly_copyable<InputLong, OutputOnlyInt>);
-static_assert(cuda::std::indirect_strict_weak_order<CompDefault, Input, InputLong>);
-static_assert(cuda::std::mergeable<Input, Input, OutputOnlyInt>);
-static_assert(!cuda::std::mergeable<Input, InputLong, OutputOnlyInt>);
-static_assert(!cuda::std::mergeable<InputLong, Input, OutputOnlyInt>);
+static_assert(cuda::std::indirectly_copyable<Input, OutputOnlyInt>, "");
+static_assert(!cuda::std::indirectly_copyable<InputLong, OutputOnlyInt>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompDefault, Input, InputLong>, "");
+static_assert(cuda::std::mergeable<Input, Input, OutputOnlyInt>, "");
+static_assert(!cuda::std::mergeable<Input, InputLong, OutputOnlyInt>, "");
+static_assert(!cuda::std::mergeable<InputLong, Input, OutputOnlyInt>, "");
 
 // No indirect strict weak order between I1 and I2 (bad comparison functor).
 using GoodComp = bool (*)(int, int);
-static_assert(cuda::std::indirect_strict_weak_order<GoodComp, Input, Input>);
-static_assert(cuda::std::mergeable<Input, Input, Output, GoodComp>);
+static_assert(cuda::std::indirect_strict_weak_order<GoodComp, Input, Input>, "");
+static_assert(cuda::std::mergeable<Input, Input, Output, GoodComp>, "");
 using BadComp = bool (*)(int*, int*);
-static_assert(!cuda::std::indirect_strict_weak_order<BadComp, Input, Input>);
-static_assert(!cuda::std::mergeable<Input, Input, Output, BadComp>);
+static_assert(!cuda::std::indirect_strict_weak_order<BadComp, Input, Input>, "");
+static_assert(!cuda::std::mergeable<Input, Input, Output, BadComp>, "");
 
 // No indirect strict weak order between I1 and I2 (bad projection).
 using ToInt = int (*)(int);
 using ToPtr = int* (*) (int);
-static_assert(cuda::std::mergeable<Input, Input, Output, GoodComp, cuda::std::identity, cuda::std::identity>);
-static_assert(cuda::std::mergeable<Input, Input, Output, GoodComp, ToInt, ToInt>);
-static_assert(!cuda::std::mergeable<Input, Input, Output, GoodComp, ToPtr, ToInt>);
-static_assert(!cuda::std::mergeable<Input, Input, Output, GoodComp, ToInt, ToPtr>);
-static_assert(!cuda::std::mergeable<Input, Input, Output, bool (*)(int*, int), ToPtr, ToInt>);
-static_assert(!cuda::std::mergeable<Input, Input, Output, bool (*)(int, int*), ToInt, ToPtr>);
+static_assert(cuda::std::mergeable<Input, Input, Output, GoodComp, cuda::std::identity, cuda::std::identity>, "");
+static_assert(cuda::std::mergeable<Input, Input, Output, GoodComp, ToInt, ToInt>, "");
+static_assert(!cuda::std::mergeable<Input, Input, Output, GoodComp, ToPtr, ToInt>, "");
+static_assert(!cuda::std::mergeable<Input, Input, Output, GoodComp, ToInt, ToPtr>, "");
+static_assert(!cuda::std::mergeable<Input, Input, Output, bool (*)(int*, int), ToPtr, ToInt>, "");
+static_assert(!cuda::std::mergeable<Input, Input, Output, bool (*)(int, int*), ToInt, ToPtr>, "");
 
 // A projection that only supports non-const references and has a non-const `operator()` still has to work.
 struct ProjectionOnlyMutable
@@ -115,7 +117,8 @@ struct ProjectionOnlyMutable
   __host__ __device__ int operator()(int&);
   int operator()(int&&) const = delete;
 };
-static_assert(cuda::std::mergeable<Input, Input, Output, CompDefault, ProjectionOnlyMutable, ProjectionOnlyMutable>);
+static_assert(cuda::std::mergeable<Input, Input, Output, CompDefault, ProjectionOnlyMutable, ProjectionOnlyMutable>,
+              "");
 
 // The output is weakly incrementable but not an output iterator.
 struct WeaklyIncrementable
@@ -129,10 +132,10 @@ struct WeaklyIncrementable
   // while `weakly_incrementable` requires only that `i++` be well-formed.
   __host__ __device__ void operator++(int);
 };
-static_assert(cuda::std::weakly_incrementable<WeaklyIncrementable>);
-static_assert(cuda::std::indirectly_copyable<int*, WeaklyIncrementable>);
-static_assert(!cuda::std::output_iterator<WeaklyIncrementable, int>);
-static_assert(cuda::std::mergeable<Input, Input, WeaklyIncrementable>);
+static_assert(cuda::std::weakly_incrementable<WeaklyIncrementable>, "");
+static_assert(cuda::std::indirectly_copyable<int*, WeaklyIncrementable>, "");
+static_assert(!cuda::std::output_iterator<WeaklyIncrementable, int>, "");
+static_assert(cuda::std::mergeable<Input, Input, WeaklyIncrementable>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.mergeable/mergeable.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.mergeable/mergeable.subsumption.compile.pass.cpp
@@ -40,7 +40,7 @@ __host__ __device__ constexpr bool test_subsumption()
   return true;
 }
 
-static_assert(test_subsumption<int*, int*, int*>());
+static_assert(test_subsumption<int*, int*, int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.permutable/permutable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.permutable/permutable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class I>
 //   concept permutable = see below; // Since C++20
@@ -17,16 +17,16 @@
 #include "test_iterators.h"
 
 using AllConstraintsSatisfied = forward_iterator<int*>;
-static_assert(cuda::std::forward_iterator<AllConstraintsSatisfied>);
-static_assert(cuda::std::indirectly_movable_storable<AllConstraintsSatisfied, AllConstraintsSatisfied>);
-static_assert(cuda::std::indirectly_swappable<AllConstraintsSatisfied>);
-static_assert(cuda::std::permutable<AllConstraintsSatisfied>);
+static_assert(cuda::std::forward_iterator<AllConstraintsSatisfied>, "");
+static_assert(cuda::std::indirectly_movable_storable<AllConstraintsSatisfied, AllConstraintsSatisfied>, "");
+static_assert(cuda::std::indirectly_swappable<AllConstraintsSatisfied>, "");
+static_assert(cuda::std::permutable<AllConstraintsSatisfied>, "");
 
 using NotAForwardIterator = cpp20_input_iterator<int*>;
-static_assert(!cuda::std::forward_iterator<NotAForwardIterator>);
-static_assert(cuda::std::indirectly_movable_storable<NotAForwardIterator, NotAForwardIterator>);
-static_assert(cuda::std::indirectly_swappable<NotAForwardIterator>);
-static_assert(!cuda::std::permutable<NotAForwardIterator>);
+static_assert(!cuda::std::forward_iterator<NotAForwardIterator>, "");
+static_assert(cuda::std::indirectly_movable_storable<NotAForwardIterator, NotAForwardIterator>, "");
+static_assert(cuda::std::indirectly_swappable<NotAForwardIterator>, "");
+static_assert(!cuda::std::permutable<NotAForwardIterator>, "");
 
 #if !defined(TEST_COMPILER_CUDACC_BELOW_11_3) && !defined(TEST_COMPILER_MSVC_2017)
 struct NonCopyable
@@ -37,10 +37,10 @@ struct NonCopyable
 };
 using NotIMS = forward_iterator<NonCopyable*>;
 
-static_assert(cuda::std::forward_iterator<NotIMS>);
-static_assert(!cuda::std::indirectly_movable_storable<NotIMS, NotIMS>);
-static_assert(cuda::std::indirectly_swappable<NotIMS>);
-static_assert(!cuda::std::permutable<NotIMS>);
+static_assert(cuda::std::forward_iterator<NotIMS>, "");
+static_assert(!cuda::std::indirectly_movable_storable<NotIMS, NotIMS>, "");
+static_assert(cuda::std::indirectly_swappable<NotIMS>, "");
+static_assert(!cuda::std::permutable<NotIMS>, "");
 #endif // !TEST_COMPILER_CUDACC_BELOW_11_3 && !TEST_COMPILER_MSVC_2017
 
 // Note: it is impossible for an iterator to satisfy `indirectly_movable_storable` but not `indirectly_swappable`:

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.permutable/permutable.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.permutable/permutable.subsumption.compile.pass.cpp
@@ -29,7 +29,7 @@ __host__ __device__ constexpr bool test_subsumption()
 {
   return true;
 }
-static_assert(test_subsumption<int*>());
+static_assert(test_subsumption<int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.sortable/sortable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.sortable/sortable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class I, class R = ranges::less, class P = identity>
@@ -20,36 +20,36 @@ using CompInt     = bool (*)(int, int);
 using CompDefault = cuda::std::ranges::less;
 
 using AllConstraintsSatisfied = int*;
-static_assert(cuda::std::permutable<AllConstraintsSatisfied>);
-static_assert(cuda::std::indirect_strict_weak_order<CompDefault, AllConstraintsSatisfied>);
-static_assert(cuda::std::sortable<AllConstraintsSatisfied>);
-static_assert(cuda::std::indirect_strict_weak_order<CompInt, AllConstraintsSatisfied>);
-static_assert(cuda::std::sortable<AllConstraintsSatisfied, CompInt>);
+static_assert(cuda::std::permutable<AllConstraintsSatisfied>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompDefault, AllConstraintsSatisfied>, "");
+static_assert(cuda::std::sortable<AllConstraintsSatisfied>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompInt, AllConstraintsSatisfied>, "");
+static_assert(cuda::std::sortable<AllConstraintsSatisfied, CompInt>, "");
 
 struct Foo
 {};
 using Proj = int (*)(Foo);
-static_assert(cuda::std::permutable<Foo*>);
-static_assert(!cuda::std::indirect_strict_weak_order<CompDefault, Foo*>);
-static_assert(cuda::std::indirect_strict_weak_order<CompDefault, cuda::std::projected<Foo*, Proj>>);
-static_assert(!cuda::std::sortable<Foo*, CompDefault>);
-static_assert(cuda::std::sortable<Foo*, CompDefault, Proj>);
-static_assert(!cuda::std::indirect_strict_weak_order<CompInt, Foo*>);
-static_assert(cuda::std::indirect_strict_weak_order<CompInt, cuda::std::projected<Foo*, Proj>>);
-static_assert(!cuda::std::sortable<Foo*, CompInt>);
-static_assert(cuda::std::sortable<Foo*, CompInt, Proj>);
+static_assert(cuda::std::permutable<Foo*>, "");
+static_assert(!cuda::std::indirect_strict_weak_order<CompDefault, Foo*>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompDefault, cuda::std::projected<Foo*, Proj>>, "");
+static_assert(!cuda::std::sortable<Foo*, CompDefault>, "");
+static_assert(cuda::std::sortable<Foo*, CompDefault, Proj>, "");
+static_assert(!cuda::std::indirect_strict_weak_order<CompInt, Foo*>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompInt, cuda::std::projected<Foo*, Proj>>, "");
+static_assert(!cuda::std::sortable<Foo*, CompInt>, "");
+static_assert(cuda::std::sortable<Foo*, CompInt, Proj>, "");
 
 using NotPermutable = const int*;
-static_assert(!cuda::std::permutable<NotPermutable>);
-static_assert(cuda::std::indirect_strict_weak_order<CompInt, NotPermutable>);
-static_assert(!cuda::std::sortable<NotPermutable, CompInt>);
+static_assert(!cuda::std::permutable<NotPermutable>, "");
+static_assert(cuda::std::indirect_strict_weak_order<CompInt, NotPermutable>, "");
+static_assert(!cuda::std::sortable<NotPermutable, CompInt>, "");
 
 struct Empty
 {};
 using NoIndirectStrictWeakOrder = Empty*;
-static_assert(cuda::std::permutable<NoIndirectStrictWeakOrder>);
-static_assert(!cuda::std::indirect_strict_weak_order<CompInt, NoIndirectStrictWeakOrder>);
-static_assert(!cuda::std::sortable<NoIndirectStrictWeakOrder, CompInt>);
+static_assert(cuda::std::permutable<NoIndirectStrictWeakOrder>, "");
+static_assert(!cuda::std::indirect_strict_weak_order<CompInt, NoIndirectStrictWeakOrder>, "");
+static_assert(!cuda::std::sortable<NoIndirectStrictWeakOrder, CompInt>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.sortable/sortable.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.sortable/sortable.subsumption.compile.pass.cpp
@@ -30,7 +30,7 @@ __host__ __device__ constexpr bool test_subsumption()
   return true;
 }
 
-static_assert(test_subsumption<int*, cuda::std::ranges::less, cuda::std::identity>());
+static_assert(test_subsumption<int*, cuda::std::ranges::less, cuda::std::identity>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_binary_predicate.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_binary_predicate.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class F, class I1, class I2>
 // concept indirect_binary_predicate;
@@ -33,8 +33,8 @@ struct GoodPredicate
 };
 
 // Should work when all constraints are satisfied
-static_assert(cuda::std::indirect_binary_predicate<GoodPredicate<It1, It2>, It1, It2>);
-static_assert(cuda::std::indirect_binary_predicate<bool (*)(int, float), int*, float*>);
+static_assert(cuda::std::indirect_binary_predicate<GoodPredicate<It1, It2>, It1, It2>, "");
+static_assert(cuda::std::indirect_binary_predicate<bool (*)(int, float), int*, float*>, "");
 
 #ifdef TEST_COMPILER_CLANG_CUDA
 #  pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
@@ -43,7 +43,7 @@ static_assert(cuda::std::indirect_binary_predicate<bool (*)(int, float), int*, f
 auto lambda = [](int i, long j) {
   return i == j;
 };
-static_assert(cuda::std::indirect_binary_predicate<decltype(lambda), int*, int*>);
+static_assert(cuda::std::indirect_binary_predicate<decltype(lambda), int*, int*>, "");
 #endif
 
 // Should fail when either of the iterators is not indirectly_readable
@@ -51,9 +51,9 @@ static_assert(cuda::std::indirect_binary_predicate<decltype(lambda), int*, int*>
 struct NotIndirectlyReadable
 {};
 static_assert(
-  !cuda::std::indirect_binary_predicate<GoodPredicate<It1, NotIndirectlyReadable>, It1, NotIndirectlyReadable>);
+  !cuda::std::indirect_binary_predicate<GoodPredicate<It1, NotIndirectlyReadable>, It1, NotIndirectlyReadable>, "");
 static_assert(
-  !cuda::std::indirect_binary_predicate<GoodPredicate<NotIndirectlyReadable, It2>, NotIndirectlyReadable, It2>);
+  !cuda::std::indirect_binary_predicate<GoodPredicate<NotIndirectlyReadable, It2>, NotIndirectlyReadable, It2>, "");
 #endif
 
 // Should fail when the predicate is not copy constructible
@@ -63,7 +63,7 @@ struct BadPredicate1
   template <class T, class U>
   __host__ __device__ bool operator()(T const&, U const&) const;
 };
-static_assert(!cuda::std::indirect_binary_predicate<BadPredicate1, It1, It2>);
+static_assert(!cuda::std::indirect_binary_predicate<BadPredicate1, It1, It2>, "");
 
 // Should fail when the predicate can't be called with (iter_value_t&, iter_value_t&)
 struct BadPredicate2
@@ -72,7 +72,7 @@ struct BadPredicate2
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const = delete;
 };
-static_assert(!cuda::std::indirect_binary_predicate<BadPredicate2, It1, It2>);
+static_assert(!cuda::std::indirect_binary_predicate<BadPredicate2, It1, It2>, "");
 
 // Should fail when the predicate can't be called with (iter_value_t&, iter_reference_t)
 struct BadPredicate3
@@ -81,7 +81,7 @@ struct BadPredicate3
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const = delete;
 };
-static_assert(!cuda::std::indirect_binary_predicate<BadPredicate3, It1, It2>);
+static_assert(!cuda::std::indirect_binary_predicate<BadPredicate3, It1, It2>, "");
 
 // Should fail when the predicate can't be called with (iter_reference_t, iter_value_t&)
 struct BadPredicate4
@@ -90,7 +90,7 @@ struct BadPredicate4
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const = delete;
 };
-static_assert(!cuda::std::indirect_binary_predicate<BadPredicate4, It1, It2>);
+static_assert(!cuda::std::indirect_binary_predicate<BadPredicate4, It1, It2>, "");
 
 // Should fail when the predicate can't be called with (iter_reference_t, iter_reference_t)
 struct BadPredicate5
@@ -99,7 +99,7 @@ struct BadPredicate5
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const = delete;
 };
-static_assert(!cuda::std::indirect_binary_predicate<BadPredicate5, It1, It2>);
+static_assert(!cuda::std::indirect_binary_predicate<BadPredicate5, It1, It2>, "");
 
 // Should fail when the predicate can't be called with (iter_common_reference_t, iter_common_reference_t)
 struct BadPredicate6
@@ -108,7 +108,7 @@ struct BadPredicate6
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const = delete;
 };
-static_assert(!cuda::std::indirect_binary_predicate<BadPredicate6, It1, It2>);
+static_assert(!cuda::std::indirect_binary_predicate<BadPredicate6, It1, It2>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_equivalence_relation.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_equivalence_relation.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class F, class I1, class I2 = I1>
 // concept indirect_equivalence_relation;
@@ -51,8 +51,8 @@ struct GoodRelation
 };
 
 // Should work when all constraints are satisfied
-static_assert(cuda::std::indirect_equivalence_relation<GoodRelation<It1, It2>, It1, It2>);
-static_assert(cuda::std::indirect_equivalence_relation<bool (*)(int, long), int*, long*>);
+static_assert(cuda::std::indirect_equivalence_relation<GoodRelation<It1, It2>, It1, It2>, "");
+static_assert(cuda::std::indirect_equivalence_relation<bool (*)(int, long), int*, long*>, "");
 
 #ifdef TEST_COMPILER_CLANG_CUDA
 #  pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
@@ -61,7 +61,7 @@ static_assert(cuda::std::indirect_equivalence_relation<bool (*)(int, long), int*
 auto lambda = [](int i, long j) {
   return i == j;
 };
-static_assert(cuda::std::indirect_equivalence_relation<decltype(lambda), int*, long*>);
+static_assert(cuda::std::indirect_equivalence_relation<decltype(lambda), int*, long*>, "");
 #endif
 
 // Should fail when either of the iterators is not indirectly_readable
@@ -69,9 +69,9 @@ static_assert(cuda::std::indirect_equivalence_relation<decltype(lambda), int*, l
 struct NotIndirectlyReadable
 {};
 static_assert(
-  !cuda::std::indirect_equivalence_relation<GoodRelation<It1, NotIndirectlyReadable>, It1, NotIndirectlyReadable>);
+  !cuda::std::indirect_equivalence_relation<GoodRelation<It1, NotIndirectlyReadable>, It1, NotIndirectlyReadable>, "");
 static_assert(
-  !cuda::std::indirect_equivalence_relation<GoodRelation<NotIndirectlyReadable, It2>, NotIndirectlyReadable, It2>);
+  !cuda::std::indirect_equivalence_relation<GoodRelation<NotIndirectlyReadable, It2>, NotIndirectlyReadable, It2>, "");
 #endif
 
 // Should fail when the function is not copy constructible
@@ -81,7 +81,7 @@ struct BadRelation1
   template <class T, class U>
   __host__ __device__ bool operator()(T const&, U const&) const;
 };
-static_assert(!cuda::std::indirect_equivalence_relation<BadRelation1, It1, It2>);
+static_assert(!cuda::std::indirect_equivalence_relation<BadRelation1, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_value_t&, iter_value_t&)
 struct BadRelation2
@@ -90,7 +90,7 @@ struct BadRelation2
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const = delete;
 };
-static_assert(!cuda::std::indirect_equivalence_relation<BadRelation2, It1, It2>);
+static_assert(!cuda::std::indirect_equivalence_relation<BadRelation2, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_value_t&, iter_reference_t)
 struct BadRelation3
@@ -99,7 +99,7 @@ struct BadRelation3
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const = delete;
 };
-static_assert(!cuda::std::indirect_equivalence_relation<BadRelation3, It1, It2>);
+static_assert(!cuda::std::indirect_equivalence_relation<BadRelation3, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_reference_t, iter_value_t&)
 struct BadRelation4
@@ -108,7 +108,7 @@ struct BadRelation4
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const = delete;
 };
-static_assert(!cuda::std::indirect_equivalence_relation<BadRelation4, It1, It2>);
+static_assert(!cuda::std::indirect_equivalence_relation<BadRelation4, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_reference_t, iter_reference_t)
 struct BadRelation5
@@ -117,7 +117,7 @@ struct BadRelation5
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const = delete;
 };
-static_assert(!cuda::std::indirect_equivalence_relation<BadRelation5, It1, It2>);
+static_assert(!cuda::std::indirect_equivalence_relation<BadRelation5, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_common_reference_t, iter_common_reference_t)
 struct BadRelation6
@@ -126,7 +126,7 @@ struct BadRelation6
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const = delete;
 };
-static_assert(!cuda::std::indirect_equivalence_relation<BadRelation6, It1, It2>);
+static_assert(!cuda::std::indirect_equivalence_relation<BadRelation6, It1, It2>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_result_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_result_t.compile.pass.cpp
@@ -7,23 +7,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // indirect_result_t
 
 #include <cuda/std/concepts>
 #include <cuda/std/iterator>
 
-static_assert(cuda::std::same_as<cuda::std::indirect_result_t<int (*)(int), int*>, int>);
+static_assert(cuda::std::same_as<cuda::std::indirect_result_t<int (*)(int), int*>, int>, "");
 static_assert(
-  cuda::std::same_as<cuda::std::indirect_result_t<double (*)(int const&, float), int const*, float*>, double>);
+  cuda::std::same_as<cuda::std::indirect_result_t<double (*)(int const&, float), int const*, float*>, double>, "");
 
 struct S
 {};
-static_assert(cuda::std::same_as<cuda::std::indirect_result_t<S (&)(int), int*>, S>);
-static_assert(cuda::std::same_as<cuda::std::indirect_result_t<long S::*, S*>, long&>);
-static_assert(cuda::std::same_as<cuda::std::indirect_result_t<S && (S::*) (), S*>, S&&>);
-static_assert(cuda::std::same_as<cuda::std::indirect_result_t<int S::* (S::*) (int) const, S*, int*>, int S::*>);
+static_assert(cuda::std::same_as<cuda::std::indirect_result_t<S (&)(int), int*>, S>, "");
+static_assert(cuda::std::same_as<cuda::std::indirect_result_t<long S::*, S*>, long&>, "");
+static_assert(cuda::std::same_as<cuda::std::indirect_result_t<S && (S::*) (), S*>, S&&>, "");
+static_assert(cuda::std::same_as<cuda::std::indirect_result_t<int S::* (S::*) (int) const, S*, int*>, int S::*>, "");
 
 #if TEST_STD_VER > 2017
 template <class F, class... Is>
@@ -36,8 +36,8 @@ template <class F, class... Is>
 _CCCL_CONCEPT has_indirect_result = _CCCL_FRAGMENT(has_indirect_result_, F, Is...);
 #endif
 
-static_assert(!has_indirect_result<int (*)(int), int>); // int isn't indirectly_readable
-static_assert(!has_indirect_result<int, int*>); // int isn't invocable
+static_assert(!has_indirect_result<int (*)(int), int>, ""); // int isn't indirectly_readable
+static_assert(!has_indirect_result<int, int*>, ""); // int isn't invocable
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_strict_weak_order.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_strict_weak_order.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class F, class I1, class I2 = I1>
 // concept indirect_strict_weak_order;
@@ -51,8 +51,8 @@ struct GoodOrder
 };
 
 // Should work when all constraints are satisfied
-static_assert(cuda::std::indirect_strict_weak_order<GoodOrder<It1, It2>, It1, It2>);
-static_assert(cuda::std::indirect_strict_weak_order<bool (*)(int, long), int*, long*>);
+static_assert(cuda::std::indirect_strict_weak_order<GoodOrder<It1, It2>, It1, It2>, "");
+static_assert(cuda::std::indirect_strict_weak_order<bool (*)(int, long), int*, long*>, "");
 
 #ifdef TEST_COMPILER_CLANG_CUDA
 #  pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
@@ -61,15 +61,17 @@ static_assert(cuda::std::indirect_strict_weak_order<bool (*)(int, long), int*, l
 auto lambda = [](int i, long j) {
   return i == j;
 };
-static_assert(cuda::std::indirect_strict_weak_order<decltype(lambda), int*, long*>);
+static_assert(cuda::std::indirect_strict_weak_order<decltype(lambda), int*, long*>, "");
 #endif
 
 // Should fail when either of the iterators is not indirectly_readable
 #if TEST_STD_VER > 2017
 struct NotIndirectlyReadable
 {};
-static_assert(!cuda::std::indirect_strict_weak_order<GoodOrder<It1, NotIndirectlyReadable>, It1, NotIndirectlyReadable>);
-static_assert(!cuda::std::indirect_strict_weak_order<GoodOrder<NotIndirectlyReadable, It2>, NotIndirectlyReadable, It2>);
+static_assert(!cuda::std::indirect_strict_weak_order<GoodOrder<It1, NotIndirectlyReadable>, It1, NotIndirectlyReadable>,
+              "");
+static_assert(!cuda::std::indirect_strict_weak_order<GoodOrder<NotIndirectlyReadable, It2>, NotIndirectlyReadable, It2>,
+              "");
 #endif
 
 // Should fail when the function is not copy constructible
@@ -79,7 +81,7 @@ struct BadOrder1
   template <class T, class U>
   __host__ __device__ bool operator()(T const&, U const&) const;
 };
-static_assert(!cuda::std::indirect_strict_weak_order<BadOrder1, It1, It2>);
+static_assert(!cuda::std::indirect_strict_weak_order<BadOrder1, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_value_t&, iter_value_t&)
 struct BadOrder2
@@ -88,7 +90,7 @@ struct BadOrder2
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_value_t<It2>&) const = delete;
 };
-static_assert(!cuda::std::indirect_strict_weak_order<BadOrder2, It1, It2>);
+static_assert(!cuda::std::indirect_strict_weak_order<BadOrder2, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_value_t&, iter_reference_t)
 struct BadOrder3
@@ -97,7 +99,7 @@ struct BadOrder3
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_value_t<It1>&, cuda::std::iter_reference_t<It2>) const = delete;
 };
-static_assert(!cuda::std::indirect_strict_weak_order<BadOrder3, It1, It2>);
+static_assert(!cuda::std::indirect_strict_weak_order<BadOrder3, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_reference_t, iter_value_t&)
 struct BadOrder4
@@ -106,7 +108,7 @@ struct BadOrder4
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_value_t<It2>&) const = delete;
 };
-static_assert(!cuda::std::indirect_strict_weak_order<BadOrder4, It1, It2>);
+static_assert(!cuda::std::indirect_strict_weak_order<BadOrder4, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_reference_t, iter_reference_t)
 struct BadOrder5
@@ -115,7 +117,7 @@ struct BadOrder5
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_reference_t<It1>, cuda::std::iter_reference_t<It2>) const = delete;
 };
-static_assert(!cuda::std::indirect_strict_weak_order<BadOrder5, It1, It2>);
+static_assert(!cuda::std::indirect_strict_weak_order<BadOrder5, It1, It2>, "");
 
 // Should fail when the function can't be called with (iter_common_reference_t, iter_common_reference_t)
 struct BadOrder6
@@ -124,7 +126,7 @@ struct BadOrder6
   __host__ __device__ bool operator()(T const&, U const&) const;
   bool operator()(cuda::std::iter_common_reference_t<It1>, cuda::std::iter_common_reference_t<It2>) const = delete;
 };
-static_assert(!cuda::std::indirect_strict_weak_order<BadOrder6, It1, It2>);
+static_assert(!cuda::std::indirect_strict_weak_order<BadOrder6, It1, It2>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_unary_predicate.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirect_unary_predicate.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class F, class I>
 // concept indirect_unary_predicate;
@@ -29,8 +29,8 @@ struct GoodPredicate
 };
 
 // Should work when all constraints are satisfied
-static_assert(cuda::std::indirect_unary_predicate<GoodPredicate<It>, It>);
-static_assert(cuda::std::indirect_unary_predicate<bool (*)(int), int*>);
+static_assert(cuda::std::indirect_unary_predicate<GoodPredicate<It>, It>, "");
+static_assert(cuda::std::indirect_unary_predicate<bool (*)(int), int*>, "");
 
 #ifdef TEST_COMPILER_CLANG_CUDA
 #  pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
@@ -39,14 +39,14 @@ static_assert(cuda::std::indirect_unary_predicate<bool (*)(int), int*>);
 auto lambda = [](int i) {
   return i % 2 == 0;
 };
-static_assert(cuda::std::indirect_unary_predicate<decltype(lambda), int*>);
+static_assert(cuda::std::indirect_unary_predicate<decltype(lambda), int*>, "");
 #endif
 
 // Should fail when the iterator is not indirectly_readable
 #if TEST_STD_VER > 2017
 struct NotIndirectlyReadable
 {};
-static_assert(!cuda::std::indirect_unary_predicate<GoodPredicate<NotIndirectlyReadable>, NotIndirectlyReadable>);
+static_assert(!cuda::std::indirect_unary_predicate<GoodPredicate<NotIndirectlyReadable>, NotIndirectlyReadable>, "");
 #endif
 
 // Should fail when the predicate is not copy constructible
@@ -56,7 +56,7 @@ struct BadPredicate1
   template <class T>
   __host__ __device__ bool operator()(T const&) const;
 };
-static_assert(!cuda::std::indirect_unary_predicate<BadPredicate1, It>);
+static_assert(!cuda::std::indirect_unary_predicate<BadPredicate1, It>, "");
 
 // Should fail when the predicate can't be called with cuda::std::iter_value_t<It>&
 struct BadPredicate2
@@ -65,7 +65,7 @@ struct BadPredicate2
   __host__ __device__ bool operator()(T const&) const;
   bool operator()(cuda::std::iter_value_t<It>&) const = delete;
 };
-static_assert(!cuda::std::indirect_unary_predicate<BadPredicate2, It>);
+static_assert(!cuda::std::indirect_unary_predicate<BadPredicate2, It>, "");
 
 // Should fail when the predicate can't be called with cuda::std::iter_reference_t<It>
 struct BadPredicate3
@@ -74,7 +74,7 @@ struct BadPredicate3
   __host__ __device__ bool operator()(T const&) const;
   bool operator()(cuda::std::iter_reference_t<It>) const = delete;
 };
-static_assert(!cuda::std::indirect_unary_predicate<BadPredicate3, It>);
+static_assert(!cuda::std::indirect_unary_predicate<BadPredicate3, It>, "");
 
 // Should fail when the predicate can't be called with cuda::std::iter_common_reference_t<It>
 struct BadPredicate4
@@ -83,7 +83,7 @@ struct BadPredicate4
   __host__ __device__ bool operator()(T const&) const;
   bool operator()(cuda::std::iter_common_reference_t<It>) const = delete;
 };
-static_assert(!cuda::std::indirect_unary_predicate<BadPredicate4, It>);
+static_assert(!cuda::std::indirect_unary_predicate<BadPredicate4, It>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_comparable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_comparable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class I1, class I2, class R, class P1, class P2>
@@ -22,14 +22,14 @@ struct Deref
   __host__ __device__ int operator()(int*) const;
 };
 
-static_assert(!cuda::std::indirectly_comparable<int, int, cuda::std::less<int>>); // not dereferenceable
-static_assert(!cuda::std::indirectly_comparable<int*, int*, int>); // not a predicate
-static_assert(cuda::std::indirectly_comparable<int*, int*, cuda::std::less<int>>);
-static_assert(!cuda::std::indirectly_comparable<int**, int*, cuda::std::less<int>>);
-static_assert(cuda::std::indirectly_comparable<int**, int*, cuda::std::less<int>, Deref>);
-static_assert(!cuda::std::indirectly_comparable<int**, int*, cuda::std::less<int>, Deref, Deref>);
-static_assert(!cuda::std::indirectly_comparable<int**, int*, cuda::std::less<int>, cuda::std::identity, Deref>);
-static_assert(cuda::std::indirectly_comparable<int*, int**, cuda::std::less<int>, cuda::std::identity, Deref>);
+static_assert(!cuda::std::indirectly_comparable<int, int, cuda::std::less<int>>, ""); // not dereferenceable
+static_assert(!cuda::std::indirectly_comparable<int*, int*, int>, ""); // not a predicate
+static_assert(cuda::std::indirectly_comparable<int*, int*, cuda::std::less<int>>, "");
+static_assert(!cuda::std::indirectly_comparable<int**, int*, cuda::std::less<int>>, "");
+static_assert(cuda::std::indirectly_comparable<int**, int*, cuda::std::less<int>, Deref>, "");
+static_assert(!cuda::std::indirectly_comparable<int**, int*, cuda::std::less<int>, Deref, Deref>, "");
+static_assert(!cuda::std::indirectly_comparable<int**, int*, cuda::std::less<int>, cuda::std::identity, Deref>, "");
+static_assert(cuda::std::indirectly_comparable<int*, int**, cuda::std::less<int>, cuda::std::identity, Deref>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_comparable.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_comparable.subsumption.compile.pass.cpp
@@ -44,8 +44,8 @@ template <class F>
   requires cuda::std::indirectly_comparable<int*, char*, F>
 __host__ __device__ void is_subsumed(F);
 
-static_assert(subsumes(cuda::std::less<int>()));
-static_assert(is_subsumed(cuda::std::less<int>()));
+static_assert(subsumes(cuda::std::less<int>()), "");
+static_assert(is_subsumed(cuda::std::less<int>()), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_regular_unary_invocable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_regular_unary_invocable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class F, class I>
 // concept indirectly_regular_unary_invocable;
@@ -30,14 +30,14 @@ struct GoodInvocable
 };
 
 // Should work when all constraints are satisfied
-static_assert(cuda::std::indirectly_regular_unary_invocable<GoodInvocable<It>, It>);
+static_assert(cuda::std::indirectly_regular_unary_invocable<GoodInvocable<It>, It>, "");
 
 // Should fail when the iterator is not indirectly_readable
 #if TEST_STD_VER > 2017
 struct NotIndirectlyReadable
 {};
 static_assert(
-  !cuda::std::indirectly_regular_unary_invocable<GoodInvocable<NotIndirectlyReadable>, NotIndirectlyReadable>);
+  !cuda::std::indirectly_regular_unary_invocable<GoodInvocable<NotIndirectlyReadable>, NotIndirectlyReadable>, "");
 #endif
 
 // Should fail when the invocable is not copy constructible
@@ -47,7 +47,7 @@ struct BadInvocable1
   template <class T>
   __host__ __device__ R1 operator()(T const&) const;
 };
-static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable1, It>);
+static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable1, It>, "");
 
 // Should fail when the invocable can't be called with (iter_value_t&)
 struct BadInvocable2
@@ -56,7 +56,7 @@ struct BadInvocable2
   __host__ __device__ R1 operator()(T const&) const;
   R1 operator()(cuda::std::iter_value_t<It>&) const = delete;
 };
-static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable2, It>);
+static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable2, It>, "");
 
 // Should fail when the invocable can't be called with (iter_reference_t)
 struct BadInvocable3
@@ -65,7 +65,7 @@ struct BadInvocable3
   __host__ __device__ R1 operator()(T const&) const;
   R1 operator()(cuda::std::iter_reference_t<It>) const = delete;
 };
-static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable3, It>);
+static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable3, It>, "");
 
 // Should fail when the invocable can't be called with (iter_common_reference_t)
 struct BadInvocable4
@@ -74,7 +74,7 @@ struct BadInvocable4
   __host__ __device__ R1 operator()(T const&) const;
   R1 operator()(cuda::std::iter_common_reference_t<It>) const = delete;
 };
-static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable4, It>);
+static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable4, It>, "");
 
 // Should fail when the invocable doesn't have a common reference between its return types
 struct BadInvocable5
@@ -85,23 +85,23 @@ struct BadInvocable5
   __host__ __device__ Unrelated operator()(cuda::std::iter_reference_t<It>) const;
   __host__ __device__ R1 operator()(cuda::std::iter_common_reference_t<It>) const;
 };
-static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable5, It>);
+static_assert(!cuda::std::indirectly_regular_unary_invocable<BadInvocable5, It>, "");
 
 // Various tests with callables
 struct S
 {};
-static_assert(cuda::std::indirectly_regular_unary_invocable<int (*)(int), int*>);
-static_assert(cuda::std::indirectly_regular_unary_invocable<int (&)(int), int*>);
-static_assert(cuda::std::indirectly_regular_unary_invocable<int S::*, S*>);
-static_assert(cuda::std::indirectly_regular_unary_invocable<int (S::*)(), S*>);
-static_assert(cuda::std::indirectly_regular_unary_invocable<int (S::*)() const, S*>);
-static_assert(cuda::std::indirectly_regular_unary_invocable<void (*)(int), int*>);
+static_assert(cuda::std::indirectly_regular_unary_invocable<int (*)(int), int*>, "");
+static_assert(cuda::std::indirectly_regular_unary_invocable<int (&)(int), int*>, "");
+static_assert(cuda::std::indirectly_regular_unary_invocable<int S::*, S*>, "");
+static_assert(cuda::std::indirectly_regular_unary_invocable<int (S::*)(), S*>, "");
+static_assert(cuda::std::indirectly_regular_unary_invocable<int (S::*)() const, S*>, "");
+static_assert(cuda::std::indirectly_regular_unary_invocable<void (*)(int), int*>, "");
 
-static_assert(!cuda::std::indirectly_regular_unary_invocable<int(int), int*>); // not move constructible
-static_assert(!cuda::std::indirectly_regular_unary_invocable<int (*)(int*, int*), int*>);
-static_assert(!cuda::std::indirectly_regular_unary_invocable<int (&)(int*, int*), int*>);
-static_assert(!cuda::std::indirectly_regular_unary_invocable<int (S::*)(int*), S*>);
-static_assert(!cuda::std::indirectly_regular_unary_invocable<int (S::*)(int*) const, S*>);
+static_assert(!cuda::std::indirectly_regular_unary_invocable<int(int), int*>, ""); // not move constructible
+static_assert(!cuda::std::indirectly_regular_unary_invocable<int (*)(int*, int*), int*>, "");
+static_assert(!cuda::std::indirectly_regular_unary_invocable<int (&)(int*, int*), int*>, "");
+static_assert(!cuda::std::indirectly_regular_unary_invocable<int (S::*)(int*), S*>, "");
+static_assert(!cuda::std::indirectly_regular_unary_invocable<int (S::*)(int*) const, S*>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_unary_invocable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/indirectinvocable/indirectly_unary_invocable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class F, class I>
 // concept indirectly_unary_invocable;
@@ -30,13 +30,13 @@ struct GoodInvocable
 };
 
 // Should work when all constraints are satisfied
-static_assert(cuda::std::indirectly_unary_invocable<GoodInvocable<It>, It>);
+static_assert(cuda::std::indirectly_unary_invocable<GoodInvocable<It>, It>, "");
 
 // Should fail when the iterator is not indirectly_readable
 #if TEST_STD_VER > 2017
 struct NotIndirectlyReadable
 {};
-static_assert(!cuda::std::indirectly_unary_invocable<GoodInvocable<NotIndirectlyReadable>, NotIndirectlyReadable>);
+static_assert(!cuda::std::indirectly_unary_invocable<GoodInvocable<NotIndirectlyReadable>, NotIndirectlyReadable>, "");
 #endif
 
 // Should fail when the invocable is not copy constructible
@@ -46,7 +46,7 @@ struct BadInvocable1
   template <class T>
   __host__ __device__ R1 operator()(T const&) const;
 };
-static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable1, It>);
+static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable1, It>, "");
 
 // Should fail when the invocable can't be called with (iter_value_t&)
 struct BadInvocable2
@@ -55,7 +55,7 @@ struct BadInvocable2
   __host__ __device__ R1 operator()(T const&) const;
   R1 operator()(cuda::std::iter_value_t<It>&) const = delete;
 };
-static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable2, It>);
+static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable2, It>, "");
 
 // Should fail when the invocable can't be called with (iter_reference_t)
 struct BadInvocable3
@@ -64,7 +64,7 @@ struct BadInvocable3
   __host__ __device__ R1 operator()(T const&) const;
   R1 operator()(cuda::std::iter_reference_t<It>) const = delete;
 };
-static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable3, It>);
+static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable3, It>, "");
 
 // Should fail when the invocable can't be called with (iter_common_reference_t)
 struct BadInvocable4
@@ -73,7 +73,7 @@ struct BadInvocable4
   __host__ __device__ R1 operator()(T const&) const;
   R1 operator()(cuda::std::iter_common_reference_t<It>) const = delete;
 };
-static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable4, It>);
+static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable4, It>, "");
 
 // Should fail when the invocable doesn't have a common reference between its return types
 struct BadInvocable5
@@ -84,23 +84,23 @@ struct BadInvocable5
   __host__ __device__ Unrelated operator()(cuda::std::iter_reference_t<It>) const;
   __host__ __device__ R1 operator()(cuda::std::iter_common_reference_t<It>) const;
 };
-static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable5, It>);
+static_assert(!cuda::std::indirectly_unary_invocable<BadInvocable5, It>, "");
 
 // Various tests with callables
 struct S
 {};
-static_assert(cuda::std::indirectly_unary_invocable<int (*)(int), int*>);
-static_assert(cuda::std::indirectly_unary_invocable<int (&)(int), int*>);
-static_assert(cuda::std::indirectly_unary_invocable<int S::*, S*>);
-static_assert(cuda::std::indirectly_unary_invocable<int (S::*)(), S*>);
-static_assert(cuda::std::indirectly_unary_invocable<int (S::*)() const, S*>);
-static_assert(cuda::std::indirectly_unary_invocable<void (*)(int), int*>);
+static_assert(cuda::std::indirectly_unary_invocable<int (*)(int), int*>, "");
+static_assert(cuda::std::indirectly_unary_invocable<int (&)(int), int*>, "");
+static_assert(cuda::std::indirectly_unary_invocable<int S::*, S*>, "");
+static_assert(cuda::std::indirectly_unary_invocable<int (S::*)(), S*>, "");
+static_assert(cuda::std::indirectly_unary_invocable<int (S::*)() const, S*>, "");
+static_assert(cuda::std::indirectly_unary_invocable<void (*)(int), int*>, "");
 
-static_assert(!cuda::std::indirectly_unary_invocable<int(int), int*>); // not move constructible
-static_assert(!cuda::std::indirectly_unary_invocable<int (*)(int*, int*), int*>);
-static_assert(!cuda::std::indirectly_unary_invocable<int (&)(int*, int*), int*>);
-static_assert(!cuda::std::indirectly_unary_invocable<int (S::*)(int*), S*>);
-static_assert(!cuda::std::indirectly_unary_invocable<int (S::*)(int*) const, S*>);
+static_assert(!cuda::std::indirectly_unary_invocable<int(int), int*>, ""); // not move constructible
+static_assert(!cuda::std::indirectly_unary_invocable<int (*)(int*, int*), int*>, "");
+static_assert(!cuda::std::indirectly_unary_invocable<int (&)(int*, int*), int*>, "");
+static_assert(!cuda::std::indirectly_unary_invocable<int (S::*)(int*), S*>, "");
+static_assert(!cuda::std::indirectly_unary_invocable<int (S::*)(int*) const, S*>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/projected/projected.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/indirectcallable/projected/projected.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // projected
 
@@ -18,42 +18,42 @@
 #include "test_iterators.h"
 
 using IntPtr = cuda::std::projected<int const*, cuda::std::identity>;
-static_assert(cuda::std::same_as<IntPtr::value_type, int>);
-static_assert(cuda::std::same_as<decltype(*cuda::std::declval<IntPtr>()), int const&>);
-static_assert(cuda::std::same_as<cuda::std::iter_difference_t<IntPtr>, cuda::std::ptrdiff_t>);
+static_assert(cuda::std::same_as<IntPtr::value_type, int>, "");
+static_assert(cuda::std::same_as<decltype(*cuda::std::declval<IntPtr>()), int const&>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_difference_t<IntPtr>, cuda::std::ptrdiff_t>, "");
 
 struct S
 {};
 
 using Cpp17InputIterator = cuda::std::projected<cpp17_input_iterator<S*>, int S::*>;
-static_assert(cuda::std::same_as<Cpp17InputIterator::value_type, int>);
-static_assert(cuda::std::same_as<decltype(*cuda::std::declval<Cpp17InputIterator>()), int&>);
-static_assert(cuda::std::same_as<cuda::std::iter_difference_t<Cpp17InputIterator>, cuda::std::ptrdiff_t>);
+static_assert(cuda::std::same_as<Cpp17InputIterator::value_type, int>, "");
+static_assert(cuda::std::same_as<decltype(*cuda::std::declval<Cpp17InputIterator>()), int&>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_difference_t<Cpp17InputIterator>, cuda::std::ptrdiff_t>, "");
 
 using Cpp20InputIterator = cuda::std::projected<cpp20_input_iterator<S*>, int S::*>;
-static_assert(cuda::std::same_as<Cpp20InputIterator::value_type, int>);
-static_assert(cuda::std::same_as<decltype(*cuda::std::declval<Cpp20InputIterator>()), int&>);
-static_assert(cuda::std::same_as<cuda::std::iter_difference_t<Cpp20InputIterator>, cuda::std::ptrdiff_t>);
+static_assert(cuda::std::same_as<Cpp20InputIterator::value_type, int>, "");
+static_assert(cuda::std::same_as<decltype(*cuda::std::declval<Cpp20InputIterator>()), int&>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_difference_t<Cpp20InputIterator>, cuda::std::ptrdiff_t>, "");
 
 using ForwardIterator = cuda::std::projected<forward_iterator<S*>, int (S::*)()>;
-static_assert(cuda::std::same_as<ForwardIterator::value_type, int>);
-static_assert(cuda::std::same_as<decltype(*cuda::std::declval<ForwardIterator>()), int>);
-static_assert(cuda::std::same_as<cuda::std::iter_difference_t<ForwardIterator>, cuda::std::ptrdiff_t>);
+static_assert(cuda::std::same_as<ForwardIterator::value_type, int>, "");
+static_assert(cuda::std::same_as<decltype(*cuda::std::declval<ForwardIterator>()), int>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_difference_t<ForwardIterator>, cuda::std::ptrdiff_t>, "");
 
 using BidirectionalIterator = cuda::std::projected<bidirectional_iterator<S*>, S* (S::*) () const>;
-static_assert(cuda::std::same_as<BidirectionalIterator::value_type, S*>);
-static_assert(cuda::std::same_as<decltype(*cuda::std::declval<BidirectionalIterator>()), S*>);
-static_assert(cuda::std::same_as<cuda::std::iter_difference_t<BidirectionalIterator>, cuda::std::ptrdiff_t>);
+static_assert(cuda::std::same_as<BidirectionalIterator::value_type, S*>, "");
+static_assert(cuda::std::same_as<decltype(*cuda::std::declval<BidirectionalIterator>()), S*>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_difference_t<BidirectionalIterator>, cuda::std::ptrdiff_t>, "");
 
 using RandomAccessIterator = cuda::std::projected<random_access_iterator<S*>, S && (S::*) ()>;
-static_assert(cuda::std::same_as<RandomAccessIterator::value_type, S>);
-static_assert(cuda::std::same_as<decltype(*cuda::std::declval<RandomAccessIterator>()), S&&>);
-static_assert(cuda::std::same_as<cuda::std::iter_difference_t<RandomAccessIterator>, cuda::std::ptrdiff_t>);
+static_assert(cuda::std::same_as<RandomAccessIterator::value_type, S>, "");
+static_assert(cuda::std::same_as<decltype(*cuda::std::declval<RandomAccessIterator>()), S&&>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_difference_t<RandomAccessIterator>, cuda::std::ptrdiff_t>, "");
 
 using ContiguousIterator = cuda::std::projected<contiguous_iterator<S*>, S& (S::*) () const>;
-static_assert(cuda::std::same_as<ContiguousIterator::value_type, S>);
-static_assert(cuda::std::same_as<decltype(*cuda::std::declval<ContiguousIterator>()), S&>);
-static_assert(cuda::std::same_as<cuda::std::iter_difference_t<ContiguousIterator>, cuda::std::ptrdiff_t>);
+static_assert(cuda::std::same_as<ContiguousIterator::value_type, S>, "");
+static_assert(cuda::std::same_as<decltype(*cuda::std::declval<ContiguousIterator>()), S&>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_difference_t<ContiguousIterator>, cuda::std::ptrdiff_t>, "");
 
 #if TEST_STD_VER > 2017
 template <class I, class F>
@@ -66,9 +66,9 @@ template <class I, class F>
 _CCCL_CONCEPT projectable = _CCCL_FRAGMENT(projectable_, I, F);
 #endif
 
-static_assert(!projectable<int, void (*)(int)>); // int isn't indirectly_readable
-static_assert(!projectable<S, void (*)(int)>); // S isn't weakly_incrementable
-static_assert(!projectable<int*, void(int)>); // void(int) doesn't satisfy indirectly_regular_unary_invcable
+static_assert(!projectable<int, void (*)(int)>, ""); // int isn't indirectly_readable
+static_assert(!projectable<S, void (*)(int)>, ""); // S isn't weakly_incrementable
+static_assert(!projectable<int*, void(int)>, ""); // void(int) doesn't satisfy indirectly_regular_unary_invcable
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/incrementable.traits/incrementable_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/incrementable.traits/incrementable_traits.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // struct incrementable_traits;
@@ -27,10 +27,10 @@ concept check_difference_type_matches =
   && cuda::std::same_as<typename cuda::std::incrementable_traits<T>::difference_type, Expected>;
 #else
 template <class T, class = void>
-inline constexpr bool check_has_difference_type = false;
+_CCCL_INLINE_VAR constexpr bool check_has_difference_type = false;
 
 template <class T>
-inline constexpr bool
+_CCCL_INLINE_VAR constexpr bool
   check_has_difference_type<T, cuda::std::void_t<typename cuda::std::incrementable_traits<T>::difference_type>> = true;
 
 template <class T, class Expected>
@@ -47,72 +47,72 @@ template <class T, class Expected>
 __host__ __device__ constexpr bool check_incrementable_traits()
 {
   constexpr bool result = check_difference_type_matches<T, Expected>;
-  static_assert(check_difference_type_matches<T const, Expected> == result);
+  static_assert(check_difference_type_matches<T const, Expected> == result, "");
   return result;
 }
 
-static_assert(check_incrementable_traits<float*, cuda::std::ptrdiff_t>());
-static_assert(check_incrementable_traits<float const*, cuda::std::ptrdiff_t>());
-static_assert(check_incrementable_traits<float volatile*, cuda::std::ptrdiff_t>());
-static_assert(check_incrementable_traits<float const volatile*, cuda::std::ptrdiff_t>());
-static_assert(check_incrementable_traits<float**, cuda::std::ptrdiff_t>());
+static_assert(check_incrementable_traits<float*, cuda::std::ptrdiff_t>(), "");
+static_assert(check_incrementable_traits<float const*, cuda::std::ptrdiff_t>(), "");
+static_assert(check_incrementable_traits<float volatile*, cuda::std::ptrdiff_t>(), "");
+static_assert(check_incrementable_traits<float const volatile*, cuda::std::ptrdiff_t>(), "");
+static_assert(check_incrementable_traits<float**, cuda::std::ptrdiff_t>(), "");
 
-static_assert(check_incrementable_traits<int[], cuda::std::ptrdiff_t>());
-static_assert(check_incrementable_traits<int[10], cuda::std::ptrdiff_t>());
+static_assert(check_incrementable_traits<int[], cuda::std::ptrdiff_t>(), "");
+static_assert(check_incrementable_traits<int[10], cuda::std::ptrdiff_t>(), "");
 
-static_assert(check_incrementable_traits<char, int>());
-static_assert(check_incrementable_traits<signed char, int>());
-static_assert(check_incrementable_traits<unsigned char, int>());
-static_assert(check_incrementable_traits<short, int>());
-static_assert(check_incrementable_traits<unsigned short, int>());
-static_assert(check_incrementable_traits<int, int>());
-static_assert(check_incrementable_traits<unsigned int, int>());
-static_assert(check_incrementable_traits<long, long>());
-static_assert(check_incrementable_traits<unsigned long, long>());
-static_assert(check_incrementable_traits<long long, long long>());
-static_assert(check_incrementable_traits<unsigned long long, long long>());
+static_assert(check_incrementable_traits<char, int>(), "");
+static_assert(check_incrementable_traits<signed char, int>(), "");
+static_assert(check_incrementable_traits<unsigned char, int>(), "");
+static_assert(check_incrementable_traits<short, int>(), "");
+static_assert(check_incrementable_traits<unsigned short, int>(), "");
+static_assert(check_incrementable_traits<int, int>(), "");
+static_assert(check_incrementable_traits<unsigned int, int>(), "");
+static_assert(check_incrementable_traits<long, long>(), "");
+static_assert(check_incrementable_traits<unsigned long, long>(), "");
+static_assert(check_incrementable_traits<long long, long long>(), "");
+static_assert(check_incrementable_traits<unsigned long long, long long>(), "");
 
-static_assert(check_incrementable_traits<int&, int>());
-static_assert(check_incrementable_traits<int const&, int>());
-static_assert(check_incrementable_traits<int volatile&, int>());
-static_assert(check_incrementable_traits<int const volatile&, int>());
-static_assert(check_incrementable_traits<int&&, int>());
-static_assert(check_incrementable_traits<int const&&, int>());
-static_assert(check_incrementable_traits<int volatile&&, int>());
-static_assert(check_incrementable_traits<int const volatile&&, int>());
+static_assert(check_incrementable_traits<int&, int>(), "");
+static_assert(check_incrementable_traits<int const&, int>(), "");
+static_assert(check_incrementable_traits<int volatile&, int>(), "");
+static_assert(check_incrementable_traits<int const volatile&, int>(), "");
+static_assert(check_incrementable_traits<int&&, int>(), "");
+static_assert(check_incrementable_traits<int const&&, int>(), "");
+static_assert(check_incrementable_traits<int volatile&&, int>(), "");
+static_assert(check_incrementable_traits<int const volatile&&, int>(), "");
 
-static_assert(check_incrementable_traits<int volatile, int>());
+static_assert(check_incrementable_traits<int volatile, int>(), "");
 #ifdef INVESTIGATE_VOLATILE_POINTER
-static_assert(check_incrementable_traits<int* volatile, cuda::std::ptrdiff_t>());
+static_assert(check_incrementable_traits<int* volatile, cuda::std::ptrdiff_t>(), "");
 #endif
 
 struct integral_difference_type
 {
   using difference_type = int;
 };
-static_assert(check_incrementable_traits<integral_difference_type, int>());
+static_assert(check_incrementable_traits<integral_difference_type, int>(), "");
 
 struct non_integral_difference_type
 {
   using difference_type = void;
 };
-static_assert(check_incrementable_traits<non_integral_difference_type, void>());
+static_assert(check_incrementable_traits<non_integral_difference_type, void>(), "");
 
 struct int_subtraction
 {
   __host__ __device__ friend int operator-(int_subtraction, int_subtraction);
 };
-static_assert(check_incrementable_traits<int_subtraction, int>());
+static_assert(check_incrementable_traits<int_subtraction, int>(), "");
 #ifdef INVESTIGATE_VOLATILE_REFERENCES
-static_assert(!check_incrementable_traits<int_subtraction volatile&, int>());
-static_assert(!check_incrementable_traits<int_subtraction const volatile&, int>());
+static_assert(!check_incrementable_traits<int_subtraction volatile&, int>(), "");
+static_assert(!check_incrementable_traits<int_subtraction const volatile&, int>(), "");
 #endif
 
 struct char_subtraction
 {
   __host__ __device__ friend char operator-(char_subtraction, char_subtraction);
 };
-static_assert(check_incrementable_traits<char_subtraction, signed char>());
+static_assert(check_incrementable_traits<char_subtraction, signed char>(), "");
 
 struct unsigned_int_subtraction_with_cv
 {
@@ -121,44 +121,50 @@ struct unsigned_int_subtraction_with_cv
   __host__ __device__ friend unsigned int
   operator-(unsigned_int_subtraction_with_cv const volatile&, unsigned_int_subtraction_with_cv const volatile&);
 };
-static_assert(check_incrementable_traits<unsigned_int_subtraction_with_cv, int>());
-static_assert(check_incrementable_traits<unsigned_int_subtraction_with_cv volatile&, int>());
-static_assert(check_incrementable_traits<unsigned_int_subtraction_with_cv const volatile&, int>());
+static_assert(check_incrementable_traits<unsigned_int_subtraction_with_cv, int>(), "");
+static_assert(check_incrementable_traits<unsigned_int_subtraction_with_cv volatile&, int>(), "");
+static_assert(check_incrementable_traits<unsigned_int_subtraction_with_cv const volatile&, int>(), "");
 
 struct specialised_incrementable_traits
 {};
+namespace cuda
+{
+namespace std
+{
 template <>
-struct cuda::std::incrementable_traits<specialised_incrementable_traits>
+struct incrementable_traits<specialised_incrementable_traits>
 {
   using difference_type = int;
 };
-static_assert(check_incrementable_traits<specialised_incrementable_traits, int>());
+} // namespace std
+} // namespace cuda
+static_assert(check_incrementable_traits<specialised_incrementable_traits, int>(), "");
 
-static_assert(!check_has_difference_type<void>);
-static_assert(!check_has_difference_type<float>);
-static_assert(!check_has_difference_type<double>);
-static_assert(!check_has_difference_type<long double>);
-static_assert(!check_has_difference_type<float&>);
-static_assert(!check_has_difference_type<float const&>);
+static_assert(!check_has_difference_type<void>, "");
+static_assert(!check_has_difference_type<float>, "");
+static_assert(!check_has_difference_type<double>, "");
+static_assert(!check_has_difference_type<long double>, "");
+static_assert(!check_has_difference_type<float&>, "");
+static_assert(!check_has_difference_type<float const&>, "");
 
 #if !defined(TEST_COMPILER_GCC) || __GNUC__ > 11 || TEST_STD_VER < 2020 // gcc 10 has an issue with void
-static_assert(!check_has_difference_type<void*>);
+static_assert(!check_has_difference_type<void*>, "");
 #endif // !defined(TEST_COMPILER_GCC) || __GNUC__ > 11 || TEST_STD_VER < 2020
-static_assert(!check_has_difference_type<cuda::std::nullptr_t>);
-static_assert(!check_has_difference_type<int()>);
-static_assert(!check_has_difference_type<int() noexcept>);
-static_assert(!check_has_difference_type<int (*)()>);
-static_assert(!check_has_difference_type<int (*)() noexcept>);
-static_assert(!check_has_difference_type<int (&)()>);
-static_assert(!check_has_difference_type<int (&)() noexcept>);
+static_assert(!check_has_difference_type<cuda::std::nullptr_t>, "");
+static_assert(!check_has_difference_type<int()>, "");
+static_assert(!check_has_difference_type<int() noexcept>, "");
+static_assert(!check_has_difference_type<int (*)()>, "");
+static_assert(!check_has_difference_type<int (*)() noexcept>, "");
+static_assert(!check_has_difference_type<int (&)()>, "");
+static_assert(!check_has_difference_type<int (&)() noexcept>, "");
 
-#define TEST_POINTER_TO_MEMBER_FUNCTION(type, cv)                           \
-  static_assert(!check_has_difference_type<int (type::*)() cv>);            \
-  static_assert(!check_has_difference_type<int (type::*)() cv noexcept>);   \
-  static_assert(!check_has_difference_type<int (type::*)() cv&>);           \
-  static_assert(!check_has_difference_type<int (type::*)() cv & noexcept>); \
-  static_assert(!check_has_difference_type<int (type::*)() cv&&>);          \
-  static_assert(!check_has_difference_type < int(type::*)() cv && noexcept >);
+#define TEST_POINTER_TO_MEMBER_FUNCTION(type, cv)                               \
+  static_assert(!check_has_difference_type<int (type::*)() cv>, "");            \
+  static_assert(!check_has_difference_type<int (type::*)() cv noexcept>, "");   \
+  static_assert(!check_has_difference_type<int (type::*)() cv&>, "");           \
+  static_assert(!check_has_difference_type<int (type::*)() cv & noexcept>, ""); \
+  static_assert(!check_has_difference_type<int (type::*)() cv&&>, "");          \
+  static_assert(!check_has_difference_type < int(type::*)() cv && noexcept >, "");
 
 struct empty
 {};
@@ -173,7 +179,7 @@ struct void_subtraction
 {
   __host__ __device__ friend void operator-(void_subtraction, void_subtraction);
 };
-static_assert(!check_has_difference_type<void_subtraction>);
+static_assert(!check_has_difference_type<void_subtraction>, "");
 
 #define TEST_NOT_DIFFERENCE_TYPE(S, qual1, qual2)               \
   struct S                                                      \

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/incrementable.traits/iter_difference_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/incrementable.traits/iter_difference_t.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // using iter_difference_t;
@@ -21,10 +21,10 @@ inline constexpr bool has_no_iter_difference_t = !requires { typename cuda::std:
 
 #else
 template <class T, class = void>
-inline constexpr bool has_no_iter_difference_t = true;
+_CCCL_INLINE_VAR constexpr bool has_no_iter_difference_t = true;
 
 template <class T>
-inline constexpr bool has_no_iter_difference_t<T, cuda::std::void_t<cuda::std::iter_difference_t<T>>> = false;
+_CCCL_INLINE_VAR constexpr bool has_no_iter_difference_t<T, cuda::std::void_t<cuda::std::iter_difference_t<T>>> = false;
 #endif
 
 #ifndef TEST_COMPILER_MSVC_2017 // MSVC 2017 cannot make this a constexpr function
@@ -32,41 +32,41 @@ template <class T, class Expected>
 __host__ __device__ constexpr bool check_iter_difference_t()
 {
   constexpr bool result = cuda::std::same_as<cuda::std::iter_difference_t<T>, Expected>;
-  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T volatile>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const volatile>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T volatile&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const volatile&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const&&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T volatile&&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const volatile&&>, Expected> == result);
+  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T volatile>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const volatile>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T volatile&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const volatile&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const&&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T volatile&&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_difference_t<T const volatile&&>, Expected> == result, "");
 
   return result;
 }
 
-static_assert(check_iter_difference_t<int, int>());
-static_assert(check_iter_difference_t<int*, cuda::std::ptrdiff_t>());
+static_assert(check_iter_difference_t<int, int>(), "");
+static_assert(check_iter_difference_t<int*, cuda::std::ptrdiff_t>(), "");
 
 struct int_subtraction
 {
   __host__ __device__ friend int operator-(int_subtraction, int_subtraction);
 };
-static_assert(check_iter_difference_t<int_subtraction, int>());
+static_assert(check_iter_difference_t<int_subtraction, int>(), "");
 #endif // !TEST_COMPILER_MSVC_2017
 
-static_assert(has_no_iter_difference_t<void>);
-static_assert(has_no_iter_difference_t<double>);
+static_assert(has_no_iter_difference_t<void>, "");
+static_assert(has_no_iter_difference_t<double>, "");
 
 struct S
 {};
-static_assert(has_no_iter_difference_t<S>);
+static_assert(has_no_iter_difference_t<S>, "");
 
 struct void_subtraction
 {
   __host__ __device__ friend void operator-(void_subtraction, void_subtraction);
 };
-static_assert(has_no_iter_difference_t<void_subtraction>);
+static_assert(has_no_iter_difference_t<void_subtraction>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/indirectly_readable_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/indirectly_readable_traits.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // struct indirectly_readable_traits;
@@ -45,14 +45,14 @@ template <class T>
 __host__ __device__ constexpr bool check_pointer()
 {
   constexpr bool result = value_type_matches<T*, T>;
-  static_assert(value_type_matches<T const*, T> == result);
-  static_assert(value_type_matches<T volatile*, T> == result);
-  static_assert(value_type_matches<T const volatile*, T> == result);
+  static_assert(value_type_matches<T const*, T> == result, "");
+  static_assert(value_type_matches<T volatile*, T> == result, "");
+  static_assert(value_type_matches<T const volatile*, T> == result, "");
 
-  static_assert(value_type_matches<T* const, T> == result);
-  static_assert(value_type_matches<T const* const, T> == result);
-  static_assert(value_type_matches<T volatile* const, T> == result);
-  static_assert(value_type_matches<T const volatile* const, T> == result);
+  static_assert(value_type_matches<T* const, T> == result, "");
+  static_assert(value_type_matches<T const* const, T> == result, "");
+  static_assert(value_type_matches<T volatile* const, T> == result, "");
+  static_assert(value_type_matches<T const volatile* const, T> == result, "");
 
   return result;
 }
@@ -60,35 +60,35 @@ __host__ __device__ constexpr bool check_pointer()
 template <class T>
 __host__ __device__ constexpr bool check_array()
 {
-  static_assert(value_type_matches<T[], T>);
-  static_assert(value_type_matches<T const[], T>);
-  static_assert(value_type_matches<T volatile[], T>);
-  static_assert(value_type_matches<T const volatile[], T>);
-  static_assert(value_type_matches<T[10], T>);
-  static_assert(value_type_matches<T const[10], T>);
-  static_assert(value_type_matches<T volatile[10], T>);
-  static_assert(value_type_matches<T const volatile[10], T>);
+  static_assert(value_type_matches<T[], T>, "");
+  static_assert(value_type_matches<T const[], T>, "");
+  static_assert(value_type_matches<T volatile[], T>, "");
+  static_assert(value_type_matches<T const volatile[], T>, "");
+  static_assert(value_type_matches<T[10], T>, "");
+  static_assert(value_type_matches<T const[10], T>, "");
+  static_assert(value_type_matches<T volatile[10], T>, "");
+  static_assert(value_type_matches<T const volatile[10], T>, "");
   return true;
 }
 
 template <class T, class Expected>
 __host__ __device__ constexpr bool check_member()
 {
-  static_assert(value_type_matches<T, Expected>);
-  static_assert(value_type_matches<T const, Expected>);
-  static_assert(value_type_matches<T volatile, Expected>);
+  static_assert(value_type_matches<T, Expected>, "");
+  static_assert(value_type_matches<T const, Expected>, "");
+  static_assert(value_type_matches<T volatile, Expected>, "");
   return true;
 }
 
-static_assert(check_pointer<int>());
-static_assert(check_pointer<int*>());
-static_assert(check_pointer<int[10]>());
-static_assert(!check_pointer<void>());
-static_assert(!check_pointer<int()>());
+static_assert(check_pointer<int>(), "");
+static_assert(check_pointer<int*>(), "");
+static_assert(check_pointer<int[10]>(), "");
+static_assert(!check_pointer<void>(), "");
+static_assert(!check_pointer<int()>(), "");
 
-static_assert(check_array<int>());
-static_assert(check_array<int*>());
-static_assert(check_array<int[10]>());
+static_assert(check_array<int>(), "");
+static_assert(check_array<int*>(), "");
+static_assert(check_array<int[10]>(), "");
 
 template <class T>
 struct ValueOf
@@ -109,59 +109,65 @@ struct TwoTypes
   using element_type = U;
 };
 
-static_assert(check_member<ValueOf<int>, int>());
-static_assert(check_member<ValueOf<int[10]>, int[10]>());
-static_assert(check_member<ValueOf<int[]>, int[]>());
-static_assert(has_no_value_type<ValueOf<void>>);
-static_assert(has_no_value_type<ValueOf<int()>>);
-static_assert(has_no_value_type<ValueOf<int&>>);
-static_assert(has_no_value_type<ValueOf<int&&>>);
+static_assert(check_member<ValueOf<int>, int>(), "");
+static_assert(check_member<ValueOf<int[10]>, int[10]>(), "");
+static_assert(check_member<ValueOf<int[]>, int[]>(), "");
+static_assert(has_no_value_type<ValueOf<void>>, "");
+static_assert(has_no_value_type<ValueOf<int()>>, "");
+static_assert(has_no_value_type<ValueOf<int&>>, "");
+static_assert(has_no_value_type<ValueOf<int&&>>, "");
 
-static_assert(check_member<ElementOf<int>, int>());
-static_assert(check_member<ElementOf<int[10]>, int[10]>());
-static_assert(check_member<ElementOf<int[]>, int[]>());
-static_assert(has_no_value_type<ElementOf<void>>);
-static_assert(has_no_value_type<ElementOf<int()>>);
-static_assert(has_no_value_type<ElementOf<int&>>);
-static_assert(has_no_value_type<ElementOf<int&&>>);
+static_assert(check_member<ElementOf<int>, int>(), "");
+static_assert(check_member<ElementOf<int[10]>, int[10]>(), "");
+static_assert(check_member<ElementOf<int[]>, int[]>(), "");
+static_assert(has_no_value_type<ElementOf<void>>, "");
+static_assert(has_no_value_type<ElementOf<int()>>, "");
+static_assert(has_no_value_type<ElementOf<int&>>, "");
+static_assert(has_no_value_type<ElementOf<int&&>>, "");
 
-static_assert(check_member<TwoTypes<int, int>, int>());
-static_assert(check_member<TwoTypes<int, int const>, int>());
-static_assert(check_member<TwoTypes<int, int volatile>, int>());
-static_assert(check_member<TwoTypes<int, int const volatile>, int>());
-static_assert(check_member<TwoTypes<int const, int>, int>());
-static_assert(check_member<TwoTypes<int const, int const>, int>());
-static_assert(check_member<TwoTypes<int const, int volatile>, int>());
-static_assert(check_member<TwoTypes<int const, int const volatile>, int>());
-static_assert(check_member<TwoTypes<int volatile, int>, int>());
-static_assert(check_member<TwoTypes<int volatile, int const>, int>());
-static_assert(check_member<TwoTypes<int volatile, int volatile>, int>());
-static_assert(check_member<TwoTypes<int volatile, int const volatile>, int>());
-static_assert(check_member<TwoTypes<int const volatile, int>, int>());
-static_assert(check_member<TwoTypes<int const volatile, int const>, int>());
-static_assert(check_member<TwoTypes<int const volatile, int volatile>, int>());
-static_assert(check_member<TwoTypes<int const volatile, int const volatile>, int>());
-static_assert(has_no_value_type<TwoTypes<int, long>>);
-static_assert(has_no_value_type<TwoTypes<int, int&>>);
-static_assert(has_no_value_type<TwoTypes<int&, int>>);
+static_assert(check_member<TwoTypes<int, int>, int>(), "");
+static_assert(check_member<TwoTypes<int, int const>, int>(), "");
+static_assert(check_member<TwoTypes<int, int volatile>, int>(), "");
+static_assert(check_member<TwoTypes<int, int const volatile>, int>(), "");
+static_assert(check_member<TwoTypes<int const, int>, int>(), "");
+static_assert(check_member<TwoTypes<int const, int const>, int>(), "");
+static_assert(check_member<TwoTypes<int const, int volatile>, int>(), "");
+static_assert(check_member<TwoTypes<int const, int const volatile>, int>(), "");
+static_assert(check_member<TwoTypes<int volatile, int>, int>(), "");
+static_assert(check_member<TwoTypes<int volatile, int const>, int>(), "");
+static_assert(check_member<TwoTypes<int volatile, int volatile>, int>(), "");
+static_assert(check_member<TwoTypes<int volatile, int const volatile>, int>(), "");
+static_assert(check_member<TwoTypes<int const volatile, int>, int>(), "");
+static_assert(check_member<TwoTypes<int const volatile, int const>, int>(), "");
+static_assert(check_member<TwoTypes<int const volatile, int volatile>, int>(), "");
+static_assert(check_member<TwoTypes<int const volatile, int const volatile>, int>(), "");
+static_assert(has_no_value_type<TwoTypes<int, long>>, "");
+static_assert(has_no_value_type<TwoTypes<int, int&>>, "");
+static_assert(has_no_value_type<TwoTypes<int&, int>>, "");
 
 struct S2
 {};
+namespace cuda
+{
+namespace std
+{
 template <>
-struct cuda::std::indirectly_readable_traits<S2>
+struct indirectly_readable_traits<S2>
 {
   using value_type = int;
 };
-static_assert(value_type_matches<S2, int>);
-static_assert(value_type_matches<const S2, int>);
-static_assert(has_no_value_type<volatile S2>);
-static_assert(has_no_value_type<const volatile S2>);
-static_assert(has_no_value_type<S2&>);
-static_assert(has_no_value_type<const S2&>);
+} // namespace std
+} // namespace cuda
+static_assert(value_type_matches<S2, int>, "");
+static_assert(value_type_matches<const S2, int>, "");
+static_assert(has_no_value_type<volatile S2>, "");
+static_assert(has_no_value_type<const volatile S2>, "");
+static_assert(has_no_value_type<S2&>, "");
+static_assert(has_no_value_type<const S2&>, "");
 
-static_assert(has_no_value_type<void>);
-static_assert(has_no_value_type<int>);
-static_assert(has_no_value_type<cuda::std::nullptr_t>);
+static_assert(has_no_value_type<void>, "");
+static_assert(has_no_value_type<int>, "");
+static_assert(has_no_value_type<cuda::std::nullptr_t>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/iter_value_t.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/iter_value_t.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // using iter_value_t;
@@ -20,48 +20,48 @@ template <class T, class Expected>
 __host__ __device__ constexpr bool check_iter_value_t()
 {
   constexpr bool result = cuda::std::same_as<cuda::std::iter_value_t<T>, Expected>;
-  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T volatile>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const volatile>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T volatile&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const volatile&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const&&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T volatile&&>, Expected> == result);
-  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const volatile&&>, Expected> == result);
+  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T volatile>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const volatile>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T volatile&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const volatile&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const&&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T volatile&&>, Expected> == result, "");
+  static_assert(cuda::std::same_as<cuda::std::iter_value_t<T const volatile&&>, Expected> == result, "");
 
   return result;
 }
 
-static_assert(check_iter_value_t<int*, int>());
-static_assert(check_iter_value_t<int[], int>());
-static_assert(check_iter_value_t<int[10], int>());
+static_assert(check_iter_value_t<int*, int>(), "");
+static_assert(check_iter_value_t<int[], int>(), "");
+static_assert(check_iter_value_t<int[10], int>(), "");
 
 struct both_members
 {
   using value_type   = double;
   using element_type = double;
 };
-static_assert(check_iter_value_t<both_members, double>());
+static_assert(check_iter_value_t<both_members, double>(), "");
 #endif // !TEST_COMPILER_MSVC_2017
 
 // clang-format off
 template <class T, class = void>
-inline constexpr bool check_no_iter_value_t = true;
+_CCCL_INLINE_VAR constexpr bool check_no_iter_value_t = true;
 
 template <class T>
-inline constexpr bool check_no_iter_value_t<T, cuda::std::void_t<cuda::std::iter_value_t<T>>> = false;
+_CCCL_INLINE_VAR constexpr bool check_no_iter_value_t<T, cuda::std::void_t<cuda::std::iter_value_t<T>>> = false;
 
-static_assert(check_no_iter_value_t<void>);
-static_assert(check_no_iter_value_t<double>);
+static_assert(check_no_iter_value_t<void>, "");
+static_assert(check_no_iter_value_t<double>, "");
 
 struct S {};
-static_assert(check_no_iter_value_t<S>);
+static_assert(check_no_iter_value_t<S>, "");
 
 struct different_value_element_members {
   using value_type = int;
   using element_type = long;
 };
-static_assert(check_no_iter_value_t<different_value_element_members>);
+static_assert(check_no_iter_value_t<different_value_element_members>, "");
 
 int main(int, char**) { return 0; }

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.bidir/bidirectional_iterator.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.bidir/bidirectional_iterator.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // concept bidirectional_iterator;
@@ -17,17 +17,17 @@
 
 #include "test_iterators.h"
 
-static_assert(!cuda::std::bidirectional_iterator<cpp17_input_iterator<int*>>);
-static_assert(!cuda::std::bidirectional_iterator<cpp20_input_iterator<int*>>);
-static_assert(!cuda::std::bidirectional_iterator<forward_iterator<int*>>);
-static_assert(cuda::std::bidirectional_iterator<bidirectional_iterator<int*>>);
-static_assert(cuda::std::bidirectional_iterator<random_access_iterator<int*>>);
-static_assert(cuda::std::bidirectional_iterator<contiguous_iterator<int*>>);
+static_assert(!cuda::std::bidirectional_iterator<cpp17_input_iterator<int*>>, "");
+static_assert(!cuda::std::bidirectional_iterator<cpp20_input_iterator<int*>>, "");
+static_assert(!cuda::std::bidirectional_iterator<forward_iterator<int*>>, "");
+static_assert(cuda::std::bidirectional_iterator<bidirectional_iterator<int*>>, "");
+static_assert(cuda::std::bidirectional_iterator<random_access_iterator<int*>>, "");
+static_assert(cuda::std::bidirectional_iterator<contiguous_iterator<int*>>, "");
 
-static_assert(cuda::std::bidirectional_iterator<int*>);
-static_assert(cuda::std::bidirectional_iterator<int const*>);
-static_assert(cuda::std::bidirectional_iterator<int volatile*>);
-static_assert(cuda::std::bidirectional_iterator<int const volatile*>);
+static_assert(cuda::std::bidirectional_iterator<int*>, "");
+static_assert(cuda::std::bidirectional_iterator<int const*>, "");
+static_assert(cuda::std::bidirectional_iterator<int volatile*>, "");
+static_assert(cuda::std::bidirectional_iterator<int const volatile*>, "");
 
 struct not_forward_iterator
 {
@@ -44,7 +44,8 @@ struct not_forward_iterator
   __host__ __device__ not_forward_iterator& operator--(int);
 };
 static_assert(cuda::std::input_iterator<not_forward_iterator> && !cuda::std::forward_iterator<not_forward_iterator>
-              && !cuda::std::bidirectional_iterator<not_forward_iterator>);
+                && !cuda::std::bidirectional_iterator<not_forward_iterator>,
+              "");
 
 struct wrong_iterator_category
 {
@@ -72,7 +73,7 @@ struct wrong_iterator_category
   };
 #endif
 };
-static_assert(!cuda::std::bidirectional_iterator<wrong_iterator_category>);
+static_assert(!cuda::std::bidirectional_iterator<wrong_iterator_category>, "");
 
 struct wrong_iterator_concept
 {
@@ -101,7 +102,7 @@ struct wrong_iterator_concept
   };
 #endif
 };
-static_assert(!cuda::std::bidirectional_iterator<wrong_iterator_concept>);
+static_assert(!cuda::std::bidirectional_iterator<wrong_iterator_concept>, "");
 
 struct no_predecrement
 {
@@ -129,7 +130,7 @@ struct no_predecrement
   };
 #endif
 };
-static_assert(!cuda::std::bidirectional_iterator<no_predecrement>);
+static_assert(!cuda::std::bidirectional_iterator<no_predecrement>, "");
 
 struct bad_predecrement
 {
@@ -158,7 +159,7 @@ struct bad_predecrement
   };
 #endif
 };
-static_assert(!cuda::std::bidirectional_iterator<bad_predecrement>);
+static_assert(!cuda::std::bidirectional_iterator<bad_predecrement>, "");
 
 struct no_postdecrement
 {
@@ -189,7 +190,7 @@ struct no_postdecrement
   };
 #endif
 };
-static_assert(!cuda::std::bidirectional_iterator<no_postdecrement>);
+static_assert(!cuda::std::bidirectional_iterator<no_postdecrement>, "");
 
 struct bad_postdecrement
 {
@@ -218,7 +219,7 @@ struct bad_postdecrement
   };
 #endif
 };
-static_assert(!cuda::std::bidirectional_iterator<bad_postdecrement>);
+static_assert(!cuda::std::bidirectional_iterator<bad_postdecrement>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.bidir/subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.bidir/subsumption.compile.pass.cpp
@@ -29,7 +29,7 @@ __host__ __device__ constexpr bool check_subsumption()
   return true;
 }
 
-static_assert(check_subsumption<int*>());
+static_assert(check_subsumption<int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.forward/forward_iterator.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.forward/forward_iterator.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // cuda::std::forward_iterator;
 
@@ -16,17 +16,17 @@
 
 #include "test_iterators.h"
 
-static_assert(!cuda::std::forward_iterator<cpp17_input_iterator<int*>>);
-static_assert(!cuda::std::forward_iterator<cpp20_input_iterator<int*>>);
-static_assert(cuda::std::forward_iterator<forward_iterator<int*>>);
-static_assert(cuda::std::forward_iterator<bidirectional_iterator<int*>>);
-static_assert(cuda::std::forward_iterator<random_access_iterator<int*>>);
-static_assert(cuda::std::forward_iterator<contiguous_iterator<int*>>);
+static_assert(!cuda::std::forward_iterator<cpp17_input_iterator<int*>>, "");
+static_assert(!cuda::std::forward_iterator<cpp20_input_iterator<int*>>, "");
+static_assert(cuda::std::forward_iterator<forward_iterator<int*>>, "");
+static_assert(cuda::std::forward_iterator<bidirectional_iterator<int*>>, "");
+static_assert(cuda::std::forward_iterator<random_access_iterator<int*>>, "");
+static_assert(cuda::std::forward_iterator<contiguous_iterator<int*>>, "");
 
-static_assert(cuda::std::forward_iterator<int*>);
-static_assert(cuda::std::forward_iterator<int const*>);
-static_assert(cuda::std::forward_iterator<int volatile*>);
-static_assert(cuda::std::forward_iterator<int const volatile*>);
+static_assert(cuda::std::forward_iterator<int*>, "");
+static_assert(cuda::std::forward_iterator<int const*>, "");
+static_assert(cuda::std::forward_iterator<int volatile*>, "");
+static_assert(cuda::std::forward_iterator<int const volatile*>, "");
 
 struct not_input_iterator
 {
@@ -52,9 +52,9 @@ struct not_input_iterator
   };
 #endif
 };
-static_assert(cuda::std::input_or_output_iterator<not_input_iterator>);
-static_assert(!cuda::std::input_iterator<not_input_iterator>);
-static_assert(!cuda::std::forward_iterator<not_input_iterator>);
+static_assert(cuda::std::input_or_output_iterator<not_input_iterator>, "");
+static_assert(!cuda::std::input_iterator<not_input_iterator>, "");
+static_assert(!cuda::std::forward_iterator<not_input_iterator>, "");
 
 struct bad_iterator_tag
 {
@@ -80,7 +80,7 @@ struct bad_iterator_tag
   };
 #endif
 };
-static_assert(!cuda::std::forward_iterator<bad_iterator_tag>);
+static_assert(!cuda::std::forward_iterator<bad_iterator_tag>, "");
 
 struct not_incrementable
 {
@@ -106,7 +106,7 @@ struct not_incrementable
   };
 #endif
 };
-static_assert(!cuda::std::forward_iterator<not_incrementable>);
+static_assert(!cuda::std::forward_iterator<not_incrementable>, "");
 
 struct not_equality_comparable
 {
@@ -121,7 +121,7 @@ struct not_equality_comparable
 
   __host__ __device__ bool operator==(not_equality_comparable const&) const = delete;
 };
-static_assert(!cuda::std::forward_iterator<not_equality_comparable>);
+static_assert(!cuda::std::forward_iterator<not_equality_comparable>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.forward/subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.forward/subsumption.compile.pass.cpp
@@ -28,7 +28,7 @@ __host__ __device__ constexpr bool check_subsumption() {
 }
 // clang-format on
 
-static_assert(check_subsumption<int*>());
+static_assert(check_subsumption<int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.inc/incrementable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.inc/incrementable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class In>
 // concept indirectly_readable;
@@ -17,29 +17,29 @@
 #include <cuda/std/concepts>
 #include <cuda/std/iterator>
 
-static_assert(cuda::std::incrementable<int>);
-static_assert(cuda::std::incrementable<int*>);
-static_assert(cuda::std::incrementable<int**>);
+static_assert(cuda::std::incrementable<int>, "");
+static_assert(cuda::std::incrementable<int*>, "");
+static_assert(cuda::std::incrementable<int**>, "");
 
-static_assert(!cuda::std::incrementable<postfix_increment_returns_void>);
-static_assert(!cuda::std::incrementable<postfix_increment_returns_copy>);
-static_assert(!cuda::std::incrementable<has_integral_minus>);
-static_assert(!cuda::std::incrementable<has_distinct_difference_type_and_minus>);
-static_assert(!cuda::std::incrementable<missing_difference_type>);
-static_assert(!cuda::std::incrementable<floating_difference_type>);
-static_assert(!cuda::std::incrementable<non_const_minus>);
-static_assert(!cuda::std::incrementable<non_integral_minus>);
-static_assert(!cuda::std::incrementable<bad_difference_type_good_minus>);
-static_assert(!cuda::std::incrementable<not_default_initializable>);
-static_assert(!cuda::std::incrementable<not_movable>);
-static_assert(!cuda::std::incrementable<preinc_not_declared>);
-static_assert(!cuda::std::incrementable<postinc_not_declared>);
-static_assert(cuda::std::incrementable<incrementable_with_difference_type>);
-static_assert(cuda::std::incrementable<incrementable_without_difference_type>);
-static_assert(cuda::std::incrementable<difference_type_and_void_minus>);
-static_assert(!cuda::std::incrementable<noncopyable_with_difference_type>);
-static_assert(!cuda::std::incrementable<noncopyable_without_difference_type>);
-static_assert(!cuda::std::incrementable<noncopyable_with_difference_type_and_minus>);
+static_assert(!cuda::std::incrementable<postfix_increment_returns_void>, "");
+static_assert(!cuda::std::incrementable<postfix_increment_returns_copy>, "");
+static_assert(!cuda::std::incrementable<has_integral_minus>, "");
+static_assert(!cuda::std::incrementable<has_distinct_difference_type_and_minus>, "");
+static_assert(!cuda::std::incrementable<missing_difference_type>, "");
+static_assert(!cuda::std::incrementable<floating_difference_type>, "");
+static_assert(!cuda::std::incrementable<non_const_minus>, "");
+static_assert(!cuda::std::incrementable<non_integral_minus>, "");
+static_assert(!cuda::std::incrementable<bad_difference_type_good_minus>, "");
+static_assert(!cuda::std::incrementable<not_default_initializable>, "");
+static_assert(!cuda::std::incrementable<not_movable>, "");
+static_assert(!cuda::std::incrementable<preinc_not_declared>, "");
+static_assert(!cuda::std::incrementable<postinc_not_declared>, "");
+static_assert(cuda::std::incrementable<incrementable_with_difference_type>, "");
+static_assert(cuda::std::incrementable<incrementable_without_difference_type>, "");
+static_assert(cuda::std::incrementable<difference_type_and_void_minus>, "");
+static_assert(!cuda::std::incrementable<noncopyable_with_difference_type>, "");
+static_assert(!cuda::std::incrementable<noncopyable_without_difference_type>, "");
+static_assert(!cuda::std::incrementable<noncopyable_with_difference_type_and_minus>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.inc/subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.inc/subsumption.compile.pass.cpp
@@ -30,7 +30,7 @@ __host__ __device__ constexpr bool check_subsumption() {
 }
 // clang-format on
 
-static_assert(check_subsumption<int*>());
+static_assert(check_subsumption<int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.input/input_iterator.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.input/input_iterator.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // concept input_iterator;
@@ -17,8 +17,8 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-static_assert(cuda::std::input_iterator<cpp17_input_iterator<int*>>);
-static_assert(cuda::std::input_iterator<cpp20_input_iterator<int*>>);
+static_assert(cuda::std::input_iterator<cpp17_input_iterator<int*>>, "");
+static_assert(cuda::std::input_iterator<cpp20_input_iterator<int*>>, "");
 
 struct no_explicit_iter_concept
 {
@@ -40,13 +40,13 @@ struct no_explicit_iter_concept
 };
 #ifndef TEST_COMPILER_MSVC_2017
 // ITER-CONCEPT is `random_access_iterator_tag` >:(
-static_assert(cuda::std::input_iterator<no_explicit_iter_concept>);
+static_assert(cuda::std::input_iterator<no_explicit_iter_concept>, "");
 #endif // TEST_COMPILER_MSVC_2017
 
-static_assert(cuda::std::input_iterator<int*>);
-static_assert(cuda::std::input_iterator<int const*>);
-static_assert(cuda::std::input_iterator<int volatile*>);
-static_assert(cuda::std::input_iterator<int const volatile*>);
+static_assert(cuda::std::input_iterator<int*>, "");
+static_assert(cuda::std::input_iterator<int const*>, "");
+static_assert(cuda::std::input_iterator<int volatile*>, "");
+static_assert(cuda::std::input_iterator<int const volatile*>, "");
 
 struct not_weakly_incrementable
 {
@@ -70,7 +70,8 @@ struct not_weakly_incrementable
 #endif // TEST_COMPILER_MSVC
 };
 static_assert(!cuda::std::input_or_output_iterator<not_weakly_incrementable>
-              && !cuda::std::input_iterator<not_weakly_incrementable>);
+                && !cuda::std::input_iterator<not_weakly_incrementable>,
+              "");
 
 struct not_indirectly_readable
 {
@@ -90,8 +91,8 @@ struct not_indirectly_readable
   __host__ __device__ not_indirectly_readable& operator++();
   __host__ __device__ void operator++(int);
 };
-static_assert(!cuda::std::indirectly_readable<not_indirectly_readable>
-              && !cuda::std::input_iterator<not_indirectly_readable>);
+static_assert(
+  !cuda::std::indirectly_readable<not_indirectly_readable> && !cuda::std::input_iterator<not_indirectly_readable>, "");
 
 struct bad_iterator_category
 {
@@ -112,7 +113,7 @@ struct bad_iterator_category
   __host__ __device__ bad_iterator_category& operator++();
   __host__ __device__ void operator++(int);
 };
-static_assert(!cuda::std::input_iterator<bad_iterator_category>);
+static_assert(!cuda::std::input_iterator<bad_iterator_category>, "");
 
 struct bad_iterator_concept
 {
@@ -133,7 +134,7 @@ struct bad_iterator_concept
   __host__ __device__ bad_iterator_concept& operator++();
   __host__ __device__ void operator++(int);
 };
-static_assert(!cuda::std::input_iterator<bad_iterator_concept>);
+static_assert(!cuda::std::input_iterator<bad_iterator_concept>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.input/subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.input/subsumption.compile.pass.cpp
@@ -30,7 +30,7 @@ __host__ __device__ constexpr bool check_subsumption() {
 }
 // clang-format on
 
-static_assert(check_subsumption<int*>());
+static_assert(check_subsumption<int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.iterator/input_or_output_iterator.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.iterator/input_or_output_iterator.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class In>
 // concept input_or_output_iterator;
@@ -16,43 +16,43 @@
 
 #include "test_iterators.h"
 
-static_assert(cuda::std::input_or_output_iterator<int*>);
-static_assert(cuda::std::input_or_output_iterator<int const*>);
-static_assert(cuda::std::input_or_output_iterator<int volatile*>);
-static_assert(cuda::std::input_or_output_iterator<int const volatile*>);
+static_assert(cuda::std::input_or_output_iterator<int*>, "");
+static_assert(cuda::std::input_or_output_iterator<int const*>, "");
+static_assert(cuda::std::input_or_output_iterator<int volatile*>, "");
+static_assert(cuda::std::input_or_output_iterator<int const volatile*>, "");
 
-static_assert(cuda::std::input_or_output_iterator<cpp17_input_iterator<int*>>);
-static_assert(cuda::std::input_or_output_iterator<cpp17_input_iterator<int const*>>);
-static_assert(cuda::std::input_or_output_iterator<cpp17_input_iterator<int volatile*>>);
-static_assert(cuda::std::input_or_output_iterator<cpp17_input_iterator<int const volatile*>>);
+static_assert(cuda::std::input_or_output_iterator<cpp17_input_iterator<int*>>, "");
+static_assert(cuda::std::input_or_output_iterator<cpp17_input_iterator<int const*>>, "");
+static_assert(cuda::std::input_or_output_iterator<cpp17_input_iterator<int volatile*>>, "");
+static_assert(cuda::std::input_or_output_iterator<cpp17_input_iterator<int const volatile*>>, "");
 
-static_assert(cuda::std::input_or_output_iterator<forward_iterator<int*>>);
-static_assert(cuda::std::input_or_output_iterator<forward_iterator<int const*>>);
-static_assert(cuda::std::input_or_output_iterator<forward_iterator<int volatile*>>);
-static_assert(cuda::std::input_or_output_iterator<forward_iterator<int const volatile*>>);
+static_assert(cuda::std::input_or_output_iterator<forward_iterator<int*>>, "");
+static_assert(cuda::std::input_or_output_iterator<forward_iterator<int const*>>, "");
+static_assert(cuda::std::input_or_output_iterator<forward_iterator<int volatile*>>, "");
+static_assert(cuda::std::input_or_output_iterator<forward_iterator<int const volatile*>>, "");
 
-static_assert(cuda::std::input_or_output_iterator<bidirectional_iterator<int*>>);
-static_assert(cuda::std::input_or_output_iterator<bidirectional_iterator<int const*>>);
-static_assert(cuda::std::input_or_output_iterator<bidirectional_iterator<int volatile*>>);
-static_assert(cuda::std::input_or_output_iterator<bidirectional_iterator<int const volatile*>>);
+static_assert(cuda::std::input_or_output_iterator<bidirectional_iterator<int*>>, "");
+static_assert(cuda::std::input_or_output_iterator<bidirectional_iterator<int const*>>, "");
+static_assert(cuda::std::input_or_output_iterator<bidirectional_iterator<int volatile*>>, "");
+static_assert(cuda::std::input_or_output_iterator<bidirectional_iterator<int const volatile*>>, "");
 
-static_assert(cuda::std::input_or_output_iterator<random_access_iterator<int*>>);
-static_assert(cuda::std::input_or_output_iterator<random_access_iterator<int const*>>);
-static_assert(cuda::std::input_or_output_iterator<random_access_iterator<int volatile*>>);
-static_assert(cuda::std::input_or_output_iterator<random_access_iterator<int const volatile*>>);
+static_assert(cuda::std::input_or_output_iterator<random_access_iterator<int*>>, "");
+static_assert(cuda::std::input_or_output_iterator<random_access_iterator<int const*>>, "");
+static_assert(cuda::std::input_or_output_iterator<random_access_iterator<int volatile*>>, "");
+static_assert(cuda::std::input_or_output_iterator<random_access_iterator<int const volatile*>>, "");
 
-static_assert(!cuda::std::input_or_output_iterator<void*>);
-static_assert(!cuda::std::input_or_output_iterator<void const*>);
-static_assert(!cuda::std::input_or_output_iterator<void volatile*>);
-static_assert(!cuda::std::input_or_output_iterator<void const volatile*>);
+static_assert(!cuda::std::input_or_output_iterator<void*>, "");
+static_assert(!cuda::std::input_or_output_iterator<void const*>, "");
+static_assert(!cuda::std::input_or_output_iterator<void volatile*>, "");
+static_assert(!cuda::std::input_or_output_iterator<void const volatile*>, "");
 
 struct S
 {};
-static_assert(!cuda::std::input_or_output_iterator<S>);
-static_assert(!cuda::std::input_or_output_iterator<int S::*>);
-static_assert(!cuda::std::input_or_output_iterator<int (S::*)()>);
-static_assert(!cuda::std::input_or_output_iterator<int (S::*)() const>);
-static_assert(!cuda::std::input_or_output_iterator<int (S::*)() volatile>);
+static_assert(!cuda::std::input_or_output_iterator<S>, "");
+static_assert(!cuda::std::input_or_output_iterator<int S::*>, "");
+static_assert(!cuda::std::input_or_output_iterator<int (S::*)()>, "");
+static_assert(!cuda::std::input_or_output_iterator<int (S::*)() const>, "");
+static_assert(!cuda::std::input_or_output_iterator<int (S::*)() volatile>, "");
 
 struct missing_dereference
 {
@@ -62,7 +62,8 @@ struct missing_dereference
   __host__ __device__ missing_dereference& operator++(int);
 };
 static_assert(cuda::std::weakly_incrementable<missing_dereference>
-              && !cuda::std::input_or_output_iterator<missing_dereference>);
+                && !cuda::std::input_or_output_iterator<missing_dereference>,
+              "");
 
 struct void_dereference
 {
@@ -72,14 +73,14 @@ struct void_dereference
   __host__ __device__ void_dereference& operator++();
   __host__ __device__ void_dereference& operator++(int);
 };
-static_assert(cuda::std::weakly_incrementable<void_dereference>
-              && !cuda::std::input_or_output_iterator<void_dereference>);
+static_assert(
+  cuda::std::weakly_incrementable<void_dereference> && !cuda::std::input_or_output_iterator<void_dereference>, "");
 
 struct not_weakly_incrementable
 {
   __host__ __device__ int operator*() const;
 };
-static_assert(!cuda::std::input_or_output_iterator<not_weakly_incrementable>);
+static_assert(!cuda::std::input_or_output_iterator<not_weakly_incrementable>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.iterator/subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.iterator/subsumption.compile.pass.cpp
@@ -28,7 +28,7 @@ __host__ __device__ constexpr bool check_subsumption() {
 }
 // clang-format on
 
-static_assert(check_subsumption<int*>());
+static_assert(check_subsumption<int*>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.output/output_iterator.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.output/output_iterator.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class It, class T>
 // concept output_iterator;
@@ -22,29 +22,29 @@ struct T
 struct DerivedFromT : T
 {};
 
-static_assert(cuda::std::output_iterator<cpp17_output_iterator<int*>, int>);
-static_assert(cuda::std::output_iterator<cpp17_output_iterator<int*>, short>);
-static_assert(cuda::std::output_iterator<cpp17_output_iterator<int*>, long>);
-static_assert(cuda::std::output_iterator<cpp17_output_iterator<T*>, T>);
-static_assert(!cuda::std::output_iterator<cpp17_output_iterator<T const*>, T>);
-static_assert(cuda::std::output_iterator<cpp17_output_iterator<T*>, T const>);
-static_assert(cuda::std::output_iterator<cpp17_output_iterator<T*>, DerivedFromT>);
-static_assert(!cuda::std::output_iterator<cpp17_output_iterator<DerivedFromT*>, T>);
+static_assert(cuda::std::output_iterator<cpp17_output_iterator<int*>, int>, "");
+static_assert(cuda::std::output_iterator<cpp17_output_iterator<int*>, short>, "");
+static_assert(cuda::std::output_iterator<cpp17_output_iterator<int*>, long>, "");
+static_assert(cuda::std::output_iterator<cpp17_output_iterator<T*>, T>, "");
+static_assert(!cuda::std::output_iterator<cpp17_output_iterator<T const*>, T>, "");
+static_assert(cuda::std::output_iterator<cpp17_output_iterator<T*>, T const>, "");
+static_assert(cuda::std::output_iterator<cpp17_output_iterator<T*>, DerivedFromT>, "");
+static_assert(!cuda::std::output_iterator<cpp17_output_iterator<DerivedFromT*>, T>, "");
 
-static_assert(cuda::std::output_iterator<cpp20_output_iterator<int*>, int>);
-static_assert(cuda::std::output_iterator<cpp20_output_iterator<int*>, short>);
-static_assert(cuda::std::output_iterator<cpp20_output_iterator<int*>, long>);
-static_assert(cuda::std::output_iterator<cpp20_output_iterator<T*>, T>);
-static_assert(!cuda::std::output_iterator<cpp20_output_iterator<T const*>, T>);
-static_assert(cuda::std::output_iterator<cpp20_output_iterator<T*>, T const>);
-static_assert(cuda::std::output_iterator<cpp20_output_iterator<T*>, DerivedFromT>);
-static_assert(!cuda::std::output_iterator<cpp20_output_iterator<DerivedFromT*>, T>);
+static_assert(cuda::std::output_iterator<cpp20_output_iterator<int*>, int>, "");
+static_assert(cuda::std::output_iterator<cpp20_output_iterator<int*>, short>, "");
+static_assert(cuda::std::output_iterator<cpp20_output_iterator<int*>, long>, "");
+static_assert(cuda::std::output_iterator<cpp20_output_iterator<T*>, T>, "");
+static_assert(!cuda::std::output_iterator<cpp20_output_iterator<T const*>, T>, "");
+static_assert(cuda::std::output_iterator<cpp20_output_iterator<T*>, T const>, "");
+static_assert(cuda::std::output_iterator<cpp20_output_iterator<T*>, DerivedFromT>, "");
+static_assert(!cuda::std::output_iterator<cpp20_output_iterator<DerivedFromT*>, T>, "");
 
 // Not satisfied when the iterator is not an input_or_output_iterator
-static_assert(!cuda::std::output_iterator<void, int>);
-static_assert(!cuda::std::output_iterator<void (*)(), int>);
-static_assert(!cuda::std::output_iterator<int&, int>);
-static_assert(!cuda::std::output_iterator<T, int>);
+static_assert(!cuda::std::output_iterator<void, int>, "");
+static_assert(!cuda::std::output_iterator<void (*)(), int>, "");
+static_assert(!cuda::std::output_iterator<int&, int>, "");
+static_assert(!cuda::std::output_iterator<T, int>, "");
 
 // Not satisfied when we can't assign a T to the result of *it++
 struct WrongPostIncrement
@@ -54,9 +54,9 @@ struct WrongPostIncrement
   __host__ __device__ WrongPostIncrement& operator++();
   __host__ __device__ T& operator*();
 };
-static_assert(cuda::std::input_or_output_iterator<WrongPostIncrement>);
-static_assert(cuda::std::indirectly_writable<WrongPostIncrement, T>);
-static_assert(!cuda::std::output_iterator<WrongPostIncrement, T>);
+static_assert(cuda::std::input_or_output_iterator<WrongPostIncrement>, "");
+static_assert(cuda::std::indirectly_writable<WrongPostIncrement, T>, "");
+static_assert(!cuda::std::output_iterator<WrongPostIncrement, T>, "");
 
 // Not satisfied when we can't assign a T to the result of *it (i.e. not indirectly_writable)
 struct NotIndirectlyWritable
@@ -66,9 +66,9 @@ struct NotIndirectlyWritable
   __host__ __device__ NotIndirectlyWritable& operator++();
   __host__ __device__ T const& operator*(); // const so we can't write to it
 };
-static_assert(cuda::std::input_or_output_iterator<NotIndirectlyWritable>);
-static_assert(!cuda::std::indirectly_writable<NotIndirectlyWritable, T>);
-static_assert(!cuda::std::output_iterator<NotIndirectlyWritable, T>);
+static_assert(cuda::std::input_or_output_iterator<NotIndirectlyWritable>, "");
+static_assert(!cuda::std::indirectly_writable<NotIndirectlyWritable, T>, "");
+static_assert(!cuda::std::output_iterator<NotIndirectlyWritable, T>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/contiguous_iterator.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/contiguous_iterator.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // concept contiguous_iterator;
@@ -17,18 +17,18 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-static_assert(!cuda::std::contiguous_iterator<cpp17_input_iterator<int*>>);
-static_assert(!cuda::std::contiguous_iterator<cpp20_input_iterator<int*>>);
-static_assert(!cuda::std::contiguous_iterator<forward_iterator<int*>>);
-static_assert(!cuda::std::contiguous_iterator<bidirectional_iterator<int*>>);
-static_assert(!cuda::std::contiguous_iterator<random_access_iterator<int*>>);
-static_assert(cuda::std::contiguous_iterator<contiguous_iterator<int*>>);
+static_assert(!cuda::std::contiguous_iterator<cpp17_input_iterator<int*>>, "");
+static_assert(!cuda::std::contiguous_iterator<cpp20_input_iterator<int*>>, "");
+static_assert(!cuda::std::contiguous_iterator<forward_iterator<int*>>, "");
+static_assert(!cuda::std::contiguous_iterator<bidirectional_iterator<int*>>, "");
+static_assert(!cuda::std::contiguous_iterator<random_access_iterator<int*>>, "");
+static_assert(cuda::std::contiguous_iterator<contiguous_iterator<int*>>, "");
 
 #ifndef TEST_COMPILER_MSVC_2017
-static_assert(cuda::std::contiguous_iterator<int*>);
-static_assert(cuda::std::contiguous_iterator<int const*>);
-static_assert(cuda::std::contiguous_iterator<int volatile*>);
-static_assert(cuda::std::contiguous_iterator<int const volatile*>);
+static_assert(cuda::std::contiguous_iterator<int*>, "");
+static_assert(cuda::std::contiguous_iterator<int const*>, "");
+static_assert(cuda::std::contiguous_iterator<int volatile*>, "");
+static_assert(cuda::std::contiguous_iterator<int const volatile*>, "");
 #endif // TEST_COMPILER_MSVC_2017
 
 struct simple_contiguous_iterator
@@ -91,8 +91,8 @@ struct simple_contiguous_iterator
   __host__ __device__ reference operator[](difference_type n) const;
 };
 
-static_assert(cuda::std::random_access_iterator<simple_contiguous_iterator>);
-static_assert(cuda::std::contiguous_iterator<simple_contiguous_iterator>);
+static_assert(cuda::std::random_access_iterator<simple_contiguous_iterator>, "");
+static_assert(cuda::std::contiguous_iterator<simple_contiguous_iterator>, "");
 
 struct mismatch_value_iter_ref_t
 {
@@ -156,8 +156,8 @@ struct mismatch_value_iter_ref_t
   __host__ __device__ reference operator[](difference_type n) const;
 };
 
-static_assert(cuda::std::random_access_iterator<mismatch_value_iter_ref_t>);
-static_assert(!cuda::std::contiguous_iterator<mismatch_value_iter_ref_t>);
+static_assert(cuda::std::random_access_iterator<mismatch_value_iter_ref_t>, "");
+static_assert(!cuda::std::contiguous_iterator<mismatch_value_iter_ref_t>, "");
 
 struct wrong_iter_reference_t
 {
@@ -219,8 +219,8 @@ struct wrong_iter_reference_t
   __host__ __device__ reference operator[](difference_type n) const;
 };
 
-static_assert(cuda::std::random_access_iterator<wrong_iter_reference_t>);
-static_assert(!cuda::std::contiguous_iterator<wrong_iter_reference_t>);
+static_assert(cuda::std::random_access_iterator<wrong_iter_reference_t>, "");
+static_assert(!cuda::std::contiguous_iterator<wrong_iter_reference_t>, "");
 
 struct to_address_wrong_return_type
 {
@@ -282,15 +282,21 @@ struct to_address_wrong_return_type
   __host__ __device__ reference operator[](difference_type n) const;
 };
 
+namespace cuda
+{
+namespace std
+{
 template <>
-struct cuda::std::pointer_traits<to_address_wrong_return_type>
+struct pointer_traits<to_address_wrong_return_type>
 {
   typedef void element_type;
   __host__ __device__ static void* to_address(to_address_wrong_return_type const&);
 };
+} // namespace std
+} // namespace cuda
 
-static_assert(cuda::std::random_access_iterator<to_address_wrong_return_type>);
-static_assert(!cuda::std::contiguous_iterator<to_address_wrong_return_type>);
+static_assert(cuda::std::random_access_iterator<to_address_wrong_return_type>, "");
+static_assert(!cuda::std::contiguous_iterator<to_address_wrong_return_type>, "");
 
 template <class>
 struct template_and_no_element_type
@@ -356,8 +362,8 @@ struct template_and_no_element_type
 };
 
 // Template param is used instead of element_type.
-static_assert(cuda::std::random_access_iterator<template_and_no_element_type<int>>);
-static_assert(cuda::std::contiguous_iterator<template_and_no_element_type<int>>);
+static_assert(cuda::std::random_access_iterator<template_and_no_element_type<int>>, "");
+static_assert(cuda::std::contiguous_iterator<template_and_no_element_type<int>>, "");
 
 template <bool DisableArrow, bool DisableToAddress>
 struct no_operator_arrow
@@ -426,15 +432,21 @@ struct no_operator_arrow
   __host__ __device__ reference operator[](difference_type n) const;
 };
 
+namespace cuda
+{
+namespace std
+{
 template <>
-struct cuda::std::pointer_traits<no_operator_arrow</*DisableArrow=*/true, /*DisableToAddress=*/false>>
+struct pointer_traits<no_operator_arrow</*DisableArrow=*/true, /*DisableToAddress=*/false>>
 {
   __host__ __device__ static constexpr int* to_address(const no_operator_arrow<true, false>&);
 };
+} // namespace std
+} // namespace cuda
 
-static_assert(cuda::std::contiguous_iterator<no_operator_arrow</*DisableArrow=*/false, /*DisableToAddress=*/true>>);
-static_assert(!cuda::std::contiguous_iterator<no_operator_arrow</*DisableArrow=*/true, /*DisableToAddress=*/true>>);
-static_assert(cuda::std::contiguous_iterator<no_operator_arrow</*DisableArrow=*/true, /*DisableToAddress=*/false>>);
+static_assert(cuda::std::contiguous_iterator<no_operator_arrow</*DisableArrow=*/false, /*DisableToAddress=*/true>>, "");
+static_assert(!cuda::std::contiguous_iterator<no_operator_arrow</*DisableArrow=*/true, /*DisableToAddress=*/true>>, "");
+static_assert(cuda::std::contiguous_iterator<no_operator_arrow</*DisableArrow=*/true, /*DisableToAddress=*/false>>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/random_access_iterator.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.access/random_access_iterator.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class T>
 // concept random_access_iterator;
@@ -17,18 +17,18 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-static_assert(!cuda::std::random_access_iterator<cpp17_input_iterator<int*>>);
-static_assert(!cuda::std::random_access_iterator<cpp20_input_iterator<int*>>);
-static_assert(!cuda::std::random_access_iterator<forward_iterator<int*>>);
-static_assert(!cuda::std::random_access_iterator<bidirectional_iterator<int*>>);
-static_assert(cuda::std::random_access_iterator<random_access_iterator<int*>>);
-static_assert(cuda::std::random_access_iterator<contiguous_iterator<int*>>);
+static_assert(!cuda::std::random_access_iterator<cpp17_input_iterator<int*>>, "");
+static_assert(!cuda::std::random_access_iterator<cpp20_input_iterator<int*>>, "");
+static_assert(!cuda::std::random_access_iterator<forward_iterator<int*>>, "");
+static_assert(!cuda::std::random_access_iterator<bidirectional_iterator<int*>>, "");
+static_assert(cuda::std::random_access_iterator<random_access_iterator<int*>>, "");
+static_assert(cuda::std::random_access_iterator<contiguous_iterator<int*>>, "");
 
 #ifndef TEST_COMPILER_MSVC_2017
-static_assert(cuda::std::random_access_iterator<int*>);
-static_assert(cuda::std::random_access_iterator<int const*>);
-static_assert(cuda::std::random_access_iterator<int volatile*>);
-static_assert(cuda::std::random_access_iterator<int const volatile*>);
+static_assert(cuda::std::random_access_iterator<int*>, "");
+static_assert(cuda::std::random_access_iterator<int const*>, "");
+static_assert(cuda::std::random_access_iterator<int volatile*>, "");
+static_assert(cuda::std::random_access_iterator<int const volatile*>, "");
 #endif // TEST_COMPILER_MSVC_2017
 
 struct wrong_iterator_category
@@ -87,8 +87,8 @@ struct wrong_iterator_category
 
   __host__ __device__ reference operator[](difference_type n) const;
 };
-static_assert(cuda::std::bidirectional_iterator<wrong_iterator_category>);
-static_assert(!cuda::std::random_access_iterator<wrong_iterator_category>);
+static_assert(cuda::std::bidirectional_iterator<wrong_iterator_category>, "");
+static_assert(!cuda::std::random_access_iterator<wrong_iterator_category>, "");
 
 template <class Child>
 struct common_base
@@ -174,8 +174,8 @@ struct simple_random_access_iterator : common_base<simple_random_access_iterator
   };
 #endif
 };
-static_assert(cuda::std::bidirectional_iterator<simple_random_access_iterator>);
-static_assert(cuda::std::random_access_iterator<simple_random_access_iterator>);
+static_assert(cuda::std::bidirectional_iterator<simple_random_access_iterator>, "");
+static_assert(cuda::std::random_access_iterator<simple_random_access_iterator>, "");
 
 struct no_plus_equals : common_base<no_plus_equals>
 {
@@ -215,8 +215,8 @@ struct no_plus_equals : common_base<no_plus_equals>
   };
 #endif
 };
-static_assert(cuda::std::bidirectional_iterator<no_plus_equals>);
-static_assert(!cuda::std::random_access_iterator<no_plus_equals>);
+static_assert(cuda::std::bidirectional_iterator<no_plus_equals>, "");
+static_assert(!cuda::std::random_access_iterator<no_plus_equals>, "");
 
 struct no_plus_difference_type : common_base<no_plus_difference_type>
 {
@@ -256,8 +256,8 @@ struct no_plus_difference_type : common_base<no_plus_difference_type>
   };
 #endif
 };
-static_assert(cuda::std::bidirectional_iterator<no_plus_difference_type>);
-static_assert(!cuda::std::random_access_iterator<no_plus_difference_type>);
+static_assert(cuda::std::bidirectional_iterator<no_plus_difference_type>, "");
+static_assert(!cuda::std::random_access_iterator<no_plus_difference_type>, "");
 
 struct difference_type_no_plus : common_base<difference_type_no_plus>
 {
@@ -297,8 +297,8 @@ struct difference_type_no_plus : common_base<difference_type_no_plus>
   };
 #endif
 };
-static_assert(cuda::std::bidirectional_iterator<difference_type_no_plus>);
-static_assert(!cuda::std::random_access_iterator<difference_type_no_plus>);
+static_assert(cuda::std::bidirectional_iterator<difference_type_no_plus>, "");
+static_assert(!cuda::std::random_access_iterator<difference_type_no_plus>, "");
 
 struct no_minus_equals : common_base<no_minus_equals>
 {
@@ -338,8 +338,8 @@ struct no_minus_equals : common_base<no_minus_equals>
   };
 #endif
 };
-static_assert(cuda::std::bidirectional_iterator<no_minus_equals>);
-static_assert(!cuda::std::random_access_iterator<no_minus_equals>);
+static_assert(cuda::std::bidirectional_iterator<no_minus_equals>, "");
+static_assert(!cuda::std::random_access_iterator<no_minus_equals>, "");
 
 struct no_minus : common_base<no_minus>
 {
@@ -379,8 +379,8 @@ struct no_minus : common_base<no_minus>
   };
 #endif
 };
-static_assert(cuda::std::bidirectional_iterator<no_minus>);
-static_assert(!cuda::std::random_access_iterator<no_minus>);
+static_assert(cuda::std::bidirectional_iterator<no_minus>, "");
+static_assert(!cuda::std::random_access_iterator<no_minus>, "");
 
 struct not_sized_sentinel : common_base<not_sized_sentinel>
 {
@@ -420,8 +420,8 @@ struct not_sized_sentinel : common_base<not_sized_sentinel>
   };
 #endif
 };
-static_assert(cuda::std::bidirectional_iterator<not_sized_sentinel>);
-static_assert(!cuda::std::random_access_iterator<not_sized_sentinel>);
+static_assert(cuda::std::bidirectional_iterator<not_sized_sentinel>, "");
+static_assert(!cuda::std::random_access_iterator<not_sized_sentinel>, "");
 
 struct no_subscript : common_base<no_subscript>
 {
@@ -461,8 +461,8 @@ struct no_subscript : common_base<no_subscript>
   };
 #endif
 };
-static_assert(cuda::std::bidirectional_iterator<no_subscript>);
-static_assert(!cuda::std::random_access_iterator<no_subscript>);
+static_assert(cuda::std::bidirectional_iterator<no_subscript>, "");
+static_assert(!cuda::std::random_access_iterator<no_subscript>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.readable/indirectly_readable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.readable/indirectly_readable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class In>
 // concept indirectly_readable;
@@ -21,32 +21,32 @@ template <class In>
 __host__ __device__ constexpr bool check_indirectly_readable()
 {
   constexpr bool result = cuda::std::indirectly_readable<In>;
-  static_assert(cuda::std::indirectly_readable<In const> == result);
-  static_assert(cuda::std::indirectly_readable<In volatile> == result);
-  static_assert(cuda::std::indirectly_readable<In const volatile> == result);
-  static_assert(cuda::std::indirectly_readable<In const&> == result);
-  static_assert(cuda::std::indirectly_readable<In volatile&> == result);
-  static_assert(cuda::std::indirectly_readable<In const volatile&> == result);
-  static_assert(cuda::std::indirectly_readable<In const&&> == result);
-  static_assert(cuda::std::indirectly_readable<In volatile&&> == result);
-  static_assert(cuda::std::indirectly_readable<In const volatile&&> == result);
+  static_assert(cuda::std::indirectly_readable<In const> == result, "");
+  static_assert(cuda::std::indirectly_readable<In volatile> == result, "");
+  static_assert(cuda::std::indirectly_readable<In const volatile> == result, "");
+  static_assert(cuda::std::indirectly_readable<In const&> == result, "");
+  static_assert(cuda::std::indirectly_readable<In volatile&> == result, "");
+  static_assert(cuda::std::indirectly_readable<In const volatile&> == result, "");
+  static_assert(cuda::std::indirectly_readable<In const&&> == result, "");
+  static_assert(cuda::std::indirectly_readable<In volatile&&> == result, "");
+  static_assert(cuda::std::indirectly_readable<In const volatile&&> == result, "");
   return result;
 }
 
-static_assert(!check_indirectly_readable<void*>());
-static_assert(!check_indirectly_readable<void const*>());
-static_assert(!check_indirectly_readable<void volatile*>());
-static_assert(!check_indirectly_readable<void const volatile*>());
+static_assert(!check_indirectly_readable<void*>(), "");
+static_assert(!check_indirectly_readable<void const*>(), "");
+static_assert(!check_indirectly_readable<void volatile*>(), "");
+static_assert(!check_indirectly_readable<void const volatile*>(), "");
 
-static_assert(check_indirectly_readable<int*>());
-static_assert(check_indirectly_readable<int const*>());
-static_assert(check_indirectly_readable<int volatile*>());
-static_assert(check_indirectly_readable<int const volatile*>());
+static_assert(check_indirectly_readable<int*>(), "");
+static_assert(check_indirectly_readable<int const*>(), "");
+static_assert(check_indirectly_readable<int volatile*>(), "");
+static_assert(check_indirectly_readable<int const volatile*>(), "");
 
-static_assert(check_indirectly_readable<value_type_indirection>());
-static_assert(check_indirectly_readable<element_type_indirection>());
-static_assert(check_indirectly_readable<proxy_indirection>());
-static_assert(check_indirectly_readable<read_only_indirection>());
+static_assert(check_indirectly_readable<value_type_indirection>(), "");
+static_assert(check_indirectly_readable<element_type_indirection>(), "");
+static_assert(check_indirectly_readable<proxy_indirection>(), "");
+static_assert(check_indirectly_readable<read_only_indirection>(), "");
 
 struct indirection_mismatch
 {
@@ -55,8 +55,9 @@ struct indirection_mismatch
 };
 static_assert(
   !cuda::std::same_as<cuda::std::iter_value_t<indirection_mismatch>, cuda::std::iter_reference_t<indirection_mismatch>>
-  && check_indirectly_readable<indirection_mismatch>());
-static_assert(!check_indirectly_readable<missing_dereference>());
+    && check_indirectly_readable<indirection_mismatch>(),
+  "");
+static_assert(!check_indirectly_readable<missing_dereference>(), "");
 
 // `iter_rvalue_reference_t` can't be missing unless the dereference operator is also missing.
 
@@ -67,7 +68,7 @@ struct iter_move_mismatch
 
   __host__ __device__ friend float& iter_move(iter_move_mismatch&);
 };
-static_assert(!check_indirectly_readable<iter_move_mismatch>());
+static_assert(!check_indirectly_readable<iter_move_mismatch>(), "");
 
 struct indirection_and_iter_move_mismatch
 {
@@ -76,13 +77,13 @@ struct indirection_and_iter_move_mismatch
 
   __host__ __device__ friend unsigned long long& iter_move(indirection_and_iter_move_mismatch&);
 };
-static_assert(!check_indirectly_readable<indirection_and_iter_move_mismatch>());
+static_assert(!check_indirectly_readable<indirection_and_iter_move_mismatch>(), "");
 
 struct missing_iter_value_t
 {
   __host__ __device__ int operator*() const;
 };
-static_assert(!check_indirectly_readable<missing_iter_value_t>());
+static_assert(!check_indirectly_readable<missing_iter_value_t>(), "");
 
 struct unrelated_lvalue_ref_and_rvalue_ref
 {};
@@ -102,14 +103,14 @@ struct common_reference<iter_ref1&&, iter_ref1&>
 {};
 } // namespace std
 } // namespace cuda
-static_assert(!cuda::std::common_reference_with<iter_ref1&, iter_ref1&&>);
+static_assert(!cuda::std::common_reference_with<iter_ref1&, iter_ref1&&>, "");
 
 struct bad_iter_reference_t
 {
   using value_type = int;
   __host__ __device__ iter_ref1& operator*() const;
 };
-static_assert(!check_indirectly_readable<bad_iter_reference_t>());
+static_assert(!check_indirectly_readable<bad_iter_reference_t>(), "");
 
 struct iter_ref2
 {};
@@ -122,7 +123,7 @@ struct unrelated_iter_ref_rvalue_and_iter_rvalue_ref_rvalue
   __host__ __device__ iter_ref2& operator*() const;
   __host__ __device__ friend iter_rvalue_ref&& iter_move(unrelated_iter_ref_rvalue_and_iter_rvalue_ref_rvalue);
 };
-static_assert(!check_indirectly_readable<unrelated_iter_ref_rvalue_and_iter_rvalue_ref_rvalue>());
+static_assert(!check_indirectly_readable<unrelated_iter_ref_rvalue_and_iter_rvalue_ref_rvalue>(), "");
 
 struct iter_ref3
 {
@@ -144,7 +145,7 @@ struct basic_common_reference<iter_rvalue_ref, iter_ref3, XQual, YQual>
 };
 } // namespace std
 } // namespace cuda
-static_assert(cuda::std::common_reference_with<iter_ref3&&, iter_rvalue_ref&&>);
+static_assert(cuda::std::common_reference_with<iter_ref3&&, iter_rvalue_ref&&>, "");
 
 struct different_reference_types_with_common_reference
 {
@@ -152,7 +153,7 @@ struct different_reference_types_with_common_reference
   __host__ __device__ iter_ref3& operator*() const;
   __host__ __device__ friend iter_rvalue_ref&& iter_move(different_reference_types_with_common_reference);
 };
-static_assert(check_indirectly_readable<different_reference_types_with_common_reference>());
+static_assert(check_indirectly_readable<different_reference_types_with_common_reference>(), "");
 
 struct iter_ref4
 {
@@ -181,8 +182,8 @@ struct common_reference<iter_rvalue_ref&&, iter_ref4 const&>
 {};
 } // namespace std
 } // namespace cuda
-static_assert(cuda::std::common_reference_with<iter_ref4&&, iter_rvalue_ref&&>);
-static_assert(!cuda::std::common_reference_with<iter_ref4 const&, iter_rvalue_ref&&>);
+static_assert(cuda::std::common_reference_with<iter_ref4&&, iter_rvalue_ref&&>, "");
+static_assert(!cuda::std::common_reference_with<iter_ref4 const&, iter_rvalue_ref&&>, "");
 
 struct different_reference_types_without_common_reference_to_const
 {
@@ -190,20 +191,20 @@ struct different_reference_types_without_common_reference_to_const
   __host__ __device__ iter_ref4& operator*() const;
   __host__ __device__ friend iter_rvalue_ref&& iter_move(different_reference_types_without_common_reference_to_const);
 };
-static_assert(!check_indirectly_readable<different_reference_types_without_common_reference_to_const>());
+static_assert(!check_indirectly_readable<different_reference_types_without_common_reference_to_const>(), "");
 
 struct non_const_deref
 {
   __host__ __device__ int& operator*();
 };
-static_assert(!check_indirectly_readable<non_const_deref>());
+static_assert(!check_indirectly_readable<non_const_deref>(), "");
 
 struct not_referenceable
 {
   using value_type = void;
   __host__ __device__ void operator*() const;
 };
-static_assert(!cuda::std::indirectly_readable<not_referenceable>);
+static_assert(!cuda::std::indirectly_readable<not_referenceable>, "");
 
 struct legacy_output_iterator
 {
@@ -211,30 +212,30 @@ struct legacy_output_iterator
   __host__ __device__ legacy_output_iterator& operator*();
 };
 
-static_assert(!cuda::std::indirectly_readable<legacy_output_iterator>);
+static_assert(!cuda::std::indirectly_readable<legacy_output_iterator>, "");
 
 struct S
 {};
-static_assert(!cuda::std::indirectly_readable<S>);
-static_assert(!cuda::std::indirectly_readable<int S::*>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)()>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() noexcept>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() &>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() & noexcept>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() &&>);
-static_assert(!cuda::std::indirectly_readable < int(S::*)() && noexcept >);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() const>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() const noexcept>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() const&>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() const & noexcept>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() const&&>);
-static_assert(!cuda::std::indirectly_readable < int(S::*)() const&& noexcept >);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile noexcept>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile&>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile & noexcept>);
-static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile&&>);
-static_assert(!cuda::std::indirectly_readable < int(S::*)() volatile && noexcept >);
+static_assert(!cuda::std::indirectly_readable<S>, "");
+static_assert(!cuda::std::indirectly_readable<int S::*>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)()>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() noexcept>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() &>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() & noexcept>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() &&>, "");
+static_assert(!cuda::std::indirectly_readable < int(S::*)() && noexcept >, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() const>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() const noexcept>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() const&>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() const & noexcept>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() const&&>, "");
+static_assert(!cuda::std::indirectly_readable < int(S::*)() const&& noexcept >, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile noexcept>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile&>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile & noexcept>, "");
+static_assert(!cuda::std::indirectly_readable<int (S::*)() volatile&&>, "");
+static_assert(!cuda::std::indirectly_readable < int(S::*)() volatile && noexcept >, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.readable/iter_common_reference_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.readable/iter_common_reference_t.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // iter_common_reference_t
 
@@ -23,7 +23,7 @@ struct T1
   using value_type = X;
   __host__ __device__ X operator*() const;
 };
-static_assert(cuda::std::same_as<cuda::std::iter_common_reference_t<T1>, X>);
+static_assert(cuda::std::same_as<cuda::std::iter_common_reference_t<T1>, X>, "");
 
 // value_type and dereferencing are the same (modulo qualifiers)
 struct T2
@@ -31,7 +31,7 @@ struct T2
   using value_type = X;
   __host__ __device__ X& operator*() const;
 };
-static_assert(cuda::std::same_as<cuda::std::iter_common_reference_t<T2>, X&>);
+static_assert(cuda::std::same_as<cuda::std::iter_common_reference_t<T2>, X&>, "");
 
 // There's a custom common reference between value_type and the type of dereferencing
 struct A
@@ -43,21 +43,28 @@ struct Common
   __host__ __device__ Common(A);
   __host__ __device__ Common(B);
 };
+
+namespace cuda
+{
+namespace std
+{
 template <template <class> class TQual, template <class> class QQual>
-struct cuda::std::basic_common_reference<A, B, TQual, QQual>
+struct basic_common_reference<A, B, TQual, QQual>
 {
   using type = Common;
 };
 template <template <class> class TQual, template <class> class QQual>
-struct cuda::std::basic_common_reference<B, A, TQual, QQual> : cuda::std::basic_common_reference<A, B, TQual, QQual>
+struct basic_common_reference<B, A, TQual, QQual> : basic_common_reference<A, B, TQual, QQual>
 {};
+} // namespace std
+} // namespace cuda
 
 struct T3
 {
   using value_type = A;
   __host__ __device__ B&& operator*() const;
 };
-static_assert(cuda::std::same_as<cuda::std::iter_common_reference_t<T3>, Common>);
+static_assert(cuda::std::same_as<cuda::std::iter_common_reference_t<T3>, Common>, "");
 
 // Make sure we're SFINAE-friendly
 #if TEST_STD_VER > 2017
@@ -72,7 +79,7 @@ _CCCL_CONCEPT has_common_reference = _CCCL_FRAGMENT(has_common_reference_, T);
 #endif
 struct NotIndirectlyReadable
 {};
-static_assert(!has_common_reference<NotIndirectlyReadable>);
+static_assert(!has_common_reference<NotIndirectlyReadable>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.sentinel/sentinel_for.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.sentinel/sentinel_for.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class S, class I>
 // concept sentinel_for;
@@ -16,8 +16,8 @@
 
 #include "test_macros.h"
 
-static_assert(cuda::std::sentinel_for<int*, int*>);
-static_assert(!cuda::std::sentinel_for<int*, long*>);
+static_assert(cuda::std::sentinel_for<int*, int*>, "");
+static_assert(!cuda::std::sentinel_for<int*, long*>, "");
 struct nth_element_sentinel
 {
   __host__ __device__ friend bool operator==(const nth_element_sentinel&, int*);
@@ -25,7 +25,7 @@ struct nth_element_sentinel
   __host__ __device__ friend bool operator!=(const nth_element_sentinel&, int*);
   __host__ __device__ friend bool operator!=(int*, const nth_element_sentinel&);
 };
-static_assert(cuda::std::sentinel_for<nth_element_sentinel, int*>);
+static_assert(cuda::std::sentinel_for<nth_element_sentinel, int*>, "");
 
 struct not_semiregular
 {
@@ -35,7 +35,7 @@ struct not_semiregular
   __host__ __device__ friend bool operator!=(const not_semiregular&, int*);
   __host__ __device__ friend bool operator!=(int*, const not_semiregular&);
 };
-static_assert(!cuda::std::sentinel_for<not_semiregular, int*>);
+static_assert(!cuda::std::sentinel_for<not_semiregular, int*>, "");
 
 struct weakly_equality_comparable_with_int
 {
@@ -44,7 +44,7 @@ struct weakly_equality_comparable_with_int
   __host__ __device__ friend bool operator!=(const weakly_equality_comparable_with_int&, int*);
   __host__ __device__ friend bool operator!=(int*, const weakly_equality_comparable_with_int&);
 };
-static_assert(!cuda::std::sentinel_for<weakly_equality_comparable_with_int, int>);
+static_assert(!cuda::std::sentinel_for<weakly_equality_comparable_with_int, int>, "");
 
 struct move_only_iterator
 {
@@ -69,8 +69,9 @@ struct move_only_iterator
 
 #ifndef TEST_COMPILER_MSVC_2017
 static_assert(cuda::std::movable<move_only_iterator> && !cuda::std::copyable<move_only_iterator>
-              && cuda::std::input_or_output_iterator<move_only_iterator>
-              && !cuda::std::sentinel_for<move_only_iterator, move_only_iterator>);
+                && cuda::std::input_or_output_iterator<move_only_iterator>
+                && !cuda::std::sentinel_for<move_only_iterator, move_only_iterator>,
+              "");
 #endif // TEST_COMPILER_MSVC_2017
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.sentinel/sentinel_for.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.sentinel/sentinel_for.subsumption.compile.pass.cpp
@@ -28,7 +28,7 @@ __host__ __device__ constexpr bool check_subsumption() {
 }
 // clang-format on
 
-static_assert(check_subsumption<cuda::std::array<int, 4>::iterator, cuda::std::array<int, 4>::iterator>());
+static_assert(check_subsumption<cuda::std::array<int, 4>::iterator, cuda::std::array<int, 4>::iterator>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.sentinel/sized_sentinel_for.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.sentinel/sized_sentinel_for.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // [iterator.concept.sizedsentinel], concept sized_sentinel_for
 //
@@ -24,8 +24,8 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-static_assert(cuda::std::sized_sentinel_for<random_access_iterator<int*>, random_access_iterator<int*>>);
-static_assert(!cuda::std::sized_sentinel_for<bidirectional_iterator<int*>, bidirectional_iterator<int*>>);
+static_assert(cuda::std::sized_sentinel_for<random_access_iterator<int*>, random_access_iterator<int*>>, "");
+static_assert(!cuda::std::sized_sentinel_for<bidirectional_iterator<int*>, bidirectional_iterator<int*>>, "");
 
 struct int_sized_sentinel
 {
@@ -40,9 +40,9 @@ struct int_sized_sentinel
   __host__ __device__ friend cuda::std::ptrdiff_t operator-(int_sized_sentinel, int*);
   __host__ __device__ friend cuda::std::ptrdiff_t operator-(int*, int_sized_sentinel);
 };
-static_assert(cuda::std::sized_sentinel_for<int_sized_sentinel, int*>);
+static_assert(cuda::std::sized_sentinel_for<int_sized_sentinel, int*>, "");
 // int_sized_sentinel is not an iterator.
-static_assert(!cuda::std::sized_sentinel_for<int*, int_sized_sentinel>);
+static_assert(!cuda::std::sized_sentinel_for<int*, int_sized_sentinel>, "");
 
 struct no_default_ctor
 {
@@ -67,7 +67,7 @@ struct no_default_ctor
   __host__ __device__ friend cuda::std::ptrdiff_t operator-(no_default_ctor, int*);
   __host__ __device__ friend cuda::std::ptrdiff_t operator-(int*, no_default_ctor);
 };
-static_assert(!cuda::std::sized_sentinel_for<no_default_ctor, int*>);
+static_assert(!cuda::std::sized_sentinel_for<no_default_ctor, int*>, "");
 
 struct not_copyable
 {
@@ -93,7 +93,7 @@ struct not_copyable
   __host__ __device__ friend cuda::std::ptrdiff_t operator-(not_copyable, int*);
   __host__ __device__ friend cuda::std::ptrdiff_t operator-(int*, not_copyable);
 };
-static_assert(!cuda::std::sized_sentinel_for<not_copyable, int*>);
+static_assert(!cuda::std::sized_sentinel_for<not_copyable, int*>, "");
 
 struct double_sized_sentinel
 {
@@ -101,10 +101,17 @@ struct double_sized_sentinel
   __host__ __device__ friend int operator-(double_sized_sentinel, double*);
   __host__ __device__ friend int operator-(double*, double_sized_sentinel);
 };
-template <>
-inline constexpr bool cuda::std::disable_sized_sentinel_for<double_sized_sentinel, double*> = true;
 
-static_assert(!cuda::std::sized_sentinel_for<double_sized_sentinel, double*>);
+namespace cuda
+{
+namespace std
+{
+template <>
+_CCCL_INLINE_VAR constexpr bool disable_sized_sentinel_for<double_sized_sentinel, double*> = true;
+}
+} // namespace cuda
+
+static_assert(!cuda::std::sized_sentinel_for<double_sized_sentinel, double*>, "");
 
 struct only_one_sub_op
 {
@@ -113,7 +120,7 @@ struct only_one_sub_op
   template <class It, cuda::std::enable_if_t<cuda::std::input_or_output_iterator<It>, int>>
   __host__ __device__ friend cuda::std::ptrdiff_t operator-(only_one_sub_op, It);
 };
-static_assert(!cuda::std::sized_sentinel_for<only_one_sub_op, int*>);
+static_assert(!cuda::std::sized_sentinel_for<only_one_sub_op, int*>, "");
 
 struct wrong_return_type
 {
@@ -124,13 +131,13 @@ struct wrong_return_type
   template <class It, cuda::std::enable_if_t<cuda::std::input_or_output_iterator<It>, int>>
   __host__ __device__ friend void operator-(It, wrong_return_type);
 };
-static_assert(!cuda::std::sized_sentinel_for<wrong_return_type, int*>);
+static_assert(!cuda::std::sized_sentinel_for<wrong_return_type, int*>, "");
 
 // Standard types
-static_assert(cuda::std::sized_sentinel_for<int*, int*>);
-static_assert(cuda::std::sized_sentinel_for<const int*, int*>);
-static_assert(cuda::std::sized_sentinel_for<const int*, const int*>);
-static_assert(cuda::std::sized_sentinel_for<int*, const int*>);
+static_assert(cuda::std::sized_sentinel_for<int*, int*>, "");
+static_assert(cuda::std::sized_sentinel_for<const int*, int*>, "");
+static_assert(cuda::std::sized_sentinel_for<const int*, const int*>, "");
+static_assert(cuda::std::sized_sentinel_for<int*, const int*>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.winc/weakly_incrementable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.winc/weakly_incrementable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class In>
 // concept cuda::std::weakly_incrementable;
@@ -18,31 +18,31 @@
 #include "../incrementable.h"
 #include "test_macros.h"
 
-static_assert(cuda::std::weakly_incrementable<int>);
-static_assert(cuda::std::weakly_incrementable<int*>);
-static_assert(cuda::std::weakly_incrementable<int**>);
-static_assert(!cuda::std::weakly_incrementable<int[]>);
-static_assert(!cuda::std::weakly_incrementable<int[10]>);
-static_assert(!cuda::std::weakly_incrementable<double>);
-static_assert(!cuda::std::weakly_incrementable<int&>);
-static_assert(!cuda::std::weakly_incrementable<int()>);
-static_assert(!cuda::std::weakly_incrementable<int (*)()>);
-static_assert(!cuda::std::weakly_incrementable<int (&)()>);
+static_assert(cuda::std::weakly_incrementable<int>, "");
+static_assert(cuda::std::weakly_incrementable<int*>, "");
+static_assert(cuda::std::weakly_incrementable<int**>, "");
+static_assert(!cuda::std::weakly_incrementable<int[]>, "");
+static_assert(!cuda::std::weakly_incrementable<int[10]>, "");
+static_assert(!cuda::std::weakly_incrementable<double>, "");
+static_assert(!cuda::std::weakly_incrementable<int&>, "");
+static_assert(!cuda::std::weakly_incrementable<int()>, "");
+static_assert(!cuda::std::weakly_incrementable<int (*)()>, "");
+static_assert(!cuda::std::weakly_incrementable<int (&)()>, "");
 #ifndef TEST_COMPILER_GCC
-static_assert(!cuda::std::weakly_incrementable<bool>);
+static_assert(!cuda::std::weakly_incrementable<bool>, "");
 #endif
 
 struct S
 {};
-static_assert(!cuda::std::weakly_incrementable<int S::*>);
+static_assert(!cuda::std::weakly_incrementable<int S::*>, "");
 
-#define CHECK_POINTER_TO_MEMBER_FUNCTIONS(qualifier)                                  \
-  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier>);            \
-  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier noexcept>);   \
-  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier&>);           \
-  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier & noexcept>); \
-  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier&&>);          \
-  static_assert(!cuda::std::weakly_incrementable < int(S::*)() qualifier && noexcept >);
+#define CHECK_POINTER_TO_MEMBER_FUNCTIONS(qualifier)                                      \
+  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier>, "");            \
+  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier noexcept>, "");   \
+  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier&>, "");           \
+  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier & noexcept>, ""); \
+  static_assert(!cuda::std::weakly_incrementable<int (S::*)() qualifier&&>, "");          \
+  static_assert(!cuda::std::weakly_incrementable < int(S::*)() qualifier && noexcept >, "");
 
 #define NO_QUALIFIER
 CHECK_POINTER_TO_MEMBER_FUNCTIONS(NO_QUALIFIER);
@@ -50,26 +50,26 @@ CHECK_POINTER_TO_MEMBER_FUNCTIONS(const);
 CHECK_POINTER_TO_MEMBER_FUNCTIONS(volatile);
 CHECK_POINTER_TO_MEMBER_FUNCTIONS(const volatile);
 
-static_assert(cuda::std::weakly_incrementable<postfix_increment_returns_void>);
-static_assert(cuda::std::weakly_incrementable<postfix_increment_returns_copy>);
-static_assert(cuda::std::weakly_incrementable<has_integral_minus>);
-static_assert(cuda::std::weakly_incrementable<has_distinct_difference_type_and_minus>);
-static_assert(!cuda::std::weakly_incrementable<missing_difference_type>);
-static_assert(!cuda::std::weakly_incrementable<floating_difference_type>);
-static_assert(!cuda::std::weakly_incrementable<non_const_minus>);
-static_assert(!cuda::std::weakly_incrementable<non_integral_minus>);
-static_assert(!cuda::std::weakly_incrementable<bad_difference_type_good_minus>);
-static_assert(!cuda::std::weakly_incrementable<not_movable>);
-static_assert(!cuda::std::weakly_incrementable<preinc_not_declared>);
-static_assert(!cuda::std::weakly_incrementable<postinc_not_declared>);
-static_assert(cuda::std::weakly_incrementable<not_default_initializable>);
-static_assert(cuda::std::weakly_incrementable<incrementable_with_difference_type>);
-static_assert(cuda::std::weakly_incrementable<incrementable_without_difference_type>);
-static_assert(cuda::std::weakly_incrementable<difference_type_and_void_minus>);
+static_assert(cuda::std::weakly_incrementable<postfix_increment_returns_void>, "");
+static_assert(cuda::std::weakly_incrementable<postfix_increment_returns_copy>, "");
+static_assert(cuda::std::weakly_incrementable<has_integral_minus>, "");
+static_assert(cuda::std::weakly_incrementable<has_distinct_difference_type_and_minus>, "");
+static_assert(!cuda::std::weakly_incrementable<missing_difference_type>, "");
+static_assert(!cuda::std::weakly_incrementable<floating_difference_type>, "");
+static_assert(!cuda::std::weakly_incrementable<non_const_minus>, "");
+static_assert(!cuda::std::weakly_incrementable<non_integral_minus>, "");
+static_assert(!cuda::std::weakly_incrementable<bad_difference_type_good_minus>, "");
+static_assert(!cuda::std::weakly_incrementable<not_movable>, "");
+static_assert(!cuda::std::weakly_incrementable<preinc_not_declared>, "");
+static_assert(!cuda::std::weakly_incrementable<postinc_not_declared>, "");
+static_assert(cuda::std::weakly_incrementable<not_default_initializable>, "");
+static_assert(cuda::std::weakly_incrementable<incrementable_with_difference_type>, "");
+static_assert(cuda::std::weakly_incrementable<incrementable_without_difference_type>, "");
+static_assert(cuda::std::weakly_incrementable<difference_type_and_void_minus>, "");
 #ifndef TEST_COMPILER_MSVC_2017
-static_assert(cuda::std::weakly_incrementable<noncopyable_with_difference_type>);
-static_assert(cuda::std::weakly_incrementable<noncopyable_without_difference_type>);
-static_assert(cuda::std::weakly_incrementable<noncopyable_with_difference_type_and_minus>);
+static_assert(cuda::std::weakly_incrementable<noncopyable_with_difference_type>, "");
+static_assert(cuda::std::weakly_incrementable<noncopyable_without_difference_type>, "");
+static_assert(cuda::std::weakly_incrementable<noncopyable_with_difference_type_and_minus>, "");
 #endif // TEST_COMPILER_MSVC_2017
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.writable/indirectly_writable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.concepts/iterator.concept.writable/indirectly_writable.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class In>
 // concept indirectly_writable;
@@ -21,35 +21,35 @@ template <class Out, class T>
 __host__ __device__ constexpr bool check_indirectly_writable()
 {
   constexpr bool result = cuda::std::indirectly_writable<Out, T>;
-  static_assert(cuda::std::indirectly_writable<Out const, T> == result);
+  static_assert(cuda::std::indirectly_writable<Out const, T> == result, "");
   return result;
 }
 
-static_assert(check_indirectly_writable<value_type_indirection, int>());
-static_assert(check_indirectly_writable<value_type_indirection, double>());
-static_assert(!check_indirectly_writable<value_type_indirection, double*>());
+static_assert(check_indirectly_writable<value_type_indirection, int>(), "");
+static_assert(check_indirectly_writable<value_type_indirection, double>(), "");
+static_assert(!check_indirectly_writable<value_type_indirection, double*>(), "");
 
-static_assert(!check_indirectly_writable<read_only_indirection, int>());
-static_assert(!check_indirectly_writable<proxy_indirection, int>());
+static_assert(!check_indirectly_writable<read_only_indirection, int>(), "");
+static_assert(!check_indirectly_writable<proxy_indirection, int>(), "");
 
-static_assert(!check_indirectly_writable<int, int>());
-static_assert(!check_indirectly_writable<missing_dereference, missing_dereference::value_type>());
+static_assert(!check_indirectly_writable<int, int>(), "");
+static_assert(!check_indirectly_writable<missing_dereference, missing_dereference::value_type>(), "");
 
-static_assert(!check_indirectly_writable<void*, int>());
-static_assert(!check_indirectly_writable<void const*, int>());
-static_assert(!check_indirectly_writable<void volatile*, int>());
-static_assert(!check_indirectly_writable<void const volatile*, int>());
-static_assert(!check_indirectly_writable<void*, double>());
-static_assert(check_indirectly_writable<void**, int*>());
-static_assert(!check_indirectly_writable<void**, int>());
+static_assert(!check_indirectly_writable<void*, int>(), "");
+static_assert(!check_indirectly_writable<void const*, int>(), "");
+static_assert(!check_indirectly_writable<void volatile*, int>(), "");
+static_assert(!check_indirectly_writable<void const volatile*, int>(), "");
+static_assert(!check_indirectly_writable<void*, double>(), "");
+static_assert(check_indirectly_writable<void**, int*>(), "");
+static_assert(!check_indirectly_writable<void**, int>(), "");
 
-static_assert(check_indirectly_writable<int*, int>());
-static_assert(!check_indirectly_writable<int const*, int>());
-static_assert(check_indirectly_writable<int volatile*, int>());
-static_assert(!check_indirectly_writable<int const volatile*, int>());
-static_assert(check_indirectly_writable<int*, double>());
-static_assert(check_indirectly_writable<int**, int*>());
-static_assert(!check_indirectly_writable<int**, int>());
+static_assert(check_indirectly_writable<int*, int>(), "");
+static_assert(!check_indirectly_writable<int const*, int>(), "");
+static_assert(check_indirectly_writable<int volatile*, int>(), "");
+static_assert(!check_indirectly_writable<int const volatile*, int>(), "");
+static_assert(check_indirectly_writable<int*, double>(), "");
+static_assert(check_indirectly_writable<int**, int*>(), "");
+static_assert(!check_indirectly_writable<int**, int>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.nodiscard.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.nodiscard.verify.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: LIBCUDACXX-has-no-incomplete-ranges
 
 // Test the [[nodiscard]] extension in libc++.

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_move.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class I>
 // unspecified iter_move;
@@ -240,12 +240,12 @@ __host__ __device__ constexpr bool test()
   assert(!noexcept(cuda::std::ranges::iter_move(some_union)));
 
   // Check noexcept-correctness
-  static_assert(noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithADL<true>>())));
-  static_assert(noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithoutADL<true>>())));
+  static_assert(noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithADL<true>>())), "");
+  static_assert(noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithoutADL<true>>())), "");
 // old GCC seems to fall over the chaining of the noexcept clauses here
 #  if (!defined(TEST_COMPILER_GCC) || __GNUC__ >= 9)
-  static_assert(!noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithADL<false>>())));
-  static_assert(!noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithoutADL<false>>())));
+  static_assert(!noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithADL<false>>())), "");
+  static_assert(!noexcept(cuda::std::ranges::iter_move(cuda::std::declval<WithoutADL<false>>())), "");
 #  endif
 #endif // TEST_COMPILER_ICC
 
@@ -253,8 +253,8 @@ __host__ __device__ constexpr bool test()
 }
 
 #if _CCCL_CUDACC_AT_LEAST(11, 3) // nvcc segfaults here
-static_assert(!cuda::std::is_invocable_v<IterMoveT, int*, int*>); // too many arguments
-static_assert(!cuda::std::is_invocable_v<IterMoveT, int>);
+static_assert(!cuda::std::is_invocable_v<IterMoveT, int*, int*>, ""); // too many arguments
+static_assert(!cuda::std::is_invocable_v<IterMoveT, int>, "");
 #endif // _CCCL_CUDACC_AT_LEAST(11, 3)
 
 #if TEST_STD_VER > 2017
@@ -265,14 +265,14 @@ struct Holder
 {
   T t;
 };
-static_assert(cuda::std::is_invocable_v<IterMoveT, Holder<Incomplete>**>);
-static_assert(cuda::std::is_invocable_v<IterMoveT, Holder<Incomplete>**&>);
+static_assert(cuda::std::is_invocable_v<IterMoveT, Holder<Incomplete>**>, "");
+static_assert(cuda::std::is_invocable_v<IterMoveT, Holder<Incomplete>**&>, "");
 #endif
 
 int main(int, char**)
 {
   test();
-  static_assert(test());
+  static_assert(test(), "");
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_rvalue_reference_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.move/iter_rvalue_reference_t.compile.pass.cpp
@@ -7,15 +7,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class I>
 // using iter_rvalue_reference;
 
 #include <cuda/std/iterator>
 
-static_assert(cuda::std::same_as<cuda::std::iter_rvalue_reference_t<int*>, int&&>);
-static_assert(cuda::std::same_as<cuda::std::iter_rvalue_reference_t<const int*>, const int&&>);
+static_assert(cuda::std::same_as<cuda::std::iter_rvalue_reference_t<int*>, int&&>, "");
+static_assert(cuda::std::same_as<cuda::std::iter_rvalue_reference_t<const int*>, const int&&>, "");
 
 __host__ __device__ void test_undefined_internal()
 {
@@ -23,7 +23,7 @@ __host__ __device__ void test_undefined_internal()
   {
     __host__ __device__ int& operator*() const;
   };
-  static_assert(cuda::std::same_as<cuda::std::iter_rvalue_reference_t<A>, int&&>);
+  static_assert(cuda::std::same_as<cuda::std::iter_rvalue_reference_t<A>, int&&>, "");
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 
 // template<class I>
 // unspecified iter_swap;
@@ -44,17 +44,17 @@ struct HasIterSwap
 };
 
 #if !defined(TEST_COMPILER_CUDACC_BELOW_11_3) && !defined(TEST_COMPILER_MSVC_2017) // nvcc segfaults here
-static_assert(cuda::std::is_invocable_v<IterSwapT, HasIterSwap&, HasIterSwap&>);
-static_assert(cuda::std::is_invocable_v<IterSwapT, HasIterSwap&, int&>);
-static_assert(!cuda::std::is_invocable_v<IterSwapT, int&, HasIterSwap&>);
+static_assert(cuda::std::is_invocable_v<IterSwapT, HasIterSwap&, HasIterSwap&>, "");
+static_assert(cuda::std::is_invocable_v<IterSwapT, HasIterSwap&, int&>, "");
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int&, HasIterSwap&>, "");
 
-static_assert(cuda::std::is_invocable_v<IterSwapT&, HasIterSwap&, HasIterSwap&>);
-static_assert(cuda::std::is_invocable_v<IterSwapT&, HasIterSwap&, int&>);
-static_assert(!cuda::std::is_invocable_v<IterSwapT&, int&, HasIterSwap&>);
+static_assert(cuda::std::is_invocable_v<IterSwapT&, HasIterSwap&, HasIterSwap&>, "");
+static_assert(cuda::std::is_invocable_v<IterSwapT&, HasIterSwap&, int&>, "");
+static_assert(!cuda::std::is_invocable_v<IterSwapT&, int&, HasIterSwap&>, "");
 
-static_assert(cuda::std::is_invocable_v<IterSwapT&&, HasIterSwap&, HasIterSwap&>);
-static_assert(cuda::std::is_invocable_v<IterSwapT&&, HasIterSwap&, int&>);
-static_assert(!cuda::std::is_invocable_v<IterSwapT&&, int&, HasIterSwap&>);
+static_assert(cuda::std::is_invocable_v<IterSwapT&&, HasIterSwap&, HasIterSwap&>, "");
+static_assert(cuda::std::is_invocable_v<IterSwapT&&, HasIterSwap&, int&>, "");
+static_assert(!cuda::std::is_invocable_v<IterSwapT&&, int&, HasIterSwap&>, "");
 #endif // !TEST_COMPILER_CUDACC_BELOW_11_3 && !TEST_COMPILER_MSVC_2017
 
 #if !defined(TEST_COMPILER_CUDACC_BELOW_11_3) && !defined(TEST_COMPILER_MSVC_2017)
@@ -109,10 +109,10 @@ struct HasRangesSwapWrapper
 };
 
 #if !defined(TEST_COMPILER_CUDACC_BELOW_11_3) && !defined(TEST_COMPILER_MSVC_2017) // nvcc segfaults here
-static_assert(cuda::std::is_invocable_v<IterSwapT, HasRangesSwapWrapper&, HasRangesSwapWrapper&>);
+static_assert(cuda::std::is_invocable_v<IterSwapT, HasRangesSwapWrapper&, HasRangesSwapWrapper&>, "");
 // Does not satisfy swappable_with, even though swap(X, Y) is valid.
-static_assert(!cuda::std::is_invocable_v<IterSwapT, HasRangesSwapWrapper&, int&>);
-static_assert(!cuda::std::is_invocable_v<IterSwapT, int&, HasRangesSwapWrapper&>);
+static_assert(!cuda::std::is_invocable_v<IterSwapT, HasRangesSwapWrapper&, int&>, "");
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int&, HasRangesSwapWrapper&>, "");
 #endif // !TEST_COMPILER_CUDACC_BELOW_11_3 && !TEST_COMPILER_MSVC_2017
 
 struct B;
@@ -255,11 +255,11 @@ __host__ __device__ constexpr bool test()
 }
 
 #ifndef TEST_COMPILER_CUDACC_BELOW_11_3 // nvcc segfaults here
-static_assert(!cuda::std::is_invocable_v<IterSwapT, int*>); // too few arguments
-static_assert(!cuda::std::is_invocable_v<IterSwapT, int*, int*, int*>); // too many arguments
-static_assert(!cuda::std::is_invocable_v<IterSwapT, int, int*>);
-static_assert(!cuda::std::is_invocable_v<IterSwapT, int*, int>);
-static_assert(!cuda::std::is_invocable_v<IterSwapT, void*, void*>);
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int*>, ""); // too few arguments
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int*, int*, int*>, ""); // too many arguments
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int, int*>, "");
+static_assert(!cuda::std::is_invocable_v<IterSwapT, int*, int>, "");
+static_assert(!cuda::std::is_invocable_v<IterSwapT, void*, void*>, "");
 #endif // TEST_COMPILER_CUDACC_BELOW_11_3
 
 #if TEST_STD_VER > 2017
@@ -270,16 +270,16 @@ struct Holder
 {
   T t;
 };
-static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**, Holder<Incomplete>**>);
-static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**, Holder<Incomplete>**&>);
-static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**&, Holder<Incomplete>**>);
-static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**&, Holder<Incomplete>**&>);
+static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**, Holder<Incomplete>**>, "");
+static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**, Holder<Incomplete>**&>, "");
+static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**&, Holder<Incomplete>**>, "");
+static_assert(cuda::std::is_invocable_v<IterSwapT, Holder<Incomplete>**&, Holder<Incomplete>**&>, "");
 #endif
 
 int main(int, char**)
 {
   test();
-  static_assert(test());
+  static_assert(test(), "");
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/ranges/range.access/begin.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.access/begin.pass.cpp
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
-// UNSUPPORTED: msvc-19.16
+// UNSUPPORTED: c++03, c++11
 
 // std::ranges::begin
 // std::ranges::cbegin
@@ -25,46 +24,45 @@ using RangeCBeginT = decltype(cuda::std::ranges::cbegin);
 
 STATIC_TEST_GLOBAL_VAR int globalBuff[8] = {};
 
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, int (&&)[10]>);
-static_assert(cuda::std::is_invocable_v<RangeBeginT, int (&)[10]>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, int (&&)[]>);
-
 // This has been made valid as a defect report for C++17 onwards, however both clang and gcc below 11.0 does not
 // implement it
 #if (!defined(__GNUC__) || __GNUC__ >= 11)
-static_assert(cuda::std::is_invocable_v<RangeBeginT, int (&)[]>);
+static_assert(cuda::std::is_invocable_v<RangeBeginT, int (&)[]>, "");
+static_assert(cuda::std::is_invocable_v<RangeCBeginT, int (&)[]>, "");
 #endif
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, int (&&)[10]>);
-static_assert(cuda::std::is_invocable_v<RangeCBeginT, int (&)[10]>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, int (&&)[]>);
-// This has been made valid as a defect report for C++17 onwards, however both clang and gcc below 11.0 does not
-// implement it
-#if (!defined(__GNUC__) || __GNUC__ >= 11)
-static_assert(cuda::std::is_invocable_v<RangeCBeginT, int (&)[]>);
+static_assert(cuda::std::is_invocable_v<RangeBeginT, int (&)[10]>, "");
+static_assert(cuda::std::is_invocable_v<RangeCBeginT, int (&)[10]>, "");
+
+#if (!defined(_MSC_VER) || _MSC_VER >= 1923)
+// old MSVC has a bug where it doesn't properly handle rvalue arrays
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, int (&&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, int (&&)[10]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, int (&&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, int (&&)[10]>, "");
 #endif
 
 struct Incomplete;
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete (&&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete (&&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete (&&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete (&&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete (&&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete (&&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete (&&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete (&&)[]>, "");
 
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete (&&)[10]>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete (&&)[10]>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete (&&)[10]>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete (&&)[10]>);
-
-// This case is IFNDR; we handle it SFINAE-friendly.
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete (&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete (&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete (&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete (&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete (&&)[10]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete (&&)[10]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete (&&)[10]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete (&&)[10]>, "");
 
 // This case is IFNDR; we handle it SFINAE-friendly.
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete (&)[10]>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete (&)[10]>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete (&)[10]>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete (&)[10]>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete (&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete (&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete (&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete (&)[]>, "");
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Incomplete (&)[10]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, const Incomplete (&)[10]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Incomplete (&)[10]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, const Incomplete (&)[10]>, "");
 
 struct BeginMember
 {
@@ -76,14 +74,14 @@ struct BeginMember
 };
 
 // Ensure that we can't call with rvalues with borrowing disabled.
-static_assert(cuda::std::is_invocable_v<RangeBeginT, BeginMember&>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMember&&>);
-static_assert(cuda::std::is_invocable_v<RangeBeginT, BeginMember const&>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMember const&&>);
-static_assert(cuda::std::is_invocable_v<RangeCBeginT, BeginMember&>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginMember&&>);
-static_assert(cuda::std::is_invocable_v<RangeCBeginT, BeginMember const&>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginMember const&&>);
+static_assert(cuda::std::is_invocable_v<RangeBeginT, BeginMember&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMember&&>, "");
+static_assert(cuda::std::is_invocable_v<RangeBeginT, BeginMember const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMember const&&>, "");
+static_assert(cuda::std::is_invocable_v<RangeCBeginT, BeginMember&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginMember&&>, "");
+static_assert(cuda::std::is_invocable_v<RangeCBeginT, BeginMember const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginMember const&&>, "");
 
 struct Different
 {
@@ -95,20 +93,20 @@ __host__ __device__ constexpr bool testReturnTypes()
   {
     int* x[2] = {};
     unused(x);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::begin(x)), int**>);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cbegin(x)), int* const*>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::begin(x)), int**>, "");
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cbegin(x)), int* const*>, "");
   }
   {
     int x[2][2] = {};
     unused(x);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::begin(x)), int(*)[2]>);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cbegin(x)), const int(*)[2]>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::begin(x)), int(*)[2]>, "");
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cbegin(x)), const int(*)[2]>, "");
   }
   {
     Different x{};
     unused(x);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::begin(x)), char*>);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cbegin(x)), short*>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::begin(x)), char*>, "");
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cbegin(x)), short*>, "");
   }
   return true;
 }
@@ -134,13 +132,13 @@ struct BeginMemberReturnsInt
 {
   __host__ __device__ int begin() const;
 };
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMemberReturnsInt const&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMemberReturnsInt const&>, "");
 
 struct BeginMemberReturnsVoidPtr
 {
   __host__ __device__ const void* begin() const;
 };
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMemberReturnsVoidPtr const&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMemberReturnsVoidPtr const&>, "");
 
 struct EmptyBeginMember
 {
@@ -148,7 +146,7 @@ struct EmptyBeginMember
   {};
   __host__ __device__ iterator begin() const;
 };
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, EmptyBeginMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, EmptyBeginMember const&>, "");
 
 struct PtrConvertibleBeginMember
 {
@@ -158,7 +156,7 @@ struct PtrConvertibleBeginMember
   };
   __host__ __device__ iterator begin() const;
 };
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, PtrConvertibleBeginMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, PtrConvertibleBeginMember const&>, "");
 
 struct NonConstBeginMember
 {
@@ -168,10 +166,10 @@ struct NonConstBeginMember
     return &x;
   }
 };
-static_assert(cuda::std::is_invocable_v<RangeBeginT, NonConstBeginMember&>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, NonConstBeginMember const&>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, NonConstBeginMember&>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, NonConstBeginMember const&>);
+static_assert(cuda::std::is_invocable_v<RangeBeginT, NonConstBeginMember&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, NonConstBeginMember const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, NonConstBeginMember&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, NonConstBeginMember const&>, "");
 
 struct EnabledBorrowingBeginMember
 {
@@ -180,8 +178,17 @@ struct EnabledBorrowingBeginMember
     return &globalBuff[0];
   }
 };
+namespace cuda
+{
+namespace std
+{
+namespace ranges
+{
 template <>
-inline constexpr bool cuda::std::ranges::enable_borrowed_range<EnabledBorrowingBeginMember> = true;
+_CCCL_INLINE_VAR constexpr bool enable_borrowed_range<EnabledBorrowingBeginMember> = true;
+}
+} // namespace std
+} // namespace cuda
 
 struct BeginMemberFunction
 {
@@ -209,12 +216,12 @@ __host__ __device__ constexpr bool testBeginMember()
   BeginMember a{};
   assert(cuda::std::ranges::begin(a) == &a.x);
   assert(cuda::std::ranges::cbegin(a) == &a.x);
-  static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMember&&>);
-  static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginMember&&>);
+  static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginMember&&>, "");
+  static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginMember&&>, "");
 
   NonConstBeginMember b{};
   assert(cuda::std::ranges::begin(b) == &b.x);
-  static_assert(!cuda::std::is_invocable_v<RangeCBeginT, NonConstBeginMember&>);
+  static_assert(!cuda::std::is_invocable_v<RangeCBeginT, NonConstBeginMember&>, "");
 
   EnabledBorrowingBeginMember c{};
   assert(cuda::std::ranges::begin(c) == &globalBuff[0]);
@@ -241,23 +248,23 @@ struct BeginFunction
     return &bf.x;
   }
 };
-static_assert(cuda::std::is_invocable_v<RangeBeginT, BeginFunction const&>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunction&&>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunction&>);
-static_assert(cuda::std::is_invocable_v<RangeCBeginT, BeginFunction const&>);
-static_assert(cuda::std::is_invocable_v<RangeCBeginT, BeginFunction&>);
+static_assert(cuda::std::is_invocable_v<RangeBeginT, BeginFunction const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunction&&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunction&>, "");
+static_assert(cuda::std::is_invocable_v<RangeCBeginT, BeginFunction const&>, "");
+static_assert(cuda::std::is_invocable_v<RangeCBeginT, BeginFunction&>, "");
 
 struct BeginFunctionReturnsInt
 {
   __host__ __device__ friend int begin(BeginFunctionReturnsInt const&);
 };
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunctionReturnsInt const&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunctionReturnsInt const&>, "");
 
 struct BeginFunctionReturnsVoidPtr
 {
   __host__ __device__ friend void* begin(BeginFunctionReturnsVoidPtr const&);
 };
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunctionReturnsVoidPtr const&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunctionReturnsVoidPtr const&>, "");
 
 struct BeginFunctionReturnsPtrConvertible
 {
@@ -267,7 +274,7 @@ struct BeginFunctionReturnsPtrConvertible
   };
   __host__ __device__ friend iterator begin(BeginFunctionReturnsPtrConvertible const&);
 };
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunctionReturnsPtrConvertible const&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, BeginFunctionReturnsPtrConvertible const&>, "");
 
 struct BeginFunctionByValue
 {
@@ -276,7 +283,7 @@ struct BeginFunctionByValue
     return &globalBuff[1];
   }
 };
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginFunctionByValue>);
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, BeginFunctionByValue>, "");
 
 struct BeginFunctionEnabledBorrowing
 {
@@ -285,8 +292,18 @@ struct BeginFunctionEnabledBorrowing
     return &globalBuff[2];
   }
 };
+
+namespace cuda
+{
+namespace std
+{
+namespace ranges
+{
 template <>
-inline constexpr bool cuda::std::ranges::enable_borrowed_range<BeginFunctionEnabledBorrowing> = true;
+_CCCL_INLINE_VAR constexpr bool enable_borrowed_range<BeginFunctionEnabledBorrowing> = true;
+}
+} // namespace std
+} // namespace cuda
 
 struct BeginFunctionReturnsEmptyPtr
 {
@@ -325,7 +342,7 @@ __host__ __device__ constexpr bool testBeginFunction()
 {
   BeginFunction a{};
   const BeginFunction aa{};
-  static_assert(!cuda::std::invocable<RangeBeginT, decltype((a))>);
+  static_assert(!cuda::std::invocable<RangeBeginT, decltype((a))>, "");
   assert(cuda::std::ranges::cbegin(a) == &a.x);
   assert(cuda::std::ranges::begin(aa) == &aa.x);
   assert(cuda::std::ranges::cbegin(aa) == &aa.x);
@@ -346,21 +363,21 @@ __host__ __device__ constexpr bool testBeginFunction()
 
   BeginFunctionReturnsEmptyPtr d{};
   const BeginFunctionReturnsEmptyPtr dd{};
-  static_assert(!cuda::std::invocable<RangeBeginT, decltype((d))>);
+  static_assert(!cuda::std::invocable<RangeBeginT, decltype((d))>, "");
   assert(cuda::std::ranges::cbegin(d) == &d.x);
   assert(cuda::std::ranges::begin(dd) == &dd.x);
   assert(cuda::std::ranges::cbegin(dd) == &dd.x);
 
   BeginFunctionWithDataMember e{};
   const BeginFunctionWithDataMember ee{};
-  static_assert(!cuda::std::invocable<RangeBeginT, decltype((e))>);
+  static_assert(!cuda::std::invocable<RangeBeginT, decltype((e))>, "");
   assert(cuda::std::ranges::begin(ee) == &ee.x);
   assert(cuda::std::ranges::cbegin(e) == &e.x);
   assert(cuda::std::ranges::cbegin(ee) == &ee.x);
 
   BeginFunctionWithPrivateBeginMember f{};
   const BeginFunctionWithPrivateBeginMember ff{};
-  static_assert(!cuda::std::invocable<RangeBeginT, decltype((f))>);
+  static_assert(!cuda::std::invocable<RangeBeginT, decltype((f))>, "");
   assert(cuda::std::ranges::cbegin(f) == &f.y);
   assert(cuda::std::ranges::begin(ff) == &ff.y);
   assert(cuda::std::ranges::cbegin(ff) == &ff.y);
@@ -370,38 +387,39 @@ __host__ __device__ constexpr bool testBeginFunction()
 ASSERT_NOEXCEPT(cuda::std::ranges::begin(cuda::std::declval<int (&)[10]>()));
 ASSERT_NOEXCEPT(cuda::std::ranges::cbegin(cuda::std::declval<int (&)[10]>()));
 
-#if !defined(TEST_COMPILER_MSVC_2019) // broken noexcept
+// needs c++17's guaranteed copy elision
+#if TEST_STD_VER > 2014 && !defined(TEST_COMPILER_MSVC_2019) // broken noexcept
 _CCCL_GLOBAL_CONSTANT struct NoThrowMemberBegin
 {
   __host__ __device__ ThrowingIterator<int> begin() const noexcept; // auto(t.begin()) doesn't throw
 } ntmb;
-static_assert(noexcept(cuda::std::ranges::begin(ntmb)));
-static_assert(noexcept(cuda::std::ranges::cbegin(ntmb)));
+static_assert(noexcept(cuda::std::ranges::begin(ntmb)), "");
+static_assert(noexcept(cuda::std::ranges::cbegin(ntmb)), "");
 
 _CCCL_GLOBAL_CONSTANT struct NoThrowADLBegin
 {
   __host__ __device__ friend ThrowingIterator<int> begin(NoThrowADLBegin&) noexcept; // auto(begin(t)) doesn't throw
   __host__ __device__ friend ThrowingIterator<int> begin(const NoThrowADLBegin&) noexcept;
 } ntab;
-static_assert(noexcept(cuda::std::ranges::begin(ntab)));
-static_assert(noexcept(cuda::std::ranges::cbegin(ntab)));
-#endif // !TEST_COMPILER_MSVC_2019
+static_assert(noexcept(cuda::std::ranges::begin(ntab)), "");
+static_assert(noexcept(cuda::std::ranges::cbegin(ntab)), "");
+#endif // TEST_STD_VER > 2014 && !TEST_COMPILER_MSVC_2019
 
 #if !defined(TEST_COMPILER_ICC)
 _CCCL_GLOBAL_CONSTANT struct NoThrowMemberBeginReturnsRef
 {
   __host__ __device__ ThrowingIterator<int>& begin() const noexcept; // auto(t.begin()) may throw
 } ntmbrr;
-static_assert(!noexcept(cuda::std::ranges::begin(ntmbrr)));
-static_assert(!noexcept(cuda::std::ranges::cbegin(ntmbrr)));
+static_assert(!noexcept(cuda::std::ranges::begin(ntmbrr)), "");
+static_assert(!noexcept(cuda::std::ranges::cbegin(ntmbrr)), "");
 #endif // !TEST_COMPILER_ICC
 
 _CCCL_GLOBAL_CONSTANT struct BeginReturnsArrayRef
 {
   __host__ __device__ auto begin() const noexcept -> int (&)[10];
 } brar;
-static_assert(noexcept(cuda::std::ranges::begin(brar)));
-static_assert(noexcept(cuda::std::ranges::cbegin(brar)));
+static_assert(noexcept(cuda::std::ranges::begin(brar)), "");
+static_assert(noexcept(cuda::std::ranges::cbegin(brar)), "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -411,31 +429,31 @@ struct Holder
 {
   T t;
 };
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, Holder<Incomplete>*>);
-static_assert(!cuda::std::is_invocable_v<RangeBeginT, Holder<Incomplete>*&>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*>);
-static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*&>);
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::is_invocable_v<RangeBeginT, Holder<Incomplete>*&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*&>, "");
 #endif // TEST_STD_VER > 2017
 
 int main(int, char**)
 {
-  static_assert(testReturnTypes());
+  static_assert(testReturnTypes(), "");
 
   testArray();
 #ifndef TEST_COMPILER_CUDACC_BELOW_11_3
-  static_assert(testArray());
+  static_assert(testArray(), "");
 #endif // TEST_COMPILER_CUDACC_BELOW_11_3
 
   testBeginMember();
-  static_assert(testBeginMember());
+  static_assert(testBeginMember(), "");
 
   testBeginFunction();
-  static_assert(testBeginFunction());
+  static_assert(testBeginFunction(), "");
 
-#if !defined(TEST_COMPILER_MSVC_2019) // broken noexcept
+#if TEST_STD_VER > 2014 && !defined(TEST_COMPILER_MSVC_2019) // broken noexcept
   unused(ntmb);
   unused(ntab);
-#endif // !TEST_COMPILER_MSVC_2019
+#endif // TEST_STD_VER > 2014 && !TEST_COMPILER_MSVC_2019
 #if !defined(TEST_COMPILER_ICC)
   unused(ntmbrr);
 #endif // !TEST_COMPILER_ICC

--- a/libcudacxx/test/libcudacxx/std/ranges/range.access/end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.access/end.pass.cpp
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
-// UNSUPPORTED: msvc-19.16
+// UNSUPPORTED: c++03, c++11
 
 // cuda::std::ranges::end
 // cuda::std::ranges::cend
@@ -25,20 +24,24 @@ using RangeCEndT = decltype(cuda::std::ranges::cend);
 
 STATIC_TEST_GLOBAL_VAR int globalBuff[8] = {};
 
-static_assert(!cuda::std::is_invocable_v<RangeEndT, int (&&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, int (&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, int (&&)[10]>);
-static_assert(cuda::std::is_invocable_v<RangeEndT, int (&)[10]>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, int (&&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, int (&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, int (&&)[10]>);
-static_assert(cuda::std::is_invocable_v<RangeCEndT, int (&)[10]>);
+#if (!defined(_MSC_VER) || _MSC_VER >= 1923)
+// old MSVC has a bug where it doesn't properly handle rvalue arrays
+static_assert(!cuda::std::is_invocable_v<RangeEndT, int (&&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, int (&&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeEndT, int (&&)[10]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, int (&&)[10]>, "");
+#endif
+
+static_assert(!cuda::std::is_invocable_v<RangeEndT, int (&)[]>, "");
+static_assert(cuda::std::is_invocable_v<RangeEndT, int (&)[10]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, int (&)[]>, "");
+static_assert(cuda::std::is_invocable_v<RangeCEndT, int (&)[10]>, "");
 
 struct Incomplete;
-static_assert(!cuda::std::is_invocable_v<RangeEndT, Incomplete (&&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, Incomplete (&&)[42]>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, Incomplete (&&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, Incomplete (&&)[42]>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, Incomplete (&&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeEndT, Incomplete (&&)[42]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, Incomplete (&&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, Incomplete (&&)[42]>, "");
 
 struct EndMember
 {
@@ -51,14 +54,14 @@ struct EndMember
 };
 
 // Ensure that we can't call with rvalues with borrowing disabled.
-static_assert(cuda::std::is_invocable_v<RangeEndT, EndMember&>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMember&&>);
-static_assert(cuda::std::is_invocable_v<RangeEndT, EndMember const&>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMember const&&>);
-static_assert(cuda::std::is_invocable_v<RangeCEndT, EndMember&>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, EndMember&&>);
-static_assert(cuda::std::is_invocable_v<RangeCEndT, EndMember const&>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, EndMember const&&>);
+static_assert(cuda::std::is_invocable_v<RangeEndT, EndMember&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMember&&>, "");
+static_assert(cuda::std::is_invocable_v<RangeEndT, EndMember const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMember const&&>, "");
+static_assert(cuda::std::is_invocable_v<RangeCEndT, EndMember&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, EndMember&&>, "");
+static_assert(cuda::std::is_invocable_v<RangeCEndT, EndMember const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, EndMember const&&>, "");
 
 struct Different
 {
@@ -72,20 +75,20 @@ __host__ __device__ constexpr bool testReturnTypes()
   {
     int* x[2] = {};
     unused(x);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::end(x)), int**>);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cend(x)), int* const*>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::end(x)), int**>, "");
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cend(x)), int* const*>, "");
   }
   {
     int x[2][2] = {};
     unused(x);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::end(x)), int(*)[2]>);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cend(x)), const int(*)[2]>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::end(x)), int(*)[2]>, "");
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cend(x)), const int(*)[2]>, "");
   }
   {
     Different x{};
     unused(x);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::end(x)), sentinel_wrapper<char*>>);
-    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cend(x)), sentinel_wrapper<short*>>);
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::end(x)), sentinel_wrapper<char*>>, "");
+    static_assert(cuda::std::same_as<decltype(cuda::std::ranges::cend(x)), sentinel_wrapper<short*>>, "");
   }
   return true;
 }
@@ -112,14 +115,14 @@ struct EndMemberReturnsInt
   __host__ __device__ int begin() const;
   __host__ __device__ int end() const;
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMemberReturnsInt const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMemberReturnsInt const&>, "");
 
 struct EndMemberReturnsVoidPtr
 {
   __host__ __device__ const void* begin() const;
   __host__ __device__ const void* end() const;
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMemberReturnsVoidPtr const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndMemberReturnsVoidPtr const&>, "");
 
 struct PtrConvertible
 {
@@ -130,13 +133,13 @@ struct PtrConvertibleEndMember
   __host__ __device__ PtrConvertible begin() const;
   __host__ __device__ PtrConvertible end() const;
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, PtrConvertibleEndMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, PtrConvertibleEndMember const&>, "");
 
 struct NoBeginMember
 {
   __host__ __device__ constexpr const int* end();
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, NoBeginMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, NoBeginMember const&>, "");
 
 struct NonConstEndMember
 {
@@ -150,10 +153,10 @@ struct NonConstEndMember
     return &x;
   }
 };
-static_assert(cuda::std::is_invocable_v<RangeEndT, NonConstEndMember&>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, NonConstEndMember const&>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, NonConstEndMember&>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, NonConstEndMember const&>);
+static_assert(cuda::std::is_invocable_v<RangeEndT, NonConstEndMember&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeEndT, NonConstEndMember const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, NonConstEndMember&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, NonConstEndMember const&>, "");
 
 struct EnabledBorrowingEndMember
 {
@@ -166,9 +169,17 @@ struct EnabledBorrowingEndMember
     return &globalBuff[0];
   }
 };
+namespace cuda
+{
+namespace std
+{
+namespace ranges
+{
 template <>
-inline constexpr bool cuda::std::ranges::enable_borrowed_range<EnabledBorrowingEndMember> = true;
-
+_CCCL_INLINE_VAR constexpr bool enable_borrowed_range<EnabledBorrowingEndMember> = true;
+}
+} // namespace std
+} // namespace cuda
 struct EndMemberFunction
 {
   int x;
@@ -190,7 +201,7 @@ struct EmptyEndMember
   __host__ __device__ Empty begin() const;
   __host__ __device__ Empty end() const;
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EmptyEndMember const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EmptyEndMember const&>, "");
 
 struct EmptyPtrEndMember
 {
@@ -213,7 +224,7 @@ __host__ __device__ constexpr bool testEndMember()
 
   NonConstEndMember b{};
   assert(cuda::std::ranges::end(b) == &b.x);
-  static_assert(!cuda::std::is_invocable_v<RangeCEndT, decltype((b))>);
+  static_assert(!cuda::std::is_invocable_v<RangeCEndT, decltype((b))>, "");
 
   EnabledBorrowingEndMember c{};
   assert(cuda::std::ranges::end(cuda::std::move(c)) == &globalBuff[0]);
@@ -243,48 +254,48 @@ struct EndFunction
   }
 };
 
-static_assert(cuda::std::is_invocable_v<RangeEndT, EndFunction const&>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunction&&>);
+static_assert(cuda::std::is_invocable_v<RangeEndT, EndFunction const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunction&&>, "");
 
-static_assert(cuda::std::is_invocable_v<RangeEndT, EndFunction const&>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunction&&>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunction&>);
-static_assert(cuda::std::is_invocable_v<RangeCEndT, EndFunction const&>);
-static_assert(cuda::std::is_invocable_v<RangeCEndT, EndFunction&>);
+static_assert(cuda::std::is_invocable_v<RangeEndT, EndFunction const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunction&&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunction&>, "");
+static_assert(cuda::std::is_invocable_v<RangeCEndT, EndFunction const&>, "");
+static_assert(cuda::std::is_invocable_v<RangeCEndT, EndFunction&>, "");
 
 struct EndFunctionReturnsInt
 {
   __host__ __device__ friend constexpr int begin(EndFunctionReturnsInt const&);
   __host__ __device__ friend constexpr int end(EndFunctionReturnsInt const&);
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsInt const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsInt const&>, "");
 
 struct EndFunctionReturnsVoidPtr
 {
   __host__ __device__ friend constexpr void* begin(EndFunctionReturnsVoidPtr const&);
   __host__ __device__ friend constexpr void* end(EndFunctionReturnsVoidPtr const&);
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsVoidPtr const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsVoidPtr const&>, "");
 
 struct EndFunctionReturnsEmpty
 {
   __host__ __device__ friend constexpr Empty begin(EndFunctionReturnsEmpty const&);
   __host__ __device__ friend constexpr Empty end(EndFunctionReturnsEmpty const&);
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsEmpty const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsEmpty const&>, "");
 
 struct EndFunctionReturnsPtrConvertible
 {
   __host__ __device__ friend constexpr PtrConvertible begin(EndFunctionReturnsPtrConvertible const&);
   __host__ __device__ friend constexpr PtrConvertible end(EndFunctionReturnsPtrConvertible const&);
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsPtrConvertible const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, EndFunctionReturnsPtrConvertible const&>, "");
 
 struct NoBeginFunction
 {
   __host__ __device__ friend constexpr const int* end(NoBeginFunction const&);
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, NoBeginFunction const&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, NoBeginFunction const&>, "");
 
 struct EndFunctionByValue
 {
@@ -297,7 +308,7 @@ struct EndFunctionByValue
     return &globalBuff[1];
   }
 };
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, EndFunctionByValue>);
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, EndFunctionByValue>, "");
 
 struct EndFunctionEnabledBorrowing
 {
@@ -310,8 +321,17 @@ struct EndFunctionEnabledBorrowing
     return &globalBuff[2];
   }
 };
+namespace cuda
+{
+namespace std
+{
+namespace ranges
+{
 template <>
-inline constexpr bool cuda::std::ranges::enable_borrowed_range<EndFunctionEnabledBorrowing> = true;
+_CCCL_INLINE_VAR constexpr bool enable_borrowed_range<EndFunctionEnabledBorrowing> = true;
+}
+} // namespace std
+} // namespace cuda
 
 struct EndFunctionReturnsEmptyPtr
 {
@@ -375,7 +395,7 @@ __host__ __device__ constexpr bool testEndFunction()
   assert(cuda::std::ranges::end(a) == &a.x);
   assert(cuda::std::ranges::cend(a) == &a.x);
   EndFunction aa{};
-  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((aa))>);
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((aa))>, "");
   assert(cuda::std::ranges::cend(aa) == &aa.x);
 
   EndFunctionByValue b{};
@@ -390,28 +410,28 @@ __host__ __device__ constexpr bool testEndFunction()
   assert(cuda::std::ranges::end(d) == &d.x);
   assert(cuda::std::ranges::cend(d) == &d.x);
   EndFunctionReturnsEmptyPtr dd{};
-  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((dd))>);
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((dd))>, "");
   assert(cuda::std::ranges::cend(dd) == &dd.x);
 
   const EndFunctionWithDataMember e{};
   assert(cuda::std::ranges::end(e) == &e.x);
   assert(cuda::std::ranges::cend(e) == &e.x);
   EndFunctionWithDataMember ee{};
-  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((ee))>);
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((ee))>, "");
   assert(cuda::std::ranges::cend(ee) == &ee.x);
 
   const EndFunctionWithPrivateEndMember f{};
   assert(cuda::std::ranges::end(f) == &f.y);
   assert(cuda::std::ranges::cend(f) == &f.y);
   EndFunctionWithPrivateEndMember ff{};
-  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((ff))>);
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((ff))>, "");
   assert(cuda::std::ranges::cend(ff) == &ff.y);
 
   const BeginMemberEndFunction g{};
   assert(cuda::std::ranges::end(g) == &g.x);
   assert(cuda::std::ranges::cend(g) == &g.x);
   BeginMemberEndFunction gg{};
-  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((gg))>);
+  static_assert(!cuda::std::is_invocable_v<RangeEndT, decltype((gg))>, "");
   assert(cuda::std::ranges::cend(gg) == &gg.x);
 
   return true;
@@ -419,14 +439,15 @@ __host__ __device__ constexpr bool testEndFunction()
 ASSERT_NOEXCEPT(cuda::std::ranges::end(cuda::std::declval<int (&)[10]>()));
 ASSERT_NOEXCEPT(cuda::std::ranges::cend(cuda::std::declval<int (&)[10]>()));
 
-#if !defined(TEST_COMPILER_MSVC_2019) // broken noexcept
+// needs c++17's guaranteed copy elision
+#if TEST_STD_VER > 2014 && !defined(TEST_COMPILER_MSVC_2019) // broken noexcept
 _CCCL_GLOBAL_CONSTANT struct NoThrowMemberEnd
 {
   __host__ __device__ ThrowingIterator<int> begin() const;
   __host__ __device__ ThrowingIterator<int> end() const noexcept; // auto(t.end()) doesn't throw
 } ntme;
-static_assert(noexcept(cuda::std::ranges::end(ntme)));
-static_assert(noexcept(cuda::std::ranges::cend(ntme)));
+static_assert(noexcept(cuda::std::ranges::end(ntme)), "");
+static_assert(noexcept(cuda::std::ranges::cend(ntme)), "");
 
 _CCCL_GLOBAL_CONSTANT struct NoThrowADLEnd
 {
@@ -434,9 +455,9 @@ _CCCL_GLOBAL_CONSTANT struct NoThrowADLEnd
   __host__ __device__ friend ThrowingIterator<int> end(NoThrowADLEnd&) noexcept; // auto(end(t)) doesn't throw
   __host__ __device__ friend ThrowingIterator<int> end(const NoThrowADLEnd&) noexcept;
 } ntae;
-static_assert(noexcept(cuda::std::ranges::end(ntae)));
-static_assert(noexcept(cuda::std::ranges::cend(ntae)));
-#endif // !TEST_COMPILER_MSVC_2019
+static_assert(noexcept(cuda::std::ranges::end(ntae)), "");
+static_assert(noexcept(cuda::std::ranges::cend(ntae)), "");
+#endif // TEST_STD_VER > 2014 && !TEST_COMPILER_MSVC_2019
 
 #if !defined(TEST_COMPILER_ICC)
 _CCCL_GLOBAL_CONSTANT struct NoThrowMemberEndReturnsRef
@@ -444,8 +465,8 @@ _CCCL_GLOBAL_CONSTANT struct NoThrowMemberEndReturnsRef
   __host__ __device__ ThrowingIterator<int> begin() const;
   __host__ __device__ ThrowingIterator<int>& end() const noexcept; // auto(t.end()) may throw
 } ntmerr;
-static_assert(!noexcept(cuda::std::ranges::end(ntmerr)));
-static_assert(!noexcept(cuda::std::ranges::cend(ntmerr)));
+static_assert(!noexcept(cuda::std::ranges::end(ntmerr)), "");
+static_assert(!noexcept(cuda::std::ranges::cend(ntmerr)), "");
 #endif // !TEST_COMPILER_ICC
 
 _CCCL_GLOBAL_CONSTANT struct EndReturnsArrayRef
@@ -453,8 +474,8 @@ _CCCL_GLOBAL_CONSTANT struct EndReturnsArrayRef
   __host__ __device__ auto begin() const noexcept -> int (&)[10];
   __host__ __device__ auto end() const noexcept -> int (&)[10];
 } erar;
-static_assert(noexcept(cuda::std::ranges::end(erar)));
-static_assert(noexcept(cuda::std::ranges::cend(erar)));
+static_assert(noexcept(cuda::std::ranges::end(erar)), "");
+static_assert(noexcept(cuda::std::ranges::cend(erar)), "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -464,31 +485,31 @@ struct Holder
 {
   T t;
 };
-static_assert(!cuda::std::is_invocable_v<RangeEndT, Holder<Incomplete>*>);
-static_assert(!cuda::std::is_invocable_v<RangeEndT, Holder<Incomplete>*&>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, Holder<Incomplete>*>);
-static_assert(!cuda::std::is_invocable_v<RangeCEndT, Holder<Incomplete>*&>);
+static_assert(!cuda::std::is_invocable_v<RangeEndT, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::is_invocable_v<RangeEndT, Holder<Incomplete>*&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::is_invocable_v<RangeCEndT, Holder<Incomplete>*&>, "");
 #endif // TEST_STD_VER > 2017
 
 int main(int, char**)
 {
-  static_assert(testReturnTypes());
+  static_assert(testReturnTypes(), "");
 
   testArray();
 #ifndef TEST_COMPILER_CUDACC_BELOW_11_3
-  static_assert(testArray());
+  static_assert(testArray(), "");
 #endif // TEST_COMPILER_CUDACC_BELOW_11_3
 
   testEndMember();
-  static_assert(testEndMember());
+  static_assert(testEndMember(), "");
 
   testEndFunction();
-  static_assert(testEndFunction());
+  static_assert(testEndFunction(), "");
 
-#if !defined(TEST_COMPILER_MSVC_2019) // broken noexcept
+#if TEST_STD_VER > 2014 && !defined(TEST_COMPILER_MSVC_2019) // broken noexcept
   unused(ntme);
   unused(ntae);
-#endif // !TEST_COMPILER_MSVC_2019
+#endif // TEST_STD_VER > 2014 && !TEST_COMPILER_MSVC_2019
 #if !defined(TEST_COMPILER_ICC)
   unused(ntmerr);
 #endif // !TEST_COMPILER_ICC

--- a/libcudacxx/test/libcudacxx/std/ranges/range.access/size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.access/size.pass.cpp
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
-// UNSUPPORTED: msvc-19.16
+// UNSUPPORTED: c++03, c++11
 
 // cuda::std::ranges::size
 
@@ -20,24 +19,24 @@
 
 using RangeSizeT = decltype(cuda::std::ranges::size);
 
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, int[]>);
-static_assert(cuda::std::is_invocable_v<RangeSizeT, int[1]>);
-static_assert(cuda::std::is_invocable_v<RangeSizeT, int (&&)[1]>);
-static_assert(cuda::std::is_invocable_v<RangeSizeT, int (&)[1]>);
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, int[]>, "");
+static_assert(cuda::std::is_invocable_v<RangeSizeT, int[1]>, "");
+static_assert(cuda::std::is_invocable_v<RangeSizeT, int (&&)[1]>, "");
+static_assert(cuda::std::is_invocable_v<RangeSizeT, int (&)[1]>, "");
 
 struct Incomplete;
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, Incomplete[]>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, Incomplete (&)[]>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, Incomplete (&&)[]>);
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, Incomplete[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, Incomplete (&)[]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, Incomplete (&&)[]>, "");
 
 #ifndef TEST_COMPILER_NVRTC
 extern Incomplete array_of_incomplete[42];
-static_assert(cuda::std::ranges::size(array_of_incomplete) == 42);
-static_assert(cuda::std::ranges::size(cuda::std::move(array_of_incomplete)) == 42);
+static_assert(cuda::std::ranges::size(array_of_incomplete) == 42, "");
+static_assert(cuda::std::ranges::size(cuda::std::move(array_of_incomplete)) == 42, "");
 
 extern const Incomplete const_array_of_incomplete[42];
-static_assert(cuda::std::ranges::size(const_array_of_incomplete) == 42);
-static_assert(cuda::std::ranges::size(static_cast<const Incomplete (&&)[42]>(array_of_incomplete)) == 42);
+static_assert(cuda::std::ranges::size(const_array_of_incomplete) == 42, "");
+static_assert(cuda::std::ranges::size(static_cast<const Incomplete (&&)[42]>(array_of_incomplete)) == 42, "");
 #endif // !TEST_COMPILER_NVRTC
 
 struct SizeMember
@@ -56,7 +55,7 @@ struct StaticSizeMember
   }
 };
 
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, const SizeMember>);
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, const SizeMember>, "");
 
 struct SizeFunction
 {
@@ -192,7 +191,7 @@ __host__ __device__ bool constexpr testHasSizeFunction()
 {
   assert(cuda::std::ranges::size(SizeFunction()) == 42);
   ASSERT_SAME_TYPE(decltype(cuda::std::ranges::size(SizeFunction())), size_t);
-  static_assert(!cuda::std::is_invocable_v<RangeSizeT, MoveOnlySizeFunction>);
+  static_assert(!cuda::std::is_invocable_v<RangeSizeT, MoveOnlySizeFunction>, "");
   assert(cuda::std::ranges::size(EnumSizeFunction()) == 42);
   assert(cuda::std::ranges::size(SizeFunctionConst()) == 42);
 
@@ -210,7 +209,7 @@ __host__ __device__ bool constexpr testHasSizeFunction()
 
 struct Empty
 {};
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, Empty>);
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, Empty>, "");
 
 struct InvalidReturnTypeMember
 {
@@ -247,14 +246,14 @@ struct BoolReturnTypeFunction
   __host__ __device__ friend bool size(BoolReturnTypeFunction const&);
 };
 
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, InvalidReturnTypeMember>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, InvalidReturnTypeFunction>);
-static_assert(cuda::std::is_invocable_v<RangeSizeT, InvalidReturnTypeMember (&)[4]>);
-static_assert(cuda::std::is_invocable_v<RangeSizeT, InvalidReturnTypeFunction (&)[4]>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, ConvertibleReturnTypeMember>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, ConvertibleReturnTypeFunction>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, BoolReturnTypeMember const&>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, BoolReturnTypeFunction const&>);
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, InvalidReturnTypeMember>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, InvalidReturnTypeFunction>, "");
+static_assert(cuda::std::is_invocable_v<RangeSizeT, InvalidReturnTypeMember (&)[4]>, "");
+static_assert(cuda::std::is_invocable_v<RangeSizeT, InvalidReturnTypeFunction (&)[4]>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, ConvertibleReturnTypeMember>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, ConvertibleReturnTypeFunction>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, BoolReturnTypeMember const&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, BoolReturnTypeFunction const&>, "");
 
 struct SizeMemberDisabled
 {
@@ -275,6 +274,7 @@ _CCCL_INLINE_VAR constexpr bool disable_sized_range<SizeMemberDisabled> = true;
 }
 } // namespace std
 } // namespace cuda
+
 struct ImproperlyDisabledMember
 {
   __host__ __device__ size_t size() const
@@ -337,10 +337,10 @@ _CCCL_INLINE_VAR constexpr bool disable_sized_range<const ImproperlyDisabledFunc
 } // namespace std
 } // namespace cuda
 
-static_assert(cuda::std::is_invocable_v<RangeSizeT, ImproperlyDisabledMember&>);
-static_assert(cuda::std::is_invocable_v<RangeSizeT, const ImproperlyDisabledMember&>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, ImproperlyDisabledFunction&>);
-static_assert(cuda::std::is_invocable_v<RangeSizeT, const ImproperlyDisabledFunction&>);
+static_assert(cuda::std::is_invocable_v<RangeSizeT, ImproperlyDisabledMember&>, "");
+static_assert(cuda::std::is_invocable_v<RangeSizeT, const ImproperlyDisabledMember&>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, ImproperlyDisabledFunction&>, "");
+static_assert(cuda::std::is_invocable_v<RangeSizeT, const ImproperlyDisabledFunction&>, "");
 
 // No begin end.
 struct HasMinusOperator
@@ -350,7 +350,7 @@ struct HasMinusOperator
     return 2;
   }
 };
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, HasMinusOperator>);
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, HasMinusOperator>, "");
 
 struct HasMinusBeginEnd
 {
@@ -416,8 +416,8 @@ struct InvalidMinusBeginEnd
 };
 
 // short is integer-like, but it is not other_forward_iterator's difference_type.
-static_assert(!cuda::std::same_as<other_forward_iterator::difference_type, short>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, InvalidMinusBeginEnd>);
+static_assert(!cuda::std::same_as<other_forward_iterator::difference_type, short>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, InvalidMinusBeginEnd>, "");
 
 struct RandomAccessRange
 {
@@ -481,8 +481,17 @@ struct DisabledSizeRangeWithBeginEnd
   }
 };
 
+namespace cuda
+{
+namespace std
+{
+namespace ranges
+{
 template <>
-inline constexpr bool cuda::std::ranges::disable_sized_range<DisabledSizeRangeWithBeginEnd> = true;
+_CCCL_INLINE_VAR constexpr bool disable_sized_range<DisabledSizeRangeWithBeginEnd> = true;
+}
+} // namespace std
+} // namespace cuda
 
 struct SizeBeginAndEndMembers
 {
@@ -532,23 +541,23 @@ struct Holder
 {
   T t;
 };
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, Holder<Incomplete>*>);
-static_assert(!cuda::std::is_invocable_v<RangeSizeT, Holder<Incomplete>*&>);
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::is_invocable_v<RangeSizeT, Holder<Incomplete>*&>, "");
 #endif // TEST_STD_VER > 2017
 
 int main(int, char**)
 {
   testArrayType();
-  static_assert(testArrayType());
+  static_assert(testArrayType(), "");
 
   testHasSizeMember();
-  static_assert(testHasSizeMember());
+  static_assert(testHasSizeMember(), "");
 
   testHasSizeFunction();
-  static_assert(testHasSizeFunction());
+  static_assert(testHasSizeFunction(), "");
 
   testRanges();
-  static_assert(testRanges());
+  static_assert(testRanges(), "");
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/borrowed_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/borrowed_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class T>
@@ -51,29 +51,29 @@ _CCCL_INLINE_VAR constexpr bool enable_borrowed_range<BorrowedRange> = true;
 } // namespace std
 } // namespace cuda
 
-static_assert(!cuda::std::ranges::borrowed_range<NotRange>);
-static_assert(!cuda::std::ranges::borrowed_range<NotRange&>);
-static_assert(!cuda::std::ranges::borrowed_range<const NotRange>);
-static_assert(!cuda::std::ranges::borrowed_range<const NotRange&>);
-static_assert(!cuda::std::ranges::borrowed_range<NotRange&&>);
+static_assert(!cuda::std::ranges::borrowed_range<NotRange>, "");
+static_assert(!cuda::std::ranges::borrowed_range<NotRange&>, "");
+static_assert(!cuda::std::ranges::borrowed_range<const NotRange>, "");
+static_assert(!cuda::std::ranges::borrowed_range<const NotRange&>, "");
+static_assert(!cuda::std::ranges::borrowed_range<NotRange&&>, "");
 
-static_assert(!cuda::std::ranges::borrowed_range<Range>);
-static_assert(cuda::std::ranges::borrowed_range<Range&>);
-static_assert(!cuda::std::ranges::borrowed_range<const Range>);
-static_assert(!cuda::std::ranges::borrowed_range<const Range&>);
-static_assert(!cuda::std::ranges::borrowed_range<Range&&>);
+static_assert(!cuda::std::ranges::borrowed_range<Range>, "");
+static_assert(cuda::std::ranges::borrowed_range<Range&>, "");
+static_assert(!cuda::std::ranges::borrowed_range<const Range>, "");
+static_assert(!cuda::std::ranges::borrowed_range<const Range&>, "");
+static_assert(!cuda::std::ranges::borrowed_range<Range&&>, "");
 
-static_assert(!cuda::std::ranges::borrowed_range<ConstRange>);
-static_assert(cuda::std::ranges::borrowed_range<ConstRange&>);
-static_assert(!cuda::std::ranges::borrowed_range<const ConstRange>);
-static_assert(cuda::std::ranges::borrowed_range<const ConstRange&>);
-static_assert(!cuda::std::ranges::borrowed_range<ConstRange&&>);
+static_assert(!cuda::std::ranges::borrowed_range<ConstRange>, "");
+static_assert(cuda::std::ranges::borrowed_range<ConstRange&>, "");
+static_assert(!cuda::std::ranges::borrowed_range<const ConstRange>, "");
+static_assert(cuda::std::ranges::borrowed_range<const ConstRange&>, "");
+static_assert(!cuda::std::ranges::borrowed_range<ConstRange&&>, "");
 
-static_assert(cuda::std::ranges::borrowed_range<BorrowedRange>);
-static_assert(cuda::std::ranges::borrowed_range<BorrowedRange&>);
-static_assert(cuda::std::ranges::borrowed_range<const BorrowedRange>);
-static_assert(cuda::std::ranges::borrowed_range<const BorrowedRange&>);
-static_assert(cuda::std::ranges::borrowed_range<BorrowedRange&&>);
+static_assert(cuda::std::ranges::borrowed_range<BorrowedRange>, "");
+static_assert(cuda::std::ranges::borrowed_range<BorrowedRange&>, "");
+static_assert(cuda::std::ranges::borrowed_range<const BorrowedRange>, "");
+static_assert(cuda::std::ranges::borrowed_range<const BorrowedRange&>, "");
+static_assert(cuda::std::ranges::borrowed_range<BorrowedRange&&>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/borrowed_range.subsumption.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/borrowed_range.subsumption.compile.pass.cpp
@@ -27,7 +27,7 @@ __host__ __device__ consteval bool check_subsumption()
   return true;
 }
 
-static_assert(check_subsumption<int (&)[8]>());
+static_assert(check_subsumption<int (&)[8]>(), "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/enable_borrowed_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/enable_borrowed_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // <ranges>
@@ -29,16 +29,16 @@ struct S
 __host__ __device__ void test()
 {
   using cuda::std::ranges::enable_borrowed_range;
-  static_assert(!enable_borrowed_range<char>);
-  static_assert(!enable_borrowed_range<int>);
-  static_assert(!enable_borrowed_range<double>);
-  static_assert(!enable_borrowed_range<S>);
+  static_assert(!enable_borrowed_range<char>, "");
+  static_assert(!enable_borrowed_range<int>, "");
+  static_assert(!enable_borrowed_range<double>, "");
+  static_assert(!enable_borrowed_range<S>, "");
 
   // Sequence containers
-  static_assert(!enable_borrowed_range<cuda::std::array<int, 0>>);
-  static_assert(!enable_borrowed_range<cuda::std::array<int, 42>>);
+  static_assert(!enable_borrowed_range<cuda::std::array<int, 0>>, "");
+  static_assert(!enable_borrowed_range<cuda::std::array<int, 42>>, "");
 #if defined(_LIBCUDACXX_HAS_VECTOR)
-  static_assert(!enable_borrowed_range<cuda::std::vector<int>>);
+  static_assert(!enable_borrowed_range<cuda::std::vector<int>>, "");
 #endif
 
   // Both cuda::std::span and cuda::std::string_view have their own test.

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/helper_aliases.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/helper_aliases.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<range R>
@@ -29,15 +29,20 @@
 #include "test_range.h"
 
 static_assert(cuda::std::same_as<cuda::std::ranges::range_difference_t<test_range<cpp20_input_iterator>>,
-                                 cuda::std::iter_difference_t<int*>>);
+                                 cuda::std::iter_difference_t<int*>>,
+              "");
 static_assert(
-  cuda::std::same_as<cuda::std::ranges::range_value_t<test_range<cpp20_input_iterator>>, cuda::std::iter_value_t<int*>>);
+  cuda::std::same_as<cuda::std::ranges::range_value_t<test_range<cpp20_input_iterator>>, cuda::std::iter_value_t<int*>>,
+  "");
 static_assert(cuda::std::same_as<cuda::std::ranges::range_reference_t<test_range<cpp20_input_iterator>>,
-                                 cuda::std::iter_reference_t<int*>>);
+                                 cuda::std::iter_reference_t<int*>>,
+              "");
 static_assert(cuda::std::same_as<cuda::std::ranges::range_rvalue_reference_t<test_range<cpp20_input_iterator>>,
-                                 cuda::std::iter_rvalue_reference_t<int*>>);
+                                 cuda::std::iter_rvalue_reference_t<int*>>,
+              "");
 static_assert(cuda::std::same_as<cuda::std::ranges::range_common_reference_t<test_range<cpp20_input_iterator>>,
-                                 cuda::std::iter_common_reference_t<int*>>);
+                                 cuda::std::iter_common_reference_t<int*>>,
+              "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/iterator_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/iterator_t.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class T>
@@ -19,20 +19,25 @@
 #include "test_range.h"
 
 static_assert(
-  cuda::std::same_as<cuda::std::ranges::iterator_t<test_range<cpp17_input_iterator>>, cpp17_input_iterator<int*>>);
+  cuda::std::same_as<cuda::std::ranges::iterator_t<test_range<cpp17_input_iterator>>, cpp17_input_iterator<int*>>, "");
 static_assert(cuda::std::same_as<cuda::std::ranges::iterator_t<test_range<cpp17_input_iterator> const>,
-                                 cpp17_input_iterator<int const*>>);
+                                 cpp17_input_iterator<int const*>>,
+              "");
 
 static_assert(cuda::std::same_as<cuda::std::ranges::iterator_t<test_non_const_range<cpp17_input_iterator>>,
-                                 cpp17_input_iterator<int*>>);
+                                 cpp17_input_iterator<int*>>,
+              "");
 
-static_assert(cuda::std::same_as<cuda::std::ranges::iterator_t<test_common_range<cpp17_input_iterator>>,
-                                 cpp17_input_iterator<int*>>);
+static_assert(
+  cuda::std::same_as<cuda::std::ranges::iterator_t<test_common_range<cpp17_input_iterator>>, cpp17_input_iterator<int*>>,
+  "");
 static_assert(cuda::std::same_as<cuda::std::ranges::iterator_t<test_common_range<cpp17_input_iterator> const>,
-                                 cpp17_input_iterator<int const*>>);
+                                 cpp17_input_iterator<int const*>>,
+              "");
 
 static_assert(cuda::std::same_as<cuda::std::ranges::iterator_t<test_non_const_common_range<cpp17_input_iterator>>,
-                                 cpp17_input_iterator<int*>>);
+                                 cpp17_input_iterator<int*>>,
+              "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class T>
@@ -17,35 +17,35 @@
 
 #include "test_range.h"
 
-static_assert(cuda::std::ranges::range<test_range<cpp20_input_iterator>>);
+static_assert(cuda::std::ranges::range<test_range<cpp20_input_iterator>>, "");
 
 struct incompatible_iterators
 {
   __host__ __device__ int* begin();
   __host__ __device__ long* end();
 };
-static_assert(!cuda::std::ranges::range<incompatible_iterators>);
+static_assert(!cuda::std::ranges::range<incompatible_iterators>, "");
 
 struct int_begin_int_end
 {
   __host__ __device__ int begin();
   __host__ __device__ int end();
 };
-static_assert(!cuda::std::ranges::range<int_begin_int_end>);
+static_assert(!cuda::std::ranges::range<int_begin_int_end>, "");
 
 struct iterator_begin_int_end
 {
   __host__ __device__ int* begin();
   __host__ __device__ int end();
 };
-static_assert(!cuda::std::ranges::range<iterator_begin_int_end>);
+static_assert(!cuda::std::ranges::range<iterator_begin_int_end>, "");
 
 struct int_begin_iterator_end
 {
   __host__ __device__ int begin();
   __host__ __device__ int* end();
 };
-static_assert(!cuda::std::ranges::range<int_begin_iterator_end>);
+static_assert(!cuda::std::ranges::range<int_begin_iterator_end>, "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -55,7 +55,7 @@ struct Holder
 {
   T t;
 };
-static_assert(!cuda::std::ranges::range<Holder<Incomplete>*>);
+static_assert(!cuda::std::ranges::range<Holder<Incomplete>*>, "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/range_size_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/range_size_t.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<sized_range R>
@@ -36,31 +36,31 @@ struct A
   __host__ __device__ int* end();
   __host__ __device__ short size();
 };
-static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<A>, short>);
-static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<A&>, short>);
-static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<A&&>, short>);
-static_assert(!has_range_size_t<const A>);
-static_assert(!has_range_size_t<const A&>);
-static_assert(!has_range_size_t<const A&&>);
+static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<A>, short>, "");
+static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<A&>, short>, "");
+static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<A&&>, short>, "");
+static_assert(!has_range_size_t<const A>, "");
+static_assert(!has_range_size_t<const A&>, "");
+static_assert(!has_range_size_t<const A&&>, "");
 
 struct B
 {
   __host__ __device__ int* begin();
   __host__ __device__ int* end();
 };
-static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<B>, cuda::std::size_t>);
-static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<B&>, cuda::std::size_t>);
-static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<B&&>, cuda::std::size_t>);
-static_assert(!has_range_size_t<const B>);
-static_assert(!has_range_size_t<const B&>);
-static_assert(!has_range_size_t<const B&&>);
+static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<B>, cuda::std::size_t>, "");
+static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<B&>, cuda::std::size_t>, "");
+static_assert(cuda::std::same_as<cuda::std::ranges::range_size_t<B&&>, cuda::std::size_t>, "");
+static_assert(!has_range_size_t<const B>, "");
+static_assert(!has_range_size_t<const B&>, "");
+static_assert(!has_range_size_t<const B&&>, "");
 
 struct C
 {
   __host__ __device__ bidirectional_iterator<int*> begin();
   __host__ __device__ bidirectional_iterator<int*> end();
 };
-static_assert(!has_range_size_t<C>);
+static_assert(!has_range_size_t<C>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/sentinel_t.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.range/sentinel_t.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<range _Rp>
@@ -19,15 +19,18 @@
 #include "test_iterators.h"
 #include "test_range.h"
 
-static_assert(cuda::std::same_as<cuda::std::ranges::sentinel_t<test_range<cpp20_input_iterator>>, sentinel>);
-static_assert(cuda::std::same_as<cuda::std::ranges::sentinel_t<test_range<cpp20_input_iterator> const>, sentinel>);
-static_assert(cuda::std::same_as<cuda::std::ranges::sentinel_t<test_non_const_range<cpp20_input_iterator>>, sentinel>);
+static_assert(cuda::std::same_as<cuda::std::ranges::sentinel_t<test_range<cpp20_input_iterator>>, sentinel>, "");
+static_assert(cuda::std::same_as<cuda::std::ranges::sentinel_t<test_range<cpp20_input_iterator> const>, sentinel>, "");
+static_assert(cuda::std::same_as<cuda::std::ranges::sentinel_t<test_non_const_range<cpp20_input_iterator>>, sentinel>,
+              "");
 static_assert(
-  cuda::std::same_as<cuda::std::ranges::sentinel_t<test_common_range<forward_iterator>>, forward_iterator<int*>>);
+  cuda::std::same_as<cuda::std::ranges::sentinel_t<test_common_range<forward_iterator>>, forward_iterator<int*>>, "");
 static_assert(cuda::std::same_as<cuda::std::ranges::sentinel_t<test_common_range<forward_iterator> const>,
-                                 forward_iterator<int const*>>);
+                                 forward_iterator<int const*>>,
+              "");
 static_assert(cuda::std::same_as<cuda::std::ranges::sentinel_t<test_non_const_common_range<forward_iterator>>,
-                                 forward_iterator<int*>>);
+                                 forward_iterator<int*>>,
+              "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/bidirectional_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/bidirectional_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class R>
@@ -21,22 +21,22 @@ template <template <class...> class I>
 __host__ __device__ constexpr bool check_bidirectional_range()
 {
   constexpr bool result = cuda::std::ranges::bidirectional_range<test_range<I>>;
-  static_assert(cuda::std::ranges::bidirectional_range<test_range<I> const> == result);
-  static_assert(cuda::std::ranges::bidirectional_range<test_non_const_common_range<I>> == result);
-  static_assert(cuda::std::ranges::bidirectional_range<test_non_const_range<I>> == result);
-  static_assert(cuda::std::ranges::bidirectional_range<test_common_range<I>> == result);
-  static_assert(cuda::std::ranges::bidirectional_range<test_common_range<I> const> == result);
-  static_assert(!cuda::std::ranges::bidirectional_range<test_non_const_common_range<I> const>);
-  static_assert(!cuda::std::ranges::bidirectional_range<test_non_const_range<I> const>);
+  static_assert(cuda::std::ranges::bidirectional_range<test_range<I> const> == result, "");
+  static_assert(cuda::std::ranges::bidirectional_range<test_non_const_common_range<I>> == result, "");
+  static_assert(cuda::std::ranges::bidirectional_range<test_non_const_range<I>> == result, "");
+  static_assert(cuda::std::ranges::bidirectional_range<test_common_range<I>> == result, "");
+  static_assert(cuda::std::ranges::bidirectional_range<test_common_range<I> const> == result, "");
+  static_assert(!cuda::std::ranges::bidirectional_range<test_non_const_common_range<I> const>, "");
+  static_assert(!cuda::std::ranges::bidirectional_range<test_non_const_range<I> const>, "");
   return result;
 }
 
-static_assert(!check_bidirectional_range<cpp17_input_iterator>());
-static_assert(!check_bidirectional_range<cpp20_input_iterator>());
-static_assert(!check_bidirectional_range<forward_iterator>());
-static_assert(check_bidirectional_range<bidirectional_iterator>());
-static_assert(check_bidirectional_range<random_access_iterator>());
-static_assert(check_bidirectional_range<contiguous_iterator>());
+static_assert(!check_bidirectional_range<cpp17_input_iterator>(), "");
+static_assert(!check_bidirectional_range<cpp20_input_iterator>(), "");
+static_assert(!check_bidirectional_range<forward_iterator>(), "");
+static_assert(check_bidirectional_range<bidirectional_iterator>(), "");
+static_assert(check_bidirectional_range<random_access_iterator>(), "");
+static_assert(check_bidirectional_range<contiguous_iterator>(), "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -47,19 +47,19 @@ struct Holder
   T t;
 };
 
-static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>*&>);
-static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>*&&>);
-static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const>);
-static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const&>);
-static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const&&>);
+static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>*&>, "");
+static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>*&&>, "");
+static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const>, "");
+static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const&>, "");
+static_assert(!cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const&&>, "");
 
-static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* [10]>);
-static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* (&) [10]>);
-static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* (&&) [10]>);
-static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const[10]>);
-static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const (&)[10]>);
-static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const (&&)[10]>);
+static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* [10]>, "");
+static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* (&) [10]>, "");
+static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* (&&) [10]>, "");
+static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const[10]>, "");
+static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const (&)[10]>, "");
+static_assert(cuda::std::ranges::bidirectional_range<Holder<Incomplete>* const (&&)[10]>, "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/common_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/common_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class R>
@@ -36,31 +36,31 @@ struct Range
   __host__ __device__ Sent end() const;
 };
 
-static_assert(!cuda::std::ranges::common_range<Common<cpp17_input_iterator<int*>>>); // not a sentinel for itself
-static_assert(!cuda::std::ranges::common_range<Common<cpp20_input_iterator<int*>>>); // not a sentinel for itself
-static_assert(cuda::std::ranges::common_range<Common<forward_iterator<int*>>>);
-static_assert(cuda::std::ranges::common_range<Common<bidirectional_iterator<int*>>>);
-static_assert(cuda::std::ranges::common_range<Common<random_access_iterator<int*>>>);
-static_assert(cuda::std::ranges::common_range<Common<contiguous_iterator<int*>>>);
-static_assert(cuda::std::ranges::common_range<Common<int*>>);
+static_assert(!cuda::std::ranges::common_range<Common<cpp17_input_iterator<int*>>>, ""); // not a sentinel for itself
+static_assert(!cuda::std::ranges::common_range<Common<cpp20_input_iterator<int*>>>, ""); // not a sentinel for itself
+static_assert(cuda::std::ranges::common_range<Common<forward_iterator<int*>>>, "");
+static_assert(cuda::std::ranges::common_range<Common<bidirectional_iterator<int*>>>, "");
+static_assert(cuda::std::ranges::common_range<Common<random_access_iterator<int*>>>, "");
+static_assert(cuda::std::ranges::common_range<Common<contiguous_iterator<int*>>>, "");
+static_assert(cuda::std::ranges::common_range<Common<int*>>, "");
 
-static_assert(!cuda::std::ranges::common_range<NonCommon<cpp17_input_iterator<int*>>>);
-static_assert(!cuda::std::ranges::common_range<NonCommon<cpp20_input_iterator<int*>>>);
-static_assert(!cuda::std::ranges::common_range<NonCommon<forward_iterator<int*>>>);
-static_assert(!cuda::std::ranges::common_range<NonCommon<bidirectional_iterator<int*>>>);
-static_assert(!cuda::std::ranges::common_range<NonCommon<random_access_iterator<int*>>>);
-static_assert(!cuda::std::ranges::common_range<NonCommon<contiguous_iterator<int*>>>);
-static_assert(!cuda::std::ranges::common_range<NonCommon<int*>>);
+static_assert(!cuda::std::ranges::common_range<NonCommon<cpp17_input_iterator<int*>>>, "");
+static_assert(!cuda::std::ranges::common_range<NonCommon<cpp20_input_iterator<int*>>>, "");
+static_assert(!cuda::std::ranges::common_range<NonCommon<forward_iterator<int*>>>, "");
+static_assert(!cuda::std::ranges::common_range<NonCommon<bidirectional_iterator<int*>>>, "");
+static_assert(!cuda::std::ranges::common_range<NonCommon<random_access_iterator<int*>>>, "");
+static_assert(!cuda::std::ranges::common_range<NonCommon<contiguous_iterator<int*>>>, "");
+static_assert(!cuda::std::ranges::common_range<NonCommon<int*>>, "");
 
 // Test when begin() and end() only differ by their constness.
-static_assert(!cuda::std::ranges::common_range<Range<int*, int const*>>);
+static_assert(!cuda::std::ranges::common_range<Range<int*, int const*>>, "");
 
 // Simple test with a sized_sentinel.
-static_assert(!cuda::std::ranges::common_range<Range<int*, sized_sentinel<int*>>>);
+static_assert(!cuda::std::ranges::common_range<Range<int*, sized_sentinel<int*>>>, "");
 
 // Make sure cv-qualification doesn't impact the concept when begin() and end() have matching qualifiers.
-static_assert(cuda::std::ranges::common_range<Common<forward_iterator<int*>> const>);
-static_assert(!cuda::std::ranges::common_range<NonCommon<forward_iterator<int*>> const>);
+static_assert(cuda::std::ranges::common_range<Common<forward_iterator<int*>> const>, "");
+static_assert(!cuda::std::ranges::common_range<NonCommon<forward_iterator<int*>> const>, "");
 
 // Test with a range that's a common_range only when const-qualified.
 struct Range1
@@ -69,8 +69,8 @@ struct Range1
   __host__ __device__ int const* begin() const;
   __host__ __device__ int const* end() const;
 };
-static_assert(!cuda::std::ranges::common_range<Range1>);
-static_assert(cuda::std::ranges::common_range<Range1 const>);
+static_assert(!cuda::std::ranges::common_range<Range1>, "");
+static_assert(cuda::std::ranges::common_range<Range1 const>, "");
 
 // Test with a range that's a common_range only when not const-qualified.
 struct Range2
@@ -79,8 +79,8 @@ struct Range2
   __host__ __device__ int* end();
   __host__ __device__ int const* end() const;
 };
-static_assert(cuda::std::ranges::common_range<Range2>);
-static_assert(!cuda::std::ranges::common_range<Range2 const>);
+static_assert(cuda::std::ranges::common_range<Range2>, "");
+static_assert(!cuda::std::ranges::common_range<Range2 const>, "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -91,19 +91,19 @@ struct Holder
   T t;
 };
 
-static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>*&>);
-static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>*&&>);
-static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>* const>);
-static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>* const&>);
-static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>* const&&>);
+static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>*&>, "");
+static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>*&&>, "");
+static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>* const>, "");
+static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>* const&>, "");
+static_assert(!cuda::std::ranges::common_range<Holder<Incomplete>* const&&>, "");
 
-static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* [10]>);
-static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* (&) [10]>);
-static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* (&&) [10]>);
-static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* const[10]>);
-static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* const (&)[10]>);
-static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* const (&&)[10]>);
+static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* [10]>, "");
+static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* (&) [10]>, "");
+static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* (&&) [10]>, "");
+static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* const[10]>, "");
+static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* const (&)[10]>, "");
+static_assert(cuda::std::ranges::common_range<Holder<Incomplete>* const (&&)[10]>, "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/contiguous_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/contiguous_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class R>
@@ -24,21 +24,21 @@ template <template <class...> class I>
 __host__ __device__ constexpr bool check_range()
 {
   constexpr bool result = ranges::contiguous_range<test_range<I>>;
-  static_assert(ranges::contiguous_range<test_range<I> const> == result);
-  static_assert(ranges::contiguous_range<test_non_const_common_range<I>> == result);
-  static_assert(ranges::contiguous_range<test_non_const_range<I>> == result);
-  static_assert(ranges::contiguous_range<test_common_range<I>> == result);
-  static_assert(ranges::contiguous_range<test_common_range<I> const> == result);
-  static_assert(!ranges::contiguous_range<test_non_const_common_range<I> const>);
-  static_assert(!ranges::contiguous_range<test_non_const_range<I> const>);
+  static_assert(ranges::contiguous_range<test_range<I> const> == result, "");
+  static_assert(ranges::contiguous_range<test_non_const_common_range<I>> == result, "");
+  static_assert(ranges::contiguous_range<test_non_const_range<I>> == result, "");
+  static_assert(ranges::contiguous_range<test_common_range<I>> == result, "");
+  static_assert(ranges::contiguous_range<test_common_range<I> const> == result, "");
+  static_assert(!ranges::contiguous_range<test_non_const_common_range<I> const>, "");
+  static_assert(!ranges::contiguous_range<test_non_const_range<I> const>, "");
   return result;
 }
 
-static_assert(!check_range<cpp20_input_iterator>());
-static_assert(!check_range<forward_iterator>());
-static_assert(!check_range<bidirectional_iterator>());
-static_assert(!check_range<random_access_iterator>());
-static_assert(check_range<contiguous_iterator>());
+static_assert(!check_range<cpp20_input_iterator>(), "");
+static_assert(!check_range<forward_iterator>(), "");
+static_assert(!check_range<bidirectional_iterator>(), "");
+static_assert(!check_range<random_access_iterator>(), "");
+static_assert(check_range<contiguous_iterator>(), "");
 
 struct ContiguousWhenNonConst
 {
@@ -48,9 +48,9 @@ struct ContiguousWhenNonConst
   __host__ __device__ int* end();
   __host__ __device__ int* data() const;
 };
-static_assert(cuda::std::ranges::contiguous_range<ContiguousWhenNonConst>);
-static_assert(cuda::std::ranges::random_access_range<const ContiguousWhenNonConst>);
-static_assert(!cuda::std::ranges::contiguous_range<const ContiguousWhenNonConst>);
+static_assert(cuda::std::ranges::contiguous_range<ContiguousWhenNonConst>, "");
+static_assert(cuda::std::ranges::random_access_range<const ContiguousWhenNonConst>, "");
+static_assert(!cuda::std::ranges::contiguous_range<const ContiguousWhenNonConst>, "");
 
 struct ContiguousWhenConst
 {
@@ -60,9 +60,9 @@ struct ContiguousWhenConst
   __host__ __device__ int* end();
   __host__ __device__ const int* data() const;
 };
-static_assert(cuda::std::ranges::contiguous_range<const ContiguousWhenConst>);
-static_assert(cuda::std::ranges::random_access_range<ContiguousWhenConst>);
-static_assert(!cuda::std::ranges::contiguous_range<ContiguousWhenConst>);
+static_assert(cuda::std::ranges::contiguous_range<const ContiguousWhenConst>, "");
+static_assert(cuda::std::ranges::random_access_range<ContiguousWhenConst>, "");
+static_assert(!cuda::std::ranges::contiguous_range<ContiguousWhenConst>, "");
 
 struct DataFunctionWrongReturnType
 {
@@ -70,8 +70,8 @@ struct DataFunctionWrongReturnType
   __host__ __device__ const int* end() const;
   __host__ __device__ const char* data() const;
 };
-static_assert(cuda::std::ranges::random_access_range<DataFunctionWrongReturnType>);
-static_assert(!cuda::std::ranges::contiguous_range<DataFunctionWrongReturnType>);
+static_assert(cuda::std::ranges::random_access_range<DataFunctionWrongReturnType>, "");
+static_assert(!cuda::std::ranges::contiguous_range<DataFunctionWrongReturnType>, "");
 
 struct WrongObjectness
 {
@@ -79,7 +79,7 @@ struct WrongObjectness
   __host__ __device__ const int* end() const;
   __host__ __device__ void* data() const;
 };
-static_assert(cuda::std::ranges::contiguous_range<WrongObjectness>);
+static_assert(cuda::std::ranges::contiguous_range<WrongObjectness>, "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -90,19 +90,19 @@ struct Holder
   T t;
 };
 
-static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>*&>);
-static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>*&&>);
-static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>* const>);
-static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>* const&>);
-static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>* const&&>);
+static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>*&>, "");
+static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>*&&>, "");
+static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>* const>, "");
+static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>* const&>, "");
+static_assert(!cuda::std::ranges::contiguous_range<Holder<Incomplete>* const&&>, "");
 
-static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* [10]>);
-static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* (&) [10]>);
-static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* (&&) [10]>);
-static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* const[10]>);
-static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* const (&)[10]>);
-static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* const (&&)[10]>);
+static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* [10]>, "");
+static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* (&) [10]>, "");
+static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* (&&) [10]>, "");
+static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* const[10]>, "");
+static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* const (&)[10]>, "");
+static_assert(cuda::std::ranges::contiguous_range<Holder<Incomplete>* const (&&)[10]>, "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/forward_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/forward_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class R>
@@ -22,22 +22,22 @@ template <template <class...> class I>
 __host__ __device__ constexpr bool check_forward_range()
 {
   constexpr bool result = cuda::std::ranges::forward_range<test_range<I>>;
-  static_assert(cuda::std::ranges::forward_range<test_range<I> const> == result);
-  static_assert(cuda::std::ranges::forward_range<test_non_const_common_range<I>> == result);
-  static_assert(cuda::std::ranges::forward_range<test_non_const_range<I>> == result);
-  static_assert(cuda::std::ranges::forward_range<test_common_range<I>> == result);
-  static_assert(cuda::std::ranges::forward_range<test_common_range<I> const> == result);
-  static_assert(!cuda::std::ranges::forward_range<test_non_const_common_range<I> const>);
-  static_assert(!cuda::std::ranges::forward_range<test_non_const_range<I> const>);
+  static_assert(cuda::std::ranges::forward_range<test_range<I> const> == result, "");
+  static_assert(cuda::std::ranges::forward_range<test_non_const_common_range<I>> == result, "");
+  static_assert(cuda::std::ranges::forward_range<test_non_const_range<I>> == result, "");
+  static_assert(cuda::std::ranges::forward_range<test_common_range<I>> == result, "");
+  static_assert(cuda::std::ranges::forward_range<test_common_range<I> const> == result, "");
+  static_assert(!cuda::std::ranges::forward_range<test_non_const_common_range<I> const>, "");
+  static_assert(!cuda::std::ranges::forward_range<test_non_const_range<I> const>, "");
   return result;
 }
 
-static_assert(!check_forward_range<cpp17_input_iterator>());
-static_assert(!check_forward_range<cpp20_input_iterator>());
-static_assert(check_forward_range<forward_iterator>());
-static_assert(check_forward_range<bidirectional_iterator>());
-static_assert(check_forward_range<random_access_iterator>());
-static_assert(check_forward_range<contiguous_iterator>());
+static_assert(!check_forward_range<cpp17_input_iterator>(), "");
+static_assert(!check_forward_range<cpp20_input_iterator>(), "");
+static_assert(check_forward_range<forward_iterator>(), "");
+static_assert(check_forward_range<bidirectional_iterator>(), "");
+static_assert(check_forward_range<random_access_iterator>(), "");
+static_assert(check_forward_range<contiguous_iterator>(), "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -48,19 +48,19 @@ struct Holder
   T t;
 };
 
-static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>*&>);
-static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>*&&>);
-static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>* const>);
-static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>* const&>);
-static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>* const&&>);
+static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>*&>, "");
+static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>*&&>, "");
+static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>* const>, "");
+static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>* const&>, "");
+static_assert(!cuda::std::ranges::forward_range<Holder<Incomplete>* const&&>, "");
 
-static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* [10]>);
-static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* (&) [10]>);
-static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* (&&) [10]>);
-static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* const[10]>);
-static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* const (&)[10]>);
-static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* const (&&)[10]>);
+static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* [10]>, "");
+static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* (&) [10]>, "");
+static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* (&&) [10]>, "");
+static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* const[10]>, "");
+static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* const (&)[10]>, "");
+static_assert(cuda::std::ranges::forward_range<Holder<Incomplete>* const (&&)[10]>, "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/input_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/input_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class R>
@@ -18,29 +18,29 @@
 #include "test_iterators.h"
 #include "test_range.h"
 
-static_assert(cuda::std::ranges::input_range<test_range<cpp17_input_iterator>>);
-static_assert(cuda::std::ranges::input_range<test_range<cpp17_input_iterator> const>);
+static_assert(cuda::std::ranges::input_range<test_range<cpp17_input_iterator>>, "");
+static_assert(cuda::std::ranges::input_range<test_range<cpp17_input_iterator> const>, "");
 
-static_assert(cuda::std::ranges::input_range<test_range<cpp20_input_iterator>>);
-static_assert(cuda::std::ranges::input_range<test_range<cpp20_input_iterator> const>);
+static_assert(cuda::std::ranges::input_range<test_range<cpp20_input_iterator>>, "");
+static_assert(cuda::std::ranges::input_range<test_range<cpp20_input_iterator> const>, "");
 
-static_assert(cuda::std::ranges::input_range<test_non_const_range<cpp17_input_iterator>>);
-static_assert(cuda::std::ranges::input_range<test_non_const_range<cpp20_input_iterator>>);
+static_assert(cuda::std::ranges::input_range<test_non_const_range<cpp17_input_iterator>>, "");
+static_assert(cuda::std::ranges::input_range<test_non_const_range<cpp20_input_iterator>>, "");
 
-static_assert(!cuda::std::ranges::input_range<test_non_const_range<cpp17_input_iterator> const>);
-static_assert(!cuda::std::ranges::input_range<test_non_const_range<cpp20_input_iterator> const>);
+static_assert(!cuda::std::ranges::input_range<test_non_const_range<cpp17_input_iterator> const>, "");
+static_assert(!cuda::std::ranges::input_range<test_non_const_range<cpp20_input_iterator> const>, "");
 
-static_assert(cuda::std::ranges::input_range<test_common_range<forward_iterator>>);
-static_assert(!cuda::std::ranges::input_range<test_common_range<cpp20_input_iterator>>);
+static_assert(cuda::std::ranges::input_range<test_common_range<forward_iterator>>, "");
+static_assert(!cuda::std::ranges::input_range<test_common_range<cpp20_input_iterator>>, "");
 
-static_assert(cuda::std::ranges::input_range<test_common_range<forward_iterator> const>);
-static_assert(!cuda::std::ranges::input_range<test_common_range<cpp20_input_iterator> const>);
+static_assert(cuda::std::ranges::input_range<test_common_range<forward_iterator> const>, "");
+static_assert(!cuda::std::ranges::input_range<test_common_range<cpp20_input_iterator> const>, "");
 
-static_assert(cuda::std::ranges::input_range<test_non_const_common_range<forward_iterator>>);
-static_assert(!cuda::std::ranges::input_range<test_non_const_common_range<cpp20_input_iterator>>);
+static_assert(cuda::std::ranges::input_range<test_non_const_common_range<forward_iterator>>, "");
+static_assert(!cuda::std::ranges::input_range<test_non_const_common_range<cpp20_input_iterator>>, "");
 
-static_assert(!cuda::std::ranges::input_range<test_non_const_common_range<forward_iterator> const>);
-static_assert(!cuda::std::ranges::input_range<test_non_const_common_range<cpp20_input_iterator> const>);
+static_assert(!cuda::std::ranges::input_range<test_non_const_common_range<forward_iterator> const>, "");
+static_assert(!cuda::std::ranges::input_range<test_non_const_common_range<cpp20_input_iterator> const>, "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -51,19 +51,19 @@ struct Holder
   T t;
 };
 
-static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>*&>);
-static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>*&&>);
-static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>* const>);
-static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>* const&>);
-static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>* const&&>);
+static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>*&>, "");
+static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>*&&>, "");
+static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>* const>, "");
+static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>* const&>, "");
+static_assert(!cuda::std::ranges::input_range<Holder<Incomplete>* const&&>, "");
 
-static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* [10]>);
-static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* (&) [10]>);
-static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* (&&) [10]>);
-static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* const[10]>);
-static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* const (&)[10]>);
-static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* const (&&)[10]>);
+static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* [10]>, "");
+static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* (&) [10]>, "");
+static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* (&&) [10]>, "");
+static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* const[10]>, "");
+static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* const (&)[10]>, "");
+static_assert(cuda::std::ranges::input_range<Holder<Incomplete>* const (&&)[10]>, "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/output_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/output_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class R, class T>
@@ -28,18 +28,18 @@ struct GoodRange
   __host__ __device__ cpp17_output_iterator<T*> begin();
   __host__ __device__ sentinel end();
 };
-static_assert(cuda::std::ranges::range<GoodRange>);
-static_assert(cuda::std::output_iterator<cuda::std::ranges::iterator_t<GoodRange>, T>);
-static_assert(cuda::std::ranges::output_range<GoodRange, T>);
+static_assert(cuda::std::ranges::range<GoodRange>, "");
+static_assert(cuda::std::output_iterator<cuda::std::ranges::iterator_t<GoodRange>, T>, "");
+static_assert(cuda::std::ranges::output_range<GoodRange, T>, "");
 
 // Not satisfied when it's not a range
 struct NotRange
 {
   __host__ __device__ cpp17_output_iterator<T*> begin();
 };
-static_assert(!cuda::std::ranges::range<NotRange>);
-static_assert(cuda::std::output_iterator<cuda::std::ranges::iterator_t<NotRange>, T>);
-static_assert(!cuda::std::ranges::output_range<NotRange, T>);
+static_assert(!cuda::std::ranges::range<NotRange>, "");
+static_assert(cuda::std::output_iterator<cuda::std::ranges::iterator_t<NotRange>, T>, "");
+static_assert(!cuda::std::ranges::output_range<NotRange, T>, "");
 
 // Not satisfied when the iterator is not an output_iterator
 struct RangeWithBadIterator
@@ -47,9 +47,9 @@ struct RangeWithBadIterator
   __host__ __device__ cpp17_input_iterator<T const*> begin();
   __host__ __device__ sentinel end();
 };
-static_assert(cuda::std::ranges::range<RangeWithBadIterator>);
-static_assert(!cuda::std::output_iterator<cuda::std::ranges::iterator_t<RangeWithBadIterator>, T>);
-static_assert(!cuda::std::ranges::output_range<RangeWithBadIterator, T>);
+static_assert(cuda::std::ranges::range<RangeWithBadIterator>, "");
+static_assert(!cuda::std::output_iterator<cuda::std::ranges::iterator_t<RangeWithBadIterator>, T>, "");
+static_assert(!cuda::std::ranges::output_range<RangeWithBadIterator, T>, "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -60,19 +60,19 @@ struct Holder
   T t;
 };
 
-static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>*, Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>*&, Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>*&&, Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const, Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const&, Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const&&, Holder<Incomplete>*>);
+static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>*, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>*&, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>*&&, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const&, Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const&&, Holder<Incomplete>*>, "");
 
-static_assert(cuda::std::ranges::output_range<Holder<Incomplete>* [10], Holder<Incomplete>*>);
-static_assert(cuda::std::ranges::output_range<Holder<Incomplete>* (&) [10], Holder<Incomplete>*>);
-static_assert(cuda::std::ranges::output_range<Holder<Incomplete>* (&&) [10], Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const[10], Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const (&)[10], Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const (&&)[10], Holder<Incomplete>*>);
+static_assert(cuda::std::ranges::output_range<Holder<Incomplete>* [10], Holder<Incomplete>*>, "");
+static_assert(cuda::std::ranges::output_range<Holder<Incomplete>* (&) [10], Holder<Incomplete>*>, "");
+static_assert(cuda::std::ranges::output_range<Holder<Incomplete>* (&&) [10], Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const[10], Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const (&)[10], Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::output_range<Holder<Incomplete>* const (&&)[10], Holder<Incomplete>*>, "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/random_access_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/random_access_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class R>
@@ -24,21 +24,21 @@ template <template <class...> class I>
 __host__ __device__ constexpr bool check_range()
 {
   constexpr bool result = ranges::random_access_range<test_range<I>>;
-  static_assert(ranges::random_access_range<test_range<I> const> == result);
-  static_assert(ranges::random_access_range<test_non_const_common_range<I>> == result);
-  static_assert(ranges::random_access_range<test_non_const_range<I>> == result);
-  static_assert(ranges::random_access_range<test_common_range<I>> == result);
-  static_assert(ranges::random_access_range<test_common_range<I> const> == result);
-  static_assert(!ranges::random_access_range<test_non_const_common_range<I> const>);
-  static_assert(!ranges::random_access_range<test_non_const_range<I> const>);
+  static_assert(ranges::random_access_range<test_range<I> const> == result, "");
+  static_assert(ranges::random_access_range<test_non_const_common_range<I>> == result, "");
+  static_assert(ranges::random_access_range<test_non_const_range<I>> == result, "");
+  static_assert(ranges::random_access_range<test_common_range<I>> == result, "");
+  static_assert(ranges::random_access_range<test_common_range<I> const> == result, "");
+  static_assert(!ranges::random_access_range<test_non_const_common_range<I> const>, "");
+  static_assert(!ranges::random_access_range<test_non_const_range<I> const>, "");
   return result;
 }
 
-static_assert(!check_range<cpp20_input_iterator>());
-static_assert(!check_range<forward_iterator>());
-static_assert(!check_range<bidirectional_iterator>());
-static_assert(check_range<random_access_iterator>());
-static_assert(check_range<contiguous_iterator>());
+static_assert(!check_range<cpp20_input_iterator>(), "");
+static_assert(!check_range<forward_iterator>(), "");
+static_assert(!check_range<bidirectional_iterator>(), "");
+static_assert(check_range<random_access_iterator>(), "");
+static_assert(check_range<contiguous_iterator>(), "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -49,19 +49,19 @@ struct Holder
   T t;
 };
 
-static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>*&>);
-static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>*&&>);
-static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>* const>);
-static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>* const&>);
-static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>* const&&>);
+static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>*&>, "");
+static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>*&&>, "");
+static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>* const>, "");
+static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>* const&>, "");
+static_assert(!cuda::std::ranges::random_access_range<Holder<Incomplete>* const&&>, "");
 
-static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* [10]>);
-static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* (&) [10]>);
-static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* (&&) [10]>);
-static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* const[10]>);
-static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* const (&)[10]>);
-static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* const (&&)[10]>);
+static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* [10]>, "");
+static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* (&) [10]>, "");
+static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* (&&) [10]>, "");
+static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* const[10]>, "");
+static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* const (&)[10]>, "");
+static_assert(cuda::std::ranges::random_access_range<Holder<Incomplete>* const (&&)[10]>, "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/viewable_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.refinements/viewable_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class R>
@@ -31,14 +31,14 @@
 // viewable_range<T> is not satisfied for (range=false, view=*, constructible_from=*, lvalue-or-movable=*)
 struct T1
 {};
-static_assert(!cuda::std::ranges::range<T1>);
+static_assert(!cuda::std::ranges::range<T1>, "");
 
-static_assert(!cuda::std::ranges::viewable_range<T1>);
-static_assert(!cuda::std::ranges::viewable_range<T1&>);
-static_assert(!cuda::std::ranges::viewable_range<T1&&>);
-static_assert(!cuda::std::ranges::viewable_range<T1 const>);
-static_assert(!cuda::std::ranges::viewable_range<T1 const&>);
-static_assert(!cuda::std::ranges::viewable_range<T1 const&&>);
+static_assert(!cuda::std::ranges::viewable_range<T1>, "");
+static_assert(!cuda::std::ranges::viewable_range<T1&>, "");
+static_assert(!cuda::std::ranges::viewable_range<T1&&>, "");
+static_assert(!cuda::std::ranges::viewable_range<T1 const>, "");
+static_assert(!cuda::std::ranges::viewable_range<T1 const&>, "");
+static_assert(!cuda::std::ranges::viewable_range<T1 const&&>, "");
 
 // viewable_range<T> is satisfied for (range=true, view=true, constructible_from=true, lvalue-or-movable=true)
 struct T2
@@ -47,16 +47,16 @@ struct T2
 {
   T2(T2 const&) = default;
 };
-static_assert(cuda::std::ranges::range<T2>);
-static_assert(cuda::std::ranges::view<T2>);
-static_assert(cuda::std::constructible_from<T2, T2>);
+static_assert(cuda::std::ranges::range<T2>, "");
+static_assert(cuda::std::ranges::view<T2>, "");
+static_assert(cuda::std::constructible_from<T2, T2>, "");
 
-static_assert(cuda::std::ranges::viewable_range<T2>);
-static_assert(cuda::std::ranges::viewable_range<T2&>);
-static_assert(cuda::std::ranges::viewable_range<T2&&>);
-static_assert(cuda::std::ranges::viewable_range<T2 const>);
-static_assert(cuda::std::ranges::viewable_range<T2 const&>);
-static_assert(cuda::std::ranges::viewable_range<T2 const&&>);
+static_assert(cuda::std::ranges::viewable_range<T2>, "");
+static_assert(cuda::std::ranges::viewable_range<T2&>, "");
+static_assert(cuda::std::ranges::viewable_range<T2&&>, "");
+static_assert(cuda::std::ranges::viewable_range<T2 const>, "");
+static_assert(cuda::std::ranges::viewable_range<T2 const&>, "");
+static_assert(cuda::std::ranges::viewable_range<T2 const&&>, "");
 
 // viewable_range<T> is satisfied for (range=true, view=true, constructible_from=true, lvalue-or-movable=false)
 struct T3
@@ -65,16 +65,16 @@ struct T3
 {
   T3(T3 const&) = default;
 };
-static_assert(cuda::std::ranges::range<T3>);
-static_assert(cuda::std::ranges::view<T3>);
-static_assert(cuda::std::constructible_from<T3, T3>);
+static_assert(cuda::std::ranges::range<T3>, "");
+static_assert(cuda::std::ranges::view<T3>, "");
+static_assert(cuda::std::constructible_from<T3, T3>, "");
 
-static_assert(cuda::std::ranges::viewable_range<T3>);
-static_assert(cuda::std::ranges::viewable_range<T3&>);
-static_assert(cuda::std::ranges::viewable_range<T3&&>);
-static_assert(cuda::std::ranges::viewable_range<T3 const>);
-static_assert(cuda::std::ranges::viewable_range<T3 const&>);
-static_assert(cuda::std::ranges::viewable_range<T3 const&&>);
+static_assert(cuda::std::ranges::viewable_range<T3>, "");
+static_assert(cuda::std::ranges::viewable_range<T3&>, "");
+static_assert(cuda::std::ranges::viewable_range<T3&&>, "");
+static_assert(cuda::std::ranges::viewable_range<T3 const>, "");
+static_assert(cuda::std::ranges::viewable_range<T3 const&>, "");
+static_assert(cuda::std::ranges::viewable_range<T3 const&&>, "");
 
 // viewable_range<T> is not satisfied for (range=true, view=true, constructible_from=false, lvalue-or-movable=true)
 struct T4
@@ -85,11 +85,11 @@ struct T4
   T4(T4&&)            = default; // necessary to model view
   T4& operator=(T4&&) = default; // necessary to model view
 };
-static_assert(cuda::std::ranges::range<T4 const&>);
-static_assert(cuda::std::ranges::view<cuda::std::remove_cvref_t<T4 const&>>);
-static_assert(!cuda::std::constructible_from<cuda::std::remove_cvref_t<T4 const&>, T4 const&>);
+static_assert(cuda::std::ranges::range<T4 const&>, "");
+static_assert(cuda::std::ranges::view<cuda::std::remove_cvref_t<T4 const&>>, "");
+static_assert(!cuda::std::constructible_from<cuda::std::remove_cvref_t<T4 const&>, T4 const&>, "");
 
-static_assert(!cuda::std::ranges::viewable_range<T4 const&>);
+static_assert(!cuda::std::ranges::viewable_range<T4 const&>, "");
 
 // A type that satisfies (range=true, view=true, constructible_from=false, lvalue-or-movable=false) can't be formed,
 // because views are movable by definition
@@ -97,31 +97,31 @@ static_assert(!cuda::std::ranges::viewable_range<T4 const&>);
 // viewable_range<T> is satisfied for (range=true, view=false, constructible_from=true, lvalue-or-movable=true)...
 struct T5 : test_range<cpp20_input_iterator>
 {};
-static_assert(cuda::std::ranges::range<T5>);
-static_assert(!cuda::std::ranges::view<T5>);
-static_assert(cuda::std::constructible_from<T5, T5>);
-static_assert(cuda::std::movable<T5>);
-static_assert(!cuda::std::movable<const T5>);
+static_assert(cuda::std::ranges::range<T5>, "");
+static_assert(!cuda::std::ranges::view<T5>, "");
+static_assert(cuda::std::constructible_from<T5, T5>, "");
+static_assert(cuda::std::movable<T5>, "");
+static_assert(!cuda::std::movable<const T5>, "");
 
-static_assert(cuda::std::ranges::viewable_range<T5>); // movable
-static_assert(cuda::std::ranges::viewable_range<T5&>); // movable
-static_assert(cuda::std::ranges::viewable_range<T5&&>); // movable
-static_assert(!cuda::std::ranges::viewable_range<const T5>);
-static_assert(cuda::std::ranges::viewable_range<const T5&>); // lvalue
-static_assert(!cuda::std::ranges::viewable_range<const T5&&>);
+static_assert(cuda::std::ranges::viewable_range<T5>, ""); // movable
+static_assert(cuda::std::ranges::viewable_range<T5&>, ""); // movable
+static_assert(cuda::std::ranges::viewable_range<T5&&>, ""); // movable
+static_assert(!cuda::std::ranges::viewable_range<const T5>, "");
+static_assert(cuda::std::ranges::viewable_range<const T5&>, ""); // lvalue
+static_assert(!cuda::std::ranges::viewable_range<const T5&&>, "");
 
 // ...but not if the (non-view, lvalue-or-movable) range is an initializer_list.
-static_assert(cuda::std::ranges::range<cuda::std::initializer_list<int>>);
-static_assert(!cuda::std::ranges::view<cuda::std::initializer_list<int>>);
-static_assert(cuda::std::constructible_from<cuda::std::initializer_list<int>, cuda::std::initializer_list<int>>);
-static_assert(cuda::std::movable<cuda::std::initializer_list<int>>);
+static_assert(cuda::std::ranges::range<cuda::std::initializer_list<int>>, "");
+static_assert(!cuda::std::ranges::view<cuda::std::initializer_list<int>>, "");
+static_assert(cuda::std::constructible_from<cuda::std::initializer_list<int>, cuda::std::initializer_list<int>>, "");
+static_assert(cuda::std::movable<cuda::std::initializer_list<int>>, "");
 
-static_assert(!cuda::std::ranges::viewable_range<cuda::std::initializer_list<int>>);
-static_assert(cuda::std::ranges::viewable_range<cuda::std::initializer_list<int>&>);
-static_assert(!cuda::std::ranges::viewable_range<cuda::std::initializer_list<int>&&>);
-static_assert(!cuda::std::ranges::viewable_range<cuda::std::initializer_list<int> const>);
-static_assert(cuda::std::ranges::viewable_range<cuda::std::initializer_list<int> const&>);
-static_assert(!cuda::std::ranges::viewable_range<cuda::std::initializer_list<int> const&&>);
+static_assert(!cuda::std::ranges::viewable_range<cuda::std::initializer_list<int>>, "");
+static_assert(cuda::std::ranges::viewable_range<cuda::std::initializer_list<int>&>, "");
+static_assert(!cuda::std::ranges::viewable_range<cuda::std::initializer_list<int>&&>, "");
+static_assert(!cuda::std::ranges::viewable_range<cuda::std::initializer_list<int> const>, "");
+static_assert(cuda::std::ranges::viewable_range<cuda::std::initializer_list<int> const&>, "");
+static_assert(!cuda::std::ranges::viewable_range<cuda::std::initializer_list<int> const&&>, "");
 
 // viewable_range<T> is not satisfied for (range=true, view=false, constructible_from=true, lvalue-or-movable=false)
 struct T6 : test_range<cpp20_input_iterator>
@@ -129,60 +129,60 @@ struct T6 : test_range<cpp20_input_iterator>
   __host__ __device__ T6(T6&&);
   T6& operator=(T6&&) = delete;
 };
-static_assert(cuda::std::ranges::range<T6>);
-static_assert(!cuda::std::ranges::view<T6>);
-static_assert(cuda::std::constructible_from<T6, T6>);
-static_assert(!cuda::std::movable<T6>);
+static_assert(cuda::std::ranges::range<T6>, "");
+static_assert(!cuda::std::ranges::view<T6>, "");
+static_assert(cuda::std::constructible_from<T6, T6>, "");
+static_assert(!cuda::std::movable<T6>, "");
 
-static_assert(!cuda::std::ranges::viewable_range<T6>);
-static_assert(cuda::std::ranges::viewable_range<T6&>); // lvalue
-static_assert(!cuda::std::ranges::viewable_range<T6&&>);
-static_assert(!cuda::std::ranges::viewable_range<const T6>);
-static_assert(cuda::std::ranges::viewable_range<const T6&>); // lvalue
-static_assert(!cuda::std::ranges::viewable_range<const T6&&>);
+static_assert(!cuda::std::ranges::viewable_range<T6>, "");
+static_assert(cuda::std::ranges::viewable_range<T6&>, ""); // lvalue
+static_assert(!cuda::std::ranges::viewable_range<T6&&>, "");
+static_assert(!cuda::std::ranges::viewable_range<const T6>, "");
+static_assert(cuda::std::ranges::viewable_range<const T6&>, ""); // lvalue
+static_assert(!cuda::std::ranges::viewable_range<const T6&&>, "");
 
 // viewable_range<T> is satisfied for (range=true, view=false, constructible_from=false, lvalue-or-movable=true)
 struct T7 : test_range<cpp20_input_iterator>
 {
   T7(T7 const&) = delete;
 };
-static_assert(cuda::std::ranges::range<T7&>);
-static_assert(!cuda::std::ranges::view<cuda::std::remove_cvref_t<T7&>>);
-static_assert(!cuda::std::constructible_from<cuda::std::remove_cvref_t<T7&>, T7&>);
+static_assert(cuda::std::ranges::range<T7&>, "");
+static_assert(!cuda::std::ranges::view<cuda::std::remove_cvref_t<T7&>>, "");
+static_assert(!cuda::std::constructible_from<cuda::std::remove_cvref_t<T7&>, T7&>, "");
 
-static_assert(!cuda::std::ranges::viewable_range<T7>);
-static_assert(cuda::std::ranges::viewable_range<T7&>);
-static_assert(!cuda::std::ranges::viewable_range<T7&&>);
-static_assert(!cuda::std::ranges::viewable_range<const T7>);
-static_assert(cuda::std::ranges::viewable_range<const T7&>);
-static_assert(!cuda::std::ranges::viewable_range<const T7&&>);
+static_assert(!cuda::std::ranges::viewable_range<T7>, "");
+static_assert(cuda::std::ranges::viewable_range<T7&>, "");
+static_assert(!cuda::std::ranges::viewable_range<T7&&>, "");
+static_assert(!cuda::std::ranges::viewable_range<const T7>, "");
+static_assert(cuda::std::ranges::viewable_range<const T7&>, "");
+static_assert(!cuda::std::ranges::viewable_range<const T7&&>, "");
 
 // viewable_range<T> is not satisfied for (range=true, view=false, constructible_from=false, lvalue-or-movable=false)
 struct T8 : test_range<cpp20_input_iterator>
 {
   T8(T8 const&) = delete;
 };
-static_assert(cuda::std::ranges::range<T8>);
-static_assert(!cuda::std::ranges::view<T8>);
-static_assert(!cuda::std::constructible_from<T8, T8>);
+static_assert(cuda::std::ranges::range<T8>, "");
+static_assert(!cuda::std::ranges::view<T8>, "");
+static_assert(!cuda::std::constructible_from<T8, T8>, "");
 
-static_assert(!cuda::std::ranges::viewable_range<T8>);
-static_assert(cuda::std::ranges::viewable_range<T8&>);
-static_assert(!cuda::std::ranges::viewable_range<T8&&>);
-static_assert(!cuda::std::ranges::viewable_range<const T8>);
-static_assert(cuda::std::ranges::viewable_range<const T8&>);
-static_assert(!cuda::std::ranges::viewable_range<const T8&&>);
+static_assert(!cuda::std::ranges::viewable_range<T8>, "");
+static_assert(cuda::std::ranges::viewable_range<T8&>, "");
+static_assert(!cuda::std::ranges::viewable_range<T8&&>, "");
+static_assert(!cuda::std::ranges::viewable_range<const T8>, "");
+static_assert(cuda::std::ranges::viewable_range<const T8&>, "");
+static_assert(!cuda::std::ranges::viewable_range<const T8&&>, "");
 
 // Test with a few degenerate types
-static_assert(!cuda::std::ranges::viewable_range<void>);
-static_assert(!cuda::std::ranges::viewable_range<int>);
-static_assert(!cuda::std::ranges::viewable_range<int (*)(char)>);
-static_assert(!cuda::std::ranges::viewable_range<int[]>);
-static_assert(!cuda::std::ranges::viewable_range<int[10]>);
-static_assert(!cuda::std::ranges::viewable_range<int (&)[]>); // not a range
-static_assert(cuda::std::ranges::viewable_range<int (&)[10]>); // OK, lvalue
-static_assert(!cuda::std::ranges::viewable_range<int (&&)[]>);
-static_assert(!cuda::std::ranges::viewable_range<int (&&)[10]>);
+static_assert(!cuda::std::ranges::viewable_range<void>, "");
+static_assert(!cuda::std::ranges::viewable_range<int>, "");
+static_assert(!cuda::std::ranges::viewable_range<int (*)(char)>, "");
+static_assert(!cuda::std::ranges::viewable_range<int[]>, "");
+static_assert(!cuda::std::ranges::viewable_range<int[10]>, "");
+static_assert(!cuda::std::ranges::viewable_range<int (&)[]>, ""); // not a range
+static_assert(cuda::std::ranges::viewable_range<int (&)[10]>, ""); // OK, lvalue
+static_assert(!cuda::std::ranges::viewable_range<int (&&)[]>, "");
+static_assert(!cuda::std::ranges::viewable_range<int (&&)[10]>, "");
 
 #if TEST_STD_VER > 2017
 // Test ADL-proofing.
@@ -193,19 +193,19 @@ struct Holder
   T t;
 };
 
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>*>);
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>*&>);
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>*&&>);
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const>);
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const&>);
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const&&>);
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>*>, "");
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>*&>, "");
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>*&&>, "");
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const>, "");
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const&>, "");
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const&&>, "");
 
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* [10]>);
-static_assert(cuda::std::ranges::viewable_range<Holder<Incomplete>* (&) [10]>);
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* (&&) [10]>);
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const[10]>);
-static_assert(cuda::std::ranges::viewable_range<Holder<Incomplete>* const (&)[10]>);
-static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const (&&)[10]>);
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* [10]>, "");
+static_assert(cuda::std::ranges::viewable_range<Holder<Incomplete>* (&) [10]>, "");
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* (&&) [10]>, "");
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const[10]>, "");
+static_assert(cuda::std::ranges::viewable_range<Holder<Incomplete>* const (&)[10]>, "");
+static_assert(!cuda::std::ranges::viewable_range<Holder<Incomplete>* const (&&)[10]>, "");
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.sized/sized_range.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.sized/sized_range.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // template<class T>
@@ -17,10 +17,10 @@
 
 #include "test_iterators.h"
 
-static_assert(cuda::std::ranges::sized_range<int[5]>);
-static_assert(cuda::std::ranges::sized_range<int (&)[5]>);
-static_assert(!cuda::std::ranges::sized_range<int (&)[]>);
-static_assert(!cuda::std::ranges::sized_range<int[]>);
+static_assert(cuda::std::ranges::sized_range<int[5]>, "");
+static_assert(cuda::std::ranges::sized_range<int (&)[5]>, "");
+static_assert(!cuda::std::ranges::sized_range<int (&)[]>, "");
+static_assert(!cuda::std::ranges::sized_range<int[]>, "");
 
 struct range_has_size
 {
@@ -28,8 +28,8 @@ struct range_has_size
   __host__ __device__ bidirectional_iterator<int*> end();
   __host__ __device__ int size();
 };
-static_assert(cuda::std::ranges::sized_range<range_has_size>);
-static_assert(!cuda::std::ranges::sized_range<range_has_size const>);
+static_assert(cuda::std::ranges::sized_range<range_has_size>, "");
+static_assert(!cuda::std::ranges::sized_range<range_has_size const>, "");
 
 struct range_has_const_size
 {
@@ -37,8 +37,8 @@ struct range_has_const_size
   __host__ __device__ bidirectional_iterator<int*> end();
   __host__ __device__ int size() const;
 };
-static_assert(cuda::std::ranges::sized_range<range_has_const_size>);
-static_assert(!cuda::std::ranges::sized_range<range_has_const_size const>);
+static_assert(cuda::std::ranges::sized_range<range_has_const_size>, "");
+static_assert(!cuda::std::ranges::sized_range<range_has_const_size const>, "");
 
 struct const_range_has_size
 {
@@ -46,9 +46,9 @@ struct const_range_has_size
   __host__ __device__ bidirectional_iterator<int*> end() const;
   __host__ __device__ int size();
 };
-static_assert(cuda::std::ranges::sized_range<const_range_has_size>);
-static_assert(cuda::std::ranges::range<const_range_has_size const>);
-static_assert(!cuda::std::ranges::sized_range<const_range_has_size const>);
+static_assert(cuda::std::ranges::sized_range<const_range_has_size>, "");
+static_assert(cuda::std::ranges::range<const_range_has_size const>, "");
+static_assert(!cuda::std::ranges::sized_range<const_range_has_size const>, "");
 
 struct const_range_has_const_size
 {
@@ -56,36 +56,36 @@ struct const_range_has_const_size
   __host__ __device__ bidirectional_iterator<int*> end() const;
   __host__ __device__ int size() const;
 };
-static_assert(cuda::std::ranges::sized_range<const_range_has_const_size>);
-static_assert(cuda::std::ranges::sized_range<const_range_has_const_size const>);
+static_assert(cuda::std::ranges::sized_range<const_range_has_const_size>, "");
+static_assert(cuda::std::ranges::sized_range<const_range_has_const_size const>, "");
 
 struct sized_sentinel_range_has_size
 {
   __host__ __device__ int* begin();
   __host__ __device__ int* end();
 };
-static_assert(cuda::std::ranges::sized_range<sized_sentinel_range_has_size>);
-static_assert(!cuda::std::ranges::sized_range<sized_sentinel_range_has_size const>);
+static_assert(cuda::std::ranges::sized_range<sized_sentinel_range_has_size>, "");
+static_assert(!cuda::std::ranges::sized_range<sized_sentinel_range_has_size const>, "");
 
 struct const_sized_sentinel_range_has_size
 {
   __host__ __device__ int* begin() const;
   __host__ __device__ int* end() const;
 };
-static_assert(cuda::std::ranges::sized_range<const_sized_sentinel_range_has_size>);
-static_assert(cuda::std::ranges::sized_range<const_sized_sentinel_range_has_size const>);
+static_assert(cuda::std::ranges::sized_range<const_sized_sentinel_range_has_size>, "");
+static_assert(cuda::std::ranges::sized_range<const_sized_sentinel_range_has_size const>, "");
 
 struct non_range_has_size
 {
   __host__ __device__ int size() const;
 };
 #if TEST_STD_VER > 2017
-static_assert(requires(non_range_has_size const x) { unused(cuda::std::ranges::size(x)); });
+static_assert(requires(non_range_has_size const x) { unused(cuda::std::ranges::size(x)); }, "");
 #else
-static_assert(cuda::std::invocable<decltype(cuda::std::ranges::size), non_range_has_size const>);
+static_assert(cuda::std::invocable<decltype(cuda::std::ranges::size), non_range_has_size const>, "");
 #endif
-static_assert(!cuda::std::ranges::sized_range<non_range_has_size>);
-static_assert(!cuda::std::ranges::sized_range<non_range_has_size const>);
+static_assert(!cuda::std::ranges::sized_range<non_range_has_size>, "");
+static_assert(!cuda::std::ranges::sized_range<non_range_has_size const>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.view/enable_view.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.view/enable_view.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // <ranges>
@@ -22,101 +22,124 @@
 // Doesn't derive from view_base
 struct Empty
 {};
-static_assert(!cuda::std::ranges::enable_view<Empty>);
-static_assert(!cuda::std::ranges::enable_view<Empty&>);
-static_assert(!cuda::std::ranges::enable_view<Empty&&>);
-static_assert(!cuda::std::ranges::enable_view<const Empty>);
-static_assert(!cuda::std::ranges::enable_view<const Empty&>);
-static_assert(!cuda::std::ranges::enable_view<const Empty&&>);
+static_assert(!cuda::std::ranges::enable_view<Empty>, "");
+static_assert(!cuda::std::ranges::enable_view<Empty&>, "");
+static_assert(!cuda::std::ranges::enable_view<Empty&&>, "");
+static_assert(!cuda::std::ranges::enable_view<const Empty>, "");
+static_assert(!cuda::std::ranges::enable_view<const Empty&>, "");
+static_assert(!cuda::std::ranges::enable_view<const Empty&&>, "");
 
 // Derives from view_base, but privately
 struct PrivateViewBase : private cuda::std::ranges::view_base
 {};
-static_assert(!cuda::std::ranges::enable_view<PrivateViewBase>);
-static_assert(!cuda::std::ranges::enable_view<PrivateViewBase&>);
-static_assert(!cuda::std::ranges::enable_view<PrivateViewBase&&>);
-static_assert(!cuda::std::ranges::enable_view<const PrivateViewBase>);
-static_assert(!cuda::std::ranges::enable_view<const PrivateViewBase&>);
-static_assert(!cuda::std::ranges::enable_view<const PrivateViewBase&&>);
+static_assert(!cuda::std::ranges::enable_view<PrivateViewBase>, "");
+static_assert(!cuda::std::ranges::enable_view<PrivateViewBase&>, "");
+static_assert(!cuda::std::ranges::enable_view<PrivateViewBase&&>, "");
+static_assert(!cuda::std::ranges::enable_view<const PrivateViewBase>, "");
+static_assert(!cuda::std::ranges::enable_view<const PrivateViewBase&>, "");
+static_assert(!cuda::std::ranges::enable_view<const PrivateViewBase&&>, "");
 
 // Derives from view_base, but specializes enable_view to false
 struct EnableViewFalse : cuda::std::ranges::view_base
 {};
-template <>
-constexpr bool cuda::std::ranges::enable_view<EnableViewFalse> = false;
 
-static_assert(!cuda::std::ranges::enable_view<EnableViewFalse>);
-static_assert(!cuda::std::ranges::enable_view<EnableViewFalse&>);
-static_assert(!cuda::std::ranges::enable_view<EnableViewFalse&&>);
-static_assert(cuda::std::ranges::enable_view<const EnableViewFalse>);
-static_assert(!cuda::std::ranges::enable_view<const EnableViewFalse&>);
-static_assert(!cuda::std::ranges::enable_view<const EnableViewFalse&&>);
+namespace cuda
+{
+namespace std
+{
+namespace ranges
+{
+template <>
+constexpr bool enable_view<EnableViewFalse> = false;
+} // namespace ranges
+} // namespace std
+} // namespace cuda
+
+static_assert(!cuda::std::ranges::enable_view<EnableViewFalse>, "");
+static_assert(!cuda::std::ranges::enable_view<EnableViewFalse&>, "");
+static_assert(!cuda::std::ranges::enable_view<EnableViewFalse&&>, "");
+static_assert(cuda::std::ranges::enable_view<const EnableViewFalse>, "");
+static_assert(!cuda::std::ranges::enable_view<const EnableViewFalse&>, "");
+static_assert(!cuda::std::ranges::enable_view<const EnableViewFalse&&>, "");
 
 // Derives from view_base
 struct PublicViewBase : cuda::std::ranges::view_base
 {};
-static_assert(cuda::std::ranges::enable_view<PublicViewBase>);
-static_assert(!cuda::std::ranges::enable_view<PublicViewBase&>);
-static_assert(!cuda::std::ranges::enable_view<PublicViewBase&&>);
-static_assert(cuda::std::ranges::enable_view<const PublicViewBase>);
-static_assert(!cuda::std::ranges::enable_view<const PublicViewBase&>);
-static_assert(!cuda::std::ranges::enable_view<const PublicViewBase&&>);
+static_assert(cuda::std::ranges::enable_view<PublicViewBase>, "");
+static_assert(!cuda::std::ranges::enable_view<PublicViewBase&>, "");
+static_assert(!cuda::std::ranges::enable_view<PublicViewBase&&>, "");
+static_assert(cuda::std::ranges::enable_view<const PublicViewBase>, "");
+static_assert(!cuda::std::ranges::enable_view<const PublicViewBase&>, "");
+static_assert(!cuda::std::ranges::enable_view<const PublicViewBase&&>, "");
 
 // Does not derive from view_base, but specializes enable_view to true
 struct EnableViewTrue
 {};
-template <>
-constexpr bool cuda::std::ranges::enable_view<EnableViewTrue> = true;
 
-static_assert(cuda::std::ranges::enable_view<EnableViewTrue>);
-static_assert(!cuda::std::ranges::enable_view<EnableViewTrue&>);
-static_assert(!cuda::std::ranges::enable_view<EnableViewTrue&&>);
-static_assert(!cuda::std::ranges::enable_view<const EnableViewTrue>);
-static_assert(!cuda::std::ranges::enable_view<const EnableViewTrue&>);
-static_assert(!cuda::std::ranges::enable_view<const EnableViewTrue&&>);
+namespace cuda
+{
+namespace std
+{
+namespace ranges
+{
+template <>
+constexpr bool enable_view<EnableViewTrue> = true;
+}
+} // namespace std
+} // namespace cuda
+
+static_assert(cuda::std::ranges::enable_view<EnableViewTrue>, "");
+static_assert(!cuda::std::ranges::enable_view<EnableViewTrue&>, "");
+static_assert(!cuda::std::ranges::enable_view<EnableViewTrue&&>, "");
+static_assert(!cuda::std::ranges::enable_view<const EnableViewTrue>, "");
+static_assert(!cuda::std::ranges::enable_view<const EnableViewTrue&>, "");
+static_assert(!cuda::std::ranges::enable_view<const EnableViewTrue&&>, "");
 
 // Make sure that enable_view is a bool, not some other contextually-convertible-to-bool type.
 ASSERT_SAME_TYPE(decltype(cuda::std::ranges::enable_view<Empty>), const bool);
 ASSERT_SAME_TYPE(decltype(cuda::std::ranges::enable_view<PublicViewBase>), const bool);
 
+// view_interface requires c++17
+#if TEST_STD_VER >= 2017
 struct V1 : cuda::std::ranges::view_interface<V1>
 {};
-static_assert(cuda::std::ranges::enable_view<V1>);
-static_assert(!cuda::std::ranges::enable_view<V1&>);
-static_assert(!cuda::std::ranges::enable_view<V1&&>);
-static_assert(cuda::std::ranges::enable_view<const V1>);
-static_assert(!cuda::std::ranges::enable_view<const V1&>);
-static_assert(!cuda::std::ranges::enable_view<const V1&&>);
+static_assert(cuda::std::ranges::enable_view<V1>, "");
+static_assert(!cuda::std::ranges::enable_view<V1&>, "");
+static_assert(!cuda::std::ranges::enable_view<V1&&>, "");
+static_assert(cuda::std::ranges::enable_view<const V1>, "");
+static_assert(!cuda::std::ranges::enable_view<const V1&>, "");
+static_assert(!cuda::std::ranges::enable_view<const V1&&>, "");
 
 struct V2
     : cuda::std::ranges::view_interface<V1>
     , cuda::std::ranges::view_interface<V2>
 {};
-#if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 2017 // MSVC seems to allow the conversion despite the ambiguity in
-                                                        // C++17
-static_assert(!cuda::std::ranges::enable_view<V2>);
-#endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 2017
-static_assert(!cuda::std::ranges::enable_view<V2&>);
-static_assert(!cuda::std::ranges::enable_view<V2&&>);
-#if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 2017 // MSVC seems to allow the conversion despite the ambiguity in
-                                                        // C++17
-static_assert(!cuda::std::ranges::enable_view<const V2>);
-#endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 2017
-static_assert(!cuda::std::ranges::enable_view<const V2&>);
-static_assert(!cuda::std::ranges::enable_view<const V2&&>);
+#  if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 2017 // MSVC seems to allow the conversion despite the ambiguity in
+                                                          // C++17
+static_assert(!cuda::std::ranges::enable_view<V2>, "");
+#  endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 2017
+static_assert(!cuda::std::ranges::enable_view<V2&>, "");
+static_assert(!cuda::std::ranges::enable_view<V2&&>, "");
+#  if !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 2017 // MSVC seems to allow the conversion despite the ambiguity in
+                                                          // C++17
+static_assert(!cuda::std::ranges::enable_view<const V2>, "");
+#  endif // !defined(TEST_COMPILER_MSVC) || TEST_STD_VER > 2017
+static_assert(!cuda::std::ranges::enable_view<const V2&>, "");
+static_assert(!cuda::std::ranges::enable_view<const V2&&>, "");
 
 struct V3 : cuda::std::ranges::view_interface<V1>
 {};
-static_assert(cuda::std::ranges::enable_view<V3>);
-static_assert(!cuda::std::ranges::enable_view<V3&>);
-static_assert(!cuda::std::ranges::enable_view<V3&&>);
-static_assert(cuda::std::ranges::enable_view<const V3>);
-static_assert(!cuda::std::ranges::enable_view<const V3&>);
-static_assert(!cuda::std::ranges::enable_view<const V3&&>);
+static_assert(cuda::std::ranges::enable_view<V3>, "");
+static_assert(!cuda::std::ranges::enable_view<V3&>, "");
+static_assert(!cuda::std::ranges::enable_view<V3&&>, "");
+static_assert(cuda::std::ranges::enable_view<const V3>, "");
+static_assert(!cuda::std::ranges::enable_view<const V3&>, "");
+static_assert(!cuda::std::ranges::enable_view<const V3&&>, "");
 
 struct PrivateInherit : private cuda::std::ranges::view_interface<PrivateInherit>
 {};
-static_assert(!cuda::std::ranges::enable_view<PrivateInherit>);
+static_assert(!cuda::std::ranges::enable_view<PrivateInherit>, "");
+#endif // TEST_STD_VER >= 2017
 
 #if TEST_STD_VER > 2017
 // ADL-proof
@@ -126,10 +149,10 @@ struct Holder
 {
   T t;
 };
-static_assert(!cuda::std::ranges::enable_view<Holder<Incomplete>*>);
+static_assert(!cuda::std::ranges::enable_view<Holder<Incomplete>*>, "");
 #endif
 
-static_assert(!cuda::std::ranges::enable_view<void>);
+static_assert(!cuda::std::ranges::enable_view<void>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.view/view.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.view/view.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // <ranges>
@@ -30,11 +30,11 @@ struct NotMoveable : cuda::std::ranges::view_base
   __host__ __device__ friend int* end(NotMoveable&);
   __host__ __device__ friend int* end(NotMoveable const&);
 };
-static_assert(cuda::std::ranges::range<NotMoveable>);
-static_assert(!cuda::std::movable<NotMoveable>);
-static_assert(cuda::std::default_initializable<NotMoveable>);
-static_assert(cuda::std::ranges::enable_view<NotMoveable>);
-static_assert(!cuda::std::ranges::view<NotMoveable>);
+static_assert(cuda::std::ranges::range<NotMoveable>, "");
+static_assert(!cuda::std::movable<NotMoveable>, "");
+static_assert(cuda::std::default_initializable<NotMoveable>, "");
+static_assert(cuda::std::ranges::enable_view<NotMoveable>, "");
+static_assert(!cuda::std::ranges::view<NotMoveable>, "");
 
 // The type would be a view, but it's not default initializable
 struct NotDefaultInit : cuda::std::ranges::view_base
@@ -45,11 +45,11 @@ struct NotDefaultInit : cuda::std::ranges::view_base
   __host__ __device__ friend int* end(NotDefaultInit&);
   __host__ __device__ friend int* end(NotDefaultInit const&);
 };
-static_assert(cuda::std::ranges::range<NotDefaultInit>);
-static_assert(cuda::std::movable<NotDefaultInit>);
-static_assert(!cuda::std::default_initializable<NotDefaultInit>);
-static_assert(cuda::std::ranges::enable_view<NotDefaultInit>);
-static_assert(cuda::std::ranges::view<NotDefaultInit>);
+static_assert(cuda::std::ranges::range<NotDefaultInit>, "");
+static_assert(cuda::std::movable<NotDefaultInit>, "");
+static_assert(!cuda::std::default_initializable<NotDefaultInit>, "");
+static_assert(cuda::std::ranges::enable_view<NotDefaultInit>, "");
+static_assert(cuda::std::ranges::view<NotDefaultInit>, "");
 
 // The type would be a view, but it doesn't enable it with enable_view
 struct NotExplicitlyEnabled
@@ -62,11 +62,11 @@ struct NotExplicitlyEnabled
   __host__ __device__ friend int* end(NotExplicitlyEnabled&);
   __host__ __device__ friend int* end(NotExplicitlyEnabled const&);
 };
-static_assert(cuda::std::ranges::range<NotExplicitlyEnabled>);
-static_assert(cuda::std::movable<NotExplicitlyEnabled>);
-static_assert(cuda::std::default_initializable<NotExplicitlyEnabled>);
-static_assert(!cuda::std::ranges::enable_view<NotExplicitlyEnabled>);
-static_assert(!cuda::std::ranges::view<NotExplicitlyEnabled>);
+static_assert(cuda::std::ranges::range<NotExplicitlyEnabled>, "");
+static_assert(cuda::std::movable<NotExplicitlyEnabled>, "");
+static_assert(cuda::std::default_initializable<NotExplicitlyEnabled>, "");
+static_assert(!cuda::std::ranges::enable_view<NotExplicitlyEnabled>, "");
+static_assert(!cuda::std::ranges::view<NotExplicitlyEnabled>, "");
 
 // The type has everything else, but it's not a range
 struct NotARange : cuda::std::ranges::view_base
@@ -75,11 +75,11 @@ struct NotARange : cuda::std::ranges::view_base
   NotARange(NotARange&&)            = default;
   NotARange& operator=(NotARange&&) = default;
 };
-static_assert(!cuda::std::ranges::range<NotARange>);
-static_assert(cuda::std::movable<NotARange>);
-static_assert(cuda::std::default_initializable<NotARange>);
-static_assert(cuda::std::ranges::enable_view<NotARange>);
-static_assert(!cuda::std::ranges::view<NotARange>);
+static_assert(!cuda::std::ranges::range<NotARange>, "");
+static_assert(cuda::std::movable<NotARange>, "");
+static_assert(cuda::std::default_initializable<NotARange>, "");
+static_assert(cuda::std::ranges::enable_view<NotARange>, "");
+static_assert(!cuda::std::ranges::view<NotARange>, "");
 
 // The type satisfies all requirements
 struct View : cuda::std::ranges::view_base
@@ -92,11 +92,11 @@ struct View : cuda::std::ranges::view_base
   __host__ __device__ friend int* end(View&);
   __host__ __device__ friend int* end(View const&);
 };
-static_assert(cuda::std::ranges::range<View>);
-static_assert(cuda::std::movable<View>);
-static_assert(cuda::std::default_initializable<View>);
-static_assert(cuda::std::ranges::enable_view<View>);
-static_assert(cuda::std::ranges::view<View>);
+static_assert(cuda::std::ranges::range<View>, "");
+static_assert(cuda::std::movable<View>, "");
+static_assert(cuda::std::default_initializable<View>, "");
+static_assert(cuda::std::ranges::enable_view<View>, "");
+static_assert(cuda::std::ranges::view<View>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/std/ranges/range.req/range.view/view_base.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.req/range.view/view_base.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// UNSUPPORTED: c++03, c++11
 // UNSUPPORTED: msvc-19.16
 
 // <ranges>
@@ -17,8 +17,8 @@
 #include <cuda/std/ranges>
 #include <cuda/std/type_traits>
 
-static_assert(cuda::std::is_empty_v<cuda::std::ranges::view_base>);
-static_assert(cuda::std::is_trivial_v<cuda::std::ranges::view_base>);
+static_assert(cuda::std::is_empty_v<cuda::std::ranges::view_base>, "");
+static_assert(cuda::std::is_trivial_v<cuda::std::ranges::view_base>, "");
 
 // Make sure we can inherit from it, as it's intended (that wouldn't be the
 // case if e.g. it was marked as final).

--- a/libcudacxx/test/support/indirectly_readable.h
+++ b/libcudacxx/test/support/indirectly_readable.h
@@ -24,15 +24,21 @@ template <class Token>
 struct T2 : Common<Token>
 {};
 
+namespace cuda
+{
+namespace std
+{
 template <template <class> class T1Qual, template <class> class T2Qual, class Token>
-struct cuda::std::basic_common_reference<T1<Token>, T2<Token>, T1Qual, T2Qual>
+struct basic_common_reference<T1<Token>, T2<Token>, T1Qual, T2Qual>
 {
   using type = Common<Token>;
 };
 template <template <class> class T2Qual, template <class> class T1Qual, class Token>
-struct cuda::std::basic_common_reference<T2<Token>, T1<Token>, T2Qual, T1Qual>
-    : cuda::std::basic_common_reference<T1<Token>, T2<Token>, T1Qual, T2Qual>
+struct basic_common_reference<T2<Token>, T1<Token>, T2Qual, T1Qual>
+    : basic_common_reference<T1<Token>, T2<Token>, T1Qual, T2Qual>
 {};
+} // namespace std
+} // namespace cuda
 
 template <class Token>
 struct IndirectlyReadable

--- a/libcudacxx/test/support/test_range.h
+++ b/libcudacxx/test/support/test_range.h
@@ -14,7 +14,7 @@
 
 #include "test_iterators.h"
 
-#if TEST_STD_VER < 2017
+#if TEST_STD_VER < 2014
 #  error "test/support/test_range.h" can only be included in builds supporting ranges
 #endif
 
@@ -89,8 +89,18 @@ struct BorrowedRange
   __host__ __device__ int* end() const;
   __host__ __device__ BorrowedRange(BorrowedRange&&) = delete;
 };
+
+namespace cuda
+{
+namespace std
+{
+namespace ranges
+{
 template <>
-inline constexpr bool cuda::std::ranges::enable_borrowed_range<BorrowedRange> = true;
+_CCCL_INLINE_VAR constexpr bool enable_borrowed_range<BorrowedRange> = true;
+} // namespace ranges
+} // namespace std
+} // namespace cuda
 
 static_assert(!cuda::std::ranges::view<BorrowedRange>, "");
 static_assert(cuda::std::ranges::borrowed_range<BorrowedRange>, "");


### PR DESCRIPTION
## Description

there's lots of needless gak in our `span` implementation to hack around the lack of proper ranges support. this pr defines just enough ranges support in c++14 to make it possible to clean up the `span` implementation.

this pr also enables c++14 testing of the following libcu++ test directories:
```
libcudacxx/test/libcudacxx/std/iterators/iterator.requirements
libcudacxx/test/libcudacxx/std/ranges/range.req
```

these tests cover all of the iterator and range concepts.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
