### PR TITLE
Deprecate thrust event, future and more

### DIFF
--- a/thrust/testing/allocator_aware_policies.cu
+++ b/thrust/testing/allocator_aware_policies.cu
@@ -1,3 +1,8 @@
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings for execute_with_allocator_and_dependencies here and inside type traits
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/seq.h>
 #include <thrust/system/cpp/detail/par.h>
 #include <thrust/system/omp/detail/par.h>
@@ -70,9 +75,7 @@ struct TestAllocatorAttachment
   {
     using thrust::detail::get_temporary_buffer;
 
-    _CCCL_SUPPRESS_DEPRECATED_PUSH
     return_temporary_buffer(policy, get_temporary_buffer<int>(policy, 123).first, 123);
-    _CCCL_SUPPRESS_DEPRECATED_POP
   }
 
   void operator()()
@@ -96,11 +99,9 @@ struct TestAllocatorAttachment
     test_temporary_allocation_valid(policy(const_alloc));
     test_temporary_allocation_valid(policy(&test_memory_resource));
 
-    _CCCL_SUPPRESS_DEPRECATED_PUSH
     test_temporary_allocation_valid(policy(std::allocator<int>()).after(1));
     test_temporary_allocation_valid(policy(alloc).after(1));
     test_temporary_allocation_valid(policy(const_alloc).after(1));
-    _CCCL_SUPPRESS_DEPRECATED_POP
   }
 };
 
@@ -122,3 +123,5 @@ SimpleUnitTest<TestAllocatorAttachment,
                                    omp_par_info,
                                    tbb_par_info>>
   TestAllocatorAttachmentInstance;
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/allocator_aware_policies.cu
+++ b/thrust/testing/allocator_aware_policies.cu
@@ -70,7 +70,9 @@ struct TestAllocatorAttachment
   {
     using thrust::detail::get_temporary_buffer;
 
+    _CCCL_SUPPRESS_DEPRECATED_PUSH
     return_temporary_buffer(policy, get_temporary_buffer<int>(policy, 123).first, 123);
+    _CCCL_SUPPRESS_DEPRECATED_POP
   }
 
   void operator()()
@@ -94,9 +96,11 @@ struct TestAllocatorAttachment
     test_temporary_allocation_valid(policy(const_alloc));
     test_temporary_allocation_valid(policy(&test_memory_resource));
 
+    _CCCL_SUPPRESS_DEPRECATED_PUSH
     test_temporary_allocation_valid(policy(std::allocator<int>()).after(1));
     test_temporary_allocation_valid(policy(alloc).after(1));
     test_temporary_allocation_valid(policy(const_alloc).after(1));
+    _CCCL_SUPPRESS_DEPRECATED_POP
   }
 };
 

--- a/thrust/testing/async/exclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/exclusive_scan/counting_iterator.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -40,3 +44,5 @@ struct test_counting_iterator
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegralTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/discard_output.cu
+++ b/thrust/testing/async/exclusive_scan/discard_output.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -37,3 +41,5 @@ struct test_discard
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/large_indices.cu
+++ b/thrust/testing/async/exclusive_scan/large_indices.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -237,3 +241,5 @@ void test_large_indices_custom_scan_op()
 DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/large_types.cu
+++ b/thrust/testing/async/exclusive_scan/large_types.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -52,3 +56,5 @@ struct test_large_types
 DECLARE_UNITTEST(test_large_types);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/exclusive_scan/mixed_types.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -115,3 +119,5 @@ void test_scan_mixed_types(size_t num_values)
 DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/simple.cu
+++ b/thrust/testing/async/exclusive_scan/simple.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -65,3 +69,5 @@ struct test_simple_in_place
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/exclusive_scan/stateful_operator.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -62,3 +66,5 @@ struct test_stateful_operator
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/exclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/exclusive_scan/using_vs_adl.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -168,3 +172,5 @@ void test_using_cpo()
 DECLARE_UNITTEST(test_using_cpo);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/counting_iterator.cu
+++ b/thrust/testing/async/inclusive_scan/counting_iterator.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -39,3 +43,5 @@ struct test_counting_iterator
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_counting_iterator, UnsignedIntegralTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/discard_output.cu
+++ b/thrust/testing/async/inclusive_scan/discard_output.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -35,3 +39,5 @@ struct test_discard
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_discard, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/large_indices.cu
+++ b/thrust/testing/async/inclusive_scan/large_indices.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -232,3 +236,5 @@ void test_large_indices_custom_scan_op()
 DECLARE_UNITTEST(test_large_indices_custom_scan_op);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/large_types.cu
+++ b/thrust/testing/async/inclusive_scan/large_types.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -52,3 +56,5 @@ struct test_large_types
 DECLARE_UNITTEST(test_large_types);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/mixed_types.cu
+++ b/thrust/testing/async/inclusive_scan/mixed_types.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -106,3 +110,5 @@ void test_scan_mixed_types(size_t num_values)
 DECLARE_SIZED_UNITTEST(test_scan_mixed_types);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/simple.cu
+++ b/thrust/testing/async/inclusive_scan/simple.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -90,3 +94,5 @@ struct test_simple_in_place
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_simple_in_place, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/stateful_operator.cu
+++ b/thrust/testing/async/inclusive_scan/stateful_operator.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -62,3 +66,5 @@ struct test_stateful_operator
 DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_stateful_operator, NumericTypes);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async/inclusive_scan/using_vs_adl.cu
+++ b/thrust/testing/async/inclusive_scan/using_vs_adl.cu
@@ -1,3 +1,7 @@
+#include <cuda/__cccl_config>
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -166,3 +170,5 @@ void test_using_cpo()
 DECLARE_UNITTEST(test_using_cpo);
 
 #endif // C++14
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async_copy.cu
+++ b/thrust/testing/async_copy.cu
@@ -1,3 +1,8 @@
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings inside a lot of thrust headers
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -9,8 +14,6 @@
 
 #  include <unittest/unittest.h>
 #  include <unittest/util_async.h>
-
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 
 #  define DEFINE_ASYNC_COPY_CALLABLE(name, ...)                                               \
     struct THRUST_PP_CAT2(name, _fn)                                                          \
@@ -316,3 +319,5 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES(test_async_copy_after, BuiltinNumericT
 // Can't do this today because we can't do cross-system with explicit policies.
 
 #endif
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async_reduce.cu
+++ b/thrust/testing/async_reduce.cu
@@ -1,5 +1,10 @@
 #define THRUST_ENABLE_FUTURE_RAW_DATA_MEMBER
 
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings inside several thrust headers
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #if _CCCL_STD_VER >= 2014
@@ -11,8 +16,6 @@
 
 #  include <unittest/unittest.h>
 #  include <unittest/util_async.h>
-
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 
 template <typename T>
 struct custom_plus
@@ -541,16 +544,12 @@ struct test_async_reduce_using
     // When you import the customization points into the global namespace,
     // they should be selected instead of the synchronous algorithms.
     {
-      _CCCL_SUPPRESS_DEPRECATED_PUSH
       using namespace thrust::async;
       f0a = reduce(d0a.begin(), d0a.end());
-      _CCCL_SUPPRESS_DEPRECATED_POP
     }
     {
-      _CCCL_SUPPRESS_DEPRECATED_PUSH
       using thrust::async::reduce;
       f0b = reduce(d0b.begin(), d0b.end());
-      _CCCL_SUPPRESS_DEPRECATED_POP
     }
 
     // ADL should find the synchronous algorithms.
@@ -884,3 +883,5 @@ struct test_async_reduce_bug1886
 DECLARE_UNITTEST(test_async_reduce_bug1886);
 
 #endif
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/async_sort.cu
+++ b/thrust/testing/async_sort.cu
@@ -1,3 +1,8 @@
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings inside a lot of thrust headers
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 // Disabled on MSVC && NVCC < 11.1 for GH issue #1098.
@@ -14,8 +19,6 @@
 #  include <thrust/host_vector.h>
 
 #  include <unittest/unittest.h>
-
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 
 enum wait_policy
 {
@@ -177,3 +180,5 @@ DECLARE_GENERIC_SIZED_UNITTEST_WITH_TYPES_AND_NAME(
 // TODO: Test future return type.
 
 #endif
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/dependencies_aware_policies.cu
+++ b/thrust/testing/dependencies_aware_policies.cu
@@ -11,6 +11,8 @@
 #  include <thrust/system/cuda/detail/par.h>
 #endif
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 template <typename T>
 struct test_allocator_t
 {};
@@ -113,3 +115,5 @@ SimpleUnitTest<TestDependencyAttachment,
 #endif
                  >>
   TestDependencyAttachmentInstance;
+
+_CCCL_SUPPRESS_DEPRECATED_POP

--- a/thrust/testing/dependencies_aware_policies.cu
+++ b/thrust/testing/dependencies_aware_policies.cu
@@ -1,3 +1,8 @@
+#include <cuda/__cccl_config>
+
+// need to suppress deprecation warnings for execute_with_allocator_and_dependencies inside type traits
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 #include <thrust/detail/config.h>
 
 #include <thrust/detail/seq.h>
@@ -10,8 +15,6 @@
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 #  include <thrust/system/cuda/detail/par.h>
 #endif
-
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 
 template <typename T>
 struct test_allocator_t

--- a/thrust/testing/event.cu
+++ b/thrust/testing/event.cu
@@ -7,6 +7,10 @@
 #  include <unittest/unittest.h>
 #  include <unittest/util_async.h>
 
+// note: there is no matching _CCCL_SUPPRESS_DEPRECATED_POP, so the warning suppression leaks into more content of the
+// generated cudafe1.stub.c file.
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 ///////////////////////////////////////////////////////////////////////////////
 
 _CCCL_HOST void test_event_default_constructed()

--- a/thrust/testing/future.cu
+++ b/thrust/testing/future.cu
@@ -7,6 +7,10 @@
 #  include <unittest/unittest.h>
 #  include <unittest/util_async.h>
 
+// note: there is no matching _CCCL_SUPPRESS_DEPRECATED_POP, so the warning suppression leaks into more content of the
+// generated cudafe1.stub.c file.
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 struct mock
 {};
 

--- a/thrust/thrust/async/copy.h
+++ b/thrust/thrust/async/copy.h
@@ -50,6 +50,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename FromPolicy, typename ToPolicy, typename ForwardIt, typename Sentinel, typename OutputIt>
 CCCL_DEPRECATED _CCCL_HOST event<FromPolicy> async_copy(
   thrust::execution_policy<FromPolicy>& from_exec,
@@ -62,6 +63,7 @@ CCCL_DEPRECATED _CCCL_HOST event<FromPolicy> async_copy(
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/async/for_each.h
+++ b/thrust/thrust/async/for_each.h
@@ -50,6 +50,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename UnaryFunction>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy>
 async_for_each(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, UnaryFunction)
@@ -58,6 +59,7 @@ async_for_each(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, Un
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/async/reduce.h
+++ b/thrust/thrust/async/reduce.h
@@ -52,6 +52,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename T, typename BinaryOp>
 CCCL_DEPRECATED _CCCL_HOST future<DerivedPolicy, T>
 async_reduce(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, T, BinaryOp)
@@ -60,6 +61,7 @@ async_reduce(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, T, B
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/async/reduce.h
+++ b/thrust/thrust/async/reduce.h
@@ -175,6 +175,7 @@ _CCCL_GLOBAL_CONSTANT reduce_detail::reduce_fn reduce{};
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename OutputIt, typename T, typename BinaryOp>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy>
 async_reduce_into(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, OutputIt, T, BinaryOp)
@@ -183,6 +184,7 @@ async_reduce_into(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel,
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/async/scan.h
+++ b/thrust/thrust/async/scan.h
@@ -51,6 +51,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename OutputIt, typename BinaryOp>
 CCCL_DEPRECATED event<DerivedPolicy>
 async_inclusive_scan(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, OutputIt, BinaryOp)
@@ -73,6 +74,7 @@ CCCL_DEPRECATED event<DerivedPolicy> async_exclusive_scan(
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/async/sort.h
+++ b/thrust/thrust/async/sort.h
@@ -52,6 +52,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename StrictWeakOrdering>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy>
 async_stable_sort(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel, StrictWeakOrdering)
@@ -60,6 +61,7 @@ async_stable_sort(thrust::execution_policy<DerivedPolicy>&, ForwardIt, Sentinel,
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 
@@ -161,12 +163,14 @@ _CCCL_GLOBAL_CONSTANT stable_sort_detail::stable_sort_fn stable_sort{};
 namespace fallback
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename StrictWeakOrdering>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy>
 async_sort(thrust::execution_policy<DerivedPolicy>& exec, ForwardIt&& first, Sentinel&& last, StrictWeakOrdering&& comp)
 {
   return async_stable_sort(thrust::detail::derived_cast(exec), THRUST_FWD(first), THRUST_FWD(last), THRUST_FWD(comp));
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace fallback
 

--- a/thrust/thrust/async/transform.h
+++ b/thrust/thrust/async/transform.h
@@ -50,6 +50,7 @@ namespace async
 namespace unimplemented
 {
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy, typename ForwardIt, typename Sentinel, typename OutputIt, typename UnaryOperation>
 CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy> async_transform(
   thrust::execution_policy<DerivedPolicy>& exec, ForwardIt first, Sentinel last, OutputIt output, UnaryOperation op)
@@ -58,6 +59,7 @@ CCCL_DEPRECATED _CCCL_HOST event<DerivedPolicy> async_transform(
                            "this algorithm is not implemented for the specified system");
   return {};
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace unimplemented
 

--- a/thrust/thrust/detail/dependencies_aware_execution_policy.h
+++ b/thrust/thrust/detail/dependencies_aware_execution_policy.h
@@ -35,48 +35,46 @@ namespace detail
 {
 
 template <template <typename> class ExecutionPolicyCRTPBase>
-struct dependencies_aware_execution_policy
+struct CCCL_DEPRECATED dependencies_aware_execution_policy{
+  template <typename... Dependencies>
+  _CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...> after(
+    Dependencies && ... dependencies) const {return {capture_as_dependency(THRUST_FWD(dependencies))...};
+}
+
+template <typename... Dependencies>
+_CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
+after(std::tuple<Dependencies...>& dependencies) const
 {
-  template <typename... Dependencies>
-  _CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
-  after(Dependencies&&... dependencies) const
-  {
-    return {capture_as_dependency(THRUST_FWD(dependencies))...};
-  }
+  return {capture_as_dependency(dependencies)};
+}
+template <typename... Dependencies>
+_CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
+after(std::tuple<Dependencies...>&& dependencies) const
+{
+  return {capture_as_dependency(std::move(dependencies))};
+}
 
-  template <typename... Dependencies>
-  _CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
-  after(std::tuple<Dependencies...>& dependencies) const
-  {
-    return {capture_as_dependency(dependencies)};
-  }
-  template <typename... Dependencies>
-  _CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
-  after(std::tuple<Dependencies...>&& dependencies) const
-  {
-    return {capture_as_dependency(std::move(dependencies))};
-  }
+template <typename... Dependencies>
+_CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
+rebind_after(Dependencies&&... dependencies) const
+{
+  return {capture_as_dependency(THRUST_FWD(dependencies))...};
+}
 
-  template <typename... Dependencies>
-  _CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
-  rebind_after(Dependencies&&... dependencies) const
-  {
-    return {capture_as_dependency(THRUST_FWD(dependencies))...};
-  }
-
-  template <typename... Dependencies>
-  _CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
-  rebind_after(std::tuple<Dependencies...>& dependencies) const
-  {
-    return {capture_as_dependency(dependencies)};
-  }
-  template <typename... Dependencies>
-  _CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
-  rebind_after(std::tuple<Dependencies...>&& dependencies) const
-  {
-    return {capture_as_dependency(std::move(dependencies))};
-  }
-};
+template <typename... Dependencies>
+_CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
+rebind_after(std::tuple<Dependencies...>& dependencies) const
+{
+  return {capture_as_dependency(dependencies)};
+}
+template <typename... Dependencies>
+_CCCL_HOST thrust::detail::execute_with_dependencies<ExecutionPolicyCRTPBase, Dependencies...>
+rebind_after(std::tuple<Dependencies...>&& dependencies) const
+{
+  return {capture_as_dependency(std::move(dependencies))};
+}
+}
+;
 
 } // namespace detail
 

--- a/thrust/thrust/detail/dependencies_aware_execution_policy.h
+++ b/thrust/thrust/detail/dependencies_aware_execution_policy.h
@@ -29,6 +29,7 @@
 
 #include <tuple>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace detail
@@ -78,4 +79,5 @@ rebind_after(std::tuple<Dependencies...>&& dependencies) const
 
 } // namespace detail
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END

--- a/thrust/thrust/detail/execute_with_allocator.h
+++ b/thrust/thrust/detail/execute_with_allocator.h
@@ -75,8 +75,9 @@ _CCCL_HOST void return_temporary_buffer(
   alloc_traits::deallocate(system.get_allocator(), to_ptr, num_elements);
 }
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename T, template <typename> class BaseSystem, typename Allocator, typename... Dependencies>
-_CCCL_HOST thrust::pair<T*, std::ptrdiff_t> get_temporary_buffer(
+CCCL_DEPRECATED _CCCL_HOST thrust::pair<T*, std::ptrdiff_t> get_temporary_buffer(
   thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>& system,
   std::ptrdiff_t n)
 {
@@ -114,6 +115,7 @@ _CCCL_HOST void return_temporary_buffer(
   pointer to_ptr = thrust::reinterpret_pointer_cast<pointer>(p);
   alloc_traits::deallocate(system.get_allocator(), to_ptr, num_elements);
 }
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 } // namespace detail
 

--- a/thrust/thrust/detail/execute_with_allocator_fwd.h
+++ b/thrust/thrust/detail/execute_with_allocator_fwd.h
@@ -33,9 +33,9 @@ THRUST_NAMESPACE_BEGIN
 
 namespace detail
 {
-
-template <typename Allocator, template <typename> class BaseSystem>
-struct execute_with_allocator : BaseSystem<execute_with_allocator<Allocator, BaseSystem>>
+_CCCL_SUPPRESS_DEPRECATED_PUSH // because of execute_with_allocator_and_dependencies
+  template <typename Allocator, template <typename> class BaseSystem>
+  struct execute_with_allocator : BaseSystem<execute_with_allocator<Allocator, BaseSystem>>
 {
 private:
   using super_t = BaseSystem<execute_with_allocator<Allocator, BaseSystem>>;
@@ -58,7 +58,6 @@ public:
     return alloc;
   }
 
-  _CCCL_SUPPRESS_DEPRECATED_PUSH
   template <typename... Dependencies>
   CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   after(Dependencies&&... dependencies) const
@@ -98,9 +97,9 @@ public:
   {
     return {alloc, capture_as_dependency(std::move(dependencies))};
   }
-  _CCCL_SUPPRESS_DEPRECATED_POP
 };
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 } // namespace detail
 
 THRUST_NAMESPACE_END

--- a/thrust/thrust/detail/execute_with_allocator_fwd.h
+++ b/thrust/thrust/detail/execute_with_allocator_fwd.h
@@ -58,6 +58,7 @@ public:
     return alloc;
   }
 
+  _CCCL_SUPPRESS_DEPRECATED_PUSH
   template <typename... Dependencies>
   CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   after(Dependencies&&... dependencies) const
@@ -97,6 +98,7 @@ public:
   {
     return {alloc, capture_as_dependency(std::move(dependencies))};
   }
+  _CCCL_SUPPRESS_DEPRECATED_POP
 };
 
 } // namespace detail

--- a/thrust/thrust/detail/execute_with_allocator_fwd.h
+++ b/thrust/thrust/detail/execute_with_allocator_fwd.h
@@ -59,40 +59,40 @@ public:
   }
 
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   after(Dependencies&&... dependencies) const
   {
     return {alloc, capture_as_dependency(THRUST_FWD(dependencies))...};
   }
 
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   after(std::tuple<Dependencies...>& dependencies) const
   {
     return {alloc, capture_as_dependency(dependencies)};
   }
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   after(std::tuple<Dependencies...>&& dependencies) const
   {
     return {alloc, capture_as_dependency(std::move(dependencies))};
   }
 
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   rebind_after(Dependencies&&... dependencies) const
   {
     return {alloc, capture_as_dependency(THRUST_FWD(dependencies))...};
   }
 
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   rebind_after(std::tuple<Dependencies...>& dependencies) const
   {
     return {alloc, capture_as_dependency(dependencies)};
   }
   template <typename... Dependencies>
-  _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
+  CCCL_DEPRECATED _CCCL_HOST execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>
   rebind_after(std::tuple<Dependencies...>&& dependencies) const
   {
     return {alloc, capture_as_dependency(std::move(dependencies))};

--- a/thrust/thrust/detail/execute_with_dependencies.h
+++ b/thrust/thrust/detail/execute_with_dependencies.h
@@ -37,22 +37,23 @@ THRUST_NAMESPACE_BEGIN
 namespace detail
 {
 
-struct capture_as_dependency_fn
-{
+struct CCCL_DEPRECATED capture_as_dependency_fn {
   template <typename Dependency>
-  auto operator()(Dependency&& dependency) const THRUST_DECLTYPE_RETURNS(capture_as_dependency(THRUST_FWD(dependency)))
+  auto
+  operator()(Dependency&& dependency) const THRUST_DECLTYPE_RETURNS(capture_as_dependency(THRUST_FWD(dependency)))
 };
 
 // Default implementation: universal forwarding.
 template <typename Dependency>
-auto capture_as_dependency(Dependency&& dependency) THRUST_DECLTYPE_RETURNS(THRUST_FWD(dependency))
+CCCL_DEPRECATED auto capture_as_dependency(Dependency&& dependency) THRUST_DECLTYPE_RETURNS(THRUST_FWD(dependency))
 
-  template <typename... Dependencies>
-  auto capture_as_dependency(std::tuple<Dependencies...>& dependencies)
+  _CCCL_SUPPRESS_DEPRECATED_PUSH template <typename... Dependencies>
+  CCCL_DEPRECATED auto capture_as_dependency(std::tuple<Dependencies...>& dependencies)
     THRUST_DECLTYPE_RETURNS(tuple_for_each(THRUST_FWD(dependencies), capture_as_dependency_fn{}))
+      _CCCL_SUPPRESS_DEPRECATED_POP
 
-      template <template <typename> class BaseSystem, typename... Dependencies>
-      struct execute_with_dependencies : BaseSystem<execute_with_dependencies<BaseSystem, Dependencies...>>
+  template <template <typename> class BaseSystem, typename... Dependencies>
+  struct CCCL_DEPRECATED execute_with_dependencies : BaseSystem<execute_with_dependencies<BaseSystem, Dependencies...>>
 {
 private:
   using super_t = BaseSystem<execute_with_dependencies<BaseSystem, Dependencies...>>;
@@ -115,7 +116,7 @@ public:
 };
 
 template <typename Allocator, template <typename> class BaseSystem, typename... Dependencies>
-struct execute_with_allocator_and_dependencies
+struct CCCL_DEPRECATED execute_with_allocator_and_dependencies
     : BaseSystem<execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>>
 {
 private:
@@ -186,33 +187,33 @@ public:
 };
 
 template <template <typename> class BaseSystem, typename... Dependencies>
-_CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...>
+CCCL_DEPRECATED _CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...>
 extract_dependencies(thrust::detail::execute_with_dependencies<BaseSystem, Dependencies...>&& system)
 {
   return std::move(system).extract_dependencies();
 }
 template <template <typename> class BaseSystem, typename... Dependencies>
-_CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...>
+CCCL_DEPRECATED _CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...>
 extract_dependencies(thrust::detail::execute_with_dependencies<BaseSystem, Dependencies...>& system)
 {
   return std::move(system).extract_dependencies();
 }
 
 template <typename Allocator, template <typename> class BaseSystem, typename... Dependencies>
-_CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...> extract_dependencies(
+CCCL_DEPRECATED _CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...> extract_dependencies(
   thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>&& system)
 {
   return std::move(system).extract_dependencies();
 }
 template <typename Allocator, template <typename> class BaseSystem, typename... Dependencies>
-_CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...> extract_dependencies(
+CCCL_DEPRECATED _CCCL_HOST std::tuple<::cuda::std::remove_cvref_t<Dependencies>...> extract_dependencies(
   thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem, Dependencies...>& system)
 {
   return std::move(system).extract_dependencies();
 }
 
 template <typename System>
-_CCCL_HOST std::tuple<> extract_dependencies(System&&)
+CCCL_DEPRECATED _CCCL_HOST std::tuple<> extract_dependencies(System&&)
 {
   return std::tuple<>{};
 }

--- a/thrust/thrust/detail/execute_with_dependencies.h
+++ b/thrust/thrust/detail/execute_with_dependencies.h
@@ -32,6 +32,7 @@
 #include <tuple>
 #include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace detail
@@ -220,4 +221,5 @@ CCCL_DEPRECATED _CCCL_HOST std::tuple<> extract_dependencies(System&&)
 
 } // namespace detail
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END

--- a/thrust/thrust/future.h
+++ b/thrust/thrust/future.h
@@ -61,6 +61,7 @@
 #  include __THRUST_DEVICE_SYSTEM_FUTURE_HEADER
 #  undef __THRUST_DEVICE_SYSTEM_FUTURE_HEADER
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -75,16 +76,14 @@ THRUST_NAMESPACE_BEGIN
 namespace unimplemented
 {
 
-struct no_unique_eager_event_type_found
-{};
+struct CCCL_DEPRECATED no_unique_eager_event_type_found{};
 
-inline _CCCL_HOST no_unique_eager_event_type_found unique_eager_event_type(...) noexcept;
+CCCL_DEPRECATED _CCCL_HOST inline no_unique_eager_event_type_found unique_eager_event_type(...) noexcept;
 
-struct no_unique_eager_future_type_found
-{};
+struct CCCL_DEPRECATED no_unique_eager_future_type_found{};
 
 template <typename T>
-_CCCL_HOST no_unique_eager_future_type_found unique_eager_future_type(...) noexcept;
+CCCL_DEPRECATED _CCCL_HOST no_unique_eager_future_type_found unique_eager_future_type(...) noexcept;
 
 } // namespace unimplemented
 
@@ -94,7 +93,7 @@ namespace unique_eager_event_type_detail
 using unimplemented::unique_eager_event_type;
 
 template <typename System>
-using select = decltype(unique_eager_event_type(std::declval<System>()));
+using select CCCL_DEPRECATED = decltype(unique_eager_event_type(std::declval<System>()));
 
 } // namespace unique_eager_event_type_detail
 
@@ -104,25 +103,25 @@ namespace unique_eager_future_type_detail
 using unimplemented::unique_eager_future_type;
 
 template <typename System, typename T>
-using select = decltype(unique_eager_future_type<T>(std::declval<System>()));
+using select CCCL_DEPRECATED = decltype(unique_eager_future_type<T>(std::declval<System>()));
 
 } // namespace unique_eager_future_type_detail
 
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename System>
-using unique_eager_event = unique_eager_event_type_detail::select<System>;
+using unique_eager_event CCCL_DEPRECATED = unique_eager_event_type_detail::select<System>;
 
 template <typename System>
-using event = unique_eager_event<System>;
+using event CCCL_DEPRECATED = unique_eager_event<System>;
 
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename System, typename T>
-using unique_eager_future = unique_eager_future_type_detail::select<System, T>;
+using unique_eager_future CCCL_DEPRECATED = unique_eager_future_type_detail::select<System, T>;
 
 template <typename System, typename T>
-using future = unique_eager_future<System, T>;
+using future CCCL_DEPRECATED = unique_eager_future<System, T>;
 
 /*
 ///////////////////////////////////////////////////////////////////////////////
@@ -144,26 +143,26 @@ using host_future = host_unique_eager_future<T>;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-using device_unique_eager_event =
+using device_unique_eager_event CCCL_DEPRECATED =
   unique_eager_event_type_detail::select<thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::tag>;
 
-using device_event = device_unique_eager_event;
+using device_event CCCL_DEPRECATED = device_unique_eager_event;
 
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
-using device_unique_eager_future =
+using device_unique_eager_future CCCL_DEPRECATED =
   unique_eager_future_type_detail::select<thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::tag, T>;
 
 template <typename T>
-using device_future = device_unique_eager_future<T>;
+using device_future CCCL_DEPRECATED = device_unique_eager_future<T>;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct new_stream_t final
+struct CCCL_DEPRECATED new_stream_t final
 {};
 
-_CCCL_GLOBAL_CONSTANT new_stream_t new_stream{};
+CCCL_DEPRECATED _CCCL_GLOBAL_CONSTANT new_stream_t new_stream{};
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -171,6 +170,7 @@ using thrust::system::__THRUST_DEVICE_SYSTEM_NAMESPACE::when_all;
 
 ///////////////////////////////////////////////////////////////////////////////
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #endif

--- a/thrust/thrust/future.h
+++ b/thrust/thrust/future.h
@@ -162,7 +162,11 @@ using device_future CCCL_DEPRECATED = device_unique_eager_future<T>;
 struct CCCL_DEPRECATED new_stream_t final
 {};
 
-CCCL_DEPRECATED _CCCL_GLOBAL_CONSTANT new_stream_t new_stream{};
+#  ifndef CCCL_HEADER_MACRO_CHECK
+// when building header tests, we get a deprecation warning from cudafe1.stub.c if we deprecate a global variable
+CCCL_DEPRECATED
+#  endif
+_CCCL_GLOBAL_CONSTANT new_stream_t new_stream{};
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/thrust/thrust/system/cuda/detail/async/copy.h
+++ b/thrust/thrust/system/cuda/detail/async/copy.h
@@ -60,6 +60,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -354,6 +355,7 @@ auto async_copy(thrust::cuda::execution_policy<FromPolicy>& from_exec,
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/customization.h
+++ b/thrust/thrust/system/cuda/detail/async/customization.h
@@ -31,6 +31,8 @@
 
 #include <thrust/detail/config.h>
 
+#include "cuda/std/__cccl/diagnostic.h"
+
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -85,10 +87,10 @@ auto get_async_device_allocator(thrust::detail::execution_policy_base<DerivedPol
     auto get_async_device_allocator(thrust::detail::execute_with_allocator<Allocator, BaseSystem>& exec)
       THRUST_RETURNS(exec.get_allocator())
 
-        template <typename Allocator, template <typename> class BaseSystem>
+        _CCCL_SUPPRESS_DEPRECATED_PUSH template <typename Allocator, template <typename> class BaseSystem>
         CCCL_DEPRECATED
   auto get_async_device_allocator(thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem>& exec)
-    THRUST_RETURNS(exec.get_allocator())
+    THRUST_RETURNS(exec.get_allocator()) _CCCL_SUPPRESS_DEPRECATED_POP
 
   ///////////////////////////////////////////////////////////////////////////////
 

--- a/thrust/thrust/system/cuda/detail/async/customization.h
+++ b/thrust/thrust/system/cuda/detail/async/customization.h
@@ -86,9 +86,9 @@ auto get_async_device_allocator(thrust::detail::execution_policy_base<DerivedPol
       THRUST_RETURNS(exec.get_allocator())
 
         template <typename Allocator, template <typename> class BaseSystem>
-        auto get_async_device_allocator(
-          thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem>& exec)
-          THRUST_RETURNS(exec.get_allocator())
+        CCCL_DEPRECATED
+  auto get_async_device_allocator(thrust::detail::execute_with_allocator_and_dependencies<Allocator, BaseSystem>& exec)
+    THRUST_RETURNS(exec.get_allocator())
 
   ///////////////////////////////////////////////////////////////////////////////
 

--- a/thrust/thrust/system/cuda/detail/async/exclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/exclusive_scan.h
@@ -55,6 +55,7 @@
 
 // TODO specialize for thrust::plus to use e.g. ExclusiveSum instead of ExcScan
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 namespace system
 {
@@ -156,6 +157,7 @@ auto async_exclusive_scan(
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/for_each.h
+++ b/thrust/thrust/system/cuda/detail/async/for_each.h
@@ -55,6 +55,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -126,6 +127,7 @@ auto async_for_each(execution_policy<DerivedPolicy>& policy, ForwardIt first, Se
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
+++ b/thrust/thrust/system/cuda/detail/async/inclusive_scan.h
@@ -55,6 +55,7 @@
 
 // TODO specialize for thrust::plus to use e.g. InclusiveSum instead of IncScan
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 namespace system
 {
@@ -243,6 +244,7 @@ auto async_inclusive_scan(
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/reduce.h
+++ b/thrust/thrust/system/cuda/detail/async/reduce.h
@@ -57,6 +57,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -226,6 +227,7 @@ auto async_reduce_into(
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/sort.h
+++ b/thrust/thrust/system/cuda/detail/async/sort.h
@@ -60,6 +60,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -318,6 +319,7 @@ auto async_stable_sort(execution_policy<DerivedPolicy>& policy, ForwardIt first,
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/async/transform.h
+++ b/thrust/thrust/system/cuda/detail/async/transform.h
@@ -56,6 +56,7 @@
 
 #    include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 namespace system
@@ -131,6 +132,7 @@ auto async_transform(
 
 } // namespace cuda_cub
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #  endif // _CCCL_CUDA_COMPILER

--- a/thrust/thrust/system/cuda/detail/execution_policy.h
+++ b/thrust/thrust/system/cuda/detail/execution_policy.h
@@ -61,11 +61,13 @@ struct execution_policy<tag> : thrust::execution_policy<tag>
   using tag_type = tag;
 };
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 struct tag
     : execution_policy<tag>
     , thrust::detail::allocator_aware_execution_policy<cuda_cub::execution_policy>
     , thrust::detail::dependencies_aware_execution_policy<cuda_cub::execution_policy>
 {};
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 template <class Derived>
 struct execution_policy : thrust::execution_policy<Derived>

--- a/thrust/thrust/system/cuda/detail/future.inl
+++ b/thrust/thrust/system/cuda/detail/future.inl
@@ -1222,13 +1222,13 @@ CCCL_DEPRECATED _CCCL_HOST unique_eager_event when_all(Events&&... evs)
 }
 
 // ADL hook for transparent `.after` move support.
-_CCCL_HOST CCCL_DEPRECATED inline auto capture_as_dependency(unique_eager_event& dependency)
+CCCL_DEPRECATED _CCCL_HOST inline auto capture_as_dependency(unique_eager_event& dependency)
   THRUST_DECLTYPE_RETURNS(std::move(dependency))
 
   // ADL hook for transparent `.after` move support.
   template <typename X>
-  _CCCL_HOST CCCL_DEPRECATED
-  auto capture_as_dependency(unique_eager_future<X>& dependency) THRUST_DECLTYPE_RETURNS(std::move(dependency))
+  CCCL_DEPRECATED _CCCL_HOST auto capture_as_dependency(unique_eager_future<X>& dependency)
+    THRUST_DECLTYPE_RETURNS(std::move(dependency))
 
 } // namespace cuda
 } // namespace system

--- a/thrust/thrust/system/cuda/detail/future.inl
+++ b/thrust/thrust/system/cuda/detail/future.inl
@@ -41,10 +41,11 @@
 
 #  include <type_traits>
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 THRUST_NAMESPACE_BEGIN
 
 // Forward declaration.
-struct new_stream_t;
+struct CCCL_DEPRECATED new_stream_t;
 
 namespace system
 {
@@ -55,14 +56,14 @@ namespace detail
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct nonowning_t final
+struct CCCL_DEPRECATED nonowning_t final
 {};
 
 _CCCL_GLOBAL_CONSTANT nonowning_t nonowning{};
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct marker_deleter final
+struct CCCL_DEPRECATED marker_deleter final
 {
   _CCCL_HOST void operator()(CUevent_st* e) const
   {
@@ -75,7 +76,7 @@ struct marker_deleter final
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct unique_marker final
+struct CCCL_DEPRECATED unique_marker final
 {
   using native_handle_type = CUevent_st*;
 
@@ -146,7 +147,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct stream_deleter final
+struct CCCL_DEPRECATED stream_deleter final
 {
   _CCCL_HOST void operator()(CUstream_st* s) const
   {
@@ -157,7 +158,7 @@ struct stream_deleter final
   }
 };
 
-struct stream_conditional_deleter final
+struct CCCL_DEPRECATED stream_conditional_deleter final
 {
 private:
   bool cond_;
@@ -182,7 +183,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct unique_stream final
+struct CCCL_DEPRECATED unique_stream final
 {
   using native_handle_type = CUstream_st*;
 
@@ -286,25 +287,25 @@ public:
 
 // Inheritance hierarchy of future/event shared state types.
 
-struct async_signal;
+struct CCCL_DEPRECATED async_signal;
 
 template <typename KeepAlives>
-struct async_keep_alives /* : virtual async_signal */;
+struct CCCL_DEPRECATED async_keep_alives /* : virtual async_signal */;
 
 template <typename T>
-struct async_value /* : virtual async_signal */;
+struct CCCL_DEPRECATED async_value /* : virtual async_signal */;
 
 template <typename T, typename Pointer, typename KeepAlives>
-struct async_addressable_value_with_keep_alives
+struct CCCL_DEPRECATED async_addressable_value_with_keep_alives
   /* : async_value<T>, async_keep_alives<KeepAlives> */;
 
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename T, typename Pointer>
-struct weak_promise;
+struct CCCL_DEPRECATED weak_promise;
 
 template <typename X, typename XPointer = pointer<X>>
-struct unique_eager_future_promise_pair final
+struct CCCL_DEPRECATED unique_eager_future_promise_pair final
 {
   unique_eager_future<X> future;
   weak_promise<X, XPointer> promise;
@@ -312,7 +313,7 @@ struct unique_eager_future_promise_pair final
 
 _CCCL_SUPPRESS_DEPRECATED_PUSH // for thrust::optional
 
-  struct acquired_stream final
+  struct CCCL_DEPRECATED acquired_stream final
 {
   unique_stream stream;
   optional<std::size_t> const acquired_from;
@@ -323,40 +324,42 @@ _CCCL_SUPPRESS_DEPRECATED_PUSH // for thrust::optional
 
 // Precondition: `device` is the current CUDA device.
 template <typename X, typename Y, typename Deleter>
-_CCCL_HOST optional<unique_stream> try_acquire_stream(int device, std::unique_ptr<Y, Deleter>&) noexcept;
+CCCL_DEPRECATED _CCCL_HOST optional<unique_stream> try_acquire_stream(int device, std::unique_ptr<Y, Deleter>&) noexcept;
 
 // Precondition: `device` is the current CUDA device.
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept;
+CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept;
 
 // Precondition: `device` is the current CUDA device.
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int device, ready_event&) noexcept;
-
-// Precondition: `device` is the current CUDA device.
-template <typename X>
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int device, ready_future<X>&) noexcept;
-
-// Precondition: `device` is the current CUDA device.
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int device, unique_eager_event& parent) noexcept;
+CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, ready_event&) noexcept;
 
 // Precondition: `device` is the current CUDA device.
 template <typename X>
-_CCCL_HOST optional<unique_stream> try_acquire_stream(int device, unique_eager_future<X>& parent) noexcept;
+CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, ready_future<X>&) noexcept;
+
+// Precondition: `device` is the current CUDA device.
+CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream>
+try_acquire_stream(int device, unique_eager_event& parent) noexcept;
+
+// Precondition: `device` is the current CUDA device.
+template <typename X>
+CCCL_DEPRECATED _CCCL_HOST optional<unique_stream>
+try_acquire_stream(int device, unique_eager_future<X>& parent) noexcept;
 
 _CCCL_SUPPRESS_DEPRECATED_POP
 
 template <typename... Dependencies>
-_CCCL_HOST acquired_stream acquire_stream(int device, Dependencies&... deps) noexcept;
+CCCL_DEPRECATED _CCCL_HOST acquired_stream acquire_stream(int device, Dependencies&... deps) noexcept;
 
 template <typename... Dependencies>
-_CCCL_HOST unique_eager_event make_dependent_event(std::tuple<Dependencies...>&& deps);
+CCCL_DEPRECATED _CCCL_HOST unique_eager_event make_dependent_event(std::tuple<Dependencies...>&& deps);
 
 template <typename X, typename XPointer, typename ComputeContent, typename... Dependencies>
-_CCCL_HOST unique_eager_future_promise_pair<X, XPointer>
+CCCL_DEPRECATED _CCCL_HOST unique_eager_future_promise_pair<X, XPointer>
 make_dependent_future(ComputeContent&& cc, std::tuple<Dependencies...>&& deps);
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct async_signal
+struct CCCL_DEPRECATED async_signal
 {
 protected:
   unique_stream stream_;
@@ -380,7 +383,7 @@ public:
 };
 
 template <typename... KeepAlives>
-struct async_keep_alives<std::tuple<KeepAlives...>> : virtual async_signal
+struct CCCL_DEPRECATED async_keep_alives<std::tuple<KeepAlives...>> : virtual async_signal
 {
   using keep_alives_type = std::tuple<KeepAlives...>;
 
@@ -400,7 +403,7 @@ public:
 };
 
 template <typename T>
-struct async_value : virtual async_signal
+struct CCCL_DEPRECATED async_value : virtual async_signal
 {
   using value_type        = T;
   using raw_const_pointer = value_type const*;
@@ -437,7 +440,7 @@ struct async_value : virtual async_signal
 };
 
 template <typename T, typename Pointer, typename... KeepAlives>
-struct async_addressable_value_with_keep_alives<T, Pointer, std::tuple<KeepAlives...>> final
+struct CCCL_DEPRECATED async_addressable_value_with_keep_alives<T, Pointer, std::tuple<KeepAlives...>> final
     : async_value<T>
     , async_keep_alives<std::tuple<KeepAlives...>>
 {
@@ -531,7 +534,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename T, typename Pointer>
-struct weak_promise final
+struct CCCL_DEPRECATED weak_promise final
 {
   using value_type = typename async_value<T>::value_type;
 
@@ -577,7 +580,7 @@ public:
 
 } // namespace detail
 
-struct ready_event final
+struct CCCL_DEPRECATED ready_event final
 {
   ready_event() = default;
 
@@ -597,7 +600,7 @@ struct ready_event final
 };
 
 template <typename T>
-struct ready_future final
+struct CCCL_DEPRECATED ready_future final
 {
   using value_type        = T;
   using raw_const_pointer = T const*;
@@ -649,7 +652,7 @@ public:
 #  endif
 };
 
-struct unique_eager_event final
+struct CCCL_DEPRECATED unique_eager_event final
 {
 protected:
   int device_ = 0;
@@ -758,7 +761,7 @@ public:
 };
 
 template <typename T>
-struct unique_eager_future final
+struct CCCL_DEPRECATED unique_eager_future final
 {
   THRUST_STATIC_ASSERT_MSG((!std::is_same<T, ::cuda::std::remove_cvref_t<void>>::value),
                            "`thrust::event` should be used to express valueless futures");
@@ -927,31 +930,31 @@ namespace detail
 _CCCL_SUPPRESS_DEPRECATED_PUSH // for thrust::optional
 
   template <typename X, typename Deleter>
-  _CCCL_HOST optional<unique_stream> try_acquire_stream(int, std::unique_ptr<X, Deleter>&) noexcept
+  CCCL_DEPRECATED _CCCL_HOST optional<unique_stream> try_acquire_stream(int, std::unique_ptr<X, Deleter>&) noexcept
 {
   // There's no stream to acquire!
   return {};
 }
 
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept
+CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept
 {
   return {std::move(stream)};
 }
 
-inline _CCCL_HOST optional<unique_stream> try_acquire_stream(int, ready_event&) noexcept
+CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, ready_event&) noexcept
 {
   // There's no stream to acquire!
   return {};
 }
 
 template <typename X>
-_CCCL_HOST optional<unique_stream> try_acquire_stream(int, ready_future<X>&) noexcept
+CCCL_DEPRECATED _CCCL_HOST optional<unique_stream> try_acquire_stream(int, ready_future<X>&) noexcept
 {
   // There's no stream to acquire!
   return {};
 }
 
-_CCCL_HOST optional<unique_stream> try_acquire_stream(int device_id, unique_eager_event& parent) noexcept
+CCCL_DEPRECATED _CCCL_HOST optional<unique_stream> try_acquire_stream(int device_id, unique_eager_event& parent) noexcept
 {
   // We have unique ownership, so we can always steal the stream if the future
   // has one as long as they are on the same device as us.
@@ -967,7 +970,8 @@ _CCCL_HOST optional<unique_stream> try_acquire_stream(int device_id, unique_eage
 }
 
 template <typename X>
-_CCCL_HOST optional<unique_stream> try_acquire_stream(int device_id, unique_eager_future<X>& parent) noexcept
+CCCL_DEPRECATED _CCCL_HOST optional<unique_stream>
+try_acquire_stream(int device_id, unique_eager_future<X>& parent) noexcept
 {
   // We have unique ownership, so we can always steal the stream if the future
   // has one as long as they are on the same device as us.
@@ -987,7 +991,8 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename... Dependencies>
-_CCCL_HOST acquired_stream acquire_stream_impl(int, std::tuple<Dependencies...>&, index_sequence<>) noexcept
+CCCL_DEPRECATED _CCCL_HOST acquired_stream
+acquire_stream_impl(int, std::tuple<Dependencies...>&, index_sequence<>) noexcept
 {
   // We tried to take a stream from all of our dependencies and failed every
   // time, so we need to make a new stream.
@@ -995,7 +1000,7 @@ _CCCL_HOST acquired_stream acquire_stream_impl(int, std::tuple<Dependencies...>&
 }
 
 template <typename... Dependencies, std::size_t I0, std::size_t... Is>
-_CCCL_HOST acquired_stream
+CCCL_DEPRECATED _CCCL_HOST acquired_stream
 acquire_stream_impl(int device_id, std::tuple<Dependencies...>& deps, index_sequence<I0, Is...>) noexcept
 {
   _CCCL_SUPPRESS_DEPRECATED_PUSH // for thrust::optional (MSVC warnings here)
@@ -1013,7 +1018,7 @@ acquire_stream_impl(int device_id, std::tuple<Dependencies...>& deps, index_sequ
 }
 
 template <typename... Dependencies>
-_CCCL_HOST acquired_stream acquire_stream(int device_id, std::tuple<Dependencies...>& deps) noexcept
+CCCL_DEPRECATED _CCCL_HOST acquired_stream acquire_stream(int device_id, std::tuple<Dependencies...>& deps) noexcept
 {
   return acquire_stream_impl(device_id, deps, make_index_sequence<sizeof...(Dependencies)>{});
 }
@@ -1021,37 +1026,38 @@ _CCCL_HOST acquired_stream acquire_stream(int device_id, std::tuple<Dependencies
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename X, typename Deleter>
-_CCCL_HOST void create_dependency(unique_stream&, std::unique_ptr<X, Deleter>&) noexcept
+CCCL_DEPRECATED _CCCL_HOST void create_dependency(unique_stream&, std::unique_ptr<X, Deleter>&) noexcept
 {}
 
-inline _CCCL_HOST void create_dependency(unique_stream&, ready_event&) noexcept {}
+CCCL_DEPRECATED _CCCL_HOST inline void create_dependency(unique_stream&, ready_event&) noexcept {}
 
 template <typename T>
-_CCCL_HOST void create_dependency(unique_stream&, ready_future<T>&) noexcept
+CCCL_DEPRECATED _CCCL_HOST void create_dependency(unique_stream&, ready_future<T>&) noexcept
 {}
 
-inline _CCCL_HOST void create_dependency(unique_stream& child, unique_stream& parent)
+CCCL_DEPRECATED _CCCL_HOST inline void create_dependency(unique_stream& child, unique_stream& parent)
 {
   child.depend_on(parent);
 }
 
-inline _CCCL_HOST void create_dependency(unique_stream& child, unique_eager_event& parent)
+CCCL_DEPRECATED _CCCL_HOST inline void create_dependency(unique_stream& child, unique_eager_event& parent)
 {
   child.depend_on(parent.stream());
 }
 
 template <typename X>
-_CCCL_HOST void create_dependency(unique_stream& child, unique_eager_future<X>& parent)
+CCCL_DEPRECATED _CCCL_HOST void create_dependency(unique_stream& child, unique_eager_future<X>& parent)
 {
   child.depend_on(parent.stream());
 }
 
 template <typename... Dependencies>
-_CCCL_HOST void create_dependencies_impl(acquired_stream&, std::tuple<Dependencies...>&, index_sequence<>)
+CCCL_DEPRECATED _CCCL_HOST void
+create_dependencies_impl(acquired_stream&, std::tuple<Dependencies...>&, index_sequence<>)
 {}
 
 template <typename... Dependencies, std::size_t I0, std::size_t... Is>
-_CCCL_HOST void
+CCCL_DEPRECATED _CCCL_HOST void
 create_dependencies_impl(acquired_stream& as, std::tuple<Dependencies...>& deps, index_sequence<I0, Is...>)
 {
   // We only need to wait on the current dependency if we didn't steal our
@@ -1067,7 +1073,7 @@ create_dependencies_impl(acquired_stream& as, std::tuple<Dependencies...>& deps,
 }
 
 template <typename... Dependencies>
-_CCCL_HOST void create_dependencies(acquired_stream& as, std::tuple<Dependencies...>& deps)
+CCCL_DEPRECATED _CCCL_HOST void create_dependencies(acquired_stream& as, std::tuple<Dependencies...>& deps)
 {
   create_dependencies_impl(as, deps, make_index_sequence<sizeof...(Dependencies)>{});
 }
@@ -1078,7 +1084,7 @@ _CCCL_HOST void create_dependencies(acquired_stream& as, std::tuple<Dependencies
 // Returns the result as an `index_sequence` of indices into the parameter
 // pack.
 template <typename Tuple, typename Indices>
-struct find_keep_alives_impl;
+struct CCCL_DEPRECATED find_keep_alives_impl;
 template <typename Tuple>
 using find_keep_alives =
   typename find_keep_alives_impl<Tuple, make_index_sequence<std::tuple_size<Tuple>::value>>::type;
@@ -1148,7 +1154,7 @@ struct find_keep_alives_impl<std::tuple<std::unique_ptr<T, Deleter>, Dependencie
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename... Dependencies>
-_CCCL_HOST unique_eager_event make_dependent_event(std::tuple<Dependencies...>&& deps)
+CCCL_DEPRECATED _CCCL_HOST unique_eager_event make_dependent_event(std::tuple<Dependencies...>&& deps)
 {
   int device_id = 0;
   thrust::cuda_cub::throw_on_error(cudaGetDevice(&device_id));
@@ -1175,7 +1181,7 @@ _CCCL_HOST unique_eager_event make_dependent_event(std::tuple<Dependencies...>&&
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename X, typename XPointer, typename ComputeContent, typename... Dependencies>
-_CCCL_HOST unique_eager_future_promise_pair<X, XPointer>
+CCCL_DEPRECATED _CCCL_HOST unique_eager_future_promise_pair<X, XPointer>
 make_dependent_future(ComputeContent&& cc, std::tuple<Dependencies...>&& deps)
 {
   int device_id = 0;
@@ -1208,7 +1214,7 @@ make_dependent_future(ComputeContent&& cc, std::tuple<Dependencies...>&& deps)
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename... Events>
-_CCCL_HOST unique_eager_event when_all(Events&&... evs)
+CCCL_DEPRECATED _CCCL_HOST unique_eager_event when_all(Events&&... evs)
 // TODO: Constrain to events, futures, and maybe streams (currently allows keep
 // alives).
 {
@@ -1216,17 +1222,18 @@ _CCCL_HOST unique_eager_event when_all(Events&&... evs)
 }
 
 // ADL hook for transparent `.after` move support.
-inline _CCCL_HOST auto capture_as_dependency(unique_eager_event& dependency)
+_CCCL_HOST CCCL_DEPRECATED inline auto capture_as_dependency(unique_eager_event& dependency)
   THRUST_DECLTYPE_RETURNS(std::move(dependency))
 
   // ADL hook for transparent `.after` move support.
   template <typename X>
-  _CCCL_HOST auto capture_as_dependency(unique_eager_future<X>& dependency)
-    THRUST_DECLTYPE_RETURNS(std::move(dependency))
+  _CCCL_HOST CCCL_DEPRECATED
+  auto capture_as_dependency(unique_eager_future<X>& dependency) THRUST_DECLTYPE_RETURNS(std::move(dependency))
 
 } // namespace cuda
 } // namespace system
 
+_CCCL_SUPPRESS_DEPRECATED_POP
 THRUST_NAMESPACE_END
 
 #endif // C++14

--- a/thrust/thrust/system/cuda/detail/future.inl
+++ b/thrust/thrust/system/cuda/detail/future.inl
@@ -56,14 +56,14 @@ namespace detail
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct CCCL_DEPRECATED nonowning_t final
+struct nonowning_t final
 {};
 
 _CCCL_GLOBAL_CONSTANT nonowning_t nonowning{};
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct CCCL_DEPRECATED marker_deleter final
+struct marker_deleter final
 {
   _CCCL_HOST void operator()(CUevent_st* e) const
   {
@@ -76,7 +76,7 @@ struct CCCL_DEPRECATED marker_deleter final
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct CCCL_DEPRECATED unique_marker final
+struct unique_marker final
 {
   using native_handle_type = CUevent_st*;
 
@@ -147,7 +147,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct CCCL_DEPRECATED stream_deleter final
+struct stream_deleter final
 {
   _CCCL_HOST void operator()(CUstream_st* s) const
   {
@@ -158,7 +158,7 @@ struct CCCL_DEPRECATED stream_deleter final
   }
 };
 
-struct CCCL_DEPRECATED stream_conditional_deleter final
+struct stream_conditional_deleter final
 {
 private:
   bool cond_;
@@ -183,7 +183,7 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct CCCL_DEPRECATED unique_stream final
+struct unique_stream final
 {
   using native_handle_type = CUstream_st*;
 
@@ -287,25 +287,25 @@ public:
 
 // Inheritance hierarchy of future/event shared state types.
 
-struct CCCL_DEPRECATED async_signal;
+struct async_signal;
 
 template <typename KeepAlives>
-struct CCCL_DEPRECATED async_keep_alives /* : virtual async_signal */;
+struct async_keep_alives /* : virtual async_signal */;
 
 template <typename T>
-struct CCCL_DEPRECATED async_value /* : virtual async_signal */;
+struct async_value /* : virtual async_signal */;
 
 template <typename T, typename Pointer, typename KeepAlives>
-struct CCCL_DEPRECATED async_addressable_value_with_keep_alives
+struct async_addressable_value_with_keep_alives
   /* : async_value<T>, async_keep_alives<KeepAlives> */;
 
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename T, typename Pointer>
-struct CCCL_DEPRECATED weak_promise;
+struct weak_promise;
 
 template <typename X, typename XPointer = pointer<X>>
-struct CCCL_DEPRECATED unique_eager_future_promise_pair final
+struct unique_eager_future_promise_pair final
 {
   unique_eager_future<X> future;
   weak_promise<X, XPointer> promise;
@@ -313,7 +313,7 @@ struct CCCL_DEPRECATED unique_eager_future_promise_pair final
 
 _CCCL_SUPPRESS_DEPRECATED_PUSH // for thrust::optional
 
-  struct CCCL_DEPRECATED acquired_stream final
+  struct acquired_stream final
 {
   unique_stream stream;
   optional<std::size_t> const acquired_from;
@@ -324,42 +324,40 @@ _CCCL_SUPPRESS_DEPRECATED_PUSH // for thrust::optional
 
 // Precondition: `device` is the current CUDA device.
 template <typename X, typename Y, typename Deleter>
-CCCL_DEPRECATED _CCCL_HOST optional<unique_stream> try_acquire_stream(int device, std::unique_ptr<Y, Deleter>&) noexcept;
+_CCCL_HOST optional<unique_stream> try_acquire_stream(int device, std::unique_ptr<Y, Deleter>&) noexcept;
 
 // Precondition: `device` is the current CUDA device.
-CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept;
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept;
 
 // Precondition: `device` is the current CUDA device.
-CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, ready_event&) noexcept;
-
-// Precondition: `device` is the current CUDA device.
-template <typename X>
-CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, ready_future<X>&) noexcept;
-
-// Precondition: `device` is the current CUDA device.
-CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream>
-try_acquire_stream(int device, unique_eager_event& parent) noexcept;
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, ready_event&) noexcept;
 
 // Precondition: `device` is the current CUDA device.
 template <typename X>
-CCCL_DEPRECATED _CCCL_HOST optional<unique_stream>
-try_acquire_stream(int device, unique_eager_future<X>& parent) noexcept;
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, ready_future<X>&) noexcept;
+
+// Precondition: `device` is the current CUDA device.
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int device, unique_eager_event& parent) noexcept;
+
+// Precondition: `device` is the current CUDA device.
+template <typename X>
+_CCCL_HOST optional<unique_stream> try_acquire_stream(int device, unique_eager_future<X>& parent) noexcept;
 
 _CCCL_SUPPRESS_DEPRECATED_POP
 
 template <typename... Dependencies>
-CCCL_DEPRECATED _CCCL_HOST acquired_stream acquire_stream(int device, Dependencies&... deps) noexcept;
+_CCCL_HOST acquired_stream acquire_stream(int device, Dependencies&... deps) noexcept;
 
 template <typename... Dependencies>
-CCCL_DEPRECATED _CCCL_HOST unique_eager_event make_dependent_event(std::tuple<Dependencies...>&& deps);
+_CCCL_HOST unique_eager_event make_dependent_event(std::tuple<Dependencies...>&& deps);
 
 template <typename X, typename XPointer, typename ComputeContent, typename... Dependencies>
-CCCL_DEPRECATED _CCCL_HOST unique_eager_future_promise_pair<X, XPointer>
+_CCCL_HOST unique_eager_future_promise_pair<X, XPointer>
 make_dependent_future(ComputeContent&& cc, std::tuple<Dependencies...>&& deps);
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct CCCL_DEPRECATED async_signal
+struct async_signal
 {
 protected:
   unique_stream stream_;
@@ -383,7 +381,7 @@ public:
 };
 
 template <typename... KeepAlives>
-struct CCCL_DEPRECATED async_keep_alives<std::tuple<KeepAlives...>> : virtual async_signal
+struct async_keep_alives<std::tuple<KeepAlives...>> : virtual async_signal
 {
   using keep_alives_type = std::tuple<KeepAlives...>;
 
@@ -403,7 +401,7 @@ public:
 };
 
 template <typename T>
-struct CCCL_DEPRECATED async_value : virtual async_signal
+struct async_value : virtual async_signal
 {
   using value_type        = T;
   using raw_const_pointer = value_type const*;
@@ -440,7 +438,7 @@ struct CCCL_DEPRECATED async_value : virtual async_signal
 };
 
 template <typename T, typename Pointer, typename... KeepAlives>
-struct CCCL_DEPRECATED async_addressable_value_with_keep_alives<T, Pointer, std::tuple<KeepAlives...>> final
+struct async_addressable_value_with_keep_alives<T, Pointer, std::tuple<KeepAlives...>> final
     : async_value<T>
     , async_keep_alives<std::tuple<KeepAlives...>>
 {
@@ -534,7 +532,7 @@ public:
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename T, typename Pointer>
-struct CCCL_DEPRECATED weak_promise final
+struct weak_promise final
 {
   using value_type = typename async_value<T>::value_type;
 
@@ -930,31 +928,31 @@ namespace detail
 _CCCL_SUPPRESS_DEPRECATED_PUSH // for thrust::optional
 
   template <typename X, typename Deleter>
-  CCCL_DEPRECATED _CCCL_HOST optional<unique_stream> try_acquire_stream(int, std::unique_ptr<X, Deleter>&) noexcept
+  _CCCL_HOST optional<unique_stream> try_acquire_stream(int, std::unique_ptr<X, Deleter>&) noexcept
 {
   // There's no stream to acquire!
   return {};
 }
 
-CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, unique_stream& stream) noexcept
 {
   return {std::move(stream)};
 }
 
-CCCL_DEPRECATED _CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, ready_event&) noexcept
+_CCCL_HOST inline optional<unique_stream> try_acquire_stream(int, ready_event&) noexcept
 {
   // There's no stream to acquire!
   return {};
 }
 
 template <typename X>
-CCCL_DEPRECATED _CCCL_HOST optional<unique_stream> try_acquire_stream(int, ready_future<X>&) noexcept
+_CCCL_HOST optional<unique_stream> try_acquire_stream(int, ready_future<X>&) noexcept
 {
   // There's no stream to acquire!
   return {};
 }
 
-CCCL_DEPRECATED _CCCL_HOST optional<unique_stream> try_acquire_stream(int device_id, unique_eager_event& parent) noexcept
+_CCCL_HOST optional<unique_stream> try_acquire_stream(int device_id, unique_eager_event& parent) noexcept
 {
   // We have unique ownership, so we can always steal the stream if the future
   // has one as long as they are on the same device as us.
@@ -970,8 +968,7 @@ CCCL_DEPRECATED _CCCL_HOST optional<unique_stream> try_acquire_stream(int device
 }
 
 template <typename X>
-CCCL_DEPRECATED _CCCL_HOST optional<unique_stream>
-try_acquire_stream(int device_id, unique_eager_future<X>& parent) noexcept
+_CCCL_HOST optional<unique_stream> try_acquire_stream(int device_id, unique_eager_future<X>& parent) noexcept
 {
   // We have unique ownership, so we can always steal the stream if the future
   // has one as long as they are on the same device as us.
@@ -991,8 +988,7 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename... Dependencies>
-CCCL_DEPRECATED _CCCL_HOST acquired_stream
-acquire_stream_impl(int, std::tuple<Dependencies...>&, index_sequence<>) noexcept
+_CCCL_HOST acquired_stream acquire_stream_impl(int, std::tuple<Dependencies...>&, index_sequence<>) noexcept
 {
   // We tried to take a stream from all of our dependencies and failed every
   // time, so we need to make a new stream.
@@ -1000,7 +996,7 @@ acquire_stream_impl(int, std::tuple<Dependencies...>&, index_sequence<>) noexcep
 }
 
 template <typename... Dependencies, std::size_t I0, std::size_t... Is>
-CCCL_DEPRECATED _CCCL_HOST acquired_stream
+_CCCL_HOST acquired_stream
 acquire_stream_impl(int device_id, std::tuple<Dependencies...>& deps, index_sequence<I0, Is...>) noexcept
 {
   _CCCL_SUPPRESS_DEPRECATED_PUSH // for thrust::optional (MSVC warnings here)
@@ -1018,7 +1014,7 @@ acquire_stream_impl(int device_id, std::tuple<Dependencies...>& deps, index_sequ
 }
 
 template <typename... Dependencies>
-CCCL_DEPRECATED _CCCL_HOST acquired_stream acquire_stream(int device_id, std::tuple<Dependencies...>& deps) noexcept
+_CCCL_HOST acquired_stream acquire_stream(int device_id, std::tuple<Dependencies...>& deps) noexcept
 {
   return acquire_stream_impl(device_id, deps, make_index_sequence<sizeof...(Dependencies)>{});
 }
@@ -1026,38 +1022,37 @@ CCCL_DEPRECATED _CCCL_HOST acquired_stream acquire_stream(int device_id, std::tu
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename X, typename Deleter>
-CCCL_DEPRECATED _CCCL_HOST void create_dependency(unique_stream&, std::unique_ptr<X, Deleter>&) noexcept
+_CCCL_HOST void create_dependency(unique_stream&, std::unique_ptr<X, Deleter>&) noexcept
 {}
 
-CCCL_DEPRECATED _CCCL_HOST inline void create_dependency(unique_stream&, ready_event&) noexcept {}
+_CCCL_HOST inline void create_dependency(unique_stream&, ready_event&) noexcept {}
 
 template <typename T>
-CCCL_DEPRECATED _CCCL_HOST void create_dependency(unique_stream&, ready_future<T>&) noexcept
+_CCCL_HOST void create_dependency(unique_stream&, ready_future<T>&) noexcept
 {}
 
-CCCL_DEPRECATED _CCCL_HOST inline void create_dependency(unique_stream& child, unique_stream& parent)
+_CCCL_HOST inline void create_dependency(unique_stream& child, unique_stream& parent)
 {
   child.depend_on(parent);
 }
 
-CCCL_DEPRECATED _CCCL_HOST inline void create_dependency(unique_stream& child, unique_eager_event& parent)
+_CCCL_HOST inline void create_dependency(unique_stream& child, unique_eager_event& parent)
 {
   child.depend_on(parent.stream());
 }
 
 template <typename X>
-CCCL_DEPRECATED _CCCL_HOST void create_dependency(unique_stream& child, unique_eager_future<X>& parent)
+_CCCL_HOST void create_dependency(unique_stream& child, unique_eager_future<X>& parent)
 {
   child.depend_on(parent.stream());
 }
 
 template <typename... Dependencies>
-CCCL_DEPRECATED _CCCL_HOST void
-create_dependencies_impl(acquired_stream&, std::tuple<Dependencies...>&, index_sequence<>)
+_CCCL_HOST void create_dependencies_impl(acquired_stream&, std::tuple<Dependencies...>&, index_sequence<>)
 {}
 
 template <typename... Dependencies, std::size_t I0, std::size_t... Is>
-CCCL_DEPRECATED _CCCL_HOST void
+_CCCL_HOST void
 create_dependencies_impl(acquired_stream& as, std::tuple<Dependencies...>& deps, index_sequence<I0, Is...>)
 {
   // We only need to wait on the current dependency if we didn't steal our
@@ -1073,7 +1068,7 @@ create_dependencies_impl(acquired_stream& as, std::tuple<Dependencies...>& deps,
 }
 
 template <typename... Dependencies>
-CCCL_DEPRECATED _CCCL_HOST void create_dependencies(acquired_stream& as, std::tuple<Dependencies...>& deps)
+_CCCL_HOST void create_dependencies(acquired_stream& as, std::tuple<Dependencies...>& deps)
 {
   create_dependencies_impl(as, deps, make_index_sequence<sizeof...(Dependencies)>{});
 }
@@ -1084,7 +1079,7 @@ CCCL_DEPRECATED _CCCL_HOST void create_dependencies(acquired_stream& as, std::tu
 // Returns the result as an `index_sequence` of indices into the parameter
 // pack.
 template <typename Tuple, typename Indices>
-struct CCCL_DEPRECATED find_keep_alives_impl;
+struct find_keep_alives_impl;
 template <typename Tuple>
 using find_keep_alives =
   typename find_keep_alives_impl<Tuple, make_index_sequence<std::tuple_size<Tuple>::value>>::type;
@@ -1154,7 +1149,7 @@ struct find_keep_alives_impl<std::tuple<std::unique_ptr<T, Deleter>, Dependencie
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename... Dependencies>
-CCCL_DEPRECATED _CCCL_HOST unique_eager_event make_dependent_event(std::tuple<Dependencies...>&& deps)
+_CCCL_HOST unique_eager_event make_dependent_event(std::tuple<Dependencies...>&& deps)
 {
   int device_id = 0;
   thrust::cuda_cub::throw_on_error(cudaGetDevice(&device_id));
@@ -1181,7 +1176,7 @@ CCCL_DEPRECATED _CCCL_HOST unique_eager_event make_dependent_event(std::tuple<De
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename X, typename XPointer, typename ComputeContent, typename... Dependencies>
-CCCL_DEPRECATED _CCCL_HOST unique_eager_future_promise_pair<X, XPointer>
+_CCCL_HOST unique_eager_future_promise_pair<X, XPointer>
 make_dependent_future(ComputeContent&& cc, std::tuple<Dependencies...>&& deps)
 {
   int device_id = 0;

--- a/thrust/thrust/system/cuda/detail/par.h
+++ b/thrust/thrust/system/cuda/detail/par.h
@@ -120,6 +120,7 @@ struct execute_on_stream_nosync : execute_on_stream_nosync_base<execute_on_strea
       : base_t(stream) {};
 };
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 struct par_t
     : execution_policy<par_t>
     , thrust::detail::allocator_aware_execution_policy<execute_on_stream_base>
@@ -138,7 +139,9 @@ struct par_t
     return execute_on_stream(stream);
   }
 };
+_CCCL_SUPPRESS_DEPRECATED_POP
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 struct par_nosync_t
     : execution_policy<par_nosync_t>
     , thrust::detail::allocator_aware_execution_policy<execute_on_stream_nosync_base>
@@ -165,6 +168,7 @@ private:
     return false;
   }
 };
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 _CCCL_GLOBAL_CONSTANT par_t par;
 

--- a/thrust/thrust/system/cuda/future.h
+++ b/thrust/thrust/system/cuda/future.h
@@ -61,6 +61,7 @@ using thrust::system::cuda::when_all;
 
 } // namespace cuda
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <typename DerivedPolicy>
 _CCCL_HOST thrust::cuda::unique_eager_event
 unique_eager_event_type(thrust::cuda::execution_policy<DerivedPolicy> const&) noexcept;
@@ -68,6 +69,7 @@ unique_eager_event_type(thrust::cuda::execution_policy<DerivedPolicy> const&) no
 template <typename T, typename DerivedPolicy>
 _CCCL_HOST thrust::cuda::unique_eager_future<T>
 unique_eager_future_type(thrust::cuda::execution_policy<DerivedPolicy> const&) noexcept;
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 THRUST_NAMESPACE_END
 


### PR DESCRIPTION
Deprecate:
* detail::dependencies_aware_execution_policy
* detail::execute_with_allocator_and_dependencies
* detail::execute_with_dependencies
* [device_]unique_eager_event
* [device_]event
* [device_]unique_eager_future
* [device_]future
* new_stream[_t]
* when_all

And many utility entities around those