### PR TITLE
Compile basic infra test with C++17

### DIFF
--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 
 # Creates a cmake executable target for the main program
 add_executable(example_project example.cu)
+target_compile_features(example_project PUBLIC cuda_std_17)
 
 # "Links" the CCCL Cmake target to the `example_project` executable. This configures everything needed to use
 # CCCL headers, including setting up include paths, compiler flags, etc.


### PR DESCRIPTION
Compiling `example/basic` requires C++17 since it uses Thrust, but no CXX standard is required by CMake. This caused a CI failure here on PR #3310: https://github.com/NVIDIA/cccl/actions/runs/12752907580/job/35573954322?pr=3310. This was somehow missed in #3255.