### PR TITLE
implement `<numbers>`

### DIFF
--- a/docs/libcudacxx/standard_api.rst
+++ b/docs/libcudacxx/standard_api.rst
@@ -76,6 +76,8 @@ Feature availability:
 
 -  C++20 ``std::assume_aligned`` in ``<memory>`` is available in C++11.
 
+-  C++20 ``<numbers>`` are available in C++14.
+
 -  C++20 ``<ranges>`` are available in C++17.
 
    -  all ``<ranges>`` concepts are available in C++17. However, they

--- a/docs/libcudacxx/standard_api/numerics_library.rst
+++ b/docs/libcudacxx/standard_api/numerics_library.rst
@@ -9,6 +9,7 @@ Numerics Library
 
    numerics_library/bit
    numerics_library/complex
+   numerics_library/numbers
    numerics_library/numeric
 
 Any Standard C++ header not listed below is omitted.
@@ -41,6 +42,9 @@ Any Standard C++ header not listed below is omitted.
    * - `\<cuda/std/cstdint\> <https://en.cppreference.com/w/cpp/header/cstdint>`_
      - Fixed-width integer types
      - libcu++ 1.0.0 / CCCL 2.0.0 / CUDA 10.2
+   * - `\<cuda/std/numbers\> <https://en.cppreference.com/w/cpp/header/numbers>`_
+     - Numeric constants
+     - CCCL 3.0.0
    * - `\<cuda/std/numeric\> <https://en.cppreference.com/w/cpp/header/numeric>`_
      - Numeric algorithms
      - CCCL 2.5.0

--- a/docs/libcudacxx/standard_api/numerics_library/numbers.rst
+++ b/docs/libcudacxx/standard_api/numerics_library/numbers.rst
@@ -1,0 +1,9 @@
+.. _libcudacxx-standard-api-numerics-numbers:
+
+``<cuda/std/numbers>``
+======================
+
+Extensions
+----------
+
+-  All features of ``<numbers>`` are made available in C++14 onwards

--- a/libcudacxx/include/cuda/std/numbers
+++ b/libcudacxx/include/cuda/std/numbers
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_NUMBERS
+#define _CUDA_STD_NUMBERS
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/is_floating_point.h>
+#include <cuda/std/version>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+namespace numbers
+{
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __e
+{
+  static constexpr _Tp value = 2.718281828459045235360287471352662;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __log2e
+{
+  static constexpr _Tp value = 1.442695040888963407359924681001892;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __log10e
+{
+  static constexpr _Tp value = 0.434294481903251827651128918916605;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __pi
+{
+  static constexpr _Tp value = 3.141592653589793238462643383279502;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __inv_pi
+{
+  static constexpr _Tp value = 0.318309886183790671537767526745028;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __inv_sqrtpi
+{
+  static constexpr _Tp value = 0.564189583547756286948079451560772;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __ln2
+{
+  static constexpr _Tp value = 0.693147180559945309417232121458176;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __ln10
+{
+  static constexpr _Tp value = 2.302585092994045684017991454684364;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __sqrt2
+{
+  static constexpr _Tp value = 1.414213562373095048801688724209698;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __sqrt3
+{
+  static constexpr _Tp value = 1.732050807568877293527446341505872;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __inv_sqrt3
+{
+  static constexpr _Tp value = 0.577350269189625764509148780501957;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __egamma
+{
+  static constexpr _Tp value = 0.577215664901532860606512090082402;
+};
+
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(_CCCL_TRAIT(is_floating_point, _Tp))
+struct __phi
+{
+  static constexpr _Tp value = 1.618033988749894848204586834365638;
+};
+
+#if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
+
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp e_v = __e<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp log2e_v = __log2e<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp log10e_v = __log10e<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp pi_v = __pi<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp inv_pi_v = __inv_pi<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp inv_sqrtpi_v = __inv_sqrtpi<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp ln2_v = __ln2<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp ln10_v = __ln10<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp sqrt2_v = __sqrt2<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp sqrt3_v = __sqrt3<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp inv_sqrt3_v = __inv_sqrt3<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp egamma_v = __egamma<_Tp>::value;
+template <class _Tp>
+_CCCL_INLINE_VAR constexpr _Tp phi_v = __phi<_Tp>::value;
+
+_CCCL_INLINE_VAR constexpr double e          = e_v<double>;
+_CCCL_INLINE_VAR constexpr double log2e      = log2e_v<double>;
+_CCCL_INLINE_VAR constexpr double log10e     = log10e_v<double>;
+_CCCL_INLINE_VAR constexpr double pi         = pi_v<double>;
+_CCCL_INLINE_VAR constexpr double inv_pi     = inv_pi_v<double>;
+_CCCL_INLINE_VAR constexpr double inv_sqrtpi = inv_sqrtpi_v<double>;
+_CCCL_INLINE_VAR constexpr double ln2        = ln2_v<double>;
+_CCCL_INLINE_VAR constexpr double ln10       = ln10_v<double>;
+_CCCL_INLINE_VAR constexpr double sqrt2      = sqrt2_v<double>;
+_CCCL_INLINE_VAR constexpr double sqrt3      = sqrt3_v<double>;
+_CCCL_INLINE_VAR constexpr double inv_sqrt3  = inv_sqrt3_v<double>;
+_CCCL_INLINE_VAR constexpr double egamma     = egamma_v<double>;
+_CCCL_INLINE_VAR constexpr double phi        = phi_v<double>;
+
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
+
+} // namespace numbers
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _CUDA_STD_NUMBERS

--- a/libcudacxx/include/cuda/std/version
+++ b/libcudacxx/include/cuda/std/version
@@ -62,7 +62,8 @@
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)
 #  define __cccl_lib_type_trait_variable_templates 201510L
-#endif
+#  define __cccl_lib_math_constants                201907L
+#endif // !_CCCL_NO_VARIABLE_TEMPLATES
 
 #if _CCCL_STD_VER >= 2014
 #  define __cccl_lib_as_const     201510L
@@ -205,7 +206,6 @@
 // #   define __cccl_lib_latch                              201907L
 #  endif // !_LIBCUDACXX_HAS_NO_THREADS
 // # define __cccl_lib_list_remove_return_type              201806L
-// # define __cccl_lib_math_constants                       201907L
 // # define __cccl_lib_polymorphic_allocator                201902L
 // # define __cccl_lib_ranges                               201811L
 // # define __cccl_lib_remove_cvref                         201711L

--- a/libcudacxx/test/libcudacxx/aaaaaaaaaaaaa/numbers/defined.pass.cpp
+++ b/libcudacxx/test/libcudacxx/aaaaaaaaaaaaa/numbers/defined.pass.cpp
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++11
+
+#include <cuda/std/numbers>
+
+#include <test_macros.h>
+
+template <class ExpectedT, class T>
+__host__ __device__ constexpr bool test_defined(const T& value)
+{
+  ASSERT_SAME_TYPE(ExpectedT, T);
+
+  const ExpectedT* addr = &value;
+  unused(addr);
+
+  return true;
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_defined<double>(cuda::std::numbers::e);
+  test_defined<double>(cuda::std::numbers::log2e);
+  test_defined<double>(cuda::std::numbers::log10e);
+  test_defined<double>(cuda::std::numbers::pi);
+  test_defined<double>(cuda::std::numbers::inv_pi);
+  test_defined<double>(cuda::std::numbers::inv_sqrtpi);
+  test_defined<double>(cuda::std::numbers::ln2);
+  test_defined<double>(cuda::std::numbers::ln10);
+  test_defined<double>(cuda::std::numbers::sqrt2);
+  test_defined<double>(cuda::std::numbers::sqrt3);
+  test_defined<double>(cuda::std::numbers::inv_sqrt3);
+  test_defined<double>(cuda::std::numbers::egamma);
+  test_defined<double>(cuda::std::numbers::phi);
+
+  test_defined<float>(cuda::std::numbers::e_v<float>);
+  test_defined<float>(cuda::std::numbers::log2e_v<float>);
+  test_defined<float>(cuda::std::numbers::log10e_v<float>);
+  test_defined<float>(cuda::std::numbers::pi_v<float>);
+  test_defined<float>(cuda::std::numbers::inv_pi_v<float>);
+  test_defined<float>(cuda::std::numbers::inv_sqrtpi_v<float>);
+  test_defined<float>(cuda::std::numbers::ln2_v<float>);
+  test_defined<float>(cuda::std::numbers::ln10_v<float>);
+  test_defined<float>(cuda::std::numbers::sqrt2_v<float>);
+  test_defined<float>(cuda::std::numbers::sqrt3_v<float>);
+  test_defined<float>(cuda::std::numbers::inv_sqrt3_v<float>);
+  test_defined<float>(cuda::std::numbers::egamma_v<float>);
+  test_defined<float>(cuda::std::numbers::phi_v<float>);
+
+  test_defined<double>(cuda::std::numbers::e_v<double>);
+  test_defined<double>(cuda::std::numbers::log2e_v<double>);
+  test_defined<double>(cuda::std::numbers::log10e_v<double>);
+  test_defined<double>(cuda::std::numbers::pi_v<double>);
+  test_defined<double>(cuda::std::numbers::inv_pi_v<double>);
+  test_defined<double>(cuda::std::numbers::inv_sqrtpi_v<double>);
+  test_defined<double>(cuda::std::numbers::ln2_v<double>);
+  test_defined<double>(cuda::std::numbers::ln10_v<double>);
+  test_defined<double>(cuda::std::numbers::sqrt2_v<double>);
+  test_defined<double>(cuda::std::numbers::sqrt3_v<double>);
+  test_defined<double>(cuda::std::numbers::inv_sqrt3_v<double>);
+  test_defined<double>(cuda::std::numbers::egamma_v<double>);
+  test_defined<double>(cuda::std::numbers::phi_v<double>);
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test_defined<long double>(cuda::std::numbers::e_v<long double>);
+  test_defined<long double>(cuda::std::numbers::log2e_v<long double>);
+  test_defined<long double>(cuda::std::numbers::log10e_v<long double>);
+  test_defined<long double>(cuda::std::numbers::pi_v<long double>);
+  test_defined<long double>(cuda::std::numbers::inv_pi_v<long double>);
+  test_defined<long double>(cuda::std::numbers::inv_sqrtpi_v<long double>);
+  test_defined<long double>(cuda::std::numbers::ln2_v<long double>);
+  test_defined<long double>(cuda::std::numbers::ln10_v<long double>);
+  test_defined<long double>(cuda::std::numbers::sqrt2_v<long double>);
+  test_defined<long double>(cuda::std::numbers::sqrt3_v<long double>);
+  test_defined<long double>(cuda::std::numbers::inv_sqrt3_v<long double>);
+  test_defined<long double>(cuda::std::numbers::egamma_v<long double>);
+  test_defined<long double>(cuda::std::numbers::phi_v<long double>);
+#endif // !defined(_LIBCUDACXX_NO_LONG_DOUBLE)
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/aaaaaaaaaaaaa/numbers/illformed.fail.cpp
+++ b/libcudacxx/test/libcudacxx/aaaaaaaaaaaaa/numbers/illformed.fail.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++11
+
+#include <cuda/std/numbers>
+
+// Initializing the primary template is ill-formed.
+int log2e{cuda::std::numbers::log2e_v<int>}; // expected-error-re@numbers:* {{static assertion failed{{.*}}A program
+                                             // that instantiates a primary template of a mathematical constant variable
+                                             // template is ill-formed.}}
+int log10e{cuda::std::numbers::log10e_v<int>};
+int pi{cuda::std::numbers::pi_v<int>};
+int inv_pi{cuda::std::numbers::inv_pi_v<int>};
+int inv_sqrtpi{cuda::std::numbers::inv_sqrtpi_v<int>};
+int ln2{cuda::std::numbers::ln2_v<int>};
+int ln10{cuda::std::numbers::ln10_v<int>};
+int sqrt2{cuda::std::numbers::sqrt2_v<int>};
+int sqrt3{cuda::std::numbers::sqrt3_v<int>};
+int inv_sqrt3{cuda::std::numbers::inv_sqrt3_v<int>};
+int egamma{cuda::std::numbers::egamma_v<int>};
+int phi{cuda::std::numbers::phi_v<int>};

--- a/libcudacxx/test/libcudacxx/aaaaaaaaaaaaa/numbers/user_type.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/aaaaaaaaaaaaa/numbers/user_type.compile.pass.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++11
+
+#include <cuda/std/numbers>
+
+struct UserType
+{
+  int value;
+};
+
+template <>
+UserType cuda::std::numbers::e_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::log2e_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::log10e_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::pi_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::inv_pi_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::inv_sqrtpi_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::ln2_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::ln10_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::sqrt2_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::sqrt3_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::inv_sqrt3_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::egamma_v<UserType>{};
+
+template <>
+UserType cuda::std::numbers::phi_v<UserType>{};
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/aaaaaaaaaaaaa/numbers/value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/aaaaaaaaaaaaa/numbers/value.pass.cpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++11
+
+#include <cuda/std/cassert>
+#include <cuda/std/numbers>
+
+#include <test_macros.h>
+
+_CCCL_NV_DIAG_SUPPRESS(1046) // Suppress "floating-point value cannot be represented exactly"
+
+__host__ __device__ constexpr bool test()
+{
+  // default constants
+  assert(cuda::std::numbers::e == 0x1.5bf0a8b145769p+1);
+  assert(cuda::std::numbers::log2e == 0x1.71547652b82fep+0);
+  assert(cuda::std::numbers::log10e == 0x1.bcb7b1526e50ep-2);
+  assert(cuda::std::numbers::pi == 0x1.921fb54442d18p+1);
+  assert(cuda::std::numbers::inv_pi == 0x1.45f306dc9c883p-2);
+  assert(cuda::std::numbers::inv_sqrtpi == 0x1.20dd750429b6dp-1);
+  assert(cuda::std::numbers::ln2 == 0x1.62e42fefa39efp-1);
+  assert(cuda::std::numbers::ln10 == 0x1.26bb1bbb55516p+1);
+  assert(cuda::std::numbers::sqrt2 == 0x1.6a09e667f3bcdp+0);
+  assert(cuda::std::numbers::sqrt3 == 0x1.bb67ae8584caap+0);
+  assert(cuda::std::numbers::inv_sqrt3 == 0x1.279a74590331cp-1);
+  assert(cuda::std::numbers::egamma == 0x1.2788cfc6fb619p-1);
+  assert(cuda::std::numbers::phi == 0x1.9e3779b97f4a8p+0);
+
+  // float constants
+  assert(cuda::std::numbers::e_v<float> == 0x1.5bf0a8p+1f);
+  assert(cuda::std::numbers::log2e_v<float> == 0x1.715476p+0f);
+  assert(cuda::std::numbers::log10e_v<float> == 0x1.bcb7b15p-2f);
+  assert(cuda::std::numbers::pi_v<float> == 0x1.921fb54p+1f);
+  assert(cuda::std::numbers::inv_pi_v<float> == 0x1.45f306p-2f);
+  assert(cuda::std::numbers::inv_sqrtpi_v<float> == 0x1.20dd76p-1f);
+  assert(cuda::std::numbers::ln2_v<float> == 0x1.62e42fp-1f);
+  assert(cuda::std::numbers::ln10_v<float> == 0x1.26bb1bp+1f);
+  assert(cuda::std::numbers::sqrt2_v<float> == 0x1.6a09e6p+0f);
+  assert(cuda::std::numbers::sqrt3_v<float> == 0x1.bb67aep+0f);
+  assert(cuda::std::numbers::inv_sqrt3_v<float> == 0x1.279a74p-1f);
+  assert(cuda::std::numbers::egamma_v<float> == 0x1.2788cfp-1f);
+  assert(cuda::std::numbers::phi_v<float> == 0x1.9e3779ap+0f);
+
+  // double constants
+  assert(cuda::std::numbers::e_v<double> == 0x1.5bf0a8b145769p+1);
+  assert(cuda::std::numbers::log2e_v<double> == 0x1.71547652b82fep+0);
+  assert(cuda::std::numbers::log10e_v<double> == 0x1.bcb7b1526e50ep-2);
+  assert(cuda::std::numbers::pi_v<double> == 0x1.921fb54442d18p+1);
+  assert(cuda::std::numbers::inv_pi_v<double> == 0x1.45f306dc9c883p-2);
+  assert(cuda::std::numbers::inv_sqrtpi_v<double> == 0x1.20dd750429b6dp-1);
+  assert(cuda::std::numbers::ln2_v<double> == 0x1.62e42fefa39efp-1);
+  assert(cuda::std::numbers::ln10_v<double> == 0x1.26bb1bbb55516p+1);
+  assert(cuda::std::numbers::sqrt2_v<double> == 0x1.6a09e667f3bcdp+0);
+  assert(cuda::std::numbers::sqrt3_v<double> == 0x1.bb67ae8584caap+0);
+  assert(cuda::std::numbers::inv_sqrt3_v<double> == 0x1.279a74590331cp-1);
+  assert(cuda::std::numbers::egamma_v<double> == 0x1.2788cfc6fb619p-1);
+  assert(cuda::std::numbers::phi_v<double> == 0x1.9e3779b97f4a8p+0);
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  // long double constants
+  assert(cuda::std::numbers::e_v<long double> == 0x1.5bf0a8b145769p+1l);
+  assert(cuda::std::numbers::log2e_v<long double> == 0x1.71547652b82fep+0l);
+  assert(cuda::std::numbers::log10e_v<long double> == 0x1.bcb7b1526e50ep-2l);
+  assert(cuda::std::numbers::pi_v<long double> == 0x1.921fb54442d18p+1l);
+  assert(cuda::std::numbers::inv_pi_v<long double> == 0x1.45f306dc9c883p-2l);
+  assert(cuda::std::numbers::inv_sqrtpi_v<long double> == 0x1.20dd750429b6dp-1l);
+  assert(cuda::std::numbers::ln2_v<long double> == 0x1.62e42fefa39efp-1l);
+  assert(cuda::std::numbers::ln10_v<long double> == 0x1.26bb1bbb55516p+1l);
+  assert(cuda::std::numbers::sqrt2_v<long double> == 0x1.6a09e667f3bcdp+0l);
+  assert(cuda::std::numbers::sqrt3_v<long double> == 0x1.bb67ae8584caap+0l);
+  assert(cuda::std::numbers::inv_sqrt3_v<long double> == 0x1.279a74590331cp-1l);
+  assert(cuda::std::numbers::egamma_v<long double> == 0x1.2788cfc6fb619p-1l);
+  assert(cuda::std::numbers::phi_v<long double> == 0x1.9e3779b97f4a8p+0l);
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test(), "");
+  return 0;
+}


### PR DESCRIPTION
This PR implements `<numbers>` from C++20 and makes it available back to C++14 (no extra effort was required).