### PR TITLE
Disable automatic header inclusion for clangd

### DIFF
--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.5-nvhpc24.7/devcontainer.json
+++ b/.devcontainer/cuda12.5-nvhpc24.7/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc10/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc11/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc12/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc13/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc7/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc8/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.8-gcc9/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm14/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm15/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm16/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm17/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.8-llvm18/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.8ext-gcc13/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,6 +42,7 @@
         "editor.formatOnSave": true,
         "clang-format.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
+          "--header-insertion=never",
           "--compile-commands-dir=${workspaceFolder}"
         ],
         "files.eol": "\n",


### PR DESCRIPTION
This commonly silently adds wrong relative includes at the wrong places
