### PR TITLE
Update upload-pages-artifact to v3

### DIFF
--- a/.github/actions/docs-build/action.yml
+++ b/.github/actions/docs-build/action.yml
@@ -54,4 +54,4 @@ runs:
     # Upload docs as pages artifacts
     - name: Upload artifact
       if: ${{ inputs.upload_pages_artifact == 'true' }}
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Description

The Build and Verify docs jobs have been failing due to using an older upload-pages-artifact. The failure looks like:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

It looks like the older `upload-artifact`  is coming from using an older `upload-pages-artifact`. I've upgraded that from v2->v3 to see if it helps.


<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
