### PR TITLE
Drop Thrust legacy arch macros

### DIFF
--- a/thrust/thrust/detail/config/cpp_compatibility.h
+++ b/thrust/thrust/detail/config/cpp_compatibility.h
@@ -52,30 +52,3 @@
 #  define THRUST_INLINE_INTEGRAL_MEMBER_CONSTANT static constexpr
 
 #endif
-
-// These definitions were intended for internal use only and are now obsolete.
-// If you relied on them, consider porting your code to use the functionality
-// in libcu++'s <nv/target> header.
-// For a temporary workaround, define THRUST_PROVIDE_LEGACY_ARCH_MACROS to make
-// them available again. These should be considered deprecated and will be
-// fully removed in a future version.
-#ifdef THRUST_PROVIDE_LEGACY_ARCH_MACROS
-#  ifndef THRUST_IS_DEVICE_CODE
-#    if defined(_NVHPC_CUDA)
-#      define THRUST_IS_DEVICE_CODE      __builtin_is_device_code()
-#      define THRUST_IS_HOST_CODE        (!__builtin_is_device_code())
-#      define THRUST_INCLUDE_DEVICE_CODE 1
-#      define THRUST_INCLUDE_HOST_CODE   1
-#    elif defined(__CUDA_ARCH__)
-#      define THRUST_IS_DEVICE_CODE      1
-#      define THRUST_IS_HOST_CODE        0
-#      define THRUST_INCLUDE_DEVICE_CODE 1
-#      define THRUST_INCLUDE_HOST_CODE   0
-#    else
-#      define THRUST_IS_DEVICE_CODE      0
-#      define THRUST_IS_HOST_CODE        1
-#      define THRUST_INCLUDE_DEVICE_CODE 0
-#      define THRUST_INCLUDE_HOST_CODE   1
-#    endif
-#  endif
-#endif // THRUST_PROVIDE_LEGACY_ARCH_MACROS

--- a/thrust/thrust/system/cuda/config.h
+++ b/thrust/thrust/system/cuda/config.h
@@ -84,19 +84,6 @@
 #  define __THRUST_HAS_CUDART__ 0
 #endif
 
-// These definitions were intended for internal use only and are now obsolete.
-// If you relied on them, consider porting your code to use the functionality
-// in libcu++'s <nv/target> header.
-//
-// For a temporary workaround, define THRUST_PROVIDE_LEGACY_ARCH_MACROS to make
-// them available again. These should be considered deprecated and will be
-// fully removed in a future version.
-#ifdef THRUST_PROVIDE_LEGACY_ARCH_MACROS
-#  ifdef __CUDA_ARCH__
-#    define THRUST_DEVICE_CODE
-#  endif // __CUDA_ARCH__
-#endif // THRUST_PROVIDE_LEGACY_ARCH_MACROS
-
 #ifdef THRUST_AGENT_ENTRY_NOINLINE
 #  define THRUST_AGENT_ENTRY_INLINE_ATTR __noinline__
 #else


### PR DESCRIPTION
Which were disabled and could be re-enabled using THRUST_PROVIDE_LEGACY_ARCH_MACROS