### PR TITLE
Fix sign-compare warning

### DIFF
--- a/cub/test/catch2_segmented_sort_helper.cuh
+++ b/cub/test/catch2_segmented_sort_helper.cuh
@@ -250,7 +250,7 @@ public:
           auto const next_end =
             (uniques_index == count - 1) ? out_keys.size() : h_unique_indexes_out[uniques_index + 1];
           REQUIRE(h_unique_keys_out[uniques_index] == i);
-          REQUIRE(next_end - h_unique_indexes_out[uniques_index] == segment_histogram[i]);
+          REQUIRE(next_end - h_unique_indexes_out[uniques_index] == static_cast<std::size_t>(segment_histogram[i]));
           current_offset += segment_histogram[i];
           uniques_index++;
         }


### PR DESCRIPTION
I get this warning in some PRs and it seems unrelated to whatever the PR proposes:
```
  /home/coder/cccl/cub/test/catch2_segmented_sort_helper.cuh:253:224: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
             REQUIRE(next_end - h_unique_indexes_out[uniques_index] == segment_histogram[i]);
```
E.g. here: https://github.com/NVIDIA/cccl/actions/runs/12792256812/job/35662342532?pr=3401

So here is a fix.