### PR TITLE
Enable PDL in triple chevron launch

### DIFF
--- a/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
+++ b/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
@@ -70,7 +70,7 @@ struct _CCCL_VISIBILITY_HIDDEN triple_chevron
   template <class K, class... Args>
   cudaError_t _CCCL_HOST doit_host(K k, Args const&... args) const
   {
-#if _THRUST_HAS_PDL
+#if _CCCL_HAS_PDL
     if (dependent_launch)
     {
       cudaLaunchAttribute attribute[1];
@@ -87,7 +87,7 @@ struct _CCCL_VISIBILITY_HIDDEN triple_chevron
       cudaLaunchKernelEx(&config, k, args...);
     }
     else
-#endif // _THRUST_HAS_PDL
+#endif // _CCCL_HAS_PDL
     {
       k<<<grid, block, shared_mem, stream>>>(args...);
     }


### PR DESCRIPTION
It seems PDL was disabled by accident when _THRUST_HAS_PDL was renamed to _CCCL_HAS_PDL during the review introducing the feature.