### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,17 @@ ci/ @nvidia/cccl-infra-codeowners
 .pre-commit-config.yaml @nvidia/cccl-infra-codeowners
 .clang-format @nvidia/cccl-infra-codeowners
 .clangd @nvidia/cccl-infra-codeowners
+c2h/ @nvidia/cccl-infra-codeowners
+.vscode @nvidia/cccl-infra-codeowners 
 
 # cmake
 **/CMakeLists.txt @nvidia/cccl-cmake-codeowners
 **/cmake/ @nvidia/cccl-cmake-codeowners
+
+# benchmarks
+benchmarks/ @nvidia/cccl-benchmark-codeowners
+**/benchmarks @nvidia/cccl-benchmark-codeowners
+
+# docs
+docs/ @cccl-docs-codeowners
+examples/ @cccl-docs-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,5 +25,5 @@ benchmarks/ @nvidia/cccl-benchmark-codeowners
 **/benchmarks @nvidia/cccl-benchmark-codeowners
 
 # docs
-docs/ @cccl-docs-codeowners
-examples/ @cccl-docs-codeowners
+docs/ @nvidia/cccl-docs-codeowners
+examples/ @nvidia/cccl-docs-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,20 +1,19 @@
-# general codeowners for all files
-# (Order matters. This needs to be at the top)
-* @nvidia/cccl-codeowners
-
 # Libraries
-thrust/ @nvidia/cccl-thrust-codeowners @nvidia/cccl-codeowners
-cub/ @nvidia/cccl-cub-codeowners @nvidia/cccl-codeowners
-libcudacxx/ @nvidia/cccl-libcudacxx-codeowners @nvidia/cccl-codeowners
+thrust/ @nvidia/cccl-thrust-codeowners
+cub/ @nvidia/cccl-cub-codeowners
+libcudacxx/ @nvidia/cccl-libcudacxx-codeowners
 cudax/ @nvidia/cccl-cudax-codeowners
 c/ @nvidia/cccl-c-codeowners
 python/ @nvidia/cccl-python-codeowners
 
 # Infrastructure
-.github/ @nvidia/cccl-infra-codeowners @nvidia/cccl-codeowners
-ci/ @nvidia/cccl-infra-codeowners @nvidia/cccl-codeowners
-.devcontainer/ @nvidia/cccl-infra-codeowners @nvidia/cccl-codeowners
+.github/ @nvidia/cccl-infra-codeowners
+ci/ @nvidia/cccl-infra-codeowners
+.devcontainer/ @nvidia/cccl-infra-codeowners
+.pre-commit-config.yaml @nvidia/cccl-infra-codeowners
+.clang-format @nvidia/cccl-infra-codeowners
+.clangd @nvidia/cccl-infra-codeowners
 
 # cmake
-**/CMakeLists.txt @nvidia/cccl-cmake-codeowners @nvidia/cccl-codeowners
-**/cmake/ @nvidia/cccl-cmake-codeowners  @nvidia/cccl-codeowners
+**/CMakeLists.txt @nvidia/cccl-cmake-codeowners
+**/cmake/ @nvidia/cccl-cmake-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@ ci/ @nvidia/cccl-infra-codeowners
 .clang-format @nvidia/cccl-infra-codeowners
 .clangd @nvidia/cccl-infra-codeowners
 c2h/ @nvidia/cccl-infra-codeowners
-.vscode @nvidia/cccl-infra-codeowners 
+.vscode @nvidia/cccl-infra-codeowners
 
 # cmake
 **/CMakeLists.txt @nvidia/cccl-cmake-codeowners


### PR DESCRIPTION
Update the CODEOWNERS in preparation for enabling 2 required reviews. 

I've changed the strategy from how it was set up before where it would assign reviewers from a general pool as well as a specific pool. This was more relevant when the team was smaller. Now that we have more people, I think we can just require 2 reviewers from the specific codeowner team.  

For reference, here is the current group membership: https://github.com/orgs/NVIDIA/teams/cccl-codeowners/teams
This should be updated as well. 
![image](https://github.com/user-attachments/assets/b7e83ed2-3710-44f2-9e66-eb0a0be0ea84)
