### PR TITLE
cuda.parallel: Address Python<3.9 TODOs

### DIFF
--- a/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/_bindings.py
@@ -7,6 +7,7 @@ import ctypes
 import os
 import shutil
 from functools import lru_cache
+from importlib.resources import as_file, files
 from typing import List, Optional
 
 from . import _cccl as cccl
@@ -30,10 +31,6 @@ def _get_cuda_path() -> Optional[str]:
 
 @lru_cache()
 def get_bindings() -> ctypes.CDLL:
-    # TODO: once docs env supports Python >= 3.9, we
-    # can move this to a module-level import.
-    from importlib.resources import as_file, files
-
     with as_file(files("cuda.parallel.experimental")) as f:
         cccl_c_path = str(f / "cccl" / "libcccl.c.parallel.so")
     _bindings = ctypes.CDLL(cccl_c_path)
@@ -55,10 +52,6 @@ def get_bindings() -> ctypes.CDLL:
 
 @lru_cache()
 def get_paths() -> List[bytes]:
-    # TODO: once docs env supports Python >= 3.9, we
-    # can move this to a module-level import.
-    from importlib.resources import as_file, files
-
     with as_file(files("cuda.parallel")) as f:
         # Using `.parent` for compatibility with pip install --editable:
         cub_include_path = str(f.parent / "_include")

--- a/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/algorithms/reduce.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from __future__ import annotations  # TODO: required for Python 3.7 docs env
-
 import ctypes
 from typing import Callable
 

--- a/python/cuda_parallel/cuda/parallel/experimental/typing.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/typing.py
@@ -1,6 +1,4 @@
-from typing_extensions import (
-    Protocol,
-)  # TODO: typing_extensions required for Python 3.7 docs env
+from typing import Protocol
 
 
 class DeviceArrayLike(Protocol):

--- a/python/cuda_parallel/setup.py
+++ b/python/cuda_parallel/setup.py
@@ -99,8 +99,7 @@ setup(
     ],
     packages=find_namespace_packages(include=["cuda.*"]),
     python_requires=">=3.9",
-    # TODO: typing_extensions required for Python 3.7 docs env
-    install_requires=["numba>=0.60.0", "cuda-python", "jinja2", "typing_extensions"],
+    install_requires=["numba>=0.60.0", "cuda-python", "jinja2"],
     extras_require={
         "test": [
             "pytest",


### PR DESCRIPTION
## Description

Following #3293, we can now use newer Python syntax and features ([no newer than Python 3.9](https://github.com/NVIDIA/cccl/blob/2c5bdcd8691c2917c06c7d4c570a3082e0180660/python/cuda_parallel/setup.py#L101)).

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
