### PR TITLE
Deprecate a few CUB macros

### DIFF
--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -51,32 +51,38 @@ CUB_NAMESPACE_BEGIN
 
 #ifndef CUB_MAX
 /// Select maximum(a, b)
+/// Deprecated since [2.8]
 #  define CUB_MAX(a, b) (((b) > (a)) ? (b) : (a))
 #endif
 
 #ifndef CUB_MIN
 /// Select minimum(a, b)
+/// Deprecated since [2.8]
 #  define CUB_MIN(a, b) (((b) < (a)) ? (b) : (a))
 #endif
 
 #ifndef CUB_QUOTIENT_FLOOR
 /// Quotient of x/y rounded down to nearest integer
+/// Deprecated since [2.8]
 #  define CUB_QUOTIENT_FLOOR(x, y) ((x) / (y))
 #endif
 
 #ifndef CUB_QUOTIENT_CEILING
 /// Quotient of x/y rounded up to nearest integer
+/// Deprecated since [2.8]
 // FIXME(bgruber): the following computation can overflow, use cuda::ceil_div instead
 #  define CUB_QUOTIENT_CEILING(x, y) (((x) + (y) - 1) / (y))
 #endif
 
 #ifndef CUB_ROUND_UP_NEAREST
 /// x rounded up to the nearest multiple of y
+/// Deprecated since [2.8]
 #  define CUB_ROUND_UP_NEAREST(x, y) (CUB_QUOTIENT_CEILING(x, y) * y)
 #endif
 
 #ifndef CUB_ROUND_DOWN_NEAREST
 /// x rounded down to the nearest multiple of y
+/// Deprecated since [2.8]
 #  define CUB_ROUND_DOWN_NEAREST(x, y) (((x) / (y)) * y)
 #endif
 


### PR DESCRIPTION
Deprecate `CUB_MAX`, `CUB_MIN`, `CUB_QUOTIENT_FLOOR`, `CUB_QUOTIENT_CEILING`, `CUB_ROUND_UP_NEAREST`, and `CUB_ROUND_DOWN_NEAREST`. No replacements are being made yet, because this PR should be backported to 2.8.x and we may need C++17 for some of the replacements. So let's not backport the replacements.