### PR TITLE
[STF] Define ctx.pick_stream() which was missing for the unified context

### DIFF
--- a/cudax/include/cuda/experimental/stf.cuh
+++ b/cudax/include/cuda/experimental/stf.cuh
@@ -752,6 +752,19 @@ public:
     }
   }
 
+  /**
+   * @brief Get a CUDA stream from the stream pool associated to the context
+   *
+   * This helper is intended to avoid creating CUDA streams manually. Using
+   * this stream after the context has been finalized is an undefined
+   * behaviour.
+   */
+  cudaStream_t pick_stream()
+  {
+     _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
+     return ::std::visit([](auto& self) { return self.pick_stream(); }, payload);
+  }
+
 private:
   template <typename Fun>
   auto visit(Fun&& fun)


### PR DESCRIPTION
## Description
Define ctx.pick_stream() which was erroneously missing for the unified context (but defined for stream_ctx and graph_ctx)

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
