### PR TITLE
[BACKPORT]: Fix assert definition for NVHPC due to constexpr issues (#3418)

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/assert.h
+++ b/libcudacxx/include/cuda/std/__cccl/assert.h
@@ -128,13 +128,14 @@ _CCCL_HOST_DEVICE
 
 //! _CCCL_VERIFY is enabled unconditionally and reserved for critical checks that are required to always be on
 //! _CCCL_ASSERT is enabled conditionally depending on CCCL_ENABLE_HOST_ASSERTIONS and CCCL_ENABLE_DEVICE_ASSERTIONS
-#if _CCCL_CUDA_COMPILER(NVHPC) // NVHPC needs to use NV_IF_TARGET instead of __CUDA_ARCH__
-#  define _CCCL_VERIFY(expression, message) \
-    NV_IF_ELSE_TARGET(                      \
-      NV_IS_DEVICE, (_CCCL_ASSERT_IMPL_DEVICE(expression, message);), (_CCCL_ASSERT_IMPL_HOST(expression, message);))
-#  define _CCCL_ASSERT(expression, message) \
-    NV_IF_ELSE_TARGET(                      \
-      NV_IS_DEVICE, (_CCCL_ASSERT_DEVICE(expression, message);), (_CCCL_ASSERT_HOST(expression, message);))
+#if _CCCL_CUDA_COMPILER(NVHPC) // NVHPC can't have different behavior for host and device.
+                               // The host version of the assert will also work in device code.
+#  define _CCCL_VERIFY(expression, message) _CCCL_ASSERT_IMPL_HOST(expression, message)
+#  if defined(CCCL_ENABLE_HOST_ASSERTIONS) || defined(CCCL_ENABLE_DEVICE_ASSERTIONS)
+#    define _CCCL_ASSERT(expression, message) _CCCL_ASSERT_HOST(expression, message)
+#  else
+#    define _CCCL_ASSERT(expression, message) ((void) 0)
+#  endif
 #elif _CCCL_HAS_CUDA_COMPILER
 #  ifdef __CUDA_ARCH__
 #    define _CCCL_VERIFY(expression, message) _CCCL_ASSERT_IMPL_DEVICE(expression, message)


### PR DESCRIPTION
NVHPC cannot decide at compile time where the code would run so _CCCL_ASSERT within a constexpr function breaks it.

Fix this by always using the host definition which should also work on device.

Fixes #3411
