### PR TITLE
Improves `DeviceSegmentedSort` test run time for large number of items and segments

### DIFF
--- a/cub/test/catch2_radix_sort_helper.cuh
+++ b/cub/test/catch2_radix_sort_helper.cuh
@@ -60,7 +60,7 @@ using all_offset_types =
 template <typename OffsetT, OffsetT Step>
 struct segment_iterator
 {
-  std::int64_t last = 0;
+  OffsetT last = 0;
 
   segment_iterator(std::int64_t last1)
       : last{last1}
@@ -68,7 +68,7 @@ struct segment_iterator
 
   __host__ __device__ OffsetT operator()(std::int64_t x) const
   {
-    return x * Step > last ? last : x * Step;
+    return ::cuda::std::min(last, x * Step);
   }
 };
 

--- a/cub/test/catch2_radix_sort_helper.cuh
+++ b/cub/test/catch2_radix_sort_helper.cuh
@@ -41,6 +41,7 @@
 #include <thrust/sequence.h>
 
 #include <cuda/std/bit>
+#include <cuda/std/functional>
 
 #include <array>
 #include <climits>

--- a/cub/test/catch2_radix_sort_helper.cuh
+++ b/cub/test/catch2_radix_sort_helper.cuh
@@ -54,43 +54,21 @@
 // Index types used for OffsetsT testing
 using offset_types = c2h::type_list<cuda::std::int32_t, cuda::std::uint64_t>;
 using all_offset_types =
-  c2h::type_list<cuda::std::int32_t, cuda::std::uint32_t, cuda::std::int64_t, cuda::std::uint64_t>;
+  c2h::type_list<cuda::std::int64_t, cuda::std::uint64_t, cuda::std::int32_t, cuda::std::uint32_t>;
 
 // Create a segment iterator that returns the next multiple of Step except for a few cases. This allows to save memory
 template <typename OffsetT, OffsetT Step>
 struct segment_iterator
 {
-  OffsetT last = 0;
+  std::int64_t last = 0;
 
-  segment_iterator(OffsetT last1)
+  segment_iterator(std::int64_t last1)
       : last{last1}
   {}
 
-  __host__ __device__ OffsetT operator()(OffsetT x) const
+  __host__ __device__ OffsetT operator()(std::int64_t x) const
   {
-    switch (x)
-    {
-      case Step * 100:
-        return Step * 100 + Step / 2;
-      case Step * 200:
-        return Step * 200 + Step / 2;
-      case Step * 300:
-        return Step * 300 + Step / 2;
-      case Step * 400:
-        return Step * 400 + Step / 2;
-      case Step * 500:
-        return Step * 500 + Step / 2;
-      case Step * 600:
-        return Step * 600 + Step / 2;
-      case Step * 700:
-        return Step * 700 + Step / 2;
-      case Step * 800:
-        return Step * 800 + Step / 2;
-      case Step * 900:
-        return Step * 900 + Step / 2;
-      default:
-        return (x >= last) ? last : x * Step;
-    }
+    return x * Step > last ? last : x * Step;
   }
 };
 

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -89,7 +89,7 @@ struct segment_index_to_offset_op
     }
     else if (i < num_segments)
     {
-      return segment_size * (i - num_empty_segments);
+      return segment_size * static_cast<OffsetT>(i - num_empty_segments);
     }
     else
     {
@@ -176,7 +176,7 @@ private:
     std::size_t end_cycle = segment_end / sequence_length;
 
     // Number of full cycles repeating the sequence
-    std::size_t full_cycles = (end_cycle > start_cycle) ? end_cycle - start_cycle : 0;
+    int full_cycles = (end_cycle > start_cycle) ? static_cast<int>(end_cycle - start_cycle) : 0;
 
     // Add contributions from full cycles
     c2h::host_vector<int> histogram(sequence_length, full_cycles);

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -47,11 +47,11 @@
 
 #include <cstdio>
 
+#include "catch2_test_launch_helper.h"
 #include <c2h/catch2_test_helper.h>
 #include <c2h/cpu_timer.h>
 #include <c2h/extended_types.h>
 #include <c2h/utility.h>
-#include <catch2_test_launch_helper.h>
 #include <nv/target>
 
 #define MAKE_SEED_MOD_FUNCTION(name, xor_mask)                  \

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -134,7 +134,7 @@ public:
 
   void verify_sorted(const c2h::device_vector<key_t>& out_keys) const
   {
-    // Verfiy keys are sorted next to each other
+    // Verify keys are sorted next to each other
     auto count = thrust::unique_count(c2h::device_policy, out_keys.cbegin(), out_keys.cend(), thrust::equal_to<int>());
     REQUIRE(count <= max_histo_size);
 
@@ -215,7 +215,7 @@ public:
     // The segments' end-offsets are provided by the segments' begin-offset iterator
     auto offsets_plus_1 = offsets + 1;
 
-    // Verfiy keys are sorted next to each other
+    // Verify keys are sorted next to each other
     const auto count = static_cast<std::size_t>(
       thrust::unique_count(c2h::device_policy, out_keys.cbegin(), out_keys.cend(), thrust::equal_to<int>()));
     REQUIRE(count <= sequence_length * num_segments);

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -116,7 +116,7 @@ class short_key_verification_helper
 private:
   using key_t = KeyT;
   // The histogram size of the keys being sorted for later verification
-  static constexpr auto max_histo_size = 1ULL << (8 * sizeof(key_t));
+  const std::int64_t max_histo_size = std::int64_t{1} << ::cuda::std::numeric_limits<key_t>::digits;
 
   // Holding the histogram of the keys being sorted for verification
   c2h::host_vector<std::size_t> keys_histogram{};
@@ -170,13 +170,13 @@ private:
   c2h::host_vector<int> compute_histogram_of_series(std::size_t segment_offset, std::size_t segment_end) const
   {
     // The i-th full cycle begins after segment_offset
-    std::size_t start_cycle = cuda::ceil_div(segment_offset, sequence_length);
+    const auto start_cycle = cuda::ceil_div(segment_offset, sequence_length);
 
     // The last full cycle ending before segment_end
-    std::size_t end_cycle = segment_end / sequence_length;
+    const auto end_cycle = segment_end / sequence_length;
 
     // Number of full cycles repeating the sequence
-    int full_cycles = (end_cycle > start_cycle) ? static_cast<int>(end_cycle - start_cycle) : 0;
+    const int full_cycles = (end_cycle > start_cycle) ? static_cast<int>(end_cycle - start_cycle) : 0;
 
     // Add contributions from full cycles
     c2h::host_vector<int> histogram(sequence_length, full_cycles);
@@ -184,14 +184,14 @@ private:
     // Partial cycles preceding the first full cycle
     for (std::size_t j = segment_offset; j < start_cycle * sequence_length; ++j)
     {
-      std::size_t value = j % sequence_length;
+      const auto value = j % sequence_length;
       histogram[value]++;
     }
 
     // Partial cycles following the last full cycle
     for (std::size_t j = end_cycle * sequence_length; j < segment_end; ++j)
     {
-      std::size_t value = j % sequence_length;
+      const auto value = j % sequence_length;
       histogram[value]++;
     }
     return histogram;

--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -38,6 +38,7 @@
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <thrust/unique.h>
 
 #include <cuda/std/limits>
 #include <cuda/std/tuple>
@@ -70,6 +71,195 @@ MAKE_SEED_MOD_FUNCTION(offset, 0x5555555555555555)
 MAKE_SEED_MOD_FUNCTION(offset_eraser, 0x3333333333333333)
 
 #undef MAKE_SEED_MOD_FUNCTION
+
+// Helper to generate a certain number of empty segments followed by equi-sized segments.
+template <typename OffsetT, typename SegmentIndexT>
+struct segment_index_to_offset_op
+{
+  SegmentIndexT num_empty_segments;
+  SegmentIndexT num_segments;
+  OffsetT segment_size;
+  OffsetT num_items;
+
+  _CCCL_HOST_DEVICE __forceinline__ OffsetT operator()(SegmentIndexT i)
+  {
+    if (i < num_empty_segments)
+    {
+      return 0;
+    }
+    else if (i < num_segments)
+    {
+      return segment_size * (i - num_empty_segments);
+    }
+    else
+    {
+      return num_items;
+    }
+  }
+};
+
+template <typename T>
+struct mod_n
+{
+  std::size_t mod;
+
+  template <typename IndexT>
+  _CCCL_HOST_DEVICE __forceinline__ T operator()(IndexT x)
+  {
+    return static_cast<T>(x % mod);
+  }
+};
+
+template <typename KeyT>
+class short_key_verification_helper
+{
+private:
+  using key_t = KeyT;
+  // The histogram size of the keys being sorted for later verification
+  static constexpr auto max_histo_size = 1ULL << (8 * sizeof(key_t));
+
+  // Holding the histogram of the keys being sorted for verification
+  c2h::host_vector<std::size_t> keys_histogram{};
+
+public:
+  void prepare_verification_data(const c2h::device_vector<key_t>& in_keys)
+  {
+    c2h::host_vector<key_t> h_in{in_keys};
+    keys_histogram = c2h::host_vector<std::size_t>(max_histo_size, 0);
+    for (const auto& key : h_in)
+    {
+      keys_histogram[key]++;
+    }
+  }
+
+  void verify_sorted(const c2h::device_vector<key_t>& out_keys) const
+  {
+    // Verfiy keys are sorted next to each other
+    auto count = thrust::unique_count(c2h::device_policy, out_keys.cbegin(), out_keys.cend(), thrust::equal_to<int>());
+    REQUIRE(count <= max_histo_size);
+
+    // Verify keys are sorted using prior histogram computation
+    auto index_it = thrust::make_counting_iterator(std::size_t{0});
+    c2h::device_vector<key_t> unique_keys_out(count);
+    c2h::device_vector<std::size_t> unique_indexes_out(count);
+    thrust::unique_by_key_copy(
+      c2h::device_policy,
+      out_keys.cbegin(),
+      out_keys.cend(),
+      index_it,
+      unique_keys_out.begin(),
+      unique_indexes_out.begin());
+
+    for (int i = 0; i < count; i++)
+    {
+      auto const next_end = (i == count - 1) ? out_keys.size() : unique_indexes_out[i + 1];
+      REQUIRE(keys_histogram[unique_keys_out[i]] == next_end - unique_indexes_out[i]);
+    }
+  }
+};
+
+template <typename KeyT>
+class segmented_verification_helper
+{
+private:
+  using key_t = KeyT;
+  const std::size_t sequence_length{};
+
+  // Analytically computes the histogram for a segment of a series of keys: [0, 1, 2, ..., mod_n - 1, 0, 1, 2, ...].
+  // `segment_end` is one-past-the-end of the segment to compute the histogram for.
+  c2h::host_vector<int> compute_histogram_of_series(std::size_t segment_offset, std::size_t segment_end) const
+  {
+    // The i-th full cycle begins after segment_offset
+    std::size_t start_cycle = cuda::ceil_div(segment_offset, sequence_length);
+
+    // The last full cycle ending before segment_end
+    std::size_t end_cycle = segment_end / sequence_length;
+
+    // Number of full cycles repeating the sequence
+    std::size_t full_cycles = (end_cycle > start_cycle) ? end_cycle - start_cycle : 0;
+
+    // Add contributions from full cycles
+    c2h::host_vector<int> histogram(sequence_length, full_cycles);
+
+    // Partial cycles preceding the first full cycle
+    for (std::size_t j = segment_offset; j < start_cycle * sequence_length; ++j)
+    {
+      std::size_t value = j % sequence_length;
+      histogram[value]++;
+    }
+
+    // Partial cycles following the last full cycle
+    for (std::size_t j = end_cycle * sequence_length; j < segment_end; ++j)
+    {
+      std::size_t value = j % sequence_length;
+      histogram[value]++;
+    }
+    return histogram;
+  }
+
+public:
+  segmented_verification_helper(int sequence_length)
+      : sequence_length(sequence_length)
+  {}
+
+  void prepare_input_data(c2h::device_vector<key_t>& in_keys) const
+  {
+    auto data_gen_it =
+      thrust::make_transform_iterator(thrust::make_counting_iterator(std::size_t{0}), mod_n<key_t>{sequence_length});
+    thrust::copy_n(data_gen_it, in_keys.size(), in_keys.begin());
+  }
+
+  template <typename SegmentOffsetItT>
+  void verify_sorted(c2h::device_vector<key_t>& out_keys, SegmentOffsetItT offsets, std::size_t num_segments) const
+  {
+    // The segments' end-offsets are provided by the segments' begin-offset iterator
+    auto offsets_plus_1 = offsets + 1;
+
+    // Verfiy keys are sorted next to each other
+    const auto count = static_cast<std::size_t>(
+      thrust::unique_count(c2h::device_policy, out_keys.cbegin(), out_keys.cend(), thrust::equal_to<int>()));
+    REQUIRE(count <= sequence_length * num_segments);
+
+    // // Verify keys are sorted using prior histogram computation
+    auto index_it = thrust::make_counting_iterator(std::size_t{0});
+    c2h::device_vector<key_t> unique_keys_out(count);
+    c2h::device_vector<std::size_t> unique_indexes_out(count);
+    thrust::unique_by_key_copy(
+      c2h::device_policy,
+      out_keys.cbegin(),
+      out_keys.cend(),
+      index_it,
+      unique_keys_out.begin(),
+      unique_indexes_out.begin());
+
+    // Copy the unique keys and indexes to host memory
+    c2h::host_vector<key_t> h_unique_keys_out{unique_keys_out};
+    c2h::host_vector<std::size_t> h_unique_indexes_out{unique_indexes_out};
+
+    // Verify keys are sorted using prior histogram computation
+    std::size_t uniques_index  = 0;
+    std::size_t current_offset = 0;
+    for (std::size_t seg_index = 0; seg_index < num_segments; ++seg_index)
+    {
+      const auto segment_offset    = offsets[seg_index];
+      const auto segment_end       = offsets_plus_1[seg_index];
+      const auto segment_histogram = compute_histogram_of_series(segment_offset, segment_end);
+      for (std::size_t i = 0; i < sequence_length; i++)
+      {
+        if (segment_histogram[i] != 0)
+        {
+          CAPTURE(seg_index, i, uniques_index, current_offset, count);
+          auto const next_end =
+            (uniques_index == count - 1) ? out_keys.size() : h_unique_indexes_out[uniques_index + 1];
+          REQUIRE(h_unique_keys_out[uniques_index] == i);
+          REQUIRE(next_end - h_unique_indexes_out[uniques_index] == segment_histogram[i]);
+          current_offset += segment_histogram[i];
+          uniques_index++;
+        }
+      }
+    }
+  }
+};
 
 template <typename T>
 struct unwrap_value_t_impl

--- a/cub/test/catch2_test_device_segmented_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys.cu
@@ -30,8 +30,8 @@
 #include <cub/device/device_segmented_sort.cuh>
 
 #include "catch2_radix_sort_helper.cuh"
+#include "catch2_segmented_sort_helper.cuh"
 #include <c2h/catch2_test_helper.h>
-#include <catch2_segmented_sort_helper.cuh>
 
 // FIXME: Graph launch disabled, algorithm syncs internally. WAR exists for device-launch, figure out how to enable for
 // graph launch.

--- a/cub/test/catch2_test_device_segmented_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys.cu
@@ -222,73 +222,48 @@ C2H_TEST("DeviceSegmentedSortKeys: Unspecified segments, random keys", "[keys][s
 
 #if defined(CCCL_TEST_ENABLE_LARGE_SEGMENTED_SORT)
 
-// we can reuse the same structure of DeviceSegmentedRadixSortKeys for simplicity
-C2H_TEST("DeviceSegmentedSortKeys: very large num. items and num. segments",
-         "[keys][segmented][sort][device]",
-         all_offset_types)
+C2H_TEST("DeviceSegmentedSortKeys: very large number of segments", "[keys][segmented][sort][device]", all_offset_types)
 try
 {
-  using key_t                      = cuda::std::uint8_t; // minimize memory footprint to support a wider range of GPUs
-  using offset_t                   = c2h::get<0, TestType>;
-  constexpr std::size_t Step       = 500;
-  using segment_iterator_t         = segment_iterator<offset_t, Step>;
-  constexpr std::size_t uint32_max = ::cuda::std::numeric_limits<std::uint32_t>::max();
-  constexpr int num_key_seeds      = 1;
-  const bool is_descending         = GENERATE(false, true);
-  const bool is_overwrite          = GENERATE(false, true);
+  using key_t                        = cuda::std::uint8_t; // minimize memory footprint to support a wider range of GPUs
+  using segment_offset_t             = int;
+  using offset_t                     = c2h::get<0, TestType>;
+  using segment_iterator_t           = segment_index_to_offset_op<offset_t, segment_offset_t>;
+  constexpr std::size_t segment_size = 1000000;
+  constexpr std::size_t uint32_max   = ::cuda::std::numeric_limits<std::uint32_t>::max();
+  constexpr bool is_descending       = false;
+  constexpr bool is_overwrite        = false;
   constexpr std::size_t num_items =
     (sizeof(offset_t) == 8) ? uint32_max + (1 << 20) : ::cuda::std::numeric_limits<offset_t>::max();
-  const std::size_t num_segments = ::cuda::ceil_div(num_items, Step);
+  constexpr std::size_t num_empty_segments = 1000;
+  const std::size_t num_segments           = num_empty_segments + ::cuda::ceil_div(num_items, segment_size);
   CAPTURE(c2h::type_name<offset_t>(), num_items, num_segments, is_descending, is_overwrite);
 
   c2h::device_vector<key_t> in_keys(num_items);
   c2h::device_vector<key_t> out_keys(num_items);
-  c2h::gen(C2H_SEED(num_key_seeds), in_keys);
-  auto offsets =
-    thrust::make_transform_iterator(thrust::make_counting_iterator(std::size_t{0}), segment_iterator_t{num_items});
-  auto offsets_plus_1 = offsets + 1;
-  // Allocate host/device-accessible memory to communicate the selected output buffer
-  bool* selector_ptr = nullptr;
-  if (is_overwrite)
-  {
-    REQUIRE(cudaMallocHost(&selector_ptr, sizeof(*selector_ptr)) == cudaSuccess);
-  }
 
-  auto ref_keys     = segmented_radix_sort_reference(in_keys, is_descending, num_segments, offsets, offsets_plus_1);
+  // Generate input keys
+  constexpr auto max_histo_size = 250;
+  segmented_verification_helper<key_t> verification_helper{max_histo_size};
+  verification_helper.prepare_input_data(in_keys);
+
+  auto offsets = thrust::make_transform_iterator(
+    thrust::make_counting_iterator(std::size_t{0}),
+    segment_iterator_t{num_empty_segments, num_segments, segment_size, num_items});
+
   auto out_keys_ptr = thrust::raw_pointer_cast(out_keys.data());
-  if (is_descending)
-  {
-    dispatch_segmented_sort_descending(
-      thrust::raw_pointer_cast(in_keys.data()),
-      out_keys_ptr,
-      static_cast<offset_t>(num_items),
-      static_cast<offset_t>(num_segments),
-      offsets,
-      offsets_plus_1,
-      selector_ptr,
-      is_overwrite);
-  }
-  else
-  {
-    dispatch_segmented_sort(
-      thrust::raw_pointer_cast(in_keys.data()),
-      out_keys_ptr,
-      static_cast<offset_t>(num_items),
-      static_cast<offset_t>(num_segments),
-      offsets,
-      offsets_plus_1,
-      selector_ptr,
-      is_overwrite);
-  }
-  if (is_overwrite)
-  {
-    if (*selector_ptr)
-    {
-      std::swap(out_keys, in_keys);
-    }
-    REQUIRE(cudaFreeHost(selector_ptr) == cudaSuccess);
-  }
-  REQUIRE((ref_keys == out_keys) == true);
+  dispatch_segmented_sort(
+    thrust::raw_pointer_cast(in_keys.data()),
+    out_keys_ptr,
+    static_cast<offset_t>(num_items),
+    static_cast<offset_t>(num_segments),
+    offsets,
+    (offsets + 1),
+    nullptr,
+    is_overwrite);
+
+  // Verify the keys are sorted correctly
+  verification_helper.verify_sorted(out_keys, offsets + num_empty_segments, num_segments - num_empty_segments);
 }
 catch (std::bad_alloc& e)
 {
@@ -302,8 +277,8 @@ try
   using offset_t                   = c2h::get<0, TestType>;
   constexpr std::size_t uint32_max = ::cuda::std::numeric_limits<std::uint32_t>::max();
   constexpr int num_key_seeds      = 1;
-  const bool is_descending         = GENERATE(false, true);
-  const bool is_overwrite          = GENERATE(false, true);
+  constexpr bool is_descending     = false;
+  const bool is_overwrite          = true;
   constexpr std::size_t num_items =
     (sizeof(offset_t) == 8) ? uint32_max + (1 << 20) : ::cuda::std::numeric_limits<offset_t>::max();
   const std::size_t num_segments = 2;
@@ -317,47 +292,34 @@ try
   offsets[1] = static_cast<offset_t>(num_items);
   offsets[2] = static_cast<offset_t>(num_items);
 
-  // Allocate host/device-accessible memory to communicate the selected output buffer
+  // Prepare information for later verification
+  short_key_verification_helper<key_t> verification_helper{};
+  verification_helper.prepare_verification_data(in_keys);
+
+  // Handle double-buffer interface: allocate host/device-accessible memory to communicate the selected output buffer
   bool* selector_ptr = nullptr;
-  if (is_overwrite)
-  {
-    REQUIRE(cudaSuccess == cudaMallocHost(&selector_ptr, sizeof(*selector_ptr)));
-  }
-  auto ref_keys     = segmented_radix_sort_reference(in_keys, is_descending, offsets);
+  REQUIRE(cudaSuccess == cudaMallocHost(&selector_ptr, sizeof(*selector_ptr)));
+
   auto out_keys_ptr = thrust::raw_pointer_cast(out_keys.data());
-  if (is_descending)
+  dispatch_segmented_sort(
+    thrust::raw_pointer_cast(in_keys.data()),
+    out_keys_ptr,
+    static_cast<offset_t>(num_items),
+    static_cast<offset_t>(num_segments),
+    thrust::raw_pointer_cast(offsets.data()),
+    offsets.cbegin() + 1,
+    selector_ptr,
+    is_overwrite);
+
+  // Handle double-buffer interface
+  if (*selector_ptr)
   {
-    dispatch_segmented_sort_descending(
-      thrust::raw_pointer_cast(in_keys.data()),
-      out_keys_ptr,
-      static_cast<offset_t>(num_items),
-      static_cast<offset_t>(num_segments),
-      thrust::raw_pointer_cast(offsets.data()),
-      offsets.cbegin() + 1,
-      selector_ptr,
-      is_overwrite);
+    std::swap(out_keys, in_keys);
   }
-  else
-  {
-    dispatch_segmented_sort(
-      thrust::raw_pointer_cast(in_keys.data()),
-      out_keys_ptr,
-      static_cast<offset_t>(num_items),
-      static_cast<offset_t>(num_segments),
-      thrust::raw_pointer_cast(offsets.data()),
-      offsets.cbegin() + 1,
-      selector_ptr,
-      is_overwrite);
-  }
-  if (is_overwrite)
-  {
-    if (*selector_ptr)
-    {
-      std::swap(out_keys, in_keys);
-    }
-    REQUIRE(cudaSuccess == cudaFreeHost(selector_ptr));
-  }
-  REQUIRE((ref_keys == out_keys) == true);
+  REQUIRE(cudaSuccess == cudaFreeHost(selector_ptr));
+
+  // Verify the keys are sorted correctly
+  verification_helper.verify_sorted(out_keys);
 }
 catch (std::bad_alloc& e)
 {

--- a/cub/test/catch2_test_device_segmented_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs.cu
@@ -32,61 +32,9 @@
 
 // FIXME: Graph launch disabled, algorithm syncs internally. WAR exists for device-launch, figure out how to enable for
 // graph launch.
-
-// TODO replace with DeviceSegmentedSort::SortPairs interface once https://github.com/NVIDIA/cccl/issues/50 is addressed
-// Temporary wrapper that allows specializing the DeviceSegmentedSort algorithm for different offset types
-template <bool IS_DESCENDING,
-          typename KeyT,
-          typename ValueT,
-          typename BeginOffsetIteratorT,
-          typename EndOffsetIteratorT,
-          typename NumItemsT>
-CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch_segmented_sort_pairs_wrapper(
-  void* d_temp_storage,
-  size_t& temp_storage_bytes,
-  const KeyT* d_keys_in,
-  KeyT* d_keys_out,
-  const ValueT* d_values_in,
-  ValueT* d_values_out,
-  NumItemsT num_items,
-  NumItemsT num_segments,
-  BeginOffsetIteratorT d_begin_offsets,
-  EndOffsetIteratorT d_end_offsets,
-  bool* selector,
-  bool is_overwrite   = false,
-  cudaStream_t stream = 0)
-{
-  cub::DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
-  cub::DoubleBuffer<ValueT> d_values(const_cast<ValueT*>(d_values_in), d_values_out);
-
-  auto status = cub::
-    DispatchSegmentedSort<IS_DESCENDING, KeyT, ValueT, NumItemsT, BeginOffsetIteratorT, EndOffsetIteratorT>::Dispatch(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys,
-      d_values,
-      num_items,
-      num_segments,
-      d_begin_offsets,
-      d_end_offsets,
-      is_overwrite,
-      stream);
-  if (status != cudaSuccess)
-  {
-    return status;
-  }
-  if (is_overwrite)
-  {
-    // Only write to selector in the DoubleBuffer invocation
-    *selector = d_keys.Current() != d_keys_out;
-  }
-  return cudaSuccess;
-}
-
 // %PARAM% TEST_LAUNCH lid 0:1
 
-DECLARE_LAUNCH_WRAPPER(dispatch_segmented_sort_pairs_wrapper<true>, dispatch_segmented_sort_pairs_descending);
-DECLARE_LAUNCH_WRAPPER(dispatch_segmented_sort_pairs_wrapper<false>, dispatch_segmented_sort_pairs);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedSort::StableSortPairs, stable_sort_pairs);
 
 using pair_types =
   c2h::type_list<c2h::type_list<bool, std::uint8_t>,
@@ -260,18 +208,16 @@ try
 {
   using key_t                        = cuda::std::uint8_t; // minimize memory footprint to support a wider range of GPUs
   using value_t                      = cuda::std::uint8_t;
-  using segment_offset_t             = int;
+  using segment_offset_t             = std::int64_t;
   using offset_t                     = c2h::get<0, TestType>;
   using segment_iterator_t           = segment_index_to_offset_op<offset_t, segment_offset_t>;
   constexpr std::size_t segment_size = 1000000;
   constexpr std::size_t uint32_max   = ::cuda::std::numeric_limits<std::uint32_t>::max();
-  constexpr bool is_descending       = false;
-  constexpr bool is_overwrite        = false;
   constexpr std::size_t num_items =
     (sizeof(offset_t) == 8) ? uint32_max + (1 << 20) : ::cuda::std::numeric_limits<offset_t>::max();
-  constexpr std::size_t num_empty_segments = 1000;
-  const std::size_t num_segments           = num_empty_segments + ::cuda::ceil_div(num_items, segment_size);
-  CAPTURE(c2h::type_name<offset_t>(), num_items, num_segments, is_descending, is_overwrite);
+  constexpr segment_offset_t num_empty_segments = uint32_max;
+  const segment_offset_t num_segments           = num_empty_segments + ::cuda::ceil_div(num_items, segment_size);
+  CAPTURE(c2h::type_name<offset_t>(), num_items, num_segments);
 
   // Generate input
   c2h::device_vector<key_t> in_keys(num_items);
@@ -293,17 +239,15 @@ try
   auto out_keys_ptr   = thrust::raw_pointer_cast(out_keys.data());
   auto out_values_ptr = thrust::raw_pointer_cast(out_values.data());
 
-  dispatch_segmented_sort_pairs(
+  stable_sort_pairs(
     thrust::raw_pointer_cast(in_keys.data()),
-    out_keys_ptr,
+    thrust::raw_pointer_cast(out_keys.data()),
     thrust::raw_pointer_cast(in_values.data()),
-    out_values_ptr,
+    thrust::raw_pointer_cast(out_values.data()),
     static_cast<offset_t>(num_items),
-    static_cast<offset_t>(num_segments),
+    static_cast<segment_offset_t>(num_segments),
     offsets,
-    offsets_plus_1,
-    nullptr,
-    is_overwrite);
+    offsets_plus_1);
 
   // Verify the keys are sorted correctly
   verification_helper.verify_sorted(out_keys, offsets + num_empty_segments, num_segments - num_empty_segments);
@@ -321,15 +265,14 @@ try
 {
   using key_t                      = cuda::std::uint8_t; // minimize memory footprint to support a wider range of GPUs
   using value_t                    = cuda::std::uint8_t;
+  using segment_offset_t           = std::int32_t;
   using offset_t                   = c2h::get<0, TestType>;
   constexpr std::size_t uint32_max = ::cuda::std::numeric_limits<std::uint32_t>::max();
   constexpr int num_key_seeds      = 1;
-  constexpr bool is_descending     = false;
-  constexpr bool is_overwrite      = true;
   constexpr std::size_t num_items =
     (sizeof(offset_t) == 8) ? uint32_max + (1 << 20) : ::cuda::std::numeric_limits<offset_t>::max();
-  constexpr std::size_t num_segments = 2;
-  CAPTURE(c2h::type_name<offset_t>(), num_items, is_descending, is_overwrite);
+  constexpr segment_offset_t num_segments = 2;
+  CAPTURE(c2h::type_name<offset_t>(), num_items, num_segments);
 
   c2h::device_vector<key_t> in_keys(num_items);
   c2h::device_vector<value_t> in_values(num_items);
@@ -346,30 +289,15 @@ try
   short_key_verification_helper<key_t> verification_helper{};
   verification_helper.prepare_verification_data(in_keys);
 
-  // Handle double-buffer interface: allocate host/device-accessible memory to communicate the selected output buffer
-  bool* selector_ptr = nullptr;
-  REQUIRE(cudaSuccess == cudaMallocHost(&selector_ptr, sizeof(*selector_ptr)));
-
-  auto out_keys_ptr   = thrust::raw_pointer_cast(out_keys.data());
-  auto out_values_ptr = thrust::raw_pointer_cast(out_values.data());
-  dispatch_segmented_sort_pairs(
+  stable_sort_pairs(
     thrust::raw_pointer_cast(in_keys.data()),
-    out_keys_ptr,
+    thrust::raw_pointer_cast(out_keys.data()),
     thrust::raw_pointer_cast(in_values.data()),
-    out_values_ptr,
+    thrust::raw_pointer_cast(out_values.data()),
     static_cast<offset_t>(num_items),
-    static_cast<offset_t>(num_segments),
+    static_cast<segment_offset_t>(num_segments),
     thrust::raw_pointer_cast(offsets.data()),
-    offsets.cbegin() + 1,
-    selector_ptr,
-    is_overwrite);
-
-  if (*selector_ptr)
-  {
-    std::swap(out_keys, in_keys);
-    std::swap(out_values, in_values);
-  }
-  REQUIRE(cudaFreeHost(selector_ptr) == cudaSuccess);
+    offsets.cbegin() + 1);
 
   // Verify the keys are sorted correctly
   verification_helper.verify_sorted(out_keys);

--- a/cub/test/catch2_test_device_segmented_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs.cu
@@ -27,8 +27,8 @@
 #include "catch2_radix_sort_helper.cuh"
 // above header needs to be included first
 
+#include "catch2_segmented_sort_helper.cuh"
 #include <c2h/catch2_test_helper.h>
-#include <catch2_segmented_sort_helper.cuh>
 
 // FIXME: Graph launch disabled, algorithm syncs internally. WAR exists for device-launch, figure out how to enable for
 // graph launch.

--- a/cub/test/catch2_test_device_segmented_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs.cu
@@ -236,9 +236,6 @@ try
     segment_iterator_t{num_empty_segments, num_segments, segment_size, num_items});
   auto offsets_plus_1 = offsets + 1;
 
-  auto out_keys_ptr   = thrust::raw_pointer_cast(out_keys.data());
-  auto out_values_ptr = thrust::raw_pointer_cast(out_values.data());
-
   stable_sort_pairs(
     thrust::raw_pointer_cast(in_keys.data()),
     thrust::raw_pointer_cast(out_keys.data()),


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes https://github.com/NVIDIA/cccl/issues/3222

Reduces the per-test run time from six minutes to six seconds. <!-- Link issue here -->

Once this PR is merged, I'm planning to integrate a similar approach to `DeviceSegmentedRadixSort` in https://github.com/NVIDIA/cccl/issues/3245.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

The PR is touching two tests:

1. The test for verifying that large segments are sorted correctly
2. The test for verifying that a large number of segments are sorted correctly

For (1), we switched from invoking `std::stable_sort` as a means of verifying that the items were sorted correctly to using histograms over the input items. This lowered per-test-instance run time from six minutes to six seconds for these tests.

For (2), (a) tests never finished and (b) segment generation was generating overlapping segments, which lead to test failures, because it creates a race on which of the segments pointing to the same output region would be sorted first. So, we switched from generating random inputs to generating a sequence of `0, 1, 2, ..., max_histo_size-1, 0, 1, 2`. We use a fixed segment size over this input sequence, chunking it up, say, every 1000 items.  We then use an analytical model to compute the histogram over the input values for a given segment and use that histogram to understand what the sorted output range of that segment would look like. E.g., if we know `0` is repeated four times in the first segment, we know the sorted sequence should start with `0` and beginning at offset four should continue with key `1`. So on and so forth.

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
