### PR TITLE
Implement more cmath functions to be usable on host and device

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -150,6 +150,20 @@
 #  undef _CCCL_BUILTIN_BSWAP128
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 
+#if _CCCL_CHECK_BUILTIN(builtin_cbrt) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_CBRTF(...) __builtin_cbrtf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_CBRT(...)  __builtin_cbrt(__VA_ARGS__)
+#  define _CCCL_BUILTIN_CBRTL(...) __builtin_cbrtl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_cbrt)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "cbrt"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_CBRTF
+#  undef _CCCL_BUILTIN_CBRT
+#  undef _CCCL_BUILTIN_CBRTL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_ceil) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_CEILF(...) __builtin_ceilf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_CEIL(...)  __builtin_ceil(__VA_ARGS__)
@@ -574,6 +588,19 @@
 // Below 11.7 nvcc treats the builtin as a host only function
 #if _CCCL_CUDACC_BELOW(11, 7)
 #  undef _CCCL_BUILTIN_SIGNBIT
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_sqrt) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SQRTF(...) __builtin_sqrtf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SQRT(...)  __builtin_sqrt(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SQRTL(...) __builtin_sqrtl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_sqrt)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_SQRTF
+#  undef _CCCL_BUILTIN_SQRT
+#  undef _CCCL_BUILTIN_SQRTL
 #endif // _CCCL_CUDACC_BELOW(11, 7)
 
 #if _CCCL_CHECK_BUILTIN(builtin_trunc) || _CCCL_COMPILER(GCC)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -193,6 +193,48 @@
 #  define _CCCL_BUILTIN_CONSTANT_P(...) __builtin_constant_p(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_contant_p)
 
+#if _CCCL_CHECK_BUILTIN(builtin_exp) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_EXPF(...) __builtin_expf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXP(...)  __builtin_exp(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXPL(...) __builtin_expl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_exp)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "expf"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_EXPF
+#  undef _CCCL_BUILTIN_EXP
+#  undef _CCCL_BUILTIN_EXPL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+
+#if _CCCL_CHECK_BUILTIN(builtin_exp2) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_EXP2F(...) __builtin_exp2f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXP2(...)  __builtin_exp2(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXP2L(...) __builtin_exp2l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_exp2)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "exp2"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_EXP2F
+#  undef _CCCL_BUILTIN_EXP2
+#  undef _CCCL_BUILTIN_EXP2L
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+
+#if _CCCL_CHECK_BUILTIN(builtin_expm1) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_EXPM1F(...) __builtin_expm1f(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXPM1(...)  __builtin_expm1(__VA_ARGS__)
+#  define _CCCL_BUILTIN_EXPM1L(...) __builtin_expm1l(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_expm1)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "expm1"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_EXPM1F
+#  undef _CCCL_BUILTIN_EXPM1
+#  undef _CCCL_BUILTIN_EXPM1L
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_expect) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_EXPECT(...) __builtin_expect(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_expect)
@@ -256,6 +298,20 @@
 #if _CCCL_CUDACC_BELOW(11, 7)
 #  undef _CCCL_BUILTIN_FPCLASSIFY
 #endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_frexp) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FREXPF(...) __builtin_frexpf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FREXP(...)  __builtin_frexp(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FREXPL(...) __builtin_frexpl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_frexp)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "frexp"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_FREXPF
+#  undef _CCCL_BUILTIN_FREXP
+#  undef _CCCL_BUILTIN_FREXPL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_HAS_BUILTIN(__builtin_FUNCTION) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_FUNCTION() __builtin_FUNCTION()
@@ -329,6 +385,20 @@
 #if _CCCL_COMPILER(CLANG, <, 10) || _CCCL_CUDACC_BELOW(11, 3)
 #  undef _CCCL_BUILTIN_LAUNDER
 #endif // clang < 10 || nvcc < 11.3
+
+#if _CCCL_CHECK_BUILTIN(builtin_ldexp) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LDEXPF(...) __builtin_ldexpf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LDEXP(...)  __builtin_ldexp(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LDEXPL(...) __builtin_ldexpl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_ldexp)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "ldexp"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LDEXPF
+#  undef _CCCL_BUILTIN_LDEXP
+#  undef _CCCL_BUILTIN_LDEXPL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_HAS_BUILTIN(__builtin_LINE) || _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_LINE() __builtin_LINE()
@@ -555,6 +625,20 @@
 #  define _CCCL_BUILTIN_OPERATOR_NEW(...)    __builtin_operator_new(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(__builtin_operator_new) && _CCCL_CHECK_BUILTIN(__builtin_operator_delete)
 
+#if _CCCL_CHECK_BUILTIN(builtin_pow) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_POWF(...) __builtin_powf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_POW(...)  __builtin_pow(__VA_ARGS__)
+#  define _CCCL_BUILTIN_POWL(...) __builtin_powl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_pow)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "pow"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_POWF
+#  undef _CCCL_BUILTIN_POW
+#  undef _CCCL_BUILTIN_POWL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+
 #if _CCCL_CHECK_BUILTIN(builtin_rint) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_RINTF(...) __builtin_rintf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_RINT(...)  __builtin_rint(__VA_ARGS__)
@@ -580,6 +664,34 @@
 #  undef _CCCL_BUILTIN_ROUND
 #  undef _CCCL_BUILTIN_ROUNDL
 #endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_scalbln) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SCALBLNF(...) __builtin_scalblnf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SCALBLN(...)  __builtin_scalbln(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SCALBLNL(...) __builtin_scalblnl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_scalbln)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "scalblnf"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_SCALBLNF
+#  undef _CCCL_BUILTIN_SCALBLN
+#  undef _CCCL_BUILTIN_SCALBLNL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+
+#if _CCCL_CHECK_BUILTIN(builtin_scalbn) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_SCALBNF(...) __builtin_scalbnf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SCALBN(...)  __builtin_scalbn(__VA_ARGS__)
+#  define _CCCL_BUILTIN_SCALBNL(...) __builtin_scalbnl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_scalbn)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "scalbnf"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_SCALBNF
+#  undef _CCCL_BUILTIN_SCALBN
+#  undef _CCCL_BUILTIN_SCALBNL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_signbit) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_SIGNBIT(...) __builtin_signbit(__VA_ARGS__)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -150,6 +150,19 @@
 #  undef _CCCL_BUILTIN_BSWAP128
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 
+#if _CCCL_CHECK_BUILTIN(builtin_ceil) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_CEILF(...) __builtin_ceilf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_CEIL(...)  __builtin_ceil(__VA_ARGS__)
+#  define _CCCL_BUILTIN_CEILL(...) __builtin_ceill(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_ceil)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_CEILF
+#  undef _CCCL_BUILTIN_CEIL
+#  undef _CCCL_BUILTIN_CEILL
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
 #if _CCCL_HAS_BUILTIN(__builtin_COLUMN) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_COLUMN() __builtin_COLUMN()
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_COLUMN) ^^^ / vvv !_CCCL_HAS_BUILTIN(__builtin_COLUMN) vvv
@@ -169,6 +182,19 @@
 #if _CCCL_CHECK_BUILTIN(builtin_expect) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_EXPECT(...) __builtin_expect(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_expect)
+
+#if _CCCL_CHECK_BUILTIN(builtin_floor) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FLOORF(...) __builtin_floorf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FLOOR(...)  __builtin_floor(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FLOORL(...) __builtin_floorl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_floor)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_FLOORF
+#  undef _CCCL_BUILTIN_FLOOR
+#  undef _CCCL_BUILTIN_FLOORL
+#endif // _CCCL_CUDACC_BELOW(11, 7)
 
 #if _CCCL_CHECK_BUILTIN(builtin_fmax) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_FMAXF(...) __builtin_fmaxf(__VA_ARGS__)
@@ -229,6 +255,20 @@
 #  define _CCCL_BUILTIN_FUNCTION() "__builtin_FUNCTION is unsupported"
 #endif // _CCCL_CUDACC_BELOW(11, 3)
 
+#if _CCCL_CHECK_BUILTIN(builtin_huge_valf) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC, <, 10)
+#  define _CCCL_BUILTIN_HUGE_VALF() __builtin_huge_valf()
+#endif // _CCCL_CHECK_BUILTIN(builtin_huge_valf)
+
+#if _CCCL_CHECK_BUILTIN(builtin_huge_val) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC, <, 10)
+#  define _CCCL_BUILTIN_HUGE_VAL() __builtin_huge_val()
+#endif // _CCCL_CHECK_BUILTIN(builtin_huge_val)
+
+#if _CCCL_CHECK_BUILTIN(builtin_huge_vall) || _CCCL_COMPILER(GCC, <, 10)
+#  define _CCCL_BUILTIN_HUGE_VALL() __builtin_huge_vall()
+#elif _CCCL_COMPILER(MSVC)
+#  define _CCCL_BUILTIN_HUGE_VALL() static_cast<long double>(__builtin_huge_val())
+#endif // _CCCL_CHECK_BUILTIN(builtin_huge_vall)
+
 #if _CCCL_CHECK_BUILTIN(builtin_is_constant_evaluated) || _CCCL_COMPILER(GCC, >=, 9) \
   || (_CCCL_COMPILER(MSVC, >, 19, 24) && _CCCL_CUDACC_AT_LEAST(11, 3))
 #  define _CCCL_BUILTIN_IS_CONSTANT_EVALUATED(...) __builtin_is_constant_evaluated(__VA_ARGS__)
@@ -288,19 +328,60 @@
 #  define _CCCL_BUILTIN_LINE() __LINE__
 #endif // _CCCL_CUDACC_BELOW(11, 3)
 
-#if _CCCL_CHECK_BUILTIN(builtin_huge_valf) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC, <, 10)
-#  define _CCCL_BUILTIN_HUGE_VALF() __builtin_huge_valf()
-#endif // _CCCL_CHECK_BUILTIN(builtin_huge_valf)
+#if _CCCL_CHECK_BUILTIN(builtin_llrint) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LLRINTF(...) __builtin_llrintf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LLRINT(...)  __builtin_llrint(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LLRINTL(...) __builtin_llrintl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_llrint)
 
-#if _CCCL_CHECK_BUILTIN(builtin_huge_val) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC, <, 10)
-#  define _CCCL_BUILTIN_HUGE_VAL() __builtin_huge_val()
-#endif // _CCCL_CHECK_BUILTIN(builtin_huge_val)
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "llrint"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LLRINTF
+#  undef _CCCL_BUILTIN_LLRINT
+#  undef _CCCL_BUILTIN_LLRINTL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
 
-#if _CCCL_CHECK_BUILTIN(builtin_huge_vall) || _CCCL_COMPILER(GCC, <, 10)
-#  define _CCCL_BUILTIN_HUGE_VALL() __builtin_huge_vall()
-#elif _CCCL_COMPILER(MSVC)
-#  define _CCCL_BUILTIN_HUGE_VALL() static_cast<long double>(__builtin_huge_val())
-#endif // _CCCL_CHECK_BUILTIN(builtin_huge_vall)
+#if _CCCL_CHECK_BUILTIN(builtin_llround) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LLROUNDF(...) __builtin_llroundf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LLROUND(...)  __builtin_llround(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LLROUNDL(...) __builtin_llroundl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_llround)
+
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "llround"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LLROUNDF
+#  undef _CCCL_BUILTIN_LLROUND
+#  undef _CCCL_BUILTIN_LLROUNDL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+
+#if _CCCL_CHECK_BUILTIN(builtin_lrint) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LRINTF(...) __builtin_lrintf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LRINT(...)  __builtin_lrint(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LRINTL(...) __builtin_lrintl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_lrint)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "lrint"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LRINTF
+#  undef _CCCL_BUILTIN_LRINT
+#  undef _CCCL_BUILTIN_LRINTL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+
+#if _CCCL_CHECK_BUILTIN(builtin_lround) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_LROUNDF(...) __builtin_lroundf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LROUND(...)  __builtin_lround(__VA_ARGS__)
+#  define _CCCL_BUILTIN_LROUNDL(...) __builtin_lroundl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_lround)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "lround"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_LROUNDF
+#  undef _CCCL_BUILTIN_LROUND
+#  undef _CCCL_BUILTIN_LROUNDL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_nanf) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(GCC, <, 10)
 #  define _CCCL_BUILTIN_NANF(...) __builtin_nanf(__VA_ARGS__)
@@ -330,6 +411,46 @@
 #  define _CCCL_BUILTIN_NANSL(...) static_cast<long double>(__builtin_nans(__VA_ARGS__))
 #endif // _CCCL_CHECK_BUILTIN(builtin_nansl)
 
+#if _CCCL_CHECK_BUILTIN(builtin_nearbyint) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_NEARBYINTF(...) __builtin_nearbyintf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEARBYINT(...)  __builtin_nearbyint(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEARBYINTL(...) __builtin_nearbyintl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_nearbyint)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_NEARBYINTF
+#  undef _CCCL_BUILTIN_NEARBYINT
+#  undef _CCCL_BUILTIN_NEARBYINTL
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_nextafter) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_NEXTAFTERF(...) __builtin_nextafterf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEXTAFTER(...)  __builtin_nextafter(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEXTAFTERL(...) __builtin_nextafterl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_nextafter)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+// clang-cuda fails with fatal error: error in backend: Undefined external symbol "nextafter"
+#if _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+#  undef _CCCL_BUILTIN_NEXTAFTERF
+#  undef _CCCL_BUILTIN_NEXTAFTER
+#  undef _CCCL_BUILTIN_NEXTAFTERL
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
+
+#if _CCCL_CHECK_BUILTIN(builtin_nexttoward) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_NEXTTOWARDF(...) __builtin_nexttowardf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEXTTOWARD(...)  __builtin_nexttoward(__VA_ARGS__)
+#  define _CCCL_BUILTIN_NEXTTOWARDL(...) __builtin_nexttowardl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_nexttoward)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_NEXTTOWARDF
+#  undef _CCCL_BUILTIN_NEXTTOWARD
+#  undef _CCCL_BUILTIN_NEXTTOWARDL
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
 #if _CCCL_CHECK_BUILTIN(builtin_log) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_LOGF(...) __builtin_logf(__VA_ARGS__)
 #  define _CCCL_BUILTIN_LOG(...)  __builtin_log(__VA_ARGS__)
@@ -356,7 +477,7 @@
 #  undef _CCCL_BUILTIN_LOG10F
 #  undef _CCCL_BUILTIN_LOG10
 #  undef _CCCL_BUILTIN_LOG10L
-#endif // _CCCL_CUDACC_BELOW(11, 7)
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_ilogb) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_ILOGBF(...) __builtin_ilogbf(__VA_ARGS__)
@@ -398,7 +519,7 @@
 #  undef _CCCL_BUILTIN_LOG2F
 #  undef _CCCL_BUILTIN_LOG2
 #  undef _CCCL_BUILTIN_LOG2L
-#endif // _CCCL_CUDACC_BELOW(11, 7)
+#endif // _CCCL_CUDACC_BELOW(11, 7) || _CCCL_CUDA_COMPILER(CLANG)
 
 #if _CCCL_CHECK_BUILTIN(builtin_logb) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_LOGBF(...) __builtin_logbf(__VA_ARGS__)
@@ -420,6 +541,32 @@
 #  define _CCCL_BUILTIN_OPERATOR_NEW(...)    __builtin_operator_new(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(__builtin_operator_new) && _CCCL_CHECK_BUILTIN(__builtin_operator_delete)
 
+#if _CCCL_CHECK_BUILTIN(builtin_rint) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_RINTF(...) __builtin_rintf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_RINT(...)  __builtin_rint(__VA_ARGS__)
+#  define _CCCL_BUILTIN_RINTL(...) __builtin_rintl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_rint)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_RINTF
+#  undef _CCCL_BUILTIN_RINT
+#  undef _CCCL_BUILTIN_RINTL
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_round) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_ROUNDF(...) __builtin_roundf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ROUND(...)  __builtin_round(__VA_ARGS__)
+#  define _CCCL_BUILTIN_ROUNDL(...) __builtin_roundl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_round)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_ROUNDF
+#  undef _CCCL_BUILTIN_ROUND
+#  undef _CCCL_BUILTIN_ROUNDL
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
 #if _CCCL_CHECK_BUILTIN(builtin_signbit) || _CCCL_COMPILER(GCC)
 #  define _CCCL_BUILTIN_SIGNBIT(...) __builtin_signbit(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_signbit)
@@ -427,6 +574,19 @@
 // Below 11.7 nvcc treats the builtin as a host only function
 #if _CCCL_CUDACC_BELOW(11, 7)
 #  undef _CCCL_BUILTIN_SIGNBIT
+#endif // _CCCL_CUDACC_BELOW(11, 7)
+
+#if _CCCL_CHECK_BUILTIN(builtin_trunc) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_TRUNCF(...) __builtin_truncf(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TRUNC(...)  __builtin_trunc(__VA_ARGS__)
+#  define _CCCL_BUILTIN_TRUNCL(...) __builtin_truncl(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_trunc)
+
+// Below 11.7 nvcc treats the builtin as a host only function
+#if _CCCL_CUDACC_BELOW(11, 7)
+#  undef _CCCL_BUILTIN_TRUNCF
+#  undef _CCCL_BUILTIN_TRUNC
+#  undef _CCCL_BUILTIN_TRUNCL
 #endif // _CCCL_CUDACC_BELOW(11, 7)
 
 #if _CCCL_HAS_BUILTIN(__decay) && _CCCL_CUDA_COMPILER(CLANG)

--- a/libcudacxx/include/cuda/std/__cmath/exponential_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/exponential_functions.h
@@ -1,0 +1,611 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___MATH_EXPONENTIAL_FUNCTIONS_H
+#define _LIBCUDACXX___MATH_EXPONENTIAL_FUNCTIONS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/promote.h>
+#include <cuda/std/cstdint>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// exp
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float exp(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_EXPF)
+  return _CCCL_BUILTIN_EXPF(__x);
+#else // ^^^ _CCCL_BUILTIN_EXPF ^^^ // vvv !_CCCL_BUILTIN_EXPF vvv
+  return ::expf(__x);
+#endif // !_CCCL_BUILTIN_EXPF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float expf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_EXPF)
+  return _CCCL_BUILTIN_EXPF(__x);
+#else // ^^^ _CCCL_BUILTIN_EXPF ^^^ // vvv !_CCCL_BUILTIN_EXPF vvv
+  return ::expf(__x);
+#endif // !_CCCL_BUILTIN_EXPF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double exp(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_EXP)
+  return _CCCL_BUILTIN_EXP(__x);
+#else // ^^^ _CCCL_BUILTIN_EXP ^^^ // vvv !_CCCL_BUILTIN_EXP vvv
+  return ::exp(__x);
+#endif // !_CCCL_BUILTIN_EXP
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double exp(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_EXPL)
+  return _CCCL_BUILTIN_EXPL(__x);
+#  else // ^^^ _CCCL_BUILTIN_EXPL ^^^ // vvv !_CCCL_BUILTIN_EXPL vvv
+  return ::expl(__x);
+#  endif // !_CCCL_BUILTIN_EXPL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double expl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_EXPL)
+  return _CCCL_BUILTIN_EXPL(__x);
+#  else // ^^^ _CCCL_BUILTIN_EXPL ^^^ // vvv !_CCCL_BUILTIN_EXPL vvv
+  return ::expl(__x);
+#  endif // !_CCCL_BUILTIN_EXPL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half exp(__half __x) noexcept
+{
+  {
+    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53, (return ::hexp(__x);), ({
+                        float __xf            = __half2float(__x);
+                        __xf                  = ::expf(__xf);
+                        __half_raw __ret_repr = ::__float2half_rn(__xf);
+
+                        uint16_t __repr = __half_raw(__x).x;
+                        switch (__repr)
+                        {
+                          case 8057:
+                          case 9679:
+                            __ret_repr.x -= 1;
+                            break;
+
+                          default:;
+                        }
+
+                        return __ret_repr;
+                      }))
+  }
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 exp(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hexp(__x);), (return __float2bfloat16(_CUDA_VSTD::expf(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double exp(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::exp((double) __x);
+}
+
+// frexp
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float frexp(float __x, int* __e) noexcept
+{
+#if defined(_CCCL_BUILTIN_FREXPF)
+  return _CCCL_BUILTIN_FREXPF(__x, __e);
+#else // ^^^ _CCCL_BUILTIN_FREXPF ^^^ // vvv !_CCCL_BUILTIN_FREXPF vvv
+  return ::frexpf(__x, __e);
+#endif // !_CCCL_BUILTIN_FREXPF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float frexpf(float __x, int* __e) noexcept
+{
+#if defined(_CCCL_BUILTIN_FREXPF)
+  return _CCCL_BUILTIN_FREXPF(__x, __e);
+#else // ^^^ _CCCL_BUILTIN_FREXPF ^^^ // vvv !_CCCL_BUILTIN_FREXPF vvv
+  return ::frexpf(__x, __e);
+#endif // !_CCCL_BUILTIN_FREXPF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double frexp(double __x, int* __e) noexcept
+{
+#if defined(_CCCL_BUILTIN_FREXP)
+  return _CCCL_BUILTIN_FREXP(__x, __e);
+#else // ^^^ _CCCL_BUILTIN_FREXP ^^^ // vvv !_CCCL_BUILTIN_FREXP vvv
+  return ::frexp(__x, __e);
+#endif // !_CCCL_BUILTIN_FREXP
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double frexp(long double __x, int* __e) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FREXPL)
+  return _CCCL_BUILTIN_FREXPL(__x, __e);
+#  else // ^^^ _CCCL_BUILTIN_FREXPL ^^^ // vvv !_CCCL_BUILTIN_FREXPL vvv
+  return ::frexpl(__x, __e);
+#  endif // !_CCCL_BUILTIN_FREXPL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double frexpl(long double __x, int* __e) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FREXPL)
+  return _CCCL_BUILTIN_FREXPL(__x, __e);
+#  else // ^^^ _CCCL_BUILTIN_FREXPL ^^^ // vvv !_CCCL_BUILTIN_FREXPL vvv
+  return ::frexpl(__x, __e);
+#  endif // !_CCCL_BUILTIN_FREXPL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half frexp(__half __x, int* __e) noexcept
+{
+  return __float2half(_CUDA_VSTD::frexpf(__half2float(__x), __e));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 frexp(__nv_bfloat16 __x, int* __e) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::frexpf(__bfloat162float(__x), __e));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double frexp(_Integer __x, int* __e) noexcept
+{
+  return _CUDA_VSTD::frexp((double) __x, __e);
+}
+
+// ldexp
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float ldexp(float __x, int __e) noexcept
+{
+#if defined(_CCCL_BUILTIN_LDEXPF)
+  return _CCCL_BUILTIN_LDEXPF(__x, __e);
+#else // ^^^ _CCCL_BUILTIN_LDEXPF ^^^ // vvv !_CCCL_BUILTIN_LDEXPF vvv
+  return ::ldexpf(__x, __e);
+#endif // !_CCCL_BUILTIN_LDEXPF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float ldexpf(float __x, int __e) noexcept
+{
+#if defined(_CCCL_BUILTIN_LDEXPF)
+  return _CCCL_BUILTIN_LDEXPF(__x, __e);
+#else // ^^^ _CCCL_BUILTIN_LDEXPF ^^^ // vvv !_CCCL_BUILTIN_LDEXPF vvv
+  return ::ldexpf(__x, __e);
+#endif // !_CCCL_BUILTIN_LDEXPF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double ldexp(double __x, int __e) noexcept
+{
+#if defined(_CCCL_BUILTIN_LDEXP)
+  return _CCCL_BUILTIN_LDEXP(__x, __e);
+#else // ^^^ _CCCL_BUILTIN_LDEXP ^^^ // vvv !_CCCL_BUILTIN_LDEXP vvv
+  return ::ldexp(__x, __e);
+#endif // !_CCCL_BUILTIN_LDEXP
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double ldexp(long double __x, int __e) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LDEXPL)
+  return _CCCL_BUILTIN_LDEXPL(__x, __e);
+#  else // ^^^ _CCCL_BUILTIN_LDEXPL ^^^ // vvv !_CCCL_BUILTIN_LDEXPL vvv
+  return ::ldexpl(__x, __e);
+#  endif // !_CCCL_BUILTIN_LDEXPL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double ldexpl(long double __x, int __e) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LDEXPL)
+  return _CCCL_BUILTIN_LDEXPL(__x, __e);
+#  else // ^^^ _CCCL_BUILTIN_LDEXPL ^^^ // vvv !_CCCL_BUILTIN_LDEXPL vvv
+  return ::ldexpl(__x, __e);
+#  endif // !_CCCL_BUILTIN_LDEXPL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half ldexp(__half __x, int __e) noexcept
+{
+  return __float2half(_CUDA_VSTD::ldexpf(__half2float(__x), __e));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 ldexp(__nv_bfloat16 __x, int __e) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::ldexpf(__bfloat162float(__x), __e));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double ldexp(_Integer __x, int __e) noexcept
+{
+  return _CUDA_VSTD::ldexp((double) __x, __e);
+}
+
+// exp2
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float exp2(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_EXP2F)
+  return _CCCL_BUILTIN_EXP2F(__x);
+#else // ^^^ _CCCL_BUILTIN_EXP2F ^^^ // vvv !_CCCL_BUILTIN_EXP2F vvv
+  return ::exp2f(__x);
+#endif // !_CCCL_BUILTIN_EXP2F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float exp2f(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_EXP2F)
+  return _CCCL_BUILTIN_EXP2F(__x);
+#else // ^^^ _CCCL_BUILTIN_EXP2F ^^^ // vvv !_CCCL_BUILTIN_EXP2F vvv
+  return ::exp2f(__x);
+#endif // !_CCCL_BUILTIN_EXP2F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double exp2(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_EXP2)
+  return _CCCL_BUILTIN_EXP2(__x);
+#else // ^^^ _CCCL_BUILTIN_EXP2 ^^^ // vvv !_CCCL_BUILTIN_EXP2 vvv
+  return ::exp2(__x);
+#endif // !_CCCL_BUILTIN_EXP2
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double exp2(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_EXP2L)
+  return _CCCL_BUILTIN_EXP2L(__x);
+#  else // ^^^ _CCCL_BUILTIN_EXP2L ^^^ // vvv !_CCCL_BUILTIN_EXP2L vvv
+  return ::exp2l(__x);
+#  endif // !_CCCL_BUILTIN_EXP2L
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double exp2l(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_EXP2L)
+  return _CCCL_BUILTIN_EXP2L(__x);
+#  else // ^^^ _CCCL_BUILTIN_EXP2L ^^^ // vvv !_CCCL_BUILTIN_EXP2L vvv
+  return ::exp2l(__x);
+#  endif // !_CCCL_BUILTIN_EXP2L
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half exp2(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hexp2(__x);), (return __float2half(_CUDA_VSTD::exp2f(__half2float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 exp2(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hexp2(__x);), (return __float2bfloat16(_CUDA_VSTD::exp2f(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double exp2(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::exp2((double) __x);
+}
+
+// expm1
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float expm1(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_EXPM1F)
+  return _CCCL_BUILTIN_EXPM1F(__x);
+#else // ^^^ _CCCL_BUILTIN_EXPM1F ^^^ // vvv !_CCCL_BUILTIN_EXPM1F vvv
+  return ::expm1f(__x);
+#endif // !_CCCL_BUILTIN_EXPM1F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float expm1f(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_EXPM1F)
+  return _CCCL_BUILTIN_EXPM1F(__x);
+#else // ^^^ _CCCL_BUILTIN_EXPM1F ^^^ // vvv !_CCCL_BUILTIN_EXPM1F vvv
+  return ::expm1f(__x);
+#endif // !_CCCL_BUILTIN_EXPM1F
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double expm1(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_EXPM1)
+  return _CCCL_BUILTIN_EXPM1(__x);
+#else // ^^^ _CCCL_BUILTIN_EXPM1 ^^^ // vvv !_CCCL_BUILTIN_EXPM1 vvv
+  return ::expm1(__x);
+#endif // !_CCCL_BUILTIN_EXPM1
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double expm1(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_EXPM1L)
+  return _CCCL_BUILTIN_EXPM1L(__x);
+#  else // ^^^ _CCCL_BUILTIN_EXPM1L ^^^ // vvv !_CCCL_BUILTIN_EXPM1L vvv
+  return ::expm1l(__x);
+#  endif // !_CCCL_BUILTIN_EXPM1L
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double expm1l(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_EXPM1L)
+  return _CCCL_BUILTIN_EXPM1L(__x);
+#  else // ^^^ _CCCL_BUILTIN_EXPM1L ^^^ // vvv !_CCCL_BUILTIN_EXPM1L vvv
+  return ::expm1l(__x);
+#  endif // !_CCCL_BUILTIN_EXPM1L
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half expm1(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::expm1f(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 expm1(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::expm1f(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double expm1(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::expm1((double) __x);
+}
+
+// scalbln
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float scalbln(float __x, long __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_SCALBLNF)
+  return _CCCL_BUILTIN_SCALBLNF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_SCALBLNF ^^^ // vvv !_CCCL_BUILTIN_SCALBLNF vvv
+  return ::scalblnf(__x, __y);
+#endif // !_CCCL_BUILTIN_SCALBLNF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float scalblnf(float __x, long __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_SCALBLNF)
+  return _CCCL_BUILTIN_SCALBLNF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_SCALBLNF ^^^ // vvv !_CCCL_BUILTIN_SCALBLNF vvv
+  return ::scalblnf(__x, __y);
+#endif // !_CCCL_BUILTIN_SCALBLNF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double scalbln(double __x, long __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_SCALBLN)
+  return _CCCL_BUILTIN_SCALBLN(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_SCALBLN ^^^ // vvv !_CCCL_BUILTIN_SCALBLN vvv
+  return ::scalbln(__x, __y);
+#endif // !_CCCL_BUILTIN_SCALBLN
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double scalbln(long double __x, long __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SCALBLNL)
+  return _CCCL_BUILTIN_SCALBLNL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_SCALBLNL ^^^ // vvv !_CCCL_BUILTIN_SCALBLNL vvv
+  return ::scalblnl(__x, __y);
+#  endif // !_CCCL_BUILTIN_SCALBLNL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double scalblnl(long double __x, long __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SCALBLNL)
+  return _CCCL_BUILTIN_SCALBLNL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_SCALBLNL ^^^ // vvv !_CCCL_BUILTIN_SCALBLNL vvv
+  return ::scalblnl(__x, __y);
+#  endif // !_CCCL_BUILTIN_SCALBLNL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half scalbln(__half __x, long __y) noexcept
+{
+  return __float2half(_CUDA_VSTD::scalblnf(__half2float(__x), __y));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 scalbln(__nv_bfloat16 __x, long __y) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::scalblnf(__bfloat162float(__x), __y));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double scalbln(_Integer __x, long __y) noexcept
+{
+  return _CUDA_VSTD::scalbln((double) __x, __y);
+}
+
+// scalbn
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float scalbn(float __x, int __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_SCALBNF)
+  return _CCCL_BUILTIN_SCALBNF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_SCALBNF ^^^ // vvv !_CCCL_BUILTIN_SCALBNF vvv
+  return ::scalbnf(__x, __y);
+#endif // !_CCCL_BUILTIN_SCALBNF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float scalbnf(float __x, int __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_SCALBNF)
+  return _CCCL_BUILTIN_SCALBNF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_SCALBNF ^^^ // vvv !_CCCL_BUILTIN_SCALBNF vvv
+  return ::scalbnf(__x, __y);
+#endif // !_CCCL_BUILTIN_SCALBNF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double scalbn(double __x, int __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_SCALBN)
+  return _CCCL_BUILTIN_SCALBN(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_SCALBN ^^^ // vvv !_CCCL_BUILTIN_SCALBN vvv
+  return ::scalbn(__x, __y);
+#endif // !_CCCL_BUILTIN_SCALBN
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double scalbn(long double __x, int __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SCALBNL)
+  return _CCCL_BUILTIN_SCALBNL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_SCALBNL ^^^ // vvv !_CCCL_BUILTIN_SCALBNL vvv
+  return ::scalbnl(__x, __y);
+#  endif // !_CCCL_BUILTIN_SCALBNL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double scalbnl(long double __x, int __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SCALBNL)
+  return _CCCL_BUILTIN_SCALBNL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_SCALBNL ^^^ // vvv !_CCCL_BUILTIN_SCALBNL vvv
+  return ::scalbnl(__x, __y);
+#  endif // !_CCCL_BUILTIN_SCALBNL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half scalbn(__half __x, int __y) noexcept
+{
+  return __float2half(_CUDA_VSTD::scalbnf(__half2float(__x), __y));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 scalbn(__nv_bfloat16 __x, int __y) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::scalbnf(__bfloat162float(__x), __y));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double scalbn(_Integer __x, int __y) noexcept
+{
+  return _CUDA_VSTD::scalbn((double) __x, __y);
+}
+
+// pow
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float pow(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_POWF)
+  return _CCCL_BUILTIN_POWF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_POWF ^^^ // vvv !_CCCL_BUILTIN_POWF vvv
+  return ::powf(__x, __y);
+#endif // !_CCCL_BUILTIN_POWF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float powf(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_POWF)
+  return _CCCL_BUILTIN_POWF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_POWF ^^^ // vvv !_CCCL_BUILTIN_POWF vvv
+  return ::powf(__x, __y);
+#endif // !_CCCL_BUILTIN_POWF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double pow(double __x, double __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_POW)
+  return _CCCL_BUILTIN_POW(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_POW ^^^ // vvv !_CCCL_BUILTIN_POW vvv
+  return ::pow(__x, __y);
+#endif // !_CCCL_BUILTIN_POW
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double pow(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_POWL)
+  return _CCCL_BUILTIN_POWL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_POWL ^^^ // vvv !_CCCL_BUILTIN_POWL vvv
+  return ::powl(__x, __y);
+#  endif // !_CCCL_BUILTIN_POWL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double powl(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_POWL)
+  return _CCCL_BUILTIN_POWL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_POWL ^^^ // vvv !_CCCL_BUILTIN_POWL vvv
+  return ::powl(__x, __y);
+#  endif // !_CCCL_BUILTIN_POWL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half pow(__half __x, __half __y) noexcept
+{
+  return __float2half(_CUDA_VSTD::powf(__half2float(__x), __half2float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 pow(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::powf(__bfloat162float(__x), __bfloat162float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, _A2> pow(_A1 __x, _A2 __y) noexcept
+{
+  using __result_type = __promote_t<_A1, _A2>;
+  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  return _CUDA_VSTD::pow((__result_type) __x, (__result_type) __y);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___MATH_EXPONENTIAL_FUNCTIONS_H

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -70,11 +70,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 atan2(__nv_bfloat16 __x, __nv_bfloat16 _
   return __float2bfloat16(::atan2f(__bfloat162float(__x), __bfloat162float(__y)));
 }
 
-_LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 sqrt(__nv_bfloat16 __x)
-{
-  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hsqrt(__x);), (return __float2bfloat16(::sqrtf(__bfloat162float(__x)));))
-}
-
 // floating point helper
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 __constexpr_copysign(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvbf16.h
@@ -55,11 +55,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 cosh(__nv_bfloat16 __v)
   return __float2bfloat16(::coshf(__bfloat162float(__v)));
 }
 
-_LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 exp(__nv_bfloat16 __v)
-{
-  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hexp(__v);), (return __float2bfloat16(::expf(__bfloat162float(__v)));))
-}
-
 _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 hypot(__nv_bfloat16 __x, __nv_bfloat16 __y)
 {
   return __float2bfloat16(::hypotf(__bfloat162float(__x), __bfloat162float(__y)));

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -97,34 +97,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __half cosh(__half __v)
   return __float2half(::coshf(__half2float(__v)));
 }
 
-// clang-format off
-_LIBCUDACXX_HIDE_FROM_ABI  __half exp(__half __v)
-{
-  NV_IF_ELSE_TARGET(NV_PROVIDES_SM_53, (
-    return ::hexp(__v);
-  ), (
-    {
-      float __vf            = __half2float(__v);
-      __vf                  = ::expf(__vf);
-      __half_raw __ret_repr = ::__float2half_rn(__vf);
-
-      uint16_t __repr = __half_raw(__v).x;
-      switch (__repr)
-      {
-        case 8057:
-        case 9679:
-          __ret_repr.x -= 1;
-          break;
-
-        default:;
-      }
-
-      return __ret_repr;
-    }
-  ))
-}
-// clang-format on
-
 _LIBCUDACXX_HIDE_FROM_ABI __half hypot(__half __x, __half __y)
 {
   return __float2half(::hypotf(__half2float(__x), __half2float(__y)));

--- a/libcudacxx/include/cuda/std/__cmath/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__cmath/nvfp16.h
@@ -135,11 +135,6 @@ _LIBCUDACXX_HIDE_FROM_ABI __half atan2(__half __x, __half __y)
   return __float2half(::atan2f(__half2float(__x), __half2float(__y)));
 }
 
-_LIBCUDACXX_HIDE_FROM_ABI __half sqrt(__half __x)
-{
-  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hsqrt(__x);), (return __float2half(::sqrtf(__half2float(__x)));))
-}
-
 // floating point helper
 _LIBCUDACXX_HIDE_FROM_ABI __half __constexpr_copysign(__half __x, __half __y) noexcept
 {

--- a/libcudacxx/include/cuda/std/__cmath/roots.h
+++ b/libcudacxx/include/cuda/std/__cmath/roots.h
@@ -1,0 +1,171 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_ROOTS_H
+#define _LIBCUDACXX___CMATH_ROOTS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_integral.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// sqrt
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float sqrt(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SQRTF)
+  return _CCCL_BUILTIN_SQRTF(__x);
+#else // ^^^ _CCCL_BUILTIN_SQRTF ^^^ // vvv !_CCCL_BUILTIN_SQRTF vvv
+  return ::sqrtf(__x);
+#endif // !_CCCL_BUILTIN_SQRTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float sqrtf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SQRTF)
+  return _CCCL_BUILTIN_SQRTF(__x);
+#else // ^^^ _CCCL_BUILTIN_SQRTF ^^^ // vvv !_CCCL_BUILTIN_SQRTF vvv
+  return ::sqrtf(__x);
+#endif // !_CCCL_BUILTIN_SQRTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double sqrt(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_SQRT)
+  return _CCCL_BUILTIN_SQRT(__x);
+#else // ^^^ _CCCL_BUILTIN_SQRT ^^^ // vvv !_CCCL_BUILTIN_SQRT vvv
+  return ::sqrt(__x);
+#endif // !_CCCL_BUILTIN_SQRT
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double sqrt(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SQRTL)
+  return _CCCL_BUILTIN_SQRTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_SQRTL ^^^ // vvv !_CCCL_BUILTIN_SQRTL vvv
+  return ::sqrtl(__x);
+#  endif // !_CCCL_BUILTIN_SQRTL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double sqrtl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_SQRTL)
+  return _CCCL_BUILTIN_SQRTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_SQRTL ^^^ // vvv !_CCCL_BUILTIN_SQRTL vvv
+  return ::sqrtl(__x);
+#  endif // !_CCCL_BUILTIN_SQRTL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half sqrt(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hsqrt(__x);), (return __float2half(_CUDA_VSTD::sqrt(__half2float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 sqrt(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hsqrt(__x);), (return __float2bfloat16(_CUDA_VSTD::sqrt(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double sqrt(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::sqrt((double) __x);
+}
+
+// cbrt
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float cbrt(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_CBRTF)
+  return _CCCL_BUILTIN_CBRTF(__x);
+#else // ^^^ _CCCL_BUILTIN_CBRTF ^^^ // vvv !_CCCL_BUILTIN_CBRTF vvv
+  return ::cbrtf(__x);
+#endif // !_CCCL_BUILTIN_CBRTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float cbrtf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_CBRTF)
+  return _CCCL_BUILTIN_CBRTF(__x);
+#else // ^^^ _CCCL_BUILTIN_CBRTF ^^^ // vvv !_CCCL_BUILTIN_CBRTF vvv
+  return ::cbrtf(__x);
+#endif // !_CCCL_BUILTIN_CBRTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double cbrt(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_CBRT)
+  return _CCCL_BUILTIN_CBRT(__x);
+#else // ^^^ _CCCL_BUILTIN_CBRT ^^^ // vvv !_CCCL_BUILTIN_CBRT vvv
+  return ::cbrt(__x);
+#endif // !_CCCL_BUILTIN_CBRT
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double cbrt(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_CBRTL)
+  return _CCCL_BUILTIN_CBRTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_CBRTL ^^^ // vvv !_CCCL_BUILTIN_CBRTL vvv
+  return ::cbrtl(__x);
+#  endif // !_CCCL_BUILTIN_CBRTL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double cbrtl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_CBRTL)
+  return _CCCL_BUILTIN_CBRTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_CBRTL ^^^ // vvv !_CCCL_BUILTIN_CBRTL vvv
+  return ::cbrtl(__x);
+#  endif // !_CCCL_BUILTIN_CBRTL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half cbrt(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::cbrt(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 cbrt(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::cbrt(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double cbrt(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::cbrt((double) __x);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_ROOTS_H

--- a/libcudacxx/include/cuda/std/__cmath/rounding_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/rounding_functions.h
@@ -1,0 +1,868 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___CMATH_ROUNDING_FUNCTIONS_H
+#define _LIBCUDACXX___CMATH_ROUNDING_FUNCTIONS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/common.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/promote.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_STD
+
+// ceil
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float ceil(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_CEILF)
+  return _CCCL_BUILTIN_CEILF(__x);
+#else // ^^^ _CCCL_BUILTIN_CEILF ^^^ // vvv !_CCCL_BUILTIN_CEILF vvv
+  return ::ceilf(__x);
+#endif // !_CCCL_BUILTIN_CEILF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float ceilf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_CEILF)
+  return _CCCL_BUILTIN_CEILF(__x);
+#else // ^^^ _CCCL_BUILTIN_CEILF ^^^ // vvv !_CCCL_BUILTIN_CEILF vvv
+  return ::ceilf(__x);
+#endif // !_CCCL_BUILTIN_CEILF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double ceil(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_CEIL)
+  return _CCCL_BUILTIN_CEIL(__x);
+#else // ^^^ _CCCL_BUILTIN_CEIL ^^^ // vvv !_CCCL_BUILTIN_CEIL vvv
+  return ::ceil(__x);
+#endif // !_CCCL_BUILTIN_CEIL
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double ceil(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_CEILL)
+  return _CCCL_BUILTIN_CEILL(__x);
+#  else // ^^^ _CCCL_BUILTIN_CEILL ^^^ // vvv !_CCCL_BUILTIN_CEILL vvv
+  return ::ceill(__x);
+#  endif // !_CCCL_BUILTIN_CEILL
+}
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double ceill(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_CEILL)
+  return _CCCL_BUILTIN_CEILL(__x);
+#  else // ^^^ _CCCL_BUILTIN_CEILL ^^^ // vvv !_CCCL_BUILTIN_CEILL vvv
+  return ::ceill(__x);
+#  endif // !_CCCL_BUILTIN_CEILL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half ceil(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hceil(__x);), (return __float2half(_CUDA_VSTD::ceil(__half2float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 ceil(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hceil(__x);), (return __float2bfloat16(_CUDA_VSTD::ceil(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double ceil(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::ceil((double) __x);
+}
+
+// floor
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float floor(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_FLOORF)
+  return _CCCL_BUILTIN_FLOORF(__x);
+#else // ^^^ _CCCL_BUILTIN_FLOORF ^^^ // vvv !_CCCL_BUILTIN_FLOORF vvv
+  return ::floorf(__x);
+#endif // !_CCCL_BUILTIN_FLOORF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float floorf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_FLOORF)
+  return _CCCL_BUILTIN_FLOORF(__x);
+#else // ^^^ _CCCL_BUILTIN_FLOORF ^^^ // vvv !_CCCL_BUILTIN_FLOORF vvv
+  return ::floorf(__x);
+#endif // !_CCCL_BUILTIN_FLOORF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double floor(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_FLOOR)
+  return _CCCL_BUILTIN_FLOOR(__x);
+#else // ^^^ _CCCL_BUILTIN_FLOOR ^^^ // vvv !_CCCL_BUILTIN_FLOOR vvv
+  return ::floor(__x);
+#endif // !_CCCL_BUILTIN_FLOOR
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double floor(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FLOORL)
+  return _CCCL_BUILTIN_FLOORL(__x);
+#  else // ^^^ _CCCL_BUILTIN_FLOORL ^^^ // vvv !_CCCL_BUILTIN_FLOORL vvv
+  return ::floorl(__x);
+#  endif // !_CCCL_BUILTIN_FLOORL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double floorl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_FLOORL)
+  return _CCCL_BUILTIN_FLOORL(__x);
+#  else // ^^^ _CCCL_BUILTIN_FLOORL ^^^ // vvv !_CCCL_BUILTIN_FLOORL vvv
+  return ::floorl(__x);
+#  endif // !_CCCL_BUILTIN_FLOORL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half floor(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hfloor(__x);), (return __float2half(_CUDA_VSTD::floor(__half2float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 floor(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hfloor(__x);), (return __float2bfloat16(_CUDA_VSTD::floor(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double floor(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::floor((double) __x);
+}
+
+// llrint
+
+_LIBCUDACXX_HIDE_FROM_ABI long long llrint(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LLRINTF)
+  return _CCCL_BUILTIN_LLRINTF(__x);
+#else // ^^^ _CCCL_BUILTIN_LLRINTF ^^^ // vvv !_CCCL_BUILTIN_LLRINTF vvv
+  return ::llrintf(__x);
+#endif // !_CCCL_BUILTIN_LLRINTF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long long llrintf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LLRINTF)
+  return _CCCL_BUILTIN_LLRINTF(__x);
+#else // ^^^ _CCCL_BUILTIN_LLRINTF ^^^ // vvv !_CCCL_BUILTIN_LLRINTF vvv
+  return ::llrintf(__x);
+#endif // !_CCCL_BUILTIN_LLRINTF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long long llrint(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LLRINT)
+  return _CCCL_BUILTIN_LLRINT(__x);
+#else // ^^^ _CCCL_BUILTIN_LLRINT ^^^ // vvv !_CCCL_BUILTIN_LLRINT vvv
+  return ::llrint(__x);
+#endif // !_CCCL_BUILTIN_LLRINT
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_LIBCUDACXX_HIDE_FROM_ABI long long llrint(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LLRINTL)
+  return _CCCL_BUILTIN_LLRINTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LLRINTL ^^^ // vvv !_CCCL_BUILTIN_LLRINTL vvv
+  return ::llrintl(__x);
+#  endif // !_CCCL_BUILTIN_LLRINTL
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long long llrintl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LLRINTL)
+  return _CCCL_BUILTIN_LLRINTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LLRINTL ^^^ // vvv !_CCCL_BUILTIN_LLRINTL vvv
+  return ::llrintl(__x);
+#  endif // !_CCCL_BUILTIN_LLRINTL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long long llrint(__half __x) noexcept
+{
+  return _CUDA_VSTD::llrintf(__half2float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long long llrint(__nv_bfloat16 __x) noexcept
+{
+  return _CUDA_VSTD::llrintf(__bfloat162float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_LIBCUDACXX_HIDE_FROM_ABI long long llrint(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::llrint((double) __x);
+}
+
+// llround
+
+_LIBCUDACXX_HIDE_FROM_ABI long long llround(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LLROUNDF)
+  return _CCCL_BUILTIN_LLROUNDF(__x);
+#else // ^^^ _CCCL_BUILTIN_LLROUNDF ^^^ // vvv !_CCCL_BUILTIN_LLROUNDF vvv
+  return ::llroundf(__x);
+#endif // !_CCCL_BUILTIN_LLROUNDF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long long llroundf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LLROUNDF)
+  return _CCCL_BUILTIN_LLROUNDF(__x);
+#else // ^^^ _CCCL_BUILTIN_LLROUNDF ^^^ // vvv !_CCCL_BUILTIN_LLROUNDF vvv
+  return ::llroundf(__x);
+#endif // !_CCCL_BUILTIN_LLROUNDF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long long llround(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LLROUND)
+  return _CCCL_BUILTIN_LLROUND(__x);
+#else // ^^^ _CCCL_BUILTIN_LLROUND ^^^ // vvv !_CCCL_BUILTIN_LLROUND vvv
+  return ::llround(__x);
+#endif // !_CCCL_BUILTIN_LLROUND
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_LIBCUDACXX_HIDE_FROM_ABI long long llround(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LLROUNDL)
+  return _CCCL_BUILTIN_LLROUNDL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LLROUNDL ^^^ // vvv !_CCCL_BUILTIN_LLROUNDL vvv
+  return ::llroundl(__x);
+#  endif // !_CCCL_BUILTIN_LLROUNDL
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long long llroundl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LLROUNDL)
+  return _CCCL_BUILTIN_LLROUNDL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LLROUNDL ^^^ // vvv !_CCCL_BUILTIN_LLROUNDL vvv
+  return ::llroundl(__x);
+#  endif // !_CCCL_BUILTIN_LLROUNDL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long long llround(__half __x) noexcept
+{
+  return _CUDA_VSTD::llroundf(__half2float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long long llround(__nv_bfloat16 __x) noexcept
+{
+  return _CUDA_VSTD::llroundf(__bfloat162float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_LIBCUDACXX_HIDE_FROM_ABI long long llround(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::llround((double) __x);
+}
+
+// lrint
+
+_LIBCUDACXX_HIDE_FROM_ABI long lrint(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LRINTF)
+  return _CCCL_BUILTIN_LRINTF(__x);
+#else // ^^^ _CCCL_BUILTIN_LRINTF ^^^ // vvv !_CCCL_BUILTIN_LRINTF vvv
+  return ::lrintf(__x);
+#endif // !_CCCL_BUILTIN_LRINTF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long lrintf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LRINTF)
+  return _CCCL_BUILTIN_LRINTF(__x);
+#else // ^^^ _CCCL_BUILTIN_LRINTF ^^^ // vvv !_CCCL_BUILTIN_LRINTF vvv
+  return ::lrintf(__x);
+#endif // !_CCCL_BUILTIN_LRINTF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long lrint(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LRINT)
+  return _CCCL_BUILTIN_LRINT(__x);
+#else // ^^^ _CCCL_BUILTIN_LRINT ^^^ // vvv !_CCCL_BUILTIN_LRINT vvv
+  return ::lrint(__x);
+#endif // !_CCCL_BUILTIN_LRINT
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_LIBCUDACXX_HIDE_FROM_ABI long lrint(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LRINTL)
+  return _CCCL_BUILTIN_LRINTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LRINTL ^^^ // vvv !_CCCL_BUILTIN_LRINTL vvv
+  return ::lrintl(__x);
+#  endif // !_CCCL_BUILTIN_LRINTL
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long lrintl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LRINTL)
+  return _CCCL_BUILTIN_LRINTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LRINTL ^^^ // vvv !_CCCL_BUILTIN_LRINTL vvv
+  return ::lrintl(__x);
+#  endif // !_CCCL_BUILTIN_LRINTL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long lrint(__half __x) noexcept
+{
+  return _CUDA_VSTD::lrintf(__half2float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long lrint(__nv_bfloat16 __x) noexcept
+{
+  return _CUDA_VSTD::lrintf(__bfloat162float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_LIBCUDACXX_HIDE_FROM_ABI long lrint(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::lrint((double) __x);
+}
+
+// lround
+
+_LIBCUDACXX_HIDE_FROM_ABI long lround(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LROUNDF)
+  return _CCCL_BUILTIN_LROUNDF(__x);
+#else // ^^^ _CCCL_BUILTIN_LROUNDF ^^^ // vvv !_CCCL_BUILTIN_LROUNDF vvv
+  return ::lroundf(__x);
+#endif // !_CCCL_BUILTIN_LROUNDF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long lroundf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LROUNDF)
+  return _CCCL_BUILTIN_LROUNDF(__x);
+#else // ^^^ _CCCL_BUILTIN_LROUNDF ^^^ // vvv !_CCCL_BUILTIN_LROUNDF vvv
+  return ::lroundf(__x);
+#endif // !_CCCL_BUILTIN_LROUNDF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long lround(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_LROUND)
+  return _CCCL_BUILTIN_LROUND(__x);
+#else // ^^^ _CCCL_BUILTIN_LROUND ^^^ // vvv !_CCCL_BUILTIN_LROUND vvv
+  return ::lround(__x);
+#endif // !_CCCL_BUILTIN_LROUND
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_LIBCUDACXX_HIDE_FROM_ABI long lround(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LROUNDL)
+  return _CCCL_BUILTIN_LROUNDL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LROUNDL ^^^ // vvv !_CCCL_BUILTIN_LROUNDL vvv
+  return ::lroundl(__x);
+#  endif // !_CCCL_BUILTIN_LROUNDL
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long lroundl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_LROUNDL)
+  return _CCCL_BUILTIN_LROUNDL(__x);
+#  else // ^^^ _CCCL_BUILTIN_LROUNDL ^^^ // vvv !_CCCL_BUILTIN_LROUNDL vvv
+  return ::lroundl(__x);
+#  endif // !_CCCL_BUILTIN_LROUNDL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long lround(__half __x) noexcept
+{
+  return _CUDA_VSTD::lroundf(__half2float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long lround(__nv_bfloat16 __x) noexcept
+{
+  return _CUDA_VSTD::lroundf(__bfloat162float(__x));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_LIBCUDACXX_HIDE_FROM_ABI long lround(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::lround((double) __x);
+}
+
+// nearbyint
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float nearbyint(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_NEARBYINTF)
+  return _CCCL_BUILTIN_NEARBYINTF(__x);
+#else // ^^^ _CCCL_BUILTIN_NEARBYINTF ^^^ // vvv !_CCCL_BUILTIN_NEARBYINTF vvv
+  return ::nearbyintf(__x);
+#endif // !_CCCL_BUILTIN_NEARBYINTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float nearbyintf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_NEARBYINTF)
+  return _CCCL_BUILTIN_NEARBYINTF(__x);
+#else // ^^^ _CCCL_BUILTIN_NEARBYINTF ^^^ // vvv !_CCCL_BUILTIN_NEARBYINTF vvv
+  return ::nearbyintf(__x);
+#endif // !_CCCL_BUILTIN_NEARBYINTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double nearbyint(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_NEARBYINT)
+  return _CCCL_BUILTIN_NEARBYINT(__x);
+#else // ^^^ _CCCL_BUILTIN_NEARBYINT ^^^ // vvv !_CCCL_BUILTIN_NEARBYINT vvv
+  return ::nearbyint(__x);
+#endif // !_CCCL_BUILTIN_NEARBYINT
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double nearbyint(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_NEARBYINTL)
+  return _CCCL_BUILTIN_NEARBYINTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_NEARBYINTL ^^^ // vvv !_CCCL_BUILTIN_NEARBYINTL vvv
+  return ::nearbyintl(__x);
+#  endif // !_CCCL_BUILTIN_NEARBYINTL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double nearbyintl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_NEARBYINTL)
+  return _CCCL_BUILTIN_NEARBYINTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_NEARBYINTL ^^^ // vvv !_CCCL_BUILTIN_NEARBYINTL vvv
+  return ::nearbyintl(__x);
+#  endif // !_CCCL_BUILTIN_NEARBYINTL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half nearbyint(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::nearbyintf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 nearbyint(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::nearbyintf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double nearbyint(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::nearbyint((double) __x);
+}
+
+// nextafter
+
+_LIBCUDACXX_HIDE_FROM_ABI float nextafter(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_NEXTAFTERF)
+  return _CCCL_BUILTIN_NEXTAFTERF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_NEXTAFTERF ^^^ // vvv !_CCCL_BUILTIN_NEXTAFTERF vvv
+  return ::nextafterf(__x, __y);
+#endif // !_CCCL_BUILTIN_NEXTAFTERF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI float nextafterf(float __x, float __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_NEXTAFTERF)
+  return _CCCL_BUILTIN_NEXTAFTERF(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_NEXTAFTERF ^^^ // vvv !_CCCL_BUILTIN_NEXTAFTERF vvv
+  return ::nextafterf(__x, __y);
+#endif // !_CCCL_BUILTIN_NEXTAFTERF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI double nextafter(double __x, double __y) noexcept
+{
+#if defined(_CCCL_BUILTIN_NEXTAFTER)
+  return _CCCL_BUILTIN_NEXTAFTER(__x, __y);
+#else // ^^^ _CCCL_BUILTIN_NEXTAFTER ^^^ // vvv !_CCCL_BUILTIN_NEXTAFTER vvv
+  return ::nextafter(__x, __y);
+#endif // !_CCCL_BUILTIN_NEXTAFTER
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_LIBCUDACXX_HIDE_FROM_ABI long double nextafter(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_NEXTAFTERL)
+  return _CCCL_BUILTIN_NEXTAFTERL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_NEXTAFTERL ^^^ // vvv !_CCCL_BUILTIN_NEXTAFTERL vvv
+  return ::nextafterl(__x, __y);
+#  endif // !_CCCL_BUILTIN_NEXTAFTERL
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long double nextafterl(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_NEXTAFTERL)
+  return _CCCL_BUILTIN_NEXTAFTERL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_NEXTAFTERL ^^^ // vvv !_CCCL_BUILTIN_NEXTAFTERL vvv
+  return ::nextafterl(__x, __y);
+#  endif // !_CCCL_BUILTIN_NEXTAFTERL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half nextafter(__half __x, __half __y) noexcept
+{
+  return __float2half(_CUDA_VSTD::nextafterf(__half2float(__x), __half2float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 nextafter(__nv_bfloat16 __x, __nv_bfloat16 __y) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::nextafterf(__bfloat162float(__x), __bfloat162float(__y)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+_LIBCUDACXX_HIDE_FROM_ABI __promote_t<_A1, _A2> nextafter(_A1 __x, _A2 __y) noexcept
+{
+  using __result_type = __promote_t<_A1, _A2>;
+  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  return _CUDA_VSTD::nextafter(static_cast<__result_type>(__x), static_cast<__result_type>(__y));
+}
+
+// nexttoward
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_LIBCUDACXX_HIDE_FROM_ABI float nexttoward(float __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_NEXTTOWARDF)
+  return _CCCL_BUILTIN_NEXTTOWARDF(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_NEXTTOWARDF ^^^ // vvv !_CCCL_BUILTIN_NEXTTOWARDF vvv
+  return ::nexttowardf(__x, __y);
+#  endif // !_CCCL_BUILTIN_NEXTTOWARDF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI float nexttowardf(float __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_NEXTTOWARDF)
+  return _CCCL_BUILTIN_NEXTTOWARDF(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_NEXTTOWARDF ^^^ // vvv !_CCCL_BUILTIN_NEXTTOWARDF vvv
+  return ::nexttowardf(__x, __y);
+#  endif // !_CCCL_BUILTIN_NEXTTOWARDF
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI double nexttoward(double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_NEXTTOWARD)
+  return _CCCL_BUILTIN_NEXTTOWARD(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_NEXTTOWARD ^^^ // vvv !_CCCL_BUILTIN_NEXTTOWARD vvv
+  return ::nexttoward(__x, __y);
+#  endif // !_CCCL_BUILTIN_NEXTTOWARD
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long double nexttoward(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_NEXTTOWARDL)
+  return _CCCL_BUILTIN_NEXTTOWARDL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_NEXTTOWARDL ^^^ // vvv !_CCCL_BUILTIN_NEXTTOWARDL vvv
+  return ::nexttowardl(__x, __y);
+#  endif // !_CCCL_BUILTIN_NEXTTOWARDL
+}
+
+_LIBCUDACXX_HIDE_FROM_ABI long double nexttowardl(long double __x, long double __y) noexcept
+{
+#  if defined(_CCCL_BUILTIN_NEXTTOWARDL)
+  return _CCCL_BUILTIN_NEXTTOWARDL(__x, __y);
+#  else // ^^^ _CCCL_BUILTIN_NEXTTOWARDL ^^^ // vvv !_CCCL_BUILTIN_NEXTTOWARDL vvv
+  return ::nexttowardl(__x, __y);
+#  endif // !_CCCL_BUILTIN_NEXTTOWARDL
+}
+
+#  if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half nexttoward(__half __x, long double __y) noexcept
+{
+  return __float2half(_CUDA_VSTD::nexttowardf(__half2float(__x), __y));
+}
+#  endif // _LIBCUDACXX_HAS_NVFP16
+
+#  if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 nexttoward(__nv_bfloat16 __x, long double __y) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::nexttowardf(__bfloat162float(__x), __y));
+}
+#  endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_LIBCUDACXX_HIDE_FROM_ABI double nexttoward(_Integer __x, long double __y) noexcept
+{
+  return _CUDA_VSTD::nexttoward((double) __x, __y);
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+// rint
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float rint(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_RINTF)
+  return _CCCL_BUILTIN_RINTF(__x);
+#else // ^^^ _CCCL_BUILTIN_RINTF ^^^ // vvv !_CCCL_BUILTIN_RINTF vvv
+  return ::rintf(__x);
+#endif // !_CCCL_BUILTIN_RINTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float rintf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_RINTF)
+  return _CCCL_BUILTIN_RINTF(__x);
+#else // ^^^ _CCCL_BUILTIN_RINTF ^^^ // vvv !_CCCL_BUILTIN_RINTF vvv
+  return ::rintf(__x);
+#endif // !_CCCL_BUILTIN_RINTF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double rint(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_RINT)
+  return _CCCL_BUILTIN_RINT(__x);
+#else // ^^^ _CCCL_BUILTIN_RINT ^^^ // vvv !_CCCL_BUILTIN_RINT vvv
+  return ::rint(__x);
+#endif // !_CCCL_BUILTIN_RINT
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double rint(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_RINTL)
+  return _CCCL_BUILTIN_RINTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_RINTL ^^^ // vvv !_CCCL_BUILTIN_RINTL vvv
+  return ::rintl(__x);
+#  endif // !_CCCL_BUILTIN_RINTL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double rintl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_RINTL)
+  return _CCCL_BUILTIN_RINTL(__x);
+#  else // ^^^ _CCCL_BUILTIN_RINTL ^^^ // vvv !_CCCL_BUILTIN_RINTL vvv
+  return ::rintl(__x);
+#  endif // !_CCCL_BUILTIN_RINTL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half rint(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::hrint(__x);), (return __float2half(_CUDA_VSTD::rint(__half2float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 rint(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::hrint(__x);), (return __float2bfloat16(_CUDA_VSTD::rint(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double rint(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::rint((double) __x);
+}
+
+// round
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float round(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ROUNDF)
+  return _CCCL_BUILTIN_ROUNDF(__x);
+#else // ^^^ _CCCL_BUILTIN_ROUNDF ^^^ // vvv !_CCCL_BUILTIN_ROUNDF vvv
+  return ::roundf(__x);
+#endif // !_CCCL_BUILTIN_ROUNDF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float roundf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ROUNDF)
+  return _CCCL_BUILTIN_ROUNDF(__x);
+#else // ^^^ _CCCL_BUILTIN_ROUNDF ^^^ // vvv !_CCCL_BUILTIN_ROUNDF vvv
+  return ::roundf(__x);
+#endif // !_CCCL_BUILTIN_ROUNDF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double round(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_ROUND)
+  return _CCCL_BUILTIN_ROUND(__x);
+#else // ^^^ _CCCL_BUILTIN_ROUND ^^^ // vvv !_CCCL_BUILTIN_ROUND vvv
+  return ::round(__x);
+#endif // !_CCCL_BUILTIN_ROUND
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double round(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ROUNDL)
+  return _CCCL_BUILTIN_ROUNDL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ROUNDL ^^^ // vvv !_CCCL_BUILTIN_ROUNDL vvv
+  return ::roundl(__x);
+#  endif // !_CCCL_BUILTIN_ROUNDL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double roundl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_ROUNDL)
+  return _CCCL_BUILTIN_ROUNDL(__x);
+#  else // ^^^ _CCCL_BUILTIN_ROUNDL ^^^ // vvv !_CCCL_BUILTIN_ROUNDL vvv
+  return ::roundl(__x);
+#  endif // !_CCCL_BUILTIN_ROUNDL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half round(__half __x) noexcept
+{
+  return __float2half(_CUDA_VSTD::roundf(__half2float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 round(__nv_bfloat16 __x) noexcept
+{
+  return __float2bfloat16(_CUDA_VSTD::roundf(__bfloat162float(__x)));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double round(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::round((double) __x);
+}
+
+// trunc
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float trunc(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TRUNCF)
+  return _CCCL_BUILTIN_TRUNCF(__x);
+#else // ^^^ _CCCL_BUILTIN_TRUNCF ^^^ // vvv !_CCCL_BUILTIN_TRUNCF vvv
+  return ::truncf(__x);
+#endif // !_CCCL_BUILTIN_TRUNCF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI float truncf(float __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TRUNCF)
+  return _CCCL_BUILTIN_TRUNCF(__x);
+#else // ^^^ _CCCL_BUILTIN_TRUNCF ^^^ // vvv !_CCCL_BUILTIN_TRUNCF vvv
+  return ::truncf(__x);
+#endif // !_CCCL_BUILTIN_TRUNCF
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double trunc(double __x) noexcept
+{
+#if defined(_CCCL_BUILTIN_TRUNC)
+  return _CCCL_BUILTIN_TRUNC(__x);
+#else // ^^^ _CCCL_BUILTIN_TRUNC ^^^ // vvv !_CCCL_BUILTIN_TRUNC vvv
+  return ::trunc(__x);
+#endif // !_CCCL_BUILTIN_TRUNC
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double trunc(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_TRUNCL)
+  return _CCCL_BUILTIN_TRUNCL(__x);
+#  else // ^^^ _CCCL_BUILTIN_TRUNCL ^^^ // vvv !_CCCL_BUILTIN_TRUNCL vvv
+  return ::truncl(__x);
+#  endif // !_CCCL_BUILTIN_TRUNCL
+}
+
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI long double truncl(long double __x) noexcept
+{
+#  if defined(_CCCL_BUILTIN_TRUNCL)
+  return _CCCL_BUILTIN_TRUNCL(__x);
+#  else // ^^^ _CCCL_BUILTIN_TRUNCL ^^^ // vvv !_CCCL_BUILTIN_TRUNCL vvv
+  return ::truncl(__x);
+#  endif // !_CCCL_BUILTIN_TRUNCL
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#if defined(_LIBCUDACXX_HAS_NVFP16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __half trunc(__half __x) noexcept
+{
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (return ::htrunc(__x);), (return __float2half(_CUDA_VSTD::trunc(__half2float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#if defined(_LIBCUDACXX_HAS_NVBF16)
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI __nv_bfloat16 trunc(__nv_bfloat16 __x) noexcept
+{
+  NV_IF_ELSE_TARGET(
+    NV_IS_DEVICE, (return ::htrunc(__x);), (return __float2bfloat16(_CUDA_VSTD::trunc(__bfloat162float(__x)));))
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+_CCCL_NODISCARD _LIBCUDACXX_HIDE_FROM_ABI double trunc(_Integer __x) noexcept
+{
+  return _CUDA_VSTD::trunc((double) __x);
+}
+
+_LIBCUDACXX_END_NAMESPACE_STD
+
+#endif // _LIBCUDACXX___CMATH_ROUNDING_FUNCTIONS_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -323,6 +323,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/min_max.h>
+#include <cuda/std/__cmath/roots.h>
 #include <cuda/std/__cmath/rounding_functions.h>
 #include <cuda/std/__cmath/traits.h>
 #include <cuda/std/__cstdlib/abs.h>
@@ -371,8 +372,6 @@ using ::sinf;
 using ::sinh;
 using ::sinhf;
 
-using ::sqrt;
-using ::sqrtf;
 using ::tan;
 using ::tanf;
 
@@ -413,8 +412,6 @@ using ::sinf;
 using ::sinh;
 using ::sinhf;
 
-using ::sqrt;
-using ::sqrtf;
 using ::tan;
 using ::tanf;
 
@@ -427,8 +424,6 @@ using ::asinh;
 using ::asinhf;
 using ::atanh;
 using ::atanhf;
-using ::cbrt;
-using ::cbrtf;
 
 using ::copysign;
 using ::copysignf;
@@ -476,13 +471,11 @@ using ::modfl;
 using ::powl;
 using ::sinhl;
 using ::sinl;
-using ::sqrtl;
 using ::tanl;
 
 using ::acoshl;
 using ::asinhl;
 using ::atanhl;
-using ::cbrtl;
 using ::tanhl;
 
 using ::copysignl;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -319,6 +319,7 @@ long double    truncl(long double x);
 #endif // _CCCL_COMPILER(NVHPC)
 
 #include <cuda/std/__cmath/abs.h>
+#include <cuda/std/__cmath/exponential_functions.h>
 #include <cuda/std/__cmath/fpclassify.h>
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
@@ -361,12 +362,6 @@ using ::cosf;
 using ::cosh;
 using ::coshf;
 
-using ::exp;
-using ::expf;
-
-using ::pow;
-using ::powf;
-
 using ::sin;
 using ::sinf;
 using ::sinh;
@@ -396,16 +391,8 @@ using ::float_t;
 using ::fmod;
 using ::fmodf;
 
-using ::frexp;
-using ::frexpf;
-using ::ldexp;
-using ::ldexpf;
-
 using ::modf;
 using ::modff;
-
-using ::pow;
-using ::powf;
 
 using ::sin;
 using ::sinf;
@@ -432,10 +419,6 @@ using ::erf;
 using ::erfc;
 using ::erfcf;
 using ::erff;
-using ::exp2;
-using ::exp2f;
-using ::expm1;
-using ::expm1f;
 using ::fdim;
 using ::fdimf;
 using ::fma;
@@ -450,10 +433,6 @@ using ::remainder;
 using ::remainderf;
 using ::remquo;
 using ::remquof;
-using ::scalbln;
-using ::scalblnf;
-using ::scalbn;
-using ::scalbnf;
 using ::tgamma;
 using ::tgammaf;
 
@@ -463,12 +442,8 @@ using ::atan2l;
 using ::atanl;
 using ::coshl;
 using ::cosl;
-using ::expl;
 using ::fmodl;
-using ::frexpl;
-using ::ldexpl;
 using ::modfl;
-using ::powl;
 using ::sinhl;
 using ::sinl;
 using ::tanl;
@@ -482,8 +457,6 @@ using ::copysignl;
 
 using ::erfcl;
 using ::erfl;
-using ::exp2l;
-using ::expm1l;
 using ::fdiml;
 using ::fmal;
 using ::hypotl;
@@ -491,8 +464,6 @@ using ::lgammal;
 using ::nanl;
 using ::remainderl;
 using ::remquol;
-using ::scalblnl;
-using ::scalbnl;
 using ::tgammal;
 
 #endif // _CCCL_COMPILER(NVRTC)

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/cmath
@@ -323,6 +323,7 @@ long double    truncl(long double x);
 #include <cuda/std/__cmath/lerp.h>
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/min_max.h>
+#include <cuda/std/__cmath/rounding_functions.h>
 #include <cuda/std/__cmath/traits.h>
 #include <cuda/std/__cstdlib/abs.h>
 #include <cuda/std/limits>
@@ -354,8 +355,6 @@ using ::atan;
 using ::atan2;
 using ::atan2f;
 using ::atanf;
-using ::ceil;
-using ::ceilf;
 using ::cos;
 using ::cosf;
 using ::cosh;
@@ -394,9 +393,6 @@ using ::hypotf;
 
 using ::double_t;
 using ::float_t;
-
-using ::floor;
-using ::floorf;
 
 using ::fmod;
 using ::fmodf;
@@ -451,50 +447,28 @@ using ::fma;
 using ::fmaf;
 using ::lgamma;
 using ::lgammaf;
-using ::llrint;
-using ::llrintf;
-using ::llround;
-using ::llroundf;
-using ::lrint;
-using ::lrintf;
-using ::lround;
-using ::lroundf;
 
 using ::nan;
 using ::nanf;
 
-using ::nearbyint;
-using ::nearbyintf;
-using ::nextafter;
-using ::nextafterf;
-using ::nexttoward;
-using ::nexttowardf;
 using ::remainder;
 using ::remainderf;
 using ::remquo;
 using ::remquof;
-using ::rint;
-using ::rintf;
-using ::round;
-using ::roundf;
 using ::scalbln;
 using ::scalblnf;
 using ::scalbn;
 using ::scalbnf;
 using ::tgamma;
 using ::tgammaf;
-using ::trunc;
-using ::truncf;
 
 using ::acosl;
 using ::asinl;
 using ::atan2l;
 using ::atanl;
-using ::ceill;
 using ::coshl;
 using ::cosl;
 using ::expl;
-using ::floorl;
 using ::fmodl;
 using ::frexpl;
 using ::ldexpl;
@@ -521,22 +495,12 @@ using ::fdiml;
 using ::fmal;
 using ::hypotl;
 using ::lgammal;
-using ::llrintl;
-using ::llroundl;
-using ::lrintl;
-using ::lroundl;
 using ::nanl;
-using ::nearbyintl;
-using ::nextafterl;
-using ::nexttowardl;
 using ::remainderl;
 using ::remquol;
-using ::rintl;
-using ::roundl;
 using ::scalblnl;
 using ::scalbnl;
 using ::tgammal;
-using ::truncl;
 
 #endif // _CCCL_COMPILER(NVRTC)
 

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/exponential_functions.pass.cpp
@@ -1,0 +1,494 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+#if defined(TEST_COMPILER_MSVC)
+#  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
+#  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
+#  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif // TEST_COMPILER_MSVC
+
+template <typename T>
+__host__ __device__ bool eq(T lhs, T rhs) noexcept
+{
+  return lhs == rhs;
+}
+
+template <typename T, typename U, cuda::std::enable_if_t<cuda::std::is_arithmetic<U>::value, int> = 0>
+__host__ __device__ bool eq(T lhs, U rhs) noexcept
+{
+  return eq(lhs, T(rhs));
+}
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+__host__ __device__ bool eq(__half lhs, __half rhs) noexcept
+{
+  return ::__heq(lhs, rhs);
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+__host__ __device__ bool eq(__nv_bfloat16 lhs, __nv_bfloat16 rhs) noexcept
+{
+  return ::__heq(lhs, rhs);
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <class Integer>
+__host__ __device__ bool is_about(Integer x, Integer y)
+{
+  return true;
+}
+
+__host__ __device__ bool is_about(float x, float y)
+{
+  return (cuda::std::abs((x - y) / (x + y)) < 1.e-6);
+}
+
+__host__ __device__ bool is_about(double x, double y)
+{
+  return (cuda::std::abs((x - y) / (x + y)) < 1.e-14);
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+__host__ __device__ bool is_about(long double x, long double y)
+{
+  return (cuda::std::abs((x - y) / (x + y)) < 1.e-14);
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+__host__ __device__ bool is_about(__half x, __half y)
+{
+  return (cuda::std::fabs((x - y) / (x + y)) <= __half(1e-3));
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+
+#ifdef _LIBCUDACXX_HAS_NVBF16
+__host__ __device__ bool is_about(__nv_bfloat16 x, __nv_bfloat16 y)
+{
+  return (cuda::std::fabs((x - y) / (x + y)) <= __nv_bfloat16(5e-3));
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <typename T>
+__host__ __device__ void test_exp(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::exp(T{})), ret>::value, "");
+
+  const T euler = T(2.718281828459045);
+  assert(eq(cuda::std::exp(T(-0.0)), T(1.0)));
+  if (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::exp(val), euler));
+    assert(eq(cuda::std::exp(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
+  }
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::expf(val), euler));
+    assert(eq(cuda::std::expf(T(-0.0)), T(1.0)));
+    assert(eq(cuda::std::expf(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::expl(val), euler));
+    assert(eq(cuda::std::expl(T(-0.0)), T(1.0)));
+    assert(eq(cuda::std::expl(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_exp2(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::exp2(T{})), ret>::value, "");
+
+  assert(eq(cuda::std::exp2(val), T(2.0)));
+  assert(eq(cuda::std::exp2(val * T(4)), T(16.0)));
+  assert(eq(cuda::std::exp2(T(-0.0)), T(1.0)));
+  if (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::exp2(val * T(-4)), T(0.0625)));
+    assert(eq(cuda::std::exp2(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
+  }
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::exp2f(val), T(2.0)));
+    assert(eq(cuda::std::exp2f(val * T(4)), T(16.0)));
+    assert(eq(cuda::std::exp2f(val * T(-4)), T(0.0625)));
+    assert(eq(cuda::std::exp2f(T(-0.0)), T(1.0)));
+    assert(eq(cuda::std::exp2f(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::exp2l(val), T(2.0)));
+    assert(eq(cuda::std::exp2l(val * T(4)), T(16.0)));
+    assert(eq(cuda::std::exp2l(val * T(-4)), T(0.0625)));
+    assert(eq(cuda::std::exp2l(T(-0.0)), T(1.0)));
+    assert(eq(cuda::std::exp2l(T(-cuda::std::numeric_limits<T>::infinity())), T(0.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_expm1(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::expm1(T{})), ret>::value, "");
+
+  const T eulerm1 = T(1.718281828459045);
+  assert(eq(cuda::std::expm1(T(-0.0)), T(-0.0)));
+  if (!cuda::std::is_integral<T>::value)
+  {
+    assert(is_about(T(cuda::std::expm1(val)), eulerm1));
+    assert(eq(cuda::std::expm1(800), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::expm1(T(-cuda::std::numeric_limits<T>::infinity())), T(-1)));
+  }
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(is_about(T(cuda::std::expm1f(val)), eulerm1));
+    assert(eq(cuda::std::expm1f(T(-0.0)), T(-0.0)));
+    assert(eq(cuda::std::expm1f(800), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::expm1f(T(-cuda::std::numeric_limits<T>::infinity())), T(-1)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(is_about(T(cuda::std::expm1l(val)), eulerm1));
+    assert(eq(cuda::std::expm1l(T(-0.0)), T(-0.0)));
+    assert(eq(cuda::std::expm1l(800), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::expm1l(T(-cuda::std::numeric_limits<T>::infinity())), T(-1)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_frexp(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::frexp(T{}, nullptr)), ret>::value, "");
+
+  int exponent = -1;
+  assert(eq(cuda::std::frexp(T(0.0), &exponent), T(0.0)));
+  assert(exponent == 0);
+  exponent = -1;
+  assert(eq(cuda::std::frexp(T(-0.0), &exponent), T(0.0)));
+  assert(exponent == 0);
+  if (!cuda::std::is_integral<T>::value)
+  {
+    exponent = -1;
+    assert(eq(cuda::std::frexp(val, &exponent), T(0.5)));
+    assert(exponent == 1);
+    // exponent is undefined here
+    assert(eq(cuda::std::frexp(T(cuda::std::numeric_limits<T>::infinity()), &exponent),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::frexp(T(-cuda::std::numeric_limits<T>::infinity()), &exponent),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::frexp(T(cuda::std::numeric_limits<T>::quiet_NaN()), &exponent)));
+  }
+  if (cuda::std::is_same<T, float>::value)
+  {
+    exponent = -1;
+    assert(eq(cuda::std::frexpf(val, &exponent), T(0.5)));
+    assert(exponent == 1);
+
+    exponent = -1;
+    assert(eq(cuda::std::frexpf(T(0.0), &exponent), T(0.0)));
+    assert(exponent == 0);
+    exponent = -1;
+    assert(eq(cuda::std::frexpf(T(-0.0), &exponent), T(0.0)));
+    assert(exponent == 0);
+
+    // exponent is undefined here
+    assert(eq(cuda::std::frexpf(T(cuda::std::numeric_limits<T>::infinity()), &exponent),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::frexpf(T(-cuda::std::numeric_limits<T>::infinity()), &exponent),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::frexpf(T(cuda::std::numeric_limits<T>::quiet_NaN()), &exponent)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    exponent = -1;
+    assert(eq(cuda::std::frexpl(val, &exponent), T(0.5)));
+    assert(exponent == 1);
+    exponent = -1;
+    assert(eq(cuda::std::frexpl(T(0.0), &exponent), T(0.0)));
+    assert(exponent == 0);
+    exponent = -1;
+    assert(eq(cuda::std::frexpl(T(-0.0), &exponent), T(0.0)));
+    assert(exponent == 0);
+
+    // exponent is undefined here
+    assert(eq(cuda::std::frexpl(T(cuda::std::numeric_limits<T>::infinity()), &exponent),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::frexpl(T(-cuda::std::numeric_limits<T>::infinity()), &exponent),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::frexpl(T(cuda::std::numeric_limits<T>::quiet_NaN()), &exponent)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_ldexp(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::ldexp(T{}, int{})), ret>::value, "");
+
+  assert(eq(cuda::std::ldexp(T(0.0), 800), T(0.0)));
+  assert(eq(cuda::std::ldexp(T(-0.0), 800), T(0.0)));
+  assert(eq(cuda::std::ldexp(val, 5), T(32.0)));
+  assert(eq(cuda::std::ldexp(val, 0), val));
+  if (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::ldexp(T(cuda::std::numeric_limits<T>::infinity()), 1),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::ldexp(T(-cuda::std::numeric_limits<T>::infinity()), 1),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::ldexp(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
+  }
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::ldexpf(T(0.0), 800), T(0.0)));
+    assert(eq(cuda::std::ldexpf(T(-0.0), 800), T(0.0)));
+    assert(eq(cuda::std::ldexpf(val, 5), T(32.0)));
+    assert(eq(cuda::std::ldexpf(val, 0), val));
+    assert(eq(cuda::std::ldexpf(T(cuda::std::numeric_limits<T>::infinity()), 1),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::ldexpf(T(-cuda::std::numeric_limits<T>::infinity()), 1),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::ldexpf(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::ldexpl(T(0.0), 800), T(0.0)));
+    assert(eq(cuda::std::ldexpl(T(-0.0), 800), T(0.0)));
+    assert(eq(cuda::std::ldexpl(val, 5), T(32.0)));
+    assert(eq(cuda::std::ldexpl(val, 0), val));
+    assert(eq(cuda::std::ldexpl(T(cuda::std::numeric_limits<T>::infinity()), 1),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::ldexpl(T(-cuda::std::numeric_limits<T>::infinity()), 1),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::ldexpl(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_scalbln(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::scalbln(T{}, long{})), ret>::value, "");
+
+  assert(eq(cuda::std::scalbln(T(0.0), 800), T(0.0)));
+  assert(eq(cuda::std::scalbln(T(-0.0), 800), T(0.0)));
+  assert(eq(cuda::std::scalbln(val, 5), T(32.0)));
+  assert(eq(cuda::std::scalbln(val, 0), val));
+  if (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::scalbln(T(cuda::std::numeric_limits<T>::infinity()), 1),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::scalbln(T(-cuda::std::numeric_limits<T>::infinity()), 1),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::scalbln(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
+  }
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::scalblnf(T(0.0), 800), T(0.0)));
+    assert(eq(cuda::std::scalblnf(T(-0.0), 800), T(0.0)));
+    assert(eq(cuda::std::scalblnf(val, 5), T(32.0)));
+    assert(eq(cuda::std::scalblnf(val, 0), val));
+    assert(eq(cuda::std::scalblnf(T(cuda::std::numeric_limits<T>::infinity()), 1),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::scalblnf(T(-cuda::std::numeric_limits<T>::infinity()), 1),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::scalblnf(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::scalblnl(T(0.0), 800), T(0.0)));
+    assert(eq(cuda::std::scalblnl(T(-0.0), 800), T(0.0)));
+    assert(eq(cuda::std::scalblnl(val, 5), T(32.0)));
+    assert(eq(cuda::std::scalblnl(val, 0), val));
+    assert(eq(cuda::std::scalblnl(T(cuda::std::numeric_limits<T>::infinity()), 1),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::scalblnl(T(-cuda::std::numeric_limits<T>::infinity()), 1),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::scalblnl(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_scalbn(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::scalbn(T{}, int{})), ret>::value, "");
+
+  assert(eq(cuda::std::scalbn(T(0.0), 800), T(0.0)));
+  assert(eq(cuda::std::scalbn(T(-0.0), 800), T(0.0)));
+  assert(eq(cuda::std::scalbn(val, 5), T(32.0)));
+  assert(eq(cuda::std::scalbn(val, 0), val));
+  if (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::scalbn(T(cuda::std::numeric_limits<T>::infinity()), 1),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::scalbn(T(-cuda::std::numeric_limits<T>::infinity()), 1),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::scalbn(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
+  }
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::scalbnf(T(0.0), 800), T(0.0)));
+    assert(eq(cuda::std::scalbnf(T(-0.0), 800), T(0.0)));
+    assert(eq(cuda::std::scalbnf(val, 5), T(32.0)));
+    assert(eq(cuda::std::scalbnf(val, 0), val));
+    assert(eq(cuda::std::scalbnf(T(cuda::std::numeric_limits<T>::infinity()), 1),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::scalbnf(T(-cuda::std::numeric_limits<T>::infinity()), 1),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::scalbnf(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::scalbnl(T(0.0), 800), T(0.0)));
+    assert(eq(cuda::std::scalbnl(T(-0.0), 800), T(0.0)));
+    assert(eq(cuda::std::scalbnl(val, 5), T(32.0)));
+    assert(eq(cuda::std::scalbnl(val, 0), val));
+    assert(eq(cuda::std::scalbnl(T(cuda::std::numeric_limits<T>::infinity()), 1),
+              T(cuda::std::numeric_limits<T>::infinity())));
+    assert(eq(cuda::std::scalbnl(T(-cuda::std::numeric_limits<T>::infinity()), 1),
+              T(-cuda::std::numeric_limits<T>::infinity())));
+    assert(cuda::std::isnan(cuda::std::scalbnl(T(cuda::std::numeric_limits<T>::quiet_NaN()), 1)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_pow(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::pow(T{}, T{})), ret>::value, "");
+
+  assert(eq(cuda::std::pow(T(2.0), T(10.0)), T(1024.0)));
+  assert(eq(cuda::std::pow(val, cuda::std::numeric_limits<T>::infinity()), val));
+  assert(eq(cuda::std::pow(-val, cuda::std::numeric_limits<T>::infinity()), val));
+  assert(eq(cuda::std::pow(T(0.0), val), T(0.0)));
+  assert(eq(cuda::std::pow(T(-0.0), val), T(-0.0)));
+  if (!cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::pow(T(2), T(-3)), T(0.125)));
+
+    // Returns always 1 even for NaN
+    assert(eq(cuda::std::pow(val, cuda::std::numeric_limits<T>::quiet_NaN()), val));
+
+    assert(
+      eq(cuda::std::pow(T(2.0), cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::pow(T(2.0), -cuda::std::numeric_limits<T>::infinity()), T(0.0)));
+
+    assert(eq(cuda::std::pow(T(0.5), cuda::std::numeric_limits<T>::infinity()), T(0.0)));
+    assert(
+      eq(cuda::std::pow(T(0.5), -cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+  }
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::powf(T(2), T(-3)), T(0.125)));
+
+    // Returns always 1 even for NaN
+    assert(eq(cuda::std::powf(val, cuda::std::numeric_limits<T>::quiet_NaN()), val));
+
+    assert(
+      eq(cuda::std::powf(T(2.0), cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::powf(T(2.0), -cuda::std::numeric_limits<T>::infinity()), T(0.0)));
+
+    assert(eq(cuda::std::powf(T(0.5), cuda::std::numeric_limits<T>::infinity()), T(0.0)));
+    assert(
+      eq(cuda::std::powf(T(0.5), -cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::powl(T(2), T(-3)), T(0.125)));
+
+    // Returns always 1 even for NaN
+    assert(eq(cuda::std::powl(val, cuda::std::numeric_limits<T>::quiet_NaN()), val));
+
+    assert(
+      eq(cuda::std::powl(T(2.0), cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+    assert(eq(cuda::std::powl(T(2.0), -cuda::std::numeric_limits<T>::infinity()), T(0.0)));
+
+    assert(eq(cuda::std::powl(T(0.5), cuda::std::numeric_limits<T>::infinity()), T(0.0)));
+    assert(
+      eq(cuda::std::powl(T(0.5), -cuda::std::numeric_limits<T>::infinity()), cuda::std::numeric_limits<T>::infinity()));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_exp<T>(val);
+  test_exp2<T>(val);
+  test_expm1<T>(val);
+  test_frexp<T>(val);
+  test_ldexp<T>(val);
+  test_scalbln<T>(val);
+  test_scalbn<T>(val);
+  test_pow<T>(val);
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 1.0f;
+  test(val);
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/roots.pass.cpp
@@ -1,0 +1,138 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "fp_compare.h"
+#include "test_macros.h"
+
+#if defined(TEST_COMPILER_MSVC)
+#  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
+#  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif // TEST_COMPILER_MSVC
+
+template <typename T>
+__host__ __device__ bool eq(T lhs, T rhs) noexcept
+{
+  return lhs == rhs;
+}
+
+template <typename T, typename U, cuda::std::enable_if_t<cuda::std::is_arithmetic<U>::value, int> = 0>
+__host__ __device__ bool eq(T lhs, U rhs) noexcept
+{
+  return eq(lhs, T(rhs));
+}
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+__host__ __device__ bool eq(__half lhs, __half rhs) noexcept
+{
+  return ::__heq(lhs, rhs);
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+__host__ __device__ bool eq(__nv_bfloat16 lhs, __nv_bfloat16 rhs) noexcept
+{
+  return ::__heq(lhs, rhs);
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <typename T>
+__host__ __device__ void test_sqrt(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::sqrt(T{})), ret>::value, "");
+
+  assert(eq(cuda::std::sqrt(val), T(8.0)));
+  assert(eq(cuda::std::sqrt(T(0.0)), T(0.0)));
+  assert(eq(cuda::std::sqrt(T(cuda::std::numeric_limits<T>::infinity())), cuda::std::numeric_limits<T>::infinity()));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::sqrtf(val), T(8.0)));
+    assert(eq(cuda::std::sqrtf(T(0.0)), T(0.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::sqrtl(val), T(8)));
+    assert(eq(cuda::std::sqrtl(T(0.0)), T(0.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_cbrt(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::cbrt(T{})), ret>::value, "");
+
+  assert(eq(cuda::std::cbrt(val), T(2)));
+  assert(eq(cuda::std::cbrt(T(0.0)), T(0.0)));
+  assert(eq(cuda::std::cbrt(-T(0.0)), -T(0.0)));
+  assert(eq(cuda::std::cbrt(T(cuda::std::numeric_limits<T>::infinity())), cuda::std::numeric_limits<T>::infinity()));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::cbrtf(val), T(2)));
+    assert(eq(cuda::std::cbrtf(T(0.0)), T(0.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::cbrtl(val), T(2)));
+    assert(eq(cuda::std::cbrtl(T(0.0)), T(0.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_sqrt<T>(val);
+  test_cbrt<T>(val / T(8));
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 64.f;
+  test(val);
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/c.math/rounding.pass.cpp
@@ -1,0 +1,506 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cmath>
+
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "fp_compare.h"
+#include "test_macros.h"
+
+#if defined(TEST_COMPILER_MSVC)
+#  pragma warning(disable : 4244) // conversion from 'double' to 'float', possible loss of data
+#  pragma warning(disable : 4305) // 'argument': truncation from 'T' to 'float'
+#  pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif // TEST_COMPILER_MSVC
+
+template <typename T>
+__host__ __device__ bool eq(T lhs, T rhs) noexcept
+{
+  return lhs == rhs;
+}
+
+template <typename T, typename U, cuda::std::enable_if_t<cuda::std::is_arithmetic<U>::value, int> = 0>
+__host__ __device__ bool eq(T lhs, U rhs) noexcept
+{
+  return eq(lhs, T(rhs));
+}
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+__host__ __device__ bool eq(__half lhs, __half rhs) noexcept
+{
+  return ::__heq(lhs, rhs);
+}
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+__host__ __device__ bool eq(__nv_bfloat16 lhs, __nv_bfloat16 rhs) noexcept
+{
+  return ::__heq(lhs, rhs);
+}
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+template <typename T>
+__host__ __device__ void test_ceil(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::ceil(T{})), ret>::value, "");
+
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::ceil(val), val));
+    assert(eq(cuda::std::ceil(-val), -val));
+  }
+  else
+  {
+    assert(eq(cuda::std::ceil(val), T(2)));
+    assert(eq(cuda::std::ceil(-val), T(-1)));
+  }
+  assert(eq(cuda::std::ceil(T(-0.0)), T(-0.0)));
+  assert(eq(cuda::std::ceil(T(0.0)), T(0.0)));
+  assert(eq(cuda::std::ceil(T(-cuda::std::numeric_limits<T>::infinity())), -cuda::std::numeric_limits<T>::infinity()));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::ceilf(val), T(2)));
+    assert(eq(cuda::std::ceilf(-val), T(-1)));
+    assert(eq(cuda::std::ceilf(T(-0.0)), T(-0.0)));
+    assert(eq(cuda::std::ceilf(T(0.0)), T(0.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::ceill(val), T(2)));
+    assert(eq(cuda::std::ceill(-val), T(-1)));
+    assert(eq(cuda::std::ceill(T(-0.0)), T(-0.0)));
+    assert(eq(cuda::std::ceill(T(0.0)), T(0.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_floor(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::floor(T{})), ret>::value, "");
+
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::floor(val), val));
+    assert(eq(cuda::std::floor(-val), -val));
+  }
+  else
+  {
+    assert(eq(cuda::std::floor(val), T(1)));
+    assert(eq(cuda::std::floor(-val), T(-2)));
+  }
+  assert(eq(cuda::std::floor(T(-0.0)), T(-0.0)));
+  assert(eq(cuda::std::floor(T(0.0)), T(0.0)));
+  assert(eq(cuda::std::floor(T(-cuda::std::numeric_limits<T>::infinity())), -cuda::std::numeric_limits<T>::infinity()));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::floorf(val), T(1)));
+    assert(eq(cuda::std::floorf(-val), T(-2)));
+    assert(eq(cuda::std::floorf(T(-0.0)), T(-0.0)));
+    assert(eq(cuda::std::floorf(T(0.0)), T(0.0)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::floorl(val), T(1)));
+    assert(eq(cuda::std::floorl(-val), T(-2)));
+    assert(eq(cuda::std::floorl(T(-0.0)), T(-0.0)));
+    assert(eq(cuda::std::floorl(T(0.0)), T(0.0)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_llrint(T val)
+{
+  static_assert(cuda::std::is_same<decltype(cuda::std::llrint(T{})), long long>::value, "");
+
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::llrint(val), val));
+  }
+  else
+  {
+    assert(cuda::std::llrint(val) == 2);
+    assert(cuda::std::llrint(-val) == -2);
+    assert(cuda::std::llrint(val - T(0.2)) == 1);
+    assert(cuda::std::llrint(-val + T(0.2)) == -1);
+  }
+  assert(cuda::std::llrint(T(-0.0)) == -0);
+  assert(cuda::std::llrint(T(0.0)) == 0);
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::llrintf(val) == 2);
+    assert(cuda::std::llrintf(-val) == -2);
+    assert(cuda::std::llrintf(val - T(0.2)) == 1);
+    assert(cuda::std::llrintf(-val + T(0.2)) == -1);
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::llrintl(val) == 2);
+    assert(cuda::std::llrintl(-val) == -2);
+    assert(cuda::std::llrintl(val - T(0.2)) == 1);
+    assert(cuda::std::llrintl(-val + T(0.2)) == -1);
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_llround(T val)
+{
+  static_assert(cuda::std::is_same<decltype(cuda::std::llround(T{})), long long>::value, "");
+
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::llround(val), val));
+  }
+  else
+  {
+    assert(cuda::std::llround(val) == 2);
+    assert(cuda::std::llround(-val) == -2);
+    assert(cuda::std::llround(val - T(0.2)) == 1);
+    assert(cuda::std::llround(-val + T(0.2)) == -1);
+  }
+  assert(cuda::std::llround(T(-0.0)) == -0);
+  assert(cuda::std::llround(T(0.0)) == 0);
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::llroundf(val) == 2);
+    assert(cuda::std::llroundf(-val) == -2);
+    assert(cuda::std::llroundf(val - T(0.2)) == 1);
+    assert(cuda::std::llroundf(-val + T(0.2)) == -1);
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::llroundl(val) == 2);
+    assert(cuda::std::llroundl(-val) == -2);
+    assert(cuda::std::llroundl(val - T(0.2)) == 1);
+    assert(cuda::std::llroundl(-val + T(0.2)) == -1);
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_lrint(T val)
+{
+  static_assert(cuda::std::is_same<decltype(cuda::std::lrint(T{})), long>::value, "");
+
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::lrint(val), val));
+  }
+  else
+  {
+    assert(cuda::std::lrint(val) == 2);
+    assert(cuda::std::lrint(-val) == -2);
+    assert(cuda::std::lrint(val - T(0.2)) == 1);
+    assert(cuda::std::lrint(-val + T(0.2)) == -1);
+  }
+  assert(cuda::std::lrint(T(-0.0)) == -0);
+  assert(cuda::std::lrint(T(0.0)) == 0);
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::lrintf(val) == 2);
+    assert(cuda::std::lrintf(-val) == -2);
+    assert(cuda::std::lrintf(val - T(0.2)) == 1);
+    assert(cuda::std::lrintf(-val + T(0.2)) == -1);
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::lrintl(val) == 2);
+    assert(cuda::std::lrintl(-val) == -2);
+    assert(cuda::std::lrintl(val - T(0.2)) == 1);
+    assert(cuda::std::lrintl(-val + T(0.2)) == -1);
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_lround(T val)
+{
+  static_assert(cuda::std::is_same<decltype(cuda::std::lround(T{})), long>::value, "");
+
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::lround(val), val));
+  }
+  else
+  {
+    assert(cuda::std::lround(val) == 2);
+    assert(cuda::std::lround(-val) == -2);
+    assert(cuda::std::lround(val - T(0.2)) == 1);
+    assert(cuda::std::lround(-val + T(0.2)) == -1);
+  }
+  assert(cuda::std::lround(T(-0.0)) == -0);
+  assert(cuda::std::lround(T(0.0)) == 0);
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(cuda::std::lroundf(val) == 2);
+    assert(cuda::std::lroundf(-val) == -2);
+    assert(cuda::std::lroundf(val - T(0.2)) == 1);
+    assert(cuda::std::lroundf(-val + T(0.2)) == -1);
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(cuda::std::lroundl(val) == 2);
+    assert(cuda::std::lroundl(-val) == -2);
+    assert(cuda::std::lroundl(val - T(0.2)) == 1);
+    assert(cuda::std::lroundl(-val + T(0.2)) == -1);
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_nearbyint(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::nearbyint(T{})), ret>::value, "");
+
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::nearbyint(val), val));
+    assert(eq(cuda::std::nearbyint(-val), -val));
+  }
+  else
+  {
+    assert(eq(cuda::std::nearbyint(val), 2));
+    assert(eq(cuda::std::nearbyint(-val), -2));
+    assert(eq(cuda::std::nearbyint(val - T(0.2)), T(1)));
+    assert(eq(cuda::std::nearbyint(-val + T(0.2)), T(-1)));
+  }
+  assert(eq(cuda::std::nearbyint(T(-0.0)), T(-0.0)));
+  assert(eq(cuda::std::nearbyint(T(0.0)), T(0.0)));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::nearbyintf(val), T(2)));
+    assert(eq(cuda::std::nearbyintf(-val), T(-2)));
+    assert(eq(cuda::std::nearbyintf(val - T(0.2)), T(1)));
+    assert(eq(cuda::std::nearbyintf(-val + T(0.2)), T(-1)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::nearbyintl(val), T(2)));
+    assert(eq(cuda::std::nearbyintl(-val), T(-2)));
+    assert(eq(cuda::std::nearbyintl(val - T(0.2)), T(1)));
+    assert(eq(cuda::std::nearbyintl(-val + T(0.2)), T(-1)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_nextafter(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::nextafter(T{}, T{})), ret>::value, "");
+
+  // assert(eq(cuda::std::nextafter(cuda::std::nextafter(val, T(10)), T(-10)), val));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::nextafterf(cuda::std::nextafterf(val, T(10)), T(-10)), val));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::nextafterl(cuda::std::nextafterl(val, T(10)), T(-10)), val));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+template <typename T>
+__host__ __device__ void test_nexttoward(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::nexttoward(T{}, long double{})), ret>::value, "");
+
+  assert(eq(cuda::std::nexttoward(cuda::std::nexttoward(val, long double(10.0)), long double(-10.0)), val));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::nexttowardf(cuda::std::nexttowardf(val, long double(10.0)), long double(-10.0)), val));
+  }
+  else if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::nexttowardl(cuda::std::nexttowardl(val, long double(10.0)), long double(-10.0)), val));
+  }
+}
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+template <typename T>
+__host__ __device__ void test_rint(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::rint(T{})), ret>::value, "");
+
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::rint(val), val));
+    assert(eq(cuda::std::rint(-val), -val));
+  }
+  else
+  {
+    assert(eq(cuda::std::rint(val), 2));
+    assert(eq(cuda::std::rint(-val), -2));
+    assert(eq(cuda::std::rint(val - T(0.2)), T(1)));
+    assert(eq(cuda::std::rint(-val + T(0.2)), T(-1)));
+  }
+  assert(eq(cuda::std::rint(T(-0.0)), T(-0.0)));
+  assert(eq(cuda::std::rint(T(0.0)), T(0.0)));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::rintf(val), T(2)));
+    assert(eq(cuda::std::rintf(-val), T(-2)));
+    assert(eq(cuda::std::rintf(val - T(0.2)), T(1)));
+    assert(eq(cuda::std::rintf(-val + T(0.2)), T(-1)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::rintl(val), T(2)));
+    assert(eq(cuda::std::rintl(-val), T(-2)));
+    assert(eq(cuda::std::rintl(val - T(0.2)), T(1)));
+    assert(eq(cuda::std::rintl(-val + T(0.2)), T(-1)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_round(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::round(T{})), ret>::value, "");
+
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::round(val), val));
+    assert(eq(cuda::std::round(-val), -val));
+  }
+  else
+  {
+    assert(eq(cuda::std::round(val), 2));
+    assert(eq(cuda::std::round(-val), -2));
+    assert(eq(cuda::std::round(val - T(0.2)), T(1)));
+    assert(eq(cuda::std::round(-val + T(0.2)), T(-1)));
+  }
+  assert(eq(cuda::std::round(T(-0.0)), T(-0.0)));
+  assert(eq(cuda::std::round(T(0.0)), T(0.0)));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::roundf(val), T(2)));
+    assert(eq(cuda::std::roundf(-val), T(-2)));
+    assert(eq(cuda::std::roundf(val - T(0.2)), T(1)));
+    assert(eq(cuda::std::roundf(-val + T(0.2)), T(-1)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::roundl(val), T(2)));
+    assert(eq(cuda::std::roundl(-val), T(-2)));
+    assert(eq(cuda::std::roundl(val - T(0.2)), T(1)));
+    assert(eq(cuda::std::roundl(-val + T(0.2)), T(-1)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test_trunc(T val)
+{
+  using ret = cuda::std::conditional_t<cuda::std::is_integral<T>::value, double, T>;
+  static_assert(cuda::std::is_same<decltype(cuda::std::trunc(T{})), ret>::value, "");
+  if (cuda::std::is_integral<T>::value)
+  {
+    assert(eq(cuda::std::trunc(val), val));
+    assert(eq(cuda::std::trunc(-val), -val));
+  }
+  else
+  {
+    assert(eq(cuda::std::trunc(val), T(1)));
+    assert(eq(cuda::std::trunc(-val), T(-1)));
+  }
+  assert(eq(cuda::std::trunc(T(-0.0)), T(-0.0)));
+  assert(eq(cuda::std::trunc(T(0.0)), T(0.0)));
+  assert(eq(cuda::std::trunc(T(-cuda::std::numeric_limits<T>::infinity())), -cuda::std::numeric_limits<T>::infinity()));
+  if (cuda::std::is_same<T, float>::value)
+  {
+    assert(eq(cuda::std::truncf(val), T(1)));
+    assert(eq(cuda::std::truncf(-val), T(-1)));
+  }
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  else if (cuda::std::is_same<T, long double>::value)
+  {
+    assert(eq(cuda::std::truncl(val), T(1)));
+    assert(eq(cuda::std::truncl(-val), T(-1)));
+  }
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+}
+
+template <typename T>
+__host__ __device__ void test(const T val)
+{
+  test_ceil<T>(val);
+  test_floor<T>(val);
+  test_llrint<T>(val);
+  test_llround<T>(val);
+  test_lrint<T>(val);
+  test_lround<T>(val);
+  test_nearbyint<T>(val);
+  test_nextafter<T>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test_nexttoward<T>(val);
+#endif // !_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+  test_rint<T>(val);
+  test_round<T>(val);
+  test_trunc<T>(val);
+}
+
+__host__ __device__ void test(const float val)
+{
+  test<float>(val);
+  test<double>(val);
+#if !defined(_LIBCUDACXX_HAS_NO_LONG_DOUBLE)
+  test<long double>();
+#endif //!_LIBCUDACXX_HAS_NO_LONG_DOUBLE
+
+#ifdef _LIBCUDACXX_HAS_NVFP16
+  test<__half>(val);
+#endif // _LIBCUDACXX_HAS_NVFP16
+#ifdef _LIBCUDACXX_HAS_NVBF16
+  test<__nv_bfloat16>(val);
+#endif // _LIBCUDACXX_HAS_NVBF16
+
+  test<unsigned short>(static_cast<unsigned short>(val));
+  test<int>(static_cast<int>(val));
+  test<unsigned int>(static_cast<unsigned int>(val));
+  test<long>(static_cast<long>(val));
+  test<unsigned long>(static_cast<unsigned long>(val));
+  test<long long>(static_cast<long long>(val));
+  test<unsigned long long>(static_cast<unsigned long long>(val));
+}
+
+__global__ void test_global_kernel(float* val)
+{
+  test(*val);
+}
+
+int main(int, char**)
+{
+  volatile float val = 1.6f;
+  test(val);
+  return 0;
+}


### PR DESCRIPTION
We currently just pull in the majority of the cmath functions from the global namespace.

However, those are mostly not annotated as host device functions so this requires users to use `--relaxed-constexpr`

Continue the sage of implementing the math functions

Partially addresses #3371