### PR TITLE
[CUDAX] Fix CI issues in the nightly testing

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/level_dimensions.cuh
@@ -118,7 +118,7 @@ struct level_dimensions
   using level_type = Level;
 
   // Needs alignas to work around an issue with tuple
-  alignas(16) const Dimensions dims; // Unit for dimensions is implicit
+  alignas(16) Dimensions dims; // Unit for dimensions is implicit
 
   _CCCL_HOST_DEVICE constexpr level_dimensions(const Dimensions& d)
       : dims(d)

--- a/cudax/test/green_context/green_ctx_smoke.cu
+++ b/cudax/test/green_context/green_ctx_smoke.cu
@@ -60,4 +60,10 @@ TEST_CASE("Green context", "[green_context]")
     }
   }
 }
+#else
+// For some reason CI fails with empty test, add a dummy test case
+TEST_CASE("Dummy test case")
+{
+  CUDAX_REQUIRE(1 == 1);
+}
 #endif // CUDART_VERSION >= 12050


### PR DESCRIPTION
1. The green context test is failing in CI with Cuda 12.0, it has all test under 12.5 ifdef, so it seems the CI doesn't like empty tests. This PR adds a dummy test case to avoid this issue

2. There is a bug in nvcc 12.0 where defaulted comparison gets deleted by the compiler if a type wraps a tuple that contains types with const members [link](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIAruiakl9ZATwDKjdAGFUtEywYgAnKUcAZPAZMADl3ACNMYgkAdlIAB1QFQjsGFzcPb3jE5IEAoNCWCKiuWKtMGxShAiZiAjT3Tx8yioEqmoI8kPDImMtq2vqMpv6OwK7CnpKASktUE2Jkdg4AUgAmAGZA5DcsAGpl9acCEzj6A%2BxljQBBS6uCTBZTpnv9w4IATzjGVkwAOn/dn5MAA3TC0BTnW4KAjEEw2XbHU6YAD6tDwAGtMLdltEAEK3Xa7EAgaHoYmIs6HIGg8H/X7nXb0GkQ9b464E3ZoBjQzCqOLEBEneiojGYCBc6FEkkEMkgClYqkgsEKOmQ1YANkZCimuwYqF5iziBA5hMJIEZSvBEHBUw5OPx0QAItjroSwqhXLtUF9iM8SAdnetHeKBJL5SLMWt1TqJQRdfrVIa4wHdlgqEwTLRjazsU6DmybtdobD4UJcwXCbHdoE43h8y6rm6PbQvT6/cQAwGQ9y42WNTHQ3G9QbMEbXo7U5h05nswWcYG59ca7sWExAhAdfaORmiAiuOPdqTiavMcj5RAy3iuPPbTnXbsd6gEasD0eQCeUefL7jr07bxW93HFMCFWet2XvR8EXWA9wzRTEIAILh/23ExdwISQYKFFE4LFRDkPvAhoM7IMEUkMDG12YhMGOYgGF2DRyPnDgZloTgAFZeE8DgtFIVBOCcORHUbJw1nxVZcUPOYFkwfYNh4UgCE0ZiZnREA2K4X4AA51kkSR1K8DQuDY9V1Q0DQ2P0ThJE4pTeM4XgFBADQFKUmY4FgGBEBQVBHjoSJyEoNBfPoKIGGBZBkC4VZnJoLNIkciAwlssJAhqd5OHklLmGId4AHkwm0cpFO4XggrYQRcoYWh0u43gsDCExgCcMRwQyuqHkMYBxFq0h8CoipQUcnreXKVClnkmswVstEwl9HKXCwNqFOIPAWCW0FiHdJRHQ6ow0SMVy%2BAMYAFAANTwTAAHdcq%2BLj5P4QQRDEdgpBkQRFBUdQet0Lh9E6lAzAsGbHMgGZvVsUNOAAWlJANkFE0Tot4VANpWrAQY3SwwSKlIHAYZxXAaPR/DGAoij0BIkgh1JCYyX7KZyBhOjJyYsesam2gGWnPF%2B5oOZGZnumKPp2kGHmRdqQWJmKGYFCkxYJBY9ibJ6viOF2YJTqcJxdii34NH13YIFwQgSFk9YkN4YqtCmFSQFWaJfg1TSHfWYy9PVLxNPVSyOGs0g1vWdZfiD0Ow7DiyuJ4tWHKclzarczyICQOYCDiVCApDYLImCH5OFUb2ofVDDgAi3YvBD3hMHwIg0b0B7hFEcRXobj61Fsn7SEu304japWOA40go%2BRzhctQ9O41QKgNa1nW9YNjQjZcbOBTWC2pit1z%2B/9wPVn1zSNGi8zDNWNiLekYe7I4WPnOt5jSHcrysGBPBFkzoK4j84hc7YThNe13We8F7tRfgra%2Bvga4kDwGSX6DcnrN2kK3JQ7dvp6D5rjCAjgxbE3xlLcm9NsjU2wQQqmKQ8Gs3Qa0EYxC2Y4yoe0chwtoSi25mggWpMhaK2WpgTA0CnL90HpfNWO1QEyXOldSIM8AHz0NsbSBq85KkF2MvT%2BIVzaW3jjbbevBA6SF%2BGxb2kgTJcHVGxSQXA3aR1sjHSwcc7621IKpSQmlfgmLYmYg%2BXtJA6UMj7ViHB1gq2jvZTRylfarCCSPcB9iZgbSSPYSQQA%3D%3D%3D). It starts passing again with nvcc 12.2, so it seems the problem was fixed already. But we still test with 12.0 and we run into this issue with comparison operator in the hierarchy type. I think the best solution is to get rid of the const member part, which is currently the case with dimensions member of `level_dimensions` type. There isn't anything about the state of that object that relies on dynamic dimensions to stay constant and public const members are generally considered a mistake.
This PR removes const from that member.