### PR TITLE
Expands support for more offset types in segmented benchmark

### DIFF
--- a/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cu
+++ b/cub/benchmarks/nvbench_helper/nvbench_helper/nvbench_helper.cu
@@ -752,7 +752,9 @@ void do_not_optimize(const void* ptr)
     seed_t, cuda::std::span<TYPE>, std::size_t, std::size_t)
 
 INSTANTIATE(int32_t);
+INSTANTIATE(uint32_t);
 INSTANTIATE(int64_t);
+INSTANTIATE(uint64_t);
 
 #undef INSTANTIATE
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
When running benchmarks on segmented algorithms like segmented sort, we need to generate segment sizes with different distributions. When using different offset types, however, generators for these distributions were previously limited to `int32` and `int64`. This PR expands support for also unsigned offset types, which is needed for experiments related to https://github.com/NVIDIA/cccl/issues/3132 <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->
