### PR TITLE
Remove dropped function objects from docs

### DIFF
--- a/docs/thrust/api_docs/function_objects/adaptors.rst
+++ b/docs/thrust/api_docs/function_objects/adaptors.rst
@@ -3,8 +3,4 @@
 Function Object Adaptors
 -------------------------
 
-  - :cpp:struct:`thrust::unary_function <thrust::unary_function>`
-  - :cpp:struct:`thrust::binary_function <thrust::binary_function>`
-  - :cpp:struct:`thrust::unary_negate <thrust::unary_negate>`
-  - :cpp:struct:`thrust::binary_negate <thrust::binary_negate>`
   - :cpp:class:`thrust::zip_function <thrust::zip_function>`


### PR DESCRIPTION
Drops `thrust::unary_function`, `thrust::binary_function`, `thrust::unary_negate` and `thrust::binary_negate` from the docs, since they have been removed.