### PR TITLE
Turn C++ dialect warning into error

### DIFF
--- a/cub/cub/util_cpp_dialect.cuh
+++ b/cub/cub/util_cpp_dialect.cuh
@@ -88,7 +88,7 @@ CUB_COMPILER_DEPRECATION_SOFT(MSVC 2019(19.20 / 16.0 / 14.20), MSVC 2017);
 // C++17 dialect check:
 #  ifndef CCCL_IGNORE_DEPRECATED_CPP_DIALECT
 #    if _CCCL_STD_VER < 2017
-CUB_COMP_DEPR_IMPL(CUB requires at least C++ 17. Define CCCL_IGNORE_DEPRECATED_CPP_DIALECT to suppress this message.)
+#      error CUB requires at least C++17. Define CCCL_IGNORE_DEPRECATED_CPP_DIALECT to suppress this message.
 #    endif // _CCCL_STD_VER >= 2017
 #  endif
 

--- a/thrust/thrust/detail/config/cpp_dialect.h
+++ b/thrust/thrust/detail/config/cpp_dialect.h
@@ -78,8 +78,7 @@ THRUST_COMPILER_DEPRECATION_SOFT(MSVC 2019(19.20 / 16.0 / 14.20), MSVC 2017);
 // C++17 dialect check:
 #ifndef CCCL_IGNORE_DEPRECATED_CPP_DIALECT
 #  if _CCCL_STD_VER < 2017
-THRUST_COMP_DEPR_IMPL(
-  Thrust requires at least C++ 17. Define CCCL_IGNORE_DEPRECATED_CPP_DIALECT to suppress this message.)
+#    error Thrust requires at least C++17. Define CCCL_IGNORE_DEPRECATED_CPP_DIALECT to suppress this message.
 #  endif // _CCCL_STD_VER >= 2017
 #endif
 


### PR DESCRIPTION
Accidentially compiling with < C++17 issues a warning (That C++ < 17 is no longer supported), but also causes errors later during compilation and the dialect warning is lost in the compiler error novel. We should error out sooner so users have a clear error message.