### PR TITLE
Add `--extended-lambda` to the list of removed clangd flags

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -51,6 +51,7 @@ CompileFlags:
     # strip CUDA flags unknown to clang
     - "-ccbin*"
     - "--compiler-options*"
+    - "--extended-lambda"
     - "--expt-extended-lambda"
     - "--expt-relaxed-constexpr"
     - "-forward-unknown-to-host-compiler"


### PR DESCRIPTION
## Description

`clangd` doesn't support `--extended-lambda` flag (Allow __host__, __device__ annotations in lambda declaration).
The PR is aligned with the flag `--expt-extended-lambda` already present in `.clangd`.