### PR TITLE
Fix all_of documentation for empty ranges

### DIFF
--- a/thrust/thrust/logical.h
+++ b/thrust/thrust/logical.h
@@ -69,7 +69,7 @@ THRUST_NAMESPACE_BEGIN
  *  thrust::all_of(thrust::host, A, A + 3, thrust::identity<bool>()); // returns false
  *
  *  // empty range
- *  thrust::all_of(thrust::host, A, A, thrust::identity<bool>()); // returns false
+ *  thrust::all_of(thrust::host, A, A, thrust::identity<bool>()); // returns true
  *
  *  \endcode
  *
@@ -108,7 +108,7 @@ all_of(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
  *  thrust::all_of(A, A + 3, thrust::identity<bool>()); // returns false
  *
  *  // empty range
- *  thrust::all_of(A, A, thrust::identity<bool>()); // returns false
+ *  thrust::all_of(A, A, thrust::identity<bool>()); // returns true
  *
  *  \endcode
  *


### PR DESCRIPTION
all_of always returns true on an empty range.

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
