### PR TITLE
cuda.parallel: Forbid non-contiguous arrays as inputs (or outputs)

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
@@ -10,6 +10,7 @@ import numba
 import numpy as np
 from numba import cuda, types
 
+from ._utils.cai import DeviceArrayLike, get_stride, get_dtype
 from .iterators._iterators import IteratorBase
 
 
@@ -131,8 +132,10 @@ def _numpy_type_to_info(numpy_type: np.dtype) -> TypeInfo:
     return _numba_type_to_info(numba_type)
 
 
-def _device_array_to_cccl_iter(array) -> Iterator:
-    info = _numpy_type_to_info(array.dtype)
+def _device_array_to_cccl_iter(array: DeviceArrayLike) -> Iterator:
+    if get_stride(array) is not None:
+        raise ValueError("Non-contiguous arrays are not supported.")
+    info = _numpy_type_to_info(get_dtype(array))
     return Iterator(
         info.size,
         info.alignment,

--- a/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
@@ -10,7 +10,7 @@ import numba
 import numpy as np
 from numba import cuda, types
 
-from ._utils.cai import DeviceArrayLike, is_contiguous, get_dtype
+from ._utils.cai import DeviceArrayLike, get_dtype, is_contiguous
 from .iterators._iterators import IteratorBase
 
 

--- a/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_cccl.py
@@ -10,7 +10,7 @@ import numba
 import numpy as np
 from numba import cuda, types
 
-from ._utils.cai import DeviceArrayLike, get_stride, get_dtype
+from ._utils.cai import DeviceArrayLike, is_contiguous, get_dtype
 from .iterators._iterators import IteratorBase
 
 
@@ -133,7 +133,7 @@ def _numpy_type_to_info(numpy_type: np.dtype) -> TypeInfo:
 
 
 def _device_array_to_cccl_iter(array: DeviceArrayLike) -> Iterator:
-    if get_stride(array) is not None:
+    if not is_contiguous(array):
         raise ValueError("Non-contiguous arrays are not supported.")
     info = _numpy_type_to_info(get_dtype(array))
     return Iterator(

--- a/python/cuda_parallel/cuda/parallel/experimental/_utils/cai.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_utils/cai.py
@@ -31,7 +31,7 @@ def is_contiguous(arr: DeviceArrayLike) -> bool:
     if strides is None:
         return True
 
-    if sum(shape) == 0:
+    if any(dim == 0 for dim in shape):
         # array has no elements
         return True
 

--- a/python/cuda_parallel/cuda/parallel/experimental/_utils/cai.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_utils/cai.py
@@ -7,6 +7,7 @@
 Utilities for extracting information from `__cuda_array_interface__`.
 """
 
+from typing import Optional, Tuple
 import numpy as np
 
 from ..typing import DeviceArrayLike
@@ -14,3 +15,7 @@ from ..typing import DeviceArrayLike
 
 def get_dtype(arr: DeviceArrayLike) -> np.dtype:
     return np.dtype(arr.__cuda_array_interface__["typestr"])
+
+
+def get_stride(arr: DeviceArrayLike) -> Optional[Tuple]:
+    return arr.__cuda_array_interface__["strides"]

--- a/python/cuda_parallel/cuda/parallel/experimental/_utils/cai.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_utils/cai.py
@@ -8,6 +8,7 @@ Utilities for extracting information from `__cuda_array_interface__`.
 """
 
 from typing import Optional, Tuple
+
 import numpy as np
 
 from ..typing import DeviceArrayLike

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -509,7 +509,10 @@ def array_2d(request):
     f_contiguous = request.param
     arr = cp.random.rand(5, 10)
     if f_contiguous:
-        return cp.asfortranarray(arr)
+        try:
+            return cp.asfortranarray(arr)
+        except ImportError:  # cublas unavailable
+            return arr
     else:
         return arr
 

--- a/python/cuda_parallel/tests/test_reduce.py
+++ b/python/cuda_parallel/tests/test_reduce.py
@@ -502,3 +502,16 @@ def test_reducer_caching():
         np.zeros([0], dtype="int64"),
     )
     assert reducer_1 is not reducer_2
+
+
+def test_reduce_non_contiguous():
+    def binary_op(x, y):
+        return x + y
+
+    size = 10
+    d_out = cp.empty(1, dtype="int64")
+    h_init = np.asarray([0], dtype="int64")
+    d_in = cp.zeros((size, 2))[:, 0]
+
+    with pytest.raises(ValueError, match="Non-contiguous arrays are not supported."):
+        _ = algorithms.reduce_into(d_in, d_out, binary_op, h_init)


### PR DESCRIPTION
## Description

Closes #3223.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
