### PR TITLE
Expose `<cuda/std/exception>`

### DIFF
--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -15,6 +15,7 @@
 #include <thrust/sequence.h>
 #include <thrust/zip_function.h>
 
+#include <cuda/std/__exception/terminate.h>
 #include <cuda/std/__functional/identity.h>
 
 #include <sstream>

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -44,6 +44,8 @@
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
 
+#include <cuda/std/exception>
+
 #include <cfloat>
 #include <cmath>
 #include <cstddef>

--- a/cudax/include/cuda/experimental/__async/sender/start_detached.cuh
+++ b/cudax/include/cuda/experimental/__async/sender/start_detached.cuh
@@ -56,7 +56,7 @@ private:
     template <class _Error>
     void set_error(_Error&&) && noexcept
     {
-      ::cuda::std::terminate();
+      _CUDA_VSTD_NOVERSION::terminate();
     }
 
     void set_stopped() && noexcept

--- a/docs/libcudacxx/standard_api/diagnostics_library.rst
+++ b/docs/libcudacxx/standard_api/diagnostics_library.rst
@@ -1,0 +1,17 @@
+.. _libcudacxx-standard-api-diagnostics:
+
+Diagnostics Library
+=======================
+
+Any Standard C++ header not listed below is omitted.
+
+.. list-table::
+   :widths: 25 45 30
+   :header-rows: 1
+
+   * - Header
+     - Content
+     - Availability
+   * - `\<cuda/std/exception\> <https://en.cppreference.com/w/cpp/header/exception>`_
+     - Provides the ``std::terminate`` function
+     - CCCL 3.0.0

--- a/libcudacxx/include/cuda/std/__exception/terminate.h
+++ b/libcudacxx/include/cuda/std/__exception/terminate.h
@@ -22,16 +22,15 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/cstdlib> // ::exit
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_MSVC(4702) // unreachable code
+#if !_CCCL_COMPILER(NVRTC)
+#  include <exception>
+#endif // !_CCCL_COMPILER(NVRTC)
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD_NOVERSION // purposefully not using versioning namespace
 
 _CCCL_NORETURN _LIBCUDACXX_HIDE_FROM_ABI void __cccl_terminate() noexcept
 {
-  NV_IF_ELSE_TARGET(NV_IS_HOST, (::exit(-1);), (__trap();))
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (::std::terminate();), (::__trap();))
   _CCCL_UNREACHABLE();
 }
 
@@ -58,12 +57,9 @@ _LIBCUDACXX_HIDE_FROM_ABI  terminate_handler get_terminate() noexcept
 
 _CCCL_NORETURN _LIBCUDACXX_HIDE_FROM_ABI void terminate() noexcept
 {
-  __cccl_terminate();
-  _CCCL_UNREACHABLE();
+  _CUDA_VSTD_NOVERSION::__cccl_terminate();
 }
 
 _LIBCUDACXX_END_NAMESPACE_STD_NOVERSION
-
-_CCCL_DIAG_POP
 
 #endif // _LIBCUDACXX___EXCEPTION_TERMINATE_H

--- a/libcudacxx/include/cuda/std/exception
+++ b/libcudacxx/include/cuda/std/exception
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_EXCEPTION
+#define _CUDA_STD_EXCEPTION
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__exception/terminate.h>
+#include <cuda/std/version>
+
+#endif //_CUDA_STD_EXCEPTION

--- a/libcudacxx/test/libcudacxx/std/language.support/support.exception/exception.terminate/set.terminate/get_terminate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.exception/exception.terminate/set.terminate/get_terminate.pass.cpp
@@ -11,8 +11,8 @@
 
 // test get_terminate
 
-#include <cuda/std/__exception/terminate.h>
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 #include <cuda/std/type_traits>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/std/language.support/support.exception/exception.terminate/set.terminate/set_terminate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.exception/exception.terminate/set.terminate/set_terminate.pass.cpp
@@ -11,8 +11,8 @@
 
 // test set_terminate
 
-#include <cuda/std/__exception/terminate.h>
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 
 #include "test_macros.h"
 

--- a/libcudacxx/test/libcudacxx/std/language.support/support.exception/exception.terminate/terminate.handler/terminate_handler.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.exception/exception.terminate/terminate.handler/terminate_handler.pass.cpp
@@ -11,8 +11,8 @@
 
 // test terminate_handler
 
-#include <cuda/std/__exception/terminate.h>
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 #include <cuda/std/type_traits>
 
 #include "test_macros.h"

--- a/libcudacxx/test/libcudacxx/std/language.support/support.exception/exception.terminate/terminate/terminate.runfail.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.exception/exception.terminate/terminate/terminate.runfail.cpp
@@ -11,8 +11,8 @@
 // UNSUPPORTED: no_execute
 // UNSUPPORTED: nvrtc
 
-#include <cuda/std/__exception/terminate.h>
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 
 #include "test_macros.h"
 

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/const_optional_U.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/const_optional_U.pass.cpp
@@ -14,6 +14,7 @@
 //   optional(const optional<U>& rhs);
 
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 #include <cuda/std/optional>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/explicit_const_optional_U.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/explicit_const_optional_U.pass.cpp
@@ -14,6 +14,7 @@
 //   explicit optional(const optional<U>& rhs);
 
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 #include <cuda/std/optional>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/explicit_optional_U.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/explicit_optional_U.pass.cpp
@@ -14,6 +14,7 @@
 //   explicit optional(optional<U>&& rhs);
 
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 #include <cuda/std/optional>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/optional_U.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.ctor/optional_U.pass.cpp
@@ -14,6 +14,7 @@
 //   optional(optional<U>&& rhs);
 
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 #include <cuda/std/optional>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.swap/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.object/optional.object.swap/swap.pass.cpp
@@ -15,6 +15,7 @@
 //              is_nothrow_swappable<T>::value)
 
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 #include <cuda/std/optional>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/optional/optional.specalg/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/optional/optional.specalg/swap.pass.cpp
@@ -16,6 +16,7 @@
 //     noexcept(noexcept(x.swap(y)));
 
 #include <cuda/std/cassert>
+#include <cuda/std/exception>
 #include <cuda/std/optional>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.swap/swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.variant/variant.swap/swap.pass.cpp
@@ -18,6 +18,7 @@
 
 #include <cuda/std/cassert>
 // #include <cuda/std/string>
+#include <cuda/std/exception>
 #include <cuda/std/type_traits>
 #include <cuda/std/variant>
 

--- a/libcudacxx/test/support/test_allocator.h
+++ b/libcudacxx/test/support/test_allocator.h
@@ -14,6 +14,7 @@
 #include <climits>
 #include <cstddef>
 #include <cstdlib>
+#include <exception>
 #include <memory>
 #include <new>
 #include <type_traits>

--- a/thrust/thrust/system/cuda/detail/util.h
+++ b/thrust/thrust/system/cuda/detail/util.h
@@ -45,8 +45,9 @@
 #include <thrust/system/cuda/error.h>
 #include <thrust/system_error.h>
 
+#include <cuda/std/__exception/terminate.h>
+
 #include <cstdio>
-#include <exception>
 
 #include <nv/target>
 
@@ -179,7 +180,7 @@ trivial_copy_device_to_device(Policy& policy, Type* dst, Type const* src, size_t
 
 CCCL_DEPRECATED_BECAUSE("Use cuda::std::terminate() instead") inline void _CCCL_HOST_DEVICE terminate()
 {
-  NV_IF_TARGET(NV_IS_HOST, (std::terminate();), (asm("trap;");));
+  ::cuda::std::terminate();
 }
 
 _CCCL_HOST_DEVICE inline void throw_on_error(cudaError_t status)


### PR DESCRIPTION
Thrust's and cub's `terminate` functions are depreceted and suggest to use `cuda::std::terminate` instead.

However libcu++ currently doesn't even expose the `<cuda/std/exception>` header where the `std::terminate` function resides.

This PR exposes the header and fixes the usage in the codebase.