### PR TITLE
cuda.parallel: In-memory caching of `cuda.parallel` build objects

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/_caching.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_caching.py
@@ -34,3 +34,43 @@ def cache_with_key(key):
         return inner
 
     return deco
+
+
+class CachableFunction:
+    """
+    A type that wraps a function and provides custom comparison
+    (__eq__) and hash (__hash__) implementations.
+
+    The purpose of this class is to enable caching and comparison of
+    functions based on their bytecode, constants, and closures, while
+    ignoring other attributes such as their names or docstrings.
+    """
+
+    def __init__(self, func):
+        self._func = func
+
+    def __eq__(self, other):
+        func1, func2 = self._func, other._func
+
+        # return True if the functions compare equal for
+        # caching purposes, False otherwise
+        code1 = func1.__code__
+        code2 = func2.__code__
+
+        return (
+            code1.co_code == code2.co_code
+            and code1.co_consts == code2.co_consts
+            and func1.__closure__ == func2.__closure__
+        )
+
+    def __hash__(self):
+        return hash(
+            (
+                self._func.__code__.co_code,
+                self._func.__code__.co_consts,
+                self._func.__closure__,
+            )
+        )
+
+    def __repr__(self):
+        return str(self._func)

--- a/python/cuda_parallel/cuda/parallel/experimental/_caching.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_caching.py
@@ -25,7 +25,7 @@ def cache_with_key(key):
         @functools.wraps(func)
         def inner(*args, **kwargs):
             cc = cuda.get_current_device().compute_capability
-            cache_key = (key(*args, **kwargs), *cc)
+            cache_key = (key(*args, **kwargs), cc)
             if cache_key not in cache:
                 result = func(*args, **kwargs)
                 cache[cache_key] = result

--- a/python/cuda_parallel/cuda/parallel/experimental/_caching.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_caching.py
@@ -48,29 +48,17 @@ class CachableFunction:
 
     def __init__(self, func):
         self._func = func
+        self._identity = (
+            self._func.__code__.co_code,
+            self._func.__code__.co_consts,
+            self._func.__closure__,
+        )
 
     def __eq__(self, other):
-        func1, func2 = self._func, other._func
-
-        # return True if the functions compare equal for
-        # caching purposes, False otherwise
-        code1 = func1.__code__
-        code2 = func2.__code__
-
-        return (
-            code1.co_code == code2.co_code
-            and code1.co_consts == code2.co_consts
-            and func1.__closure__ == func2.__closure__
-        )
+        return self._identity == other._identity
 
     def __hash__(self):
-        return hash(
-            (
-                self._func.__code__.co_code,
-                self._func.__code__.co_consts,
-                self._func.__closure__,
-            )
-        )
+        return hash(self._identity)
 
     def __repr__(self):
         return str(self._func)

--- a/python/cuda_parallel/cuda/parallel/experimental/_caching.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_caching.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import functools
+
+
+def cache_with_key(key):
+    """
+    Decorator to cache the result of the decorated function.  Uses the
+    provided `key` function to compute the key for cache lookup. `key`
+    receives all arguments passed to the function.
+    """
+
+    def deco(func):
+        cache = {}
+
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            cache_key = key(*args, **kwargs)
+            if cache_key not in cache:
+                result = func(*args, **kwargs)
+                cache[cache_key] = result
+            # `cache_key` *must* be in `cache`, use `.get()`
+            # as it is faster:
+            return cache.get(cache_key)
+
+        return inner
+
+    return deco

--- a/python/cuda_parallel/cuda/parallel/experimental/_utils/cai.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_utils/cai.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Utilities for extracting information from `__cuda_array_interface__`.
+"""
+
+import numpy as np
+
+from ..typing import DeviceArrayLike
+
+
+def get_dtype(arr: DeviceArrayLike) -> np.dtype:
+    return np.dtype(arr.__cuda_array_interface__["typestr"])

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
@@ -14,7 +14,7 @@ from typing import Callable
 
 from .. import _cccl as cccl
 from .._bindings import get_paths, get_bindings
-from .._caching import cache_with_key
+from .._caching import CachableFunction, cache_with_key
 from ..typing import DeviceArrayLike
 from ..iterators._iterators import IteratorBase
 from .._utils import cai
@@ -137,9 +137,9 @@ def make_cache_key(
     op: Callable,
     h_init: np.ndarray,
 ):
-    d_in_key = d_in if isinstance(d_in, IteratorBase) else cai.get_dtype(d_in)
+    d_in_key = d_in.kind if isinstance(d_in, IteratorBase) else cai.get_dtype(d_in)
     d_out_key = cai.get_dtype(d_out)
-    op_key = (op.__code__.co_code, op.__code__.co_consts, op.__closure__)
+    op_key = CachableFunction(op)
     h_init_key = h_init.dtype
     return (d_in_key, d_out_key, op_key, h_init_key)
 

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
@@ -17,7 +17,7 @@ from .._bindings import get_paths, get_bindings
 from .._caching import cache_with_key
 from ..typing import DeviceArrayLike
 from ..iterators._iterators import IteratorBase
-from .._utils import cai as cai
+from .._utils import cai
 
 
 class _Op:
@@ -138,7 +138,7 @@ def make_cache_key(
     h_init: np.ndarray,
 ):
     d_in_key = d_in if isinstance(d_in, IteratorBase) else cai.get_dtype(d_in)
-    d_out_key = d_out if isinstance(d_out, IteratorBase) else cai.get_dtype(d_out)
+    d_out_key = cai.get_dtype(d_out)
     op_key = (op.__code__.co_code, op.__code__.co_consts, op.__closure__)
     h_init_key = h_init.dtype
     return (d_in_key, d_out_key, op_key, h_init_key)

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from __future__ import annotations  # TODO: required for Python 3.7 docs env
+
 import ctypes
 import numba
 import numpy as np

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
@@ -126,19 +126,6 @@ class IteratorBase:
     def dereference(state):
         raise NotImplementedError("Subclasses must override dereference staticmethod")
 
-    def __hash__(self):
-        return hash((self.kind, self.cvalue.value, self.numba_type, self.value_type))
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return (
-            self.kind == other.kind
-            and self.cvalue.value == other.cvalue.value
-            and self.numba_type == other.numba_type
-            and self.value_type == other.value_type
-        )
-
 
 def sizeof_pointee(context, ptr):
     size = context.get_abi_sizeof(ptr.type.pointee)

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
@@ -160,8 +160,7 @@ def pointer_add(ptr, offset):
 
 
 class RawPointer(IteratorBase):
-    def __init__(self, ptr: int, ntype: types.Type):
-        value_type = ntype
+    def __init__(self, ptr: int, value_type: types.Type):
         cvalue = ctypes.c_void_p(ptr)
         numba_type = types.CPointer(types.CPointer(value_type))
         abi_name = f"{self.__class__.__name__}_{str(value_type)}"
@@ -181,8 +180,8 @@ class RawPointer(IteratorBase):
         return state[0][0]
 
 
-def pointer(container, ntype: types.Type) -> RawPointer:
-    return RawPointer(container.__cuda_array_interface__["data"][0], ntype)
+def pointer(container, value_type: types.Type) -> RawPointer:
+    return RawPointer(container.__cuda_array_interface__["data"][0], value_type)
 
 
 @intrinsic

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
@@ -40,9 +40,8 @@ class IteratorKind:
 
 @lru_cache(maxsize=None)
 def _get_abi_suffix(kind: IteratorKind):
-    # given an IteratorKind, return a UUID. The value
-    # is cached so that the same UUID is always returned
-    # for a given IteratorKind.
+    # given an IteratorKind, return a UUID. The value is cached so
+    # that the same UUID is always returned for a given IteratorKind.
     return uuid.uuid4().hex
 
 

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
@@ -19,14 +19,6 @@ _DEVICE_POINTER_SIZE = 8
 _DEVICE_POINTER_BITWIDTH = _DEVICE_POINTER_SIZE * 8
 
 
-@lru_cache(maxsize=None)
-def _get_abi_suffix(kind: "IteratorKind"):
-    # given an IteratorKind, return a UUID. The value
-    # is cached so that the same UUID is always returned
-    # for a given IteratorKind.
-    return uuid.uuid4().hex
-
-
 @lru_cache(maxsize=256)  # TODO: what's a reasonable value?
 def cached_compile(func, sig, abi_name=None, **kwargs):
     return cuda.compile(func, sig, abi_info={"abi_name": abi_name}, **kwargs)
@@ -44,6 +36,14 @@ class IteratorKind:
 
     def __hash__(self):
         return hash(self.value_type)
+
+
+@lru_cache(maxsize=None)
+def _get_abi_suffix(kind: IteratorKind):
+    # given an IteratorKind, return a UUID. The value
+    # is cached so that the same UUID is always returned
+    # for a given IteratorKind.
+    return uuid.uuid4().hex
 
 
 class IteratorBase:

--- a/python/cuda_parallel/cuda/parallel/experimental/typing.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/typing.py
@@ -1,4 +1,6 @@
-from typing import Protocol
+from typing_extensions import (
+    Protocol,
+)  # TODO: typing_extensions required for Python 3.7 docs env
 
 
 class DeviceArrayLike(Protocol):

--- a/python/cuda_parallel/cuda/parallel/experimental/typing.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/typing.py
@@ -1,0 +1,10 @@
+from typing import Protocol
+
+
+class DeviceArrayLike(Protocol):
+    """
+    Objects representing a device array, having a `.__cuda_array_interface__`
+    attribute.
+    """
+
+    __cuda_array_interface__: dict

--- a/python/cuda_parallel/setup.py
+++ b/python/cuda_parallel/setup.py
@@ -100,7 +100,8 @@ setup(
     ],
     packages=find_namespace_packages(include=["cuda.*"]),
     python_requires=">=3.9",
-    install_requires=["numba>=0.60.0", "cuda-python", "jinja2"],
+    # TODO: typing_extensions required for Python 3.7 docs env
+    install_requires=["numba>=0.60.0", "cuda-python", "jinja2", "typing_extensions"],
     extras_require={
         "test": [
             "pytest",

--- a/python/cuda_parallel/tests/test_iterators.py
+++ b/python/cuda_parallel/tests/test_iterators.py
@@ -1,0 +1,58 @@
+from cuda.parallel.experimental.iterators import (
+    CacheModifiedInputIterator,
+    ConstantIterator,
+    CountingIterator,
+    TransformIterator,
+)
+import cupy as cp
+import numpy as np
+
+
+def test_constant_iterator_equality():
+    assert ConstantIterator(np.int32(0)) == ConstantIterator(np.int32(0))
+    assert ConstantIterator(np.int32(0)) != ConstantIterator(np.int32(1))
+    assert ConstantIterator(np.int32(0)) != ConstantIterator(np.int64(0))
+
+
+def test_counting_iterator_equality():
+    assert CountingIterator(np.int32(0)) == CountingIterator(np.int32(0))
+    assert CountingIterator(np.int32(0)) != CountingIterator(np.int32(1))
+    assert CountingIterator(np.int32(0)) != CountingIterator(np.int64(0))
+
+
+def test_cache_modified_input_iterator_equality():
+    ary1 = cp.asarray([0, 1, 2])
+    ary2 = cp.asarray([3, 4, 5])
+    assert CacheModifiedInputIterator(ary1, "stream") == CacheModifiedInputIterator(
+        ary1, "stream"
+    )
+    assert CacheModifiedInputIterator(ary1, "stream") != CacheModifiedInputIterator(
+        ary2, "stream"
+    )
+
+
+def test_equality_transform_iterator():
+    def op1(x):
+        return x
+
+    def op2(x):
+        return 2 * x
+
+    def op3(x):
+        return x
+
+    it = CountingIterator(np.int32(0))
+    assert TransformIterator(it, op1) == TransformIterator(it, op1)
+    assert TransformIterator(it, op1) != TransformIterator(it, op2)
+    assert TransformIterator(it, op1) == TransformIterator(it, op3)
+
+    ary1 = cp.asarray([0, 1, 2])
+    ary2 = cp.asarray([3, 4, 5])
+    assert TransformIterator(ary1, op1) == TransformIterator(ary1, op1)
+    assert TransformIterator(ary1, op1) != TransformIterator(ary1, op2)
+    assert TransformIterator(ary1, op1) == TransformIterator(ary1, op3)
+    assert TransformIterator(ary1, op1) != TransformIterator(ary2, op1)
+
+
+def test_different_iterator_types_equality():
+    assert CountingIterator(np.int32(0)) != ConstantIterator(np.int64(0))

--- a/python/cuda_parallel/tests/test_iterators.py
+++ b/python/cuda_parallel/tests/test_iterators.py
@@ -48,6 +48,7 @@ def test_cache_modified_input_iterator_equality():
 
     assert it1 == it2
     assert it1 != it3
+
     assert it1.kind == it2.kind == it3.kind
     assert it1.kind != it4.kind
 
@@ -71,6 +72,7 @@ def test_equality_transform_iterator():
     assert it1 == it2
     assert it1 != it3
     assert it1 == it4
+
     assert it1.kind == it2.kind == it4.kind
 
     ary1 = cp.asarray([0, 1, 2])

--- a/python/cuda_parallel/tests/test_iterators.py
+++ b/python/cuda_parallel/tests/test_iterators.py
@@ -14,10 +14,6 @@ def test_constant_iterator_equality():
     it3 = ConstantIterator(np.int32(1))
     it4 = ConstantIterator(np.int64(9))
 
-    assert it1 == it2
-    assert it1 != it3
-    assert it1 != it4
-
     assert it1.kind == it2.kind == it3.kind
     assert it1.kind != it4.kind
 
@@ -27,10 +23,6 @@ def test_counting_iterator_equality():
     it2 = CountingIterator(np.int32(0))
     it3 = CountingIterator(np.int32(1))
     it4 = CountingIterator(np.int64(9))
-
-    assert it1 == it2
-    assert it1 != it3
-    assert it1 != it4
 
     assert it1.kind == it2.kind == it3.kind
     assert it1.kind != it4.kind
@@ -45,9 +37,6 @@ def test_cache_modified_input_iterator_equality():
     it2 = CacheModifiedInputIterator(ary1, "stream")
     it3 = CacheModifiedInputIterator(ary2, "stream")
     it4 = CacheModifiedInputIterator(ary3, "stream")
-
-    assert it1 == it2
-    assert it1 != it3
 
     assert it1.kind == it2.kind == it3.kind
     assert it1.kind != it4.kind
@@ -66,31 +55,17 @@ def test_equality_transform_iterator():
     it = CountingIterator(np.int32(0))
     it1 = TransformIterator(it, op1)
     it2 = TransformIterator(it, op1)
-    it3 = TransformIterator(it, op2)
-    it4 = TransformIterator(it, op3)
+    it3 = TransformIterator(it, op3)
 
-    assert it1 == it2
-    assert it1 != it3
-    assert it1 == it4
-
-    assert it1.kind == it2.kind == it4.kind
+    assert it1.kind == it2.kind == it3.kind
 
     ary1 = cp.asarray([0, 1, 2])
     ary2 = cp.asarray([3, 4, 5])
+    it4 = TransformIterator(ary1, op1)
     it5 = TransformIterator(ary1, op1)
-    it6 = TransformIterator(ary1, op1)
-    it7 = TransformIterator(ary1, op2)
-    it8 = TransformIterator(ary1, op3)
-    it9 = TransformIterator(ary2, op1)
+    it6 = TransformIterator(ary1, op2)
+    it7 = TransformIterator(ary1, op3)
+    it8 = TransformIterator(ary2, op1)
 
-    assert it5 == it6
-    assert it5 != it7
-    assert it5 == it8
-    assert it5 != it9
-
-    assert it5.kind == it6.kind == it8.kind == it9.kind
-    assert it5.kind != it7.kind
-
-
-def test_different_iterator_types_equality():
-    assert CountingIterator(np.int32(0)) != ConstantIterator(np.int64(0))
+    assert it4.kind == it5.kind == it7.kind == it8.kind
+    assert it4.kind != it6.kind

--- a/python/cuda_parallel/tests/test_iterators.py
+++ b/python/cuda_parallel/tests/test_iterators.py
@@ -9,26 +9,47 @@ import numpy as np
 
 
 def test_constant_iterator_equality():
-    assert ConstantIterator(np.int32(0)) == ConstantIterator(np.int32(0))
-    assert ConstantIterator(np.int32(0)) != ConstantIterator(np.int32(1))
-    assert ConstantIterator(np.int32(0)) != ConstantIterator(np.int64(0))
+    it1 = ConstantIterator(np.int32(0))
+    it2 = ConstantIterator(np.int32(0))
+    it3 = ConstantIterator(np.int32(1))
+    it4 = ConstantIterator(np.int64(9))
+
+    assert it1 == it2
+    assert it1 != it3
+    assert it1 != it4
+
+    assert it1.kind == it2.kind == it3.kind
+    assert it1.kind != it4.kind
 
 
 def test_counting_iterator_equality():
-    assert CountingIterator(np.int32(0)) == CountingIterator(np.int32(0))
-    assert CountingIterator(np.int32(0)) != CountingIterator(np.int32(1))
-    assert CountingIterator(np.int32(0)) != CountingIterator(np.int64(0))
+    it1 = CountingIterator(np.int32(0))
+    it2 = CountingIterator(np.int32(0))
+    it3 = CountingIterator(np.int32(1))
+    it4 = CountingIterator(np.int64(9))
+
+    assert it1 == it2
+    assert it1 != it3
+    assert it1 != it4
+
+    assert it1.kind == it2.kind == it3.kind
+    assert it1.kind != it4.kind
 
 
 def test_cache_modified_input_iterator_equality():
-    ary1 = cp.asarray([0, 1, 2])
-    ary2 = cp.asarray([3, 4, 5])
-    assert CacheModifiedInputIterator(ary1, "stream") == CacheModifiedInputIterator(
-        ary1, "stream"
-    )
-    assert CacheModifiedInputIterator(ary1, "stream") != CacheModifiedInputIterator(
-        ary2, "stream"
-    )
+    ary1 = cp.asarray([0, 1, 2], dtype="int32")
+    ary2 = cp.asarray([3, 4, 5], dtype="int32")
+    ary3 = cp.asarray([0, 1, 2], dtype="int64")
+
+    it1 = CacheModifiedInputIterator(ary1, "stream")
+    it2 = CacheModifiedInputIterator(ary1, "stream")
+    it3 = CacheModifiedInputIterator(ary2, "stream")
+    it4 = CacheModifiedInputIterator(ary3, "stream")
+
+    assert it1 == it2
+    assert it1 != it3
+    assert it1.kind == it2.kind == it3.kind
+    assert it1.kind != it4.kind
 
 
 def test_equality_transform_iterator():
@@ -42,16 +63,31 @@ def test_equality_transform_iterator():
         return x
 
     it = CountingIterator(np.int32(0))
-    assert TransformIterator(it, op1) == TransformIterator(it, op1)
-    assert TransformIterator(it, op1) != TransformIterator(it, op2)
-    assert TransformIterator(it, op1) == TransformIterator(it, op3)
+    it1 = TransformIterator(it, op1)
+    it2 = TransformIterator(it, op1)
+    it3 = TransformIterator(it, op2)
+    it4 = TransformIterator(it, op3)
+
+    assert it1 == it2
+    assert it1 != it3
+    assert it1 == it4
+    assert it1.kind == it2.kind == it4.kind
 
     ary1 = cp.asarray([0, 1, 2])
     ary2 = cp.asarray([3, 4, 5])
-    assert TransformIterator(ary1, op1) == TransformIterator(ary1, op1)
-    assert TransformIterator(ary1, op1) != TransformIterator(ary1, op2)
-    assert TransformIterator(ary1, op1) == TransformIterator(ary1, op3)
-    assert TransformIterator(ary1, op1) != TransformIterator(ary2, op1)
+    it5 = TransformIterator(ary1, op1)
+    it6 = TransformIterator(ary1, op1)
+    it7 = TransformIterator(ary1, op2)
+    it8 = TransformIterator(ary1, op3)
+    it9 = TransformIterator(ary2, op1)
+
+    assert it5 == it6
+    assert it5 != it7
+    assert it5 == it8
+    assert it5 != it9
+
+    assert it5.kind == it6.kind == it8.kind == it9.kind
+    assert it5.kind != it7.kind
 
 
 def test_different_iterator_types_equality():

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import cupy as cp
-import numpy
+import numpy as np
 import pytest
 import random
 import numba.cuda
@@ -14,31 +14,29 @@ import cuda.parallel.experimental.iterators as iterators
 
 
 def random_int(shape, dtype):
-    return numpy.random.randint(0, 5, size=shape).astype(dtype)
+    return np.random.randint(0, 5, size=shape).astype(dtype)
 
 
 def type_to_problem_sizes(dtype):
-    if dtype in [numpy.uint8, numpy.int8]:
+    if dtype in [np.uint8, np.int8]:
         return [2, 4, 5, 6]
-    elif dtype in [numpy.uint16, numpy.int16]:
+    elif dtype in [np.uint16, np.int16]:
         return [4, 8, 12, 14]
-    elif dtype in [numpy.uint32, numpy.int32]:
+    elif dtype in [np.uint32, np.int32]:
         return [16, 20, 24, 28]
-    elif dtype in [numpy.uint64, numpy.int64]:
+    elif dtype in [np.uint64, np.int64]:
         return [16, 20, 24, 28]
     else:
         raise ValueError("Unsupported dtype")
 
 
-@pytest.mark.parametrize(
-    "dtype", [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]
-)
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32, np.uint64])
 def test_device_reduce(dtype):
     def op(a, b):
         return a + b
 
     init_value = 42
-    h_init = numpy.array([init_value], dtype=dtype)
+    h_init = np.array([init_value], dtype=dtype)
     d_output = numba.cuda.device_array(1, dtype=dtype)
     reduce_into = algorithms.reduce_into(d_output, d_output, op, h_init)
 
@@ -47,7 +45,7 @@ def test_device_reduce(dtype):
         h_input = random_int(num_items, dtype)
         d_input = numba.cuda.to_device(h_input)
         temp_storage_size = reduce_into(None, d_input, d_output, None, h_init)
-        d_temp_storage = numba.cuda.device_array(temp_storage_size, dtype=numpy.uint8)
+        d_temp_storage = numba.cuda.device_array(temp_storage_size, dtype=np.uint8)
         reduce_into(d_temp_storage, d_input, d_output, None, h_init)
         h_output = d_output.copy_to_host()
         assert h_output[0] == sum(h_input) + init_value
@@ -57,19 +55,19 @@ def test_complex_device_reduce():
     def op(a, b):
         return a + b
 
-    h_init = numpy.array([40.0 + 2.0j], dtype=complex)
+    h_init = np.array([40.0 + 2.0j], dtype=complex)
     d_output = numba.cuda.device_array(1, dtype=complex)
     reduce_into = algorithms.reduce_into(d_output, d_output, op, h_init)
 
     for num_items in [42, 420000]:
-        h_input = numpy.random.random(num_items) + 1j * numpy.random.random(num_items)
+        h_input = np.random.random(num_items) + 1j * np.random.random(num_items)
         d_input = numba.cuda.to_device(h_input)
         temp_storage_bytes = reduce_into(None, d_input, d_output, None, h_init)
-        d_temp_storage = numba.cuda.device_array(temp_storage_bytes, numpy.uint8)
+        d_temp_storage = numba.cuda.device_array(temp_storage_bytes, np.uint8)
         reduce_into(d_temp_storage, d_input, d_output, None, h_init)
 
         result = d_output.copy_to_host()[0]
-        expected = numpy.sum(h_input, initial=h_init[0])
+        expected = np.sum(h_input, initial=h_init[0])
         assert result == pytest.approx(expected)
 
 
@@ -77,9 +75,9 @@ def test_device_reduce_dtype_mismatch():
     def min_op(a, b):
         return a if a < b else b
 
-    dtypes = [numpy.int32, numpy.int64]
-    h_inits = [numpy.array([], dt) for dt in dtypes]
-    h_inputs = [numpy.array([], dt) for dt in dtypes]
+    dtypes = [np.int32, np.int64]
+    h_inits = [np.array([], dt) for dt in dtypes]
+    h_inputs = [np.array([], dt) for dt in dtypes]
     d_outputs = [numba.cuda.device_array(1, dt) for dt in dtypes]
     d_inputs = [numba.cuda.to_device(h_inp) for h_inp in h_inputs]
 
@@ -109,14 +107,14 @@ def _test_device_sum_with_iterator(
         expected_result = add_op(expected_result, v)
 
     if use_numpy_array:
-        h_input = numpy.array(l_varr, dtype_inp)
+        h_input = np.array(l_varr, dtype_inp)
         d_input = numba.cuda.to_device(h_input)
     else:
         d_input = i_input
 
     d_output = numba.cuda.device_array(1, dtype_out)  # to store device sum
 
-    h_init = numpy.array([start_sum_with], dtype_out)
+    h_init = np.array([start_sum_with], dtype_out)
 
     reduce_into = algorithms.reduce_into(
         d_in=d_input, d_out=d_output, op=add_op, h_init=h_init
@@ -125,7 +123,7 @@ def _test_device_sum_with_iterator(
     temp_storage_size = reduce_into(
         None, d_in=d_input, d_out=d_output, num_items=len(l_varr), h_init=h_init
     )
-    d_temp_storage = numba.cuda.device_array(temp_storage_size, dtype=numpy.uint8)
+    d_temp_storage = numba.cuda.device_array(temp_storage_size, dtype=np.uint8)
 
     reduce_into(d_temp_storage, d_input, d_output, len(l_varr), h_init)
 
@@ -168,9 +166,9 @@ def test_device_sum_cache_modified_input_it(
 ):
     rng = random.Random(0)
     l_varr = [rng.randrange(100) for _ in range(num_items)]
-    dtype_inp = numpy.dtype(supported_value_type)
+    dtype_inp = np.dtype(supported_value_type)
     dtype_out = dtype_inp
-    input_devarr = numba.cuda.to_device(numpy.array(l_varr, dtype=dtype_inp))
+    input_devarr = numba.cuda.to_device(np.array(l_varr, dtype=dtype_inp))
     i_input = iterators.CacheModifiedInputIterator(input_devarr, modifier="stream")
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
@@ -181,7 +179,7 @@ def test_device_sum_constant_it(
     use_numpy_array, supported_value_type, num_items=3, start_sum_with=10
 ):
     l_varr = [42 for distance in range(num_items)]
-    dtype_inp = numpy.dtype(supported_value_type)
+    dtype_inp = np.dtype(supported_value_type)
     dtype_out = dtype_inp
     i_input = iterators.ConstantIterator(dtype_inp.type(42))
     _test_device_sum_with_iterator(
@@ -193,7 +191,7 @@ def test_device_sum_counting_it(
     use_numpy_array, supported_value_type, num_items=3, start_sum_with=10
 ):
     l_varr = [start_sum_with + distance for distance in range(num_items)]
-    dtype_inp = numpy.dtype(supported_value_type)
+    dtype_inp = np.dtype(supported_value_type)
     dtype_out = dtype_inp
     i_input = iterators.CountingIterator(dtype_inp.type(start_sum_with))
     _test_device_sum_with_iterator(
@@ -217,8 +215,8 @@ def test_device_sum_map_mul2_count_it(
 ):
     l_varr = [2 * (start_sum_with + distance) for distance in range(num_items)]
     vtn_out, vtn_inp = value_type_name_pair
-    dtype_inp = numpy.dtype(vtn_inp)
-    dtype_out = numpy.dtype(vtn_out)
+    dtype_inp = np.dtype(vtn_inp)
+    dtype_out = np.dtype(vtn_out)
     i_input = iterators.TransformIterator(
         iterators.CountingIterator(dtype_inp.type(start_sum_with)), mul2
     )
@@ -248,8 +246,8 @@ def test_device_sum_map_mul_map_mul_count_it(
         fac_out * (fac_mid * (start_sum_with + distance))
         for distance in range(num_items)
     ]
-    dtype_inp = numpy.dtype(vtn_inp)
-    dtype_out = numpy.dtype(vtn_out)
+    dtype_inp = np.dtype(vtn_inp)
+    dtype_out = np.dtype(vtn_out)
     mul_funcs = {2: mul2, 3: mul3}
     i_input = iterators.TransformIterator(
         iterators.TransformIterator(
@@ -275,8 +273,8 @@ def test_device_sum_map_mul2_cp_array_it(
     use_numpy_array, value_type_name_pair, num_items=3, start_sum_with=10
 ):
     vtn_out, vtn_inp = value_type_name_pair
-    dtype_inp = numpy.dtype(vtn_inp)
-    dtype_out = numpy.dtype(vtn_out)
+    dtype_inp = np.dtype(vtn_inp)
+    dtype_out = np.dtype(vtn_out)
     rng = random.Random(0)
     l_d_in = [rng.randrange(100) for _ in range(num_items)]
     a_d_in = cp.array(l_d_in, dtype_inp)
@@ -285,3 +283,156 @@ def test_device_sum_map_mul2_cp_array_it(
     _test_device_sum_with_iterator(
         l_varr, start_sum_with, i_input, dtype_inp, dtype_out, use_numpy_array
     )
+
+
+def test_reducer_caching():
+    def sum_op(x, y):
+        return x + y
+
+    # inputs are device arrays
+    reducer_1 = algorithms.reduce_into(
+        cp.zeros(3, dtype="int64"),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        cp.zeros(3, dtype="int64"),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is reducer_2
+
+    # inputs are device arrays of different dtype:
+    reducer_1 = algorithms.reduce_into(
+        cp.zeros(3, dtype="int64"),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        cp.zeros(3, dtype="int32"),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is not reducer_2
+
+    # outputs are of different dtype:
+    reducer_1 = algorithms.reduce_into(
+        cp.zeros(3, dtype="int64"),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        cp.zeros(3, dtype="int64"),
+        cp.zeros(1, dtype="int32"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is not reducer_2
+
+    # inputs are of same dtype but different size
+    # (should still use cached reducer):
+    reducer_1 = algorithms.reduce_into(
+        cp.zeros(3, dtype="int64"),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        cp.zeros(5, dtype="int64"),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is reducer_2
+
+    # inputs are counting iterators of the
+    # same value type:
+    reducer_1 = algorithms.reduce_into(
+        iterators.CountingIterator(np.int32(0)),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        iterators.CountingIterator(np.int32(0)),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is reducer_2
+
+    # inputs are counting iterators of different value type:
+    reducer_1 = algorithms.reduce_into(
+        iterators.CountingIterator(np.int32(0)),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        iterators.CountingIterator(np.int64(0)),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is not reducer_2
+
+    def op1(x):
+        return x
+
+    def op2(x):
+        return 2 * x
+
+    def op3(x):
+        return x
+
+    # inputs are TransformIterators
+    reducer_1 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int32(0)), op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int32(0)), op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is reducer_2
+
+    # inputs are TransformIterators with different
+    # op:
+    reducer_1 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int32(0)), op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int32(0)), op2),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is not reducer_2
+
+    # inputs are TransformIterators with same op
+    # but different name:
+    reducer_1 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int32(0)), op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int32(0)), op3),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is reducer_2

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -435,4 +435,69 @@ def test_reducer_caching():
         sum_op,
         np.zeros([0], dtype="int64"),
     )
+
+    # inputs are CountingIterators of same kind
+    # but different state:
+    reducer_1 = algorithms.reduce_into(
+        iterators.CountingIterator(np.int32(0)),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        iterators.CountingIterator(np.int32(1)),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+
     assert reducer_1 is reducer_2
+
+    # inputs are TransformIterators of same kind
+    # but different state:
+    ary1 = cp.asarray([0, 1, 2], dtype="int64")
+    ary2 = cp.asarray([0, 1], dtype="int64")
+    reducer_1 = algorithms.reduce_into(
+        iterators.TransformIterator(ary1, op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        iterators.TransformIterator(ary2, op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is reducer_2
+
+    # inputs are TransformIterators of same kind
+    # but different state:
+    reducer_1 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int32(0)), op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int32(1)), op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is reducer_2
+
+    # inputs are TransformIterators with different kind:
+    reducer_1 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int32(0)), op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    reducer_2 = algorithms.reduce_into(
+        iterators.TransformIterator(iterators.CountingIterator(np.int64(0)), op1),
+        cp.zeros(1, dtype="int64"),
+        sum_op,
+        np.zeros([0], dtype="int64"),
+    )
+    assert reducer_1 is not reducer_2


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/cccl/issues/3214.

# High level changes

This PR introduces (in-memory) caching of build objects. To achieve this, it introduces a helper decorate `@cache_with_key`, which caches the results of a function (in-memory), and accepts a custom function for constructing the cache key from the arguments.

The cache key is constructed from the considerations listed in https://github.com/NVIDIA/cccl/issues/2590:
- for device array inputs (and outputs), the `.dtype` is used to compute the corresponding component of the cache key.
- for iterator inputs, the `.kind` is used to compute the corresponding component of the cache key.
- to compute the cache key component corresponding to the the reduction function, it is wrapped in a `CachableFunction` type, which defines `__eq__` and `__hash__` such that instances whose bytecode and closure are equal, compare equal (ignoring attributes such as  function names/docstrings).


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
