### PR TITLE
Use Ruff to sort imports

### DIFF
--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -62,8 +62,8 @@ import os
 import re
 import struct
 import sys
-import yaml
 
+import yaml
 
 matrix_yaml = None
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.3
     hooks:
-    - id: ruff
-      args: ["--fix", "--show-fixes"]
-      exclude: "^docs/tools/"
-    - id: ruff-format
-      exclude: "^docs/tools/"
+    - id: ruff  # linter
+    - id: ruff-format  # formatter
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 
+import argparse
+import functools
+import itertools
+import json
+import math
 import os
 import re
-import json
+
 import cccl
-import math
-import argparse
-import itertools
-import functools
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 from scipy.stats import mannwhitneyu
 from scipy.stats.mstats import hdquantiles
 
@@ -330,8 +331,8 @@ def coverage(args):
 def parallel_coordinates_plot(df, title):
     # Parallel coordinates plot adaptation of https://stackoverflow.com/a/69411450
     import matplotlib.cm as cm
-    from matplotlib.path import Path
     import matplotlib.patches as patches
+    from matplotlib.path import Path
 
     # Variables (the first variable must be categoric):
     my_vars = df.columns.tolist()

--- a/benchmarks/scripts/cccl/bench/__init__.py
+++ b/benchmarks/scripts/cccl/bench/__init__.py
@@ -1,6 +1,6 @@
-from .config import *  # noqa: F403
-from .storage import *  # noqa: F403
 from .bench import Bench  # noqa: F401
 from .cmake import CMake  # noqa: F401
+from .config import *  # noqa: F403
 from .score import *  # noqa: F403
 from .search import *  # noqa: F403
+from .storage import *  # noqa: F403

--- a/benchmarks/scripts/cccl/bench/bench.py
+++ b/benchmarks/scripts/cccl/bench/bench.py
@@ -1,17 +1,18 @@
-import os
-import json
-import time
-import fpzip
-import signal
 import itertools
+import json
+import os
+import signal
 import subprocess
+import time
+
+import fpzip
 import numpy as np
 
 from .cmake import CMake
 from .config import BasePoint, Config
-from .storage import Storage, get_bench_table_name
-from .score import compute_axes_ids, compute_weight_matrices, get_workload_weight
 from .logger import Logger
+from .score import compute_axes_ids, compute_weight_matrices, get_workload_weight
+from .storage import Storage, get_bench_table_name
 
 
 def first_val(my_dict):

--- a/benchmarks/scripts/cccl/bench/cmake.py
+++ b/benchmarks/scripts/cccl/bench/cmake.py
@@ -1,12 +1,12 @@
 import os
-import time
 import signal
 import subprocess
+import time
 
 from .build import Build
 from .config import Config
-from .storage import Storage
 from .logger import Logger
+from .storage import Storage
 
 
 def create_builds_table(conn):

--- a/benchmarks/scripts/cccl/bench/config.py
+++ b/benchmarks/scripts/cccl/bench/config.py
@@ -1,6 +1,6 @@
 import os
-import sys
 import random
+import sys
 
 
 def randomized_cartesian_product(list_of_lists):

--- a/benchmarks/scripts/cccl/bench/score.py
+++ b/benchmarks/scripts/cccl/bench/score.py
@@ -1,4 +1,5 @@
 import math
+
 import numpy as np
 
 

--- a/benchmarks/scripts/cccl/bench/search.py
+++ b/benchmarks/scripts/cccl/bench/search.py
@@ -1,11 +1,12 @@
-import re
 import argparse
+import re
+
 import numpy as np
 
-from .bench import Bench, BaseBench
+from .bench import BaseBench, Bench
+from .cmake import CMake
 from .config import Config
 from .storage import Storage
-from .cmake import CMake
 
 
 def list_benches(algnames):

--- a/benchmarks/scripts/cccl/bench/storage.py
+++ b/benchmarks/scripts/cccl/bench/storage.py
@@ -1,9 +1,9 @@
 import os
-import fpzip
 import sqlite3
+
+import fpzip
 import numpy as np
 import pandas as pd
-
 
 db_name = "cccl_meta_bench.db"
 

--- a/benchmarks/scripts/compare.py
+++ b/benchmarks/scripts/compare.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-import os
-import cccl
 import argparse
+import os
+
+import cccl
 import numpy as np
 import pandas as pd
-
 from colorama import Fore
 
 

--- a/benchmarks/scripts/run.py
+++ b/benchmarks/scripts/run.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
+import math
 import os
 import sys
-import math
+
 import cccl.bench
 
 

--- a/benchmarks/scripts/search.py
+++ b/benchmarks/scripts/search.py
@@ -2,7 +2,6 @@
 
 import cccl.bench as bench
 
-
 # TODO:
 # - driver version
 # - host compiler + version

--- a/benchmarks/scripts/sol.py
+++ b/benchmarks/scripts/sol.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
-import os
-import cccl
 import argparse
+import os
+
+import cccl
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-import matplotlib.pyplot as plt
 
 
 def is_finite(x):

--- a/benchmarks/scripts/verify.py
+++ b/benchmarks/scripts/verify.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-import sys
 import argparse
+import sys
+
 import cccl.bench
 
 

--- a/libcudacxx/test/support/filesystem_dynamic_test_helper.py
+++ b/libcudacxx/test/support/filesystem_dynamic_test_helper.py
@@ -1,6 +1,6 @@
-import sys
 import os
 import socket
+import sys
 
 # Ensure that this is being run on a specific platform
 assert (

--- a/libcudacxx/test/utils/libcudacxx/compiler.py
+++ b/libcudacxx/test/utils/libcudacxx/compiler.py
@@ -6,8 +6,9 @@
 #
 # ===----------------------------------------------------------------------===##
 
-import platform
 import os
+import platform
+
 import libcudacxx.util
 
 

--- a/libcudacxx/test/utils/libcudacxx/sym_check/util.py
+++ b/libcudacxx/test/utils/libcudacxx/sym_check/util.py
@@ -8,10 +8,11 @@
 
 import ast
 import distutils.spawn
-import sys
 import re
-import libcudacxx.util
+import sys
 from pprint import pformat
+
+import libcudacxx.util
 
 
 def read_syms_from_list(slist):

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -6,24 +6,23 @@
 #
 # ===----------------------------------------------------------------------===##
 
+import ctypes
 import os
-import platform
 import pipes
+import platform
 import re
 import shlex
 import shutil
 import sys
-import ctypes
 
+import libcudacxx.util
 from libcudacxx.compiler import CXXCompiler
-from libcudacxx.test.target_info import make_target_info
 
 # The wildcard import is to support `eval(exec_str)` in
 # `Configuration.configure_executor()` below.
 from libcudacxx.test.executor import *  # noqa: F403
 from libcudacxx.test.executor import LocalExecutor, NoopExecutor
-
-import libcudacxx.util
+from libcudacxx.test.target_info import make_target_info
 
 
 def loadSiteConfig(lit_config, config, param_name, env_name):

--- a/libcudacxx/test/utils/libcudacxx/test/executor.py
+++ b/libcudacxx/test/utils/libcudacxx/test/executor.py
@@ -6,8 +6,8 @@
 #
 # ===----------------------------------------------------------------------===##
 
-import platform
 import os
+import platform
 
 from libcudacxx.test import tracing
 from libcudacxx.util import executeCommand

--- a/libcudacxx/test/utils/libcudacxx/test/format.py
+++ b/libcudacxx/test/utils/libcudacxx/test/format.py
@@ -13,11 +13,12 @@ import time
 
 import lit.Test  # pylint: disable=import-error
 import lit.TestRunner  # pylint: disable=import-error
-from lit.TestRunner import ParserKind, IntegratedTestKeywordParser
-# pylint: disable=import-error
+from lit.TestRunner import IntegratedTestKeywordParser, ParserKind
 
-from libcudacxx.test.executor import LocalExecutor as LocalExecutor
 import libcudacxx.util
+
+# pylint: disable=import-error
+from libcudacxx.test.executor import LocalExecutor as LocalExecutor
 
 
 class LibcxxTestFormat(object):

--- a/libcudacxx/test/utils/libcudacxx/test/googlebenchmark.py
+++ b/libcudacxx/test/utils/libcudacxx/test/googlebenchmark.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import os
 import subprocess
 import sys

--- a/libcudacxx/test/utils/libcudacxx/util.py
+++ b/libcudacxx/test/utils/libcudacxx/util.py
@@ -6,7 +6,6 @@
 #
 # ===----------------------------------------------------------------------===##
 
-from contextlib import contextmanager
 import errno
 import os
 import platform
@@ -15,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+from contextlib import contextmanager
 
 
 # FIXME: Most of these functions are cribbed from LIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 
 [tool.ruff]
 target-version = "py310"
+fix = true
+show-fixes = true
+exclude = ["docs/tools"]
 
 [tool.ruff.lint]
 extend-select = ["I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@
 [tool.ruff]
 target-version = "py310"
 
+[tool.ruff.lint]
+extend-select = ["I"]
+
 [tool.codespell]
 # To run codespell interactively and fix errors that pre-commit reports, try
 # `codespell -i 3 -w -H`. This will run with interactive review (-i 3), writes

--- a/python/cuda_cooperative/cuda/cooperative/experimental/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/__init__.py
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from cuda.cooperative.experimental import block
-from cuda.cooperative.experimental import warp
+from cuda.cooperative.experimental import block, warp
 from cuda.cooperative.experimental._types import StatefulFunction
 
 __all__ = ["block", "warp", "StatefulFunction"]

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_caching.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_caching.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import hashlib
+import json
 import os
 import pickle
-import json
-import hashlib
 
 _ENABLE_CACHE = "CCCL_ENABLE_CACHE" in os.environ
 if _ENABLE_CACHE:

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_common.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import tempfile
 import re
+import tempfile
 from collections import namedtuple
 
 version = namedtuple("version", ("major", "minor"))

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_nvrtc.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_nvrtc.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import functools
+import importlib.resources as pkg_resources
 import os
 import shutil
+
 from cuda.bindings import nvrtc
 from cuda.cooperative.experimental._caching import disk_cache
 from cuda.cooperative.experimental._common import check_in, version
-import importlib.resources as pkg_resources
-import functools
 
 
 def CHECK_NVRTC(err, prog):

--- a/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/_types.py
@@ -3,16 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import re
+
+import jinja2
 import numba
+from llvmlite import ir
 from numba import cuda, types
 from numba.core import cgutils
-from llvmlite import ir
-from numba.core.typing import signature
 from numba.core.extending import intrinsic, overload
-from cuda.cooperative.experimental._nvrtc import compile
-from cuda.cooperative.experimental._common import find_unsigned
-import jinja2
+from numba.core.typing import signature
 
+from cuda.cooperative.experimental._common import find_unsigned
+from cuda.cooperative.experimental._nvrtc import compile
 
 NUMBA_TYPES_TO_CPP = {
     types.boolean: "bool",

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/__init__.py
@@ -2,16 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from cuda.cooperative.experimental.block._block_load_store import load, store
 from cuda.cooperative.experimental.block._block_merge_sort import merge_sort_keys
-from cuda.cooperative.experimental.block._block_reduce import reduce
-from cuda.cooperative.experimental.block._block_reduce import sum
-from cuda.cooperative.experimental.block._block_scan import exclusive_sum
-from cuda.cooperative.experimental.block._block_radix_sort import radix_sort_keys
 from cuda.cooperative.experimental.block._block_radix_sort import (
+    radix_sort_keys,
     radix_sort_keys_descending,
 )
-from cuda.cooperative.experimental.block._block_load_store import load
-from cuda.cooperative.experimental.block._block_load_store import store
+from cuda.cooperative.experimental.block._block_reduce import reduce, sum
+from cuda.cooperative.experimental.block._block_scan import exclusive_sum
 
 __all__ = [
     "merge_sort_keys",

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_load_store.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_load_store.py
@@ -5,6 +5,7 @@
 
 import numba
 
+from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
@@ -14,7 +15,6 @@ from cuda.cooperative.experimental._types import (
     Pointer,
     TemplateParameter,
 )
-from cuda.cooperative.experimental._common import make_binary_tempfile
 
 CUB_BLOCK_LOAD_ALGOS = {
     "direct": "::cub::BLOCK_LOAD_DIRECT",

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_merge_sort.py
@@ -4,6 +4,7 @@
 
 import numba
 
+from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Constant,
@@ -15,7 +16,6 @@ from cuda.cooperative.experimental._types import (
     TemplateParameter,
     numba_type_to_wrapper,
 )
-from cuda.cooperative.experimental._common import make_binary_tempfile
 
 
 def merge_sort_keys(

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_radix_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_radix_sort.py
@@ -4,6 +4,7 @@
 
 import numba
 
+from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
@@ -13,7 +14,6 @@ from cuda.cooperative.experimental._types import (
     TemplateParameter,
     Value,
 )
-from cuda.cooperative.experimental._common import make_binary_tempfile
 
 
 def radix_sort_keys(dtype, threads_in_block, items_per_thread):

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_reduce.py
@@ -4,6 +4,7 @@
 
 import numba
 
+from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
@@ -15,7 +16,6 @@ from cuda.cooperative.experimental._types import (
     Value,
     numba_type_to_wrapper,
 )
-from cuda.cooperative.experimental._common import make_binary_tempfile
 
 
 def reduce(dtype, threads_in_block, binary_op, methods=None):

--- a/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/block/_block_scan.py
@@ -4,16 +4,16 @@
 
 import numba
 
+from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
-    Invocable,
     Dependency,
     DependentArray,
     DependentOperator,
+    Invocable,
     Pointer,
     TemplateParameter,
 )
-from cuda.cooperative.experimental._common import make_binary_tempfile
 
 
 def exclusive_sum(dtype, threads_in_block, items_per_thread, prefix_op=None):

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/__init__.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/__init__.py
@@ -2,9 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from cuda.cooperative.experimental.warp._warp_scan import exclusive_sum
-from cuda.cooperative.experimental.warp._warp_reduce import reduce
-from cuda.cooperative.experimental.warp._warp_reduce import sum
 from cuda.cooperative.experimental.warp._warp_merge_sort import merge_sort_keys
+from cuda.cooperative.experimental.warp._warp_reduce import reduce, sum
+from cuda.cooperative.experimental.warp._warp_scan import exclusive_sum
 
 __all__ = ["exclusive_sum", "reduce", "sum", "merge_sort_keys"]

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_merge_sort.py
@@ -4,6 +4,7 @@
 
 import numba
 
+from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Constant,
@@ -15,7 +16,6 @@ from cuda.cooperative.experimental._types import (
     TemplateParameter,
     numba_type_to_wrapper,
 )
-from cuda.cooperative.experimental._common import make_binary_tempfile
 
 
 def merge_sort_keys(

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_reduce.py
@@ -4,6 +4,7 @@
 
 import numba
 
+from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
@@ -14,7 +15,6 @@ from cuda.cooperative.experimental._types import (
     TemplateParameter,
     numba_type_to_wrapper,
 )
-from cuda.cooperative.experimental._common import make_binary_tempfile
 
 
 def reduce(dtype, binary_op, threads_in_warp=32, methods=None):

--- a/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_scan.py
+++ b/python/cuda_cooperative/cuda/cooperative/experimental/warp/_warp_scan.py
@@ -5,6 +5,7 @@
 
 import numba
 
+from cuda.cooperative.experimental._common import make_binary_tempfile
 from cuda.cooperative.experimental._types import (
     Algorithm,
     Dependency,
@@ -13,7 +14,6 @@ from cuda.cooperative.experimental._types import (
     Pointer,
     TemplateParameter,
 )
-from cuda.cooperative.experimental._common import make_binary_tempfile
 
 
 def exclusive_sum(dtype, threads_in_warp=32):

--- a/python/cuda_cooperative/pyproject.toml
+++ b/python/cuda_cooperative/pyproject.toml
@@ -5,3 +5,9 @@
 [build-system]
 requires = ["packaging", "setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+
+[tool.ruff.lint.isort]
+known-first-party = ["cuda.cooperative"]

--- a/python/cuda_cooperative/setup.py
+++ b/python/cuda_cooperative/setup.py
@@ -5,10 +5,9 @@
 import os
 import shutil
 
-from setuptools import Command, setup, find_namespace_packages
+from setuptools import Command, find_namespace_packages, setup
 from setuptools.command.build_py import build_py
 from wheel.bdist_wheel import bdist_wheel
-
 
 project_path = os.path.abspath(os.path.dirname(__file__))
 cccl_path = os.path.abspath(os.path.join(project_path, "..", ".."))

--- a/python/cuda_cooperative/tests/helpers.py
+++ b/python/cuda_cooperative/tests/helpers.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from numba import types
 import numpy as np
+from numba import types
 
 NUMBA_TYPES_TO_NP = {
     types.int8: np.int8,

--- a/python/cuda_cooperative/tests/test_block_load.py
+++ b/python/cuda_cooperative/tests/test_block_load.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-from helpers import random_int, NUMBA_TYPES_TO_NP
-import pytest
-from numba import cuda, types
 import numba
+import pytest
+from helpers import NUMBA_TYPES_TO_NP, random_int
+from numba import cuda, types
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0

--- a/python/cuda_cooperative/tests/test_block_merge_sort.py
+++ b/python/cuda_cooperative/tests/test_block_merge_sort.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import numpy as np
-import cuda.cooperative.experimental as cudax
-from helpers import random_int, NUMBA_TYPES_TO_NP
-import pytest
-from numba import cuda, types
 import numba
+import numpy as np
+import pytest
+from helpers import NUMBA_TYPES_TO_NP, random_int
+from numba import cuda, types
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0

--- a/python/cuda_cooperative/tests/test_block_merge_sort_api.py
+++ b/python/cuda_cooperative/tests/test_block_merge_sort_api.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-import numpy as np
 import numba
+import numpy as np
 from numba import cuda
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_block_radix_sort.py
+++ b/python/cuda_cooperative/tests/test_block_radix_sort.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-from helpers import random_int, NUMBA_TYPES_TO_NP
-import pytest
-from numba import cuda, types
 import numba
+import pytest
+from helpers import NUMBA_TYPES_TO_NP, random_int
+from numba import cuda, types
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0

--- a/python/cuda_cooperative/tests/test_block_radix_sort_api.py
+++ b/python/cuda_cooperative/tests/test_block_radix_sort_api.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-import numpy as np
 import numba
+import numpy as np
 from numba import cuda
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_block_reduce.py
+++ b/python/cuda_cooperative/tests/test_block_reduce.py
@@ -2,8 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
+import numba
+import numpy as np
+import pytest
+from helpers import NUMBA_TYPES_TO_NP, random_int
+from numba import cuda, types
+from numba.core import cgutils
 from numba.core.extending import (
     lower_builtin,
     make_attribute_wrapper,
@@ -12,12 +16,9 @@ from numba.core.extending import (
     type_callable,
     typeof_impl,
 )
-from numba.core import cgutils
-import numpy as np
-from helpers import random_int, NUMBA_TYPES_TO_NP
-import pytest
-from numba import cuda, types
-import numba
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_block_reduce_api.py
+++ b/python/cuda_cooperative/tests/test_block_reduce_api.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-import numpy as np
 import numba
+import numpy as np
 from numba import cuda
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_block_scan.py
+++ b/python/cuda_cooperative/tests/test_block_scan.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
 import numba
-from helpers import random_int, NUMBA_TYPES_TO_NP
+import numpy as np
+import pytest
+from helpers import NUMBA_TYPES_TO_NP, random_int
+from numba import cuda, types
+from numba.core import cgutils
 from numba.core.extending import (
     lower_builtin,
     make_attribute_wrapper,
@@ -14,10 +16,9 @@ from numba.core.extending import (
     type_callable,
     typeof_impl,
 )
-from numba.core import cgutils
-import numpy as np
-import pytest
-from numba import cuda, types
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_block_scan_api.py
+++ b/python/cuda_cooperative/tests/test_block_scan_api.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-import numpy as np
 import numba
+import numpy as np
 from numba import cuda
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_block_store.py
+++ b/python/cuda_cooperative/tests/test_block_store.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-from helpers import random_int, NUMBA_TYPES_TO_NP
-import pytest
-from numba import cuda, types
 import numba
+import pytest
+from helpers import NUMBA_TYPES_TO_NP, random_int
+from numba import cuda, types
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0

--- a/python/cuda_cooperative/tests/test_warp_merge_sort.py
+++ b/python/cuda_cooperative/tests/test_warp_merge_sort.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-from helpers import random_int, NUMBA_TYPES_TO_NP
-import pytest
-from numba import cuda, types
 import numba
+import pytest
+from helpers import NUMBA_TYPES_TO_NP, random_int
+from numba import cuda, types
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 patch.patch_numba_linker(lto=True)
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0

--- a/python/cuda_cooperative/tests/test_warp_merge_sort_api.py
+++ b/python/cuda_cooperative/tests/test_warp_merge_sort_api.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-import numpy as np
 import numba
+import numpy as np
 from numba import cuda
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_warp_reduce.py
+++ b/python/cuda_cooperative/tests/test_warp_reduce.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-import numpy as np
-from helpers import random_int, NUMBA_TYPES_TO_NP
-import pytest
-from numba import cuda, types
 import numba
+import numpy as np
+import pytest
+from helpers import NUMBA_TYPES_TO_NP, random_int
+from numba import cuda, types
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_warp_reduce_api.py
+++ b/python/cuda_cooperative/tests/test_warp_reduce_api.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-import numpy as np
 import numba
+import numpy as np
 from numba import cuda
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_warp_scan.py
+++ b/python/cuda_cooperative/tests/test_warp_scan.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
 import numba
-from helpers import random_int, NUMBA_TYPES_TO_NP
 import numpy as np
 import pytest
+from helpers import NUMBA_TYPES_TO_NP, random_int
 from numba import cuda, types
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_cooperative/tests/test_warp_scan_api.py
+++ b/python/cuda_cooperative/tests/test_warp_scan_api.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pynvjitlink import patch
-import cuda.cooperative.experimental as cudax
-import numpy as np
 import numba
+import numpy as np
 from numba import cuda
+from pynvjitlink import patch
+
+import cuda.cooperative.experimental as cudax
 
 numba.config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 

--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import ctypes
 import os
 import shutil
-import ctypes
 from functools import lru_cache
 from typing import List, Optional
 

--- a/python/cuda_parallel/cuda/parallel/experimental/_caching.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_caching.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import functools
+
 from numba import cuda
 
 

--- a/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
@@ -3,11 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import numba
-import functools
 import ctypes
+import functools
+
+import numba
 import numpy as np
-from numba import types, cuda
+from numba import cuda, types
 
 from .iterators._iterators import IteratorBase
 

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
@@ -6,18 +6,19 @@
 from __future__ import annotations  # TODO: required for Python 3.7 docs env
 
 import ctypes
+from typing import Callable
+
 import numba
 import numpy as np
 from numba import cuda
 from numba.cuda.cudadrv import enums
-from typing import Callable
 
 from .. import _cccl as cccl
-from .._bindings import get_paths, get_bindings
+from .._bindings import get_bindings, get_paths
 from .._caching import CachableFunction, cache_with_key
-from ..typing import DeviceArrayLike
-from ..iterators._iterators import IteratorBase
 from .._utils import cai
+from ..iterators._iterators import IteratorBase
+from ..typing import DeviceArrayLike
 
 
 class _Op:

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/__init__.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/__init__.py
@@ -1,5 +1,6 @@
-from . import _iterators
 import numba
+
+from . import _iterators
 
 
 def CacheModifiedInputIterator(device_array, modifier):

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
@@ -2,18 +2,17 @@ import ctypes
 import operator
 import uuid
 from functools import lru_cache
-from typing import Dict, Callable
+from typing import Callable, Dict
 
+import numba
+import numpy as np
 from llvmlite import ir
+from numba import cuda, types
 from numba.core.extending import intrinsic, overload
 from numba.core.typing.ctypes_utils import to_ctypes
 from numba.cuda.dispatcher import CUDADispatcher
-from numba import cuda, types
-import numba
-import numpy as np
 
 from .._caching import CachableFunction
-
 
 _DEVICE_POINTER_SIZE = 8
 _DEVICE_POINTER_BITWIDTH = _DEVICE_POINTER_SIZE * 8

--- a/python/cuda_parallel/pyproject.toml
+++ b/python/cuda_parallel/pyproject.toml
@@ -16,3 +16,9 @@ module = [
 ]
 ignore_missing_imports = true
 follow_imports = "skip"
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+
+[tool.ruff.lint.isort]
+known-first-party = ["cuda.parallel"]

--- a/python/cuda_parallel/setup.py
+++ b/python/cuda_parallel/setup.py
@@ -6,11 +6,10 @@ import os
 import shutil
 import subprocess
 
-from setuptools import Command, Extension, setup, find_namespace_packages
-from setuptools.command.build_py import build_py
+from setuptools import Command, Extension, find_namespace_packages, setup
 from setuptools.command.build_ext import build_ext
+from setuptools.command.build_py import build_py
 from wheel.bdist_wheel import bdist_wheel
-
 
 project_path = os.path.abspath(os.path.dirname(__file__))
 cccl_path = os.path.abspath(os.path.join(project_path, "..", ".."))

--- a/python/cuda_parallel/tests/test_iterators.py
+++ b/python/cuda_parallel/tests/test_iterators.py
@@ -1,11 +1,12 @@
+import cupy as cp
+import numpy as np
+
 from cuda.parallel.experimental.iterators import (
     CacheModifiedInputIterator,
     ConstantIterator,
     CountingIterator,
     TransformIterator,
 )
-import cupy as cp
-import numpy as np
 
 
 def test_constant_iterator_equality():

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import cupy as cp
-import numpy as np
-import pytest
 import random
+
+import cupy as cp
 import numba.cuda
 import numba.types
+import numpy as np
+import pytest
 
 import cuda.parallel.experimental.algorithms as algorithms
 import cuda.parallel.experimental.iterators as iterators

--- a/python/cuda_parallel/tests/test_reduce_api.py
+++ b/python/cuda_parallel/tests/test_reduce_api.py
@@ -5,7 +5,9 @@
 # example-begin imports
 import cupy as cp
 import numpy as np
+
 import cuda.parallel.experimental.algorithms as algorithms
+
 # example-end imports
 
 

--- a/thrust/scripts/gdb-pretty-printers.py
+++ b/thrust/scripts/gdb-pretty-printers.py
@@ -1,5 +1,6 @@
-import gdb
 import sys
+
+import gdb
 
 if sys.version_info[0] > 2:
     Iterator = object


### PR DESCRIPTION
## Description

This PR updates the ruff configuration to include sorting of imports. There are also small updates to the `pyproject.toml` files of the `cuda_parallel` and `cuda_cooperative` packages. The configuration update is in https://github.com/NVIDIA/cccl/pull/3230/commits/401ed4367857a80c8566fefc94dada391897bcc4.

In addition, following @bdice's suggestion [here](https://github.com/NVIDIA/cccl/pull/3230#discussion_r1900417376), I've made it so that:

> the pre-commit configuration is argument-free so that running ruff on its own does the same thing as pre-commit.

This is done in https://github.com/NVIDIA/cccl/pull/3230/commits/45942242583575502b628346f4faec1f4ffce781.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
