### PR TITLE
Exit with error when RAPIDS CI fails.

### DIFF
--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -134,6 +134,12 @@ jobs:
               sccache --show-adv-stats
             done
           done
+
+          # Exit with error if any failures occurred
+          if test ${#failures[@]} -ne 0; then
+            exit 1
+          fi
+
           EOF
 
           chmod +x "$RUNNER_TEMP"/ci{,-entrypoint}.sh


### PR DESCRIPTION
Fixing issue with CI not reporting RAPIDS build failures, eg. https://github.com/NVIDIA/cccl/actions/runs/12713704758/job/35442194448?pr=3330