### PR TITLE
Fix Deploy CCCL pages workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description
Meant to fix this failure:

* https://github.com/NVIDIA/cccl/actions/runs/12822341067

```
[deploy](https://github.com/NVIDIA/cccl/actions/runs/12822341067/job/35755949074#step:2:36)
Error: No uploaded artifact was found! Please check if there are any errors at build step, or uploaded artifact name is correct.
    at getSignedArtifactMetadata (/home/runner/work/_actions/actions/deploy-pages/v2/src/internal/api-client.js:94:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v2/src/internal/deployment.js:68:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v2/src/index.js:30:1)
```