### PR TITLE
By default remove canonicalization of denormals in complex multiplication / division

### DIFF
--- a/docs/libcudacxx/standard_api/numerics_library/complex.rst
+++ b/docs/libcudacxx/standard_api/numerics_library/complex.rst
@@ -15,16 +15,6 @@ Omissions
 Extensions
 --------------
 
-- Handling of infinities
-
-  Our implementation by default recovers infinite values during multiplication and division. This adds a significant runtime overhead,
-  so we allow disabling that canonicalization if it is not desired.
-
-  Definition of ``LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_OPERATIONS`` disables canonicalization for both multiplication *and* division.
-
-  Definition of ``LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_MULTIPLICATION`` or ``LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_DIVISION`` disables
-  canonicalization for multiplication or division individually.
-
 - Support for half and bfloat16 (since libcu++ 2.4.0)
 
   Our implementation includes support for the ``__half`` type from ``<cuda_fp16.h>``, when the CUDA toolkit version is at

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/complex
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/complex
@@ -270,15 +270,6 @@ template<class T> complex<T> tanh (const complex<T>&);
 
 _CCCL_PUSH_MACROS
 
-#ifdef LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_OPERATIONS
-#  ifndef LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_MULTIPLICATION
-#    define LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_MULTIPLICATION
-#  endif // LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_MULTIPLICATION
-#  ifndef LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_DIVISION
-#    define LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_DIVISION
-#  endif // LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_DIVISION
-#endif // LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_OPERATIONS
-
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
@@ -508,108 +499,37 @@ operator*(const complex<_Tp>& __z, const complex<_Tp>& __w)
   _Tp __c = __w.real();
   _Tp __d = __w.imag();
 
-#if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
-  // Avoid floating point operations that are invalid during constant evaluation
-  if (_CUDA_VSTD::is_constant_evaluated())
+  // Annex G.5.1 Multiplicative operators
+  // if one operand is an infinity and the other operand is a nonzero finite number or an
+  // infinity, then the result of the * operator is an infinity;
+  if (_CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b))
   {
-    bool __z_zero = __a == _Tp(0) && __b == _Tp(0);
-    bool __w_zero = __c == _Tp(0) && __d == _Tp(0);
-    bool __z_inf  = _CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b);
-    bool __w_inf  = _CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d);
-    bool __z_nan  = !__z_inf
-                && ((_CUDA_VSTD::isnan(__a) && _CUDA_VSTD::isnan(__b)) || (_CUDA_VSTD::isnan(__a) && __b == _Tp(0))
-                    || (__a == _Tp(0) && _CUDA_VSTD::isnan(__b)));
-    bool __w_nan = !__w_inf
-                && ((_CUDA_VSTD::isnan(__c) && _CUDA_VSTD::isnan(__d)) || (_CUDA_VSTD::isnan(__c) && __d == _Tp(0))
-                    || (__c == _Tp(0) && _CUDA_VSTD::isnan(__d)));
-    if (__z_nan || __w_nan)
+    if (_CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d))
     {
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
-    }
-    if (__z_inf || __w_inf)
-    {
-      if (__z_zero || __w_zero)
-      {
-        return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
-      }
       return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
     }
-    bool __z_nonzero_nan = !__z_inf && !__z_nan && (_CUDA_VSTD::isnan(__a) || _CUDA_VSTD::isnan(__b));
-    bool __w_nonzero_nan = !__w_inf && !__w_nan && (_CUDA_VSTD::isnan(__c) || _CUDA_VSTD::isnan(__d));
-    if (__z_nonzero_nan || __w_nonzero_nan)
+
+    if ((__c != _Tp(0) && !_CUDA_VSTD::isnan(__c)) || (__d != _Tp(0) && !_CUDA_VSTD::isnan(__d)))
     {
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+      return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
     }
   }
-#endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
+  else if (_CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d))
+  {
+    if ((__a != _Tp(0) && !_CUDA_VSTD::isnan(__a)) || (__b != _Tp(0) && !_CUDA_VSTD::isnan(__b)))
+    {
+      return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
+    }
+  }
+  else if (_CUDA_VSTD::isnan(__a) || _CUDA_VSTD::isnan(__b) || _CUDA_VSTD::isnan(__c) || _CUDA_VSTD::isnan(__d))
+  {
+    return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+  }
 
   __abcd_results<_Tp> __partials = __complex_calculate_partials(__a, __b, __c, __d);
 
   _Tp __x = __partials.__ac - __partials.__bd;
   _Tp __y = __partials.__ad + __partials.__bc;
-#ifndef LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_MULTIPLICATION
-  if (_CUDA_VSTD::isnan(__x) && _CUDA_VSTD::isnan(__y))
-  {
-    bool __recalc = false;
-    if (_CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b))
-    {
-      __a = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__a) ? _Tp(1) : _Tp(0), __a);
-      __b = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__b) ? _Tp(1) : _Tp(0), __b);
-      if (_CUDA_VSTD::isnan(__c))
-      {
-        __c = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __c);
-      }
-      if (_CUDA_VSTD::isnan(__d))
-      {
-        __d = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __d);
-      }
-      __recalc = true;
-    }
-    if (_CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d))
-    {
-      __c = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__c) ? _Tp(1) : _Tp(0), __c);
-      __d = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__d) ? _Tp(1) : _Tp(0), __d);
-      if (_CUDA_VSTD::isnan(__a))
-      {
-        __a = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __a);
-      }
-      if (_CUDA_VSTD::isnan(__b))
-      {
-        __b = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __b);
-      }
-      __recalc = true;
-    }
-    if (!__recalc
-        && (_CUDA_VSTD::isinf(__partials.__ac) || _CUDA_VSTD::isinf(__partials.__bd)
-            || _CUDA_VSTD::isinf(__partials.__ad) || _CUDA_VSTD::isinf(__partials.__bc)))
-    {
-      if (_CUDA_VSTD::isnan(__a))
-      {
-        __a = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __a);
-      }
-      if (_CUDA_VSTD::isnan(__b))
-      {
-        __b = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __b);
-      }
-      if (_CUDA_VSTD::isnan(__c))
-      {
-        __c = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __c);
-      }
-      if (_CUDA_VSTD::isnan(__d))
-      {
-        __d = _CUDA_VSTD::__constexpr_copysign(_Tp(0), __d);
-      }
-      __recalc = true;
-    }
-    if (__recalc)
-    {
-      __partials = __complex_calculate_partials(__a, __b, __c, __d);
-
-      __x = numeric_limits<_Tp>::infinity() * (__partials.__ac - __partials.__bd);
-      __y = numeric_limits<_Tp>::infinity() * (__partials.__ad + __partials.__bc);
-    }
-  }
-#endif // LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_MULTIPLICATION
   return complex<_Tp>(__x, __y);
 }
 
@@ -638,7 +558,39 @@ operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
   _Tp __b      = __z.imag();
   _Tp __c      = __w.real();
   _Tp __d      = __w.imag();
-  _Tp __logbw  = _CUDA_VSTD::__constexpr_logb(
+
+  // Annex G.5.1 Multiplicative operators
+  // if the first operand is an infinity and the second operand is a finite number, then the
+  // result of the / operator is an infinity;
+  if ((_CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b)) && _CUDA_VSTD::isfinite(__c) && _CUDA_VSTD::isfinite(__d))
+  {
+    return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
+  }
+  // if the first operand is a finite number and the second operand is an infinity, then the
+  // result of the / operator is a zero;
+  else if ((_CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d)) && _CUDA_VSTD::isfinite(__a) && _CUDA_VSTD::isfinite(__b))
+  {
+    return complex<_Tp>(_Tp(0), _Tp(0));
+  }
+  // if the first operand is a nonzero finite number or an infinity and the second operand is
+  // a zero, then the result of the / operator is an infinity.
+  else if (__c == _Tp(0) && __d == _Tp(0))
+  {
+    if (!_CUDA_VSTD::isnan(__a) && !_CUDA_VSTD::isnan(__b))
+    {
+      return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
+    }
+    else
+    {
+      return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+    }
+  }
+  else if (_CUDA_VSTD::isnan(__a) || _CUDA_VSTD::isnan(__b) || _CUDA_VSTD::isnan(__c) || _CUDA_VSTD::isnan(__d))
+  {
+    return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+  }
+
+  _Tp __logbw = _CUDA_VSTD::__constexpr_logb(
     _CUDA_VSTD::__constexpr_fmax(_CUDA_VSTD::__constexpr_fabs(__c), _CUDA_VSTD::__constexpr_fabs(__d)));
   if (_CUDA_VSTD::isfinite(__logbw))
   {
@@ -647,84 +599,12 @@ operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
     __d      = _CUDA_VSTD::__constexpr_scalbn(__d, -__ilogbw);
   }
 
-#if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
-  // Avoid floating point operations that are invalid during constant evaluation
-  if (_CUDA_VSTD::is_constant_evaluated())
-  {
-    bool __z_zero = __a == _Tp(0) && __b == _Tp(0);
-    bool __w_zero = __c == _Tp(0) && __d == _Tp(0);
-    bool __z_inf  = _CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b);
-    bool __w_inf  = _CUDA_VSTD::isinf(__c) || _CUDA_VSTD::isinf(__d);
-    bool __z_nan  = !__z_inf
-                && ((_CUDA_VSTD::isnan(__a) && _CUDA_VSTD::isnan(__b)) || (_CUDA_VSTD::isnan(__a) && __b == _Tp(0))
-                    || (__a == _Tp(0) && _CUDA_VSTD::isnan(__b)));
-    bool __w_nan = !__w_inf
-                && ((_CUDA_VSTD::isnan(__c) && _CUDA_VSTD::isnan(__d)) || (_CUDA_VSTD::isnan(__c) && __d == _Tp(0))
-                    || (__c == _Tp(0) && _CUDA_VSTD::isnan(__d)));
-    if ((__z_nan || __w_nan) || (__z_inf && __w_inf))
-    {
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
-    }
-    bool __z_nonzero_nan = !__z_inf && !__z_nan && (_CUDA_VSTD::isnan(__a) || _CUDA_VSTD::isnan(__b));
-    bool __w_nonzero_nan = !__w_inf && !__w_nan && (_CUDA_VSTD::isnan(__c) || _CUDA_VSTD::isnan(__d));
-    if (__z_nonzero_nan || __w_nonzero_nan)
-    {
-      if (__w_zero)
-      {
-        return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
-      }
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
-    }
-    if (__w_inf)
-    {
-      return complex<_Tp>(_Tp(0), _Tp(0));
-    }
-    if (__z_inf)
-    {
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
-    }
-    if (__w_zero)
-    {
-      if (__z_zero)
-      {
-        return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
-      }
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
-    }
-  }
-#endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
-
   __abcd_results<_Tp> __partials = __complex_calculate_partials(__a, __b, __c, __d);
   __ab_results<_Tp> __denom_vec  = __complex_piecewise_mul(__c, __d, __c, __d);
 
   _Tp __denom = __denom_vec.__a + __denom_vec.__b;
   _Tp __x     = _CUDA_VSTD::__constexpr_scalbn((__partials.__ac + __partials.__bd) / __denom, -__ilogbw);
   _Tp __y     = _CUDA_VSTD::__constexpr_scalbn((__partials.__bc - __partials.__ad) / __denom, -__ilogbw);
-#ifndef LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_DIVISION
-  if (_CUDA_VSTD::isnan(__x) && _CUDA_VSTD::isnan(__y))
-  {
-    if ((__denom == _Tp(0)) && (!_CUDA_VSTD::isnan(__a) || !_CUDA_VSTD::isnan(__b)))
-    {
-      __x = _CUDA_VSTD::__constexpr_copysign(numeric_limits<_Tp>::infinity(), __c) * __a;
-      __y = _CUDA_VSTD::__constexpr_copysign(numeric_limits<_Tp>::infinity(), __c) * __b;
-    }
-    else if ((_CUDA_VSTD::isinf(__a) || _CUDA_VSTD::isinf(__b)) && _CUDA_VSTD::isfinite(__c)
-             && _CUDA_VSTD::isfinite(__d))
-    {
-      __a = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__a) ? _Tp(1) : _Tp(0), __a);
-      __b = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__b) ? _Tp(1) : _Tp(0), __b);
-      __x = numeric_limits<_Tp>::infinity() * (__a * __c + __b * __d);
-      __y = numeric_limits<_Tp>::infinity() * (__b * __c - __a * __d);
-    }
-    else if (_CUDA_VSTD::isinf(__logbw) && __logbw > _Tp(0) && _CUDA_VSTD::isfinite(__a) && _CUDA_VSTD::isfinite(__b))
-    {
-      __c = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__c) ? _Tp(1) : _Tp(0), __c);
-      __d = _CUDA_VSTD::__constexpr_copysign(_CUDA_VSTD::isinf(__d) ? _Tp(1) : _Tp(0), __d);
-      __x = _Tp(0) * (__a * __c + __b * __d);
-      __y = _Tp(0) * (__b * __c - __a * __d);
-    }
-  }
-#endif // LIBCUDACXX_ENABLE_SIMPLIFIED_COMPLEX_DIVISION
   return complex<_Tp>(__x, __y);
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.ops/complex_divide_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex.ops/complex_divide_complex.pass.cpp
@@ -46,7 +46,7 @@ __host__ __device__ void test_edges()
           switch (classify(testcases[j]))
           {
             case zero:
-              assert(classify(r) == NaN);
+              assert(classify(r) == inf);
               break;
             case non_zero:
               assert(classify(r) == zero);
@@ -126,7 +126,7 @@ __host__ __device__ void test_edges()
           switch (classify(testcases[j]))
           {
             case zero:
-              assert(classify(r) == inf);
+              assert(classify(r) == NaN);
               break;
             case non_zero:
               assert(classify(r) == NaN);


### PR DESCRIPTION
But also adhere to the C standard wrt to infinities

Fixes #1000
