### PR TITLE
Implement PTX `mul` instruction for integers

### DIFF
--- a/libcudacxx/include/cuda/__ptx/instructions/mul.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/mul.h
@@ -1,0 +1,160 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_PTX_MUL_H_
+#define _CUDA_PTX_MUL_H_
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__ptx/ptx_dot_variants.h>
+#include <cuda/std/cstdint>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_PTX
+
+_CCCL_DEVICE static inline _CUDA_VSTD::int16_t
+mul(_CUDA_VPTX::mul_mode_lo_t, _CUDA_VSTD::int16_t __x, _CUDA_VSTD::int16_t __y)
+{
+  _CUDA_VSTD::int16_t __result;
+  asm("mul.lo.s16 %0, %1, %2;" : "=h"(__result) : "h"(__x), "h"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::uint16_t
+mul(_CUDA_VPTX::mul_mode_lo_t, _CUDA_VSTD::uint16_t __x, _CUDA_VSTD::uint16_t __y)
+{
+  _CUDA_VSTD::uint16_t __result;
+  asm("mul.lo.u16 %0, %1, %2;" : "=h"(__result) : "h"(__x), "h"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::int32_t
+mul(_CUDA_VPTX::mul_mode_lo_t, _CUDA_VSTD::int32_t __x, _CUDA_VSTD::int32_t __y)
+{
+  _CUDA_VSTD::int32_t __result;
+  asm("mul.lo.s32 %0, %1, %2;" : "=r"(__result) : "r"(__x), "r"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t
+mul(_CUDA_VPTX::mul_mode_lo_t, _CUDA_VSTD::uint32_t __x, _CUDA_VSTD::uint32_t __y)
+{
+  _CUDA_VSTD::uint32_t __result;
+  asm("mul.lo.u32 %0, %1, %2;" : "=r"(__result) : "r"(__x), "r"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::int64_t
+mul(_CUDA_VPTX::mul_mode_lo_t, _CUDA_VSTD::int64_t __x, _CUDA_VSTD::int64_t __y)
+{
+  _CUDA_VSTD::int64_t __result;
+  asm("mul.lo.s64 %0, %1, %2;" : "=l"(__result) : "l"(__x), "l"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::uint64_t
+mul(_CUDA_VPTX::mul_mode_lo_t, _CUDA_VSTD::uint64_t __x, _CUDA_VSTD::uint64_t __y)
+{
+  _CUDA_VSTD::uint64_t __result;
+  asm("mul.lo.u64 %0, %1, %2;" : "=l"(__result) : "l"(__x), "l"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::int16_t
+mul(_CUDA_VPTX::mul_mode_hi_t, _CUDA_VSTD::int16_t __x, _CUDA_VSTD::int16_t __y)
+{
+  _CUDA_VSTD::int16_t __result;
+  asm("mul.hi.s16 %0, %1, %2;" : "=h"(__result) : "h"(__x), "h"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::uint16_t
+mul(_CUDA_VPTX::mul_mode_hi_t, _CUDA_VSTD::uint16_t __x, _CUDA_VSTD::uint16_t __y)
+{
+  _CUDA_VSTD::uint16_t __result;
+  asm("mul.hi.u16 %0, %1, %2;" : "=h"(__result) : "h"(__x), "h"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::int32_t
+mul(_CUDA_VPTX::mul_mode_hi_t, _CUDA_VSTD::int32_t __x, _CUDA_VSTD::int32_t __y)
+{
+  _CUDA_VSTD::int32_t __result;
+  asm("mul.hi.s32 %0, %1, %2;" : "=r"(__result) : "r"(__x), "r"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t
+mul(_CUDA_VPTX::mul_mode_hi_t, _CUDA_VSTD::uint32_t __x, _CUDA_VSTD::uint32_t __y)
+{
+  _CUDA_VSTD::uint32_t __result;
+  asm("mul.hi.u32 %0, %1, %2;" : "=r"(__result) : "r"(__x), "r"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::int64_t
+mul(_CUDA_VPTX::mul_mode_hi_t, _CUDA_VSTD::int64_t __x, _CUDA_VSTD::int64_t __y)
+{
+  _CUDA_VSTD::int64_t __result;
+  asm("mul.hi.s64 %0, %1, %2;" : "=l"(__result) : "l"(__x), "l"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::uint64_t
+mul(_CUDA_VPTX::mul_mode_hi_t, _CUDA_VSTD::uint64_t __x, _CUDA_VSTD::uint64_t __y)
+{
+  _CUDA_VSTD::uint64_t __result;
+  asm("mul.hi.u64 %0, %1, %2;" : "=l"(__result) : "l"(__x), "l"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::int32_t
+mul(_CUDA_VPTX::mul_mode_wide_t, _CUDA_VSTD::int16_t __x, _CUDA_VSTD::int16_t __y)
+{
+  _CUDA_VSTD::int32_t __result;
+  asm("mul.wide.s16 %0, %1, %2;" : "=r"(__result) : "h"(__x), "h"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::uint32_t
+mul(_CUDA_VPTX::mul_mode_wide_t, _CUDA_VSTD::uint16_t __x, _CUDA_VSTD::uint16_t __y)
+{
+  _CUDA_VSTD::uint32_t __result;
+  asm("mul.wide.u16 %0, %1, %2;" : "=r"(__result) : "h"(__x), "h"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::int64_t
+mul(_CUDA_VPTX::mul_mode_wide_t, _CUDA_VSTD::int32_t __x, _CUDA_VSTD::int32_t __y)
+{
+  _CUDA_VSTD::int64_t __result;
+  asm("mul.wide.s32 %0, %1, %2;" : "=l"(__result) : "r"(__x), "r"(__y));
+  return __result;
+}
+
+_CCCL_DEVICE static inline _CUDA_VSTD::uint64_t
+mul(_CUDA_VPTX::mul_mode_wide_t, _CUDA_VSTD::uint32_t __x, _CUDA_VSTD::uint32_t __y)
+{
+  _CUDA_VSTD::uint64_t __result;
+  asm("mul.wide.u32 %0, %1, %2;" : "=l"(__result) : "r"(__x), "r"(__y));
+  return __result;
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_PTX
+
+#endif // _CUDA_PTX_MUL_H_

--- a/libcudacxx/include/cuda/__ptx/ptx_dot_variants.h
+++ b/libcudacxx/include/cuda/__ptx/ptx_dot_variants.h
@@ -111,6 +111,13 @@ enum class dot_op
   exch
 };
 
+enum class dot_mul_mode
+{
+  lo,
+  hi,
+  wide,
+};
+
 template <dot_sem __sem>
 using sem_t         = _CUDA_VSTD::integral_constant<dot_sem, __sem>;
 using sem_acq_rel_t = sem_t<dot_sem::acq_rel>;
@@ -172,6 +179,16 @@ static constexpr op_or_op_t op_or_op{};
 static constexpr op_xor_op_t op_xor_op{};
 static constexpr op_cas_t op_cas{};
 static constexpr op_exch_t op_exch{};
+
+template <dot_mul_mode __mode>
+using mul_mode_t      = _CUDA_VSTD::integral_constant<dot_mul_mode, __mode>;
+using mul_mode_lo_t   = mul_mode_t<dot_mul_mode::lo>;
+using mul_mode_hi_t   = mul_mode_t<dot_mul_mode::hi>;
+using mul_mode_wide_t = mul_mode_t<dot_mul_mode::wide>;
+
+static constexpr mul_mode_lo_t mul_mode_lo{};
+static constexpr mul_mode_hi_t mul_mode_hi{};
+static constexpr mul_mode_wide_t mul_mode_wide{};
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_PTX
 

--- a/libcudacxx/include/cuda/ptx
+++ b/libcudacxx/include/cuda/ptx
@@ -82,6 +82,7 @@
 #include <cuda/__ptx/instructions/mbarrier_arrive.h>
 #include <cuda/__ptx/instructions/mbarrier_init.h>
 #include <cuda/__ptx/instructions/mbarrier_wait.h>
+#include <cuda/__ptx/instructions/mul.h>
 #include <cuda/__ptx/instructions/red_async.h>
 #include <cuda/__ptx/instructions/st_async.h>
 #include <cuda/__ptx/instructions/tensormap_cp_fenceproxy.h>

--- a/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mul.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/ptx.mul.compile.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/ptx>
+
+#include <cuda/ptx>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+
+template <class Result, class Arg, class MulMode>
+__device__ void test_mul(MulMode mode)
+{
+  auto res = cuda::ptx::mul(mode, Arg{}, Arg{});
+  ASSERT_SAME_TYPE(Result, decltype(res));
+}
+
+__global__ void test_global_kernel()
+{
+  test_mul<cuda::std::int16_t, cuda::std::int16_t>(cuda::ptx::mul_mode_lo);
+  test_mul<cuda::std::uint16_t, cuda::std::uint16_t>(cuda::ptx::mul_mode_lo);
+  test_mul<cuda::std::int32_t, cuda::std::int32_t>(cuda::ptx::mul_mode_lo);
+  test_mul<cuda::std::uint32_t, cuda::std::uint32_t>(cuda::ptx::mul_mode_lo);
+  test_mul<cuda::std::int64_t, cuda::std::int64_t>(cuda::ptx::mul_mode_lo);
+  test_mul<cuda::std::uint64_t, cuda::std::uint64_t>(cuda::ptx::mul_mode_lo);
+
+  test_mul<cuda::std::int16_t, cuda::std::int16_t>(cuda::ptx::mul_mode_hi);
+  test_mul<cuda::std::uint16_t, cuda::std::uint16_t>(cuda::ptx::mul_mode_hi);
+  test_mul<cuda::std::int32_t, cuda::std::int32_t>(cuda::ptx::mul_mode_hi);
+  test_mul<cuda::std::uint32_t, cuda::std::uint32_t>(cuda::ptx::mul_mode_hi);
+  test_mul<cuda::std::int64_t, cuda::std::int64_t>(cuda::ptx::mul_mode_hi);
+  test_mul<cuda::std::uint64_t, cuda::std::uint64_t>(cuda::ptx::mul_mode_hi);
+
+  test_mul<cuda::std::int32_t, cuda::std::int16_t>(cuda::ptx::mul_mode_wide);
+  test_mul<cuda::std::uint32_t, cuda::std::uint16_t>(cuda::ptx::mul_mode_wide);
+  test_mul<cuda::std::int64_t, cuda::std::int32_t>(cuda::ptx::mul_mode_wide);
+  test_mul<cuda::std::uint64_t, cuda::std::uint32_t>(cuda::ptx::mul_mode_wide);
+}
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
This PR introduces `cuda::ptx::mul` instruction for integers to libcu++.