### PR TITLE
Add `__int128` and `__float128` detection macros

### DIFF
--- a/docs/cccl_development/macro.rst
+++ b/docs/cccl_development/macro.rst
@@ -87,6 +87,14 @@ The following macros are used to check the target architecture. They comply with
 | ``_CCCL_ARCH(X86_64)``  |  X86 64-bit                         |
 +-------------------------+-------------------------------------+
 
+**128-bit Types Macros**:
+
++--------------------------+-------------------------------------+
+| ``_CCCL_HAS_INT128()``   |  Support for 128-bit integer        |
++--------------------------+-------------------------------------+
+| ``_CCCL_HAS_FLOAT128()`` |  Support for 128-bit floating-point |
++--------------------------+-------------------------------------+
+
 ----
 
 OS Macros

--- a/libcudacxx/include/cuda/__cccl_config
+++ b/libcudacxx/include/cuda/__cccl_config
@@ -11,6 +11,7 @@
 #ifndef _CUDA__CCCL_CONFIG
 #define _CUDA__CCCL_CONFIG
 
+#include <cuda/std/__cccl/128bit_types.h> // IWYU pragma: export
 #include <cuda/std/__cccl/architecture.h> // IWYU pragma: export
 #include <cuda/std/__cccl/assert.h> // IWYU pragma: export
 #include <cuda/std/__cccl/attributes.h> // IWYU pragma: export

--- a/libcudacxx/include/cuda/std/__cccl/128bit_types.h
+++ b/libcudacxx/include/cuda/std/__cccl/128bit_types.h
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CCCL_128BIT_TYPES_H
+#define __CCCL_128BIT_TYPES_H
+
+#include <cuda/std/__cccl/compiler.h>
+#include <cuda/std/__cccl/os.h>
+
+#ifndef _CCCL_DISABLE_INT128
+#  if defined(__SIZEOF_INT128__)
+#    if _CCCL_COMPILER(NVRTC) && defined(__CUDACC_RTC_INT128__)
+#      define _CCCL_HAS_INT128() 1
+#    elif (_CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG) || _CCCL_COMPILER(NVHPC)) && !_CCCL_OS(WINDOWS)
+#      define _CCCL_HAS_INT128() 1
+#    else
+#      define _CCCL_HAS_INT128() 0
+#    endif
+#  endif // defined(__SIZEOF_INT128__)
+#else
+#  define _CCCL_HAS_INT128() 0
+#endif // #ifndef _CCCL_DISABLE_INT128
+
+#ifndef _CCCL_DISABLE_FLOAT128
+#  if (defined(__SIZEOF_FLOAT128__) || defined(__FLOAT128__)) && _CCCL_OS(LINUX) \
+    && (_CCCL_COMPILER(GCC) || _CCCL_COMPILER(CLANG) || _CCCL_COMPILER(NVHPC)) && !defined(__CUDA_ARCH__)
+#    define _CCCL_HAS_FLOAT128() 1
+#  else
+#    define _CCCL_HAS_FLOAT128() 0
+#  endif
+#endif // #ifndef _CCCL_DISABLE_FLOAT128
+
+#endif // __CCCL_128BIT_TYPES_H

--- a/libcudacxx/test/libcudacxx/std/cccl/128bit_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/cccl/128bit_types.compile.pass.cpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__cccl/128bit_types.h>
+
+#include "test_macros.h"
+
+int main(int, char**)
+{
+#if _CCCL_HAS_INT128()
+  auto x = __int128(123456789123) + __int128(123456789123);
+  auto y = __uint128_t(123456789123) + __uint128_t(123456789123);
+  unused(x);
+  unused(y);
+#endif
+#if _CCCL_HAS_FLOAT128()
+  auto z = __float128(3.14) + __float128(3.14);
+  unused(z);
+#endif
+  return 0;
+}


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cccl/issues/3403

## Description

Add `_CCCL_HAS_INT128` and `_CCCL_HAS_FLOAT128` to detect `__int128` and `__float128`