### PR TITLE
Architecture and OS identification macros

### DIFF
--- a/libcudacxx/include/cuda/__cccl_config
+++ b/libcudacxx/include/cuda/__cccl_config
@@ -11,6 +11,7 @@
 #ifndef _CUDA__CCCL_CONFIG
 #define _CUDA__CCCL_CONFIG
 
+#include <cuda/std/__cccl/architecture.h> // IWYU pragma: export
 #include <cuda/std/__cccl/assert.h> // IWYU pragma: export
 #include <cuda/std/__cccl/attributes.h> // IWYU pragma: export
 #include <cuda/std/__cccl/builtin.h> // IWYU pragma: export
@@ -21,6 +22,7 @@
 #include <cuda/std/__cccl/exceptions.h> // IWYU pragma: export
 #include <cuda/std/__cccl/execution_space.h> // IWYU pragma: export
 #include <cuda/std/__cccl/extended_floating_point.h> // IWYU pragma: export
+#include <cuda/std/__cccl/os.h> // IWYU pragma: export
 #include <cuda/std/__cccl/preprocessor.h> // IWYU pragma: export
 #include <cuda/std/__cccl/ptx_isa.h> // IWYU pragma: export
 #include <cuda/std/__cccl/rtti.h> // IWYU pragma: export

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -21,23 +21,12 @@
 // _CCCL_ARCH(32BIT)     Any 32 bit OS (supported by CUDA)
 
 // Determine the host compiler and its version
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) /* Windows Emulation Compatible */
-#  define _CCCL_ARCH_ARM64_() 1
-#elif defined(_M_X64) || defined(_M_IX86) || defined(__amd64__) || defined(__x86_64__)
-#  define _CCCL_ARCH_X86_() 1
-#  if defined(_M_X64) || defined(__amd64__) || defined(__x86_64__)
-#    define _CCCL_ARCH_X86_64_() 1
-#  else
-#    define _CCCL_ARCH_X86_32_() 1
-#  endif
-#endif
-
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__amd64__) || defined(__x86_64__) \
-  || defined(_M_X64)
-#  define _CCCL_ARCH_64BIT_() 1
-#elif defined(_M_IX86)
-#  define _CCCL_ARCH_32BIT_() 1
-#endif
+#define _CCCL_ARCH_ARM64_()  (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) /*emulation*/)
+#define _CCCL_ARCH_X86_64_() defined(_M_X64) || defined(__amd64__) || defined(__x86_64__)
+#define _CCCL_ARCH_X86_32_() defined(_M_IX86)
+#define _CCCL_ARCH_X86_()    (_CCCL_ARCH_X86_64_() || _CCCL_ARCH_X86_32_())
+#define _CCCL_ARCH_64BIT_()  (_CCCL_ARCH_ARM64_() || _CCCL_ARCH_X86_64_())
+#define _CCCL_ARCH_32BIT_()  defined(_M_IX86)
 
 #define _CCCL_ARCH(...) _CCCL_ARCH_##__VA_ARGS__##_()
 

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -30,7 +30,7 @@
 #if defined(_M_X64) || defined(__amd64__) || defined(__x86_64__)
 #  define _CCCL_ARCH_X86_64_() 1
 #else
-#  define _CCCL_ARCH_X86_() 0
+#  define _CCCL_ARCH_X86_64_() 0
 #endif
 
 #if defined(_M_IX86)

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -53,13 +53,15 @@
 // 64-bit
 #if _CCCL_ARCH_X86_64_() || _CCCL_ARCH_ARM64_() || defined(__CUDACC_RTC__)
 #  define _CCCL_ARCH_64BIT_() 1
-#  define _CCCL_ARCH_32BIT_() 0
+#else
+#  define _CCCL_ARCH_64BIT_() 0
 #endif
 
 // 32-bit
 #if _CCCL_ARCH_X86_32_()
-#  define _CCCL_ARCH_64BIT_() 0
 #  define _CCCL_ARCH_32BIT_() 1
+#else
+#  define _CCCL_ARCH_32BIT_() 0
 #endif
 
 #define _CCCL_ARCH(...) _CCCL_ARCH_##__VA_ARGS__##_()

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CCCL_ARCH_H
+#define __CCCL_ARCH_H
+
+// The header provides the following macros to determine the host architecture:
+//
+// _CCCL_ARCH(ARM64)     ARM64
+// _CCCL_ARCH(X86)       X86 both 32 and 64 bit
+// _CCCL_ARCH(X86_64)    X86 64 bit
+// _CCCL_ARCH(X86_32)    X86 64 bit
+// _CCCL_ARCH(64BIT)     Any 64 bit OS (supported by CUDA)
+// _CCCL_ARCH(32BIT)     Any 32 bit OS (supported by CUDA)
+
+// Determine the host compiler and its version
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) /* Windows Emulation Compatible */
+#  define _CCCL_ARCH_ARM64_() 1
+#elif defined(_M_X64) || defined(_M_IX86) || defined(__amd64__) || defined(__x86_64__)
+#  define _CCCL_ARCH_X86_() 1
+#  if defined(_M_X64) || defined(__amd64__) || defined(__x86_64__)
+#    define _CCCL_ARCH_X86_64_() 1
+#  else
+#    define _CCCL_ARCH_X86_32_() 1
+#  endif
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__amd64__) || defined(__x86_64__) \
+  || defined(_M_X64)
+#  define _CCCL_ARCH_64BIT_() 1
+#elif defined(_M_IX86)
+#  define _CCCL_ARCH_32BIT_() 1
+#endif
+
+#define _CCCL_ARCH(...) _CCCL_ARCH_##__VA_ARGS__##_()
+
+#endif // __CCCL_ARCH_H

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -50,11 +50,14 @@
 #  define _CCCL_ARCH_X86_() 0
 #endif
 
-// 64-bit / 32-bit
+// 64-bit
 #if _CCCL_ARCH_X86_64_() || _CCCL_ARCH_ARM64_() || defined(__CUDACC_RTC__)
 #  define _CCCL_ARCH_64BIT_() 1
 #  define _CCCL_ARCH_32BIT_() 0
-#else
+#endif
+
+// 32-bit
+#if _CCCL_ARCH_X86_32_()
 #  define _CCCL_ARCH_64BIT_() 0
 #  define _CCCL_ARCH_32BIT_() 1
 #endif

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -14,11 +14,7 @@
 // The header provides the following macros to determine the host architecture:
 //
 // _CCCL_ARCH(ARM64)     ARM64
-// _CCCL_ARCH(X86)       X86 both 32 and 64 bit
 // _CCCL_ARCH(X86_64)    X86 64 bit
-// _CCCL_ARCH(X86_32)    X86 64 bit
-// _CCCL_ARCH(64BIT)     Any 64 bit OS (supported by CUDA)
-// _CCCL_ARCH(32BIT)     Any 32 bit OS (supported by CUDA)
 
 // Determine the host compiler and its version
 
@@ -34,34 +30,6 @@
 #  define _CCCL_ARCH_X86_64_() 1
 #else
 #  define _CCCL_ARCH_X86_64_() 0
-#endif
-
-// X86 32-bit
-#if defined(_M_IX86)
-#  define _CCCL_ARCH_X86_32_() 1
-#else
-#  define _CCCL_ARCH_X86_32_() 0
-#endif
-
-// X86
-#if _CCCL_ARCH_X86_64_() || _CCCL_ARCH_X86_32_()
-#  define _CCCL_ARCH_X86_() 1
-#else
-#  define _CCCL_ARCH_X86_() 0
-#endif
-
-// 64-bit
-#if _CCCL_ARCH_X86_64_() || _CCCL_ARCH_ARM64_() || defined(__CUDACC_RTC__)
-#  define _CCCL_ARCH_64BIT_() 1
-#else
-#  define _CCCL_ARCH_64BIT_() 0
-#endif
-
-// 32-bit
-#if _CCCL_ARCH_X86_32_()
-#  define _CCCL_ARCH_32BIT_() 1
-#else
-#  define _CCCL_ARCH_32BIT_() 0
 #endif
 
 #define _CCCL_ARCH(...) _CCCL_ARCH_##__VA_ARGS__##_()

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -21,31 +21,37 @@
 // _CCCL_ARCH(32BIT)     Any 32 bit OS (supported by CUDA)
 
 // Determine the host compiler and its version
+
+// Arm 64-bit
 #if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) /*emulation*/)
 #  define _CCCL_ARCH_ARM64_() 1
 #else
 #  define _CCCL_ARCH_ARM64_() 0
 #endif
 
+// X86 64-bit
 #if defined(_M_X64) || defined(__amd64__) || defined(__x86_64__)
 #  define _CCCL_ARCH_X86_64_() 1
 #else
 #  define _CCCL_ARCH_X86_64_() 0
 #endif
 
+// X86 32-bit
 #if defined(_M_IX86)
 #  define _CCCL_ARCH_X86_32_() 1
 #else
 #  define _CCCL_ARCH_X86_32_() 0
 #endif
 
+// X86
 #if _CCCL_ARCH_X86_64_() || _CCCL_ARCH_X86_32_()
 #  define _CCCL_ARCH_X86_() 1
 #else
 #  define _CCCL_ARCH_X86_() 0
 #endif
 
-#if _CCCL_ARCH_X86_64_() || _CCCL_ARCH_ARM64_()
+// 64-bit / 32-bit
+#if _CCCL_ARCH_X86_64_() || _CCCL_ARCH_ARM64_() || defined(__CUDACC_RTC__)
 #  define _CCCL_ARCH_64BIT_() 1
 #  define _CCCL_ARCH_32BIT_() 0
 #else

--- a/libcudacxx/include/cuda/std/__cccl/architecture.h
+++ b/libcudacxx/include/cuda/std/__cccl/architecture.h
@@ -21,12 +21,37 @@
 // _CCCL_ARCH(32BIT)     Any 32 bit OS (supported by CUDA)
 
 // Determine the host compiler and its version
-#define _CCCL_ARCH_ARM64_()  (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) /*emulation*/)
-#define _CCCL_ARCH_X86_64_() defined(_M_X64) || defined(__amd64__) || defined(__x86_64__)
-#define _CCCL_ARCH_X86_32_() defined(_M_IX86)
-#define _CCCL_ARCH_X86_()    (_CCCL_ARCH_X86_64_() || _CCCL_ARCH_X86_32_())
-#define _CCCL_ARCH_64BIT_()  (_CCCL_ARCH_ARM64_() || _CCCL_ARCH_X86_64_())
-#define _CCCL_ARCH_32BIT_()  defined(_M_IX86)
+#if (defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) /*emulation*/)
+#  define _CCCL_ARCH_ARM64_() 1
+#else
+#  define _CCCL_ARCH_ARM64_() 0
+#endif
+
+#if defined(_M_X64) || defined(__amd64__) || defined(__x86_64__)
+#  define _CCCL_ARCH_X86_64_() 1
+#else
+#  define _CCCL_ARCH_X86_() 0
+#endif
+
+#if defined(_M_IX86)
+#  define _CCCL_ARCH_X86_32_() 1
+#else
+#  define _CCCL_ARCH_X86_32_() 0
+#endif
+
+#if _CCCL_ARCH_X86_64_() || _CCCL_ARCH_X86_32_()
+#  define _CCCL_ARCH_X86_() 1
+#else
+#  define _CCCL_ARCH_X86_() 0
+#endif
+
+#if _CCCL_ARCH_X86_64_() || _CCCL_ARCH_ARM64_()
+#  define _CCCL_ARCH_64BIT_() 1
+#  define _CCCL_ARCH_32BIT_() 0
+#else
+#  define _CCCL_ARCH_64BIT_() 0
+#  define _CCCL_ARCH_32BIT_() 1
+#endif
 
 #define _CCCL_ARCH(...) _CCCL_ARCH_##__VA_ARGS__##_()
 

--- a/libcudacxx/include/cuda/std/__cccl/os.h
+++ b/libcudacxx/include/cuda/std/__cccl/os.h
@@ -19,13 +19,13 @@
 // _CCCL_OS(QNX)
 
 // Determine the host compiler and its version
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(_WIN64) /* _WIN64 for NVRTC */
 #  define _CCCL_OS_WINDOWS_() 1
 #else
 #  define _CCCL_OS_WINDOWS_() 0
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__LP64__) /* __LP64__ for NVRTC */
 #  define _CCCL_OS_LINUX_() 1
 #else
 #  define _CCCL_OS_LINUX_() 0

--- a/libcudacxx/include/cuda/std/__cccl/os.h
+++ b/libcudacxx/include/cuda/std/__cccl/os.h
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CCCL_OS_H
+#define __CCCL_OS_H
+
+// The header provides the following macros to determine the host architecture:
+//
+// _CCCL_OS(WINDOWS)
+// _CCCL_OS(LINUX)
+// _CCCL_OS(ANDROID)
+// _CCCL_OS(QNX)
+
+// Determine the host compiler and its version
+#if defined(_WIN32)
+#  define _CCCL_OS_WINDOWS_() 1
+#elif defined(__linux__)
+#  define _CCCL_OS_LINUX_() 1
+#endif
+
+#if defined(__ANDROID__)
+#  define _CCCL_OS_ANDROID_() 1
+#elif defined(__QNX__) || defined(__QNXNTO__)
+#  define _CCCL_OS_QNX_() 1
+#endif
+
+#define _CCCL_OS(...) _CCCL_OS_##__VA_ARGS__##_()
+
+#endif // __CCCL_OS_H

--- a/libcudacxx/include/cuda/std/__cccl/os.h
+++ b/libcudacxx/include/cuda/std/__cccl/os.h
@@ -19,17 +19,10 @@
 // _CCCL_OS(QNX)
 
 // Determine the host compiler and its version
-#if defined(_WIN32)
-#  define _CCCL_OS_WINDOWS_() 1
-#elif defined(__linux__)
-#  define _CCCL_OS_LINUX_() 1
-#endif
-
-#if defined(__ANDROID__)
-#  define _CCCL_OS_ANDROID_() 1
-#elif defined(__QNX__) || defined(__QNXNTO__)
-#  define _CCCL_OS_QNX_() 1
-#endif
+#define _CCCL_OS_WINDOWS_() defined(_WIN32)
+#define _CCCL_OS_LINUX_()   defined(__linux__)
+#define _CCCL_OS_ANDROID_() defined(__ANDROID__)
+#define _CCCL_OS_QNX_()     (defined(__QNX__) || defined(__QNXNTO__))
 
 #define _CCCL_OS(...) _CCCL_OS_##__VA_ARGS__##_()
 

--- a/libcudacxx/include/cuda/std/__cccl/os.h
+++ b/libcudacxx/include/cuda/std/__cccl/os.h
@@ -19,10 +19,29 @@
 // _CCCL_OS(QNX)
 
 // Determine the host compiler and its version
-#define _CCCL_OS_WINDOWS_() defined(_WIN32)
-#define _CCCL_OS_LINUX_()   defined(__linux__)
-#define _CCCL_OS_ANDROID_() defined(__ANDROID__)
-#define _CCCL_OS_QNX_()     (defined(__QNX__) || defined(__QNXNTO__))
+#if defined(_WIN32)
+#  define _CCCL_OS_WINDOWS_() 1
+#else
+#  define _CCCL_OS_WINDOWS_() 0
+#endif
+
+#if defined(__linux__)
+#  define _CCCL_OS_LINUX_() 1
+#else
+#  define _CCCL_OS_LINUX_() 0
+#endif
+
+#if defined(__ANDROID__)
+#  define _CCCL_OS_ANDROID_() 1
+#else
+#  define _CCCL_OS_ANDROID_() 0
+#endif
+
+#if defined(__QNX__) || defined(__QNXNTO__)
+#  define _CCCL_OS_QNX_() 1
+#else
+#  define _CCCL_OS_QNX_() 0
+#endif
 
 #define _CCCL_OS(...) _CCCL_OS_##__VA_ARGS__##_()
 

--- a/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
@@ -28,8 +28,12 @@ int main(int, char**)
 #if _CCCL_ARCH(32BIT)
   static_assert(sizeof(void*) == 4, "");
 #endif
-#if _CCCL_ARCH(X86) && (_CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG))
-  static_cast<void>(__cpuidex);
+#if _CCCL_ARCH(X86)
+#  if _CCCL_COMPILER(MSVC)
+  static_cast<void>(__cpuid);
+#  elif _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
+  static_cast<void>(__get_cpuid);
+#  endif
 #endif
 #if _CCCL_ARCH(ARM64)
   static_cast<void>(__clz);

--- a/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
@@ -11,7 +11,7 @@
 #include <cuda/std/__cccl/compiler.h>
 
 #if !defined(__CUDACC_RTC__)
-#  if _CCCL_ARCH(X86)
+#  if _CCCL_ARCH(X86_64)
 #    if _CCCL_COMPILER(MSVC)
 #      include <intrin.h>
 #    elif _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
@@ -26,11 +26,6 @@
 
 int main(int, char**)
 {
-#if _CCCL_ARCH(64BIT)
   static_assert(sizeof(void*) == 8, "");
-#endif
-#if _CCCL_ARCH(32BIT)
-  static_assert(sizeof(void*) == 4, "");
-#endif
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
@@ -18,7 +18,7 @@
 #  endif
 #endif
 
-#if _CCCL_ARCH(ARM64)
+#if _CCCL_ARCH(ARM64) && defined(__ARM_ACLE)
 #  include <arm_acle.h>
 #endif
 

--- a/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__cccl/architecture.h>
+#include <cuda/std/__cccl/compiler.h>
+
+#if _CCCL_COMPILER(MSVC)
+#  include <intrin.h>
+#elif _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
+#  include <cpuid.h>
+#endif
+
+#if _CCCL_ARCH(ARM64)
+#  include <arm_acle.h>
+#endif
+
+int main(int, char**)
+{
+#if _CCCL_ARCH(64BIT)
+  static_assert(sizeof(void*) == 8, "");
+#endif
+#if _CCCL_ARCH(32BIT)
+  static_assert(sizeof(void*) == 4, "");
+#endif
+#if _CCCL_ARCH(X86) && (_CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG))
+  static_cast<void>(__cpuidex);
+#endif
+#if _CCCL_ARCH(ARM64)
+  static_cast<void>(__clz);
+#endif
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
@@ -10,16 +10,18 @@
 #include <cuda/std/__cccl/architecture.h>
 #include <cuda/std/__cccl/compiler.h>
 
-#if _CCCL_ARCH(X86)
-#  if _CCCL_COMPILER(MSVC)
-#    include <intrin.h>
-#  elif _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
-#    include <cpuid.h>
+#if !defined(__CUDACC_RTC__)
+#  if _CCCL_ARCH(X86)
+#    if _CCCL_COMPILER(MSVC)
+#      include <intrin.h>
+#    elif _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
+#      include <cpuid.h>
+#    endif
 #  endif
-#endif
 
-#if _CCCL_ARCH(ARM64) && defined(__ARM_ACLE)
-#  include <arm_acle.h>
+#  if _CCCL_ARCH(ARM64) && defined(__ARM_ACLE)
+#    include <arm_acle.h>
+#  endif
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/architecture.compile.pass.cpp
@@ -10,10 +10,12 @@
 #include <cuda/std/__cccl/architecture.h>
 #include <cuda/std/__cccl/compiler.h>
 
-#if _CCCL_COMPILER(MSVC)
-#  include <intrin.h>
-#elif _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
-#  include <cpuid.h>
+#if _CCCL_ARCH(X86)
+#  if _CCCL_COMPILER(MSVC)
+#    include <intrin.h>
+#  elif _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
+#    include <cpuid.h>
+#  endif
 #endif
 
 #if _CCCL_ARCH(ARM64)
@@ -27,16 +29,6 @@ int main(int, char**)
 #endif
 #if _CCCL_ARCH(32BIT)
   static_assert(sizeof(void*) == 4, "");
-#endif
-#if _CCCL_ARCH(X86)
-#  if _CCCL_COMPILER(MSVC)
-  static_cast<void>(__cpuid);
-#  elif _CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG)
-  static_cast<void>(__get_cpuid);
-#  endif
-#endif
-#if _CCCL_ARCH(ARM64)
-  static_cast<void>(__clz);
 #endif
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/cccl/os.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/os.compile.pass.cpp
@@ -9,20 +9,22 @@
 
 #include <cuda/std/__cccl/os.h>
 
-#if _CCCL_OS(WINDOWS)
-#  include <windows.h>
-#endif
+#if !defined(__CUDACC_RTC__)
+#  if _CCCL_OS(WINDOWS)
+#    include <windows.h>
+#  endif
 
-#if _CCCL_OS(LINUX)
-#  include <unistd.h>
-#endif
+#  if _CCCL_OS(LINUX)
+#    include <unistd.h>
+#  endif
 
-#if _CCCL_OS(ANDROID)
-#  include <android/api-level.h>
-#endif
+#  if _CCCL_OS(ANDROID)
+#    include <android/api-level.h>
+#  endif
 
-#if _CCCL_OS(QNX)
-#  include <qnx.h>
+#  if _CCCL_OS(QNX)
+#    include <qnx.h>
+#  endif
 #endif
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/cccl/os.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/os.compile.pass.cpp
@@ -11,40 +11,32 @@
 
 #if _CCCL_OS(WINDOWS)
 #  include <windows.h>
-constexpr int windows = 1;
-#else
-constexpr int windows = 0;
 #endif
 
 #if _CCCL_OS(LINUX)
 #  include <unistd.h>
-constexpr int linux_ = 1;
-#else
-constexpr int linux_ = 0;
 #endif
 
 #if _CCCL_OS(ANDROID)
 #  include <android/api-level.h>
-constexpr int android = 1;
 #endif
 
 #if _CCCL_OS(QNX)
 #  include <qnx.h>
-constexpr int qnx = 1;
 #endif
 
 int main(int, char**)
 {
-  static_assert(windows + linux_ == 1, "");
+  static_assert(_CCCL_OS(WINDOWS) + _CCCL_OS(LINUX) == 1, "");
 #if _CCCL_OS(ANDROID) || _CCCL_OS(QNX)
-  static_assert(linux_ == 1, "");
-  static_assert(android + qnx == 1, "");
+  static_assert(_CCCL_OS(LINUX) == 1, "");
+  static_assert(_CCCL_OS(ANDROID) + _CCCL_OS(QNX) == 1, "");
 #endif
 #if _CCCL_OS(LINUX)
-  static_assert(windows == 0, "");
+  static_assert(_CCCL_OS(WINDOWS) == 0, "");
 #endif
 #if _CCCL_OS(WINDOWS)
-  static_assert(android + qnx + linux_ == 0, "");
+  static_assert(_CCCL_OS(ANDROID) + _CCCL_OS(QNX) + _CCCL_OS(LINUX) == 0, "");
 #endif
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/cccl/os.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/os.compile.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__cccl/os.h>
+
+#if _CCCL_OS(WINDOWS)
+#  include <windows.h>
+constexpr int windows = 1;
+#else
+constexpr int windows = 0;
+#endif
+
+#if _CCCL_OS(LINUX)
+#  include <unistd.h>
+constexpr int linux_ = 1;
+#else
+constexpr int linux_ = 0;
+#endif
+
+#if _CCCL_OS(ANDROID)
+#  include <android/api-level.h>
+constexpr int android = 1;
+#endif
+
+#if _CCCL_OS(QNX)
+#  include <qnx.h>
+constexpr int qnx = 1;
+#endif
+
+int main(int, char**)
+{
+  static_assert(windows + linux_ == 1, "");
+#if _CCCL_OS(ANDROID) || _CCCL_OS(QNX)
+  static_assert(linux_ == 1, "");
+  static_assert(android + qnx == 1, "");
+#endif
+#if _CCCL_OS(LINUX)
+  static_assert(windows == 0, "");
+#endif
+#if _CCCL_OS(WINDOWS)
+  static_assert(android + qnx + linux_ == 0, "");
+#endif
+  return 0;
+}


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cccl/issues/2505

## Description

Add _internal_ architecture and OS identification macros for CUDA supported platforms