### PR TITLE
[CUDAX] Fix block and grid dimension order in <<<>>> in one of the hierarchy tests

### DIFF
--- a/cudax/test/hierarchy/hierarchy_smoke.cu
+++ b/cudax/test/hierarchy/hierarchy_smoke.cu
@@ -380,11 +380,11 @@ TEST_CASE("On device rank calculation", "[hierarchy]")
   CUDART(cudaMalloc((void**) &ptr, 2 * 1024 * sizeof(unsigned int)));
 
   const auto config_static = cudax::block_dims<256>() & cudax::grid_dims(dim3(2, 2, 2));
-  rank_kernel<<<256, dim3(2, 2, 2)>>>(config_static, ptr);
+  rank_kernel<<<dim3(2, 2, 2), 256>>>(config_static, ptr);
   CUDART(cudaDeviceSynchronize());
-  rank_kernel_cg<<<256, dim3(2, 2, 2)>>>(config_static, ptr);
+  rank_kernel_cg<<<dim3(2, 2, 2), 256>>>(config_static, ptr);
   CUDART(cudaDeviceSynchronize());
-  rank_kernel_optimized<<<256, dim3(2, 2, 2)>>>(config_static, ptr);
+  rank_kernel_optimized<<<dim3(2, 2, 2), 256>>>(config_static, ptr);
   CUDART(cudaDeviceSynchronize());
   CUDART(cudaFree(ptr));
 }


### PR DESCRIPTION
I am glad we have built the new `launch` API for people like me

Found by @miscco when working on mdspan refactor