### PR TITLE
Replace `typedef` with `using` in libcu++

### DIFF
--- a/libcudacxx/examples/trie.cu
+++ b/libcudacxx/examples/trie.cu
@@ -149,19 +149,19 @@ inline void assert_(cudaError_t code, const char* file, int line)
 template <class T>
 struct managed_allocator
 {
-  typedef cuda::std::size_t size_type;
-  typedef cuda::std::ptrdiff_t difference_type;
+  using size_type       = cuda::std::size_t;
+  using difference_type = cuda::std::ptrdiff_t;
 
-  typedef T value_type;
-  typedef T* pointer; // (deprecated in C++17)(removed in C++20) T*
-  typedef const T* const_pointer; // (deprecated in C++17)(removed in C++20) const T*
-  typedef T& reference; // (deprecated in C++17)(removed in C++20) T&
-  typedef const T& const_reference; // (deprecated in C++17)(removed in C++20) const T&
+  using value_type      = T;
+  using pointer         = T*; // (deprecated in C++17)(removed in C++20) T*
+  using const_pointer   = const T*; // (deprecated in C++17)(removed in C++20) const T*
+  using reference       = T&; // (deprecated in C++17)(removed in C++20) T&
+  using const_reference = const T&; // (deprecated in C++17)(removed in C++20) const T&
 
   template <class U>
   struct rebind
   {
-    typedef managed_allocator<U> other;
+    using other = managed_allocator<U>;
   };
   managed_allocator() = default;
   template <class U>

--- a/libcudacxx/include/cuda/std/__algorithm/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/for_each_n.h
@@ -28,8 +28,8 @@ template <class _InputIterator, class _Size, class _Function>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _InputIterator
 for_each_n(_InputIterator __first, _Size __orig_n, _Function __f)
 {
-  typedef decltype(_CUDA_VSTD::__convert_to_integral(__orig_n)) _IntegralSize;
-  _IntegralSize __n = __orig_n;
+  using _IntegralSize = decltype(_CUDA_VSTD::__convert_to_integral(__orig_n));
+  _IntegralSize __n   = __orig_n;
   while (__n > 0)
   {
     __f(*__first);

--- a/libcudacxx/include/cuda/std/__algorithm/is_heap_until.h
+++ b/libcudacxx/include/cuda/std/__algorithm/is_heap_until.h
@@ -30,7 +30,7 @@ template <class _Compare, class _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _RandomAccessIterator
 __is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare&& __comp)
 {
-  typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;
+  using difference_type      = typename iterator_traits<_RandomAccessIterator>::difference_type;
   difference_type __len      = __last - __first;
   difference_type __p        = 0;
   difference_type __c        = 1;

--- a/libcudacxx/include/cuda/std/__algorithm/partition_point.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partition_point.h
@@ -31,7 +31,7 @@ template <class _ForwardIterator, class _Predicate>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _ForwardIterator
 partition_point(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
-  typedef typename iterator_traits<_ForwardIterator>::difference_type difference_type;
+  using difference_type = typename iterator_traits<_ForwardIterator>::difference_type;
   difference_type __len = _CUDA_VSTD::distance(__first, __last);
   while (__len != 0)
   {

--- a/libcudacxx/include/cuda/std/__algorithm/rotate.h
+++ b/libcudacxx/include/cuda/std/__algorithm/rotate.h
@@ -35,8 +35,8 @@ template <class _AlgPolicy, class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _ForwardIterator
 __rotate_left(_ForwardIterator __first, _ForwardIterator __last)
 {
-  typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
-  using _Ops = _IterOps<_AlgPolicy>;
+  using value_type = typename iterator_traits<_ForwardIterator>::value_type;
+  using _Ops       = _IterOps<_AlgPolicy>;
 
   value_type __tmp       = _Ops::__iter_move(__first);
   _ForwardIterator __lm1 = _CUDA_VSTD::__move<_AlgPolicy>(_Ops::next(__first), __last, __first).second;
@@ -48,8 +48,8 @@ template <class _AlgPolicy, class _BidirectionalIterator>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _BidirectionalIterator
 __rotate_right(_BidirectionalIterator __first, _BidirectionalIterator __last)
 {
-  typedef typename iterator_traits<_BidirectionalIterator>::value_type value_type;
-  using _Ops = _IterOps<_AlgPolicy>;
+  using value_type = typename iterator_traits<_BidirectionalIterator>::value_type;
+  using _Ops       = _IterOps<_AlgPolicy>;
 
   _BidirectionalIterator __lm1 = _Ops::prev(__last);
   value_type __tmp             = _Ops::__iter_move(__lm1);
@@ -118,9 +118,9 @@ template <class _AlgPolicy, typename _RandomAccessIterator>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _RandomAccessIterator
 __rotate_gcd(_RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last)
 {
-  typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;
-  typedef typename iterator_traits<_RandomAccessIterator>::value_type value_type;
-  using _Ops = _IterOps<_AlgPolicy>;
+  using difference_type = typename iterator_traits<_RandomAccessIterator>::difference_type;
+  using value_type      = typename iterator_traits<_RandomAccessIterator>::value_type;
+  using _Ops            = _IterOps<_AlgPolicy>;
 
   const difference_type __m1 = __middle - __first;
   const difference_type __m2 = _Ops::distance(__middle, __last);
@@ -158,7 +158,7 @@ template <class _AlgPolicy, class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _ForwardIterator __rotate_impl(
   _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _CUDA_VSTD::forward_iterator_tag)
 {
-  typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
+  using value_type = typename iterator_traits<_ForwardIterator>::value_type;
   if (_CCCL_TRAIT(is_trivially_move_assignable, value_type))
   {
     if (_IterOps<_AlgPolicy>::next(__first) == __middle)
@@ -176,7 +176,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _BidirectionalIterator __rotate_
   _BidirectionalIterator __last,
   bidirectional_iterator_tag)
 {
-  typedef typename iterator_traits<_BidirectionalIterator>::value_type value_type;
+  using value_type = typename iterator_traits<_BidirectionalIterator>::value_type;
   if (_CCCL_TRAIT(is_trivially_move_assignable, value_type))
   {
     if (_IterOps<_AlgPolicy>::next(__first) == __middle)
@@ -198,7 +198,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 _RandomAccessIterator __rotate_i
   _RandomAccessIterator __last,
   random_access_iterator_tag)
 {
-  typedef typename iterator_traits<_RandomAccessIterator>::value_type value_type;
+  using value_type = typename iterator_traits<_RandomAccessIterator>::value_type;
   if (_CCCL_TRAIT(is_trivially_move_assignable, value_type))
   {
     if (_IterOps<_AlgPolicy>::next(__first) == __middle)

--- a/libcudacxx/include/cuda/std/__algorithm/search.h
+++ b/libcudacxx/include/cuda/std/__algorithm/search.h
@@ -93,8 +93,8 @@ __search(_RandomAccessIterator1 __first1,
          random_access_iterator_tag,
          random_access_iterator_tag)
 {
-  typedef typename iterator_traits<_RandomAccessIterator1>::difference_type _Diff1;
-  typedef typename iterator_traits<_RandomAccessIterator2>::difference_type _Diff2;
+  using _Diff1 = typename iterator_traits<_RandomAccessIterator1>::difference_type;
+  using _Diff2 = typename iterator_traits<_RandomAccessIterator2>::difference_type;
   // Take advantage of knowing source and pattern lengths.  Stop short when source is smaller than pattern
   const _Diff2 __len2 = __last2 - __first2;
   if (__len2 == 0)

--- a/libcudacxx/include/cuda/std/__algorithm/sift_down.h
+++ b/libcudacxx/include/cuda/std/__algorithm/sift_down.h
@@ -35,8 +35,8 @@ _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 void __sift_down(
 {
   using _Ops = _IterOps<_AlgPolicy>;
 
-  typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;
-  typedef typename iterator_traits<_RandomAccessIterator>::value_type value_type;
+  using difference_type = typename iterator_traits<_RandomAccessIterator>::difference_type;
+  using value_type      = typename iterator_traits<_RandomAccessIterator>::value_type;
   // left-child of __start is at 2 * __start + 1
   // right-child of __start is at 2 * __start + 2
   difference_type __child = __start - __first;

--- a/libcudacxx/include/cuda/std/__atomic/order.h
+++ b/libcudacxx/include/cuda/std/__atomic/order.h
@@ -84,15 +84,14 @@ inline constexpr auto memory_order_seq_cst = memory_order::seq_cst;
 
 #else // ^^^ C++20 ^^^ / vvv C++17 vvv
 
-typedef enum memory_order
-{
+using memory_order = enum memory_order {
   memory_order_relaxed = __mo_relaxed,
   memory_order_consume = __mo_consume,
   memory_order_acquire = __mo_acquire,
   memory_order_release = __mo_release,
   memory_order_acq_rel = __mo_acq_rel,
   memory_order_seq_cst = __mo_seq_cst,
-} memory_order;
+};
 
 #endif // _CCCL_STD_VER >= 2020
 

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -85,8 +85,8 @@ struct __type_to_vector<__nv_bfloat16>
 template <>
 struct __cccl_complex_overload_traits<__nv_bfloat16, false, false>
 {
-  typedef __nv_bfloat16 _ValueType;
-  typedef complex<__nv_bfloat16> _ComplexType;
+  using _ValueType   = __nv_bfloat16;
+  using _ComplexType = complex<__nv_bfloat16>;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -82,8 +82,8 @@ struct __type_to_vector<__half>
 template <>
 struct __cccl_complex_overload_traits<__half, false, false>
 {
-  typedef __half _ValueType;
-  typedef complex<__half> _ComplexType;
+  using _ValueType   = __half;
+  using _ComplexType = complex<__half>;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__exception/terminate.h
+++ b/libcudacxx/include/cuda/std/__exception/terminate.h
@@ -37,7 +37,7 @@ _CCCL_NORETURN _LIBCUDACXX_HIDE_FROM_ABI void __cccl_terminate() noexcept
 
 #if 0 // Expose once atomic is universally available
 
-typedef void (*terminate_handler)();
+using terminate_handler = void (*)();
 
 #  ifdef __CUDA_ARCH__
 __device__

--- a/libcudacxx/include/cuda/std/__functional/binary_function.h
+++ b/libcudacxx/include/cuda/std/__functional/binary_function.h
@@ -27,9 +27,9 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Arg1, class _Arg2, class _Result>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT _LIBCUDACXX_DEPRECATED_IN_CXX11 binary_function
 {
-  typedef _Arg1 first_argument_type;
-  typedef _Arg2 second_argument_type;
-  typedef _Result result_type;
+  using first_argument_type  = _Arg1;
+  using second_argument_type = _Arg2;
+  using result_type          = _Result;
 };
 
 #endif // _CCCL_STD_VER <= 2014 || defined(_LIBCUDACXX_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)

--- a/libcudacxx/include/cuda/std/__functional/bind.h
+++ b/libcudacxx/include/cuda/std/__functional/bind.h
@@ -122,7 +122,7 @@ template <class _Ti, class... _Uj>
 _LIBCUDACXX_HIDE_FROM_ABI enable_if_t<is_bind_expression<_Ti>::value, __invoke_of<_Ti&, _Uj...>>
 __mu(_Ti& __ti, tuple<_Uj...>& __uj)
 {
-  typedef __make_tuple_indices_t<sizeof...(_Uj)> __indices;
+  using __indices = __make_tuple_indices_t<sizeof...(_Uj)>;
   return _CUDA_VSTD::__mu_expand(__ti, __uj, __indices());
 }
 
@@ -133,7 +133,7 @@ struct __mu_return2
 template <class _Ti, class _Uj>
 struct __mu_return2<true, _Ti, _Uj>
 {
-  typedef __tuple_element_t<is_placeholder<_Ti>::value - 1, _Uj> type;
+  using type = __tuple_element_t<is_placeholder<_Ti>::value - 1, _Uj>;
 };
 
 template <class _Ti, class _Uj>
@@ -160,13 +160,13 @@ struct __mu_return_impl;
 template <bool _Invokable, class _Ti, class... _Uj>
 struct __mu_return_invokable // false
 {
-  typedef __nat type;
+  using type = __nat;
 };
 
 template <class _Ti, class... _Uj>
 struct __mu_return_invokable<true, _Ti, _Uj...>
 {
-  typedef typename __invoke_of<_Ti&, _Uj...>::type type;
+  using type = typename __invoke_of<_Ti&, _Uj...>::type;
 };
 
 template <class _Ti, class... _Uj>
@@ -177,19 +177,19 @@ struct __mu_return_impl<_Ti, false, true, false, tuple<_Uj...>>
 template <class _Ti, class _TupleUj>
 struct __mu_return_impl<_Ti, false, false, true, _TupleUj>
 {
-  typedef __tuple_element_t<is_placeholder<_Ti>::value - 1, _TupleUj>&& type;
+  using type = __tuple_element_t<is_placeholder<_Ti>::value - 1, _TupleUj>&&;
 };
 
 template <class _Ti, class _TupleUj>
 struct __mu_return_impl<_Ti, true, false, false, _TupleUj>
 {
-  typedef typename _Ti::type& type;
+  using type = typename _Ti::type&;
 };
 
 template <class _Ti, class _TupleUj>
 struct __mu_return_impl<_Ti, false, false, false, _TupleUj>
 {
-  typedef _Ti& type;
+  using type = _Ti&;
 };
 
 template <class _Ti, class _TupleUj>
@@ -226,13 +226,13 @@ struct __bind_return;
 template <class _Fp, class... _BoundArgs, class _TupleUj>
 struct __bind_return<_Fp, tuple<_BoundArgs...>, _TupleUj, true>
 {
-  typedef typename __invoke_of<_Fp&, typename __mu_return<_BoundArgs, _TupleUj>::type...>::type type;
+  using type = typename __invoke_of<_Fp&, typename __mu_return<_BoundArgs, _TupleUj>::type...>::type;
 };
 
 template <class _Fp, class... _BoundArgs, class _TupleUj>
 struct __bind_return<_Fp, const tuple<_BoundArgs...>, _TupleUj, true>
 {
-  typedef typename __invoke_of<_Fp&, typename __mu_return<const _BoundArgs, _TupleUj>::type...>::type type;
+  using type = typename __invoke_of<_Fp&, typename __mu_return<const _BoundArgs, _TupleUj>::type...>::type;
 };
 
 template <class _Fp, class _BoundArgs, class _TupleUj>
@@ -249,14 +249,14 @@ template <class _Fp, class... _BoundArgs>
 class __bind : public __weak_result_type<decay_t<_Fp>>
 {
 protected:
-  typedef decay_t<_Fp> _Fd;
-  typedef tuple<decay_t<_BoundArgs>...> _Td;
+  using _Fd = decay_t<_Fp>;
+  using _Td = tuple<decay_t<_BoundArgs>...>;
 
 private:
   _Fd __f_;
   _Td __bound_args_;
 
-  typedef __make_tuple_indices_t<sizeof...(_BoundArgs)> __indices;
+  using __indices = __make_tuple_indices_t<sizeof...(_BoundArgs)>;
 
 public:
   template <class _Gp,
@@ -291,12 +291,12 @@ struct is_bind_expression<__bind<_Fp, _BoundArgs...>> : public true_type
 template <class _Rp, class _Fp, class... _BoundArgs>
 class __bind_r : public __bind<_Fp, _BoundArgs...>
 {
-  typedef __bind<_Fp, _BoundArgs...> base;
-  typedef typename base::_Fd _Fd;
-  typedef typename base::_Td _Td;
+  using base = __bind<_Fp, _BoundArgs...>;
+  using _Fd  = typename base::_Fd;
+  using _Td  = typename base::_Td;
 
 public:
-  typedef _Rp result_type;
+  using result_type = _Rp;
 
   template <class _Gp,
             class... _BA,
@@ -311,7 +311,7 @@ public:
               result_type>
   operator()(_Args&&... __args)
   {
-    typedef __invoke_void_return_wrapper<_Rp> _Invoker;
+    using _Invoker = __invoke_void_return_wrapper<_Rp>;
     return _Invoker::__call(static_cast<base&>(*this), _CUDA_VSTD::forward<_Args>(__args)...);
   }
 
@@ -321,7 +321,7 @@ public:
     result_type>
   operator()(_Args&&... __args) const
   {
-    typedef __invoke_void_return_wrapper<_Rp> _Invoker;
+    using _Invoker = __invoke_void_return_wrapper<_Rp>;
     return _Invoker::__call(static_cast<base const&>(*this), _CUDA_VSTD::forward<_Args>(__args)...);
   }
 };
@@ -333,7 +333,7 @@ struct is_bind_expression<__bind_r<_Rp, _Fp, _BoundArgs...>> : public true_type
 template <class _Fp, class... _BoundArgs>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 __bind<_Fp, _BoundArgs...> bind(_Fp&& __f, _BoundArgs&&... __bound_args)
 {
-  typedef __bind<_Fp, _BoundArgs...> type;
+  using type = __bind<_Fp, _BoundArgs...>;
   return type(_CUDA_VSTD::forward<_Fp>(__f), _CUDA_VSTD::forward<_BoundArgs>(__bound_args)...);
 }
 
@@ -341,7 +341,7 @@ template <class _Rp, class _Fp, class... _BoundArgs>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 __bind_r<_Rp, _Fp, _BoundArgs...>
 bind(_Fp&& __f, _BoundArgs&&... __bound_args)
 {
-  typedef __bind_r<_Rp, _Fp, _BoundArgs...> type;
+  using type = __bind_r<_Rp, _Fp, _BoundArgs...>;
   return type(_CUDA_VSTD::forward<_Fp>(__f), _CUDA_VSTD::forward<_BoundArgs>(__bound_args)...);
 }
 

--- a/libcudacxx/include/cuda/std/__functional/function.h
+++ b/libcudacxx/include/cuda/std/__functional/function.h
@@ -136,8 +136,8 @@ class __alloc_func<_Fp, _Ap, _Rp(_ArgTypes...)>
   __compressed_pair<_Fp, _Ap> __f_;
 
 public:
-  typedef _CCCL_NODEBUG_ALIAS _Fp _Target;
-  typedef _CCCL_NODEBUG_ALIAS _Ap _Alloc;
+  using _Target _CCCL_NODEBUG_ALIAS = _Fp;
+  using _Alloc _CCCL_NODEBUG_ALIAS  = _Ap;
 
   _LIBCUDACXX_HIDE_FROM_ABI const _Target& __target() const
   {
@@ -170,16 +170,16 @@ public:
 
   _LIBCUDACXX_HIDE_FROM_ABI _Rp operator()(_ArgTypes&&... __arg)
   {
-    typedef __invoke_void_return_wrapper<_Rp> _Invoker;
+    using _Invoker = __invoke_void_return_wrapper<_Rp>;
     return _Invoker::__call(__f_.first(), _CUDA_VSTD::forward<_ArgTypes>(__arg)...);
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI __alloc_func* __clone() const
   {
-    typedef allocator_traits<_Alloc> __alloc_traits;
-    typedef typename __rebind_alloc_helper<__alloc_traits, __alloc_func>::type _AA;
+    using __alloc_traits = allocator_traits<_Alloc>;
+    using _AA            = typename __rebind_alloc_helper<__alloc_traits, __alloc_func>::type;
     _AA __a(__f_.second());
-    typedef __allocator_destructor<_AA> _Dp;
+    using _Dp = __allocator_destructor<_AA>;
     unique_ptr<__alloc_func, _Dp> __hold(__a.allocate(1), _Dp(__a, 1));
     ::new ((void*) __hold.get()) __alloc_func(__f_.first(), _Alloc(__a));
     return __hold.release();
@@ -192,8 +192,8 @@ public:
 
   static void __destroy_and_delete(__alloc_func* __f)
   {
-    typedef allocator_traits<_Alloc> __alloc_traits;
-    typedef typename __rebind_alloc_helper<__alloc_traits, __alloc_func>::type _FunAlloc;
+    using __alloc_traits = allocator_traits<_Alloc>;
+    using _FunAlloc      = typename __rebind_alloc_helper<__alloc_traits, __alloc_func>::type;
     _FunAlloc __a(__f->__get_allocator());
     __f->destroy();
     __a.deallocate(__f, 1);
@@ -206,7 +206,7 @@ class __default_alloc_func<_Fp, _Rp(_ArgTypes...)>
   _Fp __f_;
 
 public:
-  typedef _CCCL_NODEBUG_ALIAS _Fp _Target;
+  using _Target _CCCL_NODEBUG_ALIAS = _Fp;
 
   _LIBCUDACXX_HIDE_FROM_ABI const _Target& __target() const
   {
@@ -223,7 +223,7 @@ public:
 
   _LIBCUDACXX_HIDE_FROM_ABI _Rp operator()(_ArgTypes&&... __arg)
   {
-    typedef __invoke_void_return_wrapper<_Rp> _Invoker;
+    using _Invoker = __invoke_void_return_wrapper<_Rp>;
     return _Invoker::__call(__f_, _CUDA_VSTD::forward<_ArgTypes>(__arg)...);
   }
 
@@ -313,10 +313,10 @@ public:
 template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
 __base<_Rp(_ArgTypes...)>* __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::__clone() const
 {
-  typedef allocator_traits<_Alloc> __alloc_traits;
-  typedef typename __rebind_alloc_helper<__alloc_traits, __func>::type _Ap;
+  using __alloc_traits = allocator_traits<_Alloc>;
+  using _Ap            = typename __rebind_alloc_helper<__alloc_traits, __func>::type;
   _Ap __a(__f_.__get_allocator());
-  typedef __allocator_destructor<_Ap> _Dp;
+  using _Dp = __allocator_destructor<_Ap>;
   unique_ptr<__func, _Dp> __hold(__a.allocate(1), _Dp(__a, 1));
   ::new ((void*) __hold.get()) __func(__f_.__target(), _Alloc(__a));
   return __hold.release();
@@ -337,8 +337,8 @@ void __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy() noexcept
 template <class _Fp, class _Alloc, class _Rp, class... _ArgTypes>
 void __func<_Fp, _Alloc, _Rp(_ArgTypes...)>::destroy_deallocate() noexcept
 {
-  typedef allocator_traits<_Alloc> __alloc_traits;
-  typedef typename __rebind_alloc_helper<__alloc_traits, __func>::type _Ap;
+  using __alloc_traits = allocator_traits<_Alloc>;
+  using _Ap            = typename __rebind_alloc_helper<__alloc_traits, __func>::type;
   _Ap __a(__f_.__get_allocator());
   __f_.destroy();
   __a.deallocate(this, 1);
@@ -380,7 +380,7 @@ class __value_func<_Rp(_ArgTypes...)>
 {
   typename aligned_storage<3 * sizeof(void*)>::type __buf_;
 
-  typedef __base<_Rp(_ArgTypes...)> __func;
+  using __func = __base<_Rp(_ArgTypes...)>;
   __func* __f_;
 
   _LIBCUDACXX_NO_CFI static __func* __as_base(void* __p)
@@ -397,9 +397,9 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI __value_func(_Fp&& __f, const _Alloc& __a)
       : __f_(nullptr)
   {
-    typedef allocator_traits<_Alloc> __alloc_traits;
-    typedef __function::__func<_Fp, _Alloc, _Rp(_ArgTypes...)> _Fun;
-    typedef typename __rebind_alloc_helper<__alloc_traits, _Fun>::type _FunAlloc;
+    using __alloc_traits = allocator_traits<_Alloc>;
+    using _Fun           = __function::__func<_Fp, _Alloc, _Rp(_ArgTypes...)>;
+    using _FunAlloc      = typename __rebind_alloc_helper<__alloc_traits, _Fun>::type;
 
     if (__function::__not_null(__f))
     {
@@ -411,7 +411,7 @@ public:
       }
       else
       {
-        typedef __allocator_destructor<_FunAlloc> _Dp;
+        using _Dp = __allocator_destructor<_FunAlloc>;
         unique_ptr<__func, _Dp> __hold(__af.allocate(1), _Dp(__af, 1));
         ::new ((void*) __hold.get()) _Fun(_CUDA_VSTD::move(__f), _Alloc(__a));
         __f_ = __hold.release();
@@ -697,7 +697,7 @@ struct __policy_invoker;
 template <class _Rp, class... _ArgTypes>
 struct __policy_invoker<_Rp(_ArgTypes...)>
 {
-  typedef _Rp (*__Call)(const __policy_storage*, __fast_forward<_ArgTypes>...);
+  using __Call = _Rp (*)(const __policy_storage*, __fast_forward<_ArgTypes>...);
 
   __Call __call_;
 
@@ -746,7 +746,7 @@ class __policy_func<_Rp(_ArgTypes...)>
   // Calls the value stored in __buf_. This could technically be part of
   // policy, but storing it here eliminates a level of indirection inside
   // operator().
-  typedef __function::__policy_invoker<_Rp(_ArgTypes...)> __invoker;
+  using __invoker = __function::__policy_invoker<_Rp(_ArgTypes...)>;
   __invoker __invoker_;
 
   // The policy that describes how to move / copy / destroy __buf_. Never
@@ -762,9 +762,9 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI __policy_func(_Fp&& __f, const _Alloc& __a)
       : __policy_(__policy::__create_empty())
   {
-    typedef __alloc_func<_Fp, _Alloc, _Rp(_ArgTypes...)> _Fun;
-    typedef allocator_traits<_Alloc> __alloc_traits;
-    typedef typename __rebind_alloc_helper<__alloc_traits, _Fun>::type _FunAlloc;
+    using _Fun           = __alloc_func<_Fp, _Alloc, _Rp(_ArgTypes...)>;
+    using __alloc_traits = allocator_traits<_Alloc>;
+    using _FunAlloc      = typename __rebind_alloc_helper<__alloc_traits, _Fun>::type;
 
     if (__function::__not_null(__f))
     {
@@ -778,7 +778,7 @@ public:
       }
       else
       {
-        typedef __allocator_destructor<_FunAlloc> _Dp;
+        using _Dp = __allocator_destructor<_FunAlloc>;
         unique_ptr<_Fun, _Dp> __hold(__af.allocate(1), _Dp(__af, 1));
         ::new ((void*) __hold.get()) _Fun(_CUDA_VSTD::move(__f), _Alloc(__af));
         __buf_.__large = __hold.release();
@@ -790,7 +790,7 @@ public:
   _LIBCUDACXX_HIDE_FROM_ABI explicit __policy_func(_Fp&& __f)
       : __policy_(__policy::__create_empty())
   {
-    typedef __default_alloc_func<_Fp, _Rp(_ArgTypes...)> _Fun;
+    using _Fun = __default_alloc_func<_Fp, _Rp(_ArgTypes...)>;
 
     if (__function::__not_null(__f))
     {
@@ -913,7 +913,7 @@ extern "C" void _Block_release(const void*);
 template <class _Rp1, class... _ArgTypes1, class _Alloc, class _Rp, class... _ArgTypes>
 class __func<_Rp1 (^)(_ArgTypes1...), _Alloc, _Rp(_ArgTypes...)> : public __base<_Rp(_ArgTypes...)>
 {
-  typedef _Rp1 (^__block_type)(_ArgTypes1...);
+  using ...); = _Rp1 (^__block_type)(_ArgTypes1
   __block_type __f_;
 
 public:
@@ -989,7 +989,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT function<_Rp(_ArgTypes...)>
     : public __function::__maybe_derive_from_unary_function<_Rp(_ArgTypes...)>
     , public __function::__maybe_derive_from_binary_function<_Rp(_ArgTypes...)>
 {
-  typedef __function::__policy_func<_Rp(_ArgTypes...)> __func;
+  using __func = __function::__policy_func<_Rp(_ArgTypes...)>;
 
   __func __f_;
 
@@ -1011,7 +1011,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT function<_Rp(_ArgTypes...)>
   using _EnableIfLValueCallable = enable_if_t<__callable<_Fp&>::value>;
 
 public:
-  typedef _Rp result_type;
+  using result_type = _Rp;
 
   // construct/copy/destroy:
   _LIBCUDACXX_HIDE_FROM_ABI function() noexcept {}

--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -374,7 +374,7 @@ struct _PairT
 
 _LIBCUDACXX_HIDE_FROM_ABI size_t __hash_combine(size_t __lhs, size_t __rhs) noexcept
 {
-  typedef __scalar_hash<_PairT> _HashT;
+  using _HashT     = __scalar_hash<_PairT>;
   const _PairT __p = {__lhs, __rhs};
   return _HashT()(__p);
 }
@@ -618,7 +618,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __enum_hash : public __unary_function<_Tp, 
 {
   _LIBCUDACXX_HIDE_FROM_ABI size_t operator()(_Tp __v) const noexcept
   {
-    typedef typename underlying_type<_Tp>::type type;
+    using type = typename underlying_type<_Tp>::type;
     return hash<type>()(static_cast<type>(__v));
   }
 };

--- a/libcudacxx/include/cuda/std/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/__functional/invoke.h
@@ -56,200 +56,200 @@ struct __member_pointer_traits_imp
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...), true, false>
 {
-  typedef _Class _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...), true, false>
 {
-  typedef _Class _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...) const, true, false>
 {
-  typedef _Class const _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class const;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...) const, true, false>
 {
-  typedef _Class const _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class const;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...) volatile, true, false>
 {
-  typedef _Class volatile _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class volatile;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...) volatile, true, false>
 {
-  typedef _Class volatile _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class volatile;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...) const volatile, true, false>
 {
-  typedef _Class const volatile _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class const volatile;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...) const volatile, true, false>
 {
-  typedef _Class const volatile _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class const volatile;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...)&, true, false>
 {
-  typedef _Class& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...)&, true, false>
 {
-  typedef _Class& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...) const&, true, false>
 {
-  typedef _Class const& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class const&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...) const&, true, false>
 {
-  typedef _Class const& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class const&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...) volatile&, true, false>
 {
-  typedef _Class volatile& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class volatile&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...) volatile&, true, false>
 {
-  typedef _Class volatile& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class volatile&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...) const volatile&, true, false>
 {
-  typedef _Class const volatile& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class const volatile&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...) const volatile&, true, false>
 {
-  typedef _Class const volatile& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class const volatile&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...)&&, true, false>
 {
-  typedef _Class&& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class&&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...)&&, true, false>
 {
-  typedef _Class&& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class&&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...) const&&, true, false>
 {
-  typedef _Class const&& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class const&&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...) const&&, true, false>
 {
-  typedef _Class const&& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class const&&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...) volatile&&, true, false>
 {
-  typedef _Class volatile&& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class volatile&&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...) volatile&&, true, false>
 {
-  typedef _Class volatile&& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class volatile&&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param...) const volatile&&, true, false>
 {
-  typedef _Class const volatile&& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param...);
+  using _ClassType  = _Class const volatile&&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param...);
 };
 
 template <class _Rp, class _Class, class... _Param>
 struct __member_pointer_traits_imp<_Rp (_Class::*)(_Param..., ...) const volatile&&, true, false>
 {
-  typedef _Class const volatile&& _ClassType;
-  typedef _Rp _ReturnType;
-  typedef _Rp(_FnType)(_Param..., ...);
+  using _ClassType  = _Class const volatile&&;
+  using _ReturnType = _Rp;
+  using _FnType     = _Rp (*)(_Param..., ...);
 };
 
 template <class _Rp, class _Class>
 struct __member_pointer_traits_imp<_Rp _Class::*, false, true>
 {
-  typedef _Class _ClassType;
-  typedef _Rp _ReturnType;
+  using _ClassType  = _Class;
+  using _ReturnType = _Rp;
 };
 
 template <class _MP>
@@ -270,7 +270,7 @@ struct __member_pointer_class_type
 template <class _Ret, class _ClassType>
 struct __member_pointer_class_type<_Ret _ClassType::*>
 {
-  typedef _ClassType type;
+  using type = _ClassType;
 };
 
 template <class _Fp,
@@ -424,7 +424,7 @@ struct __nothrow_invokable_r_imp
 template <class _Ret, class _Fp, class... _Args>
 struct __nothrow_invokable_r_imp<true, false, _Ret, _Fp, _Args...>
 {
-  typedef __nothrow_invokable_r_imp _ThisT;
+  using _ThisT = __nothrow_invokable_r_imp;
 
   template <class _Tp>
   _LIBCUDACXX_HIDE_FROM_ABI static void __test_noexcept(_Tp) noexcept;

--- a/libcudacxx/include/cuda/std/__functional/mem_fn.h
+++ b/libcudacxx/include/cuda/std/__functional/mem_fn.h
@@ -33,7 +33,7 @@ class __mem_fn : public __weak_result_type<_Tp>
 {
 public:
   // types
-  typedef _Tp type;
+  using type = _Tp;
 
 private:
   type __f_;

--- a/libcudacxx/include/cuda/std/__functional/operations.h
+++ b/libcudacxx/include/cuda/std/__functional/operations.h
@@ -32,7 +32,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT plus : __binary_function<_Tp, _Tp, _Tp>
 {
-  typedef _Tp __result_type; // used by valarray
+  using __result_type = _Tp; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -52,13 +52,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT plus<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) + _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT minus : __binary_function<_Tp, _Tp, _Tp>
 {
-  typedef _Tp __result_type; // used by valarray
+  using __result_type = _Tp; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -78,13 +78,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT minus<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) - _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT multiplies : __binary_function<_Tp, _Tp, _Tp>
 {
-  typedef _Tp __result_type; // used by valarray
+  using __result_type = _Tp; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -104,13 +104,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT multiplies<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) * _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT divides : __binary_function<_Tp, _Tp, _Tp>
 {
-  typedef _Tp __result_type; // used by valarray
+  using __result_type = _Tp; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -130,13 +130,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT divides<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) / _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT modulus : __binary_function<_Tp, _Tp, _Tp>
 {
-  typedef _Tp __result_type; // used by valarray
+  using __result_type = _Tp; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -156,13 +156,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT modulus<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) % _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT negate : __unary_function<_Tp, _Tp>
 {
-  typedef _Tp __result_type; // used by valarray
+  using __result_type = _Tp; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_CONSTEXPR_CXX14 _LIBCUDACXX_HIDE_FROM_ABI _Tp operator()(const _Tp& __x) const
   {
@@ -181,7 +181,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT negate<void>
   {
     return -_CUDA_VSTD::forward<_Tp>(__x);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 // Bitwise operations
@@ -189,7 +189,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT negate<void>
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT bit_and : __binary_function<_Tp, _Tp, _Tp>
 {
-  typedef _Tp __result_type; // used by valarray
+  using __result_type = _Tp; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -209,7 +209,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT bit_and<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) & _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
@@ -233,13 +233,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT bit_not<void>
   {
     return ~_CUDA_VSTD::forward<_Tp>(__x);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT bit_or : __binary_function<_Tp, _Tp, _Tp>
 {
-  typedef _Tp __result_type; // used by valarray
+  using __result_type = _Tp; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_CONSTEXPR_CXX14 _LIBCUDACXX_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -259,13 +259,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT bit_or<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) | _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT bit_xor : __binary_function<_Tp, _Tp, _Tp>
 {
-  typedef _Tp __result_type; // used by valarray
+  using __result_type = _Tp; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr _Tp operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -285,7 +285,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT bit_xor<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) ^ _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 // Comparison operations
@@ -293,7 +293,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT bit_xor<void>
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT equal_to : __binary_function<_Tp, _Tp, bool>
 {
-  typedef bool __result_type; // used by valarray
+  using __result_type = bool; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -313,13 +313,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT equal_to<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) == _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT not_equal_to : __binary_function<_Tp, _Tp, bool>
 {
-  typedef bool __result_type; // used by valarray
+  using __result_type = bool; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -339,13 +339,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT not_equal_to<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) != _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT less : __binary_function<_Tp, _Tp, bool>
 {
-  typedef bool __result_type; // used by valarray
+  using __result_type = bool; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -365,13 +365,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT less<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) < _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT less_equal : __binary_function<_Tp, _Tp, bool>
 {
-  typedef bool __result_type; // used by valarray
+  using __result_type = bool; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -391,13 +391,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT less_equal<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) <= _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT greater_equal : __binary_function<_Tp, _Tp, bool>
 {
-  typedef bool __result_type; // used by valarray
+  using __result_type = bool; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -417,13 +417,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT greater_equal<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) >= _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT greater : __binary_function<_Tp, _Tp, bool>
 {
-  typedef bool __result_type; // used by valarray
+  using __result_type = bool; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -443,7 +443,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT greater<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) > _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 // Logical operations
@@ -451,7 +451,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT greater<void>
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT logical_and : __binary_function<_Tp, _Tp, bool>
 {
-  typedef bool __result_type; // used by valarray
+  using __result_type = bool; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -471,13 +471,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT logical_and<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) && _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT logical_not : __unary_function<_Tp, bool>
 {
-  typedef bool __result_type; // used by valarray
+  using __result_type = bool; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __x) const
   {
@@ -496,13 +496,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT logical_not<void>
   {
     return !_CUDA_VSTD::forward<_Tp>(__x);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 template <class _Tp = void>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT logical_or : __binary_function<_Tp, _Tp, bool>
 {
-  typedef bool __result_type; // used by valarray
+  using __result_type = bool; // used by valarray
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _Tp& __x, const _Tp& __y) const
   {
@@ -522,7 +522,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT logical_or<void>
   {
     return _CUDA_VSTD::forward<_T1>(__t) || _CUDA_VSTD::forward<_T2>(__u);
   }
-  typedef void is_transparent;
+  using is_transparent = void;
 };
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
@@ -35,7 +35,7 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT reference_wrapper : public __weak_result_typ
 {
 public:
   // types
-  typedef _Tp type;
+  using type = _Tp;
 
 private:
   type* __f_;

--- a/libcudacxx/include/cuda/std/__functional/unary_function.h
+++ b/libcudacxx/include/cuda/std/__functional/unary_function.h
@@ -26,8 +26,8 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Arg, class _Result>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT _LIBCUDACXX_DEPRECATED_IN_CXX11 unary_function
 {
-  typedef _Arg argument_type;
-  typedef _Result result_type;
+  using argument_type = _Arg;
+  using result_type   = _Result;
 };
 
 #endif // _CCCL_STD_VER <= 2014

--- a/libcudacxx/include/cuda/std/__functional/unwrap_ref.h
+++ b/libcudacxx/include/cuda/std/__functional/unwrap_ref.h
@@ -25,7 +25,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct __unwrap_reference
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 
 template <class _Tp>
@@ -34,7 +34,7 @@ class reference_wrapper;
 template <class _Tp>
 struct __unwrap_reference<reference_wrapper<_Tp>>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp& type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp&;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__functional/weak_result_type.h
+++ b/libcudacxx/include/cuda/std/__functional/weak_result_type.h
@@ -59,7 +59,7 @@ private:
 
 public:
   static const bool value = !is_same<decltype(__test((_Tp*) 0)), __two>::value;
-  typedef decltype(__test((_Tp*) 0)) type;
+  using type              = decltype(__test((_Tp*) 0));
 };
 
 template <class _Tp>
@@ -78,7 +78,7 @@ private:
 
 public:
   static const bool value = !is_same<decltype(__test((_Tp*) 0)), __two>::value;
-  typedef decltype(__test((_Tp*) 0)) type;
+  using type              = decltype(__test((_Tp*) 0));
 };
 
 template <class _Tp, bool = __derives_from_unary_function<_Tp>::value>
@@ -266,7 +266,7 @@ struct __weak_result_type<_Rp (_Cp::*)(_A1, _A2, _A3...) const volatile>
 template <class _Tp, class... _Args>
 struct __invoke_return
 {
-  typedef decltype(_CUDA_VSTD::__invoke(declval<_Tp>(), declval<_Args>()...)) type;
+  using type = decltype(_CUDA_VSTD::__invoke(declval<_Tp>(), declval<_Args>()...));
 };
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__fwd/string_view.h
+++ b/libcudacxx/include/cuda/std/__fwd/string_view.h
@@ -28,14 +28,14 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _CharT, class _Traits = char_traits<_CharT>>
 class _CCCL_TYPE_VISIBILITY_DEFAULT basic_string_view;
 
-typedef basic_string_view<char> string_view;
+using string_view = basic_string_view<char>;
 #ifndef _LIBCUDACXX_HAS_NO_CHAR8_T
-typedef basic_string_view<char8_t> u8string_view;
+using u8string_view = basic_string_view<char8_t>;
 #endif
-typedef basic_string_view<char16_t> u16string_view;
-typedef basic_string_view<char32_t> u32string_view;
+using u16string_view = basic_string_view<char16_t>;
+using u32string_view = basic_string_view<char32_t>;
 #ifndef _LIBCUDACXX_HAS_NO_WIDE_CHARACTERS
-typedef basic_string_view<wchar_t> wstring_view;
+using wstring_view = basic_string_view<wchar_t>;
 #endif
 
 // clang-format off

--- a/libcudacxx/include/cuda/std/__iterator/advance.h
+++ b/libcudacxx/include/cuda/std/__iterator/advance.h
@@ -74,8 +74,8 @@ template <class _InputIter,
           class                   = enable_if_t<is_integral<_IntegralDistance>::value>>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 void advance(_InputIter& __i, _Distance __orig_n)
 {
-  typedef typename iterator_traits<_InputIter>::difference_type _Difference;
-  _Difference __n = static_cast<_Difference>(_CUDA_VSTD::__convert_to_integral(__orig_n));
+  using _Difference = typename iterator_traits<_InputIter>::difference_type;
+  _Difference __n   = static_cast<_Difference>(_CUDA_VSTD::__convert_to_integral(__orig_n));
   _CCCL_ASSERT(__n >= 0 || __is_cpp17_bidirectional_iterator<_InputIter>::value,
                "Attempt to advance(it, n) with negative n on a non-bidirectional iterator");
   _CUDA_VSTD::__advance(__i, __n, typename iterator_traits<_InputIter>::iterator_category());

--- a/libcudacxx/include/cuda/std/__iterator/back_insert_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/back_insert_iterator.h
@@ -42,16 +42,16 @@ protected:
   _Container* container;
 
 public:
-  typedef output_iterator_tag iterator_category;
-  typedef void value_type;
+  using iterator_category = output_iterator_tag;
+  using value_type        = void;
 #if _CCCL_STD_VER > 2017
-  typedef ptrdiff_t difference_type;
+  using difference_type = ptrdiff_t;
 #else
-  typedef void difference_type;
+  using difference_type = void;
 #endif
-  typedef void pointer;
-  typedef void reference;
-  typedef _Container container_type;
+  using pointer        = void;
+  using reference      = void;
+  using container_type = _Container;
 
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 explicit back_insert_iterator(_Container& __x)
       : container(_CUDA_VSTD::addressof(__x))

--- a/libcudacxx/include/cuda/std/__iterator/front_insert_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/front_insert_iterator.h
@@ -42,16 +42,16 @@ protected:
   _Container* container;
 
 public:
-  typedef output_iterator_tag iterator_category;
-  typedef void value_type;
+  using iterator_category = output_iterator_tag;
+  using value_type        = void;
 #if _CCCL_STD_VER > 2017
-  typedef ptrdiff_t difference_type;
+  using difference_type = ptrdiff_t;
 #else
-  typedef void difference_type;
+  using difference_type = void;
 #endif
-  typedef void pointer;
-  typedef void reference;
-  typedef _Container container_type;
+  using pointer        = void;
+  using reference      = void;
+  using container_type = _Container;
 
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20 explicit front_insert_iterator(_Container& __x)
       : container(_CUDA_VSTD::addressof(__x))

--- a/libcudacxx/include/cuda/std/__iterator/insert_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/insert_iterator.h
@@ -46,16 +46,16 @@ protected:
   __insert_iterator_iter_t<_Container> iter;
 
 public:
-  typedef output_iterator_tag iterator_category;
-  typedef void value_type;
+  using iterator_category = output_iterator_tag;
+  using value_type        = void;
 #if _CCCL_STD_VER > 2017
-  typedef ptrdiff_t difference_type;
+  using difference_type = ptrdiff_t;
 #else
-  typedef void difference_type;
+  using difference_type = void;
 #endif
-  typedef void pointer;
-  typedef void reference;
-  typedef _Container container_type;
+  using pointer        = void;
+  using reference      = void;
+  using container_type = _Container;
 
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX20
   insert_iterator(_Container& __x, __insert_iterator_iter_t<_Container> __i)

--- a/libcudacxx/include/cuda/std/__iterator/istream_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/istream_iterator.h
@@ -40,14 +40,14 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT istream_iterator
   _CCCL_SUPPRESS_DEPRECATED_POP
 
 public:
-  typedef input_iterator_tag iterator_category;
-  typedef _Tp value_type;
-  typedef _Distance difference_type;
-  typedef const _Tp* pointer;
-  typedef const _Tp& reference;
-  typedef _CharT char_type;
-  typedef _Traits traits_type;
-  typedef basic_istream<_CharT, _Traits> istream_type;
+  using iterator_category = input_iterator_tag;
+  using value_type        = _Tp;
+  using difference_type   = _Distance;
+  using pointer           = const _Tp*;
+  using reference         = const _Tp&;
+  using char_type         = _CharT;
+  using traits_type       = _Traits;
+  using istream_type      = basic_istream<_CharT, _Traits>;
 
 private:
   istream_type* __in_stream_;

--- a/libcudacxx/include/cuda/std/__iterator/istreambuf_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/istreambuf_iterator.h
@@ -38,16 +38,16 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT istreambuf_iterator
   _CCCL_SUPPRESS_DEPRECATED_POP
 
 public:
-  typedef input_iterator_tag iterator_category;
-  typedef _CharT value_type;
-  typedef typename _Traits::off_type difference_type;
-  typedef _CharT* pointer;
-  typedef _CharT reference;
-  typedef _CharT char_type;
-  typedef _Traits traits_type;
-  typedef typename _Traits::int_type int_type;
-  typedef basic_streambuf<_CharT, _Traits> streambuf_type;
-  typedef basic_istream<_CharT, _Traits> istream_type;
+  using iterator_category = input_iterator_tag;
+  using value_type        = _CharT;
+  using difference_type   = typename _Traits::off_type;
+  using pointer           = _CharT*;
+  using reference         = _CharT;
+  using char_type         = _CharT;
+  using traits_type       = _Traits;
+  using int_type          = typename _Traits::int_type;
+  using streambuf_type    = basic_streambuf<_CharT, _Traits>;
+  using istream_type      = basic_istream<_CharT, _Traits>;
 
 private:
   mutable streambuf_type* __sbuf_;

--- a/libcudacxx/include/cuda/std/__iterator/iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator.h
@@ -28,11 +28,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Category, class _Tp, class _Distance = ptrdiff_t, class _Pointer = _Tp*, class _Reference = _Tp&>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT _LIBCUDACXX_DEPRECATED_IN_CXX17 iterator
 {
-  typedef _Tp value_type;
-  typedef _Distance difference_type;
-  typedef _Pointer pointer;
-  typedef _Reference reference;
-  typedef _Category iterator_category;
+  using value_type        = _Tp;
+  using difference_type   = _Distance;
+  using pointer           = _Pointer;
+  using reference         = _Reference;
+  using iterator_category = _Category;
 };
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -823,11 +823,11 @@ struct __iterator_traits_impl
 template <class _Iter>
 struct __iterator_traits_impl<_Iter, true>
 {
-  typedef typename _Iter::difference_type difference_type;
-  typedef typename _Iter::value_type value_type;
-  typedef typename _Iter::pointer pointer;
-  typedef typename _Iter::reference reference;
-  typedef typename _Iter::iterator_category iterator_category;
+  using difference_type   = typename _Iter::difference_type;
+  using value_type        = typename _Iter::value_type;
+  using pointer           = typename _Iter::pointer;
+  using reference         = typename _Iter::reference;
+  using iterator_category = typename _Iter::iterator_category;
 };
 
 template <class _Iter>
@@ -855,13 +855,13 @@ template <class _Tp>
 #endif
 struct _CCCL_TYPE_VISIBILITY_DEFAULT iterator_traits<_Tp*>
 {
-  typedef ptrdiff_t difference_type;
-  typedef remove_cv_t<_Tp> value_type;
-  typedef _Tp* pointer;
-  typedef typename add_lvalue_reference<_Tp>::type reference;
-  typedef random_access_iterator_tag iterator_category;
+  using difference_type   = ptrdiff_t;
+  using value_type        = remove_cv_t<_Tp>;
+  using pointer           = _Tp*;
+  using reference         = typename add_lvalue_reference<_Tp>::type;
+  using iterator_category = random_access_iterator_tag;
 #if _CCCL_STD_VER >= 2014
-  typedef contiguous_iterator_tag iterator_concept;
+  using iterator_concept = contiguous_iterator_tag;
 #endif
 };
 

--- a/libcudacxx/include/cuda/std/__iterator/move_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/move_iterator.h
@@ -151,16 +151,16 @@ public:
   using pointer         = _Iter;
   using reference       = iter_rvalue_reference_t<_Iter>;
 #else // ^^^ _CCCL_STD_VER > 2014 ^^^ / vvv _CCCL_STD_VER < 2017 vvv
-  typedef _Iter iterator_type;
-  typedef _If<__is_cpp17_random_access_iterator<_Iter>::value,
-              random_access_iterator_tag,
-              typename iterator_traits<_Iter>::iterator_category>
-    iterator_category;
-  typedef typename iterator_traits<iterator_type>::value_type value_type;
-  typedef typename iterator_traits<iterator_type>::difference_type difference_type;
-  typedef iterator_type pointer;
-  typedef typename iterator_traits<iterator_type>::reference __reference;
-  typedef conditional_t<is_reference<__reference>::value, remove_reference_t<__reference>&&, __reference> reference;
+  using iterator_type = _Iter;
+  using iterator_category =
+    _If<__is_cpp17_random_access_iterator<_Iter>::value,
+        random_access_iterator_tag,
+        typename iterator_traits<_Iter>::iterator_category>;
+  using value_type      = typename iterator_traits<iterator_type>::value_type;
+  using difference_type = typename iterator_traits<iterator_type>::difference_type;
+  using pointer         = iterator_type;
+  using __reference     = typename iterator_traits<iterator_type>::reference;
+  using reference = conditional_t<is_reference<__reference>::value, remove_reference_t<__reference>&&, __reference>;
 #endif // _CCCL_STD_VER < 2017
 
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 explicit move_iterator(_Iter __i)

--- a/libcudacxx/include/cuda/std/__iterator/ostream_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/ostream_iterator.h
@@ -39,18 +39,18 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT ostream_iterator
   _CCCL_SUPPRESS_DEPRECATED_POP
 
 public:
-  typedef output_iterator_tag iterator_category;
-  typedef void value_type;
+  using iterator_category = output_iterator_tag;
+  using value_type        = void;
 #if _CCCL_STD_VER > 2017
-  typedef ptrdiff_t difference_type;
+  using difference_type = ptrdiff_t;
 #else
-  typedef void difference_type;
+  using difference_type = void;
 #endif
-  typedef void pointer;
-  typedef void reference;
-  typedef _CharT char_type;
-  typedef _Traits traits_type;
-  typedef basic_ostream<_CharT, _Traits> ostream_type;
+  using pointer      = void;
+  using reference    = void;
+  using char_type    = _CharT;
+  using traits_type  = _Traits;
+  using ostream_type = basic_ostream<_CharT, _Traits>;
 
 private:
   ostream_type* __out_stream_;

--- a/libcudacxx/include/cuda/std/__iterator/ostreambuf_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/ostreambuf_iterator.h
@@ -38,19 +38,19 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT ostreambuf_iterator
   _CCCL_SUPPRESS_DEPRECATED_POP
 
 public:
-  typedef output_iterator_tag iterator_category;
-  typedef void value_type;
+  using iterator_category = output_iterator_tag;
+  using value_type        = void;
 #if _CCCL_STD_VER > 2017
-  typedef ptrdiff_t difference_type;
+  using difference_type = ptrdiff_t;
 #else
-  typedef void difference_type;
+  using difference_type = void;
 #endif
-  typedef void pointer;
-  typedef void reference;
-  typedef _CharT char_type;
-  typedef _Traits traits_type;
-  typedef basic_streambuf<_CharT, _Traits> streambuf_type;
-  typedef basic_ostream<_CharT, _Traits> ostream_type;
+  using pointer        = void;
+  using reference      = void;
+  using char_type      = _CharT;
+  using traits_type    = _Traits;
+  using streambuf_type = basic_streambuf<_CharT, _Traits>;
+  using ostream_type   = basic_ostream<_CharT, _Traits>;
 
 private:
   streambuf_type* __sbuf_;

--- a/libcudacxx/include/cuda/std/__iterator/wrap_iter.h
+++ b/libcudacxx/include/cuda/std/__iterator/wrap_iter.h
@@ -34,14 +34,14 @@ template <class _Iter>
 class __wrap_iter
 {
 public:
-  typedef _Iter iterator_type;
-  typedef typename iterator_traits<iterator_type>::value_type value_type;
-  typedef typename iterator_traits<iterator_type>::difference_type difference_type;
-  typedef typename iterator_traits<iterator_type>::pointer pointer;
-  typedef typename iterator_traits<iterator_type>::reference reference;
-  typedef typename iterator_traits<iterator_type>::iterator_category iterator_category;
+  using iterator_type     = _Iter;
+  using value_type        = typename iterator_traits<iterator_type>::value_type;
+  using difference_type   = typename iterator_traits<iterator_type>::difference_type;
+  using pointer           = typename iterator_traits<iterator_type>::pointer;
+  using reference         = typename iterator_traits<iterator_type>::reference;
+  using iterator_category = typename iterator_traits<iterator_type>::iterator_category;
 #if _CCCL_STD_VER > 2011
-  typedef contiguous_iterator_tag iterator_concept;
+  using iterator_concept = contiguous_iterator_tag;
 #endif
 
 private:
@@ -241,9 +241,9 @@ struct __is_cpp17_contiguous_iterator<__wrap_iter<_It>> : true_type
 template <class _It>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT pointer_traits<__wrap_iter<_It>>
 {
-  typedef __wrap_iter<_It> pointer;
-  typedef typename pointer_traits<_It>::element_type element_type;
-  typedef typename pointer_traits<_It>::difference_type difference_type;
+  using pointer         = __wrap_iter<_It>;
+  using element_type    = typename pointer_traits<_It>::element_type;
+  using difference_type = typename pointer_traits<_It>::difference_type;
 
   _LIBCUDACXX_HIDE_FROM_ABI constexpr static element_type* to_address(pointer __w) noexcept
   {

--- a/libcudacxx/include/cuda/std/__memory/allocator.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator.h
@@ -49,14 +49,14 @@ template <>
 class _CCCL_TYPE_VISIBILITY_DEFAULT allocator<void>
 {
 public:
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef void* pointer;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const void* const_pointer;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef void value_type;
+  using pointer _LIBCUDACXX_DEPRECATED_IN_CXX17       = void*;
+  using const_pointer _LIBCUDACXX_DEPRECATED_IN_CXX17 = const void*;
+  using value_type _LIBCUDACXX_DEPRECATED_IN_CXX17    = void;
 
   template <class _Up>
   struct _LIBCUDACXX_DEPRECATED_IN_CXX17 rebind
   {
-    typedef allocator<_Up> other;
+    using other = allocator<_Up>;
   };
 };
 
@@ -64,14 +64,14 @@ template <>
 class _CCCL_TYPE_VISIBILITY_DEFAULT allocator<const void>
 {
 public:
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const void* pointer;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const void* const_pointer;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const void value_type;
+  using pointer _LIBCUDACXX_DEPRECATED_IN_CXX17       = const void*;
+  using const_pointer _LIBCUDACXX_DEPRECATED_IN_CXX17 = const void*;
+  using value_type _LIBCUDACXX_DEPRECATED_IN_CXX17    = const void;
 
   template <class _Up>
   struct _LIBCUDACXX_DEPRECATED_IN_CXX17 rebind
   {
-    typedef allocator<_Up> other;
+    using other = allocator<_Up>;
   };
 };
 #endif // _CCCL_STD_VER <= 2017
@@ -109,11 +109,11 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT allocator : private __non_trivial_if<!_CCCL_
   static_assert(!_CCCL_TRAIT(is_volatile, _Tp), "std::allocator does not support volatile types");
 
 public:
-  typedef size_t size_type;
-  typedef ptrdiff_t difference_type;
-  typedef _Tp value_type;
-  typedef true_type propagate_on_container_move_assignment;
-  typedef true_type is_always_equal;
+  using size_type                              = size_t;
+  using difference_type                        = ptrdiff_t;
+  using value_type                             = _Tp;
+  using propagate_on_container_move_assignment = true_type;
+  using is_always_equal                        = true_type;
 
   _CCCL_CONSTEXPR_CXX20 allocator() noexcept = default;
 
@@ -163,15 +163,15 @@ public:
 
   // C++20 Removed members
 #if _CCCL_STD_VER <= 2017
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef _Tp* pointer;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const _Tp* const_pointer;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef _Tp& reference;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const _Tp& const_reference;
+  using pointer _LIBCUDACXX_DEPRECATED_IN_CXX17         = _Tp*;
+  using const_pointer _LIBCUDACXX_DEPRECATED_IN_CXX17   = const _Tp*;
+  using reference _LIBCUDACXX_DEPRECATED_IN_CXX17       = _Tp&;
+  using const_reference _LIBCUDACXX_DEPRECATED_IN_CXX17 = const _Tp&;
 
   template <class _Up>
   struct _LIBCUDACXX_DEPRECATED_IN_CXX17 rebind
   {
-    typedef allocator<_Up> other;
+    using other = allocator<_Up>;
   };
 
   _LIBCUDACXX_DEPRECATED_IN_CXX17 _LIBCUDACXX_HIDE_FROM_ABI pointer address(reference __x) const noexcept
@@ -213,11 +213,11 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT allocator<const _Tp>
   static_assert(!_CCCL_TRAIT(is_volatile, _Tp), "std::allocator does not support volatile types");
 
 public:
-  typedef size_t size_type;
-  typedef ptrdiff_t difference_type;
-  typedef const _Tp value_type;
-  typedef true_type propagate_on_container_move_assignment;
-  typedef true_type is_always_equal;
+  using size_type                              = size_t;
+  using difference_type                        = ptrdiff_t;
+  using value_type                             = const _Tp;
+  using propagate_on_container_move_assignment = true_type;
+  using is_always_equal                        = true_type;
 
   _CCCL_CONSTEXPR_CXX20 allocator() noexcept = default;
 
@@ -262,15 +262,15 @@ public:
 
   // C++20 Removed members
 #if _CCCL_STD_VER <= 2017
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const _Tp* pointer;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const _Tp* const_pointer;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const _Tp& reference;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef const _Tp& const_reference;
+  using pointer _LIBCUDACXX_DEPRECATED_IN_CXX17         = const _Tp*;
+  using const_pointer _LIBCUDACXX_DEPRECATED_IN_CXX17   = const _Tp*;
+  using reference _LIBCUDACXX_DEPRECATED_IN_CXX17       = const _Tp&;
+  using const_reference _LIBCUDACXX_DEPRECATED_IN_CXX17 = const _Tp&;
 
   template <class _Up>
   struct _LIBCUDACXX_DEPRECATED_IN_CXX17 rebind
   {
-    typedef allocator<_Up> other;
+    using other = allocator<_Up>;
   };
 
   _LIBCUDACXX_DEPRECATED_IN_CXX17 _LIBCUDACXX_HIDE_FROM_ABI const_pointer address(const_reference __x) const noexcept

--- a/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
@@ -42,7 +42,7 @@ _CCCL_INLINE_VAR constexpr allocator_arg_t allocator_arg = allocator_arg_t();
 template <class _Tp, class _Alloc, class... _Args>
 struct __uses_alloc_ctor_imp
 {
-  typedef _CCCL_NODEBUG_ALIAS remove_cvref_t<_Alloc> _RawAlloc;
+  using _RawAlloc        = _CCCL_NODEBUG_ALIAS remove_cvref_t<_Alloc>;
   static const bool __ua = uses_allocator<_Tp, _RawAlloc>::value;
   static const bool __ic = is_constructible<_Tp, allocator_arg_t, _Alloc, _Args...>::value;
   static const int value = __ua ? 2 - __ic : 0;

--- a/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
@@ -42,10 +42,10 @@ _CCCL_INLINE_VAR constexpr allocator_arg_t allocator_arg = allocator_arg_t();
 template <class _Tp, class _Alloc, class... _Args>
 struct __uses_alloc_ctor_imp
 {
-  using _RawAlloc        = _CCCL_NODEBUG_ALIAS remove_cvref_t<_Alloc>;
-  static const bool __ua = uses_allocator<_Tp, _RawAlloc>::value;
-  static const bool __ic = is_constructible<_Tp, allocator_arg_t, _Alloc, _Args...>::value;
-  static const int value = __ua ? 2 - __ic : 0;
+  using _RawAlloc _CCCL_NODEBUG_ALIAS = remove_cvref_t<_Alloc>;
+  static const bool __ua              = uses_allocator<_Tp, _RawAlloc>::value;
+  static const bool __ic              = is_constructible<_Tp, allocator_arg_t, _Alloc, _Args...>::value;
+  static const int value              = __ua ? 2 - __ic : 0;
 };
 
 template <class _Tp, class _Alloc, class... _Args>

--- a/libcudacxx/include/cuda/std/__memory/allocator_destructor.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_destructor.h
@@ -29,11 +29,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Alloc>
 class __allocator_destructor
 {
-  typedef _CCCL_NODEBUG_ALIAS allocator_traits<_Alloc> __alloc_traits;
+  using __alloc_traits _CCCL_NODEBUG_ALIAS = allocator_traits<_Alloc>;
 
 public:
-  typedef _CCCL_NODEBUG_ALIAS typename __alloc_traits::pointer pointer;
-  typedef _CCCL_NODEBUG_ALIAS typename __alloc_traits::size_type size_type;
+  using pointer _CCCL_NODEBUG_ALIAS   = typename __alloc_traits::pointer;
+  using size_type _CCCL_NODEBUG_ALIAS = typename __alloc_traits::size_type;
 
 private:
   _Alloc& __alloc_;

--- a/libcudacxx/include/cuda/std/__memory/allocator_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_traits.h
@@ -567,7 +567,7 @@ using __rebind_alloc _CCCL_NODEBUG_ALIAS = typename _Traits::template rebind_all
 template <class _Traits, class _Tp>
 struct __rebind_alloc_helper
 {
-  typedef _CCCL_NODEBUG_ALIAS typename _Traits::template rebind_alloc<_Tp> type;
+  using type _CCCL_NODEBUG_ALIAS = typename _Traits::template rebind_alloc<_Tp>;
 };
 
 #undef _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX

--- a/libcudacxx/include/cuda/std/__memory/builtin_new_allocator.h
+++ b/libcudacxx/include/cuda/std/__memory/builtin_new_allocator.h
@@ -36,7 +36,7 @@ struct __builtin_new_allocator
 {
   struct __builtin_new_deleter
   {
-    typedef void* pointer_type;
+    using pointer_type = void*;
 
     _LIBCUDACXX_HIDE_FROM_ABI constexpr explicit __builtin_new_deleter(size_t __size, size_t __align) noexcept
         : __size_(__size)
@@ -53,7 +53,7 @@ struct __builtin_new_allocator
     size_t __align_;
   };
 
-  typedef unique_ptr<void, __builtin_new_deleter> __holder_t;
+  using __holder_t = unique_ptr<void, __builtin_new_deleter>;
 
   _LIBCUDACXX_HIDE_FROM_ABI static __holder_t __allocate_bytes(size_t __s, size_t __align)
   {

--- a/libcudacxx/include/cuda/std/__memory/pointer_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/pointer_traits.h
@@ -49,19 +49,19 @@ struct __pointer_traits_element_type;
 template <class _Ptr>
 struct __pointer_traits_element_type<_Ptr, true>
 {
-  typedef _CCCL_NODEBUG_ALIAS typename _Ptr::element_type type;
+  using type _CCCL_NODEBUG_ALIAS = typename _Ptr::element_type;
 };
 
 template <template <class, class...> class _Sp, class _Tp, class... _Args>
 struct __pointer_traits_element_type<_Sp<_Tp, _Args...>, true>
 {
-  typedef _CCCL_NODEBUG_ALIAS typename _Sp<_Tp, _Args...>::element_type type;
+  using type _CCCL_NODEBUG_ALIAS = typename _Sp<_Tp, _Args...>::element_type;
 };
 
 template <template <class, class...> class _Sp, class _Tp, class... _Args>
 struct __pointer_traits_element_type<_Sp<_Tp, _Args...>, false>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 
 template <class _Tp, class = void>
@@ -75,13 +75,13 @@ struct __has_difference_type<_Tp, void_t<typename _Tp::difference_type>> : true_
 template <class _Ptr, bool = __has_difference_type<_Ptr>::value>
 struct __pointer_traits_difference_type
 {
-  typedef _CCCL_NODEBUG_ALIAS ptrdiff_t type;
+  using type _CCCL_NODEBUG_ALIAS = ptrdiff_t;
 };
 
 template <class _Ptr>
 struct __pointer_traits_difference_type<_Ptr, true>
 {
-  typedef _CCCL_NODEBUG_ALIAS typename _Ptr::difference_type type;
+  using type _CCCL_NODEBUG_ALIAS = typename _Ptr::difference_type;
 };
 
 template <class _Tp, class _Up>
@@ -102,27 +102,27 @@ public:
 template <class _Tp, class _Up, bool = __has_rebind<_Tp, _Up>::value>
 struct __pointer_traits_rebind
 {
-  typedef _CCCL_NODEBUG_ALIAS typename _Tp::template rebind<_Up> type;
+  using type _CCCL_NODEBUG_ALIAS = typename _Tp::template rebind<_Up>;
 };
 
 template <template <class, class...> class _Sp, class _Tp, class... _Args, class _Up>
 struct __pointer_traits_rebind<_Sp<_Tp, _Args...>, _Up, true>
 {
-  typedef _CCCL_NODEBUG_ALIAS typename _Sp<_Tp, _Args...>::template rebind<_Up> type;
+  using type _CCCL_NODEBUG_ALIAS = typename _Sp<_Tp, _Args...>::template rebind<_Up>;
 };
 
 template <template <class, class...> class _Sp, class _Tp, class... _Args, class _Up>
 struct __pointer_traits_rebind<_Sp<_Tp, _Args...>, _Up, false>
 {
-  typedef _Sp<_Up, _Args...> type;
+  using type = _Sp<_Up, _Args...>;
 };
 
 template <class _Ptr>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT pointer_traits
 {
-  typedef _Ptr pointer;
-  typedef typename __pointer_traits_element_type<pointer>::type element_type;
-  typedef typename __pointer_traits_difference_type<pointer>::type difference_type;
+  using pointer         = _Ptr;
+  using element_type    = typename __pointer_traits_element_type<pointer>::type;
+  using difference_type = typename __pointer_traits_difference_type<pointer>::type;
 
   template <class _Up>
   using rebind = typename __pointer_traits_rebind<pointer, _Up>::type;
@@ -142,9 +142,9 @@ public:
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT pointer_traits<_Tp*>
 {
-  typedef _Tp* pointer;
-  typedef _Tp element_type;
-  typedef ptrdiff_t difference_type;
+  using pointer         = _Tp*;
+  using element_type    = _Tp;
+  using difference_type = ptrdiff_t;
 
   template <class _Up>
   using rebind = _Up*;
@@ -164,7 +164,7 @@ public:
 template <class _From, class _To>
 struct __rebind_pointer
 {
-  typedef typename pointer_traits<_From>::template rebind<_To> type;
+  using type = typename pointer_traits<_From>::template rebind<_To>;
 };
 
 // to_address

--- a/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
+++ b/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
@@ -97,8 +97,8 @@ template <class _InputIterator, class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI _ForwardIterator
 uninitialized_copy(_InputIterator __ifirst, _InputIterator __ilast, _ForwardIterator __ofirst)
 {
-  typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-  auto __result = _CUDA_VSTD::__uninitialized_copy<_ValueType>(
+  using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
+  auto __result    = _CUDA_VSTD::__uninitialized_copy<_ValueType>(
     _CUDA_VSTD::move(__ifirst), _CUDA_VSTD::move(__ilast), _CUDA_VSTD::move(__ofirst), __always_false{});
   return _CUDA_VSTD::move(__result.second);
 }
@@ -124,8 +124,8 @@ template <class _InputIterator, class _Size, class _ForwardIterator>
 _LIBCUDACXX_HIDE_FROM_ABI _ForwardIterator
 uninitialized_copy_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __ofirst)
 {
-  typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-  auto __result = _CUDA_VSTD::__uninitialized_copy_n<_ValueType>(
+  using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
+  auto __result    = _CUDA_VSTD::__uninitialized_copy_n<_ValueType>(
     _CUDA_VSTD::move(__ifirst), __n, _CUDA_VSTD::move(__ofirst), __always_false{});
   return _CUDA_VSTD::move(__result.second);
 }
@@ -150,7 +150,7 @@ __uninitialized_fill(_ForwardIterator __first, _Sentinel __last, const _Tp& __x)
 template <class _ForwardIterator, class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI void uninitialized_fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __x)
 {
-  typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+  using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
   (void) _CUDA_VSTD::__uninitialized_fill<_ValueType>(__first, __last, __x);
 }
 
@@ -173,7 +173,7 @@ _LIBCUDACXX_HIDE_FROM_ABI _ForwardIterator __uninitialized_fill_n(_ForwardIterat
 template <class _ForwardIterator, class _Size, class _Tp>
 _LIBCUDACXX_HIDE_FROM_ABI _ForwardIterator uninitialized_fill_n(_ForwardIterator __first, _Size __n, const _Tp& __x)
 {
-  typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+  using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
   return _CUDA_VSTD::__uninitialized_fill_n<_ValueType>(__first, __n, __x);
 }
 

--- a/libcudacxx/include/cuda/std/__thread/threading_support_pthread.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_pthread.h
@@ -40,43 +40,43 @@
 
 _CCCL_PUSH_MACROS
 
-typedef ::timespec __cccl_timespec_t;
+using __cccl_timespec_t = ::timespec;
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // Mutex
-typedef pthread_mutex_t __cccl_mutex_t;
+using __cccl_mutex_t = pthread_mutex_t;
 #  define _LIBCUDACXX_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 
-typedef pthread_mutex_t __cccl_recursive_mutex_t;
+using __cccl_recursive_mutex_t = pthread_mutex_t;
 
 // Condition Variable
-typedef pthread_cond_t __cccl_condvar_t;
+using __cccl_condvar_t = pthread_cond_t;
 #  define _LIBCUDACXX_CONDVAR_INITIALIZER PTHREAD_COND_INITIALIZER
 
 // Semaphore
 #  if defined(__APPLE__)
-typedef dispatch_semaphore_t __cccl_semaphore_t;
+using __cccl_semaphore_t = dispatch_semaphore_t;
 #    define _LIBCUDACXX_SEMAPHORE_MAX numeric_limits<long>::max()
 #  else // ^^^ __APPLE__ ^^^ / vvv !__APPLE__ vvv
-typedef sem_t __cccl_semaphore_t;
+using __cccl_semaphore_t = sem_t;
 #    define _LIBCUDACXX_SEMAPHORE_MAX SEM_VALUE_MAX
 #  endif // !__APPLE__
 
 // Execute once
-typedef pthread_once_t __cccl_exec_once_flag;
+using __cccl_exec_once_flag = pthread_once_t;
 #  define _LIBCUDACXX_EXEC_ONCE_INITIALIZER PTHREAD_ONCE_INIT
 
 // Thread id
-typedef pthread_t __cccl_thread_id;
+using __cccl_thread_id = pthread_t;
 
 // Thread
 #  define _LIBCUDACXX_NULL_THREAD 0U
 
-typedef pthread_t __cccl_thread_t;
+using __cccl_thread_t = pthread_t;
 
 // Thread Local Storage
-typedef pthread_key_t __cccl_tls_key;
+using __cccl_tls_key = pthread_key_t;
 
 #  define _LIBCUDACXX_TLS_DESTRUCTOR_CC
 
@@ -85,7 +85,7 @@ _LIBCUDACXX_HIDE_FROM_ABI __cccl_timespec_t __cccl_to_timespec(const _CUDA_VSTD:
   using namespace chrono;
   seconds __s = duration_cast<seconds>(__ns);
   __cccl_timespec_t __ts;
-  typedef decltype(__ts.tv_sec) ts_sec;
+  using ts_sec                  = decltype(__ts.tv_sec);
   constexpr ts_sec __ts_sec_max = numeric_limits<ts_sec>::max();
 
   if (__s.count() < __ts_sec_max)

--- a/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
+++ b/libcudacxx/include/cuda/std/__thread/threading_support_win32.h
@@ -32,38 +32,38 @@ _CCCL_PUSH_MACROS
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // Mutex
-typedef void* __cccl_mutex_t;
+using __cccl_mutex_t = void*;
 #  define _LIBCUDACXX_MUTEX_INITIALIZER 0
 
 #  if defined(_M_IX86) || defined(__i386__) || defined(_M_ARM) || defined(__arm__)
-typedef void* __cccl_recursive_mutex_t[6];
+using __cccl_recursive_mutex_t = void* [6];
 #  elif defined(_M_AMD64) || defined(__x86_64__) || defined(_M_ARM64) || defined(__aarch64__)
-typedef void* __cccl_recursive_mutex_t[5];
+using __cccl_recursive_mutex_t = void* [5];
 #  else
 #    error Unsupported architecture
 #  endif
 
 // Condition Variable
-typedef void* __cccl_condvar_t;
+using __cccl_condvar_t = void*;
 #  define _LIBCUDACXX_CONDVAR_INITIALIZER 0
 
 // Semaphore
-typedef void* __cccl_semaphore_t;
+using __cccl_semaphore_t = void*;
 
 // Execute Once
-typedef void* __cccl_exec_once_flag;
+using __cccl_exec_once_flag = void*;
 #  define _LIBCUDACXX_EXEC_ONCE_INITIALIZER 0
 
 // Thread ID
-typedef long __cccl_thread_id;
+using __cccl_thread_id = long;
 
 // Thread
 #  define _LIBCUDACXX_NULL_THREAD 0U
 
-typedef void* __cccl_thread_t;
+using __cccl_thread_t = void*;
 
 // Thread Local Storage
-typedef long __cccl_tls_key;
+using __cccl_tls_key = long;
 
 #  define _LIBCUDACXX_TLS_DESTRUCTOR_CC __stdcall
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
@@ -77,13 +77,13 @@ struct __make_tuple_types
 template <class... _Types, size_t _Ep>
 struct __make_tuple_types<tuple<_Types...>, _Ep, 0, true>
 {
-  typedef _CCCL_NODEBUG_ALIAS __tuple_types<_Types...> type;
+  using type _CCCL_NODEBUG_ALIAS = __tuple_types<_Types...>;
 };
 
 template <class... _Types, size_t _Ep>
 struct __make_tuple_types<__tuple_types<_Types...>, _Ep, 0, true>
 {
-  typedef _CCCL_NODEBUG_ALIAS __tuple_types<_Types...> type;
+  using type _CCCL_NODEBUG_ALIAS = __tuple_types<_Types...>;
 };
 
 template <class _Tp, size_t _Ep = tuple_size<remove_reference_t<_Tp>>::value, size_t _Sp = 0>

--- a/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
@@ -118,7 +118,7 @@ struct __tuple_assignable<_Tp, _Up, true, true>
 template <size_t _Ip, class... _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, tuple<_Tp...>>
 {
-  typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, __tuple_types<_Tp...>> type;
+  using type _CCCL_NODEBUG_ALIAS = __tuple_element_t<_Ip, __tuple_types<_Tp...>>;
 };
 
 template <bool _IsTuple, class _SizeTrait, size_t _Expected>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_element.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_element.h
@@ -39,26 +39,26 @@ using __tuple_element_t _CCCL_NODEBUG_ALIAS = typename tuple_element<_Ip, _Tp...
 template <size_t _Ip, class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, const _Tp>
 {
-  typedef _CCCL_NODEBUG_ALIAS typename add_const<__tuple_element_t<_Ip, _Tp>>::type type;
+  using type _CCCL_NODEBUG_ALIAS = typename add_const<__tuple_element_t<_Ip, _Tp>>::type;
 };
 
 template <size_t _Ip, class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, volatile _Tp>
 {
-  typedef _CCCL_NODEBUG_ALIAS typename add_volatile<__tuple_element_t<_Ip, _Tp>>::type type;
+  using type _CCCL_NODEBUG_ALIAS = typename add_volatile<__tuple_element_t<_Ip, _Tp>>::type;
 };
 
 template <size_t _Ip, class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, const volatile _Tp>
 {
-  typedef _CCCL_NODEBUG_ALIAS typename add_cv<__tuple_element_t<_Ip, _Tp>>::type type;
+  using type _CCCL_NODEBUG_ALIAS = typename add_cv<__tuple_element_t<_Ip, _Tp>>::type;
 };
 
 template <size_t _Ip, class... _Types>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, __tuple_types<_Types...>>
 {
   static_assert(_Ip < sizeof...(_Types), "tuple_element index out of range");
-  typedef _CCCL_NODEBUG_ALIAS __type_index_c<_Ip, _Types...> type;
+  using type _CCCL_NODEBUG_ALIAS = __type_index_c<_Ip, _Types...>;
 };
 
 #if _CCCL_STD_VER > 2011

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_indices.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_indices.h
@@ -29,7 +29,7 @@ template <size_t _Ep, size_t _Sp = 0>
 struct __make_tuple_indices
 {
   static_assert(_Sp <= _Ep, "__make_tuple_indices input error");
-  typedef __make_indices_imp<_Ep, _Sp> type;
+  using type = __make_indices_imp<_Ep, _Sp>;
 };
 
 template <size_t _Ep, size_t _Sp = 0>

--- a/libcudacxx/include/cuda/std/__type_traits/add_const.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_const.h
@@ -25,7 +25,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT add_const
 {
-  typedef _CCCL_NODEBUG_ALIAS const _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = const _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/add_cv.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_cv.h
@@ -25,7 +25,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT add_cv
 {
-  typedef _CCCL_NODEBUG_ALIAS const volatile _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = const volatile _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_lvalue_reference.h
@@ -34,12 +34,12 @@ using add_lvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_LVALUE_REFE
 template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value>
 struct __add_lvalue_reference_impl
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 template <class _Tp>
 struct __add_lvalue_reference_impl<_Tp, true>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp& type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp&;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_pointer.h
@@ -37,12 +37,12 @@ using add_pointer_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_POINTER(_Tp);
 template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value || is_void<_Tp>::value>
 struct __add_pointer_impl
 {
-  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tp>* type;
+  using type _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tp>*;
 };
 template <class _Tp>
 struct __add_pointer_impl<_Tp, false>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_rvalue_reference.h
@@ -34,12 +34,12 @@ using add_rvalue_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_ADD_RVALUE_REFE
 template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value>
 struct __add_rvalue_reference_impl
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 template <class _Tp>
 struct __add_rvalue_reference_impl<_Tp, true>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp&& type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp&&;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/add_volatile.h
+++ b/libcudacxx/include/cuda/std/__type_traits/add_volatile.h
@@ -25,7 +25,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT add_volatile
 {
-  typedef _CCCL_NODEBUG_ALIAS volatile _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = volatile _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/aligned_storage.h
+++ b/libcudacxx/include/cuda/std/__type_traits/aligned_storage.h
@@ -31,7 +31,7 @@ template <class _Tp>
 struct __align_type
 {
   static const size_t value = _LIBCUDACXX_PREFERRED_ALIGNOF(_Tp);
-  typedef _Tp type;
+  using type                = _Tp;
 };
 
 struct __struct_double
@@ -43,17 +43,17 @@ struct __struct_double4
   double __lx[4];
 };
 
-typedef __type_list<__align_type<unsigned char>,
-                    __align_type<unsigned short>,
-                    __align_type<unsigned int>,
-                    __align_type<unsigned long>,
-                    __align_type<unsigned long long>,
-                    __align_type<double>,
-                    __align_type<long double>,
-                    __align_type<__struct_double>,
-                    __align_type<__struct_double4>,
-                    __align_type<int*>>
-  __all_types;
+using __all_types =
+  __type_list<__align_type<unsigned char>,
+              __align_type<unsigned short>,
+              __align_type<unsigned int>,
+              __align_type<unsigned long>,
+              __align_type<unsigned long long>,
+              __align_type<double>,
+              __align_type<long double>,
+              __align_type<__struct_double>,
+              __align_type<__struct_double4>,
+              __align_type<int*>>;
 
 template <size_t _Align>
 struct _CCCL_ALIGNAS(_Align) __fallback_overaligned
@@ -98,7 +98,7 @@ struct __find_max_align : public __type_fold_left<_TL, integral_constant<size_t,
 template <size_t _Len, size_t _Align = __find_max_align<__all_types, _Len>::value>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT aligned_storage
 {
-  typedef typename __find_pod<__all_types, _Align>::type _Aligner;
+  using _Aligner = typename __find_pod<__all_types, _Align>::type;
   union type
   {
     _Aligner __align;

--- a/libcudacxx/include/cuda/std/__type_traits/aligned_union.h
+++ b/libcudacxx/include/cuda/std/__type_traits/aligned_union.h
@@ -47,7 +47,7 @@ struct aligned_union
   static const size_t alignment_value =
     __static_max<_LIBCUDACXX_PREFERRED_ALIGNOF(_Type0), _LIBCUDACXX_PREFERRED_ALIGNOF(_Types)...>::value;
   static const size_t __len = __static_max<_Len, sizeof(_Type0), sizeof(_Types)...>::value;
-  typedef typename aligned_storage<__len, alignment_value>::type type;
+  using type                = typename aligned_storage<__len, alignment_value>::type;
 };
 
 template <size_t _Len, class... _Types>

--- a/libcudacxx/include/cuda/std/__type_traits/common_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/common_type.h
@@ -101,7 +101,7 @@ using __msvc_declval_workaround =
 template <class _Tp, class _Up>
 struct __common_type2_imp<_Tp, _Up, void_t<__cond_type<_Tp, _Up>, __msvc_declval_workaround<_Tp, _Up>>>
 {
-  typedef _CCCL_NODEBUG_ALIAS decay_t<__cond_type<_Tp, _Up>> type;
+  using type _CCCL_NODEBUG_ALIAS = decay_t<__cond_type<_Tp, _Up>>;
 };
 
 template <class, class = void>
@@ -114,7 +114,7 @@ struct __common_types;
 template <class _Tp, class _Up>
 struct __common_type_impl<__common_types<_Tp, _Up>, void_t<common_type_t<_Tp, _Up>>>
 {
-  typedef common_type_t<_Tp, _Up> type;
+  using type = common_type_t<_Tp, _Up>;
 };
 
 template <class _Tp, class _Up, class _Vp, class... _Rest>

--- a/libcudacxx/include/cuda/std/__type_traits/conditional.h
+++ b/libcudacxx/include/cuda/std/__type_traits/conditional.h
@@ -45,12 +45,12 @@ using _If _CCCL_NODEBUG_ALIAS = typename _IfImpl<_Cond>::template _Select<_IfRes
 template <bool _Bp, class _If, class _Then>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional
 {
-  typedef _If type;
+  using type = _If;
 };
 template <class _If, class _Then>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional<false, _If, _Then>
 {
-  typedef _Then type;
+  using type = _Then;
 };
 
 template <bool _Bp, class _If, class _Then>

--- a/libcudacxx/include/cuda/std/__type_traits/decay.h
+++ b/libcudacxx/include/cuda/std/__type_traits/decay.h
@@ -46,27 +46,27 @@ using decay_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_DECAY(_Tp);
 template <class _Up, bool>
 struct __decay_impl
 {
-  typedef _CCCL_NODEBUG_ALIAS remove_cv_t<_Up> type;
+  using type _CCCL_NODEBUG_ALIAS = remove_cv_t<_Up>;
 };
 
 template <class _Up>
 struct __decay_impl<_Up, true>
 {
 public:
-  typedef _CCCL_NODEBUG_ALIAS conditional_t<is_array<_Up>::value,
-                                            remove_extent_t<_Up>*,
-                                            conditional_t<is_function<_Up>::value, add_pointer_t<_Up>, remove_cv_t<_Up>>>
-    type;
+  using type _CCCL_NODEBUG_ALIAS =
+    conditional_t<is_array<_Up>::value,
+                  remove_extent_t<_Up>*,
+                  conditional_t<is_function<_Up>::value, add_pointer_t<_Up>, remove_cv_t<_Up>>>;
 };
 
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT decay
 {
 private:
-  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tp> _Up;
+  using _Up _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tp>;
 
 public:
-  typedef _CCCL_NODEBUG_ALIAS typename __decay_impl<_Up, __cccl_is_referenceable<_Up>::value>::type type;
+  using type _CCCL_NODEBUG_ALIAS = typename __decay_impl<_Up, __cccl_is_referenceable<_Up>::value>::type;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/enable_if.h
+++ b/libcudacxx/include/cuda/std/__type_traits/enable_if.h
@@ -28,7 +28,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT enable_if
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT enable_if<true, _Tp>
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 
 template <bool _Bp, class _Tp = void>

--- a/libcudacxx/include/cuda/std/__type_traits/integral_constant.h
+++ b/libcudacxx/include/cuda/std/__type_traits/integral_constant.h
@@ -26,8 +26,8 @@ template <class _Tp, _Tp __v>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT integral_constant
 {
   static constexpr const _Tp value = __v;
-  typedef _Tp value_type;
-  typedef integral_constant type;
+  using value_type                 = _Tp;
+  using type                       = integral_constant;
   _LIBCUDACXX_HIDE_FROM_ABI constexpr operator value_type() const noexcept
   {
     return value;
@@ -41,8 +41,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT integral_constant
 template <class _Tp, _Tp __v>
 constexpr const _Tp integral_constant<_Tp, __v>::value;
 
-typedef integral_constant<bool, true> true_type;
-typedef integral_constant<bool, false> false_type;
+using true_type  = integral_constant<bool, true>;
+using false_type = integral_constant<bool, false>;
 
 template <bool _Val>
 using _BoolConstant _LIBCUDACXX_DEPRECATED _CCCL_NODEBUG_ALIAS = integral_constant<bool, _Val>;

--- a/libcudacxx/include/cuda/std/__type_traits/is_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_assignable.h
@@ -29,7 +29,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <typename, typename _Tp>
 struct __select_2nd
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 
 #if defined(_CCCL_BUILTIN_IS_ASSIGNABLE) && !defined(_LIBCUDACXX_USE_IS_ASSIGNABLE_FALLBACK)

--- a/libcudacxx/include/cuda/std/__type_traits/is_base_of.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_base_of.h
@@ -58,7 +58,7 @@ struct _Src
 template <size_t>
 struct __one
 {
-  typedef char type;
+  using type = char;
 };
 template <class _Bp, class _Dp>
 _CCCL_HOST_DEVICE typename __one<sizeof(_Dst<_Bp>(_CUDA_VSTD::declval<_Src<_Dp>>()))>::type __test(int);

--- a/libcudacxx/include/cuda/std/__type_traits/is_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_constructible.h
@@ -125,7 +125,7 @@ template <class _Tp, class... _Args>
 struct __cccl_is_constructible
 {
   static_assert(sizeof...(_Args) > 1, "Wrong specialization");
-  typedef decltype(__is_constructible_helper::__test_nary<_Tp, _Args...>(0)) type;
+  using type = decltype(__is_constructible_helper::__test_nary<_Tp, _Args...>(0));
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_destructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_destructible.h
@@ -52,7 +52,7 @@ _CCCL_INLINE_VAR constexpr bool is_destructible_v = _CCCL_BUILTIN_IS_DESTRUCTIBL
 template <class>
 struct __is_destructible_apply
 {
-  typedef int type;
+  using type = int;
 };
 
 template <typename _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
@@ -127,8 +127,8 @@ struct __swappable_with
   _LIBCUDACXX_HIDE_FROM_ABI static __nat __test_swap(long);
 
   // Extra parens are needed for the C++03 definition of decltype.
-  typedef decltype((__test_swap<_Tp, _Up>(0))) __swap1;
-  typedef decltype((__test_swap<_Up, _Tp>(0))) __swap2;
+  using __swap1 = decltype((__test_swap<_Tp, _Up>(0)));
+  using __swap2 = decltype((__test_swap<_Up, _Tp>(0)));
 
   static const bool value = _IsNotSame<__swap1, __nat>::value && _IsNotSame<__swap2, __nat>::value;
 };

--- a/libcudacxx/include/cuda/std/__type_traits/make_signed.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_signed.h
@@ -36,17 +36,17 @@ template <class _Tp>
 using make_signed_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_MAKE_SIGNED(_Tp);
 
 #else
-typedef __type_list<signed char,
-                    signed short,
-                    signed int,
-                    signed long,
-                    signed long long
+using __signed_types =
+  __type_list<signed char,
+              signed short,
+              signed int,
+              signed long,
+              signed long long
 #  ifndef _LIBCUDACXX_HAS_NO_INT128
-                    ,
-                    __int128_t
+              ,
+              __int128_t
 #  endif
-                    >
-  __signed_types;
+              >;
 
 template <class _Tp, bool = is_integral<_Tp>::value || is_enum<_Tp>::value>
 struct __make_signed_impl
@@ -70,53 +70,53 @@ struct __make_signed_impl<bool, true>
 template <>
 struct __make_signed_impl<signed short, true>
 {
-  typedef short type;
+  using type = short;
 };
 template <>
 struct __make_signed_impl<unsigned short, true>
 {
-  typedef short type;
+  using type = short;
 };
 template <>
 struct __make_signed_impl<signed int, true>
 {
-  typedef int type;
+  using type = int;
 };
 template <>
 struct __make_signed_impl<unsigned int, true>
 {
-  typedef int type;
+  using type = int;
 };
 template <>
 struct __make_signed_impl<signed long, true>
 {
-  typedef long type;
+  using type = long;
 };
 template <>
 struct __make_signed_impl<unsigned long, true>
 {
-  typedef long type;
+  using type = long;
 };
 template <>
 struct __make_signed_impl<signed long long, true>
 {
-  typedef long long type;
+  using type = long long;
 };
 template <>
 struct __make_signed_impl<unsigned long long, true>
 {
-  typedef long long type;
+  using type = long long;
 };
 #  ifndef _LIBCUDACXX_HAS_NO_INT128
 template <>
 struct __make_signed_impl<__int128_t, true>
 {
-  typedef __int128_t type;
+  using type = __int128_t;
 };
 template <>
 struct __make_signed_impl<__uint128_t, true>
 {
-  typedef __int128_t type;
+  using type = __int128_t;
 };
 #  endif // !_LIBCUDACXX_HAS_NO_INT128
 

--- a/libcudacxx/include/cuda/std/__type_traits/make_unsigned.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_unsigned.h
@@ -38,17 +38,17 @@ template <class _Tp>
 using make_unsigned_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_MAKE_UNSIGNED(_Tp);
 
 #else
-typedef __type_list<unsigned char,
-                    unsigned short,
-                    unsigned int,
-                    unsigned long,
-                    unsigned long long
+using __unsigned_types =
+  __type_list<unsigned char,
+              unsigned short,
+              unsigned int,
+              unsigned long,
+              unsigned long long
 #  ifndef _LIBCUDACXX_HAS_NO_INT128
-                    ,
-                    __uint128_t
+              ,
+              __uint128_t
 #  endif
-                    >
-  __unsigned_types;
+              >;
 
 template <class _Tp, bool = is_integral<_Tp>::value || is_enum<_Tp>::value>
 struct __make_unsigned_impl
@@ -72,53 +72,53 @@ struct __make_unsigned_impl<bool, true>
 template <>
 struct __make_unsigned_impl<signed short, true>
 {
-  typedef unsigned short type;
+  using type = unsigned short;
 };
 template <>
 struct __make_unsigned_impl<unsigned short, true>
 {
-  typedef unsigned short type;
+  using type = unsigned short;
 };
 template <>
 struct __make_unsigned_impl<signed int, true>
 {
-  typedef unsigned int type;
+  using type = unsigned int;
 };
 template <>
 struct __make_unsigned_impl<unsigned int, true>
 {
-  typedef unsigned int type;
+  using type = unsigned int;
 };
 template <>
 struct __make_unsigned_impl<signed long, true>
 {
-  typedef unsigned long type;
+  using type = unsigned long;
 };
 template <>
 struct __make_unsigned_impl<unsigned long, true>
 {
-  typedef unsigned long type;
+  using type = unsigned long;
 };
 template <>
 struct __make_unsigned_impl<signed long long, true>
 {
-  typedef unsigned long long type;
+  using type = unsigned long long;
 };
 template <>
 struct __make_unsigned_impl<unsigned long long, true>
 {
-  typedef unsigned long long type;
+  using type = unsigned long long;
 };
 #  ifndef _LIBCUDACXX_HAS_NO_INT128
 template <>
 struct __make_unsigned_impl<__int128_t, true>
 {
-  typedef __uint128_t type;
+  using type = __uint128_t;
 };
 template <>
 struct __make_unsigned_impl<__uint128_t, true>
 {
-  typedef __uint128_t type;
+  using type = __uint128_t;
 };
 #  endif // !_LIBCUDACXX_HAS_NO_INT128
 

--- a/libcudacxx/include/cuda/std/__type_traits/promote.h
+++ b/libcudacxx/include/cuda/std/__type_traits/promote.h
@@ -59,7 +59,7 @@ struct __numeric_type
   _LIBCUDACXX_HIDE_FROM_ABI static double __test(double);
   _LIBCUDACXX_HIDE_FROM_ABI static long double __test(long double);
 
-  typedef decltype(__test(declval<_Tp>())) type;
+  using type              = decltype(__test(declval<_Tp>()));
   static const bool value = _IsNotSame<type, void>::value;
 };
 
@@ -128,12 +128,12 @@ template <class _A1, class _A2, class _A3>
 class __promote_imp<_A1, _A2, _A3, true>
 {
 private:
-  typedef typename __promote_imp<_A1>::type __type1;
-  typedef typename __promote_imp<_A2>::type __type2;
-  typedef typename __promote_imp<_A3>::type __type3;
+  using __type1 = typename __promote_imp<_A1>::type;
+  using __type2 = typename __promote_imp<_A2>::type;
+  using __type3 = typename __promote_imp<_A3>::type;
 
 public:
-  typedef decltype(__type1() + __type2() + __type3()) type;
+  using type              = decltype(__type1() + __type2() + __type3());
   static const bool value = true;
 };
 
@@ -145,7 +145,7 @@ private:
   using __type2 = typename __promote_imp<_A2>::type;
 
 public:
-  typedef decltype(__type1() + __type2()) type;
+  using type              = decltype(__type1() + __type2());
   static const bool value = true;
 };
 
@@ -153,7 +153,7 @@ template <class _A1>
 class __promote_imp<_A1, void, void, true>
 {
 public:
-  typedef typename __numeric_type<_A1>::type type;
+  using type              = typename __numeric_type<_A1>::type;
   static const bool value = true;
 };
 

--- a/libcudacxx/include/cuda/std/__type_traits/remove_all_extents.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_all_extents.h
@@ -39,17 +39,17 @@ using remove_all_extents_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_ALL_EXTENT
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_all_extents
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_all_extents<_Tp[]>
 {
-  typedef typename remove_all_extents<_Tp>::type type;
+  using type = typename remove_all_extents<_Tp>::type;
 };
 template <class _Tp, size_t _Np>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_all_extents<_Tp[_Np]>
 {
-  typedef typename remove_all_extents<_Tp>::type type;
+  using type = typename remove_all_extents<_Tp>::type;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/remove_const.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_const.h
@@ -37,12 +37,12 @@ using remove_const_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CONST(_Tp);
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_const
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_const<const _Tp>
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_cv.h
@@ -40,7 +40,7 @@ using remove_cv_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_CV(_Tp);
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_cv
 {
-  typedef remove_volatile_t<remove_const_t<_Tp>> type;
+  using type = remove_volatile_t<remove_const_t<_Tp>>;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/remove_extent.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_extent.h
@@ -38,17 +38,17 @@ using remove_extent_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_EXTENT(_Tp);
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_extent
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_extent<_Tp[]>
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 template <class _Tp, size_t _Np>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_extent<_Tp[_Np]>
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/remove_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_pointer.h
@@ -36,27 +36,27 @@ using remove_pointer_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_POINTER(_Tp);
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer<_Tp*>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer<_Tp* const>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer<_Tp* volatile>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_pointer<_Tp* const volatile>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/remove_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_reference.h
@@ -45,17 +45,17 @@ using remove_reference_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_REFERENCE_T(
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_reference
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_reference<_Tp&>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_reference<_Tp&&>
 {
-  typedef _CCCL_NODEBUG_ALIAS _Tp type;
+  using type _CCCL_NODEBUG_ALIAS = _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/remove_volatile.h
+++ b/libcudacxx/include/cuda/std/__type_traits/remove_volatile.h
@@ -36,12 +36,12 @@ using remove_volatile_t _CCCL_NODEBUG_ALIAS = _CCCL_BUILTIN_REMOVE_VOLATILE(_Tp)
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_volatile
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT remove_volatile<volatile _Tp>
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/type_identity.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_identity.h
@@ -25,7 +25,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct type_identity
 {
-  typedef _Tp type;
+  using type = _Tp;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/underlying_type.h
@@ -36,7 +36,7 @@ struct __underlying_type_impl<_Tp, false>
 template <class _Tp>
 struct __underlying_type_impl<_Tp, true>
 {
-  typedef _CCCL_BUILTIN_UNDERLYING_TYPE(_Tp) type;
+  using type = _CCCL_BUILTIN_UNDERLYING_TYPE(_Tp);
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__utility/convert_to_integral.h
+++ b/libcudacxx/include/cuda/std/__utility/convert_to_integral.h
@@ -79,8 +79,8 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr __uint128_t __convert_to_integral(__uint128_
 template <class _Tp, bool = is_enum<_Tp>::value>
 struct __sfinae_underlying_type
 {
-  typedef typename underlying_type<_Tp>::type type;
-  typedef decltype(((type) 1) + 0) __promoted_type;
+  using type            = typename underlying_type<_Tp>::type;
+  using __promoted_type = decltype(((type) 1) + 0);
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__utility/integer_sequence.h
+++ b/libcudacxx/include/cuda/std/__utility/integer_sequence.h
@@ -61,7 +61,7 @@ struct __repeat;
 template <typename _Tp, _Tp... _Np, size_t... _Extra>
 struct __repeat<__integer_sequence<_Tp, _Np...>, _Extra...>
 {
-  typedef _CCCL_NODEBUG_ALIAS __integer_sequence<
+  using type _CCCL_NODEBUG_ALIAS = __integer_sequence<
     _Tp,
     _Np...,
     sizeof...(_Np) + _Np...,
@@ -71,8 +71,7 @@ struct __repeat<__integer_sequence<_Tp, _Np...>, _Extra...>
     5 * sizeof...(_Np) + _Np...,
     6 * sizeof...(_Np) + _Np...,
     7 * sizeof...(_Np) + _Np...,
-    _Extra...>
-    type;
+    _Extra...>;
 };
 
 template <size_t _Np>
@@ -85,42 +84,42 @@ struct __make : __parity<_Np % 8>::template __pmake<_Np>
 template <>
 struct __make<0>
 {
-  typedef __integer_sequence<size_t> type;
+  using type = __integer_sequence<size_t>;
 };
 template <>
 struct __make<1>
 {
-  typedef __integer_sequence<size_t, 0> type;
+  using type = __integer_sequence<size_t, 0>;
 };
 template <>
 struct __make<2>
 {
-  typedef __integer_sequence<size_t, 0, 1> type;
+  using type = __integer_sequence<size_t, 0, 1>;
 };
 template <>
 struct __make<3>
 {
-  typedef __integer_sequence<size_t, 0, 1, 2> type;
+  using type = __integer_sequence<size_t, 0, 1, 2>;
 };
 template <>
 struct __make<4>
 {
-  typedef __integer_sequence<size_t, 0, 1, 2, 3> type;
+  using type = __integer_sequence<size_t, 0, 1, 2, 3>;
 };
 template <>
 struct __make<5>
 {
-  typedef __integer_sequence<size_t, 0, 1, 2, 3, 4> type;
+  using type = __integer_sequence<size_t, 0, 1, 2, 3, 4>;
 };
 template <>
 struct __make<6>
 {
-  typedef __integer_sequence<size_t, 0, 1, 2, 3, 4, 5> type;
+  using type = __integer_sequence<size_t, 0, 1, 2, 3, 4, 5>;
 };
 template <>
 struct __make<7>
 {
-  typedef __integer_sequence<size_t, 0, 1, 2, 3, 4, 5, 6> type;
+  using type = __integer_sequence<size_t, 0, 1, 2, 3, 4, 5, 6>;
 };
 
 template <>
@@ -192,7 +191,7 @@ using __make_indices_imp _CCCL_NODEBUG_ALIAS =
 template <class _Tp, _Tp... _Ip>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT integer_sequence
 {
-  typedef _Tp value_type;
+  using value_type = _Tp;
   static_assert(is_integral<_Tp>::value, "std::integer_sequence can only be instantiated with an integral type");
   static _LIBCUDACXX_HIDE_FROM_ABI constexpr size_t size() noexcept
   {
@@ -226,7 +225,7 @@ struct __make_integer_sequence_checked
   static_assert(0 <= _Ep, "std::make_integer_sequence must have a non-negative sequence length");
   // Workaround GCC bug by preventing bad installations when 0 <= _Ep
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68929
-  typedef _CCCL_NODEBUG_ALIAS __make_integer_sequence_unchecked<_Tp, 0 <= _Ep ? _Ep : 0> type;
+  using type _CCCL_NODEBUG_ALIAS = __make_integer_sequence_unchecked<_Tp, 0 <= _Ep ? _Ep : 0>;
 };
 
 template <class _Tp, _Tp _Ep>

--- a/libcudacxx/include/cuda/std/__utility/move.h
+++ b/libcudacxx/include/cuda/std/__utility/move.h
@@ -31,7 +31,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 _CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI constexpr remove_reference_t<_Tp>&& move(_Tp&& __t) noexcept
 {
-  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tp> _Up;
+  using _Up _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tp>;
   return static_cast<_Up&&>(__t);
 }
 

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -224,8 +224,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 {
   using __base = __pair_base<_T1, _T2>;
 
-  typedef _T1 first_type;
-  typedef _T2 second_type;
+  using first_type  = _T1;
+  using second_type = _T2;
 
   template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
             enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
@@ -645,13 +645,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, pair<_T1, _T2>>
 template <class _T1, class _T2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<0, pair<_T1, _T2>>
 {
-  typedef _CCCL_NODEBUG_ALIAS _T1 type;
+  using type _CCCL_NODEBUG_ALIAS = _T1;
 };
 
 template <class _T1, class _T2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<1, pair<_T1, _T2>>
 {
-  typedef _CCCL_NODEBUG_ALIAS _T2 type;
+  using type _CCCL_NODEBUG_ALIAS = _T2;
 };
 
 template <size_t _Ip>

--- a/libcudacxx/include/cuda/std/atomic
+++ b/libcudacxx/include/cuda/std/atomic
@@ -761,60 +761,60 @@ _LIBCUDACXX_HIDE_FROM_ABI void atomic_signal_fence(memory_order __m) noexcept
 
 // Atomics for standard typedef types
 
-typedef atomic<bool> atomic_bool;
-typedef atomic<char> atomic_char;
-typedef atomic<signed char> atomic_schar;
-typedef atomic<unsigned char> atomic_uchar;
-typedef atomic<short> atomic_short;
-typedef atomic<unsigned short> atomic_ushort;
-typedef atomic<int> atomic_int;
-typedef atomic<unsigned int> atomic_uint;
-typedef atomic<long> atomic_long;
-typedef atomic<unsigned long> atomic_ulong;
-typedef atomic<long long> atomic_llong;
-typedef atomic<unsigned long long> atomic_ullong;
-typedef atomic<char16_t> atomic_char16_t;
-typedef atomic<char32_t> atomic_char32_t;
-typedef atomic<wchar_t> atomic_wchar_t;
+using atomic_bool     = atomic<bool>;
+using atomic_char     = atomic<char>;
+using atomic_schar    = atomic<signed char>;
+using atomic_uchar    = atomic<unsigned char>;
+using atomic_short    = atomic<short>;
+using atomic_ushort   = atomic<unsigned short>;
+using atomic_int      = atomic<int>;
+using atomic_uint     = atomic<unsigned int>;
+using atomic_long     = atomic<long>;
+using atomic_ulong    = atomic<unsigned long>;
+using atomic_llong    = atomic<long long>;
+using atomic_ullong   = atomic<unsigned long long>;
+using atomic_char16_t = atomic<char16_t>;
+using atomic_char32_t = atomic<char32_t>;
+using atomic_wchar_t  = atomic<wchar_t>;
 
-typedef atomic<int_least8_t> atomic_int_least8_t;
-typedef atomic<uint_least8_t> atomic_uint_least8_t;
-typedef atomic<int_least16_t> atomic_int_least16_t;
-typedef atomic<uint_least16_t> atomic_uint_least16_t;
-typedef atomic<int_least32_t> atomic_int_least32_t;
-typedef atomic<uint_least32_t> atomic_uint_least32_t;
-typedef atomic<int_least64_t> atomic_int_least64_t;
-typedef atomic<uint_least64_t> atomic_uint_least64_t;
+using atomic_int_least8_t   = atomic<int_least8_t>;
+using atomic_uint_least8_t  = atomic<uint_least8_t>;
+using atomic_int_least16_t  = atomic<int_least16_t>;
+using atomic_uint_least16_t = atomic<uint_least16_t>;
+using atomic_int_least32_t  = atomic<int_least32_t>;
+using atomic_uint_least32_t = atomic<uint_least32_t>;
+using atomic_int_least64_t  = atomic<int_least64_t>;
+using atomic_uint_least64_t = atomic<uint_least64_t>;
 
-typedef atomic<int_fast8_t> atomic_int_fast8_t;
-typedef atomic<uint_fast8_t> atomic_uint_fast8_t;
-typedef atomic<int_fast16_t> atomic_int_fast16_t;
-typedef atomic<uint_fast16_t> atomic_uint_fast16_t;
-typedef atomic<int_fast32_t> atomic_int_fast32_t;
-typedef atomic<uint_fast32_t> atomic_uint_fast32_t;
-typedef atomic<int_fast64_t> atomic_int_fast64_t;
-typedef atomic<uint_fast64_t> atomic_uint_fast64_t;
+using atomic_int_fast8_t   = atomic<int_fast8_t>;
+using atomic_uint_fast8_t  = atomic<uint_fast8_t>;
+using atomic_int_fast16_t  = atomic<int_fast16_t>;
+using atomic_uint_fast16_t = atomic<uint_fast16_t>;
+using atomic_int_fast32_t  = atomic<int_fast32_t>;
+using atomic_uint_fast32_t = atomic<uint_fast32_t>;
+using atomic_int_fast64_t  = atomic<int_fast64_t>;
+using atomic_uint_fast64_t = atomic<uint_fast64_t>;
 
-typedef atomic<int8_t> atomic_int8_t;
-typedef atomic<uint8_t> atomic_uint8_t;
-typedef atomic<int16_t> atomic_int16_t;
-typedef atomic<uint16_t> atomic_uint16_t;
-typedef atomic<int32_t> atomic_int32_t;
-typedef atomic<uint32_t> atomic_uint32_t;
-typedef atomic<int64_t> atomic_int64_t;
-typedef atomic<uint64_t> atomic_uint64_t;
+using atomic_int8_t   = atomic<int8_t>;
+using atomic_uint8_t  = atomic<uint8_t>;
+using atomic_int16_t  = atomic<int16_t>;
+using atomic_uint16_t = atomic<uint16_t>;
+using atomic_int32_t  = atomic<int32_t>;
+using atomic_uint32_t = atomic<uint32_t>;
+using atomic_int64_t  = atomic<int64_t>;
+using atomic_uint64_t = atomic<uint64_t>;
 
-typedef atomic<intptr_t> atomic_intptr_t;
-typedef atomic<uintptr_t> atomic_uintptr_t;
-typedef atomic<size_t> atomic_size_t;
-typedef atomic<ptrdiff_t> atomic_ptrdiff_t;
-typedef atomic<intmax_t> atomic_intmax_t;
-typedef atomic<uintmax_t> atomic_uintmax_t;
+using atomic_intptr_t  = atomic<intptr_t>;
+using atomic_uintptr_t = atomic<uintptr_t>;
+using atomic_size_t    = atomic<size_t>;
+using atomic_ptrdiff_t = atomic<ptrdiff_t>;
+using atomic_intmax_t  = atomic<intmax_t>;
+using atomic_uintmax_t = atomic<uintmax_t>;
 
 static_assert(LIBCUDACXX_ATOMIC_INT_LOCK_FREE, "This library assumes atomic<int> is lock-free.");
 
-typedef atomic<int> atomic_signed_lock_free;
-typedef atomic<unsigned> atomic_unsigned_lock_free;
+using atomic_signed_lock_free   = atomic<int>;
+using atomic_unsigned_lock_free = atomic<unsigned>;
 
 #define LIBCUDACXX_ATOMIC_FLAG_INIT     {false}
 #define LIBCUDACXX_ATOMIC_VAR_INIT(__v) {__v}

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -184,14 +184,14 @@ template <size_t _N_words, size_t _Size>
 class __bitset
 {
 public:
-  typedef ptrdiff_t difference_type;
-  typedef size_t size_type;
-  typedef __avoid_promotions<uint32_t> __storage_type;
+  using difference_type = ptrdiff_t;
+  using size_type       = size_t;
+  using __storage_type  = __avoid_promotions<uint32_t>;
 
 protected:
-  typedef __bitset __self;
-  typedef __storage_type* __storage_pointer;
-  typedef const __storage_type* __const_storage_pointer;
+  using __self                          = __bitset;
+  using __storage_pointer               = __storage_type*;
+  using __const_storage_pointer         = const __storage_type*;
   static const unsigned __bits_per_word = static_cast<unsigned>(sizeof(__storage_type) * CHAR_BIT);
 
   friend class __bit_reference<__bitset>;
@@ -202,10 +202,10 @@ protected:
 
   __storage_type __first_[_N_words];
 
-  typedef __bit_reference<__bitset> reference;
-  typedef __bit_const_reference<__bitset> const_reference;
-  typedef __bit_iterator<__bitset, false> iterator;
-  typedef __bit_iterator<__bitset, true> const_iterator;
+  using reference       = __bit_reference<__bitset>;
+  using const_reference = __bit_const_reference<__bitset>;
+  using iterator        = __bit_iterator<__bitset, false>;
+  using const_iterator  = __bit_iterator<__bitset, true>;
 
   _LIBCUDACXX_HIDE_FROM_ABI static constexpr __storage_type __clip_top_word_to_size(unsigned long long __v)
   {
@@ -436,15 +436,15 @@ template <size_t _Size>
 class __bitset<1, _Size>
 {
 public:
-  typedef ptrdiff_t difference_type;
-  typedef size_t size_type;
-  typedef __avoid_promotions<conditional_t<_Size <= 8, uint8_t, conditional_t<_Size <= 16, uint16_t, uint32_t>>>
-    __storage_type;
+  using difference_type = ptrdiff_t;
+  using size_type       = size_t;
+  using __storage_type =
+    __avoid_promotions<conditional_t<_Size <= 8, uint8_t, conditional_t<_Size <= 16, uint16_t, uint32_t>>>;
 
 protected:
-  typedef __bitset __self;
-  typedef __storage_type* __storage_pointer;
-  typedef const __storage_type* __const_storage_pointer;
+  using __self                          = __bitset;
+  using __storage_pointer               = __storage_type*;
+  using __const_storage_pointer         = const __storage_type*;
   static const unsigned __bits_per_word = static_cast<unsigned>(sizeof(__storage_type) * CHAR_BIT);
 
   friend class __bit_reference<__bitset>;
@@ -455,10 +455,10 @@ protected:
 
   __storage_type __first_;
 
-  typedef __bit_reference<__bitset> reference;
-  typedef __bit_const_reference<__bitset> const_reference;
-  typedef __bit_iterator<__bitset, false> iterator;
-  typedef __bit_iterator<__bitset, true> const_iterator;
+  using reference       = __bit_reference<__bitset>;
+  using const_reference = __bit_const_reference<__bitset>;
+  using iterator        = __bit_iterator<__bitset, false>;
+  using const_iterator  = __bit_iterator<__bitset, true>;
 
   _LIBCUDACXX_HIDE_FROM_ABI constexpr __bitset() noexcept
       : __first_(0)
@@ -564,14 +564,14 @@ template <>
 class __bitset<0, 0>
 {
 public:
-  typedef ptrdiff_t difference_type;
-  typedef size_t size_type;
-  typedef __avoid_promotions<uint32_t> __storage_type;
+  using difference_type = ptrdiff_t;
+  using size_type       = size_t;
+  using __storage_type  = __avoid_promotions<uint32_t>;
 
 protected:
-  typedef __bitset __self;
-  typedef __storage_type* __storage_pointer;
-  typedef const __storage_type* __const_storage_pointer;
+  using __self                          = __bitset;
+  using __storage_pointer               = __storage_type*;
+  using __const_storage_pointer         = const __storage_type*;
   static const unsigned __bits_per_word = static_cast<unsigned>(sizeof(__storage_type) * CHAR_BIT);
 
   friend class __bit_reference<__bitset>;
@@ -580,10 +580,10 @@ protected:
   friend class __bit_iterator<__bitset, true>;
   friend struct __bit_array<__bitset>;
 
-  typedef __bit_reference<__bitset> reference;
-  typedef __bit_const_reference<__bitset> const_reference;
-  typedef __bit_iterator<__bitset, false> iterator;
-  typedef __bit_iterator<__bitset, true> const_iterator;
+  using reference       = __bit_reference<__bitset>;
+  using const_reference = __bit_const_reference<__bitset>;
+  using iterator        = __bit_iterator<__bitset, false>;
+  using const_iterator  = __bit_iterator<__bitset, true>;
 
   _LIBCUDACXX_HIDE_FROM_ABI constexpr __bitset() noexcept {}
   _LIBCUDACXX_HIDE_FROM_ABI explicit constexpr __bitset(unsigned long long) noexcept {}
@@ -662,11 +662,11 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT bitset : private __bitset<_Size == 0 ? 0 : (
 {
 public:
   static const unsigned __n_words = _Size == 0 ? 0 : (_Size - 1) / 32 + 1;
-  typedef __bitset<__n_words, _Size> base;
+  using base                      = __bitset<__n_words, _Size>;
 
 public:
-  typedef typename base::reference reference;
-  typedef typename base::const_reference const_reference;
+  using reference       = typename base::reference;
+  using const_reference = typename base::const_reference;
 
   // 23.3.5.1 constructors:
   _LIBCUDACXX_HIDE_FROM_ABI constexpr bitset() noexcept {}

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -144,8 +144,8 @@ extern "C++" {
 #  endif //  _CCCL_COMPILER(CLANG)
 
 #  ifdef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
-typedef unsigned short char16_t;
-typedef unsigned int char32_t;
+using char16_t = unsigned short;
+using char32_t = unsigned int;
 #  endif // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
 
 #  ifdef _LIBCUDACXX_DEBUG

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/array
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/array
@@ -549,6 +549,7 @@ template <size_t _Ip, class _Tp, size_t _Size>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, array<_Tp, _Size>>
 {
   static_assert(_Ip < _Size, "Index out of bounds in std::tuple_element<> (std::array)");
+  using type = _Tp;
 };
 
 template <size_t _Ip, class _Tp, size_t _Size>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/array
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/array
@@ -168,18 +168,18 @@ template <class _Tp, size_t _Size>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT array
 {
   // types:
-  typedef array __self;
-  typedef _Tp value_type;
-  typedef value_type& reference;
-  typedef const value_type& const_reference;
-  typedef value_type* iterator;
-  typedef const value_type* const_iterator;
-  typedef value_type* pointer;
-  typedef const value_type* const_pointer;
-  typedef size_t size_type;
-  typedef ptrdiff_t difference_type;
-  typedef _CUDA_VSTD::reverse_iterator<iterator> reverse_iterator;
-  typedef _CUDA_VSTD::reverse_iterator<const_iterator> const_reverse_iterator;
+  using __self                 = array;
+  using value_type             = _Tp;
+  using reference              = value_type&;
+  using const_reference        = const value_type&;
+  using iterator               = value_type*;
+  using const_iterator         = const value_type*;
+  using pointer                = value_type*;
+  using const_pointer          = const value_type*;
+  using size_type              = size_t;
+  using difference_type        = ptrdiff_t;
+  using reverse_iterator       = _CUDA_VSTD::reverse_iterator<iterator>;
+  using const_reverse_iterator = _CUDA_VSTD::reverse_iterator<const_iterator>;
 
   _Tp __elems_[_Size];
 
@@ -321,20 +321,20 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT array<_Tp, 0>
 {
   // types:
-  typedef array __self;
-  typedef _Tp value_type;
-  typedef value_type& reference;
-  typedef const value_type& const_reference;
-  typedef value_type* iterator;
-  typedef const value_type* const_iterator;
-  typedef value_type* pointer;
-  typedef const value_type* const_pointer;
-  typedef size_t size_type;
-  typedef ptrdiff_t difference_type;
-  typedef _CUDA_VSTD::reverse_iterator<iterator> reverse_iterator;
-  typedef _CUDA_VSTD::reverse_iterator<const_iterator> const_reverse_iterator;
+  using __self                 = array;
+  using value_type             = _Tp;
+  using reference              = value_type&;
+  using const_reference        = const value_type&;
+  using iterator               = value_type*;
+  using const_iterator         = const value_type*;
+  using pointer                = value_type*;
+  using const_pointer          = const value_type*;
+  using size_type              = size_t;
+  using difference_type        = ptrdiff_t;
+  using reverse_iterator       = _CUDA_VSTD::reverse_iterator<iterator>;
+  using const_reverse_iterator = _CUDA_VSTD::reverse_iterator<const_iterator>;
 
-  typedef conditional_t<is_const<_Tp>::value, const char, char> _CharType;
+  using _CharType = conditional_t<is_const<_Tp>::value, const char, char>;
 
   struct _ArrayInStructT
   {
@@ -549,7 +549,6 @@ template <size_t _Ip, class _Tp, size_t _Size>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, array<_Tp, _Size>>
 {
   static_assert(_Ip < _Size, "Index out of bounds in std::tuple_element<> (std::array)");
-  typedef _Tp type;
 };
 
 template <size_t _Ip, class _Tp, size_t _Size>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -907,8 +907,8 @@ struct __is_duration<const volatile duration<_Rep, _Period>> : true_type
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT common_type<chrono::duration<_Rep1, _Period1>, chrono::duration<_Rep2, _Period2>>
 {
-  typedef chrono::duration<typename common_type<_Rep1, _Rep2>::type, typename __ratio_gcd<_Period1, _Period2>::type>
-    type;
+  using type =
+    chrono::duration<typename common_type<_Rep1, _Rep2>::type, typename __ratio_gcd<_Period1, _Period2>::type>;
 };
 
 namespace chrono
@@ -937,7 +937,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, true, false>
 {
   _LIBCUDACXX_HIDE_FROM_ABI constexpr _ToDuration operator()(const _FromDuration& __fd) const
   {
-    typedef typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type _Ct;
+    using _Ct = typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type;
     return _ToDuration(
       static_cast<typename _ToDuration::rep>(static_cast<_Ct>(__fd.count()) / static_cast<_Ct>(_Period::den)));
   }
@@ -948,7 +948,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, false, true>
 {
   _LIBCUDACXX_HIDE_FROM_ABI constexpr _ToDuration operator()(const _FromDuration& __fd) const
   {
-    typedef typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type _Ct;
+    using _Ct = typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type;
     return _ToDuration(
       static_cast<typename _ToDuration::rep>(static_cast<_Ct>(__fd.count()) * static_cast<_Ct>(_Period::num)));
   }
@@ -959,7 +959,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, false, false>
 {
   _LIBCUDACXX_HIDE_FROM_ABI constexpr _ToDuration operator()(const _FromDuration& __fd) const
   {
-    typedef typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type _Ct;
+    using _Ct = typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type;
     return _ToDuration(static_cast<typename _ToDuration::rep>(
       static_cast<_Ct>(__fd.count()) * static_cast<_Ct>(_Period::num) / static_cast<_Ct>(_Period::den)));
   }
@@ -1079,12 +1079,12 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT duration
 
   public:
     static const bool value = (__n1 <= max / __d2) && (__n2 <= max / __d1);
-    typedef ratio<__mul<__n1, __d2, !value>::value, __mul<__n2, __d1, !value>::value> type;
+    using type              = ratio<__mul<__n1, __d2, !value>::value, __mul<__n2, __d1, !value>::value>;
   };
 
 public:
-  typedef _Rep rep;
-  typedef typename _Period::type period;
+  using rep    = _Rep;
+  using period = typename _Period::type;
 
 private:
   rep __rep_;
@@ -1195,17 +1195,17 @@ public:
   }
 };
 
-typedef duration<long long, nano> nanoseconds;
-typedef duration<long long, micro> microseconds;
-typedef duration<long long, milli> milliseconds;
-typedef duration<long long> seconds;
-typedef duration<long, ratio<60>> minutes;
-typedef duration<long, ratio<3600>> hours;
+using nanoseconds  = duration<long long, nano>;
+using microseconds = duration<long long, micro>;
+using milliseconds = duration<long long, milli>;
+using seconds      = duration<long long>;
+using minutes      = duration<long, ratio<60>>;
+using hours        = duration<long, ratio<3600>>;
 #if _CCCL_STD_VER > 2011
-typedef duration<int, ratio_multiply<ratio<24>, hours::period>> days;
-typedef duration<int, ratio_multiply<ratio<7>, days::period>> weeks;
-typedef duration<int, ratio_multiply<ratio<146097, 400>, days::period>> years;
-typedef duration<int, ratio_divide<years::period, ratio<12>>> months;
+using days   = duration<int, ratio_multiply<ratio<24>, hours::period>>;
+using weeks  = duration<int, ratio_multiply<ratio<7>, days::period>>;
+using years  = duration<int, ratio_multiply<ratio<146097, 400>, days::period>>;
+using months = duration<int, ratio_divide<years::period, ratio<12>>>;
 #endif // _CCCL_STD_VER > 2011
 // Duration ==
 
@@ -1214,7 +1214,7 @@ struct __duration_eq
 {
   _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _LhsDuration& __lhs, const _RhsDuration& __rhs) const
   {
-    typedef typename common_type<_LhsDuration, _RhsDuration>::type _Ct;
+    using _Ct = typename common_type<_LhsDuration, _RhsDuration>::type;
     return _Ct(__lhs).count() == _Ct(__rhs).count();
   }
 };
@@ -1251,7 +1251,7 @@ struct __duration_lt
 {
   _LIBCUDACXX_HIDE_FROM_ABI constexpr bool operator()(const _LhsDuration& __lhs, const _RhsDuration& __rhs) const
   {
-    typedef typename common_type<_LhsDuration, _RhsDuration>::type _Ct;
+    using _Ct = typename common_type<_LhsDuration, _RhsDuration>::type;
     return _Ct(__lhs).count() < _Ct(__rhs).count();
   }
 };
@@ -1305,7 +1305,7 @@ template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type
 operator+(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
-  typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type _Cd;
+  using _Cd = typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type;
   return _Cd(_Cd(__lhs).count() + _Cd(__rhs).count());
 }
 
@@ -1315,7 +1315,7 @@ template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type
 operator-(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
-  typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type _Cd;
+  using _Cd = typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type;
   return _Cd(_Cd(__lhs).count() - _Cd(__rhs).count());
 }
 
@@ -1326,8 +1326,8 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<is_convertible<_Rep2, typename c
                                                 duration<typename common_type<_Rep1, _Rep2>::type, _Period>>
 operator*(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
 {
-  typedef typename common_type<_Rep1, _Rep2>::type _Cr;
-  typedef duration<_Cr, _Period> _Cd;
+  using _Cr = typename common_type<_Rep1, _Rep2>::type;
+  using _Cd = duration<_Cr, _Period>;
   return _Cd(_Cd(__d).count() * static_cast<_Cr>(__s));
 }
 
@@ -1347,8 +1347,8 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   duration<typename common_type<_Rep1, _Rep2>::type, _Period>>
 operator/(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
 {
-  typedef typename common_type<_Rep1, _Rep2>::type _Cr;
-  typedef duration<_Cr, _Period> _Cd;
+  using _Cr = typename common_type<_Rep1, _Rep2>::type;
+  using _Cd = duration<_Cr, _Period>;
   return _Cd(_Cd(__d).count() / static_cast<_Cr>(__s));
 }
 
@@ -1356,7 +1356,7 @@ template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr typename common_type<_Rep1, _Rep2>::type
 operator/(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
-  typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type _Ct;
+  using _Ct = typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type;
   return _Ct(__lhs).count() / _Ct(__rhs).count();
 }
 
@@ -1368,8 +1368,8 @@ _LIBCUDACXX_HIDE_FROM_ABI constexpr enable_if_t<
   duration<typename common_type<_Rep1, _Rep2>::type, _Period>>
 operator%(const duration<_Rep1, _Period>& __d, const _Rep2& __s)
 {
-  typedef typename common_type<_Rep1, _Rep2>::type _Cr;
-  typedef duration<_Cr, _Period> _Cd;
+  using _Cr = typename common_type<_Rep1, _Rep2>::type;
+  using _Cd = duration<_Cr, _Period>;
   return _Cd(_Cd(__d).count() % static_cast<_Cr>(__s));
 }
 
@@ -1377,8 +1377,8 @@ template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 _LIBCUDACXX_HIDE_FROM_ABI constexpr typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type
 operator%(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
-  typedef typename common_type<_Rep1, _Rep2>::type _Cr;
-  typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type _Cd;
+  using _Cr = typename common_type<_Rep1, _Rep2>::type;
+  using _Cd = typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::type;
   return _Cd(static_cast<_Cr>(_Cd(__lhs).count()) % static_cast<_Cr>(_Cd(__rhs).count()));
 }
 
@@ -1393,10 +1393,10 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT time_point
                 "Second template parameter of time_point must be a std::chrono::duration");
 
 public:
-  typedef _Clock clock;
-  typedef _Duration duration;
-  typedef typename duration::rep rep;
-  typedef typename duration::period period;
+  using clock    = _Clock;
+  using duration = _Duration;
+  using rep      = typename duration::rep;
+  using period   = typename duration::period;
 
 private:
   duration __d_;
@@ -1454,7 +1454,7 @@ template <class _Clock, class _Duration1, class _Duration2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
 common_type<chrono::time_point<_Clock, _Duration1>, chrono::time_point<_Clock, _Duration2>>
 {
-  typedef chrono::time_point<_Clock, typename common_type<_Duration1, _Duration2>::type> type;
+  using type = chrono::time_point<_Clock, typename common_type<_Duration1, _Duration2>::type>;
 };
 
 namespace chrono
@@ -1558,7 +1558,7 @@ _LIBCUDACXX_HIDE_FROM_ABI
 _CCCL_CONSTEXPR_CXX14 time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2>>::type>
 operator+(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
-  typedef time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2>>::type> _Tr;
+  using _Tr = time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2>>::type>;
   return _Tr(__lhs.time_since_epoch() + __rhs);
 }
 
@@ -1579,7 +1579,7 @@ _LIBCUDACXX_HIDE_FROM_ABI
 _CCCL_CONSTEXPR_CXX14 time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2>>::type>
 operator-(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs)
 {
-  typedef time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2>>::type> _Ret;
+  using _Ret = time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2>>::type>;
   return _Ret(__lhs.time_since_epoch() - __rhs);
 }
 
@@ -1598,10 +1598,10 @@ operator-(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, 
 class _CCCL_TYPE_VISIBILITY_DEFAULT system_clock
 {
 public:
-  typedef _LIBCUDACXX_SYS_CLOCK_DURATION duration;
-  typedef duration::rep rep;
-  typedef duration::period period;
-  typedef chrono::time_point<system_clock> time_point;
+  using duration                                    = _LIBCUDACXX_SYS_CLOCK_DURATION;
+  using rep                                         = duration::rep;
+  using period                                      = duration::period;
+  using time_point                                  = chrono::time_point<system_clock>;
   static _CCCL_CONSTEXPR_CXX14 const bool is_steady = false;
 
   _LIBCUDACXX_HIDE_FROM_ABI static time_point now() noexcept;
@@ -1613,18 +1613,18 @@ public:
 class _CCCL_TYPE_VISIBILITY_DEFAULT steady_clock
 {
 public:
-  typedef nanoseconds duration;
-  typedef duration::rep rep;
-  typedef duration::period period;
-  typedef chrono::time_point<steady_clock, duration> time_point;
+  using duration                                    = nanoseconds;
+  using rep                                         = duration::rep;
+  using period                                      = duration::period;
+  using time_point                                  = chrono::time_point<steady_clock, duration>;
   static _CCCL_CONSTEXPR_CXX14 const bool is_steady = true;
 
   static time_point now() noexcept;
 };
 
-typedef steady_clock high_resolution_clock;
+using high_resolution_clock = steady_clock;
 #else
-typedef system_clock high_resolution_clock;
+using high_resolution_clock = system_clock;
 #endif
 
 #if _CCCL_STD_VER > 2011
@@ -3650,15 +3650,15 @@ _LIBCUDACXX_BEGIN_NAMESPACE_FILESYSTEM
 struct _FilesystemClock
 {
 #  if !defined(_LIBCUDACXX_HAS_NO_INT128)
-  typedef __int128_t rep;
-  typedef nano period;
+  using rep    = __int128_t;
+  using period = nano;
 #  else
-  typedef long long rep;
-  typedef nano period;
+  using rep    = long long;
+  using period = nano;
 #  endif
 
-  typedef chrono::duration<rep, period> duration;
-  typedef chrono::time_point<_FilesystemClock> time_point;
+  using duration   = chrono::duration<rep, period>;
+  using time_point = chrono::time_point<_FilesystemClock>;
 
   _CCCL_VISIBILITY_DEFAULT static _CCCL_CONSTEXPR_CXX14 const bool is_steady = false;
 
@@ -3666,13 +3666,13 @@ struct _FilesystemClock
 
   _LIBCUDACXX_HIDE_FROM_ABI static time_t to_time_t(const time_point& __t) noexcept
   {
-    typedef chrono::duration<rep> __secs;
+    using __secs = chrono::duration<rep>;
     return time_t(chrono::duration_cast<__secs>(__t.time_since_epoch()).count());
   }
 
   _LIBCUDACXX_HIDE_FROM_ABI static time_point from_time_t(time_t __t) noexcept
   {
-    typedef chrono::duration<rep> __secs;
+    using __secs = chrono::duration<rep>;
     return time_point(__secs(__t));
   }
 };

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/ctime
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/ctime
@@ -58,7 +58,7 @@ int timespec_get( struct timespec *ts, int base); // C++17
 #if !_CCCL_COMPILER(NVRTC)
 #  include <time.h>
 #else
-typedef long long int time_t;
+using time_t = long long int;
 #endif // _CCCL_COMPILER(NVRTC)
 
 _CCCL_PUSH_MACROS

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/optional
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/optional
@@ -272,7 +272,7 @@ struct __optional_destruct_base;
 template <class _Tp>
 struct __optional_destruct_base<_Tp, false>
 {
-  typedef _Tp value_type;
+  using value_type = _Tp;
   static_assert(_CCCL_TRAIT(is_object, value_type),
                 "instantiation of optional with a non-object type is undefined behavior");
   union
@@ -323,7 +323,7 @@ struct __optional_destruct_base<_Tp, false>
 template <class _Tp>
 struct __optional_destruct_base<_Tp, true>
 {
-  typedef _Tp value_type;
+  using value_type = _Tp;
   static_assert(_CCCL_TRAIT(is_object, value_type),
                 "instantiation of optional with a non-object type is undefined behavior");
   union
@@ -1404,8 +1404,8 @@ template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<__enable_hash_helper<optional<_Tp>, remove_const_t<_Tp>>>
 {
 #    if _CCCL_STD_VER <= 2017 || defined(_LIBCUDACXX_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef optional<_Tp> argument_type;
-  _LIBCUDACXX_DEPRECATED_IN_CXX17 typedef size_t result_type;
+  using argument_type _LIBCUDACXX_DEPRECATED_IN_CXX17 = optional<_Tp>;
+  using result_type _LIBCUDACXX_DEPRECATED_IN_CXX17   = size_t;
 #    endif
 
   _LIBCUDACXX_HIDE_FROM_ABI size_t operator()(const optional<_Tp>& __opt) const

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/ratio
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/ratio
@@ -269,7 +269,7 @@ public:
   static constexpr intmax_t num = __s * __na / __gcd;
   static constexpr intmax_t den = __da / __gcd;
 
-  typedef ratio<num, den> type;
+  using type = ratio<num, den>;
 };
 
 template <intmax_t _Num, intmax_t _Den>
@@ -285,22 +285,22 @@ template <intmax_t _Num, intmax_t _Den>
 struct __is_ratio<ratio<_Num, _Den>> : true_type
 {};
 
-typedef ratio<1LL, 1000000000000000000LL> atto;
-typedef ratio<1LL, 1000000000000000LL> femto;
-typedef ratio<1LL, 1000000000000LL> pico;
-typedef ratio<1LL, 1000000000LL> nano;
-typedef ratio<1LL, 1000000LL> micro;
-typedef ratio<1LL, 1000LL> milli;
-typedef ratio<1LL, 100LL> centi;
-typedef ratio<1LL, 10LL> deci;
-typedef ratio<10LL, 1LL> deca;
-typedef ratio<100LL, 1LL> hecto;
-typedef ratio<1000LL, 1LL> kilo;
-typedef ratio<1000000LL, 1LL> mega;
-typedef ratio<1000000000LL, 1LL> giga;
-typedef ratio<1000000000000LL, 1LL> tera;
-typedef ratio<1000000000000000LL, 1LL> peta;
-typedef ratio<1000000000000000000LL, 1LL> exa;
+using atto  = ratio<1LL, 1000000000000000000LL>;
+using femto = ratio<1LL, 1000000000000000LL>;
+using pico  = ratio<1LL, 1000000000000LL>;
+using nano  = ratio<1LL, 1000000000LL>;
+using micro = ratio<1LL, 1000000LL>;
+using milli = ratio<1LL, 1000LL>;
+using centi = ratio<1LL, 100LL>;
+using deci  = ratio<1LL, 10LL>;
+using deca  = ratio<10LL, 1LL>;
+using hecto = ratio<100LL, 1LL>;
+using kilo  = ratio<1000LL, 1LL>;
+using mega  = ratio<1000000LL, 1LL>;
+using giga  = ratio<1000000000LL, 1LL>;
+using tera  = ratio<1000000000000LL, 1LL>;
+using peta  = ratio<1000000000000000LL, 1LL>;
+using exa   = ratio<1000000000000000000LL, 1LL>;
 
 template <class _R1, class _R2>
 struct __ratio_multiply
@@ -310,8 +310,8 @@ struct __ratio_multiply
   static const intmax_t __gcd_d1_n2 = __static_gcd<_R1::den, _R2::num>::value;
 
 public:
-  typedef typename ratio<__ll_mul<_R1::num / __gcd_n1_d2, _R2::num / __gcd_d1_n2>::value,
-                         __ll_mul<_R2::den / __gcd_n1_d2, _R1::den / __gcd_d1_n2>::value>::type type;
+  using type = typename ratio<__ll_mul<_R1::num / __gcd_n1_d2, _R2::num / __gcd_d1_n2>::value,
+                              __ll_mul<_R2::den / __gcd_n1_d2, _R1::den / __gcd_d1_n2>::value>::type;
 };
 
 template <class _R1, class _R2>
@@ -325,8 +325,8 @@ struct __ratio_divide
   static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
 
 public:
-  typedef typename ratio<__ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,
-                         __ll_mul<_R2::num / __gcd_n1_n2, _R1::den / __gcd_d1_d2>::value>::type type;
+  using type = typename ratio<__ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,
+                              __ll_mul<_R2::num / __gcd_n1_n2, _R1::den / __gcd_d1_d2>::value>::type;
 };
 
 template <class _R1, class _R2>
@@ -340,11 +340,11 @@ struct __ratio_add
   static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
 
 public:
-  typedef
+  using type =
     typename ratio_multiply<ratio<__gcd_n1_n2, _R1::den / __gcd_d1_d2>,
                             ratio<__ll_add<__ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,
                                            __ll_mul<_R2::num / __gcd_n1_n2, _R1::den / __gcd_d1_d2>::value>::value,
-                                  _R2::den>>::type type;
+                                  _R2::den>>::type;
 };
 
 template <class _R1, class _R2>
@@ -358,11 +358,11 @@ struct __ratio_subtract
   static const intmax_t __gcd_d1_d2 = __static_gcd<_R1::den, _R2::den>::value;
 
 public:
-  typedef
+  using type =
     typename ratio_multiply<ratio<__gcd_n1_n2, _R1::den / __gcd_d1_d2>,
                             ratio<__ll_sub<__ll_mul<_R1::num / __gcd_n1_n2, _R2::den / __gcd_d1_d2>::value,
                                            __ll_mul<_R2::num / __gcd_n1_n2, _R1::den / __gcd_d1_d2>::value>::value,
-                                  _R2::den>>::type type;
+                                  _R2::den>>::type;
 };
 
 template <class _R1, class _R2>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/ratio
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/ratio
@@ -456,7 +456,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT ratio_greater_equal : public bool_constant<
 template <class _R1, class _R2>
 struct __ratio_gcd
 {
-  typedef ratio<__static_gcd<_R1::num, _R2::num>::value, __static_lcm<_R1::den, _R2::den>::value> type;
+  using type = ratio<__static_gcd<_R1::num, _R2::num>::value, __static_lcm<_R1::den, _R2::den>::value>;
 };
 
 #if !defined(_CCCL_NO_VARIABLE_TEMPLATES)

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -723,7 +723,7 @@ struct __tuple_constraints
 template <class... _Tp>
 class _CCCL_TYPE_VISIBILITY_DEFAULT tuple
 {
-  typedef __tuple_impl<__make_tuple_indices_t<sizeof...(_Tp)>, _Tp...> _BaseT;
+  using _BaseT = __tuple_impl<__make_tuple_indices_t<sizeof...(_Tp)>, _Tp...>;
 
   _BaseT __base_;
 
@@ -739,28 +739,28 @@ public:
   template <size_t _Ip>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __tuple_element_t<_Ip, tuple>& __get_impl() & noexcept
   {
-    typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, tuple> type;
+    using type _CCCL_NODEBUG_ALIAS = __tuple_element_t<_Ip, tuple>;
     return static_cast<__tuple_leaf<_Ip, type>&>(__base_).get();
   }
 
   template <size_t _Ip>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 const __tuple_element_t<_Ip, tuple>& __get_impl() const& noexcept
   {
-    typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, tuple> type;
+    using type _CCCL_NODEBUG_ALIAS = __tuple_element_t<_Ip, tuple>;
     return static_cast<const __tuple_leaf<_Ip, type>&>(__base_).get();
   }
 
   template <size_t _Ip>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 __tuple_element_t<_Ip, tuple>&& __get_impl() && noexcept
   {
-    typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, tuple> type;
+    using type _CCCL_NODEBUG_ALIAS = __tuple_element_t<_Ip, tuple>;
     return static_cast<type&&>(static_cast<__tuple_leaf<_Ip, type>&&>(__base_).get());
   }
 
   template <size_t _Ip>
   _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 const __tuple_element_t<_Ip, tuple>&& __get_impl() const&& noexcept
   {
-    typedef _CCCL_NODEBUG_ALIAS __tuple_element_t<_Ip, tuple> type;
+    using type _CCCL_NODEBUG_ALIAS = __tuple_element_t<_Ip, tuple>;
     return static_cast<const type&&>(static_cast<const __tuple_leaf<_Ip, type>&&>(__base_).get());
   }
 
@@ -1216,7 +1216,7 @@ struct __tuple_cat_type;
 template <class... _Ttypes, class... _Utypes>
 struct __tuple_cat_type<tuple<_Ttypes...>, __tuple_types<_Utypes...>>
 {
-  typedef _CCCL_NODEBUG_ALIAS tuple<_Ttypes..., _Utypes...> type;
+  using type _CCCL_NODEBUG_ALIAS = tuple<_Ttypes..., _Utypes...>;
 };
 
 template <class _ResultTuple, bool _Is_Tuple0TupleLike, class... _Tuples>
@@ -1226,8 +1226,8 @@ struct __tuple_cat_return_1
 template <class... _Types, class _Tuple0>
 struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0>
 {
-  typedef _CCCL_NODEBUG_ALIAS
-    typename __tuple_cat_type<tuple<_Types...>, __make_tuple_types_t<remove_cvref_t<_Tuple0>>>::type type;
+  using type _CCCL_NODEBUG_ALIAS =
+    typename __tuple_cat_type<tuple<_Types...>, __make_tuple_types_t<remove_cvref_t<_Tuple0>>>::type;
 };
 
 template <class... _Types, class _Tuple0, class _Tuple1, class... _Tuples>
@@ -1250,7 +1250,7 @@ struct __tuple_cat_return<_Tuple0, _Tuples...>
 template <>
 struct __tuple_cat_return<>
 {
-  typedef _CCCL_NODEBUG_ALIAS tuple<> type;
+  using type _CCCL_NODEBUG_ALIAS = tuple<>;
 };
 
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 tuple<> tuple_cat()
@@ -1264,8 +1264,8 @@ struct __tuple_cat_return_ref_imp;
 template <class... _Types, size_t... _I0, class _Tuple0>
 struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>, _Tuple0>
 {
-  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tuple0> _T0;
-  typedef tuple<_Types..., __copy_cvref_t<_Tuple0, __tuple_element_t<_I0, _T0>>&&...> type;
+  using _T0 _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tuple0>;
+  using type                    = tuple<_Types..., __copy_cvref_t<_Tuple0, __tuple_element_t<_I0, _T0>>&&...>;
 };
 
 template <class... _Types, size_t... _I0, class _Tuple0, class _Tuple1, class... _Tuples>
@@ -1306,8 +1306,8 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
   operator()(tuple<_Types...> __t, _Tuple0&& __t0, _Tuple1&& __t1, _Tuples&&... __tpls)
   {
     (void) __t;
-    typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tuple0> _T0;
-    typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tuple1> _T1;
+    using _T0 _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tuple0>;
+    using _T1 _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tuple1>;
     return __tuple_cat<tuple<_Types..., __copy_cvref_t<_Tuple0, __tuple_element_t<_J0, _T0>>&&...>,
                        __make_tuple_indices_t<sizeof...(_Types) + tuple_size<_T0>::value>,
                        __make_tuple_indices_t<tuple_size<_T1>::value>>()(
@@ -1322,7 +1322,7 @@ template <class _Tuple0, class... _Tuples>
 _LIBCUDACXX_HIDE_FROM_ABI _CCCL_CONSTEXPR_CXX14 typename __tuple_cat_return<_Tuple0, _Tuples...>::type
 tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls)
 {
-  typedef _CCCL_NODEBUG_ALIAS remove_reference_t<_Tuple0> _T0;
+  using _T0 _CCCL_NODEBUG_ALIAS = remove_reference_t<_Tuple0>;
   return __tuple_cat<tuple<>, __tuple_indices<>, __make_tuple_indices_t<tuple_size<_T0>::value>>()(
     tuple<>(), _CUDA_VSTD::forward<_Tuple0>(__t0), _CUDA_VSTD::forward<_Tuples>(__tpls)...);
 }


### PR DESCRIPTION
This PR replaces all `typedef`s with modern `using` syntax in all "alive" headers in libcu++.