### PR TITLE
[DO NOT MERGE] `ceil_div`  return common type and optmize

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/cmath.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath.pass.cpp
@@ -25,15 +25,15 @@ __host__ __device__ TEST_CONSTEXPR_CXX14 void test()
   constexpr T maxv = cuda::std::numeric_limits<T>::max();
 
   // ensure that we return the right type
-  static_assert(cuda::std::is_same<decltype(cuda::ceil_div(T(0), U(1))), T>::value, "");
-
-  assert(cuda::ceil_div(T(0), U(1)) == T(0));
-  assert(cuda::ceil_div(T(1), U(1)) == T(1));
-  assert(cuda::ceil_div(T(126), U(64)) == T(2));
+  using Common = decltype(T(0) / U(1));
+  static_assert(cuda::std::is_same<decltype(cuda::ceil_div(T(0), U(1))), Common>::value);
+  assert(cuda::ceil_div(T(0), U(1)) == Common(0));
+  assert(cuda::ceil_div(T(1), U(1)) == Common(1));
+  assert(cuda::ceil_div(T(126), U(64)) == Common(2));
 
   // ensure that we are resilient against overflow
   assert(cuda::ceil_div(maxv, U(1)) == maxv);
-  assert(cuda::ceil_div(maxv, maxv) == T(1));
+  assert(cuda::ceil_div(maxv, maxv) == Common(1));
 }
 
 template <class T>


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cccl/issues/2845, https://github.com/NVIDIA/cccl/issues/2391 

## Description

`ceil_div` returns the resulting type of the operation and has been optmized for CUDA

#### DO NOT MERGE

- require C++17
- breaking change in the API