### PR TITLE
Extract scan kernels into NVRTC-compilable header

### DIFF
--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -52,8 +52,6 @@
 
 #include <cuda/std/type_traits>
 
-#include <iterator>
-
 CUB_NAMESPACE_BEGIN
 
 /******************************************************************************
@@ -162,7 +160,7 @@ struct AgentScan
   // Wrap the native input pointer with CacheModifiedInputIterator
   // or directly use the supplied input iterator type
   using WrappedInputIteratorT =
-    ::cuda::std::_If<std::is_pointer<InputIteratorT>::value,
+    ::cuda::std::_If<::cuda::std::is_pointer<InputIteratorT>::value,
                      CacheModifiedInputIterator<AgentScanPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
                      InputIteratorT>;
 
@@ -170,7 +168,7 @@ struct AgentScan
   enum
   {
     // Inclusive scan if no init_value type is provided
-    HAS_INIT     = !std::is_same<InitValueT, NullType>::value,
+    HAS_INIT     = !::cuda::std::is_same<InitValueT, NullType>::value,
     IS_INCLUSIVE = ForceInclusive || !HAS_INIT, // We are relying on either initial value not being `NullType`
                                                 // or the ForceInclusive tag to be true for inclusive scan
                                                 // to get picked up.

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -53,8 +53,6 @@
 
 #include <cuda/std/type_traits>
 
-#include <iterator>
-
 #include <nv/target>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/detail/strong_load.cuh
+++ b/cub/cub/detail/strong_load.cuh
@@ -45,8 +45,6 @@
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
 
-#include <iterator>
-
 CUB_NAMESPACE_BEGIN
 
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -37,6 +37,8 @@
 
 #include <cub/config.cuh>
 
+#include "cub/util_namespace.cuh"
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -46,6 +48,7 @@
 #endif // no system header
 
 #include <cub/agent/agent_scan.cuh>
+#include <cub/device/dispatch/kernels/scan.cuh>
 #include <cub/device/dispatch/tuning/tuning_scan.cuh>
 #include <cub/grid/grid_queue.cuh>
 #include <cub/thread/thread_operators.cuh>
@@ -57,148 +60,7 @@
 
 #include <cuda/std/type_traits>
 
-#include <iterator>
-
 CUB_NAMESPACE_BEGIN
-
-/******************************************************************************
- * Kernel entry points
- *****************************************************************************/
-
-/**
- * @brief Initialization kernel for tile status initialization (multi-block)
- *
- * @tparam ScanTileStateT
- *   Tile status interface type
- *
- * @param[in] tile_state
- *   Tile status interface
- *
- * @param[in] num_tiles
- *   Number of tiles
- */
-template <typename ScanTileStateT>
-CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanInitKernel(ScanTileStateT tile_state, int num_tiles)
-{
-  // Initialize tile status
-  tile_state.InitializeStatus(num_tiles);
-}
-
-/**
- * Initialization kernel for tile status initialization (multi-block)
- *
- * @tparam ScanTileStateT
- *   Tile status interface type
- *
- * @tparam NumSelectedIteratorT
- *   Output iterator type for recording the number of items selected
- *
- * @param[in] tile_state
- *   Tile status interface
- *
- * @param[in] num_tiles
- *   Number of tiles
- *
- * @param[out] d_num_selected_out
- *   Pointer to the total number of items selected
- *   (i.e., length of `d_selected_out`)
- */
-template <typename ScanTileStateT, typename NumSelectedIteratorT>
-CUB_DETAIL_KERNEL_ATTRIBUTES void
-DeviceCompactInitKernel(ScanTileStateT tile_state, int num_tiles, NumSelectedIteratorT d_num_selected_out)
-{
-  // Initialize tile status
-  tile_state.InitializeStatus(num_tiles);
-
-  // Initialize d_num_selected_out
-  if ((blockIdx.x == 0) && (threadIdx.x == 0))
-  {
-    *d_num_selected_out = 0;
-  }
-}
-
-/**
- * @brief Scan kernel entry point (multi-block)
- *
- *
- * @tparam ChainedPolicyT
- *   Chained tuning policy
- *
- * @tparam InputIteratorT
- *   Random-access input iterator type for reading scan inputs @iterator
- *
- * @tparam OutputIteratorT
- *   Random-access output iterator type for writing scan outputs @iterator
- *
- * @tparam ScanTileStateT
- *   Tile status interface type
- *
- * @tparam ScanOpT
- *   Binary scan functor type having member
- *   `auto operator()(const T &a, const U &b)`
- *
- * @tparam InitValueT
- *   Initial value to seed the exclusive scan
- *   (cub::NullType for inclusive scans)
- *
- * @tparam OffsetT
- *   Unsigned integer type for global offsets
- *
- * @paramInput d_in
- *   data
- *
- * @paramOutput d_out
- *   data
- *
- * @paramTile tile_state
- *   status interface
- *
- * @paramThe start_tile
- *   starting tile for the current grid
- *
- * @paramBinary scan_op
- *   scan functor
- *
- * @paramInitial init_value
- *   value to seed the exclusive scan
- *
- * @paramTotal num_items
- *   number of scan items for the entire problem
- */
-template <typename ChainedPolicyT,
-          typename InputIteratorT,
-          typename OutputIteratorT,
-          typename ScanTileStateT,
-          typename ScanOpT,
-          typename InitValueT,
-          typename OffsetT,
-          typename AccumT,
-          bool ForceInclusive>
-__launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanPolicyT::BLOCK_THREADS))
-  CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanKernel(
-    InputIteratorT d_in,
-    OutputIteratorT d_out,
-    ScanTileStateT tile_state,
-    int start_tile,
-    ScanOpT scan_op,
-    InitValueT init_value,
-    OffsetT num_items)
-{
-  using RealInitValueT = typename InitValueT::value_type;
-  using ScanPolicyT    = typename ChainedPolicyT::ActivePolicy::ScanPolicyT;
-
-  // Thread block type for scanning input tiles
-  using AgentScanT =
-    AgentScan<ScanPolicyT, InputIteratorT, OutputIteratorT, ScanOpT, RealInitValueT, OffsetT, AccumT, ForceInclusive>;
-
-  // Shared memory for AgentScan
-  __shared__ typename AgentScanT::TempStorage temp_storage;
-
-  RealInitValueT real_init_value = init_value;
-
-  // Process tiles
-  AgentScanT(temp_storage, d_in, d_out, scan_op, real_init_value).ConsumeRange(num_items, tile_state, start_tile);
-}
 
 /******************************************************************************
  * Dispatch

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -37,7 +37,7 @@
 
 #include <cub/config.cuh>
 
-#include "cub/util_namespace.cuh"
+#include <cub/util_namespace.cuh>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/cub/cub/device/dispatch/kernels/scan.cuh
+++ b/cub/cub/device/dispatch/kernels/scan.cuh
@@ -1,0 +1,184 @@
+/******************************************************************************
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cub/agent/agent_scan.cuh>
+#include <cub/util_macro.cuh>
+
+CUB_NAMESPACE_BEGIN
+
+/******************************************************************************
+ * Kernel entry points
+ *****************************************************************************/
+
+/**
+ * @brief Initialization kernel for tile status initialization (multi-block)
+ *
+ * @tparam ScanTileStateT
+ *   Tile status interface type
+ *
+ * @param[in] tile_state
+ *   Tile status interface
+ *
+ * @param[in] num_tiles
+ *   Number of tiles
+ */
+template <typename ScanTileStateT>
+CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanInitKernel(ScanTileStateT tile_state, int num_tiles)
+{
+  // Initialize tile status
+  tile_state.InitializeStatus(num_tiles);
+}
+
+/**
+ * Initialization kernel for tile status initialization (multi-block)
+ *
+ * @tparam ScanTileStateT
+ *   Tile status interface type
+ *
+ * @tparam NumSelectedIteratorT
+ *   Output iterator type for recording the number of items selected
+ *
+ * @param[in] tile_state
+ *   Tile status interface
+ *
+ * @param[in] num_tiles
+ *   Number of tiles
+ *
+ * @param[out] d_num_selected_out
+ *   Pointer to the total number of items selected
+ *   (i.e., length of `d_selected_out`)
+ */
+template <typename ScanTileStateT, typename NumSelectedIteratorT>
+CUB_DETAIL_KERNEL_ATTRIBUTES void
+DeviceCompactInitKernel(ScanTileStateT tile_state, int num_tiles, NumSelectedIteratorT d_num_selected_out)
+{
+  // Initialize tile status
+  tile_state.InitializeStatus(num_tiles);
+
+  // Initialize d_num_selected_out
+  if ((blockIdx.x == 0) && (threadIdx.x == 0))
+  {
+    *d_num_selected_out = 0;
+  }
+}
+
+/**
+ * @brief Scan kernel entry point (multi-block)
+ *
+ *
+ * @tparam ChainedPolicyT
+ *   Chained tuning policy
+ *
+ * @tparam InputIteratorT
+ *   Random-access input iterator type for reading scan inputs @iterator
+ *
+ * @tparam OutputIteratorT
+ *   Random-access output iterator type for writing scan outputs @iterator
+ *
+ * @tparam ScanTileStateT
+ *   Tile status interface type
+ *
+ * @tparam ScanOpT
+ *   Binary scan functor type having member
+ *   `auto operator()(const T &a, const U &b)`
+ *
+ * @tparam InitValueT
+ *   Initial value to seed the exclusive scan
+ *   (cub::NullType for inclusive scans)
+ *
+ * @tparam OffsetT
+ *   Unsigned integer type for global offsets
+ *
+ * @paramInput d_in
+ *   data
+ *
+ * @paramOutput d_out
+ *   data
+ *
+ * @paramTile tile_state
+ *   status interface
+ *
+ * @paramThe start_tile
+ *   starting tile for the current grid
+ *
+ * @paramBinary scan_op
+ *   scan functor
+ *
+ * @paramInitial init_value
+ *   value to seed the exclusive scan
+ *
+ * @paramTotal num_items
+ *   number of scan items for the entire problem
+ */
+template <typename ChainedPolicyT,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename ScanTileStateT,
+          typename ScanOpT,
+          typename InitValueT,
+          typename OffsetT,
+          typename AccumT,
+          bool ForceInclusive>
+__launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanPolicyT::BLOCK_THREADS))
+  CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceScanKernel(
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    ScanTileStateT tile_state,
+    int start_tile,
+    ScanOpT scan_op,
+    InitValueT init_value,
+    OffsetT num_items)
+{
+  using RealInitValueT = typename InitValueT::value_type;
+  using ScanPolicyT    = typename ChainedPolicyT::ActivePolicy::ScanPolicyT;
+
+  // Thread block type for scanning input tiles
+  using AgentScanT =
+    AgentScan<ScanPolicyT, InputIteratorT, OutputIteratorT, ScanOpT, RealInitValueT, OffsetT, AccumT, ForceInclusive>;
+
+  // Shared memory for AgentScan
+  __shared__ typename AgentScanT::TempStorage temp_storage;
+
+  RealInitValueT real_init_value = init_value;
+
+  // Process tiles
+  AgentScanT(temp_storage, d_in, d_out, scan_op, real_init_value).ConsumeRange(num_items, tile_state, start_tile);
+}
+
+CUB_NAMESPACE_END

--- a/cub/test/catch2_test_nvrtc.cu
+++ b/cub/test/catch2_test_nvrtc.cu
@@ -57,6 +57,7 @@ TEST_CASE("Test nvrtc", "[test][nvrtc]")
     "#include <cub/block/block_scan.cuh>                                                         \n"
     "#include <cub/device/dispatch/kernels/reduce.cuh>                                           \n"
     "#include <cub/device/dispatch/kernels/for_each.cuh>                                         \n"
+    "#include <cub/device/dispatch/kernels/scan.cuh>                                             \n"
     "                                                                                            \n"
     "extern \"C\" __global__ void kernel(int *ptr, int *errors)                                  \n"
     "{                                                                                           \n"

--- a/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
+++ b/python/cuda_parallel/cuda/parallel/experimental/iterators/_iterators.py
@@ -155,12 +155,12 @@ def pointer_add(ptr, offset):
     return impl
 
 
-class RawPointerType(IteratorKind):
+class RawPointerKind(IteratorKind):
     pass
 
 
 class RawPointer(IteratorBase):
-    iterator_kind_type = RawPointerType
+    iterator_kind_type = RawPointerKind
 
     def __init__(self, ptr: int, value_type: types.Type):
         cvalue = ctypes.c_void_p(ptr)
@@ -205,12 +205,12 @@ def load_cs(typingctx, base):
     return base.dtype(base), codegen
 
 
-class CacheModifiedPointerType(IteratorKind):
+class CacheModifiedPointerKind(IteratorKind):
     pass
 
 
 class CacheModifiedPointer(IteratorBase):
-    iterator_kind_type = CacheModifiedPointerType
+    iterator_kind_type = CacheModifiedPointerKind
 
     def __init__(self, ptr: int, ntype: types.Type):
         cvalue = ctypes.c_void_p(ptr)


### PR DESCRIPTION
## Description

Closes #3336 

Analogous to #2231, this PR extracts `DeviceCompactInitKernel` and `DeviceScanKernel` into an NVRTC-compilable header.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
